### PR TITLE
feat(kaizen): StructuredOutput helper class (M4)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/core/__init__.py
@@ -10,6 +10,7 @@ This module contains the foundational classes and interfaces for the Kaizen fram
 
 from .agents import Agent, AgentManager
 from .config import KaizenConfig, MemoryProvider, OptimizationEngine
+from .structured_output import StructuredOutput
 
 # PERFORMANCE OPTIMIZED: Use lightweight imports for <100ms startup
 from .framework import Kaizen

--- a/packages/kailash-kaizen/src/kaizen/core/structured_output.py
+++ b/packages/kailash-kaizen/src/kaizen/core/structured_output.py
@@ -396,3 +396,85 @@ def create_structured_output_config(
         # Legacy format (prompt-based, best-effort)
         # OpenAI expects only {"type": "json_object"} without schema key
         return {"type": "json_object"}
+
+
+class StructuredOutput:
+    """High-level helper for explicit structured output configuration.
+
+    Wraps ``create_structured_output_config`` with a fluent API that
+    translates to provider-specific ``response_format`` dicts.
+
+    Usage::
+
+        from kaizen.core.structured_output import StructuredOutput
+
+        so = StructuredOutput.from_signature(MySig)
+        config = BaseAgentConfig(
+            response_format=so.for_provider("azure"),
+            structured_output_mode="explicit",
+        )
+        # For Azure, append to system prompt:
+        # system_prompt = base_prompt + so.prompt_hint()
+    """
+
+    def __init__(self, schema: Dict[str, Any], name: str = "response"):
+        self._schema = schema
+        self._name = name
+
+    @classmethod
+    def from_signature(
+        cls, signature: Any, name: str | None = None
+    ) -> "StructuredOutput":
+        """Generate structured output config from a Kaizen signature.
+
+        Args:
+            signature: A Kaizen Signature instance.
+            name: Schema name (defaults to the signature class name).
+
+        Returns:
+            A StructuredOutput instance ready for ``for_provider()``.
+        """
+        resolved_name = name or getattr(signature.__class__, "__name__", "response")
+        schema = StructuredOutputGenerator.signature_to_json_schema(signature)
+        return cls(schema=schema, name=resolved_name)
+
+    def for_provider(self, provider: str) -> Dict[str, Any]:
+        """Translate to provider-specific ``response_format`` dict.
+
+        Args:
+            provider: One of ``"openai"``, ``"azure"``, ``"google"``,
+                ``"gemini"``, or ``"anthropic"``.
+
+        Returns:
+            Dict suitable for ``BaseAgentConfig.response_format``.
+        """
+        provider_lower = provider.lower()
+
+        if provider_lower == "openai":
+            strict_schema = _make_all_properties_required(
+                json.loads(json.dumps(self._schema))  # deep copy
+            )
+            return {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": self._name,
+                    "strict": True,
+                    "schema": strict_schema,
+                },
+            }
+
+        # Azure, Google/Gemini, and others use json_object (legacy mode)
+        return {"type": "json_object"}
+
+    def prompt_hint(self) -> str:
+        """Return a prompt instruction containing 'json' for Azure compatibility.
+
+        Azure requires the word 'json' in messages when using
+        ``response_format.type == "json_object"``. Append this to your
+        system prompt when targeting Azure.
+        """
+        return "\n\nRespond with a JSON object containing the output fields."
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the raw JSON schema dict."""
+        return dict(self._schema)

--- a/packages/kailash-kaizen/src/kaizen/core/workflow_generator.py
+++ b/packages/kailash-kaizen/src/kaizen/core/workflow_generator.py
@@ -21,6 +21,7 @@ Created: 2025-10-01
 
 import asyncio
 import logging
+import os
 from typing import Any, Callable, Dict, List, Optional
 
 from kailash.workflow.builder import WorkflowBuilder
@@ -267,7 +268,7 @@ class WorkflowGenerator:
         # Create LLMAgentNode with signature-based configuration
         node_config = {
             "provider": llm_provider or "openai",
-            "model": model or "gpt-4",
+            "model": model or os.environ.get("DEFAULT_LLM_MODEL", "gpt-4"),
             "system_prompt": self._get_system_prompt(),
             "generation_config": generation_config,
         }
@@ -398,7 +399,7 @@ class WorkflowGenerator:
         # Create simple LLMAgentNode configuration (no signature)
         node_config = {
             "provider": self.config.llm_provider or "openai",
-            "model": self.config.model or "gpt-4",
+            "model": self.config.model or os.environ.get("DEFAULT_LLM_MODEL", "gpt-4"),
             "generation_config": generation_config,
         }
 

--- a/packages/kailash-kaizen/tests/unit/core/test_structured_output_helper.py
+++ b/packages/kailash-kaizen/tests/unit/core/test_structured_output_helper.py
@@ -1,0 +1,109 @@
+"""Tests for StructuredOutput helper class.
+
+Covers the fluent API for explicit structured output configuration.
+"""
+
+import pytest
+
+from kaizen.core.structured_output import StructuredOutput
+from kaizen.signatures import InputField, OutputField, Signature
+
+
+class SimpleSig(Signature):
+    """Simple test signature."""
+
+    question: str = InputField(desc="A question")
+    answer: str = OutputField(desc="The answer")
+
+
+class ComplexSig(Signature):
+    """Complex signature with multiple types."""
+
+    text: str = InputField(desc="Input text")
+    summary: str = OutputField(desc="Summary")
+    confidence: float = OutputField(desc="Confidence 0-1")
+    tags: list = OutputField(desc="Tags")
+
+
+class TestStructuredOutputFromSignature:
+    """Test StructuredOutput.from_signature()."""
+
+    def test_creates_from_simple_signature(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        assert so.to_dict() is not None
+        schema = so.to_dict()
+        assert "properties" in schema
+        assert "answer" in schema["properties"]
+
+    def test_uses_signature_class_name(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        result = so.for_provider("openai")
+        assert result["json_schema"]["name"] == "SimpleSig"
+
+    def test_uses_custom_name(self):
+        so = StructuredOutput.from_signature(SimpleSig(), name="custom_name")
+        result = so.for_provider("openai")
+        assert result["json_schema"]["name"] == "custom_name"
+
+
+class TestStructuredOutputForProvider:
+    """Test StructuredOutput.for_provider()."""
+
+    def test_openai_returns_json_schema_strict(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        result = so.for_provider("openai")
+        assert result["type"] == "json_schema"
+        assert result["json_schema"]["strict"] is True
+        assert "schema" in result["json_schema"]
+
+    def test_azure_returns_json_object(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        result = so.for_provider("azure")
+        assert result == {"type": "json_object"}
+
+    def test_google_returns_json_object(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        result = so.for_provider("google")
+        assert result == {"type": "json_object"}
+
+    def test_gemini_returns_json_object(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        result = so.for_provider("gemini")
+        assert result == {"type": "json_object"}
+
+    def test_case_insensitive(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        assert so.for_provider("OpenAI")["type"] == "json_schema"
+        assert so.for_provider("AZURE")["type"] == "json_object"
+
+
+class TestStructuredOutputPromptHint:
+    """Test StructuredOutput.prompt_hint()."""
+
+    def test_contains_json(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        hint = so.prompt_hint()
+        assert "json" in hint.lower()
+        assert "JSON object" in hint
+
+    def test_is_string(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        assert isinstance(so.prompt_hint(), str)
+
+
+class TestStructuredOutputToDict:
+    """Test StructuredOutput.to_dict()."""
+
+    def test_returns_schema_dict(self):
+        so = StructuredOutput.from_signature(ComplexSig())
+        schema = so.to_dict()
+        assert isinstance(schema, dict)
+        assert "properties" in schema
+
+    def test_returns_copy(self):
+        so = StructuredOutput.from_signature(SimpleSig())
+        d1 = so.to_dict()
+        d2 = so.to_dict()
+        assert d1 == d2
+        d1["extra"] = "modified"
+        assert "extra" not in so.to_dict()


### PR DESCRIPTION
## Summary

- `StructuredOutput.from_signature(MySig).for_provider("azure")` — fluent API for explicit structured output
- `prompt_hint()` returns Azure-compatible "Respond with JSON" instruction
- `to_dict()` returns raw JSON schema
- Exported from `kaizen.core`
- Replaced hardcoded `"gpt-4"` default with `os.environ.get("DEFAULT_LLM_MODEL", "gpt-4")`

## Test plan

- [x] 12 new tests covering from_signature, for_provider (4 providers), prompt_hint, to_dict
- [x] All passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)