### PR TITLE
chore(sync): upstream per-session capacity budget rule

### DIFF
--- a/.claude/commands/todos.md
+++ b/.claude/commands/todos.md
@@ -22,6 +22,8 @@ description: "Load phase 02 (todos) for the current workspace"
 
 This phase executes under the **autonomous execution model** (see `rules/autonomous-execution.md`). All effort estimates in todos MUST use autonomous execution cycles, not human-days. When referencing external plans that estimate in human-days, apply the 10x multiplier to translate. Do not phase work based on "team bandwidth" — phase based on dependency order and validation gates.
 
+**Per-session capacity budget (MUST):** Each todo MUST fit within a single session's capacity — ≤500 LOC load-bearing logic, ≤5–10 simultaneous invariants, ≤3–4 call-graph hops, describable in 3 sentences. See `rules/autonomous-execution.md` § Per-Session Capacity Budget. Todos that exceed the budget MUST be sharded at this phase, not deferred to `/implement`.
+
 **The /todos approval gate is a structural gate**: the human approves the plan (what and why), not the execution (how and when). Once approved, /implement executes autonomously.
 
 ## Workflow

--- a/.claude/rules/autonomous-execution.md
+++ b/.claude/rules/autonomous-execution.md
@@ -44,3 +44,80 @@ Autonomous AI execution with mature COC institutional knowledge produces ~10x su
 **Structural (human required):** Plan approval (/todos), release authorization (/release), envelope changes.
 
 **Execution (autonomous convergence):** Analysis quality (/analyze), implementation correctness (/implement), validation rigor (/redteam), knowledge capture (/codify). Human observes but does NOT block.
