### PR TITLE
feat(ml): add cardinality guard to PreprocessingPipeline one-hot encoding

### DIFF
--- a/packages/kailash-ml/src/kailash_ml/engines/preprocessing.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/preprocessing.py
@@ -146,6 +146,8 @@ class PreprocessingPipeline:
         imputation_strategy: str = "mean",
         remove_outliers: bool = False,
         outlier_threshold: float = 0.05,
+        max_cardinality: int = 50,
+        exclude_columns: list[str] | None = None,
     ) -> SetupResult:
         """Auto-configure preprocessing and return transformed data splits.
 
@@ -182,6 +184,15 @@ class PreprocessingPipeline:
         outlier_threshold:
             IQR multiplier for outlier detection (fraction of data that
             can be considered outlier).  Lower values are more aggressive.
+        max_cardinality:
+            Maximum number of unique values for one-hot encoding.
+            Categorical columns exceeding this threshold are automatically
+            downgraded to ordinal encoding.  Only applies when
+            ``categorical_encoding="onehot"``.
+        exclude_columns:
+            Column names to exclude from categorical encoding.  Excluded
+            columns are left as-is (no encoding applied).  All names must
+            exist in *data*.
         """
         if target not in data.columns:
             raise ValueError(f"Target column '{target}' not found in data.")
@@ -199,6 +210,13 @@ class PreprocessingPipeline:
                 f"imputation_strategy must be 'mean', 'median', 'mode', or 'drop', "
                 f"got '{imputation_strategy}'."
             )
+        if exclude_columns is not None:
+            invalid_cols = [c for c in exclude_columns if c not in data.columns]
+            if invalid_cols:
+                msg = (
+                    f"exclude_columns contains columns not in DataFrame: {invalid_cols}"
+                )
+                raise ValueError(msg)
 
         original_shape = (data.height, data.width)
 
@@ -239,7 +257,12 @@ class PreprocessingPipeline:
 
         # 2. Encode categoricals
         result_df = self._encode_categoricals(
-            result_df, categorical_cols, target, categorical_encoding
+            result_df,
+            categorical_cols,
+            target,
+            categorical_encoding,
+            max_cardinality=max_cardinality,
+            exclude_columns=exclude_columns,
         )
 
         # 3. Normalize numerics
@@ -449,17 +472,46 @@ class PreprocessingPipeline:
         categorical_cols: list[str],
         target: str,
         encoding: str,
+        *,
+        max_cardinality: int = 50,
+        exclude_columns: list[str] | None = None,
     ) -> pl.DataFrame:
         """Encode categorical columns and store fitted mappings."""
         if not categorical_cols:
             return data
 
-        cols_present = [c for c in categorical_cols if c in data.columns]
+        # Filter out excluded columns
+        cols_to_encode = [
+            c for c in categorical_cols if c not in (exclude_columns or [])
+        ]
+        cols_present = [c for c in cols_to_encode if c in data.columns]
         if not cols_present:
             return data
 
         if encoding == "onehot":
-            return self._onehot_encode(data, cols_present)
+            # Split by cardinality: low-cardinality → onehot, high → ordinal
+            low_card_cols: list[str] = []
+            high_card_cols: list[str] = []
+            for col in cols_present:
+                n_unique = data[col].drop_nulls().n_unique()
+                if n_unique > max_cardinality:
+                    logger.warning(
+                        "Column '%s' has %d unique values (> max_cardinality=%d), "
+                        "using ordinal encoding",
+                        col,
+                        n_unique,
+                        max_cardinality,
+                    )
+                    high_card_cols.append(col)
+                else:
+                    low_card_cols.append(col)
+
+            result = data
+            if low_card_cols:
+                result = self._onehot_encode(result, low_card_cols)
+            if high_card_cols:
+                result = self._ordinal_encode_overflow(result, high_card_cols)
+            return result
         elif encoding == "ordinal":
             return self._ordinal_encode(data, cols_present)
         elif encoding == "target":
@@ -522,6 +574,39 @@ class PreprocessingPipeline:
         self._transformers["ordinal_mappings"] = ordinal_mappings
         return result
 
