### PR TITLE
fix(dataflow): coerce record IDs to match model primary key type

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -75,6 +75,64 @@ def _error_enhancer():
     return _ERROR_ENHANCER_CACHE
 
 
+def _coerce_record_id(model_fields: Dict[str, Any], id_value: Any) -> Any:
+    """Coerce record_id to match the model's primary key type.
+
+    Handles Optional[int], Union[int, None], and other wrapped types
+    by normalizing the type annotation before comparison. Fixes #439:
+    express_sync.update/read/delete reject integer record IDs on PostgreSQL
+    when callers pass string IDs for integer primary key columns.
+    """
+    if id_value is None:
+        return None
+
+    id_field_info = model_fields.get("id", {})
+    id_type = id_field_info.get("type")
+
+    if id_type is None:
+        # No type info — try int conversion for backward compatibility
+        if isinstance(id_value, str):
+            try:
+                return int(id_value)
+            except (ValueError, TypeError):
+                return id_value
+        return id_value
+
+    # Normalize type annotation to handle Optional[int], Union[int, None], etc.
+    normalized = _normalize_id_type(id_type)
+
+    if normalized == int:
+        if isinstance(id_value, int):
+            return id_value
+        try:
+            return int(id_value)
+        except (ValueError, TypeError):
+            return id_value
+    elif normalized == str:
+        return str(id_value) if not isinstance(id_value, str) else id_value
+    else:
+        # Other types (UUID, custom) — preserve as-is
+        return id_value
+
+
+def _normalize_id_type(type_annotation: Any) -> Any:
+    """Normalize a type annotation for ID coercion, stripping Optional/Union wrappers."""
+    import typing
+
+    origin = getattr(type_annotation, "__origin__", None)
+    if origin is Union:
+        args = getattr(type_annotation, "__args__", ())
+        non_none_types = [arg for arg in args if arg is not type(None)]
+        if non_none_types:
+            return _normalize_id_type(non_none_types[0])
+        return str  # fallback
+
+    if isinstance(type_annotation, type):
+        return type_annotation
+
+    return str  # fallback for unknown
+
+
 def convert_datetime_fields(data_dict: dict, model_fields: dict, logger) -> dict:
     """
     Convert ISO 8601 datetime strings to Python datetime objects for datetime fields.
@@ -1824,32 +1882,21 @@ class NodeGenerator:
                     # Determine record_id from conditions or direct parameters
                     record_id = None
                     if conditions and "id" in conditions:
-                        record_id = conditions["id"]
+                        record_id = _coerce_record_id(
+                            self.model_fields, conditions["id"]
+                        )
                     else:
                         # Fall back to direct parameters for backward compatibility
                         # Prioritize record_id over id to avoid conflicts with node's own id
                         record_id = kwargs.get("record_id")
-                        if record_id is None:
-                            # Get the ID parameter for record lookup
+                        if record_id is not None:
+                            record_id = _coerce_record_id(self.model_fields, record_id)
+                        else:
                             id_param = kwargs.get("id")
                             if id_param is not None:
-                                # Type-aware ID conversion to fix string ID bug
-                                id_field_info = self.model_fields.get("id", {})
-                                id_type = id_field_info.get("type")
-
-                                if id_type == str:
-                                    # Model explicitly defines ID as string - preserve it
-                                    record_id = id_param
-                                elif id_type == int or id_type is None:
-                                    # Model defines ID as int OR no type info (backward compat)
-                                    try:
-                                        record_id = int(id_param)
-                                    except (ValueError, TypeError):
-                                        # If conversion fails, preserve original
-                                        record_id = id_param
-                                else:
-                                    # Other types (UUID, custom) - preserve as-is
-                                    record_id = id_param
+                                record_id = _coerce_record_id(
+                                    self.model_fields, id_param
+                                )
 
                     if record_id is None:
                         from kailash.sdk_exceptions import NodeValidationError
@@ -2062,14 +2109,17 @@ class NodeGenerator:
                     # Determine record_id from conditions or direct parameters
                     record_id = None
                     if conditions and "id" in conditions:
-                        record_id = conditions["id"]
+                        record_id = _coerce_record_id(
+                            self.model_fields, conditions["id"]
+                        )
                     else:
                         # Fall back to record_id parameter - prioritize this over 'id'
                         # since 'id' often contains the node ID which is not a record ID
                         record_id = kwargs.get("record_id")
-
-                        # Only use 'id' parameter if no record_id is available and 'id' looks like a record ID
-                        if record_id is None:
+                        if record_id is not None:
+                            record_id = _coerce_record_id(self.model_fields, record_id)
+                        else:
+                            # Only use 'id' parameter if no record_id is available and 'id' looks like a record ID
                             id_param = kwargs.get("id")
                             # Check if id_param looks like a record ID, not a node ID
                             if (
@@ -2086,23 +2136,9 @@ class NodeGenerator:
                                     and len(id_param) < 50
                                 )
                             ):  # Reasonable ID length
-                                # Type-aware ID conversion to fix string ID bug
-                                id_field_info = self.model_fields.get("id", {})
-                                id_type = id_field_info.get("type")
-
-                                if id_type == str:
-                                    # Model explicitly defines ID as string - preserve it
-                                    record_id = id_param
-                                elif id_type == int or id_type is None:
-                                    # Model defines ID as int OR no type info (backward compat)
-                                    try:
-                                        record_id = int(id_param)
-                                    except (ValueError, TypeError):
-                                        # If conversion fails, don't use this value
-                                        record_id = None
-                                else:
-                                    # Other types (UUID, custom) - preserve as-is
-                                    record_id = id_param
+                                record_id = _coerce_record_id(
+                                    self.model_fields, id_param
+                                )
 
                     if record_id is None:
                         from kailash.sdk_exceptions import NodeValidationError
@@ -2391,32 +2427,21 @@ class NodeGenerator:
                     # Determine record_id from conditions or direct parameters
                     record_id = None
                     if conditions and "id" in conditions:
-                        record_id = conditions["id"]
+                        record_id = _coerce_record_id(
+                            self.model_fields, conditions["id"]
+                        )
                     else:
                         # Fall back to direct parameters for backward compatibility
                         # Prioritize record_id over id to avoid conflicts with node's own id
                         record_id = kwargs.get("record_id")
-                        if record_id is None:
-                            # Get the ID parameter for record lookup
+                        if record_id is not None:
+                            record_id = _coerce_record_id(self.model_fields, record_id)
+                        else:
                             id_param = kwargs.get("id")
                             if id_param is not None:
-                                # Type-aware ID conversion to fix string ID bug
-                                id_field_info = self.model_fields.get("id", {})
-                                id_type = id_field_info.get("type")
-
-                                if id_type == str:
-                                    # Model explicitly defines ID as string - preserve it
-                                    record_id = id_param
-                                elif id_type == int or id_type is None:
-                                    # Model defines ID as int OR no type info (backward compat)
-                                    try:
-                                        record_id = int(id_param)
-                                    except (ValueError, TypeError):
-                                        # If conversion fails, preserve original
-                                        record_id = id_param
-                                else:
-                                    # Other types (UUID, custom) - preserve as-is
-                                    record_id = id_param
+                                record_id = _coerce_record_id(
+                                    self.model_fields, id_param
+                                )
 
                     if record_id is None:
                         raise _error_enhancer().enhance_delete_node_missing_id(

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -516,7 +516,7 @@ class DataFlowExpress:
     async def read(
         self,
         model: str,
-        id: str,
+        id: Union[str, int],
         cache_ttl: Optional[int] = None,
         use_primary: bool = False,  # TSG-105
     ) -> Optional[Dict[str, Any]]:
@@ -597,7 +597,7 @@ class DataFlowExpress:
         return await self._execute_with_timing(f"{model}.read", _read())
 
     async def update(
-        self, model: str, id: str, fields: Dict[str, Any]
+        self, model: str, id: Union[str, int], fields: Dict[str, Any]
     ) -> Dict[str, Any]:
         """
         Update a single record.
