### PR TITLE
chore(docker): kailash 2.8.5 + kailash-mcp 0.2.3 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-# Kailash Python SDK — Full Image
-# Includes Core SDK + DataFlow + Nexus + Kaizen + PACT + Trust
+# Kailash Python SDK — Standard Image
+# Includes Core SDK + DataFlow + Nexus + Kaizen + PACT + ML + Trust
+# (kailash-align excluded — requires CUDA/GPU runtime)
 # Published to: docker.io/terrenefoundation/kailash
 #
 # Build:  docker build -t terrenefoundation/kailash .
@@ -23,9 +24,9 @@ WORKDIR /build
 COPY pyproject.toml README.md ./
 COPY src ./src
 
-# Install the full SDK with all extras
+# Install the SDK with standard extras (align excluded — requires CUDA/GPU)
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    pip install --no-cache-dir ".[all]"
+    pip install --no-cache-dir ".[dataflow,nexus,kaizen,pact,ml]"
 
 # ============================================================================
 # Stage 2: Runtime — lean production image

--- a/docker/Dockerfile.mcp-server
+++ b/docker/Dockerfile.mcp-server
@@ -1,45 +1,70 @@
-FROM python:3.11-slim
+# Kailash MCP Platform Server
+# Unified MCP introspection for AI assistants (Claude Code, Cursor, etc.)
+# Published to: docker.io/terrenefoundation/kailash-mcp
+#
+# Build:  docker build -f docker/Dockerfile.mcp-server -t terrenefoundation/kailash-mcp .
+# Run:    docker run --rm terrenefoundation/kailash-mcp --transport stdio
+# SSE:    docker run --rm -p 8900:8900 terrenefoundation/kailash-mcp --transport sse --port 8900
 
-WORKDIR /app
+# ============================================================================
+# Stage 1: Builder — install dependencies
+# ============================================================================
+FROM python:3.12-slim AS builder
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Install from PyPI — kailash-mcp pulls kailash>=2.8.5 automatically
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir "kailash-mcp[full]>=0.2.3"
+
+# ============================================================================
+# Stage 2: Runtime — lean production image
+# ============================================================================
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq5 \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements and create minimal README for setup.py
-COPY pyproject.toml setup.py ./
-COPY src/kailash/__init__.py src/kailash/
-RUN echo "# Kailash MCP Server" > README.md
+# Non-root user
+RUN groupadd -g 1000 kailash && \
+    useradd -u 1000 -g kailash -m -s /bin/bash kailash && \
+    mkdir -p /app && \
+    chown -R kailash:kailash /app
 
-# Install Python dependencies
-RUN pip install --no-cache-dir -e . && \
-    pip install --no-cache-dir mcp aiohttp
+WORKDIR /app
 
-# Copy source code and required files
-COPY src/ ./src/
-# Copy research data if available
-# COPY research/combined_ai_registry.json ./research/
+# Copy installed packages from builder
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
 
-# Create health check script
-RUN echo '#!/usr/bin/env python3\n\
-import asyncio\n\
-from aiohttp import web\n\
-\n\
-async def health(request):\n\
-    return web.json_response({"status": "healthy", "service": "mcp-server"})\n\
-\n\
-async def create_app():\n\
-    app = web.Application()\n\
-    app.router.add_get("/health", health)\n\
-    return app\n\
-\n\
-if __name__ == "__main__":\n\
-    app = asyncio.run(create_app())\n\
-    web.run_app(app, host="0.0.0.0", port=8765)\n' > /app/health_server.py
+USER kailash
 
-# Expose ports
-EXPOSE 8765
+# Default project root inside the container — mount your project here
+ENV KAILASH_PROJECT_ROOT=/app/project
 
