### PR TITLE
chore(codify): capture 4 institutional learnings from PR #430 red team

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -532,9 +532,12 @@ changes:
 # resets status to pending_review because the new entries have not been
 # classified by loom yet. The 51 prior entries remain intact.
 
-status: reviewed
+status: pending_review
 reviewed_date: "2026-04-12"
 distributed_date: "2026-04-12"
+# Status reset to pending_review on 2026-04-12 (post-v2.8.4 codify) —
+# per rules/artifact-flow.md MUST "Reset Status on Append", new entries
+# appended below have not been classified by loom yet.
 reviewed_notes: |
   Most of this proposal was already upstreamed in a prior sync cycle (identical
   in loom/ vs kailash-py/). Only two files had genuinely new changes from the
@@ -651,3 +654,70 @@ reviewed_notes: |
     suggested_tier: coc
     reason: "Previously deferred. Documents trust._json module — canonical_json_loads (duplicate key + NaN/Inf rejection), canonical_json_dumps (sorted keys), DuplicateKeyError, 8-row parser differential table. Cross-SDK parity per EATP D6."
     diff_lines: "+80"
+
+  # --- 2026-04-12: post-v2.8.4 codify — red team institutional learnings ---
+  # Origin: PR #430 red team review + CI failure analysis (2026-04-12)
+  # SDK version at codify time: 2.8.4
+  # Session: post-v2.8.4 codify pass capturing 4 nuggets from PR #430 review
+
+  - file: rules/dataflow-identifier-safety.md
+    action: modified
+    suggested_tier: coc
+    reason: |
+      Added MUST Rule 5 "Hardcoded Identifier Lists MUST Still Validate" —
+      defense-in-depth: every element of a static list MUST route through
+      _validate_identifier() at the call site, even when the list is a
+      Python literal. Prevents regression if the list later becomes
+      dynamic (reads from config, appends caller input, etc.). BLOCKED
+      rationalizations for "hardcoded so safe". Origin: PR #430 red team
+      found schema_manager._drop_existing_schema and _get_table_row_counts
+      interpolating hardcoded lists without validation; fixed in 803e10e0.
+    diff_lines: "+50"
+
+  - file: rules/python-environment.md
+    action: modified
+    suggested_tier: coc
+    reason: |
+      Added MUST Rule 4 "MUST NOT Duplicate Sub-Package Test Deps In Root
+      Dev Deps" — re-declaring a sub-package's test dep at the root level
+      installs it into the root venv where pytest plugin discovery loads
+      it for every test run. For hypothesis specifically, this triggers a
+      MemoryError in pytest's assertion rewriter during collection. Cost
+      hours of debugging on CI before root cause was isolated. BLOCKED
+      rationalizations. Origin: PR #430 CI failure (commit a9fd4e56).
+    diff_lines: "+55"
+
+  - file: rules/observability.md
+    action: modified
+    suggested_tier: coc
+    reason: |
+      Added MUST Rule 8 "Schema-Revealing Field Names MUST Be Logged At
+      DEBUG Or Hashed" — structured log lines containing model/field/column
+      names from classification/masking/validation code paths MUST use
+      DEBUG level or hash the identifier. Operational WARN signal via
+      counter, not via raw field name. Log aggregators typically have
+      broader access than the database, so schema names in logs leak
+      PII-adjacency metadata. Origin: PR #430 red team found
+      classification.default_applied at WARN level with field name in
+      structured extra; downgraded to DEBUG in 62d64ac7.
+    diff_lines: "+50"
+
+  - file: skills/02-dataflow/cache-cas-fail-closed.md
+    action: created
+    suggested_tier: coc-py
+    reason: |
+      New skill: CAS (compare-and-swap) fail-closed pattern when the
+      primitive's correctness depends on in-process state. Rejects CAS
+      requests at the outer API boundary when backend != memory, returns
+      structured error directing caller to server-side CAS (Redis
+      WATCH/MULTI). Covers the general pattern: when a primitive can only
+      be correctly served by one backend, fail-closed at the API edge
+      rather than silently degrade. Origin: PR #430 red team review of
+      CacheNode CAS implementation; guard added in 62d64ac7.
+    diff_lines: "+100"
+
+  - file: skills/02-dataflow/SKILL.md
+    action: modified
+    suggested_tier: coc-py
+    reason: "Added 'Cache Patterns' section referencing cache-cas-fail-closed.md"
+    diff_lines: "+4"

--- a/.claude/rules/dataflow-identifier-safety.md
+++ b/.claude/rules/dataflow-identifier-safety.md
@@ -109,6 +109,38 @@ async def drop_model(self, model_name: str) -> None:
 
 **Why:** Dropped data is unrecoverable. The explicit flag is the last human gate before destruction; without it, a typo or a mis-scoped rm-equivalent takes the production table with it.
 
