### PR TITLE
refactor(trust-plane): rename Delegate to DelegationRecipient

### DIFF
--- a/.claude/skills/26-eatp-reference/eatp-store-backends.md
+++ b/.claude/skills/26-eatp-reference/eatp-store-backends.md
@@ -65,7 +65,7 @@ from __future__ import annotations
 import json
 import logging
 from kailash.trust.plane._locking import validate_id
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import DelegationRecipient, DelegateStatus, ReviewResolution
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.models import DecisionRecord, MilestoneRecord, ProjectManifest
 

--- a/src/kailash/trust/plane/delegation.py
+++ b/src/kailash/trust/plane/delegation.py
@@ -71,8 +71,8 @@ class DelegateStatus(Enum):
 
 
 @dataclass
-class Delegate:
-    """A delegate authorized to review actions in specific dimensions."""
+class DelegationRecipient:
+    """A delegation recipient authorized to review actions in specific dimensions."""
 
     delegate_id: str
     name: str
@@ -112,7 +112,7 @@ class Delegate:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Delegate:
+    def from_dict(cls, data: dict[str, Any]) -> DelegationRecipient:
         for field_name in (
             "delegate_id",
             "name",
@@ -122,12 +122,12 @@ class Delegate:
         ):
             if field_name not in data:
                 raise ValueError(
-                    f"Delegate.from_dict: missing required field '{field_name}'"
+                    f"DelegationRecipient.from_dict: missing required field '{field_name}'"
                 )
         depth = data.get("depth", 0)
         if not isinstance(depth, int) or depth < 0:
             raise ValueError(
-                f"Delegate.from_dict: 'depth' must be a non-negative integer, got {depth!r}"
+                f"DelegationRecipient.from_dict: 'depth' must be a non-negative integer, got {depth!r}"
             )
         return cls(
             delegate_id=data["delegate_id"],
@@ -230,7 +230,7 @@ class DelegationManager:
         delegated_by: str = "owner",
         expires_at: datetime | None = None,
         parent_delegate_id: str | None = None,
-    ) -> Delegate:
+    ) -> DelegationRecipient:
         """Add a new delegate with specific dimension scope.
 
         Args:
@@ -241,7 +241,7 @@ class DelegationManager:
             parent_delegate_id: If sub-delegating, the parent delegate's ID
 
         Returns:
-            The created Delegate
+            The created DelegationRecipient
 
         Raises:
             ValueError: If dimensions are invalid or depth exceeded
@@ -285,7 +285,7 @@ class DelegationManager:
             content = f"delegate:{name}:{now.isoformat()}:{nonce}"
             delegate_id = f"del-{hashlib.sha256(content.encode()).hexdigest()[:12]}"
 
-            delegate = Delegate(
+            delegate = DelegationRecipient(
                 delegate_id=delegate_id,
                 name=name,
                 dimensions=dimensions,
@@ -303,15 +303,15 @@ class DelegationManager:
         )
         return delegate
 
-    def get_delegate(self, delegate_id: str) -> Delegate:
+    def get_delegate(self, delegate_id: str) -> DelegationRecipient:
         """Get a delegate by ID."""
         return self._store.get_delegate(delegate_id)
 
-    def list_delegates(self, active_only: bool = True) -> list[Delegate]:
+    def list_delegates(self, active_only: bool = True) -> list[DelegationRecipient]:
         """List all delegates."""
         return self._store.list_delegates(active_only=active_only)
 
-    def find_reviewers(self, dimension: str) -> list[Delegate]:
+    def find_reviewers(self, dimension: str) -> list[DelegationRecipient]:
         """Find active delegates who can review a given dimension."""
         return [d for d in self.list_delegates() if d.can_review(dimension)]
 
@@ -585,6 +585,10 @@ class DelegationManager:
         """Get review resolutions, optionally filtered by hold ID."""
         return self._store.list_reviews(hold_id=hold_id)
 
-    def _all_delegates(self) -> list[Delegate]:
+    def _all_delegates(self) -> list[DelegationRecipient]:
         """List all delegates including inactive ones."""
         return self.list_delegates(active_only=False)
+
+
+# Backward compatibility alias (deprecated — use DelegationRecipient)
+Delegate = DelegationRecipient

--- a/src/kailash/trust/plane/store/__init__.py
+++ b/src/kailash/trust/plane/store/__init__.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 from typing import Protocol, runtime_checkable
 
-from kailash.trust.plane.delegation import Delegate, ReviewResolution
+from kailash.trust.plane.delegation import DelegationRecipient, ReviewResolution
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.models import DecisionRecord, MilestoneRecord, ProjectManifest
 
@@ -151,7 +151,7 @@ class TrustPlaneStore(Protocol):
 
     # --- Delegate Records ---
 
-    def store_delegate(self, delegate: Delegate) -> None:
+    def store_delegate(self, delegate: DelegationRecipient) -> None:
         """Persist a delegate record.
 
         Raises:
