### PR TITLE
fix(docker): remove missing setup.py from Dockerfile COPY

### DIFF
--- a/packages/kailash-kaizen/Dockerfile
+++ b/packages/kailash-kaizen/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /build
 
 # Copy dependency files first (for better caching)
-COPY pyproject.toml setup.py README.md ./
+COPY pyproject.toml README.md ./
 
 # Copy source code
 COPY src ./src


### PR DESCRIPTION
## Summary

The Kaizen Dockerfile referenced `setup.py` which doesn't exist — the package uses `pyproject.toml` exclusively. This caused the Production Deployment Pipeline to fail on every push with:
```
ERROR: "/setup.py": not found
```

## Test Plan
- [x] Dockerfile syntax verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)