### PR TITLE
fix(ci): replace stale self-hosted setup in test-with-infrastructure

### DIFF
--- a/.github/workflows/test-with-infrastructure.yml
+++ b/.github/workflows/test-with-infrastructure.yml
@@ -23,71 +23,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Python (self-hosted)
-        run: |
-          # Self-hosted runners have Python pre-installed
-          # Check available Python versions
-          echo "Checking Python setup..."
-
-          if command -v pyenv &> /dev/null; then
-            echo "Found pyenv, initializing..."
-            export PYENV_ROOT="$HOME/.pyenv"
-            export PATH="$PYENV_ROOT/bin:$PATH"
-            eval "$(pyenv init -)"
-
-            echo "Available Python versions:"
-            pyenv versions
-
-            # Use Python 3.11 if available
-            if pyenv versions | grep -q "3.11"; then
-              echo "✓ Python 3.11 available via pyenv"
-            else
-              echo "⚠️  Python 3.11 not found in pyenv"
-            fi
-          else
-            echo "pyenv not found, checking system Python"
-            which python3
-            python3 --version
-          fi
-
-      - name: Install uv
-        run: |
-          # Install uv in a custom location to avoid permission issues
-          export CARGO_HOME="${GITHUB_WORKSPACE}/.cargo"
-          export RUSTUP_HOME="${GITHUB_WORKSPACE}/.rustup"
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "${GITHUB_WORKSPACE}/.cargo/bin" >> $GITHUB_PATH
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
-          # Initialize pyenv if available
-          if command -v pyenv &> /dev/null; then
-            export PYENV_ROOT="$HOME/.pyenv"
-            export PATH="$PYENV_ROOT/bin:$PATH"
-            eval "$(pyenv init -)"
-          fi
-
-          # Add Homebrew to PATH for gcc/gfortran (needed for scipy/numpy compilation)
-          if [ -d "/opt/homebrew/bin" ]; then
-            export PATH="/opt/homebrew/bin:$PATH"
-            echo "Added /opt/homebrew/bin to PATH (Apple Silicon)"
-          elif [ -d "/usr/local/bin" ]; then
-            export PATH="/usr/local/bin:$PATH"
-            echo "Added /usr/local/bin to PATH (Intel Mac)"
-          fi
-
-          # Verify gfortran is available
-          if command -v gfortran &> /dev/null; then
-            echo "✓ gfortran found: $(which gfortran)"
-          else
-            echo "⚠️  gfortran not found - scipy/numpy compilation may fail"
-          fi
-
-          # Install [dev] extras only from local source.
-          # [all] pulls kailash-dataflow/nexus/kaizen from PyPI which may not
-          # yet be available. Sub-packages are installed separately below if present.
-          uv pip install -e ".[dev]" --python "$(which python3)"
-          uv pip install pytest-cov --python "$(which python3)"
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install pytest-cov
 
       - name: Check Node.js for mock API server
         run: |


### PR DESCRIPTION
## Summary

- Workflow uses `ubuntu-latest` but had self-hosted pyenv/homebrew/gfortran boilerplate
- Replaced with `actions/setup-python@v5` + standard `pip install`
- Fixes PEP 668 externally-managed-environment error on Ubuntu 24.04
- Verified install works in Docker python:3.12-slim

## Test plan

- [x] Docker local test: `pip install -e ".[dev]"` succeeds
- [x] Test collection works after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)