### PR TITLE
fix(core): add config to special params, fix cache alias path

### DIFF
--- a/src/kailash/nodes/base.py
+++ b/src/kailash/nodes/base.py
@@ -167,7 +167,7 @@ class Node(ABC):
 
     # Class-level configuration
     _DEFAULT_CACHE_SIZE = 128
-    _SPECIAL_PARAMS = {"context"}  # Parameters excluded from cache key
+    _SPECIAL_PARAMS = {"context", "config"}  # Parameters excluded from cache key
     _strict_unknown_params = False  # Subclasses can set True to error on unknown params
 
     def __init__(self, **kwargs):
@@ -813,7 +813,8 @@ class Node(ABC):
                     cached_mapping = self._param_cache[cache_key]
                     resolved = self._apply_cached_mapping(kwargs, cached_mapping)
                     # Reconstruct used_inputs from cached mapping
-                    used_inputs = set(cached_mapping.keys()) & set(kwargs.keys())
+                    # cached_mapping is {param_name: input_key}, so values() are the kwargs keys consumed
+                    used_inputs = set(cached_mapping.values()) & set(kwargs.keys())
                 else:
                     self._cache_misses += 1
 

--- a/tests/unit/test_unknown_param_validation.py
+++ b/tests/unit/test_unknown_param_validation.py
@@ -319,3 +319,60 @@ class TestStrictUnknownParams:
         error_msg = str(exc_info.value)
         assert "alpha" in error_msg
         assert "beta" in error_msg
+
+
+# ---------------------------------------------------------------------------
+# Tests: cache + alias path regression
+# ---------------------------------------------------------------------------
+
+
+class TestCacheAliasPath:
+    """Regression tests for cache hit path with workflow_alias parameters.
+
+    Verifies that on a cache hit the alias key is still recognised as valid
+    (no spurious unknown-param warning) and that a genuinely unknown key still
+    produces exactly one warning.
+    """
+
+    def test_alias_key_no_warning_on_cache_miss(self, caplog):
+        """First call (cache miss) with alias key must not warn."""
+        node = NodeWithAlias(id="test")
+        node._cache_enabled = True
+
+        with caplog.at_level(logging.WARNING, logger="kailash.nodes.base"):
+            result = node.validate_inputs(input="hello")
+
+        assert result["input_data"] == "hello"
+        assert "unknown" not in caplog.text.lower()
+
+    def test_alias_key_no_warning_on_cache_hit(self, caplog):
+        """Second call (cache hit) with alias key must not warn."""
+        node = NodeWithAlias(id="test")
+        node._cache_enabled = True
+
+        # Populate cache
+        node.validate_inputs(input="first")
+        caplog.clear()
+
+        # Cache hit — alias key must still be recognised
+        with caplog.at_level(logging.WARNING, logger="kailash.nodes.base"):
+            result = node.validate_inputs(input="second")
+
+        assert result["input_data"] == "second"
+        assert "unknown" not in caplog.text.lower()
+
+    def test_unknown_key_warns_on_cache_hit(self, caplog):
+        """On a cache hit, an unknown key (not alias) must still trigger a warning."""
+        node = NodeWithAlias(id="test")
+        node._cache_enabled = True
+
+        # Populate cache with alias key only
+        node.validate_inputs(input="first")
+        caplog.clear()
+
+        # Cache hit + extra unknown key
+        with caplog.at_level(logging.WARNING, logger="kailash.nodes.base"):
+            node.validate_inputs(input="second", bogus_key="oops")
+
+        assert "bogus_key" in caplog.text
+        assert "unknown" in caplog.text.lower()


### PR DESCRIPTION
Red team fixes: config false positive, cache+alias regression test. 36 unknown param tests + 146 node/workflow tests pass.