### PR TITLE
chore(release): convergence complete — 6 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,65 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### Platform Architecture Convergence Complete — 2026-04-11
+
+kailash 2.8.0 + kailash-kaizen 2.7.0 + kaizen-agents 0.9.0 + kailash-pact 0.8.1 + kailash-dataflow 2.0.2 + kailash-ml 0.8.0
+
+#### [kailash 2.8.0]
+
+##### Added
+
+- **CostEvent** frozen dataclass with call_id dedup and `CostDeduplicator` bounded LRU (SPEC-08)
+- **Canonical JSON** module (`kailash.trust._json`) with duplicate key rejection, NaN/Inf rejection, sorted-key deterministic output (SPEC-09)
+- **Cross-SDK test vectors** for agent-result, streaming, and parser-differential edge cases (SPEC-09)
+- **TrustPosture backward-compatible aliases** — `PSEUDO_AGENT`, `SHARED_PLANNING`, `CONTINUOUS_INSIGHT`, `DELEGATED` resolve to canonical names via enum aliases (Decision 007)
+
+##### Fixed
+
+- CI: `kailash-mcp` sub-package now installed in unified-ci.yml
+- `PactAuditAction` count assertion (16→19)
+
+#### [kailash-kaizen 2.7.0]
+
+##### Added
+
+- **SPEC-02 Provider registry** — 14 providers with prefix-dispatch model detection, `CostTracker` with thread-safe accumulation, 390 tests
+- **SPEC-04 BaseAgent slimming** — 2103→859 LOC, removed duplicate MCP methods, eliminated extension point shim layer, posture immutability guard
+
+##### Fixed
+
+- `AgentPosture.DELEGATED` → `AgentPosture.DELEGATING` (Decision 007 alignment)
+
+#### [kaizen-agents 0.9.0]
+
+##### Added
+
+- **SPEC-05 Delegate facade** — `ConstructorIOError`, `ToolRegistryCollisionError`, `run_sync()` event loop guard, deferred MCP, introspection properties (`.core_agent`, `.signature`, `.model`), 57 new tests
+- **SPEC-10 Multi-agent deprecation** — 11 subclasses emit `DeprecationWarning`, `max_total_delegations` cap (default 20), `DelegationCapExceeded` error, 30 new tests
+
+#### [kailash-pact 0.8.1]
+
+##### Fixed
+
+- Version consistency: `__init__.py` 0.7.2 → 0.8.1 to match `pyproject.toml`
+- PACT tests updated from old posture names to canonical Decision 007 names
+- `TrustPostureLevel` backward-compatible enum aliases
+
+#### [kailash-dataflow 2.0.2]
+
+##### Fixed
+
+- Platform clearance fixes from full convergence
+
+#### [kailash-ml 0.8.0]
+
+##### Added
+
+- PCA dimensionality reduction engine
+- Full clearance features (8 ML engine improvements)
+
+---
+
 ### Platform Architecture Convergence — 2026-04-09
 
 kailash 2.7.0 + kailash-kaizen 2.6.0 + kailash-nexus 2.0.0 + kaizen-agents 0.8.0 + kailash-mcp 0.2.0 + kailash-dataflow 2.0.1

--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -17,15 +17,15 @@
 
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
-| kailash (core)   | `v*`               | 2.7.0           |
-| kailash-dataflow | `dataflow-v*`      | 2.0.1           |
-| kailash-kaizen   | `kaizen-v*`        | 2.6.0           |
+| kailash (core)   | `v*`               | 2.8.0           |
+| kailash-dataflow | `dataflow-v*`      | 2.0.2           |
+| kailash-kaizen   | `kaizen-v*`        | 2.7.0           |
 | kailash-nexus    | `nexus-v*`         | 2.0.0           |
-| kailash-pact     | `pact-v*`          | 0.8.0           |
-| kailash-ml       | `ml-v*`            | 0.7.0           |
+| kailash-pact     | `pact-v*`          | 0.8.1           |
+| kailash-ml       | `ml-v*`            | 0.8.0           |
 | kailash-align    | `align-v*`         | 0.3.1           |
 | kailash-mcp      | `mcp-v*`           | 0.2.0           |
-| kaizen-agents    | `kaizen-agents-v*` | 0.8.0           |
+| kaizen-agents    | `kaizen-agents-v*` | 0.9.0           |
 
 ## Release Runbook
 

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.0.1"
+version = "2.0.2"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "kailash>=2.7.0",
+    "kailash>=2.8.0",
     "sqlalchemy>=2.0.0",
     "alembic>=1.12.0",
     "asyncpg>=0.28.0",

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -87,7 +87,7 @@ from .validation import (
 )
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.6.0"
+version = "2.7.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -23,7 +23,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "kailash>=2.7.0",
+    "kailash>=2.8.0",
     "pydantic>=2.0.0",
     "typing-extensions>=4.5.0",
     "PyJWT>=2.8.0",

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 
@@ -15,7 +15,9 @@ __license__ = "Apache-2.0"
 try:
     from kaizen_agents import Agent  # Full async Agent (requires kaizen-agents)
 except ImportError:
