### PR TITLE
fix(mcp): implement ResourceCache and fix CI collection error

### DIFF
--- a/src/kailash/mcp_server/resource_cache.py
+++ b/src/kailash/mcp_server/resource_cache.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Mtime-based resource cache for MCP platform discovery (MCP-507).
+
+Caches computed MCP resource data (platform maps, model lists, etc.) and
+invalidates when source files change. Thread-safe for concurrent MCP access.
+
+The cache watches a project directory for file modifications. When any
+Python file's mtime changes, cached resources are invalidated and rebuilt
+on the next access.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ResourceCache"]
+
+# Directories to skip when scanning for mtime changes
+_SKIP_DIRS = frozenset(
+    {
+        "__pycache__",
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+    }
+)
+
+
+class ResourceCache:
+    """Mtime-based cache for MCP resource builders.
+
+    Watches a project directory for file changes. When any Python file's
+    mtime changes, cached data is invalidated and rebuilt on the next
+    ``get_or_refresh()`` call.
+
+    Thread-safe: concurrent calls to ``get_or_refresh()`` are serialized
+    via a lock. The builder runs at most once per invalidation cycle.
+
+    Args:
+        project_path: Root directory to watch for file changes.
+        extensions: File extensions to monitor (default: .py files).
+    """
+
+    def __init__(
+        self,
+        project_path: Path | str,
+        extensions: tuple[str, ...] = (".py",),
+    ) -> None:
+        self._project_path = Path(project_path)
+        self._extensions = extensions
+        self._lock = threading.Lock()
+        self._cache: dict[str, Any] = {}
+        self._last_mtime: float = 0.0
+
+    def get_or_refresh(
+        self,
+        uri: str,
+        builder: Callable[[], Any],
+    ) -> Any:
+        """Get cached data or rebuild if source files changed.
+
+        Args:
+            uri: Cache key (typically an MCP resource URI).
+            builder: Callable that produces the data to cache.
+
+        Returns:
+            Cached or freshly built data.
+        """
+        with self._lock:
+            current_mtime = self._scan_max_mtime()
+            if current_mtime != self._last_mtime:
+                # Source files changed — invalidate everything
+                self._cache.clear()
+                self._last_mtime = current_mtime
+
+            if uri not in self._cache:
+                self._cache[uri] = builder()
+
+            return self._cache[uri]
+
+    def invalidate(self, uri: str | None = None) -> None:
+        """Invalidate cached data.
+
+        Args:
+            uri: Specific URI to invalidate. If None, invalidates all.
+        """
+        with self._lock:
+            if uri is None:
+                self._cache.clear()
+                self._last_mtime = 0.0  # Force rescan on next access
+            else:
+                self._cache.pop(uri, None)
+
+    def _scan_max_mtime(self) -> float:
+        """Scan project directory for the latest mtime among tracked files.
+
+        Skips hidden directories and __pycache__.
+        """
+        max_mtime = 0.0
+        if not self._project_path.is_dir():
+            return max_mtime
+
+        for root, dirs, files in os.walk(self._project_path):
+            # Prune hidden dirs and __pycache__ in-place
+            dirs[:] = [d for d in dirs if not d.startswith(".") and d not in _SKIP_DIRS]
+            for f in files:
+                if any(f.endswith(ext) for ext in self._extensions):
+                    try:
+                        mtime = os.path.getmtime(os.path.join(root, f))
+                        if mtime > max_mtime:
+                            max_mtime = mtime
+                    except OSError:
+                        pass
+
+        return max_mtime

--- a/tests/unit/mcp/test_resources.py
+++ b/tests/unit/mcp/test_resources.py
@@ -14,29 +14,7 @@ import pytest
 # The kailash.mcp.__init__ imports from a Rust native module (kailash._kailash).
 # When the native module is not built, we need to import ResourceCache by path
 # manipulation to avoid the __init__ import chain.
-try:
-    from kailash.mcp.resources import ResourceCache
-except (ImportError, ModuleNotFoundError):
-    # Direct import bypassing the package __init__
-    import importlib.util
-    import sys
-    from pathlib import Path as _Path
-
-    _spec = importlib.util.spec_from_file_location(
-        "kailash.mcp.resources",
-        _Path(__file__).resolve().parents[3]
-        / "src"
-        / "kailash"
-        / "mcp"
-        / "resources.py",
-    )
-    if _spec and _spec.loader:
-        _mod = importlib.util.module_from_spec(_spec)
-        sys.modules["kailash.mcp.resources"] = _mod
-        _spec.loader.exec_module(_mod)
-        ResourceCache = _mod.ResourceCache  # type: ignore[assignment]
-    else:
-        pytest.skip("Cannot import ResourceCache", allow_module_level=True)
+from kailash.mcp_server.resource_cache import ResourceCache
 
 
 class TestResourceCache:


### PR DESCRIPTION
## Summary

- Implements `ResourceCache` in `kailash.mcp_server.resource_cache` — mtime-based cache for MCP platform discovery (MCP-507)
- Fixes CI collection error: `tests/unit/mcp/test_resources.py` referenced a module that was never created

## Root Cause

The test file was written for a planned `kailash.mcp.resources.ResourceCache` class during the MCP-507 work. The module was never implemented — the old `kailash.mcp` namespace was unified into `kailash.mcp_server`. The test's fallback tried to load the file by path, which failed with `FileNotFoundError`, crashing CI test collection.

## Fix

Implemented `ResourceCache` with the exact API the tests specify:
- `get_or_refresh(uri, builder)` — returns cached data or rebuilds
- `invalidate(uri=None)` — invalidates specific URI or all
- mtime-based invalidation — watches project directory for Python file changes
- Thread-safe via internal lock
- Skips hidden dirs and `__pycache__`

## Test plan

- [x] All 9 existing `test_resources.py` tests pass
- [x] 2590 core SDK unit tests pass (1 pre-existing libomp failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)