### PR TITLE
chore(release): kailash 2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [2.3.3] - 2026-03-31
+
+**Patch Release** — kailash 2.3.3
+
+#### Fixed
+
+- **TrustPosture pseudo alias** (#191): `TrustPosture("pseudo")` now resolves correctly via `_missing_` classmethod instead of raising `ValueError`
+- **ShadowEnforcer test attribute** (#193): Corrected `bounded_memory` test to use `_call_log` attribute (renamed from `call_log` during red team hardening)
+- **Hardcoded version assertions**: Removed 2 fragile hardcoded version checks in trust CLI and coverage tests
+
+---
+
 ### [kailash-dataflow 1.4.0] - 2026-03-31
 
 #### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.3.2"
+version = "2.3.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- Bump kailash version to 2.3.3
- Includes fixes from PRs #192 (TrustPosture pseudo alias) and #193 (ShadowEnforcer test attribute)
- Updated CHANGELOG.md with release entry

## Test plan

- [x] 3072 unit tests passed
- [x] 1139 PACT tests passed
- [x] 17 regression tests passed
- [x] CI green on PR #193 (all changes already validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)