### PR TITLE
fix(pact): update MCP middleware test to match sanitized error

### DIFF
--- a/packages/kailash-pact/tests/unit/mcp/test_middleware.py
+++ b/packages/kailash-pact/tests/unit/mcp/test_middleware.py
@@ -177,7 +177,7 @@ class TestHandlerErrors:
         # Decision was approved, but handler failed
         assert result.decision.level == "auto_approved"
         assert result.executed is False
-        assert result.tool_error == "connection lost"
+        assert result.tool_error == "Tool execution failed"
         assert result.tool_result is None
 
 
@@ -249,9 +249,7 @@ class TestMiddlewareProperties:
         assert handler.calls[0] == ("search", {})
 
     @pytest.mark.asyncio
-    async def test_metadata_passed(
-        self, middleware: McpGovernanceMiddleware
-    ) -> None:
+    async def test_metadata_passed(self, middleware: McpGovernanceMiddleware) -> None:
         """Metadata is passed through to governance context."""
         result = await middleware.invoke(
             "search",


### PR DESCRIPTION
## Summary

- Update `test_handler_error_captured` to expect `"Tool execution failed"` instead of raw `"connection lost"`
- The middleware was sanitized in v2.2.0 (H4) but the test wasn't updated

## Test plan

- [x] `test_handler_error_captured` passes locally
- [x] 1149 PACT tests + 1 fixed = all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)