### PR TITLE
feat(kaizen-agents): S7 tool search/hydration for large tool sets

### DIFF
--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/__init__.py
@@ -1,15 +1,32 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
 """LLM provider adapters for the Delegate.
 
-Each adapter implements the LLMAdapter protocol, providing model-agnostic
-streaming completions. The Delegate doesn't know which LLM provider is
-being used — it just calls the adapter.
+Each adapter implements the :class:`StreamingChatAdapter` protocol, providing
+model-agnostic streaming completions.  The Delegate does not know which LLM
+provider is being used -- it calls the adapter through a uniform interface.
 
-Current:
-    openai_stream.py — OpenAI SSE stream processing (moved from kz/cli/stream.py)
-
-Planned:
-    openai.py — Full OpenAI adapter (extract from loop.py's AsyncOpenAI usage)
-    anthropic.py — Anthropic adapter (wire to kailash-kaizen's Anthropic provider)
-    google.py — Google Gemini adapter
-    ollama.py — Ollama local model adapter
+Adapters:
+    protocol        -- StreamingChatAdapter protocol and StreamEvent dataclass
+    openai_adapter  -- OpenAI / OpenAI-compatible endpoints
+    anthropic_adapter -- Anthropic Claude models (native SDK)
+    google_adapter  -- Google Gemini models (native SDK)
+    ollama_adapter  -- Local Ollama models (httpx streaming)
+    openai_stream   -- Low-level OpenAI SSE stream processor (internal)
 """
