### PR TITLE
release: bump kaizen-agents to 0.5.0

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -22,7 +22,7 @@
 | kailash-kaizen   | `kaizen-v*`        | 2.3.1           |
 | kailash-nexus    | `nexus-v*`         | 1.6.0           |
 | kailash-pact     | `pact-v*`          | 0.4.1           |
-| kaizen-agents    | `kaizen-agents-v*` | 0.4.0           |
+| kaizen-agents    | `kaizen-agents-v*` | 0.5.0           |
 
 ## Release Runbook
 

--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-03-30
+
+### Added
+
+- **ToolCallStart/ToolCallEnd event wiring** — Delegate streaming now emits all 6 defined event types. Applications can pattern-match on `ToolCallStart(name=...)` and `ToolCallEnd(name=..., result=...)` for tool execution visibility (spinners, SSE, progress bars). Closes #159.
+- 8 new unit tests for tool call event emission, ordering, error handling, multi-turn, and consumer compatibility.
+
+### Fixed
+
+- **Error message sanitization** — `str(exc)` replaced with `type(exc).__name__` in 5 error paths (`Delegate.run()`, `PrintRunner.run()`, `AgentLoop._run_single()`, `run_interactive()`, `HookManager._run_hook()`). Prevents internal detail leakage (file paths, connection strings) via events and API responses.
+
+### Changed
+
+- `AgentLoop.run_turn()` return type widened to `AsyncGenerator[str | DelegateEvent, None]` (internal API — only consumed by `Delegate.run()`).
+- `AgentLoop._execute_tool_calls()` now returns `list[DelegateEvent]` instead of `None`.
+- `run_interactive()`, `run_print()`, and `PrintRunner.run()` filter non-string chunks from `run_turn()`.
+
+## [0.4.0] - 2026-03-27
+
+### Added
+
+- **Delegate facade** — `Delegate` class as the primary user-facing API for autonomous AI execution with typed event system, progressive disclosure (Layer 1/2/3), and budget tracking. Closes #114.
+- **Incremental streaming** — `AgentLoop.run_turn()` yields text tokens incrementally as they arrive from the model. Closes #115.
+- **Multi-provider LLM adapter** — `StreamingChatAdapter` protocol with 4 provider adapters (OpenAI, Anthropic, Google, Ollama). Closes #113.
+- **Tool hydration** — `ToolHydrator` with BM25 search for large tool sets (100+ tools). Closes #76.
+- **Hook system** — `HookManager` with lifecycle events (PRE/POST tool use, model, session).
+
 ## [0.3.0] - 2026-03-25
 
 ### Added

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.4.0"
+version = "0.5.0"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 from kaizen_agents.supervisor import GovernedSupervisor, SupervisorResult
 


### PR DESCRIPTION
## Summary

- Bump kaizen-agents 0.4.0 → 0.5.0
- CHANGELOG updated for 0.5.0 (tool events + error sanitization) and backfills 0.4.0 (Delegate, streaming, multi-provider, hydration)
- Version consistent across pyproject.toml, __init__.py, deployment-config.md

## Test plan

- [x] 420 delegate tests pass, 0 regressions
- [x] Tag `kaizen-agents-v0.5.0` after merge triggers OIDC publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)