+### 5. Hardcoded Identifier Lists MUST Still Validate
+
+Even when an identifier list is a static Python literal in the source file, every element MUST route through `_validate_identifier()` (or `dialect.quote_identifier()`) at the call site before interpolation into DDL. "The list is hardcoded, so it's safe" is BLOCKED.
+
+```python
+# DO — defense-in-depth validation on hardcoded list
+from kailash.db.dialect import _validate_identifier
+
+tables_to_drop = ["users", "roles", "permissions"]
+for table in tables_to_drop:
+    _validate_identifier(table)  # defense-in-depth
+    await conn.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+
+# DO NOT — assume hardcoded means safe
+tables_to_drop = ["users", "roles", "permissions"]
+for table in tables_to_drop:
+    await conn.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+# ↑ works today; breaks the moment someone makes the list dynamic
+# (e.g., reads from config, appends from a function parameter)
+```
+
+**BLOCKED rationalizations:**
+
+- "The list is hardcoded so there's no injection vector"
+- "Adding validation is overkill for a static list"
+- "We'll add validation when the list becomes dynamic"
+- "This is an admin-only path, no attacker can reach it"
+
+**Why:** Hardcoded lists become dynamic lists. A future refactor that reads the table list from a config file, or appends a caller-supplied suffix, or loops over model names from a registry, silently re-opens the injection vector with no test signal because the validation call was never there. The validation call is a permanent marker of intent that survives the refactor.
+
+Origin: Red team review of PR #430 (2026-04-12) surfaced this in `src/kailash/nodes/admin/schema_manager.py::_drop_existing_schema` and `_get_table_row_counts` — hardcoded lists without validation. Fixed in commit 803e10e0.
+
 ## MUST NOT
 
 - Use `f"..."` or `%` formatting to interpolate a dynamic identifier into DDL

--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -238,6 +238,46 @@ except Exception:
 - "We return a failure list, that's enough"
 - "We already log at DEBUG"
 
+### 8. Schema-Revealing Field Names MUST Be Logged At DEBUG Or Hashed
+
+Structured log lines that emit schema-level identifiers (model names, column names, field names from classification/masking/validation code paths) MUST be logged at DEBUG level — not WARN or INFO. If an operational WARN is genuinely needed for the condition, emit a counter or a hash, not the raw field name.
+
+```python
+# DO — schema names at DEBUG only; operational signal via counter
+logger.debug(
+    "classification.default_applied",
+    extra={"model": model_name, "field": field_name, "default": default},
+)
+# Operators who need to audit unclassified fields enable DEBUG.
+metrics.classification_defaults.inc()  # operational signal without field name
+
+# DO — hash when WARN is required
+field_hash = hashlib.sha256(f"{model_name}.{field_name}".encode()).hexdigest()[:8]
+logger.warning(
+    "classification.default_applied",
+    extra={"field_hash": field_hash, "default": default},
+)
+
+# DO NOT — schema names at WARN bleed into log aggregators
+logger.warning(
+    "classification.default_applied",
+    extra={"model": "users", "field": "ssn", "default": "public"},
+)
+# ↑ any log aggregator with broader access than the database now knows
+# the schema has `users.ssn`, which is schema-level sensitive info
+```
+
+**BLOCKED responses:**
+
+- "The field name isn't the value, it's just the schema"
+- "Operators need to see which fields are unclassified"
+- "Log aggregator access is the same as database access"
+- "DEBUG is off in prod, nobody will see it"
+
+**Why:** Log aggregators (Datadog, Splunk, CloudWatch) are typically accessible to a broader audience than the production database — SREs, on-call engineers, support staff, third-party observability vendors. A WARN log containing `field=ssn` reveals the schema has an `ssn` column to everyone with log read permission, even if the VALUES never leak. Classification metadata is itself schema-level PII-adjacency. DEBUG-level field names stay out of alerting paths and routine dashboards; operators who need to audit unclassified fields enable DEBUG explicitly for the audit window.
+
+Origin: Red team review of PR #430 (2026-04-12) flagged `packages/kailash-dataflow/src/dataflow/classification/policy.py::ClassificationPolicy.classify` emitting field names at WARN. Downgraded to DEBUG in commit 62d64ac7.
+
 ## MUST NOT
 
 - **No log-and-continue on caught exceptions without action.** If you catch an exception, log it AND either retry, fall back, or re-raise. `logger.error(...); pass` is BLOCKED — same class as `except: pass` in `rules/zero-tolerance.md` Rule 3. **Exception:** hooks and cleanup paths where failure is expected — log at WARN and continue, same carve-out as `zero-tolerance.md` Rule 3.