+
+from kaizen_agents.delegate.adapters.protocol import (
+    StreamEvent,
+    StreamingChatAdapter,
+)
+from kaizen_agents.delegate.adapters.registry import (
+    get_adapter,
+    get_adapter_for_model,
+)
+
+__all__ = [
+    "StreamEvent",
+    "StreamingChatAdapter",
+    "get_adapter",
+    "get_adapter_for_model",
+]

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/anthropic_adapter.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/anthropic_adapter.py
@@ -1,0 +1,294 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Anthropic Claude streaming chat adapter.
+
+Implements the :class:`StreamingChatAdapter` protocol using the native
+``anthropic`` Python SDK.  Maps Anthropic's ``content_block_start``,
+``content_block_delta``, and ``content_block_stop`` events to the unified
+``StreamEvent`` format.
+
+Tool-use blocks are normalised to OpenAI-compatible tool call dicts for
+downstream compatibility with the AgentLoop's tool execution pipeline.
+
+Lazy-imports the ``anthropic`` package so that users of other providers
+do not need it installed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from typing import Any, AsyncGenerator
+
+from kaizen_agents.delegate.adapters.protocol import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+
+def _convert_messages_for_anthropic(
+    messages: list[dict[str, Any]],
+) -> tuple[str, list[dict[str, Any]]]:
+    """Separate system prompt from messages and convert to Anthropic format.
+
+    OpenAI format puts the system message in the messages list.  Anthropic
+    expects it as a top-level ``system`` parameter, and uses separate
+    ``tool_result`` blocks instead of ``role: "tool"`` messages.
+
+    Returns (system_prompt, anthropic_messages).
+    """
+    system_prompt = ""
+    anthropic_msgs: list[dict[str, Any]] = []
+
+    for msg in messages:
+        role = msg.get("role", "")
+
+        if role == "system":
+            system_prompt = msg.get("content", "")
+
+        elif role == "user":
+            anthropic_msgs.append({"role": "user", "content": msg["content"]})
+
+        elif role == "assistant":
+            content_blocks: list[dict[str, Any]] = []
+            text = msg.get("content", "")
+            if text:
+                content_blocks.append({"type": "text", "text": text})
+            # Convert OpenAI tool_calls to Anthropic tool_use blocks
+            for tc in msg.get("tool_calls", []):
+                func = tc.get("function", {})
+                args_str = func.get("arguments", "{}")
+                try:
+                    args = json.loads(args_str) if args_str else {}
+                except json.JSONDecodeError:
+                    args = {}
+                content_blocks.append({
+                    "type": "tool_use",
+                    "id": tc.get("id", str(uuid.uuid4())),
+                    "name": func.get("name", ""),
+                    "input": args,
+                })
+            if content_blocks:
+                anthropic_msgs.append({"role": "assistant", "content": content_blocks})
+            else:
+                anthropic_msgs.append({"role": "assistant", "content": text or ""})
+
+        elif role == "tool":
+            # Anthropic expects tool results as user messages with tool_result blocks
+            anthropic_msgs.append({
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": msg.get("tool_call_id", ""),
+                    "content": msg.get("content", ""),
+                }],
+            })
+
+    return system_prompt, anthropic_msgs
+
+
+def _convert_tools_for_anthropic(
+    tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Convert OpenAI-format tool definitions to Anthropic format.
+
+    OpenAI: ``{"type": "function", "function": {"name": ..., "description": ..., "parameters": ...}}``
+    Anthropic: ``{"name": ..., "description": ..., "input_schema": ...}``
+    """
+    if not tools:
+        return []
+
+    anthropic_tools: list[dict[str, Any]] = []
+    for tool in tools:
+        func = tool.get("function", {})
+        anthropic_tools.append({
+            "name": func.get("name", ""),
+            "description": func.get("description", ""),
+            "input_schema": func.get("parameters", {"type": "object", "properties": {}}),
+        })
+    return anthropic_tools
+
+
+class AnthropicStreamAdapter:
+    """Adapter for Anthropic Claude models via the native anthropic SDK.
+
+    Parameters
+    ----------
+    api_key:
+        Anthropic API key.  Falls back to ``ANTHROPIC_API_KEY`` env var.
+    default_model:
+        Model to use when none is supplied per-call.
+    default_temperature:
+        Default sampling temperature.
+    default_max_tokens:
+        Default max token limit.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        default_model: str = "",
+        default_temperature: float = 0.4,
+        default_max_tokens: int = 16384,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "No Anthropic API key found.  Set ANTHROPIC_API_KEY in your .env "
+                "file or pass api_key explicitly."
+            )
+
+        self._default_model = default_model
+        self._default_temperature = default_temperature
+        self._default_max_tokens = default_max_tokens
+
+        try:
+            import anthropic
+        except ImportError as exc:
+            raise ImportError(
+                "The anthropic package is required for Anthropic adapters.  "
+                "Install it with: pip install anthropic"
+            ) from exc
+
+        self._client = anthropic.AsyncAnthropic(api_key=resolved_key)
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """Stream a chat completion via the Anthropic API.
+
+        Yields :class:`StreamEvent` instances as tokens arrive.
+        """
+        resolved_model = model or self._default_model
+        resolved_temp = temperature if temperature is not None else self._default_temperature
+        resolved_max = max_tokens if max_tokens is not None else self._default_max_tokens
+
+        system_prompt, anthropic_messages = _convert_messages_for_anthropic(messages)
+        anthropic_tools = _convert_tools_for_anthropic(tools)
+
+        request_kwargs: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": anthropic_messages,
+            "max_tokens": resolved_max,
+            "temperature": resolved_temp,
+        }
+
+        if system_prompt:
+            request_kwargs["system"] = system_prompt
+
+        if anthropic_tools:
+            request_kwargs["tools"] = anthropic_tools
+
+        request_kwargs.update(kwargs)
+
+        # Accumulate state
+        content = ""
+        resp_model = resolved_model
+        tool_blocks: dict[int, dict[str, Any]] = {}
+        current_block_idx = -1
+        usage: dict[str, int] = {}
+        finish_reason: str | None = None
+
+        async with self._client.messages.stream(**request_kwargs) as stream:
+            async for event in stream:
+                event_type = getattr(event, "type", "")
+
+                if event_type == "message_start":
+                    msg = getattr(event, "message", None)
+                    if msg:
+                        resp_model = getattr(msg, "model", resolved_model)
+                        msg_usage = getattr(msg, "usage", None)
+                        if msg_usage:
+                            usage["prompt_tokens"] = getattr(msg_usage, "input_tokens", 0)
+
+                elif event_type == "content_block_start":
+                    current_block_idx += 1
+                    block = getattr(event, "content_block", None)
+                    if block:
+                        block_type = getattr(block, "type", "")
+                        if block_type == "tool_use":
+                            tool_blocks[current_block_idx] = {
+                                "id": getattr(block, "id", str(uuid.uuid4())),
+                                "type": "function",
+                                "function": {
+                                    "name": getattr(block, "name", ""),
+                                    "arguments": "",
+                                },
+                            }
+                            yield StreamEvent(
+                                event_type="tool_call_start",
+                                content=content,
+                                model=resp_model,
+                            )
+
+                elif event_type == "content_block_delta":
+                    delta = getattr(event, "delta", None)
+                    if delta:
+                        delta_type = getattr(delta, "type", "")
+                        if delta_type == "text_delta":
+                            text = getattr(delta, "text", "")
+                            if text:
+                                content += text
+                                yield StreamEvent(
+                                    event_type="text_delta",
+                                    content=content,
+                                    delta_text=text,
+                                    model=resp_model,
+                                )
+                        elif delta_type == "input_json_delta":
+                            partial_json = getattr(delta, "partial_json", "")
+                            if partial_json and current_block_idx in tool_blocks:
+                                tool_blocks[current_block_idx]["function"]["arguments"] += partial_json
+                                yield StreamEvent(
+                                    event_type="tool_call_delta",
+                                    content=content,
+                                    model=resp_model,
+                                )
+
+                elif event_type == "content_block_stop":
+                    if current_block_idx in tool_blocks:
+                        yield StreamEvent(
+                            event_type="tool_call_end",
+                            content=content,
+                            model=resp_model,
+                        )
+
+                elif event_type == "message_delta":
+                    delta = getattr(event, "delta", None)
+                    if delta:
+                        stop_reason = getattr(delta, "stop_reason", None)
+                        if stop_reason:
+                            # Map Anthropic stop reasons to OpenAI finish reasons
+                            if stop_reason == "tool_use":
+                                finish_reason = "tool_calls"
+                            elif stop_reason == "end_turn":
+                                finish_reason = "stop"
+                            else:
+                                finish_reason = stop_reason
+                    msg_usage = getattr(event, "usage", None)
+                    if msg_usage:
+                        usage["completion_tokens"] = getattr(msg_usage, "output_tokens", 0)
+                        usage["total_tokens"] = usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
+
+        # Finalise tool calls
+        final_tool_calls: list[dict[str, Any]] = []
+        for idx in sorted(tool_blocks.keys()):
+            final_tool_calls.append(tool_blocks[idx])
+
+        yield StreamEvent(
+            event_type="done",
+            content=content,
+            tool_calls=final_tool_calls,
+            finish_reason=finish_reason,
+            model=resp_model,
+            usage=usage,
+        )

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/google_adapter.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/google_adapter.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Google Gemini streaming chat adapter.
+
+Implements the :class:`StreamingChatAdapter` protocol using the
+``google.generativeai`` SDK.  Converts between OpenAI-format messages and
+Gemini's native content format.
+
+Lazy-imports the ``google-generativeai`` package so that users of other
+providers do not need it installed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from typing import Any, AsyncGenerator
+
+from kaizen_agents.delegate.adapters.protocol import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+
+def _convert_messages_for_gemini(
+    messages: list[dict[str, Any]],
+) -> tuple[str, list[dict[str, Any]]]:
+    """Convert OpenAI-format messages to Gemini content format.
+
+    Returns (system_instruction, gemini_contents).
+
+    Gemini uses ``user``/``model`` roles and ``parts`` instead of
+    ``content`` strings.  Tool results are ``function_response`` parts.
+    """
+    system_instruction = ""
+    contents: list[dict[str, Any]] = []
+
+    for msg in messages:
+        role = msg.get("role", "")
+
+        if role == "system":
+            system_instruction = msg.get("content", "")
+
+        elif role == "user":
+            contents.append({
+                "role": "user",
+                "parts": [{"text": msg.get("content", "")}],
+            })
+
+        elif role == "assistant":
+            parts: list[dict[str, Any]] = []
+            text = msg.get("content", "")
+            if text:
+                parts.append({"text": text})
+            for tc in msg.get("tool_calls", []):
+                func = tc.get("function", {})
+                args_str = func.get("arguments", "{}")
+                try:
+                    args = json.loads(args_str) if args_str else {}
+                except json.JSONDecodeError:
+                    args = {}
+                parts.append({
+                    "function_call": {
+                        "name": func.get("name", ""),
+                        "args": args,
+                    }
+                })
+            if parts:
+                contents.append({"role": "model", "parts": parts})
+
+        elif role == "tool":
+            contents.append({
+                "role": "user",
+                "parts": [{
+                    "function_response": {
+                        "name": msg.get("name", ""),
+                        "response": {"result": msg.get("content", "")},
+                    }
+                }],
+            })
+
+    return system_instruction, contents
+
+
+def _convert_tools_for_gemini(
+    tools: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]] | None:
+    """Convert OpenAI-format tool defs to Gemini function_declarations.
+
+    Gemini expects tools as:
+    ``[{"function_declarations": [{"name": ..., "description": ..., "parameters": ...}]}]``
+    """
+    if not tools:
+        return None
+
+    declarations: list[dict[str, Any]] = []
+    for tool in tools:
+        func = tool.get("function", {})
+        declarations.append({
+            "name": func.get("name", ""),
+            "description": func.get("description", ""),
+            "parameters": func.get("parameters", {"type": "object", "properties": {}}),
+        })
+
+    return [{"function_declarations": declarations}]
+
+
+class GoogleStreamAdapter:
+    """Adapter for Google Gemini models via the google-generativeai SDK.
+
+    Parameters
+    ----------
+    api_key:
+        Google API key.  Falls back to ``GOOGLE_API_KEY`` or
+        ``GEMINI_API_KEY`` env vars.
+    default_model:
+        Model to use when none is supplied per-call.
+    default_temperature:
+        Default sampling temperature.
+    default_max_tokens:
+        Default max token limit.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        default_model: str = "",
+        default_temperature: float = 0.4,
+        default_max_tokens: int = 16384,
+    ) -> None:
+        resolved_key = (
+            api_key
+            or os.environ.get("GOOGLE_API_KEY")
+            or os.environ.get("GEMINI_API_KEY")
+        )
+        if not resolved_key:
+            raise ValueError(
+                "No Google API key found.  Set GOOGLE_API_KEY or GEMINI_API_KEY "
+                "in your .env file or pass api_key explicitly."
+            )
+
+        self._default_model = default_model
+        self._default_temperature = default_temperature
+        self._default_max_tokens = default_max_tokens
+
+        try:
+            import google.generativeai as genai
+        except ImportError as exc:
+            raise ImportError(
+                "The google-generativeai package is required for Google adapters.  "
+                "Install it with: pip install google-generativeai"
+            ) from exc
+
+        genai.configure(api_key=resolved_key)
+        self._genai = genai
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """Stream a chat completion via the Gemini API.
+
+        Yields :class:`StreamEvent` instances as tokens arrive.
+        """
+        resolved_model = model or self._default_model
+        resolved_temp = temperature if temperature is not None else self._default_temperature
+        resolved_max = max_tokens if max_tokens is not None else self._default_max_tokens
+
+        system_instruction, gemini_contents = _convert_messages_for_gemini(messages)
+        gemini_tools = _convert_tools_for_gemini(tools)
+
+        generation_config = {
+            "temperature": resolved_temp,
+            "max_output_tokens": resolved_max,
+        }
+
+        model_kwargs: dict[str, Any] = {
+            "model_name": resolved_model,
+            "generation_config": generation_config,
+        }
+        if system_instruction:
+            model_kwargs["system_instruction"] = system_instruction
+        if gemini_tools:
+            model_kwargs["tools"] = gemini_tools
+
+        generative_model = self._genai.GenerativeModel(**model_kwargs)
+
+        # Accumulate state
+        content = ""
+        tool_calls: list[dict[str, Any]] = []
+        resp_model = resolved_model
+        usage: dict[str, int] = {}
+        finish_reason: str | None = None
+
+        response = await generative_model.generate_content_async(
+            gemini_contents,
+            stream=True,
+        )
+
+        async for chunk in response:
+            # Extract text from parts
+            if chunk.parts:
+                for part in chunk.parts:
+                    # Text part
+                    if hasattr(part, "text") and part.text:
+                        content += part.text
+                        yield StreamEvent(
+                            event_type="text_delta",
+                            content=content,
+                            delta_text=part.text,
+                            model=resp_model,
+                        )
+
+                    # Function call part
+                    if hasattr(part, "function_call") and part.function_call:
+                        fc = part.function_call
+                        tc_dict = {
+                            "id": f"call_{uuid.uuid4().hex[:12]}",
+                            "type": "function",
+                            "function": {
+                                "name": fc.name,
+                                "arguments": json.dumps(dict(fc.args)) if fc.args else "{}",
+                            },
+                        }
+                        tool_calls.append(tc_dict)
+                        yield StreamEvent(
+                            event_type="tool_call_start",
+                            content=content,
+                            model=resp_model,
+                        )
+                        yield StreamEvent(
+                            event_type="tool_call_end",
+                            content=content,
+                            model=resp_model,
+                        )
+
+            # Usage metadata (if available)
+            if hasattr(chunk, "usage_metadata") and chunk.usage_metadata:
+                um = chunk.usage_metadata
+                usage = {
+                    "prompt_tokens": getattr(um, "prompt_token_count", 0) or 0,
+                    "completion_tokens": getattr(um, "candidates_token_count", 0) or 0,
+                    "total_tokens": getattr(um, "total_token_count", 0) or 0,
+                }
+
+        # Determine finish reason
+        if tool_calls:
+            finish_reason = "tool_calls"
+        else:
+            finish_reason = "stop"
+
+        yield StreamEvent(
+            event_type="done",
+            content=content,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            model=resp_model,
+            usage=usage,
+        )

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/ollama_adapter.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/ollama_adapter.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Ollama local model streaming chat adapter.
+
+Implements the :class:`StreamingChatAdapter` protocol for local Ollama models.
+Uses ``httpx`` for async HTTP streaming against Ollama's ``/api/chat`` endpoint
+(already a dependency of the ``openai`` package).
+
+No additional SDK install is required -- httpx is always available.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, AsyncGenerator
+
+from kaizen_agents.delegate.adapters.protocol import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+
+
+class OllamaStreamAdapter:
+    """Adapter for local Ollama models via HTTP streaming.
+
+    Uses the ``/api/chat`` endpoint which supports streaming JSON lines.
+
+    Parameters
+    ----------
+    base_url:
+        Ollama base URL.  Falls back to ``OLLAMA_BASE_URL`` env var or
+        ``http://localhost:11434``.
+    default_model:
+        Model to use when none is supplied per-call.
+    default_temperature:
+        Default sampling temperature.
+    default_max_tokens:
+        Default max token limit (``num_predict`` in Ollama).
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        default_model: str = "",
+        default_temperature: float = 0.4,
+        default_max_tokens: int = 16384,
+    ) -> None:
+        self._base_url = (
+            base_url
+            or os.environ.get("OLLAMA_BASE_URL")
+            or _DEFAULT_OLLAMA_BASE_URL
+        ).rstrip("/")
+        self._default_model = default_model
+        self._default_temperature = default_temperature
+        self._default_max_tokens = default_max_tokens
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """Stream a chat completion from a local Ollama instance.
+
+        Yields :class:`StreamEvent` instances as tokens arrive.
+        """
+        import httpx
+
+        resolved_model = model or self._default_model
+        resolved_temp = temperature if temperature is not None else self._default_temperature
+        resolved_max = max_tokens if max_tokens is not None else self._default_max_tokens
+
+        # Convert messages: Ollama supports a subset of OpenAI format
+        # (role/content pairs).  System, user, assistant are supported natively.
+        # Tool results become assistant messages with tool content.
+        ollama_messages = _convert_messages_for_ollama(messages)
+
+        request_body: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": ollama_messages,
+            "stream": True,
+            "options": {
+                "temperature": resolved_temp,
+                "num_predict": resolved_max,
+            },
+        }
+
+        if tools:
+            request_body["tools"] = tools
+
+        request_body.update(kwargs)
+
+        url = f"{self._base_url}/api/chat"
+
+        # Accumulate state
+        content = ""
+        tool_calls: list[dict[str, Any]] = []
+        resp_model = resolved_model
+        usage: dict[str, int] = {}
+        finish_reason: str | None = None
+
+        async with httpx.AsyncClient(timeout=httpx.Timeout(connect=10, read=120, write=30, pool=10)) as client:
+            async with client.stream("POST", url, json=request_body) as response:
+                if response.status_code != 200:
+                    body = await response.aread()
+                    raise ConnectionError(
+                        f"Ollama returned status {response.status_code}: "
+                        f"{body.decode('utf-8', errors='replace')[:500]}"
+                    )
+
+                async for line in response.aiter_lines():
+                    if not line.strip():
+                        continue
+
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.warning("Failed to parse Ollama stream line: %s", line[:200])
+                        continue
+
+                    # Model name
+                    if "model" in data:
+                        resp_model = data["model"]
+
+                    # Text delta from message.content
+                    msg = data.get("message", {})
+                    delta_text = msg.get("content", "")
+                    if delta_text:
+                        content += delta_text
+                        yield StreamEvent(
+                            event_type="text_delta",
+                            content=content,
+                            delta_text=delta_text,
+                            model=resp_model,
+                        )
+
+                    # Tool calls (Ollama returns them in message.tool_calls)
+                    raw_tool_calls = msg.get("tool_calls", [])
+                    for tc in raw_tool_calls:
+                        func = tc.get("function", {})
+                        tc_dict = {
+                            "id": f"call_ollama_{len(tool_calls)}",
+                            "type": "function",
+                            "function": {
+                                "name": func.get("name", ""),
+                                "arguments": json.dumps(func.get("arguments", {})),
+                            },
+                        }
+                        tool_calls.append(tc_dict)
+                        yield StreamEvent(
+                            event_type="tool_call_start",
+                            content=content,
+                            model=resp_model,
+                        )
+                        yield StreamEvent(
+                            event_type="tool_call_end",
+                            content=content,
+                            model=resp_model,
+                        )
+
+                    # Done indicator
+                    if data.get("done", False):
+                        # Extract usage from the final message
+                        usage = {
+                            "prompt_tokens": data.get("prompt_eval_count", 0) or 0,
+                            "completion_tokens": data.get("eval_count", 0) or 0,
+                            "total_tokens": (
+                                (data.get("prompt_eval_count", 0) or 0)
+                                + (data.get("eval_count", 0) or 0)
+                            ),
+                        }
+                        if tool_calls:
+                            finish_reason = "tool_calls"
+                        else:
+                            finish_reason = "stop"
+
+        yield StreamEvent(
+            event_type="done",
+            content=content,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            model=resp_model,
+            usage=usage,
+        )
+
+
+def _convert_messages_for_ollama(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert OpenAI-format messages for Ollama's /api/chat.
+
+    Ollama supports system/user/assistant/tool roles natively.
+    Tool messages are passed through mostly unchanged; Ollama expects
+    the same structure as OpenAI for tool results.
+    """
+    result: list[dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role", "")
+        if role in ("system", "user", "assistant", "tool"):
+            converted: dict[str, Any] = {"role": role, "content": msg.get("content", "")}
+            # Pass through tool_calls for assistant messages
+            if role == "assistant" and "tool_calls" in msg:
+                converted["tool_calls"] = msg["tool_calls"]
+            result.append(converted)
+    return result

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/openai_adapter.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/openai_adapter.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""OpenAI streaming chat adapter.
+
+Wraps the ``openai`` SDK's ``AsyncOpenAI`` client behind the
+:class:`StreamingChatAdapter` protocol.  Existing stream-processing logic
+from ``openai_stream.py`` is reused via delegation.
+
+Lazy-imports the ``openai`` package so that users of other providers do not
+need it installed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, AsyncGenerator
+
+from kaizen_agents.delegate.adapters.protocol import StreamEvent
+
+logger = logging.getLogger(__name__)
+
+# Prefixes that require max_completion_tokens instead of max_tokens
+# and do not support custom temperature (GPT-5, reasoning models).
+_NEW_API_PREFIXES = ("o1", "o3", "gpt-5")
+
+
+class OpenAIStreamAdapter:
+    """Adapter for OpenAI and OpenAI-compatible API endpoints.
+
+    Parameters
+    ----------
+    api_key:
+        OpenAI API key.  Falls back to ``OPENAI_API_KEY`` env var.
+    base_url:
+        Optional base URL override (for proxies or compatible APIs).
+    default_model:
+        Model to use when none is supplied per-call.
+    default_temperature:
+        Default sampling temperature.
+    default_max_tokens:
+        Default max token limit.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_model: str = "",
+        default_temperature: float = 0.4,
+        default_max_tokens: int = 16384,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "No OpenAI API key found.  Set OPENAI_API_KEY in your .env file "
+                "or pass api_key explicitly."
+            )
+
+        self._default_model = default_model
+        self._default_temperature = default_temperature
+        self._default_max_tokens = default_max_tokens
+
+        # Lazy import
+        try:
+            from openai import AsyncOpenAI
+        except ImportError as exc:
+            raise ImportError(
+                "The openai package is required for OpenAI adapters.  "
+                "Install it with: pip install openai"
+            ) from exc
+
+        import httpx
+
+        client_kwargs: dict[str, Any] = {
+            "api_key": resolved_key,
+            "timeout": httpx.Timeout(connect=10, read=120, write=30, pool=10),
+        }
+        resolved_base = base_url or os.environ.get("OPENAI_BASE_URL")
+        if resolved_base:
+            client_kwargs["base_url"] = resolved_base
+        self._client = AsyncOpenAI(**client_kwargs)
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """Stream a chat completion via the OpenAI API.
+
+        Yields :class:`StreamEvent` instances as tokens arrive.
+        """
+        resolved_model = model or self._default_model
+        resolved_temp = temperature if temperature is not None else self._default_temperature
+        resolved_max = max_tokens if max_tokens is not None else self._default_max_tokens
+
+        is_new_api = any(resolved_model.startswith(p) for p in _NEW_API_PREFIXES)
+
+        request_kwargs: dict[str, Any] = {
+            "model": resolved_model,
+            "messages": messages,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+
+        if not is_new_api:
+            request_kwargs["temperature"] = resolved_temp
+
+        if is_new_api:
+            request_kwargs["max_completion_tokens"] = resolved_max
+        else:
+            request_kwargs["max_tokens"] = resolved_max
+
+        if tools:
+            request_kwargs["tools"] = tools
+            request_kwargs["tool_choice"] = "auto"
+
+        # Merge any extra provider-specific kwargs
+        request_kwargs.update(kwargs)
+
+        stream = await self._client.chat.completions.create(**request_kwargs)
+
+        # Accumulate state
+        content = ""
+        tool_accumulators: dict[int, dict[str, Any]] = {}
+        resp_model = ""
+        usage: dict[str, int] = {}
+        finish_reason: str | None = None
+
+        async for chunk in stream:
+            if not chunk.choices:
+                # Usage-only chunk (sent at end by some models)
+                if chunk.usage:
+                    usage = {
+                        "prompt_tokens": chunk.usage.prompt_tokens,
+                        "completion_tokens": chunk.usage.completion_tokens,
+                        "total_tokens": chunk.usage.total_tokens,
+                    }
+                continue
+
+            if chunk.model:
+                resp_model = chunk.model
+
+            choice = chunk.choices[0]
+            delta = choice.delta
+
+            # Text content
+            if delta.content:
+                content += delta.content
+                yield StreamEvent(
+                    event_type="text_delta",
+                    content=content,
+                    delta_text=delta.content,
+                    model=resp_model,
+                )
+
+            # Tool calls (streamed as deltas)
+            if delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+
+                    if idx not in tool_accumulators:
+                        acc = {
+                            "id": tc_delta.id or "",
+                            "type": tc_delta.type or "function",
+                            "function": {
+                                "name": (tc_delta.function.name if tc_delta.function else "") or "",
+                                "arguments": (tc_delta.function.arguments if tc_delta.function else "") or "",
+                            },
+                        }
+                        tool_accumulators[idx] = acc
+                        yield StreamEvent(
+                            event_type="tool_call_start",
+                            content=content,
+                            model=resp_model,
+                        )
+                    else:
+                        acc = tool_accumulators[idx]
+                        if tc_delta.function and tc_delta.function.arguments:
+                            acc["function"]["arguments"] += tc_delta.function.arguments
+                        yield StreamEvent(
+                            event_type="tool_call_delta",
+                            content=content,
+                            model=resp_model,
+                        )
+
+            # Finish reason
+            if choice.finish_reason:
+                finish_reason = choice.finish_reason
+
+        # Finalise tool calls in index order
+        final_tool_calls: list[dict[str, Any]] = []
+        for idx in sorted(tool_accumulators.keys()):
+            final_tool_calls.append(tool_accumulators[idx])
+
+        # Emit tool_call_end events
+        for _ in final_tool_calls:
+            yield StreamEvent(
+                event_type="tool_call_end",
+                content=content,
+                model=resp_model,
+            )
+
+        yield StreamEvent(
+            event_type="done",
+            content=content,
+            tool_calls=final_tool_calls,
+            finish_reason=finish_reason,
+            model=resp_model,
+            usage=usage,
+        )

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/protocol.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/protocol.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""StreamingChatAdapter protocol and StreamEvent dataclass.
+
+Defines the uniform interface that all LLM provider adapters implement.
+The Delegate's AgentLoop uses this protocol exclusively -- it never imports
+a provider SDK directly.
+
+Stream events use a simple string-tagged dataclass rather than a union type
+so that new event kinds can be added without breaking existing consumers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, AsyncGenerator, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Stream event
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StreamEvent:
+    """A single event emitted during a streaming LLM response.
+
+    Attributes:
+        event_type: One of ``"text_delta"``, ``"tool_call_start"``,
+            ``"tool_call_delta"``, ``"tool_call_end"``, ``"done"``.
+        content: Accumulated text content so far (for ``text_delta`` events).
+        tool_calls: Accumulated tool calls so far (for ``done`` events,
+            in OpenAI-compatible format for consistency across providers).
+        finish_reason: Model finish reason (set on ``"done"``).
+        model: Model identifier from the response.
+        usage: Token usage dict (set on ``"done"``).
+        delta_text: The new text fragment in this specific event (only the
+            incremental piece, not the accumulated total).
+    """
+
+    event_type: str
+    content: str = ""
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    finish_reason: str | None = None
+    model: str = ""
+    usage: dict[str, int] = field(default_factory=dict)
+    delta_text: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Adapter protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class StreamingChatAdapter(Protocol):
+    """Protocol for LLM provider adapters.
+
+    Implementors provide ``stream_chat()`` which yields ``StreamEvent``
+    objects as the model generates its response.  The AgentLoop consumes
+    these events to drive incremental rendering, tool calling, and
+    conversation management.
+
+    All tool calls are normalised to OpenAI-compatible format (dict with
+    ``id``, ``type``, ``function.name``, ``function.arguments``) regardless
+    of the underlying provider.
+    """
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> AsyncGenerator[StreamEvent, None]:
+        """Stream a chat completion.
+
+        Parameters
+        ----------
+        messages:
+            Conversation messages in OpenAI-compatible format
+            (``[{"role": ..., "content": ...}, ...]``).
+        tools:
+            Optional tool definitions in OpenAI function-calling format.
+        model:
+            Override the adapter's default model for this call.
+        temperature:
+            Override the adapter's default temperature.
+        max_tokens:
+            Override the adapter's default max tokens.
+        **kwargs:
+            Provider-specific options.
+
+        Yields
+        ------
+        StreamEvent instances in chronological order, always ending with
+        a ``"done"`` event.
+        """
+        ...  # pragma: no cover
+        # The yield statement is needed so that the type-checker recognises
+        # this as an AsyncGenerator, not a plain coroutine.
+        yield StreamEvent(event_type="done")  # type: ignore[misc]  # pragma: no cover

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/registry.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/registry.py
@@ -1,0 +1,164 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Adapter registry -- resolve a provider name or model name to an adapter.
+
+This module provides the deterministic configuration-driven logic that maps
+``config.provider`` or model-name prefixes to concrete adapter instances.
+This is *configuration branching* (permitted by the agent-reasoning rules),
+NOT agent decision-making.
+
+Provider resolution order:
+    1. Explicit ``config.provider`` setting (if set)
+    2. Model-name prefix heuristic (``claude-*`` -> anthropic, etc.)
+    3. Default: ``openai``
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from kaizen_agents.delegate.adapters.protocol import StreamingChatAdapter
+
+logger = logging.getLogger(__name__)
+
+# Model-name prefix -> provider mapping.
+# This is infrastructure configuration, not agent reasoning.
+_MODEL_PREFIX_MAP: list[tuple[str, str]] = [
+    ("claude-", "anthropic"),
+    ("gemini-", "google"),
+    # Ollama models don't have a standard prefix; detected via explicit config
+]
+
+
+def get_adapter(
+    provider: str,
+    *,
+    model: str = "",
+    api_key: str | None = None,
+    base_url: str | None = None,
+    temperature: float = 0.4,
+    max_tokens: int = 16384,
+    **kwargs: Any,
+) -> StreamingChatAdapter:
+    """Create a streaming adapter for the named provider.
+
+    Parameters
+    ----------
+    provider:
+        Provider identifier: ``"openai"``, ``"anthropic"``, ``"google"``,
+        ``"ollama"``.
+    model:
+        Default model name for the adapter.
+    api_key:
+        API key override (otherwise read from environment).
+    base_url:
+        Base URL override (for proxies or local endpoints).
+    temperature:
+        Default sampling temperature.
+    max_tokens:
+        Default max tokens.
+    **kwargs:
+        Extra keyword arguments forwarded to the adapter constructor.
+
+    Returns
+    -------
+    A :class:`StreamingChatAdapter` instance.
+
+    Raises
+    ------
+    ValueError:
+        If the provider name is not recognised.
+    """
+    provider = provider.lower().strip()
+
+    if provider == "openai":
+        from kaizen_agents.delegate.adapters.openai_adapter import OpenAIStreamAdapter
+
+        return OpenAIStreamAdapter(
+            api_key=api_key,
+            base_url=base_url,
+            default_model=model,
+            default_temperature=temperature,
+            default_max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    if provider == "anthropic":
+        from kaizen_agents.delegate.adapters.anthropic_adapter import AnthropicStreamAdapter
+
+        return AnthropicStreamAdapter(
+            api_key=api_key,
+            default_model=model,
+            default_temperature=temperature,
+            default_max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    if provider == "google":
+        from kaizen_agents.delegate.adapters.google_adapter import GoogleStreamAdapter
+
+        return GoogleStreamAdapter(
+            api_key=api_key,
+            default_model=model,
+            default_temperature=temperature,
+            default_max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    if provider == "ollama":
+        from kaizen_agents.delegate.adapters.ollama_adapter import OllamaStreamAdapter
+
+        return OllamaStreamAdapter(
+            base_url=base_url,
+            default_model=model,
+            default_temperature=temperature,
+            default_max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    raise ValueError(
+        f"Unknown provider '{provider}'.  "
+        f"Supported providers: openai, anthropic, google, ollama"
+    )
+
+
+def get_adapter_for_model(
+    model: str,
+    *,
+    provider: str = "",
+    **kwargs: Any,
+) -> StreamingChatAdapter:
+    """Auto-detect the provider from a model name and create an adapter.
+
+    If ``provider`` is explicitly given and non-empty, it takes precedence
+    over model-name heuristics.  Otherwise the model name prefix is
+    checked against known provider patterns.
+
+    Parameters
+    ----------
+    model:
+        The model name (e.g., ``"claude-sonnet-4-6"``, ``"gemini-2.0-flash"``).
+    provider:
+        Optional explicit provider override.
+    **kwargs:
+        Forwarded to :func:`get_adapter`.
+
+    Returns
+    -------
+    A :class:`StreamingChatAdapter` instance.
+    """
+    if provider:
+        return get_adapter(provider, model=model, **kwargs)
+
+    # Auto-detect from model name prefix
+    for prefix, detected_provider in _MODEL_PREFIX_MAP:
+        if model.startswith(prefix):
+            logger.debug(
+                "Auto-detected provider '%s' from model prefix '%s'",
+                detected_provider, prefix,
+            )
+            return get_adapter(detected_provider, model=model, **kwargs)
+
+    # Default to OpenAI
+    return get_adapter("openai", model=model, **kwargs)

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/loop.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/loop.py
@@ -26,12 +26,13 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, AsyncGenerator, AsyncIterator, Callable, Awaitable, TYPE_CHECKING
 
-from openai import AsyncOpenAI
-
 if TYPE_CHECKING:
+    from openai import AsyncOpenAI
     from kaizen_agents.delegate.compact import CompactionResult
+    from kaizen_agents.delegate.tools.hydrator import ToolHydrator
 
-from kaizen_agents.delegate.adapters.openai_stream import StreamResult, process_stream
+from kaizen_agents.delegate.adapters.openai_stream import StreamResult
+from kaizen_agents.delegate.adapters.protocol import StreamEvent, StreamingChatAdapter
 from kaizen_agents.delegate.config.loader import KzConfig
 
 logger = logging.getLogger(__name__)
@@ -274,8 +275,10 @@ class AgentLoop:
         tools: ToolRegistry,
         *,
         client: AsyncOpenAI | None = None,
+        adapter: StreamingChatAdapter | None = None,
         system_prompt: str | None = None,
         budget_check: Callable[[], bool] | None = None,
+        hydrator: ToolHydrator | None = None,
     ) -> None:
         """Initialise the agent loop.
 
@@ -286,7 +289,14 @@ class AgentLoop:
         tools:
             Registry of tools available to the agent.
         client:
-            Optional AsyncOpenAI client override (for testing).
+            Optional AsyncOpenAI client override (for testing / backward
+            compat).  When provided, the loop wraps it in a legacy
+            streaming path.  Prefer ``adapter`` for new code.
+        adapter:
+            A :class:`StreamingChatAdapter` instance for multi-provider
+            support.  When provided, ``client`` is ignored.  If neither
+            ``adapter`` nor ``client`` is provided, an adapter is created
+            automatically from ``config.provider``.
         system_prompt:
             Override the default system prompt. If None, uses the built-in
             default. In production, this will be assembled from KZ.md context.
@@ -294,22 +304,111 @@ class AgentLoop:
             Optional callback that returns True if budget is available, False
             if exhausted. When provided, the loop checks budget before each
             LLM call and stops early if exhausted.
+        hydrator:
+            Optional :class:`~kaizen_agents.delegate.tools.hydrator.ToolHydrator`
+            for large tool sets. When provided, the loop delegates tool
+            selection and discovery to the hydrator. When ``None`` and the
+            tool count exceeds the hydrator's default threshold, a hydrator
+            is created automatically.
         """
         self._config = config
         self._tools = tools
-        self._client = client or self._build_client()
+
+        # Resolve the streaming adapter.
+        # Priority: explicit adapter > explicit client (legacy) > auto-detect
+        if adapter is not None:
+            self._adapter: StreamingChatAdapter | None = adapter
+            self._client: Any = None
+        elif client is not None:
+            # Legacy backward-compat path: wrap the raw AsyncOpenAI client
+            self._adapter = None
+            self._client = client
+        else:
+            self._adapter = self._build_adapter()
+            self._client = None
+
         self._conversation = Conversation()
         self._usage = UsageTracker()
         self._interrupted = False
         self._budget_check = budget_check
 
+        # Tool hydration: set up when tool count exceeds threshold
+        self._hydrator = hydrator
+        self._setup_hydration()
+
         # Set system prompt
         prompt = system_prompt if system_prompt is not None else _DEFAULT_SYSTEM_PROMPT
         self._conversation.add_system(prompt)
 
-    def _build_client(self) -> AsyncOpenAI:
-        """Build an AsyncOpenAI client from environment variables.
+    def _setup_hydration(self) -> None:
+        """Initialise tool hydration if the tool count warrants it.
 
+        When a hydrator is provided or the tool count exceeds the default
+        threshold, the hydrator is loaded with the full tool set and the
+        ``search_tools`` meta-tool is injected into the registry.
+        """
+        from kaizen_agents.delegate.tools.hydrator import ToolHydrator
+        from kaizen_agents.delegate.tools.search import (
+            SEARCH_TOOLS_SCHEMA,
+            create_search_tools_executor,
+        )
+
+        tool_count = len(self._tools.tool_names)
+
+        if self._hydrator is None:
+            # Auto-create a hydrator only if the tool count exceeds the threshold
+            default_threshold = ToolHydrator().threshold
+            if tool_count <= default_threshold:
+                return
+            self._hydrator = ToolHydrator()
+
+        # Register the search_tools meta-tool into the ToolRegistry so it
+        # appears in the tool definitions sent to the LLM
+        if not self._tools.has_tool("search_tools"):
+            search_executor = create_search_tools_executor(self._hydrator)
+            func_def = SEARCH_TOOLS_SCHEMA["function"]
+            self._tools.register(
+                name="search_tools",
+                description=func_def["description"],
+                parameters=func_def["parameters"],
+                executor=search_executor,
+            )
+
+        # Load all tool defs and executors into the hydrator
+        all_defs: dict[str, Any] = {}
+        all_executors: dict[str, Any] = {}
+        for tool_def in self._tools._tools.values():
+            openai_fmt = tool_def.to_openai_format()
+            all_defs[tool_def.name] = openai_fmt
+            all_executors[tool_def.name] = self._tools._executors[tool_def.name]
+
+        self._hydrator.load_tools(all_defs, all_executors)
+
+    @property
+    def hydrator(self) -> ToolHydrator | None:
+        """The tool hydrator, if active."""
+        return self._hydrator
+
+    def _build_adapter(self) -> StreamingChatAdapter:
+        """Build a streaming adapter from config.
+
+        Provider selection is configuration branching (permitted deterministic
+        logic), not agent reasoning.
+        """
+        from kaizen_agents.delegate.adapters.registry import get_adapter_for_model
+
+        model = self._config.model or os.environ.get("DEFAULT_LLM_MODEL", "")
+        return get_adapter_for_model(
+            model=model,
+            provider=self._config.provider,
+            temperature=self._config.temperature,
+            max_tokens=self._config.max_tokens,
+        )
+
+    def _build_client(self) -> Any:
+        """Build an AsyncOpenAI client from environment variables (legacy).
+
+        Kept for backward compatibility when ``client`` is passed directly.
         API key comes from .env (single source of truth).
         """
         api_key = os.environ.get("OPENAI_API_KEY")
@@ -317,6 +416,7 @@ class AgentLoop:
             raise ValueError("No OpenAI API key found. Set OPENAI_API_KEY in your .env file.")
 
         import httpx
+        from openai import AsyncOpenAI
 
         base_url = os.environ.get("OPENAI_BASE_URL")
         kwargs: dict[str, Any] = {
@@ -425,9 +525,10 @@ class AgentLoop:
         """Make a streaming completion request and yield events incrementally.
 
         Yields (event_type, stream_result) tuples as they arrive from the
-        underlying OpenAI stream.  The StreamResult is the SAME mutable object
-        throughout -- it accumulates content, tool_calls, and usage as the
-        stream progresses.
+        underlying streaming adapter (or legacy OpenAI client).
+
+        The StreamResult is the SAME mutable object throughout -- it
+        accumulates content, tool_calls, and usage as the stream progresses.
 
         Event types
         -----------
@@ -440,40 +541,77 @@ class AgentLoop:
         ``"done"``
             The stream completed.  ``stream_result`` is final.
         """
-        tools = self._tools.get_openai_tools()
-
-        model = self._config.model or "gpt-5-chat-latest"
-
-        # GPT-5 variants and reasoning models use max_completion_tokens
-        # instead of max_tokens, and do not support custom temperature.
-        _GPT5_AND_REASONING = ("o1", "o3", "gpt-5")
-        is_new_api = any(model.startswith(p) for p in _GPT5_AND_REASONING)
-
-        kwargs: dict[str, Any] = {
-            "model": model,
-            "messages": self._conversation.messages,
-            "stream": True,
-            "stream_options": {"include_usage": True},
-        }
-
-        if not is_new_api:
-            kwargs["temperature"] = self._config.temperature
-
-        if is_new_api:
-            kwargs["max_completion_tokens"] = self._config.max_tokens
+        # Use hydrator for tool selection when active, otherwise all tools
+        if self._hydrator is not None and self._hydrator.is_active:
+            tools = self._hydrator.get_active_tool_defs()
         else:
-            kwargs["max_tokens"] = self._config.max_tokens
+            tools = self._tools.get_openai_tools()
 
-        if tools:
-            kwargs["tools"] = tools
-            kwargs["tool_choice"] = "auto"
+        model = self._config.model or os.environ.get("DEFAULT_LLM_MODEL", "")
 
-        stream = await self._client.chat.completions.create(**kwargs)
+        if self._adapter is not None:
+            # New adapter-based path: provider-agnostic streaming
+            async for event in self._adapter.stream_chat(
+                messages=self._conversation.messages,
+                tools=tools or None,
+                model=model,
+                temperature=self._config.temperature,
+                max_tokens=self._config.max_tokens,
+            ):
+                if self._interrupted:
+                    break
 
-        async for event_type, result in process_stream(stream):
-            if self._interrupted:
-                break
-            yield event_type, result
+                # Convert StreamEvent -> (event_type, StreamResult) for
+                # backward compatibility with the rest of the loop
+                result = StreamResult(
+                    content=event.content,
+                    tool_calls=event.tool_calls,
+                    finish_reason=event.finish_reason,
+                    model=event.model,
+                    usage=event.usage,
+                )
+
+                # Map adapter event types to legacy event types
+                if event.event_type == "text_delta":
+                    yield ("text", result)
+                elif event.event_type == "tool_call_start":
+                    yield ("tool_call_start", result)
+                elif event.event_type == "tool_call_delta":
+                    yield ("tool_call_delta", result)
+                elif event.event_type == "done":
+                    yield ("done", result)
+        else:
+            # Legacy path: direct AsyncOpenAI client (backward compat)
+            from kaizen_agents.delegate.adapters.openai_stream import process_stream
+
+            _GPT5_AND_REASONING = ("o1", "o3", "gpt-5")
+            is_new_api = any(model.startswith(p) for p in _GPT5_AND_REASONING)
+
+            kwargs: dict[str, Any] = {
+                "model": model,
+                "messages": self._conversation.messages,
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            }
+
+            if not is_new_api:
+                kwargs["temperature"] = self._config.temperature
+
+            if is_new_api:
+                kwargs["max_completion_tokens"] = self._config.max_tokens
+            else:
+                kwargs["max_tokens"] = self._config.max_tokens
+
+            if tools:
+                kwargs["tools"] = tools
+                kwargs["tool_choice"] = "auto"
+
+            stream = await self._client.chat.completions.create(**kwargs)
+
+            async for event_type, result in process_stream(stream):
+                if self._interrupted:
+                    break
+                yield event_type, result
 
     async def _execute_tool_calls(self, tool_calls: list[dict[str, Any]]) -> None:
         """Execute tool calls from the model's response.
@@ -503,7 +641,17 @@ class AgentLoop:
                 return tc_id, name, json.dumps({"error": error_msg})
 
             try:
-                result = await self._tools.execute(name, arguments)
+                # When hydration is active, the tool may have been just
+                # hydrated by a search_tools call in this same batch of
+                # tool calls. Use the hydrator's force-lookup which
+                # bypasses the active-set check.
+                if self._hydrator is not None and self._hydrator.is_active:
+                    executor = self._hydrator.get_executor_force(name)
+                    if executor is None:
+                        raise KeyError(f"Unknown tool: {name}")
+                    result = await executor(**arguments)
+                else:
+                    result = await self._tools.execute(name, arguments)
                 return tc_id, name, result
             except KeyError:
                 error_msg = f"Unknown tool: {name}"

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/tools/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/tools/__init__.py
@@ -1,4 +1,4 @@
-"""kz tool system — file operations, search, and shell execution."""
+"""kz tool system — file operations, search, shell execution, and tool hydration."""
 
 from __future__ import annotations
 
@@ -11,6 +11,11 @@ from kaizen_agents.delegate.tools.file_read import FileReadTool
 from kaizen_agents.delegate.tools.file_write import FileWriteTool
 from kaizen_agents.delegate.tools.glob_tool import GlobTool
 from kaizen_agents.delegate.tools.grep_tool import GrepTool
+from kaizen_agents.delegate.tools.hydrator import ToolHydrator
+from kaizen_agents.delegate.tools.search import (
+    SEARCH_TOOLS_SCHEMA,
+    create_search_tools_executor,
+)
 
 
 def create_default_tools(*, permission_gate: Any | None = None) -> ToolRegistry:
@@ -41,8 +46,11 @@ __all__ = [
     "FileWriteTool",
     "GlobTool",
     "GrepTool",
+    "SEARCH_TOOLS_SCHEMA",
     "Tool",
+    "ToolHydrator",
     "ToolRegistry",
     "ToolResult",
     "create_default_tools",
+    "create_search_tools_executor",
 ]

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/tools/hydrator.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/tools/hydrator.py
@@ -1,0 +1,361 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tool hydration for large tool sets.
+
+When an agent has access to many tools (e.g. MCP-discovered tools from
+multiple servers), sending all tool schemas on every LLM call wastes
+tokens and degrades model accuracy. The :class:`ToolHydrator` splits
+tools into an always-available base set and a deferred set that the LLM
+can pull in on demand via the ``search_tools`` meta-tool.
+
+Architecture
+------------
+The hydrator sits between the :class:`~kaizen_agents.delegate.loop.ToolRegistry`
+and the LLM call. When the total tool count exceeds the configurable
+*threshold* (default 30), the hydrator activates:
+
+- **Base tools** (~15) are always sent to the LLM.
+- **Deferred tools** are indexed but not sent until the LLM calls
+  ``search_tools`` with a query.
+- The LLM decides when it needs more tools — no deterministic routing.
+
+Below threshold, all tools are passed directly (existing behaviour).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default base tools — these are always available regardless of hydration
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BASE_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "file_read",
+        "file_write",
+        "file_edit",
+        "glob",
+        "grep",
+        "bash",
+        "search_tools",
+    }
+)
+
+_DEFAULT_THRESHOLD: int = 30
+
+
+# ---------------------------------------------------------------------------
+# BM25-style scoring (stdlib only)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ToolDoc:
+    """A searchable document for one tool."""
+
+    name: str
+    description: str
+    tokens: list[str]
+
+
+def _tokenize(text: str) -> list[str]:
+    """Split text into lowercase alpha-numeric tokens."""
+    return re.findall(r"[a-z0-9]+", text.lower())
+
+
+def _build_index(tools: dict[str, _ToolDoc]) -> dict[str, int]:
+    """Build document-frequency index across all tool docs."""
+    df: Counter[str] = Counter()
+    for doc in tools.values():
+        unique = set(doc.tokens)
+        for token in unique:
+            df[token] += 1
+    return dict(df)
+
+
+def _bm25_score(
+    query_tokens: list[str],
+    doc: _ToolDoc,
+    df: dict[str, int],
+    n_docs: int,
+    avgdl: float,
+    *,
+    k1: float = 1.5,
+    b: float = 0.75,
+) -> float:
+    """Compute BM25 relevance score for a single document.
+
+    Parameters
+    ----------
+    query_tokens:
+        Tokenized search query.
+    doc:
+        The tool document to score.
+    df:
+        Document frequency map (token -> number of docs containing it).
+    n_docs:
+        Total number of documents in the corpus.
+    avgdl:
+        Average document length (in tokens) across the corpus.
+    k1:
+        Term saturation parameter.
+    b:
+        Length normalization parameter.
+    """
+    if avgdl == 0:
+        return 0.0
+
+    score = 0.0
+    doc_len = len(doc.tokens)
+    tf_map: Counter[str] = Counter(doc.tokens)
+
+    for term in query_tokens:
+        if term not in tf_map:
+            continue
+        tf = tf_map[term]
+        doc_freq = df.get(term, 0)
+        # IDF with floor to avoid negative scores for very common terms
+        idf = max(0.0, math.log((n_docs - doc_freq + 0.5) / (doc_freq + 0.5) + 1.0))
+        # BM25 TF component
+        numerator = tf * (k1 + 1)
+        denominator = tf + k1 * (1 - b + b * (doc_len / avgdl))
+        score += idf * (numerator / denominator)
+
+    # Boost for exact name match
+    name_tokens = set(_tokenize(doc.name))
+    for term in query_tokens:
+        if term in name_tokens:
+            score += 2.0
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# ToolHydrator
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolHydrator:
+    """Manages tool hydration for large tool sets.
+
+    When the total number of registered tools exceeds *threshold*, only
+    the base tools are sent to the LLM. The LLM can discover and
+    hydrate additional tools by calling ``search_tools``.
+
+    Parameters
+    ----------
+    threshold:
+        Minimum tool count to activate hydration. Below this, all tools
+        are passed through directly. Default: 30.
+    base_tool_names:
+        Names of tools that are always available. Defaults to the
+        standard kz tool set plus ``search_tools``.
+    """
+
+    threshold: int = _DEFAULT_THRESHOLD
+    base_tool_names: frozenset[str] = field(default_factory=lambda: _DEFAULT_BASE_TOOL_NAMES)
+
+    # Internal state
+    _all_tool_defs: dict[str, dict[str, Any]] = field(default_factory=dict, repr=False)
+    _all_tool_executors: dict[str, Any] = field(default_factory=dict, repr=False)
+    _hydrated_names: set[str] = field(default_factory=set, repr=False)
+    _search_index: dict[str, _ToolDoc] = field(default_factory=dict, repr=False)
+    _df: dict[str, int] = field(default_factory=dict, repr=False)
+    _avgdl: float = field(default=0.0, repr=False)
+
+    @property
+    def is_active(self) -> bool:
+        """Whether hydration is active (tool count exceeds threshold)."""
+        return len(self._all_tool_defs) > self.threshold
+
+    @property
+    def total_tool_count(self) -> int:
+        """Total number of registered tools."""
+        return len(self._all_tool_defs)
+
+    def load_tools(
+        self,
+        tool_defs: dict[str, dict[str, Any]],
+        tool_executors: dict[str, Any],
+    ) -> None:
+        """Load the full tool set into the hydrator.
+
+        Parameters
+        ----------
+        tool_defs:
+            Mapping of tool name to OpenAI function-calling format dict.
+        tool_executors:
+            Mapping of tool name to async executor callable.
+        """
+        self._all_tool_defs = dict(tool_defs)
+        self._all_tool_executors = dict(tool_executors)
+        self._hydrated_names = set()
+        self._build_search_index()
+        logger.info(
+            "ToolHydrator loaded %d tools (threshold=%d, active=%s)",
+            len(self._all_tool_defs),
+            self.threshold,
+            self.is_active,
+        )
+
+    def _build_search_index(self) -> None:
+        """Build the BM25 search index over all deferred tools."""
+        self._search_index = {}
+        for name, tool_def in self._all_tool_defs.items():
+            if name in self.base_tool_names:
+                continue
+            func_info = tool_def.get("function", {})
+            desc = func_info.get("description", "")
+            text = f"{name} {desc}"
+            tokens = _tokenize(text)
+            self._search_index[name] = _ToolDoc(name=name, description=desc, tokens=tokens)
+
+        self._df = _build_index(self._search_index)
+        total_tokens = sum(len(doc.tokens) for doc in self._search_index.values())
+        n_docs = len(self._search_index)
+        self._avgdl = total_tokens / n_docs if n_docs > 0 else 0.0
+
+    def get_active_tool_defs(self) -> list[dict[str, Any]]:
+        """Return OpenAI-format tool defs for currently active tools.
+
+        If hydration is not active (below threshold), returns all tools.
+        Otherwise returns base tools + currently hydrated tools.
+        """
+        if not self.is_active:
+            return list(self._all_tool_defs.values())
+
+        active_names = self._get_active_names()
+        return [
+            self._all_tool_defs[name]
+            for name in active_names
+            if name in self._all_tool_defs
+        ]
+
+    def get_active_executor(self, name: str) -> Any | None:
+        """Return the executor for a tool if it is currently active or if hydration is off.
+
+        Parameters
+        ----------
+        name:
+            Tool name to look up.
+
+        Returns
+        -------
+        The async executor callable, or None if the tool is not active.
+        """
+        if not self.is_active:
+            return self._all_tool_executors.get(name)
+
+        if name in self._get_active_names():
+            return self._all_tool_executors.get(name)
+
+        return None
+
+    def has_executor(self, name: str) -> bool:
+        """Check if a tool exists (regardless of hydration state)."""
+        return name in self._all_tool_executors
+
+    def get_executor_force(self, name: str) -> Any | None:
+        """Return executor for any registered tool, bypassing hydration check.
+
+        Used internally when the loop needs to execute a tool that was
+        just hydrated in the same turn.
+        """
+        return self._all_tool_executors.get(name)
+
+    def hydrate(self, tool_names: list[str]) -> list[str]:
+        """Add tools to the active set.
+
+        Parameters
+        ----------
+        tool_names:
+            Names of tools to hydrate (make available to the LLM).
+
+        Returns
+        -------
+        List of tool names that were successfully hydrated (exist in
+        the registry).
+        """
+        hydrated: list[str] = []
+        for name in tool_names:
+            if name in self._all_tool_defs and name not in self.base_tool_names:
+                self._hydrated_names.add(name)
+                hydrated.append(name)
+                logger.debug("Hydrated tool: %s", name)
+
+        logger.info("Hydrated %d tools: %s", len(hydrated), hydrated)
+        return hydrated
+
+    def dehydrate(self) -> None:
+        """Reset the active set to base tools only."""
+        count = len(self._hydrated_names)
+        self._hydrated_names.clear()
+        logger.info("Dehydrated %d tools, reset to base set", count)
+
+    def search(self, query: str, *, top_n: int = 10) -> list[dict[str, Any]]:
+        """Search over tool names and descriptions.
+
+        Parameters
+        ----------
+        query:
+            Free-text search query.
+        top_n:
+            Maximum number of results to return.
+
+        Returns
+        -------
+        List of dicts with ``name``, ``description``, and ``score``
+        keys, sorted by relevance (highest first).
+        """
+        query_tokens = _tokenize(query)
+        if not query_tokens:
+            return []
+
+        n_docs = len(self._search_index)
+        if n_docs == 0:
+            return []
+
+        scored: list[tuple[float, str, str]] = []
+        for name, doc in self._search_index.items():
+            score = _bm25_score(
+                query_tokens,
+                doc,
+                self._df,
+                n_docs,
+                self._avgdl,
+            )
+            if score > 0:
+                scored.append((score, name, doc.description))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+
+        results: list[dict[str, Any]] = []
+        for score, name, description in scored[:top_n]:
+            results.append(
+                {
+                    "name": name,
+                    "description": description,
+                    "score": round(score, 3),
+                }
+            )
+
+        return results
+
+    def _get_active_names(self) -> set[str]:
+        """Return the set of currently active tool names."""
+        active = set()
+        for name in self.base_tool_names:
+            if name in self._all_tool_defs:
+                active.add(name)
+        active.update(self._hydrated_names)
+        return active

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/tools/search.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/tools/search.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""The ``search_tools`` meta-tool for tool discovery.
+
+This tool enables the LLM to search over available tools by name and
+description when the tool set is too large to send in full. The LLM
+decides when to search -- this is a dumb data endpoint that returns
+matching tool schemas.
+
+The tool is registered as a built-in when hydration is active. It uses
+BM25-style scoring from :mod:`kaizen_agents.delegate.tools.hydrator`
+with no external dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kaizen_agents.delegate.tools.hydrator import ToolHydrator
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tool schema (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+SEARCH_TOOLS_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "search_tools",
+        "description": (
+            "Search for available tools by keyword. Use this when you need a "
+            "tool that is not in your current active set. Returns matching "
+            "tool names, descriptions, and relevance scores. After finding "
+            "the tools you need, they will be automatically added to your "
+            "active tool set for the rest of this conversation."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Search query describing what tool you need. "
+                        "Use descriptive terms like 'database query', "
+                        "'send email', 'kubernetes deploy', etc."
+                    ),
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return. Default: 10.",
+                    "default": 10,
+                },
+            },
+            "required": ["query"],
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Executor factory
+# ---------------------------------------------------------------------------
+
+
+def create_search_tools_executor(
+    hydrator: ToolHydrator,
+) -> Any:
+    """Create the async executor for the ``search_tools`` meta-tool.
+
+    The executor searches the hydrator's index and automatically hydrates
+    the matching tools into the active set so they are available on the
+    next LLM call.
+
+    Parameters
+    ----------
+    hydrator:
+        The :class:`ToolHydrator` instance to search and hydrate from.
+
+    Returns
+    -------
+    An async callable that accepts ``query`` and optional ``top_n``,
+    returning a JSON string with search results.
+    """
+
+    async def _execute_search_tools(query: str, top_n: int = 10) -> str:
+        """Search for tools and hydrate matches into the active set."""
+        if not query or not query.strip():
+            return json.dumps({"error": "Empty search query", "results": []})
+
+        results = hydrator.search(query, top_n=top_n)
+
+        if not results:
+            return json.dumps(
+                {
+                    "query": query,
+                    "results": [],
+                    "message": "No matching tools found. Try different keywords.",
+                }
+            )
+
+        # Auto-hydrate the found tools so they are available on the next turn
+        found_names = [r["name"] for r in results]
+        hydrated = hydrator.hydrate(found_names)
+
+        logger.info(
+            "search_tools query=%r found=%d hydrated=%d",
+            query,
+            len(results),
+            len(hydrated),
+        )
+
+        return json.dumps(
+            {
+                "query": query,
+                "results": results,
+                "hydrated": hydrated,
+                "message": (
+                    f"Found {len(results)} tools. "
+                    f"{len(hydrated)} tools have been added to your active set "
+                    f"and are now available for use."
+                ),
+            },
+            indent=2,
+        )
+
+    return _execute_search_tools

--- a/packages/kaizen-agents/tests/unit/delegate/test_tool_hydration.py
+++ b/packages/kaizen-agents/tests/unit/delegate/test_tool_hydration.py
@@ -1,0 +1,584 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for tool hydration (S7).
+
+Covers:
+    - ToolHydrator lifecycle (hydrate/dehydrate)
+    - BM25 search accuracy (keyword matching)
+    - Threshold behaviour (below threshold = all tools)
+    - Multi-round hydration (search, hydrate, search again)
+    - Integration with AgentLoop (mock LLM that calls search_tools)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kaizen_agents.delegate.tools.hydrator import (
+    ToolHydrator,
+    _bm25_score,
+    _build_index,
+    _tokenize,
+    _ToolDoc,
+    _DEFAULT_THRESHOLD,
+)
+from kaizen_agents.delegate.tools.search import (
+    SEARCH_TOOLS_SCHEMA,
+    create_search_tools_executor,
+)
+from kaizen_agents.delegate.loop import AgentLoop, ToolRegistry
+from kaizen_agents.delegate.config.loader import KzConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_def(name: str, description: str) -> dict[str, Any]:
+    """Create an OpenAI-format tool definition."""
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+async def _noop_executor(**kwargs: Any) -> str:
+    return json.dumps({"status": "ok"})
+
+
+def _build_registry(tool_count: int) -> tuple[ToolRegistry, dict[str, dict[str, Any]], dict[str, Any]]:
+    """Build a ToolRegistry with N tools, returning (registry, defs, executors)."""
+    registry = ToolRegistry()
+    all_defs: dict[str, dict[str, Any]] = {}
+    all_executors: dict[str, Any] = {}
+
+    # Add base tools
+    base_tools = [
+        ("file_read", "Read a file from the filesystem"),
+        ("file_write", "Write content to a file"),
+        ("file_edit", "Edit a file with string replacement"),
+        ("glob", "Find files matching a glob pattern"),
+        ("grep", "Search file contents with regex"),
+        ("bash", "Execute a shell command"),
+    ]
+
+    for name, desc in base_tools:
+        registry.register(name, desc, {"type": "object", "properties": {}}, _noop_executor)
+
+    # Add extra tools up to tool_count
+    extra_tools = [
+        ("mcp_github_create_issue", "Create a new GitHub issue in a repository"),
+        ("mcp_github_list_prs", "List pull requests for a GitHub repository"),
+        ("mcp_github_merge_pr", "Merge a pull request on GitHub"),
+        ("mcp_slack_send_message", "Send a message to a Slack channel"),
+        ("mcp_slack_list_channels", "List available Slack channels"),
+        ("mcp_jira_create_ticket", "Create a new Jira ticket"),
+        ("mcp_jira_search", "Search Jira tickets with JQL"),
+        ("mcp_kubernetes_deploy", "Deploy a container to Kubernetes"),
+        ("mcp_kubernetes_get_pods", "List pods in a Kubernetes namespace"),
+        ("mcp_kubernetes_logs", "Get logs from a Kubernetes pod"),
+        ("mcp_database_query", "Execute a SQL query against a database"),
+        ("mcp_database_schema", "Get the schema of a database table"),
+        ("mcp_email_send", "Send an email message"),
+        ("mcp_email_list_inbox", "List messages in an email inbox"),
+        ("mcp_calendar_create_event", "Create a calendar event"),
+        ("mcp_calendar_list_events", "List upcoming calendar events"),
+        ("mcp_aws_s3_upload", "Upload a file to AWS S3"),
+        ("mcp_aws_s3_list", "List objects in an S3 bucket"),
+        ("mcp_aws_lambda_invoke", "Invoke an AWS Lambda function"),
+        ("mcp_docker_run", "Run a Docker container"),
+        ("mcp_docker_ps", "List running Docker containers"),
+        ("mcp_docker_logs", "Get logs from a Docker container"),
+        ("mcp_redis_get", "Get a value from Redis"),
+        ("mcp_redis_set", "Set a value in Redis"),
+        ("mcp_prometheus_query", "Query Prometheus metrics"),
+        ("mcp_grafana_dashboard", "Get a Grafana dashboard"),
+        ("mcp_terraform_plan", "Run Terraform plan"),
+        ("mcp_terraform_apply", "Apply a Terraform configuration"),
+        ("mcp_vault_read", "Read a secret from HashiCorp Vault"),
+        ("mcp_vault_write", "Write a secret to HashiCorp Vault"),
+    ]
+
+    needed = tool_count - len(base_tools)
+    for i, (name, desc) in enumerate(extra_tools):
+        if i >= needed:
+            break
+        registry.register(name, desc, {"type": "object", "properties": {}}, _noop_executor)
+
+    # If we need even more tools, generate synthetic ones
+    for i in range(needed - len(extra_tools)):
+        if i < 0:
+            break
+        name = f"mcp_synthetic_tool_{i}"
+        desc = f"Synthetic tool number {i} for testing"
+        registry.register(name, desc, {"type": "object", "properties": {}}, _noop_executor)
+
+    # Build defs and executors dicts
+    for tool_def in registry._tools.values():
+        all_defs[tool_def.name] = tool_def.to_openai_format()
+        all_executors[tool_def.name] = registry._executors[tool_def.name]
+
+    return registry, all_defs, all_executors
+
+
+# =====================================================================
+# Tokenizer
+# =====================================================================
+
+
+class TestTokenize:
+    def test_basic(self) -> None:
+        tokens = _tokenize("Hello World 123")
+        assert tokens == ["hello", "world", "123"]
+
+    def test_special_chars(self) -> None:
+        tokens = _tokenize("mcp_github_create-issue.v2")
+        assert tokens == ["mcp", "github", "create", "issue", "v2"]
+
+    def test_empty(self) -> None:
+        assert _tokenize("") == []
+        assert _tokenize("   ") == []
+
+
+# =====================================================================
+# BM25 Scoring
+# =====================================================================
+
+
+class TestBM25Score:
+    def test_exact_match_scores_higher(self) -> None:
+        docs = {
+            "github": _ToolDoc("github", "Create GitHub issues", _tokenize("github create issues")),
+            "slack": _ToolDoc("slack", "Send Slack messages", _tokenize("slack send messages")),
+        }
+        df = _build_index(docs)
+        n_docs = len(docs)
+        avgdl = sum(len(d.tokens) for d in docs.values()) / n_docs
+
+        github_score = _bm25_score(
+            _tokenize("github"), docs["github"], df, n_docs, avgdl
+        )
+        slack_score = _bm25_score(
+            _tokenize("github"), docs["slack"], df, n_docs, avgdl
+        )
+        assert github_score > slack_score
+        assert slack_score == 0.0
+
+    def test_empty_query_scores_zero(self) -> None:
+        doc = _ToolDoc("test", "A test tool", _tokenize("test tool"))
+        score = _bm25_score([], doc, {"test": 1}, 1, 2.0)
+        assert score == 0.0
+
+    def test_empty_corpus_scores_zero(self) -> None:
+        doc = _ToolDoc("test", "A test tool", [])
+        score = _bm25_score(_tokenize("test"), doc, {}, 0, 0.0)
+        assert score == 0.0
+
+
+# =====================================================================
+# ToolHydrator — lifecycle
+# =====================================================================
+
+
+class TestToolHydratorLifecycle:
+    def test_below_threshold_not_active(self) -> None:
+        hydrator = ToolHydrator(threshold=30)
+        _, defs, executors = _build_registry(10)
+        hydrator.load_tools(defs, executors)
+        assert not hydrator.is_active
+        assert hydrator.total_tool_count == 10
+
+    def test_above_threshold_is_active(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+        assert hydrator.is_active
+        assert hydrator.total_tool_count == 15
+
+    def test_below_threshold_returns_all_tools(self) -> None:
+        hydrator = ToolHydrator(threshold=30)
+        _, defs, executors = _build_registry(10)
+        hydrator.load_tools(defs, executors)
+        active = hydrator.get_active_tool_defs()
+        assert len(active) == 10
+
+    def test_above_threshold_returns_only_base_tools(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+        active = hydrator.get_active_tool_defs()
+        # Should only have base tools (those in the base_tool_names set)
+        active_names = {d["function"]["name"] for d in active}
+        base_names = hydrator.base_tool_names & set(defs.keys())
+        assert active_names == base_names
+        assert len(active) < 20
+
+    def test_hydrate_adds_tools(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+
+        before = len(hydrator.get_active_tool_defs())
+        hydrated = hydrator.hydrate(["mcp_github_create_issue", "mcp_slack_send_message"])
+        after = len(hydrator.get_active_tool_defs())
+
+        assert len(hydrated) == 2
+        assert after == before + 2
+
+    def test_hydrate_ignores_unknown_tools(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+
+        hydrated = hydrator.hydrate(["nonexistent_tool", "also_fake"])
+        assert hydrated == []
+
+    def test_hydrate_ignores_base_tools(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+
+        hydrated = hydrator.hydrate(["file_read", "grep"])
+        # Base tools cannot be hydrated (they are always available)
+        assert hydrated == []
+
+    def test_dehydrate_resets_to_base(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+
+        hydrator.hydrate(["mcp_github_create_issue", "mcp_slack_send_message"])
+        hydrator.dehydrate()
+
+        active = hydrator.get_active_tool_defs()
+        active_names = {d["function"]["name"] for d in active}
+        base_names = hydrator.base_tool_names & set(defs.keys())
+        assert active_names == base_names
+
+    def test_get_active_executor_respects_hydration(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+
+        # Before hydration, deferred tool executor should not be accessible
+        assert hydrator.get_active_executor("mcp_github_create_issue") is None
+
+        # After hydration, it should be accessible
+        hydrator.hydrate(["mcp_github_create_issue"])
+        assert hydrator.get_active_executor("mcp_github_create_issue") is not None
+
+    def test_get_executor_force_always_works(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+
+        # Even without hydration, force lookup works
+        assert hydrator.get_executor_force("mcp_github_create_issue") is not None
+
+    def test_has_executor(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+
+        assert hydrator.has_executor("file_read")
+        assert hydrator.has_executor("mcp_github_create_issue")
+        assert not hydrator.has_executor("nonexistent")
+
+
+# =====================================================================
+# ToolHydrator — search
+# =====================================================================
+
+
+class TestToolHydratorSearch:
+    def test_search_finds_relevant_tools(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+
+        results = hydrator.search("github issue")
+        names = [r["name"] for r in results]
+        assert "mcp_github_create_issue" in names
+
+    def test_search_returns_scored_results(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+
+        results = hydrator.search("kubernetes deploy")
+        assert len(results) > 0
+        # Results should be sorted by score descending
+        scores = [r["score"] for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_search_respects_top_n(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+
+        results = hydrator.search("mcp", top_n=3)
+        assert len(results) <= 3
+
+    def test_search_empty_query(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+
+        results = hydrator.search("")
+        assert results == []
+
+    def test_search_no_matches(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+
+        results = hydrator.search("zzzznonexistentzzzz")
+        assert results == []
+
+    def test_search_does_not_include_base_tools(self) -> None:
+        """Base tools are excluded from the search index."""
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(15)
+        hydrator.load_tools(defs, executors)
+
+        results = hydrator.search("file read")
+        names = [r["name"] for r in results]
+        # file_read is a base tool, should not appear in search
+        assert "file_read" not in names
+
+
+# =====================================================================
+# search_tools executor
+# =====================================================================
+
+
+class TestSearchToolsExecutor:
+    @pytest.fixture
+    def hydrator_with_tools(self) -> ToolHydrator:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+        return hydrator
+
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, hydrator_with_tools: ToolHydrator) -> None:
+        executor = create_search_tools_executor(hydrator_with_tools)
+        result_str = await executor(query="github issue")
+        result = json.loads(result_str)
+
+        assert "results" in result
+        assert len(result["results"]) > 0
+        assert "hydrated" in result
+
+    @pytest.mark.asyncio
+    async def test_search_auto_hydrates(self, hydrator_with_tools: ToolHydrator) -> None:
+        executor = create_search_tools_executor(hydrator_with_tools)
+
+        # Before search, the tool is not in the active set
+        assert hydrator_with_tools.get_active_executor("mcp_github_create_issue") is None
+
+        await executor(query="github issue")
+
+        # After search, the tool should be hydrated
+        assert hydrator_with_tools.get_active_executor("mcp_github_create_issue") is not None
+
+    @pytest.mark.asyncio
+    async def test_search_empty_query(self, hydrator_with_tools: ToolHydrator) -> None:
+        executor = create_search_tools_executor(hydrator_with_tools)
+        result_str = await executor(query="")
+        result = json.loads(result_str)
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_search_no_matches(self, hydrator_with_tools: ToolHydrator) -> None:
+        executor = create_search_tools_executor(hydrator_with_tools)
+        result_str = await executor(query="zzzznonexistentzzzz")
+        result = json.loads(result_str)
+        assert result["results"] == []
+        assert "No matching tools" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_search_top_n(self, hydrator_with_tools: ToolHydrator) -> None:
+        executor = create_search_tools_executor(hydrator_with_tools)
+        result_str = await executor(query="mcp", top_n=2)
+        result = json.loads(result_str)
+        assert len(result["results"]) <= 2
+
+
+# =====================================================================
+# Multi-round hydration
+# =====================================================================
+
+
+class TestMultiRoundHydration:
+    def test_search_hydrate_search_accumulates(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+
+        # Round 1: search and hydrate GitHub tools
+        results1 = hydrator.search("github")
+        hydrator.hydrate([r["name"] for r in results1])
+        count_after_round1 = len(hydrator.get_active_tool_defs())
+
+        # Round 2: search and hydrate Kubernetes tools
+        results2 = hydrator.search("kubernetes")
+        hydrator.hydrate([r["name"] for r in results2])
+        count_after_round2 = len(hydrator.get_active_tool_defs())
+
+        # Round 2 should have accumulated more tools
+        assert count_after_round2 >= count_after_round1
+
+    def test_dehydrate_between_rounds_resets(self) -> None:
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(20)
+        hydrator.load_tools(defs, executors)
+
+        base_count = len(hydrator.get_active_tool_defs())
+
+        # Round 1
+        results1 = hydrator.search("github")
+        hydrator.hydrate([r["name"] for r in results1])
+
+        # Dehydrate
+        hydrator.dehydrate()
+        assert len(hydrator.get_active_tool_defs()) == base_count
+
+
+# =====================================================================
+# SEARCH_TOOLS_SCHEMA validation
+# =====================================================================
+
+
+class TestSearchToolsSchema:
+    def test_schema_has_required_fields(self) -> None:
+        assert SEARCH_TOOLS_SCHEMA["type"] == "function"
+        func = SEARCH_TOOLS_SCHEMA["function"]
+        assert func["name"] == "search_tools"
+        assert "description" in func
+        assert "parameters" in func
+        assert "query" in func["parameters"]["properties"]
+        assert "query" in func["parameters"]["required"]
+
+
+# =====================================================================
+# AgentLoop integration
+# =====================================================================
+
+
+class TestAgentLoopHydrationIntegration:
+    """Test that AgentLoop correctly integrates with ToolHydrator."""
+
+    def test_no_hydration_below_threshold(self) -> None:
+        """Below threshold, no hydrator is created."""
+        registry = ToolRegistry()
+        registry.register("file_read", "Read a file", {}, _noop_executor)
+        registry.register("bash", "Run shell command", {}, _noop_executor)
+
+        config = KzConfig(model="test-model")
+        loop = AgentLoop(
+            config=config,
+            tools=registry,
+            client=MagicMock(),
+        )
+        # Hydrator should not be set up since we only have 2 tools
+        assert loop.hydrator is None
+
+    def test_hydration_auto_activates_above_threshold(self) -> None:
+        """Above threshold, hydrator is auto-created and search_tools is injected."""
+        registry, _, _ = _build_registry(35)
+
+        config = KzConfig(model="test-model")
+        loop = AgentLoop(
+            config=config,
+            tools=registry,
+            client=MagicMock(),
+        )
+        assert loop.hydrator is not None
+        assert loop.hydrator.is_active
+        # search_tools should have been injected
+        assert registry.has_tool("search_tools")
+
+    def test_explicit_hydrator_used(self) -> None:
+        """An explicitly provided hydrator is used."""
+        registry, _, _ = _build_registry(10)
+        hydrator = ToolHydrator(threshold=5)
+
+        config = KzConfig(model="test-model")
+        loop = AgentLoop(
+            config=config,
+            tools=registry,
+            client=MagicMock(),
+            hydrator=hydrator,
+        )
+        assert loop.hydrator is hydrator
+        assert hydrator.is_active  # 10 > threshold of 5
+
+    def test_explicit_hydrator_with_low_count(self) -> None:
+        """An explicit hydrator still respects is_active based on loaded tools."""
+        registry = ToolRegistry()
+        registry.register("file_read", "Read a file", {}, _noop_executor)
+
+        hydrator = ToolHydrator(threshold=30)
+        config = KzConfig(model="test-model")
+        loop = AgentLoop(
+            config=config,
+            tools=registry,
+            client=MagicMock(),
+            hydrator=hydrator,
+        )
+        assert loop.hydrator is hydrator
+        # With only 2 tools (file_read + search_tools), not active
+        assert not hydrator.is_active
+
+
+# =====================================================================
+# Threshold configurability
+# =====================================================================
+
+
+class TestThresholdConfiguration:
+    def test_default_threshold(self) -> None:
+        hydrator = ToolHydrator()
+        assert hydrator.threshold == _DEFAULT_THRESHOLD
+
+    def test_custom_threshold(self) -> None:
+        hydrator = ToolHydrator(threshold=50)
+        assert hydrator.threshold == 50
+
+    def test_threshold_boundary_exact(self) -> None:
+        """At exactly the threshold, hydration is NOT active."""
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(10)
+        hydrator.load_tools(defs, executors)
+        assert not hydrator.is_active
+
+    def test_threshold_boundary_plus_one(self) -> None:
+        """One above threshold, hydration IS active."""
+        hydrator = ToolHydrator(threshold=10)
+        _, defs, executors = _build_registry(11)
+        hydrator.load_tools(defs, executors)
+        assert hydrator.is_active
+
+    def test_custom_base_tool_names(self) -> None:
+        hydrator = ToolHydrator(
+            threshold=5,
+            base_tool_names=frozenset({"file_read", "bash"}),
+        )
+        _, defs, executors = _build_registry(10)
+        hydrator.load_tools(defs, executors)
+
+        active = hydrator.get_active_tool_defs()
+        active_names = {d["function"]["name"] for d in active}
+        assert active_names == {"file_read", "bash"}


### PR DESCRIPTION
## Summary

- **S7-001**: `ToolHydrator` class that splits tools into always-available base set (~7 tools) and deferred set, with `hydrate()`/`dehydrate()` lifecycle management
- **S7-002**: `search_tools` meta-tool with BM25-style keyword scoring (stdlib only, no external deps) — the LLM decides when to search for tools
- **S7-003**: AgentLoop integration — auto-activates hydration when tool count exceeds threshold, routes tool execution through hydrator when active
- **S7-004**: Configurable threshold (default 30) — below threshold, all tools passed directly (existing behavior unchanged)
- **S7-005**: 40 unit tests covering hydration lifecycle, BM25 search accuracy, threshold behavior, multi-round hydration, and AgentLoop integration

Also includes the multi-provider streaming adapter protocol (`StreamEvent`, `StreamingChatAdapter`) needed by the updated `AgentLoop`.

Closes #76

## Test plan

- [x] 40 unit tests pass (`test_tool_hydration.py`)
- [x] All 379 existing delegate unit tests pass (zero regressions)
- [x] Hydration lifecycle: hydrate/dehydrate correctly manages active tool set
- [x] BM25 search: relevant tools ranked higher, exact name matches boosted
- [x] Threshold: below 30 tools = passthrough, above 30 = hydration active
- [x] Multi-round: search + hydrate accumulates, dehydrate resets
- [x] AgentLoop: auto-creates hydrator above threshold, injects `search_tools`


🤖 Generated with [Claude Code](https://claude.com/claude-code)