+    def _ordinal_encode_overflow(
+        self,
+        data: pl.DataFrame,
+        cols: list[str],
+    ) -> pl.DataFrame:
+        """Ordinal-encode columns that exceeded the cardinality threshold.
+
+        Mappings are stored separately from explicit ordinal encoding
+        to preserve backward compatibility of the transformers dict.
+        """
+        result = data
+        overflow_mappings: dict[str, dict[str, int]] = {}
+        for col in cols:
+            if col not in result.columns:
+                continue
+            categories = (
+                result[col].drop_nulls().cast(pl.Utf8).unique().sort().to_list()
+            )
+            mapping = {cat: i for i, cat in enumerate(categories)}
+            overflow_mappings[col] = mapping
+            result = result.with_columns(
+                pl.col(col)
+                .cast(pl.Utf8)
+                .replace_strict(
+                    {k: str(v) for k, v in mapping.items()},
+                    default="-1",
+                )
+                .cast(pl.Int64)
+                .alias(col)
+            )
+        self._transformers["ordinal_overflow_mappings"] = overflow_mappings
+        return result
+
     def _target_encode(
         self, data: pl.DataFrame, cols: list[str], target: str
     ) -> pl.DataFrame:
@@ -563,7 +648,11 @@ class PreprocessingPipeline:
         return result
 
     def _apply_fitted_encoding(self, data: pl.DataFrame) -> pl.DataFrame:
-        """Apply previously fitted encoding to new data."""
+        """Apply previously fitted encoding to new data.
+
+        Uses separate ``if`` blocks (not ``elif``) so that mixed encoding
+        (onehot + ordinal overflow) can coexist in the same pipeline.
+        """
         result = data
 
         if "onehot_mappings" in self._transformers:
@@ -580,7 +669,23 @@ class PreprocessingPipeline:
                     )
                 result = result.drop(col)
 
-        elif "ordinal_mappings" in self._transformers:
+        if "ordinal_overflow_mappings" in self._transformers:
+            overflow = self._transformers["ordinal_overflow_mappings"]
+            for col, mapping in overflow.items():
+                if col not in result.columns:
+                    continue
+                result = result.with_columns(
+                    pl.col(col)
+                    .cast(pl.Utf8)
+                    .replace_strict(
+                        {k: str(v) for k, v in mapping.items()},
+                        default="-1",
+                    )
+                    .cast(pl.Int64)
+                    .alias(col)
+                )
+
+        if "ordinal_mappings" in self._transformers:
             mappings = self._transformers["ordinal_mappings"]
             for col, mapping in mappings.items():
                 if col not in result.columns:
@@ -593,7 +698,7 @@ class PreprocessingPipeline:
                     .alias(col)
                 )
 
-        elif "target_mappings" in self._transformers:
+        if "target_mappings" in self._transformers:
             mappings = self._transformers["target_mappings"]
             global_mean = self._transformers.get("target_global_mean", 0.0)
             for col, mapping in mappings.items():

--- a/packages/kailash-ml/tests/unit/test_preprocessing.py
+++ b/packages/kailash-ml/tests/unit/test_preprocessing.py
@@ -615,3 +615,161 @@ class TestEdgeCases:
         result2 = pipeline.setup(regression_df, "target", seed=99)
         # Extremely unlikely to produce the same split
         assert not result1.train_data.equals(result2.train_data)
