### PR TITLE
fix(kaizen): detect multimodal inputs — #410

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -312,9 +312,32 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
 
-        user_content = " | ".join(
-            str(v) for v in inputs.values() if not str(v).startswith("_")
-        )
+        # Build user content, detecting multimodal inputs (#410)
+        from kaizen.strategies.async_single_shot import _classify_input_value
+
+        text_parts: list[str] = []
+        multimodal_parts: list[dict] = []
+        has_multimodal = False
+
+        for k, v in inputs.items():
+            if v is None or str(k).startswith("_"):
+                continue
+            content_part = _classify_input_value(v, k, {})
+            if content_part is not None:
+                has_multimodal = True
+                multimodal_parts.append(content_part)
+            else:
+                text_parts.append(str(v))
+
+        if has_multimodal:
+            content_list: list[dict] = []
+            if text_parts:
+                content_list.append({"type": "text", "text": " | ".join(text_parts)})
+            content_list.extend(multimodal_parts)
+            user_content = content_list
+        else:
+            user_content = " | ".join(text_parts) if text_parts else "No input provided"
+
         messages.append({"role": "user", "content": user_content})
 
         response = await provider.chat_async(

--- a/packages/kailash-kaizen/src/kaizen/strategies/async_single_shot.py
+++ b/packages/kailash-kaizen/src/kaizen/strategies/async_single_shot.py
@@ -10,7 +10,7 @@ Provides async execution for improved performance:
 import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from kailash.runtime import AsyncLocalRuntime
 from kailash.workflow.builder import WorkflowBuilder
@@ -19,6 +19,83 @@ logger = logging.getLogger(__name__)
 
 # Allowlist regex for MCP tool names — validates before execution
 _TOOL_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.:-]{0,127}$")