-# Start MCP server with health endpoint
-CMD ["python", "-m", "kailash.mcp.ai_registry_server"]
+# SSE transport port (only used with --transport sse)
+EXPOSE 8900
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+    CMD python -c "\
+from kailash_mcp.platform_server import create_platform_server; \
+print('healthy')" || exit 1
+
+# Labels (OCI standard)
+LABEL org.opencontainers.image.title="Kailash MCP Platform Server"
+LABEL org.opencontainers.image.description="Unified MCP introspection server for Kailash projects — models, handlers, agents, node types"
+LABEL org.opencontainers.image.vendor="Terrene Foundation"
+LABEL org.opencontainers.image.url="https://github.com/terrene-foundation/kailash-py"
+LABEL org.opencontainers.image.source="https://github.com/terrene-foundation/kailash-py"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# Default: STDIO transport (for MCP client integration)
+ENTRYPOINT ["kailash-mcp"]
+CMD ["--transport", "stdio"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,12 +26,13 @@ This image bundles all Kailash frameworks and dependencies:
 
 | Framework         | Version  | What It Does                                                                      |
 | ----------------- | -------- | --------------------------------------------------------------------------------- |
-| **Core SDK**      | 2.2.1    | 140+ workflow nodes, sync/async runtimes, cyclic workflows                        |
-| **Kaizen**        | 2.3.1    | AI agents with signature-based programming and multi-agent coordination           |
-| **kaizen-agents** | 0.5.0    | Delegate architecture for supervised agent execution                              |
-| **DataFlow**      | 1.2.1    | Zero-config database operations — one decorator generates 11 CRUD nodes per model |
-| **Nexus**         | 1.6.0    | Deploy as REST API + CLI + MCP tool simultaneously                                |
-| **PACT**          | 0.4.1    | Organizational governance — D/T/R accountability, operating envelopes             |
+| **Core SDK**      | 2.8.5    | 140+ workflow nodes, sync/async runtimes, cyclic workflows                        |
+| **Kaizen**        | 2.7.3    | AI agents with signature-based programming and multi-agent coordination           |
+| **kaizen-agents** | 0.9.2    | Delegate architecture for supervised agent execution                              |
+| **DataFlow**      | 2.0.6    | Zero-config database operations — one decorator generates 11 CRUD nodes per model |
+| **Nexus**         | 2.0.0    | Deploy as REST API + CLI + MCP tool simultaneously                                |
+| **PACT**          | 0.8.1    | Organizational governance — D/T/R accountability, operating envelopes             |
+| **MCP**           | 0.2.3    | Unified MCP platform server for AI assistant introspection                        |
 | **Trust**         | included | CARE/EATP cryptographic trust chains, constraint propagation, audit trails        |
 
 Plus: PostgreSQL/MySQL/SQLite drivers, Redis, Prometheus, OpenTelemetry, MCP, authentication, scheduling, and more.
@@ -122,7 +123,7 @@ services:
 ## Tags
 
 - `latest` — latest stable release
-- `X.Y.Z` — specific version (e.g., `2.2.1`)
+- `X.Y.Z` — specific version (e.g., `2.8.5`)
 
 ## Links
 

--- a/docker/docker-compose.sdk-dev.yml
+++ b/docker/docker-compose.sdk-dev.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 # SDK Development Infrastructure
 # This provides all services needed for running Kailash SDK examples and tests
@@ -112,7 +112,14 @@ services:
     ports:
       - "9092:9092"
     healthcheck:
-      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      test:
+        [
+          "CMD",
+          "kafka-topics",
+          "--bootstrap-server",
+          "localhost:9092",
+          "--list",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -177,25 +184,30 @@ services:
       retries: 5
     restart: unless-stopped
 
-  # MCP Server (AI Registry)
+  # MCP Platform Server (kailash-mcp)
   mcp-server:
     build:
       context: ..
       dockerfile: docker/Dockerfile.mcp-server
     container_name: kailash-sdk-mcp-server
     environment:
-      MCP_SERVER_PORT: 8765
-      PYTHONPATH: /app/src
+      KAILASH_PROJECT_ROOT: /app/project
     ports:
-      - "8765:8765"
+      - "8900:8900"
     volumes:
-      - ../src:/app/src
-      # - ../research/combined_ai_registry.json:/app/research/combined_ai_registry.json
+      - ..:/app/project:ro
+    command: ["--transport", "sse", "--port", "8900"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8765/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "from kailash_mcp.platform_server import create_platform_server; print('ok')",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     restart: unless-stopped
 
   # Health check aggregator

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.2.2"
+version = "0.2.3"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (


### PR DESCRIPTION
## Summary

- Rewrote MCP server Dockerfile — old one referenced deleted `kailash.mcp` module path, used nonexistent `setup.py`, and targeted a module that doesn't exist
- Fixed main Dockerfile — exclude `kailash-align[all]` which requires CUDA and fails in slim images
- Updated compose and README with current versions
- Bumped kailash-mcp to 0.2.3 (kailash>=2.8.5 floor)

## Images pushed

- `terrenefoundation/kailash:2.8.5` + `:latest`
- `terrenefoundation/kailash-mcp:0.2.3` + `:latest`

## Test plan

- [x] Main image: kailash 2.8.5, dataflow, nexus, kaizen all import correctly
- [x] MCP image: kailash-mcp 0.2.3 with correct entry point, kailash 2.8.5
- [x] Both pushed to DockerHub

## Related issues

Part of #435 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)