### PR TITLE
fix(ci): add --break-system-packages for uv pip on Ubuntu 24.04

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -49,8 +49,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e ".[dev]" --system
-          uv pip install -e "packages/kailash-kaizen[dev]" --system
+          uv pip install -e ".[dev]" --system --break-system-packages
+          uv pip install -e "packages/kailash-kaizen[dev]" --system --break-system-packages
 
       - name: Run Security Test Suite
         run: |

--- a/.github/workflows/trust-tests.yml
+++ b/.github/workflows/trust-tests.yml
@@ -55,10 +55,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install -e ".[dev]" --system
-          uv pip install -e "packages/kailash-kaizen[dev]" --system
-          uv pip install -e "packages/kailash-dataflow[dev]" --system
-          uv pip install -e "packages/kailash-nexus[dev]" --system
+          uv pip install -e ".[dev]" --system --break-system-packages
+          uv pip install -e "packages/kailash-kaizen[dev]" --system --break-system-packages
+          uv pip install -e "packages/kailash-dataflow[dev]" --system --break-system-packages
+          uv pip install -e "packages/kailash-nexus[dev]" --system --break-system-packages
 
       - name: Create reports directory
         run: mkdir -p reports


### PR DESCRIPTION
## Summary

- trust-tests.yml and security-tests.yml fail on Ubuntu 24.04 because PEP 668 marks the system Python as externally managed
- `uv pip install --system` needs `--break-system-packages` flag

## Test plan

- [x] Verified fix matches Ubuntu 24.04 PEP 668 requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)