### PR TITLE
chore(release): kailash 2.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [2.3.4] - 2026-03-31
+
+**Patch Release** — kailash 2.3.4
+
+#### Fixed
+
+- **PACT default constraint envelope** (#195): Relaxed two overly restrictive defaults on `ConstraintEnvelopeConfig`:
+  - `financial`: Changed from `FinancialConstraintConfig(max_spend_usd=0.0)` to `None` — financial dimension is now skipped during evaluation when not explicitly configured, matching the M23/2301 design intent
+  - `CommunicationConstraintConfig.internal_only`: Changed from `True` to `False` — agents are no longer restricted to internal-only communication by default. Predefined postures already set explicit values per trust level.
+
+---
+
 ### [2.3.3] - 2026-03-31
 
 **Patch Release** — kailash 2.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.3.3"
+version = "2.3.4"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.3.3"
+__version__ = "2.3.4"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- Bump kailash version to 2.3.4
- Includes PR #195: relaxed PACT default constraint envelope defaults

## Test plan

- [x] 3072 unit tests passed
- [x] 1139 PACT tests passed
- [x] 5335 trust tests passed
- [x] 23 regression tests passed
- [x] CI green on PR #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)