### PR TITLE
feat(kaizen): SPEC-04 BaseAgent slimming — 2103 → 859 LOC

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -254,4 +254,36 @@ changes:
     reason: "New rule: every refactor claiming to shrink a file MUST land a numeric invariant test in the same commit. Invariant MUST be in CI default test path. From SPEC-04 regression where planned TASK-04-50 was never committed."
     diff_lines: "+60 (proposed, not yet created)"
 
+  # --- 2026-04-11: CI fix + Decision 007 backward compat ---
+
+  - file: skills/29-pact/SKILL.md
+    action: modified
+    suggested_tier: coc
+    reason: "Added TrustPostureLevel (Decision 007) section — 5 canonical posture names, POSTURE_CEILING mapping, backward-compatible aliases table, _missing_() mechanism"
+    diff_lines: "+30 -0"
+
+  - file: skills/29-pact/pact-access-enforcement.md
+    action: modified
+    suggested_tier: coc
+    reason: "Updated POSTURE_CEILING code examples to canonical names, added backward-compat alias docs, fixed SUPERVISED→TOOL ceiling example"
+    diff_lines: "+15 -10"
+
+  - file: skills/29-pact/pact-envelopes.md
+    action: modified
+    suggested_tier: coc
+    reason: "Replaced default-envelope-by-posture table with canonical 5-level names including new TOOL posture, added backward-compat note"
+    diff_lines: "+12 -8"
+
+  - file: skills/29-pact/pact-governance-engine.md
+    action: modified
+    suggested_tier: coc
+    reason: "Updated check_access() code example from CONTINUOUS_INSIGHT to DELEGATING"
+    diff_lines: "+1 -1"
+
+  - file: skills/29-pact/pact-governed-agents.md
+    action: modified
+    suggested_tier: coc
+    reason: "Updated frozen-context example from DELEGATED to AUTONOMOUS"
+    diff_lines: "+1 -1"
+
 status: pending_review

--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -240,4 +240,18 @@ changes:
     reason: "Added parallel-merge-workflow.md to the documentation references section"
     diff_lines: "+1"
 
+  # --- 2026-04-11: SPEC-04 post-mortem codification ---
+
+  - file: skills/30-claude-code-patterns/parallel-merge-workflow.md
+    action: modified
+    suggested_tier: cc
+    reason: "Added stale-base detection gate, mandatory numeric invariant rule, and post-merge invariant re-check. From 2026-04-11 post-mortem: worktree merge silently re-inlined 1,079 LOC of extracted code into base_agent.py because no LOC invariant test existed."
+    diff_lines: "+75 -2"
+
+  - file: rules/refactor-invariants.md
+    action: proposed
+    suggested_tier: coc
+    reason: "New rule: every refactor claiming to shrink a file MUST land a numeric invariant test in the same commit. Invariant MUST be in CI default test path. From SPEC-04 regression where planned TASK-04-50 was never committed."
+    diff_lines: "+60 (proposed, not yet created)"
+
 status: pending_review

--- a/.claude/skills/29-pact/SKILL.md
+++ b/.claude/skills/29-pact/SKILL.md
@@ -48,6 +48,20 @@ from pact.mcp import (
 )
 ```
 
+## TrustPostureLevel (Decision 007)
+
+Five canonical posture levels with autonomy gradient:
+
+| Canonical  | Autonomy | Ceiling      | Old Name (alias)   |
+| ---------- | -------- | ------------ | ------------------ |
+| PSEUDO     | 1        | PUBLIC       | PSEUDO_AGENT       |
+| TOOL       | 2        | RESTRICTED   | _(new, no old)_    |
+| SUPERVISED | 3        | CONFIDENTIAL | SHARED_PLANNING    |
+| DELEGATING | 4        | SECRET       | CONTINUOUS_INSIGHT |
+| AUTONOMOUS | 5        | TOP_SECRET   | DELEGATED          |
+
+Old names work as enum aliases (`TrustPostureLevel.PSEUDO_AGENT` resolves to `PSEUDO`). String deserialization of old values is handled by `_missing_()`.
+
 ## Rules
 
 See `.claude/rules/pact-governance.md` for security invariants.

--- a/.claude/skills/29-pact/pact-access-enforcement.md
+++ b/.claude/skills/29-pact/pact-access-enforcement.md
@@ -34,7 +34,7 @@ item = KnowledgeItem(
 decision = engine.check_access(
     role_address="D1-R1-D2-R1-T1-R1",
     knowledge_item=item,
-    posture=TrustPostureLevel.SHARED_PLANNING,
+    posture=TrustPostureLevel.SUPERVISED,
 )
 
 decision.allowed      # bool
@@ -72,18 +72,22 @@ Effective clearance = `min(role.max_clearance, POSTURE_CEILING[posture])`.
 ```python
 from kailash.trust.pact.clearance import POSTURE_CEILING, effective_clearance
 
-# The mapping:
-# PSEUDO_AGENT     -> PUBLIC
-# SUPERVISED       -> RESTRICTED
-# SHARED_PLANNING  -> CONFIDENTIAL
-# CONTINUOUS_INSIGHT -> SECRET
-# DELEGATED        -> TOP_SECRET
+# Canonical POSTURE_CEILING mapping (Decision 007):
+# PSEUDO       -> PUBLIC        (autonomy_level=1)
+# TOOL         -> RESTRICTED    (autonomy_level=2)
+# SUPERVISED   -> CONFIDENTIAL  (autonomy_level=3)
+# DELEGATING   -> SECRET        (autonomy_level=4)
+# AUTONOMOUS   -> TOP_SECRET    (autonomy_level=5)
+#
+# Backward-compatible aliases (enum aliases, not _missing_):
+#   PSEUDO_AGENT -> PSEUDO, SHARED_PLANNING -> SUPERVISED,
+#   CONTINUOUS_INSIGHT -> DELEGATING, DELEGATED -> AUTONOMOUS
 
-eff = effective_clearance(clearance, TrustPostureLevel.SUPERVISED)
-# Even SECRET clearance is capped at RESTRICTED when SUPERVISED
+eff = effective_clearance(clearance, TrustPostureLevel.TOOL)
+# Even SECRET clearance is capped at RESTRICTED when TOOL posture
 ```
 
-A role with TOP_SECRET clearance operating at SUPERVISED posture can only access RESTRICTED data.
+A role with TOP_SECRET clearance operating at TOOL posture can only access RESTRICTED data.
 
 ## Step 3: Compartment Check
 
@@ -194,7 +198,7 @@ from kailash.trust.pact.access import can_access
 decision = can_access(
     role_address="D1-R1-D3-R1-T1-R1",
     knowledge_item=item,
-    posture=TrustPostureLevel.SHARED_PLANNING,
+    posture=TrustPostureLevel.SUPERVISED,
     compiled_org=compiled_org,
     clearances={"D1-R1-D3-R1-T1-R1": clearance},
     ksps=[ksp],

--- a/.claude/skills/29-pact/pact-envelopes.md
+++ b/.claude/skills/29-pact/pact-envelopes.md
@@ -217,13 +217,15 @@ env = default_envelope_for_posture(TrustPostureLevel.SUPERVISED)
 # max_spend_usd=100.0, allowed_actions=["read", "write"], internal_only=True
 ```
 
-| Posture            | max_spend_usd | Allowed Actions            | Internal Only |
-| ------------------ | ------------- | -------------------------- | ------------- |
-| PSEUDO_AGENT       | 0             | read                       | Yes           |
-| SUPERVISED         | 100           | read, write                | Yes           |
-| SHARED_PLANNING    | 1,000         | read, write, plan, propose | No            |
-| CONTINUOUS_INSIGHT | 10,000        | +execute, deploy           | No            |
-| DELEGATED          | 100,000       | +approve, delegate         | No            |
+| Posture (canonical) | Autonomy | max_spend_usd | Allowed Actions            | Internal Only |
+| ------------------- | -------- | ------------- | -------------------------- | ------------- |
+| PSEUDO              | 1        | 0             | read                       | Yes           |
+| TOOL                | 2        | 50            | read, write                | Yes           |
+| SUPERVISED          | 3        | 1,000         | read, write, plan, propose | No            |
+| DELEGATING          | 4        | 10,000        | +execute, deploy           | No            |
+| AUTONOMOUS          | 5        | 100,000       | +approve, delegate         | No            |
+
+Old names (`PSEUDO_AGENT`, `SHARED_PLANNING`, `CONTINUOUS_INSIGHT`, `DELEGATED`) are accepted as enum aliases and via `_missing_()` for backward compatibility with serialized data.
 
 ## Degenerate Envelope Detection
 

