### PR TITLE
chore(release): kailash 2.4.1, kailash-dataflow 1.6.0, kailash-nexus 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [2.4.1] - 2026-04-03
+
+**Patch Release** — kailash 2.4.1
+
+#### Fixed
+
+- MCP `ResourceCache` implementation and collection error fix
+- Removed editable install symlinks accidentally committed
+- Resolved 42 pre-existing DataFlow test failures (knowledge_base path, SQLite isolation, flaky assertions)
+- Resolved 7 pre-existing trust/PACT test failures (audit action count, vacancy enforcement, MCP import)
+
 ### [2.4.0] - 2026-04-01
 
 **Minor Release** — kailash 2.4.0

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # DataFlow Changelog
 
-## [Unreleased]
+## [1.6.0] - 2026-04-03
 
 ### Added
 

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "1.5.1"
+version = "1.6.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -91,7 +91,7 @@ from .utils.suppress_warnings import (
 suppress_core_sdk_warnings()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "1.5.1"
+__version__ = "1.6.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Nexus Changelog
 
+## [1.7.2] - 2026-04-03
+
+### Fixed
+
+- **Nexus auth security hardening** (#226): API key auth validation, token age checking, stale session detection hook
+- Auth JWT module refactored for security (constant-time comparison, bounded token cache)
+
 ## [1.7.1] - 2026-04-01
 
 ### Fixed

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "1.7.1"
+version = "1.7.2"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -36,7 +36,7 @@ from .files import NexusFile
 from .registry import HandlerDef, HandlerParam, HandlerRegistry
 from .transports import HTTPTransport, MCPTransport, Transport
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 __all__ = [
     # Core
     "Nexus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.4.0"
+version = "2.4.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- **kailash 2.4.1** (patch): MCP ResourceCache fix, 49 pre-existing test failures resolved
- **kailash-dataflow 1.6.0** (minor): Data Fabric Engine — `db.source()`, `@db.product()`, `db.start()`
- **kailash-nexus 1.7.2** (patch): Auth security hardening (API key, token age, JWT refactor)

## Version Matrix

| Package | Old | New | Bump |
|---------|-----|-----|------|
| kailash | 2.4.0 | 2.4.1 | patch |
| kailash-dataflow | 1.5.1 | 1.6.0 | minor |
| kailash-nexus | 1.7.1 | 1.7.2 | patch |

## Test Results

- Core (unit + trust + security): 8470 passed, 0 failed
- DataFlow (unit + fabric): 3945 passed, 0 failed

## Post-Merge

Tag on main to trigger `publish-pypi.yml`:
```
git tag v2.4.1 && git push origin v2.4.1
git tag dataflow-v1.6.0 && git push origin dataflow-v1.6.0
git tag nexus-v1.7.2 && git push origin nexus-v1.7.2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)