### PR TITLE
chore(release): bump kailash 2.5.0, pact 0.7.0, dataflow 1.7.0, nexus 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,46 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [2.5.0] - 2026-04-04
+
+**Multi-Package Release** — kailash 2.5.0, kailash-pact 0.7.0, kailash-dataflow 1.7.0, kailash-nexus 1.8.0
+
+Consolidated 23 GitHub issues (#231-#253) across 5 workstreams.
+
+#### Added
+
+- PACT: Enforcement modes ENFORCE/SHADOW/DISABLED with env var guard (#239)
+- PACT: Per-node GovernanceCallback protocol (#234)
+- PACT: HELD verdict distinct from BLOCKED with HeldActionCallback (#238)
+- PACT: Envelope-to-execution adapter mapping 5 PACT dimensions (#240)
+- PACT: Degenerate envelope detection at init (#241)
+- Governance: reject_bridge() with vacancy check (#231)
+- Nexus: Prometheus /metrics endpoint (optional dependency) (#233)
+- Nexus: SSE /events/stream with filtered subscriptions (#233)
+- DataFlow: Provenance[T] field-level source tracking (#242)
+- DataFlow: Audit trail persistence — SQLite + PostgreSQL (#243)
+- DataFlow: Consumer adapter registry for product transforms (#244)
+- Fabric: Cache invalidation API (#246)
+- Fabric: ?refresh=true cache bypass (#247)
+- Fabric: MCP tool generation from products (#250)
+- Fabric: FileSourceAdapter directory scanning (#249)
+- Fabric: Fabric-only mode without database (#251)
+
+#### Fixed
+
+- PACT: Stale supervisor budget — fresh per submit() (#235)
+- PACT: Mutable GovernanceEngine → ReadOnlyGovernanceView (#236)
+- PACT: NaN guard on budget_consumed (#237)
+- Governance: Vacant roles blocked from bridge approval (#231)
+- Fabric: Virtual products execute inline instead of returning None (#245)
+- Fabric: dev_mode pre-warming with prewarm parameter (#248)
+- Fabric: ChangeDetector dict-vs-adapter crash (#253)
+
+#### Changed
+
+- DataFlow: BaseAdapter.database_type → source_type with deprecation shim (#252)
+- DataFlow: datetime.utcnow() → datetime.now(UTC) in audit code
+
 ### [2.4.1] - 2026-04-03
 
 **Patch Release** — kailash 2.4.1

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "1.6.0"
+version = "1.7.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -92,7 +92,7 @@ from .utils.suppress_warnings import (
 suppress_core_sdk_warnings()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "1.7.2"
+version = "1.8.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -38,7 +38,7 @@ from .registry import HandlerDef, HandlerParam, HandlerRegistry
 from .sse import register_sse_endpoint
 from .transports import HTTPTransport, MCPTransport, Transport
 
-__version__ = "1.7.2"
+__version__ = "1.8.0"
 __all__ = [
     # Core
     "Nexus",

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.6.0"
+version = "0.7.0"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 # --- Governance (re-exported from kailash.trust.pact) ---
 from kailash.trust.pact import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.4.1"
+version = "2.5.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}
@@ -76,14 +76,17 @@ dependencies = [
 [project.optional-dependencies]
 # Sub-packages (separate PyPI packages)
 dataflow = [
-    "kailash-dataflow>=1.3.0,<3.0.0",
+    "kailash-dataflow>=1.7.0,<3.0.0",
 ]
 nexus = [
-    "kailash-nexus>=1.6.0",
+    "kailash-nexus>=1.8.0",
 ]
 kaizen = [
     "kailash-kaizen>=2.3.2,<3.0.0",
     "kaizen-agents>=0.6.0",
+]
+pact = [
+    "kailash-pact>=0.7.0",
 ]
 # Secret backends (vendor-specific SDKs)
 vault = [
@@ -130,11 +133,11 @@ docs = [
 ]
 # Everything (core + all sub-packages)
 all = [
-    "kailash-dataflow>=1.3.0,<3.0.0",
-    "kailash-nexus>=1.6.0",
+    "kailash-dataflow>=1.7.0,<3.0.0",
+    "kailash-nexus>=1.8.0",
     "kailash-kaizen>=2.3.2,<3.0.0",
     "kaizen-agents>=0.6.0",
-    "kailash-pact>=0.4.1",
+    "kailash-pact>=0.7.0",
 ]
 
 [project.urls]

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.4.1"
+__version__ = "2.5.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Version bump for multi-package release covering 23 GitHub issues (#231-#253).

| Package | Previous | New |
|---------|----------|-----|
| kailash (core) | 2.4.1 | 2.5.0 |
| kailash-pact | 0.6.0 | 0.7.0 |
| kailash-dataflow | 1.6.0 | 1.7.0 |
| kailash-nexus | 1.7.2 | 1.8.0 |

## Test plan

- [x] 1,361 PACT tests pass
- [x] All DataFlow tests pass
- [x] All Nexus tests pass
- [x] Version consistency verified (pyproject.toml + __init__.py match)
- [x] CHANGELOG.md updated

## Related issues

Release for: #231-#253, PR #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)