### PR TITLE
fix(dataflow): bump to 1.2.0 — fix kailash dependency upper bound

### DIFF
--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "1.1.0"
+version = "1.2.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -56,7 +56,7 @@ from .utils.suppress_warnings import (
 suppress_core_sdk_warnings()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

- Bumps kailash-dataflow version 1.1.0 → 1.2.0
- Fixes dependency constraint: `kailash>=1.0.0,<3.0.0` (was `kailash<2.0.0` in the 1.1.0 PyPI release)
- Already published to PyPI: https://pypi.org/project/kailash-dataflow/1.2.0/

The stale upper bound prevented `kailash-dataflow` from coexisting with `kailash-kaizen>=2.0.0` (which requires `kailash>=2.0.0`).

## Test plan

- [x] `pip install --dry-run kailash-dataflow kailash-kaizen kailash-pact` resolves cleanly
- [x] PyPI metadata verified: `kailash>=1.0.0,<3.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)