### PR TITLE
fix(ci): install ALL local packages in deploy pipeline

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -172,6 +172,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e ".[server,database,trust,trust-sso,trust-encryption,dev]"
+          pip install -e "./packages/kailash-dataflow[dev,semantic,performance]"
+          pip install -e "./packages/kailash-nexus[dev]"
           pip install -e "./packages/kailash-kaizen[dev,server,database,rag,observability,security]"
           pip install pytest pytest-timeout pytest-cov python-dotenv
 


### PR DESCRIPTION
## Summary

Deploy pipeline was missing kailash-dataflow and kailash-nexus local installs. When kailash-kaizen tests import kailash core modules that transitively import dataflow deps (pymongo, etc.), they fail.

Fix: install all 4 local packages from source with their extras:
- kailash core [server,database,trust,trust-sso,trust-encryption,dev]
- kailash-dataflow [dev,semantic,performance]
- kailash-nexus [dev]
- kailash-kaizen [dev,server,database,rag,observability,security]

🤖 Generated with [Claude Code](https://claude.com/claude-code)