### PR TITLE
chore(ci): remove Docker Hub description update step

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -71,13 +71,3 @@ jobs:
           docker pull terrenefoundation/kailash:${{ steps.meta.outputs.version }}
           docker run --rm terrenefoundation/kailash:${{ steps.meta.outputs.version }} \
             python -c "import kailash; print(f'kailash {kailash.__version__}')"
-
-      - name: Update Docker Hub description
-        continue-on-error: true
-        uses: peter-evans/dockerhub-description@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: terrenefoundation/kailash
-          readme-filepath: docker/README.md
-          short-description: "Kailash Python SDK — workflow orchestration, AI agents, database ops, trust governance"


### PR DESCRIPTION
## Summary

- Remove the `peter-evans/dockerhub-description@v4` step entirely — requires account password (not PAT) for the Hub metadata API, consistently returns Forbidden

## Test plan

- [ ] CI passes
- [ ] Docker publish workflow has no warning annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)