### PR TITLE
chore: release kailash 2.1.0, kailash-pact 0.4.0, kaizen-agents 0.2.0, kailash-kaizen 2.2.1

### DIFF
--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "kailash[trust]>=2.0.0,<3.0.0",
+    "kailash[trust]>=2.1.0,<3.0.0",
     "pydantic>=2.0.0",
     "typing-extensions>=4.5.0",
     "PyJWT>=2.8.0",

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -22,8 +22,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "kailash-kaizen>=2.1.0",
-    "kailash-pact>=0.1.0",
+    "kailash[pact]>=2.1.0",
+    "kailash-kaizen>=2.2.1",
+    "kailash-pact>=0.4.0",
     "openai>=1.30.0",
     "python-dotenv>=1.0.0",
     "structlog>=23.1.0",


### PR DESCRIPTION
## Summary

- Update dependency pins for multi-package release
- kaizen-agents: kailash[pact]>=2.1.0, kailash-pact>=0.4.0, kailash-kaizen>=2.2.1
- kailash-kaizen: kailash[trust]>=2.1.0

## Release Plan

| Package | Version | PyPI |
|---------|---------|------|
| kailash | 2.1.0 | publish first (core) |
| kailash-pact | 0.4.0 | publish second |
| kailash-kaizen | 2.2.1 | publish third |
| kaizen-agents | 0.2.0 | publish last (depends on all above) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)