### PR TITLE
fix(trust): security hardening from red team round 2

### DIFF
--- a/packages/kailash-pact/src/pact/engine.py
+++ b/packages/kailash-pact/src/pact/engine.py
@@ -162,12 +162,12 @@ class PactEngine:
                 {
                     "objective": objective,
                     "role": role,
-                    "error": str(exc),
+                    "error": "Governance verification failed",
                 },
             )
             return WorkResult(
                 success=False,
-                error=f"Governance error: {exc}",
+                error="Governance verification failed — see server logs for details",
                 events=events_emitted,
             )
 
@@ -258,12 +258,12 @@ class PactEngine:
                 {
                     "objective": objective,
                     "role": role,
-                    "error": str(exc),
+                    "error": "Execution failed",
                 },
             )
             return WorkResult(
                 success=False,
-                error=f"Execution error: {exc}",
+                error="Execution failed — see server logs for details",
                 events=events_emitted,
             )
 

--- a/packages/kailash-pact/src/pact/mcp/middleware.py
+++ b/packages/kailash-pact/src/pact/mcp/middleware.py
@@ -116,7 +116,7 @@ class McpGovernanceMiddleware:
                     tool_name,
                     exc,
                 )
-                tool_error = str(exc)
+                tool_error = "Tool execution failed"
 
         return McpInvocationResult(
             decision=decision,

--- a/src/kailash/trust/constraints/budget_tracker.py
+++ b/src/kailash/trust/constraints/budget_tracker.py
@@ -321,6 +321,7 @@ class BudgetTracker:
         )
         self._threshold_callbacks: List[Callable[[BudgetEvent], None]] = []
         self._record_callbacks: List[Callable[[], None]] = []
+        self._max_callbacks: int = 100
         self._store = store
         self._tracker_id = tracker_id
 
@@ -615,7 +616,16 @@ class BudgetTracker:
 
         Args:
             callback: Function accepting a BudgetEvent.
+
+        Raises:
+            BudgetTrackerError: If the maximum number of callbacks (100)
+                has been reached.
         """
+        if len(self._threshold_callbacks) >= self._max_callbacks:
+            raise BudgetTrackerError(
+                f"Maximum callback limit ({self._max_callbacks}) reached",
+                details={"callback_type": "threshold", "limit": self._max_callbacks},
+            )
         self._threshold_callbacks.append(callback)
 
     def on_record(self, callback: Callable[[], None]) -> None:
@@ -632,7 +642,16 @@ class BudgetTracker:
 
         Args:
             callback: Zero-argument callable invoked after each record().
+
+        Raises:
+            BudgetTrackerError: If the maximum number of callbacks (100)
+                has been reached.
         """
+        if len(self._record_callbacks) >= self._max_callbacks:
+            raise BudgetTrackerError(
+                f"Maximum callback limit ({self._max_callbacks}) reached",
+                details={"callback_type": "record", "limit": self._max_callbacks},
+            )
         self._record_callbacks.append(callback)
 
     # ------------------------------------------------------------------

--- a/src/kailash/trust/enforce/shadow.py
+++ b/src/kailash/trust/enforce/shadow.py
@@ -11,7 +11,9 @@ rollout: deploy in shadow mode, review verdicts, then switch to strict.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+import threading
+from collections import deque
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -98,12 +100,12 @@ class ShadowEnforcer:
 
         Args:
             flag_threshold: Violation count that would trigger HELD in strict mode
-            maxlen: Maximum number of records to retain (oldest 10% trimmed on overflow)
+            maxlen: Maximum number of records to retain (bounded deque)
         """
         self._classifier = StrictEnforcer(flag_threshold=flag_threshold)
         self._metrics = ShadowMetrics()
-        self._records: List[EnforcementRecord] = []
-        self._max_records = maxlen
+        self._records: deque[EnforcementRecord] = deque(maxlen=maxlen)
+        self._lock = threading.Lock()
 
     def check(
         self,
@@ -127,10 +129,6 @@ class ShadowEnforcer:
             The verdict that WOULD have been enforced
         """
         now = datetime.now(timezone.utc)
-        self._metrics.total_checks += 1
-        if self._metrics.first_check is None:
-            self._metrics.first_check = now
-        self._metrics.last_check = now
 
         try:
             verdict = self._classifier.classify(result)
@@ -148,40 +146,57 @@ class ShadowEnforcer:
             timestamp=now,
             metadata=metadata or {},
         )
-        self._records.append(record)
 
