### PR TITLE
fix(ci): make OAuth import lazy, add deploy pipeline deps

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -173,7 +173,7 @@ jobs:
         working-directory: ./packages/kailash-kaizen
         run: |
           pip install -e ".[dev]"
-          pip install pytest pytest-timeout pytest-cov python-dotenv Pillow
+          pip install pytest pytest-timeout pytest-cov python-dotenv Pillow aiohttp pyjwt cryptography
 
       - name: Run unit tests
         working-directory: ./packages/kailash-kaizen

--- a/src/kailash/mcp_server/__init__.py
+++ b/src/kailash/mcp_server/__init__.py
@@ -148,24 +148,27 @@ from .errors import (
     ValidationError,
 )
 
-# OAuth 2.1 Authentication
-from .oauth import (
-    AccessToken,
-    AuthorizationCode,
-    AuthorizationServer,
-    ClientStore,
-    ClientType,
-    GrantType,
-    InMemoryClientStore,
-    InMemoryTokenStore,
-    JWTManager,
-    OAuth2Client,
-    OAuthClient,
-    RefreshToken,
-    ResourceServer,
-    TokenStore,
-    TokenType,
-)
+# OAuth 2.1 Authentication (requires aiohttp + jwt + cryptography)
+try:
+    from .oauth import (
+        AccessToken,
+        AuthorizationCode,
+        AuthorizationServer,
+        ClientStore,
+        ClientType,
+        GrantType,
+        InMemoryClientStore,
+        InMemoryTokenStore,
+        JWTManager,
+        OAuth2Client,
+        OAuthClient,
+        RefreshToken,
+        ResourceServer,
+        TokenStore,
+        TokenType,
+    )
+except ImportError:
+    pass  # OAuth requires aiohttp, jwt, cryptography — optional deps
 
 # Complete Protocol Implementation
 from .protocol import (


### PR DESCRIPTION
## Summary

Final fix for Production Deployment Pipeline. The import chain:
`kaizen.core.base_agent` → `kailash.mcp_server.client` → `kailash.mcp_server.__init__` → `.oauth` → `import aiohttp` **crashes** because aiohttp isn't installed.

- Wrap OAuth imports in `mcp_server/__init__.py` with try/except (aiohttp, jwt, cryptography are optional deps)
- Add aiohttp, pyjwt, cryptography to deploy pipeline pip install

## Test plan

- [x] `from kailash.mcp_server import MCPServer` works without aiohttp
- [x] OAuth features available when deps installed
- [x] Full local test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)