### PR TITLE
feat(kaizen): add L3 EATP event system — governance events to audit records

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/l3/eatp_translator.py
+++ b/packages/kailash-kaizen/src/kaizen/l3/eatp_translator.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""EATP audit record translator for L3 governance events.
+
+Converts L3Event instances into EATP-compatible audit record dicts.
+Subscribe the translator's ``handle_event`` method to the L3EventBus
+to automatically generate audit trail entries for all governance events.
+
+Translation mapping:
+    L3Event.event_type  ->  EATP record ``action_type``
+    L3Event.agent_id    ->  EATP record ``subject_id``
+    L3Event.timestamp   ->  EATP record ``recorded_at``
+    L3Event.details     ->  EATP record ``context``
+
+Security:
+    - Bounded deque (maxlen=10000) per production-readiness-patterns
+    - threading.Lock on all mutable state
+    - NaN/Inf sanitized at the L3Event level (see events.py)
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from collections import deque
+from typing import Any
+
+from kaizen.l3.events import L3Event, L3EventType
+
+__all__ = [
+    "EatpTranslator",
+]
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_RECORDS = 10_000
+
+# Classification of event types for EATP severity mapping.
+# Events that indicate policy violations or failures map to higher
+# severity levels in the audit record.
+
+_SEVERITY_MAP: dict[str, str] = {
+    L3EventType.ENVELOPE_VIOLATION.value: "high",
+    L3EventType.AGENT_TERMINATED.value: "medium",
+    L3EventType.MESSAGE_DEAD_LETTERED.value: "medium",
+    L3EventType.PLAN_NODE_FAILED.value: "medium",
+    L3EventType.PLAN_NODE_HELD.value: "medium",
+    L3EventType.CONTEXT_ACCESS_DENIED.value: "high",
+}
+
+_DEFAULT_SEVERITY = "low"
+
+
+class EatpTranslator:
+    """Translates L3 events into EATP-compatible audit records.
+
+    Subscribe this to the L3EventBus to automatically generate
+    audit trail entries for all governance events.
+
+    Usage::
+
+        translator = EatpTranslator()
+        bus = L3EventBus()
+        bus.subscribe_all(translator.handle_event)
+
+        # Events are now automatically translated and stored:
+        bus.emit(L3Event.create(L3EventType.AGENT_SPAWNED, "agent-1"))
+
+        records = translator.get_records()
+    """
+
+    def __init__(self, max_records: int = _DEFAULT_MAX_RECORDS) -> None:
+        """Initialize the translator.
+
+        Args:
+            max_records: Maximum number of audit records to retain.
+                Oldest records are evicted when this limit is reached.
+                Defaults to 10,000.
+        """
+        if max_records < 1:
+            raise ValueError(f"max_records must be >= 1, got {max_records}")
+        self._records: deque[dict[str, Any]] = deque(maxlen=max_records)
+        self._lock = threading.Lock()
+        self._max_records = max_records
+
+    def translate(self, event: L3Event) -> dict[str, Any]:
+        """Convert an L3Event to an EATP audit record dict.
+
+        The returned dict follows the EATP audit record schema:
+            - record_id: Unique identifier for the audit record
+            - action_type: Maps from event_type
+            - subject_id: Maps from agent_id
+            - recorded_at: Maps from timestamp
+            - context: Maps from details
+            - severity: Derived from event type classification
+            - source: Always "l3_event_bus"
+
+        Args:
+            event: The L3Event to translate.
+
+        Returns:
+            An EATP-compatible audit record dict.
+        """
+        return {
+            "record_id": str(uuid.uuid4()),
+            "action_type": event.event_type,
+            "subject_id": event.agent_id,
+            "recorded_at": event.timestamp,
+            "context": dict(event.details),
+            "severity": _SEVERITY_MAP.get(event.event_type, _DEFAULT_SEVERITY),
+            "source": "l3_event_bus",
+        }
+
+    def handle_event(self, event: L3Event) -> None:
+        """Event handler -- translates and stores the audit record.
+
+        This method is designed to be passed directly to
+        ``L3EventBus.subscribe()`` or ``L3EventBus.subscribe_all()``.
+
+        Args:
+            event: The L3Event to handle.
+        """
+        record = self.translate(event)
+        with self._lock:
+            self._records.append(record)
+        logger.debug(
+            "Translated L3 event %s from agent %s -> audit record %s",
+            event.event_type,
+            event.agent_id,
+            record["record_id"],
+        )
+
+    def get_records(self) -> list[dict[str, Any]]:
+        """Return all audit records as a list (newest last).
+
+        Returns:
+            A copy of all stored audit records.
+        """
+        with self._lock:
+            return list(self._records)
+
+    def get_records_by_agent(self, agent_id: str) -> list[dict[str, Any]]:
+        """Return audit records for a specific agent.
+
+        Args:
+            agent_id: The agent instance ID to filter by.
+
+        Returns:
+            Records matching the agent_id, ordered oldest to newest.
+        """
+        with self._lock:
+            return [r for r in self._records if r["subject_id"] == agent_id]
+
+    def get_records_by_type(
+        self, event_type: str | L3EventType
+    ) -> list[dict[str, Any]]:
+        """Return audit records for a specific event type.
+
+        Args:
+            event_type: The event type string or L3EventType to filter by.
+
+        Returns:
+            Records matching the event type, ordered oldest to newest.
+        """
+        key = event_type.value if isinstance(event_type, L3EventType) else event_type
+        with self._lock:
+            return [r for r in self._records if r["action_type"] == key]
+
+    @property
+    def record_count(self) -> int:
+        """Number of audit records currently stored."""
+        with self._lock:
+            return len(self._records)
+
+    def clear(self) -> None:
+        """Remove all stored records. Useful for test teardown."""
+        with self._lock:
+            self._records.clear()

