### PR TITLE
chore(release): kailash 2.8.5 — remove conflicting kailash-mcp entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
-### kailash-mcp 0.2.2 — 2026-04-13
+### kailash 2.8.5 + kailash-mcp 0.2.2 — 2026-04-13
 
 #### Fixed
 

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "kailash>=2.7.0",
+    "kailash>=2.8.5",
     "mcp[cli]>=1.23.0",
     "pydantic>=2.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.8.4"
+version = "2.8.5"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.8.4"
+__version__ = "2.8.5"
 
 __all__ = [
     # Core workflow components

--- a/uv.lock
+++ b/uv.lock
@@ -2758,7 +2758,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.8.4"
+version = "2.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -3155,7 +3155,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "kailash-mcp"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "packages/kailash-mcp" }
 dependencies = [
     { name = "kailash" },
@@ -3173,7 +3173,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'platform'", specifier = ">=0.115.12" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115.12" },
     { name = "httpx", marker = "extra == 'http'", specifier = ">=0.25.0" },
-    { name = "kailash", specifier = ">=2.7.0" },
+    { name = "kailash", specifier = ">=2.8.5" },
     { name = "kailash-mcp", extras = ["http", "sse", "websocket", "auth-jwt", "auth-oauth", "server", "platform"], marker = "extra == 'full'" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
     { name = "pydantic", specifier = ">=2.6" },


### PR DESCRIPTION
## Summary

- Patch release to remove the conflicting `kailash-mcp` console script entry point from the root `kailash` package
- Without this, `pip install kailash-mcp==0.2.2` still gets kailash 2.8.4 from PyPI which re-introduces the broken entry point
- Bumps kailash-mcp's kailash floor to `>=2.8.5`

## Test plan

- [x] kailash-mcp 0.2.2 already published with correct entry point
- [x] This release removes the conflicting entry point from the root package
- [ ] After publishing: `pip install kailash-mcp==0.2.3 && kailash-mcp --help` works

## Related issues

Part of #435 fix (companion to PR #436)

🤖 Generated with [Claude Code](https://claude.com/claude-code)