### PR TITLE
fix(ci): replace broken coc-sync with notification-only workflow

### DIFF
--- a/.github/workflows/coc-sync.yml
+++ b/.github/workflows/coc-sync.yml
@@ -1,5 +1,14 @@
 name: COC Sync to USE Repo
 
+# COC sync requires the coc-sync agent (content transformation, BUILD→USE
+# softening, contamination checks). This cannot be done with a shell script.
+#
+# Sync is performed manually via `/codify` → coc-sync agent, or via
+# Claude Code action when CC quota is available.
+#
+# This workflow notifies when COC artifacts change so the owner knows
+# a manual sync is needed.
+
 on:
   push:
     branches: [main]
@@ -9,114 +18,26 @@ on:
       - ".claude/rules/**"
       - ".claude/commands/**"
       - "scripts/hooks/**"
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Dry run (no push/PR)"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
-  sync:
+  notify:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
+    timeout-minutes: 2
     steps:
-      - name: Checkout BUILD repo
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 1
-          path: build-repo
-
-      - name: Checkout USE repo
-        uses: actions/checkout@v5
-        with:
-          repository: terrene-foundation/kailash-coc-claude-py
-          token: ${{ secrets.COC_SYNC_PAT }}
-          fetch-depth: 1
-          path: use-repo
-
-      - name: Sync COC artifacts
+      - name: Notify COC sync needed
         run: |
-          BUILD="$GITHUB_WORKSPACE/build-repo"
-          USE="$GITHUB_WORKSPACE/use-repo"
-          BRANCH="coc-sync/$(date +%Y%m%d-%H%M%S)"
-
-          cd "$USE"
-          git checkout -b "$BRANCH"
-
-          # Sync rules
-          for rule in zero-tolerance.md no-stubs.md agents.md e2e-god-mode.md terrene-naming.md git.md; do
-            src="$BUILD/.claude/rules/$rule"
-            dst="$USE/.claude/rules/$rule"
-            if [ -f "$src" ]; then
-              cp "$src" "$dst"
-            fi
-          done
-
-          # Sync hooks
-          for hook in validate-workflow.js validate-bash-command.js validate-deployment.js auto-format.js user-prompt-rules-reminder.js session-start.js session-end.js pre-compact.js stop.js; do
-            src="$BUILD/scripts/hooks/$hook"
-            dst="$USE/scripts/hooks/$hook"
-            if [ -f "$src" ]; then
-              cp "$src" "$dst"
-            fi
-          done
-
-          if [ -d "$BUILD/scripts/hooks/lib" ]; then
-            mkdir -p "$USE/scripts/hooks/lib"
-            cp -r "$BUILD/scripts/hooks/lib/"* "$USE/scripts/hooks/lib/" 2>/dev/null || true
-          fi
-
-          # Write sync marker
-          mkdir -p "$USE/.claude"
-          cat > "$USE/.claude/.coc-sync-marker" <<MARKER
-          {"synced_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)", "template_commit": "$(git -C "$BUILD" rev-parse --short HEAD)", "source": "kailash-py"}
-          MARKER
-
-          # Check for changes
-          if git diff --quiet && git diff --cached --quiet; then
-            echo "No COC changes to sync"
-            exit 0
-          fi
-
-          # Commit and push (skip if dry run)
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "Dry run — showing diff:"
-            git diff --stat
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "chore(coc): sync from kailash-py $(git -C "$BUILD" rev-parse --short HEAD)
-
-          Automated COC sync from BUILD repo.
-
-          Co-Authored-By: Claude Maintenance <noreply@anthropic.com>"
-
-          git push origin "$BRANCH"
-
-          gh pr create \
-            --repo terrene-foundation/kailash-coc-claude-py \
-            --title "chore(coc): sync from kailash-py" \
-            --body "Automated COC sync. Source commit: $(git -C "$BUILD" rev-parse --short HEAD)" \
-            --label "coc-sync" \
-            --head "$BRANCH"
-        env:
-          GH_TOKEN: ${{ secrets.COC_SYNC_PAT }}
+          echo "## COC Sync Required" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "COC artifacts changed in this push. Run \`/codify\` with the coc-sync agent to sync to the USE template repo." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The coc-sync agent transforms BUILD content to USE content (softens rules, strips builder paths, checks contamination). A shell script cannot do this correctly." >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Discord
         if: always()
         run: |
           if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            STATUS="${{ job.status }}"
-            COLOR=$( [ "$STATUS" = "success" ] && echo 3447003 || echo 15158332 )
             curl -s -H "Content-Type: application/json" \
-              -d "{\"embeds\":[{\"title\":\"[COC-SYNC $STATUS] kailash-py → kailash-coc-claude-py\",\"color\":${COLOR}}]}" \
+              -d "{\"embeds\":[{\"title\":\"[COC-SYNC NEEDED] kailash-py COC artifacts changed\",\"description\":\"Run /codify with coc-sync agent to sync to USE repo.\",\"color\":16776960}]}" \
               "$DISCORD_WEBHOOK_URL" || true
           fi
         env:


### PR DESCRIPTION
## Summary

The coc-sync workflow was a shell script that copied BUILD rules verbatim to USE — bypassing the coc-sync agent's transformation logic (rule softening, builder content stripping, contamination checks). This would overwrite properly transformed USE content.

Replaced with a notification-only workflow that alerts (GitHub summary + Discord) when COC artifacts change, prompting manual `/codify` + coc-sync agent run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)