### PR TITLE
chore(release): batch version bump for 5 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,57 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### kailash 2.6.0 + kailash-pact 0.8.0 + kailash-dataflow 1.8.0 + kailash-ml 0.5.0 + kailash-align 0.3.0 — 2026-04-06
+
+#### [kailash 2.6.0]
+
+##### Added
+
+- **SUSPENDED VettingStatus** in clearance FSM with full transition validation (#309)
+- FSM transitions: PENDING→ACTIVE→SUSPENDED→ACTIVE (reinstatement) or →REVOKED (terminal)
+- `validate_transition()` for clearance state machine enforcement
+- `transition_clearance()` for safe status transitions with audit trail
+- Revoke guard against already-revoked clearances
+
+##### Fixed
+
+- **Security**: Code injection and shell injection vulnerabilities addressed (#306)
+- `AuditChain.from_dict()` called nonexistent `verify_integrity()` method
+
+#### [kailash-pact 0.8.0]
+
+##### Added
+
+- **SUSPENDED** added to `VettingStatus` enum with FSM transition validation (#309)
+- Clearance FSM pattern: PENDING→ACTIVE→SUSPENDED↔ACTIVE, SUSPENDED→REVOKED
+- `revoke_clearance()` preserves record with REVOKED status for audit trail
+
+#### [kailash-dataflow 1.8.0]
+
+##### Added
+
+- `bulk_upsert` operation for efficient batch insert-or-update (#294-#303)
+
+#### [kailash-ml 0.5.0]
+
+##### Added
+
+- ML correlation robustness improvements (#294-#303)
+
+##### Fixed
+
+- Cramer's V pivot fallback with logging for edge cases
+
+#### [kailash-align 0.3.0]
+
+##### Added
+
+- Agent support and on-premises deployment patterns (#294-#303)
+
+##### Fixed
+
+- **Security**: Code injection prevention in alignment pipeline (#306)
+
 ### kailash-ml 0.4.0 + kailash-pact 0.7.2 — 2026-04-05
 
 #### [kailash-ml 0.4.0]

--- a/packages/kailash-align/pyproject.toml
+++ b/packages/kailash-align/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-align"
-version = "0.2.1"
+version = "0.3.0"
 description = "LLM fine-tuning and alignment framework for the Kailash platform"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/kailash-align/src/kailash_align/_version.py
+++ b/packages/kailash-align/src/kailash_align/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-align package."""
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "1.7.1"
+version = "1.8.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.4.0"
+version = "0.5.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.7.2"
+version = "0.8.0"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.5.1"
+version = "2.6.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -75,7 +75,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.5.1"
+__version__ = "2.6.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- **kailash** 2.5.1 → 2.6.0 — SUSPENDED FSM, security fixes, #294-#303 batch
- **kailash-pact** 0.7.2 → 0.8.0 — SUSPENDED VettingStatus + FSM transition validation
- **kailash-dataflow** 1.7.1 → 1.8.0 — bulk_upsert from #294-#303
- **kailash-ml** 0.4.0 → 0.5.0 — correlation robustness, Cramer's V fix
- **kailash-align** 0.2.1 → 0.3.0 — security fixes, agents + on-prem

All changes already merged to main — this PR adds version bumps and CHANGELOG entries only.

## Post-merge

After merging, push these tags to trigger CI publish:

```bash
git tag v2.6.0 && git push origin v2.6.0
git tag pact-v0.8.0 && git push origin pact-v0.8.0
git tag dataflow-v1.8.0 && git push origin dataflow-v1.8.0
git tag ml-v0.5.0 && git push origin ml-v0.5.0
git tag align-v0.3.0 && git push origin align-v0.3.0
```

## Related issues

Closes accumulated unreleased changes from #294-#303, #306, #309, #310.

## Test plan

- [ ] CI passes on this branch
- [ ] Version strings consistent across pyproject.toml and __init__.py/_version.py
- [ ] CHANGELOG entries match actual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)