### PR TITLE
feat(ml): PyCaret/MLflow parity — kailash-ml 0.7.0

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -22,7 +22,7 @@
 | kailash-kaizen   | `kaizen-v*`        | 2.5.0           |
 | kailash-nexus    | `nexus-v*`         | 1.9.0           |
 | kailash-pact     | `pact-v*`          | 0.8.0           |
-| kailash-ml       | `ml-v*`            | 0.6.0           |
+| kailash-ml       | `ml-v*`            | 0.7.0           |
 | kailash-align    | `align-v*`         | 0.3.1           |
 | kaizen-agents    | `kaizen-agents-v*` | 0.7.0           |
 

--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,44 @@
 # kailash-ml Changelog
 
+## [0.7.0] - 2026-04-07
+
+### Added
+
+- **ModelExplainer engine** — SHAP-based model explainability with global, local, and dependence explanations; plotly visualizations; optional `[explain]` extra (`shap>=0.44`)
+- **Model calibration** — `TrainingPipeline.calibrate()` wraps classifiers in `CalibratedClassifierCV` (Platt scaling, isotonic regression)
+- **Auto-logging** — `TrainingPipeline.train(tracker=...)`, `HyperparameterSearch.search(tracker=...)`, and `AutoMLEngine.run(tracker=...)` automatically log params, metrics, and artifacts to ExperimentTracker
+- **Nested experiment runs** — `ExperimentTracker.start_run(parent_run_id=...)` for hierarchical run organization; HPO trials log as children of the search run
+- **Inference signature validation** — `InferenceServer.predict()` validates required features against model signature instead of silently defaulting missing features to 0.0
+- **Preprocessing: 4 normalization methods** — `normalize_method` parameter: zscore, minmax, robust, maxabs
+- **Preprocessing: KNN and iterative imputation** — `imputation_strategy="knn"` and `"iterative"` via sklearn imputers
+- **Preprocessing: multicollinearity removal** — `remove_multicollinearity=True` drops highly correlated features using Pearson correlation
+- **Preprocessing: class imbalance handling** — `fix_imbalance=True` with SMOTE, ADASYN (optional `[imbalance]` extra), or `class_weight` method
+- **New optional extras** — `[imbalance]` (imbalanced-learn>=0.12), `[explain]` (shap>=0.44)
+
+### Fixed
+
+- **Stratified k-fold** — `split_strategy="stratified_kfold"` now uses `sklearn.model_selection.StratifiedKFold` instead of silently falling back to regular k-fold
+- **Successive halving** — `strategy="successive_halving"` now uses Optuna's `SuccessiveHalvingPruner` with progressive resource allocation instead of silently falling back to random search
+- **K-fold shuffling** — `_kfold_first_fold` now shuffles data via `sklearn.model_selection.KFold` instead of naively slicing
+- Silent `except: pass` on `predict_proba` replaced with `logger.debug`
+- Schema migration `except Exception: pass` narrowed to check for "duplicate column"
+- `BaseException` catch in run context manager changed to `Exception`
+- Path traversal guard added to `delete_run` artifact cleanup
+- String target + multicollinearity no longer crashes (falls back to index-based dropping)
+- AutoML deep search now passes `parent_run_id` to nested HPO search
+
+### Changed
+
+- **Breaking**: `scikit-learn>=1.5` (was >=1.4) — required for `FrozenEstimator` in calibration
+- `asyncio.get_event_loop()` replaced with `asyncio.get_running_loop()` (Python 3.12+ deprecation fix)
+
+### Security
+
+- R1 red team converged: 0 CRITICAL, 0 HIGH findings after fixes
+- Inference server no longer silently produces wrong predictions for missing features
+- Experiment tracker artifact deletion has path containment validation
+- 750 tests passing (677 unit + 60 integration + 13 examples), 0 regressions
+
 ## [0.6.0] - 2026-04-07
 
 ### Added

