### PR TITLE
revert(rules): restore paths frontmatter on 8 files (loom 2.5.1 was wrong)

### DIFF
--- a/.claude/rules/agent-reasoning.md
+++ b/.claude/rules/agent-reasoning.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/kaizen/**"
+  - "**/*agent*"
+  - "**/agents/**"
+---
+
 # Agent Reasoning Architecture — LLM-First Rule
 
 ## Scope

--- a/.claude/rules/artifact-flow.md
+++ b/.claude/rules/artifact-flow.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - ".claude/**"
+  - "sync-manifest.yaml"
+  - "**/VERSION"
+  - "*.md"
+---
+
 # Artifact Flow Rules
 
 ## Authority Chain

--- a/.claude/rules/env-models.md
+++ b/.claude/rules/env-models.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.js"
+  - ".env*"
+---
+
 # Environment Variables & Model Rules
 
 ## .env Is The Single Source of Truth

--- a/.claude/rules/framework-first.md
+++ b/.claude/rules/framework-first.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.rs"
+---
+
 # Framework-First: Use the Highest Abstraction Layer
 
 Default to Engines. Drop to Primitives only when Engines can't express the behavior. Never use Raw.

--- a/.claude/rules/patterns.md
+++ b/.claude/rules/patterns.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "**/*.py"
+  - "**/*.ts"
+  - "**/*.js"
+---
+
 # Kailash Pattern Rules
 
 ## Runtime Execution

--- a/.claude/rules/python-environment.md
+++ b/.claude/rules/python-environment.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.py"
+  - "pyproject.toml"
+  - "conftest.py"
+  - "tests/**"
+---
+
 # Python Environment Rules
 
 Every Python project MUST use `.venv` at the project root, managed by `uv`. Global Python is BLOCKED.

--- a/.claude/rules/terrene-naming.md
+++ b/.claude/rules/terrene-naming.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "**/*.md"
+  - "**/README*"
+  - "**/LICENSE*"
+  - "**/CLAUDE.md"
+---
+
 # Terrene Foundation Naming
 
 ## Rules

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "tests/**"
+  - "**/*test*"
+  - "**/*spec*"
+  - "conftest.py"
+---
+
 # Testing Rules
 
 ## Test-Once Protocol


### PR DESCRIPTION
## Summary

Reverts the `paths:` frontmatter strip from PR #349 (loom 2.5.1). That strip was based on an incorrect diagnosis: I believed path-scoped rules re-injected on every matching tool call. They do not.

**Actual Claude Code behavior** (verified empirically + docs):
- Rules WITHOUT `paths:` → loaded at session start, always-on
- Rules WITH `paths:` → load **once** on first matching tool call, then sticky
- Claude Code docs: *"Path-scoped rules trigger when Claude reads files matching the pattern, not on every tool use."*

**Effect of the bad strip**: moved 8 rules (including 266-line `agent-reasoning.md`) into the always-on baseline, adding ~5500 tokens per stripped large rule to every session start. Caused the 89K first-hit baseline the user reported.

**This PR**: restores the exact wide `paths:` patterns from before the strip. Rule bodies unchanged.

Synced from loom 2.5.2 (revert commit).

## Test plan
- [x] All 8 rule files have YAML frontmatter restored
- [x] Frontmatter patterns match the pre-strip state exactly (verified against `git show e3b06a4c`)
- [x] Rule bodies unchanged (only frontmatter prepended)

## Related issues
Reverts #349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)