### PR TITLE
feat(tracing): S5 OpenTelemetry tracing enhancement

### DIFF
--- a/src/kailash/runtime/instrumentation/__init__.py
+++ b/src/kailash/runtime/instrumentation/__init__.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenTelemetry instrumentation for Kailash runtime components.
+
+Sub-modules provide progressive instrumentation controlled by
+:class:`~kailash.runtime.tracing.TracingLevel`:
+
+- :mod:`.nodes`     -- Node-level execution spans (DETAILED+).
+- :mod:`.dataflow`  -- DataFlow query tracing (FULL).
+- :mod:`.database`  -- ConnectionManager auto-instrumentation (FULL).
+
+All instrumentation degrades gracefully when ``opentelemetry`` is not installed.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "NodeInstrumentor",
+    "DataFlowInstrumentor",
+    "DatabaseInstrumentor",
+]
+
+
+def __getattr__(name: str):  # noqa: ANN001
+    """Lazy imports to avoid loading OTel at module scope."""
+    if name == "NodeInstrumentor":
+        from kailash.runtime.instrumentation.nodes import NodeInstrumentor
+
+        return NodeInstrumentor
+    if name == "DataFlowInstrumentor":
+        from kailash.runtime.instrumentation.dataflow import DataFlowInstrumentor
+
+        return DataFlowInstrumentor
+    if name == "DatabaseInstrumentor":
+        from kailash.runtime.instrumentation.database import DatabaseInstrumentor
+
+        return DatabaseInstrumentor
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/kailash/runtime/instrumentation/database.py
+++ b/src/kailash/runtime/instrumentation/database.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Auto-instrumentation for ``ConnectionManager`` database operations.
+
+Wraps the key ``ConnectionManager`` methods (``execute``, ``fetchone``,
+``fetchall``) with OTel spans so that every query is visible in traces
+without manual instrumentation at each call site.
+
+Active only at :attr:`~kailash.runtime.tracing.TracingLevel.FULL`.
+
+Usage::
+
+    from kailash.runtime.instrumentation.database import DatabaseInstrumentor
+
+    instrumentor = DatabaseInstrumentor()
+    instrumentor.instrument(connection_manager)
+    # All subsequent queries on connection_manager emit OTel spans.
+
+    instrumentor.uninstrument(connection_manager)
+    # Restores original methods.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Callable, Optional
+
+from kailash.runtime.tracing import TracingLevel, get_workflow_tracer
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["DatabaseInstrumentor"]
+
+_MAX_STATEMENT_LEN = 1024
+_INSTRUMENTED_ATTR = "_kailash_otel_instrumented"
+
+
+class DatabaseInstrumentor:
+    """Monkey-patches a ``ConnectionManager`` to emit OTel spans per query.
+
+    Thread-safe.  Calling :meth:`instrument` twice on the same object is safe
+    (the second call is a no-op).
+
+    Attributes:
+        db_system: The ``db.system`` semantic-convention value attached to spans.
+    """
+
+    def __init__(self, db_system: str = "") -> None:
+        self._db_system = db_system
+        self._lock = threading.Lock()
+        self._originals: dict[int, dict[str, Callable[..., Any]]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def instrument(self, conn_manager: Any) -> None:
+        """Wrap ``execute``, ``fetchone``, ``fetchall`` on *conn_manager*.
+
+        Args:
+            conn_manager: A ``ConnectionManager`` instance (or any object with
+                the three named methods).
+        """
+        obj_id = id(conn_manager)
+        with self._lock:
+            if getattr(conn_manager, _INSTRUMENTED_ATTR, False):
+                return  # Already instrumented
+
+            originals: dict[str, Callable[..., Any]] = {}
+            for method_name in ("execute", "fetchone", "fetchall"):
+                original = getattr(conn_manager, method_name, None)
+                if original is None:
+                    continue
+                originals[method_name] = original
+                wrapped = self._make_wrapper(original, method_name)
+                setattr(conn_manager, method_name, wrapped)
+
+            self._originals[obj_id] = originals
+            setattr(conn_manager, _INSTRUMENTED_ATTR, True)
+            logger.debug(
+                "Instrumented ConnectionManager %s (db_system=%s)",
+                obj_id,
+                self._db_system,
+            )
+
+    def uninstrument(self, conn_manager: Any) -> None:
+        """Restore original methods on *conn_manager*.
+
+        Safe to call even if the object was never instrumented.
+        """
+        obj_id = id(conn_manager)
+        with self._lock:
+            originals = self._originals.pop(obj_id, None)
+            if originals is None:
+                return
+            for method_name, original in originals.items():
+                setattr(conn_manager, method_name, original)
+            setattr(conn_manager, _INSTRUMENTED_ATTR, False)
+            logger.debug("Uninstrumented ConnectionManager %s", obj_id)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _make_wrapper(
+        self,
+        original: Callable[..., Any],
+        method_name: str,
+    ) -> Callable[..., Any]:
+        """Create a tracing wrapper around *original*."""
+        db_system = self._db_system
+
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            tracer = get_workflow_tracer()
+            if not tracer.enabled or tracer.level is not TracingLevel.FULL:
+                return original(*args, **kwargs)
+
+            statement = args[0] if args and isinstance(args[0], str) else method_name
+            truncated = statement[:_MAX_STATEMENT_LEN]
+
+            operation = method_name.upper()
+            span = tracer.start_db_span(
+                operation=operation,
+                statement=truncated,
+                db_system=db_system,
+            )
+            start = time.monotonic()
+            try:
+                result = original(*args, **kwargs)
+                duration = time.monotonic() - start
+                tracer.set_attribute(span, "db.duration_s", round(duration, 6))
+                _set_row_count(tracer, span, result)
+                tracer.end_span(span, status="ok")
+                return result
+            except Exception as exc:
+                duration = time.monotonic() - start
+                tracer.set_attribute(span, "db.duration_s", round(duration, 6))
+                tracer.end_span(span, error=exc)
+                raise
+
+        wrapper.__name__ = original.__name__ if hasattr(original, "__name__") else method_name
+        wrapper.__qualname__ = getattr(original, "__qualname__", method_name)
+        return wrapper
+
+
+def _set_row_count(tracer: Any, span: Optional[Any], result: Any) -> None:
+    """Best-effort row count extraction and attribute setting."""
+    if result is None:
+        tracer.set_attribute(span, "db.row_count", 0)
+    elif isinstance(result, (list, tuple)):
+        tracer.set_attribute(span, "db.row_count", len(result))
+    elif hasattr(result, "rowcount"):
+        rc = result.rowcount
+        if isinstance(rc, int) and rc >= 0:
+            tracer.set_attribute(span, "db.row_count", rc)

--- a/src/kailash/runtime/instrumentation/dataflow.py
+++ b/src/kailash/runtime/instrumentation/dataflow.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""DataFlow query tracing with OpenTelemetry semantic conventions.
+
+Instruments DataFlow database operations with OTel spans following the
+`OpenTelemetry Database semantic conventions
+<https://opentelemetry.io/docs/specs/semconv/database/>`_:
+
+- ``db.system``    -- Database system identifier (``sqlite``, ``postgresql``, etc.).
+- ``db.statement`` -- SQL statement text (truncated to 1024 chars).
+- ``db.operation`` -- High-level operation (``SELECT``, ``INSERT``, ...).
+- ``db.row_count`` -- Number of rows returned / affected.
+- ``db.duration_s``-- Query wall-clock time in seconds.
+
+Active only at :attr:`~kailash.runtime.tracing.TracingLevel.FULL`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+from typing import Any, Callable, Optional
+
+from kailash.runtime.tracing import TracingLevel, get_workflow_tracer
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["DataFlowInstrumentor"]
+
+_SQL_OP_RE = re.compile(r"^\s*(\w+)", re.IGNORECASE)
+_MAX_STATEMENT_LEN = 1024
+
+
+def _extract_operation(statement: str) -> str:
+    """Extract the leading SQL verb from *statement*."""
+    m = _SQL_OP_RE.match(statement)
+    return m.group(1).upper() if m else "UNKNOWN"
+
+
+class DataFlowInstrumentor:
+    """Instruments DataFlow / database operations with OTel spans.
+
+    Thread-safe.  When tracing is not at ``FULL``, all methods are no-ops.
+
+    Example::
+
+        inst = DataFlowInstrumentor(db_system="postgresql")
+        result = inst.trace_query(
+            statement="SELECT * FROM users WHERE id = ?",
+            execute_fn=conn.fetchall,
+            args=("SELECT * FROM users WHERE id = ?", user_id),
+            parent_span=node_span,
+        )
+    """
+
+    def __init__(self, db_system: str = "") -> None:
+        self._db_system = db_system
+        self._lock = threading.Lock()
+
+    def trace_query(
+        self,
+        statement: str,
+        execute_fn: Callable[..., Any],
+        args: tuple[Any, ...] = (),
+        kwargs: Optional[dict[str, Any]] = None,
+        parent_span: Optional[Any] = None,
+    ) -> Any:
+        """Execute *execute_fn* inside an OTel database span.
+
+        Args:
+            statement:   SQL statement text (for span attributes).
+            execute_fn:  The callable that actually runs the query.
+            args:        Positional arguments forwarded to *execute_fn*.
+            kwargs:      Keyword arguments forwarded to *execute_fn*.
+            parent_span: Optional parent span for hierarchy.
+
+        Returns:
+            Whatever *execute_fn* returns.
+
+        Raises:
+            Any exception raised by *execute_fn* (recorded on the span first).
+        """
+        kwargs = kwargs or {}
+        tracer = get_workflow_tracer()
+
+        if not tracer.enabled or tracer.level is not TracingLevel.FULL:
+            return execute_fn(*args, **kwargs)
+
+        operation = _extract_operation(statement)
+        span = tracer.start_db_span(
+            operation=operation,
+            statement=statement[:_MAX_STATEMENT_LEN],
+            db_system=self._db_system,
+            parent_span=parent_span,
+        )
+        start = time.monotonic()
+        try:
+            result = execute_fn(*args, **kwargs)
+            duration = time.monotonic() - start
+            tracer.set_attribute(span, "db.duration_s", round(duration, 6))
+            row_count = self._count_rows(result)
+            if row_count is not None:
+                tracer.set_attribute(span, "db.row_count", row_count)
+            tracer.end_span(span, status="ok")
+            return result
+        except Exception as exc:
+            duration = time.monotonic() - start
+            tracer.set_attribute(span, "db.duration_s", round(duration, 6))
+            tracer.end_span(span, error=exc)
+            raise
+
+    @staticmethod
+    def _count_rows(result: Any) -> Optional[int]:
+        """Attempt to determine a row count from a query result.
+
+        Returns ``None`` when the result type is not countable.
+        """
+        if result is None:
+            return 0
+        if isinstance(result, (list, tuple)):
+            return len(result)
+        if hasattr(result, "rowcount"):
+            rc = result.rowcount
+            if isinstance(rc, int) and rc >= 0:
+                return rc
+        return None

--- a/src/kailash/runtime/instrumentation/nodes.py
+++ b/src/kailash/runtime/instrumentation/nodes.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Node-level OpenTelemetry instrumentation.
+
+Wraps individual node executions with child spans that capture:
+
+- ``node.id``         -- The node's unique identifier.
+- ``node.type``       -- The node class name.
+- ``node.duration_s`` -- Execution wall-clock time in seconds.
+- ``node.input_size`` -- Byte-length estimate of serialised inputs.
+- ``node.output_size``-- Byte-length estimate of serialised outputs.
+
+Active at :attr:`~kailash.runtime.tracing.TracingLevel.DETAILED` and above.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from functools import wraps
+from typing import Any, Callable, Optional, TypeVar
+
+from kailash.runtime.tracing import TracingLevel, get_workflow_tracer
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["NodeInstrumentor", "instrument_node"]
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _estimate_size(obj: Any) -> int:
+    """Return a rough byte-size estimate for *obj*.
+
+    Uses ``sys.getsizeof`` as a fast, zero-dependency heuristic.  This is
+    intentionally approximate -- the goal is order-of-magnitude awareness, not
+    precision.
+    """
+    try:
+        return sys.getsizeof(obj)
+    except (TypeError, ValueError):
+        return 0
+
+
+class NodeInstrumentor:
+    """Wraps node execution functions with OTel spans.
+
+    Thread-safe.  When tracing is disabled or OTel is unavailable, the
+    instrumented function runs with near-zero overhead (one ``if`` check).
+
+    Example::
+
+        instrumentor = NodeInstrumentor()
+        result = instrumentor.execute(
+            node_id="transform_1",
+            node_type="PythonCodeNode",
+            func=node.execute,
+            args=(inputs,),
+            parent_span=workflow_span,
+        )
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def execute(
+        self,
+        node_id: str,
+        node_type: str,
+        func: Callable[..., Any],
+        args: tuple[Any, ...] = (),
+        kwargs: Optional[dict[str, Any]] = None,
+        parent_span: Optional[Any] = None,
+    ) -> Any:
+        """Execute *func* inside an OTel span and return its result.
+
+        If the tracer is not enabled at ``DETAILED`` or higher, *func* is
+        called directly with no instrumentation overhead.
+
+        Args:
+            node_id:     Unique identifier for the node.
+            node_type:   Class name / type label.
+            func:        The callable to execute.
+            args:        Positional arguments forwarded to *func*.
+            kwargs:      Keyword arguments forwarded to *func*.
+            parent_span: Optional parent span for hierarchy.
+
+        Returns:
+            Whatever *func* returns.
+
+        Raises:
+            Any exception raised by *func* (after recording it on the span).
+        """
+        kwargs = kwargs or {}
+        tracer = get_workflow_tracer()
+
+        if not tracer.enabled or tracer.level not in (
+            TracingLevel.DETAILED,
+            TracingLevel.FULL,
+        ):
+            return func(*args, **kwargs)
+
+        span = tracer.start_node_span(node_id, node_type, parent_span=parent_span)
+        start = time.monotonic()
+        try:
+            tracer.set_attribute(span, "node.input_size", _estimate_size(args))
+            result = func(*args, **kwargs)
+            duration = time.monotonic() - start
+            tracer.set_attribute(span, "node.duration_s", round(duration, 6))
+            tracer.set_attribute(span, "node.output_size", _estimate_size(result))
+            tracer.end_span(span, status="ok")
+            return result
+        except Exception as exc:
+            duration = time.monotonic() - start
+            tracer.set_attribute(span, "node.duration_s", round(duration, 6))
+            tracer.end_span(span, error=exc)
+            raise
+
+
+def instrument_node(
+    node_id: str,
+    node_type: str,
+    parent_span: Optional[Any] = None,
+) -> Callable[[F], F]:
+    """Decorator that instruments a function as a node execution.
+
+    Example::
+
+        @instrument_node("etl_step", "PythonCodeNode")
+        def etl_step(data):
+            ...
+    """
+    _instrumentor = NodeInstrumentor()
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return _instrumentor.execute(
+                node_id=node_id,
+                node_type=node_type,
+                func=func,
+                args=args,
+                kwargs=kwargs,
+                parent_span=parent_span,
+            )
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/src/kailash/runtime/metrics.py
+++ b/src/kailash/runtime/metrics.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prometheus-compatible metrics bridge for Kailash runtime.
+
+Exposes workflow and node execution metrics as OTel metric instruments.  When a
+Prometheus exporter is configured these appear as standard Prometheus
+counters and histograms:
+
+- ``kailash_workflow_executions_total``    -- Counter of workflow runs.
+- ``kailash_workflow_duration_seconds``    -- Histogram of workflow durations.
+- ``kailash_node_execution_duration_seconds`` -- Histogram of per-node durations.
+
+All instruments degrade gracefully when ``opentelemetry-api`` is not installed.
+Install with: ``pip install kailash[otel]``
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["MetricsBridge", "get_metrics_bridge"]
+
+# Lazy OTel metrics import.
+_OTEL_METRICS_AVAILABLE = False
+_metrics_mod: Any = None
+
+try:
+    from opentelemetry import metrics as _otel_metrics_module
+
+    _metrics_mod = _otel_metrics_module
+    _OTEL_METRICS_AVAILABLE = True
+except ImportError:
+    pass
+
+
+class MetricsBridge:
+    """Prometheus-compatible metrics instruments backed by OTel.
+
+    All recording methods are safe no-ops when ``opentelemetry`` is absent.
+
+    Attributes:
+        enabled: Whether OTel metrics API is available.
+    """
+
+    def __init__(self, meter_name: str = "kailash") -> None:
+        self._lock = threading.Lock()
+        self._enabled = _OTEL_METRICS_AVAILABLE
+
+        self._workflow_counter: Any = None
+        self._workflow_duration: Any = None
+        self._node_duration: Any = None
+
+        if self._enabled and _metrics_mod is not None:
+            meter = _metrics_mod.get_meter(meter_name)
+            self._workflow_counter = meter.create_counter(
+                name="kailash_workflow_executions_total",
+                description="Total number of workflow executions",
+                unit="1",
+            )
+            self._workflow_duration = meter.create_histogram(
+                name="kailash_workflow_duration_seconds",
+                description="Duration of workflow executions in seconds",
+                unit="s",
+            )
+            self._node_duration = meter.create_histogram(
+                name="kailash_node_execution_duration_seconds",
+                description="Duration of individual node executions in seconds",
+                unit="s",
+            )
+
+    @property
+    def enabled(self) -> bool:
+        """True when OTel metrics API is available."""
+        return self._enabled
+
+    # ------------------------------------------------------------------
+    # Recording methods
+    # ------------------------------------------------------------------
+
+    def record_workflow_start(
+        self,
+        workflow_name: str,
+        tenant_id: str = "",
+    ) -> None:
+        """Increment the workflow execution counter.
+
+        Args:
+            workflow_name: Human-readable workflow identifier.
+            tenant_id:     Optional tenant label.
+        """
+        if not self._enabled or self._workflow_counter is None:
+            return
+        attrs: dict[str, str] = {"workflow.name": workflow_name}
+        if tenant_id:
+            attrs["tenant.id"] = tenant_id
+        self._workflow_counter.add(1, attributes=attrs)
+
+    def record_workflow_duration(
+        self,
+        workflow_name: str,
+        duration_s: float,
+        status: str = "ok",
+        tenant_id: str = "",
+    ) -> None:
+        """Record a workflow execution duration in the histogram.
+
+        Args:
+            workflow_name: Human-readable workflow identifier.
+            duration_s:    Elapsed time in seconds.
+            status:        ``"ok"`` or ``"error"``.
+            tenant_id:     Optional tenant label.
+        """
+        if not self._enabled or self._workflow_duration is None:
+            return
+        attrs: dict[str, str] = {
+            "workflow.name": workflow_name,
+            "status": status,
+        }
+        if tenant_id:
+            attrs["tenant.id"] = tenant_id
+        self._workflow_duration.record(duration_s, attributes=attrs)
+
+    def record_node_duration(
+        self,
+        node_id: str,
+        node_type: str,
+        duration_s: float,
+        status: str = "ok",
+    ) -> None:
+        """Record a node execution duration in the histogram.
+
+        Args:
+            node_id:    The node identifier.
+            node_type:  Class name / type label of the node.
+            duration_s: Elapsed time in seconds.
+            status:     ``"ok"`` or ``"error"``.
+        """
+        if not self._enabled or self._node_duration is None:
+            return
+        self._node_duration.record(
+            duration_s,
+            attributes={
+                "node.id": node_id,
+                "node.type": node_type,
+                "status": status,
+            },
+        )
+
+
+# ------------------------------------------------------------------
+# Module-level singleton
+# ------------------------------------------------------------------
+
+_global_bridge: Optional[MetricsBridge] = None
+_global_bridge_lock = threading.Lock()
+
+
+def get_metrics_bridge() -> MetricsBridge:
+    """Return the module-level ``MetricsBridge`` singleton (thread-safe)."""
+    global _global_bridge
+    if _global_bridge is None:
+        with _global_bridge_lock:
+            if _global_bridge is None:
+                _global_bridge = MetricsBridge()
+    return _global_bridge

--- a/src/kailash/runtime/tracing.py
+++ b/src/kailash/runtime/tracing.py
@@ -10,8 +10,17 @@ This module provides lightweight OpenTelemetry integration for the core SDK runt
 It is independent of Kaizen's TracingManager (which targets Jaeger + HookContext).
 Both can coexist: Kaizen traces agent-level hooks, this traces workflow/node execution.
 
+Progressive configuration via ``TracingLevel``:
+
+- ``NONE``:     No instrumentation (zero overhead).
+- ``BASIC``:    Workflow-level spans only.
+- ``DETAILED``: Workflow + node-level spans.
+- ``FULL``:     Workflow + node + database + custom spans.
+
+Configure via the ``KAILASH_TRACING_LEVEL`` environment variable or programmatically.
+
 Example:
-    >>> from kailash.runtime.tracing import get_workflow_tracer
+    >>> from kailash.runtime.tracing import get_workflow_tracer, TracingLevel
     >>> tracer = get_workflow_tracer()
     >>> if tracer.enabled:
     ...     span = tracer.start_workflow_span("wf-123", "my_workflow")
@@ -22,11 +31,19 @@ Example:
 from __future__ import annotations
 
 import logging
+import os
+import threading
+from enum import Enum
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["WorkflowTracer", "get_workflow_tracer"]
+__all__ = [
+    "TracingLevel",
+    "WorkflowTracer",
+    "get_workflow_tracer",
+    "configure_tracing",
+]
 
 # Graceful degradation: if opentelemetry-api is not installed, all tracing is no-op.
 _OTEL_AVAILABLE = False
@@ -44,27 +61,90 @@ except ImportError:
     pass
 
 
+class TracingLevel(Enum):
+    """Progressive tracing configuration levels.
+
+    Controls the granularity of OpenTelemetry instrumentation.
+
+    Attributes:
+        NONE:     No instrumentation.  All tracing methods are no-ops.
+        BASIC:    Workflow-level spans only (start/end per workflow execution).
+        DETAILED: Workflow + node-level spans (each node gets a child span).
+        FULL:     Workflow + node + database + custom spans (maximum visibility).
+    """
+
+    NONE = "none"
+    BASIC = "basic"
+    DETAILED = "detailed"
+    FULL = "full"
+
+
+def _resolve_tracing_level() -> TracingLevel:
+    """Resolve tracing level from the ``KAILASH_TRACING_LEVEL`` env var.
+
+    Falls back to ``NONE`` if the variable is unset or has an unrecognised value.
+    """
+    raw = os.environ.get("KAILASH_TRACING_LEVEL", "none").strip().lower()
+    for level in TracingLevel:
+        if level.value == raw:
+            return level
+    logger.warning(
+        "Unrecognised KAILASH_TRACING_LEVEL=%r; defaulting to NONE", raw
+    )
+    return TracingLevel.NONE
+
+
 class WorkflowTracer:
     """Traces workflow execution with OpenTelemetry spans.
 
-    When opentelemetry-api is not installed, every method is a safe no-op that
-    returns ``None`` for spans and performs no work.  This guarantees zero overhead
-    in environments that do not opt into tracing.
+    When opentelemetry-api is not installed **or** the tracing level is ``NONE``,
+    every method is a safe no-op that returns ``None`` for spans and performs no
+    work.  This guarantees zero overhead in environments that do not opt into
+    tracing.
 
     Attributes:
-        enabled: Whether OpenTelemetry is available and the tracer is active.
+        enabled: Whether OpenTelemetry is available and tracing level is not NONE.
+        level:   The active :class:`TracingLevel`.
     """
 
-    def __init__(self, service_name: str = "kailash") -> None:
-        self._enabled: bool = _OTEL_AVAILABLE
+    def __init__(
+        self,
+        service_name: str = "kailash",
+        level: Optional[TracingLevel] = None,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._level: TracingLevel = level if level is not None else _resolve_tracing_level()
+        self._service_name = service_name
         self._tracer: Any = None
-        if self._enabled and _trace is not None:
+
+        otel_active = _OTEL_AVAILABLE and self._level is not TracingLevel.NONE
+        if otel_active and _trace is not None:
             self._tracer = _trace.get_tracer(service_name)
+        self._enabled: bool = otel_active and self._tracer is not None
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
 
     @property
     def enabled(self) -> bool:
-        """Return True when OpenTelemetry is installed and the tracer is active."""
+        """Return True when OpenTelemetry is installed and tracing is active."""
         return self._enabled
+
+    @property
+    def level(self) -> TracingLevel:
+        """Return the current tracing level."""
+        return self._level
+
+    @level.setter
+    def level(self, new_level: TracingLevel) -> None:
+        """Reconfigure the tracing level at runtime (thread-safe)."""
+        with self._lock:
+            self._level = new_level
+            otel_active = _OTEL_AVAILABLE and new_level is not TracingLevel.NONE
+            if otel_active and _trace is not None and self._tracer is None:
+                self._tracer = _trace.get_tracer(self._service_name)
+            self._enabled = otel_active and self._tracer is not None
 
     # ------------------------------------------------------------------
     # Span lifecycle
@@ -75,25 +155,33 @@ class WorkflowTracer:
         workflow_id: str,
         workflow_name: str,
         run_id: str = "",
+        tenant_id: str = "",
     ) -> Optional[Any]:
         """Start a span for the entire workflow execution.
 
         Args:
-            workflow_id: Unique identifier for this workflow run.
+            workflow_id: Unique identifier for this workflow definition.
             workflow_name: Human-readable workflow name.
             run_id: Runtime-assigned execution run ID.
+            tenant_id: Optional tenant identifier for multi-tenant deployments.
 
         Returns:
-            An OpenTelemetry ``Span`` if tracing is enabled, else ``None``.
+            An OpenTelemetry ``Span`` if tracing is enabled at BASIC or above,
+            else ``None``.
         """
         if not self._enabled or self._tracer is None:
             return None
-        attrs = {
+        if self._level is TracingLevel.NONE:
+            return None
+
+        attrs: dict[str, Any] = {
             "workflow.id": workflow_id,
             "workflow.name": workflow_name,
         }
         if run_id:
             attrs["workflow.run_id"] = run_id
+        if tenant_id:
+            attrs["tenant.id"] = tenant_id
         span = self._tracer.start_span(
             f"workflow.{workflow_name}",
             attributes=attrs,
@@ -117,10 +205,14 @@ class WorkflowTracer:
             parent_span: Optional parent span for hierarchy.
 
         Returns:
-            An OpenTelemetry ``Span`` if tracing is enabled, else ``None``.
+            An OpenTelemetry ``Span`` if tracing is enabled at DETAILED or above,
+            else ``None``.
         """
         if not self._enabled or self._tracer is None or _trace is None:
             return None
+        if self._level not in (TracingLevel.DETAILED, TracingLevel.FULL):
+            return None
+
         ctx = _trace.set_span_in_context(parent_span) if parent_span else None
         span = self._tracer.start_span(
             f"node.{node_type}",
@@ -129,6 +221,46 @@ class WorkflowTracer:
                 "node.id": node_id,
                 "node.type": node_type,
             },
+        )
+        return span
+
+    def start_db_span(
+        self,
+        operation: str,
+        statement: str = "",
+        db_system: str = "",
+        parent_span: Optional[Any] = None,
+    ) -> Optional[Any]:
+        """Start a span for a database operation.
+
+        Only active at ``TracingLevel.FULL``.
+
+        Args:
+            operation: The database operation (e.g. ``"SELECT"``, ``"INSERT"``).
+            statement: The SQL statement (will be truncated to 1024 chars).
+            db_system: Database system identifier (e.g. ``"sqlite"``, ``"postgresql"``).
+            parent_span: Optional parent span for hierarchy.
+
+        Returns:
+            An OpenTelemetry ``Span`` if tracing level is FULL, else ``None``.
+        """
+        if not self._enabled or self._tracer is None or _trace is None:
+            return None
+        if self._level is not TracingLevel.FULL:
+            return None
+
+        ctx = _trace.set_span_in_context(parent_span) if parent_span else None
+        attrs: dict[str, Any] = {
+            "db.operation": operation,
+        }
+        if statement:
+            attrs["db.statement"] = statement[:1024]
+        if db_system:
+            attrs["db.system"] = db_system
+        span = self._tracer.start_span(
+            f"db.{operation}",
+            context=ctx,
+            attributes=attrs,
         )
         return span
 