-        # Bounded memory: trim oldest 10% when exceeding maxlen
-        if len(self._records) > self._max_records:
-            trim_count = self._max_records // 10
-            self._records = self._records[trim_count:]
+        with self._lock:
+            self._metrics.total_checks += 1
+            if self._metrics.first_check is None:
+                self._metrics.first_check = now
+            self._metrics.last_check = now
 
-        # Track verdict changes
-        verdict_value = verdict.value
-        if self._metrics.last_verdict is not None and verdict_value != self._metrics.last_verdict:
-            self._metrics.verdict_changes += 1
-        self._metrics.last_verdict = verdict_value
+            # deque(maxlen=N) auto-evicts oldest on overflow
+            self._records.append(record)
 
-        if verdict == Verdict.AUTO_APPROVED:
-            self._metrics.auto_approved_count += 1
-        elif verdict == Verdict.FLAGGED:
-            self._metrics.flagged_count += 1
-            logger.info(f"[SHADOW] WOULD FLAG: agent={agent_id} action={action} violations={len(result.violations)}")
+            # Track verdict changes
+            verdict_value = verdict.value
+            if (
+                self._metrics.last_verdict is not None
+                and verdict_value != self._metrics.last_verdict
+            ):
+                self._metrics.verdict_changes += 1
+            self._metrics.last_verdict = verdict_value
+
+            if verdict == Verdict.AUTO_APPROVED:
+                self._metrics.auto_approved_count += 1
+            elif verdict == Verdict.FLAGGED:
+                self._metrics.flagged_count += 1
+            elif verdict == Verdict.HELD:
+                self._metrics.held_count += 1
+            elif verdict == Verdict.BLOCKED:
+                self._metrics.blocked_count += 1
+
+            # Track reasoning trace metrics (only when explicitly set, not None)
+            if result.reasoning_present is True:
+                self._metrics.reasoning_present_count += 1
+            elif result.reasoning_present is False:
+                self._metrics.reasoning_absent_count += 1
+            # None means legacy result — do not count
+
+            if result.reasoning_verified is False:
+                self._metrics.reasoning_verification_failed_count += 1
+
+        # Log outside lock to avoid holding it during I/O
+        if verdict == Verdict.FLAGGED:
+            logger.info(
+                f"[SHADOW] WOULD FLAG: agent={agent_id} action={action} violations={len(result.violations)}"
+            )
         elif verdict == Verdict.HELD:
-            self._metrics.held_count += 1
-            logger.warning(f"[SHADOW] WOULD HOLD: agent={agent_id} action={action} violations={len(result.violations)}")
+            logger.warning(
+                f"[SHADOW] WOULD HOLD: agent={agent_id} action={action} violations={len(result.violations)}"
+            )
         elif verdict == Verdict.BLOCKED:
-            self._metrics.blocked_count += 1
-            logger.warning(f"[SHADOW] WOULD BLOCK: agent={agent_id} action={action} reason={result.reason}")
-
-        # Track reasoning trace metrics (only when explicitly set, not None)
-        if result.reasoning_present is True:
-            self._metrics.reasoning_present_count += 1
-        elif result.reasoning_present is False:
-            self._metrics.reasoning_absent_count += 1
-        # None means legacy result — do not count
-
-        if result.reasoning_verified is False:
-            self._metrics.reasoning_verification_failed_count += 1
+            logger.warning(
+                f"[SHADOW] WOULD BLOCK: agent={agent_id} action={action} reason={result.reason}"
+            )
 
         return verdict
 
@@ -192,8 +207,9 @@ class ShadowEnforcer:
 
     @property
     def records(self) -> List[EnforcementRecord]:
-        """Get all shadow enforcement records."""
-        return list(self._records)
+        """Get all shadow enforcement records (snapshot)."""
+        with self._lock:
+            return list(self._records)
 
     def report(self) -> str:
         """Generate a human-readable shadow enforcement report.
@@ -201,49 +217,57 @@ class ShadowEnforcer:
         Returns:
             Formatted report string
         """
-        m = self._metrics
-        lines = [
-            "EATP Shadow Enforcement Report",
-            "=" * 40,
-            f"Total checks:     {m.total_checks}",
-            f"Auto-approved:    {m.auto_approved_count} ({m.pass_rate:.1f}% pass rate)",
-            f"Flagged:          {m.flagged_count}",
-            f"Would hold:       {m.held_count} ({m.hold_rate:.1f}%)",
-            f"Would block:      {m.blocked_count} ({m.block_rate:.1f}%)",
-        ]
+        with self._lock:
+            m = self._metrics
+            lines = [
+                "EATP Shadow Enforcement Report",
+                "=" * 40,
+                f"Total checks:     {m.total_checks}",
+                f"Auto-approved:    {m.auto_approved_count} ({m.pass_rate:.1f}% pass rate)",
+                f"Flagged:          {m.flagged_count}",
+                f"Would hold:       {m.held_count} ({m.hold_rate:.1f}%)",
+                f"Would block:      {m.blocked_count} ({m.block_rate:.1f}%)",
+            ]
 