@@ -159,7 +159,7 @@ class TrustPlaneStore(Protocol):
         """
         ...
 
-    def get_delegate(self, delegate_id: str) -> Delegate:
+    def get_delegate(self, delegate_id: str) -> DelegationRecipient:
         """Retrieve a delegate by ID.
 
         Raises:
@@ -170,7 +170,7 @@ class TrustPlaneStore(Protocol):
 
     def list_delegates(
         self, active_only: bool = True, limit: int = 1000
-    ) -> list[Delegate]:
+    ) -> list[DelegationRecipient]:
         """List delegates, optionally filtered by active status.
 
         Args:
@@ -179,7 +179,7 @@ class TrustPlaneStore(Protocol):
         """
         ...
 
-    def update_delegate(self, delegate: Delegate) -> None:
+    def update_delegate(self, delegate: DelegationRecipient) -> None:
         """Update an existing delegate record (e.g. after revocation).
 
         Raises:
@@ -275,6 +275,8 @@ from kailash.trust.plane.store.sqlite import SqliteTrustPlaneStore  # noqa: E402
 
 # Conditional import — PostgreSQL backend requires psycopg3.
 try:
-    from kailash.trust.plane.store.postgres import PostgresTrustPlaneStore  # noqa: E402, F401
+    from kailash.trust.plane.store.postgres import (
+        PostgresTrustPlaneStore,
+    )  # noqa: E402, F401
 except ImportError:
     pass  # psycopg not installed — PostgresTrustPlaneStore unavailable

--- a/src/kailash/trust/plane/store/filesystem.py
+++ b/src/kailash/trust/plane/store/filesystem.py
@@ -24,7 +24,11 @@ from typing import Any
 
 from kailash.trust._locking import atomic_write, file_lock, safe_read_json, validate_id
 from kailash.trust.plane.exceptions import RecordNotFoundError
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import (
+    DelegationRecipient,
+    DelegateStatus,
+    ReviewResolution,
+)
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.models import DecisionRecord, MilestoneRecord, ProjectManifest
 
@@ -174,36 +178,36 @@ class FileSystemTrustPlaneStore:
     # Delegate Records
     # ------------------------------------------------------------------
 
-    def store_delegate(self, delegate: Delegate) -> None:
+    def store_delegate(self, delegate: DelegationRecipient) -> None:
         validate_id(delegate.delegate_id)
         path = self._dir / "delegates" / f"{delegate.delegate_id}.json"
         atomic_write(path, delegate.to_dict())
 
-    def get_delegate(self, delegate_id: str) -> Delegate:
+    def get_delegate(self, delegate_id: str) -> DelegationRecipient:
         validate_id(delegate_id)
         path = self._dir / "delegates" / f"{delegate_id}.json"
         if not path.exists():
             raise RecordNotFoundError("delegate", delegate_id)
-        return Delegate.from_dict(safe_read_json(path))
+        return DelegationRecipient.from_dict(safe_read_json(path))
 
     def list_delegates(
         self, active_only: bool = True, limit: int = 1000
-    ) -> list[Delegate]:
+    ) -> list[DelegationRecipient]:
         limit = max(0, limit)
         delegates_dir = self._dir / "delegates"
         if not delegates_dir.exists():
             return []
-        records: list[Delegate] = []
+        records: list[DelegationRecipient] = []
         for path in sorted(delegates_dir.glob("*.json")):
             if len(records) >= limit:
                 break
-            d = Delegate.from_dict(safe_read_json(path))
+            d = DelegationRecipient.from_dict(safe_read_json(path))
             if active_only and not d.is_active():
                 continue
             records.append(d)
         return records
 
-    def update_delegate(self, delegate: Delegate) -> None:
+    def update_delegate(self, delegate: DelegationRecipient) -> None:
         # update_delegate delegates to store_delegate — same atomic write
         self.store_delegate(delegate)
 

--- a/src/kailash/trust/plane/store/postgres.py
+++ b/src/kailash/trust/plane/store/postgres.py
@@ -41,7 +41,11 @@ except ImportError:
     )
 
 from kailash.trust._locking import validate_id
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import (
+    DelegationRecipient,
+    DelegateStatus,
+    ReviewResolution,
+)
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.models import DecisionRecord, MilestoneRecord, ProjectManifest
 from kailash.trust.plane.exceptions import (
@@ -525,7 +529,7 @@ class PostgresTrustPlaneStore:
     # Delegate Records
     # ------------------------------------------------------------------
 
-    def store_delegate(self, delegate: Delegate) -> None:
+    def store_delegate(self, delegate: DelegationRecipient) -> None:
         """Persist a delegate record.
 
         Raises:
