### PR TITLE
fix(ci): install local kailash before kailash-kaizen in deploy pipeline

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -170,10 +170,10 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
-        working-directory: ./packages/kailash-kaizen
         run: |
-          pip install -e ".[dev]"
-          pip install pytest pytest-timeout pytest-cov python-dotenv Pillow aiohttp pyjwt cryptography
+          pip install -e .
+          pip install -e "./packages/kailash-kaizen[dev]"
+          pip install pytest pytest-timeout pytest-cov python-dotenv Pillow aiohttp pyjwt cryptography websockets
 
       - name: Run unit tests
         working-directory: ./packages/kailash-kaizen


### PR DESCRIPTION
## Summary

Root cause: deploy pipeline ran `pip install -e ".[dev]"` from kailash-kaizen directory, which pulled `kailash` from **PyPI (v2.1.0)** — not the local repo. The PyPI version has unconditional `import aiohttp` and `import websockets` at module level, crashing test collection.

Fix: install local `kailash` first (`pip install -e .` from repo root), then `kailash-kaizen[dev]` on top. The local kailash has lazy OAuth imports from PR #120.

Also adds `websockets` to explicit deps list.

## Test plan

- [x] Deploy pipeline installs local kailash (with lazy OAuth)
- [x] kailash-kaizen tests can collect without aiohttp/websockets errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)