+
+
+# ---------------------------------------------------------------------------
+# Cardinality guard (#313)
+# ---------------------------------------------------------------------------
+
+
+class TestCardinalityGuard:
+    """Tests for max_cardinality and exclude_columns (#313)."""
+
+    @pytest.fixture()
+    def high_card_df(self) -> pl.DataFrame:
+        """DataFrame with a high-cardinality categorical column."""
+        n = 200
+        return pl.DataFrame(
+            {
+                "id": [f"id_{i}" for i in range(n)],
+                "color": ["red", "blue", "green"] * 66 + ["red", "blue"],
+                "size": ["S", "M", "L", "XL"] * 50,
+                "value": list(range(n)),
+                "target": [0, 1] * 100,
+            }
+        )
+
+    def test_high_cardinality_auto_downgrade(self, high_card_df: pl.DataFrame) -> None:
+        """Columns exceeding max_cardinality are ordinal-encoded."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            high_card_df,
+            "target",
+            categorical_encoding="onehot",
+            max_cardinality=10,
+            normalize=False,
+        )
+        # 'id' has 200 unique -> ordinal (1 column kept)
+        # 'color' has 3 unique -> onehot (3 columns)
+        # 'size' has 4 unique -> onehot (4 columns)
+        train_cols = result.train_data.columns
+        # Should NOT have 200 id_* columns
+        id_onehot = [c for c in train_cols if c.startswith("id_")]
+        assert len(id_onehot) == 0, f"id was one-hot encoded: {id_onehot[:5]}"
+        # Should still have color/size one-hot columns
+        color_onehot = [c for c in train_cols if c.startswith("color_")]
+        assert len(color_onehot) == 3
+
+    def test_all_columns_exceed_threshold(self, high_card_df: pl.DataFrame) -> None:
+        """When all categoricals exceed threshold, all get ordinal."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            high_card_df,
+            "target",
+            categorical_encoding="onehot",
+            max_cardinality=2,
+            normalize=False,
+        )
+        train_cols = result.train_data.columns
+        # No one-hot columns should exist for any of the categoricals
+        onehot_cols = [
+            c
+            for c in train_cols
+            if any(c.startswith(f"{cat}_") for cat in ["id", "color", "size"])
+        ]
+        assert len(onehot_cols) == 0, f"Unexpected one-hot columns: {onehot_cols}"
+        # Original columns should remain (ordinal-encoded as Int64)
+        assert "id" in train_cols
+        assert "color" in train_cols
+        assert "size" in train_cols
+
+    def test_exclude_columns(self, high_card_df: pl.DataFrame) -> None:
+        """Excluded columns are not encoded."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            high_card_df,
+            "target",
+            categorical_encoding="onehot",
+            exclude_columns=["id"],
+            normalize=False,
+        )
+        train_cols = result.train_data.columns
+        # id should NOT be one-hot encoded (excluded)
+        id_onehot = [c for c in train_cols if c.startswith("id_")]
+        assert len(id_onehot) == 0
+        # id should remain as its original string column
+        assert "id" in train_cols
+
+    def test_exclude_nonexistent_column_raises(
+        self, high_card_df: pl.DataFrame
+    ) -> None:
+        """Excluding a nonexistent column raises ValueError."""
+        pipeline = PreprocessingPipeline()
+        with pytest.raises(ValueError, match="not in DataFrame"):
+            pipeline.setup(
+                high_card_df,
+                "target",
+                categorical_encoding="onehot",
+                exclude_columns=["nonexistent"],
+            )
+
+    def test_exclude_noncategorical_ignored(self, high_card_df: pl.DataFrame) -> None:
+        """Excluding a numeric column is silently ignored (it's not categorical)."""
+        pipeline = PreprocessingPipeline()
+        # Should not raise -- 'value' is numeric, not categorical
+        result = pipeline.setup(
+            high_card_df,
+            "target",
+            categorical_encoding="onehot",
+            exclude_columns=["value"],
+            normalize=False,
+        )
+        assert result.train_data is not None
+
+    def test_target_encoding_ignores_cardinality(
+        self, high_card_df: pl.DataFrame
+    ) -> None:
+        """Target encoding is cardinality-safe; max_cardinality should not apply."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            high_card_df,
+            "target",
+            categorical_encoding="target",
+            max_cardinality=2,
+            normalize=False,
+        )
+        # Should work without any cardinality warnings
+        assert result.train_data is not None
+
+    def test_default_threshold_preserves_existing(self) -> None:
+        """Default max_cardinality=50 doesn't affect small category counts."""
+        df = pl.DataFrame(
+            {
+                "color": ["red", "blue", "green"] * 20,
+                "target": [0, 1] * 30,
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            df, "target", categorical_encoding="onehot", normalize=False
+        )
+        train_cols = result.train_data.columns
+        color_onehot = [c for c in train_cols if c.startswith("color_")]
+        assert len(color_onehot) == 3
+
+    def test_transform_applies_mixed_encoding(self, high_card_df: pl.DataFrame) -> None:
+        """transform() correctly applies mixed onehot+ordinal to new data."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            high_card_df,
+            "target",
+            categorical_encoding="onehot",
+            max_cardinality=10,
+            normalize=False,
+        )
+        # transform should work on test data
+        assert result.test_data is not None
+        test_cols = result.test_data.columns
+        # Same encoding should be applied
+        id_onehot = [c for c in test_cols if c.startswith("id_")]
+        assert len(id_onehot) == 0


### PR DESCRIPTION
## Summary
- Add `max_cardinality` (default 50) and `exclude_columns` parameters to `PreprocessingPipeline.setup()` (#313)
- High-cardinality categorical columns are auto-downgraded to ordinal encoding with a logged warning, preventing silent column explosion
- Separate `_ordinal_encode_overflow()` stores mappings under `ordinal_overflow_mappings` key for backward compatibility
- Changed `_apply_fitted_encoding()` from `elif` chain to separate `if` blocks so mixed onehot+ordinal coexist

## Related issues
Fixes #313

## Test plan
- [x] High-cardinality auto-downgrade to ordinal
- [x] All columns exceed threshold → pure ordinal fallback
- [x] `exclude_columns` with non-categorical → silently ignored
- [x] `exclude_columns` with nonexistent column → ValueError
- [x] Target encoding + `max_cardinality` → guard not applied
- [x] Default threshold preserves existing behavior (3-category tests unaffected)
- [x] Mixed encoding applied correctly on `transform()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>