### PR TITLE
fix(pact): MCP governance red team hardening — monotonic tightening, bounded tracker, immutable types

### DIFF
--- a/packages/kailash-pact/src/pact/mcp/audit.py
+++ b/packages/kailash-pact/src/pact/mcp/audit.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import types as _builtin_types
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -50,6 +51,14 @@ class McpAuditEntry:
     timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
     cost_estimate: float | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # H4: Replace mutable metadata dict with immutable MappingProxyType.
+        object.__setattr__(
+            self,
+            "metadata",
+            _builtin_types.MappingProxyType(dict(self.metadata)),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/packages/kailash-pact/src/pact/mcp/enforcer.py
+++ b/packages/kailash-pact/src/pact/mcp/enforcer.py
@@ -182,16 +182,103 @@ class McpGovernanceEnforcer:
 
         return decision
 
+    _MAX_RATE_TRACKER_ENTRIES = 10_000
+
     def register_tool(self, policy: McpToolPolicy) -> None:
         """Register or update a tool policy at runtime.
+
+        Enforces monotonic tightening: if a policy already exists for this tool
+        (either from config or a prior registration), the new policy must be
+        equal to or more restrictive than the existing one.
 
         Thread-safe: acquires self._lock.
 
         Args:
             policy: The tool policy to register.
+
+        Raises:
+            ValueError: If the new policy would widen constraints relative to
+                the existing policy (monotonic tightening violation).
         """
         with self._lock:
+            existing = self._policy_overlay.get(policy.tool_name)
+            if existing is None:
+                existing = self._config.tool_policies.get(policy.tool_name)
+            if existing is not None:
+                self._validate_monotonic_tightening(existing, policy)
             self._policy_overlay[policy.tool_name] = policy
+
+    @staticmethod
+    def _validate_monotonic_tightening(
+        existing: McpToolPolicy, new: McpToolPolicy
+    ) -> None:
+        """Verify that ``new`` is equal to or more restrictive than ``existing``.
+
+        Checks:
+        - max_cost: new must be <= existing (None means "no limit" = wider)
+        - rate_limit: new must be <= existing (None means "no limit" = wider)
+        - allowed_args: new must be subset of existing (empty means "any" = wider)
+        - denied_args: new must be superset of existing (wider deny = tighter)
+
+        Raises:
+            ValueError: On any widening.
+        """
+        # max_cost: None means unlimited (widest). A number is tighter.
+        # new=None when existing has a number -> widening
+        # new > existing -> widening
+        if existing.max_cost is not None:
+            if new.max_cost is None:
+                raise ValueError(
+                    f"Monotonic tightening violation: max_cost widened from "
+                    f"{existing.max_cost} to None (unlimited) for tool "
+                    f"'{new.tool_name}'"
+                )
+            if new.max_cost > existing.max_cost:
+                raise ValueError(
+                    f"Monotonic tightening violation: max_cost widened from "
+                    f"{existing.max_cost} to {new.max_cost} for tool "
+                    f"'{new.tool_name}'"
+                )
+
+        # rate_limit: None means unlimited (widest). A number is tighter.
+        if existing.rate_limit is not None:
+            if new.rate_limit is None:
+                raise ValueError(
+                    f"Monotonic tightening violation: rate_limit widened from "
+                    f"{existing.rate_limit} to None (unlimited) for tool "
+                    f"'{new.tool_name}'"
+                )
+            if new.rate_limit > existing.rate_limit:
+                raise ValueError(
+                    f"Monotonic tightening violation: rate_limit widened from "
+                    f"{existing.rate_limit} to {new.rate_limit} for tool "
+                    f"'{new.tool_name}'"
+                )
+
+        # allowed_args: empty means "any arg allowed" (widest).
+        # Non-empty must be subset of existing (or equal).
+        if existing.allowed_args:
+            if not new.allowed_args:
+                raise ValueError(
+                    f"Monotonic tightening violation: allowed_args widened from "
+                    f"{sorted(existing.allowed_args)} to empty (any) for tool "
+                    f"'{new.tool_name}'"
+                )
+            if not new.allowed_args <= existing.allowed_args:
+                extra = sorted(new.allowed_args - existing.allowed_args)
+                raise ValueError(
+                    f"Monotonic tightening violation: allowed_args widened with "
+                    f"extra args {extra} for tool '{new.tool_name}'"
+                )
+
+        # denied_args: new must be superset of existing (wider deny = tighter).
+        if existing.denied_args:
+            if not existing.denied_args <= new.denied_args:
+                missing = sorted(existing.denied_args - new.denied_args)
+                raise ValueError(
+                    f"Monotonic tightening violation: denied_args narrowed, "
+                    f"missing {missing} for tool '{new.tool_name}'"
+                )
 
     def _get_policy(self, tool_name: str) -> McpToolPolicy | None:
         """Resolve the effective policy for a tool.
@@ -373,6 +460,9 @@ class McpGovernanceEnforcer:
         key = f"{agent_id}:{tool_name}"
         with self._lock:
             if key not in self._rate_tracker:
+                # Evict oldest entries if dict exceeds max size
+                if len(self._rate_tracker) >= self._MAX_RATE_TRACKER_ENTRIES:
+                    self._evict_oldest_rate_entries()
                 # Bounded deque for rate tracking
                 self._rate_tracker[key] = deque(maxlen=rate_limit + 1)
 
@@ -399,3 +489,24 @@ class McpGovernanceEnforcer:
             tracker.append(now)
 
         return None
+
+    def _evict_oldest_rate_entries(self) -> None:
+        """Evict the oldest 10% of rate tracker entries by last-access timestamp.
+
+        Must be called while holding self._lock.
+        """
+        if not self._rate_tracker:
+            return
+
+        # Sort keys by the most recent (last) timestamp in their deque.
+        # Empty deques sort to epoch so they are evicted first.
+        epoch = datetime.min.replace(tzinfo=UTC)
+
+        def _last_ts(k: str) -> datetime:
+            dq = self._rate_tracker[k]
+            return dq[-1] if dq else epoch
+
+        sorted_keys = sorted(self._rate_tracker.keys(), key=_last_ts)
+        evict_count = max(1, len(sorted_keys) // 10)
+        for k in sorted_keys[:evict_count]:
+            del self._rate_tracker[k]

--- a/packages/kailash-pact/src/pact/mcp/types.py
+++ b/packages/kailash-pact/src/pact/mcp/types.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import math
+import types as _builtin_types
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
@@ -72,18 +73,14 @@ class McpToolPolicy:
         if self.max_cost is not None:
             cost = float(self.max_cost)
             if not math.isfinite(cost):
-                raise ValueError(
-                    f"max_cost must be finite, got {self.max_cost!r}"
-                )
+                raise ValueError(f"max_cost must be finite, got {self.max_cost!r}")
             if cost < 0:
                 raise ValueError(
                     f"max_cost must be non-negative, got {self.max_cost!r}"
                 )
         if self.rate_limit is not None:
             if self.rate_limit < 1:
-                raise ValueError(
-                    f"rate_limit must be >= 1, got {self.rate_limit!r}"
-                )
+                raise ValueError(f"rate_limit must be >= 1, got {self.rate_limit!r}")
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
@@ -147,14 +144,20 @@ class McpGovernanceConfig:
                     f"tool_policies key '{key}' does not match "
                     f"policy.tool_name '{policy.tool_name}'"
                 )
+        # C3: Replace mutable dict with immutable MappingProxyType.
+        # Use object.__setattr__ because the dataclass is frozen.
+        object.__setattr__(
+            self,
+            "tool_policies",
+            _builtin_types.MappingProxyType(dict(self.tool_policies)),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""
         return {
             "default_policy": self.default_policy.value,
             "tool_policies": {
-                name: policy.to_dict()
-                for name, policy in self.tool_policies.items()
+                name: policy.to_dict() for name, policy in self.tool_policies.items()
             },
             "audit_enabled": self.audit_enabled,
             "max_audit_entries": self.max_audit_entries,
@@ -214,6 +217,17 @@ class McpActionContext:
                 raise ValueError(
                     f"cost_estimate must be non-negative, got {self.cost_estimate!r}"
                 )
+        # H3: Replace mutable dicts with immutable MappingProxyType.
+        object.__setattr__(
+            self,
+            "args",
+            _builtin_types.MappingProxyType(dict(self.args)),
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            _builtin_types.MappingProxyType(dict(self.metadata)),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary."""

--- a/packages/kailash-pact/tests/unit/mcp/test_enforcer.py
+++ b/packages/kailash-pact/tests/unit/mcp/test_enforcer.py
@@ -449,20 +449,20 @@ class TestRuntimeRegistration:
         ctx = _context(tool_name="new_tool", cost_estimate=5.0)
         assert enforcer.check_tool_call(ctx).level == "auto_approved"
 
-    def test_register_overrides_config(self) -> None:
-        """Runtime registration overrides config policy."""
+    def test_register_tightens_config(self) -> None:
+        """Runtime registration tightens (not widens) config policy."""
         policy = _policy("t", max_cost=10.0)
         config = _config(policies={"t": policy})
         enforcer = McpGovernanceEnforcer(config)
 
-        # Original limit: 10.0
-        ctx = _context(tool_name="t", cost_estimate=15.0)
-        assert enforcer.check_tool_call(ctx).level == "blocked"
-
-        # Override with higher limit
-        enforcer.register_tool(_policy("t", max_cost=20.0))
-        ctx = _context(tool_name="t", cost_estimate=15.0)
+        # Original limit: 10.0 -- cost 8.0 is auto_approved
+        ctx = _context(tool_name="t", cost_estimate=8.0)
         assert enforcer.check_tool_call(ctx).level == "auto_approved"
+
+        # Tighten to 5.0 -- cost 8.0 should now be blocked
+        enforcer.register_tool(_policy("t", max_cost=5.0))
+        ctx = _context(tool_name="t", cost_estimate=8.0)
+        assert enforcer.check_tool_call(ctx).level == "blocked"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kailash-pact/tests/unit/mcp/test_redteam_fixes.py
+++ b/packages/kailash-pact/tests/unit/mcp/test_redteam_fixes.py
@@ -1,0 +1,434 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for PACT MCP red team findings C1, C2, C3, H3, H4.
+
+C1: register_tool() must enforce monotonic tightening
+C2: _rate_tracker dict must be bounded (10,000 entries max)
+C3: McpGovernanceConfig.tool_policies must be immutable (MappingProxyType)
+H3: McpActionContext.args and .metadata must be immutable (MappingProxyType)
+H4: McpAuditEntry.metadata must be immutable (MappingProxyType)
+"""
+
+from __future__ import annotations
+
+import types as _builtin_types
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from pact.mcp.audit import McpAuditEntry
+from pact.mcp.enforcer import McpGovernanceEnforcer
+from pact.mcp.types import (
+    DefaultPolicy,
+    McpActionContext,
+    McpGovernanceConfig,
+    McpToolPolicy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _policy(
+    name: str = "web_search",
+    max_cost: float | None = 10.0,
+    rate_limit: int | None = None,
+    allowed_args: frozenset[str] | None = None,
+    denied_args: frozenset[str] | None = None,
+) -> McpToolPolicy:
+    return McpToolPolicy(
+        tool_name=name,
+        max_cost=max_cost,
+        rate_limit=rate_limit,
+        allowed_args=allowed_args or frozenset(),
+        denied_args=denied_args or frozenset(),
+    )
+
+
+def _config(
+    policies: dict[str, McpToolPolicy] | None = None,
+    default_policy: DefaultPolicy = DefaultPolicy.DENY,
+    audit_enabled: bool = True,
+) -> McpGovernanceConfig:
+    return McpGovernanceConfig(
+        default_policy=default_policy,
+        tool_policies=policies or {},
+        audit_enabled=audit_enabled,
+    )
+
+
+def _context(
+    tool_name: str = "web_search",
+    args: dict[str, Any] | None = None,
+    agent_id: str = "agent-1",
+    cost_estimate: float | None = None,
+    timestamp: datetime | None = None,
+) -> McpActionContext:
+    return McpActionContext(
+        tool_name=tool_name,
+        args=args or {},
+        agent_id=agent_id,
+        cost_estimate=cost_estimate,
+        timestamp=timestamp or datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# C1: register_tool() monotonic tightening
+# ---------------------------------------------------------------------------
+
+
+class TestC1MonotonicTightening:
+    """register_tool() must reject policies that widen constraints."""
+
+    def test_widen_max_cost_rejected(self) -> None:
+        """Increasing max_cost is a widening violation."""
+        policy = _policy("t", max_cost=10.0)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        with pytest.raises(ValueError, match="Monotonic tightening violation.*max_cost"):
+            enforcer.register_tool(_policy("t", max_cost=20.0))
+
+    def test_remove_max_cost_rejected(self) -> None:
+        """Setting max_cost to None (unlimited) when it was set is widening."""
+        policy = _policy("t", max_cost=10.0)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        with pytest.raises(ValueError, match="Monotonic tightening violation.*max_cost.*None"):
+            enforcer.register_tool(_policy("t", max_cost=None))
+
+    def test_tighten_max_cost_accepted(self) -> None:
+        """Decreasing max_cost is allowed (tightening)."""
+        policy = _policy("t", max_cost=10.0)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        enforcer.register_tool(_policy("t", max_cost=5.0))
+        # Verify the tightened policy is active
+        ctx = _context(tool_name="t", cost_estimate=8.0)
+        assert enforcer.check_tool_call(ctx).level == "blocked"
+
+    def test_equal_max_cost_accepted(self) -> None:
+        """Same max_cost is allowed (not widening)."""
+        policy = _policy("t", max_cost=10.0)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        enforcer.register_tool(_policy("t", max_cost=10.0))  # should not raise
+
+    def test_widen_rate_limit_rejected(self) -> None:
+        """Increasing rate_limit is a widening violation."""
+        policy = _policy("t", max_cost=None, rate_limit=5)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        with pytest.raises(ValueError, match="Monotonic tightening violation.*rate_limit"):
+            enforcer.register_tool(_policy("t", max_cost=None, rate_limit=10))
+
+    def test_remove_rate_limit_rejected(self) -> None:
+        """Setting rate_limit to None (unlimited) when it was set is widening."""
+        policy = _policy("t", max_cost=None, rate_limit=5)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        with pytest.raises(ValueError, match="Monotonic tightening violation.*rate_limit.*None"):
+            enforcer.register_tool(_policy("t", max_cost=None, rate_limit=None))
+
+    def test_tighten_rate_limit_accepted(self) -> None:
+        """Decreasing rate_limit is allowed."""
+        policy = _policy("t", max_cost=None, rate_limit=10)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        enforcer.register_tool(_policy("t", max_cost=None, rate_limit=5))
+
+    def test_widen_allowed_args_rejected(self) -> None:
+        """Adding new allowed args is a widening violation."""
+        policy = _policy("t", max_cost=None, allowed_args=frozenset({"query"}))
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        with pytest.raises(ValueError, match="Monotonic tightening violation.*allowed_args"):
+            enforcer.register_tool(
+                _policy("t", max_cost=None, allowed_args=frozenset({"query", "extra"}))
+            )
+
+    def test_remove_allowed_args_rejected(self) -> None:
+        """Setting allowed_args to empty (any) when it was restricted is widening."""
+        policy = _policy("t", max_cost=None, allowed_args=frozenset({"query"}))
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        with pytest.raises(ValueError, match="Monotonic tightening violation.*allowed_args.*empty"):
+            enforcer.register_tool(_policy("t", max_cost=None, allowed_args=frozenset()))
+
+    def test_subset_allowed_args_accepted(self) -> None:
+        """Restricting allowed_args to a subset is tightening."""
+        policy = _policy("t", max_cost=None, allowed_args=frozenset({"query", "limit"}))
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        enforcer.register_tool(
+            _policy("t", max_cost=None, allowed_args=frozenset({"query"}))
+        )
+
+    def test_narrow_denied_args_rejected(self) -> None:
+        """Removing denied args is a narrowing violation."""
+        policy = _policy("t", max_cost=None, denied_args=frozenset({"password", "secret"}))
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        with pytest.raises(ValueError, match="Monotonic tightening violation.*denied_args"):
+            enforcer.register_tool(
+                _policy("t", max_cost=None, denied_args=frozenset({"password"}))
+            )
+
+    def test_superset_denied_args_accepted(self) -> None:
+        """Adding more denied args is tightening (wider deny list)."""
+        policy = _policy("t", max_cost=None, denied_args=frozenset({"password"}))
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        enforcer.register_tool(
+            _policy("t", max_cost=None, denied_args=frozenset({"password", "secret"}))
+        )
+
+    def test_new_tool_no_existing_accepted(self) -> None:
+        """Registering a brand-new tool (no existing policy) always succeeds."""
+        config = _config()
+        enforcer = McpGovernanceEnforcer(config)
+
+        enforcer.register_tool(_policy("brand_new", max_cost=100.0))
+        ctx = _context(tool_name="brand_new", cost_estimate=5.0)
+        assert enforcer.check_tool_call(ctx).level == "auto_approved"
+
+    def test_successive_tightening(self) -> None:
+        """Multiple successive tightenings are all valid."""
+        config = _config()
+        enforcer = McpGovernanceEnforcer(config)
+
+        enforcer.register_tool(_policy("t", max_cost=100.0))
+        enforcer.register_tool(_policy("t", max_cost=50.0))
+        enforcer.register_tool(_policy("t", max_cost=25.0))
+
+        # Cannot widen back
+        with pytest.raises(ValueError, match="Monotonic tightening violation"):
+            enforcer.register_tool(_policy("t", max_cost=30.0))
+
+    def test_overlay_checked_before_config(self) -> None:
+        """If overlay already has a tighter policy, widening relative to overlay fails."""
+        policy = _policy("t", max_cost=10.0)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        # Tighten via overlay to 5.0
+        enforcer.register_tool(_policy("t", max_cost=5.0))
+
+        # Now try to widen to 8.0 (still tighter than config's 10.0 but wider
+        # than overlay's 5.0) -- should fail because overlay takes precedence
+        with pytest.raises(ValueError, match="Monotonic tightening violation"):
+            enforcer.register_tool(_policy("t", max_cost=8.0))
+
+
+# ---------------------------------------------------------------------------
+# C2: _rate_tracker bounded dict
+# ---------------------------------------------------------------------------
+
+
+class TestC2BoundedRateTracker:
+    """_rate_tracker dict must be bounded to _MAX_RATE_TRACKER_ENTRIES."""
+
+    def test_rate_tracker_bounded(self) -> None:
+        """When rate_tracker reaches max size, old entries are evicted."""
+        policy = _policy("t", max_cost=None, rate_limit=100)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        # Lower the limit for test speed
+        enforcer._MAX_RATE_TRACKER_ENTRIES = 100
+
+        now = datetime.now(UTC)
+        # Create 110 unique agent:tool keys to exceed the limit
+        for i in range(110):
+            ctx = _context(
+                tool_name="t",
+                agent_id=f"agent-{i}",
+                timestamp=now + timedelta(milliseconds=i),
+            )
+            enforcer.check_tool_call(ctx)
+
+        # The tracker should have been evicted down below the limit
+        assert len(enforcer._rate_tracker) <= 100
+
+    def test_eviction_preserves_recent_entries(self) -> None:
+        """Eviction removes the oldest entries, not the newest."""
+        policy = _policy("t", max_cost=None, rate_limit=100)
+        config = _config(policies={"t": policy})
+        enforcer = McpGovernanceEnforcer(config)
+
+        enforcer._MAX_RATE_TRACKER_ENTRIES = 10
+
+        now = datetime.now(UTC)
+        # Create entries 0..14 with progressively newer timestamps
+        for i in range(15):
+            ctx = _context(
+                tool_name="t",
+                agent_id=f"agent-{i}",
+                timestamp=now + timedelta(seconds=i),
+            )
+            enforcer.check_tool_call(ctx)
+
+        # The newest entries should still be present
+        newest_key = "agent-14:t"
+        assert newest_key in enforcer._rate_tracker
+
+    def test_max_rate_tracker_entries_constant(self) -> None:
+        """The constant exists and has the expected default value."""
+        assert McpGovernanceEnforcer._MAX_RATE_TRACKER_ENTRIES == 10_000
+
+
+# ---------------------------------------------------------------------------
+# C3: McpGovernanceConfig.tool_policies immutable
+# ---------------------------------------------------------------------------
+
+
+class TestC3ImmutableToolPolicies:
+    """McpGovernanceConfig.tool_policies must be a MappingProxyType."""
+
+    def test_tool_policies_is_mapping_proxy(self) -> None:
+        """tool_policies should be MappingProxyType after construction."""
+        policy = _policy("t")
+        config = _config(policies={"t": policy})
+        assert isinstance(config.tool_policies, _builtin_types.MappingProxyType)
+
+    def test_tool_policies_not_mutable(self) -> None:
+        """Attempting to mutate tool_policies should raise TypeError."""
+        policy = _policy("t")
+        config = _config(policies={"t": policy})
+        with pytest.raises(TypeError):
+            config.tool_policies["new_tool"] = _policy("new_tool")  # type: ignore[index]
+
+    def test_tool_policies_deletion_blocked(self) -> None:
+        """Attempting to delete from tool_policies should raise TypeError."""
+        policy = _policy("t")
+        config = _config(policies={"t": policy})
+        with pytest.raises(TypeError):
+            del config.tool_policies["t"]  # type: ignore[arg-type]
+
+    def test_empty_tool_policies_is_mapping_proxy(self) -> None:
+        """Even empty tool_policies should be a MappingProxyType."""
+        config = _config()
+        assert isinstance(config.tool_policies, _builtin_types.MappingProxyType)
+
+    def test_original_dict_not_linked(self) -> None:
+        """Mutating the original dict should not affect config.tool_policies."""
+        policies = {"t": _policy("t")}
+        config = McpGovernanceConfig(tool_policies=policies)
+        policies["new"] = _policy("new")  # mutate original
+        assert "new" not in config.tool_policies
+
+
+# ---------------------------------------------------------------------------
+# H3: McpActionContext.args and .metadata immutable
+# ---------------------------------------------------------------------------
+
+
+class TestH3ImmutableActionContext:
+    """McpActionContext.args and .metadata must be MappingProxyType."""
+
+    def test_args_is_mapping_proxy(self) -> None:
+        ctx = _context(args={"query": "test"})
+        assert isinstance(ctx.args, _builtin_types.MappingProxyType)
+
+    def test_args_not_mutable(self) -> None:
+        ctx = _context(args={"query": "test"})
+        with pytest.raises(TypeError):
+            ctx.args["new_key"] = "val"  # type: ignore[index]
+
+    def test_metadata_is_mapping_proxy(self) -> None:
+        ctx = McpActionContext(tool_name="t", metadata={"env": "test"})
+        assert isinstance(ctx.metadata, _builtin_types.MappingProxyType)
+
+    def test_metadata_not_mutable(self) -> None:
+        ctx = McpActionContext(tool_name="t", metadata={"env": "test"})
+        with pytest.raises(TypeError):
+            ctx.metadata["injected"] = "attack"  # type: ignore[index]
+
+    def test_original_dict_not_linked(self) -> None:
+        """Mutating the original dict should not affect ctx.args."""
+        args = {"query": "test"}
+        ctx = McpActionContext(tool_name="t", args=args)
+        args["injected"] = "attack"
+        assert "injected" not in ctx.args
+
+    def test_empty_args_is_mapping_proxy(self) -> None:
+        ctx = _context()
+        assert isinstance(ctx.args, _builtin_types.MappingProxyType)
+
+    def test_empty_metadata_is_mapping_proxy(self) -> None:
+        ctx = _context()
+        assert isinstance(ctx.metadata, _builtin_types.MappingProxyType)
+
+
+# ---------------------------------------------------------------------------
+# H4: McpAuditEntry.metadata immutable
+# ---------------------------------------------------------------------------
+
+
+class TestH4ImmutableAuditMetadata:
+    """McpAuditEntry.metadata must be a MappingProxyType."""
+
+    def test_metadata_is_mapping_proxy(self) -> None:
+        entry = McpAuditEntry(
+            tool_name="t",
+            agent_id="a",
+            decision="blocked",
+            metadata={"key": "val"},
+        )
+        assert isinstance(entry.metadata, _builtin_types.MappingProxyType)
+
+    def test_metadata_not_mutable(self) -> None:
+        entry = McpAuditEntry(
+            tool_name="t",
+            agent_id="a",
+            decision="blocked",
+            metadata={"key": "val"},
+        )
+        with pytest.raises(TypeError):
+            entry.metadata["injected"] = "attack"  # type: ignore[index]
+
+    def test_original_dict_not_linked(self) -> None:
+        metadata = {"key": "val"}
+        entry = McpAuditEntry(
+            tool_name="t",
+            agent_id="a",
+            decision="blocked",
+            metadata=metadata,
+        )
+        metadata["injected"] = "attack"
+        assert "injected" not in entry.metadata
+
+    def test_empty_metadata_is_mapping_proxy(self) -> None:
+        entry = McpAuditEntry(
+            tool_name="t",
+            agent_id="a",
+            decision="blocked",
+        )
+        assert isinstance(entry.metadata, _builtin_types.MappingProxyType)
+
+    def test_from_dict_roundtrip_preserves_metadata(self) -> None:
+        """from_dict should produce a MappingProxyType metadata too."""
+        entry = McpAuditEntry(
+            tool_name="t",
+            agent_id="a",
+            decision="blocked",
+            metadata={"key": "val"},
+        )
+        restored = McpAuditEntry.from_dict(entry.to_dict())
+        assert isinstance(restored.metadata, _builtin_types.MappingProxyType)
+        assert dict(restored.metadata) == {"key": "val"}


### PR DESCRIPTION
Red team fixes: C1 monotonic tightening in register_tool, C2 bounded rate tracker, C3+H3+H4 MappingProxyType on frozen dicts. 134 MCP tests pass.