### PR TITLE
feat(kaizen-agents): wire ToolCallStart/ToolCallEnd events in Delegate streaming

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1,0 +1,18 @@
+source_repo: kailash-py
+codify_date: 2026-03-29
+codify_session: "feat(kaizen-agents): Wire ToolCallStart/ToolCallEnd events + error sanitization"
+
+changes:
+  - file: .claude/skills/04-kaizen/kaizen-delegate.md
+    action: modified
+    suggested_tier: coc-py
+    reason: "Added event ordering documentation and error reporting patterns for ToolCallStart/ToolCallEnd"
+    diff_lines: "+22 -0"
+
+  - file: .claude/skills/04-kaizen/kaizen-agents-security.md
+    action: modified
+    suggested_tier: coc-py
+    reason: "Added error message sanitization section — str(exc) → type(exc).__name__ pattern with enforcement table"
+    diff_lines: "+30 -0"
+
+status: pending_review

--- a/.claude/skills/04-kaizen/kaizen-agents-security.md
+++ b/.claude/skills/04-kaizen/kaizen-agents-security.md
@@ -184,6 +184,34 @@ File tools accept any path the process can access. Use workspace root restrictio
 
 Uses allowlist regex: `re.sub(r"[^a-zA-Z0-9_-]", "_", name)` — not blacklist replacement.
 
+## Error Message Sanitization
+
+Exception messages (`str(exc)`) MUST NOT be exposed in programmatic API surfaces (events, JSON responses, tool results). Raw exception messages can leak file paths, connection strings, and internal implementation details.
+
+```python
+# CORRECT — type name only, details in log
+except Exception as exc:
+    logger.error("Tool %s failed: %s", name, exc, exc_info=True)
+    safe_msg = f"Tool '{name}' failed with {type(exc).__name__}"
+    return json.dumps({"error": safe_msg})
+
+# WRONG — raw str(exc) in API response
+except Exception as exc:
+    return json.dumps({"error": f"Tool error: {exc}"})  # Leaks internals!
+```
+
+### Where sanitization is enforced
+
+| Location                    | Pattern                                   | Since |
+| --------------------------- | ----------------------------------------- | ----- |
+| `_run_single` in `loop.py`  | `type(exc).__name__` in tool result JSON  | S11   |
+| `Delegate.run()` ErrorEvent | `type(exc).__name__` in error field       | S11   |
+| `PrintRunner.run()` error   | `type(exc).__name__` in PrintResult       | S11   |
+| `run_interactive()` display | `type(exc).__name__` in show_error        | S11   |
+| `HookManager._run_hook()`   | `type(exc).__name__` in HookResult.stderr | S11   |
+
+**Source**: Red team R2 findings H1-H3, M4.
+
 ## Behavioral Test Vectors
 
 45+ cross-SDK conformance tests define the canonical security behavior across Python and Rust SDKs. See `workspaces/kaizen-agents/01-analysis/01-research/13-behavioral-test-vectors.md`.

--- a/.claude/skills/04-kaizen/kaizen-delegate.md
+++ b/.claude/skills/04-kaizen/kaizen-delegate.md
@@ -53,6 +53,28 @@ async for event in delegate.run("Analyze this dataset"):
 | `BudgetExhausted` | `spent, limit`                 | Budget exceeded          |
 | `ErrorEvent`      | `error, error_type`            | Unrecoverable error      |
 
