### PR TITLE
chore(release): bump kailash-kaizen 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,43 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### [kailash-kaizen 2.4.0] - 2026-04-04
+
+Explicit provider configuration refactor — eliminates implicit magic that caused #254-257.
+
+#### Added
+
+- `response_format` field on BaseAgentConfig for explicit structured output configuration
+- `structured_output_mode` field ("auto"/"explicit"/"off") with deprecation path
+- `StructuredOutput` helper class: `from_signature()`, `for_provider()`, `prompt_hint()`
+- `prompt_utils.py` — single source of truth for signature-based prompt generation
+- `resolve_azure_env()` helper for canonical-first env var resolution with deprecation
+- NaN/Inf guard on `temperature` and `budget_limit_usd` fields
+
+#### Changed
+
+- `provider_config` now holds only provider-specific settings (api_version, deployment)
+- Azure env vars canonicalized: `AZURE_ENDPOINT`, `AZURE_API_KEY`, `AZURE_API_VERSION`
+- System prompt generation unified — BaseAgent and WorkflowGenerator share `prompt_utils`
+- Hardcoded `"gpt-4"` model default replaced with `os.environ.get("DEFAULT_LLM_MODEL")`
+
+#### Deprecated
+
+- `provider_config` for structured output (use `response_format` instead) — migration shim auto-converts
+- `structured_output_mode="auto"` (will change to "explicit" in next minor)
+- Legacy Azure env vars (`AZURE_OPENAI_*`, `AZURE_AI_INFERENCE_*`) — use canonical names
+
+#### Fixed
+
+- #254: Azure json_object response_format requires 'json' in system prompt
+- #255: provider_config dual purpose — api_version misinterpreted as response_format
+- #256: Azure endpoint detection missing cognitiveservices.azure.com pattern
+- #257: AZURE_OPENAI_API_VERSION env var not read
+
+#### Removed
+
+- Error-based Azure backend fallback (`handle_error()`) — use `AZURE_BACKEND` explicitly
+
 ### [2.5.0] - 2026-04-04
 
 **Multi-Package Release** — kailash 2.5.0, kailash-pact 0.7.0, kailash-dataflow 1.7.0, kailash-nexus 1.8.0

--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -17,11 +17,11 @@
 
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
-| kailash (core)   | `v*`               | 2.3.2           |
-| kailash-dataflow | `dataflow-v*`      | 1.4.0           |
-| kailash-kaizen   | `kaizen-v*`        | 2.3.3           |
-| kailash-nexus    | `nexus-v*`         | 1.6.1           |
-| kailash-pact     | `pact-v*`          | 0.6.0           |
+| kailash (core)   | `v*`               | 2.5.0           |
+| kailash-dataflow | `dataflow-v*`      | 1.7.0           |
+| kailash-kaizen   | `kaizen-v*`        | 2.4.0           |
+| kailash-nexus    | `nexus-v*`         | 1.8.0           |
+| kailash-pact     | `pact-v*`          | 0.7.0           |
 | kaizen-agents    | `kaizen-agents-v*` | 0.6.0           |
 
 ## Release Runbook

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.3.3"
+version = "2.4.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.3.3"
+__version__ = "2.4.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

Release kailash-kaizen 2.4.0 — explicit provider configuration refactor.

See CHANGELOG.md for full details. Key changes:
- `response_format` field separated from `provider_config`
- `StructuredOutput` helper class
- Azure env var canonicalization
- Prompt unification via `prompt_utils.py`
- Fixes #254, #255, #256, #257

## Test plan

- [x] 821 passed, 0 new regressions
- [x] Version consistency: pyproject.toml and __init__.py both 2.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)