### PR TITLE
release: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,45 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [2.2.0] - 2026-03-28
+
+**Multi-Package Release** — kailash 2.2.0, kailash-nexus 1.6.0, kaizen-agents 0.4.0, kailash-kaizen 2.3.1, kailash-dataflow 1.2.1, kailash-pact 0.4.1
+
+#### Added
+
+- **OpenTelemetry Progressive Tracing** (S5): `TracingLevel` enum (NONE/BASIC/DETAILED/FULL), node-level instrumentation, DataFlow/DB instrumentation, Prometheus metrics bridge
+- **Nexus K8s Integration** (S4): K8s probe endpoints (`/healthz`, `/readyz`, `/startup`), OpenAPI 3.0.3 generation, security headers middleware, CSRF middleware, middleware presets (Lightweight/Standard/SaaS/Enterprise)
+- **Delegate Facade** (S9): Unified `Delegate` class with typed events (`TextDelta`, `ToolCallStart`, `ToolCallEnd`, `TurnComplete`), progressive disclosure API, budget tracking with NaN/Inf defense
+- **Multi-Provider LLM Adapters** (S8): `StreamingChatAdapter` protocol with OpenAI, Anthropic, Google (Gemini), and Ollama adapters; auto-detection from model name
+- **Tool Search/Hydration** (S7): BM25 tool search for large tool sets (30+), automatic hydration with `search_tools` meta-tool
+- **Incremental Token Streaming** (S6): `AgentLoop.run_turn()` yields text deltas as they arrive instead of buffering
+
+#### Changed
+
+- Trust-plane `Delegate` renamed to `DelegationRecipient` with backward-compatible alias (S3e-004, #97)
+- `TracingLevel` defaults to BASIC when OpenTelemetry is installed (backward compatible)
+- CI pipeline: per-test timeout (30s), Python 3.13 continue-on-error, thread-heavy tests marked slow
+
+#### Fixed
+
+- 52-file security hardening: bare excepts replaced with specific types, CORS deny-by-default, bind 127.0.0.1, error message disclosure
+- PACT monotonic tightening test compliance
+- Pickle RCE removal from CacheNode and persistent tiers
+- Redis URL SSRF validation
+- eval/exec hardening with bounded power operator
+- 21 missing dependency declarations
+- CI test isolation (test pollution, thread leaks, module identity)
+
+#### Security
+
+- All 42 bare `except:` replaced with specific exception types (E722 re-enabled)
+- CORS default changed from `["*"]` to `[]` (deny-by-default)
+- Server bind default changed from `0.0.0.0` to `127.0.0.1`
+- Error responses no longer leak internal details via `str(e)`
+- Timing-safe HMAC comparison enforced across trust plane
+
+---
+
 ### [2.1.0] - 2026-03-26
 
 **Multi-Package Release** — kailash 2.1.0, kailash-dataflow 1.2.0, kailash-nexus 1.5.0, kailash-kaizen 2.3.0, kaizen-agents 0.3.0

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "1.2.0"
+version = "1.2.1"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "kailash>=2.1.0,<3.0.0",
+    "kailash>=2.2.0,<3.0.0",
     "sqlalchemy>=2.0.0",
     "alembic>=1.12.0",
     "asyncpg>=0.28.0",  # PostgreSQL async driver

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -35,7 +35,13 @@ from .configuration import (
 )
 from .core.config import DataFlowConfig, LoggingConfig, mask_sensitive
 from .core.engine import DataFlow
-from .engine import DataFlowEngine, HealthStatus, QueryEngine, ValidationLayer, DataClassificationPolicy
+from .engine import (
+    DataFlowEngine,
+    HealthStatus,
+    QueryEngine,
+    ValidationLayer,
+    DataClassificationPolicy,
+)
 from .core.logging_config import DEFAULT_SENSITIVE_PATTERNS
 from .core.logging_config import LoggingConfig as AdvancedLoggingConfig
 from .core.logging_config import SensitiveMaskingFilter, mask_sensitive_values
@@ -44,6 +50,7 @@ from .core.models import DataFlowModel
 from .core.tenant_context import TenantContextSwitch, TenantInfo, get_current_tenant_id
 from .core.type_processor import TypeAwareFieldProcessor
 from .core.workflow_binding import DataFlowWorkflowBinder
+
 # Field-level validation (issue #82)
 from .validation import (
     FieldValidationError,
@@ -83,7 +90,7 @@ from .utils.suppress_warnings import (
 suppress_core_sdk_warnings()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.3.0"
+version = "2.3.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "kailash[trust]>=2.1.0,<3.0.0",
+    "kailash[trust]>=2.2.0,<3.0.0",
     "pydantic>=2.0.0",
     "typing-extensions>=4.5.0",
     "PyJWT>=2.8.0",

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "1.5.0"
+version = "1.6.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "kailash>=2.1.0,<3.0.0",
+    "kailash>=2.2.0,<3.0.0",
     "starlette>=0.36.0",
     "fastapi>=0.104.0",
     "websockets>=12.0",

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -31,7 +31,7 @@ from .openapi import OpenApiGenerator, OpenApiInfo
 from .presets import PRESETS, NexusConfig, PresetConfig, apply_preset, get_preset
 from .probes import ProbeManager, ProbeResponse, ProbeState
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 __all__ = [
     # Core
     "Nexus",

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.4.0"
+version = "0.4.1"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ classifiers = [
 readme = "README.md"
 keywords = ["governance", "pact", "agent", "trust", "D/T/R", "envelopes", "clearance", "EATP", "AI"]
 dependencies = [
-    "kailash[pact]>=2.1.0",
+    "kailash[pact]>=2.2.0",
     "click>=8.0",
     "fastapi>=0.109",
     "slowapi>=0.1.9",

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # --- Governance (re-exported from kailash.trust.pact) ---
 from kailash.trust.pact import (

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.3.0"
+version = "0.4.0"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -22,9 +22,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "kailash[pact]>=2.1.0",
-    "kailash-kaizen>=2.3.0",
-    "kailash-pact>=0.4.0",
+    "kailash[pact]>=2.2.0",
+    "kailash-kaizen>=2.3.1",
+    "kailash-pact>=0.4.1",
     "openai>=1.30.0",
     "python-dotenv>=1.0.0",
     "structlog>=23.1.0",

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from kaizen_agents.supervisor import GovernedSupervisor, SupervisorResult
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.1.0"
+version = "2.2.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}
@@ -118,14 +118,14 @@ otel = [
 ]
 # Sub-packages
 dataflow = [
-    "kailash-dataflow>=1.2.0,<3.0.0",
+    "kailash-dataflow>=1.2.1,<3.0.0",
 ]
 nexus = [
-    "kailash-nexus>=1.5.0",
+    "kailash-nexus>=1.6.0",
 ]
 kaizen = [
-    "kailash-kaizen>=2.3.0,<3.0.0",
-    "kaizen-agents>=0.3.0",
+    "kailash-kaizen>=2.3.1,<3.0.0",
+    "kaizen-agents>=0.4.0",
 ]
 pact = [
     "pydantic>=2.6",
@@ -185,11 +185,11 @@ docs = [
 # Everything (restores pre-1.0 behavior)
 all = [
     "kailash[server,cli,http,database,postgres,mysql,files,auth,mfa,microsoft,monitoring,distributed,mcp,scheduler,otel,trust,trust-encryption,trust-sso,pact]",
-    "kailash-dataflow>=1.2.0,<3.0.0",
-    "kailash-nexus>=1.5.0",
-    "kailash-kaizen>=2.3.0,<3.0.0",
-    "kaizen-agents>=0.3.0",
-    "kailash-pact>=0.4.0",
+    "kailash-dataflow>=1.2.1,<3.0.0",
+    "kailash-nexus>=1.6.0",
+    "kailash-kaizen>=2.3.1,<3.0.0",
+    "kaizen-agents>=0.4.0",
+    "kailash-pact>=0.4.1",
 ]
 
 [project.urls]

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Release v2.2.0

**Multi-Package Release** — kailash 2.2.0, kailash-nexus 1.6.0, kaizen-agents 0.4.0, kailash-kaizen 2.3.1, kailash-dataflow 1.2.1, kailash-pact 0.4.1

## Version Bumps

| Package | Previous | New |
|---------|----------|-----|
| kailash (core) | 2.1.0 | 2.2.0 |
| kailash-nexus | 1.5.0 | 1.6.0 |
| kaizen-agents | 0.3.0 | 0.4.0 |
| kailash-kaizen | 2.3.0 | 2.3.1 |
| kailash-dataflow | 1.2.0 | 1.2.1 |
| kailash-pact | 0.4.0 | 0.4.1 |

## What's New (v2.2.0)

### Added
- **OpenTelemetry Progressive Tracing** (S5): `TracingLevel` enum (NONE/BASIC/DETAILED/FULL), node-level instrumentation, DataFlow/DB instrumentation, Prometheus metrics bridge
- **Nexus K8s Integration** (S4): K8s probe endpoints (`/healthz`, `/readyz`, `/startup`), OpenAPI 3.0.3 generation, security headers middleware, CSRF middleware, middleware presets (Lightweight/Standard/SaaS/Enterprise)
- **Delegate Facade** (S9): Unified `Delegate` class with typed events (`TextDelta`, `ToolCallStart`, `ToolCallEnd`, `TurnComplete`), progressive disclosure API, budget tracking with NaN/Inf defense
- **Multi-Provider LLM Adapters** (S8): `StreamingChatAdapter` protocol with OpenAI, Anthropic, Google (Gemini), and Ollama adapters; auto-detection from model name
- **Tool Search/Hydration** (S7): BM25 tool search for large tool sets (30+), automatic hydration with `search_tools` meta-tool
- **Incremental Token Streaming** (S6): `AgentLoop.run_turn()` yields text deltas as they arrive instead of buffering

### Changed
- Trust-plane `Delegate` renamed to `DelegationRecipient` with backward-compatible alias (S3e-004, #97)
- `TracingLevel` defaults to BASIC when OpenTelemetry is installed (backward compatible)
- CI pipeline: per-test timeout (30s), Python 3.13 continue-on-error, thread-heavy tests marked slow

### Fixed
- 52-file security hardening: bare excepts replaced with specific types, CORS deny-by-default, bind 127.0.0.1, error message disclosure
- PACT monotonic tightening test compliance
- Pickle RCE removal from CacheNode and persistent tiers
- Redis URL SSRF validation
- eval/exec hardening with bounded power operator
- 21 missing dependency declarations
- CI test isolation (test pollution, thread leaks, module identity)

### Security
- All 42 bare `except:` replaced with specific exception types (E722 re-enabled)
- CORS default changed from `["*"]` to `[]` (deny-by-default)
- Server bind default changed from `0.0.0.0` to `127.0.0.1`
- Error responses no longer leak internal details via `str(e)`
- Timing-safe HMAC comparison enforced across trust plane

## Test plan

- [ ] CI green on all Python versions (3.11, 3.12, 3.13)
- [ ] All 13 files changed are version bumps + CHANGELOG only (no logic changes)
- [ ] Version consistency verified: all `pyproject.toml` and `__init__.py` pairs match
- [ ] Cross-package dependency pins updated to `kailash>=2.2.0`
- [ ] CHANGELOG.md entry present at top of Recent Releases section

## Merge instructions

After CI passes:
```bash
gh pr merge <N> --admin --merge --delete-branch
```

Then tag:
```bash
git tag v2.2.0
git push origin v2.2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)