--- a/packages/kailash-ml/README.md
+++ b/packages/kailash-ml/README.md
@@ -4,7 +4,7 @@ Machine learning lifecycle for the Kailash ecosystem. Train models, store featur
 
 Part of the [Kailash Python SDK](https://github.com/terrene-foundation/kailash-py) by the Terrene Foundation.
 
-**Version**: 0.2.0 | **License**: Apache-2.0 | **Python**: 3.10+
+**Version**: 0.7.0 | **License**: Apache-2.0 | **Python**: 3.11+
 
 ---
 
@@ -36,6 +36,9 @@ pip install kailash-ml[agents]    # + Kaizen (LLM-augmented ML)
 pip install kailash-ml[xgb]       # + XGBoost
 pip install kailash-ml[catboost]  # + CatBoost
 pip install kailash-ml[stats]     # + statsmodels
+pip install kailash-ml[hpo]       # + Optuna (Bayesian HPO, successive halving)
+pip install kailash-ml[imbalance] # + imbalanced-learn (SMOTE, ADASYN)
+pip install kailash-ml[explain]   # + SHAP (model explainability)
 pip install kailash-ml[all]       # Everything above
 pip install kailash-ml[all-gpu]   # Everything + GPU runtime
 ```
@@ -140,6 +143,7 @@ async def main():
     |   |  DataExplorer            |                          |
     |   |  FeatureEngineer         |                          |
     |   |  ModelVisualizer         |                          |
+    |   |  ModelExplainer          |                          |
     |   +------------|-------------+                          |
     |                |                                        |
     |   bridge/      |     compat/       dashboard/           |
@@ -165,7 +169,7 @@ All engines persist through `ConnectionManager` from the core Kailash SDK. The `
 
 ## Engines Reference
 
-kailash-ml provides 13 engines plus a bridge and compatibility layer, organized by purpose and stability.
+kailash-ml provides 14 engines plus a bridge and compatibility layer, organized by purpose and stability.
 
 ### Core Engines (P0 -- stable API, full test coverage)
 
@@ -195,9 +199,9 @@ Key operations: `register_model()`, `promote()`, `get_model()`, `list_models()`,
 from kailash_ml.engines.training_pipeline import TrainingPipeline, ModelSpec, EvalSpec
 ```
 
-Orchestrates the full training lifecycle: load features, train a model, evaluate metrics, and register the result. Supports scikit-learn and LightGBM model classes out of the box. Model class imports are restricted to a security allowlist (`sklearn.*`, `lightgbm.*`, `xgboost.*`, `catboost.*`, `torch.*`, `lightning.*`, `kailash_ml.*`) to prevent arbitrary code execution.
+Orchestrates the full training lifecycle: load features, train a model, evaluate metrics, and register the result. Supports scikit-learn and LightGBM model classes out of the box. Model class imports are restricted to a security allowlist (`sklearn.*`, `lightgbm.*`, `xgboost.*`, `catboost.*`, `torch.*`, `lightning.*`, `kailash_ml.*`) to prevent arbitrary code execution. Includes model calibration (Platt scaling, isotonic regression) and optional auto-logging to ExperimentTracker.
 
-Key operations: `train()`.
+Key operations: `train()`, `calibrate()`, `retrain()`.
 
 #### InferenceServer
 
@@ -205,7 +209,7 @@ Key operations: `train()`.
 from kailash_ml.engines.inference_server import InferenceServer
 ```
 
-Loads models from ModelRegistry, caches them in an LRU memory cache, and serves predictions. Supports single-record and batch prediction. Nexus integration is lazy-loaded -- if kailash-nexus is installed, predictions can be auto-exposed as REST endpoints.
+Loads models from ModelRegistry, caches them in an LRU memory cache, and serves predictions. Supports single-record and batch prediction with model signature validation -- missing or mistyped features raise errors instead of silently defaulting. Nexus integration is lazy-loaded -- if kailash-nexus is installed, predictions can be auto-exposed as REST endpoints.
 
 Key operations: `predict()`, `predict_batch()`, `load_model()`, `evict()`.
 
@@ -225,9 +229,9 @@ Key operations: `set_reference()`, `check_drift()`, `get_drift_history()`, `chec
 from kailash_ml.engines.experiment_tracker import ExperimentTracker
 ```
 
-Provides MLflow-compatible experiment tracking: experiments, runs, parameters, step-based metrics (for training curves), and artifact metadata. Artifacts are stored on the local filesystem; the database holds metadata only -- no binary blobs in SQL.
+Provides MLflow-compatible experiment tracking: experiments, runs, parameters, step-based metrics (for training curves), and artifact metadata. Supports nested runs for hierarchical tracking (parent sweep with child trials). Artifacts are stored on the local filesystem; the database holds metadata only -- no binary blobs in SQL.
 
-Key operations: `create_experiment()`, `run()` (context manager), `log_param()`, `log_metric()`, `log_artifact()`, `get_run()`, `list_runs()`. Standalone usage: `await ExperimentTracker.create("sqlite:///ml.db")`.
+Key operations: `create_experiment()`, `run()` (context manager), `start_run(parent_run_id=...)`, `log_param()`, `log_metric()`, `log_artifact()`, `get_run()`, `list_runs()`, `list_child_runs()`. Standalone usage: `await ExperimentTracker.create("sqlite:///ml.db")`.
 
 ### Search and Optimization Engines (P1 -- tested, API may evolve)
 
@@ -237,7 +241,7 @@ Key operations: `create_experiment()`, `run()` (context manager), `log_param()`,
 from kailash_ml.engines.hyperparameter_search import HyperparameterSearch, SearchSpace, SearchConfig
 ```
 
-Supports four search strategies for hyperparameter optimization: **grid** (exhaustive), **random** (sampling), **bayesian** (surrogate-model guided), and **successive halving** (early stopping of poor candidates). Integrates with TrainingPipeline for execution and ModelRegistry for result tracking.
+Supports four search strategies for hyperparameter optimization: **grid** (exhaustive), **random** (sampling), **bayesian** (surrogate-model guided via Optuna), and **successive halving** (progressive resource allocation with Optuna pruning). Auto-logs trials to ExperimentTracker as nested child runs when a tracker is provided.
 
 Key operations: `search()`.
 
@@ -267,9 +271,9 @@ Key operations: `blend()`, `stack()`, `bag()`, `boost()`.
 from kailash_ml.engines.preprocessing import PreprocessingPipeline
 ```
 
-Automatic data preprocessing for ML workflows. Auto-detects task type, encodes categoricals, scales numerics, imputes missing values, and splits train/test. Returns a `SetupResult` with transformed data ready for training.
+Automatic data preprocessing for ML workflows. Auto-detects task type, encodes categoricals, scales numerics (zscore, minmax, robust, maxabs), imputes missing values (mean, median, mode, KNN, iterative), removes multicollinear features, handles class imbalance (SMOTE, ADASYN, class_weight), and splits train/test with stratification support. Returns a `SetupResult` with transformed data ready for training.
 
-Key operations: `setup()`.
+Key operations: `setup()`, `transform()`, `inverse_transform()`.
 
 ### Experimental Engines (P2 -- functional, API may change)
 
@@ -302,6 +306,16 @@ from kailash_ml.engines.model_visualizer import ModelVisualizer
 Produces interactive plotly visualizations for ML model analysis: confusion matrix, ROC curve, precision-recall curve, feature importance, learning curves, residual plots, calibration curves, metric comparison, and training history. All methods return plotly `Figure` objects.
 
 Key operations: `confusion_matrix()`, `roc_curve()`, `precision_recall()`, `feature_importance()`, `learning_curve()`.
+
+#### ModelExplainer
+
+```python
+from kailash_ml.engines.model_explainer import ModelExplainer
+```
+
+SHAP-based model explainability for global and local feature importance. Requires `pip install kailash-ml[explain]`. Provides per-prediction explanations (why did the model make this specific prediction?) alongside global feature importance (which features matter most overall). All visualizations use plotly for consistency with ModelVisualizer.
+
+Key operations: `explain_global()`, `explain_local()`, `explain_dependence()`, `to_plotly()`.
 
 ### Bridge and Compatibility
 

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.6.0"
+version = "0.7.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -34,7 +34,7 @@ dependencies = [
     "pyarrow>=14.0",
     "numpy>=1.24",
     "scipy>=1.11",
-    "scikit-learn>=1.4",
+    "scikit-learn>=1.5",
     "lightgbm>=4.0",
     "plotly>=5.18",
     "skl2onnx>=1.16",
@@ -68,6 +68,8 @@ rl = [
 agents = [
     "kailash-kaizen>=1.0",
 ]
+explain = ["shap>=0.44"]
+imbalance = ["imbalanced-learn>=0.12"]
 xgb = ["xgboost>=2.0"]
 catboost = ["catboost>=1.2"]
 stats = ["statsmodels>=0.14"]
@@ -79,8 +81,8 @@ dashboard = [
     "uvicorn>=0.27",
 ]
 interop = ["pandas>=2.0"]
-all = ["kailash-ml[dl,xgb,catboost,stats,rl,agents,hpo,mlflow,huggingface,dashboard,interop]"]
-all-gpu = ["kailash-ml[dl-gpu,xgb,catboost,stats,rl,agents,hpo,mlflow,huggingface,dashboard,interop]"]
+all = ["kailash-ml[dl,xgb,catboost,stats,rl,agents,hpo,mlflow,huggingface,dashboard,interop,imbalance,explain]"]
+all-gpu = ["kailash-ml[dl-gpu,xgb,catboost,stats,rl,agents,hpo,mlflow,huggingface,dashboard,interop,imbalance,explain]"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/packages/kailash-ml/src/kailash_ml/__init__.py
+++ b/packages/kailash-ml/src/kailash_ml/__init__.py
@@ -36,6 +36,7 @@ def __getattr__(name: str):  # noqa: N807
         "ExperimentTracker": "kailash_ml.engines.experiment_tracker",
         "PreprocessingPipeline": "kailash_ml.engines.preprocessing",
         "ModelVisualizer": "kailash_ml.engines.model_visualizer",
+        "ModelExplainer": "kailash_ml.engines.model_explainer",
         # Bridge
         "OnnxBridge": "kailash_ml.bridge.onnx_bridge",
         # Compat
@@ -78,6 +79,7 @@ __all__ = [
     "ExperimentTracker",
     "PreprocessingPipeline",
     "ModelVisualizer",
+    "ModelExplainer",
     "OnnxBridge",
     "MlflowFormatReader",
     "MlflowFormatWriter",

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/packages/kailash-ml/src/kailash_ml/engines/automl_engine.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/automl_engine.py
@@ -331,6 +331,8 @@ class AutoMLEngine:
         config: AutoMLConfig,
         eval_spec: Any,
         experiment_name: str,
+        *,
+        tracker: Any | None = None,
     ) -> AutoMLResult:
         """Run automated model selection + hyperparameter optimization.
 
@@ -340,6 +342,14 @@ class AutoMLEngine:
         4. Rank candidates by metric
         5. Run HyperparameterSearch on top candidate
         6. Register best model if requested
+
+        Parameters
+        ----------
+        tracker:
+            Optional ExperimentTracker instance. When provided, creates a
+            parent run for the AutoML session and passes the tracker to
+            all training and search calls for hierarchical logging.
+            Typed as ``Any`` to avoid circular imports.
         """
         from kailash_ml.engines.hyperparameter_search import (
             ParamDistribution,
@@ -350,87 +360,124 @@ class AutoMLEngine:
 
         start_time = time.perf_counter()
 
-        # Guardrail 4: baseline recommendation
-        baseline = self._compute_baseline_recommendation(data, schema, config)
+        # Start parent run for AutoML if tracker provided
+        parent_run_id: str | None = None
+        parent_run_obj: Any | None = None
+        if tracker is not None:
+            parent_run_obj = await tracker.start_run(
+                experiment_name,
+                run_name="automl",
+            )
+            parent_run_id = parent_run_obj.id
+            await tracker.log_params(
+                parent_run_id,
+                {
+                    "task_type": config.task_type,
+                    "metric_to_optimize": config.metric_to_optimize,
+                    "direction": config.direction,
+                    "search_strategy": config.search_strategy,
+                    "search_n_trials": str(config.search_n_trials),
+                },
+            )
 
-        # Agent augmentation (not implemented in v1 -- requires kaizen agents)
-        agent_rec: AgentRecommendation | None = None
+        try:
+            # Guardrail 4: baseline recommendation
+            baseline = self._compute_baseline_recommendation(data, schema, config)
 
-        # Determine candidates
-        candidates_spec = self._get_candidates(config)
+            # Agent augmentation (not implemented in v1 -- requires kaizen agents)
+            agent_rec: AgentRecommendation | None = None
 
-        # Quick-train each candidate
-        candidate_results: list[CandidateResult] = []
-        for model_class, framework, default_hp in candidates_spec:
-            try:
-                spec = ModelSpec(model_class, default_hp, framework)
-                train_result = await self._pipeline.train(
-                    data,
-                    schema,
-                    spec,
-                    eval_spec,
-                    f"{experiment_name}_{model_class.split('.')[-1]}",
-                )
-                candidate_results.append(
-                    CandidateResult(
-                        model_class=model_class,
-                        framework=framework,
-                        default_metrics=train_result.metrics,
+            # Determine candidates
+            candidates_spec = self._get_candidates(config)
+
+            # Quick-train each candidate
+            candidate_results: list[CandidateResult] = []
+            for model_class, framework, default_hp in candidates_spec:
+                try:
+                    spec = ModelSpec(model_class, default_hp, framework)
+                    train_result = await self._pipeline.train(
+                        data,
+                        schema,
+                        spec,
+                        eval_spec,
+                        f"{experiment_name}_{model_class.split('.')[-1]}",
+                        tracker=tracker,
+                        parent_run_id=parent_run_id,
                     )
+                    candidate_results.append(
+                        CandidateResult(
+                            model_class=model_class,
+                            framework=framework,
+                            default_metrics=train_result.metrics,
+                        )
+                    )
+                except Exception as exc:
+                    logger.warning("Candidate %s failed: %s", model_class, exc)
+
+            if not candidate_results:
+                raise RuntimeError("All AutoML candidates failed during quick-train")
+
+            # Rank by metric
+            if config.direction == "maximize":
+                candidate_results.sort(
+                    key=lambda c: c.default_metrics.get(config.metric_to_optimize, 0.0),
+                    reverse=True,
                 )
-            except Exception as exc:
-                logger.warning("Candidate %s failed: %s", model_class, exc)
+            else:
+                candidate_results.sort(
+                    key=lambda c: c.default_metrics.get(
+                        config.metric_to_optimize, float("inf")
+                    ),
+                )
 
-        if not candidate_results:
-            raise RuntimeError("All AutoML candidates failed during quick-train")
+            for i, c in enumerate(candidate_results):
+                c.rank = i + 1
 
-        # Rank by metric
-        if config.direction == "maximize":
-            candidate_results.sort(
-                key=lambda c: c.default_metrics.get(config.metric_to_optimize, 0.0),
-                reverse=True,
+            # Deep search on top candidate
+            top = candidate_results[0]
+            search_space = self._default_search_space(top.model_class, top.framework)
+            search_config = SearchConfig(
+                strategy=config.search_strategy,
+                n_trials=config.search_n_trials,
+                metric_to_optimize=config.metric_to_optimize,
+                direction=config.direction,
+                register_best=False,  # We register manually
             )
+
+            base_spec = ModelSpec(top.model_class, {}, top.framework)
+            search_result = await self._search.search(
+                data,
+                schema,
+                base_spec,
+                search_space,
+                search_config,
+                eval_spec,
+                f"{experiment_name}_hp_search",
+                tracker=tracker,
+                parent_run_id=parent_run_id,
+            )
+            top.search_result = search_result
+
+            # Best metrics from search
+            best_metrics = (
+                search_result.best_metrics
+                if search_result.best_metrics
+                else top.default_metrics
+            )
+
+            total_time = time.perf_counter() - start_time
+
+            # Log best metrics on parent run
+            if tracker is not None and parent_run_id is not None and best_metrics:
+                await tracker.log_metrics(parent_run_id, best_metrics)
+
+        except BaseException:
+            if tracker is not None and parent_run_id is not None:
+                await tracker.end_run(parent_run_id, status="FAILED")
+            raise
         else:
-            candidate_results.sort(
-                key=lambda c: c.default_metrics.get(
-                    config.metric_to_optimize, float("inf")
-                ),
-            )
-
-        for i, c in enumerate(candidate_results):
-            c.rank = i + 1
-
-        # Deep search on top candidate
-        top = candidate_results[0]
-        search_space = self._default_search_space(top.model_class, top.framework)
-        search_config = SearchConfig(
-            strategy=config.search_strategy,
-            n_trials=config.search_n_trials,
-            metric_to_optimize=config.metric_to_optimize,
-            direction=config.direction,
-            register_best=False,  # We register manually
-        )
-
-        base_spec = ModelSpec(top.model_class, {}, top.framework)
-        search_result = await self._search.search(
-            data,
-            schema,
-            base_spec,
-            search_space,
-            search_config,
-            eval_spec,
-            f"{experiment_name}_hp_search",
-        )
-        top.search_result = search_result
-
-        # Best metrics from search
-        best_metrics = (
-            search_result.best_metrics
-            if search_result.best_metrics
-            else top.default_metrics
-        )
-
-        total_time = time.perf_counter() - start_time
+            if tracker is not None and parent_run_id is not None:
+                await tracker.end_run(parent_run_id, status="COMPLETED")
 
         return AutoMLResult(
             best_model=top,

--- a/packages/kailash-ml/src/kailash_ml/engines/experiment_tracker.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/experiment_tracker.py
@@ -107,6 +107,7 @@ class Run:
     params: dict[str, str]
     metrics: dict[str, float]  # Latest value per key
     artifacts: list[str]  # Artifact paths
+    parent_run_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -120,6 +121,7 @@ class Run:
             "params": dict(self.params),
             "metrics": dict(self.metrics),
             "artifacts": list(self.artifacts),
+            "parent_run_id": self.parent_run_id,
         }
 
     @classmethod
@@ -135,6 +137,7 @@ class Run:
             params=data.get("params", {}),
             metrics=data.get("metrics", {}),
             artifacts=data.get("artifacts", []),
+            parent_run_id=data.get("parent_run_id"),
         )
 
 
@@ -217,9 +220,17 @@ async def _create_tracker_tables(conn: ConnectionManager) -> None:
         "  start_time TEXT NOT NULL,"
         "  end_time TEXT,"
         "  tags_json TEXT DEFAULT '{}',"
-        "  FOREIGN KEY (experiment_id) REFERENCES kailash_experiments(id)"
+        "  parent_run_id TEXT,"
+        "  FOREIGN KEY (experiment_id) REFERENCES kailash_experiments(id),"
+        "  FOREIGN KEY (parent_run_id) REFERENCES kailash_runs(id)"
         ")"
     )
+    # Migration for existing databases that lack parent_run_id column
+    try:
+        await conn.execute("ALTER TABLE kailash_runs ADD COLUMN parent_run_id TEXT")
+    except Exception as exc:
+        if "duplicate column" not in str(exc).lower():
+            logger.warning("Schema migration failed: %s", exc)
     await conn.execute(
         "CREATE TABLE IF NOT EXISTS kailash_run_params ("
         "  run_id TEXT NOT NULL,"
@@ -462,17 +473,31 @@ class ExperimentTracker:
         experiment_name: str,
         run_name: str | None = None,
         tags: dict[str, str] | None = None,
+        parent_run_id: str | None = None,
     ) -> AsyncIterator[RunContext]:
         """Context manager for run lifecycle.
 
         Auto-creates experiment if not exists. Ends run as COMPLETED on
         normal exit, FAILED on exception.
+
+        Parameters
+        ----------
+        experiment_name:
+            Name of the parent experiment.
+        run_name:
+            Optional human-readable run name.
+        tags:
+            Optional key-value tags.
+        parent_run_id:
+            Optional parent run ID for nested runs.
         """
-        run_obj = await self.start_run(experiment_name, run_name, tags)
+        run_obj = await self.start_run(
+            experiment_name, run_name, tags, parent_run_id=parent_run_id
+        )
         ctx = RunContext(self, run_obj)
         try:
             yield ctx
-        except BaseException:
+        except Exception:
             await self.end_run(run_obj.id, status="FAILED")
             raise
         else:
@@ -569,6 +594,8 @@ class ExperimentTracker:
         experiment_name: str,
         run_name: str | None = None,
         tags: dict[str, str] | None = None,
+        *,
+        parent_run_id: str | None = None,
     ) -> Run:
         """Start a new run. Auto-creates experiment if not exists.
 
@@ -580,6 +607,8 @@ class ExperimentTracker:
             Optional human-readable run name.
         tags:
             Optional key-value tags.
+        parent_run_id:
+            Optional parent run ID for nested runs.
 
         Returns
         -------
@@ -591,6 +620,10 @@ class ExperimentTracker:
         # Ensure experiment exists
         experiment_id = await self.create_experiment(experiment_name)
 
+        # Validate parent run exists if specified
+        if parent_run_id is not None:
+            await self._verify_run_exists(parent_run_id)
+
         run_id = str(uuid.uuid4())
         now_iso = datetime.now(timezone.utc).isoformat()
         tags = tags or {}
@@ -599,8 +632,8 @@ class ExperimentTracker:
 
         await self._conn.execute(
             "INSERT INTO kailash_runs "
-            "(id, experiment_id, name, status, start_time, end_time, tags_json) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "(id, experiment_id, name, status, start_time, end_time, tags_json, parent_run_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             run_id,
             experiment_id,
             run_name,
@@ -608,6 +641,7 @@ class ExperimentTracker:
             now_iso,
             None,
             tags_json,
+            parent_run_id,
         )
 
         logger.info(
@@ -628,6 +662,7 @@ class ExperimentTracker:
             params={},
             metrics={},
             artifacts=[],
+            parent_run_id=parent_run_id,
         )
 
     async def end_run(self, run_id: str, status: str = "COMPLETED") -> None:
@@ -723,6 +758,34 @@ class ExperimentTracker:
                 exp.id,
             )
 
+        return [await self._hydrate_run(r) for r in rows]
+
+    async def list_child_runs(self, parent_run_id: str) -> list[Run]:
+        """List all child runs of a given parent run.
+
+        Parameters
+        ----------
+        parent_run_id:
+            The parent run ID whose children to list.
+
+        Returns
+        -------
+        list[Run]
+            Child runs ordered by start time (most recent first).
+
+        Raises
+        ------
+        RunNotFoundError
+            If the parent run does not exist.
+        """
+        await self._ensure_tables()
+        await self._verify_run_exists(parent_run_id)
+
+        rows = await self._conn.fetch(
+            "SELECT * FROM kailash_runs "
+            "WHERE parent_run_id = ? ORDER BY start_time DESC",
+            parent_run_id,
+        )
         return [await self._hydrate_run(r) for r in rows]
 
     async def search_runs(
@@ -1116,7 +1179,10 @@ class ExperimentTracker:
         # Clean up artifact directory
         artifact_dir = self._artifact_root / run_id
         if artifact_dir.exists():
-            shutil.rmtree(artifact_dir)
+            resolved = artifact_dir.resolve()
+            if not str(resolved).startswith(str(self._artifact_root.resolve())):
+                raise ValueError(f"Invalid artifact path: {run_id}")
+            shutil.rmtree(resolved)
 
         logger.info("Deleted run '%s' and all associated data.", run_id)
 
@@ -1210,6 +1276,7 @@ class ExperimentTracker:
             params=params,
             metrics=metrics,
             artifacts=artifacts,
+            parent_run_id=row.get("parent_run_id"),
         )
 
     @staticmethod

--- a/packages/kailash-ml/src/kailash_ml/engines/hyperparameter_search.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/hyperparameter_search.py
@@ -290,58 +290,118 @@ class HyperparameterSearch:
         config: SearchConfig,
         eval_spec: Any,
         experiment_name: str,
+        *,
+        tracker: Any | None = None,
+        parent_run_id: str | None = None,
     ) -> SearchResult:
         """Run hyperparameter search.
 
         Iterates over hyperparameter configurations using the selected
         strategy, trains a model for each, and returns the best result.
+
+        Parameters
+        ----------
+        tracker:
+            Optional ExperimentTracker instance. When provided, creates a
+            parent run for the search and logs each trial as a child run.
+            Typed as ``Any`` to avoid circular imports.
+        parent_run_id:
+            Optional parent run ID. When provided, the search parent run
+            is created as a child of this run.
         """
         start_time = time.perf_counter()
 
-        if config.strategy == "bayesian":
-            result = await self._bayesian_search(
-                data,
-                schema,
-                base_model_spec,
-                search_space,
-                config,
-                eval_spec,
+        # Start a parent run for the search if tracker is provided
+        search_run_id: str | None = None
+        if tracker is not None:
+            parent_run_obj = await tracker.start_run(
                 experiment_name,
+                run_name=f"search_{config.strategy}",
+                parent_run_id=parent_run_id,
             )
-        elif config.strategy == "successive_halving":
-            result = await self._successive_halving_search(
-                data,
-                schema,
-                base_model_spec,
-                search_space,
-                config,
-                eval_spec,
-                experiment_name,
+            search_run_id = parent_run_obj.id  # type: ignore[union-attr]
+            # Log search config as params on the search run
+            await tracker.log_params(
+                search_run_id,
+                {
+                    "search_strategy": config.strategy,
+                    "n_trials": str(config.n_trials),
+                    "metric_to_optimize": config.metric_to_optimize,
+                    "direction": config.direction,
+                    "model_class": str(getattr(base_model_spec, "model_class", "")),
+                },
             )
-        elif config.strategy == "random":
-            result = await self._random_search(
-                data,
-                schema,
-                base_model_spec,
-                search_space,
-                config,
-                eval_spec,
-                experiment_name,
-            )
-        elif config.strategy == "grid":
-            result = await self._grid_search(
-                data,
-                schema,
-                base_model_spec,
-                search_space,
-                config,
-                eval_spec,
-                experiment_name,
-            )
-        else:
-            raise ValueError(f"Unknown search strategy: {config.strategy}")
 
-        result.total_time_seconds = time.perf_counter() - start_time
+        try:
+            if config.strategy == "bayesian":
+                result = await self._bayesian_search(
+                    data,
+                    schema,
+                    base_model_spec,
+                    search_space,
+                    config,
+                    eval_spec,
+                    experiment_name,
+                    tracker=tracker,
+                    parent_run_id=search_run_id,
+                )
+            elif config.strategy == "successive_halving":
+                result = await self._successive_halving_search(
+                    data,
+                    schema,
+                    base_model_spec,
+                    search_space,
+                    config,
+                    eval_spec,
+                    experiment_name,
+                    tracker=tracker,
+                    parent_run_id=search_run_id,
+                )
+            elif config.strategy == "random":
+                result = await self._random_search(
+                    data,
+                    schema,
+                    base_model_spec,
+                    search_space,
+                    config,
+                    eval_spec,
+                    experiment_name,
+                    tracker=tracker,
+                    parent_run_id=search_run_id,
+                )
+            elif config.strategy == "grid":
+                result = await self._grid_search(
+                    data,
+                    schema,
+                    base_model_spec,
+                    search_space,
+                    config,
+                    eval_spec,
+                    experiment_name,
+                    tracker=tracker,
+                    parent_run_id=search_run_id,
+                )
+            else:
+                raise ValueError(f"Unknown search strategy: {config.strategy}")
+
+            result.total_time_seconds = time.perf_counter() - start_time
+
+            # Log best trial metrics on search run
+            if (
+                tracker is not None
+                and search_run_id is not None
+                and result.best_metrics
+            ):
+                await tracker.log_metrics(search_run_id, result.best_metrics)
+
+        except Exception:
+            if tracker is not None and search_run_id is not None:
+                await tracker.end_run(search_run_id, status="FAILED")
+            raise
+        else:
+            if tracker is not None and search_run_id is not None:
+                await tracker.end_run(search_run_id, status="COMPLETED")
+
         return result
 
     # ------------------------------------------------------------------
@@ -357,6 +417,9 @@ class HyperparameterSearch:
         config,
         eval_spec,
         experiment_name,
+        *,
+        tracker: Any | None = None,
+        parent_run_id: str | None = None,
     ) -> SearchResult:
         from kailash_ml.engines.training_pipeline import ModelSpec
 
@@ -377,6 +440,8 @@ class HyperparameterSearch:
                 merged_spec,
                 eval_spec,
                 f"{experiment_name}_trial_{i}",
+                tracker=tracker,
+                parent_run_id=parent_run_id,
             )
             trial_time = time.perf_counter() - trial_start
             all_trials.append(
@@ -412,6 +477,9 @@ class HyperparameterSearch:
         config,
         eval_spec,
         experiment_name,
+        *,
+        tracker: Any | None = None,
+        parent_run_id: str | None = None,
     ) -> SearchResult:
         from kailash_ml.engines.training_pipeline import ModelSpec
 
@@ -431,6 +499,8 @@ class HyperparameterSearch:
                 merged_spec,
                 eval_spec,
                 f"{experiment_name}_trial_{i}",
+                tracker=tracker,
+                parent_run_id=parent_run_id,
             )
             trial_time = time.perf_counter() - trial_start
             all_trials.append(
@@ -466,6 +536,9 @@ class HyperparameterSearch:
         config,
         eval_spec,
         experiment_name,
+        *,
+        tracker: Any | None = None,
+        parent_run_id: str | None = None,
     ) -> SearchResult:
         import optuna
         from kailash_ml.engines.training_pipeline import ModelSpec
@@ -473,7 +546,7 @@ class HyperparameterSearch:
         optuna.logging.set_verbosity(optuna.logging.WARNING)
 
         all_trials: list[TrialResult] = []
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def objective(trial: optuna.Trial) -> float:
             params: dict[str, Any] = {}
@@ -508,6 +581,8 @@ class HyperparameterSearch:
                     merged_spec,
                     eval_spec,
                     f"{experiment_name}_trial_{trial.number}",
+                    tracker=tracker,
+                    parent_run_id=parent_run_id,
                 ),
                 loop,
             )
@@ -556,16 +631,128 @@ class HyperparameterSearch:
         config,
         eval_spec,
         experiment_name,
+        *,
+        tracker: Any | None = None,
+        parent_run_id: str | None = None,
     ) -> SearchResult:
-        # Successive halving is Bayesian with a pruner; for simplicity
-        # in v1, delegate to random search with early stopping heuristic:
-        # train fewer estimators for early trials.
-        return await self._random_search(
+        """Successive halving via Optuna's SuccessiveHalvingPruner.
+
+        Trains each configuration at increasing resource budgets (data
+        fractions). Poor performers are pruned early, concentrating
+        compute on the most promising hyperparameter regions.
+        """
+        import optuna
+        from kailash_ml.engines.training_pipeline import ModelSpec
+
+        optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+        # Resource rungs: train on 12.5%, 25%, 50%, 100% of data
+        n_rungs = 4
+        rung_fractions = [1.0 / (2 ** (n_rungs - 1 - i)) for i in range(n_rungs)]
+
+        all_trials: list[TrialResult] = []
+        loop = asyncio.get_running_loop()
+
+        def objective(trial: optuna.Trial) -> float:
+            params: dict[str, Any] = {}
+            for p in search_space.params:
+                if p.type == "uniform" and p.low is not None and p.high is not None:
+                    params[p.name] = trial.suggest_float(p.name, p.low, p.high)
+                elif (
+                    p.type == "log_uniform" and p.low is not None and p.high is not None
+                ):
+                    params[p.name] = trial.suggest_float(
+                        p.name, p.low, p.high, log=True
+                    )
+                elif (
+                    p.type == "int_uniform" and p.low is not None and p.high is not None
+                ):
+                    params[p.name] = trial.suggest_int(p.name, int(p.low), int(p.high))
+                elif p.type == "categorical" and p.choices is not None:
+                    params[p.name] = trial.suggest_categorical(p.name, p.choices)
+
+            merged_spec = ModelSpec(
+                model_class=base_model_spec.model_class,
+                hyperparameters={**base_model_spec.hyperparameters, **params},
+                framework=base_model_spec.framework,
+            )
+
+            trial_start = time.perf_counter()
+            last_value = 0.0
+            last_metrics: dict[str, float] = {}
+
+            for step, frac in enumerate(rung_fractions):
+                # Sub-sample data for this rung
+                n_rows = data.height
+                sample_n = max(1, int(n_rows * frac))
+                if sample_n >= n_rows:
+                    rung_data = data
+                else:
+                    rung_data = data.sample(n=sample_n, seed=42 + trial.number)
+
+                future = asyncio.run_coroutine_threadsafe(
+                    self._pipeline.train(
+                        rung_data,
+                        schema,
+                        merged_spec,
+                        eval_spec,
+                        f"{experiment_name}_trial_{trial.number}_rung_{step}",
+                        tracker=tracker,
+                        parent_run_id=parent_run_id,
+                    ),
+                    loop,
+                )
+                train_result = future.result(timeout=config.timeout_seconds)
+                last_value = train_result.metrics.get(config.metric_to_optimize, 0.0)
+                last_metrics = train_result.metrics
+
+                # Report intermediate value and check for pruning
+                trial.report(last_value, step)
+                if trial.should_prune():
+                    trial_time = time.perf_counter() - trial_start
+                    all_trials.append(
+                        TrialResult(
+                            trial_number=trial.number,
+                            params=params,
+                            metrics=last_metrics,
+                            training_time_seconds=trial_time,
+                            pruned=True,
+                        )
+                    )
+                    raise optuna.TrialPruned()
+
+            trial_time = time.perf_counter() - trial_start
+            all_trials.append(
+                TrialResult(
+                    trial_number=trial.number,
+                    params=params,
+                    metrics=last_metrics,
+                    training_time_seconds=trial_time,
+                    pruned=False,
+                )
+            )
+            return last_value
+
+        pruner = optuna.pruners.SuccessiveHalvingPruner(
+            min_resource=1,
+            reduction_factor=2,
+            min_early_stopping_rate=0,
+        )
+        study = optuna.create_study(direction=config.direction, pruner=pruner)
+        await loop.run_in_executor(
+            None,
+            lambda: study.optimize(
+                objective, n_trials=config.n_trials, timeout=config.timeout_seconds
+            ),
+        )
+
+        return self._build_result(
+            all_trials,
+            config,
+            "successive_halving",
+            base_model_spec,
             data,
             schema,
-            base_model_spec,
-            search_space,
-            config,
             eval_spec,
             experiment_name,
         )
@@ -596,13 +783,18 @@ class HyperparameterSearch:
                 strategy=strategy,
             )
 
+        # Only consider completed (non-pruned) trials for best selection
+        completed = [t for t in all_trials if not t.pruned]
+        candidates = completed if completed else all_trials
+
         if config.direction == "maximize":
             best = max(
-                all_trials, key=lambda t: t.metrics.get(config.metric_to_optimize, 0.0)
+                candidates,
+                key=lambda t: t.metrics.get(config.metric_to_optimize, 0.0),
             )
         else:
             best = min(
-                all_trials,
+                candidates,
                 key=lambda t: t.metrics.get(config.metric_to_optimize, float("inf")),
             )
 

--- a/packages/kailash-ml/src/kailash_ml/engines/inference_server.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/inference_server.py
@@ -155,6 +155,7 @@ class InferenceServer:
         *,
         version: int | None = None,
         options: dict | None = None,
+        strict: bool = True,
     ) -> PredictionResult:
         """Single-record prediction.
 
@@ -166,8 +167,15 @@ class InferenceServer:
             Feature dict, e.g. {"feature_a": 1.0, "feature_b": 2.0}.
         version:
             Specific version. If None, uses the latest version.
+        strict:
+            If True (default), raise ValueError when required features are
+            missing or contain non-numeric values. If False, log a warning
+            and substitute 0.0 for missing features (legacy behaviour).
         """
         model_entry = await self._get_model(model_name, version)
+
+        feature_names = self._resolve_feature_names(model_entry, features)
+        self._validate_features(features, feature_names, strict=strict)
 
         start = time.perf_counter()
 
@@ -200,6 +208,7 @@ class InferenceServer:
         records: list[dict[str, Any]],
         *,
         version: int | None = None,
+        strict: bool = True,
     ) -> list[PredictionResult]:
         """Batch prediction. Converts records to polars -> numpy for efficiency.
 
@@ -211,19 +220,43 @@ class InferenceServer:
             List of feature dicts.
         version:
             Specific version. If None, uses the latest version.
+        strict:
+            If True (default), raise ValueError when required features are
+            missing or contain non-numeric values. If False, log a warning
+            and substitute 0.0 for missing features (legacy behaviour).
         """
         if not records:
             return []
 
         model_entry = await self._get_model(model_name, version)
 
+        feature_cols = self._resolve_feature_names(model_entry, records[0])
+
+        # Validate every record in the batch
+        for idx, record in enumerate(records):
+            self._validate_features(
+                record, feature_cols, strict=strict, record_index=idx
+            )
+
+        # In non-strict mode, fill missing features with 0.0 so the
+        # DataFrame has all expected columns.
+        if not strict:
+            patched_records: list[dict[str, Any]] = []
+            for record in records:
+                patched = dict(record)
+                for col in feature_cols:
+                    if col not in patched:
+                        patched[col] = 0.0
+                    else:
+                        try:
+                            patched[col] = float(patched[col])
+                        except (TypeError, ValueError):
+                            patched[col] = 0.0
+                patched_records.append(patched)
+            records = patched_records
+
         # Convert list[dict] -> polars -> numpy in one shot
         df = pl.DataFrame(records)
-        feature_cols = (
-            [f.name for f in model_entry.signature.input_schema.features]
-            if model_entry.signature
-            else list(records[0].keys())
-        )
         X, _, _col_info = to_sklearn_input(df, feature_columns=feature_cols)
 
         start = time.perf_counter()
@@ -232,7 +265,8 @@ class InferenceServer:
         if hasattr(model_entry.model, "predict_proba"):
             try:
                 probabilities = model_entry.model.predict_proba(X).tolist()
-            except Exception:
+            except Exception as exc:
+                logger.debug("predict_proba failed: %s", exc)
                 probabilities = None
         inference_ms = (time.perf_counter() - start) * 1000
 
@@ -380,6 +414,85 @@ class InferenceServer:
             return inference._cache.stats()
 
     # ------------------------------------------------------------------
+    # Private: feature validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_feature_names(
+        entry: _CachedModel,
+        features: dict[str, Any],
+    ) -> list[str]:
+        """Return the ordered list of expected feature names."""
+        if entry.signature:
+            return [f.name for f in entry.signature.input_schema.features]
+        return list(features.keys())
+
+    @staticmethod
+    def _validate_features(
+        features: dict[str, Any],
+        feature_names: list[str],
+        *,
+        strict: bool = True,
+        record_index: int | None = None,
+    ) -> None:
+        """Validate that *features* contains all required names with numeric values.
+
+        Parameters
+        ----------
+        features:
+            The feature dict from the caller.
+        feature_names:
+            Ordered list of expected feature names (from model signature).
+        strict:
+            If True, raise ``ValueError`` on problems. If False, log a
+            warning and allow the caller to fall back to 0.0.
+        record_index:
+            If set, included in error/warning messages to identify which
+            record in a batch is problematic.
+        """
+        record_label = (
+            f" (record index {record_index})" if record_index is not None else ""
+        )
+
+        # --- missing features ---
+        missing = [n for n in feature_names if n not in features]
+        if missing:
+            msg = (
+                f"Missing required features{record_label}: {missing}. "
+                f"Expected features: {feature_names}"
+            )
+            if strict:
+                raise ValueError(msg)
+            logger.warning("Non-strict mode: %s — substituting 0.0", msg)
+
+        # --- type validation (only for keys that are present) ---
+        non_numeric: list[str] = []
+        for name in feature_names:
+            if name not in features:
+                continue
+            val = features[name]
+            # Allow int, float, bool (bool is subclass of int), np scalars
+            if isinstance(val, (int, float)):
+                continue
+            if hasattr(val, "item"):
+                # numpy scalar — try conversion
+                continue
+            try:
+                float(val)
+            except (TypeError, ValueError):
+                non_numeric.append(name)
+
+        if non_numeric:
+            bad_pairs = {n: type(features[n]).__name__ for n in non_numeric}
+            msg = (
+                f"Non-numeric feature values{record_label}: {bad_pairs}. "
+                "All feature values must be numeric."
+            )
+            if strict:
+                raise ValueError(msg)
+            logger.warning("Non-strict mode: %s — substituting 0.0", msg)
+
+    # ------------------------------------------------------------------
     # Private: model loading
     # ------------------------------------------------------------------
 
@@ -469,8 +582,8 @@ class InferenceServer:
             try:
                 proba = model.predict_proba(X)[0].tolist()
                 result["probabilities"] = proba
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("predict_proba failed: %s", exc)
 
         return result
 

--- a/packages/kailash-ml/src/kailash_ml/engines/model_explainer.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/model_explainer.py
@@ -1,0 +1,468 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""ModelExplainer engine -- SHAP-based model explainability.
+
+Provides global and local explanations for fitted sklearn-compatible models.
+Requires the ``[explain]`` extra: ``pip install kailash-ml[explain]``.
+
+All methods accept polars DataFrames (consistent with kailash-ml's
+polars-native design) and convert to numpy at the framework boundary
+via the interop pattern.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ModelExplainer",
+]
+
+
+def _ensure_shap() -> Any:
+    """Import and return the shap module; raise helpful error if missing."""
+    try:
+        import shap
+
+        return shap
+    except ImportError as exc:
+        raise ImportError(
+            "SHAP is required for model explainability. "
+            "Install it with: pip install kailash-ml[explain]"
+        ) from exc
+
+
+def _polars_to_numpy(df: pl.DataFrame) -> np.ndarray:
+    """Convert a polars DataFrame to a 2-D float64 numpy array.
+
+    Handles boolean and categorical columns by casting to numeric.
+    Nulls become NaN.
+    """
+    arrays: list[np.ndarray] = []
+    for col_name in df.columns:
+        col = df[col_name]
+        dtype = col.dtype
+
+        if dtype == pl.Boolean:
+            arrays.append(col.cast(pl.Int8).fill_null(0).to_numpy().astype(np.float64))
+        elif dtype == pl.Categorical:
+            arrays.append(col.to_physical().fill_null(-1).to_numpy().astype(np.float64))
+        elif dtype in (pl.Utf8, pl.String):
+            raise ValueError(
+                f"Column '{col_name}' is Utf8/String -- cast to pl.Categorical first."
+            )
+        else:
+            arrays.append(col.fill_null(float("nan")).to_numpy().astype(np.float64))
+
+    if not arrays:
+        return np.empty((df.height, 0), dtype=np.float64)
+    return np.column_stack(arrays)
+
+
+class ModelExplainer:
+    """SHAP-based model explainability engine.
+
+    Provides global and local explanations for fitted sklearn-compatible
+    models.  Requires the ``[explain]`` extra::
+
+        pip install kailash-ml[explain]
+
+    Parameters
+    ----------
+    model:
+        A fitted sklearn-compatible model (must have ``predict`` or
+        ``predict_proba``).
+    X:
+        Reference/background data as a polars DataFrame.  Used for
+        SHAP value calculations.
+    feature_names:
+        Optional feature name override.  When ``None`` the column
+        names from *X* are used.
+    """
+
+    def __init__(
+        self,
+        model: Any,
+        X: pl.DataFrame,
+        *,
+        feature_names: list[str] | None = None,
+    ) -> None:
+        shap = _ensure_shap()
+
+        if not isinstance(X, pl.DataFrame):
+            raise TypeError("X must be a polars DataFrame")
+
+        self._model = model
+        self._feature_names = (
+            feature_names if feature_names is not None else list(X.columns)
+        )
+        self._X_numpy = _polars_to_numpy(X)
+
+        # shap.Explainer auto-selects the best algorithm:
+        # TreeExplainer for tree-based, KernelExplainer for others.
+        self._explainer = shap.Explainer(model, self._X_numpy)
+        self._shap_values: np.ndarray | None = None
+
+    def _compute_shap_values(self) -> np.ndarray:
+        """Compute and cache SHAP values for the reference data."""
+        if self._shap_values is None:
+            explanation = self._explainer(self._X_numpy)
+            values = explanation.values
+            # For binary classification, shap may return 3-D array
+            # (n_samples, n_features, n_classes).  Use the positive-class
+            # slice for consistency.
+            if values.ndim == 3:
+                if values.shape[2] == 2:
+                    values = values[:, :, 1]
+                else:
+                    # Multi-class: use mean absolute across classes
+                    values = np.mean(np.abs(values), axis=2)
+            self._shap_values = values
+        assert self._shap_values is not None  # set above
+        return self._shap_values
+
+    def explain_global(self, *, max_display: int = 20) -> dict[str, Any]:
+        """Compute global SHAP values -- feature importance across all samples.
+
+        Parameters
+        ----------
+        max_display:
+            Maximum number of features to include in the importance
+            ranking.  Defaults to 20.
+
+        Returns
+        -------
+        dict with:
+            - ``shap_values``: numpy array of SHAP values (n_samples x n_features)
+            - ``feature_importance``: dict mapping feature name to mean |SHAP|
+            - ``feature_names``: list of feature names
+        """
+        shap_values = self._compute_shap_values()
+
+        # Mean absolute SHAP value per feature
+        mean_abs_shap = np.mean(np.abs(shap_values), axis=0)
+
+        # Build importance dict sorted by value descending, limited to max_display
+        indices = np.argsort(mean_abs_shap)[::-1][:max_display]
+        feature_importance: dict[str, float] = {}
+        for idx in indices:
+            name = (
+                self._feature_names[idx]
+                if idx < len(self._feature_names)
+                else f"feature_{idx}"
+            )
+            feature_importance[name] = float(mean_abs_shap[idx])
+
+        return {
+            "shap_values": shap_values,
+            "feature_importance": feature_importance,
+            "feature_names": self._feature_names,
+        }
+
+    def explain_local(self, X: pl.DataFrame, *, index: int = 0) -> dict[str, Any]:
+        """Compute per-prediction SHAP values.
+
+        Parameters
+        ----------
+        X:
+            Data to explain as a polars DataFrame.
+        index:
+            Which row (prediction) to explain.
+
+        Returns
+        -------
+        dict with:
+            - ``shap_values``: SHAP values for the selected prediction
+              (1-D array of length n_features)
+            - ``base_value``: expected model output (scalar)
+            - ``feature_values``: actual feature values for the selected row
+              (1-D array)
+            - ``feature_names``: list of feature names
+        """
+        if not isinstance(X, pl.DataFrame):
+            raise TypeError("X must be a polars DataFrame")
+
+        X_numpy = _polars_to_numpy(X)
+        if index < 0 or index >= X_numpy.shape[0]:
+            raise IndexError(
+                f"index {index} out of range for data with {X_numpy.shape[0]} rows"
+            )
+
+        explanation = self._explainer(X_numpy)
+        values = explanation.values
+
+        # Handle multi-output (binary/multiclass)
+        if values.ndim == 3:
+            if values.shape[2] == 2:
+                values = values[:, :, 1]
+            else:
+                values = np.mean(np.abs(values), axis=2)
+
+        base_values = explanation.base_values
+        if isinstance(base_values, np.ndarray):
+            if base_values.ndim == 2:
+                # Multi-class base values: pick positive class or mean
+                if base_values.shape[1] == 2:
+                    base_value = float(base_values[index, 1])
+                else:
+                    base_value = float(np.mean(base_values[index]))
+            elif base_values.ndim == 1:
+                base_value = float(base_values[index])
+            else:
+                base_value = float(base_values)
+        else:
+            base_value = float(base_values)
+
+        return {
+            "shap_values": values[index],
+            "base_value": base_value,
+            "feature_values": X_numpy[index],
+            "feature_names": self._feature_names,
+        }
+
+    def explain_dependence(
+        self, feature: str, *, interaction_feature: str | None = None
+    ) -> dict[str, Any]:
+        """Compute SHAP dependence for a specific feature.
+
+        Shows how a feature's value affects the model's prediction,
+        optionally colored by an interaction feature.
+
+        Parameters
+        ----------
+        feature:
+            Name of the feature to analyze.
+        interaction_feature:
+            Optional second feature for interaction coloring.
+
+        Returns
+        -------
+        dict with:
+            - ``feature_values``: values of the feature (1-D array)
+            - ``shap_values``: SHAP values for that feature (1-D array)
+            - ``interaction_values``: values of the interaction feature
+              (1-D array, or ``None`` if not specified)
+        """
+        if feature not in self._feature_names:
+            raise ValueError(
+                f"Feature '{feature}' not found. "
+                f"Available features: {self._feature_names}"
+            )
+
+        shap_values = self._compute_shap_values()
+        feat_idx = self._feature_names.index(feature)
+
+        result: dict[str, Any] = {
+            "feature_values": self._X_numpy[:, feat_idx],
+            "shap_values": shap_values[:, feat_idx],
+            "interaction_values": None,
+        }
+
+        if interaction_feature is not None:
+            if interaction_feature not in self._feature_names:
+                raise ValueError(
+                    f"Interaction feature '{interaction_feature}' not found. "
+                    f"Available features: {self._feature_names}"
+                )
+            interact_idx = self._feature_names.index(interaction_feature)
+            result["interaction_values"] = self._X_numpy[:, interact_idx]
+
+        return result
+
+    def to_plotly(self, plot_type: str = "summary", **kwargs: Any) -> Any:
+        """Generate a plotly Figure for SHAP visualization.
+
+        Parameters
+        ----------
+        plot_type:
+            One of ``"summary"`` (bar chart of mean |SHAP|),
+            ``"beeswarm"`` (dot plot showing value distribution),
+            or ``"dependence"`` (dependence plot for a single feature,
+            requires ``feature`` kwarg).
+        **kwargs:
+            Additional keyword arguments:
+
+            - ``max_display`` (int): For summary/beeswarm, max features
+              to show.  Default 20.
+            - ``feature`` (str): For dependence plot, the feature name.
+            - ``interaction_feature`` (str): For dependence plot, optional
+              interaction feature.
+
+        Returns
+        -------
+        plotly.graph_objects.Figure
+        """
+        import plotly.graph_objects as go
+
+        max_display = kwargs.get("max_display", 20)
+
+        if plot_type == "summary":
+            return self._plot_summary(max_display=max_display)
+        elif plot_type == "beeswarm":
+            return self._plot_beeswarm(max_display=max_display)
+        elif plot_type == "dependence":
+            feature = kwargs.get("feature")
+            if feature is None:
+                raise ValueError(
+                    "plot_type='dependence' requires a 'feature' keyword argument"
+                )
+            interaction_feature = kwargs.get("interaction_feature")
+            return self._plot_dependence(
+                feature=feature, interaction_feature=interaction_feature
+            )
+        else:
+            raise ValueError(
+                f"Unknown plot_type '{plot_type}'. "
+                f"Choose from: 'summary', 'beeswarm', 'dependence'"
+            )
+
+    def _plot_summary(self, *, max_display: int = 20) -> Any:
+        """Bar chart of mean |SHAP| values (global importance)."""
+        import plotly.graph_objects as go
+
+        global_result = self.explain_global(max_display=max_display)
+        importance = global_result["feature_importance"]
+
+        # Sort ascending for horizontal bar (top feature at top visually)
+        sorted_items = sorted(importance.items(), key=lambda x: x[1])
+        names = [item[0] for item in sorted_items]
+        values = [item[1] for item in sorted_items]
+
+        fig = go.Figure(
+            data=go.Bar(
+                x=values,
+                y=names,
+                orientation="h",
+                marker_color="steelblue",
+            )
+        )
+        fig.update_layout(
+            title=f"SHAP Feature Importance (Top {len(names)})",
+            xaxis_title="Mean |SHAP Value|",
+            yaxis_title="Feature",
+        )
+        return fig
+
+    def _plot_beeswarm(self, *, max_display: int = 20) -> Any:
+        """Dot plot showing SHAP value distribution per feature."""
+        import plotly.graph_objects as go
+
+        shap_values = self._compute_shap_values()
+        mean_abs = np.mean(np.abs(shap_values), axis=0)
+
+        # Select top features by importance
+        top_indices = np.argsort(mean_abs)[::-1][:max_display]
+        # Reverse for display (most important at top)
+        top_indices = top_indices[::-1]
+
+        fig = go.Figure()
+
+        for rank, feat_idx in enumerate(top_indices):
+            feat_shap = shap_values[:, feat_idx]
+            feat_vals = self._X_numpy[:, feat_idx]
+            feat_name = (
+                self._feature_names[feat_idx]
+                if feat_idx < len(self._feature_names)
+                else f"feature_{feat_idx}"
+            )
+
+            # Normalize feature values to [0, 1] for color mapping
+            fmin, fmax = float(np.nanmin(feat_vals)), float(np.nanmax(feat_vals))
+            if fmax > fmin:
+                normed = (feat_vals - fmin) / (fmax - fmin)
+            else:
+                normed = np.full_like(feat_vals, 0.5)
+
+            # Map to color: low=blue, high=red
+            colors = [
+                f"rgb({int(v * 255)}, {int((1 - abs(2 * v - 1)) * 100)}, {int((1 - v) * 255)})"
+                for v in normed
+            ]
+
+            # Add jitter to y for readability
+            jitter = np.random.default_rng(42).uniform(-0.2, 0.2, size=len(feat_shap))
+
+            fig.add_trace(
+                go.Scatter(
+                    x=feat_shap,
+                    y=np.full(len(feat_shap), rank) + jitter,
+                    mode="markers",
+                    marker=dict(
+                        size=4,
+                        color=colors,
+                        opacity=0.6,
+                    ),
+                    name=feat_name,
+                    showlegend=False,
+                    hovertemplate=(
+                        f"{feat_name}<br>" "SHAP: %{x:.4f}<br>" "<extra></extra>"
+                    ),
+                )
+            )
+
+        tick_labels = [
+            (
+                self._feature_names[idx]
+                if idx < len(self._feature_names)
+                else f"feature_{idx}"
+            )
+            for idx in top_indices
+        ]
+        fig.update_layout(
+            title=f"SHAP Beeswarm Plot (Top {len(top_indices)})",
+            xaxis_title="SHAP Value",
+            yaxis=dict(
+                tickmode="array",
+                tickvals=list(range(len(top_indices))),
+                ticktext=tick_labels,
+            ),
+        )
+        return fig
+
+    def _plot_dependence(
+        self, *, feature: str, interaction_feature: str | None = None
+    ) -> Any:
+        """Scatter plot of feature value vs SHAP value."""
+        import plotly.graph_objects as go
+
+        dep = self.explain_dependence(feature, interaction_feature=interaction_feature)
+
+        marker_kwargs: dict[str, Any] = {
+            "size": 5,
+            "opacity": 0.7,
+        }
+
+        if dep["interaction_values"] is not None:
+            marker_kwargs["color"] = dep["interaction_values"]
+            marker_kwargs["colorscale"] = "RdBu"
+            marker_kwargs["colorbar"] = dict(title=interaction_feature)
+
+        fig = go.Figure(
+            data=go.Scatter(
+                x=dep["feature_values"],
+                y=dep["shap_values"],
+                mode="markers",
+                marker=marker_kwargs,
+                hovertemplate=(
+                    f"{feature}: " + "%{x:.4f}<br>"
+                    "SHAP: %{y:.4f}<br>"
+                    "<extra></extra>"
+                ),
+            )
+        )
+
+        title = f"SHAP Dependence: {feature}"
+        if interaction_feature:
+            title += f" (colored by {interaction_feature})"
+
+        fig.update_layout(
+            title=title,
+            xaxis_title=feature,
+            yaxis_title=f"SHAP Value for {feature}",
+        )
+        return fig

--- a/packages/kailash-ml/src/kailash_ml/engines/preprocessing.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/preprocessing.py
@@ -130,9 +130,18 @@ class PreprocessingPipeline:
         self._task_type: str = ""
         self._encoding: str = ""
         self._normalize: bool = False
+        self._normalize_method: str = "zscore"
         self._imputation_strategy: str = ""
+        self._impute_n_neighbors: int = 5
         # For inverse_transform of target encoding
         self._target_encoding_maps: dict[str, dict[int, str]] = {}
+        # Multicollinearity removal
+        self._remove_multicollinearity: bool = False
+        self._multicollinearity_threshold: float = 0.9
+        # Class imbalance handling
+        self._fix_imbalance: bool = False
+        self._imbalance_method: str = "smote"
+        self._use_balanced_class_weight: bool = False
 
     def setup(
         self,
@@ -142,12 +151,18 @@ class PreprocessingPipeline:
         train_size: float = 0.8,
         seed: int = 42,
         normalize: bool = True,
+        normalize_method: str = "zscore",
         categorical_encoding: str = "onehot",
         imputation_strategy: str = "mean",
+        impute_n_neighbors: int = 5,
         remove_outliers: bool = False,
         outlier_threshold: float = 0.05,
         max_cardinality: int = 50,
         exclude_columns: list[str] | None = None,
+        remove_multicollinearity: bool = False,
+        multicollinearity_threshold: float = 0.9,
+        fix_imbalance: bool = False,
+        imbalance_method: str = "smote",
     ) -> SetupResult:
         """Auto-configure preprocessing and return transformed data splits.
 
@@ -159,9 +174,11 @@ class PreprocessingPipeline:
         Applies (in order):
         1. Missing value imputation
         2. Categorical encoding (one-hot, ordinal, or target encoding)
-        3. Numeric scaling (StandardScaler if ``normalize=True``)
-        4. Optional outlier removal (IQR-based)
-        5. Train/test split
+        3. Multicollinearity removal (optional, correlation-based)
+        4. Numeric scaling (StandardScaler if ``normalize=True``)
+        5. Optional outlier removal (IQR-based)
+        6. Train/test split
+        7. Class imbalance correction (optional, training data only)
 
         Parameters
         ----------
@@ -174,11 +191,19 @@ class PreprocessingPipeline:
         seed:
             Random seed for reproducibility.
         normalize:
-            Whether to apply StandardScaler to numeric columns.
+            Whether to apply scaling to numeric columns.
+        normalize_method:
+            Scaling method: ``"zscore"`` (StandardScaler), ``"minmax"``
+            (MinMaxScaler), ``"robust"`` (RobustScaler), or ``"maxabs"``
+            (MaxAbsScaler).
         categorical_encoding:
             ``"onehot"``, ``"ordinal"``, or ``"target"``.
         imputation_strategy:
-            ``"mean"``, ``"median"``, ``"mode"``, or ``"drop"``.
+            ``"mean"``, ``"median"``, ``"mode"``, ``"drop"``, ``"knn"``,
+            or ``"iterative"``.
+        impute_n_neighbors:
+            Number of neighbors for KNN imputation (only used when
+            ``imputation_strategy="knn"``).
         remove_outliers:
             Whether to remove outliers using IQR method.
         outlier_threshold:
@@ -193,6 +218,25 @@ class PreprocessingPipeline:
             Column names to exclude from categorical encoding.  Excluded
             columns are left as-is (no encoding applied).  All names must
             exist in *data*.
+        remove_multicollinearity:
+            Whether to remove highly correlated feature columns.  When
+            enabled, pairs with absolute Pearson correlation above
+            ``multicollinearity_threshold`` are detected and the column
+            with lower absolute correlation to the target is dropped.
+        multicollinearity_threshold:
+            Absolute Pearson correlation threshold for multicollinearity
+            detection.  Column pairs exceeding this value trigger removal.
+            Must be between 0 and 1.
+        fix_imbalance:
+            Whether to apply class imbalance correction on the training
+            split.  Only applies for classification tasks.
+        imbalance_method:
+            Strategy for fixing class imbalance: ``"smote"`` (Synthetic
+            Minority Oversampling), ``"adasyn"`` (Adaptive Synthetic
+            Sampling), or ``"class_weight"`` (flag for downstream
+            consumers to use balanced class weights instead of
+            resampling).  ``"smote"`` and ``"adasyn"`` require the
+            ``kailash-ml[imbalance]`` extra.
         """
         if target not in data.columns:
             raise ValueError(f"Target column '{target}' not found in data.")
@@ -205,9 +249,16 @@ class PreprocessingPipeline:
                 f"categorical_encoding must be 'onehot', 'ordinal', or 'target', "
                 f"got '{categorical_encoding}'."
             )
-        if imputation_strategy not in ("mean", "median", "mode", "drop"):
+        _valid_normalize = ("zscore", "minmax", "robust", "maxabs")
+        if normalize_method not in _valid_normalize:
             raise ValueError(
-                f"imputation_strategy must be 'mean', 'median', 'mode', or 'drop', "
+                f"normalize_method must be one of {_valid_normalize}, "
+                f"got '{normalize_method}'."
+            )
+        _valid_impute = ("mean", "median", "mode", "drop", "knn", "iterative")
+        if imputation_strategy not in _valid_impute:
+            raise ValueError(
+                f"imputation_strategy must be one of {_valid_impute}, "
                 f"got '{imputation_strategy}'."
             )
         if exclude_columns is not None:
@@ -217,6 +268,16 @@ class PreprocessingPipeline:
                     f"exclude_columns contains columns not in DataFrame: {invalid_cols}"
                 )
                 raise ValueError(msg)
+        if remove_multicollinearity and not (0.0 < multicollinearity_threshold <= 1.0):
+            raise ValueError(
+                f"multicollinearity_threshold must be in (0, 1], got {multicollinearity_threshold}."
+            )
+        _valid_imbalance = ("smote", "adasyn", "class_weight")
+        if imbalance_method not in _valid_imbalance:
+            raise ValueError(
+                f"imbalance_method must be one of {_valid_imbalance}, "
+                f"got '{imbalance_method}'."
+            )
 
         original_shape = (data.height, data.width)
 
@@ -231,19 +292,32 @@ class PreprocessingPipeline:
         self._categorical_columns = categorical_cols
         self._encoding = categorical_encoding
         self._normalize = normalize
+        self._normalize_method = normalize_method
         self._imputation_strategy = imputation_strategy
+        self._impute_n_neighbors = impute_n_neighbors
+        self._remove_multicollinearity = remove_multicollinearity
+        self._multicollinearity_threshold = multicollinearity_threshold
+        self._fix_imbalance = fix_imbalance
+        self._imbalance_method = imbalance_method
+        self._use_balanced_class_weight = False
         self._config = {
             "target": target,
             "task_type": task_type,
             "train_size": train_size,
             "seed": seed,
             "normalize": normalize,
+            "normalize_method": normalize_method,
             "categorical_encoding": categorical_encoding,
             "imputation_strategy": imputation_strategy,
+            "impute_n_neighbors": impute_n_neighbors,
             "remove_outliers": remove_outliers,
             "outlier_threshold": outlier_threshold,
             "numeric_columns": list(numeric_cols),
             "categorical_columns": list(categorical_cols),
+            "remove_multicollinearity": remove_multicollinearity,
+            "multicollinearity_threshold": multicollinearity_threshold,
+            "fix_imbalance": fix_imbalance,
+            "imbalance_method": imbalance_method,
         }
 
         # Reset transformers
@@ -265,23 +339,36 @@ class PreprocessingPipeline:
             exclude_columns=exclude_columns,
         )
 
-        # 3. Normalize numerics
+        # 3. Remove multicollinear features (after encoding, before scaling)
+        if remove_multicollinearity:
+            result_df = self._remove_multicollinear_features(
+                result_df, target, multicollinearity_threshold
+            )
+
+        # 4. Normalize numerics
         if normalize and numeric_cols:
             result_df = self._scale_numerics(result_df, numeric_cols)
 
-        # 4. Outlier removal (before split, so we don't lose test data shape)
+        # 5. Outlier removal (before split, so we don't lose test data shape)
         if remove_outliers and numeric_cols:
             result_df = self._remove_outliers(
                 result_df, numeric_cols, outlier_threshold
             )
 
-        # 5. Train/test split
+        # 6. Train/test split
         train_df, test_df = self._split(result_df, train_size, seed)
+
+        # 7. Class imbalance correction (on training data only)
+        if fix_imbalance and task_type == "classification":
+            train_df = self._apply_imbalance_correction(
+                train_df, target, imbalance_method, seed
+            )
 
         transformed_shape = (result_df.height, result_df.width)
         self._fitted = True
 
         # Build summary
+        multicollinear_dropped = self._transformers.get("multicollinear_dropped", [])
         summary_lines = [
             f"Task type: {task_type}",
             f"Original shape: {original_shape[0]} rows x {original_shape[1]} cols",
@@ -292,6 +379,8 @@ class PreprocessingPipeline:
             f"Normalization: {'yes' if normalize else 'no'}",
             f"Imputation: {imputation_strategy}",
             f"Outlier removal: {'yes (threshold={:.2f})'.format(outlier_threshold) if remove_outliers else 'no'}",
+            f"Multicollinearity removal: {'yes (dropped {})'.format(multicollinear_dropped) if remove_multicollinearity and multicollinear_dropped else 'no'}",
+            f"Imbalance correction: {imbalance_method if fix_imbalance and task_type == 'classification' else 'no'}",
             f"Train size: {train_df.height} rows",
             f"Test size: {test_df.height} rows",
         ]
@@ -322,8 +411,8 @@ class PreprocessingPipeline:
     def transform(self, data: pl.DataFrame) -> pl.DataFrame:
         """Apply fitted transforms to new data (inference time).
 
-        Applies the same imputation, encoding, and scaling that were
-        fitted during ``setup()``.
+        Applies the same imputation, encoding, multicollinearity removal,
+        and scaling that were fitted during ``setup()``.
 
         Raises ``RuntimeError`` if ``setup()`` has not been called.
         """
@@ -338,7 +427,14 @@ class PreprocessingPipeline:
         # 2. Encode categoricals
         result_df = self._apply_fitted_encoding(result_df)
 
-        # 3. Scale numerics
+        # 3. Drop multicollinear columns
+        multicollinear_dropped = self._transformers.get("multicollinear_dropped", [])
+        if multicollinear_dropped:
+            cols_to_drop = [c for c in multicollinear_dropped if c in result_df.columns]
+            if cols_to_drop:
+                result_df = result_df.drop(cols_to_drop)
+
+        # 4. Scale numerics
         if self._normalize and self._numeric_columns:
             result_df = self._apply_fitted_scaling(result_df)
 
@@ -401,6 +497,10 @@ class PreprocessingPipeline:
             self._transformers["imputer_strategy"] = "drop"
             return result
 
+        # KNN / iterative: sklearn-based imputation for numeric columns
+        if strategy in ("knn", "iterative"):
+            return self._impute_sklearn(data, numeric_cols, categorical_cols, strategy)
+
         result = data
         imputer_stats: dict[str, Any] = {}
 
@@ -443,6 +543,59 @@ class PreprocessingPipeline:
         self._transformers["imputer_strategy"] = strategy
         return result
 
+    def _impute_sklearn(
+        self,
+        data: pl.DataFrame,
+        numeric_cols: list[str],
+        categorical_cols: list[str],
+        strategy: str,
+    ) -> pl.DataFrame:
+        """Impute numeric columns using sklearn KNN or Iterative imputer.
+
+        Categorical columns still receive mode imputation (KNN and iterative
+        imputers are numeric-only).
+        """
+        result = data
+
+        # Numeric imputation via sklearn
+        cols_present = [c for c in numeric_cols if c in data.columns]
+        if cols_present:
+            arr = data.select(cols_present).to_numpy().astype(np.float64)
+
+            if strategy == "knn":
+                from sklearn.impute import KNNImputer
+
+                imputer = KNNImputer(n_neighbors=self._impute_n_neighbors)
+            else:  # "iterative"
+                from sklearn.experimental import enable_iterative_imputer  # noqa: F401
+                from sklearn.impute import IterativeImputer
+
+                imputer = IterativeImputer(random_state=42)
+
+            imputed = imputer.fit_transform(arr)
+            self._transformers["sklearn_imputer"] = imputer
+            self._transformers["sklearn_imputer_cols"] = cols_present
+
+            for i, col in enumerate(cols_present):
+                result = result.with_columns(pl.Series(col, imputed[:, i]))
+
+        # Categorical imputation: always use mode
+        cat_stats: dict[str, Any] = {}
+        for col in categorical_cols:
+            if col not in data.columns:
+                continue
+            null_count = data[col].null_count()
+            if null_count == 0:
+                continue
+            mode_series = data[col].drop_nulls().mode()
+            fill_val = mode_series[0] if len(mode_series) > 0 else "unknown"
+            cat_stats[col] = fill_val
+            result = result.with_columns(pl.col(col).fill_null(fill_val))
+
+        self._transformers["imputer_stats"] = cat_stats
+        self._transformers["imputer_strategy"] = strategy
+        return result
+
     def _apply_fitted_imputation(self, data: pl.DataFrame) -> pl.DataFrame:
         """Apply previously fitted imputation to new data."""
         strategy = self._transformers.get("imputer_strategy", "mean")
@@ -455,8 +608,21 @@ class PreprocessingPipeline:
             cols_in_data = [c for c in all_cols if c in data.columns]
             return data.drop_nulls(subset=cols_in_data)
 
-        stats = self._transformers.get("imputer_stats", {})
         result = data
+
+        # sklearn-based imputers (knn / iterative)
+        if strategy in ("knn", "iterative") and "sklearn_imputer" in self._transformers:
+            imputer = self._transformers["sklearn_imputer"]
+            cols = self._transformers.get("sklearn_imputer_cols", [])
+            cols_present = [c for c in cols if c in result.columns]
+            if cols_present:
+                arr = result.select(cols_present).to_numpy().astype(np.float64)
+                imputed = imputer.transform(arr)
+                for i, col in enumerate(cols_present):
+                    result = result.with_columns(pl.Series(col, imputed[:, i]))
+
+        # Simple stats-based imputation (mean/median/mode or categorical mode)
+        stats = self._transformers.get("imputer_stats", {})
         for col, fill_val in stats.items():
             if col in result.columns:
                 result = result.with_columns(pl.col(col).fill_null(fill_val))
@@ -489,7 +655,7 @@ class PreprocessingPipeline:
             return data
 
         if encoding == "onehot":
-            # Split by cardinality: low-cardinality → onehot, high → ordinal
+            # Split by cardinality: low-cardinality -> onehot, high -> ordinal
             low_card_cols: list[str] = []
             high_card_cols: list[str] = []
             for col in cols_present:
@@ -715,21 +881,143 @@ class PreprocessingPipeline:
         return result
 
     # ------------------------------------------------------------------
+    # Private: multicollinearity removal
+    # ------------------------------------------------------------------
+
+    def _remove_multicollinear_features(
+        self,
+        data: pl.DataFrame,
+        target: str,
+        threshold: float,
+    ) -> pl.DataFrame:
+        """Remove features with high pairwise Pearson correlation.
+
+        For each pair where ``|r| > threshold``, the column with lower
+        absolute correlation to the target is dropped.  Dropped column
+        names are stored in ``self._transformers["multicollinear_dropped"]``.
+        """
+        from kailash_ml.engines._shared import NUMERIC_DTYPES as _NUMERIC_DTYPES
+
+        # Identify numeric feature columns currently in the DataFrame
+        numeric_feature_cols = [
+            col
+            for col in data.columns
+            if col != target and data[col].dtype in _NUMERIC_DTYPES
+        ]
+        if len(numeric_feature_cols) < 2:
+            self._transformers["multicollinear_dropped"] = []
+            return data
+
+        # Build numpy correlation matrix
+        arr = data.select(numeric_feature_cols).to_numpy().astype(np.float64)
+        corr_matrix = np.corrcoef(arr, rowvar=False)
+
+        # Compute absolute correlation of each feature with the target
+        target_dtype = data[target].dtype
+        if target_dtype in (pl.Utf8, pl.String, pl.Categorical):
+            # Target is non-numeric; skip target-aware dropping and drop
+            # the higher-indexed feature from each correlated pair
+            logger.debug(
+                "Target '%s' is non-numeric (%s); using index-based "
+                "multicollinearity removal.",
+                target,
+                target_dtype,
+            )
+            dropped: set[str] = set()
+            n = len(numeric_feature_cols)
+            for i in range(n):
+                if numeric_feature_cols[i] in dropped:
+                    continue
+                for j in range(i + 1, n):
+                    if numeric_feature_cols[j] in dropped:
+                        continue
+                    if abs(corr_matrix[i, j]) > threshold:
+                        dropped.add(numeric_feature_cols[j])
+            self._transformers["multicollinear_dropped"] = list(dropped)
+            return data.drop(list(dropped))
+        target_arr = data[target].to_numpy().astype(np.float64)
+        target_corrs: dict[str, float] = {}
+        for i, col in enumerate(numeric_feature_cols):
+            col_arr = arr[:, i]
+            # Handle constant columns (correlation undefined)
+            if np.std(col_arr) == 0.0 or np.std(target_arr) == 0.0:
+                target_corrs[col] = 0.0
+            else:
+                r = np.corrcoef(col_arr, target_arr)[0, 1]
+                target_corrs[col] = abs(r) if np.isfinite(r) else 0.0
+
+        # Find columns to drop
+        dropped: set[str] = set()
+        n = len(numeric_feature_cols)
+        for i in range(n):
+            if numeric_feature_cols[i] in dropped:
+                continue
+            for j in range(i + 1, n):
+                if numeric_feature_cols[j] in dropped:
+                    continue
+                r = corr_matrix[i, j]
+                if not np.isfinite(r):
+                    continue
+                if abs(r) > threshold:
+                    col_i = numeric_feature_cols[i]
+                    col_j = numeric_feature_cols[j]
+                    # Drop the one with lower target correlation
+                    if target_corrs[col_i] >= target_corrs[col_j]:
+                        drop_col = col_j
+                    else:
+                        drop_col = col_i
+                    dropped.add(drop_col)
+                    logger.info(
+                        "Multicollinearity: dropping '%s' (|r|=%.3f with '%s', "
+                        "target_corr=%.3f vs %.3f)",
+                        drop_col,
+                        abs(r),
+                        col_j if drop_col == col_i else col_i,
+                        target_corrs[drop_col],
+                        target_corrs[col_j if drop_col == col_i else col_i],
+                    )
+
+        dropped_list = sorted(dropped)
+        self._transformers["multicollinear_dropped"] = dropped_list
+
+        if dropped_list:
+            data = data.drop(dropped_list)
+        return data
+
+    # ------------------------------------------------------------------
     # Private: scaling
     # ------------------------------------------------------------------
 
     def _scale_numerics(
         self, data: pl.DataFrame, numeric_cols: list[str]
     ) -> pl.DataFrame:
-        """Fit StandardScaler on numeric columns and transform data."""
-        from sklearn.preprocessing import StandardScaler
+        """Fit a scaler on numeric columns and transform data.
+
+        The scaler type is determined by ``self._normalize_method``:
+        ``"zscore"`` -> StandardScaler, ``"minmax"`` -> MinMaxScaler,
+        ``"robust"`` -> RobustScaler, ``"maxabs"`` -> MaxAbsScaler.
+        """
+        from sklearn.preprocessing import (
+            MaxAbsScaler,
+            MinMaxScaler,
+            RobustScaler,
+            StandardScaler,
+        )
 
         cols_present = [c for c in numeric_cols if c in data.columns]
         if not cols_present:
             return data
 
+        scaler_classes = {
+            "zscore": StandardScaler,
+            "minmax": MinMaxScaler,
+            "robust": RobustScaler,
+            "maxabs": MaxAbsScaler,
+        }
+        scaler_cls = scaler_classes[self._normalize_method]
+
         arr = data.select(cols_present).to_numpy().astype(np.float64)
-        scaler = StandardScaler()
+        scaler = scaler_cls()
         scaled = scaler.fit_transform(arr)
         self._transformers["scaler"] = scaler
 
@@ -799,6 +1087,79 @@ class PreprocessingPipeline:
                 100 * n_removed / data.height,
             )
         return result
+
+    # ------------------------------------------------------------------
+    # Private: class imbalance correction
+    # ------------------------------------------------------------------
+
+    def _apply_imbalance_correction(
+        self,
+        train_df: pl.DataFrame,
+        target: str,
+        method: str,
+        seed: int,
+    ) -> pl.DataFrame:
+        """Apply class imbalance correction to training data.
+
+        ``"class_weight"`` sets a flag for downstream consumers (e.g.
+        ``TrainingPipeline``).  ``"smote"`` and ``"adasyn"`` perform
+        actual oversampling and require ``imbalanced-learn``.
+        """
+        if method == "class_weight":
+            self._use_balanced_class_weight = True
+            logger.info(
+                "Imbalance correction: using balanced class weights "
+                "(no resampling applied)"
+            )
+            return train_df
+
+        # SMOTE / ADASYN -- require imbalanced-learn
+        try:
+            if method == "smote":
+                from imblearn.over_sampling import SMOTE
+
+                sampler = SMOTE(random_state=seed)
+            else:  # "adasyn"
+                from imblearn.over_sampling import ADASYN
+
+                sampler = ADASYN(random_state=seed)
+        except ImportError:
+            raise ImportError(
+                f"imbalanced-learn is required for imbalance_method='{method}'. "
+                "Install it with: pip install kailash-ml[imbalance]"
+            ) from None
+
+        feature_cols = [c for c in train_df.columns if c != target]
+        X = train_df.select(feature_cols).to_numpy().astype(np.float64)
+        y = train_df[target].to_numpy()
+
+        original_height = train_df.height
+        X_res, y_res = sampler.fit_resample(X, y)
+
+        # Rebuild polars DataFrame
+        result_data: dict[str, list[Any]] = {}
+        for i, col in enumerate(feature_cols):
+            result_data[col] = X_res[:, i].tolist()
+        result_data[target] = y_res.tolist()
+        result_df = pl.DataFrame(result_data)
+
+        # Preserve original dtypes
+        cast_exprs = []
+        for col in result_df.columns:
+            if col in train_df.columns:
+                orig_dtype = train_df[col].dtype
+                if result_df[col].dtype != orig_dtype:
+                    cast_exprs.append(pl.col(col).cast(orig_dtype))
+        if cast_exprs:
+            result_df = result_df.with_columns(cast_exprs)
+
+        logger.info(
+            "Imbalance correction (%s): %d -> %d training samples",
+            method,
+            original_height,
+            result_df.height,
+        )
+        return result_df
 
     # ------------------------------------------------------------------
     # Private: splitting

--- a/packages/kailash-ml/src/kailash_ml/engines/training_pipeline.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/training_pipeline.py
@@ -127,6 +127,7 @@ class TrainingResult:
     data_shape: tuple[int, int]
     registered: bool  # True if model was registered
     threshold_met: bool
+    run_id: str | None = None  # ExperimentTracker run ID (set when tracker provided)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -136,6 +137,7 @@ class TrainingResult:
             "data_shape": list(self.data_shape),
             "registered": self.registered,
             "threshold_met": self.threshold_met,
+            "run_id": self.run_id,
         }
 
     @classmethod
@@ -148,6 +150,7 @@ class TrainingResult:
             data_shape=(shape[0], shape[1]) if shape else (0, 0),
             registered=data["registered"],
             threshold_met=data["threshold_met"],
+            run_id=data.get("run_id"),
         )
 
 
@@ -206,6 +209,8 @@ class TrainingPipeline:
         experiment_name: str,
         *,
         agent: AgentInfusionProtocol | None = None,
+        tracker: Any | None = None,
+        parent_run_id: str | None = None,
     ) -> TrainingResult:
         """Full training pipeline.
 
@@ -215,6 +220,17 @@ class TrainingPipeline:
         4. Fit model
         5. Evaluate
         6. If threshold met, register at STAGING
+        7. If tracker provided, log params/metrics to ExperimentTracker
+
+        Parameters
+        ----------
+        tracker:
+            Optional ExperimentTracker instance. When provided, a run is
+            created and all parameters and metrics are logged automatically.
+            Typed as ``Any`` to avoid circular imports.
+        parent_run_id:
+            Optional parent run ID for nested runs (used by
+            HyperparameterSearch and AutoMLEngine).
         """
         # Validate
         self._validate_data(data, schema)
@@ -231,7 +247,7 @@ class TrainingPipeline:
                 logger.debug("Agent model suggestion failed, continuing with spec.")
 
         # Split
-        train_data, test_data = self._split(data, eval_spec)
+        train_data, test_data = self._split(data, eval_spec, target_col)
 
         # Train
         start = time.perf_counter()
@@ -283,6 +299,20 @@ class TrainingPipeline:
             except Exception:
                 logger.debug("Agent result interpretation failed.")
 
+        # Auto-log to ExperimentTracker when provided
+        run_id: str | None = None
+        if tracker is not None:
+            run_id = await self._log_to_tracker(
+                tracker,
+                experiment_name,
+                model_spec,
+                eval_spec,
+                metrics,
+                data,
+                training_time,
+                parent_run_id,
+            )
+
         return TrainingResult(
             model_version=model_version,
             metrics=metrics,
@@ -290,7 +320,114 @@ class TrainingPipeline:
             data_shape=(data.height, data.width),
             registered=model_version is not None,
             threshold_met=threshold_met,
+            run_id=run_id,
         )
+
+    # ------------------------------------------------------------------
+    # Private: experiment tracking
+    # ------------------------------------------------------------------
+
+    async def _log_to_tracker(
+        self,
+        tracker: Any,
+        experiment_name: str,
+        model_spec: ModelSpec,
+        eval_spec: EvalSpec,
+        metrics: dict[str, float],
+        data: pl.DataFrame,
+        training_time: float,
+        parent_run_id: str | None,
+    ) -> str:
+        """Log training run to ExperimentTracker. Returns the run ID."""
+        run_name = model_spec.model_class.rsplit(".", 1)[-1]
+        async with tracker.run(
+            experiment_name,
+            run_name=run_name,
+            parent_run_id=parent_run_id,
+        ) as ctx:
+            # Log params: model spec + eval spec + data shape
+            params: dict[str, str] = {
+                "model_class": model_spec.model_class,
+                "framework": model_spec.framework,
+                "split_strategy": eval_spec.split_strategy,
+                "test_size": str(eval_spec.test_size),
+                "n_rows": str(data.height),
+                "n_cols": str(data.width),
+            }
+            for k, v in model_spec.hyperparameters.items():
+                params[f"hp.{k}"] = str(v)
+            await ctx.log_params(params)
+
+            # Log metrics
+            for key, value in metrics.items():
+                await ctx.log_metric(key, value)
+
+            # Log training time as metric
+            await ctx.log_metric("training_time_seconds", training_time)
+
+            return ctx.run_id
+
+    # ------------------------------------------------------------------
+    # calibrate
+    # ------------------------------------------------------------------
+
+    async def calibrate(
+        self,
+        model: Any,
+        X_val: pl.DataFrame,
+        y_val: pl.Series,
+        *,
+        method: str = "sigmoid",
+    ) -> Any:
+        """Calibrate a classifier's probability estimates.
+
+        Wraps the model with ``CalibratedClassifierCV`` from sklearn,
+        fitting on the provided validation data.  The returned model is
+        a drop-in replacement: it still exposes ``predict()`` and
+        ``predict_proba()`` and is compatible with ModelRegistry and
+        InferenceServer.
+
+        Parameters
+        ----------
+        model:
+            A fitted sklearn-compatible classifier.
+        X_val:
+            Validation features as a polars DataFrame.
+        y_val:
+            Validation labels as a polars Series.
+        method:
+            ``"sigmoid"`` for Platt scaling or ``"isotonic"`` for
+            isotonic regression.
+
+        Returns
+        -------
+        CalibratedClassifierCV
+            The calibrated model wrapping *model*.
+
+        Raises
+        ------
+        ValueError
+            If *method* is not ``"sigmoid"`` or ``"isotonic"``.
+        """
+        _valid_methods = ("sigmoid", "isotonic")
+        if method not in _valid_methods:
+            raise ValueError(f"method must be one of {_valid_methods}, got {method!r}")
+
+        from sklearn.calibration import CalibratedClassifierCV
+        from sklearn.frozen import FrozenEstimator
+
+        X_np, y_np, _ = to_sklearn_input(
+            X_val.with_columns(y_val.alias("__calibrate_target__")),
+            feature_columns=X_val.columns,
+            target_column="__calibrate_target__",
+        )
+
+        # FrozenEstimator prevents re-fitting during cross-validation,
+        # so all validation data is used purely for calibration.
+        frozen = FrozenEstimator(model)
+        calibrated = CalibratedClassifierCV(frozen, method=method, cv=5)
+        calibrated.fit(X_np, y_np)
+        return calibrated
 
     # ------------------------------------------------------------------
     # evaluate (standalone)
@@ -334,9 +471,13 @@ class TrainingPipeline:
         model_spec: ModelSpec,
         eval_spec: EvalSpec,
         data: pl.DataFrame,
+        *,
+        tracker: Any | None = None,
     ) -> TrainingResult:
         """Retrain using new data, register as next version of existing model."""
-        return await self.train(data, schema, model_spec, eval_spec, model_name)
+        return await self.train(
+            data, schema, model_spec, eval_spec, model_name, tracker=tracker
+        )
 
     # ------------------------------------------------------------------
     # Private: training
@@ -502,7 +643,7 @@ class TrainingPipeline:
     # ------------------------------------------------------------------
 
     def _split(
-        self, data: pl.DataFrame, eval_spec: EvalSpec
+        self, data: pl.DataFrame, eval_spec: EvalSpec, target_col: str
     ) -> tuple[pl.DataFrame, pl.DataFrame]:
         """Split data according to eval_spec strategy."""
         if eval_spec.split_strategy == "holdout":
@@ -510,7 +651,9 @@ class TrainingPipeline:
         elif eval_spec.split_strategy == "kfold":
             return self._kfold_first_fold(data, eval_spec.n_splits)
         elif eval_spec.split_strategy == "stratified_kfold":
-            return self._stratified_kfold_first_fold(data, eval_spec.n_splits)
+            return self._stratified_kfold_first_fold(
+                data, eval_spec.n_splits, target_col
+            )
         elif eval_spec.split_strategy == "walk_forward":
             return self._walk_forward_split(data, eval_spec.test_size)
         else:
@@ -532,16 +675,22 @@ class TrainingPipeline:
     def _kfold_first_fold(
         self, data: pl.DataFrame, n_splits: int
     ) -> tuple[pl.DataFrame, pl.DataFrame]:
-        fold_size = data.height // n_splits
-        test_data = data[:fold_size]
-        train_data = data[fold_size:]
-        return train_data, test_data
+        from sklearn.model_selection import KFold
+
+        kf = KFold(n_splits=n_splits, shuffle=True, random_state=42)
+        indices = np.arange(data.height)
+        train_idx, test_idx = next(kf.split(indices))
+        return data[train_idx.tolist()], data[test_idx.tolist()]
 
     def _stratified_kfold_first_fold(
-        self, data: pl.DataFrame, n_splits: int
+        self, data: pl.DataFrame, n_splits: int, target_col: str
     ) -> tuple[pl.DataFrame, pl.DataFrame]:
-        # Fallback to regular kfold for simplicity in v1
-        return self._kfold_first_fold(data, n_splits)
+        from sklearn.model_selection import StratifiedKFold
+
+        y = data[target_col].to_numpy()
+        skf = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
+        train_idx, test_idx = next(skf.split(np.arange(data.height), y))
+        return data[train_idx.tolist()], data[test_idx.tolist()]
 
     def _walk_forward_split(
         self, data: pl.DataFrame, test_size: float

--- a/packages/kailash-ml/tests/unit/test_auto_logging.py
+++ b/packages/kailash-ml/tests/unit/test_auto_logging.py
@@ -1,0 +1,467 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ExperimentTracker auto-logging integration.
+
+Verifies that TrainingPipeline, HyperparameterSearch, and AutoMLEngine
+automatically log params and metrics when a tracker is provided, and
+that behaviour is unchanged when tracker=None (backward compatibility).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import polars as pl
+import pytest
+
+from kailash.db.connection import ConnectionManager
+from kailash_ml.engines.experiment_tracker import ExperimentTracker
+from kailash_ml.engines.feature_store import FeatureStore
+from kailash_ml.engines.model_registry import (
+    LocalFileArtifactStore,
+    ModelRegistry,
+)
+from kailash_ml.engines.training_pipeline import (
+    EvalSpec,
+    ModelSpec,
+    TrainingPipeline,
+    TrainingResult,
+)
+from kailash_ml.types import FeatureField, FeatureSchema
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def conn():
+    """Real SQLite ConnectionManager (in-memory)."""
+    cm = ConnectionManager("sqlite://:memory:")
+    await cm.initialize()
+    yield cm
+    await cm.close()
+
+
+@pytest.fixture
+async def feature_store(conn: ConnectionManager) -> FeatureStore:
+    fs = FeatureStore(conn)
+    await fs.initialize()
+    return fs
+
+
+@pytest.fixture
+async def registry(conn: ConnectionManager, tmp_path: Path) -> ModelRegistry:
+    store = LocalFileArtifactStore(root_dir=tmp_path / "artifacts")
+    return ModelRegistry(conn, artifact_store=store)
+
+
+@pytest.fixture
+def pipeline(feature_store: FeatureStore, registry: ModelRegistry) -> TrainingPipeline:
+    return TrainingPipeline(feature_store, registry)
+
+
+@pytest.fixture
+async def tracker(conn: ConnectionManager, tmp_path: Path) -> ExperimentTracker:
+    """ExperimentTracker backed by real SQLite + tmp_path artifacts."""
+    return ExperimentTracker(conn, artifact_root=str(tmp_path / "mlartifacts"))
+
+
+@pytest.fixture
+def sample_schema() -> FeatureSchema:
+    return FeatureSchema(
+        "test",
+        [
+            FeatureField("feature_a", "float64"),
+            FeatureField("feature_b", "float64"),
+        ],
+        entity_id_column="entity_id",
+    )
+
+
+@pytest.fixture
+def sample_df() -> pl.DataFrame:
+    """Classification dataset with clear separation."""
+    rng = np.random.RandomState(42)
+    n = 200
+    feature_a = np.concatenate([rng.normal(0, 1, n // 2), rng.normal(3, 1, n // 2)])
+    feature_b = np.concatenate([rng.normal(0, 1, n // 2), rng.normal(3, 1, n // 2)])
+    target = np.array([0] * (n // 2) + [1] * (n // 2))
+    return pl.DataFrame(
+        {
+            "entity_id": [f"e{i}" for i in range(n)],
+            "feature_a": feature_a.tolist(),
+            "feature_b": feature_b.tolist(),
+            "target": target.tolist(),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# TrainingPipeline auto-logging
+# ---------------------------------------------------------------------------
+
+
+class TestTrainingPipelineAutoLogging:
+    """Tests for TrainingPipeline.train() with tracker parameter."""
+
+    @pytest.mark.asyncio
+    async def test_train_without_tracker_backward_compat(
+        self,
+        pipeline: TrainingPipeline,
+        sample_df: pl.DataFrame,
+        sample_schema: FeatureSchema,
+    ) -> None:
+        """Training without tracker works exactly as before."""
+        result = await pipeline.train(
+            sample_df,
+            sample_schema,
+            ModelSpec(
+                "sklearn.ensemble.RandomForestClassifier",
+                {"n_estimators": 5, "random_state": 42},
+            ),
+            EvalSpec(metrics=["accuracy"], min_threshold={"accuracy": 0.3}),
+            "no_tracker_test",
+        )
+        assert result.registered is True
+        assert result.run_id is None
+        assert "accuracy" in result.metrics
+
+    @pytest.mark.asyncio
+    async def test_train_with_tracker_logs_run(
+        self,
+        pipeline: TrainingPipeline,
+        tracker: ExperimentTracker,
+        sample_df: pl.DataFrame,
+        sample_schema: FeatureSchema,
+    ) -> None:
+        """Training with tracker creates a run and logs params/metrics."""
+        result = await pipeline.train(
+            sample_df,
+            sample_schema,
+            ModelSpec(
+                "sklearn.ensemble.RandomForestClassifier",
+                {"n_estimators": 5, "random_state": 42},
+            ),
+            EvalSpec(metrics=["accuracy", "f1"], min_threshold={"accuracy": 0.3}),
+            "tracked_experiment",
+            tracker=tracker,
+        )
+
+        # run_id should be populated
+        assert result.run_id is not None
+        assert isinstance(result.run_id, str)
+        assert len(result.run_id) > 0
+
+        # Verify the run exists in tracker
+        run = await tracker.get_run(result.run_id)
+        assert run.status == "COMPLETED"
+
+        # Verify params were logged
+        assert run.params["model_class"] == "sklearn.ensemble.RandomForestClassifier"
+        assert run.params["framework"] == "sklearn"
+        assert run.params["hp.n_estimators"] == "5"
+        assert run.params["hp.random_state"] == "42"
+        assert run.params["split_strategy"] == "holdout"
+        assert run.params["n_rows"] == "200"
+        assert run.params["n_cols"] == "4"
+
+        # Verify metrics were logged
+        assert "accuracy" in run.metrics
+        assert "f1" in run.metrics
+        assert "training_time_seconds" in run.metrics
+        assert run.metrics["accuracy"] > 0.3
+
+    @pytest.mark.asyncio
+    async def test_train_with_tracker_run_name_uses_class(
+        self,
+        pipeline: TrainingPipeline,
+        tracker: ExperimentTracker,
+        sample_df: pl.DataFrame,
+        sample_schema: FeatureSchema,
+    ) -> None:
+        """Run name is derived from model class short name."""
+        result = await pipeline.train(
+            sample_df,
+            sample_schema,
+            ModelSpec("sklearn.tree.DecisionTreeClassifier", {"random_state": 42}),
+            EvalSpec(metrics=["accuracy"]),
+            "name_test",
+            tracker=tracker,
+        )
+
+        run = await tracker.get_run(result.run_id)
+        assert run.name == "DecisionTreeClassifier"
+
+    @pytest.mark.asyncio
+    async def test_train_with_tracker_parent_run_id(
+        self,
+        pipeline: TrainingPipeline,
+        tracker: ExperimentTracker,
+        sample_df: pl.DataFrame,
+        sample_schema: FeatureSchema,
+    ) -> None:
+        """Training with parent_run_id creates a child run."""
+        # Create a parent run first
+        parent = await tracker.start_run("parent_test", run_name="parent")
+
+        result = await pipeline.train(
+            sample_df,
+            sample_schema,
+            ModelSpec(
+                "sklearn.ensemble.RandomForestClassifier",
+                {"n_estimators": 5, "random_state": 42},
+            ),
+            EvalSpec(metrics=["accuracy"]),
+            "parent_test",
+            tracker=tracker,
+            parent_run_id=parent.id,
+        )
+
+        # Verify child run has parent set
+        child_run = await tracker.get_run(result.run_id)
+        assert child_run.parent_run_id == parent.id
+
+        # Verify parent can list child
+        children = await tracker.list_child_runs(parent.id)
+        assert len(children) == 1
+        assert children[0].id == result.run_id
+
+        await tracker.end_run(parent.id)
+
+    @pytest.mark.asyncio
+    async def test_training_result_run_id_serialization(self) -> None:
+        """TrainingResult.run_id round-trips through to_dict/from_dict."""
+        result = TrainingResult(
+            model_version=None,
+            metrics={"accuracy": 0.9},
+            training_time_seconds=1.0,
+            data_shape=(100, 5),
+            registered=False,
+            threshold_met=True,
+            run_id="test-run-id-123",
+        )
+        d = result.to_dict()
+        assert d["run_id"] == "test-run-id-123"
+
+        restored = TrainingResult.from_dict(d)
+        assert restored.run_id == "test-run-id-123"
+
+    @pytest.mark.asyncio
+    async def test_training_result_run_id_none_serialization(self) -> None:
+        """TrainingResult with no run_id serializes correctly."""
+        result = TrainingResult(
+            model_version=None,
+            metrics={"accuracy": 0.9},
+            training_time_seconds=1.0,
+            data_shape=(100, 5),
+            registered=False,
+            threshold_met=True,
+        )
+        d = result.to_dict()
+        assert d["run_id"] is None
+
+        restored = TrainingResult.from_dict(d)
+        assert restored.run_id is None
+
+
+# ---------------------------------------------------------------------------
+# HyperparameterSearch auto-logging
+# ---------------------------------------------------------------------------
+
+
+class TestHyperparameterSearchAutoLogging:
+    """Tests for HyperparameterSearch.search() with tracker parameter."""
+
+    @pytest.mark.asyncio
+    async def test_search_with_tracker_creates_parent_and_child_runs(
+        self,
+        pipeline: TrainingPipeline,
+        tracker: ExperimentTracker,
+        sample_df: pl.DataFrame,
+        sample_schema: FeatureSchema,
+    ) -> None:
+        """Search creates a parent run, each trial creates a child run."""
+        from kailash_ml.engines.hyperparameter_search import (
+            HyperparameterSearch,
+            ParamDistribution,
+            SearchConfig,
+            SearchSpace,
+        )
+
+        search = HyperparameterSearch(pipeline)
+        search_space = SearchSpace(
+            [ParamDistribution("n_estimators", "categorical", choices=[5, 10])]
+        )
+        config = SearchConfig(
+            strategy="grid",
+            n_trials=2,
+            metric_to_optimize="accuracy",
+            direction="maximize",
+        )
+
+        result = await search.search(
+            sample_df,
+            sample_schema,
+            ModelSpec("sklearn.ensemble.RandomForestClassifier", {"random_state": 42}),
+            search_space,
+            config,
+            EvalSpec(metrics=["accuracy"]),
+            "search_tracked",
+            tracker=tracker,
+        )
+
+        assert len(result.all_trials) == 2
+
+        # Find the parent run (search run)
+        runs = await tracker.list_runs("search_tracked")
+        parent_runs = [r for r in runs if r.parent_run_id is None]
+        assert len(parent_runs) == 1
+        parent_run = parent_runs[0]
+        assert parent_run.name == "search_grid"
+        assert parent_run.status == "COMPLETED"
+
+        # Verify search params on parent
+        assert parent_run.params["search_strategy"] == "grid"
+        assert parent_run.params["metric_to_optimize"] == "accuracy"
+
+        # Verify best metrics logged on parent
+        assert "accuracy" in parent_run.metrics
+
+        # Verify child runs exist
+        children = await tracker.list_child_runs(parent_run.id)
+        assert len(children) == 2
+
+    @pytest.mark.asyncio
+    async def test_search_without_tracker_backward_compat(
+        self,
+        pipeline: TrainingPipeline,
+        sample_df: pl.DataFrame,
+        sample_schema: FeatureSchema,
+    ) -> None:
+        """Search without tracker works exactly as before."""
+        from kailash_ml.engines.hyperparameter_search import (
+            HyperparameterSearch,
+            ParamDistribution,
+            SearchConfig,
+            SearchSpace,
+        )
+
+        search = HyperparameterSearch(pipeline)
+        search_space = SearchSpace(
+            [ParamDistribution("n_estimators", "categorical", choices=[5])]
+        )
+        config = SearchConfig(
+            strategy="grid",
+            n_trials=1,
+            metric_to_optimize="accuracy",
+            direction="maximize",
+        )
+
+        result = await search.search(
+            sample_df,
+            sample_schema,
+            ModelSpec("sklearn.ensemble.RandomForestClassifier", {"random_state": 42}),
+            search_space,
+            config,
+            EvalSpec(metrics=["accuracy"]),
+            "search_no_tracker",
+        )
+
+        assert len(result.all_trials) == 1
+        assert result.best_metrics.get("accuracy", 0) > 0
+
+
+# ---------------------------------------------------------------------------
+# AutoMLEngine auto-logging
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMLEngineAutoLogging:
+    """Tests for AutoMLEngine.run() with tracker parameter."""
+
+    @pytest.mark.asyncio
+    async def test_automl_with_tracker_creates_parent_run(
+        self,
+        pipeline: TrainingPipeline,
+        tracker: ExperimentTracker,
+        sample_df: pl.DataFrame,
+        sample_schema: FeatureSchema,
+    ) -> None:
+        """AutoML creates a parent run and passes tracker to sub-calls."""
+        from kailash_ml.engines.automl_engine import AutoMLConfig, AutoMLEngine
+        from kailash_ml.engines.hyperparameter_search import HyperparameterSearch
+
+        search = HyperparameterSearch(pipeline)
+        engine = AutoMLEngine(pipeline, search)
+
+        config = AutoMLConfig(
+            task_type="classification",
+            search_strategy="random",
+            search_n_trials=2,
+        )
+
+        result = await engine.run(
+            sample_df,
+            sample_schema,
+            config,
+            EvalSpec(metrics=["accuracy"]),
+            "automl_tracked",
+            tracker=tracker,
+        )
+
+        assert result.best_metrics.get("accuracy", 0) > 0
+
+        # Find the automl parent run
+        runs = await tracker.list_runs("automl_tracked")
+        # There should be an automl parent run with no parent
+        automl_runs = [
+            r for r in runs if r.name == "automl" and r.parent_run_id is None
+        ]
+        assert len(automl_runs) == 1
+        automl_run = automl_runs[0]
+        assert automl_run.status == "COMPLETED"
+
+        # Verify AutoML config params
+        assert automl_run.params["task_type"] == "classification"
+        assert automl_run.params["search_strategy"] == "random"
+
+        # Verify best metrics logged on parent
+        assert "accuracy" in automl_run.metrics
+
+        # Verify child runs were created (candidates + search trials)
+        all_child_runs = await tracker.list_child_runs(automl_run.id)
+        assert len(all_child_runs) > 0
+
+    @pytest.mark.asyncio
+    async def test_automl_without_tracker_backward_compat(
+        self,
+        pipeline: TrainingPipeline,
+        sample_df: pl.DataFrame,
+        sample_schema: FeatureSchema,
+    ) -> None:
+        """AutoML without tracker works exactly as before."""
+        from kailash_ml.engines.automl_engine import AutoMLConfig, AutoMLEngine
+        from kailash_ml.engines.hyperparameter_search import HyperparameterSearch
+
+        search = HyperparameterSearch(pipeline)
+        engine = AutoMLEngine(pipeline, search)
+
+        config = AutoMLConfig(
+            task_type="classification",
+            search_strategy="random",
+            search_n_trials=2,
+        )
+
+        result = await engine.run(
+            sample_df,
+            sample_schema,
+            config,
+            EvalSpec(metrics=["accuracy"]),
+            "automl_no_tracker",
+        )
+
+        assert result.best_metrics.get("accuracy", 0) > 0
+        assert len(result.all_candidates) > 0

--- a/packages/kailash-ml/tests/unit/test_calibration.py
+++ b/packages/kailash-ml/tests/unit/test_calibration.py
@@ -1,0 +1,223 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for TrainingPipeline.calibrate() method."""
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.calibration import CalibratedClassifierCV
+from sklearn.ensemble import RandomForestClassifier
+
+from kailash_ml.engines.training_pipeline import TrainingPipeline
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline() -> TrainingPipeline:
+    """Construct a TrainingPipeline without registry/feature_store.
+
+    calibrate() is self-contained and does not need a database
+    connection or model registry.
+    """
+    return TrainingPipeline.__new__(TrainingPipeline)
+
+
+def _fit_rf_and_data(
+    n_train: int = 400,
+    n_val: int = 200,
+    seed: int = 42,
+) -> tuple[RandomForestClassifier, pl.DataFrame, pl.Series]:
+    """Train a RandomForestClassifier and return (model, X_val, y_val).
+
+    The synthetic dataset has 4 numeric features and a binary target.
+    """
+    rng = np.random.RandomState(seed)
+
+    # Training data
+    X_train = rng.randn(n_train, 4)
+    y_train = (X_train[:, 0] + X_train[:, 1] > 0).astype(int)
+
+    rf = RandomForestClassifier(n_estimators=20, random_state=seed)
+    rf.fit(X_train, y_train)
+
+    # Validation data (polars-native)
+    X_val_np = rng.randn(n_val, 4)
+    y_val_np = (X_val_np[:, 0] + X_val_np[:, 1] > 0).astype(int)
+
+    X_val = pl.DataFrame(
+        {
+            "f0": X_val_np[:, 0].tolist(),
+            "f1": X_val_np[:, 1].tolist(),
+            "f2": X_val_np[:, 2].tolist(),
+            "f3": X_val_np[:, 3].tolist(),
+        }
+    )
+    y_val = pl.Series("target", y_val_np.tolist())
+
+    return rf, X_val, y_val
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCalibrateSigmoid:
+    """Calibrate with method='sigmoid' (Platt scaling)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_calibrated_model(self) -> None:
+        """calibrate() returns a CalibratedClassifierCV instance."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        calibrated = await pipe.calibrate(model, X_val, y_val, method="sigmoid")
+
+        assert isinstance(calibrated, CalibratedClassifierCV)
+
+    @pytest.mark.asyncio
+    async def test_has_predict_and_predict_proba(self) -> None:
+        """Calibrated model exposes predict() and predict_proba()."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        calibrated = await pipe.calibrate(model, X_val, y_val, method="sigmoid")
+
+        assert hasattr(calibrated, "predict")
+        assert hasattr(calibrated, "predict_proba")
+
+    @pytest.mark.asyncio
+    async def test_predict_proba_valid_probabilities(self) -> None:
+        """predict_proba() produces values in [0, 1] that sum to 1."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        calibrated = await pipe.calibrate(model, X_val, y_val, method="sigmoid")
+
+        X_np = X_val.to_numpy()
+        proba = calibrated.predict_proba(X_np)
+
+        assert proba.shape == (X_val.height, 2)
+        assert np.all(proba >= 0.0)
+        assert np.all(proba <= 1.0)
+        np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-10)
+
+    @pytest.mark.asyncio
+    async def test_predict_returns_correct_shape(self) -> None:
+        """predict() returns one label per validation sample."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        calibrated = await pipe.calibrate(model, X_val, y_val, method="sigmoid")
+
+        X_np = X_val.to_numpy()
+        preds = calibrated.predict(X_np)
+
+        assert preds.shape == (X_val.height,)
+        assert set(np.unique(preds)).issubset({0, 1})
+
+
+class TestCalibrateIsotonic:
+    """Calibrate with method='isotonic'."""
+
+    @pytest.mark.asyncio
+    async def test_returns_calibrated_model(self) -> None:
+        """isotonic calibration produces a CalibratedClassifierCV."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        calibrated = await pipe.calibrate(model, X_val, y_val, method="isotonic")
+
+        assert isinstance(calibrated, CalibratedClassifierCV)
+
+    @pytest.mark.asyncio
+    async def test_predict_proba_valid_probabilities(self) -> None:
+        """isotonic calibration produces valid probabilities."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        calibrated = await pipe.calibrate(model, X_val, y_val, method="isotonic")
+
+        X_np = X_val.to_numpy()
+        proba = calibrated.predict_proba(X_np)
+
+        assert proba.shape == (X_val.height, 2)
+        assert np.all(proba >= 0.0)
+        assert np.all(proba <= 1.0)
+        np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-10)
+
+
+class TestCalibrateDefaultMethod:
+    """Default method is sigmoid when not specified."""
+
+    @pytest.mark.asyncio
+    async def test_default_is_sigmoid(self) -> None:
+        """Calling calibrate() without method= uses sigmoid."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        calibrated = await pipe.calibrate(model, X_val, y_val)
+
+        assert isinstance(calibrated, CalibratedClassifierCV)
+        # The underlying calibrators use sigmoid
+        assert calibrated.method == "sigmoid"
+
+
+class TestCalibrateValidation:
+    """Validation of the method parameter."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_method_raises(self) -> None:
+        """An unsupported method raises ValueError."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        with pytest.raises(ValueError, match="method must be one of"):
+            await pipe.calibrate(model, X_val, y_val, method="beta")
+
+    @pytest.mark.asyncio
+    async def test_empty_method_raises(self) -> None:
+        """Empty string method raises ValueError."""
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data()
+
+        with pytest.raises(ValueError, match="method must be one of"):
+            await pipe.calibrate(model, X_val, y_val, method="")
+
+
+class TestCalibrateBrierScore:
+    """Calibrated model should produce well-calibrated probabilities."""
+
+    @pytest.mark.asyncio
+    async def test_brier_score_not_degraded(self) -> None:
+        """Brier score of calibrated model is not worse than uncalibrated.
+
+        RandomForest is typically already well-calibrated, so we verify
+        that calibration at least does not make things significantly worse.
+        """
+        from sklearn.metrics import brier_score_loss
+
+        pipe = _make_pipeline()
+        model, X_val, y_val = _fit_rf_and_data(n_val=500, seed=99)
+
+        calibrated = await pipe.calibrate(model, X_val, y_val, method="sigmoid")
+
+        X_np = X_val.to_numpy()
+        y_np = y_val.to_numpy()
+
+        raw_proba = model.predict_proba(X_np)[:, 1]
+        cal_proba = calibrated.predict_proba(X_np)[:, 1]
+
+        raw_brier = brier_score_loss(y_np, raw_proba)
+        cal_brier = brier_score_loss(y_np, cal_proba)
+
+        # Calibrated Brier should not be dramatically worse
+        # (allow 10% relative degradation since we calibrate on same data)
+        assert cal_brier < raw_brier * 1.10 + 0.01, (
+            f"Calibrated Brier {cal_brier:.4f} is significantly worse "
+            f"than raw {raw_brier:.4f}"
+        )

--- a/packages/kailash-ml/tests/unit/test_experiment_tracker.py
+++ b/packages/kailash-ml/tests/unit/test_experiment_tracker.py
@@ -1046,3 +1046,169 @@ class TestFactoryCreate:
             assert conn is not None
         finally:
             await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Nested runs (#333)
+# ---------------------------------------------------------------------------
+
+
+class TestNestedRuns:
+    """Tests for nested (parent/child) experiment runs (#333)."""
+
+    @pytest.mark.asyncio
+    async def test_start_child_run(self, tracker: ExperimentTracker) -> None:
+        """Child run stores parent_run_id."""
+        parent = await tracker.start_run("nested-exp", run_name="parent")
+        child = await tracker.start_run(
+            "nested-exp", run_name="child", parent_run_id=parent.id
+        )
+        assert child.parent_run_id == parent.id
+        assert parent.parent_run_id is None
+
+    @pytest.mark.asyncio
+    async def test_get_run_includes_parent_run_id(
+        self, tracker: ExperimentTracker
+    ) -> None:
+        """get_run hydrates parent_run_id from the database."""
+        parent = await tracker.start_run("hydrate-exp", run_name="parent")
+        child = await tracker.start_run(
+            "hydrate-exp", run_name="child", parent_run_id=parent.id
+        )
+        fetched = await tracker.get_run(child.id)
+        assert fetched.parent_run_id == parent.id
+
+        # Parent has no parent
+        fetched_parent = await tracker.get_run(parent.id)
+        assert fetched_parent.parent_run_id is None
+
+    @pytest.mark.asyncio
+    async def test_list_child_runs(self, tracker: ExperimentTracker) -> None:
+        """list_child_runs returns only direct children."""
+        parent = await tracker.start_run("children-exp", run_name="parent")
+        child1 = await tracker.start_run(
+            "children-exp", run_name="child-1", parent_run_id=parent.id
+        )
+        child2 = await tracker.start_run(
+            "children-exp", run_name="child-2", parent_run_id=parent.id
+        )
+        # Unrelated run in same experiment
+        await tracker.start_run("children-exp", run_name="standalone")
+
+        children = await tracker.list_child_runs(parent.id)
+        assert len(children) == 2
+        child_ids = {c.id for c in children}
+        assert child1.id in child_ids
+        assert child2.id in child_ids
+
+    @pytest.mark.asyncio
+    async def test_list_child_runs_empty(self, tracker: ExperimentTracker) -> None:
+        """Run with no children returns empty list."""
+        parent = await tracker.start_run("no-children-exp", run_name="lonely")
+        children = await tracker.list_child_runs(parent.id)
+        assert children == []
+
+    @pytest.mark.asyncio
+    async def test_list_child_runs_parent_not_found(
+        self, tracker: ExperimentTracker
+    ) -> None:
+        """list_child_runs raises if parent does not exist."""
+        with pytest.raises(RunNotFoundError, match="not found"):
+            await tracker.list_child_runs("nonexistent-run-id")
+
+    @pytest.mark.asyncio
+    async def test_parent_and_child_same_experiment(
+        self, tracker: ExperimentTracker
+    ) -> None:
+        """Parent and child runs belong to the same experiment."""
+        parent = await tracker.start_run("same-exp", run_name="parent")
+        child = await tracker.start_run(
+            "same-exp", run_name="child", parent_run_id=parent.id
+        )
+        assert child.experiment_id == parent.experiment_id
+
+    @pytest.mark.asyncio
+    async def test_nested_context_manager(self, tracker: ExperimentTracker) -> None:
+        """Context manager supports parent_run_id for nested runs."""
+        async with tracker.run("ctx-nested-exp", run_name="parent") as parent_ctx:
+            await parent_ctx.log_param("model", "rf")
+
+            async with tracker.run(
+                "ctx-nested-exp",
+                run_name="child-fold-1",
+                parent_run_id=parent_ctx.run_id,
+            ) as child_ctx:
+                await child_ctx.log_metric("fold_acc", 0.92)
+
+        # Both runs should be COMPLETED
+        parent_run = await tracker.get_run(parent_ctx.run_id)
+        child_run = await tracker.get_run(child_ctx.run_id)
+        assert parent_run.status == "COMPLETED"
+        assert child_run.status == "COMPLETED"
+        assert child_run.parent_run_id == parent_ctx.run_id
+        assert child_run.metrics["fold_acc"] == 0.92
+        assert parent_run.params["model"] == "rf"
+
+    @pytest.mark.asyncio
+    async def test_child_run_invalid_parent(self, tracker: ExperimentTracker) -> None:
+        """start_run raises if parent_run_id does not exist."""
+        with pytest.raises(RunNotFoundError, match="not found"):
+            await tracker.start_run(
+                "bad-parent-exp", run_name="orphan", parent_run_id="no-such-run"
+            )
+
+    @pytest.mark.asyncio
+    async def test_list_runs_includes_parent_run_id(
+        self, tracker: ExperimentTracker
+    ) -> None:
+        """list_runs returns runs with parent_run_id populated."""
+        parent = await tracker.start_run("list-nested-exp", run_name="parent")
+        await tracker.start_run(
+            "list-nested-exp", run_name="child", parent_run_id=parent.id
+        )
+        runs = await tracker.list_runs("list-nested-exp")
+        child_runs = [r for r in runs if r.parent_run_id is not None]
+        assert len(child_runs) == 1
+        assert child_runs[0].parent_run_id == parent.id
+
+    @pytest.mark.asyncio
+    async def test_run_to_dict_includes_parent_run_id(self) -> None:
+        """Run.to_dict() / from_dict() round-trips parent_run_id."""
+        run = Run(
+            id="child1",
+            experiment_id="exp1",
+            name="child",
+            status="COMPLETED",
+            start_time="2026-01-01T00:00:00",
+            end_time="2026-01-01T01:00:00",
+            tags={},
+            params={},
+            metrics={},
+            artifacts=[],
+            parent_run_id="parent1",
+        )
+        d = run.to_dict()
+        assert d["parent_run_id"] == "parent1"
+        restored = Run.from_dict(d)
+        assert restored.parent_run_id == "parent1"
+        assert restored == run
+
+    @pytest.mark.asyncio
+    async def test_run_to_dict_null_parent(self) -> None:
+        """Run.to_dict() includes None for top-level runs."""
+        run = Run(
+            id="r1",
+            experiment_id="exp1",
+            name="top",
+            status="RUNNING",
+            start_time="2026-01-01T00:00:00",
+            end_time=None,
+            tags={},
+            params={},
+            metrics={},
+            artifacts=[],
+        )
+        d = run.to_dict()
+        assert d["parent_run_id"] is None
+        restored = Run.from_dict(d)
+        assert restored.parent_run_id is None

--- a/packages/kailash-ml/tests/unit/test_hyperparameter_search.py
+++ b/packages/kailash-ml/tests/unit/test_hyperparameter_search.py
@@ -222,3 +222,140 @@ class TestBuildResult:
         assert result.best_params == {}
         assert result.best_trial_number == -1
         assert result.all_trials == []
+
+    def test_build_result_excludes_pruned_from_best(self) -> None:
+        """_build_result picks best from completed trials, not pruned ones."""
+        from unittest.mock import MagicMock
+
+        pipeline = MagicMock()
+        hs = HyperparameterSearch(pipeline)
+
+        trials = [
+            TrialResult(0, {"lr": 0.1}, {"accuracy": 0.99}, 1.0, pruned=True),
+            TrialResult(1, {"lr": 0.01}, {"accuracy": 0.85}, 2.0, pruned=False),
+            TrialResult(2, {"lr": 0.5}, {"accuracy": 0.80}, 0.5, pruned=False),
+        ]
+        config = SearchConfig(direction="maximize", metric_to_optimize="accuracy")
+
+        result = hs._build_result(
+            trials, config, "successive_halving", None, None, None, None, "exp"
+        )
+        # Trial 0 has best metric but was pruned; best should be trial 1
+        assert result.best_trial_number == 1
+        assert result.best_metrics["accuracy"] == 0.85
+        # All trials (including pruned) are still in the result
+        assert len(result.all_trials) == 3
+
+
+# ---------------------------------------------------------------------------
+# Successive halving search
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessiveHalvingSearch:
+    """Tests for successive halving with Optuna's SuccessiveHalvingPruner."""
+
+    @pytest.mark.asyncio
+    async def test_successive_halving_prunes_trials(self) -> None:
+        """Successive halving actually prunes poor trials (not all run to completion)."""
+        import asyncio
+        from dataclasses import dataclass
+        from unittest.mock import AsyncMock, MagicMock
+
+        @dataclass
+        class FakeTrainResult:
+            metrics: dict
+            model_version: object = None
+            training_time_seconds: float = 0.1
+            data_shape: tuple = (100, 2)
+            registered: bool = False
+            threshold_met: bool = True
+
+        # Track how many train calls happen per trial
+        call_log: list[str] = []
+
+        trial_metrics: dict[int, float] = {}
+        call_counter = 0
+
+        async def fake_train(
+            data, schema, model_spec, eval_spec, experiment_name, **kwargs
+        ):
+            nonlocal call_counter
+            call_counter += 1
+            call_log.append(experiment_name)
+            # Extract trial number from experiment name
+            # Format: "exp_trial_{N}_rung_{S}"
+            parts = experiment_name.split("_")
+            trial_idx = int(parts[parts.index("trial") + 1])
+            rung_idx = int(parts[parts.index("rung") + 1])
+
+            # Give deterministic but varied accuracy:
+            # Even trials get high accuracy, odd trials get low accuracy.
+            # This ensures the pruner has signal to prune odd trials.
+            if trial_idx % 2 == 0:
+                acc = 0.9 + rung_idx * 0.01
+            else:
+                acc = 0.3 + rung_idx * 0.01
+
+            return FakeTrainResult(metrics={"accuracy": acc})
+
+        pipeline = MagicMock()
+        pipeline.train = fake_train
+
+        hs = HyperparameterSearch(pipeline)
+
+        import polars as pl
+
+        data = pl.DataFrame(
+            {"f1": list(range(200)), "f2": list(range(200)), "target": [0, 1] * 100}
+        )
+
+        schema = MagicMock()
+        base_model_spec = MagicMock()
+        base_model_spec.model_class = "sklearn.ensemble.RandomForestClassifier"
+        base_model_spec.hyperparameters = {}
+        base_model_spec.framework = "sklearn"
+
+        search_space = SearchSpace(
+            [ParamDistribution("n_estimators", "int_uniform", low=10, high=200)]
+        )
+
+        # Use enough trials that pruning has a chance to kick in.
+        # SuccessiveHalvingPruner needs a few initial trials before it prunes.
+        config = SearchConfig(
+            strategy="successive_halving",
+            n_trials=20,
+            metric_to_optimize="accuracy",
+            direction="maximize",
+        )
+
+        eval_spec = MagicMock()
+
+        result = await hs._successive_halving_search(
+            data, schema, base_model_spec, search_space, config, eval_spec, "exp"
+        )
+
+        assert result.strategy == "successive_halving"
+        assert len(result.all_trials) == 20
+
+        pruned_trials = [t for t in result.all_trials if t.pruned]
+        completed_trials = [t for t in result.all_trials if not t.pruned]
+
+        # The pruner should have pruned at least some trials
+        assert (
+            len(pruned_trials) > 0
+        ), "Successive halving should prune at least some trials"
+
+        # Pruned trials should have fewer train calls (fewer rungs) than
+        # completed trials (4 rungs each). Total calls < 20 * 4 = 80.
+        max_calls_without_pruning = 20 * 4
+        assert call_counter < max_calls_without_pruning, (
+            f"Expected fewer train calls than {max_calls_without_pruning} "
+            f"due to pruning, got {call_counter}"
+        )
+
+        # Best trial should NOT be pruned
+        assert not result.all_trials[result.best_trial_number].pruned
+
+        # Best trial should come from completed trials
+        assert result.best_trial_number in {t.trial_number for t in completed_trials}

--- a/packages/kailash-ml/tests/unit/test_inference_server.py
+++ b/packages/kailash-ml/tests/unit/test_inference_server.py
@@ -1,0 +1,371 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for InferenceServer feature validation (strict mode).
+
+Covers the fix for #335: silent 0.0 default for missing features.
+Tier 1 (unit) -- mocking allowed for registry/model internals.
+"""
+from __future__ import annotations
+
+import logging
+import pickle
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+from sklearn.ensemble import RandomForestClassifier
+
+from kailash_ml.engines.inference_server import (
+    InferenceServer,
+    PredictionResult,
+    _CachedModel,
+)
+from kailash_ml.types import FeatureField, FeatureSchema, ModelSignature
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_signature(*feature_names: str) -> ModelSignature:
+    """Build a minimal ModelSignature with the given feature names."""
+    return ModelSignature(
+        input_schema=FeatureSchema(
+            "input",
+            [FeatureField(name, "float64") for name in feature_names],
+            "id",
+        ),
+        output_columns=["prediction"],
+        output_dtypes=["int64"],
+        model_type="classifier",
+    )
+
+
+def _make_trained_model() -> RandomForestClassifier:
+    """Return a tiny trained RF for testing."""
+    model = RandomForestClassifier(n_estimators=5, random_state=42)
+    X = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+    y = np.array([0, 1, 0, 1])
+    model.fit(X, y)
+    return model
+
+
+def _make_cached_entry(
+    model: Any,
+    signature: ModelSignature,
+    name: str = "test_model",
+) -> _CachedModel:
+    return _CachedModel(
+        model=model,
+        onnx_session=None,
+        version=1,
+        name=name,
+        signature=signature,
+        framework="sklearn",
+        inference_path="native",
+    )
+
+
+def _make_server_with_model(model: Any, signature: ModelSignature) -> InferenceServer:
+    """Create an InferenceServer backed by a mock registry that returns
+    the given model and signature."""
+    entry = _make_cached_entry(model, signature)
+    registry = MagicMock()
+    server = InferenceServer(registry, cache_size=5)
+    # Pre-populate cache so _get_model never hits the registry
+    server._cache.put(f"test_model:v1", entry)
+    # Mock _get_model to return our cached entry directly
+    server._get_model = AsyncMock(return_value=entry)
+    return server
+
+
+# ---------------------------------------------------------------------------
+# _validate_features (static method -- no async needed)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFeatures:
+    """Direct tests for the static _validate_features method."""
+
+    def test_complete_features_passes(self) -> None:
+        """No error when all features present with numeric values."""
+        InferenceServer._validate_features(
+            {"a": 1.0, "b": 2.0}, ["a", "b"], strict=True
+        )
+
+    def test_missing_features_strict_raises(self) -> None:
+        """strict=True raises ValueError listing missing features."""
+        with pytest.raises(ValueError, match="Missing required features.*feature_b"):
+            InferenceServer._validate_features(
+                {"feature_a": 1.0}, ["feature_a", "feature_b"], strict=True
+            )
+
+    def test_missing_multiple_features_strict_lists_all(self) -> None:
+        """Error message lists all missing features, not just the first."""
+        with pytest.raises(ValueError, match="feature_b") as exc_info:
+            InferenceServer._validate_features(
+                {"feature_a": 1.0},
+                ["feature_a", "feature_b", "feature_c"],
+                strict=True,
+            )
+        assert "feature_c" in str(exc_info.value)
+
+    def test_missing_features_nonstrict_logs_warning(self, caplog) -> None:
+        """strict=False logs a warning instead of raising."""
+        with caplog.at_level(logging.WARNING):
+            InferenceServer._validate_features(
+                {"feature_a": 1.0},
+                ["feature_a", "feature_b"],
+                strict=False,
+            )
+        assert "Missing required features" in caplog.text
+        assert "feature_b" in caplog.text
+        assert "substituting 0.0" in caplog.text
+
+    def test_non_numeric_value_strict_raises(self) -> None:
+        """strict=True raises ValueError for non-numeric values."""
+        with pytest.raises(ValueError, match="Non-numeric feature values.*feature_a"):
+            InferenceServer._validate_features(
+                {"feature_a": "not_a_number", "feature_b": 2.0},
+                ["feature_a", "feature_b"],
+                strict=True,
+            )
+
+    def test_non_numeric_value_nonstrict_logs_warning(self, caplog) -> None:
+        """strict=False logs a warning for non-numeric values."""
+        with caplog.at_level(logging.WARNING):
+            InferenceServer._validate_features(
+                {"feature_a": "bad", "feature_b": 2.0},
+                ["feature_a", "feature_b"],
+                strict=False,
+            )
+        assert "Non-numeric feature values" in caplog.text
+
+    def test_none_value_strict_raises(self) -> None:
+        """None is not numeric -- strict=True raises."""
+        with pytest.raises(ValueError, match="Non-numeric"):
+            InferenceServer._validate_features(
+                {"a": None, "b": 2.0}, ["a", "b"], strict=True
+            )
+
+    def test_int_values_accepted(self) -> None:
+        """Integer values are valid numeric input."""
+        InferenceServer._validate_features({"a": 1, "b": 2}, ["a", "b"], strict=True)
+
+    def test_bool_values_accepted(self) -> None:
+        """Boolean values are valid (bool is subclass of int in Python)."""
+        InferenceServer._validate_features(
+            {"a": True, "b": False}, ["a", "b"], strict=True
+        )
+
+    def test_numpy_scalar_accepted(self) -> None:
+        """numpy scalars are valid numeric input."""
+        InferenceServer._validate_features(
+            {"a": np.float64(1.5), "b": np.int32(3)}, ["a", "b"], strict=True
+        )
+
+    def test_string_numeric_accepted(self) -> None:
+        """String that can be parsed as float is accepted (e.g. '1.5')."""
+        InferenceServer._validate_features(
+            {"a": "1.5", "b": 2.0}, ["a", "b"], strict=True
+        )
+
+    def test_record_index_in_error(self) -> None:
+        """record_index is included in the error message for batch diagnostics."""
+        with pytest.raises(ValueError, match="record index 3"):
+            InferenceServer._validate_features(
+                {"feature_a": 1.0},
+                ["feature_a", "feature_b"],
+                strict=True,
+                record_index=3,
+            )
+
+    def test_empty_features_raises(self) -> None:
+        """Empty feature dict with non-empty expected list raises."""
+        with pytest.raises(ValueError, match="Missing required features"):
+            InferenceServer._validate_features(
+                {}, ["feature_a", "feature_b"], strict=True
+            )
+
+    def test_extra_features_ignored(self) -> None:
+        """Extra features beyond expected are silently ignored (no error)."""
+        InferenceServer._validate_features(
+            {"a": 1.0, "b": 2.0, "extra": 3.0}, ["a", "b"], strict=True
+        )
+
+    def test_list_value_strict_raises(self) -> None:
+        """List values are non-numeric."""
+        with pytest.raises(ValueError, match="Non-numeric"):
+            InferenceServer._validate_features(
+                {"a": [1, 2, 3], "b": 2.0}, ["a", "b"], strict=True
+            )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_feature_names
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFeatureNames:
+    """Tests for feature name resolution from model signature."""
+
+    def test_with_signature(self) -> None:
+        sig = _make_signature("x", "y", "z")
+        entry = _make_cached_entry(None, sig)
+        names = InferenceServer._resolve_feature_names(entry, {"a": 1})
+        assert names == ["x", "y", "z"]
+
+    def test_without_signature_uses_feature_keys(self) -> None:
+        entry = _CachedModel(
+            model=None,
+            onnx_session=None,
+            version=1,
+            name="test",
+            signature=None,
+            framework="sklearn",
+            inference_path="native",
+        )
+        names = InferenceServer._resolve_feature_names(
+            entry, {"col_a": 1.0, "col_b": 2.0}
+        )
+        assert names == ["col_a", "col_b"]
+
+
+# ---------------------------------------------------------------------------
+# predict() end-to-end (async, with mock registry)
+# ---------------------------------------------------------------------------
+
+
+class TestPredictStrict:
+    """Test predict() with strict=True (default)."""
+
+    @pytest.fixture
+    def server(self) -> InferenceServer:
+        model = _make_trained_model()
+        sig = _make_signature("feature_a", "feature_b")
+        return _make_server_with_model(model, sig)
+
+    @pytest.mark.asyncio
+    async def test_complete_features_succeeds(self, server) -> None:
+        result = await server.predict(
+            "test_model", {"feature_a": 1.0, "feature_b": 2.0}
+        )
+        assert isinstance(result, PredictionResult)
+        assert result.prediction in (0, 1)
+        assert result.model_name == "test_model"
+
+    @pytest.mark.asyncio
+    async def test_missing_feature_raises_valueerror(self, server) -> None:
+        with pytest.raises(ValueError, match="Missing required features.*feature_b"):
+            await server.predict("test_model", {"feature_a": 1.0})
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_feature_raises_valueerror(self, server) -> None:
+        with pytest.raises(ValueError, match="Non-numeric"):
+            await server.predict("test_model", {"feature_a": "bad", "feature_b": 2.0})
+
+    @pytest.mark.asyncio
+    async def test_empty_features_raises_valueerror(self, server) -> None:
+        with pytest.raises(ValueError, match="Missing required features"):
+            await server.predict("test_model", {})
+
+
+class TestPredictNonStrict:
+    """Test predict() with strict=False (legacy behaviour)."""
+
+    @pytest.fixture
+    def server(self) -> InferenceServer:
+        model = _make_trained_model()
+        sig = _make_signature("feature_a", "feature_b")
+        return _make_server_with_model(model, sig)
+
+    @pytest.mark.asyncio
+    async def test_missing_feature_falls_back_to_zero(self, server, caplog) -> None:
+        """Missing feature produces a prediction (using 0.0 fallback)."""
+        with caplog.at_level(logging.WARNING):
+            result = await server.predict(
+                "test_model", {"feature_a": 1.0}, strict=False
+            )
+        assert isinstance(result, PredictionResult)
+        assert result.prediction in (0, 1)
+        assert "Missing required features" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_complete_features_still_works(self, server) -> None:
+        result = await server.predict(
+            "test_model",
+            {"feature_a": 1.0, "feature_b": 2.0},
+            strict=False,
+        )
+        assert isinstance(result, PredictionResult)
+
+
+# ---------------------------------------------------------------------------
+# predict_batch() end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestPredictBatchStrict:
+    """Test predict_batch() with strict=True (default)."""
+
+    @pytest.fixture
+    def server(self) -> InferenceServer:
+        model = _make_trained_model()
+        sig = _make_signature("feature_a", "feature_b")
+        return _make_server_with_model(model, sig)
+
+    @pytest.mark.asyncio
+    async def test_complete_batch_succeeds(self, server) -> None:
+        records = [
+            {"feature_a": 1.0, "feature_b": 2.0},
+            {"feature_a": 3.0, "feature_b": 4.0},
+        ]
+        results = await server.predict_batch("test_model", records)
+        assert len(results) == 2
+        for r in results:
+            assert isinstance(r, PredictionResult)
+
+    @pytest.mark.asyncio
+    async def test_missing_feature_in_batch_raises(self, server) -> None:
+        records = [
+            {"feature_a": 1.0, "feature_b": 2.0},
+            {"feature_a": 3.0},  # missing feature_b
+        ]
+        with pytest.raises(ValueError, match="record index 1"):
+            await server.predict_batch("test_model", records)
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_in_batch_raises(self, server) -> None:
+        records = [
+            {"feature_a": "bad", "feature_b": 2.0},
+        ]
+        with pytest.raises(ValueError, match="Non-numeric"):
+            await server.predict_batch("test_model", records)
+
+    @pytest.mark.asyncio
+    async def test_empty_batch_returns_empty(self, server) -> None:
+        results = await server.predict_batch("test_model", [])
+        assert results == []
+
+
+class TestPredictBatchNonStrict:
+    """Test predict_batch() with strict=False."""
+
+    @pytest.fixture
+    def server(self) -> InferenceServer:
+        model = _make_trained_model()
+        sig = _make_signature("feature_a", "feature_b")
+        return _make_server_with_model(model, sig)
+
+    @pytest.mark.asyncio
+    async def test_missing_feature_falls_back(self, server, caplog) -> None:
+        records = [
+            {"feature_a": 1.0},  # missing feature_b
+            {"feature_a": 3.0, "feature_b": 4.0},
+        ]
+        with caplog.at_level(logging.WARNING):
+            results = await server.predict_batch("test_model", records, strict=False)
+        assert len(results) == 2
+        assert "Missing required features" in caplog.text

--- a/packages/kailash-ml/tests/unit/test_model_explainer.py
+++ b/packages/kailash-ml/tests/unit/test_model_explainer.py
@@ -1,0 +1,362 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ModelExplainer -- SHAP-based model explainability (#328)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import polars as pl
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+
+shap = pytest.importorskip("shap")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def clf_data() -> tuple[pl.DataFrame, RandomForestClassifier, list[str]]:
+    """Binary classification dataset with fitted RandomForestClassifier.
+
+    Returns (polars DataFrame of features, fitted model, feature names).
+    """
+    X_np, y_np = make_classification(
+        n_samples=100, n_features=5, n_informative=3, random_state=42
+    )
+    feature_names = [f"feat_{i}" for i in range(5)]
+    df = pl.DataFrame({name: X_np[:, i] for i, name in enumerate(feature_names)})
+    model = RandomForestClassifier(n_estimators=10, random_state=42)
+    model.fit(X_np, y_np)
+    return df, model, feature_names
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestModelExplainerInit:
+    """Tests for ModelExplainer initialization."""
+
+    def test_creates_from_polars_dataframe(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        assert explainer._feature_names == names
+
+    def test_custom_feature_names(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, _ = clf_data
+        custom = ["a", "b", "c", "d", "e"]
+        explainer = ModelExplainer(model, df, feature_names=custom)
+        assert explainer._feature_names == custom
+
+    def test_rejects_non_polars_data(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        _, model, _ = clf_data
+        with pytest.raises(TypeError, match="polars DataFrame"):
+            ModelExplainer(model, [[1, 2], [3, 4]])  # type: ignore[arg-type]
+
+    def test_lazy_import_from_package(self) -> None:
+        from kailash_ml import ModelExplainer
+        from kailash_ml.engines.model_explainer import (
+            ModelExplainer as DirectExplainer,
+        )
+
+        assert ModelExplainer is DirectExplainer
+
+
+# ---------------------------------------------------------------------------
+# explain_global
+# ---------------------------------------------------------------------------
+
+
+class TestExplainGlobal:
+    """Tests for ModelExplainer.explain_global()."""
+
+    def test_returns_expected_keys(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_global()
+        assert "shap_values" in result
+        assert "feature_importance" in result
+        assert "feature_names" in result
+
+    def test_shap_values_shape(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_global()
+        shap_vals = result["shap_values"]
+        assert shap_vals.shape == (100, 5)
+
+    def test_feature_importance_is_dict(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_global()
+        importance = result["feature_importance"]
+        assert isinstance(importance, dict)
+        assert len(importance) == 5
+        # All values should be non-negative
+        for val in importance.values():
+            assert val >= 0.0
+
+    def test_max_display_limits_features(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_global(max_display=3)
+        assert len(result["feature_importance"]) == 3
+
+    def test_feature_names_match(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_global()
+        assert result["feature_names"] == names
+
+
+# ---------------------------------------------------------------------------
+# explain_local
+# ---------------------------------------------------------------------------
+
+
+class TestExplainLocal:
+    """Tests for ModelExplainer.explain_local()."""
+
+    def test_returns_expected_keys(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_local(df)
+        assert "shap_values" in result
+        assert "base_value" in result
+        assert "feature_values" in result
+        assert "feature_names" in result
+
+    def test_shap_values_shape_single_row(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_local(df, index=0)
+        assert result["shap_values"].shape == (5,)
+
+    def test_feature_values_match_input(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_local(df, index=2)
+        expected = df.row(2)
+        for i, val in enumerate(expected):
+            assert result["feature_values"][i] == pytest.approx(val, abs=1e-10)
+
+    def test_base_value_is_scalar(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_local(df)
+        assert isinstance(result["base_value"], float)
+
+    def test_index_out_of_range_raises(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        with pytest.raises(IndexError, match="out of range"):
+            explainer.explain_local(df, index=999)
+
+    def test_rejects_non_polars(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        with pytest.raises(TypeError, match="polars DataFrame"):
+            explainer.explain_local(np.zeros((5, 5)))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# explain_dependence
+# ---------------------------------------------------------------------------
+
+
+class TestExplainDependence:
+    """Tests for ModelExplainer.explain_dependence()."""
+
+    def test_returns_expected_keys(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_dependence("feat_0")
+        assert "feature_values" in result
+        assert "shap_values" in result
+        assert "interaction_values" in result
+
+    def test_feature_values_shape(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_dependence("feat_0")
+        assert result["feature_values"].shape == (100,)
+        assert result["shap_values"].shape == (100,)
+
+    def test_no_interaction_returns_none(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_dependence("feat_0")
+        assert result["interaction_values"] is None
+
+    def test_with_interaction_feature(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        result = explainer.explain_dependence("feat_0", interaction_feature="feat_1")
+        assert result["interaction_values"] is not None
+        assert result["interaction_values"].shape == (100,)
+
+    def test_unknown_feature_raises(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        with pytest.raises(ValueError, match="not found"):
+            explainer.explain_dependence("nonexistent")
+
+    def test_unknown_interaction_feature_raises(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        with pytest.raises(ValueError, match="not found"):
+            explainer.explain_dependence("feat_0", interaction_feature="bad")
+
+
+# ---------------------------------------------------------------------------
+# to_plotly
+# ---------------------------------------------------------------------------
+
+
+class TestToPlotly:
+    """Tests for ModelExplainer.to_plotly()."""
+
+    def test_summary_returns_figure(self, clf_data) -> None:
+        import plotly.graph_objects as go
+
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        fig = explainer.to_plotly("summary")
+        assert isinstance(fig, go.Figure)
+        assert "SHAP" in fig.layout.title.text
+
+    def test_beeswarm_returns_figure(self, clf_data) -> None:
+        import plotly.graph_objects as go
+
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        fig = explainer.to_plotly("beeswarm")
+        assert isinstance(fig, go.Figure)
+        assert "Beeswarm" in fig.layout.title.text
+
+    def test_dependence_returns_figure(self, clf_data) -> None:
+        import plotly.graph_objects as go
+
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        fig = explainer.to_plotly("dependence", feature="feat_0")
+        assert isinstance(fig, go.Figure)
+        assert "feat_0" in fig.layout.title.text
+
+    def test_dependence_without_feature_raises(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        with pytest.raises(ValueError, match="requires a 'feature'"):
+            explainer.to_plotly("dependence")
+
+    def test_unknown_plot_type_raises(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        with pytest.raises(ValueError, match="Unknown plot_type"):
+            explainer.to_plotly("nonexistent")
+
+    def test_summary_max_display(self, clf_data) -> None:
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        fig = explainer.to_plotly("summary", max_display=3)
+        # Horizontal bar chart should have 3 bars
+        assert len(fig.data[0].y) == 3
+
+    def test_dependence_with_interaction(self, clf_data) -> None:
+        import plotly.graph_objects as go
+
+        from kailash_ml.engines.model_explainer import ModelExplainer
+
+        df, model, names = clf_data
+        explainer = ModelExplainer(model, df)
+        fig = explainer.to_plotly(
+            "dependence", feature="feat_0", interaction_feature="feat_1"
+        )
+        assert isinstance(fig, go.Figure)
+        assert "feat_1" in fig.layout.title.text
+
+
+# ---------------------------------------------------------------------------
+# ImportError when shap is not installed
+# ---------------------------------------------------------------------------
+
+
+class TestShapImportError:
+    """Test that a clear error is raised when shap is not installed."""
+
+    def test_import_error_message(self, clf_data) -> None:
+        df, model, _ = clf_data
+
+        with patch.dict("sys.modules", {"shap": None}):
+            # Re-import to trigger the import check
+            import importlib
+
+            from kailash_ml.engines import model_explainer
+
+            importlib.reload(model_explainer)
+
+            with pytest.raises(
+                ImportError, match="pip install kailash-ml\\[explain\\]"
+            ):
+                model_explainer.ModelExplainer(model, df)
+
+            # Restore module so other tests are unaffected
+            importlib.reload(model_explainer)

--- a/packages/kailash-ml/tests/unit/test_preprocessing.py
+++ b/packages/kailash-ml/tests/unit/test_preprocessing.py
@@ -773,3 +773,602 @@ class TestCardinalityGuard:
         # Same encoding should be applied
         id_onehot = [c for c in test_cols if c.startswith("id_")]
         assert len(id_onehot) == 0
+
+
+# ---------------------------------------------------------------------------
+# Normalization methods (#330)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizationMethods:
+    """Tests for normalize_method parameter (#330)."""
+
+    @pytest.fixture()
+    def norm_df(self) -> pl.DataFrame:
+        """DataFrame with known numeric values for normalization checks."""
+        return pl.DataFrame(
+            {
+                "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+                "b": [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0],
+                "target": list(range(10)),
+            }
+        )
+
+    def test_zscore_approximately_zero_mean_unit_var(
+        self, norm_df: pl.DataFrame
+    ) -> None:
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            norm_df, "target", normalize=True, normalize_method="zscore"
+        )
+        combined = pl.concat([result.train_data, result.test_data])
+        for col in ["a", "b"]:
+            mean_val = combined[col].mean()
+            std_val = combined[col].std()
+            assert mean_val is not None and abs(mean_val) < 0.5
+            assert std_val is not None and abs(std_val - 1.0) < 0.5
+
+    def test_minmax_range_zero_to_one(self, norm_df: pl.DataFrame) -> None:
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            norm_df, "target", normalize=True, normalize_method="minmax"
+        )
+        combined = pl.concat([result.train_data, result.test_data])
+        for col in ["a", "b"]:
+            min_val = combined[col].min()
+            max_val = combined[col].max()
+            assert min_val is not None and min_val >= -0.01
+            assert max_val is not None and max_val <= 1.01
+
+    def test_robust_uses_median_centering(self, norm_df: pl.DataFrame) -> None:
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            norm_df, "target", normalize=True, normalize_method="robust"
+        )
+        combined = pl.concat([result.train_data, result.test_data])
+        for col in ["a", "b"]:
+            median_val = combined[col].median()
+            # RobustScaler centers on median; after transform the median
+            # of the full dataset should be close to 0
+            assert median_val is not None and abs(median_val) < 0.5
+
+    def test_maxabs_range_minus_one_to_one(self, norm_df: pl.DataFrame) -> None:
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            norm_df, "target", normalize=True, normalize_method="maxabs"
+        )
+        combined = pl.concat([result.train_data, result.test_data])
+        for col in ["a", "b"]:
+            min_val = combined[col].min()
+            max_val = combined[col].max()
+            assert min_val is not None and min_val >= -1.01
+            assert max_val is not None and max_val <= 1.01
+
+    def test_invalid_normalize_method_raises(self, norm_df: pl.DataFrame) -> None:
+        pipeline = PreprocessingPipeline()
+        with pytest.raises(ValueError, match="normalize_method"):
+            pipeline.setup(norm_df, "target", normalize_method="invalid")
+
+    def test_scaler_stored_in_transformers(self, norm_df: pl.DataFrame) -> None:
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            norm_df, "target", normalize=True, normalize_method="minmax"
+        )
+        assert "scaler" in result.transformers
+        from sklearn.preprocessing import MinMaxScaler
+
+        assert isinstance(result.transformers["scaler"], MinMaxScaler)
+
+    def test_transform_uses_fitted_scaler(self, norm_df: pl.DataFrame) -> None:
+        """transform() on new data uses the same scaler fitted during setup."""
+        pipeline = PreprocessingPipeline()
+        pipeline.setup(norm_df, "target", normalize=True, normalize_method="minmax")
+        new_data = norm_df.head(3)
+        transformed = pipeline.transform(new_data)
+        for col in ["a", "b"]:
+            min_val = transformed[col].min()
+            max_val = transformed[col].max()
+            assert min_val is not None and min_val >= -0.01
+            assert max_val is not None and max_val <= 1.01
+
+
+# ---------------------------------------------------------------------------
+# Advanced imputation (#331)
+# ---------------------------------------------------------------------------
+
+
+class TestAdvancedImputation:
+    """Tests for KNN and iterative imputation (#331)."""
+
+    @pytest.fixture()
+    def impute_df(self) -> pl.DataFrame:
+        """DataFrame with nulls for advanced imputation testing."""
+        return pl.DataFrame(
+            {
+                "a": [1.0, None, 3.0, None, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+                "b": [10.0, 20.0, None, 40.0, 50.0, None, 70.0, 80.0, 90.0, 100.0],
+                "cat": ["x", None, "y", "x", "y", "x", None, "y", "x", "y"],
+                "target": [0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+            }
+        )
+
+    def test_knn_fills_nulls(self, impute_df: pl.DataFrame) -> None:
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            impute_df,
+            "target",
+            imputation_strategy="knn",
+            normalize=False,
+        )
+        combined = pl.concat([result.train_data, result.test_data])
+        for col in ["a", "b"]:
+            assert combined[col].null_count() == 0
+
+    def test_knn_categorical_gets_mode(self, impute_df: pl.DataFrame) -> None:
+        """Categorical columns still receive mode imputation under knn."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            impute_df,
+            "target",
+            imputation_strategy="knn",
+            categorical_encoding="ordinal",
+            normalize=False,
+        )
+        combined = pl.concat([result.train_data, result.test_data])
+        # cat column should have no nulls after encoding
+        assert combined["cat"].null_count() == 0
+
+    def test_knn_n_neighbors(self, impute_df: pl.DataFrame) -> None:
+        """Custom n_neighbors is respected."""
+        pipeline = PreprocessingPipeline()
+        pipeline.setup(
+            impute_df,
+            "target",
+            imputation_strategy="knn",
+            impute_n_neighbors=3,
+            normalize=False,
+        )
+        imputer = pipeline._transformers["sklearn_imputer"]
+        assert imputer.n_neighbors == 3
+
+    def test_iterative_fills_nulls(self, impute_df: pl.DataFrame) -> None:
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            impute_df,
+            "target",
+            imputation_strategy="iterative",
+            normalize=False,
+        )
+        combined = pl.concat([result.train_data, result.test_data])
+        for col in ["a", "b"]:
+            assert combined[col].null_count() == 0
+
+    def test_iterative_categorical_gets_mode(self, impute_df: pl.DataFrame) -> None:
+        """Categorical columns still receive mode imputation under iterative."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            impute_df,
+            "target",
+            imputation_strategy="iterative",
+            categorical_encoding="ordinal",
+            normalize=False,
+        )
+        combined = pl.concat([result.train_data, result.test_data])
+        assert combined["cat"].null_count() == 0
+
+    def test_knn_transform_uses_fitted_imputer(self, impute_df: pl.DataFrame) -> None:
+        """transform() on new data uses the fitted KNN imputer."""
+        pipeline = PreprocessingPipeline()
+        pipeline.setup(
+            impute_df,
+            "target",
+            imputation_strategy="knn",
+            categorical_encoding="ordinal",
+            normalize=False,
+        )
+        new_data = pl.DataFrame(
+            {
+                "a": [None, 4.0, 6.0],
+                "b": [30.0, None, 80.0],
+                "cat": ["x", "y", "x"],
+                "target": [0, 1, 0],
+            }
+        )
+        transformed = pipeline.transform(new_data)
+        for col in ["a", "b"]:
+            assert transformed[col].null_count() == 0
+
+    def test_iterative_transform_uses_fitted_imputer(
+        self, impute_df: pl.DataFrame
+    ) -> None:
+        """transform() on new data uses the fitted iterative imputer."""
+        pipeline = PreprocessingPipeline()
+        pipeline.setup(
+            impute_df,
+            "target",
+            imputation_strategy="iterative",
+            categorical_encoding="ordinal",
+            normalize=False,
+        )
+        new_data = pl.DataFrame(
+            {
+                "a": [None, 4.0, 6.0],
+                "b": [30.0, None, 80.0],
+                "cat": ["x", "y", "x"],
+                "target": [0, 1, 0],
+            }
+        )
+        transformed = pipeline.transform(new_data)
+        for col in ["a", "b"]:
+            assert transformed[col].null_count() == 0
+
+    def test_sklearn_imputer_stored(self, impute_df: pl.DataFrame) -> None:
+        """The fitted sklearn imputer is stored in transformers."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            impute_df,
+            "target",
+            imputation_strategy="knn",
+            normalize=False,
+        )
+        assert "sklearn_imputer" in result.transformers
+        from sklearn.impute import KNNImputer
+
+        assert isinstance(result.transformers["sklearn_imputer"], KNNImputer)
+
+
+# ---------------------------------------------------------------------------
+# Multicollinearity removal (#332)
+# ---------------------------------------------------------------------------
+
+
+class TestMulticollinearityRemoval:
+    """Tests for remove_multicollinearity parameter (#332)."""
+
+    def test_highly_correlated_feature_dropped(self) -> None:
+        """When two features are nearly identical, the one with lower
+        target correlation is dropped."""
+        rng = np.random.RandomState(42)
+        n = 200
+        base = rng.randn(n)
+        target = (base > 0).astype(int)
+        df = pl.DataFrame(
+            {
+                "feat_a": base.tolist(),
+                # feat_b is a near-perfect copy of feat_a (r ~ 1.0)
+                "feat_b": (base + rng.randn(n) * 0.001).tolist(),
+                # feat_c is independent
+                "feat_c": rng.randn(n).tolist(),
+                "target": target.tolist(),
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            df,
+            "target",
+            normalize=False,
+            remove_multicollinearity=True,
+            multicollinearity_threshold=0.9,
+        )
+        dropped = result.transformers.get("multicollinear_dropped", [])
+        # One of feat_a / feat_b should be dropped
+        assert len(dropped) == 1
+        assert dropped[0] in ("feat_a", "feat_b")
+        # The dropped column should not be in train or test data
+        assert dropped[0] not in result.train_data.columns
+        assert dropped[0] not in result.test_data.columns
+        # feat_c (independent) should be kept
+        assert "feat_c" in result.train_data.columns
+
+    def test_weakly_correlated_features_kept(self) -> None:
+        """Features below the threshold are not removed."""
+        rng = np.random.RandomState(42)
+        n = 200
+        df = pl.DataFrame(
+            {
+                "feat_a": rng.randn(n).tolist(),
+                "feat_b": rng.randn(n).tolist(),
+                "target": rng.randint(0, 2, n).tolist(),
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            df,
+            "target",
+            normalize=False,
+            remove_multicollinearity=True,
+            multicollinearity_threshold=0.9,
+        )
+        dropped = result.transformers.get("multicollinear_dropped", [])
+        assert len(dropped) == 0
+        assert "feat_a" in result.train_data.columns
+        assert "feat_b" in result.train_data.columns
+
+    def test_disabled_by_default(self) -> None:
+        """Multicollinearity removal is off by default."""
+        rng = np.random.RandomState(42)
+        n = 100
+        base = rng.randn(n)
+        df = pl.DataFrame(
+            {
+                "feat_a": base.tolist(),
+                "feat_b": base.tolist(),  # perfect copy
+                "target": rng.randint(0, 2, n).tolist(),
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(df, "target", normalize=False)
+        # Both columns should still be present
+        assert "feat_a" in result.train_data.columns
+        assert "feat_b" in result.train_data.columns
+
+    def test_transform_drops_same_columns(self) -> None:
+        """transform() on new data drops the same columns that were
+        removed during setup."""
+        rng = np.random.RandomState(42)
+        n = 200
+        base = rng.randn(n)
+        df = pl.DataFrame(
+            {
+                "feat_a": base.tolist(),
+                "feat_b": (base + rng.randn(n) * 0.001).tolist(),
+                "feat_c": rng.randn(n).tolist(),
+                "target": rng.randint(0, 2, n).tolist(),
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        pipeline.setup(
+            df,
+            "target",
+            normalize=False,
+            remove_multicollinearity=True,
+            multicollinearity_threshold=0.9,
+        )
+        dropped = pipeline._transformers.get("multicollinear_dropped", [])
+        assert len(dropped) == 1
+
+        new_data = df.head(5)
+        transformed = pipeline.transform(new_data)
+        assert dropped[0] not in transformed.columns
+
+    def test_drops_column_with_lower_target_correlation(self) -> None:
+        """When two features are correlated, the one with lower
+        absolute target correlation is dropped."""
+        rng = np.random.RandomState(42)
+        n = 200
+        target = rng.randint(0, 2, n)
+        # feat_a has strong target correlation
+        feat_a = target.astype(float) + rng.randn(n) * 0.1
+        # feat_b is a near-copy of feat_a with small noise to keep
+        # inter-feature correlation above 0.9 while having slightly
+        # lower target correlation
+        feat_b = feat_a + rng.randn(n) * 0.05
+        df = pl.DataFrame(
+            {
+                "feat_a": feat_a.tolist(),
+                "feat_b": feat_b.tolist(),
+                "target": target.tolist(),
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            df,
+            "target",
+            normalize=False,
+            remove_multicollinearity=True,
+            multicollinearity_threshold=0.8,
+        )
+        dropped = result.transformers.get("multicollinear_dropped", [])
+        # feat_b has lower target correlation, so it should be dropped
+        assert dropped == ["feat_b"]
+
+    def test_single_feature_no_removal(self) -> None:
+        """With only one numeric feature, nothing can be removed."""
+        df = pl.DataFrame(
+            {
+                "feat": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+                "target": [0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            df,
+            "target",
+            normalize=False,
+            remove_multicollinearity=True,
+            multicollinearity_threshold=0.5,
+        )
+        dropped = result.transformers.get("multicollinear_dropped", [])
+        assert len(dropped) == 0
+
+    def test_multicollinear_dropped_in_config(self) -> None:
+        """Config reflects multicollinearity settings."""
+        df = pl.DataFrame(
+            {
+                "a": [1.0, 2.0, 3.0, 4.0, 5.0],
+                "target": [0, 1, 0, 1, 0],
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        pipeline.setup(
+            df,
+            "target",
+            normalize=False,
+            remove_multicollinearity=True,
+            multicollinearity_threshold=0.85,
+        )
+        config = pipeline.get_config()
+        assert config["remove_multicollinearity"] is True
+        assert config["multicollinearity_threshold"] == 0.85
+
+
+# ---------------------------------------------------------------------------
+# Class imbalance handling (#327)
+# ---------------------------------------------------------------------------
+
+
+class TestClassImbalance:
+    """Tests for fix_imbalance parameter (#327)."""
+
+    @pytest.fixture()
+    def imbalanced_df(self) -> pl.DataFrame:
+        """DataFrame with severe class imbalance (90/10 split)."""
+        rng = np.random.RandomState(42)
+        n_majority = 180
+        n_minority = 20
+        n = n_majority + n_minority
+        df = pl.DataFrame(
+            {
+                "feat_a": rng.randn(n).tolist(),
+                "feat_b": rng.randn(n).tolist(),
+                "target": ([0] * n_majority + [1] * n_minority),
+            }
+        )
+        return df
+
+    def test_class_weight_sets_flag(self, imbalanced_df: pl.DataFrame) -> None:
+        """class_weight method sets the flag without resampling."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            imbalanced_df,
+            "target",
+            normalize=False,
+            fix_imbalance=True,
+            imbalance_method="class_weight",
+        )
+        assert pipeline._use_balanced_class_weight is True
+        # No resampling -- row counts should match normal split
+        total = result.train_data.height + result.test_data.height
+        assert total == imbalanced_df.height
+
+    def test_class_weight_no_extra_dependency(
+        self, imbalanced_df: pl.DataFrame
+    ) -> None:
+        """class_weight works without imbalanced-learn installed."""
+        pipeline = PreprocessingPipeline()
+        # Should not raise ImportError
+        result = pipeline.setup(
+            imbalanced_df,
+            "target",
+            normalize=False,
+            fix_imbalance=True,
+            imbalance_method="class_weight",
+        )
+        assert result.train_data.height > 0
+
+    def test_fix_imbalance_disabled_by_default(
+        self, imbalanced_df: pl.DataFrame
+    ) -> None:
+        """Imbalance correction is off by default."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(imbalanced_df, "target", normalize=False)
+        assert pipeline._use_balanced_class_weight is False
+        # Train size should be the normal 80%
+        assert result.train_data.height == int(imbalanced_df.height * 0.8)
+
+    def test_fix_imbalance_skipped_for_regression(self) -> None:
+        """Imbalance correction is not applied for regression tasks."""
+        rng = np.random.RandomState(42)
+        n = 100
+        df = pl.DataFrame(
+            {
+                "feat": rng.randn(n).tolist(),
+                "target": rng.randn(n).tolist(),  # continuous -> regression
+            }
+        )
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            df,
+            "target",
+            normalize=False,
+            fix_imbalance=True,
+            imbalance_method="class_weight",
+        )
+        assert pipeline._use_balanced_class_weight is False
+        assert result.task_type == "regression"
+
+    def test_invalid_imbalance_method_raises(self, imbalanced_df: pl.DataFrame) -> None:
+        """Invalid imbalance_method raises ValueError."""
+        pipeline = PreprocessingPipeline()
+        with pytest.raises(ValueError, match="imbalance_method"):
+            pipeline.setup(
+                imbalanced_df,
+                "target",
+                fix_imbalance=True,
+                imbalance_method="invalid",
+            )
+
+    def test_imbalance_config_stored(self, imbalanced_df: pl.DataFrame) -> None:
+        """Config reflects imbalance settings."""
+        pipeline = PreprocessingPipeline()
+        pipeline.setup(
+            imbalanced_df,
+            "target",
+            normalize=False,
+            fix_imbalance=True,
+            imbalance_method="class_weight",
+        )
+        config = pipeline.get_config()
+        assert config["fix_imbalance"] is True
+        assert config["imbalance_method"] == "class_weight"
+
+    def test_summary_includes_imbalance(self, imbalanced_df: pl.DataFrame) -> None:
+        """Summary mentions imbalance correction."""
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            imbalanced_df,
+            "target",
+            normalize=False,
+            fix_imbalance=True,
+            imbalance_method="class_weight",
+        )
+        assert "class_weight" in result.summary
+
+    def test_smote_resamples_training_data(self, imbalanced_df: pl.DataFrame) -> None:
+        """SMOTE increases the minority class in training data."""
+        imblearn = pytest.importorskip("imblearn")  # noqa: F841
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            imbalanced_df,
+            "target",
+            normalize=False,
+            fix_imbalance=True,
+            imbalance_method="smote",
+        )
+        # After SMOTE, training data should have more rows
+        normal_train_size = int(imbalanced_df.height * 0.8)
+        assert result.train_data.height > normal_train_size
+        # Classes should be balanced in training data
+        class_counts = result.train_data["target"].value_counts()
+        counts = class_counts["count"].to_list()
+        assert counts[0] == counts[1]
+        # Test data should be unmodified
+        assert result.test_data.height == imbalanced_df.height - normal_train_size
+
+    def test_adasyn_resamples_training_data(self, imbalanced_df: pl.DataFrame) -> None:
+        """ADASYN increases the minority class in training data."""
+        imblearn = pytest.importorskip("imblearn")  # noqa: F841
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            imbalanced_df,
+            "target",
+            normalize=False,
+            fix_imbalance=True,
+            imbalance_method="adasyn",
+        )
+        normal_train_size = int(imbalanced_df.height * 0.8)
+        assert result.train_data.height > normal_train_size
+
+    def test_smote_only_on_train_not_test(self, imbalanced_df: pl.DataFrame) -> None:
+        """SMOTE modifies training data only; test data is untouched."""
+        imblearn = pytest.importorskip("imblearn")  # noqa: F841
+        pipeline = PreprocessingPipeline()
+        result = pipeline.setup(
+            imbalanced_df,
+            "target",
+            normalize=False,
+            fix_imbalance=True,
+            imbalance_method="smote",
+        )
+        expected_test = imbalanced_df.height - int(imbalanced_df.height * 0.8)
+        assert result.test_data.height == expected_test

--- a/packages/kailash-ml/tests/unit/test_training_splits.py
+++ b/packages/kailash-ml/tests/unit/test_training_splits.py
@@ -1,0 +1,247 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for TrainingPipeline split methods (kfold, stratified_kfold)."""
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from kailash_ml.engines.training_pipeline import EvalSpec, TrainingPipeline
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline() -> TrainingPipeline:
+    """Construct a TrainingPipeline with no registry/feature_store.
+
+    The split methods are pure functions on the instance and don't need
+    a database connection or model registry.
+    """
+    return TrainingPipeline.__new__(TrainingPipeline)
+
+
+def _binary_df(n: int = 200, ratio: float = 0.3) -> pl.DataFrame:
+    """Create a DataFrame with imbalanced binary target."""
+    rng = np.random.RandomState(42)
+    n_pos = int(n * ratio)
+    n_neg = n - n_pos
+    target = [1] * n_pos + [0] * n_neg
+    return pl.DataFrame(
+        {
+            "feat_a": rng.randn(n).tolist(),
+            "feat_b": rng.randn(n).tolist(),
+            "target": target,
+        }
+    )
+
+
+def _multiclass_df(n: int = 300) -> pl.DataFrame:
+    """Create a DataFrame with 3-class target (uneven distribution)."""
+    rng = np.random.RandomState(42)
+    # 50% class-0, 30% class-1, 20% class-2
+    target = [0] * (n // 2) + [1] * (3 * n // 10) + [2] * (n - n // 2 - 3 * n // 10)
+    return pl.DataFrame(
+        {
+            "feat_a": rng.randn(n).tolist(),
+            "feat_b": rng.randn(n).tolist(),
+            "target": target,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# KFold
+# ---------------------------------------------------------------------------
+
+
+class TestKFoldSplit:
+    """Tests for _kfold_first_fold using sklearn.model_selection.KFold."""
+
+    def test_fold_sizes(self) -> None:
+        """Train and test sizes are correct for the first fold."""
+        pipe = _make_pipeline()
+        df = _binary_df(200)
+        train, test = pipe._kfold_first_fold(df, n_splits=5)
+        # 5-fold: test = 200/5 = 40, train = 160
+        assert test.height == 40
+        assert train.height == 160
+
+    def test_no_overlap(self) -> None:
+        """Train and test sets must not share any rows."""
+        pipe = _make_pipeline()
+        df = _binary_df(200)
+        train, test = pipe._kfold_first_fold(df, n_splits=5)
+        # Check feat_a+feat_b pairs -- each row has unique random values
+        train_keys = set(zip(train["feat_a"].to_list(), train["feat_b"].to_list()))
+        test_keys = set(zip(test["feat_a"].to_list(), test["feat_b"].to_list()))
+        assert train_keys.isdisjoint(test_keys)
+
+    def test_all_data_covered(self) -> None:
+        """Union of train + test equals original data (no data loss)."""
+        pipe = _make_pipeline()
+        df = _binary_df(200)
+        train, test = pipe._kfold_first_fold(df, n_splits=5)
+        assert train.height + test.height == df.height
+
+    def test_shuffle_changes_order(self) -> None:
+        """Shuffled kfold does not simply take the first N rows as test."""
+        pipe = _make_pipeline()
+        df = _binary_df(200)
+        _, test = pipe._kfold_first_fold(df, n_splits=5)
+        # The naive (unshuffled) approach would take rows 0..39
+        naive_test = df[:40]
+        # With shuffle=True and random_state=42, the test set should differ
+        assert not test["feat_a"].to_list() == naive_test["feat_a"].to_list()
+
+    def test_deterministic(self) -> None:
+        """Same data produces the same split every time."""
+        pipe = _make_pipeline()
+        df = _binary_df(200)
+        train1, test1 = pipe._kfold_first_fold(df, n_splits=5)
+        train2, test2 = pipe._kfold_first_fold(df, n_splits=5)
+        assert train1.equals(train2)
+        assert test1.equals(test2)
+
+
+# ---------------------------------------------------------------------------
+# Stratified KFold
+# ---------------------------------------------------------------------------
+
+
+class TestStratifiedKFoldSplit:
+    """Tests for _stratified_kfold_first_fold preserving class distribution."""
+
+    def test_binary_class_ratio_preserved(self) -> None:
+        """Binary target: class ratio in each split matches the original."""
+        pipe = _make_pipeline()
+        df = _binary_df(200, ratio=0.3)  # 30% positive
+        train, test = pipe._stratified_kfold_first_fold(
+            df, n_splits=5, target_col="target"
+        )
+
+        original_ratio = df["target"].mean()
+        train_ratio = train["target"].mean()
+        test_ratio = test["target"].mean()
+
+        # Stratified split should preserve ratio within a small tolerance
+        assert (
+            abs(train_ratio - original_ratio) < 0.05
+        ), f"Train ratio {train_ratio:.3f} deviates from original {original_ratio:.3f}"
+        assert (
+            abs(test_ratio - original_ratio) < 0.05
+        ), f"Test ratio {test_ratio:.3f} deviates from original {original_ratio:.3f}"
+
+    def test_multiclass_distribution_preserved(self) -> None:
+        """Multiclass target: each class proportion preserved in both splits."""
+        pipe = _make_pipeline()
+        df = _multiclass_df(300)  # 50/30/20 split
+        train, test = pipe._stratified_kfold_first_fold(
+            df, n_splits=5, target_col="target"
+        )
+
+        for cls_val in [0, 1, 2]:
+            original_frac = (df["target"] == cls_val).mean()
+            train_frac = (train["target"] == cls_val).mean()
+            test_frac = (test["target"] == cls_val).mean()
+            assert (
+                abs(train_frac - original_frac) < 0.05
+            ), f"Class {cls_val}: train {train_frac:.3f} vs original {original_frac:.3f}"
+            assert (
+                abs(test_frac - original_frac) < 0.05
+            ), f"Class {cls_val}: test {test_frac:.3f} vs original {original_frac:.3f}"
+
+    def test_fold_sizes(self) -> None:
+        """Train and test sizes are correct for the first fold."""
+        pipe = _make_pipeline()
+        df = _binary_df(200)
+        train, test = pipe._stratified_kfold_first_fold(
+            df, n_splits=5, target_col="target"
+        )
+        assert test.height == 40
+        assert train.height == 160
+
+    def test_no_overlap(self) -> None:
+        """Train and test sets must not share any rows."""
+        pipe = _make_pipeline()
+        df = _binary_df(200)
+        train, test = pipe._stratified_kfold_first_fold(
+            df, n_splits=5, target_col="target"
+        )
+        train_keys = set(zip(train["feat_a"].to_list(), train["feat_b"].to_list()))
+        test_keys = set(zip(test["feat_a"].to_list(), test["feat_b"].to_list()))
+        assert train_keys.isdisjoint(test_keys)
+
+    def test_deterministic(self) -> None:
+        """Same data produces the same split every time."""
+        pipe = _make_pipeline()
+        df = _binary_df(200)
+        train1, test1 = pipe._stratified_kfold_first_fold(
+            df, n_splits=5, target_col="target"
+        )
+        train2, test2 = pipe._stratified_kfold_first_fold(
+            df, n_splits=5, target_col="target"
+        )
+        assert train1.equals(train2)
+        assert test1.equals(test2)
+
+    def test_differs_from_regular_kfold(self) -> None:
+        """Stratified split should produce different indices than regular kfold."""
+        pipe = _make_pipeline()
+        # Highly imbalanced data -- stratification matters
+        df = _binary_df(200, ratio=0.1)  # Only 10% positive
+        train_reg, _ = pipe._kfold_first_fold(df, n_splits=5)
+        train_strat, _ = pipe._stratified_kfold_first_fold(
+            df, n_splits=5, target_col="target"
+        )
+        # The two should differ because stratification constrains the split
+        assert not train_reg["feat_a"].to_list() == train_strat["feat_a"].to_list()
+
+
+# ---------------------------------------------------------------------------
+# _split dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestSplitDispatcher:
+    """Tests for the _split method that routes to the correct strategy."""
+
+    def test_kfold_dispatch(self) -> None:
+        """split_strategy='kfold' routes to _kfold_first_fold."""
+        pipe = _make_pipeline()
+        df = _binary_df(100)
+        spec = EvalSpec(split_strategy="kfold", n_splits=5)
+        train, test = pipe._split(df, spec, target_col="target")
+        assert train.height + test.height == 100
+
+    def test_stratified_kfold_dispatch(self) -> None:
+        """split_strategy='stratified_kfold' routes to stratified method."""
+        pipe = _make_pipeline()
+        df = _binary_df(100, ratio=0.3)
+        spec = EvalSpec(split_strategy="stratified_kfold", n_splits=5)
+        train, test = pipe._split(df, spec, target_col="target")
+        assert train.height + test.height == 100
+        # Verify stratification preserved class ratio
+        original_ratio = df["target"].mean()
+        test_ratio = test["target"].mean()
+        assert abs(test_ratio - original_ratio) < 0.1
+
+    def test_holdout_dispatch(self) -> None:
+        """split_strategy='holdout' still works with target_col param."""
+        pipe = _make_pipeline()
+        df = _binary_df(100)
+        spec = EvalSpec(split_strategy="holdout", test_size=0.2)
+        train, test = pipe._split(df, spec, target_col="target")
+        assert test.height == 20
+        assert train.height == 80
+
+    def test_unknown_strategy_raises(self) -> None:
+        """Unknown split strategy raises ValueError."""
+        pipe = _make_pipeline()
+        df = _binary_df(100)
+        spec = EvalSpec(split_strategy="invalid")
+        with pytest.raises(ValueError, match="Unknown split strategy"):
+            pipe._split(df, spec, target_col="target")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ pact = [
     "kailash-pact>=0.8.0",
 ]
 ml = [
-    "kailash-ml>=0.6.0",
+    "kailash-ml>=0.7.0",
 ]
 align = [
     "kailash-align>=0.3.0",
@@ -144,7 +144,7 @@ all = [
     "kailash-kaizen>=2.5.0",
     "kaizen-agents>=0.7.0",
     "kailash-pact>=0.8.0",
-    "kailash-ml[all]>=0.6.0",
+    "kailash-ml[all]>=0.7.0",
     "kailash-align[all]>=0.3.0",
 ]
 


### PR DESCRIPTION
## Summary

- **11 new features** achieving PyCaret and MLflow parity for kailash-ml
- **ModelExplainer engine** — SHAP-based global/local/dependence explainability (`[explain]` extra)
- **Preprocessing enhancements** — 4 normalization methods, KNN/iterative imputation, multicollinearity removal, SMOTE/ADASYN class imbalance handling (`[imbalance]` extra)
- **Model calibration** — Platt scaling and isotonic regression via `TrainingPipeline.calibrate()`
- **Nested experiment runs** — parent/child run hierarchy for HPO and AutoML tracking
- **Auto-logging** — TrainingPipeline, HyperparameterSearch, AutoMLEngine → ExperimentTracker
- **Inference signature validation** — missing features raise errors instead of silently defaulting to 0.0
- **2 stub fixes** — stratified k-fold and successive halving now work correctly
- **Breaking**: `scikit-learn>=1.5` (was >=1.4) for `FrozenEstimator`

## Test plan

- [x] 750 tests passing (677 unit + 60 integration + 13 examples)
- [x] Red team R1 converged (10 findings fixed)
- [x] Security review passed (no CRITICAL/HIGH findings)
- [x] Version consistency verified (pyproject.toml + _version.py = 0.7.0)
- [ ] CI passes on PR
- [ ] Tag `ml-v0.7.0` after merge → triggers PyPI publish

## Related issues

Fixes #325, #326, #327, #328, #329, #330, #331, #332, #333, #334, #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)