### PR TITLE
fix(security): red team findings — bound power operator, complete Redis URL validation

### DIFF
--- a/src/kailash/api/mcp_integration.py
+++ b/src/kailash/api/mcp_integration.py
@@ -80,7 +80,15 @@ def _eval_math_node(node: ast.AST) -> float:
     elif isinstance(node, ast.BinOp) and type(node.op) in _SAFE_MATH_OPS:
         left = _eval_math_node(node.left)
         right = _eval_math_node(node.right)
-        return _SAFE_MATH_OPS[type(node.op)](left, right)
+        if isinstance(node.op, ast.Pow):
+            if right > 1000:
+                raise ValueError("Exponent too large (max 1000)")
+            if left > 1e15:
+                raise ValueError("Base too large for exponentiation")
+        result = _SAFE_MATH_OPS[type(node.op)](left, right)
+        if isinstance(result, float) and (abs(result) > 1e308 or result != result):
+            raise ValueError("Result out of range")
+        return result
     elif isinstance(node, ast.UnaryOp) and type(node.op) in _SAFE_MATH_OPS:
         return _SAFE_MATH_OPS[type(node.op)](_eval_math_node(node.operand))
     raise ValueError("Unsupported expression")

--- a/src/kailash/core/resilience/distributed_circuit_breaker.py
+++ b/src/kailash/core/resilience/distributed_circuit_breaker.py
@@ -129,10 +129,9 @@ class RedisCircuitBreakerBackend:
         if self._client is None:
             import redis as redis_lib
 
-            if not self.redis_url.startswith(("redis://", "rediss://")):
-                raise ValueError(
-                    f"Invalid Redis URL '{self.redis_url}': must start with redis:// or rediss://"
-                )
+            from kailash.utils.validation import validate_redis_url
+
+            validate_redis_url(self.redis_url)
             self._client = redis_lib.Redis.from_url(
                 self.redis_url,
                 decode_responses=True,

--- a/src/kailash/mcp_server/__init__.py
+++ b/src/kailash/mcp_server/__init__.py
@@ -168,7 +168,11 @@ try:
         TokenType,
     )
 except ImportError:
-    pass  # OAuth requires aiohttp, jwt, cryptography — optional deps
+    import logging as _logging
+
+    _logging.getLogger(__name__).debug(
+        "OAuth module not available — install with: pip install kailash[server,trust-sso]"
+    )
 
 # Complete Protocol Implementation
 from .protocol import (
@@ -220,7 +224,11 @@ try:
         get_transport_manager,
     )
 except ImportError:
-    pass  # Transports require aiohttp, websockets — optional deps
+    import logging as _logging
+
+    _logging.getLogger(__name__).debug(
+        "Transport modules not available — install with: pip install kailash[server]"
+    )
 
 __all__ = [
     # Core MCP Components

--- a/src/kailash/nodes/cache/redis_pool_manager.py
+++ b/src/kailash/nodes/cache/redis_pool_manager.py
@@ -266,6 +266,9 @@ class RedisPoolManagerNode(AsyncNode):
                     )
 
                 try:
+                    from kailash.utils.validation import validate_redis_url
+
+                    validate_redis_url(redis_url)
                     pool = ConnectionPool.from_url(  # type: ignore[possibly-unbound]
                         redis_url,
                         db=database,

--- a/src/kailash/runtime/distributed.py
+++ b/src/kailash/runtime/distributed.py
@@ -190,10 +190,9 @@ class TaskQueue:
         if self._client is None:
             import redis as redis_lib
 
-            if not self._redis_url.startswith(("redis://", "rediss://")):
-                raise ValueError(
-                    f"Invalid Redis URL '{self._redis_url}': must start with redis:// or rediss://"
-                )
+            from kailash.utils.validation import validate_redis_url
+
+            validate_redis_url(self._redis_url)
             self._client = redis_lib.Redis.from_url(
                 self._redis_url,
                 decode_responses=True,
@@ -637,10 +636,9 @@ class Worker:
         if self._redis_client is None:
             import redis as redis_lib
 
-            if not self._redis_url.startswith(("redis://", "rediss://")):
-                raise ValueError(
-                    f"Invalid Redis URL '{self._redis_url}': must start with redis:// or rediss://"
-                )
+            from kailash.utils.validation import validate_redis_url
+
+            validate_redis_url(self._redis_url)
             self._redis_client = redis_lib.Redis.from_url(
                 self._redis_url,
                 decode_responses=True,


### PR DESCRIPTION
## Summary

Red team review of PRs #116-#124 found 2 CRITICAL and 4 HIGH issues. This PR fixes the CRITICALs and HIGH-1:

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| C1 | CRITICAL | 3 Redis `from_url()` sites missing validation | Replaced inline `startswith` with `validate_redis_url()` |
| C2 | CRITICAL | `_safe_math_eval` allows `2**2**2**...` DoS | Exponent capped at 1000, base at 1e15, result at 1e308 |
| H1 | HIGH | OAuth/transports import failures silent | Now log debug messages |

Remaining HIGH findings (H2-H4) are pre-existing and tracked in S3 milestones.

## Test plan

- [x] `_safe_math_eval('2**8')` returns 256 (normal pow works)
- [x] `_safe_math_eval('2**2**2**20')` raises ValueError (DoS blocked)
- [x] All 4 Redis URL sites use canonical `validate_redis_url()`
- [x] OAuth import failure logs debug message
- [x] Full test suite: 10,883 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)