### PR TITLE
Release v2.8.4 — post-convergence security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,33 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### Post-Convergence Security Hardening — 2026-04-12
+
+kailash 2.8.4 + kailash-dataflow 2.0.6 + kailash-kaizen 2.7.3
+
+#### Security
+
+- **SQL injection fix in kaizen security audit** (`kailash-kaizen 2.7.3`): `query_events()` in `security/audit.py` built a raw f-string `WHERE` clause from caller-supplied `event_type` and `agent_id` — these arguments could contain SQL metacharacters. Fixed to use parameterized queries; identifier path validated with `re.match` before interpolation.
+- **Identifier fingerprint error messages** (`kailash 2.8.4`, `kailash-dataflow 2.0.6`): all `IdentifierError` messages now emit a hex fingerprint of the offending input (`hash(name) & 0xFFFF:04x`) rather than echoing the raw value, preventing log-poisoning / stored-XSS via crafted identifier names.
+- **CAS fail-closed guards** (`kailash 2.8.4`): `cache.py` CAS path now raises `CASConflictError` on version mismatch instead of silently overwriting. Guards added to the async write-through path.
+- **Tenant-scoped cache `_clear`** (`kailash 2.8.4`): `InMemoryCache._clear()` now accepts an optional `tenant_id` parameter; without it the method refuses to clear across tenants, preventing accidental cross-tenant cache eviction.
+- **`schema_manager` defense-in-depth** (`kailash 2.8.4`): `SchemaManager.drop_table()` and `drop_column()` require `force_drop=True` per `rules/dataflow-identifier-safety.md` Rule 4; previously a missing flag would silently drop.
+- **EATP human-origin identifier validation** (`kailash 2.8.4`): `eatp_human_origin.py` migration now routes all dynamic identifiers through `dialect.quote_identifier()` — the earlier version interpolated tenant-supplied model names directly into DDL.
+- **Audit forwarding with `exc_info`** (`kailash-kaizen 2.7.3`): audit `logger.error()` calls in `core/autonomy/observability/audit.py` and `security/audit.py` now pass `exc_info=True` so stack traces appear in the log pipeline instead of just the message string.
+- **Classification fail-closed** (`kailash-dataflow 2.0.6`): `ClassificationPolicy.classify()` changed default from `PUBLIC` (fail-open) to `HIGHLY_CONFIDENTIAL` (fail-closed) for unclassified fields, matching kailash-rs semantics per EATP D6 (cross-SDK alignment #418). A WARN log is emitted when the default is applied.
+- **Connection parser consolidated credential decode** (`kailash-dataflow 2.0.6`): `connection_parser.py` now routes credential decode through the shared `decode_userinfo_or_raise` helper, eliminating a hand-rolled `unquote()` site that lacked null-byte rejection.
+
+#### Fixed
+
+- **Cache CAS + tenant eviction** (`kailash 2.8.4`): `cache.py` CAS version eviction path now correctly scopes eviction to the originating tenant's partition; previously a version mismatch could evict entries belonging to a different tenant.
+- **Bulk operations WARN on partial failure** (`kailash 2.8.4`): `bulk_operations.py` `BulkCreate._handle_batch_error()` and `BulkUpsert` now emit a structured `WARN` log when `failed > 0`, including attempted count, failure count, and first error sample. Previously these swallowed exceptions silently.
+- **`CoreErrorEnhancer` runtime/validation exports** (`kailash 2.8.4`): `src/kailash/runtime/validation/__init__.py` now exports `CoreErrorEnhancer` so downstream importers can reach it via the public package path without private module traversal.
+- **Strategy deprecations in kaizen** (`kailash-kaizen 2.7.3`): `async_single_shot.py` and `single_shot.py` emit `DeprecationWarning` when called, directing users to the canonical `DelegateEngine` strategies.
+
+#### Breaking Changes
+
+- **`ClassificationPolicy.classify()` default changed** (`kailash-dataflow 2.0.6`): unclassified fields now default to `HIGHLY_CONFIDENTIAL` instead of `PUBLIC`. Callers that relied on implicit PUBLIC classification must now explicitly annotate fields with `@classify("field", DataClassification.PUBLIC)`. See migration notes in `packages/kailash-dataflow/CHANGELOG.md`.
+
 ### Platform Architecture Convergence — Completion — 2026-04-12
 
 kailash 2.8.3 + kailash-ml 0.9.0 + kailash-dataflow 2.0.5 + kaizen-agents 0.9.2

--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -17,9 +17,9 @@
 
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
-| kailash (core)   | `v*`               | 2.8.3           |
-| kailash-dataflow | `dataflow-v*`      | 2.0.5           |
-| kailash-kaizen   | `kaizen-v*`        | 2.7.2           |
+| kailash (core)   | `v*`               | 2.8.4           |
+| kailash-dataflow | `dataflow-v*`      | 2.0.6           |
+| kailash-kaizen   | `kaizen-v*`        | 2.7.3           |
 | kailash-nexus    | `nexus-v*`         | 2.0.1           |
 | kailash-pact     | `pact-v*`          | 0.8.1           |
 | kailash-ml       | `ml-v*`            | 0.9.0           |

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,22 @@
 # DataFlow Changelog
 
+## [2.0.6] - 2026-04-12 — Post-Convergence Security Hardening
+
+### Security
+
+- **Classification fail-closed** (cross-SDK alignment #418, EATP D6): `ClassificationPolicy.classify()` default changed from `PUBLIC` (fail-open) to `HIGHLY_CONFIDENTIAL` (fail-closed) for unclassified fields, matching kailash-rs semantics. A `WARN` log is emitted each time the fail-closed default is applied so operators can identify and classify missing fields.
+  - **Breaking**: Fields that were implicitly readable as PUBLIC must now carry `@classify("field", DataClassification.PUBLIC)`. Failure to classify will result in redaction for all callers without explicit PUBLIC clearance.
+- **Connection parser consolidated credential decode**: `connection_parser.py` now routes credential extraction through the shared `kailash.utils.url_credentials.decode_userinfo_or_raise` helper. The prior hand-rolled `unquote()` call lacked null-byte rejection, enabling the `mysql://user:%00bypass@host/db` auth-bypass (same class as R3 null-byte CVE).
+- **Identifier fingerprint error messages**: `IdentifierError` messages from `dialect.quote_identifier()` now emit a hex fingerprint (`hash(name) & 0xFFFF:04x`) instead of echoing the raw identifier value, preventing log-poisoning via crafted model or column names.
+- **Cache CAS + tenant eviction** (#419): `InMemoryCache` CAS path now scopes version-eviction to the originating tenant's partition. A version mismatch no longer silently evicts cache entries belonging to a different tenant.
+- **Tenant-scoped `_clear`**: `InMemoryCache._clear()` requires an explicit `tenant_id` when the cache is operating in multi-tenant mode; clearing all tenants at once is blocked without an explicit override flag.
+
+### Fixed
+
+- **Regression tests** (34 total, 5 new test classes): `test_classification_fail_closed.py`, `test_cache_cas_tenant.py`, `test_create_index_identifier_validation.py`, `test_loc_invariants.py`, plus additions to existing regression files.
+
+---
+
 ## [2.0.0] - unreleased — DataFlow 2.0 Perfection Sprint
 
 Comprehensive rework of DataFlow's core, cache, fabric, security, and

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.0.5"
+version = "2.0.6"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -87,7 +87,7 @@ from .validation import (
 )
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.3] - 2026-04-12 — Post-Convergence Security Hardening
+
+### Security
+
+- **SQL injection fix in `security/audit.py` `query_events()`**: the prior implementation built a raw f-string `WHERE` clause from caller-supplied `event_type` and `agent_id` parameters. These arguments could contain SQL metacharacters, enabling injection via crafted event type strings. Fixed to use parameterized queries; identifier segments validated with `re.match` before interpolation.
+- **Audit forwarding with `exc_info=True`**: `logger.error()` calls in `core/autonomy/observability/audit.py` and `security/audit.py` now include `exc_info=True`, ensuring stack traces appear in the log pipeline rather than just the message string. Previously, exceptions were swallowed silently on the audit forwarding path.
+
+### Changed
+
+- **Strategy deprecation warnings**: `async_single_shot.py` and `single_shot.py` now emit `DeprecationWarning` when invoked, directing users to `DelegateEngine` as the canonical async strategy. The single-shot strategies remain functional but are officially deprecated.
+
 ## [2.3.0] - 2026-03-25
 
 ### Changed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.7.2"
+version = "2.7.3"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.7.2"
+__version__ = "2.7.3"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.8.3"
+version = "2.8.4"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.8.3"
+__version__ = "2.8.4"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- Bump versions atomically: kailash 2.8.3→2.8.4, kailash-dataflow 2.0.5→2.0.6, kailash-kaizen 2.7.2→2.7.3
- Update CHANGELOGs for all three packages with dated v2.8.4/v2.0.6/v2.7.3 entries
- Update deploy/deployment-config.md version table

## Changes shipped in this release (via PR #430, commit 5c7e618e)

**Security hardening:**
- H4: SQL injection in kaizen `security/audit.py` `query_events()` — parameterized queries
- H5: Classification fail-closed — `ClassificationPolicy` default `PUBLIC` → `HIGHLY_CONFIDENTIAL` (EATP D6, cross-SDK #418) — **BREAKING**
- Connection parser credential decode consolidated through `decode_userinfo_or_raise`
- Identifier fingerprint error messages (no raw echo — prevents log-poisoning)
- CAS fail-closed guards + tenant-scoped `_clear` (#419)
- `schema_manager` `force_drop=True` required on all DROP paths
- EATP human-origin DDL identifier validation via `quote_identifier`
- Audit forwarding `exc_info=True` — stack traces now reach log pipeline
- Bulk operations WARN on partial failure (#420)

**34 regression tests (5 new test classes):**
- `test_classification_fail_closed.py`
- `test_cache_cas_tenant.py`
- `test_create_index_identifier_validation.py`
- `test_loc_invariants.py`
- additions to existing regression files

## Test plan

- [ ] CI passes (all tier 1 unit tests)
- [ ] No new failures from pre-commit hooks
- [ ] Version consistency verified: pyproject.toml == __init__.py for all 3 packages
- [ ] After merge: push tags `v2.8.4`, `dataflow-v2.0.6`, `kaizen-v2.7.3` to trigger PyPI publish via OIDC

## Related issues

Fixes #418, fixes #419, fixes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)