### PR TITLE
fix(pact): update revoke tests to match FSM audit-trail semantics

### DIFF
--- a/packages/kailash-pact/tests/unit/governance/test_audit.py
+++ b/packages/kailash-pact/tests/unit/governance/test_audit.py
@@ -59,7 +59,9 @@ class TestPactAuditAction:
 
     def test_all_audit_actions_exist(self) -> None:
         """All action types per thesis Section 5.7 normative mapping + LCA bridge approval + vacancy + bilateral consent."""
-        assert len(PactAuditAction) == 15  # 14 original + BRIDGE_REJECTED (#231)
+        assert (
+            len(PactAuditAction) == 16
+        )  # 14 original + BRIDGE_REJECTED (#231) + CLEARANCE_SUSPENDED (#309)
 
 
 # ===========================================================================

--- a/packages/kailash-pact/tests/unit/governance/test_sqlite_stores.py
+++ b/packages/kailash-pact/tests/unit/governance/test_sqlite_stores.py
@@ -434,7 +434,9 @@ class TestSqliteClearanceStore:
         clr = _make_clearance("D1-R1-T1-R1")
         store.grant_clearance(clr)
         store.revoke_clearance("D1-R1-T1-R1")
-        assert store.get_clearance("D1-R1-T1-R1") is None
+        revoked = store.get_clearance("D1-R1-T1-R1")
+        assert revoked is not None
+        assert revoked.vetting_status == VettingStatus.REVOKED
 
     def test_revoke_nonexistent_no_error(self) -> None:
         store = SqliteClearanceStore(":memory:")

--- a/packages/kailash-pact/tests/unit/governance/test_store_thread_safety.py
+++ b/packages/kailash-pact/tests/unit/governance/test_store_thread_safety.py
@@ -423,7 +423,9 @@ class TestMemoryClearanceStoreThreadSafety:
         # All grants should be present, all revokes should have taken effect
         for i in range(NUM_THREADS):
             assert store.get_clearance(f"grant-D{i}-R1") is not None
-            assert store.get_clearance(f"revoke-D{i}-R1") is None
+            revoked = store.get_clearance(f"revoke-D{i}-R1")
+            assert revoked is not None
+            assert revoked.vetting_status == VettingStatus.REVOKED
 
 
 # ===========================================================================

--- a/packages/kailash-pact/tests/unit/governance/test_stores.py
+++ b/packages/kailash-pact/tests/unit/governance/test_stores.py
@@ -384,7 +384,9 @@ class TestMemoryClearanceStore:
         clr = _make_clearance("D1-R1-T1-R1")
         store.grant_clearance(clr)
         store.revoke_clearance("D1-R1-T1-R1")
-        assert store.get_clearance("D1-R1-T1-R1") is None
+        revoked = store.get_clearance("D1-R1-T1-R1")
+        assert revoked is not None
+        assert revoked.vetting_status == VettingStatus.REVOKED
 
     def test_revoke_nonexistent_clearance_no_error(self) -> None:
         """Revoking a clearance that does not exist should not raise."""


### PR DESCRIPTION
## Summary

- 4 PACT tests expected `get_clearance()` to return `None` after revoke, but #309 changed revoke to preserve records with `REVOKED` status for audit trail
- Updated assertions to check for `VettingStatus.REVOKED` instead of `None`
- Updated audit action count from 15 to 16 (new FSM action)

## Related issues

Fixes CI failure from #309 / #310

## Test plan

- [x] All 4 previously failing tests now pass locally
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)