--- a/packages/kailash-kaizen/src/kaizen/l3/event_hooks.py
+++ b/packages/kailash-kaizen/src/kaizen/l3/event_hooks.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""L3 event bus — central pub/sub for governance events.
+
+The L3EventBus provides thread-safe subscription and emission of L3
+governance events. Primitives call ``emit()`` to publish events; listeners
+(such as the EATP translator) subscribe to specific event types or to all
+events via ``subscribe_all()``.
+
+Thread safety: All listener registration and emission is protected by a
+threading.Lock. The L3 primitives themselves use asyncio.Lock (per
+AD-L3-04-AMENDED), but the event bus is designed to also work from
+synchronous call sites (test harnesses, CLI tools) so it uses
+threading.Lock.
+
+Bounded listeners: Each event type key is capped at 1000 listeners to
+prevent unbounded memory growth from leaked subscriptions.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import defaultdict
+from typing import Any, Callable
+
+from kaizen.l3.events import L3Event, L3EventType
+
+__all__ = [
+    "L3EventBus",
+]
+
+logger = logging.getLogger(__name__)
+
+_MAX_LISTENERS_PER_KEY = 1000
+_WILDCARD_KEY = "__all__"
+
+
+class L3EventBus:
+    """Central event bus for L3 governance events.
+
+    Usage::
+
+        bus = L3EventBus()
+        bus.subscribe(L3EventType.AGENT_SPAWNED, my_handler)
+        bus.subscribe_all(audit_handler)
+
+        # Primitives emit events:
+        bus.emit(L3Event.create(L3EventType.AGENT_SPAWNED, "agent-1", {...}))
+    """
+
+    def __init__(self) -> None:
+        self._listeners: dict[str, list[Callable[[L3Event], None]]] = defaultdict(list)
+        self._lock = threading.Lock()
+
+    def subscribe(
+        self,
+        event_type: str | L3EventType,
+        listener: Callable[[L3Event], None],
+    ) -> None:
+        """Subscribe to a specific event type.
+
+        Args:
+            event_type: The event type string or L3EventType enum member.
+            listener: Callable that receives an L3Event.
+
+        Raises:
+            ValueError: If listener limit for this event type is exceeded.
+        """
+        key = event_type.value if isinstance(event_type, L3EventType) else event_type
+        with self._lock:
+            current = self._listeners[key]
+            if len(current) >= _MAX_LISTENERS_PER_KEY:
+                raise ValueError(
+                    f"Listener limit ({_MAX_LISTENERS_PER_KEY}) reached for "
+                    f"event type {key!r}. Possible listener leak."
+                )
+            current.append(listener)
+
+    def subscribe_all(self, listener: Callable[[L3Event], None]) -> None:
+        """Subscribe to ALL event types via the wildcard key.
+
+        Args:
+            listener: Callable that receives every L3Event.
+
+        Raises:
+            ValueError: If listener limit for the wildcard key is exceeded.
+        """
+        self.subscribe(_WILDCARD_KEY, listener)
+
+    def emit(self, event: L3Event) -> None:
+        """Emit an event to all matching subscribers.
+
+        Listeners are called synchronously in registration order. If a
+        listener raises an exception, it is logged and the remaining
+        listeners still receive the event (fail-open on individual
+        listener errors; the event bus itself never suppresses emission).
+
+        Args:
+            event: The L3Event to dispatch.
+        """
+        with self._lock:
+            # Snapshot listener lists under lock to avoid mutation during iteration
+            specific = list(self._listeners.get(event.event_type, []))
+            wildcard = list(self._listeners.get(_WILDCARD_KEY, []))
+
+        # Dispatch outside the lock to prevent deadlock if a listener
+        # tries to subscribe/unsubscribe.
+        for listener in specific + wildcard:
+            try:
+                listener(event)
+            except Exception:
+                logger.exception(
+                    "Listener %r raised during event %s for agent %s",
+                    listener,
+                    event.event_type,
+                    event.agent_id,
+                )
+
+    def unsubscribe(
+        self,
+        event_type: str | L3EventType,
+        listener: Callable[[L3Event], None],
+    ) -> bool:
+        """Remove a listener from a specific event type.
+
+        Args:
+            event_type: The event type to unsubscribe from.
+            listener: The listener to remove.
+
+        Returns:
+            True if the listener was found and removed, False otherwise.
+        """
+        key = event_type.value if isinstance(event_type, L3EventType) else event_type
+        with self._lock:
+            current = self._listeners.get(key, [])
+            try:
+                current.remove(listener)
+                return True
+            except ValueError:
+                return False
+
+    def unsubscribe_all(self, listener: Callable[[L3Event], None]) -> bool:
+        """Remove a wildcard listener.
+
+        Args:
+            listener: The listener to remove from the wildcard key.
+
+        Returns:
+            True if found and removed, False otherwise.
+        """
+        return self.unsubscribe(_WILDCARD_KEY, listener)
+
+    def clear(self) -> None:
+        """Remove all listeners. Useful for test teardown."""
+        with self._lock:
+            self._listeners.clear()
+
+    @property
+    def listener_count(self) -> int:
+        """Total number of registered listeners across all event types."""
+        with self._lock:
+            return sum(len(v) for v in self._listeners.values())