--- a/.claude/rules/python-environment.md
+++ b/.claude/rules/python-environment.md
@@ -151,6 +151,53 @@ debugging time every session.
 
 Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-12)
 
+### 4. MUST NOT Duplicate Sub-Package Test Deps In Root Dev Deps
+
+A dev dependency declared by a sub-package (`packages/*/pyproject.toml`)
+MUST NOT also be declared in the root `pyproject.toml [dev]` section.
+Re-declaring at the root is BLOCKED — it installs the package into the
+root test venv where pytest's plugin auto-discovery loads it for every
+test run, including runs that don't need it.
+
+```toml
+# DO — sub-packages own their test deps
+# packages/kailash-pact/pyproject.toml:
+[project.optional-dependencies]
+test = ["hypothesis>=6.98"]
+
+# pyproject.toml [dev]:
+# (no hypothesis entry — sub-package venv provides it for its own tests)
+
+# DO NOT — duplicate the dep at the root
+[project.optional-dependencies]
+dev = [
+    "hypothesis>=6.0.0",   # already in kailash-pact + kailash-ml
+]
+```
+
+**BLOCKED rationalizations:**
+
+- "The version is different, it's not a duplicate"
+- "hypothesis is small, it won't hurt to install at root"
+- "Our test command might need it someday"
+- "The sub-package pin is for test-time only, this one is for dev-time"
+
+**Why:** `hypothesis` registers itself as a pytest plugin. When pytest
+starts a test run in the root venv, it auto-discovers hypothesis and
+imports `hypothesis.internal.conjecture.shrinking.collection` through
+pytest's assertion rewriter. The recursive AST rewrite of that module
+exhausts memory on GitHub runners, producing a `MemoryError` during
+test collection with no root-cause signal (the stack trace points at
+`_pytest/assertion/rewrite.py` internals). This bit us twice — once
+caught by main CI, once in a cross-SDK PR — and cost hours of
+debugging. Root cause: the root venv shouldn't install what only
+sub-package test venvs need.
+
+Origin: PR #430 CI failure (2026-04-12), commit a9fd4e56 — hypothesis
+was added to root `[dev]` to enable a prior test collection workaround
+and surfaced as a MemoryError three commits later. Fixed by removing
+hypothesis from root dev deps.
+
 ## Rules
 
 - `.venv/` MUST be in `.gitignore`

--- a/.claude/skills/02-dataflow/SKILL.md
+++ b/.claude/skills/02-dataflow/SKILL.md
@@ -158,6 +158,10 @@ Each `@db.model` class generates:
 - **[dataflow-provenance-audit](dataflow-provenance-audit.md)** - Provenance[T] field tracking, audit trail persistence, EventStoreBackend
 - **[dataflow-fabric-cache-consumers](dataflow-fabric-cache-consumers.md)** - Fabric cache control, consumer adapters, MCP tool generation
 
+### Cache Patterns
+
+- **[cache-cas-fail-closed](cache-cas-fail-closed.md)** - CAS (compare-and-swap) fail-closed pattern when primitive can only be satisfied by one backend
+
 ### Troubleshooting
 
 - **[dataflow-gotchas](dataflow-gotchas.md)** - Common pitfalls