+
+## Per-Session Capacity Budget
+
+Autonomous capacity is high but not infinite. It degrades along multiple axes simultaneously — LOC is only the proxy. Work that exceeds the budget below MUST be sharded at `/todos` time, before implementation begins.
+
+### 1. Shard When Any Threshold Is Exceeded (MUST)
+
+A single shard (one session, one worktree, one implementation pass) MUST stay within ALL of:
+
+- **≤500 LOC of load-bearing logic** — state machines, schedulers, invariant-holding code. Does NOT count CRUD, DTOs, route registration, or generated boilerplate.
+- **≤5–10 simultaneous invariants** the implementation must hold (tenant isolation + audit + redaction + cache key shape + error taxonomy = 5).
+- **≤3–4 call-graph hops** of cross-file reasoning.
+- **≤15k LOC of relevant surface area** in working context for correctness.
+- Describable in **3 sentences or fewer**. If it takes more, the shard is too big.
+
+```markdown
+# DO — sharded plan with explicit invariant count
+
+- Shard 1: wire TrustExecutor into express.read (invariants: redact, audit, clearance)
+- Shard 2: wire into express.list (same 3 invariants, batch path)
+- Shard 3: tenant isolation across both paths (cache key, audit rows, metric labels)
+
+# DO NOT — one mega-todo
+
+- Wire TrustExecutor through express, add audit rows, handle tenant isolation,
+  update all 14 call sites, add integration tests, migrate legacy callers
+```
+
+**Why:** Beyond the budget the model stops tracking cross-file invariants and pattern-matches instead. Errors on line 400 poison everything after and surface only at `/redteam`. Evidence: the Phase 5.11 orphan (2,407 LOC of trust integration code with zero production call sites) was one conceptual change that exceeded the invariant budget — nothing caught it until the audit.
+
+### 2. Size By Complexity, Not LOC Alone (MUST)
+
+Todo sizing MUST distinguish boilerplate from load-bearing logic. Boilerplate scales ~5× further than logic before sharding triggers, because the model holds a single pattern and stamps it out.
+
+```markdown
+# DO — differentiated sizing
+
+- Todo: generate 14 CRUD repositories (~2k LOC boilerplate, single shard)
+- Todo: rewrite job scheduler (~400 LOC logic, single shard)
+- Todo: migrate scheduler across 6 services (6 shards, one per service)
+
+# DO NOT — uniform LOC cap
+
+- Every todo under 500 LOC — fragments CRUD into meaningless shards AND
+  overflows the invariant budget on scheduler work
+```
+
+**Why:** Uniform LOC caps fail on both ends. Sizing reflects what's held in attention (invariants, call-graph depth), not what's typed (line count).
+
+### 3. Feedback Loops Multiply Capacity (MUST)
+
+Shards with an executable feedback loop (unit tests, `cargo check`, type checker, integration harness that runs during the session) MAY use up to 3–5× the base budget. Shards without a live loop (spec drafting, config editing, refactors in untested modules) MUST use the base budget.
+
+**Why:** Feedback loops convert "write 2000 LOC then discover it's wrong" into "write 200 LOC, test, continue." The multiplier is real but requires the loop to actually fire during the session — "redteam will catch it later" is not a feedback loop.
+
+## MUST NOT (Sharding)
+
+- Size shards by LOC alone, ignoring invariant count and call-graph depth
+
+**Why:** LOC is a proxy that fragments trivial work and overflows complex work.
+
+- Defer sharding decisions to `/implement`
+
+**Why:** Sharding at `/todos` costs a plan rewrite; sharding mid-`/implement` abandons work in progress and leaves partial state the next session must untangle.
+
+**BLOCKED rationalizations:**
+
+- "The 1M context window handles it"
+- "Opus can keep track of more than 5 invariants"
+- "We'll see how far we get"
+- "Splitting is artificial, it's one conceptual change"
+- "The test suite will catch any errors that slip through"
+- "It's mostly boilerplate" (when it isn't)
+
+**Why:** Context window is not attention. Model capability claims are not evidence for a specific task. "One conceptual change" is exactly how Phase 5.11 shipped 2,407 LOC of orphaned code.
+
+Origin: Session 2026-04-13 — capacity bands discussion (~500 LOC load-bearing, ~5–10 invariants, ~3–4 call-graph hops, "describe in 3 sentences" heuristic), grounded in the Phase 5.11 orphan failure mode documented in `rules/orphan-detection.md`.

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -27,12 +27,14 @@ All protected repos require PRs to main. Direct push is rejected by GitHub.
 
 **Why:** Direct pushes bypass CI checks and code review, allowing broken or unreviewed code to reach the release branch.
 
-| Repository                                 | Branch | Protection          |
-| ------------------------------------------ | ------ | ------------------- |
-| `terrene-foundation/kailash-py`            | `main` | Full (admin bypass) |
-| `terrene-foundation/kailash-coc-claude-py` | `main` | Full (admin bypass) |
-| `terrene-foundation/kailash-coc-claude-rs` | `main` | Full (admin bypass) |
-| `esperie/kailash-rs`                       | `main` | Full (admin bypass) |
+| Repository                                    | Branch | Protection          |
+| --------------------------------------------- | ------ | ------------------- |
+| `terrene-foundation/kailash-py`               | `main` | Full (admin bypass) |
+| `terrene-foundation/kailash-coc-claude-py`    | `main` | Full (admin bypass) |
+| `terrene-foundation/kailash-coc-claude-rs`    | `main` | Full (admin bypass) |
+| `esperie/kailash-rs`                          | `main` | Full (admin bypass) |
+| `terrene-foundation/kailash-prism`            | `main` | Full (admin bypass) |
+| `terrene-foundation/kailash-coc-claude-prism` | `main` | Full (admin bypass) |
 
 **Owner workflow**: Branch → commit → push → PR → `gh pr merge <N> --admin --merge --delete-branch`
 
@@ -91,9 +93,7 @@ gh issue close 374 --comment "Covered by recent refactor"
 - "Obsoleted by refactor"
 - "Resolved without code change"
 
-**Why:** Three issues (#351, #370, #374) were closed in this session's lineage with zero delivered code; the next-session plan only caught it on a manual re-audit. The commit-reference requirement is the cheapest structural gate against this failure.
-
-Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-12)
+**Why:** Issues closed with zero delivered code references break traceability; the next session cannot verify whether the fix actually shipped.
 
 ## Pre-Commit Hook Workarounds
 
@@ -114,7 +114,7 @@ EOF
 
 # DO NOT — silent --no-verify with no documentation
 git commit --no-verify -m "fix(security): add null-byte rejection"
-# ↑ no record of why hooks were skipped; next session repeats discovery
+# no record of why hooks were skipped; next session repeats discovery
 ```
 
 **BLOCKED rationalizations:**
@@ -124,5 +124,3 @@ git commit --no-verify -m "fix(security): add null-byte rejection"
 - "The auto-stash bug is a known issue"
 
 **Why:** Recurring across sessions; without documentation each session re-discovers the workaround at high cost. With documentation the next agent finds it via `git log --grep`.
-
-Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-12)


### PR DESCRIPTION
## Summary
- Adds per-session capacity budget section to `autonomous-execution.md` (≤500 LOC logic, ≤5–10 invariants, ≤3–4 call-graph hops, 3-sentence test)
- Updates `/todos` command to enforce sharding at plan time
- Adds kailash-prism repos to branch protection table in `git.md`

## Source
loom commit e523b22

🤖 Generated with [Claude Code](https://claude.com/claude-code)