@@ -543,7 +547,7 @@ class PostgresTrustPlaneStore:
             )
             conn.commit()
 
-    def get_delegate(self, delegate_id: str) -> Delegate:
+    def get_delegate(self, delegate_id: str) -> DelegationRecipient:
         """Retrieve a delegate by ID.
 
         Raises:
@@ -558,11 +562,11 @@ class PostgresTrustPlaneStore:
             ).fetchone()
         if row is None:
             raise RecordNotFoundError("delegate", delegate_id)
-        return Delegate.from_dict(row["data"])
+        return DelegationRecipient.from_dict(row["data"])
 
     def list_delegates(
         self, active_only: bool = True, limit: int = 1000
-    ) -> list[Delegate]:
+    ) -> list[DelegationRecipient]:
         """List delegates, optionally filtered by active status.
 
         Args:
@@ -579,9 +583,9 @@ class PostgresTrustPlaneStore:
                     "ORDER BY delegate_id LIMIT %s",
                     (DelegateStatus.ACTIVE.value, limit),
                 )
-                results: list[Delegate] = []
+                results: list[DelegationRecipient] = []
                 for row in cursor.fetchall():
-                    d = Delegate.from_dict(row["data"])
+                    d = DelegationRecipient.from_dict(row["data"])
                     if d.is_active():
                         results.append(d)
                 return results
@@ -590,9 +594,9 @@ class PostgresTrustPlaneStore:
                     "SELECT data FROM delegates ORDER BY delegate_id LIMIT %s",
                     (limit,),
                 )
-                return [Delegate.from_dict(row["data"]) for row in cursor.fetchall()]
+                return [DelegationRecipient.from_dict(row["data"]) for row in cursor.fetchall()]
 
-    def update_delegate(self, delegate: Delegate) -> None:
+    def update_delegate(self, delegate: DelegationRecipient) -> None:
         """Update an existing delegate record (e.g. after revocation).
 
         Raises:

--- a/src/kailash/trust/plane/store/sqlite.py
+++ b/src/kailash/trust/plane/store/sqlite.py
@@ -32,7 +32,11 @@ from pathlib import Path
 from typing import Any
 
 from kailash.trust._locking import validate_id
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import (
+    DelegationRecipient,
+    DelegateStatus,
+    ReviewResolution,
+)
 from kailash.trust.plane.exceptions import (
     RecordNotFoundError,
     SchemaMigrationError,
@@ -488,7 +492,7 @@ class SqliteTrustPlaneStore:
     # Delegate Records
     # ------------------------------------------------------------------
 
-    def store_delegate(self, delegate: Delegate) -> None:
+    def store_delegate(self, delegate: DelegationRecipient) -> None:
         """Persist a delegate record.
 
         Raises:
@@ -504,7 +508,7 @@ class SqliteTrustPlaneStore:
         )
         conn.commit()
 
-    def get_delegate(self, delegate_id: str) -> Delegate:
+    def get_delegate(self, delegate_id: str) -> DelegationRecipient:
         """Retrieve a delegate by ID.
 
         Raises:
@@ -519,11 +523,11 @@ class SqliteTrustPlaneStore:
         ).fetchone()
         if row is None:
             raise RecordNotFoundError("delegate", delegate_id)
-        return Delegate.from_dict(json.loads(row["data"]))
+        return DelegationRecipient.from_dict(json.loads(row["data"]))
 
     def list_delegates(
         self, active_only: bool = True, limit: int = 1000
-    ) -> list[Delegate]:
+    ) -> list[DelegationRecipient]:
         """List delegates, optionally filtered by active status.
 
         Args:
@@ -540,9 +544,9 @@ class SqliteTrustPlaneStore:
                 "ORDER BY delegate_id LIMIT ?",
                 (DelegateStatus.ACTIVE.value, limit),
             )
