### PR TITLE
feat(nexus): S4 K8s probes, OpenAPI generation, security middleware

### DIFF
--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -27,7 +27,9 @@ Usage:
 
 from .core import MiddlewareInfo, Nexus, NexusPluginProtocol, RouterInfo, create_nexus
 from .engine import EnterpriseMiddlewareConfig, NexusEngine, Preset
+from .openapi import OpenApiGenerator, OpenApiInfo
 from .presets import PRESETS, NexusConfig, PresetConfig, apply_preset, get_preset
+from .probes import ProbeManager, ProbeResponse, ProbeState
 
 __version__ = "1.5.0"
 __all__ = [
@@ -48,4 +50,11 @@ __all__ = [
     "PRESETS",
     "get_preset",
     "apply_preset",
+    # Kubernetes Probes
+    "ProbeManager",
+    "ProbeState",
+    "ProbeResponse",
+    # OpenAPI
+    "OpenApiGenerator",
+    "OpenApiInfo",
 ]

--- a/packages/kailash-nexus/src/nexus/middleware/__init__.py
+++ b/packages/kailash-nexus/src/nexus/middleware/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Nexus middleware components.
+
+Provides security headers, CSRF protection, and other middleware
+for hardening Nexus deployments.
+"""
+
+from __future__ import annotations
+
+from nexus.middleware.csrf import CSRFMiddleware
+from nexus.middleware.security_headers import SecurityHeadersConfig, SecurityHeadersMiddleware
+
+__all__ = [
+    "CSRFMiddleware",
+    "SecurityHeadersConfig",
+    "SecurityHeadersMiddleware",
+]

--- a/packages/kailash-nexus/src/nexus/middleware/csrf.py
+++ b/packages/kailash-nexus/src/nexus/middleware/csrf.py
@@ -1,0 +1,183 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""CSRF (Cross-Site Request Forgery) protection middleware for Nexus.
+
+Validates Origin and Referer headers for state-changing HTTP methods
+(POST, PUT, DELETE, PATCH). Safe methods (GET, HEAD, OPTIONS) bypass
+validation entirely.
+
+This is a lightweight, stateless CSRF protection suitable for API
+servers. For cookie-based CSRF with token generation, use a
+dedicated CSRF library.
+
+Usage:
+    from nexus.middleware.csrf import CSRFMiddleware
+
+    # Allow requests from specific origins
+    app.add_middleware(
+        CSRFMiddleware,
+        allowed_origins=["https://app.example.com", "https://admin.example.com"],
+    )
+
+    # Exempt specific paths (e.g., webhooks)
+    app.add_middleware(
+        CSRFMiddleware,
+        allowed_origins=["https://app.example.com"],
+        exempt_paths=["/webhooks/stripe"],
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Set
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CSRFMiddleware",
+]
+
+# HTTP methods that may change server state
+_UNSAFE_METHODS = frozenset({"POST", "PUT", "DELETE", "PATCH"})
+
+# HTTP methods that are safe (idempotent reads)
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+
+def _extract_origin(header_value: str) -> Optional[str]:
+    """Extract the origin (scheme + host + port) from a URL or Origin header.
+
+    Args:
+        header_value: The raw header value.
+
+    Returns:
+        Normalized origin string, or None if parsing fails.
+    """
+    if not header_value:
+        return None
+
+    # Origin header is already scheme://host[:port]
+    # Referer is a full URL — extract origin from it
+    try:
+        parsed = urlparse(header_value)
+        if not parsed.scheme or not parsed.netloc:
+            return None
+        # Rebuild as origin (scheme://host[:port])
+        return f"{parsed.scheme}://{parsed.netloc}"
+    except Exception:
+        return None
+
+
+class CSRFMiddleware:
+    """ASGI middleware for CSRF protection via Origin/Referer validation.
+
+    For state-changing requests (POST, PUT, DELETE, PATCH), validates
+    that the Origin or Referer header matches one of the allowed origins.
+
+    Safe methods (GET, HEAD, OPTIONS) are always allowed.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        allowed_origins: Optional[List[str]] = None,
+        exempt_paths: Optional[List[str]] = None,
+        allow_missing_origin: bool = False,
+    ) -> None:
+        """Initialize CSRF middleware.
+
+        Args:
+            app: The ASGI application to wrap.
+            allowed_origins: List of allowed origin strings
+                (e.g., ["https://app.example.com"]). If None or empty,
+                all origins are rejected for unsafe methods.
+            exempt_paths: Paths exempt from CSRF validation
+                (e.g., ["/webhooks/stripe"]).
+            allow_missing_origin: If True, requests without Origin AND
+                Referer headers are allowed (useful for non-browser clients).
+                Defaults to False for maximum security.
+        """
+        self.app = app
+        self._allowed_origins: Set[str] = set()
+        for origin in (allowed_origins or []):
+            normalized = origin.rstrip("/").lower()
+            self._allowed_origins.add(normalized)
+
+        self._exempt_paths: Set[str] = set(exempt_paths or [])
+        self._allow_missing_origin = allow_missing_origin
+
+    def _is_origin_allowed(self, origin: Optional[str]) -> bool:
+        """Check if the given origin is in the allowed set.
+
+        Args:
+            origin: Normalized origin string.
+
+        Returns:
+            True if origin is allowed.
+        """
+        if not origin:
+            return self._allow_missing_origin
+        return origin.lower() in self._allowed_origins
+
+    async def __call__(self, scope: Dict[str, Any], receive: Any, send: Any) -> None:
+        """ASGI interface."""
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "GET").upper()
+
+        # Safe methods bypass CSRF
+        if method in _SAFE_METHODS:
+            await self.app(scope, receive, send)
+            return
+
+        # Exempt paths bypass CSRF
+        path = scope.get("path", "")
+        if path in self._exempt_paths:
+            await self.app(scope, receive, send)
+            return
+
+        # For unsafe methods, validate Origin/Referer
+        headers = dict(scope.get("headers", []))
+        origin_header = headers.get(b"origin", b"").decode("latin-1", errors="replace")
+        referer_header = headers.get(b"referer", b"").decode(
+            "latin-1", errors="replace"
+        )
+
+        # Try Origin first, then Referer
+        origin = _extract_origin(origin_header) if origin_header else None
+        if origin is None and referer_header:
+            origin = _extract_origin(referer_header)
+
+        if self._is_origin_allowed(origin):
+            await self.app(scope, receive, send)
+            return
+
+        # CSRF validation failed — return 403
+        logger.warning(
+            "CSRF validation failed: method=%s path=%s origin=%s",
+            method,
+            path,
+            origin or "(missing)",
+        )
+
+        response_body = b'{"error": "CSRF validation failed"}'
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 403,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(response_body)).encode()),
+                ],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": response_body,
+            }
+        )

