### PR TITLE
fix(ci): add kaizen-agents to deploy pipeline installs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -174,6 +174,7 @@ jobs:
           pip install -e ".[server,database,trust,trust-sso,trust-encryption,dev]"
           pip install -e "./packages/kailash-dataflow[dev,semantic,performance]"
           pip install -e "./packages/kailash-nexus[dev]"
+          pip install -e "./packages/kaizen-agents[dev]"
           pip install -e "./packages/kailash-kaizen[dev,server,database,rag,observability,security]"
           pip install pytest pytest-timeout pytest-cov python-dotenv
 


### PR DESCRIPTION
## Summary

Deploy pipeline tests import `kaizen_agents` but the package wasn't installed. Add local install of `packages/kaizen-agents[dev]`.

Result: 225 passed, 6 failed (pre-existing kaizen example test failures), 0 import errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)