### PR TITLE
fix(ci): handle pre-existing releases + scope deploy pipeline

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -56,6 +56,10 @@ jobs:
   setup:
     name: Setup Deployment
     runs-on: ubuntu-latest
+    # Only run for kailash-kaizen releases (kaizen-v* tags), not other packages
+    if: >-
+      github.event_name != 'release' ||
+      startsWith(github.event.release.tag_name, 'kaizen-v')
     outputs:
       environment: ${{ steps.config.outputs.environment }}
       version: ${{ steps.config.outputs.version }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -197,7 +197,13 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
           RELEASE_TITLE: "${{ needs.determine-package.outputs.package }} ${{ needs.determine-package.outputs.version }}"
         run: |
-          gh release create "$TAG_NAME" \
-            dist/* \
-            --title "$RELEASE_TITLE" \
-            --generate-notes
+          # Skip if release already exists (e.g., created manually before CI ran)
+          if gh release view "$TAG_NAME" > /dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists — uploading artifacts only"
+            gh release upload "$TAG_NAME" dist/* --clobber
+          else
+            gh release create "$TAG_NAME" \
+              dist/* \
+              --title "$RELEASE_TITLE" \
+              --generate-notes
+          fi


### PR DESCRIPTION
## Summary

- `publish-pypi.yml`: Check if GitHub release exists before creating; upload artifacts to existing release instead of failing with "release already exists"
- `deploy-production.yml`: Only trigger container builds for `kaizen-v*` releases (not all package releases like `kaizen-agents-v*` which don't have containers)

Fixes the CI failures on the kaizen-agents v0.5.0 release.

## Test plan

- [x] Verified publish-pypi.yml logic: `gh release view` + fallback to `gh release upload --clobber`
- [x] Verified deploy-production.yml condition: `startsWith(github.event.release.tag_name, 'kaizen-v')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)