+### Event Ordering
+
+Tool events follow a deterministic pattern per tool batch:
+
+```
+TextDelta("Let me search...")          # Optional pre-tool text
+ToolCallStart(call_id="c1", name="search")   # All starts before execution
+ToolCallStart(call_id="c2", name="read")
+ToolCallEnd(call_id="c1", name="search", result="...")  # All ends after gather
+ToolCallEnd(call_id="c2", name="read", result="...")
+TextDelta("Based on results...")       # Next turn text
+TurnComplete(text="...", usage={...})
+```
+
+For consecutive tool turns (model calls tools, sees results, calls more tools), each batch emits its own start/end events sequentially.
+
+### Error Reporting in ToolCallEnd
+
+- **Normal tool errors** (exception caught inside executor): Error JSON in `result` field, `error` field empty. The error is sent back to the model as a tool result.
+- **Catastrophic failures** (BaseException escaping asyncio.gather): `error` field populated with `"Tool execution was interrupted"`, `result` field empty.
+- **Error messages are sanitized**: Exception messages use `type(exc).__name__` only — raw `str(exc)` is never exposed in events (prevents internal detail leakage).
+
 ## Synchronous Convenience
 
 ```python

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
@@ -308,7 +308,12 @@ class Delegate:
 
         try:
             async for chunk in self._loop.run_turn(prompt):
-                # AgentLoop yields raw text deltas
+                # Tool call events from the loop — yield as-is
+                if isinstance(chunk, DelegateEvent):
+                    yield chunk
+                    continue
+
+                # str chunks — text deltas
                 # Check if this is the budget-exhausted sentinel
                 if chunk == "[Budget exhausted — stopping.]":
                     yield BudgetExhausted(
@@ -323,7 +328,7 @@ class Delegate:
         except Exception as exc:
             logger.error("Delegate run failed: %s", exc, exc_info=True)
             yield ErrorEvent(
-                error=str(exc),
+                error=f"Delegate execution failed ({type(exc).__name__})",
                 details={"exception_type": type(exc).__name__},
             )
             return
@@ -362,6 +367,7 @@ class Delegate:
         RuntimeError:
             If the Delegate has been closed or budget is exhausted.
         """
+
         async def _collect() -> str:
             text_parts: list[str] = []
             async for event in self.run(prompt):

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/hooks.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/hooks.py
@@ -328,5 +328,5 @@ class HookManager:
                 event=event,
                 script=script,
                 exit_code=1,
-                stderr=str(exc),
+                stderr=f"Hook spawn failed ({type(exc).__name__})",
             )

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/loop.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/loop.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 from kaizen_agents.delegate.adapters.openai_stream import StreamResult
 from kaizen_agents.delegate.adapters.protocol import StreamEvent, StreamingChatAdapter
 from kaizen_agents.delegate.config.loader import KzConfig
+from kaizen_agents.delegate.events import DelegateEvent, ToolCallEnd, ToolCallStart
 
 logger = logging.getLogger(__name__)
 
@@ -441,12 +442,12 @@ class AgentLoop:
         """Signal the loop to stop after the current operation."""
         self._interrupted = True
 
-    async def run_turn(self, user_message: str) -> AsyncGenerator[str, None]:
+    async def run_turn(self, user_message: str) -> AsyncGenerator[str | DelegateEvent, None]:
         """Run one turn of the agent loop.
 
         A "turn" starts with a user message and continues until the model
         produces a text-only response (no tool calls) or max turns is reached.
-        Yields text chunks incrementally as they stream from the model.
+        Yields text chunks and tool call events incrementally.
 
         Parameters
         ----------
@@ -455,9 +456,12 @@ class AgentLoop:
 
         Yields
         ------
-        Text delta strings from the model's response, as each token arrives.
-        Callers that join all yielded chunks will get the same final text as
-        the previous buffered implementation.
+        ``str``
+            Text delta strings from the model's response.
+        :class:`ToolCallStart`
+            Emitted before each tool begins execution.
+        :class:`ToolCallEnd`
+            Emitted after each tool completes (with result or error).
         """
         self._interrupted = False
         self._conversation.add_user(user_message)
@@ -516,7 +520,9 @@ class AgentLoop:
                 tool_calls=stream_result.tool_calls,
             )
 
-            await self._execute_tool_calls(stream_result.tool_calls)
+            tool_events = await self._execute_tool_calls(stream_result.tool_calls)
+            for event in tool_events:
+                yield event
 
         # Max turns reached -- we ran out of turns without a text-only response
         logger.warning("Max turns (%d) reached in run_turn", self._config.max_turns)
@@ -613,19 +619,32 @@ class AgentLoop:
                     break
                 yield event_type, result
 
-    async def _execute_tool_calls(self, tool_calls: list[dict[str, Any]]) -> None:
+    async def _execute_tool_calls(self, tool_calls: list[dict[str, Any]]) -> list[DelegateEvent]:
         """Execute tool calls from the model's response.
 
         Independent tool calls are executed in parallel. Results are
-        appended to the conversation as tool messages.
+        appended to the conversation as tool messages. Returns a list of
+        :class:`ToolCallStart` and :class:`ToolCallEnd` events for each
+        tool call.
 
         Parameters
         ----------
         tool_calls:
             List of tool call dicts in OpenAI format.
+
+        Returns
+        -------
+        List of ``ToolCallStart`` and ``ToolCallEnd`` events in order:
+        all starts first, then all ends (matching ``tool_calls`` list order).
         """
         if not tool_calls:
-            return
+            return []
+
+        events: list[DelegateEvent] = []
+
+        # Emit ToolCallStart for each tool before execution begins
+        for tc in tool_calls:
+            events.append(ToolCallStart(call_id=tc["id"], name=tc["function"]["name"]))
 
         async def _run_single(tc: dict[str, Any]) -> tuple[str, str, str]:
             """Execute a single tool call. Returns (tool_call_id, name, result)."""
@@ -658,9 +677,12 @@ class AgentLoop:
                 logger.warning(error_msg)
                 return tc_id, name, json.dumps({"error": error_msg})
             except Exception as exc:
-                error_msg = f"Tool execution error: {exc}"
+                # Log the full exception for debugging but return a
+                # sanitized message — str(exc) can leak file paths,
+                # connection strings, or other internal details.
                 logger.error("Tool %s failed: %s", name, exc, exc_info=True)
-                return tc_id, name, json.dumps({"error": error_msg})
+                safe_msg = f"Tool '{name}' failed with {type(exc).__name__}"
+                return tc_id, name, json.dumps({"error": safe_msg})
 
         # Execute all tool calls in parallel
         tasks = [_run_single(tc) for tc in tool_calls]
@@ -680,10 +702,20 @@ class AgentLoop:
                     tc_name,
                     json.dumps({"error": "Tool execution was interrupted"}),
                 )
+                events.append(
+                    ToolCallEnd(
+                        call_id=tc_id,
+                        name=tc_name,
+                        error="Tool execution was interrupted",
+                    )
+                )
                 continue
 
             tc_id, name, content = result
             self._conversation.add_tool_result(tc_id, name, content)
+            events.append(ToolCallEnd(call_id=tc_id, name=name, result=content))
+
+        return events
 
     async def run_interactive(
         self,
@@ -728,6 +760,8 @@ class AgentLoop:
                 try:
                     full_text = ""
                     async for chunk in self.run_turn(user_input):
+                        if not isinstance(chunk, str):
+                            continue
                         display.append_text(chunk)
                         full_text += chunk
 
@@ -735,7 +769,7 @@ class AgentLoop:
 
                 except Exception as exc:
                     display.finish_streaming()
-                    display.show_error(str(exc))
+                    display.show_error(f"Turn failed ({type(exc).__name__})")
                     logger.error("Turn failed: %s", exc, exc_info=True)
 
             except KeyboardInterrupt:
@@ -769,5 +803,7 @@ class AgentLoop:
         """
         full_text = ""
         async for chunk in self.run_turn(prompt):
+            if not isinstance(chunk, str):
+                continue
             full_text += chunk
         return full_text

--- a/packages/kaizen-agents/src/kaizen_agents/delegate/print_mode.py
+++ b/packages/kaizen-agents/src/kaizen_agents/delegate/print_mode.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import sys
 from dataclasses import dataclass, field
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from kaizen_agents.delegate.config.loader import KzConfig
 from kaizen_agents.delegate.loop import AgentLoop, ToolRegistry
@@ -85,9 +88,15 @@ class PrintRunner:
         try:
             full_text = ""
             async for chunk in self._loop.run_turn(prompt):
+                if not isinstance(chunk, str):
+                    continue
                 full_text += chunk
         except Exception as exc:
-            return PrintResult(is_error=True, error_message=str(exc))
+            logger.error("PrintRunner failed: %s", exc, exc_info=True)
+            return PrintResult(
+                is_error=True,
+                error_message=f"Execution failed ({type(exc).__name__})",
+            )
 
         tools_used = self._extract_tools_used()
         usage = self._loop.usage

--- a/packages/kaizen-agents/tests/unit/delegate/test_delegate.py
+++ b/packages/kaizen-agents/tests/unit/delegate/test_delegate.py
@@ -368,8 +368,431 @@ class TestDelegateRun:
 
         error_events = [e for e in events if isinstance(e, ErrorEvent)]
         assert len(error_events) == 1
-        assert "API connection failed" in error_events[0].error
+        assert "RuntimeError" in error_events[0].error  # exception type is included
+        assert "API connection failed" not in error_events[0].error  # raw message is sanitized
         assert error_events[0].details["exception_type"] == "RuntimeError"
+
+
+# ---------------------------------------------------------------------------
+# Tool call event emission tests (GH #159)
+# ---------------------------------------------------------------------------
+
+
+def _tool_call_stream_events(
+    tool_calls: list[dict[str, Any]],
+    final_text: str = "Done.",
+) -> tuple[list[FakeStreamEvent], list[FakeStreamEvent]]:
+    """Create stream events for a tool-call response followed by a text response.
+
+    Returns (tool_turn_events, text_turn_events) — two turns that FakeAdapter
+    should yield sequentially.
+    """
+    # Turn 1: tool call
+    tool_turn: list[FakeStreamEvent] = []
+    # The adapter emits tool_call_start for each tool, then done with tool_calls
+    for tc in tool_calls:
+        tool_turn.append(
+            FakeStreamEvent(
+                event_type="tool_call_start",
+                content="",
+                model="test-model",
+            )
+        )
+    tool_turn.append(
+        FakeStreamEvent(
+            event_type="done",
+            content="",
+            tool_calls=tool_calls,
+            finish_reason="tool_calls",
+            usage={"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70},
+        )
+    )
+
+    # Turn 2: text response after tool results
+    text_turn = _text_stream_events(final_text)
+
+    return tool_turn, text_turn
+
+
+class _MultiTurnFakeAdapter:
+    """FakeAdapter that serves multiple turns of events sequentially."""
+
+    def __init__(self, *turns: list[FakeStreamEvent]) -> None:
+        self._turns = list(turns)
+        self._call_count = 0
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[FakeStreamEvent]:
+        idx = min(self._call_count, len(self._turns) - 1)
+        self._call_count += 1
+        for event in self._turns[idx]:
+            yield event  # type: ignore[misc]
+
+
+class TestDelegateToolCallEvents:
+    """Tests for ToolCallStart/ToolCallEnd event emission (GH #159)."""
+
+    def test_single_tool_call_emits_start_and_end(self) -> None:
+        """A single tool call yields ToolCallStart then ToolCallEnd."""
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path": "foo.py"}'},
+            }
+        ]
+        tool_turn, text_turn = _tool_call_stream_events(tool_calls, "Here is the file.")
+
+        adapter = _MultiTurnFakeAdapter(tool_turn, text_turn)
+        registry = ToolRegistry()
+
+        async def fake_read_file(path: str = "") -> str:
+            return f"contents of {path}"
+
+        registry.register(
+            "read_file",
+            "Read a file",
+            {"type": "object", "properties": {"path": {"type": "string"}}},
+            fake_read_file,
+        )
+
+        d = Delegate(model="test-model", tools=registry, adapter=adapter)
+
+        async def _run() -> list[DelegateEvent]:
+            events: list[DelegateEvent] = []
+            async for event in d.run("read foo.py"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_run())
+
+        starts = [e for e in events if isinstance(e, ToolCallStart)]
+        ends = [e for e in events if isinstance(e, ToolCallEnd)]
+
+        assert len(starts) == 1
+        assert starts[0].call_id == "call_1"
+        assert starts[0].name == "read_file"
+
+        assert len(ends) == 1
+        assert ends[0].call_id == "call_1"
+        assert ends[0].name == "read_file"
+        assert "contents of foo.py" in ends[0].result
+        assert ends[0].error == ""
+
+    def test_parallel_tool_calls_emit_multiple_events(self) -> None:
+        """Multiple tool calls yield multiple ToolCallStart/ToolCallEnd pairs."""
+        tool_calls = [
+            {
+                "id": "call_a",
+                "type": "function",
+                "function": {"name": "tool_a", "arguments": "{}"},
+            },
+            {
+                "id": "call_b",
+                "type": "function",
+                "function": {"name": "tool_b", "arguments": "{}"},
+            },
+        ]
+        tool_turn, text_turn = _tool_call_stream_events(tool_calls, "Both done.")
+
+        adapter = _MultiTurnFakeAdapter(tool_turn, text_turn)
+        registry = ToolRegistry()
+
+        async def tool_a_exec() -> str:
+            return "result_a"
+
+        async def tool_b_exec() -> str:
+            return "result_b"
+
+        registry.register("tool_a", "A", {"type": "object", "properties": {}}, tool_a_exec)
+        registry.register("tool_b", "B", {"type": "object", "properties": {}}, tool_b_exec)
+
+        d = Delegate(model="test-model", tools=registry, adapter=adapter)
+
+        async def _run() -> list[DelegateEvent]:
+            events: list[DelegateEvent] = []
+            async for event in d.run("run both"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_run())
+
+        starts = [e for e in events if isinstance(e, ToolCallStart)]
+        ends = [e for e in events if isinstance(e, ToolCallEnd)]
+
+        assert len(starts) == 2
+        assert {s.call_id for s in starts} == {"call_a", "call_b"}
+        assert {s.name for s in starts} == {"tool_a", "tool_b"}
+
+        assert len(ends) == 2
+        assert {e.call_id for e in ends} == {"call_a", "call_b"}
+
+    def test_tool_error_populates_error_field(self) -> None:
+        """A failing tool yields ToolCallEnd with error field populated."""
+        tool_calls = [
+            {
+                "id": "call_fail",
+                "type": "function",
+                "function": {"name": "failing", "arguments": "{}"},
+            }
+        ]
+        tool_turn, text_turn = _tool_call_stream_events(tool_calls, "Tool failed.")
+
+        adapter = _MultiTurnFakeAdapter(tool_turn, text_turn)
+        registry = ToolRegistry()
+
+        async def failing_tool() -> str:
+            raise RuntimeError("Something broke")
+
+        registry.register("failing", "Fails", {"type": "object", "properties": {}}, failing_tool)
+
+        d = Delegate(model="test-model", tools=registry, adapter=adapter)
+
+        async def _run() -> list[DelegateEvent]:
+            events: list[DelegateEvent] = []
+            async for event in d.run("try it"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_run())
+
+        ends = [e for e in events if isinstance(e, ToolCallEnd)]
+        assert len(ends) == 1
+        assert ends[0].call_id == "call_fail"
+        assert "error" in ends[0].result  # error is in the JSON result string
+        assert "RuntimeError" in ends[0].result  # exception type is included
+        assert "Something broke" not in ends[0].result  # raw message is sanitized
+        assert ends[0].name == "failing"
+
+    def test_event_ordering_starts_before_ends(self) -> None:
+        """All ToolCallStart events appear before any ToolCallEnd events."""
+        tool_calls = [
+            {
+                "id": "call_x",
+                "type": "function",
+                "function": {"name": "tool_x", "arguments": "{}"},
+            },
+            {
+                "id": "call_y",
+                "type": "function",
+                "function": {"name": "tool_y", "arguments": "{}"},
+            },
+        ]
+        tool_turn, text_turn = _tool_call_stream_events(tool_calls, "OK")
+
+        adapter = _MultiTurnFakeAdapter(tool_turn, text_turn)
+        registry = ToolRegistry()
+
+        async def tool_x() -> str:
+            return "x"
+
+        async def tool_y() -> str:
+            return "y"
+
+        registry.register("tool_x", "X", {"type": "object", "properties": {}}, tool_x)
+        registry.register("tool_y", "Y", {"type": "object", "properties": {}}, tool_y)
+
+        d = Delegate(model="test-model", tools=registry, adapter=adapter)
+
+        async def _run() -> list[DelegateEvent]:
+            events: list[DelegateEvent] = []
+            async for event in d.run("go"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_run())
+
+        # Extract indices of tool events
+        tool_events = [
+            (i, e) for i, e in enumerate(events) if isinstance(e, (ToolCallStart, ToolCallEnd))
+        ]
+        start_indices = [i for i, e in tool_events if isinstance(e, ToolCallStart)]
+        end_indices = [i for i, e in tool_events if isinstance(e, ToolCallEnd)]
+
+        # All starts must come before all ends
+        assert max(start_indices) < min(end_indices)
+
+    def test_text_only_response_has_no_tool_events(self) -> None:
+        """A text-only response yields no ToolCallStart/ToolCallEnd events."""
+        stream_events = _text_stream_events("Just text, no tools.")
+        adapter = FakeAdapter(stream_events)
+        d = Delegate(model="test-model", adapter=adapter)
+
+        async def _run() -> list[DelegateEvent]:
+            events: list[DelegateEvent] = []
+            async for event in d.run("hello"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_run())
+
+        starts = [e for e in events if isinstance(e, ToolCallStart)]
+        ends = [e for e in events if isinstance(e, ToolCallEnd)]
+        assert len(starts) == 0
+        assert len(ends) == 0
+
+        # Should still have text and turn complete
+        assert any(isinstance(e, TextDelta) for e in events)
+        assert any(isinstance(e, TurnComplete) for e in events)
+
+    def test_run_sync_ignores_tool_events(self) -> None:
+        """run_sync() returns text only — tool events are silently ignored."""
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "my_tool", "arguments": "{}"},
+            }
+        ]
+        tool_turn, text_turn = _tool_call_stream_events(tool_calls, "Final answer.")
+
+        adapter = _MultiTurnFakeAdapter(tool_turn, text_turn)
+        registry = ToolRegistry()
+
+        async def my_tool() -> str:
+            return "tool result"
+
+        registry.register("my_tool", "T", {"type": "object", "properties": {}}, my_tool)
+
+        d = Delegate(model="test-model", tools=registry, adapter=adapter)
+        result = d.run_sync("do it")
+
+        assert result == "Final answer."
+        assert "ToolCallStart" not in result
+        assert "ToolCallEnd" not in result
+
+    def test_multi_turn_event_sequence(self) -> None:
+        """Multi-turn: tool turn followed by text turn produces correct event sequence."""
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": '{"q": "test"}'},
+            }
+        ]
+        tool_turn, text_turn = _tool_call_stream_events(tool_calls, "Found results.")
+
+        adapter = _MultiTurnFakeAdapter(tool_turn, text_turn)
+        registry = ToolRegistry()
+
+        async def search(q: str = "") -> str:
+            return f"results for {q}"
+
+        registry.register(
+            "search",
+            "Search",
+            {"type": "object", "properties": {"q": {"type": "string"}}},
+            search,
+        )
+
+        d = Delegate(model="test-model", tools=registry, adapter=adapter)
+
+        async def _run() -> list[DelegateEvent]:
+            events: list[DelegateEvent] = []
+            async for event in d.run("search for test"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_run())
+
+        # Should see: ToolCallStart, ToolCallEnd, TextDelta(s), TurnComplete
+        event_types = [type(e).__name__ for e in events]
+        assert "ToolCallStart" in event_types
+        assert "ToolCallEnd" in event_types
+        assert "TextDelta" in event_types
+        assert "TurnComplete" in event_types
+
+        # ToolCallStart must come before TextDelta from the second turn
+        tc_start_idx = event_types.index("ToolCallStart")
+        tc_end_idx = event_types.index("ToolCallEnd")
+        last_text_idx = len(event_types) - 1 - event_types[::-1].index("TextDelta")
+
+        assert tc_start_idx < tc_end_idx
+        assert tc_end_idx < last_text_idx
+
+    def test_consecutive_tool_turns_emit_events_for_each_batch(self) -> None:
+        """Two consecutive tool turns (tool->tool->text) emit events for each batch."""
+        tool_calls_1 = [
+            {
+                "id": "call_a",
+                "type": "function",
+                "function": {"name": "step_one", "arguments": "{}"},
+            }
+        ]
+        tool_calls_2 = [
+            {
+                "id": "call_b",
+                "type": "function",
+                "function": {"name": "step_two", "arguments": "{}"},
+            }
+        ]
+
+        # Turn 1: tool call
+        turn1: list[FakeStreamEvent] = [
+            FakeStreamEvent(event_type="tool_call_start", content="", model="test-model"),
+            FakeStreamEvent(
+                event_type="done",
+                content="",
+                tool_calls=tool_calls_1,
+                finish_reason="tool_calls",
+                usage={"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70},
+            ),
+        ]
+        # Turn 2: another tool call
+        turn2: list[FakeStreamEvent] = [
+            FakeStreamEvent(event_type="tool_call_start", content="", model="test-model"),
+            FakeStreamEvent(
+                event_type="done",
+                content="",
+                tool_calls=tool_calls_2,
+                finish_reason="tool_calls",
+                usage={"prompt_tokens": 80, "completion_tokens": 30, "total_tokens": 110},
+            ),
+        ]
+        # Turn 3: text response
+        turn3 = _text_stream_events("All steps done.")
+
+        adapter = _MultiTurnFakeAdapter(turn1, turn2, turn3)
+        registry = ToolRegistry()
+
+        async def step_one() -> str:
+            return "step_one_result"
+
+        async def step_two() -> str:
+            return "step_two_result"
+
+        registry.register("step_one", "S1", {"type": "object", "properties": {}}, step_one)
+        registry.register("step_two", "S2", {"type": "object", "properties": {}}, step_two)
+
+        d = Delegate(model="test-model", tools=registry, adapter=adapter)
+
+        async def _run() -> list[DelegateEvent]:
+            events: list[DelegateEvent] = []
+            async for event in d.run("do both steps"):
+                events.append(event)
+            return events
+
+        events = asyncio.run(_run())
+
+        starts = [e for e in events if isinstance(e, ToolCallStart)]
+        ends = [e for e in events if isinstance(e, ToolCallEnd)]
+
+        # Should have 2 starts and 2 ends (one per tool batch)
+        assert len(starts) == 2
+        assert {s.name for s in starts} == {"step_one", "step_two"}
+
+        assert len(ends) == 2
+        assert {e.name for e in ends} == {"step_one", "step_two"}
+
+        # Verify batch ordering: batch 1 events before batch 2 events
+        start_names = [s.name for s in starts]
+        end_names = [e.name for e in ends]
+        assert start_names == ["step_one", "step_two"]
+        assert end_names == ["step_one", "step_two"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kaizen-agents/tests/unit/delegate/test_loop.py
+++ b/packages/kaizen-agents/tests/unit/delegate/test_loop.py
@@ -403,7 +403,8 @@ class TestAgentLoopTextResponse:
 
         collected: list[str] = []
         async for chunk in loop.run_turn("Hi there"):
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
         full_text = "".join(collected)
         assert full_text == response_text
@@ -487,7 +488,8 @@ class TestAgentLoopToolCalls:
 
         collected: list[str] = []
         async for chunk in loop.run_turn("List files"):
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
         full_text = "".join(collected)
         assert "file1.py" in full_text
@@ -542,7 +544,8 @@ class TestAgentLoopToolCalls:
 
         collected: list[str] = []
         async for chunk in loop.run_turn("Run both"):
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
         # Both tools should have been called (parallel via asyncio.gather)
         assert "a_start" in execution_order
@@ -580,12 +583,14 @@ class TestAgentLoopToolCalls:
 
         collected: list[str] = []
         async for chunk in loop.run_turn("Try the tool"):
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
-        # The error should be in the tool result message
+        # The error should be in the tool result message (sanitized — no raw exc message)
         tool_msg = next(m for m in loop.conversation.messages if m["role"] == "tool")
         assert "error" in tool_msg["content"].lower()
-        assert "Something went wrong" in tool_msg["content"]
+        assert "RuntimeError" in tool_msg["content"]  # exception type is included
+        assert "Something went wrong" not in tool_msg["content"]  # raw message is sanitized
 
     async def test_unknown_tool_handled(self) -> None:
         """Unknown tool names in model responses are handled gracefully."""
@@ -606,7 +611,8 @@ class TestAgentLoopToolCalls:
 
         collected: list[str] = []
         async for chunk in loop.run_turn("Use a fake tool"):
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
         tool_msg = next(m for m in loop.conversation.messages if m["role"] == "tool")
         assert "Unknown tool" in tool_msg["content"]
@@ -670,7 +676,8 @@ class TestAgentLoopToolCalls:
 
         collected: list[str] = []
         async for chunk in loop.run_turn("Bad args"):
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
         # Should have a tool result with an error message
         tool_msg = next(m for m in loop.conversation.messages if m["role"] == "tool")
@@ -717,7 +724,8 @@ class TestAgentLoopMaxTurns:
 
         collected: list[str] = []
         async for chunk in loop.run_turn("Keep going"):
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
         # Should have stopped after max_turns (3) API calls, not all 5
         assert loop.usage.turns <= 3
@@ -733,7 +741,8 @@ class TestAgentLoopMaxTurns:
 
         collected: list[str] = []
         async for chunk in loop.run_turn("One shot"):
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
         assert "".join(collected) == "Single turn response"
         assert loop.usage.turns == 1
@@ -792,14 +801,16 @@ class TestAgentLoopInterrupt:
         # Patch _execute_tool_calls to interrupt after executing
         original_execute = loop._execute_tool_calls
 
-        async def interrupt_after_execute(tc: list[dict[str, Any]]) -> None:
-            await original_execute(tc)
+        async def interrupt_after_execute(tc: list[dict[str, Any]]) -> list:
+            result = await original_execute(tc)
             loop.interrupt()
+            return result
 
         loop._execute_tool_calls = interrupt_after_execute  # type: ignore[assignment]
 
         async for chunk in turn_gen:
-            collected.append(chunk)
+            if isinstance(chunk, str):
+                collected.append(chunk)
 
         # The second API call should have been skipped due to interrupt.
         # The client was called once (tool call response), not twice.

--- a/workspaces/kailash/.test-results
+++ b/workspaces/kailash/.test-results
@@ -1,0 +1,27 @@
+# Test Results — Sprint S11 (post red team R2)
+# Date: 2026-03-29
+# Base commit: 904bbb7c
+
+## Baseline (pre-implementation)
+- delegate tests: 412 passed, 0 failed
+- core unit tests: 3072 passed, 3 skipped, 0 failed
+
+## Post red team R2
+- delegate tests: 420 passed, 0 failed (+8 new)
+- core unit tests: 3072 passed, 3 skipped, 0 failed
+
+## New tests added (8)
+1. test_single_tool_call_emits_start_and_end
+2. test_parallel_tool_calls_emit_multiple_events
+3. test_tool_error_populates_error_field (with sanitization assertions)
+4. test_event_ordering_starts_before_ends
+5. test_text_only_response_has_no_tool_events
+6. test_run_sync_ignores_tool_events
+7. test_multi_turn_event_sequence
+8. test_consecutive_tool_turns_emit_events_for_each_batch
+
+## Existing tests updated
+- test_exception_during_run_yields_error_event (sanitization assertion)
+- test_tool_execution_error_handled (sanitization assertion)
+
+## Regressions: 0

--- a/workspaces/kailash/01-analysis/03-sprint-s11-analysis.md
+++ b/workspaces/kailash/01-analysis/03-sprint-s11-analysis.md
@@ -1,0 +1,196 @@
+# Sprint S11 Analysis — Delegate Tool Call Event Wiring
+
+**Date**: 2026-03-29
+**Issues**: #159
+**Status**: Analysis phase
+
+## Open Issues
+
+| #       | Title                                                       | Type | Severity | Dependencies |
+| ------- | ----------------------------------------------------------- | ---- | -------- | ------------ |
+| **159** | Wire ToolCallStart/ToolCallEnd events in Delegate streaming | FEAT | HIGH     | None         |
+
+## Issue #159: ToolCallStart/ToolCallEnd Event Wiring
+
+### Problem Statement
+
+The Delegate streaming system defines six event types but only emits four. `ToolCallStart` and `ToolCallEnd` are fully defined in `events.py` (lines 72-100) with correct dataclass structure, but never yielded during `Delegate.run()`. Applications that need tool execution visibility (spinners, progress bars, structured SSE) must build custom agent loops — defeating the Delegate's purpose as a reusable autonomous engine.
+
+### Architecture Analysis
+
+The streaming pipeline has three layers with a type mismatch at the boundary between loop and delegate:
+
+```
+Layer 3: Delegate.run()           yields DelegateEvent (TextDelta, TurnComplete, ...)
+         ↑ consumes str chunks from Layer 2
+Layer 2: AgentLoop.run_turn()     yields str (text deltas only)
+         ↑ consumes (event_type, StreamResult) from Layer 1
+Layer 1: _stream_completion()     yields ("text"|"tool_call_start"|..., StreamResult)
+         ↑ consumes StreamEvent from adapter
+Layer 0: StreamingChatAdapter     yields StreamEvent with tool_call_start/end events
+```
+
+**The gap**: Layer 1 emits `tool_call_start` events, but Layer 2 discards them (line 497: `has_tool_calls = True` — flag only, no yield). Layer 2's `_execute_tool_calls()` runs tools in parallel but emits nothing about execution progress. Layer 3 only receives `str` chunks, so it cannot distinguish text from tool events.
+
+### Root Cause
+
+`AgentLoop.run_turn()` (line 444) is typed as `AsyncGenerator[str, None]`. It can only yield text strings. When the streaming adapter reports a tool call starting, the loop sets a boolean flag and moves on. When tools execute, the method runs them silently and appends results to the conversation — no event is surfaced to the Delegate.
+
+The Delegate's `run()` method (line 268) documents yielding `ToolCallStart` and `ToolCallEnd` in its docstring, but the implementation at lines 309-343 only processes `str` chunks as `TextDelta`.
+
+### Existing Infrastructure (What's Already Done)
+
+| Component                                  | File                                   | Lines    | Status          |
+| ------------------------------------------ | -------------------------------------- | -------- | --------------- |
+| `ToolCallStart` dataclass                  | `delegate/events.py`                   | 72-82    | Complete        |
+| `ToolCallEnd` dataclass                    | `delegate/events.py`                   | 86-100   | Complete        |
+| `DelegateEvent` base class                 | `delegate/events.py`                   | 45-56    | Complete        |
+| `_stream_completion()` emits tool events   | `delegate/loop.py`                     | 524-614  | Complete        |
+| `_execute_tool_calls()` parallel execution | `delegate/loop.py`                     | 616-687  | Complete        |
+| Streaming adapter protocol                 | `delegate/adapters/protocol.py`        | 27-51    | Complete        |
+| Event type unit tests                      | `tests/unit/delegate/test_delegate.py` | ~160-173 | Type tests only |
+
+**Estimated: 80% of the infrastructure exists. Only the wiring is missing.**
+
+### Red Team Findings (Incorporated)
+
+| #   | Severity | Finding                                                                                                                                | Resolution                                                                                   |
+| --- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| F1  | CRITICAL | `call_id`/`name` not in `StreamResult` at `tool_call_start` time — adapters don't populate `StreamEvent.tool_calls` until `done` event | Emit `ToolCallStart` from `_execute_tool_calls()` where full metadata is available           |
+| F2  | HIGH     | `run_interactive()`, `run_print()`, and `PrintRunner` also consume `run_turn()` — not just `Delegate.run()`                            | All three must filter `isinstance(chunk, str)` to skip `DelegateEvent` objects               |
+| F3  | HIGH     | `run_interactive()` crashes on `DelegateEvent` objects (`display.append_text(chunk)` and `full_text += chunk`)                         | Filter at minimum; enhanced tool display is future scope                                     |
+| F7  | MEDIUM   | `asyncio.Queue` callback approach over-engineered — simpler gather-then-yield pattern exists                                           | Use gather-then-yield: parallel tools complete via `asyncio.gather`, then yield sequentially |
+| F6  | MEDIUM   | Test plan missing multi-turn tool scenario (tool turn 1 -> text turn 2 in same `run_turn()` call)                                      | Added to test plan                                                                           |
+
+### Implementation Approach (Post Red Team)
+
+Widen `run_turn()` yield type to `str | DelegateEvent`. Emit `ToolCallStart` and `ToolCallEnd` from `_execute_tool_calls()` (not during streaming detection), where full tool metadata is available.
+
+**Why NOT emit during streaming detection**: At `tool_call_start` time in the stream, `StreamEvent.tool_calls` is empty — adapters accumulate tool metadata locally and only populate it at `done` time. The full `call_id` and `name` are only available in `stream_result.tool_calls` after the stream completes, which is exactly when `_execute_tool_calls()` is called.
+
+**Semantic correctness**: "ToolCallStart" meaning "tool execution started" (not "model started generating tool call JSON") is more useful for frontends showing spinners. The model's streaming of tool call arguments is an internal detail; the user cares when the tool actually runs.
+
+#### Changes Required (7 files)
+
+**1. `loop.py:run_turn()` — Type annotation + event yielding**
+
+- Change return type: `AsyncGenerator[str, None]` -> `AsyncGenerator[str | DelegateEvent, None]`
+- Import `ToolCallStart`, `ToolCallEnd` from `events.py`
+- At line 519, replace `await self._execute_tool_calls(...)` with yield-from pattern
+
+**2. `loop.py:_execute_tool_calls()` — Return events alongside conversation updates**
+
+- Change return type from `None` to `list[DelegateEvent]`
+- Emit `ToolCallStart` for each tool BEFORE `asyncio.gather`
+- After gather completes, emit `ToolCallEnd` for each result
+- Continue appending to conversation as before
+
+**3. `delegate.py:run()` — Dispatch on type**
+
+- `isinstance(chunk, str)` -> wrap in `TextDelta` (current behavior)
+- `isinstance(chunk, DelegateEvent)` -> yield as-is
+- Guard `accumulated_text += chunk` to only operate on strings
+
+**4. `loop.py:run_interactive()` line 730 — Filter DelegateEvents**
+
+- Add: `if not isinstance(chunk, str): continue`
+
+**5. `loop.py:run_print()` line 771 — Filter DelegateEvents**
+
+- Add: `if not isinstance(chunk, str): continue`
+
+**6. `print_mode.py:PrintRunner.run()` line 87 — Filter DelegateEvents**
+
+- Add: `if not isinstance(chunk, str): continue`
+
+**7. `tests/unit/delegate/test_delegate.py` — New event emission tests**
+
+#### Event Emission Pattern
+
+```python
+# In _execute_tool_calls (simplified):
+async def _execute_tool_calls(self, tool_calls) -> list[DelegateEvent]:
+    events: list[DelegateEvent] = []
+
+    # Emit ToolCallStart for each tool before execution
+    for tc in tool_calls:
+        events.append(ToolCallStart(
+            call_id=tc["id"], name=tc["function"]["name"]
+        ))
+
+    # Execute all tools in parallel (unchanged)
+    results = await asyncio.gather(
+        *[_run_single(tc) for tc in tool_calls], return_exceptions=True
+    )
+
+    # Process results and emit ToolCallEnd (unchanged conversation logic)
+    for idx, result in enumerate(results):
+        tc = tool_calls[idx]
+        if isinstance(result, BaseException):
+            events.append(ToolCallEnd(
+                call_id=tc["id"], name=tc["function"]["name"],
+                error="Tool execution was interrupted"
+            ))
+            self._conversation.add_tool_result(...)
+        else:
+            tc_id, name, content = result
+            events.append(ToolCallEnd(
+                call_id=tc_id, name=name, result=content
+            ))
+            self._conversation.add_tool_result(tc_id, name, content)
+
+    return events
+
+# In run_turn (at line 519):
+    tool_events = await self._execute_tool_calls(stream_result.tool_calls)
+    for event in tool_events:
+        yield event
+```
+
+### Event Ordering Guarantee
+
+```
+TextDelta("Let me search for that...")     # Model reasoning (optional)
+ToolCallStart(call_id="tc_1", name="web_search")   # All starts emitted before execution
+ToolCallStart(call_id="tc_2", name="read_file")
+ToolCallEnd(call_id="tc_1", name="web_search", result="...")   # Ends in gather order
+ToolCallEnd(call_id="tc_2", name="read_file", result="...")
+TextDelta("Based on what I found...")      # Next turn's text
+TurnComplete(text="...", usage={...})
+```
+
+All `ToolCallStart` events are emitted before parallel execution begins. `ToolCallEnd` events are emitted after `asyncio.gather` completes (order matches `tool_calls` list order, not completion order). This provides deterministic ordering — simpler for frontend rendering.
+
+### Scope Estimate
+
+~60-90 lines of production code across 4 files (`loop.py`, `delegate.py`, `print_mode.py` + imports). ~60-100 lines of new tests. Estimated: 1 autonomous session.
+
+### Test Plan
+
+1. **Unit**: FakeAdapter with tool calls -> verify `ToolCallStart` emitted by `Delegate.run()`
+2. **Unit**: Tool execution -> verify `ToolCallEnd` emitted with correct result/error fields
+3. **Unit**: Parallel tool calls -> verify multiple `ToolCallStart` + `ToolCallEnd` pairs
+4. **Unit**: Tool error -> verify `ToolCallEnd` with error field populated, result empty
+5. **Unit**: Multi-turn scenario (turn 1: tools, turn 2: text-only) -> verify correct event sequence across turns
+6. **Unit**: Budget exhaustion mid-tool -> verify clean event sequence
+7. **Regression**: Existing `TextDelta` and `TurnComplete` behavior unchanged
+8. **Regression**: `run_sync()` ignores tool events (returns text only)
+9. **Regression**: `run_print()` and `run_interactive()` continue working with str-only filtering
+
+### Cross-SDK Alignment
+
+Issue #159 notes the same gap exists in kailash-rs (`CallerEvent::ToolCallStart` defined but never emitted in `streaming/agent.rs`). A cross-SDK issue should be filed after implementation, including:
+
+- Matching event field names (`call_id`, `name`, `result`, `error`)
+- Matching ordering guarantee (all starts before execution, ends after gather)
+- Spec-level requirement that both SDKs emit these events
+
+### Risk Assessment
+
+| Risk                                        | Severity   | Mitigation                                                                   |
+| ------------------------------------------- | ---------- | ---------------------------------------------------------------------------- |
+| Breaking existing consumers of `run_turn()` | MEDIUM     | 3 hidden consumers (F2/F3) — all need `isinstance` filter (6 lines total)    |
+| Event ordering confusion                    | LOW        | Deterministic: all starts before gather, ends in list order after gather     |
+| Performance overhead of yielding events     | NEGLIGIBLE | One yield per tool call — tools are already the bottleneck                   |
+| `run_sync()` compatibility                  | LOW        | Verified: tool events fall through with no handler (correct)                 |
+| Adapter changes needed                      | NONE       | Resolved by emitting from `_execute_tool_calls()` instead of streaming layer |

--- a/workspaces/kailash/04-validate/01-redteam-s11.md
+++ b/workspaces/kailash/04-validate/01-redteam-s11.md
@@ -1,0 +1,69 @@
+# Red Team Report — Sprint S11
+
+**Date**: 2026-03-29
+**Issue**: #159 — Wire ToolCallStart/ToolCallEnd events in Delegate streaming
+**Rounds**: R1 → R2 (converged)
+
+## Test Results
+
+- delegate tests: 420 passed (+8 new), 0 failed, 0 regressions
+- core unit tests: 3072 passed, 0 failed, 0 regressions
+
+## R1 Findings (fixed in R2)
+
+| #   | Severity  | Finding                                                    | Fix                                                            |
+| --- | --------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
+| S1  | LOW→FIXED | `str(exc)` in `_run_single` passes raw exception to events | Sanitized: `f"Tool '{name}' failed with {type(exc).__name__}"` |
+
+## R2 Security Findings (3 HIGH — all fixed)
+
+| #   | Severity   | Finding                                                              | Fix                                                         |
+| --- | ---------- | -------------------------------------------------------------------- | ----------------------------------------------------------- |
+| H1  | HIGH→FIXED | `str(exc)` in `Delegate.run()` ErrorEvent leaks internal details     | `f"Delegate execution failed ({type(exc).__name__})"`       |
+| H2  | HIGH→FIXED | `str(exc)` in `PrintRunner.run()` error message leaks to JSON output | `f"Execution failed ({type(exc).__name__})"` + logger added |
+| H3  | HIGH→FIXED | `str(exc)` in `hooks.py` HookResult.stderr leaks file paths          | `f"Hook spawn failed ({type(exc).__name__})"`               |
+
+## R2 Medium Findings (accepted)
+
+| #   | Severity     | Finding                                                      | Status                                                                                                                                            |
+| --- | ------------ | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1  | MEDIUM       | ToolCallEnd.result passes raw tool output without truncation | ACCEPTED — same data already in conversation.messages; truncation would break model's ability to see tool results                                 |
+| M2  | MEDIUM       | Event dataclasses not frozen=True                            | ACCEPTED — events are ephemeral (consumed and GC'd by async generator); freezing would add overhead with no security benefit for streaming events |
+| M4  | MEDIUM→FIXED | `run_interactive` `display.show_error(str(exc))`             | `f"Turn failed ({type(exc).__name__})"`                                                                                                           |
+| M5  | MEDIUM       | `type(exc).__name__` reveals library names                   | ACCEPTED — exception type names are generic enough; the trade-off between debuggability and minimal information disclosure is reasonable          |
+
+## R2 Edge Case Gap (fixed)
+
+| #   | Finding                                   | Fix                                                                       |
+| --- | ----------------------------------------- | ------------------------------------------------------------------------- |
+| R1  | Multi-tool-turn (tool→tool→text) untested | Added `test_consecutive_tool_turns_emit_events_for_each_batch` — 8th test |
+
+## R2 Code Quality Findings (from intermediate-reviewer)
+
+| #   | Severity | Finding                                                                                 | Status                                                                                           |
+| --- | -------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Q1  | MEDIUM   | Unused imports in loop.py (`time`, `AsyncIterator`, `StreamEvent`)                      | PRE-EXISTING — not introduced by S11; keeping diff focused                                       |
+| Q2  | MEDIUM   | ToolCallEnd.error inconsistency (normal errors in `.result`, BaseException in `.error`) | ACCEPTED — matches pre-existing tool result behavior; normalizing would be a breaking API change |
+| Q3  | LOW      | `_MultiTurnFakeAdapter` silently clamps to last turn                                    | ACCEPTED — simple test helper, explicit error would over-engineer                                |
+
+## R2 Edge Case Findings (from deep-analyst)
+
+All 10 edge cases rated COVERED. R1 gap (multi-tool-turn) was fixed during R2 with `test_consecutive_tool_turns_emit_events_for_each_batch`.
+
+## Convergence
+
+**R2 converged**: 3 agents deployed (security-reviewer, intermediate-reviewer, deep-analyst). 0 CRITICAL, 0 HIGH remaining. 4 HIGH fixed (H1-H3, M4), 1 edge case gap fixed (R1). 420 tests pass, 0 regressions.
+
+## Files Changed (complete list)
+
+### Production
+
+- `delegate/loop.py` — Core wiring + error sanitization in `_run_single` + `run_interactive`
+- `delegate/delegate.py` — Type dispatch in `run()` + error sanitization in ErrorEvent
+- `delegate/print_mode.py` — isinstance filter + error sanitization + logger
+- `delegate/hooks.py` — Error sanitization in HookResult.stderr
+
+### Tests
+
+- `tests/unit/delegate/test_delegate.py` — 8 new tests + test infrastructure
+- `tests/unit/delegate/test_loop.py` — isinstance filters + sanitization assertions

--- a/workspaces/kailash/journal/0001-DISCOVERY-delegate-streaming-architecture-gap.md
+++ b/workspaces/kailash/journal/0001-DISCOVERY-delegate-streaming-architecture-gap.md
@@ -1,0 +1,31 @@
+---
+type: DISCOVERY
+date: 2026-03-29
+project: kailash
+topic: Delegate streaming has a type-boundary gap preventing tool event emission
+phase: analyze
+tags: [kaizen-agents, delegate, streaming, events, architecture]
+---
+
+# Delegate Streaming Architecture Gap
+
+## Discovery
+
+The Delegate streaming pipeline has a type-boundary mismatch at the loop-to-delegate layer that prevents tool call events from reaching consumers:
+
+- **Layer 0** (Adapters): Emit `StreamEvent` with `tool_call_start` — but `StreamEvent.tool_calls` is empty at this time (metadata accumulated locally, only populated at `done` time)
+- **Layer 1** (`_stream_completion`): Converts to `(event_type, StreamResult)` — forwards the empty metadata
+- **Layer 2** (`run_turn`): Typed as `AsyncGenerator[str, None]` — can only yield text, discards tool events as a boolean flag
+- **Layer 3** (`Delegate.run`): Yields `DelegateEvent` — documents `ToolCallStart`/`ToolCallEnd` in docstring but never emits them
+
+## Key Insight
+
+The correct emission point for `ToolCallStart`/`ToolCallEnd` is `_execute_tool_calls()`, NOT during streaming detection. At execution time, the full tool metadata (`call_id`, `name`) is available in `stream_result.tool_calls`. This also has better semantic meaning: "tool execution started" is what frontends care about, not "model started generating tool call JSON".
+
+## Additional Discovery
+
+Three hidden consumers of `run_turn()` beyond `Delegate.run()`: `run_interactive()` (line 730), `run_print()` (line 771), and `PrintRunner` (print_mode.py:87). All three do `full_text += chunk` and would crash on `DelegateEvent` objects. They need isinstance filtering.
+
+## Impact
+
+This gap is the subject of GH #159 and blocks frontend integration for applications needing tool execution status (spinners, SSE events). The fix requires widening `run_turn()` to `AsyncGenerator[str | DelegateEvent, None]` — a minimal internal API change with no adapter modifications needed.

--- a/workspaces/kailash/journal/0002-DECISION-emit-from-execute-not-stream.md
+++ b/workspaces/kailash/journal/0002-DECISION-emit-from-execute-not-stream.md
@@ -1,0 +1,35 @@
+---
+type: DECISION
+date: 2026-03-29
+project: kailash
+topic: Emit tool events from _execute_tool_calls, not streaming detection
+phase: todos
+tags: [kaizen-agents, delegate, streaming, architecture]
+---
+
+# Decision: Emit Tool Events from Execution, Not Detection
+
+## Choice
+
+Emit `ToolCallStart` and `ToolCallEnd` events from `_execute_tool_calls()` (after stream completes), NOT from the streaming detection phase in `run_turn()`.
+
+## Alternatives Considered
+
+1. **Emit during streaming detection** (rejected): When `_stream_completion()` yields `tool_call_start`, immediately yield a `ToolCallStart` event. Problem: `StreamEvent.tool_calls` is empty at this time — adapters accumulate tool metadata locally and only populate it on the `done` event. Would require modifying all 4 adapter implementations to propagate metadata earlier.
+
+2. **Callback + asyncio.Queue** (rejected): Add `on_tool_start`/`on_tool_end` callbacks to `_execute_tool_calls()`, push events into a queue, drain from `run_turn()`. Problem: Over-engineered. The gather-then-yield pattern achieves the same result with zero new infrastructure.
+
+3. **Emit from execution (chosen)**: Build all events in `_execute_tool_calls()` which already has full tool metadata, return as list, yield from `run_turn()`.
+
+## Rationale
+
+- Full `call_id` and `name` are available at execution time (from `stream_result.tool_calls`)
+- No adapter modifications needed (zero blast radius on 4 adapter implementations)
+- Semantically correct: "tool started" means "execution started", not "model started generating JSON"
+- Deterministic ordering: all starts before gather, all ends after gather (simplifies frontend rendering)
+- ~60 lines vs ~120 lines for the alternatives
+
+## Consequences
+
+- `ToolCallStart` events are slightly delayed compared to streaming detection (by the time arguments finish streaming). In practice this is milliseconds — tools themselves take seconds.
+- Event ordering is deterministic (all starts, then all ends) rather than interleaved (start1, end1, start2, end2). This is simpler but less "real-time" for long-running parallel tools.

--- a/workspaces/kailash/journal/0003-DECISION-codify-error-sanitization-pattern.md
+++ b/workspaces/kailash/journal/0003-DECISION-codify-error-sanitization-pattern.md
@@ -1,0 +1,28 @@
+---
+type: DECISION
+date: 2026-03-29
+project: kailash
+topic: Codified error sanitization as institutional security pattern
+phase: codify
+tags: [kaizen-agents, security, error-handling, codification]
+---
+
+# Decision: Codify Error Sanitization Pattern
+
+## Choice
+
+Added `str(exc)` → `type(exc).__name__` sanitization pattern to `kaizen-agents-security.md` as an institutional security pattern with enforcement table.
+
+## Rationale
+
+The red team (R2) found `str(exc)` leaking internal details in 4 locations across the delegate system. After fixing all 4, the pattern should be codified so future development follows the same approach. This prevents regression and ensures the pattern is applied consistently in new code.
+
+## What Was Codified
+
+1. **kaizen-delegate.md**: Event ordering documentation + error reporting semantics (which field carries errors in which path)
+2. **kaizen-agents-security.md**: Error sanitization pattern with DO/DON'T examples and enforcement table listing all 5 sanitized locations
+
+## What Was NOT Codified
+
+- The error sanitization pattern was not promoted to a global rule — it's kaizen-agents specific. Global security rules (`rules/security.md`) already cover the principle; the skill captures the delegate-specific implementation.
+- No new agent was created — the existing kaizen-specialist already covers this domain.


### PR DESCRIPTION
## Summary

- Wire `ToolCallStart` and `ToolCallEnd` events in Delegate streaming — the Delegate now emits all 6 defined event types (closes #159)
- Sanitize `str(exc)` → `type(exc).__name__` across 5 error paths to prevent internal detail leakage (red team R2: H1-H3, M4)
- Add 8 new tests covering single/parallel/multi-turn tool events, error handling, event ordering, and consumer compatibility

## Changes

**Production (4 files):**
- `loop.py` — `run_turn()` yields `str | DelegateEvent`; `_execute_tool_calls()` returns events list; 3 consumer filters; error sanitization
- `delegate.py` — `run()` dispatches on type; error sanitization in ErrorEvent
- `print_mode.py` — isinstance filter + error sanitization + logger
- `hooks.py` — Error sanitization in HookResult.stderr

**Skills (2 files):**
- `kaizen-delegate.md` — Event ordering + error reporting docs
- `kaizen-agents-security.md` — Error sanitization pattern codified

## Test plan

- [x] 420 delegate tests pass (+8 new), 0 regressions
- [x] 3072 core unit tests pass, 0 regressions
- [x] Red team R2 converged: 0 CRITICAL, 0 HIGH remaining

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)