### PR TITLE
feat(rules): institutionalize branch protection + PR workflow

### DIFF
--- a/.claude/rules/branch-protection.md
+++ b/.claude/rules/branch-protection.md
@@ -1,0 +1,83 @@
+# Branch Protection Rules
+
+## Scope
+
+These rules apply to ALL git operations across ALL repositories in the Kailash ecosystem.
+
+## Protected Repositories
+
+| Repository                                 | Branch | Protection Level    |
+| ------------------------------------------ | ------ | ------------------- |
+| `terrene-foundation/kailash-py`            | `main` | Full (admin bypass) |
+| `terrene-foundation/kailash-coc-claude-py` | `main` | Full (admin bypass) |
+| `terrene-foundation/kailash-coc-claude-rs` | `main` | Full (admin bypass) |
+| `esperie/kailash-rs`                       | `main` | Full (admin bypass) |
+
+## Protection Settings
+
+All repositories enforce:
+
+- **1 approving review** required for PRs (admin can bypass)
+- **Dismiss stale reviews** on new pushes
+- **Status checks must pass** (strict mode)
+- **No force pushes** to main
+- **No branch deletion** for main
+- **Conversation resolution required**
+- **Enforce admins: OFF** — repo admins can merge without reviews
+
+## Workflow
+
+### For the repo owner (admin)
+
+1. Create feature branch: `git checkout -b type/description`
+2. Commit changes on the branch
+3. Push branch: `git push -u origin type/description`
+4. Create PR: `gh pr create --title "..." --body "..."`
+5. Review the diff (Claude Code assists with review)
+6. Merge with admin bypass: `gh pr merge <N> --admin --merge --delete-branch`
+
+### For contributors (non-admin)
+
+1. Fork the repository
+2. Create feature branch
+3. Submit PR
+4. Wait for 1 approving review from a maintainer
+5. CI must pass before merge
+
+## Claude Code Integration
+
+Claude Code creates branches and PRs. The owner reviews and merges:
+
+```bash
+# Claude Code creates the PR
+git checkout -b feat/my-feature
+# ... make changes ...
+git push -u origin feat/my-feature
+gh pr create --title "feat: my feature" --body "..."
+
+# Owner merges after vetting with Claude Code
+gh pr merge <N> --admin --merge --delete-branch
+```
+
+## MUST NOT Rules
+
+### 1. No Direct Push to Main
+
+All changes to main MUST go through a PR. Direct pushes are rejected by GitHub.
+
+### 2. No Force Push
+
+Force pushes to main are blocked. No exceptions.
+
+### 3. No Disabling Protection
+
+Branch protection settings MUST NOT be weakened without explicit owner approval and documentation of the reason.
+
+## Rationale
+
+These repositories are open source (Apache 2.0, Terrene Foundation). Branch protection ensures:
+
+- All changes are traceable via PRs
+- CI validates every change before merge
+- Contributors follow the same process as maintainers
+- Admin bypass allows the owner to move fast while maintaining the audit trail

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -113,10 +113,12 @@ Each commit MUST be self-contained.
 
 ### 1. No Direct Push to Main
 
-MUST NOT push directly to main/master branch.
+MUST NOT push directly to main/master branch. All changes go through PRs.
 
-**Enforced by**: Branch protection
-**Consequence**: Push rejected
+**Enforced by**: GitHub branch protection (active on all 4 repos)
+**Consequence**: Push rejected by GitHub
+**Workflow**: See `rules/branch-protection.md` for the PR workflow
+**Admin bypass**: Owner can merge with `gh pr merge <N> --admin --merge --delete-branch`
 
 ### 2. No Force Push to Main
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Phase commands replace the manual copy-paste workflow. Each loads the correspond
 | E2E god-mode testing                  | `rules/e2e-god-mode.md`       | `tests/e2e/**`, `**/*e2e*`, `**/*playwright*`                         |
 | API keys & model names                | `rules/env-models.md`         | `**/*.py`, `**/*.ts`, `**/*.js`, `.env*`                              |
 | Git commits, branches, PRs            | `rules/git.md`                | Global                                                                |
+| Branch protection & PR workflow       | `rules/branch-protection.md`  | Global                                                                |
 | No stubs, TODOs, or placeholders      | `rules/no-stubs.md`           | Global                                                                |
 | Kailash SDK execution patterns        | `rules/patterns.md`           | `**/*.py`, `**/*.ts`, `**/*.js`                                       |
 | Security (secrets, injection)         | `rules/security.md`           | Global                                                                |


### PR DESCRIPTION
## Summary

- New `rules/branch-protection.md` documenting protection settings for all 4 repos
- Updated `rules/git.md` with cross-reference and admin bypass instructions  
- Updated CLAUDE.md rules index

Branch protection is now enforced on:
- terrene-foundation/kailash-py
- terrene-foundation/kailash-coc-claude-py
- terrene-foundation/kailash-coc-claude-rs
- esperie/kailash-rs

## Test plan

- [x] Rule file follows existing format
- [x] Cross-references are accurate
- [x] Admin bypass workflow documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)