--- a/packages/kailash-kaizen/src/kaizen/l3/events.py
+++ b/packages/kailash-kaizen/src/kaizen/l3/events.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""L3 governance event types for EATP audit trail integration.
+
+Defines the canonical event types emitted by L3 autonomy primitives
+(envelope enforcement, agent lifecycle, messaging, plan execution,
+context scoping). These events are consumed by translators that convert
+them into EATP audit records.
+
+All event types are frozen dataclasses per AD-L3-15 (value types).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+__all__ = [
+    "L3Event",
+    "L3EventType",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class L3EventType(str, Enum):
+    """Canonical L3 governance event types.
+
+    These map to the five L3 primitive categories:
+
+    Envelope (Spec 01):
+        ENVELOPE_VIOLATION, ENVELOPE_REGISTERED, ENVELOPE_SPLIT
+
+    Factory (Spec 04):
+        AGENT_SPAWNED, AGENT_TERMINATED, AGENT_STATE_CHANGED
+
+    Messaging (Spec 03):
+        MESSAGE_ROUTED, MESSAGE_DEAD_LETTERED
+
+    Plan (Spec 05):
+        PLAN_VALIDATED, PLAN_EXECUTED, PLAN_NODE_COMPLETED,
+        PLAN_NODE_FAILED, PLAN_NODE_HELD
+
+    Context (Spec 02):
+        CONTEXT_SCOPE_CREATED, CONTEXT_ACCESS_DENIED
+    """
+
+    # Envelope events (Spec 01)
+    ENVELOPE_VIOLATION = "envelope_violation"
+    ENVELOPE_REGISTERED = "envelope_registered"
+    ENVELOPE_SPLIT = "envelope_split"
+
+    # Factory events (Spec 04)
+    AGENT_SPAWNED = "agent_spawned"
+    AGENT_TERMINATED = "agent_terminated"
+    AGENT_STATE_CHANGED = "agent_state_changed"
+
+    # Messaging events (Spec 03)
+    MESSAGE_ROUTED = "message_routed"
+    MESSAGE_DEAD_LETTERED = "message_dead_lettered"
+
+    # Plan events (Spec 05)
+    PLAN_VALIDATED = "plan_validated"
+    PLAN_EXECUTED = "plan_executed"
+    PLAN_NODE_COMPLETED = "plan_node_completed"
+    PLAN_NODE_FAILED = "plan_node_failed"
+    PLAN_NODE_HELD = "plan_node_held"
+
+    # Context events (Spec 02)
+    CONTEXT_SCOPE_CREATED = "context_scope_created"
+    CONTEXT_ACCESS_DENIED = "context_access_denied"
+
+
+def _sanitize_details(details: dict[str, Any]) -> dict[str, Any]:
+    """Sanitize event detail values to prevent NaN/Inf corruption.
+
+    Replaces non-finite float values with a string sentinel and logs a
+    warning. This ensures audit records never contain values that would
+    poison downstream numeric comparisons.
+
+    Args:
+        details: Raw event details dict.
+
+    Returns:
+        Sanitized copy with non-finite floats replaced.
+    """
+    sanitized: dict[str, Any] = {}
+    for key, value in details.items():
+        if isinstance(value, float) and not math.isfinite(value):
+            logger.warning(
+                "Non-finite value in event details: key=%r value=%r — replaced with sentinel",
+                key,
+                value,
+            )
+            sanitized[key] = f"<non-finite:{value!r}>"
+        elif isinstance(value, dict):
+            sanitized[key] = _sanitize_details(value)
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
+@dataclass(frozen=True)
+class L3Event:
+    """Base L3 governance event.
+
+    All L3 primitives emit events through this type. The event bus
+    dispatches these to registered listeners (including the EATP
+    translator for audit trail integration).
+
+    Attributes:
+        event_type: Canonical event type from L3EventType.
+        agent_id: The agent instance ID that caused the event.
+        timestamp: ISO 8601 timestamp of when the event occurred.
+        details: Structured event-specific data (sanitized on creation).
+    """
+
+    event_type: str
+    agent_id: str
+    timestamp: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate fields and sanitize details."""
+        if not self.event_type:
+            raise ValueError("event_type must not be empty")
+        if not self.agent_id:
+            raise ValueError("agent_id must not be empty")
+        if not self.timestamp:
+            raise ValueError("timestamp must not be empty")
+        # Sanitize details to prevent NaN/Inf propagation.
+        # We use object.__setattr__ because the dataclass is frozen.
+        sanitized = _sanitize_details(self.details)
+        object.__setattr__(self, "details", sanitized)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict for transport/storage."""
+        return {
+            "event_type": self.event_type,
+            "agent_id": self.agent_id,
+            "timestamp": self.timestamp,
+            "details": self.details,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> L3Event:
+        """Deserialize from dict."""
+        return cls(
+            event_type=data["event_type"],
+            agent_id=data["agent_id"],
+            timestamp=data["timestamp"],
+            details=data.get("details", {}),
+        )
+
+    @classmethod
+    def create(
+        cls,
+        event_type: L3EventType,
+        agent_id: str,
+        details: dict[str, Any] | None = None,
+    ) -> L3Event:
+        """Factory method with auto-generated ISO 8601 timestamp.
+
+        Args:
+            event_type: The L3EventType enum member.
+            agent_id: Agent instance ID.
+            details: Optional event-specific data.
+
+        Returns:
+            A new L3Event with the current UTC timestamp.
+        """
+        return cls(
+            event_type=event_type.value,
+            agent_id=agent_id,
+            timestamp=datetime.now(UTC).isoformat(),
+            details=details or {},
+        )

--- a/packages/kailash-kaizen/tests/unit/l3/test_eatp_translator.py
+++ b/packages/kailash-kaizen/tests/unit/l3/test_eatp_translator.py
@@ -1,0 +1,407 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for EATP audit record translator.
+
+Covers:
+- Translation mapping for each L3EventType
+- Severity classification
+- Bounded deque eviction
+- Thread safety of handle_event
+- NaN/Inf in event details does not corrupt records
+- Filtering by agent and event type
+- Integration with L3EventBus
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+
+import pytest
+
+from kaizen.l3.eatp_translator import EatpTranslator, _SEVERITY_MAP, _DEFAULT_SEVERITY
+from kaizen.l3.event_hooks import L3EventBus
+from kaizen.l3.events import L3Event, L3EventType
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    event_type: str = "agent_spawned",
+    agent_id: str = "agent-001",
+    details: dict | None = None,
+) -> L3Event:
+    return L3Event(
+        event_type=event_type,
+        agent_id=agent_id,
+        timestamp="2026-03-23T12:00:00+00:00",
+        details=details or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# EatpTranslator basic tests
+# ---------------------------------------------------------------------------
+
+
+class TestEatpTranslatorBasic:
+    """Core translation logic."""
+
+    def test_translate_mapping(self):
+        translator = EatpTranslator()
+        event = _make_event(
+            event_type="agent_spawned",
+            agent_id="agent-001",
+            details={"spec_id": "researcher"},
+        )
+        record = translator.translate(event)
+
+        assert record["action_type"] == "agent_spawned"
+        assert record["subject_id"] == "agent-001"
+        assert record["recorded_at"] == "2026-03-23T12:00:00+00:00"
+        assert record["context"] == {"spec_id": "researcher"}
+        assert record["source"] == "l3_event_bus"
+        assert "record_id" in record
+
+    def test_translate_returns_unique_record_ids(self):
+        translator = EatpTranslator()
+        event = _make_event()
+        r1 = translator.translate(event)
+        r2 = translator.translate(event)
+        assert r1["record_id"] != r2["record_id"]
+
+    def test_handle_event_stores_record(self):
+        translator = EatpTranslator()
+        event = _make_event()
+        translator.handle_event(event)
+
+        records = translator.get_records()
+        assert len(records) == 1
+        assert records[0]["action_type"] == "agent_spawned"
+
+    def test_get_records_returns_copy(self):
+        """Modifying the returned list must not affect internal state."""
+        translator = EatpTranslator()
+        translator.handle_event(_make_event())
+
+        records = translator.get_records()
+        records.clear()
+        assert translator.record_count == 1
+
+    def test_record_count(self):
+        translator = EatpTranslator()
+        assert translator.record_count == 0
+        translator.handle_event(_make_event())
+        assert translator.record_count == 1
+
+    def test_clear(self):
+        translator = EatpTranslator()
+        translator.handle_event(_make_event())
+        translator.clear()
+        assert translator.record_count == 0
+
+    def test_invalid_max_records(self):
+        with pytest.raises(ValueError, match="max_records must be >= 1"):
+            EatpTranslator(max_records=0)
+
+        with pytest.raises(ValueError, match="max_records must be >= 1"):
+            EatpTranslator(max_records=-5)
+
+
+# ---------------------------------------------------------------------------
+# Severity classification tests
+# ---------------------------------------------------------------------------
+
+
+class TestEatpTranslatorSeverity:
+    """Verify severity mapping for all event types."""
+
+    def test_high_severity_events(self):
+        translator = EatpTranslator()
+        for event_type in ["envelope_violation", "context_access_denied"]:
+            record = translator.translate(_make_event(event_type=event_type))
+            assert record["severity"] == "high", f"{event_type} should be high severity"
+
+    def test_medium_severity_events(self):
+        translator = EatpTranslator()
+        for event_type in [
+            "agent_terminated",
+            "message_dead_lettered",
+            "plan_node_failed",
+            "plan_node_held",
+        ]:
+            record = translator.translate(_make_event(event_type=event_type))
+            assert (
+                record["severity"] == "medium"
+            ), f"{event_type} should be medium severity"
+
+    def test_low_severity_events(self):
+        translator = EatpTranslator()
+        for event_type in [
+            "envelope_registered",
+            "envelope_split",
+            "agent_spawned",
+            "agent_state_changed",
+            "message_routed",
+            "plan_validated",
+            "plan_executed",
+            "plan_node_completed",
+            "context_scope_created",
+        ]:
+            record = translator.translate(_make_event(event_type=event_type))
+            assert record["severity"] == "low", f"{event_type} should be low severity"
+
+    def test_all_event_types_have_severity(self):
+        """Every L3EventType must translate to a valid severity."""
+        translator = EatpTranslator()
+        valid_severities = {"low", "medium", "high"}
+        for et in L3EventType:
+            record = translator.translate(_make_event(event_type=et.value))
+            assert (
+                record["severity"] in valid_severities
+            ), f"Event type {et.value} has invalid severity: {record['severity']}"
+
+
+# ---------------------------------------------------------------------------
+# Per-event-type translation tests
+# ---------------------------------------------------------------------------
+
+
+class TestEatpTranslatorPerEventType:
+    """Each L3EventType translates correctly."""
+
+    @pytest.mark.parametrize("event_type", list(L3EventType))
+    def test_translates_event_type(self, event_type: L3EventType):
+        translator = EatpTranslator()
+        event = L3Event.create(event_type, "agent-test", {"key": "value"})
+        record = translator.translate(event)
+
+        assert record["action_type"] == event_type.value
+        assert record["subject_id"] == "agent-test"
+        assert record["context"] == {"key": "value"}
+        assert record["source"] == "l3_event_bus"
+        assert record["record_id"]  # non-empty
+        assert record["recorded_at"]  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# Bounded collection tests
+# ---------------------------------------------------------------------------
+
+
+class TestEatpTranslatorBounded:
+    """Bounded deque eviction behavior."""
+
+    def test_eviction_at_max(self):
+        translator = EatpTranslator(max_records=5)
+        for i in range(10):
+            translator.handle_event(_make_event(agent_id=f"agent-{i:03d}"))
+
+        assert translator.record_count == 5
+        records = translator.get_records()
+        # Oldest records (agent-000 through agent-004) should have been evicted
+        agent_ids = [r["subject_id"] for r in records]
+        assert agent_ids == [f"agent-{i:03d}" for i in range(5, 10)]
+
+    def test_max_records_1(self):
+        translator = EatpTranslator(max_records=1)
+        translator.handle_event(_make_event(agent_id="first"))
+        translator.handle_event(_make_event(agent_id="second"))
+
+        assert translator.record_count == 1
+        assert translator.get_records()[0]["subject_id"] == "second"
+
+    def test_default_max_records(self):
+        translator = EatpTranslator()
+        # Default is 10,000 — just verify it's set
+        assert translator._max_records == 10_000
+
+
+# ---------------------------------------------------------------------------
+# NaN/Inf in details tests
+# ---------------------------------------------------------------------------
+
+
+class TestEatpTranslatorNanInf:
+    """NaN/Inf in event details must not corrupt audit records."""
+
+    def test_nan_in_details_sanitized_before_translation(self):
+        """NaN is sanitized at L3Event creation time, so it never reaches the translator."""
+        event = L3Event(
+            event_type="envelope_violation",
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"cost": float("nan")},
+        )
+        translator = EatpTranslator()
+        record = translator.translate(event)
+        # The context should contain the sanitized sentinel, not a float NaN
+        assert isinstance(record["context"]["cost"], str)
+        assert "non-finite" in record["context"]["cost"]
+
+    def test_inf_in_details_sanitized_before_translation(self):
+        event = L3Event(
+            event_type="envelope_violation",
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"cost": float("inf")},
+        )
+        translator = EatpTranslator()
+        record = translator.translate(event)
+        assert isinstance(record["context"]["cost"], str)
+        assert "non-finite" in record["context"]["cost"]
+
+    def test_normal_floats_preserved(self):
+        event = _make_event(details={"cost": 42.5, "limit": 100.0})
+        translator = EatpTranslator()
+        record = translator.translate(event)
+        assert record["context"]["cost"] == 42.5
+        assert record["context"]["limit"] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Filtering tests
+# ---------------------------------------------------------------------------
+
+
+class TestEatpTranslatorFiltering:
+    """Filter records by agent and event type."""
+
+    def test_get_records_by_agent(self):
+        translator = EatpTranslator()
+        translator.handle_event(_make_event(agent_id="agent-001"))
+        translator.handle_event(_make_event(agent_id="agent-002"))
+        translator.handle_event(_make_event(agent_id="agent-001"))
+
+        records = translator.get_records_by_agent("agent-001")
+        assert len(records) == 2
+        assert all(r["subject_id"] == "agent-001" for r in records)
+
+    def test_get_records_by_agent_empty(self):
+        translator = EatpTranslator()
+        translator.handle_event(_make_event(agent_id="agent-001"))
+        assert translator.get_records_by_agent("nonexistent") == []
+
+    def test_get_records_by_type_string(self):
+        translator = EatpTranslator()
+        translator.handle_event(_make_event(event_type="agent_spawned"))
+        translator.handle_event(_make_event(event_type="envelope_violation"))
+        translator.handle_event(_make_event(event_type="agent_spawned"))
+
+        records = translator.get_records_by_type("agent_spawned")
+        assert len(records) == 2
+        assert all(r["action_type"] == "agent_spawned" for r in records)
+
+    def test_get_records_by_type_enum(self):
+        translator = EatpTranslator()
+        translator.handle_event(_make_event(event_type="agent_spawned"))
+        translator.handle_event(_make_event(event_type="envelope_violation"))
+
+        records = translator.get_records_by_type(L3EventType.ENVELOPE_VIOLATION)
+        assert len(records) == 1
+        assert records[0]["action_type"] == "envelope_violation"
+
+
+# ---------------------------------------------------------------------------
+# Thread safety tests
+# ---------------------------------------------------------------------------
+
+
+class TestEatpTranslatorThreadSafety:
+    """Concurrent handle_event calls must not corrupt state."""
+
+    def test_concurrent_handle_event(self):
+        translator = EatpTranslator()
+        events_per_thread = 100
+        num_threads = 10
+        errors: list[Exception] = []
+
+        def worker(thread_id: int) -> None:
+            try:
+                for i in range(events_per_thread):
+                    translator.handle_event(
+                        _make_event(agent_id=f"thread-{thread_id}-{i}")
+                    )
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=worker, args=(t,)) for t in range(num_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert translator.record_count == num_threads * events_per_thread
+
+    def test_concurrent_handle_and_read(self):
+        """Reading while writing must not raise."""
+        translator = EatpTranslator()
+        errors: list[Exception] = []
+
+        def writer() -> None:
+            try:
+                for i in range(200):
+                    translator.handle_event(_make_event(agent_id=f"w-{i}"))
+            except Exception as exc:
+                errors.append(exc)
+
+        def reader() -> None:
+            try:
+                for _ in range(200):
+                    translator.get_records()
+                    translator.get_records_by_agent("w-0")
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=writer),
+            threading.Thread(target=reader),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Integration with L3EventBus
+# ---------------------------------------------------------------------------
+
+
+class TestEatpTranslatorBusIntegration:
+    """EatpTranslator works end-to-end with L3EventBus."""
+
+    def test_subscribe_all_captures_events(self):
+        bus = L3EventBus()
+        translator = EatpTranslator()
+        bus.subscribe_all(translator.handle_event)
+
+        bus.emit(L3Event.create(L3EventType.AGENT_SPAWNED, "agent-001"))
+        bus.emit(L3Event.create(L3EventType.ENVELOPE_VIOLATION, "agent-002"))
+        bus.emit(L3Event.create(L3EventType.PLAN_EXECUTED, "agent-001"))
+
+        records = translator.get_records()
+        assert len(records) == 3
+        assert records[0]["action_type"] == "agent_spawned"
+        assert records[1]["action_type"] == "envelope_violation"
+        assert records[2]["action_type"] == "plan_executed"
+
+    def test_subscribe_specific_type(self):
+        bus = L3EventBus()
+        translator = EatpTranslator()
+        bus.subscribe(L3EventType.ENVELOPE_VIOLATION, translator.handle_event)
+
+        bus.emit(L3Event.create(L3EventType.AGENT_SPAWNED, "agent-001"))
+        bus.emit(L3Event.create(L3EventType.ENVELOPE_VIOLATION, "agent-002"))
+
+        records = translator.get_records()
+        assert len(records) == 1
+        assert records[0]["action_type"] == "envelope_violation"

