### PR TITLE
fix: remove editable install symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,19 @@ node_modules/
 # Python
 __pycache__/
 
+# Editable install symlinks (pip install -e creates these)
+src/kailash/runtime.py
+src/kailash/dataflow
+src/kailash/enterprise
+src/kailash/infra
+src/kailash/kaizen
+src/kailash/mcp
+src/kailash/nexus
+src/kailash/pact
+src/kailash/py.typed
+src/kailash/trust_plane
+src/kailash/_kailash.cpython-*.so
+
 # Test artifacts (mock objects leaking to filesystem)
 <Mock *
 *.py[cod]

--- a/src/kailash/dataflow
+++ b/src/kailash/dataflow
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/dataflow

--- a/src/kailash/enterprise
+++ b/src/kailash/enterprise
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/enterprise

--- a/src/kailash/infra
+++ b/src/kailash/infra
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/infra

--- a/src/kailash/kaizen
+++ b/src/kailash/kaizen
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/kaizen

--- a/src/kailash/mcp
+++ b/src/kailash/mcp
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/mcp

--- a/src/kailash/nexus
+++ b/src/kailash/nexus
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/nexus

--- a/src/kailash/pact
+++ b/src/kailash/pact
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/pact

--- a/src/kailash/py.typed
+++ b/src/kailash/py.typed
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/py.typed

--- a/src/kailash/runtime.py
+++ b/src/kailash/runtime.py
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/runtime.py

--- a/src/kailash/trust_plane
+++ b/src/kailash/trust_plane
@@ -1,1 +1,0 @@
-/Users/esperie/.pyenv/versions/3.12.9/lib/python3.12/site-packages/kailash/trust_plane


### PR DESCRIPTION
## Summary

- Removed 10 symlinks from `pip install -e .` that were accidentally committed
- These broke Docker builds (`can't copy 'src/kailash/runtime.py': doesn't exist or not a regular file`)
- Added symlink paths to `.gitignore` to prevent recurrence

## Test plan

- [x] Docker build should now succeed
- [x] PyPI publish unaffected (symlinks were excluded from wheel builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)