-            results: list[Delegate] = []
+            results: list[DelegationRecipient] = []
             for row in cursor.fetchall():
-                d = Delegate.from_dict(json.loads(row["data"]))
+                d = DelegationRecipient.from_dict(json.loads(row["data"]))
                 if d.is_active():
                     results.append(d)
             return results
@@ -552,10 +556,11 @@ class SqliteTrustPlaneStore:
                 (limit,),
             )
             return [
-                Delegate.from_dict(json.loads(row["data"])) for row in cursor.fetchall()
+                DelegationRecipient.from_dict(json.loads(row["data"]))
+                for row in cursor.fetchall()
             ]
 
-    def update_delegate(self, delegate: Delegate) -> None:
+    def update_delegate(self, delegate: DelegationRecipient) -> None:
         """Update an existing delegate record (e.g. after revocation).
 
         Raises:

--- a/tests/trust/plane/e2e/store/test_postgres_store.py
+++ b/tests/trust/plane/e2e/store/test_postgres_store.py
@@ -31,7 +31,7 @@ psycopg = pytest.importorskip(
     "psycopg", reason="psycopg not installed", exc_type=ImportError
 )
 
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import DelegationRecipient, DelegateStatus, ReviewResolution
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.models import (
     DecisionRecord,
@@ -149,7 +149,7 @@ def _make_hold(**kwargs) -> HoldRecord:
     return HoldRecord(**defaults)
 
 
-def _make_delegate(**kwargs) -> Delegate:
+def _make_delegate(**kwargs) -> DelegationRecipient:
     defaults = dict(
         delegate_id="del-abc123def456",
         name="Alice",
@@ -157,7 +157,7 @@ def _make_delegate(**kwargs) -> Delegate:
         delegated_by="owner",
     )
     defaults.update(kwargs)
-    return Delegate(**defaults)
+    return DelegationRecipient(**defaults)
 
 
 def _make_review(**kwargs) -> ReviewResolution:

--- a/tests/trust/plane/integration/security/test_security_patterns.py
+++ b/tests/trust/plane/integration/security/test_security_patterns.py
@@ -587,21 +587,21 @@ class TestPattern11FromDictValidation:
     """
 
     def test_delegate_from_dict_missing_fields(self) -> None:
-        """Delegate.from_dict must raise on missing required fields."""
-        from kailash.trust.plane.delegation import Delegate
+        """DelegationRecipient.from_dict must raise on missing required fields."""
+        from kailash.trust.plane.delegation import DelegationRecipient
 
         with pytest.raises(ValueError, match="missing required field"):
-            Delegate.from_dict({})
+            DelegationRecipient.from_dict({})
 
         with pytest.raises(ValueError, match="missing required field"):
-            Delegate.from_dict({"delegate_id": "del-x"})
+            DelegationRecipient.from_dict({"delegate_id": "del-x"})
 
     def test_delegate_from_dict_invalid_depth(self) -> None:
-        """Delegate.from_dict must reject negative depth values."""
-        from kailash.trust.plane.delegation import Delegate
+        """DelegationRecipient.from_dict must reject negative depth values."""
+        from kailash.trust.plane.delegation import DelegationRecipient
 
         with pytest.raises(ValueError, match="depth"):
