### PR TITLE
fix(ci): add pull-requests write permission to labeler job

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -28,6 +28,9 @@ jobs:
     name: Auto-label based on files changed
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

- Add `pull-requests: write` permission to the `label-based-on-files` job
- Fixes pre-existing "Resource not accessible by integration" error on every PR

## Test plan

- [x] This PR itself will validate — the labeler should succeed on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)