### PR TITLE
chore(coc): add VERSION file + mark codify proposal reviewed

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -15,4 +15,6 @@ changes:
     reason: "Added error message sanitization section — str(exc) → type(exc).__name__ pattern with enforcement table"
     diff_lines: "+30 -0"
 
-status: pending_review
+status: reviewed
+review_date: 2026-03-30
+review_notes: "Both classified global by sync-reviewer agent. Follows established pattern: kaizen globals are Python-flavored, rs has separate variant-only files."

--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "type": "coc-build",
+  "variant": "py",
+  "updated": "2026-03-30",
+  "description": "Kailash Python SDK BUILD repo",
+  "upstream": {
+    "source": "kailash",
+    "build_version": "1.0.0",
+    "synced_at": "2026-03-30T00:00:00Z"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/VERSION` file (v1.0.0, type `coc-build`) for COC artifact currency tracking
- Mark `/codify` proposal as reviewed after `/sync py` Gate 1 classified both changes as global

## Test plan
- [ ] VERSION file is valid JSON with correct `coc-build` type
- [ ] Proposal status shows `reviewed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)