### PR TITLE
fix(ci): install trust+dev extras in cross-sdk conformance workflow

### DIFF
--- a/.github/workflows/cross-sdk-interop.yml
+++ b/.github/workflows/cross-sdk-interop.yml
@@ -45,8 +45,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv
-          uv sync
+          uv venv .venv
+          source .venv/bin/activate
+          uv pip install -e ".[trust,dev]"
 
       - name: Verify vector integrity
         run: |
@@ -55,8 +56,8 @@ jobs:
 
       - name: Run N6 conformance tests
         run: |
-          uv run python -m pytest tests/trust/pact/conformance/test_n6_conformance.py -v --tb=short
+          .venv/bin/python -m pytest tests/trust/pact/conformance/test_n6_conformance.py -v --tb=short
 
       - name: Run full PACT test suite
         run: |
-          uv run python -m pytest tests/trust/pact/ -v --tb=short -q
+          .venv/bin/python -m pytest tests/trust/pact/ -v --tb=short -q


### PR DESCRIPTION
## Summary
- Fixed PACT N6 Conformance Vectors CI job that was failing with `No module named pytest`
- Root cause: `uv sync` only installs base dependencies; the conformance tests need `pytest` (dev extra) and `kailash.trust` imports (trust extra)
- Aligned install pattern with `trust-tests.yml` which correctly uses `uv pip install -e ".[trust,dev]"`

## Related issues
Fixes the recurring "PACT N6 Conformance Vectors" CI failure visible on PR #423 and main branch pushes.

## Test plan
- [x] PACT N6 conformance tests pass locally (32/32)
- [ ] CI workflow runs successfully with new dependency install

🤖 Generated with [Claude Code](https://claude.com/claude-code)