--- a/.claude/skills/02-dataflow/cache-cas-fail-closed.md
+++ b/.claude/skills/02-dataflow/cache-cas-fail-closed.md
@@ -1,0 +1,95 @@
+---
+name: Cache CAS fail-closed pattern
+description: When a CAS (compare-and-swap) primitive can only be satisfied by one backend, reject at the API boundary instead of silently degrading across backends.
+---
+
+# Cache CAS Fail-Closed Pattern
+
+When a cache primitive offers compare-and-swap semantics but the CAS tracking state lives in-process, the operation is ONLY correct on the in-process memory backend. For Redis, Memcached, or hybrid backends, the in-process version tag has no atomicity guarantee — two processes sharing the Redis instance each maintain independent version dicts, and the CAS check becomes meaningless.
+
+The fail-closed pattern: reject the CAS request at the outer API boundary when the backend cannot satisfy it atomically. Do NOT allow the request to proceed, silently ignore `expected_version`, or produce misleading success on a non-atomic write.
+
+## The Pattern
+
+```python
+async def async_run(self, **kwargs) -> Dict[str, Any]:
+    operation = kwargs["operation"].lower()
+    backend = CacheBackend(kwargs.get("backend", "memory"))
+
+    # Fail-closed guard BEFORE any backend init.
+    # CAS (expected_version) is only supported with memory backend.
+    if (
+        operation == "set"
+        and kwargs.get("expected_version") is not None
+        and backend != CacheBackend.MEMORY
+    ):
+        return {
+            "success": False,
+            "cas_failed": True,
+            "error": (
+                "CAS (expected_version) is only supported with "
+                "backend='memory'. Redis and hybrid backends require "
+                "server-side CAS (e.g., Redis WATCH/MULTI)."
+            ),
+        }
+    # ... rest of execution
+```
+
+## Key points
+
+1. **Reject at the outer boundary** — before backend initialization, so we don't even attempt to connect to a Redis we can't correctly serve. This keeps error paths cheap and fails fast.
+
+2. **Return structured error, not exception** — the caller gets `success=False`, `cas_failed=True`, and an error message directing them to server-side CAS. The existing error-handling contract (not a new exception class) is preserved.
+
+3. **Direct the caller to the correct API** — the error message names the alternative (Redis WATCH/MULTI). This converts the failure into actionable guidance, not a dead-end.
+
+4. **Test both directions** — a regression test must verify (a) CAS works correctly on memory backend, (b) CAS is rejected with a clear error on every other backend. See `tests/regression/test_cache_cas_tenant.py::TestCacheCASRace::test_cas_rejected_on_redis_backend`.
+
+## When to use
+
+This pattern applies any time a primitive's correctness depends on state that only one backend can provide:
+
+- **CAS / optimistic locking** — in-process version tags only work for in-process backends
+- **Transactional multi-key writes** — local transaction only applies to local backend
+- **Last-writer-wins timestamps** — local clock only authoritative for local backend
+- **Structural guarantees** — e.g. "exactly-once delivery" that relies on an in-process dedup set
+
+## When NOT to use (false positives)
+
+- **Backend-agnostic primitives** — `get`, `set`, `delete`, `exists` work identically across backends; don't reject them.
+- **Primitives with a correct multi-backend implementation** — if you can implement CAS correctly on Redis via WATCH/MULTI, implement it; don't just reject.
+
+## Anti-patterns
+
+```python
+# BLOCKED — silently ignore expected_version on non-memory backends
+async def _set(self, kwargs):
+    expected_version = kwargs.get("expected_version")
+    if expected_version is not None:
+        current = self._version_tags.get(key)  # empty dict for Redis
+        if current != expected_version:
+            return {"cas_failed": True}
+    # write to Redis without CAS check at all
+    await self._redis_set(...)
+# ↑ for Redis: _version_tags is empty, current is always None,
+# CAS check passes when expected_version is None, silently bypasses guarantee
+
+# BLOCKED — raise NotImplementedError deep in the call stack
+async def _set(self, kwargs):
+    expected_version = kwargs.get("expected_version")
+    backend = kwargs["backend"]
+    if expected_version is not None and backend != "memory":
+        raise NotImplementedError("CAS only works with memory")
+# ↑ by the time this fires, the caller is deep in a workflow and
+# the error surfaces as an uncaught exception, not an API contract
+
+# BLOCKED — fall back to non-CAS write when backend can't support it
+if expected_version is not None and backend != "memory":
+    logger.warning("CAS not supported on this backend, ignoring")
+    # fall through to regular write
+# ↑ the caller thinks their CAS succeeded; concurrent writer clobbers them
+```
+
+## Origin
+
+PR #430 red team review (2026-04-12) surfaced the silent-degradation pattern in `src/kailash/nodes/cache/cache.py::CacheNode._set`. Fixed in commits bd411c44 and 62d64ac7. Tests in `tests/regression/test_cache_cas_tenant.py`.


### PR DESCRIPTION
## Summary

Post-v2.8.4 codify pass capturing 4 non-obvious failure patterns surfaced during the PR #430 red team review that weren't in any existing rule/skill:

1. **rules/dataflow-identifier-safety.md §5** — hardcoded identifier lists MUST still validate (defense-in-depth for future-dynamic regression)
2. **rules/python-environment.md §4** — MUST NOT duplicate sub-package test deps in root dev deps (hypothesis-as-root-dev-dep OOM trap)
3. **rules/observability.md §8** — schema-revealing field names MUST be DEBUG or hashed (log aggregator access ≠ database access)
4. **skills/02-dataflow/cache-cas-fail-closed.md** — new skill for CAS fail-closed pattern when primitive needs in-process state

All 4 appended to `.claude/.proposals/latest.yaml` for loom `/sync py` distribution. Proposal status reset to `pending_review`.

## Related

- PR #430 (merged) — the red team review that surfaced these patterns
- v2.8.4 release — already shipped the code fixes

## Test plan

- [x] Rule files follow the \"Loud, Linguistic, Layered\" authoring meta-rule
- [x] Every MUST clause has DO/DO NOT examples
- [x] Every MUST clause has **Why:** line
- [x] Origin lines reference PR #430 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)