### PR TITLE
fix(ci): make Pillow optional at import time, add deploy CI deps

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -173,7 +173,7 @@ jobs:
         working-directory: ./packages/kailash-kaizen
         run: |
           pip install -e ".[dev]"
-          pip install pytest pytest-timeout pytest-cov
+          pip install pytest pytest-timeout pytest-cov python-dotenv Pillow
 
       - name: Run unit tests
         working-directory: ./packages/kailash-kaizen

--- a/packages/kailash-kaizen/src/kaizen/signatures/multi_modal.py
+++ b/packages/kailash-kaizen/src/kaizen/signatures/multi_modal.py
@@ -29,9 +29,7 @@ from typing import Any, Dict, List, Optional, Union
 try:
     from PIL import Image
 except ImportError:
-    raise ImportError(
-        "PIL (Pillow) is required for ImageField. Install it with: pip install Pillow"
-    )
+    Image = None  # Pillow optional — ImageField validates at construction time
 
 try:
     import requests
@@ -103,6 +101,9 @@ class ImageField:
             Self for chaining
 
         Raises:
+            ImportError: If Pillow is not installed
+
+        Raises:
             FileNotFoundError: If file path doesn't exist
             ValueError: If base64 data is invalid or format unsupported
             RuntimeError: If URL loading fails
@@ -113,6 +114,11 @@ class ImageField:
             >>> field.load("https://example.com/image.png")  # From URL
             >>> field.load("data:image/jpeg;base64,...")  # From base64
         """
+        if Image is None:
+            raise ImportError(
+                "PIL (Pillow) is required for ImageField. "
+                "Install it with: pip install Pillow"
+            )
         if isinstance(source, (Path, str)):
             source_str = str(source)
             self._source = source_str  # Store original source


### PR DESCRIPTION
## Summary

Fixes the remaining Production Deployment Pipeline failure. The kaizen `multi_modal.py` raised `ImportError` at **import time** if Pillow wasn't installed — this crashed pytest test collection in the deploy CI even though no test uses `ImageField`.

- Make Pillow optional at import time (`Image = None`)
- Guard at `ImageField.load()` — raises `ImportError` only when actually used
- Add `python-dotenv` and `Pillow` to deploy pipeline `pip install`

## Test plan

- [x] `from kaizen.signatures import ImageField` works without Pillow installed
- [x] `ImageField().load(...)` raises ImportError if Pillow missing
- [x] Full behavior unchanged when Pillow IS installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)