### PR TITLE
chore(release): kailash-dataflow v2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### kailash-dataflow 2.0.7 — 2026-04-13
+
+#### Fixed
+
+- **Integer record ID coercion for PostgreSQL** (`kailash-dataflow 2.0.7`): `express_sync.update/read/delete` rejected string IDs for integer primary key models on PostgreSQL because type coercion compared raw annotations (`Optional[int]`) against `int` directly. Additionally, the `conditions["id"]` path (used by update's filter dict) had zero type coercion. Extracted `_coerce_record_id()` helper that normalizes type annotations and applied at all 9 record ID paths. Express API type hints updated to accept `Union[str, int]`. Fixes #439. Cross-SDK: esperie-enterprise/kailash-rs#377.
+
 ### kailash 2.8.5 + kailash-mcp 0.2.2 — 2026-04-13
 
 #### Fixed

--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -17,14 +17,14 @@
 
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
-| kailash (core)   | `v*`               | 2.8.4           |
-| kailash-dataflow | `dataflow-v*`      | 2.0.6           |
+| kailash (core)   | `v*`               | 2.8.5           |
+| kailash-dataflow | `dataflow-v*`      | 2.0.7           |
 | kailash-kaizen   | `kaizen-v*`        | 2.7.3           |
 | kailash-nexus    | `nexus-v*`         | 2.0.1           |
 | kailash-pact     | `pact-v*`          | 0.8.1           |
 | kailash-ml       | `ml-v*`            | 0.9.0           |
 | kailash-align    | `align-v*`         | 0.3.1           |
-| kailash-mcp      | `mcp-v*`           | 0.2.1           |
+| kailash-mcp      | `mcp-v*`           | 0.2.3           |
 | kaizen-agents    | `kaizen-agents-v*` | 0.9.2           |
 
 ## Release Runbook

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.0.6"
+version = "2.0.7"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -87,7 +87,7 @@ from .validation import (
 )
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.0.6"
+__version__ = "2.0.7"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

- Bump kailash-dataflow from 2.0.6 to 2.0.7
- Update CHANGELOG.md with #439 fix description
- Update deployment-config.md version table

## Related issues

Release for #439 fix (merged in #441)

## Test plan

- [x] Version consistency verified (pyproject.toml + __init__.py both 2.0.7)
- [x] All 22 regression tests pass
- [ ] CI passes
- [ ] Tag `dataflow-v2.0.7` triggers PyPI publish after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)