@@ -649,7 +649,7 @@ class DataFlowExpress:
 
         return await self._execute_with_timing(f"{model}.update", _update())
 
-    async def delete(self, model: str, id: str) -> bool:
+    async def delete(self, model: str, id: Union[str, int]) -> bool:
         """
         Delete a single record.
 
@@ -1678,7 +1678,7 @@ class SyncExpress:
     def read(
         self,
         model: str,
-        id: str,
+        id: Union[str, int],
         cache_ttl: Optional[int] = None,
         use_primary: bool = False,  # TSG-105
     ) -> Optional[Dict[str, Any]]:
@@ -1697,7 +1697,9 @@ class SyncExpress:
             self._express.read(model, id, cache_ttl, use_primary=use_primary)
         )
 
-    def update(self, model: str, id: str, fields: Dict[str, Any]) -> Dict[str, Any]:
+    def update(
+        self, model: str, id: Union[str, int], fields: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Update a single record (sync).
 
         Args:
@@ -1710,7 +1712,7 @@ class SyncExpress:
         """
         return self._run_sync(self._express.update(model, id, fields))
 
-    def delete(self, model: str, id: str) -> bool:
+    def delete(self, model: str, id: Union[str, int]) -> bool:
         """Delete a single record (sync).
 
         Args:

--- a/tests/regression/test_issue_439.py
+++ b/tests/regression/test_issue_439.py
@@ -1,0 +1,295 @@
+"""Regression: #439 — express_sync.update/read/delete reject integer record IDs on PostgreSQL.
+
+When a model has an integer primary key, passing str(record_id) to
+express_sync.update/read/delete causes PostgreSQL to reject the query
+because it cannot compare a TEXT argument to an INTEGER column.
+
+The fix normalizes record IDs to match the model's primary key type,
+handling Optional[int], Union[int, None], and other wrapped types.
+"""
+
+from typing import Optional, Union
+
+import pytest
+
+from dataflow.core.nodes import _coerce_record_id, _normalize_id_type
+
+
+# --- _normalize_id_type unit tests ---
+
+
+class TestNormalizeIdType:
+    """Verify type annotation normalization strips Optional/Union wrappers."""
+
+    def test_plain_int(self):
+        assert _normalize_id_type(int) == int
+
+    def test_plain_str(self):
+        assert _normalize_id_type(str) == str
+
+    def test_optional_int(self):
+        assert _normalize_id_type(Optional[int]) == int
+
+    def test_optional_str(self):
+        assert _normalize_id_type(Optional[str]) == str
+
+    def test_union_int_none(self):
+        assert _normalize_id_type(Union[int, None]) == int
+
+    def test_union_str_none(self):
+        assert _normalize_id_type(Union[str, None]) == str
+
+    def test_union_int_str(self):
+        """Complex union — returns first non-None type."""
+        result = _normalize_id_type(Union[int, str])
+        assert result == int
+
+
+# --- _coerce_record_id unit tests ---
+
+
+class TestCoerceRecordId:
+    """Verify record ID coercion matches model PK type."""
+
+    def test_string_to_int_coercion(self):
+        """Core bug: string ID passed for int PK model."""
+        fields = {"id": {"type": int, "required": True}}
+        assert _coerce_record_id(fields, "5") == 5
+        assert isinstance(_coerce_record_id(fields, "5"), int)
+
+    def test_int_preserved_for_int_pk(self):
+        """Int ID stays int for int PK model."""
+        fields = {"id": {"type": int, "required": True}}
+        assert _coerce_record_id(fields, 5) == 5
+
+    def test_string_preserved_for_str_pk(self):
+        """String ID stays string for str PK model."""
+        fields = {"id": {"type": str, "required": True}}
+        assert _coerce_record_id(fields, "abc-123") == "abc-123"
+
+    def test_int_to_string_coercion_for_str_pk(self):
+        """Int ID converted to string for str PK model."""
+        fields = {"id": {"type": str, "required": True}}
+        assert _coerce_record_id(fields, 42) == "42"
+
+    def test_optional_int_pk_string_to_int(self):
+        """Core bug path: Optional[int] PK with string ID."""
+        fields = {"id": {"type": Optional[int], "required": False}}
+        assert _coerce_record_id(fields, "5") == 5
+        assert isinstance(_coerce_record_id(fields, "5"), int)
+
+    def test_union_int_none_pk_string_to_int(self):
+        """Union[int, None] PK with string ID."""
+        fields = {"id": {"type": Union[int, None], "required": False}}
+        assert _coerce_record_id(fields, "5") == 5
+
+    def test_no_type_info_falls_back_to_int(self):
+        """No type info — backward compatibility tries int conversion."""
+        fields = {"id": {"required": True}}
+        assert _coerce_record_id(fields, "5") == 5
+
+    def test_no_type_info_preserves_non_numeric_string(self):
+        """No type info — non-numeric string preserved as-is."""
+        fields = {"id": {"required": True}}
+        assert _coerce_record_id(fields, "abc-123") == "abc-123"
+
+    def test_none_passthrough(self):
+        """None ID returns None."""
+        fields = {"id": {"type": int, "required": True}}
+        assert _coerce_record_id(fields, None) is None
+
+    def test_no_id_field_in_model(self):
+        """Model without id field — backward compat tries int."""
+        fields = {"name": {"type": str, "required": True}}
+        assert _coerce_record_id(fields, "5") == 5
+
+    def test_invalid_string_for_int_pk_preserved(self):
+        """Non-numeric string for int PK — preserve as-is, let DB reject."""
+        fields = {"id": {"type": int, "required": True}}
+        assert _coerce_record_id(fields, "not-a-number") == "not-a-number"
+
+
+@pytest.mark.regression
+def test_issue_439_read_with_string_id_for_int_pk(tmp_path):
+    """Read with string ID for int PK model — was broken on PostgreSQL."""
+    from kailash.runtime import LocalRuntime
+    from kailash.workflow.builder import WorkflowBuilder
+
+    from dataflow import DataFlow
+
+    db_file = str(tmp_path / "test_439_read.db")
+    db = DataFlow(f"sqlite:///{db_file}", auto_migrate=False, cache_enabled=False)
+
+    Model = type(
+        "Item439R",
+        (),
+        {
+            "__annotations__": {"id": int, "name": str},
+            "__tablename__": "items_439r",
+            "name": "",
+        },
+    )
+    db.model(Model)
+
+    wf = WorkflowBuilder()
+    wf.add_node(
+        "SQLDatabaseNode",
+        "create_table",
+        {
+            "query": "CREATE TABLE IF NOT EXISTS items_439r (id INTEGER PRIMARY KEY, name TEXT DEFAULT '')",
+            "connection_string": f"sqlite:///{db_file}",
+        },
+    )
+    with LocalRuntime() as runtime:
+        runtime.execute(wf.build())
+
+    db.express_sync.create("Item439R", {"id": 42, "name": "Alice"})
+
+    # Read with int — should work
+    item = db.express_sync.read("Item439R", 42)
+    assert item is not None
+    assert item["name"] == "Alice"
+
+    # Read with string — was broken on PostgreSQL before fix
+    item2 = db.express_sync.read("Item439R", "42")
+    assert item2 is not None
+    assert item2["name"] == "Alice"
+
+
+@pytest.mark.regression
+def test_issue_439_update_with_string_id_for_int_pk(tmp_path):
+    """Update with string ID for int PK model — was broken on PostgreSQL."""
+    from kailash.runtime import LocalRuntime
+    from kailash.workflow.builder import WorkflowBuilder
+
+    from dataflow import DataFlow
+
+    db_file = str(tmp_path / "test_439_update.db")
+    db = DataFlow(f"sqlite:///{db_file}", auto_migrate=False, cache_enabled=False)
+
+    Model = type(
+        "Item439U",
+        (),
+        {
+            "__annotations__": {"id": int, "name": str},
+            "__tablename__": "items_439u",
+            "name": "",
+        },
+    )
+    db.model(Model)
+
+    wf = WorkflowBuilder()
+    wf.add_node(
+        "SQLDatabaseNode",
+        "create_table",
+        {
+            "query": "CREATE TABLE IF NOT EXISTS items_439u (id INTEGER PRIMARY KEY, name TEXT DEFAULT '')",
+            "connection_string": f"sqlite:///{db_file}",
+        },
+    )
+    with LocalRuntime() as runtime:
+        runtime.execute(wf.build())
+
+    db.express_sync.create("Item439U", {"id": 7, "name": "Alice"})
+
+    # Update with string ID — was broken on PostgreSQL before fix
+    db.express_sync.update("Item439U", "7", {"name": "Bob"})
+
+    # Verify read-back with int ID
+    item = db.express_sync.read("Item439U", 7)
+    assert item is not None, "Record missing after update"
+    assert item["name"] == "Bob", f"Update not persisted: {item}"
+
+
+@pytest.mark.regression
+def test_issue_439_delete_with_string_id_for_int_pk(tmp_path):
+    """Delete with string ID for int PK model — was broken on PostgreSQL."""
+    from kailash.runtime import LocalRuntime
+    from kailash.workflow.builder import WorkflowBuilder
+
+    from dataflow import DataFlow
+
+    db_file = str(tmp_path / "test_439_delete.db")
+    db = DataFlow(f"sqlite:///{db_file}", auto_migrate=False, cache_enabled=False)
+
+    Model = type(
+        "Item439D",
+        (),
+        {
+            "__annotations__": {"id": int, "name": str},
+            "__tablename__": "items_439d",
+            "name": "",
+        },
+    )
+    db.model(Model)
+
+    wf = WorkflowBuilder()
+    wf.add_node(
+        "SQLDatabaseNode",
+        "create_table",
+        {
+            "query": "CREATE TABLE IF NOT EXISTS items_439d (id INTEGER PRIMARY KEY, name TEXT DEFAULT '')",
+            "connection_string": f"sqlite:///{db_file}",
+        },
+    )
+    with LocalRuntime() as runtime:
+        runtime.execute(wf.build())
+
+    db.express_sync.create("Item439D", {"id": 99, "name": "Alice"})
+
+    # Delete with string ID — was broken on PostgreSQL before fix
+    deleted = db.express_sync.delete("Item439D", "99")
+    assert deleted is True
+
+    # Verify deleted
+    item = db.express_sync.read("Item439D", 99)
+    assert item is None
+
+
+@pytest.mark.regression
+def test_issue_439_int_id_still_works(tmp_path):
+    """Int IDs still work after the fix (no regression on the working path)."""
+    from kailash.runtime import LocalRuntime
+    from kailash.workflow.builder import WorkflowBuilder
+
+    from dataflow import DataFlow
+
+    db_file = str(tmp_path / "test_439_int.db")
+    db = DataFlow(f"sqlite:///{db_file}", auto_migrate=False, cache_enabled=False)
+
+    Model = type(
+        "Item439I",
+        (),
+        {
+            "__annotations__": {"id": int, "name": str},
+            "__tablename__": "items_439i",
+            "name": "",
+        },
+    )
+    db.model(Model)
+
+    wf = WorkflowBuilder()
+    wf.add_node(
+        "SQLDatabaseNode",
+        "create_table",
+        {
+            "query": "CREATE TABLE IF NOT EXISTS items_439i (id INTEGER PRIMARY KEY, name TEXT DEFAULT '')",
+            "connection_string": f"sqlite:///{db_file}",
+        },
+    )
+    with LocalRuntime() as runtime:
+        runtime.execute(wf.build())
+
+    db.express_sync.create("Item439I", {"id": 1, "name": "Alice"})
+
+    item = db.express_sync.read("Item439I", 1)
+    assert item is not None
+    assert item["name"] == "Alice"
+
+    db.express_sync.update("Item439I", 1, {"name": "Bob"})
+    item2 = db.express_sync.read("Item439I", 1)
+    assert item2 is not None
+    assert item2["name"] == "Bob"
+
+    deleted = db.express_sync.delete("Item439I", 1)
+    assert deleted is True


### PR DESCRIPTION
## Summary

- Extract `_coerce_record_id()` helper that normalizes type annotations (handles `Optional[int]`, `Union[int, None]`) before comparing with the model's PK type
- Apply coercion at all 9 record ID paths (read/update/delete x conditions/record_id/id)
- Update express API type hints to accept `Union[str, int]` for record IDs
- Add 22 regression tests (18 unit + 4 integration with real SQLite)

## Related issues

Fixes #439
Cross-SDK: esperie-enterprise/kailash-rs#377

## Test plan

- [x] Unit tests verify `_normalize_id_type` handles `int`, `str`, `Optional[int]`, `Union[int, None]`
- [x] Unit tests verify `_coerce_record_id` converts string-to-int, int-to-string, handles None, preserves unknown types
- [x] Integration tests verify express_sync.read/update/delete accept string IDs for integer PK models
- [x] Integration tests verify int IDs still work (no regression)
- [ ] CI passes on PostgreSQL matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)