### PR TITLE
chore: release kailash 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [2.3.1] - 2026-03-30
+
+**Patch Release** — kailash 2.3.1
+
+#### Fixed
+
+- **PACT internal_only enforcement** (#179): Actions without explicit `is_external` context no longer blocked for internal-only agents. Only explicitly external actions are denied.
+
+---
+
 ### [kailash-pact 0.5.0] - 2026-03-30
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.3.0"
+version = "2.3.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- Patch release including PACT `internal_only` enforcement fix (#179)

## Test plan

- [x] 951 PACT unit tests pass
- [x] 2483 kaizen-agents unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)