### PR TITLE
fix: convergence cleanup — #391 #398 #401 #402 #404

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/fabric/pipeline.py
+++ b/packages/kailash-dataflow/src/dataflow/fabric/pipeline.py
@@ -615,9 +615,9 @@ class PipelineExecutor:
                 }
             )
 
-            # Step 2: Serialize
+            # Step 2: Serialize (off event loop — CPU-bound for large products)
             step_start = time.monotonic()
-            data_bytes = _serialize(raw_data)
+            data_bytes = await asyncio.to_thread(_serialize, raw_data)
             steps.append(
                 {
                     "name": "serialize",
@@ -652,9 +652,9 @@ class PipelineExecutor:
                     f"({self._max_result_bytes / (1024 * 1024):.0f} MB limit)"
                 )
 
-            # Step 4: Content hash
+            # Step 4: Content hash (off event loop — CPU-bound for large payloads)
             step_start = time.monotonic()
-            new_hash = _content_hash(data_bytes)
+            new_hash = await asyncio.to_thread(_content_hash, data_bytes)
             steps.append(
                 {
                     "name": "hash",

--- a/packages/kailash-kaizen/tests/benchmarks/conftest.py
+++ b/packages/kailash-kaizen/tests/benchmarks/conftest.py
@@ -1,8 +1,15 @@
 """
 Shared fixtures and configuration for performance benchmarks.
+
+Requires pytest-benchmark. This conftest is loaded only when running
+tests from the benchmarks/ directory.
 """
 
 import pytest
+
+pytest.importorskip(
+    "pytest_benchmark", reason="pytest-benchmark required for benchmarks"
+)
 
 
 def pytest_configure(config):

--- a/packages/kailash-kaizen/tests/deployment/test_cicd_pipeline.py
+++ b/packages/kailash-kaizen/tests/deployment/test_cicd_pipeline.py
@@ -13,12 +13,21 @@ import os
 import stat
 from pathlib import Path
 
+import pytest
 import yaml
 
 # Get repository root
 REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
 
+# deploy-production.yml does not exist yet — tests were TDD-first
+_DEPLOY_WORKFLOW = REPO_ROOT / ".github/workflows/deploy-production.yml"
+_SKIP = pytest.mark.skipif(
+    not _DEPLOY_WORKFLOW.exists(),
+    reason="deploy-production.yml not created yet (TDD-first tests)",
+)
 
+
+@_SKIP
 class TestPROD005GitHubActionsWorkflow:
     """
     PROD-005: GitHub Actions Workflow
@@ -33,9 +42,9 @@ class TestPROD005GitHubActionsWorkflow:
     def test_deployment_workflow_file_exists(self):
         """Verify deployment workflow file exists"""
         workflow_path = REPO_ROOT / ".github/workflows/deploy-production.yml"
-        assert workflow_path.exists(), (
-            f"Deployment workflow file not found at {workflow_path}"
-        )
+        assert (
+            workflow_path.exists()
+        ), f"Deployment workflow file not found at {workflow_path}"
 
     def test_deployment_workflow_has_required_structure(self):
         """Verify deployment workflow has correct structure"""
@@ -127,9 +136,9 @@ class TestPROD005GitHubActionsWorkflow:
             and "staging" in content.lower()
             and "prod" in content.lower()
         )
-        assert has_env_support, (
-            "Workflow must support multiple environments (dev/staging/prod)"
-        )
+        assert (
+            has_env_support
+        ), "Workflow must support multiple environments (dev/staging/prod)"
 
     def test_deployment_workflow_has_proper_triggers(self):
         """Verify workflow has appropriate triggers"""
@@ -140,9 +149,9 @@ class TestPROD005GitHubActionsWorkflow:
         # YAML parses "on" as boolean True
         triggers = workflow.get(True, workflow.get("on", {}))
         # Should support at least workflow_dispatch for manual deployments
-        assert "workflow_dispatch" in triggers or "push" in triggers, (
-            "Workflow must have appropriate triggers (workflow_dispatch or push)"
-        )
+        assert (
+            "workflow_dispatch" in triggers or "push" in triggers
+        ), "Workflow must have appropriate triggers (workflow_dispatch or push)"
 
     def test_deployment_workflow_has_permissions(self):
         """Verify workflow has proper permissions defined"""
@@ -151,11 +160,12 @@ class TestPROD005GitHubActionsWorkflow:
             workflow = yaml.safe_load(f)
 
         # Permissions should be explicitly defined for security
-        assert "permissions" in workflow, (
-            "Workflow should define permissions explicitly"
-        )
+        assert (
+            "permissions" in workflow
+        ), "Workflow should define permissions explicitly"
 
 
+@_SKIP
 class TestPROD006DeploymentValidation:
     """
     PROD-006: Deployment Validation
@@ -200,9 +210,9 @@ class TestPROD006DeploymentValidation:
             or "/health" in content
             or "healthcheck" in content.lower()
         )
-        assert has_health_check, (
-            "Validation script must include health check validation"
-        )
+        assert (
+            has_health_check
+        ), "Validation script must include health check validation"
 
     def test_validation_script_has_smoke_tests(self):
         """Verify validation script includes smoke tests"""
@@ -291,6 +301,7 @@ class TestPROD006DeploymentValidation:
         assert script_path.exists(), "Python validation helper should exist"
 
 
+@_SKIP
 class TestPROD007RollbackProcedures:
     """
     PROD-007: Rollback Procedures
@@ -441,6 +452,7 @@ class TestPROD007RollbackProcedures:
         assert has_troubleshooting, "Rollback runbook should include troubleshooting"
 
 
+@_SKIP
 class TestCICDIntegration:
     """
     Integration tests verifying all components work together
@@ -453,9 +465,9 @@ class TestCICDIntegration:
             content = f.read()
 
         # Should reference validation script
-        assert "validate_deployment.sh" in content or "validate_env.py" in content, (
-            "Deployment workflow must use validation script"
-        )
+        assert (
+            "validate_deployment.sh" in content or "validate_env.py" in content
+        ), "Deployment workflow must use validation script"
 
     def test_deployment_workflow_uses_rollback_script(self):
         """Verify deployment workflow can trigger rollback script"""
@@ -464,9 +476,9 @@ class TestCICDIntegration:
             content = f.read()
 
         # Should reference rollback script or procedure
-        assert "rollback.sh" in content or "rollback" in content.lower(), (
-            "Deployment workflow must reference rollback procedures"
-        )
+        assert (
+            "rollback.sh" in content or "rollback" in content.lower()
+        ), "Deployment workflow must reference rollback procedures"
 
     def test_all_scripts_in_scripts_directory(self):
         """Verify all required scripts are in scripts/ directory"""
@@ -481,9 +493,9 @@ class TestCICDIntegration:
 
         for script_name in required_scripts:
             script_path = scripts_dir / script_name
-            assert script_path.exists(), (
-                f"Required script {script_name} not found in scripts/"
-            )
+            assert (
+                script_path.exists()
+            ), f"Required script {script_name} not found in scripts/"
 
     def test_all_docs_in_docs_directory(self):
         """Verify all required documentation is in docs/ directory"""
@@ -511,6 +523,7 @@ class TestCICDIntegration:
         assert has_env, "Deployment workflow should define environment variables"
 
 
+@_SKIP
 class TestSecurityAndCompliance:
     """
     Security and compliance tests for CI/CD pipeline

--- a/packages/kailash-ml/tests/integration/test_hyperparameter_search.py
+++ b/packages/kailash-ml/tests/integration/test_hyperparameter_search.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import numpy as np
 import polars as pl
 import pytest
-
 from kailash.db.connection import ConnectionManager
 from kailash_ml.engines.feature_store import FeatureStore
 from kailash_ml.engines.hyperparameter_search import (
@@ -18,19 +17,10 @@ from kailash_ml.engines.hyperparameter_search import (
     SearchConfig,
     SearchResult,
     SearchSpace,
-    TrialResult,
 )
-from kailash_ml.engines.model_registry import (
-    LocalFileArtifactStore,
-    ModelRegistry,
-)
-from kailash_ml.engines.training_pipeline import (
-    EvalSpec,
-    ModelSpec,
-    TrainingPipeline,
-)
+from kailash_ml.engines.model_registry import LocalFileArtifactStore, ModelRegistry
+from kailash_ml.engines.training_pipeline import EvalSpec, ModelSpec, TrainingPipeline
 from kailash_ml.types import FeatureField, FeatureSchema
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -166,6 +156,7 @@ async def test_bayesian_search_converges(
     sample_schema: FeatureSchema,
 ) -> None:
     """Bayesian search runs and returns results."""
+    pytest.importorskip("optuna", reason="optuna required for Bayesian search")
     result = await search.search(
         sample_df,
         sample_schema,

--- a/src/kailash/trust/plane/models.py
+++ b/src/kailash/trust/plane/models.py
@@ -228,6 +228,12 @@ class CommunicationConstraints:
 class ConstraintEnvelope:
     """Structured constraints across all 5 EATP dimensions.
 
+    .. deprecated::
+        This is the legacy trust-plane constraint envelope. The canonical
+        PACT envelope is ``kailash.trust.pact.config.ConstraintEnvelopeConfig``
+        (SPEC-07). This class remains for trust-plane backward compatibility
+        and will be removed in a future major release.
+
     Maps directly to EATP ConstraintType enum values:
     - OPERATIONAL → what the AI can do
     - DATA_ACCESS → what data it can see/modify


### PR DESCRIPTION
## Summary
- **#391**: benchmark conftest guarded with `pytest.importorskip("pytest_benchmark")`
- **#398**: Legacy `ConstraintEnvelope` in `plane/models.py` marked deprecated with pointer to canonical `ConstraintEnvelopeConfig`
- **#401**: Bayesian search test guarded with `pytest.importorskip("optuna")`
- **#402**: 5 CICD test classes skipped when `deploy-production.yml` absent (TDD-first tests)
- **#404**: `PipelineExecutor._serialize` and `_content_hash` moved to `asyncio.to_thread` to prevent event-loop blocking

## Test plan
- [x] Pre-commit hooks pass (Tier 1 unit tests)
- [ ] CI pipeline

Closes #391 #398 #401 #402 #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)