@@ -178,14 +310,43 @@ class WorkflowTracer:
 # ------------------------------------------------------------------
 
 _global_tracer: Optional[WorkflowTracer] = None
+_global_lock = threading.Lock()
 
 
 def get_workflow_tracer() -> WorkflowTracer:
     """Return the module-level ``WorkflowTracer`` singleton.
 
     The instance is created lazily on first call and reused thereafter.
+    Thread-safe via a module-level lock.
     """
     global _global_tracer
     if _global_tracer is None:
-        _global_tracer = WorkflowTracer()
+        with _global_lock:
+            if _global_tracer is None:
+                _global_tracer = WorkflowTracer()
+    return _global_tracer
+
+
+def configure_tracing(
+    level: TracingLevel,
+    service_name: str = "kailash",
+) -> WorkflowTracer:
+    """Configure the global tracer with the given level and service name.
+
+    If the global tracer already exists its level is updated in-place.
+    Otherwise a new tracer is created.
+
+    Args:
+        level: Desired tracing granularity.
+        service_name: OpenTelemetry service name.
+
+    Returns:
+        The (re)configured global :class:`WorkflowTracer` singleton.
+    """
+    global _global_tracer
+    with _global_lock:
+        if _global_tracer is None:
+            _global_tracer = WorkflowTracer(service_name=service_name, level=level)
+        else:
+            _global_tracer.level = level
     return _global_tracer