+
+
+def _classify_input_value(
+    value: Any, desc: str, field_info: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Classify an input value as a multimodal content part, or None for text.
+
+    Returns a content-part dict (e.g. ``{"type": "image_url", ...}``) when the
+    value is binary data or an already-structured content part.  Returns None
+    when the value should be rendered as plain text.
+
+    This function is provider-agnostic -- it produces the multimodal content
+    list format understood by all major LLM providers.
+    """
+    import base64
+
+    # Already a structured content part dict (caller pre-built it)
+    if isinstance(value, dict) and "type" in value:
+        return value
+
+    # Raw bytes -- detect media type and build a content part
+    if isinstance(value, (bytes, bytearray)):
+        media_type = (
+            field_info.get("media_type", "") if isinstance(field_info, dict) else ""
+        )
+        if not media_type:
+            media_type = _guess_media_type(value)
+
+        b64_data = base64.b64encode(value).decode("ascii")
+
+        if media_type.startswith("audio/"):
+            return {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": b64_data,
+                    "format": media_type.split("/", 1)[1],
+                },
+            }
+        # Images (and unknown binary) use the image_url data-URI form
+        return {
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:{media_type};base64,{b64_data}",
+            },
+        }
+
+    return None
+
+
+def _guess_media_type(data: bytes) -> str:
+    """Best-effort media type detection from magic bytes.
+
+    Falls back to ``application/octet-stream`` when the format is unknown.
+    """
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:4] == b"GIF8":
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    # MP3 sync word (0xFFE0-0xFFFF) or ID3 tag
+    if data[:3] == b"ID3" or (
+        len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0
+    ):
+        return "audio/mpeg"
+    # OGG container (Vorbis / Opus)
+    if data[:4] == b"OggS":
+        return "audio/ogg"
+    # WAV
+    if data[:4] == b"RIFF" and data[8:12] == b"WAVE":
+        return "audio/wav"
+    # FLAC
+    if data[:4] == b"fLaC":
+        return "audio/flac"
+    return "application/octet-stream"
 
 
 class AsyncSingleShotStrategy:
@@ -331,29 +408,65 @@ class AsyncSingleShotStrategy:
     def _create_messages_from_inputs(
         self, agent: Any, inputs: Dict[str, Any]
     ) -> List[Dict[str, str]]:
-        """Transform signature inputs into OpenAI message format."""
-        message_parts = []
+        """Transform signature inputs into OpenAI message format.
+
+        Handles both text-only inputs (flat string content) and multimodal
+        inputs containing bytes or structured content parts (content list).
+        Binary data (bytes) is converted to the provider-agnostic multimodal
+        content list format rather than being coerced to a string
+        representation like ``b'\\xff\\xfb...'``.
+        """
+        text_parts: List[str] = []
+        multimodal_parts: List[Dict[str, Any]] = []
+        has_multimodal = False
 
         if hasattr(agent.signature, "input_fields"):
             for field_name, field_info in agent.signature.input_fields.items():
-                if field_name in inputs and inputs[field_name]:
+                if field_name in inputs and inputs[field_name] is not None:
                     desc = field_info.get("desc", field_name.title())
                     value = inputs[field_name]
-                    message_parts.append(f"{desc}: {value}")
+                    content_part = _classify_input_value(value, desc, field_info)
+                    if content_part is not None:
+                        has_multimodal = True
+                        multimodal_parts.append(content_part)
+                    else:
+                        text_parts.append(f"{desc}: {value}")
         else:
-            message_parts = [f"{k}: {v}" for k, v in inputs.items() if v]
+            for k, v in inputs.items():
+                if v is not None:
+                    content_part = _classify_input_value(v, k.title(), {})
+                    if content_part is not None:
+                        has_multimodal = True
+                        multimodal_parts.append(content_part)
+                    else:
+                        text_parts.append(f"{k}: {v}")
 
-        content = "\n\n".join(message_parts) if message_parts else "No input provided"
-
-        # FIX: If using response_format with type=json_object (strict=False),
-        # OpenAI requires "json" to be mentioned in messages
+        # Build the json_object suffix if needed
+        json_suffix = ""
         if hasattr(agent, "config") and hasattr(agent.config, "response_format"):
             response_format = agent.config.response_format
             if (
                 isinstance(response_format, dict)
                 and response_format.get("type") == "json_object"
             ):
-                content += "\n\nPlease respond in JSON format."
+                json_suffix = "\n\nPlease respond in JSON format."
+
+        if has_multimodal:
+            # Build a content list combining text and multimodal parts
+            content_list: List[Dict[str, Any]] = []
+            if text_parts:
+                combined_text = "\n\n".join(text_parts) + json_suffix
+                content_list.append({"type": "text", "text": combined_text})
+            elif json_suffix:
+                content_list.append(
+                    {"type": "text", "text": "No text input provided" + json_suffix}
+                )
+            content_list.extend(multimodal_parts)
+            return [{"role": "user", "content": content_list}]
+
+        # Common case: all inputs are text — flat string content
+        content = "\n\n".join(text_parts) if text_parts else "No input provided"
+        content += json_suffix
 
         return [{"role": "user", "content": content}]
 

--- a/packages/kailash-kaizen/tests/regression/test_issue_410_multimodal.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_410_multimodal.py
@@ -1,0 +1,317 @@
+"""Regression tests for issue #410: multimodal input detection.
+
+The bug: ``_create_messages_from_inputs()`` coerced ALL input values to
+strings via f-string interpolation.  Binary data (audio bytes, image bytes)
+became ``b'\\xff\\xfb...'`` as text -- the LLM never saw the actual content.
+
+The fix: detect bytes / structured-dict inputs and produce a multimodal
+content list instead of a flat string.
+"""
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+
+from kaizen.strategies.async_single_shot import (
+    AsyncSingleShotStrategy,
+    _classify_input_value,
+    _guess_media_type,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal agent mock with signature input_fields
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(input_fields: dict, response_format=None):
+    """Build a lightweight agent mock for _create_messages_from_inputs."""
+    agent = MagicMock()
+    agent.signature.input_fields = input_fields
+    if response_format is not None:
+        agent.config.response_format = response_format
+    else:
+        # Ensure hasattr(agent.config, "response_format") is False
+        del agent.config.response_format
+    return agent
+
+
+# ===================================================================
+# _classify_input_value unit tests
+# ===================================================================
+
+
+class TestClassifyInputValue:
+    """Unit tests for the multimodal input classifier."""
+
+    @pytest.mark.regression
+    def test_string_returns_none(self):
+        """String values are text -- classifier returns None."""
+        assert _classify_input_value("hello", "Greeting", {}) is None
+
+    @pytest.mark.regression
+    def test_int_returns_none(self):
+        """Numeric values are text -- classifier returns None."""
+        assert _classify_input_value(42, "Count", {}) is None
+
+    @pytest.mark.regression
+    def test_bytes_jpeg_detected(self):
+        """JPEG magic bytes produce an image_url content part."""
+        jpeg_header = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        result = _classify_input_value(jpeg_header, "Photo", {})
+        assert result is not None
+        assert result["type"] == "image_url"
+        assert "data:image/jpeg;base64," in result["image_url"]["url"]
+
+    @pytest.mark.regression
+    def test_bytes_png_detected(self):
+        """PNG magic bytes produce an image_url content part."""
+        png_header = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        result = _classify_input_value(png_header, "Screenshot", {})
+        assert result is not None
+        assert result["type"] == "image_url"
+        assert "data:image/png;base64," in result["image_url"]["url"]
+
+    @pytest.mark.regression
+    def test_bytes_mp3_detected_as_audio(self):
+        """MP3 bytes produce an input_audio content part (not image_url)."""
+        # ID3 tag header
+        mp3_data = b"ID3" + b"\x00" * 100
+        result = _classify_input_value(mp3_data, "Audio", {})
+        assert result is not None
+        assert result["type"] == "input_audio"
+        assert result["input_audio"]["format"] == "mpeg"
+
+    @pytest.mark.regression
+    def test_bytes_mp3_sync_word(self):
+        """MP3 sync word (0xFFE0+) detected as audio."""
+        mp3_data = bytes([0xFF, 0xFB]) + b"\x00" * 100
+        result = _classify_input_value(mp3_data, "Audio", {})
+        assert result is not None
+        assert result["type"] == "input_audio"
+        assert result["input_audio"]["format"] == "mpeg"
+
+    @pytest.mark.regression
+    def test_bytes_with_explicit_media_type(self):
+        """field_info media_type overrides magic-byte detection."""
+        raw = b"\x00\x01\x02\x03"
+        result = _classify_input_value(raw, "Audio", {"media_type": "audio/wav"})
+        assert result is not None
+        assert result["type"] == "input_audio"
+        assert result["input_audio"]["format"] == "wav"
+
+    @pytest.mark.regression
+    def test_dict_with_type_key_passthrough(self):
+        """Pre-built content-part dicts are passed through unchanged."""
+        part = {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/img.png"},
+        }
+        result = _classify_input_value(part, "Image", {})
+        assert result is part  # exact same object
+
+    @pytest.mark.regression
+    def test_dict_without_type_key_returns_none(self):
+        """Regular dicts (no 'type' key) are treated as text."""
+        data = {"key": "value", "count": 42}
+        assert _classify_input_value(data, "Data", {}) is None
+
+    @pytest.mark.regression
+    def test_bytearray_treated_like_bytes(self):
+        """bytearray inputs are handled the same as bytes."""
+        png = bytearray(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+        result = _classify_input_value(png, "Image", {})
+        assert result is not None
+        assert result["type"] == "image_url"
+
+    @pytest.mark.regression
+    def test_unknown_bytes_fallback(self):
+        """Unknown binary falls back to application/octet-stream image_url."""
+        raw = b"\x01\x02\x03\x04\x05"
+        result = _classify_input_value(raw, "Binary", {})
+        assert result is not None
+        assert result["type"] == "image_url"
+        assert "application/octet-stream" in result["image_url"]["url"]
+
+
+# ===================================================================
+# _guess_media_type unit tests
+# ===================================================================
+
+
+class TestGuessMediaType:
+    """Unit tests for magic-byte media type detection."""
+
+    @pytest.mark.regression
+    def test_wav_detection(self):
+        data = b"RIFF" + b"\x00\x00\x00\x00" + b"WAVE" + b"\x00" * 20
+        assert _guess_media_type(data) == "audio/wav"
+
+    @pytest.mark.regression
+    def test_webp_detection(self):
+        data = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 20
+        assert _guess_media_type(data) == "image/webp"
+
+    @pytest.mark.regression
+    def test_flac_detection(self):
+        assert _guess_media_type(b"fLaC" + b"\x00" * 20) == "audio/flac"
+
+    @pytest.mark.regression
+    def test_ogg_detection(self):
+        assert _guess_media_type(b"OggS" + b"\x00" * 20) == "audio/ogg"
+
+    @pytest.mark.regression
+    def test_gif_detection(self):
+        assert _guess_media_type(b"GIF89a" + b"\x00" * 20) == "image/gif"
+
+
+# ===================================================================
+# _create_messages_from_inputs integration tests
+# ===================================================================
+
+
+class TestCreateMessagesFromInputs:
+    """Test the full message-building pipeline."""
+
+    @pytest.mark.regression
+    def test_string_only_produces_flat_content(self):
+        """When all inputs are strings, content is a flat string (no regression)."""
+        strategy = AsyncSingleShotStrategy()
+        agent = _make_agent(
+            {
+                "question": {"desc": "The question"},
+                "context": {"desc": "Context"},
+            }
+        )
+        inputs = {"question": "What is AI?", "context": "Computer science"}
+
+        messages = strategy._create_messages_from_inputs(agent, inputs)
+
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        # Content must be a plain string, not a list
+        assert isinstance(messages[0]["content"], str)
+        assert "What is AI?" in messages[0]["content"]
+        assert "Computer science" in messages[0]["content"]
+
+    @pytest.mark.regression
+    def test_bytes_input_produces_content_list(self):
+        """When an input is bytes, content becomes a multimodal list."""
+        strategy = AsyncSingleShotStrategy()
+        agent = _make_agent(
+            {
+                "question": {"desc": "The question"},
+                "image": {"desc": "An image"},
+            }
+        )
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+        inputs = {"question": "Describe this image", "image": png_bytes}
+
+        messages = strategy._create_messages_from_inputs(agent, inputs)
+
+        assert len(messages) == 1
+        content = messages[0]["content"]
+        # Content must be a list (multimodal)
+        assert isinstance(
+            content, list
+        ), f"Expected list for multimodal content, got {type(content).__name__}"
+        # Should have a text part and an image part
+        types = [part["type"] for part in content]
+        assert "text" in types
+        assert "image_url" in types
+        # Text part should contain the question
+        text_part = next(p for p in content if p["type"] == "text")
+        assert "Describe this image" in text_part["text"]
+        # Image part should have base64 data
+        img_part = next(p for p in content if p["type"] == "image_url")
+        assert "data:image/png;base64," in img_part["image_url"]["url"]
+
+    @pytest.mark.regression
+    def test_audio_bytes_produce_input_audio_part(self):
+        """Audio bytes produce input_audio content parts."""
+        strategy = AsyncSingleShotStrategy()
+        agent = _make_agent(
+            {
+                "prompt": {"desc": "Instruction"},
+                "audio": {"desc": "Audio clip"},
+            }
+        )
+        mp3_bytes = b"ID3" + b"\x00" * 100
+        inputs = {"prompt": "Transcribe this", "audio": mp3_bytes}
+
+        messages = strategy._create_messages_from_inputs(agent, inputs)
+
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        types = [part["type"] for part in content]
+        assert "input_audio" in types
+        audio_part = next(p for p in content if p["type"] == "input_audio")
+        assert audio_part["input_audio"]["format"] == "mpeg"
+
+    @pytest.mark.regression
+    def test_dict_content_part_passthrough(self):
+        """Pre-built content-part dicts are included in the content list."""
+        strategy = AsyncSingleShotStrategy()
+        agent = _make_agent(
+            {
+                "question": {"desc": "Question"},
+                "image": {"desc": "Image part"},
+            }
+        )
+        pre_built = {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/photo.jpg"},
+        }
+        inputs = {"question": "What do you see?", "image": pre_built}
+
+        messages = strategy._create_messages_from_inputs(agent, inputs)
+
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        # The pre-built part should appear as-is
+        img_parts = [p for p in content if p["type"] == "image_url"]
+        assert len(img_parts) == 1
+        assert img_parts[0]["image_url"]["url"] == "https://example.com/photo.jpg"
+
+    @pytest.mark.regression
+    def test_no_signature_input_fields_with_bytes(self):
+        """Multimodal detection works even without signature input_fields."""
+        strategy = AsyncSingleShotStrategy()
+        agent = MagicMock()
+        # Remove input_fields attribute so the else branch is taken
+        del agent.signature.input_fields
+        del agent.config.response_format
+
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+        inputs = {"text": "Describe", "img": png_bytes}
+
+        messages = strategy._create_messages_from_inputs(agent, inputs)
+
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        types = [part["type"] for part in content]
+        assert "image_url" in types
+
+    @pytest.mark.regression
+    def test_bytes_not_coerced_to_string(self):
+        """The core bug: bytes must NOT appear as b'...' string in content."""
+        strategy = AsyncSingleShotStrategy()
+        agent = _make_agent(
+            {
+                "audio": {"desc": "Audio data"},
+            }
+        )
+        audio_bytes = b"\xff\xfb\x90\x00" + b"\x00" * 100
+        inputs = {"audio": audio_bytes}
+
+        messages = strategy._create_messages_from_inputs(agent, inputs)
+
+        content = messages[0]["content"]
+        # If content is a string, the bug is back
+        if isinstance(content, str):
+            assert (
+                "b'" not in content
+            ), "Binary data was coerced to string representation -- issue #410 regression"
+            pytest.fail("bytes input should produce a content list, not a string")
+        # Content should be a list with an audio part
+        assert isinstance(content, list)


### PR DESCRIPTION
## Summary
`_create_messages_from_inputs()` silently coerced binary inputs (audio, images) to their `repr()` string. The LLM received `b'\xff\xfb...'` as text instead of actual multimodal content.

**Fix**: Added `_classify_input_value()` that detects bytes/bytearray and pre-built content-part dicts, routing them into the OpenAI multimodal content list format. Added `_guess_media_type()` for magic-byte detection (JPEG, PNG, GIF, WebP, MP3, OGG, WAV, FLAC). String-only inputs preserve existing flat-string behavior (no regression).

Same fix applied to `base_agent.py` fallback path.

## Test plan
- [x] 22 regression tests (classifier, media type detection, message pipeline)
- [x] 974 existing unit tests pass, 0 regressions
- [ ] CI pipeline

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)