### PR TITLE
chore(release): v2.8.3 — convergence-202 completion

### DIFF
--- a/.github/workflows/cross-sdk-interop.yml
+++ b/.github/workflows/cross-sdk-interop.yml
@@ -45,8 +45,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv
-          uv sync
+          uv venv .venv
+          source .venv/bin/activate
+          uv pip install -e ".[trust,dev]"
 
       - name: Verify vector integrity
         run: |
@@ -55,8 +56,8 @@ jobs:
 
       - name: Run N6 conformance tests
         run: |
-          uv run python -m pytest tests/trust/pact/conformance/test_n6_conformance.py -v --tb=short
+          .venv/bin/python -m pytest tests/trust/pact/conformance/test_n6_conformance.py -v --tb=short
 
       - name: Run full PACT test suite
         run: |
-          uv run python -m pytest tests/trust/pact/ -v --tb=short -q
+          .venv/bin/python -m pytest tests/trust/pact/ -v --tb=short -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### Platform Architecture Convergence — Completion — 2026-04-12
+
+kailash 2.8.3 + kailash-ml 0.9.0 + kailash-dataflow 2.0.5 + kaizen-agents 0.9.2
+
+#### Added
+
+- **EventLoopWatchdog** (kailash 2.8.3): async stall detection that fires when the event loop blocks for longer than a configurable threshold, emitting structured WARN logs with stack traces of the blocking coroutine. Integrated into `AsyncLocalRuntime`.
+- **ProgressUpdate contract** (kailash 2.8.3): long-running nodes can now emit structured progress updates via `ProgressRegistry`, enabling real-time status reporting to callers without polling.
+- **PACT N4/N5/N6 exports** (kailash 2.8.3): complete public API surface for PACT conformance types with cross-SDK vector integrity verification (32 conformance tests, SHA-256 vector checksums).
+- **Cross-SDK conformance CI** (kailash 2.8.3): new GitHub Actions workflow validates PACT N6 byte-identical JSON serialization against committed test vectors on every push to trust/pact code.
+- **Convergence verification script** (`scripts/verify-convergence.py`): automated check that all convergence-202 deliverables are present and wired.
+- **v2-to-v3 migration guide** expanded with convergence deliverables and upgrade paths.
+
+#### Changed
+
+- **DriftMonitor API rename** (kailash-ml 0.9.0, **breaking**): `set_reference()` → `set_reference_data()`, `_load_baseline`/`_store_baseline` → `_load_performance_baseline`/`_store_performance_baseline`. New `DriftCallback` type alias for the `on_drift_detected` handler. The `DriftSpec.on_drift_detected` field is now properly typed as `DriftCallback | None` instead of `Any`.
+- **CodeQL sanitizer barriers** (kailash-dataflow 2.0.5): `safe_log_value()` helper added to `dataflow.utils.masking` as a taint-sink barrier for structured log fields. PostgreSQL, MySQL, and factory adapter init logs now route connection coordinates through this helper, eliminating false-positive HIGH alerts from CodeQL's `py/clear-text-logging-sensitive-data` rule.
+- **SQLAlchemy availability probe** (kaizen-agents 0.9.2): replaced `try/import/except` pattern with `importlib.util.find_spec()` to eliminate CodeQL unused-import false positives.
+- **MongoDB adapter typing** (kailash-dataflow 2.0.5): motor type hints changed from `TYPE_CHECKING` forward references to `Any` to avoid CodeQL false positives on unused imports.
+
+#### Fixed
+
+- **PACT N6 conformance CI** (kailash 2.8.3): workflow was failing with `No module named pytest` because `uv sync` doesn't install optional extras. Fixed to use `uv pip install -e ".[trust,dev]"`.
+- **Watchdog `loop=` deprecation** (kailash 2.8.3): removed deprecated `loop=` parameter from `asyncio.ensure_future` calls in the watchdog module.
+- **Progress registry orphan wiring** (kailash 2.8.3): `ProgressRegistry` context var lifecycle fixed under exception paths to prevent orphaned registries.
+
+#### Internal
+
+- **Specs authority system** synced from loom — `specs/_index.md` manifest and domain-organized spec files now available for all phase commands.
+- **Convergence-202 knowledge codified** into skills and proposal manifest (95+ entries at `pending_review`).
+- **12 institutional patterns** from R1/R2/R3 audit rounds captured as rule updates and CodeQL configuration.
+
 ### Arbor Upstream Fixes — Security Patch — 2026-04-12
 
 kailash 2.8.2 + kailash-dataflow 2.0.4 + kailash-nexus 2.0.1 + kailash-mcp 0.2.1 + kailash-kaizen 2.7.2 + kaizen-agents 0.9.1

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.0.4"
+version = "2.0.5"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -87,7 +87,7 @@ from .validation import (
 )
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.8.1"
+version = "0.9.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.8.1"
+__version__ = "0.9.0"

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.9.1"
+version = "0.9.2"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.8.2"
+version = "2.8.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}
@@ -90,7 +90,7 @@ pact = [
     "kailash-pact>=0.8.1",
 ]
 ml = [
-    "kailash-ml>=0.8.1",
+    "kailash-ml>=0.9.0",
 ]
 align = [
     "kailash-align>=0.3.0",

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.8.2"
+__version__ = "2.8.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary
- Version bumps: kailash 2.8.3, kailash-ml 0.9.0, kailash-dataflow 2.0.5, kaizen-agents 0.9.2
- CHANGELOG updated with all changes since v2.8.2
- Includes cherry-picked CI fix for PACT N6 conformance workflow (#425)

## Packages
| Package | Old | New | Change type |
|---------|-----|-----|-------------|
| kailash | 2.8.2 | 2.8.3 | patch — new features (EventLoopWatchdog, ProgressUpdate, PACT N4/N5/N6) |
| kailash-ml | 0.8.1 | 0.9.0 | **minor (breaking)** — DriftMonitor API rename |
| kailash-dataflow | 2.0.4 | 2.0.5 | patch — CodeQL sanitizer barriers |
| kaizen-agents | 0.9.1 | 0.9.2 | patch — SQLAlchemy probe refactor |

## Related issues
Completes convergence-202 deliverables. Fixes PACT N6 CI failure.

## Test plan
- [ ] CI passes on all Python versions (3.10-3.13)
- [ ] Version consistency check passes
- [ ] PACT N6 conformance passes with new workflow
- [ ] Merge, tag v2.8.3, PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)