--- a/tests/unit/runtime/test_instrumentation.py
+++ b/tests/unit/runtime/test_instrumentation.py
@@ -1,0 +1,617 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for S5 OpenTelemetry tracing enhancement.
+
+Covers:
+- TracingLevel configuration and env-var resolution.
+- WorkflowTracer span lifecycle at each level.
+- NodeInstrumentor wrapping and attribute recording.
+- DataFlowInstrumentor query tracing.
+- DatabaseInstrumentor auto-instrumentation.
+- MetricsBridge recording methods.
+
+All tests work regardless of whether ``opentelemetry`` is installed:
+when absent the tests verify graceful no-op behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — detect whether OTel is available
+# ---------------------------------------------------------------------------
+def _otel_available() -> bool:
+    try:
+        import opentelemetry  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+HAS_OTEL = _otel_available()
+
+
+# ---------------------------------------------------------------------------
+# TracingLevel
+# ---------------------------------------------------------------------------
+
+
+class TestTracingLevel:
+    """TracingLevel enum and env-var resolution."""
+
+    def test_enum_values(self) -> None:
+        from kailash.runtime.tracing import TracingLevel
+
+        assert TracingLevel.NONE.value == "none"
+        assert TracingLevel.BASIC.value == "basic"
+        assert TracingLevel.DETAILED.value == "detailed"
+        assert TracingLevel.FULL.value == "full"
+
+    def test_resolve_from_env_basic(self) -> None:
+        from kailash.runtime.tracing import _resolve_tracing_level, TracingLevel
+
+        with patch.dict(os.environ, {"KAILASH_TRACING_LEVEL": "basic"}):
+            assert _resolve_tracing_level() is TracingLevel.BASIC
+
+    def test_resolve_from_env_full(self) -> None:
+        from kailash.runtime.tracing import _resolve_tracing_level, TracingLevel
+
+        with patch.dict(os.environ, {"KAILASH_TRACING_LEVEL": "full"}):
+            assert _resolve_tracing_level() is TracingLevel.FULL
+
+    def test_resolve_from_env_unknown_defaults_to_none(self) -> None:
+        from kailash.runtime.tracing import _resolve_tracing_level, TracingLevel
+
+        with patch.dict(os.environ, {"KAILASH_TRACING_LEVEL": "turbo"}):
+            assert _resolve_tracing_level() is TracingLevel.NONE
+
+    def test_resolve_unset_defaults_to_none(self) -> None:
+        from kailash.runtime.tracing import _resolve_tracing_level, TracingLevel
+
+        env = os.environ.copy()
+        env.pop("KAILASH_TRACING_LEVEL", None)
+        with patch.dict(os.environ, env, clear=True):
+            assert _resolve_tracing_level() is TracingLevel.NONE
+
+
+# ---------------------------------------------------------------------------
+# WorkflowTracer — without OTel
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowTracerNoOtel:
+    """WorkflowTracer behaviour when OTel is *not* available."""
+
+    def test_disabled_when_otel_missing(self) -> None:
+        from kailash.runtime import tracing as mod
+
+        original = mod._OTEL_AVAILABLE
+        try:
+            mod._OTEL_AVAILABLE = False
+            tracer = mod.WorkflowTracer(level=mod.TracingLevel.FULL)
+            assert tracer.enabled is False
+            assert tracer.start_workflow_span("wf", "name") is None
+            assert tracer.start_node_span("n", "T") is None
+            assert tracer.start_db_span("SELECT") is None
+            tracer.end_span(None)
+            tracer.set_attribute(None, "k", "v")
+        finally:
+            mod._OTEL_AVAILABLE = original
+
+    def test_none_level_disables_even_with_otel(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.NONE)
+        assert tracer.level is TracingLevel.NONE
+        # Even if OTel is installed, NONE means no spans
+        assert tracer.start_workflow_span("wf", "name") is None
+
+
+# ---------------------------------------------------------------------------
+# WorkflowTracer — with OTel (skip if not installed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+class TestWorkflowTracerWithOtel:
+    """WorkflowTracer behaviour when OTel *is* available."""
+
+    def test_basic_creates_workflow_spans(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.BASIC)
+        assert tracer.enabled is True
+        span = tracer.start_workflow_span("wf-1", "test_wf", run_id="run-1")
+        assert span is not None
+        tracer.end_span(span)
+
+    def test_basic_skips_node_spans(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.BASIC)
+        assert tracer.start_node_span("n1", "SomeNode") is None
+
+    def test_detailed_creates_node_spans(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.DETAILED)
+        span = tracer.start_node_span("n1", "PythonCodeNode")
+        assert span is not None
+        tracer.end_span(span)
+
+    def test_detailed_skips_db_spans(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.DETAILED)
+        assert tracer.start_db_span("SELECT") is None
+
+    def test_full_creates_db_spans(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.FULL)
+        span = tracer.start_db_span(
+            "SELECT", statement="SELECT 1", db_system="sqlite"
+        )
+        assert span is not None
+        tracer.end_span(span)
+
+    def test_end_span_records_error(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.BASIC)
+        span = tracer.start_workflow_span("wf", "err_test")
+        assert span is not None
+        tracer.end_span(span, error=ValueError("boom"))
+
+    def test_set_attribute(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.BASIC)
+        span = tracer.start_workflow_span("wf", "attr_test")
+        tracer.set_attribute(span, "custom.key", "custom_value")
+        tracer.end_span(span)
+
+    def test_tenant_id_attribute(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.BASIC)
+        span = tracer.start_workflow_span(
+            "wf", "tenant_test", tenant_id="tenant-42"
+        )
+        assert span is not None
+        tracer.end_span(span)
+
+    def test_level_setter_thread_safe(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.NONE)
+        assert tracer.enabled is False
+
+        tracer.level = TracingLevel.FULL
+        assert tracer.level is TracingLevel.FULL
+        assert tracer.enabled is True
+
+        tracer.level = TracingLevel.NONE
+        assert tracer.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# configure_tracing / get_workflow_tracer
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureTracing:
+    """Global configuration helpers."""
+
+    def test_configure_creates_singleton(self) -> None:
+        from kailash.runtime import tracing as mod
+
+        # Reset global state for isolation
+        old = mod._global_tracer
+        mod._global_tracer = None
+        try:
+            result = mod.configure_tracing(mod.TracingLevel.BASIC)
+            assert result is mod.get_workflow_tracer()
+            assert result.level is mod.TracingLevel.BASIC
+        finally:
+            mod._global_tracer = old
+
+    def test_configure_updates_existing(self) -> None:
+        from kailash.runtime import tracing as mod
+
+        old = mod._global_tracer
+        mod._global_tracer = None
+        try:
+            first = mod.configure_tracing(mod.TracingLevel.BASIC)
+            second = mod.configure_tracing(mod.TracingLevel.FULL)
+            assert first is second
+            assert first.level is mod.TracingLevel.FULL
+        finally:
+            mod._global_tracer = old
+
+
+# ---------------------------------------------------------------------------
+# NodeInstrumentor
+# ---------------------------------------------------------------------------
+
+
+class TestNodeInstrumentor:
+    """Node-level instrumentation."""
+
+    def test_passthrough_when_disabled(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.nodes import NodeInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.NONE)
+        try:
+            inst = NodeInstrumentor()
+            result = inst.execute(
+                node_id="n1",
+                node_type="TestNode",
+                func=lambda x: x * 2,
+                args=(21,),
+            )
+            assert result == 42
+        finally:
+            mod._global_tracer = old
+
+    def test_propagates_exception(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.nodes import NodeInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.NONE)
+        try:
+            inst = NodeInstrumentor()
+
+            def boom() -> None:
+                raise RuntimeError("test error")
+
+            with pytest.raises(RuntimeError, match="test error"):
+                inst.execute(node_id="n1", node_type="T", func=boom)
+        finally:
+            mod._global_tracer = old
+
+    @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+    def test_creates_span_at_detailed(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.nodes import NodeInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.DETAILED)
+        try:
+            inst = NodeInstrumentor()
+            result = inst.execute(
+                node_id="n1",
+                node_type="PythonCodeNode",
+                func=lambda: "hello",
+            )
+            assert result == "hello"
+        finally:
+            mod._global_tracer = old
+
+    def test_decorator_instrument_node(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.nodes import instrument_node
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.NONE)
+        try:
+
+            @instrument_node("step1", "PythonCodeNode")
+            def my_step(x: int) -> int:
+                return x + 1
+
+            assert my_step(10) == 11
+        finally:
+            mod._global_tracer = old
+
+
+# ---------------------------------------------------------------------------
+# DataFlowInstrumentor
+# ---------------------------------------------------------------------------
+
+
+class TestDataFlowInstrumentor:
+    """DataFlow query tracing."""
+
+    def test_passthrough_when_not_full(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.dataflow import DataFlowInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.DETAILED)
+        try:
+            inst = DataFlowInstrumentor(db_system="sqlite")
+            result = inst.trace_query(
+                statement="SELECT 1",
+                execute_fn=lambda: [{"a": 1}],
+            )
+            assert result == [{"a": 1}]
+        finally:
+            mod._global_tracer = old
+
+    @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+    def test_traces_query_at_full(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.dataflow import DataFlowInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.FULL)
+        try:
+            inst = DataFlowInstrumentor(db_system="postgresql")
+            result = inst.trace_query(
+                statement="SELECT id FROM users WHERE active = ?",
+                execute_fn=lambda: [{"id": 1}, {"id": 2}],
+            )
+            assert len(result) == 2
+        finally:
+            mod._global_tracer = old
+
+    def test_propagates_query_error(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.dataflow import DataFlowInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.NONE)
+        try:
+            inst = DataFlowInstrumentor()
+
+            def fail() -> None:
+                raise ConnectionError("db down")
+
+            with pytest.raises(ConnectionError, match="db down"):
+                inst.trace_query(statement="SELECT 1", execute_fn=fail)
+        finally:
+            mod._global_tracer = old
+
+    def test_count_rows_list(self) -> None:
+        from kailash.runtime.instrumentation.dataflow import DataFlowInstrumentor
+
+        assert DataFlowInstrumentor._count_rows([1, 2, 3]) == 3
+
+    def test_count_rows_none(self) -> None:
+        from kailash.runtime.instrumentation.dataflow import DataFlowInstrumentor
+
+        assert DataFlowInstrumentor._count_rows(None) == 0
+
+    def test_count_rows_unknown(self) -> None:
+        from kailash.runtime.instrumentation.dataflow import DataFlowInstrumentor
+
+        assert DataFlowInstrumentor._count_rows("not a result") is None
+
+
+# ---------------------------------------------------------------------------
+# DatabaseInstrumentor
+# ---------------------------------------------------------------------------
+
+
+class TestDatabaseInstrumentor:
+    """Auto-instrumentation for ConnectionManager-like objects."""
+
+    def _make_fake_conn(self) -> Any:
+        """Create a fake connection manager with execute/fetchone/fetchall."""
+
+        class FakeConn:
+            def execute(self, sql: str, *args: Any) -> int:
+                return 1
+
+            def fetchone(self, sql: str, *args: Any) -> Optional[dict[str, Any]]:
+                return {"id": 1}
+
+            def fetchall(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+                return [{"id": 1}, {"id": 2}]
+
+        return FakeConn()
+
+    def test_instrument_and_uninstrument(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.database import DatabaseInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.NONE)
+        try:
+            conn = self._make_fake_conn()
+            inst = DatabaseInstrumentor(db_system="sqlite")
+
+            inst.instrument(conn)
+            assert getattr(conn, "_kailash_otel_instrumented", False) is True
+            # Methods still work
+            assert conn.execute("INSERT INTO t VALUES (?)") == 1
+            assert conn.fetchone("SELECT 1") == {"id": 1}
+            assert len(conn.fetchall("SELECT *")) == 2
+
+            inst.uninstrument(conn)
+            assert getattr(conn, "_kailash_otel_instrumented", False) is False
+            # Methods restored
+            assert conn.execute("INSERT INTO t VALUES (?)") == 1
+        finally:
+            mod._global_tracer = old
+
+    def test_double_instrument_is_noop(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.database import DatabaseInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.NONE)
+        try:
+            conn = self._make_fake_conn()
+            inst = DatabaseInstrumentor()
+            inst.instrument(conn)
+            inst.instrument(conn)  # Should not raise or double-wrap
+            assert conn.execute("SELECT 1") == 1
+            inst.uninstrument(conn)
+        finally:
+            mod._global_tracer = old
+
+    def test_uninstrument_without_instrument_is_safe(self) -> None:
+        from kailash.runtime.instrumentation.database import DatabaseInstrumentor
+
+        conn = self._make_fake_conn()
+        inst = DatabaseInstrumentor()
+        inst.uninstrument(conn)  # Should not raise
+
+    @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+    def test_spans_created_at_full(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.database import DatabaseInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.FULL)
+        try:
+            conn = self._make_fake_conn()
+            inst = DatabaseInstrumentor(db_system="sqlite")
+            inst.instrument(conn)
+            result = conn.fetchall("SELECT * FROM users")
+            assert len(result) == 2
+            inst.uninstrument(conn)
+        finally:
+            mod._global_tracer = old
+
+
+# ---------------------------------------------------------------------------
+# MetricsBridge
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsBridge:
+    """Prometheus metrics bridge."""
+
+    def test_noop_when_otel_missing(self) -> None:
+        from kailash.runtime import metrics as mod
+
+        original = mod._OTEL_METRICS_AVAILABLE
+        try:
+            mod._OTEL_METRICS_AVAILABLE = False
+            bridge = mod.MetricsBridge()
+            assert bridge.enabled is False
+            # All methods are safe no-ops
+            bridge.record_workflow_start("wf")
+            bridge.record_workflow_duration("wf", 1.5)
+            bridge.record_node_duration("n1", "T", 0.5)
+        finally:
+            mod._OTEL_METRICS_AVAILABLE = original
+
+    @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+    def test_enabled_with_otel(self) -> None:
+        from kailash.runtime.metrics import MetricsBridge
+
+        bridge = MetricsBridge()
+        assert bridge.enabled is True
+
+    @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+    def test_record_workflow_start(self) -> None:
+        from kailash.runtime.metrics import MetricsBridge
+
+        bridge = MetricsBridge()
+        bridge.record_workflow_start("test_wf", tenant_id="t-1")
+
+    @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+    def test_record_workflow_duration(self) -> None:
+        from kailash.runtime.metrics import MetricsBridge
+
+        bridge = MetricsBridge()
+        bridge.record_workflow_duration("test_wf", 2.5, status="ok")
+
+    @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+    def test_record_node_duration(self) -> None:
+        from kailash.runtime.metrics import MetricsBridge
+
+        bridge = MetricsBridge()
+        bridge.record_node_duration("n1", "PythonCodeNode", 0.42, status="ok")
+
+    @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed")
+    def test_record_workflow_duration_error(self) -> None:
+        from kailash.runtime.metrics import MetricsBridge
+
+        bridge = MetricsBridge()
+        bridge.record_workflow_duration("fail_wf", 0.1, status="error")
+
+    def test_singleton_get_metrics_bridge(self) -> None:
+        from kailash.runtime import metrics as mod
+
+        old = mod._global_bridge
+        mod._global_bridge = None
+        try:
+            b1 = mod.get_metrics_bridge()
+            b2 = mod.get_metrics_bridge()
+            assert b1 is b2
+        finally:
+            mod._global_bridge = old
+
+
+# ---------------------------------------------------------------------------
+# Thread-safety smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    """Verify key components are safe under concurrent access."""
+
+    def test_concurrent_tracer_level_changes(self) -> None:
+        from kailash.runtime.tracing import TracingLevel, WorkflowTracer
+
+        tracer = WorkflowTracer(level=TracingLevel.NONE)
+        errors: list[Exception] = []
+
+        def toggle(level: TracingLevel) -> None:
+            try:
+                for _ in range(50):
+                    tracer.level = level
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=toggle, args=(TracingLevel.FULL,)),
+            threading.Thread(target=toggle, args=(TracingLevel.NONE,)),
+            threading.Thread(target=toggle, args=(TracingLevel.BASIC,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+        assert errors == [], f"Thread errors: {errors}"
+
+    def test_concurrent_node_instrumentation(self) -> None:
+        from kailash.runtime import tracing as mod
+        from kailash.runtime.instrumentation.nodes import NodeInstrumentor
+
+        old = mod._global_tracer
+        mod._global_tracer = mod.WorkflowTracer(level=mod.TracingLevel.NONE)
+        try:
+            inst = NodeInstrumentor()
+            results: list[int] = []
+            errors: list[Exception] = []
+
+            def run_node(val: int) -> None:
+                try:
+                    r = inst.execute(
+                        node_id=f"n-{val}",
+                        node_type="TestNode",
+                        func=lambda v: v * 2,
+                        args=(val,),
+                    )
+                    results.append(r)
+                except Exception as exc:
+                    errors.append(exc)
+
+            threads = [threading.Thread(target=run_node, args=(i,)) for i in range(10)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+            assert errors == []
+            assert sorted(results) == [i * 2 for i in range(10)]
+        finally:
+            mod._global_tracer = old


### PR DESCRIPTION
## Summary

- **S5-001/005**: Extended `WorkflowTracer` with `TracingLevel` enum (NONE/BASIC/DETAILED/FULL), `KAILASH_TRACING_LEVEL` env-var configuration, enriched span attributes (tenant_id, run_id), thread-safe `configure_tracing()` API
- **S5-002**: Created `src/kailash/runtime/instrumentation/` package with `NodeInstrumentor` — wraps node execution with child spans capturing node_id, node_type, duration, input/output size. Includes `@instrument_node` decorator
- **S5-003**: `DataFlowInstrumentor` for database query tracing with OTel semantic conventions (db.system, db.statement, db.operation, db.row_count, db.duration_s)
- **S5-004**: `DatabaseInstrumentor` for auto-instrumenting ConnectionManager — monkey-patches execute/fetchone/fetchall with OTel spans, supports instrument/uninstrument lifecycle
- **S5-006**: `MetricsBridge` exposing OTel metrics as Prometheus-compatible instruments: `kailash_workflow_executions_total`, `kailash_workflow_duration_seconds`, `kailash_node_execution_duration_seconds`
- **S5-007**: 41 tests covering all components, thread-safety, graceful degradation when opentelemetry is not installed

## Test plan

- [x] `python -m pytest tests/unit/runtime/test_instrumentation.py -v --timeout=30` — 41 passed, 0 failed
- [x] All components degrade gracefully when `opentelemetry` is absent (lazy imports via `pip install kailash[otel]`)
- [x] Thread-safety verified with concurrent level changes and parallel node instrumentation

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)