### PR TITLE
chore(core): bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [2.0.1] - 2026-03-23
+
+#### Fixed
+
+- Node validation now detects and warns on unknown/misspelled parameters (#45)
+
+#### Changed
+
+- kailash-dataflow dependency constraint relaxed to `>=1.0.0,<3.0.0` (was `<2.0.0`)
+
 ### kailash-kaizen [2.1.0] - 2026-03-22
 
 **L3 Autonomy Primitives** — Five deterministic SDK primitives for governed agent autonomy (`kaizen.l3`). EnvelopeTracker/Splitter/Enforcer, ScopedContext, MessageRouter/Channel, AgentFactory/Registry, Plan DAG/Validator/Executor. 868 new tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}
@@ -118,7 +118,7 @@ otel = [
 ]
 # Sub-packages
 dataflow = [
-    "kailash-dataflow>=1.0.0,<2.0.0",
+    "kailash-dataflow>=1.0.0,<3.0.0",
 ]
 nexus = [
     "kailash-nexus>=1.4.3",
@@ -175,7 +175,7 @@ docs = [
 # Everything (restores pre-1.0 behavior)
 all = [
     "kailash[server,cli,http,database,postgres,mysql,files,auth,mfa,microsoft,monitoring,distributed,mcp,scheduler,otel,trust,trust-encryption,trust-sso]",
-    "kailash-dataflow>=1.0.0,<2.0.0",
+    "kailash-dataflow>=1.0.0,<3.0.0",
     "kailash-nexus>=1.4.3",
     "kailash-kaizen>=2.0.0,<3.0.0",
     "kailash-pact>=0.2.0",

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- Version bump: 2.0.0 → 2.0.1 (pyproject.toml + __init__.py)
- CHANGELOG.md updated with 2.0.1 entry
- kailash-dataflow optional dep constraint relaxed to `<3.0.0`

## Test plan

- [x] `python -c "import kailash; print(kailash.__version__)"` → 2.0.1
- [x] 19 unknown param validation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)