### PR TITLE
feat(middleware): add EventBus with pluggable backends (#79)

### DIFF
--- a/src/kailash/middleware/communication/__init__.py
+++ b/src/kailash/middleware/communication/__init__.py
@@ -2,7 +2,7 @@
 Communication Layer for Kailash Middleware
 
 Handles all external communication including REST APIs, WebSockets,
-and events.
+events, and domain event buses with pluggable backends.
 
 Note:
     AI chat functionality has been moved to the Kaizen framework.
@@ -11,6 +11,9 @@ Note:
 """
 
 from .api_gateway import APIGateway, create_gateway
+from .backends import InMemoryEventBus
+from .domain_event import DomainEvent
+from .event_bus import EventBus, EventBusError, PublishError, SubscriptionError
 from .events import (
     EventPriority,
     EventStream,
@@ -29,6 +32,13 @@ __all__ = [
     "WorkflowEvent",
     "NodeEvent",
     "UIEvent",
+    # EventBus (pluggable backends)
+    "EventBus",
+    "DomainEvent",
+    "InMemoryEventBus",
+    "EventBusError",
+    "PublishError",
+    "SubscriptionError",
     # Real-time communication
     "RealtimeMiddleware",
     # API Gateway

--- a/src/kailash/middleware/communication/backends/__init__.py
+++ b/src/kailash/middleware/communication/backends/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+EventBus backend implementations.
+
+Currently ships with:
+
+* :class:`InMemoryEventBus` -- zero-dependency, thread-safe, suitable for
+  single-process applications and tests.
+
+Additional backends (Redis Streams, Kafka, etc.) can be added as separate
+modules in this package.
+"""
+
+from .memory import InMemoryEventBus
+
+__all__ = ["InMemoryEventBus"]

--- a/src/kailash/middleware/communication/backends/memory.py
+++ b/src/kailash/middleware/communication/backends/memory.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+In-memory EventBus backend.
+
+Thread-safe, zero-dependency implementation backed by a dict of handler
+lists protected by a :class:`threading.Lock`. Suitable for single-process
+applications, unit/integration tests, and local development.
+
+Design notes
+------------
+* Subscriber list is bounded to ``max_subscribers`` (default 10 000) to
+  prevent unbounded memory growth.  See ``dataflow-pool.md`` Rule 4
+  (bounded collections) and ``trust-plane-security.md`` Rule 4.
+* All mutations and reads of the subscription registry acquire
+  ``self._lock`` to guarantee thread safety.
+* Handler invocation happens **outside** the lock so that slow handlers
+  cannot starve other publishers.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Tuple
+
+from ..domain_event import DomainEvent
+from ..event_bus import EventBus, PublishError, SubscriptionError
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["InMemoryEventBus"]
+
+_DEFAULT_MAX_SUBSCRIBERS = 10_000
+
+
+class InMemoryEventBus(EventBus):
+    """Thread-safe, bounded, in-memory event bus.
+
+    Args:
+        max_subscribers: Upper bound on total subscriptions across all
+            event types.  When the limit is reached, new :meth:`subscribe`
+            calls raise :class:`SubscriptionError`.
+    """
+
+    def __init__(self, max_subscribers: int = _DEFAULT_MAX_SUBSCRIBERS) -> None:
+        self._lock = threading.Lock()
+        # event_type -> OrderedDict[subscription_id, handler]
+        # OrderedDict preserves insertion order and allows O(1) delete.
+        self._subscribers: Dict[
+            str, OrderedDict[str, Callable[[DomainEvent], None]]
+        ] = {}
+        # subscription_id -> event_type  (reverse index for fast unsubscribe)
+        self._sub_index: Dict[str, str] = {}
+        self._max_subscribers = max_subscribers
+        self._total_subscriptions = 0
+
+    # ------------------------------------------------------------------
+    # EventBus interface
+    # ------------------------------------------------------------------
+
+    def publish(self, event: DomainEvent) -> None:
+        """Publish *event* to all handlers registered for its type.
+
+        Handlers are invoked **synchronously** in subscription order.  If
+        a handler raises, the exception is logged and the remaining
+        handlers still execute (fail-open per handler, not per publish).
+
+        Raises:
+            PublishError: If *event* is ``None`` or not a
+                :class:`DomainEvent`.
+        """
+        if not isinstance(event, DomainEvent):
+            raise PublishError(
+                "event must be a DomainEvent instance",
+                details={"received_type": type(event).__name__},
+            )
+
+        # Snapshot handlers under the lock so we can invoke outside it.
+        handlers: List[Tuple[str, Callable[[DomainEvent], None]]] = []
+        with self._lock:
+            bucket = self._subscribers.get(event.event_type)
+            if bucket:
+                handlers = list(bucket.items())
+
+        for sub_id, handler in handlers:
+            try:
+                handler(event)
+            except Exception:
+                logger.exception(
+                    "Handler %s for event %s raised an exception",
+                    sub_id,
+                    event.event_type,
+                )
+
+    def subscribe(
+        self,
+        event_type: str,
+        handler: Callable[[DomainEvent], None],
+    ) -> str:
+        """Register *handler* for *event_type*.
+
+        Returns:
+            A unique subscription ID.
+
+        Raises:
+            SubscriptionError: If *event_type* is empty, *handler* is not
+                callable, or the subscriber limit has been reached.
+        """
+        if not event_type:
+            raise SubscriptionError(
+                "event_type must be a non-empty string",
+                details={"event_type": event_type},
+            )
+        if not callable(handler):
+            raise SubscriptionError(
+                "handler must be callable",
+                details={"handler_type": type(handler).__name__},
+            )
+
+        sub_id = str(uuid.uuid4())
+
+        with self._lock:
+            if self._total_subscriptions >= self._max_subscribers:
+                raise SubscriptionError(
+                    f"Subscriber limit reached ({self._max_subscribers})",
+                    details={
+                        "max_subscribers": self._max_subscribers,
+                        "current": self._total_subscriptions,
+                    },
+                )
+
+            if event_type not in self._subscribers:
+                self._subscribers[event_type] = OrderedDict()
+
+            self._subscribers[event_type][sub_id] = handler
+            self._sub_index[sub_id] = event_type
+            self._total_subscriptions += 1
+
+        logger.debug(
+            "Subscription %s registered for event_type=%s (total=%d)",
+            sub_id,
+            event_type,
+            self._total_subscriptions,
+        )
+        return sub_id
+
+    def unsubscribe(self, subscription_id: str) -> None:
+        """Remove the subscription identified by *subscription_id*.
+
+        Raises:
+            SubscriptionError: If the ID does not correspond to an active
+                subscription.
+        """
+        with self._lock:
+            event_type = self._sub_index.pop(subscription_id, None)
+            if event_type is None:
+                raise SubscriptionError(
+                    f"Unknown subscription ID: {subscription_id}",
+                    details={"subscription_id": subscription_id},
+                )
+
+            bucket = self._subscribers.get(event_type)
+            if bucket is not None:
+                bucket.pop(subscription_id, None)
+                if not bucket:
+                    del self._subscribers[event_type]
+
+            self._total_subscriptions -= 1
+
+        logger.debug(
+            "Subscription %s removed for event_type=%s (total=%d)",
+            subscription_id,
+            event_type,
+            self._total_subscriptions,
+        )

--- a/src/kailash/middleware/communication/domain_event.py
+++ b/src/kailash/middleware/communication/domain_event.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Domain Event model for the EventBus system.
+
+Provides a strongly-typed, serializable event dataclass used across all
+EventBus backends. Every domain event carries a correlation ID for
+distributed tracing and a schema version for forward-compatible evolution.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, ClassVar, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["DomainEvent"]
+
+
+@dataclass
+class DomainEvent:
+    """Immutable domain event transported through the EventBus.
+
+    Attributes:
+        event_type: Dot-delimited event type identifier (e.g. ``"order.created"``).
+        payload: Arbitrary event data. Must be JSON-serializable.
+        correlation_id: UUID linking related events across a workflow or saga.
+            Auto-generated when not supplied.
+        timestamp: UTC datetime of event creation. Auto-generated when not
+            supplied.
+        actor: Optional identifier of the entity that caused the event
+            (user ID, agent ID, service name, etc.).
+        schema_version: Semantic version of the payload schema. Consumers
+            should use this to handle backward/forward compatibility.
+    """
+
+    event_type: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    correlation_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    actor: Optional[str] = None
+    schema_version: str = "1.0"
+
+    # Class-level constant for schema version validation
+    _SUPPORTED_SCHEMA_VERSIONS: ClassVar[frozenset] = frozenset({"1.0"})
+
+    def __post_init__(self) -> None:
+        if not self.event_type:
+            raise ValueError("event_type must be a non-empty string")
+        if not isinstance(self.payload, dict):
+            raise ValueError("payload must be a dict")
+        if not isinstance(self.correlation_id, str) or not self.correlation_id:
+            raise ValueError("correlation_id must be a non-empty string")
+        if not isinstance(self.timestamp, datetime):
+            raise ValueError("timestamp must be a datetime instance")
+        if self.timestamp.tzinfo is None:
+            raise ValueError("timestamp must be timezone-aware (UTC)")
+
+    # ------------------------------------------------------------------
+    # Serialization (EATP SDK convention: to_dict / from_dict)
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize event to a JSON-compatible dictionary."""
+        return {
+            "event_type": self.event_type,
+            "payload": self.payload,
+            "correlation_id": self.correlation_id,
+            "timestamp": self.timestamp.isoformat(),
+            "actor": self.actor,
+            "schema_version": self.schema_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> DomainEvent:
+        """Deserialize event from a dictionary.
+
+        Args:
+            data: Dictionary previously produced by :meth:`to_dict`.
+
+        Returns:
+            A new ``DomainEvent`` instance.
+
+        Raises:
+            ValueError: If required fields are missing or malformed.
+            KeyError: If a required key is absent.
+        """
+        timestamp_raw = data["timestamp"]
+        if isinstance(timestamp_raw, str):
+            ts = datetime.fromisoformat(timestamp_raw)
+            # Ensure timezone-aware
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+        elif isinstance(timestamp_raw, datetime):
+            ts = timestamp_raw
+        else:
+            raise ValueError(
+                f"timestamp must be an ISO-8601 string or datetime, got {type(timestamp_raw)}"
+            )
+
+        return cls(
+            event_type=data["event_type"],
+            payload=data.get("payload", {}),
+            correlation_id=data.get("correlation_id", str(uuid.uuid4())),
+            timestamp=ts,
+            actor=data.get("actor"),
+            schema_version=data.get("schema_version", "1.0"),
+        )

--- a/src/kailash/middleware/communication/event_bus.py
+++ b/src/kailash/middleware/communication/event_bus.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Abstract EventBus with pluggable backends.
+
+Defines the ``EventBus`` interface and the ``EventBusError`` exception
+hierarchy. Concrete backends (in-memory, Redis, Kafka, etc.) implement
+this interface so that application code remains transport-agnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict
+
+from .domain_event import DomainEvent
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EventBus",
+    "EventBusError",
+    "PublishError",
+    "SubscriptionError",
+]
+
+
+# ------------------------------------------------------------------
+# Exception hierarchy
+# ------------------------------------------------------------------
+
+
+class EventBusError(Exception):
+    """Base exception for all EventBus operations.
+
+    Attributes:
+        details: Structured context about the error (agent-friendly).
+    """
+
+    def __init__(self, message: str, details: Dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details: Dict[str, Any] = details or {}
+
+
+class PublishError(EventBusError):
+    """Raised when an event cannot be published."""
+
+
+class SubscriptionError(EventBusError):
+    """Raised when a subscribe / unsubscribe operation fails."""
+
+
+# ------------------------------------------------------------------
+# Abstract bus
+# ------------------------------------------------------------------
+
+
+class EventBus(ABC):
+    """Abstract event bus with pluggable backends.
+
+    Implementations **must** be thread-safe and **must** enforce a bounded
+    subscriber list (``maxlen=10_000`` by default) to prevent unbounded
+    memory growth in long-running processes.
+    """
+
+    @abstractmethod
+    def publish(self, event: DomainEvent) -> None:
+        """Publish an event to all matching subscribers.
+
+        Args:
+            event: The domain event to publish.
+
+        Raises:
+            PublishError: If the event cannot be delivered.
+        """
+
+    @abstractmethod
+    def subscribe(self, event_type: str, handler: Callable[[DomainEvent], None]) -> str:
+        """Register a handler for a given event type.
+
+        Args:
+            event_type: Dot-delimited event type to listen for
+                (e.g. ``"order.created"``).
+            handler: Callable invoked synchronously when a matching event
+                is published.
+
+        Returns:
+            A unique subscription ID that can be passed to
+            :meth:`unsubscribe`.
+
+        Raises:
+            SubscriptionError: If the subscriber limit has been reached or
+                the handler is invalid.
+        """
+
+    @abstractmethod
+    def unsubscribe(self, subscription_id: str) -> None:
+        """Remove a previously registered subscription.
+
+        Args:
+            subscription_id: The ID returned by :meth:`subscribe`.
+
+        Raises:
+            SubscriptionError: If the subscription ID is unknown.
+        """


### PR DESCRIPTION
## Summary

- Adds abstract `EventBus` interface with `publish`, `subscribe`, `unsubscribe` contract
- Implements `InMemoryEventBus` backend: thread-safe (`threading.Lock`), bounded subscriber list (`maxlen=10000`), synchronous handler dispatch
- Adds `DomainEvent` dataclass with `event_type`, `payload`, `correlation_id`, `timestamp`, `actor`, `schema_version`, and `to_dict`/`from_dict` serialization
- Adds `EventBusError` hierarchy (`PublishError`, `SubscriptionError`) with structured `.details`
- Creates `backends/` package for future pluggable backends (Redis, Kafka, etc.)
- Exports all new types from `communication/__init__.py`

Closes #79

## Test plan

- [x] Manual verification: DomainEvent creation, serialization round-trip
- [x] Manual verification: InMemoryEventBus publish/subscribe/unsubscribe
- [x] Manual verification: Bounded subscriber limit enforcement
- [x] Manual verification: Thread safety under concurrent subscriptions
- [x] Manual verification: Exception hierarchy correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)