### PR TITLE
fix(ci): increase step timeout to 15 min

### DIFF
--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -99,7 +99,7 @@ jobs:
           .venv/bin/pyright src/kailash/ --pythonversion ${{ matrix.python-version }} --level error 2>&1 | tail -5
 
       - name: Test (Tier 1 — unit tests)
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           .venv/bin/python -m pytest \
             tests/unit/ \


### PR DESCRIPTION
Install+lint+pyright eat 5 min, leaving only 5 for tests.