--- a/packages/kailash-kaizen/tests/unit/l3/test_events.py
+++ b/packages/kailash-kaizen/tests/unit/l3/test_events.py
@@ -1,0 +1,415 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for L3 event types and event bus.
+
+Covers:
+- L3Event creation, frozen invariant, validation
+- L3EventType enum membership
+- L3EventBus subscribe/emit/unsubscribe
+- L3EventBus thread safety
+- L3EventBus subscribe_all wildcard
+- L3EventBus listener limit enforcement
+- NaN/Inf sanitization in event details
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from kaizen.l3.events import L3Event, L3EventType, _sanitize_details
+from kaizen.l3.event_hooks import L3EventBus
+
+
+# ---------------------------------------------------------------------------
+# L3EventType tests
+# ---------------------------------------------------------------------------
+
+
+class TestL3EventType:
+    """L3EventType enum: 15 canonical governance event types."""
+
+    def test_all_members_exist(self):
+        expected = {
+            "ENVELOPE_VIOLATION",
+            "ENVELOPE_REGISTERED",
+            "ENVELOPE_SPLIT",
+            "AGENT_SPAWNED",
+            "AGENT_TERMINATED",
+            "AGENT_STATE_CHANGED",
+            "MESSAGE_ROUTED",
+            "MESSAGE_DEAD_LETTERED",
+            "PLAN_VALIDATED",
+            "PLAN_EXECUTED",
+            "PLAN_NODE_COMPLETED",
+            "PLAN_NODE_FAILED",
+            "PLAN_NODE_HELD",
+            "CONTEXT_SCOPE_CREATED",
+            "CONTEXT_ACCESS_DENIED",
+        }
+        actual = {m.name for m in L3EventType}
+        assert actual == expected
+
+    def test_is_str_enum(self):
+        """L3EventType members are usable as strings."""
+        assert isinstance(L3EventType.AGENT_SPAWNED, str)
+        assert L3EventType.AGENT_SPAWNED == "agent_spawned"
+
+    def test_member_count(self):
+        assert len(L3EventType) == 15
+
+
+# ---------------------------------------------------------------------------
+# L3Event tests
+# ---------------------------------------------------------------------------
+
+
+class TestL3Event:
+    """L3Event frozen dataclass: validation and serialization."""
+
+    def test_create_basic(self):
+        event = L3Event(
+            event_type="agent_spawned",
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"spec_id": "researcher"},
+        )
+        assert event.event_type == "agent_spawned"
+        assert event.agent_id == "agent-001"
+        assert event.details == {"spec_id": "researcher"}
+
+    def test_frozen_invariant(self):
+        event = L3Event(
+            event_type="agent_spawned",
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+        )
+        with pytest.raises(AttributeError):
+            event.agent_id = "agent-002"  # type: ignore[misc]
+
+    def test_empty_event_type_rejected(self):
+        with pytest.raises(ValueError, match="event_type must not be empty"):
+            L3Event(event_type="", agent_id="a", timestamp="t")
+
+    def test_empty_agent_id_rejected(self):
+        with pytest.raises(ValueError, match="agent_id must not be empty"):
+            L3Event(event_type="x", agent_id="", timestamp="t")
+
+    def test_empty_timestamp_rejected(self):
+        with pytest.raises(ValueError, match="timestamp must not be empty"):
+            L3Event(event_type="x", agent_id="a", timestamp="")
+
+    def test_to_dict_round_trip(self):
+        event = L3Event(
+            event_type="envelope_violation",
+            agent_id="agent-002",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"dimension": "financial", "usage_pct": 0.95},
+        )
+        d = event.to_dict()
+        restored = L3Event.from_dict(d)
+        assert restored == event
+
+    def test_from_dict_missing_details(self):
+        d = {
+            "event_type": "agent_spawned",
+            "agent_id": "agent-001",
+            "timestamp": "2026-03-23T12:00:00+00:00",
+        }
+        event = L3Event.from_dict(d)
+        assert event.details == {}
+
+    def test_create_factory_method(self):
+        event = L3Event.create(
+            L3EventType.AGENT_SPAWNED,
+            "agent-001",
+            {"spec_id": "researcher"},
+        )
+        assert event.event_type == "agent_spawned"
+        assert event.agent_id == "agent-001"
+        assert event.details == {"spec_id": "researcher"}
+        # Timestamp should be a valid ISO 8601 string
+        datetime.fromisoformat(event.timestamp)
+
+    def test_create_factory_no_details(self):
+        event = L3Event.create(L3EventType.PLAN_VALIDATED, "agent-001")
+        assert event.details == {}
+
+    def test_nan_in_details_sanitized(self):
+        event = L3Event(
+            event_type="envelope_violation",
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"cost": float("nan"), "limit": 100.0},
+        )
+        # NaN should be replaced with a sentinel string
+        assert isinstance(event.details["cost"], str)
+        assert "non-finite" in event.details["cost"]
+        # Normal float should be preserved
+        assert event.details["limit"] == 100.0
+
+    def test_inf_in_details_sanitized(self):
+        event = L3Event(
+            event_type="envelope_violation",
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"cost": float("inf")},
+        )
+        assert isinstance(event.details["cost"], str)
+        assert "non-finite" in event.details["cost"]
+
+    def test_negative_inf_in_details_sanitized(self):
+        event = L3Event(
+            event_type="envelope_violation",
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"cost": float("-inf")},
+        )
+        assert isinstance(event.details["cost"], str)
+        assert "non-finite" in event.details["cost"]
+
+    def test_nested_dict_nan_sanitized(self):
+        event = L3Event(
+            event_type="envelope_violation",
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"inner": {"bad_value": float("nan")}},
+        )
+        assert isinstance(event.details["inner"]["bad_value"], str)
+        assert "non-finite" in event.details["inner"]["bad_value"]
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_details tests
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeDetails:
+    """Direct tests for the sanitization helper."""
+
+    def test_normal_values_unchanged(self):
+        d = {"a": 1, "b": "hello", "c": 3.14, "d": True, "e": None}
+        assert _sanitize_details(d) == d
+
+    def test_nan_replaced(self):
+        result = _sanitize_details({"x": float("nan")})
+        assert isinstance(result["x"], str)
+
+    def test_inf_replaced(self):
+        result = _sanitize_details({"x": float("inf")})
+        assert isinstance(result["x"], str)
+
+    def test_nested_dict_sanitized(self):
+        result = _sanitize_details({"outer": {"inner": float("nan")}})
+        assert isinstance(result["outer"]["inner"], str)
+
+    def test_empty_dict(self):
+        assert _sanitize_details({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# L3EventBus tests
+# ---------------------------------------------------------------------------
+
+
+class TestL3EventBus:
+    """L3EventBus: subscribe, emit, unsubscribe, thread safety."""
+
+    def _make_event(self, event_type: str = "agent_spawned") -> L3Event:
+        return L3Event(
+            event_type=event_type,
+            agent_id="agent-001",
+            timestamp="2026-03-23T12:00:00+00:00",
+            details={"test": True},
+        )
+
+    def test_subscribe_and_emit(self):
+        bus = L3EventBus()
+        received: list[L3Event] = []
+        bus.subscribe(L3EventType.AGENT_SPAWNED, received.append)
+
+        event = self._make_event("agent_spawned")
+        bus.emit(event)
+
+        assert len(received) == 1
+        assert received[0] is event
+
+    def test_subscribe_by_string(self):
+        bus = L3EventBus()
+        received: list[L3Event] = []
+        bus.subscribe("agent_spawned", received.append)
+
+        bus.emit(self._make_event("agent_spawned"))
+        assert len(received) == 1
+
+    def test_no_cross_delivery(self):
+        """Events for one type should not be delivered to another type's subscribers."""
+        bus = L3EventBus()
+        received: list[L3Event] = []
+        bus.subscribe(L3EventType.AGENT_SPAWNED, received.append)
+
+        bus.emit(self._make_event("agent_terminated"))
+        assert len(received) == 0
+
+    def test_subscribe_all(self):
+        bus = L3EventBus()
+        received: list[L3Event] = []
+        bus.subscribe_all(received.append)
+
+        bus.emit(self._make_event("agent_spawned"))
+        bus.emit(self._make_event("envelope_violation"))
+        bus.emit(self._make_event("plan_executed"))
+
+        assert len(received) == 3
+
+    def test_subscribe_all_plus_specific(self):
+        """Wildcard and specific listeners both receive the event."""
+        bus = L3EventBus()
+        all_received: list[L3Event] = []
+        specific_received: list[L3Event] = []
+
+        bus.subscribe_all(all_received.append)
+        bus.subscribe(L3EventType.AGENT_SPAWNED, specific_received.append)
+
+        bus.emit(self._make_event("agent_spawned"))
+
+        assert len(all_received) == 1
+        assert len(specific_received) == 1
+
+    def test_unsubscribe(self):
+        bus = L3EventBus()
+        received: list[L3Event] = []
+        bus.subscribe(L3EventType.AGENT_SPAWNED, received.append)
+
+        result = bus.unsubscribe(L3EventType.AGENT_SPAWNED, received.append)
+        assert result is True
+
+        bus.emit(self._make_event("agent_spawned"))
+        assert len(received) == 0
+
+    def test_unsubscribe_nonexistent(self):
+        bus = L3EventBus()
+        result = bus.unsubscribe(L3EventType.AGENT_SPAWNED, lambda e: None)
+        assert result is False
+
+    def test_unsubscribe_all(self):
+        bus = L3EventBus()
+        received: list[L3Event] = []
+        bus.subscribe_all(received.append)
+        bus.unsubscribe_all(received.append)
+
+        bus.emit(self._make_event("agent_spawned"))
+        assert len(received) == 0
+
+    def test_clear(self):
+        bus = L3EventBus()
+        bus.subscribe(L3EventType.AGENT_SPAWNED, lambda e: None)
+        bus.subscribe_all(lambda e: None)
+        assert bus.listener_count > 0
+
+        bus.clear()
+        assert bus.listener_count == 0
+
+    def test_listener_count(self):
+        bus = L3EventBus()
+        bus.subscribe(L3EventType.AGENT_SPAWNED, lambda e: None)
+        bus.subscribe(L3EventType.AGENT_SPAWNED, lambda e: None)
+        bus.subscribe(L3EventType.PLAN_EXECUTED, lambda e: None)
+        assert bus.listener_count == 3
+
+    def test_listener_error_does_not_suppress_others(self):
+        """A failing listener must not prevent other listeners from receiving the event."""
+        bus = L3EventBus()
+        received: list[L3Event] = []
+
+        def bad_listener(event: L3Event) -> None:
+            raise RuntimeError("boom")
+
+        bus.subscribe(L3EventType.AGENT_SPAWNED, bad_listener)
+        bus.subscribe(L3EventType.AGENT_SPAWNED, received.append)
+
+        bus.emit(self._make_event("agent_spawned"))
+        assert len(received) == 1
+
+    def test_listener_limit_enforced(self):
+        bus = L3EventBus()
+        for _ in range(1000):
+            bus.subscribe(L3EventType.AGENT_SPAWNED, lambda e: None)
+
+        with pytest.raises(ValueError, match="Listener limit"):
+            bus.subscribe(L3EventType.AGENT_SPAWNED, lambda e: None)
+
+    def test_thread_safety_concurrent_emit(self):
+        """Multiple threads emitting concurrently must not corrupt state."""
+        bus = L3EventBus()
+        received: list[L3Event] = []
+        lock = threading.Lock()
+
+        def safe_append(event: L3Event) -> None:
+            with lock:
+                received.append(event)
+
+        bus.subscribe_all(safe_append)
+
+        threads = []
+        events_per_thread = 100
+        num_threads = 10
+
+        def emit_batch(thread_id: int) -> None:
+            for i in range(events_per_thread):
+                event = L3Event(
+                    event_type="agent_spawned",
+                    agent_id=f"thread-{thread_id}-event-{i}",
+                    timestamp="2026-03-23T12:00:00+00:00",
+                )
+                bus.emit(event)
+
+        for t_id in range(num_threads):
+            t = threading.Thread(target=emit_batch, args=(t_id,))
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        assert len(received) == num_threads * events_per_thread
+
+    def test_thread_safety_concurrent_subscribe_and_emit(self):
+        """Subscribing and emitting concurrently must not raise."""
+        bus = L3EventBus()
+        errors: list[Exception] = []
+
+        def subscriber_thread() -> None:
+            try:
+                for _ in range(50):
+                    bus.subscribe("agent_spawned", lambda e: None)
+            except Exception as exc:
+                errors.append(exc)
+
+        def emitter_thread() -> None:
+            try:
+                for _ in range(50):
+                    bus.emit(
+                        L3Event(
+                            event_type="agent_spawned",
+                            agent_id="test",
+                            timestamp="2026-03-23T12:00:00+00:00",
+                        )
+                    )
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=subscriber_thread),
+            threading.Thread(target=emitter_thread),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []


### PR DESCRIPTION
## Summary

- 15 canonical L3 governance event types (envelope, factory, messaging, plan, context)
- L3EventBus pub/sub with thread safety and bounded listeners (1000/key)
- EatpTranslator converts L3 events to EATP audit records with severity classification
- NaN/Inf sanitized at event construction time
- Bounded deque storage (maxlen=10000)

## Test plan

- [x] 863 existing L3 tests pass (0 regressions)
- [x] 75 new tests (35 events + 40 translator)
- [x] No existing files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)