-    from kaizen.core.agents import Agent  # type: ignore[assignment]  # CoreAgent fallback
+    from kaizen.core.agents import (
+        Agent,  # type: ignore[assignment]  # CoreAgent fallback
+    )
 
 # Import nodes module to trigger agent registration
 # Agent nodes are registered when kaizen-agents is installed

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.7.0"
+version = "0.8.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ classifiers = [
 readme = "README.md"
 keywords = ["ml", "machine-learning", "kailash", "automl", "feature-store", "model-registry"]
 dependencies = [
-    "kailash>=1.0",
+    "kailash>=2.8.0",
     "kailash-dataflow>=1.0",
     "kailash-nexus>=1.0",
     "polars>=1.0",

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "kailash>=2.7.0",
+    "kailash>=2.8.0",
     "starlette>=0.36.0",
     "fastapi>=0.104.0",
     "websockets>=12.0",

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-pact"
-version = "0.8.0"
+version = "0.8.1"
 description = "PACT governance framework — D/T/R accountability grammar, operating envelopes, knowledge clearance, and verification gradient for AI agent organizations"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ classifiers = [
 readme = "README.md"
 keywords = ["governance", "pact", "agent", "trust", "D/T/R", "envelopes", "clearance", "EATP", "AI"]
 dependencies = [
-    "kailash>=2.2.0",
+    "kailash>=2.8.0",
     "click>=8.0",
     "fastapi>=0.109",
     "slowapi>=0.1.9",

--- a/packages/kailash-pact/src/pact/__init__.py
+++ b/packages/kailash-pact/src/pact/__init__.py
@@ -14,7 +14,7 @@ Architecture:
     pact.mcp               -- Governance enforcement on MCP tool invocations (kailash-pact)
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 # --- Trust types (re-exported from kailash.trust) ---
 from kailash.trust import (

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.8.0"
+version = "0.9.0"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "kailash>=2.7.0",
+    "kailash>=2.8.0",
     "kailash-kaizen>=2.3.2",
     "kailash-pact>=0.4.1",
     "httpx>=0.27.0",

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,12 +14,11 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.8.0"
-
-from kaizen_agents.supervisor import GovernedSupervisor, SupervisorResult
+__version__ = "0.9.0"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate
+from kaizen_agents.supervisor import GovernedSupervisor, SupervisorResult
 
 # Canonical async Agent API (moved from kailash-kaizen api/)
 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.7.0"
+version = "2.8.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}
@@ -76,20 +76,20 @@ dependencies = [
 [project.optional-dependencies]
 # Sub-packages (separate PyPI packages)
 dataflow = [
-    "kailash-dataflow>=1.8.0",
+    "kailash-dataflow>=2.0.2",
 ]
 nexus = [
-    "kailash-nexus>=1.9.0",
+    "kailash-nexus>=2.0.0",
 ]
 kaizen = [
-    "kailash-kaizen>=2.5.0",
-    "kaizen-agents>=0.7.0",
+    "kailash-kaizen>=2.7.0",
+    "kaizen-agents>=0.9.0",
 ]
 pact = [
-    "kailash-pact>=0.8.0",
+    "kailash-pact>=0.8.1",
 ]
 ml = [
-    "kailash-ml>=0.7.0",
+    "kailash-ml>=0.8.0",
 ]
 align = [
     "kailash-align>=0.3.0",
@@ -139,12 +139,12 @@ docs = [
 ]
 # Everything (core + all sub-packages with their optional deps)
 all = [
-    "kailash-dataflow>=1.8.0",
-    "kailash-nexus>=1.9.0",
-    "kailash-kaizen>=2.5.0",
-    "kaizen-agents>=0.7.0",
-    "kailash-pact>=0.8.0",
-    "kailash-ml[all]>=0.7.0",
+    "kailash-dataflow>=2.0.2",
+    "kailash-nexus>=2.0.0",
+    "kailash-kaizen>=2.7.0",
+    "kaizen-agents>=0.9.0",
+    "kailash-pact>=0.8.1",
+    "kailash-ml[all]>=0.8.0",
     "kailash-align[all]>=0.3.0",
 ]
 

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary
- **kailash 2.8.0**: CostEvent, canonical JSON, TrustPosture aliases, cross-SDK vectors
- **kailash-kaizen 2.7.0**: Provider registry (14 providers), BaseAgent 2103→859 LOC
- **kaizen-agents 0.9.0**: Delegate facade, multi-agent deprecation (11 subclasses)
- **kailash-pact 0.8.1**: Version consistency fix, Decision 007 posture aliases
- **kailash-dataflow 2.0.2**: Platform clearance fixes
- **kailash-ml 0.8.0**: PCA engine, full clearance features

All 10 convergence SPECs complete. CHANGELOG updated. Deployment config updated.

## Test plan
- [x] 6,948 tests pass locally
- [x] Version consistency verified (all pyproject.toml match __init__.py)
- [x] SDK dependency pins updated to 2.8.0
- [ ] CI pipeline (Python 3.11/3.12/3.13 + PACT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)