### PR TITLE
release: v2.2.1 multi-package PyPI publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [2.2.1] - 2026-03-29
+
+**Patch Release** — kailash 2.2.1 (security hardening post-release fix)
+
+#### Fixed
+
+- Trust-plane security hardening from red team round 2: ShadowEnforcer `deque(maxlen=N)`, BudgetTracker callback bounds, `str(exc)` leak in PactEngine + MCP middleware, `EnforcementRecord frozen=True`, ShadowEnforcer `threading.Lock`
+
+---
+
 ### [2.2.0] - 2026-03-28
 
 **Multi-Package Release** — kailash 2.2.0, kailash-nexus 1.6.0, kaizen-agents 0.4.0, kailash-kaizen 2.3.1, kailash-dataflow 1.2.1, kailash-pact 0.4.1

--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -17,12 +17,12 @@
 
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
-| kailash (core)   | `v*`               | 2.1.0           |
-| kailash-dataflow | `dataflow-v*`      | 1.2.0           |
-| kailash-kaizen   | `kaizen-v*`        | 2.3.0           |
-| kailash-nexus    | `nexus-v*`         | 1.5.0           |
-| kailash-pact     | `pact-v*`          | 0.4.0           |
-| kaizen-agents    | `kaizen-agents-v*` | 0.3.0           |
+| kailash (core)   | `v*`               | 2.2.1           |
+| kailash-dataflow | `dataflow-v*`      | 1.2.1           |
+| kailash-kaizen   | `kaizen-v*`        | 2.3.1           |
+| kailash-nexus    | `nexus-v*`         | 1.6.0           |
+| kailash-pact     | `pact-v*`          | 0.4.1           |
+| kaizen-agents    | `kaizen-agents-v*` | 0.4.0           |
 
 ## Release Runbook
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.2.0"
+version = "2.2.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- Bumps core `kailash` from 2.2.0 to 2.2.1 (post-release security hardening from PR #156)
- Updates deployment-config.md with current versions for all 6 packages
- Adds CHANGELOG entry for 2.2.1

After merge, will tag all 6 packages to trigger PyPI publish:

| Package | Tag | Version |
|---------|-----|---------|
| kailash | `v2.2.1` | 2.2.1 |
| kailash-dataflow | `dataflow-v1.2.1` | 1.2.1 |
| kailash-kaizen | `kaizen-v2.3.1` | 2.3.1 |
| kailash-nexus | `nexus-v1.6.0` | 1.6.0 |
| kailash-pact | `pact-v0.4.1` | 0.4.1 |
| kaizen-agents | `kaizen-agents-v0.4.0` | 0.4.0 |

## Test plan

- [x] Unit tests: 3,072 passed, 0 failures
- [x] Version consistency verified (pyproject.toml matches __init__.py for all packages)
- [ ] CI green on PR
- [ ] Tags trigger publish-pypi.yml → OIDC publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)