--- a/.claude/skills/29-pact/pact-governance-engine.md
+++ b/.claude/skills/29-pact/pact-governance-engine.md
@@ -119,7 +119,7 @@ item = KnowledgeItem(
 decision = engine.check_access(
     role_address="D1-R1-D2-R1-T1-R1",
     knowledge_item=item,
-    posture=TrustPostureLevel.CONTINUOUS_INSIGHT,
+    posture=TrustPostureLevel.DELEGATING,
 )
 decision.allowed      # bool
 decision.reason       # str

--- a/.claude/skills/29-pact/pact-governed-agents.md
+++ b/.claude/skills/29-pact/pact-governed-agents.md
@@ -24,7 +24,7 @@ ctx = agent.context                        # GovernanceContext (frozen=True)
 ctx.allowed_actions                        # frozenset({"read", "write"})
 ctx.posture                                # TrustPostureLevel.SUPERVISED
 ctx.effective_clearance_level              # ConfidentialityLevel.RESTRICTED
-# ctx.posture = TrustPostureLevel.DELEGATED  -> FrozenInstanceError
+# ctx.posture = TrustPostureLevel.AUTONOMOUS  -> FrozenInstanceError
 ```
 
 ### Tool Registration (Default-Deny)

--- a/.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md
+++ b/.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md
@@ -63,13 +63,73 @@ Features that both touch the same method need explicit ordering instructions. Ex
 
 Run the specialist's own test suite to verify the merge compiles and all features work together. Then run the project-wide suite to catch regressions from interaction points.
 
+### 6. Stale-base detection (MUST — pre-merge gate)
+
+Before merging a worktree branch, check if its merge-base is older than the target branch's latest changes to the same files. If the two sides differ by >200 lines on the same file, **STOP** and require human disambiguation.
+
+```bash
+# For each worktree about to merge, compare LOC of shared files
+TARGET_FILE="packages/kailash-kaizen/src/kaizen/core/base_agent.py"
+for wt in .claude/worktrees/agent-*/; do
+    wt_file="${wt}${TARGET_FILE}"
+    [ -f "$wt_file" ] || continue
+    main_loc=$(wc -l < "$TARGET_FILE")
+    wt_loc=$(wc -l < "$wt_file")
+    delta=$(( wt_loc - main_loc ))
+    abs_delta=${delta#-}
+    if [ "$abs_delta" -gt 200 ]; then
+        echo "STOP: $(basename $wt) diverges by ${abs_delta} lines on ${TARGET_FILE}"
+        echo "  main: ${main_loc} LOC, worktree: ${wt_loc} LOC"
+        echo "  Requires human disambiguation before merge"
+    fi
+done
+```
+
+**Why:** On 2026-04-10 a worktree based on a pre-slimming HEAD (3681 LOC) merged into a post-slimming target (994 LOC), silently re-inlining 1,079 lines. The 2,687-line delta would have triggered this gate.
+
+### 7. Mandatory numeric invariants (MUST — same-commit rule)
+
+Every refactor that shrinks, extracts, or consolidates a file MUST land a programmatic invariant test in the **same commit** as the extraction. The test MUST be in CI's default test path.
+
+```python
+# tests/invariants/test_<module>_line_count.py
+import pathlib
+
+TARGET = pathlib.Path("path/to/slimmed_module.py")
+HARD_LIMIT = 1000  # set to ~120% of post-refactor LOC
+
+def test_module_stays_under_budget():
+    loc = len(TARGET.read_text().splitlines())
+    assert loc < HARD_LIMIT, (
+        f"{TARGET.name} grew to {loc} LOC (budget: <{HARD_LIMIT}). "
+        f"Likely a merge regression re-inlined extracted code."
+    )
+```
+
+**Why:** SPEC-04's TASK-04-50 planned this test but never committed it. The regression was invisible for two sessions because no test checked the line count.
+
+### 8. Post-merge invariant re-check (MUST)
+
+After each worktree merge, re-run the numeric invariants. A violation is a **STOP** signal — do not proceed to the next merge.
+
+```bash
+# Re-check after each merge
+uv run pytest tests/invariants/ -x --tb=short -q
+```
+
+**Why:** Without per-merge checks, a regression from merge 2 compounds through merges 3-5 and is discovered only at the end of the session.
+
 ## Anti-Patterns
 
 - **Sequential worktree rebasing**: Each rebase fights the previous merge's line shifts
 - **Cherry-picking across worktrees**: Loses the per-feature test verification
 - **Manual three-way merge**: Error-prone for 5+ concurrent features
 - **Trusting the "individually passing" claim**: Interaction points are rarely tested in isolation — always re-run full suite after merge
+- **Merging without stale-base check**: A worktree based on pre-refactor HEAD silently reverses the refactor on merge
+- **Landing a refactor without a numeric invariant test**: The regression is invisible until someone manually checks the line count
 
 ## Origin
 
 2026-04-10 session: 5 PACT conformance features (N1 KnowledgeFilter, N2 EnvelopeCache, N3 PlanSuspension, N4 AuditTiers, N5 ObservationSink) merged from 5 independent worktrees into `engine.py` (2329 → 3211 lines). All 1192 PACT tests passed on first merged run after specialist applied the changes with explicit injection-point documentation.
+
+**Post-mortem addendum (2026-04-11):** This skill was created in the same session that produced a silent regression on `base_agent.py`. A worktree merge re-inlined 1,079 LOC of extracted MCPMixin methods because: (a) the worktree was based on a stale pre-slimming HEAD, (b) no LOC invariant test existed, and (c) this skill did not include stale-base detection. Steps 6-8 were added to prevent recurrence. See `journal/0003-RISK-spec04-silent-regression-via-parallel-merge.md`.

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -109,6 +109,7 @@ jobs:
         run: |
           uv venv .venv
           uv pip install -e ".[dev,server,cli,database,postgres,mysql,files,distributed,monitoring,http,auth,mfa,mcp,scheduler,otel]" --python .venv/bin/python
+          uv pip install -e packages/kailash-mcp --python .venv/bin/python
           uv pip install numpy --python .venv/bin/python
 
       - name: Lint (ruff)

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "isort>=5.12",
     "ruff>=0.1.0",
     "fakeredis>=2.20.0",
+    "respx>=0.21.0",
 ]
 
 [project.urls]
@@ -85,6 +86,7 @@ markers = [
     "requires_azure: Tests requiring Azure AI Foundry credentials",
     "requires_docker: Tests requiring Docker Model Runner",
     "requires_google: Tests requiring Google Gemini credentials",
+    "regression: Regression tests for fixed bugs",
 ]
 asyncio_mode = "auto"
 

--- a/packages/kailash-kaizen/src/kaizen/core/agent_loop.py
+++ b/packages/kailash-kaizen/src/kaizen/core/agent_loop.py
@@ -334,12 +334,7 @@ class AgentLoop:
             # Load memory context
             _load_memory_context(agent, inputs, session_id)
 
-            # Pre-execution hook (SPEC-04: route through _invoke_extension_point
-            # so vanilla agents skip the deprecation warning path while
-            # subclass overrides continue to execute).
-            processed_inputs = agent._invoke_extension_point(
-                "_pre_execution_hook", inputs
-            )
+            processed_inputs = agent._pre_execution_hook(inputs)
 
             # Trigger PRE_AGENT_LOOP hook
             _trigger_hook_sync(
@@ -356,10 +351,10 @@ class AgentLoop:
             result = _execute_strategy(agent, processed_inputs)
 
             # Validate output
-            agent._invoke_extension_point("_validate_signature_output", result)
+            agent._validate_signature_output(result)
 
             # Post-execution hook
-            final_result = agent._invoke_extension_point("_post_execution_hook", result)
+            final_result = agent._post_execution_hook(result)
 
             # Trigger POST_AGENT_LOOP hook
             _trigger_hook_sync(
@@ -381,9 +376,7 @@ class AgentLoop:
             import gc
 
             gc.collect()
-            return agent._invoke_extension_point(
-                "_handle_error", error, {"inputs": inputs}
-            )
+            return agent._handle_error(error, {"inputs": inputs})
 
     @staticmethod
     async def run_async(agent, **inputs) -> Dict[str, Any]:
@@ -410,10 +403,7 @@ class AgentLoop:
             # Load memory context (sync -- memory is sync API)
             _load_memory_context(agent, inputs, session_id)
 
-            # Pre-execution hook (SPEC-04: route through _invoke_extension_point)
-            processed_inputs = agent._invoke_extension_point(
-                "_pre_execution_hook", inputs
-            )
+            processed_inputs = agent._pre_execution_hook(inputs)
 
             # Trigger PRE_AGENT_LOOP hook (async)
             await _trigger_hook_async(
@@ -430,10 +420,10 @@ class AgentLoop:
             result = await _execute_strategy_async(agent, processed_inputs)
 
             # Validate output
-            agent._invoke_extension_point("_validate_signature_output", result)
+            agent._validate_signature_output(result)
 
             # Post-execution hook
-            final_result = agent._invoke_extension_point("_post_execution_hook", result)
+            final_result = agent._post_execution_hook(result)
 
             # Trigger POST_AGENT_LOOP hook (async)
             await _trigger_hook_async(
@@ -454,6 +444,4 @@ class AgentLoop:
             return final_result
 
         except Exception as error:
-            return agent._invoke_extension_point(
-                "_handle_error", error, {"inputs": inputs}
-            )
+            return agent._handle_error(error, {"inputs": inputs})

--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -27,34 +27,18 @@ Licensed under Apache-2.0
 import json
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
-# Core SDK imports
 from kailash.nodes.base import Node, NodeParameter
 from kailash.workflow.builder import WorkflowBuilder
 from kailash_mcp.client import MCPClient
 
-# Type checking imports (not available at runtime in all environments)
-if TYPE_CHECKING:
-    try:
-        from kaizen.nodes.ai.a2a import (
-            A2AAgentCard,
-            Capability,
-            CollaborationStyle,
-            PerformanceMetrics,
-            ResourceRequirements,
-        )
-    except ImportError:
-        pass
-
-# Kaizen framework imports
 from kaizen.signatures import InputField, OutputField, Signature
 from kaizen.tools.types import ToolCategory, ToolDefinition, ToolParameter
 
 from .a2a_mixin import A2AMixin
 from .agent_loop import AgentLoop
 from .config import BaseAgentConfig
-from .deprecation import deprecated
 from .mcp_mixin import MCPMixin
 
 __all__ = ["BaseAgent", "BaseAgentConfig"]
@@ -69,55 +53,9 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
     Execution is delegated to AgentLoop for both sync and async paths.
     """
 
-    # SPEC-04: Extension points deprecated in v2.5.0 — override emits warning.
-    # Replacement: composition wrappers.
-    _DEPRECATED_EXTENSION_POINTS = (
-        "_default_signature",
-        "_default_strategy",
-        "_generate_system_prompt",
-        "_validate_signature_output",
-        "_pre_execution_hook",
-        "_post_execution_hook",
-        "_handle_error",
-    )
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Warn subclasses that override deprecated extension points."""
-        super().__init_subclass__(**kwargs)
-        import warnings as _warnings
-
-        base_attrs = {
-            name: getattr(BaseAgent, name, None)
-            for name in cls._DEPRECATED_EXTENSION_POINTS
-        }
-        for name in cls._DEPRECATED_EXTENSION_POINTS:
-            if name in cls.__dict__ and cls.__dict__[name] is not base_attrs[name]:
-                _warnings.warn(
-                    f"{cls.__name__} overrides deprecated extension point "
-                    f"BaseAgent.{name}() (deprecated in v2.5.0). Use composition "
-                    f"wrappers (kaizen_agents.StreamingAgent, MonitoredAgent, "
-                    f"GovernedAgent) instead of subclassing.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
-    def _invoke_extension_point(self, name: str, *args: Any, **kwargs: Any) -> Any:
-        """Dispatch to a subclass override or the private ``_impl`` default.
-
-        SPEC-04 deprecates the seven extension points. Subclass overrides
-        run unchanged (they shadow the decorated wrapper). When no override
-        exists, the private ``_<name>_impl`` runs directly so vanilla
-        agents emit no deprecation warnings. ``__init_subclass__`` already
-        warned once at class-definition time for any override.
-        """
-        base_slot = getattr(BaseAgent, name, None)
-        actual_slot = getattr(type(self), name, None)
-        if actual_slot is not None and actual_slot is not base_slot:
-            return actual_slot(self, *args, **kwargs)
-        impl = getattr(self, f"{name}_impl", None)
-        if impl is None:
-            return getattr(self, name)(*args, **kwargs)
-        return impl(*args, **kwargs)
+    # Extension points — subclasses may override these directly.
+    # Composition wrappers (StreamingAgent, MonitoredAgent, GovernedAgent)
+    # are preferred for new code.
 
     def __init__(
         self,
@@ -130,9 +68,8 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         control_protocol: Optional[Any] = None,
         mcp_servers: Optional[List[Dict[str, Any]]] = None,
         hook_manager: Optional[Any] = None,
-        **kwargs,
     ):
-        """Initialize BaseAgent with lazy loading pattern.
+        """Initialize BaseAgent.
 
         Args:
             config: Agent configuration (BaseAgentConfig or domain config, auto-converted).
@@ -145,7 +82,6 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
             mcp_servers: Optional MCP server configurations. None = auto-connect builtin.
                         Set to [] to disable MCP.
             hook_manager: Optional HookManager instance for lifecycle hooks.
-            **kwargs: Additional arguments passed to Node.__init__
         """
         # Auto-convert domain config to BaseAgentConfig
         if not isinstance(config, BaseAgentConfig):
@@ -154,22 +90,11 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         self.config = config
         agent_config = config
 
-        # Signature and strategy (extension points).
-        # BaseAgent resolves defaults via ``_invoke_extension_point``: if the
-        # subclass overrides the slot, the override runs (no decorator
-        # warning because subclass methods are not decorated); otherwise the
-        # private ``_impl`` helper runs directly (no decorator warning on
-        # vanilla BaseAgent construction). See SPEC-04 § 1 item 5.
+        # Signature and strategy — subclass overrides win via normal MRO.
         self.signature = (
-            signature
-            if signature is not None
-            else self._invoke_extension_point("_default_signature")
+            signature if signature is not None else self._default_signature()
         )
-        self.strategy = (
-            strategy
-            if strategy is not None
-            else self._invoke_extension_point("_default_strategy")
-        )
+        self.strategy = strategy if strategy is not None else self._default_strategy()
 
         # Memory
         self.memory = memory
@@ -260,7 +185,7 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         self._observability_manager = None
 
         # Node.__init__
-        super().__init__(**kwargs)
+        super().__init__()
 
         # Restore config (Node.__init__ overwrites with dict)
         self.config = agent_config
@@ -273,82 +198,43 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         # WorkflowGenerator
         from .workflow_generator import WorkflowGenerator
 
-        # Route prompt generation through _invoke_extension_point so
-        # subclass overrides still win while vanilla agents skip the
-        # deprecation warning path (SPEC-04 § 1 item 5).
         self.workflow_generator = WorkflowGenerator(
             config=self.config,
             signature=self.signature,
-            prompt_generator=lambda: self._invoke_extension_point(
-                "_generate_system_prompt"
-            ),
+            prompt_generator=lambda: self._generate_system_prompt(),
             agent=self,
         )
 
-        # Mixin state tracking
-        self._mixins_applied = []
+        # Apply mixins based on config flags (lazy imports to avoid cycles)
+        _MIXIN_MAP = (
+            ("logging_enabled", "kaizen.core.mixins.logging_mixin", "LoggingMixin"),
+            ("performance_enabled", "kaizen.core.mixins.metrics_mixin", "MetricsMixin"),
+            ("error_handling_enabled", "kaizen.core.mixins.retry_mixin", "RetryMixin"),
+            (
+                "batch_processing_enabled",
+                "kaizen.core.mixins.caching_mixin",
+                "CachingMixin",
+            ),
+            ("memory_enabled", "kaizen.core.mixins.timeout_mixin", "TimeoutMixin"),
+            (
+                "transparency_enabled",
+                "kaizen.core.mixins.tracing_mixin",
+                "TracingMixin",
+            ),
+            ("mcp_enabled", "kaizen.core.mixins.validation_mixin", "ValidationMixin"),
+        )
+        for flag, mod_path, cls_name in _MIXIN_MAP:
+            if getattr(config, flag, False):
+                import importlib
 
-        # Apply mixins based on config
-        if config.logging_enabled:
-            self._apply_logging_mixin()
-        if config.performance_enabled:
-            self._apply_performance_mixin()
-        if config.error_handling_enabled:
-            self._apply_error_handling_mixin()
-        if config.batch_processing_enabled:
-            self._apply_batch_processing_mixin()
-        if config.memory_enabled:
-            self._apply_memory_mixin()
-        if config.transparency_enabled:
-            self._apply_transparency_mixin()
-        if config.mcp_enabled:
-            self._apply_mcp_integration_mixin()
-
-    # =========================================================================
-    # Mixin application
-    # =========================================================================
-
-    def _apply_logging_mixin(self):
-        from kaizen.core.mixins.logging_mixin import LoggingMixin
-
-        LoggingMixin.apply(self)
-        self._mixins_applied.append("LoggingMixin")
-
-    def _apply_performance_mixin(self):
-        from kaizen.core.mixins.metrics_mixin import MetricsMixin
-
-        MetricsMixin.apply(self)
-        self._mixins_applied.append("PerformanceMixin")
-
-    def _apply_error_handling_mixin(self):
-        from kaizen.core.mixins.retry_mixin import RetryMixin
-
-        RetryMixin.apply(self)
-        self._mixins_applied.append("ErrorHandlingMixin")
-
-    def _apply_batch_processing_mixin(self):
-        from kaizen.core.mixins.caching_mixin import CachingMixin
-
-        CachingMixin.apply(self)
-        self._mixins_applied.append("BatchProcessingMixin")
-
-    def _apply_memory_mixin(self):
-        from kaizen.core.mixins.timeout_mixin import TimeoutMixin
-
-        TimeoutMixin.apply(self)
-        self._mixins_applied.append("MemoryMixin")
-
-    def _apply_transparency_mixin(self):
-        from kaizen.core.mixins.tracing_mixin import TracingMixin
-
-        TracingMixin.apply(self)
-        self._mixins_applied.append("TransparencyMixin")
-
-    def _apply_mcp_integration_mixin(self):
-        from kaizen.core.mixins.validation_mixin import ValidationMixin
-
-        ValidationMixin.apply(self)
-        self._mixins_applied.append("MCPIntegrationMixin")
+                try:
+                    mixin_cls = getattr(importlib.import_module(mod_path), cls_name)
+                except (ImportError, AttributeError) as exc:
+                    raise ImportError(
+                        f"Failed to load mixin {cls_name} from {mod_path} "
+                        f"(config flag: {flag}): {exc}"
+                    ) from exc
+                mixin_cls.apply(self)
 
     # =========================================================================
     # Node interface
@@ -422,7 +308,7 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         provider = OpenAIProvider(use_async=True)
 
         messages = []
-        system_prompt = self._invoke_extension_point("_generate_system_prompt")
+        system_prompt = self._generate_system_prompt()
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
 
@@ -450,8 +336,11 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         return {"response": response["content"]}
 
     def _simple_execute(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """Simple execution without strategy (fallback)."""
-        return {"result": "Simple execution placeholder"}
+        """Fallback when no strategy is configured."""
+        raise NotImplementedError(
+            "No execution strategy configured. Pass strategy= to "
+            "BaseAgent.__init__() or override _default_strategy()."
+        )
 
     # =========================================================================
     # Convenience methods
@@ -567,7 +456,7 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         workflow = WorkflowBuilder()
 
         node_config = {
-            "system_prompt": self._invoke_extension_point("_generate_system_prompt"),
+            "system_prompt": self._generate_system_prompt(),
         }
 
         if self.config.model is not None:
@@ -593,12 +482,10 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         return self
 
     # =========================================================================
-    # Extension Points (SPEC-04 § 1 item 5 -- deprecated in v2.5.0)
-    # ``_*_impl`` are the private default implementations BaseAgent uses.
-    # The public slots below carry the deprecation wrapper for subclasses.
+    # Extension Points — override in subclasses or pass params to __init__
     # =========================================================================
 
-    def _default_signature_impl(self) -> Signature:
+    def _default_signature(self) -> Signature:
         """Default signature used by BaseAgent when no signature is provided."""
 
         class DefaultSignature(Signature):
@@ -609,7 +496,7 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
 
         return DefaultSignature()
 
-    def _default_strategy_impl(self) -> Any:
+    def _default_strategy(self) -> Any:
         """Default execution strategy resolved from config.strategy_type."""
         try:
             from kaizen.strategies.async_single_shot import AsyncSingleShotStrategy
@@ -627,7 +514,7 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
 
             return SimpleStrategy()
 
-    def _generate_system_prompt_impl(self) -> str:
+    def _generate_system_prompt(self) -> str:
         """Generate the default system prompt from signature + discovered tools."""
         from kaizen.core.prompt_utils import generate_prompt_from_signature
 
@@ -671,7 +558,7 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
 
         return "\n".join(prompt_parts)
 
-    def _validate_signature_output_impl(self, output: Dict[str, Any]) -> bool:
+    def _validate_signature_output(self, output: Dict[str, Any]) -> bool:
         """Validate that output matches signature (default implementation)."""
         has_special_keys = any(
             key in output for key in ["_write_insight", "response", "result"]
@@ -687,7 +574,7 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
                     raise ValueError(f"Missing required output field: {field_name}")
         return True
 
-    def _pre_execution_hook_impl(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def _pre_execution_hook(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Default pre-execution hook (logs execution start)."""
         logging_enabled = getattr(self.config, "logging_enabled", True)
         if logging_enabled:
@@ -695,14 +582,14 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
             logger.info(f"Executing {signature_name} with inputs: {inputs}")
         return inputs
 
-    def _post_execution_hook_impl(self, result: Dict[str, Any]) -> Dict[str, Any]:
+    def _post_execution_hook(self, result: Dict[str, Any]) -> Dict[str, Any]:
         """Default post-execution hook (logs completion)."""
         logging_enabled = getattr(self.config, "logging_enabled", True)
         if logging_enabled:
             logger.info(f"Execution complete. Result: {result}")
         return result
 
-    def _handle_error_impl(
+    def _handle_error(
         self, error: Exception, context: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Default error handler."""
@@ -712,58 +599,6 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
             return {"error": str(error), "type": type(error).__name__, "success": False}
         else:
             raise error
-
-    # -------------------------------------------------------------------------
-    # Deprecated extension-point slots (SPEC-04 § 1 item 5)
-    #
-    # Each slot delegates to its ``_impl`` sibling so existing overrides
-    # keep working. The deprecation wrapper fires only when the slot is
-    # invoked directly; BaseAgent and AgentLoop route around the slots via
-    # ``_invoke_extension_point`` so vanilla agents stay warning-free.
-    # -------------------------------------------------------------------------
-
-    _DEPRECATION_MSG = (
-        "BaseAgent extension points are deprecated. Use composition wrappers "
-        "(kaizen_agents.StreamingAgent, MonitoredAgent, GovernedAgent) or "
-        "BaseAgentConfig/signature parameters instead of subclassing."
-    )
-
-    @deprecated(_DEPRECATION_MSG, since="2.5.0")
-    def _default_signature(self) -> Signature:
-        """Deprecated extension point: return the default Signature."""
-        return self._default_signature_impl()
-
-    @deprecated(_DEPRECATION_MSG, since="2.5.0")
-    def _default_strategy(self) -> Any:
-        """Deprecated extension point: return the default strategy."""
-        return self._default_strategy_impl()
-
-    @deprecated(_DEPRECATION_MSG, since="2.5.0")
-    def _generate_system_prompt(self) -> str:
-        """Deprecated extension point: generate the system prompt."""
-        return self._generate_system_prompt_impl()
-
-    @deprecated(_DEPRECATION_MSG, since="2.5.0")
-    def _validate_signature_output(self, output: Dict[str, Any]) -> bool:
-        """Deprecated extension point: validate LLM output against signature."""
-        return self._validate_signature_output_impl(output)
-
-    @deprecated(_DEPRECATION_MSG, since="2.5.0")
-    def _pre_execution_hook(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """Deprecated extension point: called before execution."""
-        return self._pre_execution_hook_impl(inputs)
-
-    @deprecated(_DEPRECATION_MSG, since="2.5.0")
-    def _post_execution_hook(self, result: Dict[str, Any]) -> Dict[str, Any]:
-        """Deprecated extension point: called after execution."""
-        return self._post_execution_hook_impl(result)
-
-    @deprecated(_DEPRECATION_MSG, since="2.5.0")
-    def _handle_error(
-        self, error: Exception, context: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Deprecated extension point: handle execution errors."""
-        return self._handle_error_impl(error, context)
 
     # =========================================================================
     # Control Protocol helpers
@@ -852,1087 +687,8 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         request = ControlRequest.create("progress_update", data)
         await self.control_protocol._transport.write(request.to_json())
 
-    # =============================================================================
-    # TOOL CALLING INTEGRATION - MCP Only
-    # =============================================================================
-
-    async def discover_tools(
-        self,
-        category: Optional[ToolCategory] = None,
-        safe_only: bool = False,
-        keyword: Optional[str] = None,
-    ) -> List[ToolDefinition]:
-        """
-        Discover available MCP tools with optional filtering.
-
-        Discovers tools from configured MCP servers, with optional filters
-        by category, danger level, or keyword search.
-
-        Args:
-            category: Optional filter by tool category
-            safe_only: If True, only return SAFE tools (default: False)
-            keyword: Optional keyword to search in tool names/descriptions
-
-        Returns:
-            List of matching ToolDefinition objects
-
-        Raises:
-            RuntimeError: If no MCP servers configured
-
-        Example:
-            >>> # Discover all MCP tools
-            >>> all_tools = await agent.discover_tools()
-            >>>
-            >>> # Find only safe tools
-            >>> safe_tools = await agent.discover_tools(safe_only=True)
-            >>>
-            >>> # Search by keyword
-            >>> file_tools = await agent.discover_tools(keyword="file")
-        """
-        tools = []
-
-        # Raise error if no MCP servers configured
-        if self._mcp_servers is None:
-            raise RuntimeError(
-                "No MCP servers configured. "
-                "Pass mcp_servers parameter to BaseAgent.__init__() "
-                "to enable tool discovery."
-            )
-
-        # Discover MCP tools
-        mcp_tools_raw = await self.discover_mcp_tools()
-
-        # Convert MCP tools to ToolDefinition format
-        for mcp_tool in mcp_tools_raw:
-            # Extract parameters from MCP tool schema
-            params = []
-            if "parameters" in mcp_tool and isinstance(mcp_tool["parameters"], dict):
-                for param_name, param_schema in mcp_tool["parameters"].items():
-                    param_type = param_schema.get("type", "string")
-                    param_desc = param_schema.get("description", "")
-                    param_required = param_schema.get("required", False)
-
-                    params.append(
-                        ToolParameter(
-                            name=param_name,
-                            type=param_type,
-                            description=param_desc,
-                            required=param_required,
-                        )
-                    )
-
-            # Create ToolDefinition for MCP tool
-            tool_def = ToolDefinition(
-                name=mcp_tool["name"],
-                description=mcp_tool.get("description", ""),
-                category=ToolCategory.SYSTEM,  # Default to SYSTEM for MCP tools
-                danger_level=DangerLevel.SAFE,  # Default to SAFE (can be configured)
-                parameters=params,
-                returns={},  # MCP tools don't have typed returns
-                executor=None,  # MCP tools use execute_mcp_tool
-            )
-
-            # Apply filters
-            if category is not None and tool_def.category != category:
-                continue
-            if safe_only and tool_def.danger_level != DangerLevel.SAFE:
-                continue
-            if keyword is not None:
-                keyword_lower = keyword.lower()
-                if not (
-                    keyword_lower in tool_def.name.lower()
-                    or keyword_lower in tool_def.description.lower()
-                ):
-                    continue
-
-            tools.append(tool_def)
-
-        return tools
-
-    # =============================================================================
-    # MCP INTEGRATION - Tool Discovery and Execution
-    # =============================================================================
-    # These methods integrate MCP (Model Context Protocol) tools with BaseAgent,
-    # enabling agents to discover and execute tools from external MCP servers.
-    #
-    # Architecture: Uses Kailash SDK MCPClient for real protocol support
-    # Naming Convention: mcp__<serverName>__<toolName>
-    # =============================================================================
-
-    def has_mcp_support(self) -> bool:
-        """
-        Check if agent has MCP integration configured.
-
-        Returns:
-            True if mcp_servers is configured, False otherwise
-
-        Example:
-            >>> agent = BaseAgent(config=config, signature=signature)
-            >>> print(agent.has_mcp_support())  # False
-            >>>
-            >>> agent_with_mcp = BaseAgent(
-            ...     config=config,
-            ...     signature=signature,
-            ...     mcp_servers=[{"name": "fs", "transport": "stdio", ...}]
-            ... )
-            >>> print(agent_with_mcp.has_mcp_support())  # True
-        """
-        return self._mcp_servers is not None
-
-    async def discover_mcp_tools(
-        self, server_name: Optional[str] = None, force_refresh: bool = False
-    ) -> List[Dict[str, Any]]:
-        """
-        Discover MCP tools from configured servers with naming convention.
-
-        Discovers tools from MCP servers and applies naming convention:
-        mcp__<serverName>__<toolName>
-
-        Args:
-            server_name: Optional filter by server name (None = all servers)
-            force_refresh: Bypass cache and rediscover tools (default: False)
-
-        Returns:
-            List of tool definitions with naming convention applied
-
-        Raises:
-            RuntimeError: If MCP not configured
-
-        Example:
-            >>> agent = BaseAgent(
-            ...     config=config,
-            ...     signature=signature,
-            ...     mcp_servers=[
-            ...         {"name": "filesystem", "transport": "stdio", ...}
-            ...     ]
-            ... )
-            >>>
-            >>> # Discover all tools
-            >>> tools = await agent.discover_mcp_tools()
-            >>> print(tools[0]["name"])  # "mcp__filesystem__read_file"
-            >>>
-            >>> # Discover from specific server
-            >>> tools = await agent.discover_mcp_tools(server_name="filesystem")
-        """
-        if self._mcp_servers is None:
-            raise RuntimeError(
-                "MCP not configured. Pass mcp_servers parameter to BaseAgent.__init__()"
-            )
-
-        # Filter servers if server_name provided
-        servers = self._mcp_servers
-        if server_name is not None:
-            # Support both string and dict formats
-            filtered_servers = []
-            for s in servers:
-                if isinstance(s, str):
-                    # String format: ["kaizen_builtin"] (auto-connect)
-                    if s == server_name:
-                        filtered_servers.append(s)
-                elif isinstance(s, dict):
-                    # Dict format: [{"name": "filesystem", ...}]
-                    if s.get("name") == server_name:
-                        filtered_servers.append(s)
-            servers = filtered_servers
-
-        # Collect tools from all selected servers
-        all_tools = []
-        for server_config in servers:
-            # Support both string and dict formats
-            if isinstance(server_config, str):
-                # String format: "kaizen_builtin" (auto-connect)
-                server_key = server_config
-            elif isinstance(server_config, dict):
-                # Dict format: {"name": "filesystem", "command": "npx", ...}
-                server_key = server_config.get("name", "unknown")
-            else:
-                logger.warning(
-                    f"Skipping invalid server config: {server_config}. "
-                    f"Expected string or dict, got {type(server_config)}"
-                )
-                continue
-
-            # Check cache if not forcing refresh
-            if not force_refresh and server_key in self._discovered_mcp_tools:
-                all_tools.extend(self._discovered_mcp_tools[server_key])
-                continue
-
-            # Resolve string format to dict format for MCP client
-            if isinstance(server_config, str):
-                # Auto-connect pattern: string server name needs to be resolved
-                # Currently only "kaizen_builtin" is supported
-                if server_config == "kaizen_builtin":
-                    resolved_config = {
-                        "name": "kaizen_builtin",
-                        "command": "python",
-                        "args": ["-m", "kaizen.mcp.builtin_server"],
-                        "transport": "stdio",
-                        "description": "Kaizen builtin tools (file, HTTP, bash, web)",
-                    }
-                else:
-                    logger.warning(
-                        f"Unknown auto-connect server: {server_config}. "
-                        f"Only 'kaizen_builtin' is currently supported."
-                    )
-                    continue
-            else:
-                # Already in dict format
-                resolved_config = server_config
-
-            # Discover tools from server
-            tools = await self._mcp_client.discover_tools(
-                resolved_config, force_refresh=force_refresh
-            )
-
-            # Apply naming convention: mcp__<serverName>__<toolName>
-            renamed_tools = []
-            for tool in tools:
-                renamed_tool = tool.copy()
-                renamed_tool["name"] = f"mcp__{server_key}__{tool['name']}"
-                renamed_tools.append(renamed_tool)
-
-            # Cache the renamed tools
-            self._discovered_mcp_tools[server_key] = renamed_tools
-            all_tools.extend(renamed_tools)
-
-        return all_tools
-
-    def _convert_mcp_result_to_dict(self, result) -> Dict[str, Any]:
-        """
-        Convert MCP CallToolResult to dict format expected by tests.
-
-        MCPClient.call_tool() returns a dict (already converted from CallToolResult).
-        This method extracts content fields and standardizes format for tests.
-
-        Args:
-            result: Dict from MCPClient.call_tool() (NOT CallToolResult object)
-
-        Returns:
-            Dict with success, output, stdout, content, error, and structured_content fields
-
-        Example:
-            >>> result = await self._mcp_client.call_tool(...)
-            >>> dict_result = self._convert_mcp_result_to_dict(result)
-            >>> print(dict_result["success"])  # True or False
-        """
-        # Result is already a dict from MCPClient
-        if not isinstance(result, dict):
-            raise TypeError(
-                f"Expected dict from MCPClient.call_tool(), got {type(result)}"
-            )
-
-        # MCPClient returns dict with:
-        # - 'result': CallToolResult object (has structuredContent)
-        # - 'content': JSON string or list
-        # - 'success': bool
-        # - 'tool_name': str
-
-        # Extract structured content from CallToolResult if available
-        call_tool_result = result.get("result")
-        structured_content = {}
-
-        if call_tool_result and hasattr(call_tool_result, "structuredContent"):
-            structured_content = call_tool_result.structuredContent or {}
-
-        # Extract stdout/stderr for bash commands, or content for other tools
-        stdout = structured_content.get("stdout", "")
-        stderr = structured_content.get("stderr", "")
-        exit_code = structured_content.get("exit_code", 0)
-
-        # For bash tools: use stdout as output (plain string)
-        # For file/HTTP tools: JSON-encode structured_content dict (tests expect JSON string)
-        import json
-
-        data = None  # For HTTP tools: parsed JSON response body
-
-        if stdout:
-            # Bash tool - plain stdout string
-            output = stdout
-            content = stdout
-        else:
-            # File/HTTP tool - JSON-encode the structured_content
-            output = json.dumps(structured_content) if structured_content else "{}"
-            content = output
-
-            # For HTTP tools: parse JSON body and expose in 'data' field
-            if "body" in structured_content and isinstance(
-                structured_content.get("body"), str
-            ):
-                try:
-                    data = json.loads(structured_content["body"])
-                except json.JSONDecodeError:
-                    # If body is not valid JSON, leave data as None
-                    pass
-
-        # Build standardized dict response (tests expect these fields)
-        result_dict = {
-            "success": result.get("success", False)
-            and not result.get("isError", False),
-            "output": output,
-            "stdout": stdout,  # For bash commands
-            "stderr": stderr,  # For bash commands
-            "exit_code": exit_code,  # For bash commands
-            "content": content,  # For bash: plain string, for file/HTTP: JSON string
-            "error": (
-                stderr
-                if stderr
-                else ("" if result.get("success", False) else "Unknown error")
-            ),
-            "isError": result.get("isError", False),
-            "structured_content": structured_content,
-        }
-
-        # Add 'data' field for HTTP tools with parsed JSON body
-        if data is not None:
-            result_dict["data"] = data
-
-        # Flatten structured_content fields to top level for easy access
-        # This allows tests to call result.get("exists") instead of result.get("structured_content").get("exists")
-        for key, value in structured_content.items():
-            if key not in result_dict:  # Don't overwrite existing keys
-                result_dict[key] = value
-
-        return result_dict
-
-    async def execute_tool(
-        self, tool_name: str, params: Dict[str, Any], timeout: Optional[float] = None
-    ) -> Dict[str, Any]:
-        """
-        Execute tool via MCP integration.
-
-        Wrapper for execute_mcp_tool() that handles naming conventions.
-        Called by MultiCycleStrategy when agent autonomously decides to use a tool.
-
-        If tool_name doesn't have mcp__ prefix, assumes kaizen_builtin server.
-
-        Args:
-            tool_name: Tool name (with or without mcp__ prefix)
-            params: Tool parameters
-            timeout: Optional execution timeout
-
-        Returns:
-            Tool execution result
-
-        Example:
-            >>> # Direct tool name (assumes kaizen_builtin server)
-            >>> result = await agent.execute_tool("read_file", {"path": "test.txt"})
-            >>>
-            >>> # Fully qualified tool name
-            >>> result = await agent.execute_tool(
-            ...     "mcp__filesystem__read_file",
-            ...     {"path": "test.txt"}
-            ... )
-        """
-        # Ensure tool name has mcp__ prefix
-        if not tool_name.startswith("mcp__"):
-            # Default to kaizen_builtin server for unprefixed tools
-            tool_name = f"mcp__kaizen_builtin__{tool_name}"
-
-        # Delegate to execute_mcp_tool which handles:
-        # - Server routing
-        # - Permission checking
-        # - Approval workflow
-        # - MCP protocol execution
-        return await self.execute_mcp_tool(tool_name, params, timeout)
-
-    async def execute_mcp_tool(
-        self, tool_name: str, params: Dict[str, Any], timeout: Optional[float] = None
-    ) -> Dict[str, Any]:
-        """
-        Execute MCP tool with server routing and approval workflow.
-
-        Routes tool execution to the correct MCP server based on naming convention:
-        mcp__<serverName>__<toolName>
-
-        For builtin MCP tools (kaizen_builtin server), implements danger-level based
-        approval workflow:
-        - SAFE tools: Execute immediately (read_file, file_exists, etc.)
-        - MEDIUM tools: Request approval (write_file, http_post, etc.)
-        - HIGH tools: Always request approval (delete_file, bash_command, etc.)
-
-        Args:
-            tool_name: Tool name with naming convention (mcp__server__tool)
-            params: Tool parameters
-            timeout: Optional execution timeout
-
-        Returns:
-            Tool execution result
-
-        Raises:
-            ValueError: If tool_name format invalid or server not found
-            PermissionError: If approval required but denied or control_protocol not configured
-
-        Example:
-            >>> agent = BaseAgent(
-            ...     config=config,
-            ...     signature=signature,
-            ...     mcp_servers=[{"name": "filesystem", ...}]
-            ... )
-            >>>
-            >>> result = await agent.execute_mcp_tool(
-            ...     "mcp__filesystem__read_file",
-            ...     {"path": "/data/test.txt"}
-            ... )
-            >>> print(result["content"])
-        """
-        # Validate naming convention
-        if not tool_name.startswith("mcp__") or tool_name.count("__") < 2:
-            raise ValueError(
-                f"Invalid MCP tool name format: {tool_name}. "
-                "Expected: mcp__<serverName>__<toolName>"
-            )
-
-        # Parse tool name
-        parts = tool_name.split("__")
-        server_name = parts[1]
-        original_tool_name = "__".join(parts[2:])  # Handle tool names with __
-
-        # Find server config
-        server_config = None
-        for config in self._mcp_servers:
-            if config.get("name") == server_name:
-                server_config = config
-                break
-
-        if server_config is None:
-            raise ValueError(
-                f"MCP server '{server_name}' not found in configured servers"
-            )
-
-        # Check danger level and request approval if needed (builtin tools only)
-        if server_name == "kaizen_builtin":
-            from kaizen.mcp.builtin_server.danger_levels import (
-                get_tool_danger_level,
-                is_tool_safe,
-            )
-            from kaizen.tools.types import DangerLevel
-
-            try:
-                danger_level = get_tool_danger_level(original_tool_name)
-            except ValueError:
-                # Unknown tool - treat as MEDIUM danger by default
-                danger_level = DangerLevel.MEDIUM
-
-            # Request approval if tool is not SAFE
-            if not is_tool_safe(original_tool_name):
-                # Check permission policy first (supports BYPASS mode for E2E tests)
-                permission_decision, denial_reason = (
-                    self.permission_policy.check_permission(
-                        tool_name=original_tool_name,
-                        tool_input=params,
-                        estimated_cost=0.0,
-                    )
-                )
-
-                # Permission policy says allow (e.g., BYPASS mode)
-                if permission_decision is True:
-                    pass  # Allow execution without approval
-
-                # Permission policy says deny
-                elif permission_decision is False:
-                    raise PermissionError(
-                        f"Tool '{original_tool_name}' denied by permission policy: {denial_reason}"
-                    )
-
-                # Permission policy says ask user (requires approval_manager)
-                else:
-                    if self.approval_manager is None:
-                        raise PermissionError(
-                            f"Tool '{original_tool_name}' (danger={danger_level.value}) "
-                            "requires approval but control_protocol not configured. "
-                            "Pass control_protocol to BaseAgent.__init__() to enable approval workflow."
-                        )
-
-                    # Request approval via control protocol
-                    from kaizen.core.autonomy.permissions.context import (
-                        ExecutionContext,
-                    )
-
-                    context = (
-                        getattr(self, "execution_context", None) or ExecutionContext()
-                    )
-                    approved = await self.approval_manager.request_approval(
-                        tool_name=original_tool_name,
-                        tool_input=params,
-                        context=context,
-                        timeout=timeout or 60.0,
-                    )
-
-                    if not approved:
-                        raise PermissionError(
-                            f"User denied approval for tool '{original_tool_name}' "
-                            f"(danger={danger_level.value})"
-                        )
-
-        # Execute tool via MCPClient
-        result = await self._mcp_client.call_tool(
-            server_config, original_tool_name, params, timeout=timeout
-        )
-
-        # Convert CallToolResult to dict format expected by tests/external code
-        return self._convert_mcp_result_to_dict(result)
-
-    async def discover_mcp_resources(
-        self, server_name: str, force_refresh: bool = False
-    ) -> List[Dict[str, Any]]:
-        """
-        Discover MCP resources from a specific server.
-
-        Args:
-            server_name: Server name to query
-            force_refresh: Bypass cache and rediscover (default: False)
-
-        Returns:
-            List of resource definitions
-
-        Raises:
-            RuntimeError: If MCP not configured
-
-        Example:
-            >>> resources = await agent.discover_mcp_resources("filesystem")
-            >>> print(resources[0]["uri"])  # "file:///data/file.txt"
-        """
-        if self._mcp_servers is None:
-            raise RuntimeError("MCP not configured")
-
-        # Find server config
-        server_config = None
-        for config in self._mcp_servers:
-            if config.get("name") == server_name:
-                server_config = config
-                break
-
-        if server_config is None:
-            raise ValueError(f"MCP server '{server_name}' not found")
-
-        # Check cache
-        if not force_refresh and server_name in self._discovered_mcp_resources:
-            return self._discovered_mcp_resources[server_name]
-
-        # Discover resources via MCPClient session
-        resources = await self._with_mcp_session(
-            server_config, self._mcp_client.list_resources
-        )
-        self._discovered_mcp_resources[server_name] = resources
-        return resources
-
-    async def read_mcp_resource(self, server_name: str, uri: str) -> Any:
-        """
-        Read MCP resource content from a specific server.
-
-        Args:
-            server_name: Server name
-            uri: Resource URI
-
-        Returns:
-            Resource content
-
-        Raises:
-            RuntimeError: If MCP not configured
-
-        Example:
-            >>> content = await agent.read_mcp_resource(
-            ...     "filesystem",
-            ...     "file:///data/test.txt"
-            ... )
-        """
-        if self._mcp_servers is None:
-            raise RuntimeError("MCP not configured")
-
-        # Find server config
-        server_config = None
-        for config in self._mcp_servers:
-            if config.get("name") == server_name:
-                server_config = config
-                break
-
-        if server_config is None:
-            raise ValueError(f"MCP server '{server_name}' not found")
-
-        # Read resource via MCPClient session
-        return await self._with_mcp_session(
-            server_config, self._mcp_client.read_resource, uri
-        )
-
-    async def discover_mcp_prompts(
-        self, server_name: str, force_refresh: bool = False
-    ) -> List[Dict[str, Any]]:
-        """
-        Discover MCP prompts from a specific server.
-
-        Args:
-            server_name: Server name to query
-            force_refresh: Bypass cache and rediscover (default: False)
-
-        Returns:
-            List of prompt definitions
-
-        Raises:
-            RuntimeError: If MCP not configured
-
-        Example:
-            >>> prompts = await agent.discover_mcp_prompts("api-tools")
-            >>> print(prompts[0]["name"])  # "greeting"
-        """
-        if self._mcp_servers is None:
-            raise RuntimeError("MCP not configured")
-
-        # Find server config
-        server_config = None
-        for config in self._mcp_servers:
-            if config.get("name") == server_name:
-                server_config = config
-                break
-
-        if server_config is None:
-            raise ValueError(f"MCP server '{server_name}' not found")
-
-        # Check cache
-        if not force_refresh and server_name in self._discovered_mcp_prompts:
-            return self._discovered_mcp_prompts[server_name]
-
-        # Discover prompts via MCPClient session
-        prompts = await self._with_mcp_session(
-            server_config, self._mcp_client.list_prompts
-        )
-        self._discovered_mcp_prompts[server_name] = prompts
-        return prompts
-
-    async def get_mcp_prompt(
-        self, server_name: str, prompt_name: str, arguments: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """
-        Get MCP prompt with arguments from a specific server.
-
-        Args:
-            server_name: Server name
-            prompt_name: Prompt name
-            arguments: Prompt arguments
-
-        Returns:
-            Prompt with messages
-
-        Raises:
-            RuntimeError: If MCP not configured
-
-        Example:
-            >>> prompt = await agent.get_mcp_prompt(
-            ...     "api-tools",
-            ...     "greeting",
-            ...     {"name": "Alice"}
-            ... )
-        """
-        if self._mcp_servers is None:
-            raise RuntimeError("MCP not configured")
-
-        # Find server config
-        server_config = None
-        for config in self._mcp_servers:
-            if config.get("name") == server_name:
-                server_config = config
-                break
-
-        if server_config is None:
-            raise ValueError(f"MCP server '{server_name}' not found")
-
-        # Get prompt via MCPClient session
-        return await self._with_mcp_session(
-            server_config, self._mcp_client.get_prompt, prompt_name, arguments
-        )
-
-    async def _with_mcp_session(self, server_config: Dict[str, Any], method, *args):
-        """
-        Create a temporary MCP session to a server and invoke a session-based method.
-
-        Opens a connection using the appropriate transport (STDIO, SSE, HTTP, or
-        WebSocket), initialises the session, calls ``method(session, *args)`` and
-        returns the result.  The connection is torn down automatically when done.
-
-        Args:
-            server_config: Server configuration dict (must include 'transport').
-            method: An async callable that accepts ``(session, *args)`` -- one of
-                the MCPClient session helpers such as ``list_resources``,
-                ``read_resource``, ``list_prompts``, or ``get_prompt``.
-            *args: Extra positional arguments forwarded to *method* after *session*.
-
-        Returns:
-            Whatever *method* returns.
-        """
-        import asyncio
-        import os
-        from contextlib import AsyncExitStack
-
-        transport_type = server_config.get("transport", "stdio")
-
-        async with AsyncExitStack() as stack:
-            if transport_type == "stdio":
-                from mcp import ClientSession, StdioServerParameters
-                from mcp.client.stdio import stdio_client
-
-                command = server_config.get("command", "python")
-                cmd_args = server_config.get("args", [])
-                env = server_config.get("env", {})
-                server_env = os.environ.copy()
-                server_env.update(env)
-                server_params = StdioServerParameters(
-                    command=command, args=cmd_args, env=server_env
-                )
-                stdio = await stack.enter_async_context(stdio_client(server_params))
-                session = await stack.enter_async_context(
-                    ClientSession(stdio[0], stdio[1])
-                )
-
-            elif transport_type == "sse":
-                from mcp import ClientSession
-                from mcp.client.sse import sse_client
-
-                url = server_config["url"]
-                headers = self._mcp_client._get_auth_headers(server_config)
-                sse = await stack.enter_async_context(
-                    sse_client(url=url, headers=headers)
-                )
-                session = await stack.enter_async_context(ClientSession(sse[0], sse[1]))
-
-            elif transport_type == "http":
-                from mcp import ClientSession
-                from mcp.client.streamable_http import streamable_http_client
-
-                url = server_config["url"]
-                headers = self._mcp_client._get_auth_headers(server_config)
-                http = await stack.enter_async_context(
-                    streamable_http_client(url=url, headers=headers)
-                )
-                session = await stack.enter_async_context(
-                    ClientSession(http[0], http[1])
-                )
-
-            elif transport_type == "websocket":
-                from mcp import ClientSession
-                from mcp.client.websocket import websocket_client
-
-                url = server_config.get("url", server_config.get("uri"))
-                if not url:
-                    raise ValueError("WebSocket server config must include 'url'")
-                ws = await stack.enter_async_context(websocket_client(url=url))
-                session = await stack.enter_async_context(ClientSession(ws[0], ws[1]))
-
-            else:
-                raise ValueError(f"Unsupported transport type: {transport_type}")
-
-            await session.initialize()
-            return await method(session, *args)
-
-    # =============================================================================
-    # MCP INTEGRATION HELPERS (using kailash.mcp_server)
-    # =============================================================================
-    # These methods provide convenient MCP integration using Kailash SDK's
-    # production-ready MCP implementation. No mocking - real JSON-RPC protocol.
-    #
-    # Architecture: Kaizen EXTENDS Kailash SDK MCP (not recreate)
-    # Implementation: kailash.mcp_server (100% MCP spec compliant)
-    # =============================================================================
-
-    async def setup_mcp_client(
-        self,
-        servers: List[Dict[str, Any]],
-        retry_strategy: str = "circuit_breaker",
-        enable_metrics: bool = True,
-        **client_kwargs,
-    ):
-        """
-        Setup MCP client for consuming external MCP tools.
-
-        Uses Kailash SDK's production-ready MCPClient with full protocol support.
-
-        Args:
-            servers: List of MCP server configurations. Each server dict should contain:
-                - name (str): Server name
-                - transport (str): "stdio", "http", "sse", or "websocket"
-                - command (str): Command to start server (for stdio)
-                - args (List[str]): Arguments for command (for stdio)
-                - url (str): Server URL (for http/sse/websocket)
-                - headers (Dict): Optional HTTP headers
-                - env (Dict): Optional environment variables
-            retry_strategy: Retry strategy ("simple", "exponential", "circuit_breaker")
-            enable_metrics: Enable metrics collection
-            **client_kwargs: Additional MCPClient arguments
-
-        Returns:
-            MCPClient: Configured MCPClient instance
-
-        Raises:
-            ImportError: If kailash.mcp_server not available
-            ValueError: If server config is invalid
-
-        Example:
-            >>> # STDIO transport (local process)
-            >>> await agent.setup_mcp_client([
-            ...     {
-            ...         "name": "filesystem-tools",
-            ...         "transport": "stdio",
-            ...         "command": "npx",
-            ...         "args": ["@modelcontextprotocol/server-filesystem", "/data"]
-            ...     }
-            ... ])
-            >>>
-            >>> # HTTP transport (remote server)
-            >>> await agent.setup_mcp_client([
-            ...     {
-            ...         "name": "api-tools",
-            ...         "transport": "http",
-            ...         "url": "http://localhost:8080",
-            ...         "headers": {"Authorization": "Bearer token"}
-            ...     }
-            ... ])
-
-        Note:
-            - All MCP methods are async (use await)
-            - Real JSON-RPC protocol (no mocking)
-            - Enterprise features: auth, retry, circuit breaker
-            - 100% MCP spec compliant: tools, resources, prompts
-        """
-        try:
-            from kailash_mcp import MCPClient
-        except ImportError:
-            raise ImportError(
-                "kailash_mcp not available. Install with: pip install kailash"
-            )
-
-        # Create production MCP client
-        self._mcp_client = MCPClient(
-            retry_strategy=retry_strategy,
-            enable_metrics=enable_metrics,
-            **client_kwargs,
-        )
-
-        # Discover tools from all servers
-        self._available_mcp_tools = {}
-
-        for server_config in servers:
-            # Validate server config
-            if "name" not in server_config or "transport" not in server_config:
-                raise ValueError(
-                    "Server config must include 'name' and 'transport' fields"
-                )
-
-            # Discover tools via real MCP protocol
-            tools = await self._mcp_client.discover_tools(
-                server_config, force_refresh=True
-            )
-
-            # Store tools with server info
-            for tool in tools:
-                tool_id = f"{server_config['name']}:{tool['name']}"
-                self._available_mcp_tools[tool_id] = {
-                    **tool,
-                    "server_config": server_config,
-                }
-
-            logger.info(
-                f"Discovered {len(tools)} tools from MCP server: {server_config['name']}"
-            )
-
-        logger.info(
-            f"MCP client setup complete. {len(self._available_mcp_tools)} tools available."
-        )
-
-        return self._mcp_client
-
-    async def call_mcp_tool(
-        self,
-        tool_id: str,
-        arguments: Dict[str, Any],
-        timeout: float = 30.0,
-        store_in_memory: bool = True,
-    ) -> Dict[str, Any]:
-        """
-        Call MCP tool by ID using real JSON-RPC protocol.
-
-        Args:
-            tool_id: Tool ID (format: "server_name:tool_name")
-            arguments: Tool arguments (must match tool schema)
-            timeout: Timeout in seconds
-            store_in_memory: Store tool call in shared memory
-
-        Returns:
-            Dict with tool result. Structure depends on tool implementation.
-
-        Raises:
-            RuntimeError: If MCP client not setup
-            ValueError: If tool_id not found
-            Exception: If tool invocation fails
-
-        Example:
-            >>> # Setup MCP client first
-            >>> await agent.setup_mcp_client([...])
-            >>>
-            >>> # Call tool
-            >>> result = await agent.call_mcp_tool(
-            ...     "filesystem-tools:read_file",
-            ...     {"path": "/data/input.txt"}
-            ... )
-            >>> print(result)
-
-        Note:
-            - Tool calls are async (use await)
-            - Results stored in shared memory automatically
-            - Real MCP tool invocation via JSON-RPC
-        """
-        if not hasattr(self, "_mcp_client") or self._mcp_client is None:
-            raise RuntimeError("MCP client not setup. Call setup_mcp_client() first.")
-
-        if tool_id not in self._available_mcp_tools:
-            available_tools = list(self._available_mcp_tools.keys())
-            raise ValueError(
-                f"Tool {tool_id} not found. Available tools: {available_tools}"
-            )
-
-        # Get tool info
-        tool_info = self._available_mcp_tools[tool_id]
-        server_config = tool_info["server_config"]
-        tool_name = tool_info["name"]
-
-        # Call via real MCP protocol
-        result = await self._mcp_client.call_tool(
-            server_config, tool_name, arguments, timeout=timeout
-        )
-
-        # Store in shared memory if enabled
-        if store_in_memory and hasattr(self, "shared_memory") and self.shared_memory:
-            self.write_to_memory(
-                content={
-                    "tool_id": tool_id,
-                    "server": server_config["name"],
-                    "tool_name": tool_name,
-                    "arguments": arguments,
-                    "result": result,
-                    "agent_id": self.agent_id,
-                },
-                tags=["mcp_tool_call", server_config["name"], tool_name],
-                importance=0.8,
-            )
-
-        # Convert CallToolResult to dict format expected by tests/external code
-        return self._convert_mcp_result_to_dict(result)
-
-    def expose_as_mcp_server(
-        self,
-        server_name: str,
-        tools: Optional[List[str]] = None,
-        auth_provider: Optional[Any] = None,
-        enable_auto_discovery: bool = True,
-        **server_kwargs,
-    ):
-        """
-        Expose agent as MCP server with real protocol support.
-
-        Creates a production MCP server that exposes agent methods as MCP tools.
-
-        Args:
-            server_name: Server name for MCP registration
-            tools: List of agent methods to expose (default: auto-detect public methods)
-            auth_provider: Optional auth provider (APIKeyAuth, JWTAuth, etc.)
-            enable_auto_discovery: Enable network discovery
-            **server_kwargs: Additional MCPServer arguments
-
-        Returns:
-            MCPServer: Configured server (call .run() to start)
-
-        Raises:
-            ImportError: If kailash_mcp not available
-
-        Example:
-            >>> from kailash_mcp.auth.providers import APIKeyAuth
-            >>>
-            >>> # Create agent
-            >>> agent = MyAgent(config=config, signature=signature)
-            >>>
-            >>> # Expose as MCP server
-            >>> auth = APIKeyAuth({"client1": "secret-key"})
-            >>> server = agent.expose_as_mcp_server(
-            ...     "analysis-agent",
-            ...     tools=["analyze", "summarize"],
-            ...     auth_provider=auth
-            ... )
-            >>>
-            >>> # Start server (blocks)
-            >>> server.run()
-
-        Note:
-            - Agent methods exposed as async MCP tools
-            - Real JSON-RPC 2.0 protocol
-            - Enterprise features: auth, metrics, monitoring
-            - Service discovery via registry + network
-        """
-        try:
-            from kailash_mcp import MCPServer
-            from kailash_mcp import enable_auto_discovery as enable_discovery
-        except ImportError:
-            raise ImportError(
-                "kailash_mcp not available. Install with: pip install kailash"
-            )
-
-        # Create production MCP server
-        server = MCPServer(
-            name=server_name,
-            auth_provider=auth_provider,
-            enable_metrics=True,
-            enable_http_transport=True,
-            **server_kwargs,
-        )
-
-        # Auto-detect tools if not specified
-        if tools is None:
-            # Expose all public methods (not starting with _)
-            tools = [
-                m
-                for m in dir(self)
-                if not m.startswith("_") and callable(getattr(self, m))
-            ]
-
-        # Wrap agent methods as MCP tools
-        for tool_name in tools:
-            if not hasattr(self, tool_name):
-                logger.warning(f"Tool {tool_name} not found on agent, skipping")
-                continue
-
-            method = getattr(self, tool_name)
-
-            # Create tool wrapper with dynamic name
-            # Note: MCPServer.tool() decorator infers name from function __name__
-            async def tool_wrapper(**kwargs):
-                """Auto-generated MCP tool from agent method."""
-                # Execute agent method
-                result = method(**kwargs)
-
-                # If result is awaitable, await it
-                if hasattr(result, "__await__"):
-                    result = await result
-
-                return result
-
-            # Set the function name so the decorator can infer it
-            tool_wrapper.__name__ = tool_name
-
-            # Register with MCP server
-            server.tool()(tool_wrapper)
-
-        # Store server reference
-        self._mcp_server = server
-
-        # Enable auto-discovery if requested
-        if enable_auto_discovery:
-            registrar = enable_discovery(server, enable_network_discovery=True)
-            self._mcp_registrar = registrar
-            logger.info(f"MCP server '{server_name}' ready with auto-discovery enabled")
-        else:
-            self._mcp_registrar = None
-            logger.info(f"MCP server '{server_name}' ready")
-
-        return server
-
     # =========================================================================
-    # Observability
+    # Observability (MCP tool methods inherited from MCPMixin)
     # =========================================================================
 
     def enable_observability(

--- a/packages/kailash-kaizen/src/kaizen/core/config.py
+++ b/packages/kailash-kaizen/src/kaizen/core/config.py
@@ -108,18 +108,33 @@ class BaseAgentConfig:
     # continue to work without churn.
     posture: Optional[AgentPosture] = None
 
+    # SPEC-04 §10.3: posture is immutable after construction to prevent
+    # posture tampering. The guard activates after __post_init__ completes.
+    _IMMUTABLE_AFTER_INIT = frozenset({"posture"})
+
+    def __setattr__(self, name: str, value: object) -> None:
+        if (
+            name in self._IMMUTABLE_AFTER_INIT
+            and hasattr(self, "_initialized")
+            and self._initialized
+        ):
+            raise AttributeError(
+                f"BaseAgentConfig.{name} is immutable after construction "
+                f"(SPEC-04 §10.3). Use dataclasses.replace() to create a "
+                f"new config with a different {name}."
+            )
+        super().__setattr__(name, value)
+
     def __post_init__(self):
-        """Validate configuration after initialization."""
+        """Validate and coerce fields."""
         # Set default permission_mode if not specified
         if self.permission_mode is None:
-            # Import here to avoid circular dependency
             from kaizen.core.autonomy.permissions.types import PermissionMode
 
             self.permission_mode = PermissionMode.DEFAULT
 
         # Coerce posture: accept a string wire value for backward compat
-        # and convert to the canonical AgentPosture enum. Invalid values
-        # raise a clear error at construction time (SPEC-04 § 1 item 4).
+        # and convert to the canonical AgentPosture enum (SPEC-04 §10.3).
         if self.posture is not None and not isinstance(self.posture, AgentPosture):
             if isinstance(self.posture, str):
                 try:
@@ -140,6 +155,9 @@ class BaseAgentConfig:
         self._migrate_provider_config()
 
         self._validate_parameters()
+
+        # Activate immutability guard for security-critical fields
+        self._initialized = True
 
     @property
     def has_structured_output(self) -> bool:
@@ -165,7 +183,6 @@ class BaseAgentConfig:
             and "type" in self.provider_config
         ):
             if self.response_format is None:
-                # Split: structured output keys → response_format, rest stays
                 response_format_parts = {}
                 remaining = {}
                 for k, v in self.provider_config.items():
@@ -185,7 +202,6 @@ class BaseAgentConfig:
                     stacklevel=3,
                 )
             else:
-                # Both set — strip structured output keys from provider_config
                 remaining = {
                     k: v
                     for k, v in self.provider_config.items()

--- a/packages/kailash-kaizen/tests/unit/core/test_base_agent_posture_and_deprecation.py
+++ b/packages/kailash-kaizen/tests/unit/core/test_base_agent_posture_and_deprecation.py
@@ -1,18 +1,12 @@
 # Copyright 2026 Terrene Foundation
 # Licensed under the Apache License, Version 2.0
-"""Tests for BaseAgent SPEC-04 Wave 1G -- posture typing + @deprecated decorators.
-
-Covers CRITICAL #3 and #4 from the convergence spec compliance audit v2:
+"""Tests for BaseAgent SPEC-04 — posture typing + extension point architecture.
 
 - ``BaseAgentConfig.posture`` is typed ``Optional[AgentPosture]`` and
   coerces legacy string inputs while rejecting unknown values.
-- The seven extension-point slots on ``BaseAgent`` carry the
-  ``@deprecated`` decorator (detected via the ``_deprecated`` marker that
-  the decorator sets on the wrapped function).
-- Vanilla ``BaseAgent`` construction and execution emit zero
-  ``DeprecationWarning`` from the extension-point slots (internal callers
-  go through ``_invoke_extension_point``).
-- Direct external invocation of a deprecated slot DOES emit the warning.
+- The seven extension points are direct methods on BaseAgent (no shims).
+- Subclass overrides win via normal MRO — no dispatcher needed.
+- Vanilla ``BaseAgent`` construction emits zero ``DeprecationWarning``.
 """
 
 from __future__ import annotations
@@ -42,9 +36,6 @@ class TestBaseAgentConfigPostureType:
     def test_posture_field_annotation_is_agent_posture(self) -> None:
         fields = {f.name: f.type for f in dataclasses.fields(BaseAgentConfig)}
         annotation = fields["posture"]
-        # Annotation is ``Optional[AgentPosture]`` which reduces to
-        # ``typing.Optional[kailash.trust.envelope.AgentPosture]``. Accept
-        # either the raw class or the string form.
         assert "AgentPosture" in str(annotation)
 
     def test_none_is_default(self) -> None:
@@ -74,40 +65,34 @@ class TestBaseAgentConfigPostureType:
             assert config.posture is posture
 
 
-class TestSevenExtensionPointsDeprecated:
-    """Every extension point MUST carry ``@deprecated`` (SPEC-04 CRITICAL #3)."""
+class TestSevenExtensionPointsAreDirect:
+    """Extension points are direct methods — no dispatcher, no decorator."""
 
     @pytest.mark.parametrize("name", _EXTENSION_POINTS)
-    def test_slot_is_decorated(self, name: str) -> None:
+    def test_extension_point_is_callable(self, name: str) -> None:
+        assert callable(getattr(BaseAgent, name))
+
+    def test_all_seven_exist(self) -> None:
+        for name in _EXTENSION_POINTS:
+            assert hasattr(BaseAgent, name), f"{name} missing from BaseAgent"
+
+    @pytest.mark.parametrize("name", _EXTENSION_POINTS)
+    def test_no_deprecated_decorator(self, name: str) -> None:
+        """Extension points should NOT have deprecated decorators (removed in SPEC-04)."""
         slot = getattr(BaseAgent, name)
-        # The ``deprecated`` decorator in ``kaizen.core.deprecation`` sets
-        # ``_deprecated`` and ``_deprecated_message`` attributes on the
-        # wrapper function; assert both are present so a future refactor
-        # that drops the wrapper fails loudly.
-        assert (
-            getattr(slot, "_deprecated", False) is True
-        ), f"{name} is missing the @deprecated wrapper"
-        assert "deprecated" in slot._deprecated_message.lower()
+        assert not getattr(
+            slot, "_deprecated", False
+        ), f"{name} still has @deprecated — shim layer should be removed"
 
-    def test_all_seven_slots_decorated(self) -> None:
-        decorated = [
-            name
-            for name in _EXTENSION_POINTS
-            if getattr(getattr(BaseAgent, name), "_deprecated", False)
-        ]
-        assert (
-            len(decorated) == 7
-        ), f"expected 7 decorated extension points, got {len(decorated)}: {decorated}"
+    def test_subclass_override_wins_via_mro(self) -> None:
+        """Subclass overrides should work via normal Python MRO."""
 
-    def test_decorator_count_matches_spec(self) -> None:
-        # SPEC-04 validation criterion: ``grep -c "@deprecated"`` in
-        # base_agent.py MUST return 7. We assert the semantic equivalent
-        # via runtime introspection.
-        slot_names = _EXTENSION_POINTS
-        wrapped = sum(
-            1 for name in slot_names if hasattr(getattr(BaseAgent, name), "_deprecated")
-        )
-        assert wrapped == 7
+        class CustomAgent(BaseAgent):
+            def _default_signature(self):
+                return "custom"
+
+        agent = CustomAgent(config=BaseAgentConfig(), mcp_servers=[])
+        assert agent._default_signature() == "custom"
 
 
 class TestVanillaBaseAgentIsWarningFree:
@@ -122,48 +107,43 @@ class TestVanillaBaseAgentIsWarningFree:
             for w in captured
             if issubclass(w.category, DeprecationWarning)
             and "extension point" in str(w.message).lower()
-            or "BaseAgent extension points are deprecated" in str(w.message)
         ]
         assert offenders == [], (
             f"expected zero extension-point warnings on vanilla construction, "
             f"got {[str(w.message) for w in offenders]}"
         )
 
-    def test_direct_slot_invocation_emits_warning(self) -> None:
+    def test_direct_call_emits_no_warning(self) -> None:
+        """Direct calls to extension points should NOT emit warnings anymore."""
         agent = BaseAgent(config=BaseAgentConfig(), mcp_servers=[])
-        with pytest.warns(
-            DeprecationWarning, match="BaseAgent extension points are deprecated"
-        ):
-            agent._default_signature()
-
-    @pytest.mark.parametrize("name", _EXTENSION_POINTS)
-    def test_every_slot_emits_warning_when_called_directly(self, name: str) -> None:
-        agent = BaseAgent(config=BaseAgentConfig(), mcp_servers=[])
-        slot = getattr(agent, name)
-        # Call with the smallest possible argument set that satisfies each
-        # method signature. The arity varies: signature/strategy/prompt
-        # take no args; validate/hooks/error take 1-2.
         with warnings.catch_warnings(record=True) as captured:
             warnings.simplefilter("always")
-            try:
-                if name in {
-                    "_default_signature",
-                    "_default_strategy",
-                    "_generate_system_prompt",
-                }:
-                    slot()
-                elif name == "_validate_signature_output":
-                    slot({"response": "ok"})
-                elif name in {"_pre_execution_hook", "_post_execution_hook"}:
-                    slot({})
-                elif name == "_handle_error":
-                    try:
-                        slot(ValueError("x"), {"inputs": {}})
-                    except Exception:
-                        pass
-            except Exception:
-                # Some impls may raise on trivial args; the warning still
-                # fires before the body executes.
-                pass
+            agent._default_signature()
         deps = [w for w in captured if issubclass(w.category, DeprecationWarning)]
-        assert deps, f"expected DeprecationWarning on direct call to {name}"
+        assert not deps, "extension points should not emit deprecation warnings"
+
+
+class TestPostureImmutability:
+    """SPEC-04 §10.3: posture is immutable after construction."""
+
+    def test_posture_mutation_blocked(self) -> None:
+        config = BaseAgentConfig(posture=AgentPosture.SUPERVISED)
+        with pytest.raises(AttributeError, match="immutable after construction"):
+            config.posture = AgentPosture.AUTONOMOUS
+
+    def test_posture_set_during_construction_works(self) -> None:
+        config = BaseAgentConfig(posture="supervised")
+        assert config.posture is AgentPosture.SUPERVISED
+
+    def test_non_guarded_fields_still_mutable(self) -> None:
+        config = BaseAgentConfig()
+        config.model = "gpt-4o"
+        assert config.model == "gpt-4o"
+
+    def test_replace_creates_new_config_with_different_posture(self) -> None:
+        import dataclasses
+
+        original = BaseAgentConfig(posture=AgentPosture.SUPERVISED)
+        updated = dataclasses.replace(original, posture=AgentPosture.AUTONOMOUS)
+        assert original.posture is AgentPosture.SUPERVISED
+        assert updated.posture is AgentPosture.AUTONOMOUS

--- a/packages/kailash-kaizen/tests/unit/core/test_base_agent_security.py
+++ b/packages/kailash-kaizen/tests/unit/core/test_base_agent_security.py
@@ -18,7 +18,6 @@ import pytest
 from kaizen.core.base_agent import BaseAgent
 from kaizen.core.config import BaseAgentConfig
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -80,29 +79,24 @@ class TestDeferredMcpNoAutoConnect:
 # ---------------------------------------------------------------------------
 
 
-class TestLegacyKwargsIgnored:
-    """Unknown kwargs passed to BaseAgent.__init__ should not crash."""
+class TestUnknownKwargsRejected:
+    """SPEC-04 §10.2: Unknown kwargs MUST be rejected (no catch-all)."""
 
-    def test_unknown_kwargs_accepted(self) -> None:
-        """Extra kwargs are passed through to Node.__init__ without crashing."""
+    def test_unknown_kwargs_raise_type_error(self) -> None:
+        """Extra kwargs cause TypeError — the **kwargs catch-all is gone."""
         config = BaseAgentConfig()
-        # These unknown kwargs should be absorbed by **kwargs -> Node.__init__
-        agent = _StubAgent(
-            config=config,
-            mcp_servers=[],
-            unknown_param="value",
-            another_param=42,
-        )
-        assert agent is not None
+        with pytest.raises(TypeError):
+            _StubAgent(
+                config=config,
+                mcp_servers=[],
+                unknown_param="value",
+                another_param=42,
+            )
 
-    def test_agent_functional_with_extra_kwargs(self) -> None:
-        """Agent still works correctly even with extra kwargs."""
+    def test_known_kwargs_still_accepted(self) -> None:
+        """Valid params continue to work."""
         config = BaseAgentConfig()
-        agent = _StubAgent(
-            config=config,
-            mcp_servers=[],
-            legacy_flag=True,
-        )
+        agent = _StubAgent(config=config, mcp_servers=[])
         result = agent.run()
         assert result == {"text": "stub"}
 
@@ -112,84 +106,62 @@ class TestLegacyKwargsIgnored:
 # ---------------------------------------------------------------------------
 
 
-class TestExtensionShadowDeprecated:
-    """Overriding deprecated extension points must emit DeprecationWarning."""
+class TestExtensionPointOverrides:
+    """Subclass extension point overrides work via normal MRO."""
 
-    def test_override_pre_execution_hook_warns(self) -> None:
-        """Subclass overriding _pre_execution_hook emits DeprecationWarning."""
+    def test_override_pre_execution_hook_works(self) -> None:
+        """Subclass overriding _pre_execution_hook takes effect via MRO."""
+
+        class _CustomAgent(BaseAgent):
+            def _pre_execution_hook(self, inputs: Any) -> Any:
+                inputs["custom"] = True
+                return inputs
+
+        agent = _CustomAgent(config=BaseAgentConfig(), mcp_servers=[])
+        result = agent._pre_execution_hook({"key": "val"})
+        assert result["custom"] is True
+
+    def test_override_post_execution_hook_works(self) -> None:
+        """Subclass overriding _post_execution_hook takes effect via MRO."""
+
+        class _PostHookAgent(BaseAgent):
+            def _post_execution_hook(self, result: Any) -> Any:
+                result["hooked"] = True
+                return result
+
+        agent = _PostHookAgent(config=BaseAgentConfig(), mcp_servers=[])
+        result = agent._post_execution_hook({"text": "ok"})
+        assert result["hooked"] is True
+
+    def test_override_handle_error_works(self) -> None:
+        """Subclass overriding _handle_error takes effect via MRO."""
+
+        class _ErrorAgent(BaseAgent):
+            def _handle_error(self, error: Exception, context: Any) -> Any:
+                return {"custom_error": str(error)}
+
+        agent = _ErrorAgent(config=BaseAgentConfig(), mcp_servers=[])
+        result = agent._handle_error(ValueError("test"), {})
+        assert result["custom_error"] == "test"
+
+    def test_no_override_uses_default(self) -> None:
+        """Without override, the base implementation runs."""
+
+        class _CleanAgent(BaseAgent):
+            pass
+
+        agent = _CleanAgent(config=BaseAgentConfig(), mcp_servers=[])
+        result = agent._pre_execution_hook({"key": "val"})
+        assert result["key"] == "val"
+
+    def test_no_deprecation_warnings_on_subclass(self) -> None:
+        """Subclassing with overrides should NOT emit deprecation warnings."""
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
 
-            class _CustomAgent(BaseAgent):
-                def _pre_execution_hook(self, **kwargs: Any) -> None:
-                    pass
-
-                def run(self, **inputs: Any) -> dict[str, Any]:
-                    return {"text": "custom"}
-
-                async def run_async(self, **inputs: Any) -> dict[str, Any]:
-                    return {"text": "custom-async"}
-
-        deprecation_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
-        ]
-        assert len(deprecation_warnings) >= 1
-        assert "_pre_execution_hook" in str(deprecation_warnings[0].message)
-        assert "deprecated" in str(deprecation_warnings[0].message).lower()
-
-    def test_override_post_execution_hook_warns(self) -> None:
-        """Subclass overriding _post_execution_hook emits DeprecationWarning."""
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-
-            class _PostHookAgent(BaseAgent):
-                def _post_execution_hook(self, result: Any, **kwargs: Any) -> Any:
-                    return result
-
-                def run(self, **inputs: Any) -> dict[str, Any]:
-                    return {"text": "post"}
-
-                async def run_async(self, **inputs: Any) -> dict[str, Any]:
-                    return {"text": "post-async"}
-
-        deprecation_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
-        ]
-        assert len(deprecation_warnings) >= 1
-        assert "_post_execution_hook" in str(deprecation_warnings[0].message)
-
-    def test_override_handle_error_warns(self) -> None:
-        """Subclass overriding _handle_error emits DeprecationWarning."""
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-
-            class _ErrorAgent(BaseAgent):
-                def _handle_error(self, error: Exception, **kwargs: Any) -> Any:
-                    return {"error": str(error)}
-
-                def run(self, **inputs: Any) -> dict[str, Any]:
-                    return {"text": "err"}
-
-                async def run_async(self, **inputs: Any) -> dict[str, Any]:
-                    return {"text": "err-async"}
-
-        deprecation_warnings = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
-        ]
-        assert len(deprecation_warnings) >= 1
-        assert "_handle_error" in str(deprecation_warnings[0].message)
-
-    def test_no_override_no_warning(self) -> None:
-        """Subclass that does NOT override extension points emits no warning."""
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-
-            class _CleanAgent(BaseAgent):
-                def run(self, **inputs: Any) -> dict[str, Any]:
-                    return {"text": "clean"}
-
-                async def run_async(self, **inputs: Any) -> dict[str, Any]:
-                    return {"text": "clean-async"}
+            class _Agent(BaseAgent):
+                def _pre_execution_hook(self, inputs: Any) -> Any:
+                    return inputs
 
         deprecation_warnings = [
             w

--- a/packages/kailash-kaizen/tests/unit/core/test_base_agent_slimming.py
+++ b/packages/kailash-kaizen/tests/unit/core/test_base_agent_slimming.py
@@ -29,8 +29,10 @@ class TestBaseAgentLineCount:
         )
         lines = path.read_text().splitlines()
         assert len(lines) < 1000, (
-            f"base_agent.py has {len(lines)} lines, must be under 1,000. "
-            f"Extract more responsibilities into separate modules."
+            f"base_agent.py has grown to {len(lines)} lines (budget: <1000). "
+            f"This likely indicates a merge regression that re-inlined mixin "
+            f"code. MCP methods belong in MCPMixin, A2A in A2AMixin. "
+            f"See journal/0003-RISK-spec04-silent-regression-via-parallel-merge.md"
         )
 
     def test_extracted_modules_exist(self):

--- a/packages/kailash-pact/tests/unit/governance/test_access_matrix.py
+++ b/packages/kailash-pact/tests/unit/governance/test_access_matrix.py
@@ -22,6 +22,9 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from kailash.trust.pact.access import KnowledgeSharePolicy, PactBridge, can_access
+from kailash.trust.pact.clearance import RoleClearance, VettingStatus
+from kailash.trust.pact.compilation import CompiledOrg, RoleDefinition, compile_org
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     DepartmentConfig,
@@ -29,15 +32,7 @@ from kailash.trust.pact.config import (
     TeamConfig,
     TrustPostureLevel,
 )
-from kailash.trust.pact.access import (
-    KnowledgeSharePolicy,
-    PactBridge,
-    can_access,
-)
-from kailash.trust.pact.clearance import RoleClearance, VettingStatus
-from kailash.trust.pact.compilation import CompiledOrg, RoleDefinition, compile_org
 from kailash.trust.pact.knowledge import KnowledgeItem
-
 
 # ---------------------------------------------------------------------------
 # Shared fixture: Financial services org (same structure as flagship scenario)
@@ -402,11 +397,11 @@ def test_clearance_level_matrix(
 # ===========================================================================
 
 _POSTURE_CEILING = {
-    TrustPostureLevel.PSEUDO_AGENT: ConfidentialityLevel.PUBLIC,
-    TrustPostureLevel.SUPERVISED: ConfidentialityLevel.RESTRICTED,
-    TrustPostureLevel.SHARED_PLANNING: ConfidentialityLevel.CONFIDENTIAL,
-    TrustPostureLevel.CONTINUOUS_INSIGHT: ConfidentialityLevel.SECRET,
-    TrustPostureLevel.DELEGATED: ConfidentialityLevel.TOP_SECRET,
+    TrustPostureLevel.PSEUDO: ConfidentialityLevel.PUBLIC,
+    TrustPostureLevel.TOOL: ConfidentialityLevel.RESTRICTED,
+    TrustPostureLevel.SUPERVISED: ConfidentialityLevel.CONFIDENTIAL,
+    TrustPostureLevel.DELEGATING: ConfidentialityLevel.SECRET,
+    TrustPostureLevel.AUTONOMOUS: ConfidentialityLevel.TOP_SECRET,
 }
 
 _POSTURE_CASES = [

--- a/packages/kailash-pact/tests/unit/governance/test_audit.py
+++ b/packages/kailash-pact/tests/unit/governance/test_audit.py
@@ -11,10 +11,7 @@ Covers:
 
 from __future__ import annotations
 
-import pytest
-
 from kailash.trust.pact.audit import PactAuditAction, create_pact_audit_details
-
 
 # ===========================================================================
 # PactAuditAction enum
@@ -60,8 +57,8 @@ class TestPactAuditAction:
     def test_all_audit_actions_exist(self) -> None:
         """All action types per thesis Section 5.7 normative mapping + LCA bridge approval + vacancy + bilateral consent."""
         assert (
-            len(PactAuditAction) == 16
-        )  # 14 original + BRIDGE_REJECTED (#231) + CLEARANCE_SUSPENDED (#309)
+            len(PactAuditAction) == 19
+        )  # 14 original + BRIDGE_REJECTED + CLEARANCE_TRANSITIONED + PLAN_SUSPENDED + PLAN_RESUMED + RESUME_CONDITION_UPDATED
 
 
 # ===========================================================================

--- a/packages/kailash-pact/tests/unit/governance/test_clearance.py
+++ b/packages/kailash-pact/tests/unit/governance/test_clearance.py
@@ -18,14 +18,13 @@ from datetime import datetime, timezone
 
 import pytest
 
-from kailash.trust.pact.config import ConfidentialityLevel, TrustPostureLevel
 from kailash.trust.pact.clearance import (
     POSTURE_CEILING,
     RoleClearance,
     VettingStatus,
     effective_clearance,
 )
-
+from kailash.trust.pact.config import ConfidentialityLevel, TrustPostureLevel
 
 # ---------------------------------------------------------------------------
 # VettingStatus enum
@@ -59,31 +58,45 @@ class TestVettingStatus:
 class TestPostureCeiling:
     """POSTURE_CEILING maps every TrustPostureLevel to a ConfidentialityLevel."""
 
-    def test_pseudo_agent_ceiling_is_public(self) -> None:
+    def test_pseudo_ceiling_is_public(self) -> None:
+        assert POSTURE_CEILING[TrustPostureLevel.PSEUDO] == ConfidentialityLevel.PUBLIC
+
+    def test_tool_ceiling_is_restricted(self) -> None:
+        assert (
+            POSTURE_CEILING[TrustPostureLevel.TOOL] == ConfidentialityLevel.RESTRICTED
+        )
+
+    def test_supervised_ceiling_is_confidential(self) -> None:
+        assert (
+            POSTURE_CEILING[TrustPostureLevel.SUPERVISED]
+            == ConfidentialityLevel.CONFIDENTIAL
+        )
+
+    def test_delegating_ceiling_is_secret(self) -> None:
+        assert (
+            POSTURE_CEILING[TrustPostureLevel.DELEGATING] == ConfidentialityLevel.SECRET
+        )
+
+    def test_autonomous_ceiling_is_top_secret(self) -> None:
+        assert (
+            POSTURE_CEILING[TrustPostureLevel.AUTONOMOUS]
+            == ConfidentialityLevel.TOP_SECRET
+        )
+
+    def test_backward_compat_aliases_resolve_correctly(self) -> None:
+        """Old enum names resolve to the same ceiling as canonical names."""
         assert (
             POSTURE_CEILING[TrustPostureLevel.PSEUDO_AGENT]
             == ConfidentialityLevel.PUBLIC
         )
-
-    def test_supervised_ceiling_is_restricted(self) -> None:
-        assert (
-            POSTURE_CEILING[TrustPostureLevel.SUPERVISED]
-            == ConfidentialityLevel.RESTRICTED
-        )
-
-    def test_shared_planning_ceiling_is_confidential(self) -> None:
         assert (
             POSTURE_CEILING[TrustPostureLevel.SHARED_PLANNING]
             == ConfidentialityLevel.CONFIDENTIAL
         )
-
-    def test_continuous_insight_ceiling_is_secret(self) -> None:
         assert (
             POSTURE_CEILING[TrustPostureLevel.CONTINUOUS_INSIGHT]
             == ConfidentialityLevel.SECRET
         )
-
-    def test_delegated_ceiling_is_top_secret(self) -> None:
         assert (
             POSTURE_CEILING[TrustPostureLevel.DELEGATED]
             == ConfidentialityLevel.TOP_SECRET
@@ -207,18 +220,34 @@ class TestEffectiveClearance:
     @pytest.mark.parametrize(
         "posture, role_level, expected",
         [
-            # PSEUDO_AGENT ceiling = PUBLIC
+            # PSEUDO ceiling = PUBLIC
             (
-                TrustPostureLevel.PSEUDO_AGENT,
+                TrustPostureLevel.PSEUDO,
                 ConfidentialityLevel.PUBLIC,
                 ConfidentialityLevel.PUBLIC,
             ),
             (
-                TrustPostureLevel.PSEUDO_AGENT,
+                TrustPostureLevel.PSEUDO,
                 ConfidentialityLevel.SECRET,
                 ConfidentialityLevel.PUBLIC,
             ),
-            # SUPERVISED ceiling = RESTRICTED
+            # TOOL ceiling = RESTRICTED
+            (
+                TrustPostureLevel.TOOL,
+                ConfidentialityLevel.PUBLIC,
+                ConfidentialityLevel.PUBLIC,
+            ),
+            (
+                TrustPostureLevel.TOOL,
+                ConfidentialityLevel.RESTRICTED,
+                ConfidentialityLevel.RESTRICTED,
+            ),
+            (
+                TrustPostureLevel.TOOL,
+                ConfidentialityLevel.CONFIDENTIAL,
+                ConfidentialityLevel.RESTRICTED,
+            ),
+            # SUPERVISED ceiling = CONFIDENTIAL
             (
                 TrustPostureLevel.SUPERVISED,
                 ConfidentialityLevel.PUBLIC,
@@ -226,49 +255,33 @@ class TestEffectiveClearance:
             ),
             (
                 TrustPostureLevel.SUPERVISED,
-                ConfidentialityLevel.RESTRICTED,
-                ConfidentialityLevel.RESTRICTED,
+                ConfidentialityLevel.CONFIDENTIAL,
+                ConfidentialityLevel.CONFIDENTIAL,
             ),
             (
                 TrustPostureLevel.SUPERVISED,
-                ConfidentialityLevel.CONFIDENTIAL,
-                ConfidentialityLevel.RESTRICTED,
-            ),
-            # SHARED_PLANNING ceiling = CONFIDENTIAL
-            (
-                TrustPostureLevel.SHARED_PLANNING,
-                ConfidentialityLevel.PUBLIC,
-                ConfidentialityLevel.PUBLIC,
-            ),
-            (
-                TrustPostureLevel.SHARED_PLANNING,
-                ConfidentialityLevel.CONFIDENTIAL,
-                ConfidentialityLevel.CONFIDENTIAL,
-            ),
-            (
-                TrustPostureLevel.SHARED_PLANNING,
                 ConfidentialityLevel.TOP_SECRET,
                 ConfidentialityLevel.CONFIDENTIAL,
             ),
-            # CONTINUOUS_INSIGHT ceiling = SECRET
+            # DELEGATING ceiling = SECRET
             (
-                TrustPostureLevel.CONTINUOUS_INSIGHT,
+                TrustPostureLevel.DELEGATING,
                 ConfidentialityLevel.SECRET,
                 ConfidentialityLevel.SECRET,
             ),
             (
-                TrustPostureLevel.CONTINUOUS_INSIGHT,
+                TrustPostureLevel.DELEGATING,
                 ConfidentialityLevel.TOP_SECRET,
                 ConfidentialityLevel.SECRET,
             ),
-            # DELEGATED ceiling = TOP_SECRET
+            # AUTONOMOUS ceiling = TOP_SECRET
             (
-                TrustPostureLevel.DELEGATED,
+                TrustPostureLevel.AUTONOMOUS,
                 ConfidentialityLevel.TOP_SECRET,
                 ConfidentialityLevel.TOP_SECRET,
             ),
             (
-                TrustPostureLevel.DELEGATED,
+                TrustPostureLevel.AUTONOMOUS,
                 ConfidentialityLevel.PUBLIC,
                 ConfidentialityLevel.PUBLIC,
             ),

--- a/packages/kailash-pact/tests/unit/governance/test_context.py
+++ b/packages/kailash-pact/tests/unit/governance/test_context.py
@@ -18,19 +18,14 @@ from datetime import UTC, datetime
 
 import pytest
 
+from kailash.trust.pact.clearance import RoleClearance, effective_clearance
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
     OperationalConstraintConfig,
     TrustPostureLevel,
 )
-from kailash.trust.pact.clearance import (
-    POSTURE_CEILING,
-    RoleClearance,
-    effective_clearance,
-)
 from kailash.trust.pact.context import GovernanceContext
-
 
 # ---------------------------------------------------------------------------
 # Frozen immutability
@@ -230,12 +225,12 @@ class TestEffectiveClearancePostureCapped:
     """effective_clearance_level must be capped by POSTURE_CEILING."""
 
     def test_effective_clearance_posture_capped(self) -> None:
-        """A role with SECRET clearance at SUPERVISED posture gets RESTRICTED."""
+        """A role with SECRET clearance at TOOL posture gets RESTRICTED."""
         clearance = RoleClearance(
             role_address="D1-R1",
             max_clearance=ConfidentialityLevel.SECRET,
         )
-        eff = effective_clearance(clearance, TrustPostureLevel.SUPERVISED)
+        eff = effective_clearance(clearance, TrustPostureLevel.TOOL)
         assert eff == ConfidentialityLevel.RESTRICTED
 
         ctx = GovernanceContext(

--- a/packages/kailash-pact/tests/unit/governance/test_envelopes.py
+++ b/packages/kailash-pact/tests/unit/governance/test_envelopes.py
@@ -28,15 +28,14 @@ from kailash.trust.pact.config import (
     TrustPostureLevel,
 )
 from kailash.trust.pact.envelopes import (
+    MonotonicTighteningError,
     RoleEnvelope,
     TaskEnvelope,
     check_degenerate_envelope,
     compute_effective_envelope,
     default_envelope_for_posture,
     intersect_envelopes,
-    MonotonicTighteningError,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers -- build constraint configs for tests
@@ -713,63 +712,63 @@ class TestComputeEffectiveEnvelope:
 class TestDefaultEnvelopeForPosture:
     """Conservative defaults calibrated to trust posture level."""
 
-    def test_pseudo_agent_no_financial(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.PSEUDO_AGENT)
+    def test_pseudo_no_financial(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.PSEUDO)
         assert env.financial is not None
         assert env.financial.max_spend_usd == 0.0
 
-    def test_pseudo_agent_public_only(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.PSEUDO_AGENT)
+    def test_pseudo_public_only(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.PSEUDO)
         assert env.confidentiality_clearance == ConfidentialityLevel.PUBLIC
 
-    def test_pseudo_agent_internal_only(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.PSEUDO_AGENT)
+    def test_pseudo_internal_only(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.PSEUDO)
         assert env.communication.internal_only is True
 
-    def test_supervised_low_financial(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.SUPERVISED)
+    def test_tool_low_financial(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.TOOL)
         assert env.financial is not None
         assert env.financial.max_spend_usd == 100.0
 
-    def test_supervised_restricted(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.SUPERVISED)
+    def test_tool_restricted(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.TOOL)
         assert env.confidentiality_clearance == ConfidentialityLevel.RESTRICTED
 
-    def test_shared_planning_moderate_financial(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.SHARED_PLANNING)
+    def test_supervised_moderate_financial(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.SUPERVISED)
         assert env.financial is not None
         assert env.financial.max_spend_usd == 1000.0
 
-    def test_shared_planning_confidential(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.SHARED_PLANNING)
+    def test_supervised_confidential(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.SUPERVISED)
         assert env.confidentiality_clearance == ConfidentialityLevel.CONFIDENTIAL
 
-    def test_continuous_insight_higher_financial(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.CONTINUOUS_INSIGHT)
+    def test_delegating_higher_financial(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.DELEGATING)
         assert env.financial is not None
         assert env.financial.max_spend_usd == 10000.0
 
-    def test_continuous_insight_secret(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.CONTINUOUS_INSIGHT)
+    def test_delegating_secret(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.DELEGATING)
         assert env.confidentiality_clearance == ConfidentialityLevel.SECRET
 
-    def test_delegated_highest_financial(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.DELEGATED)
+    def test_autonomous_highest_financial(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.AUTONOMOUS)
         assert env.financial is not None
         assert env.financial.max_spend_usd == 100000.0
 
-    def test_delegated_top_secret(self) -> None:
-        env = default_envelope_for_posture(TrustPostureLevel.DELEGATED)
+    def test_autonomous_top_secret(self) -> None:
+        env = default_envelope_for_posture(TrustPostureLevel.AUTONOMOUS)
         assert env.confidentiality_clearance == ConfidentialityLevel.TOP_SECRET
 
     def test_posture_ordering_tightens_monotonically(self) -> None:
         """Higher postures produce more permissive envelopes (higher spend)."""
         postures = [
-            TrustPostureLevel.PSEUDO_AGENT,
+            TrustPostureLevel.PSEUDO,
+            TrustPostureLevel.TOOL,
             TrustPostureLevel.SUPERVISED,
-            TrustPostureLevel.SHARED_PLANNING,
-            TrustPostureLevel.CONTINUOUS_INSIGHT,
-            TrustPostureLevel.DELEGATED,
+            TrustPostureLevel.DELEGATING,
+            TrustPostureLevel.AUTONOMOUS,
         ]
         spends = []
         for p in postures:

--- a/src/kailash/trust/posture/postures.py
+++ b/src/kailash/trust/posture/postures.py
@@ -29,7 +29,8 @@ class TrustPosture(str, Enum):
     - PSEUDO: Agent is interface only; human performs all reasoning (autonomy_level=1)
 
     Old names (DELEGATED, CONTINUOUS_INSIGHT, SHARED_PLANNING, PSEUDO_AGENT) are
-    accepted via ``_missing_()`` for backward compatibility with serialized data.
+    accepted both as attribute aliases and via ``_missing_()`` for backward
+    compatibility with serialized data.
     """
 
     AUTONOMOUS = "autonomous"
@@ -37,6 +38,13 @@ class TrustPosture(str, Enum):
     SUPERVISED = "supervised"
     TOOL = "tool"
     PSEUDO = "pseudo"
+
+    # Backward-compatible aliases (pre-Decision-007 names).
+    # Each alias resolves to the canonical member with the same value.
+    DELEGATED = "autonomous"
+    CONTINUOUS_INSIGHT = "delegating"
+    SHARED_PLANNING = "supervised"
+    PSEUDO_AGENT = "pseudo"
 
     @classmethod
     def _missing_(cls, value: object) -> TrustPosture | None:

--- a/uv.lock
+++ b/uv.lock
@@ -2562,7 +2562,7 @@ name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools" },
+    { name = "more-itertools", marker = "platform_machine != 's390x'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
 wheels = [
@@ -2574,7 +2574,7 @@ name = "jaraco-context"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+    { name = "backports-tarfile", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/9c/a788f5bb29c61e456b8ee52ce76dbdd32fd72cd73dd67bc95f42c7a8d13c/jaraco_context-6.1.0.tar.gz", hash = "sha256:129a341b0a85a7db7879e22acd66902fda67882db771754574338898b2d5d86f", size = 15850, upload-time = "2026-01-13T02:53:53.847Z" }
 wheels = [
@@ -2586,7 +2586,7 @@ name = "jaraco-functools"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "more-itertools" },
+    { name = "more-itertools", marker = "platform_machine != 's390x'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
 wheels = [
@@ -2758,7 +2758,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -3150,13 +3150,13 @@ name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "jaraco-classes" },
-    { name = "jaraco-context" },
-    { name = "jaraco-functools" },
-    { name = "jeepney", marker = "sys_platform == 'linux'" },
-    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
-    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12' and platform_machine != 's390x'" },
+    { name = "jaraco-classes", marker = "platform_machine != 's390x'" },
+    { name = "jaraco-context", marker = "platform_machine != 's390x'" },
+    { name = "jaraco-functools", marker = "platform_machine != 's390x'" },
+    { name = "jeepney", marker = "platform_machine != 's390x' and sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "platform_machine != 's390x' and sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "platform_machine != 's390x' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
@@ -4458,7 +4458,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 's390x' and platform_machine != 'x86_64') or (platform_machine != 's390x' and sys_platform != 'darwin')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4488,7 +4488,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 's390x' and platform_machine != 'x86_64') or (platform_machine != 's390x' and sys_platform != 'darwin')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4515,9 +4515,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 's390x' and platform_machine != 'x86_64') or (platform_machine != 's390x' and sys_platform != 'darwin')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 's390x' and platform_machine != 'x86_64') or (platform_machine != 's390x' and sys_platform != 'darwin')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 's390x' and platform_machine != 'x86_64') or (platform_machine != 's390x' and sys_platform != 'darwin')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4528,7 +4528,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 's390x' and platform_machine != 'x86_64') or (platform_machine != 's390x' and sys_platform != 'darwin')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -7046,8 +7046,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
-    { name = "jeepney", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
+    { name = "cryptography", marker = "(platform_machine != 's390x' and platform_machine != 'x86_64') or (platform_machine != 's390x' and sys_platform != 'darwin')" },
+    { name = "jeepney", marker = "(platform_machine != 's390x' and platform_machine != 'x86_64') or (platform_machine != 's390x' and sys_platform != 'darwin')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/workspaces/platform-architecture-convergence/01-analysis/09-spec04-drift-verification.md
+++ b/workspaces/platform-architecture-convergence/01-analysis/09-spec04-drift-verification.md
@@ -1,0 +1,145 @@
+# SPEC-04 Drift Verification — 2026-04-10
+
+**Purpose**: Re-baseline the SPEC-04 "BaseAgent slimming" plan against current `main` state before resuming `/implement`. The prior session's `.session-notes` (1h old) called SPEC-04 "0/53 tasks, 2103 LOC". Verification found a much more complicated picture.
+
+## TL;DR
+
+**SPEC-04 was already completed, then silently regressed by a parallel-worktree merge from the last clearance session.** The 53-task plan in `todos/active/05-phase3-baseagent.md` was never re-baselined after the first slimming pass and describes a world that no longer exists.
+
+The right next action is **NOT** to execute the 53-task plan. It is:
+
+1. Diagnose the regression (what exactly got re-inlined)
+2. Re-extract the regressed code (most extraction modules still exist)
+3. Add the line-count guard test (TASK-04-50) so this cannot recur
+4. Restore orphaned workspace artifacts (spec + research + ADR) from scrap branch to main
+5. Update the `parallel-merge-workflow` skill with the regression lesson
+6. Rewrite the todos file against current state
+
+## Timeline: base_agent.py line count across commits
+
+| Commit     | Date   | base_agent.py LOC | Event                                                               |
+| ---------- | ------ | ----------------- | ------------------------------------------------------------------- |
+| `4cd5ef51` | Apr 8  | (3,132 baseline)  | Snapshot of pre-triage working tree (scrap safety net)              |
+| `626b008b` | Apr 8  | **925**           | **SPEC-02 provider split + SPEC-04 slimming** (extraction complete) |
+| `1e39a061` | Apr 9  | **994**           | SPEC-04 `@deprecated` + `AgentPosture` enum applied                 |
+| `7d237786` | Apr 9  | **2,019**         | 🚨 Merge `worktree-agent-a0ad1085` — **+1,094 insertions**          |
+| `c9bd9e50` | Apr 9  | **2,088**         | 🚨 Merge `worktree-agent-ab1c46d6` — **+69 more lines**             |
+| `fca3b1fb` | Apr 10 | **2,103**         | full clearance remaining 8 issues                                   |
+| `HEAD`     | Apr 10 | **2,103**         | current                                                             |
+
+**The regression is silent because the line-count invariant test (TASK-04-50) from the plan was never added.**
+
+## What happened in the regression
+
+`7d237786` merged `worktree-agent-a0ad1085` into `feat/platform-architecture-convergence`. The worktree branch was based on a **stale pre-slimming base**. The merge conflict in `base_agent.py` resolved by **taking the worktree branch's full 2,000+ LOC version**, wiping out the SPEC-04 slimming that had landed on the target branch one commit earlier.
+
+Representative diff from `git diff 7d237786^1 7d237786^2`:
+
+```diff
+-Extension Points (7 total, deprecated in v2.5.0 -- use composition wrappers):
++Extension Points (7 total):
++1. _default_signature() - Override to provide agent-specific signature
++2. _default_strategy() - Override to provide agent-specific strategy
++...
+```
+
+The worktree branch restored the pre-deprecation docstring and re-inlined the mixin methods that had been properly extracted to `mcp_mixin.py` and `a2a_mixin.py`. **`class BaseAgent(MCPMixin, A2AMixin, Node)` is still present**, so the file now has duplicated implementations: the inherited mixin methods AND the re-inlined copies that shadow them.
+
+`c9bd9e50` compounded the problem with a second merge. `fca3b1fb` added 15 lines on top as part of the full clearance.
+
+## What the plan assumes vs. what exists
+
+| Plan assumption                                       | Reality on main                                                                   | Drift           |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------- | --------------- |
+| `base_agent.py` is 2,103 LOC baseline                 | 2,103 LOC (numerical match, different contents)                                   | **Yes**         |
+| `_build_messages` method exists to refactor           | Does NOT exist — was removed during slimming                                      | **Yes**         |
+| `_DEPRECATED_PARAMETERS` filter exists                | Does NOT exist                                                                    | **Yes**         |
+| `_deferred_mcp` tuple exists                          | Does NOT exist — MCP initialization is direct in `__init__`                       | **Yes**         |
+| TAOD loop inlined in BaseAgent                        | Extracted to `agent_loop.py` (459 LOC) — but partially re-inlined via regression  | **Yes**         |
+| 7 extension points need `@deprecated` applied         | Already applied (commit `1e39a061`), implemented via `_impl` + wrapper pattern    | **Done**        |
+| `BaseAgentConfig` is plain dataclass, needs freezing  | Still plain `@dataclass` (not frozen) at `config.py:37`                           | No (still open) |
+| 188 subclasses across packages/, examples/, tests/    | 439 raw grep matches, ~189 real subclasses (rest are test stubs / re-exports)     | Partial         |
+| `AgentPosture` enum needs creation                    | Exists in `kailash.trust.envelope`; used via `kaizen.trust.postures` shim         | **Done**        |
+| `MCPMixin`, `A2AMixin`, `AgentLoop`, `deprecation.py` | All exist (774, 295, 459, 51 LOC respectively)                                    | **Done**        |
+| Provider split (SPEC-02 dependency)                   | Done (`providers/` package with llm/, embedding/ subpackages)                     | **Done**        |
+| 5 security surfaces §10.1-§10.5 open                  | Only §10.2 and §10.3 confirmably open; §10.1/§10.5 referred to removed structures | **Yes**         |
+
+## Orphaned workspace artifacts
+
+The 53-task plan references three files that **do not exist on main**. They live only on `scrap/pre-triage-snapshot-2026-04-08`:
+
+| Artifact                                                         | Lines | Status            |
+| ---------------------------------------------------------------- | ----- | ----------------- |
+| `01-analysis/03-specs/04-spec-baseagent-slimming.md`             | 940   | Scrap branch only |
+| `01-analysis/01-research/07-baseagent-audit.md`                  | 208   | Scrap branch only |
+| `01-analysis/04-adrs/02-adr-baseagent-keeps-node-inheritance.md` | ?     | Scrap branch only |
+
+`workspaces/platform-architecture-convergence/01-analysis/03-specs/` is an **empty directory on main** (contains only `.claude/` and `.env`). Anyone opening the todos file and following the spec reference finds nothing. The snapshot commit `4cd5ef51` lists these as "legitimate SPEC convergence work plus drift plus landmines" — they were classified as drift and never brought forward.
+
+**Disposition needed**: Cherry-pick these files from scrap → main, or decide they're obsolete and rewrite from current state.
+
+## Security surface status (actual, against current code)
+
+| Surface                              | Status                                                                                                                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| §10.1 Deferred MCP window            | Concept no longer applies — `_deferred_mcp` doesn't exist. MCP is initialized directly at `base_agent.py:182-224`. Needs re-analysis: is there a mutation window between `__init__` and first `run()`? |
+| §10.2 Legacy `**kwargs` catch-all    | **OPEN**. `base_agent.py:133` accepts `**kwargs`, passed to `super().__init__(**kwargs)` at line 263. No allowlist filter.                                                                             |
+| §10.3 Posture tampering              | **OPEN**. `config.py:37` is `@dataclass` (not frozen). `config.posture = X` mutation is unguarded.                                                                                                     |
+| §10.4 Extension point shadow hooks   | PARTIAL. `_impl` wrapper pattern + `__init_subclass__` warning + `@deprecated` applied. No runtime block.                                                                                              |
+| §10.5 `_build_messages` key fallback | N/A — `_build_messages` was removed. If the fallback logic exists elsewhere (AgentLoop or strategy), re-analyze there.                                                                                 |
+
+## What needs to happen next
+
+### Option A — Undo the regression, then resume
+
+**Pros**: Fastest path to <1000 LOC target. The SPEC-04 work actually converged at commit `1e39a061`; we just need to restore that state.
+
+**Cons**: The regression merges also brought in the "full clearance" changes across 33 issues. Restoring base_agent.py to the 994 LOC version would need surgical: take the `1e39a061` base_agent.py, apply only the legitimate fixes from `fca3b1fb`/`c9bd9e50`/`7d237786` that aren't re-inlining. This is not a clean revert.
+
+**Steps**:
+
+1. Extract `base_agent.py` at `1e39a061` (994 LOC) to a reference file
+2. Diff against current HEAD (2103 LOC) to identify the 1109 lines of drift
+3. Split the drift into (a) legitimate new code, (b) re-inlined methods shadowing mixin methods
+4. Delete (b); keep (a)
+5. Run full kaizen test suite — any regressions will come from the shadow-method removal
+6. Add TASK-04-50 line-count guard test: `assert wc -l base_agent.py < 1000`
+7. Close §10.2 (`**kwargs` → allowlist) and §10.3 (freeze config)
+8. Restore spec + research + ADR from scrap to main
+9. Rewrite `todos/active/05-phase3-baseagent.md` against the new baseline
+
+### Option B — Rewrite the plan from current state
+
+**Pros**: Clean slate. The current code is a hybrid — partially slimmed, partially re-inlined. Treating it as a new baseline gives a cleaner narrative.
+
+**Cons**: Abandons validated work from `626b008b`+`1e39a061`. Re-deliberates decisions already made.
+
+### Recommendation
+
+**Option A**, with the first three steps run as an `/analyze` pass (no code changes) to confirm the diff is surgically separable. If the drift is entangled, fall back to Option B.
+
+## Parallel-merge skill update needed
+
+The codified skill `.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md` (from the prior session's `/codify`) describes the pattern that produced this regression. The skill needs to add:
+
+- **Invariant checks before merge**: for any file being touched by multiple worktree branches, define numeric invariants (line count, method count, specific imports) and verify them after each merge.
+- **Stale base detection**: before merging a worktree branch back, check if its merge-base is older than the target branch's latest changes to the same files. If so, rebase the worktree branch first OR explicitly choose which version wins per file.
+- **Test the invariant**: the line-count guard test (TASK-04-50) is not a SPEC-04 implementation detail — it is a _category_ of test that every "shrink N by M lines" refactor should add. Generalize it as a skill.
+
+## For Discussion
+
+1. **Is Option A's surgical diff actually feasible?** The 1109-line drift between `1e39a061` (994 LOC) and HEAD (2103 LOC) could be: (a) ~1100 lines of re-inlined mixin methods (easy to remove), or (b) a tangled mix of regression + legitimate fixes (hard to separate). A diff pass will answer this.
+
+2. **Counterfactual: what if the worktree merge had hit a build break instead of a silent line-count regression?** The build would have failed and the merge would have been re-done. A line-count regression has no build signal — it only shows up in a metric that nobody looked at. Should every refactor spec now include a numeric invariant test as a hard requirement, not an optional one?
+
+3. **Why did the full clearance session's codify phase not catch this?** The session journal and skills should have captured "the BaseAgent was slimmed to 994 LOC and then re-grew to 2103". The codify phase ran after the regression had already happened; the skill it produced (`parallel-merge-workflow.md`) didn't include the failure mode that was sitting right in its own commit history.
+
+## See also
+
+- Journal: `workspaces/platform-architecture-convergence/journal/0002-DECISION-spec04-is-the-critical-path.md` (now partially invalidated by this finding)
+- Commit `626b008b` — the original slimming (925 LOC)
+- Commit `1e39a061` — deprecation + AgentPosture (994 LOC)
+- Commit `7d237786` — the regression merge (+1,094 LOC)
+- Commit `c9bd9e50` — the second regression merge (+69 LOC)
+- Scrap branch `scrap/pre-triage-snapshot-2026-04-08` — orphaned spec/research/ADR files
+- Skill `.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md` — describes the pattern that produced the regression

--- a/workspaces/platform-architecture-convergence/01-analysis/10-spec04-drift-inventory.md
+++ b/workspaces/platform-architecture-convergence/01-analysis/10-spec04-drift-inventory.md
@@ -1,0 +1,235 @@
+# SPEC-04 Drift Inventory & Removal List — 2026-04-10
+
+**Purpose**: After confirming the regression in `09-spec04-drift-verification.md` and `journal/0003-RISK-...`, this document gives a line-by-line disposition of the drift and a concrete removal list for Option A. Also: a feasibility verdict (trivial / tractable / tangled).
+
+## TL;DR — Feasibility verdict
+
+**Option A is TRIVIAL.** The 1,109-line regression is concentrated in a single deletable block. No byte-level conflict analysis is needed; there is zero functional code to preserve.
+
+- Delete one contiguous 1,079-line block (`base_agent.py` lines 855–1933, the `# TOOL CALLING INTEGRATION - MCP Only` section)
+- Preserve one 15-line bug fix (#357 Gemini structured output)
+- Optionally drop 15 lines of decorative imports
+- Result: `base_agent.py` goes from **2,103 → 1,024 LOC** (or 1,009 with the optional drop)
+
+## Full diff decomposition
+
+`git diff 1e39a061 HEAD -- base_agent.py` produces exactly **three hunks**. Every added line falls into one of these three groups; there is no drift outside them.
+
+| Hunk | Old range | New range  | Δ lines   | What it is                                | Origin commit      | Disposition   |
+| ---- | --------- | ---------- | --------- | ----------------------------------------- | ------------------ | ------------- |
+| 1    | `29,10`   | `29,25`    | +15       | TYPE_CHECKING block + decorative comments | `7d237786` (merge) | Optional drop |
+| 2    | `165,16`  | `180,31`   | +15       | #357 Gemini structured output fix         | `fca3b1fb`         | **KEEP**      |
+| 3    | `821,7`   | `851,1086` | +1079     | Re-inlined MCPMixin methods (shadow code) | `7d237786` (merge) | **DELETE**    |
+|      |           |            | **+1109** | (matches 2103 - 994)                      |                    |               |
+
+### Hunk 1 — TYPE_CHECKING + comments (lines 29–53 in HEAD)
+
+```python
+# Core SDK imports                                                  # +1 comment
+from kailash.nodes.base import Node, NodeParameter
+from kailash.workflow.builder import WorkflowBuilder
+from kailash_mcp.client import MCPClient
+
+# Type checking imports (not available at runtime in all environments)  # +1 comment
+if TYPE_CHECKING:                                                    # +1
+    try:                                                             # +1
+        from kaizen.nodes.ai.a2a import (                            # +1
+            A2AAgentCard,                                            # +1
+            Capability,                                              # +1
+            CollaborationStyle,                                      # +1
+            PerformanceMetrics,                                      # +1
+            ResourceRequirements,                                    # +1
+        )                                                            # +1
+    except ImportError:                                              # +1
+        pass                                                         # +1
+
+# Kaizen framework imports                                           # +1 comment
+```
+
+**Analysis**: These are `TYPE_CHECKING` imports — they don't execute at runtime. The types (`A2AAgentCard`, etc.) are not used by any method in the current HEAD `base_agent.py` (confirmed by grep). They were useful in the pre-slim 3681 LOC version where those type hints appeared in method signatures; after slimming those methods were moved to `a2a_mixin.py`, so the imports are now orphaned.
+
+**Disposition**: Optional drop. Low-risk delete saves 15 lines. Keeping them has no functional effect. Recommendation: drop them for line-count target.
+
+### Hunk 2 — #357 Gemini structured output fix (lines 180–210 in HEAD)
+
+```python
+# MCP initialization
+# When mcp_servers is not specified (None), auto-inject the builtin       # +6 comment lines
+# MCP server UNLESS the config requests structured output.  Gemini
+# (and potentially other providers) reject requests that combine
+# function calling with JSON response mode (response_mime_type).
+# Structured output takes priority over auto-tool discovery.
+# See: https://github.com/terrene-foundation/kailash-py/issues/357
+if mcp_servers is None:
+    if self.config.has_structured_output:                                 # +8 functional lines
+        logger.debug(
+            "MCP auto-discovery suppressed: config has structured output "
+            "enabled (response_format=%s), which is incompatible with "
+            "function calling on some providers (e.g. Gemini).",
+            self.config.response_format,
+        )
+        self._mcp_servers = []
+    else:
+        self._mcp_servers = [ ... builtin kaizen server ... ]
+```
+
+**Analysis**: Introduced by `fca3b1fb` (full clearance). Resolves issue #357 — Gemini rejects requests combining function calling with `response_mime_type`. The fix suppresses auto-tool-discovery when the config requests structured output. The +15 lines include 6 comment lines documenting the rationale and 9 functional lines.
+
+**Disposition**: **KEEP**. This is a legitimate bug fix with an upstream issue reference. Attempting to remove or slim it would require re-solving #357.
+
+### Hunk 3 — Re-inlined MCPMixin methods (lines 855–1933 in HEAD)
+
+A 1,079-line block starts at section header:
+
+```python
+# =============================================================================
+# TOOL CALLING INTEGRATION - MCP Only
+# =============================================================================
+```
+
+and ends before:
+
+```python
+# =========================================================================
+# Observability
+# =========================================================================
+```
+
+**14 methods in the block**:
+
+| Method                        | Inline LOC | Mixin LOC | Δ   | Delta explanation                      |
+| ----------------------------- | ---------- | --------- | --- | -------------------------------------- |
+| `discover_tools`              | 35         | ?         | —   | Thin wrapper over `discover_mcp_tools` |
+| `execute_tool`                | ?          | ?         | —   | Thin wrapper over `call_mcp_tool`      |
+| `discover_mcp_tools`          | 119        | 86        | +33 | Verbose docstring with example         |
+| `call_mcp_tool`               | 78         | 52        | +26 | Verbose docstring (md5-matched body)   |
+| `execute_mcp_tool`            | 138        | 99        | +39 | Verbose docstring                      |
+| `discover_mcp_resources`      | ?          | ?         | —   | Verbose docstring                      |
+| `read_mcp_resource`           | ?          | ?         | —   | Verbose docstring                      |
+| `discover_mcp_prompts`        | ?          | ?         | —   | Verbose docstring                      |
+| `get_mcp_prompt`              | ?          | ?         | —   | Verbose docstring                      |
+| `setup_mcp_client`            | ?          | ?         | —   | Verbose docstring                      |
+| `expose_as_mcp_server`        | 116        | 71        | +45 | Verbose docstring                      |
+| `_with_mcp_session`           | ?          | ?         | —   | Verbose docstring                      |
+| `_convert_mcp_result_to_dict` | 98         | 68        | +30 | Verbose docstring                      |
+| `has_mcp_support`             | 21         | 5         | +16 | `>>> Example:` block in docstring      |
+
+**Every method is present in `mcp_mixin.py`** — verified by symmetric difference:
+
+```
+comm -12 methods-reinlined.txt methods-mcpmixin.txt  # = 14 methods (intersection = full set)
+comm -23 methods-reinlined.txt methods-mcpmixin.txt  # = 0 methods (nothing unique to inline)
+```
+
+**The line-count difference between inline (1,079) and mixin (774) is explained entirely by docstring verbosity.** Spot-checks:
+
+- `has_mcp_support` — 21 lines inline (16 lines are `>>> Example:` docstring), 5 lines mixin. Logic: `return self._mcp_servers is not None`. Identical.
+- `call_mcp_tool` — first 50 lines of inline version md5-match the mixin version byte-for-byte.
+
+**Disposition**: **DELETE ENTIRELY**. The mixin inheritance (`class BaseAgent(MCPMixin, A2AMixin, Node)`) is already present. Removing the inline shadows exposes the mixin methods via MRO. Zero functional code is lost. The only user-visible effect is: `help(agent.has_mcp_support)` will show the terser mixin docstring instead of the verbose example-rich one.
+
+**Risk**: If any consumer has built tooling around the verbose docstrings (e.g., auto-generated docs that snapshot the inline version), they would see a docstring change on upgrade. This is a **documentation** concern, not a functional one.
+
+## Proposed removal plan
+
+### Step 1 — Delete the shadow block
+
+```bash
+# Remove lines 855-1933 (inclusive) of base_agent.py
+# Result: 2103 → 1024 LOC
+```
+
+Concrete: delete from the `# TOOL CALLING INTEGRATION - MCP Only` section header through the last line before `# Observability` section header.
+
+### Step 2 — Optionally drop Hunk 1 imports
+
+```bash
+# Remove the 15 decorative import lines (29-53 in current HEAD)
+# Result: 1024 → 1009 LOC
+```
+
+### Step 3 — Add the line-count invariant test
+
+```python
+# tests/invariants/test_base_agent_line_count.py
+import pathlib
+import pytest
+
+BASE_AGENT = pathlib.Path("packages/kailash-kaizen/src/kaizen/core/base_agent.py")
+HARD_LIMIT = 1050  # see SPEC-04 §6 "line-count budget"
+
+def test_base_agent_line_count_under_budget():
+    """SPEC-04: base_agent.py MUST stay under budget. Regression guard."""
+    loc = len(BASE_AGENT.read_text().splitlines())
+    assert loc < HARD_LIMIT, (
+        f"base_agent.py has grown to {loc} LOC (budget: <{HARD_LIMIT}). "
+        f"This likely indicates a merge regression re-inlined mixin code. "
+        f"See workspaces/platform-architecture-convergence/journal/"
+        f"0003-RISK-spec04-silent-regression-via-parallel-merge.md"
+    )
+```
+
+**Why `<1050` not `<1000`**: Gives ~26 LOC of headroom for legitimate fixes that may land between now and the next slimming pass. Matches the Option A final state of 1024 LOC. A stricter `<1000` would block legitimate bug fixes; a looser `<2000` would not catch the next regression.
+
+### Step 4 — Run kaizen test suite
+
+Expected result: all tests pass, because:
+
+- Every deleted method is still resolved via `MCPMixin` inheritance
+- Python's MRO prefers the first class in the bases list: `class BaseAgent(MCPMixin, A2AMixin, Node)` → `MCPMixin` wins
+- The inline versions were shadowing the mixin (MRO was ignoring MCPMixin entirely for these methods), so deleting inline versions REVEALS the mixin
+
+Risk: If any subclass explicitly calls `super()._convert_mcp_result_to_dict(...)` or similar, it was calling the inline version (MCPMixin wouldn't be in its MRO). After deletion, `super()` will find `MCPMixin` via the base class. Same interface, same logic — should be transparent.
+
+### Step 5 — Close the remaining §10 security surfaces
+
+Independent of the regression fix, the following SPEC-04 §10 surfaces are still open and should be closed in the same PR:
+
+- **§10.2 `**kwargs`allowlist**:`base_agent.py:133`accepts`\*\*kwargs`. Replace with explicit allowlist + `\_DEPRECATED_PARAMETERS`filter +`UnknownParameterError`.
+- **§10.3 Freeze `BaseAgentConfig`**: `config.py:37` is plain `@dataclass`. Add `frozen=True`. Private `_posture` copy per SPEC-04 TASK-04-06.
+
+## What this means for the 53-task plan
+
+With Option A, the following tasks from `todos/active/05-phase3-baseagent.md` are **already done** (from commits `626b008b` + `1e39a061`):
+
+- TASK-04-03 — `agent_loop.py` module ✓
+- TASK-04-04 — `BaseAgentConfig` frozen dataclass — PARTIAL (field added, frozen=True not applied)
+- TASK-04-07 — `AgentPosture` helpers ✓
+- TASK-04-15 — `@deprecated` decorator ✓
+- TASK-04-16 — Apply `@deprecated` to 7 hooks ✓
+- TASK-04-32 — `__init__` rewrite — PARTIAL (structure rewritten, `**kwargs` not removed)
+- TASK-04-33..04-40 — BaseAgent slim phase ✓ (but regressed, needs restoration)
+- SPEC-02 provider split — already done, not a SPEC-04 task
+
+Tasks that become **new work** after Option A:
+
+- **TASK-04-50 (upgraded)** — Add the line-count invariant test as the first action (prevents recurrence)
+- **TASK-04-20..27** — `_DEPRECATED_PARAMETERS` filter + UnknownParameterError (§10.2) — not yet started
+- **TASK-04-04 finalization** — freeze `BaseAgentConfig` (§10.3) — started, not finished
+- **TASK-04-01** — Subclass audit (still useful; numbers may have changed)
+- **TASK-04-48..49** — Posture tests + security tests §10.1-§10.5
+- **TASK-04-51** — Migration guide — not yet started
+- **TASK-04-52** — Cross-SDK issue — not yet started
+
+Tasks that are **no longer relevant** (the spec assumed structures that no longer exist):
+
+- TASK-04-28 `_build_messages` signature-first — `_build_messages` does not exist in current code
+- TASK-04-24..27 `_deferred_mcp` tuple guard — `_deferred_mcp` does not exist; MCP is initialized directly
+- Various TAOD-loop extraction tasks — already completed in `agent_loop.py`
+
+Net new task count after Option A: approximately **20 tasks** (down from the claimed 53).
+
+## For Discussion
+
+1. **Why did the inline versions get verbose docstrings in the first place?** The `>>> Example:` blocks in `has_mcp_support` and friends look like they were added by a docstring-generation pass, probably as part of an earlier "documentation sprint." Someone saw `def has_mcp_support(self): return self._mcp_servers is not None` as "too terse" and wrote a 16-line example. This is a case study in how "well-intentioned documentation" creates regression fodder — the slimming pass correctly moved these methods to a mixin with terser docstrings, and the regression brought back the verbose originals. Does the project want a rule that says "docstrings live with the canonical implementation, not in wrappers"?
+
+2. **Counterfactual: what if the regression had removed a method instead of duplicating one?** The current regression is "easy" because the mixin still has the canonical version — MRO hides the problem at runtime. If a future regression instead DELETES a mixin method from a worktree branch's stale base, the merge could silently remove a method from production. The line-count guard doesn't catch deletions — we need a method-count invariant too (`len(MCPMixin.__dict__) >= 14`), or a set-membership invariant (`{discover_mcp_tools, call_mcp_tool, ...} ⊆ dir(MCPMixin)`).
+
+3. **Is 1024 LOC close enough to `<1000`?** The SPEC-04 target is `<1000 LOC`. Option A lands at 1024. Options: (a) accept the overage, document the 24-line deviation in the spec; (b) aggressively slim the `__init__` method to shed ~30 lines; (c) extract something else (e.g., the `_apply_*_mixin` methods at lines 311-353 that are just delegation shims — move to a `mixin_application.py` helper). (c) is cleanest and gives another extracted module to test independently. Which does the team prefer?
+
+## See also
+
+- `09-spec04-drift-verification.md` — the finding that led to this inventory
+- `journal/0003-RISK-spec04-silent-regression-via-parallel-merge.md` — risk framing
+- `packages/kailash-kaizen/src/kaizen/core/mcp_mixin.py` — the canonical home for the 14 shadow methods
+- `/tmp/spec04-verify/` — extracted reference files (post-slim 925, post-deprecated 994, head 2103)

--- a/workspaces/platform-architecture-convergence/journal/0003-RISK-spec04-silent-regression-via-parallel-merge.md
+++ b/workspaces/platform-architecture-convergence/journal/0003-RISK-spec04-silent-regression-via-parallel-merge.md
@@ -1,0 +1,98 @@
+---
+type: RISK
+date: 2026-04-10
+created_at: 2026-04-10T18:15:00Z
+author: agent
+session_id: 2026-04-10-spec04-reverify
+session_turn: analyze
+project: platform-architecture-convergence
+topic: SPEC-04 slimming was silently regressed by parallel-worktree merge from clearance session
+phase: analyze
+tags:
+  [
+    spec-04,
+    regression,
+    parallel-merge,
+    line-count-guard,
+    invariant-test,
+    base-agent,
+    clearance-session,
+  ]
+---
+
+# SPEC-04 Silently Regressed via Parallel-Worktree Merge
+
+## Context
+
+On 2026-04-10 we opened a session to begin SPEC-04 BaseAgent slimming based on prior `.session-notes` that called it the critical path and reported "0/53 tasks, 2103 LOC". A pre-`/implement` verification pass discovered the `.session-notes` was wrong in a subtle and dangerous way.
+
+## The finding
+
+`base_agent.py` has been slimmed before — and silently regressed.
+
+| Commit     | LOC  | Event                                                       |
+| ---------- | ---- | ----------------------------------------------------------- |
+| `626b008b` | 925  | SPEC-04 slimming landed (under 1000 LOC target)             |
+| `1e39a061` | 994  | `@deprecated` + `AgentPosture` applied                      |
+| `7d237786` | 2019 | Merge `worktree-agent-a0ad1085` — **+1094 line regression** |
+| `c9bd9e50` | 2088 | Merge `worktree-agent-ab1c46d6` — +69 more                  |
+| `fca3b1fb` | 2103 | full clearance +15                                          |
+| `HEAD`     | 2103 | current                                                     |
+
+The mixin inheritance (`class BaseAgent(MCPMixin, A2AMixin, Node)`) is still present AND the mixin classes still exist as separate modules (`mcp_mixin.py` 774 LOC, `a2a_mixin.py` 295 LOC). But ~1100 LOC of duplicate/shadow method implementations got re-inlined into `base_agent.py` by a merge from a worktree branch that had been based on a stale pre-slimming tree.
+
+The `.session-notes` from the clearance session reported "2103 LOC / 0 tasks complete" because it measured the file's line count, did NOT examine git history for prior SPEC-04 commits, and did NOT notice that extraction modules already existed. The codified skill `parallel-merge-workflow.md` — which was created in the same session that produced the regression — does not mention the failure mode.
+
+## Why this matters — the missing invariant
+
+SPEC-04's TASK-04-50 was a line-count invariant test: `assert wc -l base_agent.py < 1000`. It was never added. If it had been, the regression merge would have immediately failed CI with "base_agent.py grew from 994 to 2019, invariant violated". Instead, the merge silently succeeded, the session reported "SPEC-04 done via 626b008b + 1e39a061", and the next session (this one) was told SPEC-04 was untouched.
+
+Two separate failure modes compounded:
+
+1. **Content-based merge resolution took the stale version**. The worktree branch's `base_agent.py` was 2000+ LOC (pre-slimming); the target branch's was 994 LOC (post-slimming). The merge tool had no way to know which was "correct" and the agent resolving the conflict chose the larger one — probably because it had more methods that matched the mental model of "BaseAgent does lots of things".
+
+2. **No numeric invariant to detect it**. Line count, method count, specific imports — any of these would have caught the regression at the moment it happened. None were in place.
+
+## Risk classification
+
+**HIGH.** This failure mode is:
+
+- **Silent** — no build break, no test failure, no runtime error
+- **Recurring** — same failure pattern could hit every future slimming refactor
+- **Concealed by "done" commits** — the SPEC-04 commits are on main, so a naive search for "is SPEC-04 done" finds them and reports yes
+- **Captured in a codified skill** — the `parallel-merge-workflow.md` skill was created in the same session that produced this regression and does not warn against it
+
+## Mitigation
+
+Short-term (this session):
+
+1. Write drift-verification report (done: `01-analysis/09-spec04-drift-verification.md`)
+2. Escalate to user; do NOT run `/implement` on the 53-task plan as-is
+
+Medium-term (next 1-2 sessions): 3. Restore base_agent.py to ~994 LOC by surgically removing re-inlined shadow methods 4. Add line-count guard test as a permanent pytest invariant (`tests/invariants/test_base_agent_line_count.py`) 5. Restore orphaned workspace artifacts (spec, research, ADR) from scrap branch 6. Close §10.2 (`**kwargs` allowlist) and §10.3 (freeze `BaseAgentConfig`) — the two security surfaces still open 7. Rewrite `todos/active/05-phase3-baseagent.md` against the new baseline
+
+Long-term (skill + rule update): 8. Update `.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md` with:
+
+- Stale-base detection before any worktree merge
+- Mandatory numeric invariant for any "shrink N" refactor
+- Conflict-resolution protocol: if the two sides differ by >200 lines on the same file, STOP and ask for human disambiguation
+
+9. Add a rule (`rules/refactor-invariants.md` or extend `zero-tolerance.md`): "Every refactor that claims to shrink, extract, or consolidate a file MUST land a programmatic invariant test in the same commit."
+
+## For Discussion
+
+1. **Counterfactual**: if the worktree merge had been a REBASE instead of a merge, would the conflict have surfaced earlier? A rebase would have tried to replay the worktree branch's pre-slimming commits on top of the post-slimming target, producing a sequence of loud conflicts that no agent would have auto-resolved without noticing. Merges are seductive because they "just work" — but that's exactly the problem when the two sides encode incompatible intents.
+
+2. **Data question**: how many other files in this repo have been silently grown by the same pattern? The audit protocol is: for every `refactor:` or `feat:` commit message that mentions "slimming" / "extract" / "consolidate", grep the file's subsequent history for merge commits that increased the line count by >20%. Worth running as an automated scan before the next release — the answer to "how often does this happen" determines whether the mitigation is "add one invariant test" or "add an invariant framework".
+
+3. **Codify failure mode**: the `parallel-merge-workflow` skill was created in the same session that produced the regression. The skill-authoring agent and the implementing agent had access to the same git log but drew different conclusions. Why didn't `/codify` notice the line-count drift? Because `/codify`'s validation step is "did the final commit compile and pass tests" — neither of which detects a 1100-line growth in a previously-slimmed file. The codify phase needs a "diff against the decision record" step: if a journal entry says "SPEC-04 target is <1000 LOC", the codify phase should verify that claim against current state.
+
+## See also
+
+- `01-analysis/09-spec04-drift-verification.md` — full drift report with per-task reconciliation
+- Commit `626b008b` — the original slimming
+- Commit `1e39a061` — deprecation application
+- Commit `7d237786` — the regression merge
+- Commit `c9bd9e50` — compounding merge
+- `.claude/skills/30-claude-code-patterns/parallel-merge-workflow.md` — the skill that needs updating
+- `journal/0002-DECISION-spec04-is-the-critical-path.md` — the prior decision this invalidates


### PR DESCRIPTION
## Summary

- Restore and extend SPEC-04 BaseAgent slimming that was silently regressed by a parallel-worktree merge (2103 → 859 LOC, 59% reduction)
- Close security surfaces §10.2 (remove `**kwargs` catch-all) and §10.3 (posture immutability guard)
- Eliminate three shim layers: shadow MCP block, extension point dispatcher, and mixin application methods

## What happened

Commits `626b008b` + `1e39a061` had already slimmed `base_agent.py` to 994 LOC. A subsequent worktree merge (`7d237786`) based on a stale pre-slimming tree re-inlined 1,079 lines of MCPMixin methods as shadow copies. The line-count invariant test existed but was never in the regression's CI path.

## Changes

- **base_agent.py**: 2,103 → 859 LOC
  - Delete 1,079-line shadow MCP block (14 methods already in MCPMixin)
  - Eliminate `_invoke_extension_point` dispatcher + 7 `_*_impl` + 7 `@deprecated` wrappers
  - Replace 7 `_apply_*_mixin` shim methods with data-driven loop
  - Remove `**kwargs` from `__init__` (§10.2)
  - Replace `_simple_execute` placeholder with `NotImplementedError`
- **config.py**: Add `__setattr__` guard preventing posture mutation after construction (§10.3)
- **agent_loop.py**: Direct method calls replace dispatcher indirection
- **Tests**: Updated 3 test files, added posture immutability tests (485 pass, 0 regressions)
- **Pre-existing fixes**: Added `respx` dev dep, registered `regression` pytest marker

## Test plan

- [x] Core unit tests: 485 passed, 0 failed (baseline 481)
- [x] Line-count invariant: `assert LOC < 1000` passes at 859
- [x] Red team review: 2 findings fixed (placeholder data, mixin error handling)
- [x] Security review: §10.2 + §10.3 closed, no new vulnerabilities
- [x] Pre-commit hooks: all passed including Tier 1 unit tests

## Related issues

- Fixes #392 (SPEC-04 BaseAgent slimming)
- Unblocks #393 (SPEC-05 Delegate facade)
- Unblocks #394 (SPEC-10 multi-agent migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)