### PR TITLE
chore: release kailash-kaizen 2.2.0

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -19,7 +19,7 @@
 | ---------------- | ------------- | --------------- |
 | kailash (core)   | `v*`          | 2.0.0           |
 | kailash-dataflow | `dataflow-v*` | 1.1.0           |
-| kailash-kaizen   | `kaizen-v*`   | 2.0.0           |
+| kailash-kaizen   | `kaizen-v*`   | 2.2.0           |
 | kailash-nexus    | `nexus-v*`    | 1.4.3           |
 | kailash-pact     | `pact-v*`     | 0.2.0           |
 

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-03-24
+
+### LLM-First Autonomous Agents
+
+All autonomous agents now default to MCP tool discovery enabled, and the framework enforces LLM-first reasoning as an absolute directive.
+
+### Changed
+
+- **ReActAgent**: `mcp_discovery_enabled` default changed from `False` to `True`
+- **CodeGenerationAgent**: Added `mcp_enabled: bool = True` to config
+- **RAGResearchAgent**: Added `mcp_enabled: bool = True` to config
+- **SelfReflectionAgent**: Added `mcp_enabled: bool = True` to config (now classified as autonomous)
+- Agent Classification updated: 4 autonomous agents (was 3), SelfReflectionAgent promoted
+
+### Removed
+
+- **ReActAgent.\_discover_mcp_tools()**: Removed no-op stub method. MCP discovery flows through `BaseAgent.discover_mcp_tools()` (the real async implementation)
+
+### Fixed
+
+- `test_memory_agent`: Fixed mock provider detection in execution test
+- `test_http_transport`: Fixed `base_url` fixture scope conflict with pytest-base-url plugin
+- `test_agent_execution_patterns_e2e`: Relaxed content assertions for mock provider compatibility
+
 ## [2.1.0] - 2026-03-22
 
 ### L3 Autonomy Primitives

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.1.1"
+version = "2.2.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- Version bump kailash-kaizen 2.1.1 → 2.2.0
- CHANGELOG updated with LLM-First Autonomous Agents section
- deployment-config.md updated

Changes included from PR #58 (already merged to main):
- MCP discovery enabled by default on 4 autonomous agents
- Removed `_discover_mcp_tools()` stub from ReActAgent
- New COC rule: `rules/agent-reasoning.md` (Absolute Directive #6)
- Fixed 3 pre-existing test failures

## Test plan

- [x] All agent unit tests pass (751 passed)
- [x] All 4 previously-failing tests fixed and verified
- [x] Version consistency verified (pyproject.toml == __init__.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)