### PR TITLE
chore(sync): mark proposal as reviewed by loom

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -312,4 +312,99 @@ changes:
     reason: "SPEC-09 canonical JSON module (trust._json) — DuplicateKeyError, parse_constant NaN/Inf rejection, sorted-key deterministic output. Cross-SDK parser differential documentation with 8 edge-case vectors."
     diff_lines: "+80"
 
+  # --- 2026-04-11: Arbor upstream fixes — session gotchas promoted to rules ---
+  # Origin: workspaces/arbor-upstream-fixes/.session-notes § "Traps / gotchas"
+  # Three traps hit during this session that cost time to rediscover. Filing
+  # as proposals so loom/ can classify global vs variant and distribute.
+  # Each rule edit was applied locally to kailash-py/.claude/rules/ for
+  # immediate use in the next session here.
+
+  - file: rules/python-environment.md
+    action: modified
+    suggested_tier: coc
+    reason: |
+      Added two MUST rules (and two MUST NOT entries under the Rules section):
+
+      (1) MUST Address the Venv Interpreter Explicitly — bare `python` /
+          `python3` / `pytest` is BLOCKED. Pyenv, asdf, and Homebrew install
+          shims that can resolve to a different interpreter than the project
+          `.venv`, and during this session that trap silently routed `import
+          kailash` to a Python interpreter with Rust bindings pre-installed
+          for `kailash-rs` — tests "passed" without exercising the Python
+          source. Rule covers DO patterns (`.venv/bin/python`, `uv run`,
+          activated shell), DO NOT patterns (`python`, `python3`,
+          `python3.13`, bare `pytest`), and BLOCKED rationalizations.
+
+      (2) Monorepo Sub-Packages MUST Be Installed Editable — when a repo
+          contains `packages/*/pyproject.toml`, every sub-package MUST be
+          installed editable into the root `.venv`. The `PYTHONPATH=
+          packages/foo/src:packages/bar/src ...` workaround is BLOCKED —
+          it's invisible to editors, Pyright, and ad-hoc scripts, leaving
+          them pointed at stale installations. Affected this session:
+          kailash-dataflow, kailash-nexus, kailash-kaizen in kailash-py.
+
+      Both rules are globally applicable (every Python monorepo hits these
+      traps). Classification suggestion: global coc (applies to USE repos
+      and BUILD repos equally — both use `.venv` + `uv`, both can be
+      monorepos). Not a variant — rules are language-agnostic in spirit,
+      though the examples cite Python. Rust/rb monorepos hit analogous
+      traps with cargo workspaces and bundler groups, so the spiritual
+      twin lives in `variants/rs/` and `variants/rb/` if loom decides to
+      mirror.
+    diff_lines: "+75 -1"
+
+  - file: rules/infrastructure-sql.md
+    action: modified
+    suggested_tier: coc
+    reason: |
+      Rewrote § 8 "Lazy Driver Imports" as a stricter MUST rule and added
+      § 8a requiring a regression test.
+
+      Previous text said "Lazy imports remain acceptable for consistency" —
+      a `should`-style permission phrase that the rule-authoring meta-rule
+      identifies as BLOCKED ("`should` tells the agent it is permitted to
+      skip"). Upgraded to MUST with BLOCKED rationalizations.
+
+      § 8 MUST: every adapter class that wraps an optional backend driver
+      (motor, pymongo, aiomysql, asyncpg, aiosqlite, aiokafka, redis.asyncio,
+      etc.) MUST import the driver inside the method that first needs it,
+      with a descriptive `ImportError` raised at the call site if the
+      driver is missing. Top-level `from <driver> import ...` on the
+      adapter module is BLOCKED.
+
+      § 8a MUST: every lazy-driver adapter MUST have a regression test
+      that asserts the top-level package import succeeds with the driver
+      absent. Static grep alone is BLOCKED — a future "tidy up imports"
+      refactor silently reintroduces the eager-import bug.
+
+      Origin: the MongoDB adapter in kailash-dataflow imported
+      motor.motor_asyncio at module top, so `from dataflow import
+      DataFlow` died with `ModuleNotFoundError: No module named 'motor'`
+      for any project that didn't install motor. Fixed this session by
+      moving the import into `MongoDBAdapter.connect()`.
+
+      This rule applies to BUILD repos (BUILD-authored adapter code) AND
+      USE repos (USE-project adapter classes that wrap optional drivers).
+      Classification suggestion: global coc — the pattern is not
+      SDK-specific. Rust equivalent would be feature-gated crate imports
+      with a `#[cfg(feature = "mongodb")]` gate; similar spirit but
+      different mechanism, so variants/rs may need its own wording.
+    diff_lines: "+85 -6"
+
 status: reviewed
+reviewed_date: "2026-04-11"
+reviewed_notes: |
+  Most of this proposal was already upstreamed in a prior sync cycle (identical
+  in loom/ vs kailash-py/). Only two files had genuinely new changes from the
+  2026-04-11 arbor-upstream-fixes session:
+
+  - rules/python-environment.md  → accepted as global coc, distributed to both
+    kailash-coc-claude-py and kailash-coc-claude-rs (Python/Ruby devs consuming
+    Rust bindings hit the same pyenv/editable-install traps).
+  - rules/infrastructure-sql.md  → accepted as global coc, distributed to both
+    templates (adapter lazy-import pattern is language-agnostic in spirit).
+
+  Skipped:
+  - rules/refactor-invariants.md — listed as "created" in the proposal but the
+    file does not exist in kailash-py/.claude/rules/. Deferred; the BUILD repo
+    should actually author it in a follow-up /codify, then sync.


### PR DESCRIPTION
## Summary
- Marked .claude/.proposals/latest.yaml as reviewed
- 2 rules ingested (python-environment, infrastructure-sql), rest already upstreamed
- refactor-invariants.md deferred (file not created on disk)

## Test plan
- [x] Proposal status updated to reviewed with notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)