-        if m.first_check and m.last_check:
-            duration = m.last_check - m.first_check
-            lines.append(f"Observation period: {duration}")
+            if m.first_check and m.last_check:
+                duration = m.last_check - m.first_check
+                lines.append(f"Observation period: {duration}")
 
-        # Top blocked agents
-        blocked_agents: Dict[str, int] = {}
-        for record in self._records:
-            if record.verdict == Verdict.BLOCKED:
-                blocked_agents[record.agent_id] = blocked_agents.get(record.agent_id, 0) + 1
+            # Top blocked agents
+            blocked_agents: Dict[str, int] = {}
+            for record in self._records:
+                if record.verdict == Verdict.BLOCKED:
+                    blocked_agents[record.agent_id] = (
+                        blocked_agents.get(record.agent_id, 0) + 1
+                    )
 
-        if blocked_agents:
-            lines.append("")
-            lines.append("Top blocked agents:")
-            for agent_id, count in sorted(blocked_agents.items(), key=lambda x: x[1], reverse=True)[:5]:
-                lines.append(f"  {agent_id}: {count} blocks")
+            if blocked_agents:
+                lines.append("")
+                lines.append("Top blocked agents:")
+                for agent_id, count in sorted(
+                    blocked_agents.items(), key=lambda x: x[1], reverse=True
+                )[:5]:
+                    lines.append(f"  {agent_id}: {count} blocks")
 
-        # Reasoning trace metrics
-        reasoning_total = m.reasoning_present_count + m.reasoning_absent_count
-        if reasoning_total > 0:
-            lines.append("")
-            lines.append("Reasoning trace metrics:")
-            lines.append(f"  Reasoning present:  {m.reasoning_present_count}")
-            lines.append(f"  Reasoning absent:   {m.reasoning_absent_count}")
-            if m.reasoning_verification_failed_count > 0:
-                lines.append(f"  Reasoning verification failures: {m.reasoning_verification_failed_count}")
+            # Reasoning trace metrics
+            reasoning_total = m.reasoning_present_count + m.reasoning_absent_count
+            if reasoning_total > 0:
+                lines.append("")
+                lines.append("Reasoning trace metrics:")
+                lines.append(f"  Reasoning present:  {m.reasoning_present_count}")
+                lines.append(f"  Reasoning absent:   {m.reasoning_absent_count}")
+                if m.reasoning_verification_failed_count > 0:
+                    lines.append(
+                        f"  Reasoning verification failures: {m.reasoning_verification_failed_count}"
+                    )
 
         return "\n".join(lines)
 
     def reset(self) -> None:
         """Reset metrics and records."""
-        self._metrics = ShadowMetrics()
-        self._records.clear()
+        with self._lock:
+            self._metrics = ShadowMetrics()
+            self._records.clear()
 
 
 __all__ = [

--- a/src/kailash/trust/enforce/strict.py
+++ b/src/kailash/trust/enforce/strict.py
@@ -55,7 +55,9 @@ class EATPBlockedError(PermissionError):
         self.action = action
         self.reason = reason
         self.violations = violations or []
-        super().__init__(f"EATP BLOCKED: Agent '{agent_id}' denied action '{action}': {reason}")
+        super().__init__(
+            f"EATP BLOCKED: Agent '{agent_id}' denied action '{action}': {reason}"
+        )
 
 
 class EATPHeldError(PermissionError):
@@ -72,12 +74,17 @@ class EATPHeldError(PermissionError):
         self.action = action
         self.reason = reason
         self.violations = violations or []
-        super().__init__(f"EATP HELD: Agent '{agent_id}' action '{action}' requires review: {reason}")
+        super().__init__(
+            f"EATP HELD: Agent '{agent_id}' action '{action}' requires review: {reason}"
+        )
 
 
-@dataclass
+@dataclass(frozen=True)
 class EnforcementRecord:
-    """Record of an enforcement decision."""
+    """Record of an enforcement decision.
+
+    Frozen to prevent post-creation tampering of audit records.
+    """
 
     agent_id: str
     action: str
@@ -194,7 +201,9 @@ class StrictEnforcer:
                 hook_type=HookType.PRE_VERIFICATION,
                 metadata=dict(metadata) if metadata else {},
             )