-            Delegate.from_dict(
+            DelegationRecipient.from_dict(
                 {
                     "delegate_id": "del-x",
                     "name": "Alice",

--- a/tests/trust/plane/integration/security/test_static_checks.py
+++ b/tests/trust/plane/integration/security/test_static_checks.py
@@ -189,13 +189,13 @@ class TestStaticFromDictValidation:
 
     def test_key_from_dict_methods_exist(self) -> None:
         """Key data classes must have from_dict() methods that validate."""
-        from kailash.trust.plane.delegation import Delegate
+        from kailash.trust.plane.delegation import DelegationRecipient
         from kailash.trust.plane.models import DecisionRecord, MilestoneRecord
         from kailash.trust.plane.rbac import RolePermission
         from kailash.trust.plane.shadow import ShadowSession, ShadowToolCall
 
         classes_with_from_dict = [
-            Delegate,
+            DelegationRecipient,
             DecisionRecord,
             MilestoneRecord,
             RolePermission,
@@ -225,13 +225,13 @@ class TestStaticFromDictValidation:
         SECURITY: An attacker sending {} should get a clear error, not
         an object with all-default values.
         """
-        from kailash.trust.plane.delegation import Delegate
+        from kailash.trust.plane.delegation import DelegationRecipient
         from kailash.trust.plane.models import DecisionRecord, MilestoneRecord
         from kailash.trust.plane.rbac import RolePermission
         from kailash.trust.plane.shadow import ShadowSession, ShadowToolCall
 
         classes_to_check = [
-            ("Delegate", Delegate),
+            ("DelegationRecipient", DelegationRecipient),
             ("DecisionRecord", DecisionRecord),
             ("MilestoneRecord", MilestoneRecord),
             ("RolePermission", RolePermission),

--- a/tests/trust/plane/integration/store/test_sqlite_trustplane_store.py
+++ b/tests/trust/plane/integration/store/test_sqlite_trustplane_store.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import DelegationRecipient, DelegateStatus, ReviewResolution
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.models import (
     DecisionRecord,
@@ -87,7 +87,7 @@ def _make_hold(**kwargs) -> HoldRecord:
     return HoldRecord(**defaults)
 
 
-def _make_delegate(**kwargs) -> Delegate:
+def _make_delegate(**kwargs) -> DelegationRecipient:
     defaults = dict(
         delegate_id="del-abc123def456",
         name="Alice",
@@ -95,7 +95,7 @@ def _make_delegate(**kwargs) -> Delegate:
         delegated_by="owner",
     )
     defaults.update(kwargs)
-    return Delegate(**defaults)
+    return DelegationRecipient(**defaults)
 
 
 def _make_review(**kwargs) -> ReviewResolution:

--- a/tests/trust/plane/integration/store/test_store_conformance.py
+++ b/tests/trust/plane/integration/store/test_store_conformance.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import pytest
 
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import DelegationRecipient, DelegateStatus, ReviewResolution
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.models import (
     DecisionRecord,
@@ -202,7 +202,7 @@ def _make_hold(**kwargs) -> HoldRecord:
     return HoldRecord(**defaults)
 
 
-def _make_delegate(**kwargs) -> Delegate:
+def _make_delegate(**kwargs) -> DelegationRecipient:
     defaults = dict(
         delegate_id="del-abc123def456",
         name="Alice",
@@ -210,7 +210,7 @@ def _make_delegate(**kwargs) -> Delegate:
         delegated_by="owner",
     )
     defaults.update(kwargs)
-    return Delegate(**defaults)
+    return DelegationRecipient(**defaults)
 
 
 def _make_review(**kwargs) -> ReviewResolution:

--- a/tests/trust/plane/integration/test_delegation.py
+++ b/tests/trust/plane/integration/test_delegation.py
@@ -14,7 +14,7 @@ import pytest
 from kailash.trust.plane.delegation import (
     DEFAULT_MAX_DELEGATION_DEPTH,
     VALID_DIMENSIONS,
-    Delegate,
+    DelegationRecipient,
     DelegateStatus,
     DelegationManager,
     ReviewResolution,
@@ -41,7 +41,7 @@ def hold_mgr(trust_dir):
 
 class TestDelegateModel:
     def test_create_delegate(self):
-        d = Delegate(
+        d = DelegationRecipient(
             delegate_id="del-abc",
             name="Alice",
             dimensions=["operational", "data_access"],
@@ -53,20 +53,20 @@ class TestDelegateModel:
         assert not d.can_review("financial")
 
     def test_roundtrip(self):
-        d = Delegate(
+        d = DelegationRecipient(
             delegate_id="del-abc",
             name="Alice",
             dimensions=["operational"],
             delegated_by="owner",
         )
         data = d.to_dict()
-        restored = Delegate.from_dict(data)
+        restored = DelegationRecipient.from_dict(data)
         assert restored.delegate_id == d.delegate_id
         assert restored.name == d.name
         assert restored.dimensions == d.dimensions
 
     def test_expired_delegate_not_active(self):
-        d = Delegate(
+        d = DelegationRecipient(
             delegate_id="del-abc",
             name="Bob",
             dimensions=["operational"],
@@ -77,7 +77,7 @@ class TestDelegateModel:
         assert not d.can_review("operational")
 
     def test_revoked_delegate_not_active(self):
-        d = Delegate(
+        d = DelegationRecipient(
             delegate_id="del-abc",
             name="Charlie",
             dimensions=["operational"],

--- a/tests/trust/plane/integration/test_migrate_sqlite.py
+++ b/tests/trust/plane/integration/test_migrate_sqlite.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import pytest
 
 from kailash.trust._locking import safe_read_json
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import DelegationRecipient, DelegateStatus, ReviewResolution
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.migrate import migrate_to_sqlite
 from kailash.trust.plane.models import (
@@ -70,7 +70,7 @@ def _make_hold(**kwargs) -> HoldRecord:
     return HoldRecord(**defaults)
 
 
-def _make_delegate(**kwargs) -> Delegate:
+def _make_delegate(**kwargs) -> DelegationRecipient:
     defaults = dict(
         delegate_id="del-abc123def456",
         name="Alice",
@@ -78,7 +78,7 @@ def _make_delegate(**kwargs) -> Delegate:
         delegated_by="owner",
     )
     defaults.update(kwargs)
-    return Delegate(**defaults)
+    return DelegationRecipient(**defaults)
 
 
 def _make_review(**kwargs) -> ReviewResolution:

--- a/tests/trust/plane/integration/test_trustplane_store.py
+++ b/tests/trust/plane/integration/test_trustplane_store.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from kailash.trust.plane.delegation import Delegate, DelegateStatus, ReviewResolution
+from kailash.trust.plane.delegation import DelegationRecipient, DelegateStatus, ReviewResolution
 from kailash.trust.plane.holds import HoldRecord
 from kailash.trust.plane.models import (
     DecisionRecord,
@@ -86,7 +86,7 @@ def _make_hold(**kwargs) -> HoldRecord:
     return HoldRecord(**defaults)
 
 
-def _make_delegate(**kwargs) -> Delegate:
+def _make_delegate(**kwargs) -> DelegationRecipient:
     defaults = dict(
         delegate_id="del-abc123def456",
         name="Alice",
@@ -94,7 +94,7 @@ def _make_delegate(**kwargs) -> Delegate:
         delegated_by="owner",
     )
     defaults.update(kwargs)
-    return Delegate(**defaults)
+    return DelegationRecipient(**defaults)
 
 
 def _make_review(**kwargs) -> ReviewResolution:

--- a/tests/trust/plane/unit/test_models.py
+++ b/tests/trust/plane/unit/test_models.py
@@ -370,10 +370,10 @@ class TestFromDictValidation:
             )
 
     def test_delegate_missing_required_field(self):
-        from kailash.trust.plane.delegation import Delegate
+        from kailash.trust.plane.delegation import DelegationRecipient
 
         with pytest.raises(ValueError, match="missing required field 'delegate_id'"):
-            Delegate.from_dict(
+            DelegationRecipient.from_dict(
                 {
                     "name": "x",
                     "dimensions": [],
@@ -383,10 +383,10 @@ class TestFromDictValidation:
             )
 
     def test_delegate_negative_depth(self):
-        from kailash.trust.plane.delegation import Delegate
+        from kailash.trust.plane.delegation import DelegationRecipient
 
         with pytest.raises(ValueError, match="'depth' must be a non-negative integer"):
-            Delegate.from_dict(
+            DelegationRecipient.from_dict(
                 {
                     "delegate_id": "del-test",
                     "name": "x",
@@ -398,10 +398,10 @@ class TestFromDictValidation:
             )
 
     def test_delegate_non_integer_depth(self):
-        from kailash.trust.plane.delegation import Delegate
+        from kailash.trust.plane.delegation import DelegationRecipient
 
         with pytest.raises(ValueError, match="'depth' must be a non-negative integer"):
-            Delegate.from_dict(
+            DelegationRecipient.from_dict(
                 {
                     "delegate_id": "del-test",
                     "name": "x",


### PR DESCRIPTION
## Summary

- Rename trust-plane `Delegate` class to `DelegationRecipient` to prevent naming conflict with kaizen-agents `Delegate` (issue #114, cross-SDK alignment #97)
- Preserve backward-compatible alias `Delegate = DelegationRecipient` in `delegation.py`
- Update all 15 affected files: source (6), tests (8), skill reference (1)

## Test plan

- [x] 1482 trust-plane tests pass, 0 failures (`python -m pytest tests/trust/plane/ -v --timeout=30`)
- [x] Backward-compat alias verified: `Delegate is DelegationRecipient` evaluates to `True`
- [x] All store implementations (filesystem, sqlite, postgres) updated and tested
- [x] Security pattern tests and static checks updated and passing

## Related issues

Addresses S3e-004 (naming alignment)
Related to #114, #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)