--- a/packages/kailash-nexus/src/nexus/middleware/security_headers.py
+++ b/packages/kailash-nexus/src/nexus/middleware/security_headers.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Security headers middleware for Nexus platform.
+
+Adds standard security headers to all HTTP responses:
+- Content-Security-Policy (CSP)
+- Strict-Transport-Security (HSTS)
+- X-Content-Type-Options
+- X-Frame-Options
+- X-XSS-Protection
+- Referrer-Policy
+- Permissions-Policy
+
+Usage:
+    from nexus.middleware.security_headers import SecurityHeadersMiddleware
+
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    # Custom configuration
+    from nexus.middleware.security_headers import SecurityHeadersConfig
+    config = SecurityHeadersConfig(frame_options="SAMEORIGIN")
+    app.add_middleware(SecurityHeadersMiddleware, config=config)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SecurityHeadersConfig",
+    "SecurityHeadersMiddleware",
+]
+
+
+@dataclass(frozen=True)
+class SecurityHeadersConfig:
+    """Configuration for security response headers.
+
+    All fields have secure defaults. Override only when you have a
+    specific reason to relax a policy.
+    """
+
+    # Content-Security-Policy
+    csp: str = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; frame-ancestors 'none'"
+
+    # Strict-Transport-Security (max-age in seconds, default 1 year)
+    hsts_max_age: int = 31536000
+    hsts_include_subdomains: bool = True
+    hsts_preload: bool = False
+
+    # X-Content-Type-Options
+    content_type_options: str = "nosniff"
+
+    # X-Frame-Options (DENY or SAMEORIGIN)
+    frame_options: str = "DENY"
+
+    # X-XSS-Protection (legacy, but harmless)
+    xss_protection: str = "1; mode=block"
+
+    # Referrer-Policy
+    referrer_policy: str = "strict-origin-when-cross-origin"
+
+    # Permissions-Policy (formerly Feature-Policy)
+    permissions_policy: str = "camera=(), microphone=(), geolocation=(), payment=()"
+
+    # Paths to exclude from security headers (e.g., /healthz)
+    exclude_paths: Tuple[str, ...] = ()
+
+    def to_header_pairs(self) -> List[Tuple[str, str]]:
+        """Generate header name-value pairs from this configuration.
+
+        Returns:
+            List of (header_name, header_value) tuples.
+        """
+        headers: List[Tuple[str, str]] = []
+
+        # CSP
+        if self.csp:
+            headers.append(("content-security-policy", self.csp))
+
+        # HSTS
+        hsts_parts = [f"max-age={self.hsts_max_age}"]
+        if self.hsts_include_subdomains:
+            hsts_parts.append("includeSubDomains")
+        if self.hsts_preload:
+            hsts_parts.append("preload")
+        headers.append(("strict-transport-security", "; ".join(hsts_parts)))
+
+        # X-Content-Type-Options
+        if self.content_type_options:
+            headers.append(("x-content-type-options", self.content_type_options))
+
+        # X-Frame-Options
+        if self.frame_options:
+            headers.append(("x-frame-options", self.frame_options))
+
+        # X-XSS-Protection
+        if self.xss_protection:
+            headers.append(("x-xss-protection", self.xss_protection))
+
+        # Referrer-Policy
+        if self.referrer_policy:
+            headers.append(("referrer-policy", self.referrer_policy))
+
+        # Permissions-Policy
+        if self.permissions_policy:
+            headers.append(("permissions-policy", self.permissions_policy))
+
+        return headers
+
+
+class SecurityHeadersMiddleware:
+    """ASGI middleware that injects security headers into all responses.
+
+    Compatible with Starlette's add_middleware() pattern.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        config: Optional[SecurityHeadersConfig] = None,
+    ) -> None:
+        """Initialize the middleware.
+
+        Args:
+            app: The ASGI application to wrap.
+            config: Security headers configuration. Uses secure defaults if None.
+        """
+        self.app = app
+        self.config = config or SecurityHeadersConfig()
+        self._header_pairs = self.config.to_header_pairs()
+        self._exclude_paths = set(self.config.exclude_paths)
+
+    async def __call__(self, scope: Dict[str, Any], receive: Any, send: Any) -> None:
+        """ASGI interface."""
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Check path exclusions
+        path = scope.get("path", "")
+        if path in self._exclude_paths:
+            await self.app(scope, receive, send)
+            return
+
+        # Wrap the send callable to inject headers
+        header_pairs = self._header_pairs
+
+        async def send_with_headers(message: Dict[str, Any]) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                for name, value in header_pairs:
+                    headers.append((name.encode(), value.encode()))
+                message["headers"] = headers
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)

--- a/packages/kailash-nexus/src/nexus/openapi.py
+++ b/packages/kailash-nexus/src/nexus/openapi.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAPI 3.0.3 specification generator for Nexus platform.
+
+Auto-generates an OpenAPI specification from registered Nexus workflows
+and handlers, including input/output schemas derived from workflow
+parameters and handler function signatures.
+
+Usage:
+    from nexus.openapi import OpenApiGenerator
+
+    generator = OpenApiGenerator(title="My API", version="1.0.0")
+    generator.add_workflow("greet", workflow, description="Greet a user")
+    spec = generator.generate()
+
+    # Mount /openapi.json endpoint
+    generator.install(app)
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, get_type_hints
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "OpenApiGenerator",
+    "OpenApiInfo",
+]
+
+# Python type -> OpenAPI type mapping
+_TYPE_MAP: Dict[type, Dict[str, str]] = {
+    str: {"type": "string"},
+    int: {"type": "integer"},
+    float: {"type": "number"},
+    bool: {"type": "boolean"},
+    list: {"type": "array", "items": {"type": "string"}},
+    dict: {"type": "object"},
+    bytes: {"type": "string", "format": "binary"},
+}
+
+
+def _python_type_to_openapi(py_type: Any) -> Dict[str, Any]:
+    """Convert a Python type annotation to an OpenAPI schema fragment.
+
+    Args:
+        py_type: Python type annotation.
+
+    Returns:
+        OpenAPI schema dict.
+    """
+    if py_type is None or py_type is inspect.Parameter.empty:
+        return {"type": "string"}
+
+    # Handle Optional (Union[X, None])
+    origin = getattr(py_type, "__origin__", None)
+    if origin is not None:
+        args = getattr(py_type, "__args__", ())
+        # Union types (Optional)
+        import typing
+
+        if origin is typing.Union:
+            non_none = [a for a in args if a is not type(None)]
+            if non_none:
+                return _python_type_to_openapi(non_none[0])
+            return {"type": "string"}
+        # List[X]
+        if origin is list:
+            item_type = args[0] if args else str
+            return {"type": "array", "items": _python_type_to_openapi(item_type)}
+        # Dict[K, V]
+        if origin is dict:
+            return {"type": "object"}
+
+    # Direct type lookup
+    if py_type in _TYPE_MAP:
+        return dict(_TYPE_MAP[py_type])
+
+    # Fallback
+    return {"type": "string"}
+
+
+def _derive_schema_from_handler(
+    handler_func: Callable,
+) -> Dict[str, Any]:
+    """Derive an OpenAPI request schema from a handler function's signature.
+
+    Args:
+        handler_func: The handler function.
+
+    Returns:
+        OpenAPI schema dict for the request body.
+    """
+    sig = inspect.signature(handler_func)
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+
+    try:
+        hints = get_type_hints(handler_func)
+    except Exception:
+        hints = {}
+
+    for name, param in sig.parameters.items():
+        if name in ("self", "cls"):
+            continue
+
+        py_type = hints.get(name, param.annotation)
+        schema = _python_type_to_openapi(py_type)
+
+        if param.default is not inspect.Parameter.empty:
+            schema["default"] = param.default
+        else:
+            required.append(name)
+
+        properties[name] = schema
+
+    result: Dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+    }
+    if required:
+        result["required"] = required
+
+    return result
+
+
+def _derive_schema_from_workflow(workflow: Any) -> Dict[str, Any]:
+    """Derive an OpenAPI request schema from a workflow's parameters.
+
+    Args:
+        workflow: Kailash Workflow instance.
+
+    Returns:
+        OpenAPI schema dict for the request body.
+    """
+    properties: Dict[str, Any] = {}
+
+    # Try to extract parameters from workflow metadata
+    if hasattr(workflow, "metadata") and workflow.metadata:
+        meta = workflow.metadata
+        if hasattr(meta, "parameters") and meta.parameters:
+            for param_name, param_info in meta.parameters.items():
+                if isinstance(param_info, dict):
+                    param_type = param_info.get("type", "string")
+                    properties[param_name] = {"type": param_type}
+                else:
+                    properties[param_name] = {"type": "string"}
+
+    # Try to extract from workflow nodes' input parameters
+    if not properties and hasattr(workflow, "nodes"):
+        for node_id, node in workflow.nodes.items():
+            if hasattr(node, "parameters"):
+                for param in node.parameters:
+                    p_name = getattr(param, "name", None)
+                    if p_name and p_name not in properties:
+                        properties[p_name] = {"type": "string"}
+
+    if not properties:
+        # Fallback: accept any JSON object
+        return {"type": "object", "additionalProperties": True}
+
+    return {"type": "object", "properties": properties}
+
+
+@dataclass
+class OpenApiInfo:
+    """OpenAPI info object configuration."""
+
+    title: str = "Kailash Nexus API"
+    version: str = "1.0.0"
+    description: str = "Auto-generated API specification for Nexus workflows"
+    terms_of_service: Optional[str] = None
+    contact_name: Optional[str] = None
+    contact_email: Optional[str] = None
+    license_name: str = "Apache-2.0"
+    license_url: str = "https://www.apache.org/licenses/LICENSE-2.0"
+
+
+class OpenApiGenerator:
+    """Generates OpenAPI 3.0.3 specifications from Nexus workflows and handlers.
+
+    Thread-safe: the generate() method produces an immutable spec dict from
+    the current state. Registration methods are not thread-safe; call them
+    during startup only.
+    """
+
+    def __init__(
+        self,
+        info: Optional[OpenApiInfo] = None,
+        title: Optional[str] = None,
+        version: Optional[str] = None,
+        servers: Optional[List[Dict[str, str]]] = None,
+    ) -> None:
+        if info is not None:
+            self._info = info
+        else:
+            self._info = OpenApiInfo(
+                title=title or "Kailash Nexus API",
+                version=version or "1.0.0",
+            )
+        self._servers = servers or []
+        self._paths: Dict[str, Dict[str, Any]] = {}
+        self._schemas: Dict[str, Dict[str, Any]] = {}
+
+    def add_workflow(
+        self,
+        name: str,
+        workflow: Any,
+        description: str = "",
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        """Register a workflow for OpenAPI spec generation.
+
+        Args:
+            name: Workflow name.
+            workflow: Kailash Workflow instance.
+            description: Human-readable description.
+            tags: OpenAPI tags for grouping.
+        """
+        schema = _derive_schema_from_workflow(workflow)
+        schema_name = f"{name}_input"
+        self._schemas[schema_name] = schema
+
+        path = f"/workflows/{name}/execute"
+        self._paths[path] = {
+            "post": {
+                "summary": f"Execute {name} workflow",
+                "description": description or f"Execute the {name} workflow",
+                "operationId": f"execute_{name}",
+                "tags": tags or ["workflows"],
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": f"#/components/schemas/{schema_name}"},
+                        },
+                    },
+                },
+                "responses": {
+                    "200": {
+                        "description": "Workflow execution result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "results": {"type": "object"},
+                                        "run_id": {"type": "string"},
+                                        "status": {"type": "string"},
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    "400": {"description": "Invalid input"},
+                    "404": {"description": "Workflow not found"},
+                    "500": {"description": "Execution error"},
+                },
+            },
+        }
+
+        # Also add info endpoint
+        info_path = f"/workflows/{name}/workflow/info"
+        self._paths[info_path] = {
+            "get": {
+                "summary": f"Get {name} workflow info",
+                "description": f"Retrieve metadata for the {name} workflow",
+                "operationId": f"info_{name}",
+                "tags": tags or ["workflows"],
+                "responses": {
+                    "200": {
+                        "description": "Workflow metadata",
+                        "content": {
+                            "application/json": {
+                                "schema": {"type": "object"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+    def add_handler(
+        self,
+        name: str,
+        handler_func: Callable,
+        description: str = "",
+        tags: Optional[List[str]] = None,
+    ) -> None:
+        """Register a handler function for OpenAPI spec generation.
+
+        Args:
+            name: Handler name.
+            handler_func: The handler function (schema derived from signature).
+            description: Human-readable description.
+            tags: OpenAPI tags for grouping.
+        """
+        schema = _derive_schema_from_handler(handler_func)
+        schema_name = f"{name}_input"
+        self._schemas[schema_name] = schema
+
+        path = f"/workflows/{name}/execute"
+        doc = description or getattr(handler_func, "__doc__", "") or ""
+        self._paths[path] = {
+            "post": {
+                "summary": f"Execute {name}",
+                "description": doc.strip(),
+                "operationId": f"execute_{name}",
+                "tags": tags or ["handlers"],
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": f"#/components/schemas/{schema_name}"},
+                        },
+                    },
+                },
+                "responses": {
+                    "200": {
+                        "description": "Handler result",
+                        "content": {
+                            "application/json": {
+                                "schema": {"type": "object"},
+                            },
+                        },
+                    },
+                    "400": {"description": "Invalid input"},
+                    "500": {"description": "Execution error"},
+                },
+            },
+        }
+
+    def generate(self) -> Dict[str, Any]:
+        """Generate the complete OpenAPI 3.0.3 specification.
+
+        Returns:
+            OpenAPI spec as a dictionary.
+        """
+        info: Dict[str, Any] = {
+            "title": self._info.title,
+            "version": self._info.version,
+            "description": self._info.description,
+            "license": {
+                "name": self._info.license_name,
+                "url": self._info.license_url,
+            },
+        }
+        if self._info.terms_of_service:
+            info["termsOfService"] = self._info.terms_of_service
+        if self._info.contact_name or self._info.contact_email:
+            contact: Dict[str, str] = {}
+            if self._info.contact_name:
+                contact["name"] = self._info.contact_name
+            if self._info.contact_email:
+                contact["email"] = self._info.contact_email
+            info["contact"] = contact
+
+        spec: Dict[str, Any] = {
+            "openapi": "3.0.3",
+            "info": info,
+            "paths": dict(self._paths),
+            "components": {
+                "schemas": dict(self._schemas),
+            },
+        }
+
+        if self._servers:
+            spec["servers"] = list(self._servers)
+
+        return spec
+
+    def generate_json(self, indent: int = 2) -> str:
+        """Generate the OpenAPI spec as a JSON string.
+
+        Args:
+            indent: JSON indentation level.
+
+        Returns:
+            JSON string.
+        """
+        return json.dumps(self.generate(), indent=indent)
+
+    def install(self, app: Any) -> None:
+        """Install /openapi.json endpoint on a FastAPI or Starlette application.
+
+        Args:
+            app: FastAPI or Starlette application instance.
+        """
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+
+        generator = self
+
+        async def openapi_json(request: Request) -> JSONResponse:
+            spec = generator.generate()
+            return JSONResponse(spec)
+
+        route = Route("/openapi.json", openapi_json, methods=["GET"])
+
+        if hasattr(app, "routes"):
+            app.routes.append(route)
+        else:
+            logger.warning(
+                "Unable to install /openapi.json route: app has no 'routes' attribute"
+            )
+
+        logger.info("OpenAPI endpoint installed: /openapi.json")

--- a/packages/kailash-nexus/src/nexus/presets.py
+++ b/packages/kailash-nexus/src/nexus/presets.py
@@ -137,6 +137,43 @@ def _cors_middleware_factory(config: NexusConfig) -> tuple:
     )
 
 
+def _security_headers_middleware_factory(config: NexusConfig) -> Optional[tuple]:
+    """Create security headers middleware configuration."""
+    from nexus.middleware.security_headers import (
+        SecurityHeadersConfig,
+        SecurityHeadersMiddleware,
+    )
+
+    sec_config = SecurityHeadersConfig(
+        exclude_paths=("/healthz", "/readyz", "/startup"),
+    )
+    return (SecurityHeadersMiddleware, {"config": sec_config})
+
+
+def _csrf_middleware_factory(config: NexusConfig) -> Optional[tuple]:
+    """Create CSRF middleware configuration.
+
+    Uses the CORS origins as allowed origins for CSRF validation.
+    Non-browser API clients that omit Origin/Referer are allowed
+    when cors_origins includes the wildcard "*".
+    """
+    from nexus.middleware.csrf import CSRFMiddleware
+
+    # If wildcard origins, allow missing Origin (non-browser clients)
+    allow_missing = "*" in config.cors_origins
+    # Use non-wildcard origins for CSRF validation
+    allowed = [o for o in config.cors_origins if o != "*"]
+
+    return (
+        CSRFMiddleware,
+        {
+            "allowed_origins": allowed,
+            "allow_missing_origin": allow_missing,
+            "exempt_paths": ["/healthz", "/readyz", "/startup", "/openapi.json"],
+        },
+    )
+
+
 # NOTE: Placeholder factories for WS02 auth package.
 # These will be replaced with real implementations when auth package is complete.
 
@@ -246,17 +283,20 @@ PRESETS: Dict[str, PresetConfig] = {
     ),
     "lightweight": PresetConfig(
         name="lightweight",
-        description="CORS only - for development and internal tools",
+        description="CORS + Security Headers - for development and internal tools",
         middleware_factories=[
             _cors_middleware_factory,
+            _security_headers_middleware_factory,
         ],
         plugin_factories=[],
     ),
     "standard": PresetConfig(
         name="standard",
-        description="CORS + Rate Limiting + Error Handling - for public APIs without auth",
+        description="CORS + Security Headers + CSRF + Rate Limiting - for public APIs without auth",
         middleware_factories=[
             _cors_middleware_factory,
+            _security_headers_middleware_factory,
+            _csrf_middleware_factory,
             _rate_limit_middleware_factory,
             _error_handler_middleware_factory,
         ],
@@ -264,9 +304,11 @@ PRESETS: Dict[str, PresetConfig] = {
     ),
     "saas": PresetConfig(
         name="saas",
-        description="Full SaaS stack - CORS, JWT, RBAC, Rate Limiting, Tenant Isolation, Audit",
+        description="Full SaaS stack - CORS, Security Headers, CSRF, JWT, RBAC, Rate Limiting, Tenant Isolation, Audit",
         middleware_factories=[
             _cors_middleware_factory,
+            _security_headers_middleware_factory,
+            _csrf_middleware_factory,
             _rate_limit_middleware_factory,
             _error_handler_middleware_factory,
         ],
@@ -282,6 +324,8 @@ PRESETS: Dict[str, PresetConfig] = {
         description="Enterprise stack - Everything in SaaS + SSO + ABAC + Feature Gates",
         middleware_factories=[
             _cors_middleware_factory,
+            _security_headers_middleware_factory,
+            _csrf_middleware_factory,
             _rate_limit_middleware_factory,
             _error_handler_middleware_factory,
         ],

--- a/packages/kailash-nexus/src/nexus/probes.py
+++ b/packages/kailash-nexus/src/nexus/probes.py
@@ -1,0 +1,389 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Kubernetes probe endpoints for Nexus platform.
+
+Provides liveness, readiness, and startup probe endpoints following
+Kubernetes health check conventions. Thread-safe state management
+with atomic transitions.
+
+Usage:
+    from nexus.probes import ProbeManager, ProbeState
+
+    probes = ProbeManager()
+    probes.mark_ready()
+
+    # Mount on FastAPI/Starlette
+    probes.install(app)
+
+Endpoints:
+    /healthz  - Liveness probe: 200 if process is alive
+    /readyz   - Readiness probe: 200 when all workflows are ready
+    /startup  - Startup probe: 200 after initialization complete
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ProbeState",
+    "ProbeManager",
+    "ProbeResponse",
+]
+
+
+class ProbeState(Enum):
+    """Lifecycle state for Kubernetes probe management.
+
+    State transitions are monotonic during normal operation:
+        STARTING -> READY -> DRAINING
+
+    FAILED can be reached from any state and is terminal
+    (only manual intervention via reset() can recover).
+
+    Allowed transitions:
+        STARTING -> READY
+        STARTING -> FAILED
+        READY    -> DRAINING
+        READY    -> FAILED
+        DRAINING -> FAILED
+    """
+
+    STARTING = "starting"
+    READY = "ready"
+    DRAINING = "draining"
+    FAILED = "failed"
+
+
+# Valid state transitions (from -> set of allowed targets)
+_VALID_TRANSITIONS: Dict[ProbeState, frozenset] = {
+    ProbeState.STARTING: frozenset({ProbeState.READY, ProbeState.FAILED}),
+    ProbeState.READY: frozenset({ProbeState.DRAINING, ProbeState.FAILED}),
+    ProbeState.DRAINING: frozenset({ProbeState.FAILED}),
+    ProbeState.FAILED: frozenset(),  # Terminal — use reset() to recover
+}
+
+
+@dataclass
+class ProbeResponse:
+    """Structured response from a probe check."""
+
+    status: str
+    http_status: int
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary for JSON response."""
+        result: Dict[str, Any] = {
+            "status": self.status,
+        }
+        if self.details:
+            result["details"] = self.details
+        return result
+
+
+class ProbeManager:
+    """Thread-safe Kubernetes probe manager.
+
+    Manages liveness, readiness, and startup state for a Nexus instance.
+    All state transitions are atomic and validated.
+
+    Attributes:
+        state: Current ProbeState (read via property).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state = ProbeState.STARTING
+        self._started_at = time.monotonic()
+        self._ready_at: Optional[float] = None
+        self._failed_reason: Optional[str] = None
+        self._workflow_count = 0
+        self._check_callbacks: List[Any] = []
+
+    # -- State properties (read-only outside lock) ---
+
+    @property
+    def state(self) -> ProbeState:
+        """Current probe state (thread-safe read)."""
+        with self._lock:
+            return self._state
+
+    @property
+    def is_alive(self) -> bool:
+        """True if process is alive (not FAILED)."""
+        with self._lock:
+            return self._state != ProbeState.FAILED
+
+    @property
+    def is_ready(self) -> bool:
+        """True if fully ready to serve traffic."""
+        with self._lock:
+            return self._state == ProbeState.READY
+
+    @property
+    def is_started(self) -> bool:
+        """True if startup is complete (READY or DRAINING)."""
+        with self._lock:
+            return self._state in (ProbeState.READY, ProbeState.DRAINING)
+
+    # -- State transitions ---
+
+    def _transition(self, target: ProbeState, reason: Optional[str] = None) -> bool:
+        """Atomically transition to a new state.
+
+        Args:
+            target: Target state.
+            reason: Optional reason (used for FAILED state).
+
+        Returns:
+            True if transition succeeded, False if invalid.
+        """
+        with self._lock:
+            allowed = _VALID_TRANSITIONS.get(self._state, frozenset())
+            if target not in allowed:
+                logger.warning(
+                    "Invalid probe state transition: %s -> %s (allowed: %s)",
+                    self._state.value,
+                    target.value,
+                    ", ".join(s.value for s in allowed) if allowed else "none",
+                )
+                return False
+
+            old = self._state
+            self._state = target
+
+            if target == ProbeState.READY:
+                self._ready_at = time.monotonic()
+            elif target == ProbeState.FAILED:
+                self._failed_reason = reason
+
+            logger.info(
+                "Probe state transition: %s -> %s%s",
+                old.value,
+                target.value,
+                f" (reason: {reason})" if reason else "",
+            )
+            return True
+
+    def mark_ready(self) -> bool:
+        """Mark the instance as ready to serve traffic.
+
+        Returns:
+            True if transition succeeded.
+        """
+        return self._transition(ProbeState.READY)
+
+    def mark_draining(self) -> bool:
+        """Mark the instance as draining (graceful shutdown).
+
+        Returns:
+            True if transition succeeded.
+        """
+        return self._transition(ProbeState.DRAINING)
+
+    def mark_failed(self, reason: str = "unknown") -> bool:
+        """Mark the instance as failed.
+
+        Args:
+            reason: Human-readable failure reason.
+
+        Returns:
+            True if transition succeeded.
+        """
+        return self._transition(ProbeState.FAILED, reason=reason)
+
+    def reset(self) -> None:
+        """Reset to STARTING state (for recovery/testing).
+
+        This is the only way to recover from FAILED state.
+        """
+        with self._lock:
+            old = self._state
+            self._state = ProbeState.STARTING
+            self._ready_at = None
+            self._failed_reason = None
+            self._started_at = time.monotonic()
+            logger.info("Probe state reset: %s -> STARTING", old.value)
+
+    # -- Workflow tracking ---
+
+    def set_workflow_count(self, count: int) -> None:
+        """Update the registered workflow count.
+
+        Args:
+            count: Number of registered workflows.
+        """
+        with self._lock:
+            self._workflow_count = count
+
+    # -- Readiness check callbacks ---
+
+    def add_readiness_check(self, callback: Any) -> None:
+        """Register an additional readiness check callback.
+
+        The callback should return True if the component is ready,
+        False otherwise. Callbacks are invoked during readiness checks.
+
+        Args:
+            callback: Callable returning bool.
+        """
+        with self._lock:
+            self._check_callbacks.append(callback)
+
+    # -- Probe checks ---
+
+    def check_liveness(self) -> ProbeResponse:
+        """Check liveness (is the process alive?).
+
+        Returns 200 for all states except FAILED.
+        """
+        with self._lock:
+            alive = self._state != ProbeState.FAILED
+            uptime = time.monotonic() - self._started_at
+
+        if alive:
+            return ProbeResponse(
+                status="ok",
+                http_status=200,
+                details={"uptime_seconds": round(uptime, 2)},
+            )
+
+        return ProbeResponse(
+            status="failed",
+            http_status=503,
+            details={
+                "reason": self._failed_reason or "unknown",
+                "uptime_seconds": round(uptime, 2),
+            },
+        )
+
+    def check_readiness(self) -> ProbeResponse:
+        """Check readiness (can the instance serve traffic?).
+
+        Returns 200 only in READY state and all readiness callbacks pass.
+        """
+        with self._lock:
+            ready = self._state == ProbeState.READY
+            state_value = self._state.value
+            wf_count = self._workflow_count
+            callbacks = list(self._check_callbacks)
+
+        if not ready:
+            return ProbeResponse(
+                status="not_ready",
+                http_status=503,
+                details={"state": state_value, "workflows": wf_count},
+            )
+
+        # Run readiness callbacks
+        failed_checks: List[str] = []
+        for cb in callbacks:
+            try:
+                if not cb():
+                    name = getattr(cb, "__name__", str(cb))
+                    failed_checks.append(name)
+            except Exception as exc:
+                name = getattr(cb, "__name__", str(cb))
+                failed_checks.append(f"{name}: {exc}")
+
+        if failed_checks:
+            return ProbeResponse(
+                status="not_ready",
+                http_status=503,
+                details={
+                    "state": state_value,
+                    "workflows": wf_count,
+                    "failed_checks": failed_checks,
+                },
+            )
+
+        return ProbeResponse(
+            status="ready",
+            http_status=200,
+            details={"state": state_value, "workflows": wf_count},
+        )
+
+    def check_startup(self) -> ProbeResponse:
+        """Check startup (has initialization completed?).
+
+        Returns 200 once the instance has moved past STARTING state.
+        """
+        with self._lock:
+            started = self._state in (ProbeState.READY, ProbeState.DRAINING)
+            state_value = self._state.value
+            uptime = time.monotonic() - self._started_at
+
+        if started:
+            return ProbeResponse(
+                status="started",
+                http_status=200,
+                details={
+                    "state": state_value,
+                    "startup_duration_seconds": (
+                        round(self._ready_at - self._started_at, 3)
+                        if self._ready_at
+                        else None
+                    ),
+                },
+            )
+
+        return ProbeResponse(
+            status="starting",
+            http_status=503,
+            details={
+                "state": state_value,
+                "elapsed_seconds": round(uptime, 2),
+            },
+        )
+
+    # -- FastAPI/Starlette integration ---
+
+    def install(self, app: Any) -> None:
+        """Install probe endpoints on a FastAPI or Starlette application.
+
+        Adds /healthz, /readyz, and /startup routes.
+
+        Args:
+            app: FastAPI or Starlette application instance.
+        """
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+
+        probe_mgr = self
+
+        async def healthz(request: Request) -> JSONResponse:
+            resp = probe_mgr.check_liveness()
+            return JSONResponse(resp.to_dict(), status_code=resp.http_status)
+
+        async def readyz(request: Request) -> JSONResponse:
+            resp = probe_mgr.check_readiness()
+            return JSONResponse(resp.to_dict(), status_code=resp.http_status)
+
+        async def startup(request: Request) -> JSONResponse:
+            resp = probe_mgr.check_startup()
+            return JSONResponse(resp.to_dict(), status_code=resp.http_status)
+
+        routes = [
+            Route("/healthz", healthz, methods=["GET"]),
+            Route("/readyz", readyz, methods=["GET"]),
+            Route("/startup", startup, methods=["GET"]),
+        ]
+
+        # Support both FastAPI (include_router) and raw Starlette (routes.extend)
+        if hasattr(app, "routes"):
+            app.routes.extend(routes)
+        else:
+            logger.warning(
+                "Unable to install probe routes: app has no 'routes' attribute"
+            )
+
+        logger.info("Kubernetes probe endpoints installed: /healthz, /readyz, /startup")

--- a/packages/kailash-nexus/tests/unit/test_csrf.py
+++ b/packages/kailash-nexus/tests/unit/test_csrf.py
@@ -1,0 +1,322 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for CSRF middleware (S4-004).
+
+Covers:
+- Safe method bypass (GET, HEAD, OPTIONS)
+- Unsafe method validation (POST, PUT, DELETE, PATCH)
+- Origin header matching
+- Referer header fallback
+- Missing origin handling
+- Exempt paths
+- Case-insensitive origin matching
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nexus.middleware.csrf import CSRFMiddleware, _extract_origin
+
+
+class TestOriginExtraction:
+    """Test _extract_origin helper."""
+
+    def test_simple_origin(self):
+        assert _extract_origin("https://example.com") == "https://example.com"
+
+    def test_origin_with_port(self):
+        assert (
+            _extract_origin("https://example.com:8080") == "https://example.com:8080"
+        )
+
+    def test_full_url_extracts_origin(self):
+        assert (
+            _extract_origin("https://example.com/path?query=1")
+            == "https://example.com"
+        )
+
+    def test_empty_string(self):
+        assert _extract_origin("") is None
+
+    def test_invalid_url(self):
+        assert _extract_origin("not-a-url") is None
+
+    def test_no_scheme(self):
+        assert _extract_origin("example.com") is None
+
+
+class TestCSRFSafeMethods:
+    """Test that safe methods bypass CSRF validation."""
+
+    @pytest.fixture
+    def app_response(self):
+        """Run a request through CSRF middleware and return status code."""
+
+        async def run(method, path="/api/test", origin=None, referer=None):
+            status_code = None
+            body = None
+
+            async def dummy_app(scope, receive, send):
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 200,
+                        "headers": [],
+                    }
+                )
+                await send({"type": "http.response.body", "body": b"ok"})
+
+            mw = CSRFMiddleware(
+                dummy_app,
+                allowed_origins=["https://app.example.com"],
+            )
+
+            headers = []
+            if origin:
+                headers.append((b"origin", origin.encode()))
+            if referer:
+                headers.append((b"referer", referer.encode()))
+
+            scope = {
+                "type": "http",
+                "method": method,
+                "path": path,
+                "headers": headers,
+            }
+
+            sent = []
+
+            async def mock_send(msg):
+                sent.append(msg)
+
+            async def mock_receive():
+                return {"type": "http.request", "body": b""}
+
+            await mw(scope, mock_receive, mock_send)
+
+            for msg in sent:
+                if msg["type"] == "http.response.start":
+                    status_code = msg["status"]
+                if msg["type"] == "http.response.body":
+                    body = msg.get("body", b"")
+
+            return status_code, body
+
+        return run
+
+    @pytest.mark.asyncio
+    async def test_get_bypasses_csrf(self, app_response):
+        status, _ = await app_response("GET")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_head_bypasses_csrf(self, app_response):
+        status, _ = await app_response("HEAD")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_options_bypasses_csrf(self, app_response):
+        status, _ = await app_response("OPTIONS")
+        assert status == 200
+
+
+class TestCSRFUnsafeMethods:
+    """Test that unsafe methods require valid origin."""
+
+    @pytest.fixture
+    def csrf_check(self):
+        """Run an unsafe request and return status code."""
+
+        async def run(
+            method="POST",
+            origin=None,
+            referer=None,
+            allowed_origins=None,
+            allow_missing_origin=False,
+            path="/api/test",
+            exempt_paths=None,
+        ):
+            status_code = None
+
+            async def dummy_app(scope, receive, send):
+                await send(
+                    {"type": "http.response.start", "status": 200, "headers": []}
+                )
+                await send({"type": "http.response.body", "body": b"ok"})
+
+            mw = CSRFMiddleware(
+                dummy_app,
+                allowed_origins=allowed_origins or ["https://app.example.com"],
+                allow_missing_origin=allow_missing_origin,
+                exempt_paths=exempt_paths,
+            )
+
+            headers = []
+            if origin:
+                headers.append((b"origin", origin.encode()))
+            if referer:
+                headers.append((b"referer", referer.encode()))
+
+            scope = {
+                "type": "http",
+                "method": method,
+                "path": path,
+                "headers": headers,
+            }
+
+            sent = []
+
+            async def mock_send(msg):
+                sent.append(msg)
+
+            async def mock_receive():
+                return {"type": "http.request", "body": b""}
+
+            await mw(scope, mock_receive, mock_send)
+
+            for msg in sent:
+                if msg["type"] == "http.response.start":
+                    status_code = msg["status"]
+
+            return status_code
+
+        return run
+
+    @pytest.mark.asyncio
+    async def test_post_with_valid_origin(self, csrf_check):
+        status = await csrf_check(method="POST", origin="https://app.example.com")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_post_with_invalid_origin(self, csrf_check):
+        status = await csrf_check(method="POST", origin="https://evil.com")
+        assert status == 403
+
+    @pytest.mark.asyncio
+    async def test_put_with_valid_origin(self, csrf_check):
+        status = await csrf_check(method="PUT", origin="https://app.example.com")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_with_invalid_origin(self, csrf_check):
+        status = await csrf_check(method="DELETE", origin="https://attacker.com")
+        assert status == 403
+
+    @pytest.mark.asyncio
+    async def test_patch_with_valid_origin(self, csrf_check):
+        status = await csrf_check(method="PATCH", origin="https://app.example.com")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_missing_origin_rejected_by_default(self, csrf_check):
+        status = await csrf_check(method="POST")
+        assert status == 403
+
+    @pytest.mark.asyncio
+    async def test_missing_origin_allowed_when_configured(self, csrf_check):
+        status = await csrf_check(method="POST", allow_missing_origin=True)
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_referer_fallback(self, csrf_check):
+        """When Origin is missing, Referer is used as fallback."""
+        status = await csrf_check(
+            method="POST", referer="https://app.example.com/page"
+        )
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_referer_invalid(self, csrf_check):
+        status = await csrf_check(method="POST", referer="https://evil.com/page")
+        assert status == 403
+
+    @pytest.mark.asyncio
+    async def test_origin_case_insensitive(self, csrf_check):
+        status = await csrf_check(method="POST", origin="HTTPS://APP.EXAMPLE.COM")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_origin_trailing_slash_normalized(self, csrf_check):
+        """Origins with trailing slashes should be handled."""
+        status = await csrf_check(
+            method="POST",
+            origin="https://app.example.com",
+            allowed_origins=["https://app.example.com/"],
+        )
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_exempt_path(self, csrf_check):
+        """Exempt paths bypass CSRF validation."""
+        status = await csrf_check(
+            method="POST",
+            path="/webhooks/stripe",
+            exempt_paths=["/webhooks/stripe"],
+        )
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_non_exempt_path_still_validated(self, csrf_check):
+        status = await csrf_check(
+            method="POST",
+            path="/api/test",
+            origin="https://evil.com",
+            exempt_paths=["/webhooks/stripe"],
+        )
+        assert status == 403
+
+
+class TestCSRFNonHTTP:
+    """Test CSRF middleware with non-HTTP scopes."""
+
+    @pytest.mark.asyncio
+    async def test_websocket_passthrough(self):
+        call_count = 0
+
+        async def dummy_app(scope, receive, send):
+            nonlocal call_count
+            call_count += 1
+
+        mw = CSRFMiddleware(dummy_app, allowed_origins=["https://example.com"])
+        scope = {"type": "websocket", "path": "/ws"}
+        await mw(scope, None, None)
+        assert call_count == 1
+
+
+class TestCSRFResponseBody:
+    """Test CSRF error response format."""
+
+    @pytest.mark.asyncio
+    async def test_error_response_is_json(self):
+        async def dummy_app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        mw = CSRFMiddleware(
+            dummy_app, allowed_origins=["https://app.example.com"]
+        )
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/test",
+            "headers": [(b"origin", b"https://evil.com")],
+        }
+
+        sent = []
+
+        async def mock_send(msg):
+            sent.append(msg)
+
+        async def mock_receive():
+            return {"type": "http.request", "body": b""}
+
+        await mw(scope, mock_receive, mock_send)
+
+        body_msg = [m for m in sent if m["type"] == "http.response.body"][0]
+        body = json.loads(body_msg["body"])
+        assert "error" in body
+        assert "CSRF" in body["error"]

--- a/packages/kailash-nexus/tests/unit/test_openapi.py
+++ b/packages/kailash-nexus/tests/unit/test_openapi.py
@@ -1,0 +1,314 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for OpenAPI 3.0.3 spec generation (S4-002).
+
+Covers:
+- Schema generation from handler function signatures
+- Schema generation from workflows
+- Full spec structure validation
+- JSON output
+- Type mapping (str, int, float, bool, list, dict, Optional)
+- OpenApiInfo configuration
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Optional
+
+import pytest
+
+from nexus.openapi import OpenApiGenerator, OpenApiInfo, _python_type_to_openapi
+
+
+class TestTypeMapping:
+    """Test Python type -> OpenAPI schema mapping."""
+
+    def test_str_mapping(self):
+        schema = _python_type_to_openapi(str)
+        assert schema == {"type": "string"}
+
+    def test_int_mapping(self):
+        schema = _python_type_to_openapi(int)
+        assert schema == {"type": "integer"}
+
+    def test_float_mapping(self):
+        schema = _python_type_to_openapi(float)
+        assert schema == {"type": "number"}
+
+    def test_bool_mapping(self):
+        schema = _python_type_to_openapi(bool)
+        assert schema == {"type": "boolean"}
+
+    def test_list_mapping(self):
+        schema = _python_type_to_openapi(list)
+        assert schema["type"] == "array"
+
+    def test_dict_mapping(self):
+        schema = _python_type_to_openapi(dict)
+        assert schema == {"type": "object"}
+
+    def test_none_fallback(self):
+        schema = _python_type_to_openapi(None)
+        assert schema["type"] == "string"
+
+    def test_optional_str(self):
+        schema = _python_type_to_openapi(Optional[str])
+        assert schema == {"type": "string"}
+
+    def test_optional_int(self):
+        schema = _python_type_to_openapi(Optional[int])
+        assert schema == {"type": "integer"}
+
+    def test_list_of_int(self):
+        schema = _python_type_to_openapi(List[int])
+        assert schema == {"type": "array", "items": {"type": "integer"}}
+
+    def test_dict_complex(self):
+        schema = _python_type_to_openapi(Dict[str, int])
+        assert schema == {"type": "object"}
+
+
+class TestHandlerSchemaDerivation:
+    """Test schema generation from handler functions."""
+
+    def test_simple_handler(self):
+        gen = OpenApiGenerator()
+
+        async def greet(name: str, greeting: str = "Hello") -> dict:
+            return {"message": f"{greeting}, {name}!"}
+
+        gen.add_handler("greet", greet, description="Greet a user")
+        spec = gen.generate()
+
+        path = spec["paths"]["/workflows/greet/execute"]
+        assert "post" in path
+        assert path["post"]["operationId"] == "execute_greet"
+
+        schema_ref = path["post"]["requestBody"]["content"]["application/json"][
+            "schema"
+        ]["$ref"]
+        assert schema_ref == "#/components/schemas/greet_input"
+
+        input_schema = spec["components"]["schemas"]["greet_input"]
+        assert "name" in input_schema["properties"]
+        assert "greeting" in input_schema["properties"]
+        assert "name" in input_schema["required"]
+        assert "greeting" not in input_schema.get("required", [])
+
+    def test_handler_with_default(self):
+        gen = OpenApiGenerator()
+
+        async def process(data: dict, timeout: int = 30) -> dict:
+            return data
+
+        gen.add_handler("process", process)
+        spec = gen.generate()
+        schema = spec["components"]["schemas"]["process_input"]
+        assert schema["properties"]["timeout"]["default"] == 30
+        assert "data" in schema["required"]
+
+    def test_handler_no_annotations(self):
+        gen = OpenApiGenerator()
+
+        async def raw_handler(x, y):
+            return {"sum": x + y}
+
+        gen.add_handler("raw", raw_handler)
+        spec = gen.generate()
+        schema = spec["components"]["schemas"]["raw_input"]
+        assert "x" in schema["properties"]
+        assert "y" in schema["properties"]
+
+    def test_handler_with_optional_params(self):
+        gen = OpenApiGenerator()
+
+        async def search(query: str, limit: Optional[int] = None) -> dict:
+            return {}
+
+        gen.add_handler("search", search)
+        spec = gen.generate()
+        schema = spec["components"]["schemas"]["search_input"]
+        assert schema["properties"]["limit"]["type"] == "integer"
+
+    def test_handler_tags(self):
+        gen = OpenApiGenerator()
+
+        async def health() -> dict:
+            return {"ok": True}
+
+        gen.add_handler("health", health, tags=["system"])
+        spec = gen.generate()
+        assert spec["paths"]["/workflows/health/execute"]["post"]["tags"] == ["system"]
+
+
+class TestWorkflowSchemaDerivation:
+    """Test schema generation from workflows."""
+
+    def test_workflow_fallback_schema(self):
+        """Without metadata, workflow schema accepts any JSON object."""
+        gen = OpenApiGenerator()
+
+        class MockWorkflow:
+            metadata = None
+            nodes = {}
+
+        gen.add_workflow("test_wf", MockWorkflow())
+        spec = gen.generate()
+        schema = spec["components"]["schemas"]["test_wf_input"]
+        assert schema["type"] == "object"
+
+    def test_workflow_with_metadata(self):
+        gen = OpenApiGenerator()
+
+        class MockMetadata:
+            parameters = {
+                "name": {"type": "string"},
+                "count": {"type": "integer"},
+            }
+
+        class MockWorkflow:
+            metadata = MockMetadata()
+            nodes = {}
+
+        gen.add_workflow("counted", MockWorkflow())
+        spec = gen.generate()
+        schema = spec["components"]["schemas"]["counted_input"]
+        assert "name" in schema["properties"]
+        assert schema["properties"]["name"]["type"] == "string"
+        assert schema["properties"]["count"]["type"] == "integer"
+
+    def test_workflow_execute_and_info_endpoints(self):
+        gen = OpenApiGenerator()
+
+        class MockWorkflow:
+            metadata = None
+            nodes = {}
+
+        gen.add_workflow("my_flow", MockWorkflow(), description="My flow")
+        spec = gen.generate()
+        assert "/workflows/my_flow/execute" in spec["paths"]
+        assert "/workflows/my_flow/workflow/info" in spec["paths"]
+        assert (
+            spec["paths"]["/workflows/my_flow/workflow/info"]["get"]["operationId"]
+            == "info_my_flow"
+        )
+
+
+class TestOpenApiSpec:
+    """Test the overall OpenAPI spec structure."""
+
+    def test_spec_version(self):
+        gen = OpenApiGenerator()
+        spec = gen.generate()
+        assert spec["openapi"] == "3.0.3"
+
+    def test_spec_info(self):
+        gen = OpenApiGenerator(title="Test API", version="2.0.0")
+        spec = gen.generate()
+        assert spec["info"]["title"] == "Test API"
+        assert spec["info"]["version"] == "2.0.0"
+
+    def test_custom_info_object(self):
+        info = OpenApiInfo(
+            title="Custom API",
+            version="3.0.0",
+            description="My custom API",
+            contact_name="Dev Team",
+            contact_email="dev@example.com",
+            terms_of_service="https://example.com/tos",
+        )
+        gen = OpenApiGenerator(info=info)
+        spec = gen.generate()
+        assert spec["info"]["title"] == "Custom API"
+        assert spec["info"]["contact"]["name"] == "Dev Team"
+        assert spec["info"]["contact"]["email"] == "dev@example.com"
+        assert spec["info"]["termsOfService"] == "https://example.com/tos"
+
+    def test_servers(self):
+        gen = OpenApiGenerator(
+            servers=[
+                {"url": "https://api.example.com", "description": "Production"},
+            ]
+        )
+        spec = gen.generate()
+        assert len(spec["servers"]) == 1
+        assert spec["servers"][0]["url"] == "https://api.example.com"
+
+    def test_empty_spec(self):
+        gen = OpenApiGenerator()
+        spec = gen.generate()
+        assert spec["paths"] == {}
+        assert spec["components"]["schemas"] == {}
+
+    def test_license_defaults(self):
+        gen = OpenApiGenerator()
+        spec = gen.generate()
+        assert spec["info"]["license"]["name"] == "Apache-2.0"
+
+    def test_components_schemas_populated(self):
+        gen = OpenApiGenerator()
+
+        async def handler(x: str) -> dict:
+            return {}
+
+        gen.add_handler("test", handler)
+        spec = gen.generate()
+        assert "test_input" in spec["components"]["schemas"]
+
+
+class TestJsonOutput:
+    """Test JSON serialization."""
+
+    def test_generate_json(self):
+        gen = OpenApiGenerator()
+
+        async def h(x: str) -> dict:
+            return {}
+
+        gen.add_handler("h", h)
+        json_str = gen.generate_json()
+        parsed = json.loads(json_str)
+        assert parsed["openapi"] == "3.0.3"
+
+    def test_generate_json_indent(self):
+        gen = OpenApiGenerator()
+        json_str = gen.generate_json(indent=4)
+        assert "    " in json_str  # 4-space indent
+
+
+class TestMultipleRegistrations:
+    """Test registering multiple workflows and handlers."""
+
+    def test_multiple_handlers(self):
+        gen = OpenApiGenerator()
+
+        async def h1(a: str) -> dict:
+            return {}
+
+        async def h2(b: int) -> dict:
+            return {}
+
+        gen.add_handler("h1", h1)
+        gen.add_handler("h2", h2)
+        spec = gen.generate()
+        assert "/workflows/h1/execute" in spec["paths"]
+        assert "/workflows/h2/execute" in spec["paths"]
+        assert "h1_input" in spec["components"]["schemas"]
+        assert "h2_input" in spec["components"]["schemas"]
+
+    def test_mixed_handlers_and_workflows(self):
+        gen = OpenApiGenerator()
+
+        async def h(x: str) -> dict:
+            return {}
+
+        class MockWorkflow:
+            metadata = None
+            nodes = {}
+
+        gen.add_handler("handler1", h)
+        gen.add_workflow("workflow1", MockWorkflow())
+        spec = gen.generate()
+        assert "/workflows/handler1/execute" in spec["paths"]
+        assert "/workflows/workflow1/execute" in spec["paths"]

--- a/packages/kailash-nexus/tests/unit/test_preset_system.py
+++ b/packages/kailash-nexus/tests/unit/test_preset_system.py
@@ -183,33 +183,33 @@ class TestPresetRegistry:
         assert preset.middleware_factories == []
         assert preset.plugin_factories == []
 
-    def test_lightweight_has_cors_only(self):
-        """'lightweight' preset has CORS middleware only."""
+    def test_lightweight_has_cors_and_security_headers(self):
+        """'lightweight' preset has CORS + Security Headers middleware."""
         preset = get_preset("lightweight")
 
-        assert len(preset.middleware_factories) == 1
+        assert len(preset.middleware_factories) == 2
         assert preset.middleware_factories[0] is _cors_middleware_factory
         assert preset.plugin_factories == []
 
-    def test_standard_has_three_middleware(self):
-        """'standard' preset has CORS + rate limit + error handler."""
+    def test_standard_has_five_middleware(self):
+        """'standard' preset has CORS + security headers + CSRF + rate limit + error handler."""
         preset = get_preset("standard")
 
-        assert len(preset.middleware_factories) == 3
+        assert len(preset.middleware_factories) == 5
         assert preset.plugin_factories == []
 
     def test_saas_has_middleware_and_plugins(self):
         """'saas' preset has middleware and plugin factories."""
         preset = get_preset("saas")
 
-        assert len(preset.middleware_factories) == 3
+        assert len(preset.middleware_factories) == 5
         assert len(preset.plugin_factories) == 4
 
     def test_enterprise_has_most_plugins(self):
         """'enterprise' preset has the most plugin factories."""
         preset = get_preset("enterprise")
 
-        assert len(preset.middleware_factories) == 3
+        assert len(preset.middleware_factories) == 5
         assert len(preset.plugin_factories) == 6
 
 
@@ -319,16 +319,18 @@ class TestApplyPreset:
 
         assert len(app._middleware_stack) == initial_middleware
 
-    def test_apply_lightweight_adds_cors(self):
-        """Applying 'lightweight' adds CORS middleware."""
+    def test_apply_lightweight_adds_cors_and_security_headers(self):
+        """Applying 'lightweight' adds CORS + Security Headers middleware."""
         app = Nexus(enable_durability=False)
         initial_middleware = len(app._middleware_stack)
         config = NexusConfig(cors_origins=["http://test.com"])
 
         apply_preset(app, "lightweight", config)
 
-        assert len(app._middleware_stack) == initial_middleware + 1
-        assert app._middleware_stack[-1].name == "CORSMiddleware"
+        assert len(app._middleware_stack) == initial_middleware + 2
+        names = [m.name for m in app._middleware_stack]
+        assert "CORSMiddleware" in names
+        assert "SecurityHeadersMiddleware" in names
 
     def test_apply_preset_logs_info(self, caplog):
         """apply_preset() logs info messages."""

--- a/packages/kailash-nexus/tests/unit/test_presets_s4.py
+++ b/packages/kailash-nexus/tests/unit/test_presets_s4.py
@@ -1,0 +1,234 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for middleware presets (S4-005).
+
+Covers:
+- Preset registry completeness
+- Each preset's middleware composition
+- Security headers and CSRF integration in presets
+- get_preset() validation
+- Middleware factory return types
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.presets import (
+    PRESETS,
+    NexusConfig,
+    PresetConfig,
+    _cors_middleware_factory,
+    _csrf_middleware_factory,
+    _security_headers_middleware_factory,
+    apply_preset,
+    get_preset,
+)
+
+
+class TestPresetRegistry:
+    """Test the preset registry structure."""
+
+    def test_all_presets_present(self):
+        expected = {"none", "lightweight", "standard", "saas", "enterprise"}
+        assert set(PRESETS.keys()) == expected
+
+    def test_presets_are_preset_configs(self):
+        for name, preset in PRESETS.items():
+            assert isinstance(preset, PresetConfig), f"Preset '{name}' is not PresetConfig"
+
+    def test_preset_names_match_keys(self):
+        for key, preset in PRESETS.items():
+            assert preset.name == key
+
+    def test_presets_have_descriptions(self):
+        for name, preset in PRESETS.items():
+            assert preset.description, f"Preset '{name}' has no description"
+
+
+class TestGetPreset:
+    """Test get_preset() function."""
+
+    def test_get_valid_preset(self):
+        preset = get_preset("standard")
+        assert preset.name == "standard"
+
+    def test_get_invalid_preset_raises(self):
+        with pytest.raises(ValueError, match="Unknown preset"):
+            get_preset("nonexistent")
+
+    def test_get_all_presets(self):
+        for name in PRESETS:
+            preset = get_preset(name)
+            assert preset.name == name
+
+
+class TestNonePreset:
+    """Test the 'none' preset has no middleware."""
+
+    def test_no_middleware(self):
+        preset = get_preset("none")
+        assert len(preset.middleware_factories) == 0
+
+    def test_no_plugins(self):
+        preset = get_preset("none")
+        assert len(preset.plugin_factories) == 0
+
+
+class TestLightweightPreset:
+    """Test the 'lightweight' preset has CORS + security headers."""
+
+    def test_has_cors(self):
+        preset = get_preset("lightweight")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_cors_middleware_factory" in factory_names
+
+    def test_has_security_headers(self):
+        preset = get_preset("lightweight")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_security_headers_middleware_factory" in factory_names
+
+    def test_no_csrf(self):
+        preset = get_preset("lightweight")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_csrf_middleware_factory" not in factory_names
+
+    def test_no_plugins(self):
+        preset = get_preset("lightweight")
+        assert len(preset.plugin_factories) == 0
+
+
+class TestStandardPreset:
+    """Test the 'standard' preset adds CSRF."""
+
+    def test_has_cors(self):
+        preset = get_preset("standard")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_cors_middleware_factory" in factory_names
+
+    def test_has_security_headers(self):
+        preset = get_preset("standard")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_security_headers_middleware_factory" in factory_names
+
+    def test_has_csrf(self):
+        preset = get_preset("standard")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_csrf_middleware_factory" in factory_names
+
+    def test_has_rate_limit(self):
+        preset = get_preset("standard")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_rate_limit_middleware_factory" in factory_names
+
+
+class TestSaaSPreset:
+    """Test the 'saas' preset includes security middleware + auth plugins."""
+
+    def test_has_security_headers(self):
+        preset = get_preset("saas")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_security_headers_middleware_factory" in factory_names
+
+    def test_has_csrf(self):
+        preset = get_preset("saas")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_csrf_middleware_factory" in factory_names
+
+    def test_has_auth_plugins(self):
+        preset = get_preset("saas")
+        plugin_names = [f.__name__ for f in preset.plugin_factories]
+        assert "_jwt_auth_plugin_factory" in plugin_names
+        assert "_rbac_plugin_factory" in plugin_names
+        assert "_tenant_isolation_plugin_factory" in plugin_names
+        assert "_audit_plugin_factory" in plugin_names
+
+
+class TestEnterprisePreset:
+    """Test the 'enterprise' preset includes everything."""
+
+    def test_has_security_headers(self):
+        preset = get_preset("enterprise")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_security_headers_middleware_factory" in factory_names
+
+    def test_has_csrf(self):
+        preset = get_preset("enterprise")
+        factory_names = [f.__name__ for f in preset.middleware_factories]
+        assert "_csrf_middleware_factory" in factory_names
+
+    def test_has_sso_plugin(self):
+        preset = get_preset("enterprise")
+        plugin_names = [f.__name__ for f in preset.plugin_factories]
+        assert "_sso_plugin_factory" in plugin_names
+
+    def test_has_feature_flags_plugin(self):
+        preset = get_preset("enterprise")
+        plugin_names = [f.__name__ for f in preset.plugin_factories]
+        assert "_feature_flags_plugin_factory" in plugin_names
+
+    def test_superset_of_saas(self):
+        saas = get_preset("saas")
+        enterprise = get_preset("enterprise")
+
+        saas_mw = {f.__name__ for f in saas.middleware_factories}
+        enterprise_mw = {f.__name__ for f in enterprise.middleware_factories}
+        assert saas_mw.issubset(enterprise_mw)
+
+        saas_plugins = {f.__name__ for f in saas.plugin_factories}
+        enterprise_plugins = {f.__name__ for f in enterprise.plugin_factories}
+        assert saas_plugins.issubset(enterprise_plugins)
+
+
+class TestMiddlewareFactories:
+    """Test individual middleware factories produce correct output."""
+
+    def test_cors_factory_returns_tuple(self):
+        config = NexusConfig()
+        result = _cors_middleware_factory(config)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_security_headers_factory_returns_tuple(self):
+        config = NexusConfig()
+        result = _security_headers_middleware_factory(config)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        middleware_class, kwargs = result
+        assert "config" in kwargs
+
+    def test_csrf_factory_returns_tuple(self):
+        config = NexusConfig(cors_origins=["https://app.example.com"])
+        result = _csrf_middleware_factory(config)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        middleware_class, kwargs = result
+        assert "allowed_origins" in kwargs
+        assert "https://app.example.com" in kwargs["allowed_origins"]
+
+    def test_csrf_factory_wildcard_allows_missing(self):
+        config = NexusConfig(cors_origins=["*"])
+        _, kwargs = _csrf_middleware_factory(config)
+        assert kwargs["allow_missing_origin"] is True
+        # Wildcard should NOT be in allowed_origins list
+        assert "*" not in kwargs["allowed_origins"]
+
+    def test_csrf_factory_specific_origins_strict(self):
+        config = NexusConfig(cors_origins=["https://specific.com"])
+        _, kwargs = _csrf_middleware_factory(config)
+        assert kwargs["allow_missing_origin"] is False
+
+
+class TestNexusConfigRepr:
+    """Test NexusConfig secret redaction."""
+
+    def test_repr_redacts_jwt_secret(self):
+        config = NexusConfig(jwt_secret="super-secret-key-that-is-very-long")
+        r = repr(config)
+        assert "super-secret" not in r
+        assert "[REDACTED]" in r
+
+    def test_repr_no_jwt_secret(self):
+        config = NexusConfig()
+        r = repr(config)
+        assert "jwt_secret=None" in r

--- a/packages/kailash-nexus/tests/unit/test_probes.py
+++ b/packages/kailash-nexus/tests/unit/test_probes.py
@@ -1,0 +1,404 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Kubernetes probe endpoints (S4-001).
+
+Covers:
+- ProbeState enum values and transitions
+- Thread-safe state management
+- Liveness, readiness, and startup probe responses
+- Readiness check callbacks
+- Invalid transition rejection
+- Reset from FAILED state
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import threading
+
+import pytest
+
+from nexus.probes import ProbeManager, ProbeResponse, ProbeState
+
+
+class TestProbeState:
+    """Test ProbeState enum values."""
+
+    def test_state_values(self):
+        assert ProbeState.STARTING.value == "starting"
+        assert ProbeState.READY.value == "ready"
+        assert ProbeState.DRAINING.value == "draining"
+        assert ProbeState.FAILED.value == "failed"
+
+    def test_all_states_present(self):
+        states = {s.value for s in ProbeState}
+        assert states == {"starting", "ready", "draining", "failed"}
+
+
+class TestProbeResponse:
+    """Test ProbeResponse serialization."""
+
+    def test_to_dict_basic(self):
+        resp = ProbeResponse(status="ok", http_status=200)
+        d = resp.to_dict()
+        assert d == {"status": "ok"}
+
+    def test_to_dict_with_details(self):
+        resp = ProbeResponse(
+            status="ready",
+            http_status=200,
+            details={"workflows": 3, "state": "ready"},
+        )
+        d = resp.to_dict()
+        assert d["status"] == "ready"
+        assert d["details"]["workflows"] == 3
+
+    def test_to_dict_empty_details_omitted(self):
+        resp = ProbeResponse(status="ok", http_status=200, details={})
+        d = resp.to_dict()
+        assert "details" not in d
+
+
+class TestProbeManagerInit:
+    """Test ProbeManager initial state."""
+
+    def test_initial_state_is_starting(self):
+        pm = ProbeManager()
+        assert pm.state == ProbeState.STARTING
+
+    def test_initial_is_alive(self):
+        pm = ProbeManager()
+        assert pm.is_alive is True
+
+    def test_initial_not_ready(self):
+        pm = ProbeManager()
+        assert pm.is_ready is False
+
+    def test_initial_not_started(self):
+        pm = ProbeManager()
+        assert pm.is_started is False
+
+
+class TestProbeStateTransitions:
+    """Test valid and invalid state transitions."""
+
+    def test_starting_to_ready(self):
+        pm = ProbeManager()
+        assert pm.mark_ready() is True
+        assert pm.state == ProbeState.READY
+
+    def test_starting_to_failed(self):
+        pm = ProbeManager()
+        assert pm.mark_failed("crash") is True
+        assert pm.state == ProbeState.FAILED
+
+    def test_ready_to_draining(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        assert pm.mark_draining() is True
+        assert pm.state == ProbeState.DRAINING
+
+    def test_ready_to_failed(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        assert pm.mark_failed("oom") is True
+        assert pm.state == ProbeState.FAILED
+
+    def test_draining_to_failed(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.mark_draining()
+        assert pm.mark_failed("timeout") is True
+        assert pm.state == ProbeState.FAILED
+
+    # Invalid transitions
+    def test_starting_to_draining_rejected(self):
+        pm = ProbeManager()
+        assert pm.mark_draining() is False
+        assert pm.state == ProbeState.STARTING
+
+    def test_ready_to_starting_not_possible(self):
+        """READY cannot go back to STARTING (use reset for that)."""
+        pm = ProbeManager()
+        pm.mark_ready()
+        # There's no mark_starting, and direct _transition is internal
+        assert pm.state == ProbeState.READY
+
+    def test_failed_is_terminal(self):
+        pm = ProbeManager()
+        pm.mark_failed("crash")
+        assert pm.mark_ready() is False
+        assert pm.mark_draining() is False
+        assert pm.state == ProbeState.FAILED
+
+    def test_double_ready_rejected(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        assert pm.mark_ready() is False  # READY -> READY not allowed
+
+    def test_reset_from_failed(self):
+        pm = ProbeManager()
+        pm.mark_failed("crash")
+        pm.reset()
+        assert pm.state == ProbeState.STARTING
+        assert pm.is_alive is True
+
+    def test_reset_from_ready(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.reset()
+        assert pm.state == ProbeState.STARTING
+
+
+class TestProbeProperties:
+    """Test is_alive, is_ready, is_started properties."""
+
+    def test_alive_in_all_non_failed_states(self):
+        pm = ProbeManager()
+        assert pm.is_alive  # STARTING
+        pm.mark_ready()
+        assert pm.is_alive  # READY
+        pm.mark_draining()
+        assert pm.is_alive  # DRAINING
+
+    def test_not_alive_when_failed(self):
+        pm = ProbeManager()
+        pm.mark_failed("crash")
+        assert pm.is_alive is False
+
+    def test_ready_only_in_ready_state(self):
+        pm = ProbeManager()
+        assert pm.is_ready is False  # STARTING
+        pm.mark_ready()
+        assert pm.is_ready is True  # READY
+        pm.mark_draining()
+        assert pm.is_ready is False  # DRAINING
+
+    def test_started_in_ready_and_draining(self):
+        pm = ProbeManager()
+        assert pm.is_started is False  # STARTING
+        pm.mark_ready()
+        assert pm.is_started is True  # READY
+        pm.mark_draining()
+        assert pm.is_started is True  # DRAINING
+
+
+class TestLivenessCheck:
+    """Test check_liveness() responses."""
+
+    def test_liveness_ok_when_starting(self):
+        pm = ProbeManager()
+        resp = pm.check_liveness()
+        assert resp.status == "ok"
+        assert resp.http_status == 200
+        assert "uptime_seconds" in resp.details
+
+    def test_liveness_ok_when_ready(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        resp = pm.check_liveness()
+        assert resp.status == "ok"
+        assert resp.http_status == 200
+
+    def test_liveness_ok_when_draining(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.mark_draining()
+        resp = pm.check_liveness()
+        assert resp.status == "ok"
+        assert resp.http_status == 200
+
+    def test_liveness_failed_when_failed(self):
+        pm = ProbeManager()
+        pm.mark_failed("disk full")
+        resp = pm.check_liveness()
+        assert resp.status == "failed"
+        assert resp.http_status == 503
+        assert resp.details["reason"] == "disk full"
+
+
+class TestReadinessCheck:
+    """Test check_readiness() responses."""
+
+    def test_not_ready_when_starting(self):
+        pm = ProbeManager()
+        resp = pm.check_readiness()
+        assert resp.status == "not_ready"
+        assert resp.http_status == 503
+
+    def test_ready_when_ready(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.set_workflow_count(5)
+        resp = pm.check_readiness()
+        assert resp.status == "ready"
+        assert resp.http_status == 200
+        assert resp.details["workflows"] == 5
+
+    def test_not_ready_when_draining(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.mark_draining()
+        resp = pm.check_readiness()
+        assert resp.status == "not_ready"
+        assert resp.http_status == 503
+
+    def test_not_ready_when_failed(self):
+        pm = ProbeManager()
+        pm.mark_failed("crash")
+        resp = pm.check_readiness()
+        assert resp.status == "not_ready"
+        assert resp.http_status == 503
+
+
+class TestReadinessCallbacks:
+    """Test readiness check callback system."""
+
+    def test_callback_passing(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.add_readiness_check(lambda: True)
+        resp = pm.check_readiness()
+        assert resp.status == "ready"
+        assert resp.http_status == 200
+
+    def test_callback_failing(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+
+        def db_check():
+            return False
+
+        pm.add_readiness_check(db_check)
+        resp = pm.check_readiness()
+        assert resp.status == "not_ready"
+        assert resp.http_status == 503
+        assert "failed_checks" in resp.details
+
+    def test_callback_exception_treated_as_failure(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+
+        def broken_check():
+            raise ConnectionError("database down")
+
+        pm.add_readiness_check(broken_check)
+        resp = pm.check_readiness()
+        assert resp.status == "not_ready"
+        assert resp.http_status == 503
+
+    def test_multiple_callbacks_all_must_pass(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.add_readiness_check(lambda: True)
+        pm.add_readiness_check(lambda: True)
+        resp = pm.check_readiness()
+        assert resp.status == "ready"
+
+    def test_one_failing_callback_fails_overall(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.add_readiness_check(lambda: True)
+        pm.add_readiness_check(lambda: False)
+        resp = pm.check_readiness()
+        assert resp.status == "not_ready"
+
+
+class TestStartupCheck:
+    """Test check_startup() responses."""
+
+    def test_starting_during_init(self):
+        pm = ProbeManager()
+        resp = pm.check_startup()
+        assert resp.status == "starting"
+        assert resp.http_status == 503
+
+    def test_started_when_ready(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        resp = pm.check_startup()
+        assert resp.status == "started"
+        assert resp.http_status == 200
+        assert "startup_duration_seconds" in resp.details
+
+    def test_started_when_draining(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.mark_draining()
+        resp = pm.check_startup()
+        assert resp.status == "started"
+        assert resp.http_status == 200
+
+    def test_starting_when_failed(self):
+        pm = ProbeManager()
+        pm.mark_failed("crash")
+        resp = pm.check_startup()
+        assert resp.status == "starting"
+        assert resp.http_status == 503
+
+
+class TestThreadSafety:
+    """Test concurrent access to ProbeManager."""
+
+    def test_concurrent_mark_ready(self):
+        """Only one thread should succeed in transitioning STARTING -> READY."""
+        pm = ProbeManager()
+        results = []
+        barrier = threading.Barrier(10)
+
+        def try_mark_ready():
+            barrier.wait()
+            results.append(pm.mark_ready())
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(try_mark_ready) for _ in range(10)]
+            concurrent.futures.wait(futures)
+
+        # Exactly one True (successful transition), rest False
+        assert results.count(True) == 1
+        assert results.count(False) == 9
+        assert pm.state == ProbeState.READY
+
+    def test_concurrent_reads_safe(self):
+        """Multiple concurrent reads should not corrupt state."""
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.set_workflow_count(10)
+
+        errors = []
+
+        def check_all():
+            try:
+                for _ in range(100):
+                    assert pm.is_alive
+                    assert pm.is_ready
+                    pm.check_liveness()
+                    pm.check_readiness()
+                    pm.check_startup()
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=check_all) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+
+class TestWorkflowCount:
+    """Test workflow count tracking."""
+
+    def test_set_workflow_count(self):
+        pm = ProbeManager()
+        pm.mark_ready()
+        pm.set_workflow_count(42)
+        resp = pm.check_readiness()
+        assert resp.details["workflows"] == 42
+
+    def test_workflow_count_in_not_ready(self):
+        pm = ProbeManager()
+        pm.set_workflow_count(3)
+        resp = pm.check_readiness()
+        assert resp.details["workflows"] == 3

--- a/packages/kailash-nexus/tests/unit/test_security_headers.py
+++ b/packages/kailash-nexus/tests/unit/test_security_headers.py
@@ -1,0 +1,223 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for security headers middleware (S4-003).
+
+Covers:
+- SecurityHeadersConfig default values
+- Header pair generation
+- Custom configuration
+- ASGI middleware behavior
+- Path exclusions
+- Frozen config immutability
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.middleware.security_headers import SecurityHeadersConfig, SecurityHeadersMiddleware
+
+
+class TestSecurityHeadersConfig:
+    """Test SecurityHeadersConfig defaults and customization."""
+
+    def test_default_csp(self):
+        config = SecurityHeadersConfig()
+        assert "default-src 'self'" in config.csp
+        assert "frame-ancestors 'none'" in config.csp
+
+    def test_default_hsts(self):
+        config = SecurityHeadersConfig()
+        assert config.hsts_max_age == 31536000  # 1 year
+        assert config.hsts_include_subdomains is True
+        assert config.hsts_preload is False
+
+    def test_default_content_type_options(self):
+        config = SecurityHeadersConfig()
+        assert config.content_type_options == "nosniff"
+
+    def test_default_frame_options(self):
+        config = SecurityHeadersConfig()
+        assert config.frame_options == "DENY"
+
+    def test_default_xss_protection(self):
+        config = SecurityHeadersConfig()
+        assert config.xss_protection == "1; mode=block"
+
+    def test_default_referrer_policy(self):
+        config = SecurityHeadersConfig()
+        assert config.referrer_policy == "strict-origin-when-cross-origin"
+
+    def test_default_permissions_policy(self):
+        config = SecurityHeadersConfig()
+        assert "camera=()" in config.permissions_policy
+
+    def test_frozen_immutability(self):
+        config = SecurityHeadersConfig()
+        with pytest.raises(AttributeError):
+            config.csp = "new-policy"
+
+    def test_custom_frame_options(self):
+        config = SecurityHeadersConfig(frame_options="SAMEORIGIN")
+        assert config.frame_options == "SAMEORIGIN"
+
+    def test_custom_hsts_preload(self):
+        config = SecurityHeadersConfig(hsts_preload=True)
+        assert config.hsts_preload is True
+
+
+class TestHeaderPairGeneration:
+    """Test to_header_pairs() output."""
+
+    def test_default_header_count(self):
+        config = SecurityHeadersConfig()
+        pairs = config.to_header_pairs()
+        # CSP, HSTS, X-Content-Type-Options, X-Frame-Options,
+        # X-XSS-Protection, Referrer-Policy, Permissions-Policy
+        assert len(pairs) == 7
+
+    def test_csp_header_present(self):
+        config = SecurityHeadersConfig()
+        pairs = dict(config.to_header_pairs())
+        assert "content-security-policy" in pairs
+        assert "default-src 'self'" in pairs["content-security-policy"]
+
+    def test_hsts_header_format(self):
+        config = SecurityHeadersConfig()
+        pairs = dict(config.to_header_pairs())
+        hsts = pairs["strict-transport-security"]
+        assert "max-age=31536000" in hsts
+        assert "includeSubDomains" in hsts
+        assert "preload" not in hsts
+
+    def test_hsts_with_preload(self):
+        config = SecurityHeadersConfig(hsts_preload=True)
+        pairs = dict(config.to_header_pairs())
+        hsts = pairs["strict-transport-security"]
+        assert "preload" in hsts
+
+    def test_hsts_without_subdomains(self):
+        config = SecurityHeadersConfig(hsts_include_subdomains=False)
+        pairs = dict(config.to_header_pairs())
+        hsts = pairs["strict-transport-security"]
+        assert "includeSubDomains" not in hsts
+
+    def test_all_expected_headers(self):
+        config = SecurityHeadersConfig()
+        pairs = dict(config.to_header_pairs())
+        expected_headers = {
+            "content-security-policy",
+            "strict-transport-security",
+            "x-content-type-options",
+            "x-frame-options",
+            "x-xss-protection",
+            "referrer-policy",
+            "permissions-policy",
+        }
+        assert set(pairs.keys()) == expected_headers
+
+    def test_empty_csp_omits_header(self):
+        config = SecurityHeadersConfig(csp="")
+        pairs = dict(config.to_header_pairs())
+        assert "content-security-policy" not in pairs
+
+    def test_empty_frame_options_omits_header(self):
+        config = SecurityHeadersConfig(frame_options="")
+        pairs = dict(config.to_header_pairs())
+        assert "x-frame-options" not in pairs
+
+
+class TestSecurityHeadersMiddleware:
+    """Test ASGI middleware behavior."""
+
+    @pytest.fixture
+    def captured_headers(self):
+        """Fixture that captures response headers from middleware."""
+        captured = {}
+
+        async def dummy_app(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"{}"})
+
+        async def run(scope, middleware_cls, **kwargs):
+            mw = middleware_cls(dummy_app, **kwargs)
+            sent_messages = []
+
+            async def mock_send(msg):
+                sent_messages.append(msg)
+
+            async def mock_receive():
+                return {"type": "http.request", "body": b""}
+
+            await mw(scope, mock_receive, mock_send)
+
+            for msg in sent_messages:
+                if msg["type"] == "http.response.start":
+                    for name, value in msg.get("headers", []):
+                        if isinstance(name, bytes):
+                            name = name.decode()
+                        if isinstance(value, bytes):
+                            value = value.decode()
+                        captured[name] = value
+
+            return captured
+
+        return run
+
+    @pytest.mark.asyncio
+    async def test_injects_security_headers(self, captured_headers):
+        scope = {"type": "http", "method": "GET", "path": "/api/test"}
+        headers = await captured_headers(scope, SecurityHeadersMiddleware)
+        assert "x-content-type-options" in headers
+        assert headers["x-content-type-options"] == "nosniff"
+        assert "x-frame-options" in headers
+
+    @pytest.mark.asyncio
+    async def test_preserves_existing_headers(self, captured_headers):
+        scope = {"type": "http", "method": "GET", "path": "/api/test"}
+        headers = await captured_headers(scope, SecurityHeadersMiddleware)
+        assert "content-type" in headers
+
+    @pytest.mark.asyncio
+    async def test_path_exclusion(self, captured_headers):
+        config = SecurityHeadersConfig(exclude_paths=("/healthz",))
+        scope = {"type": "http", "method": "GET", "path": "/healthz"}
+        headers = await captured_headers(
+            scope, SecurityHeadersMiddleware, config=config
+        )
+        # Security headers should NOT be present on excluded paths
+        assert "x-frame-options" not in headers
+
+    @pytest.mark.asyncio
+    async def test_non_http_passthrough(self):
+        """Non-HTTP scopes should pass through without modification."""
+        call_count = 0
+
+        async def dummy_app(scope, receive, send):
+            nonlocal call_count
+            call_count += 1
+
+        mw = SecurityHeadersMiddleware(dummy_app)
+        scope = {"type": "websocket", "path": "/ws"}
+
+        await mw(scope, None, None)
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_custom_config(self, captured_headers):
+        config = SecurityHeadersConfig(
+            frame_options="SAMEORIGIN",
+            referrer_policy="no-referrer",
+        )
+        scope = {"type": "http", "method": "GET", "path": "/test"}
+        headers = await captured_headers(
+            scope, SecurityHeadersMiddleware, config=config
+        )
+        assert headers["x-frame-options"] == "SAMEORIGIN"
+        assert headers["referrer-policy"] == "no-referrer"


### PR DESCRIPTION
## Summary

- **S4-001**: K8s probe endpoints (`/healthz`, `/readyz`, `/startup`) with thread-safe `ProbeState` enum and atomic state transitions (STARTING -> READY -> DRAINING -> FAILED)
- **S4-002**: OpenAPI 3.0.3 generator that auto-derives schemas from handler function signatures and workflow metadata, with `/openapi.json` endpoint
- **S4-003**: `SecurityHeadersMiddleware` — CSP, HSTS, X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy (frozen `@dataclass` config, path exclusions)
- **S4-004**: `CSRFMiddleware` — Origin/Referer validation for state-changing methods (POST/PUT/DELETE/PATCH), safe method bypass (GET/HEAD/OPTIONS), configurable allowed origins and exempt paths
- **S4-005**: Wire security headers and CSRF into preset system (lightweight gets security headers, standard+ gets CSRF)
- **S4-006**: 154 new unit tests covering all components, including thread safety for concurrent probe state transitions

Closes #98

## Test plan

- [x] 154 new unit tests pass (`test_probes.py`, `test_openapi.py`, `test_security_headers.py`, `test_csrf.py`, `test_presets_s4.py`)
- [x] 41 existing preset tests updated and pass (`test_preset_system.py`)
- [x] Full Nexus unit test suite: 817 pass, 1 pre-existing failure (unrelated MCP runtime test)
- [x] Thread safety verified with 10-thread concurrent barrier test on `ProbeManager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)