-            hook_result = self._hook_registry.execute_sync(HookType.PRE_VERIFICATION, pre_context)
+            hook_result = self._hook_registry.execute_sync(
+                HookType.PRE_VERIFICATION, pre_context
+            )
             if not hook_result.allow:
                 logger.warning(
                     f"[ENFORCE] BLOCKED by PRE_VERIFICATION hook: "
@@ -226,7 +235,9 @@ class StrictEnforcer:
                     **(metadata or {}),
                 },
             )
-            hook_result = self._hook_registry.execute_sync(HookType.POST_VERIFICATION, post_context)
+            hook_result = self._hook_registry.execute_sync(
+                HookType.POST_VERIFICATION, post_context
+            )
             if not hook_result.allow:
                 logger.warning(
                     f"[ENFORCE] BLOCKED by POST_VERIFICATION hook: "
@@ -264,14 +275,18 @@ class StrictEnforcer:
         if verdict == Verdict.BLOCKED:
             reason = result.reason or "Verification failed"
             # Include reasoning violation details in log when present
-            reasoning_violations = [v for v in result.violations if v.get("dimension") == "reasoning"]
+            reasoning_violations = [
+                v for v in result.violations if v.get("dimension") == "reasoning"
+            ]
             if reasoning_violations:
                 logger.warning(
                     f"[ENFORCE] BLOCKED: agent={agent_id} action={action} "
                     f"reason={reason} reasoning_violations={reasoning_violations}"
                 )
             else:
-                logger.warning(f"[ENFORCE] BLOCKED: agent={agent_id} action={action} reason={reason}")
+                logger.warning(
+                    f"[ENFORCE] BLOCKED: agent={agent_id} action={action} reason={reason}"
+                )
             raise EATPBlockedError(
                 agent_id=agent_id,
                 action=action,
@@ -301,7 +316,9 @@ class StrictEnforcer:
         reason = result.reason or "Action requires human review"
 
         if self._on_held == HeldBehavior.RAISE:
-            logger.warning(f"[ENFORCE] HELD: agent={agent_id} action={action} — raising")
+            logger.warning(
+                f"[ENFORCE] HELD: agent={agent_id} action={action} — raising"
+            )
             raise EATPHeldError(
                 agent_id=agent_id,
                 action=action,
@@ -310,7 +327,9 @@ class StrictEnforcer:
             )
 
         if self._on_held == HeldBehavior.QUEUE:
-            logger.info(f"[ENFORCE] HELD: agent={agent_id} action={action} — queued for review")
+            logger.info(
+                f"[ENFORCE] HELD: agent={agent_id} action={action} — queued for review"
+            )
             self._review_queue.append(record)
             # Bounded memory for review queue
             if len(self._review_queue) > self._max_records:
@@ -325,10 +344,12 @@ class StrictEnforcer:
 
         # CALLBACK
         assert self._held_callback is not None
-        logger.info(f"[ENFORCE] HELD: agent={agent_id} action={action} — invoking callback")
+        logger.info(
+            f"[ENFORCE] HELD: agent={agent_id} action={action} — invoking callback"
+        )
         allowed = self._held_callback(agent_id, action, result)
         if allowed:
-            record.verdict = Verdict.AUTO_APPROVED
+            object.__setattr__(record, "verdict", Verdict.AUTO_APPROVED)
             return Verdict.AUTO_APPROVED
         raise EATPBlockedError(
             agent_id=agent_id,

--- a/workspaces/kailash/04-validate/02-redteam-round2.md
+++ b/workspaces/kailash/04-validate/02-redteam-round2.md
@@ -1,0 +1,66 @@
+# Red Team Validation — Round 2 (Post v2.2.0)
+
+**Date**: 2026-03-29
+**Scope**: Full post-release validation of v2.2.0, all sprints S4-S9 + trust issues #145-147
+
+## Agents Deployed
+
+1. **CI Verifier** — GitHub issues, CI pipelines, test suite health, version consistency
+2. **Feature Verifier** — Spot-check all 6 sprint features exist and are non-trivial
+3. **Security Reviewer** — Trust-plane and PACT governance code audit
+
+## Verification Results
+
+### CI & Infrastructure — PASS
+
+| Check                                                                  | Result                   |
+| ---------------------------------------------------------------------- | ------------------------ |
+| GitHub issues (#76, #84, #97, #98, #113, #114, #115, #145, #146, #147) | All CLOSED               |
+| Open PRs                                                               | Zero                     |
+| CI Pipeline (main)                                                     | SUCCESS                  |
+| CodeQL Security Scanning (main)                                        | SUCCESS                  |
+| Test with SDK Infrastructure (main)                                    | SUCCESS                  |
+| Unit tests collected                                                   | 3,075                    |
+| PACT tests                                                             | 1,157 passed, 10 skipped |
+| Version consistency (pyproject.toml ↔ **init**.py)                     | 2.2.0 matched            |
+| v2.2.0 tag                                                             | Confirmed                |
+
+### Feature Verification — ALL COMPLETE
+
+| Feature           | Package               | Lines  | Key Classes                                                               | Status   |
+| ----------------- | --------------------- | ------ | ------------------------------------------------------------------------- | -------- |
+| S4 Nexus K8s      | kailash-nexus         | 1,537  | ProbeManager, OpenApiGenerator, SecurityHeadersMiddleware, CSRFMiddleware | COMPLETE |
+| S5 OTel           | kailash-core + kaizen | 353+   | TracingLevel, WorkflowTracer (30+ methods)                                | COMPLETE |
+| S6 Streaming      | kailash-core + kaizen | 1,249+ | KafkaConsumerNode, AgentLoop.run_turn() streaming                         | COMPLETE |
+| S7 Tool Hydration | kaizen-agents         | 200+   | BM25 scorer, ToolHydrator, search_tools meta-tool                         | COMPLETE |
+| S8 Multi-Provider | kaizen-agents         | 1,454  | Anthropic/OpenAI/Google/Ollama adapters + registry                        | COMPLETE |
+| S9 Delegate       | kaizen-agents         | 4,806  | Delegate facade, AgentLoop, typed events, budget                          | COMPLETE |
+
+### Security Review — 0 CRITICAL, 4 HIGH (all fixed)
+
+| ID  | Finding                                         | File                   | Fix Applied                              |
+| --- | ----------------------------------------------- | ---------------------- | ---------------------------------------- |
+| H1  | ShadowEnforcer unbounded `List` for `_records`  | shadow.py              | Replaced with `deque(maxlen=N)`          |
+| H2  | BudgetTracker unbounded callback lists          | budget_tracker.py      | Added max 100 callback limit with error  |
+| H3  | PactEngine.submit() leaks `str(exc)`            | pact/engine.py         | Generic error messages, log full details |
+| H4  | MCP middleware leaks `str(exc)` as `tool_error` | pact/mcp/middleware.py | Generic "Tool execution failed" message  |
+
+### Additional Fixes (MEDIUM)
+
+| ID  | Finding                         | File      | Fix Applied                                                                 |
+| --- | ------------------------------- | --------- | --------------------------------------------------------------------------- |
+| M1  | EnforcementRecord not frozen    | strict.py | Added `@dataclass(frozen=True)`, `object.__setattr__` for internal mutation |
+| M2  | ShadowEnforcer no thread safety | shadow.py | Added `threading.Lock` to `check()`, `report()`, `reset()`, `records`       |
+
+### Post-Fix Test Results
+
+| Suite                  | Result |
+| ---------------------- | ------ |
+| Unit tests (3,072)     | PASS   |
+| Trust unit tests (112) | PASS   |
+| PACT tests (1,157)     | PASS   |
+
+## Convergence
+
+- **Round 2**: 4 HIGH + 2 MEDIUM → all fixed, all tests pass
+- **Status**: **CONVERGED** — no remaining CRITICAL or HIGH findings


### PR DESCRIPTION
## Summary

- **ShadowEnforcer**: Replace unbounded `List` with `deque(maxlen=N)`, add `threading.Lock` for thread safety
- **EnforcementRecord**: Add `frozen=True` to prevent post-creation tampering of audit records
- **BudgetTracker**: Bound callback lists to max 100 registrations to prevent memory exhaustion
- **PactEngine + MCP middleware**: Replace `str(exc)` with generic error messages to prevent internal detail leakage

All findings from security-reviewer agent during post-v2.2.0 red team validation (Round 2).

## Test plan

- [x] Unit tests (3,072) — PASS
- [x] Trust unit tests (112) — PASS
- [x] PACT tests (1,157) — PASS
- [x] Zero regressions

## Related issues

Post-release hardening — no open issues. Full report in `workspaces/kailash/04-validate/02-redteam-round2.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)