### PR TITLE
fix: GH issues #443/#446 + adjacent red-team findings

### DIFF
--- a/docs/mcp/examples.md
+++ b/docs/mcp/examples.md
@@ -23,7 +23,7 @@ This document provides practical code examples and recipes for common MCP (Model
 
 ```python
 # server/hello_world.py
-from kailash.mcp_server import MCPServer
+from kailash_mcp import MCPServer
 
 # Create MCP server
 server = MCPServer("Hello World Server")
@@ -51,7 +51,7 @@ if __name__ == "__main__":
 ```python
 # client/hello_world.py
 import asyncio
-from kailash.mcp_server.client import MCPClient
+from kailash_mcp.client import MCPClient
 
 async def main():
     # Connect to server
@@ -984,8 +984,8 @@ async def clear_cache(pattern: str = "*") -> Dict[str, Any]:
 
 ```python
 # patterns/rate_limiting.py
-from kailash.mcp_server import MCPServer
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp import MCPServer
+from kailash_mcp.auth import APIKeyAuth
 
 # Create server with rate limiting
 auth = APIKeyAuth(keys=["api-key-1", "api-key-2"])

--- a/docs/mcp/index.rst
+++ b/docs/mcp/index.rst
@@ -43,7 +43,7 @@ Quick Example
 
 .. code-block:: python
 
-   from kailash.mcp_server import MCPServer
+   from kailash_mcp import MCPServer
 
    # Create server
    server = MCPServer("my-server")

--- a/docs/mcp/quickstart.rst
+++ b/docs/mcp/quickstart.rst
@@ -21,7 +21,7 @@ Create a simple MCP server with basic tools:
 
    # mcp_server.py
    import asyncio
-   from kailash.mcp_server import MCPServer
+   from kailash_mcp import MCPServer
 
    # Create server
    server = MCPServer("quickstart-server")
@@ -86,7 +86,7 @@ Create a client to connect to your server:
 
    # mcp_client.py
    import asyncio
-   from kailash.mcp_server import MCPClient
+   from kailash_mcp import MCPClient
 
    async def main():
        # Create client
@@ -193,7 +193,7 @@ Here's a complete example of an MCP-powered math tutor:
    # math_tutor_server.py
    import asyncio
    import math
-   from kailash.mcp_server import MCPServer
+   from kailash_mcp import MCPServer
 
    server = MCPServer("math-tutor")
 

--- a/docs/mcp/server_development.rst
+++ b/docs/mcp/server_development.rst
@@ -11,7 +11,7 @@ Creating a Server
 
 .. code-block:: python
 
-   from kailash.mcp_server import MCPServer
+   from kailash_mcp import MCPServer
 
    # Basic server
    server = MCPServer("my-server")
@@ -119,7 +119,7 @@ Error Handling
 
 .. code-block:: python
 
-   from kailash.mcp_server.errors import (
+   from kailash_mcp.errors import (
        ToolExecutionError,
        ValidationError,
        ResourceNotFoundError
@@ -205,7 +205,7 @@ Bearer Token
 
 .. code-block:: python
 
-   from kailash.mcp_server.auth import BearerTokenAuth
+   from kailash_mcp.auth import BearerTokenAuth
 
    auth = BearerTokenAuth(token="secret-token")
    server = MCPServer("secure-server", auth=auth)
@@ -215,7 +215,7 @@ API Key
 
 .. code-block:: python
 
-   from kailash.mcp_server.auth import APIKeyAuth
+   from kailash_mcp.auth import APIKeyAuth
 
    auth = APIKeyAuth(
        api_keys=["key1", "key2", "key3"],
@@ -228,7 +228,7 @@ JWT Authentication
 
 .. code-block:: python
 
-   from kailash.mcp_server.auth import JWTAuth
+   from kailash_mcp.auth import JWTAuth
 
    auth = JWTAuth(
        secret_key="your-secret-key",
@@ -244,7 +244,7 @@ Custom Authentication
 
 .. code-block:: python
 
-   from kailash.mcp_server.auth import AuthHandler
+   from kailash_mcp.auth import AuthHandler
 
    class DatabaseAuth(AuthHandler):
        def __init__(self, db_connection):
@@ -298,7 +298,7 @@ Middleware
 
 .. code-block:: python
 
-   from kailash.mcp_server import Middleware
+   from kailash_mcp import Middleware
 
    class LoggingMiddleware(Middleware):
        async def process_request(self, request, context):
@@ -316,7 +316,7 @@ Rate Limiting
 
 .. code-block:: python
 
-   from kailash.mcp_server.middleware import RateLimiter
+   from kailash_mcp.middleware import RateLimiter
 
    # Global rate limit
    rate_limiter = RateLimiter(
@@ -459,7 +459,7 @@ Unit Testing Tools
 .. code-block:: python
 
    import pytest
-   from kailash.mcp_server import MCPServer
+   from kailash_mcp import MCPServer
 
    @pytest.fixture
    def test_server():

--- a/packages/kailash-dataflow/src/dataflow/adapters/dialect.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/dialect.py
@@ -100,11 +100,26 @@ class SQLDialect(ABC):
 class PostgreSQLDialect(SQLDialect):
     """PostgreSQL dialect."""
 
+    _MAX_IDENTIFIER_LENGTH = 63  # PostgreSQL NAMEDATALEN-1
+
     def get_parameter_placeholder(self, position: int) -> str:
         return f"${position}"
 
     def quote_identifier(self, name: str) -> str:
-        if not name or not _SAFE_IDENTIFIER_RE.match(name):
+        if not isinstance(name, str) or not name:
+            raise InvalidIdentifierError(
+                f"Invalid SQL identifier "
+                f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+                f"must be a non-empty string"
+            )
+        if len(name) > self._MAX_IDENTIFIER_LENGTH:
+            raise InvalidIdentifierError(
+                f"Invalid SQL identifier "
+                f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+                f"exceeds {self._MAX_IDENTIFIER_LENGTH}-char PostgreSQL limit "
+                f"(len={len(name)})"
+            )
+        if not _SAFE_IDENTIFIER_RE.match(name):
             raise InvalidIdentifierError(
                 f"Invalid SQL identifier "
                 f"(fingerprint={hash(name) & 0xFFFF:04x}): "
@@ -198,11 +213,26 @@ class PostgreSQLDialect(SQLDialect):
 class MySQLDialect(SQLDialect):
     """MySQL dialect."""
 
+    _MAX_IDENTIFIER_LENGTH = 64  # MySQL identifier length limit
+
     def get_parameter_placeholder(self, position: int) -> str:
         return "%s"
 
     def quote_identifier(self, name: str) -> str:
-        if not name or not _SAFE_IDENTIFIER_RE.match(name):
+        if not isinstance(name, str) or not name:
+            raise InvalidIdentifierError(
+                f"Invalid SQL identifier "
+                f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+                f"must be a non-empty string"
+            )
+        if len(name) > self._MAX_IDENTIFIER_LENGTH:
+            raise InvalidIdentifierError(
+                f"Invalid SQL identifier "
+                f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+                f"exceeds {self._MAX_IDENTIFIER_LENGTH}-char MySQL limit "
+                f"(len={len(name)})"
+            )
+        if not _SAFE_IDENTIFIER_RE.match(name):
             raise InvalidIdentifierError(
                 f"Invalid SQL identifier "
                 f"(fingerprint={hash(name) & 0xFFFF:04x}): "
@@ -291,11 +321,26 @@ class MySQLDialect(SQLDialect):
 class SQLiteDialect(SQLDialect):
     """SQLite dialect."""
 
+    _MAX_IDENTIFIER_LENGTH = 128  # SQLite practical limit
+
     def get_parameter_placeholder(self, position: int) -> str:
         return "?"
 
     def quote_identifier(self, name: str) -> str:
-        if not name or not _SAFE_IDENTIFIER_RE.match(name):
+        if not isinstance(name, str) or not name:
+            raise InvalidIdentifierError(
+                f"Invalid SQL identifier "
+                f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+                f"must be a non-empty string"
+            )
+        if len(name) > self._MAX_IDENTIFIER_LENGTH:
+            raise InvalidIdentifierError(
+                f"Invalid SQL identifier "
+                f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+                f"exceeds {self._MAX_IDENTIFIER_LENGTH}-char SQLite limit "
+                f"(len={len(name)})"
+            )
+        if not _SAFE_IDENTIFIER_RE.match(name):
             raise InvalidIdentifierError(
                 f"Invalid SQL identifier "
                 f"(fingerprint={hash(name) & 0xFFFF:04x}): "

--- a/packages/kailash-kaizen/docs/integrations/mcp/IMPLEMENTATION_SUMMARY.md
+++ b/packages/kailash-kaizen/docs/integrations/mcp/IMPLEMENTATION_SUMMARY.md
@@ -9,7 +9,7 @@
 ## Executive Summary
 
 Successfully implemented production-ready MCP integration for Kaizen by:
-1. **Using Kailash SDK's complete MCP implementation** (kailash.mcp_server)
+1. **Using Kailash SDK's complete MCP implementation** (kailash_mcp)
 2. **Deleting partial/mocked kaizen.mcp module** (eliminated technical debt)
 3. **Adding MCP helpers to BaseAgent** (3 new async methods)
 4. **Creating comprehensive documentation** (5 guides in docs/integrations/mcp/)
@@ -23,7 +23,7 @@ Successfully implemented production-ready MCP integration for Kaizen by:
 
 ### 1. Architecture Decision ✅
 
-**Decision**: USE Kailash SDK MCP (kailash.mcp_server) - DO NOT recreate
+**Decision**: USE Kailash SDK MCP (kailash_mcp) - DO NOT recreate
 
 **Rationale**:
 - ✅ **100% MCP Spec Compliant** - Tools, Resources, Prompts + advanced features
@@ -81,7 +81,7 @@ async def setup_mcp_client(
 ```
 
 **Features**:
-- Real MCPClient from kailash.mcp_server
+- Real MCPClient from kailash_mcp
 - Real tool discovery via JSON-RPC
 - Multiple transport support (STDIO, HTTP, SSE, WebSocket)
 - Circuit breaker retry strategy
@@ -145,7 +145,7 @@ def expose_as_mcp_server(
 ```
 
 **Features**:
-- Real MCPServer from kailash.mcp_server
+- Real MCPServer from kailash_mcp
 - Auto-detect public agent methods
 - Wrap methods as async MCP tools
 - Optional authentication (API Key, JWT, etc.)
@@ -153,7 +153,7 @@ def expose_as_mcp_server(
 
 **Example**:
 ```python
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp.auth import APIKeyAuth
 
 auth = APIKeyAuth({"client1": "secret-key"})
 server = agent.expose_as_mcp_server(
@@ -176,7 +176,7 @@ server.run()
 - Architecture overview
 - 4 implementation patterns
 - Testing guide (3-tier strategy)
-- Migration guide (kaizen.mcp → kailash.mcp_server)
+- Migration guide (kaizen.mcp → kailash_mcp)
 - FAQ and troubleshooting
 
 #### 4.2 Architecture Guide - `architecture.md` (24.5KB)
@@ -218,7 +218,7 @@ server.run()
 **Task**: Find Kailash SDK MCP implementation patterns
 
 **Findings**:
-- Located 30+ MCP files in kailash.mcp_server
+- Located 30+ MCP files in kailash_mcp
 - Identified MCPClient, MCPServer, ServiceRegistry, ServiceMesh
 - Found 407 tests (100% pass rate)
 - Documented all transports, auth providers, enterprise features
@@ -230,11 +230,11 @@ server.run()
 
 **Task**: Validate MCP integration approach
 
-**Decision**: ✅ USE kailash.mcp_server (8/8 score)
+**Decision**: ✅ USE kailash_mcp (8/8 score)
 
 **Recommendations**:
 1. Delete kaizen.mcp entirely ✅ DONE
-2. Use kailash.mcp_server directly ✅ DONE
+2. Use kailash_mcp directly ✅ DONE
 3. Add BaseAgent helpers ✅ DONE
 4. Update examples (PENDING)
 5. Update tests (PENDING)
@@ -264,7 +264,7 @@ Kaizen Application
       ↓
 BaseAgent MCP Helpers
       ↓
-kailash.mcp_server (production)
+kailash_mcp (production)
    - MCPClient (real protocol)
    - MCPServer (real protocol)
    - ServiceRegistry, ServiceMesh
@@ -352,7 +352,7 @@ parameters = {
 1. Current implementation is mocked (test-only)
 2. Kailash SDK MCP is comprehensive
 3. No Kaizen-specific extensions identified
-4. Direct imports clearer (`from kailash.mcp_server import MCPClient`)
+4. Direct imports clearer (`from kailash_mcp import MCPClient`)
 5. Zero maintenance burden
 
 **Alternative Considered**: Keep thin wrapper
@@ -367,7 +367,7 @@ parameters = {
 **Rationale**:
 1. Convenient for all agent types
 2. Natural integration with signature/memory
-3. Thin layer - delegates to kailash.mcp_server
+3. Thin layer - delegates to kailash_mcp
 4. Async methods match MCP protocol
 5. Auto memory storage integration
 
@@ -401,7 +401,7 @@ from kaizen.mcp import MCPConnection, MCPRegistry
 
 **After** (production):
 ```python
-from kailash.mcp_server import MCPClient, ServiceRegistry
+from kailash_mcp import MCPClient, ServiceRegistry
 ```
 
 ### API Changes
@@ -452,8 +452,8 @@ mcp_servers = [
 # Find all kaizen.mcp imports
 grep -r "from kaizen.mcp import" packages/kailash-kaizen/
 
-# Replace with kailash.mcp_server
-sed -i '' 's/from kaizen.mcp import/from kailash.mcp_server import/g' file.py
+# Replace with kailash_mcp
+sed -i '' 's/from kaizen.mcp import/from kailash_mcp import/g' file.py
 ```
 
 **Step 2**: Update to async
@@ -517,7 +517,7 @@ class MyAgent(BaseAgent):
 
 **Use SimpleMCPServer for fast tests**:
 ```python
-from kailash.mcp_server import SimpleMCPServer
+from kailash_mcp import SimpleMCPServer
 
 @pytest.fixture
 def mock_mcp_server():
@@ -681,7 +681,7 @@ Successfully implemented production-ready MCP integration for Kaizen by:
 
 **Architecture**: Clean, maintainable, production-ready
 - Zero code duplication
-- Single source of truth (kailash.mcp_server)
+- Single source of truth (kailash_mcp)
 - 100% MCP spec compliance
 - Enterprise features included
 

--- a/packages/kailash-kaizen/docs/integrations/mcp/README.md
+++ b/packages/kailash-kaizen/docs/integrations/mcp/README.md
@@ -25,13 +25,13 @@ Kaizen integrates with the Model Context Protocol (MCP) through Kailash SDK's pr
 MCP is included with Kailash SDK (no additional installation needed):
 
 ```bash
-pip install kailash  # Includes kailash.mcp_server
+pip install kailash  # Includes kailash_mcp
 ```
 
 ### Basic Client (3 lines)
 
 ```python
-from kailash.mcp_server import MCPClient
+from kailash_mcp import MCPClient
 
 client = MCPClient(enable_metrics=True)
 result = await client.call_tool(server_config, "tool_name", {"arg": "value"})
@@ -40,7 +40,7 @@ result = await client.call_tool(server_config, "tool_name", {"arg": "value"})
 ### Basic Server (5 lines)
 
 ```python
-from kailash.mcp_server import SimpleMCPServer
+from kailash_mcp import SimpleMCPServer
 
 server = SimpleMCPServer("my-tools")
 
@@ -144,7 +144,7 @@ result = await agent.execute_mcp_tool(
 │   (BaseAgent + MCP integration)     │
 ├─────────────────────────────────────┤
 │   Kailash MCP Server                │
-│   (kailash.mcp_server)               │
+│   (kailash_mcp)               │
 │   - MCPClient, MCPServer             │
 │   - ServiceRegistry, ServiceMesh     │
 │   - Auth, Discovery, Load Balancing  │
@@ -161,11 +161,11 @@ result = await agent.execute_mcp_tool(
 
 | Component | Purpose | Location |
 |-----------|---------|----------|
-| **MCPClient** | Connect to MCP servers, invoke tools | `kailash.mcp_server.MCPClient` |
-| **MCPServer** | Expose tools/resources/prompts | `kailash.mcp_server.MCPServer` |
-| **SimpleMCPServer** | Lightweight server for prototyping | `kailash.mcp_server.SimpleMCPServer` |
-| **ServiceRegistry** | Service discovery & registration | `kailash.mcp_server.ServiceRegistry` |
-| **ServiceMesh** | Load balancing & failover | `kailash.mcp_server.ServiceMesh` |
+| **MCPClient** | Connect to MCP servers, invoke tools | `kailash_mcp.MCPClient` |
+| **MCPServer** | Expose tools/resources/prompts | `kailash_mcp.MCPServer` |
+| **SimpleMCPServer** | Lightweight server for prototyping | `kailash_mcp.SimpleMCPServer` |
+| **ServiceRegistry** | Service discovery & registration | `kailash_mcp.ServiceRegistry` |
+| **ServiceMesh** | Load balancing & failover | `kailash_mcp.ServiceMesh` |
 
 ### Why Use Kailash SDK MCP?
 
@@ -198,7 +198,7 @@ result = await agent.execute_mcp_tool(
 
 ```python
 from kaizen.core.base_agent import BaseAgent
-from kailash.mcp_server import MCPClient, discover_mcp_servers
+from kailash_mcp import MCPClient, discover_mcp_servers
 
 class ResearchAgent(BaseAgent):
     async def setup_mcp(self):
@@ -245,7 +245,7 @@ class ResearchAgent(BaseAgent):
 
 ```python
 from kaizen.core.base_agent import BaseAgent
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp.auth import APIKeyAuth
 
 class AnalysisAgent(BaseAgent):
     def start_as_server(self):
@@ -284,8 +284,8 @@ class AnalysisAgent(BaseAgent):
 
 ```python
 from kaizen.core.base_agent import BaseAgent
-from kailash.mcp_server import MCPServer, enable_auto_discovery
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp import MCPServer, enable_auto_discovery
+from kailash_mcp.auth import APIKeyAuth
 
 class AnalysisAgent(BaseAgent):
     def expose_as_mcp_server(self):
@@ -336,7 +336,7 @@ class AnalysisAgent(BaseAgent):
 **Use Case**: Intelligent routing across multiple MCP servers
 
 ```python
-from kailash.mcp_server import ServiceRegistry, ServiceMesh
+from kailash_mcp import ServiceRegistry, ServiceMesh
 
 class MultiServerAgent(BaseAgent):
     async def setup_service_mesh(self):
@@ -408,7 +408,7 @@ Test with mock MCP servers (fast, no external dependencies):
 
 ```python
 import pytest
-from kailash.mcp_server import SimpleMCPServer
+from kailash_mcp import SimpleMCPServer
 
 @pytest.fixture
 def mock_mcp_server():
@@ -433,7 +433,7 @@ Test with real MCP servers and real LLM providers:
 
 ```python
 import pytest
-from kailash.mcp_server import MCPClient
+from kailash_mcp import MCPClient
 
 @pytest.mark.asyncio
 async def test_real_mcp_integration():
@@ -478,9 +478,9 @@ See [testing-guide.md](./testing-guide.md) for comprehensive testing patterns.
 
 ## Migration Guide
 
-### Migrating from `kaizen.mcp` to `kailash.mcp_server`
+### Migrating from `kaizen.mcp` to `kailash_mcp`
 
-If you're using the deprecated `kaizen.mcp` module, migrate to `kailash.mcp_server`:
+If you're using the deprecated `kaizen.mcp` module, migrate to `kailash_mcp`:
 
 #### Before (Deprecated - Mocked Implementation)
 
@@ -503,7 +503,7 @@ result = connection.call_tool("search", {"query": "AI"})
 #### After (Recommended - Real Implementation)
 
 ```python
-from kailash.mcp_server import MCPClient, discover_mcp_servers
+from kailash_mcp import MCPClient, discover_mcp_servers
 
 # Real MCP client with production features
 client = MCPClient(
@@ -545,14 +545,14 @@ See [migration-guide.md](./migration-guide.md) for step-by-step migration instru
 - **[Implementation Guide](./implementation-guide.md)** - Detailed implementation patterns
 - **[Quick Reference](./quick-reference.md)** - Common patterns and code snippets
 - **[Testing Guide](./testing-guide.md)** - Comprehensive testing strategies
-- **[Migration Guide](./migration-guide.md)** - Migrate from kaizen.mcp to kailash.mcp_server
+- **[Migration Guide](./migration-guide.md)** - Migrate from kaizen.mcp to kailash_mcp
 
 ### Kailash SDK Documentation
 
 For comprehensive Kailash SDK MCP documentation, refer to the main Kailash repository:
 
 - **MCP Server Implementation** - `src/kailash/mcp_server/` in Kailash SDK repository
-- **API Reference** - Import docstrings: `from kailash.mcp_server import MCPClient, MCPServer`
+- **API Reference** - Import docstrings: `from kailash_mcp import MCPClient, MCPServer`
 - **Test Examples** - `tests/integration/mcp_server/` in Kailash SDK repository
 
 ### Example Implementations
@@ -594,8 +594,8 @@ def sync_call_tool(server, tool, args):
 **A**: Use auth providers:
 
 ```python
-from kailash.mcp_server import MCPClient
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp import MCPClient
+from kailash_mcp.auth import APIKeyAuth
 
 auth = APIKeyAuth({"user": "secret-key"})
 client = MCPClient(auth_provider=auth)
@@ -620,7 +620,7 @@ client = MCPClient(
 **A**: Yes, use ServiceMesh for load balancing:
 
 ```python
-from kailash.mcp_server import ServiceRegistry, ServiceMesh
+from kailash_mcp import ServiceRegistry, ServiceMesh
 
 registry = ServiceRegistry()
 mesh = ServiceMesh(registry)

--- a/packages/kailash-kaizen/docs/integrations/mcp/architecture.md
+++ b/packages/kailash-kaizen/docs/integrations/mcp/architecture.md
@@ -10,7 +10,7 @@
 
 **Finding**: Kailash SDK has a **COMPLETE, production-ready MCP implementation** using the official Anthropic MCP SDK. Kaizen's `mcp/` module is a **partial recreation** with mocked implementations.
 
-**Recommendation**: **MIGRATE** to Kailash SDK MCP implementation. Delete `kaizen/mcp/` and use `kailash.mcp_server` directly.
+**Recommendation**: **MIGRATE** to Kailash SDK MCP implementation. Delete `kaizen/mcp/` and use `kailash_mcp` directly.
 
 **Rationale**: "We should always extend and not recreate" - The official MCP SDK is already integrated into Kailash SDK with comprehensive enterprise features. Recreating this in Kaizen violates DRY principles and creates maintenance burden.
 
@@ -18,7 +18,7 @@
 
 ## Comparison: Kailash SDK vs. Kaizen MCP
 
-### Kailash SDK MCP (`kailash.mcp_server`) ✅
+### Kailash SDK MCP (`kailash_mcp`) ✅
 
 **Foundation**: Built on official Anthropic MCP Python SDK
 - `from mcp import ClientSession, StdioServerParameters` ← Official SDK
@@ -203,7 +203,7 @@ class MCPClientAgent(BaseAgent):
 **Should Be** (using Kailash SDK):
 ```python
 # Using Kailash SDK MCP implementation
-from kailash.mcp_server import MCPClient, discover_mcp_servers, get_mcp_client
+from kailash_mcp import MCPClient, discover_mcp_servers, get_mcp_client
 
 class MCPClientAgent(BaseAgent):
     async def _setup_mcp_connections(self):
@@ -323,7 +323,7 @@ grep -r "from mcp import"
 
 ### Option 1: Migrate to Kailash SDK (RECOMMENDED) ✅
 
-**Approach**: Delete `kaizen/mcp/` and use `kailash.mcp_server` directly
+**Approach**: Delete `kaizen/mcp/` and use `kailash_mcp` directly
 
 **Rationale**:
 1. **DRY Principle**: Don't recreate what already exists and is better
@@ -344,7 +344,7 @@ tools = connection.available_tools  # ← String matching
 result = connection.call_tool("search", {"query": "AI"})  # ← Hardcoded
 
 # After (Kailash SDK - REAL)
-from kailash.mcp_server import MCPClient, discover_mcp_servers, get_mcp_client
+from kailash_mcp import MCPClient, discover_mcp_servers, get_mcp_client
 
 # Discover servers
 servers = await discover_mcp_servers(capability="search")
@@ -361,7 +361,7 @@ result = await client.call_tool(server_config, "search", {"query": "AI"})
 
 **Migration Steps**:
 1. ✅ Delete `src/kaizen/mcp/` directory
-2. ✅ Update imports in examples to use `kailash.mcp_server`
+2. ✅ Update imports in examples to use `kailash_mcp`
 3. ✅ Update agent-as-client to use `MCPClient`
 4. ✅ Update agent-as-server to use `MCPServer`
 5. ✅ Remove test helpers (no longer needed with real implementation)
@@ -387,14 +387,14 @@ result = await client.call_tool(server_config, "search", {"query": "AI"})
 
 ### Option 2: Keep Kaizen mcp/ as Extension Layer (NOT RECOMMENDED) ❌
 
-**Approach**: Keep `kaizen/mcp/` but make it extend `kailash.mcp_server`
+**Approach**: Keep `kaizen/mcp/` but make it extend `kailash_mcp`
 
 **Rationale**: If Kaizen needs MCP-specific extensions that don't belong in Kailash SDK
 
 **Implementation**:
 ```python
 # kaizen/mcp/__init__.py
-from kailash.mcp_server import (
+from kailash_mcp import (
     MCPClient,
     MCPServer,
     ServiceRegistry,
@@ -437,7 +437,7 @@ __all__ = [
 
 ### Option 3: Move Kailash SDK MCP to Kaizen (STRONGLY NOT RECOMMENDED) ❌❌
 
-**Approach**: Move `kailash.mcp_server` to `kaizen.mcp`
+**Approach**: Move `kailash_mcp` to `kaizen.mcp`
 
 **Rationale**: If MCP is only for LLM/agent usage
 
@@ -475,12 +475,12 @@ __all__ = [
 
 ### Phase 1: Immediate (1 day)
 1. ✅ **Audit current usage** of `kaizen.mcp` in examples and tests
-2. ✅ **Document migration path** from `kaizen.mcp` to `kailash.mcp_server`
+2. ✅ **Document migration path** from `kaizen.mcp` to `kailash_mcp`
 3. ✅ **Create migration guide** for examples
 
 ### Phase 2: Migration (1-2 days)
-1. ✅ **Update agent-as-client example** to use `kailash.mcp_server.MCPClient`
-2. ✅ **Update agent-as-server example** to use `kailash.mcp_server.MCPServer`
+1. ✅ **Update agent-as-client example** to use `kailash_mcp.MCPClient`
+2. ✅ **Update agent-as-server example** to use `kailash_mcp.MCPServer`
 3. ✅ **Remove test helpers** (`populate_agent_tools` - no longer needed)
 4. ✅ **Update integration tests** to use real protocol
 5. ✅ **Delete `src/kaizen/mcp/`** directory
@@ -527,9 +527,9 @@ class MCPClientAgent(BaseAgent):
         return result
 ```
 
-**After** (using `kailash.mcp_server` - real):
+**After** (using `kailash_mcp` - real):
 ```python
-from kailash.mcp_server import MCPClient, discover_mcp_servers
+from kailash_mcp import MCPClient, discover_mcp_servers
 
 class MCPClientAgent(BaseAgent):
     async def _setup_mcp_connections(self):
@@ -593,10 +593,10 @@ class MCPServerAgent(BaseAgent):
         self.registry.register_server(self.mcp_server_config)
 ```
 
-**After** (using `kailash.mcp_server` - real):
+**After** (using `kailash_mcp` - real):
 ```python
-from kailash.mcp_server import MCPServer, enable_auto_discovery
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp import MCPServer, enable_auto_discovery
+from kailash_mcp.auth import APIKeyAuth
 
 class MCPServerAgent(BaseAgent):
     def start_server(self):
@@ -669,7 +669,7 @@ class MCPServerAgent(BaseAgent):
 
 ### Recommendation: MIGRATE ✅
 
-**Delete `src/kaizen/mcp/` and use `kailash.mcp_server` directly.**
+**Delete `src/kaizen/mcp/` and use `kailash_mcp` directly.**
 
 **Rationale**:
 - ✅ "Extend, not recreate" principle
@@ -689,7 +689,7 @@ class MCPServerAgent(BaseAgent):
 ## Next Steps
 
 1. **Immediate**: Review this recommendation with team
-2. **Decision**: Approve migration to `kailash.mcp_server`
+2. **Decision**: Approve migration to `kailash_mcp`
 3. **Implementation**: Execute migration plan (Phases 1-3)
 4. **Validation**: Verify all tests pass with real implementation
 5. **Optional**: Evaluate if Kaizen-specific extensions needed (Phase 4)

--- a/packages/kailash-kaizen/docs/integrations/mcp/implementation-guide.md
+++ b/packages/kailash-kaizen/docs/integrations/mcp/implementation-guide.md
@@ -46,13 +46,13 @@ Kailash SDK has a **complete, production-ready MCP implementation** in `src/kail
 ### 2.1 Basic Client Creation
 
 ```python
-from kailash.mcp_server import MCPClient
+from kailash_mcp import MCPClient
 
 # Minimal client
 client = MCPClient()
 
 # Client with authentication
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp.auth import APIKeyAuth
 
 auth = APIKeyAuth({"user1": "secret-key"})
 client = MCPClient(
@@ -205,7 +205,7 @@ async with client:
 ### 3.1 Simple Server (Prototyping)
 
 ```python
-from kailash.mcp_server import SimpleMCPServer
+from kailash_mcp import SimpleMCPServer
 
 # Lightweight server for development
 server = SimpleMCPServer("my-tools")
@@ -234,8 +234,8 @@ if __name__ == "__main__":
 ### 3.2 Production Server with Features
 
 ```python
-from kailash.mcp_server import MCPServer
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp import MCPServer
+from kailash_mcp.auth import APIKeyAuth
 
 # Create production server
 auth = APIKeyAuth({
@@ -268,7 +268,7 @@ if __name__ == "__main__":
 ### 3.3 Server Base Class Pattern
 
 ```python
-from kailash.mcp_server import MCPServerBase
+from kailash_mcp import MCPServerBase
 
 class MyCustomServer(MCPServerBase):
     """Custom MCP server with specific tools."""
@@ -301,8 +301,8 @@ server.start()
 ### 3.4 WebSocket Server Transport
 
 ```python
-from kailash.mcp_server import MCPServer
-from kailash.mcp_server.transports import WebSocketTransport
+from kailash_mcp import MCPServer
+from kailash_mcp.transports import WebSocketTransport
 
 # Create WebSocket server
 server = MCPServer(
@@ -333,7 +333,7 @@ if __name__ == "__main__":
 ### 4.1 Server Registration
 
 ```python
-from kailash.mcp_server import ServiceRegistry, ServerInfo
+from kailash_mcp import ServiceRegistry, ServerInfo
 
 # Create registry
 registry = ServiceRegistry()
@@ -370,7 +370,7 @@ for server in servers:
 ### 4.3 Auto-Discovery with Registration
 
 ```python
-from kailash.mcp_server import MCPServer, enable_auto_discovery
+from kailash_mcp import MCPServer, enable_auto_discovery
 
 # Create server
 server = MCPServer("my-server")
@@ -396,7 +396,7 @@ registrar.start_with_registration()
 ### 4.4 Health Checking
 
 ```python
-from kailash.mcp_server.discovery import HealthChecker
+from kailash_mcp.discovery import HealthChecker
 
 # Create health checker
 health_checker = HealthChecker(registry)
@@ -419,7 +419,7 @@ else:
 ### 5.1 API Key Authentication
 
 ```python
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp.auth import APIKeyAuth
 
 # Simple API key auth
 auth = APIKeyAuth(["secret-key-1", "secret-key-2"])
@@ -443,7 +443,7 @@ client = MCPClient(auth_provider=auth)
 ### 5.2 JWT Authentication
 
 ```python
-from kailash.mcp_server.auth import JWTAuth
+from kailash_mcp.auth import JWTAuth
 
 # Create JWT auth provider
 auth = JWTAuth(
@@ -467,7 +467,7 @@ client = MCPClient(auth_provider=auth)
 ### 5.3 Bearer Token Authentication
 
 ```python
-from kailash.mcp_server.auth import BearerTokenAuth
+from kailash_mcp.auth import BearerTokenAuth
 
 # Simple bearer tokens
 auth = BearerTokenAuth(tokens=["bearer-token-123"])
@@ -491,7 +491,7 @@ auth = BearerTokenAuth(
 ### 5.4 Permission Management
 
 ```python
-from kailash.mcp_server.auth import PermissionManager
+from kailash_mcp.auth import PermissionManager
 
 # Create permission manager
 perm_manager = PermissionManager()
@@ -513,7 +513,7 @@ can_admin = perm_manager.has_permission(user_perms, "tools.admin")  # False
 ### 5.5 Rate Limiting
 
 ```python
-from kailash.mcp_server.auth import RateLimiter
+from kailash_mcp.auth import RateLimiter
 
 # Create rate limiter
 rate_limiter = RateLimiter(
@@ -655,7 +655,7 @@ tool_discovery_config = {
 ### 7.1 Error Hierarchy
 
 ```python
-from kailash.mcp_server.errors import (
+from kailash_mcp.errors import (
     MCPError,                    # Base error
     AuthenticationError,         # Auth failures
     AuthorizationError,          # Permission denied
@@ -668,7 +668,7 @@ from kailash.mcp_server.errors import (
 )
 
 # Error codes
-from kailash.mcp_server.errors import MCPErrorCode
+from kailash_mcp.errors import MCPErrorCode
 
 MCPErrorCode.AUTHENTICATION_FAILED
 MCPErrorCode.AUTHORIZATION_FAILED
@@ -684,7 +684,7 @@ MCPErrorCode.TRANSPORT_ERROR
 ### 7.2 Retry Strategies
 
 ```python
-from kailash.mcp_server.errors import (
+from kailash_mcp.errors import (
     ExponentialBackoffRetry,
     CircuitBreakerRetry,
     RetryableOperation
@@ -717,7 +717,7 @@ result = await operation.execute(async_function)
 ### 7.3 Error Aggregation
 
 ```python
-from kailash.mcp_server.errors import ErrorAggregator
+from kailash_mcp.errors import ErrorAggregator
 
 # Collect errors from multiple operations
 aggregator = ErrorAggregator()
@@ -750,8 +750,8 @@ if aggregator.has_errors():
 
 ```python
 import pytest
-from kailash.mcp_server import MCPClient
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp import MCPClient
+from kailash_mcp.auth import APIKeyAuth
 
 def test_mcp_client_initialization():
     """Test client initialization."""
@@ -788,7 +788,7 @@ async def test_tool_discovery():
 
 ```python
 import pytest
-from kailash.mcp_server import MCPClient, MCPServer
+from kailash_mcp import MCPClient, MCPServer
 
 @pytest.mark.integration
 async def test_real_mcp_server_communication():
@@ -874,8 +874,8 @@ async def test_llm_agent_with_mcp_tools():
 ### 9.1 Server Configuration
 
 ```python
-from kailash.mcp_server import MCPServer
-from kailash.mcp_server.auth import JWTAuth
+from kailash_mcp import MCPServer
+from kailash_mcp.auth import JWTAuth
 
 # Production server setup
 auth = JWTAuth(
@@ -937,8 +937,8 @@ if __name__ == "__main__":
 ### 9.2 Client Configuration
 
 ```python
-from kailash.mcp_server import MCPClient
-from kailash.mcp_server.auth import JWTAuth
+from kailash_mcp import MCPClient
+from kailash_mcp.auth import JWTAuth
 
 # Production client
 auth = JWTAuth(secret=os.getenv("JWT_SECRET"))
@@ -1009,17 +1009,17 @@ CMD ["python", "-m", "mcp_server"]
 
 ```python
 # MCP Client
-from kailash.mcp_server import MCPClient
+from kailash_mcp import MCPClient
 
 # Authentication
-from kailash.mcp_server.auth import (
+from kailash_mcp.auth import (
     APIKeyAuth,
     BearerTokenAuth,
     JWTAuth
 )
 
 # Error Handling
-from kailash.mcp_server.errors import (
+from kailash_mcp.errors import (
     MCPError,
     AuthenticationError,
     ToolError,
@@ -1029,7 +1029,7 @@ from kailash.mcp_server.errors import (
 )
 
 # Discovery
-from kailash.mcp_server import (
+from kailash_mcp import (
     discover_mcp_servers,
     get_mcp_client
 )
@@ -1039,21 +1039,21 @@ from kailash.mcp_server import (
 
 ```python
 # MCP Server
-from kailash.mcp_server import (
+from kailash_mcp import (
     MCPServer,           # Production server
     SimpleMCPServer,     # Prototyping server
     MCPServerBase        # Custom server base class
 )
 
 # Service Discovery
-from kailash.mcp_server import (
+from kailash_mcp import (
     ServiceRegistry,
     ServerInfo,
     enable_auto_discovery
 )
 
 # Authentication
-from kailash.mcp_server.auth import (
+from kailash_mcp.auth import (
     AuthProvider,
     APIKeyAuth,
     JWTAuth,
@@ -1090,7 +1090,7 @@ from kailash.nodes.ai import LLMAgentNode
 from kaizen.mcp import MCPClient  # ❌ Partial implementation
 
 # Use Kailash's proven implementation
-from kailash.mcp_server import MCPClient  # ✅ Production-ready
+from kailash_mcp import MCPClient  # ✅ Production-ready
 ```
 
 ### 11.2 Example Updates
@@ -1100,7 +1100,7 @@ Update Kaizen examples to use Kailash MCP patterns:
 ```python
 # examples/5-mcp-integration/agent-as-client/workflow.py
 
-from kailash.mcp_server import MCPClient
+from kailash_mcp import MCPClient
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.runtime.local import LocalRuntime
 
@@ -1159,9 +1159,9 @@ See [Kailash MCP Quick Start](../../kailash_python_sdk/sdk-users/1-quickstart/mc
 
 ## Patterns
 
-- Client: Use `kailash.mcp_server.MCPClient`
-- Server: Use `kailash.mcp_server.MCPServer`
-- Auth: Use `kailash.mcp_server.auth` module
+- Client: Use `kailash_mcp.MCPClient`
+- Server: Use `kailash_mcp.MCPServer`
+- Auth: Use `kailash_mcp.auth` module
 ```
 
 ---
@@ -1199,7 +1199,7 @@ See [Kailash MCP Quick Start](../../kailash_python_sdk/sdk-users/1-quickstart/mc
 ## 13. Next Steps for Kaizen Integration
 
 1. **Remove partial MCP implementation** in `src/kaizen/mcp/`
-2. **Update imports** in Kaizen examples to use `kailash.mcp_server`
+2. **Update imports** in Kaizen examples to use `kailash_mcp`
 3. **Add MCP examples** following Kailash patterns
 4. **Implement tests** using 3-tier strategy
 5. **Update documentation** to reference Kailash MCP docs

--- a/packages/kailash-kaizen/docs/integrations/mcp/quick-reference.md
+++ b/packages/kailash-kaizen/docs/integrations/mcp/quick-reference.md
@@ -8,19 +8,19 @@
 
 ```python
 # Client
-from kailash.mcp_server import MCPClient
+from kailash_mcp import MCPClient
 
 # Server
-from kailash.mcp_server import MCPServer, SimpleMCPServer
+from kailash_mcp import MCPServer, SimpleMCPServer
 
 # Authentication
-from kailash.mcp_server.auth import APIKeyAuth, JWTAuth, BearerTokenAuth
+from kailash_mcp.auth import APIKeyAuth, JWTAuth, BearerTokenAuth
 
 # Discovery
-from kailash.mcp_server import ServiceRegistry, ServerInfo, enable_auto_discovery
+from kailash_mcp import ServiceRegistry, ServerInfo, enable_auto_discovery
 
 # Error Handling
-from kailash.mcp_server.errors import (
+from kailash_mcp.errors import (
     MCPError, AuthenticationError, ToolError, TransportError
 )
 ```
@@ -30,7 +30,7 @@ from kailash.mcp_server.errors import (
 ## Client Pattern (3 Lines)
 
 ```python
-from kailash.mcp_server import MCPClient
+from kailash_mcp import MCPClient
 
 client = MCPClient(enable_metrics=True)
 tools = await client.discover_tools(server_config)
@@ -42,7 +42,7 @@ result = await client.call_tool(server_config, "tool_name", {"arg": "value"})
 ## Simple Server Pattern (5 Lines)
 
 ```python
-from kailash.mcp_server import SimpleMCPServer
+from kailash_mcp import SimpleMCPServer
 
 server = SimpleMCPServer("my-tools")
 
@@ -131,7 +131,7 @@ results, _ = runtime.execute(
 ### API Key
 
 ```python
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp.auth import APIKeyAuth
 
 auth = APIKeyAuth({
     "admin_key": {"permissions": ["read", "write", "admin"]},
@@ -143,7 +143,7 @@ server = MCPServer("secure-server", auth_provider=auth)
 ### JWT
 
 ```python
-from kailash.mcp_server.auth import JWTAuth
+from kailash_mcp.auth import JWTAuth
 
 auth = JWTAuth(secret="my-secret", expiration=3600)
 token = auth.create_token({"user": "alice", "permissions": ["read", "write"]})
@@ -154,8 +154,8 @@ token = auth.create_token({"user": "alice", "permissions": ["read", "write"]})
 ## Production Server
 
 ```python
-from kailash.mcp_server import MCPServer
-from kailash.mcp_server.auth import JWTAuth
+from kailash_mcp import MCPServer
+from kailash_mcp.auth import JWTAuth
 
 auth = JWTAuth(secret="production-secret")
 server = MCPServer(
@@ -179,7 +179,7 @@ server.run()
 ## Service Discovery
 
 ```python
-from kailash.mcp_server import ServiceRegistry, ServerInfo
+from kailash_mcp import ServiceRegistry, ServerInfo
 
 registry = ServiceRegistry()
 
@@ -201,7 +201,7 @@ servers = await registry.discover_servers(capability="weather.get")
 ## Error Handling
 
 ```python
-from kailash.mcp_server.errors import (
+from kailash_mcp.errors import (
     MCPError, AuthenticationError, ToolError, TransportError
 )
 
@@ -223,7 +223,7 @@ except TransportError:
 ## Retry Strategies
 
 ```python
-from kailash.mcp_server import MCPClient
+from kailash_mcp import MCPClient
 
 # Exponential backoff
 client = MCPClient(retry_strategy="exponential")
@@ -243,7 +243,7 @@ client = MCPClient(
 
 ```python
 def test_mcp_client():
-    from kailash.mcp_server import MCPClient
+    from kailash_mcp import MCPClient
     client = MCPClient(enable_metrics=True)
     assert client.metrics is not None
 ```
@@ -253,7 +253,7 @@ def test_mcp_client():
 ```python
 @pytest.mark.integration
 async def test_real_server():
-    from kailash.mcp_server import MCPClient, MCPServer
+    from kailash_mcp import MCPClient, MCPServer
 
     server = MCPServer("test")
     @server.tool()
@@ -323,7 +323,7 @@ if health["status"] == "healthy":
 
 ## For Kaizen Integration
 
-1. **Replace** `from kaizen.mcp import ...` with `from kailash.mcp_server import ...`
+1. **Replace** `from kaizen.mcp import ...` with `from kailash_mcp import ...`
 2. **Use** Kailash's proven patterns instead of custom implementations
 3. **Follow** Kailash's 3-tier testing strategy
 4. **Reference** Kailash MCP docs in Kaizen documentation

--- a/packages/kailash-kaizen/docs/integrations/mcp/testing-guide.md
+++ b/packages/kailash-kaizen/docs/integrations/mcp/testing-guide.md
@@ -60,7 +60,7 @@ Test agent logic in isolation without network overhead or external dependencies.
 
 ```python
 import pytest
-from kailash.mcp_server import SimpleMCPServer
+from kailash_mcp import SimpleMCPServer
 
 @pytest.fixture
 def mock_mcp_server():
@@ -170,7 +170,7 @@ Test real MCP client-server communication with real JSON-RPC protocol.
 
 ```python
 import pytest
-from kailash.mcp_server import MCPClient, SimpleMCPServer
+from kailash_mcp import MCPClient, SimpleMCPServer
 
 @pytest.fixture
 async def real_mcp_server():
@@ -313,8 +313,8 @@ async def test_baseagent_call_mcp_tool():
 @pytest.mark.asyncio
 async def test_mcp_server_authentication():
     """Test MCP server with authentication."""
-    from kailash.mcp_server import MCPServer
-    from kailash.mcp_server.auth import APIKeyAuth
+    from kailash_mcp import MCPServer
+    from kailash_mcp.auth import APIKeyAuth
 
     # Create server with auth
     auth = APIKeyAuth({
@@ -465,7 +465,7 @@ async def test_mcp_workflow_performance():
 # tests/conftest.py
 
 import pytest
-from kailash.mcp_server import SimpleMCPServer, MCPClient
+from kailash_mcp import SimpleMCPServer, MCPClient
 
 @pytest.fixture
 def mock_mcp_server():
@@ -527,7 +527,7 @@ def mcp_server_configs():
 async def wait_for_server_ready(server_config, timeout=10):
     """Wait for MCP server to be ready."""
     import asyncio
-    from kailash.mcp_server import MCPClient
+    from kailash_mcp import MCPClient
 
     client = MCPClient()
     start_time = asyncio.get_event_loop().time()

--- a/packages/kailash-kaizen/examples/5-mcp-integration/agent-as-client/README.md
+++ b/packages/kailash-kaizen/examples/5-mcp-integration/agent-as-client/README.md
@@ -2,7 +2,7 @@
 
 ## ✅ Migration Complete (2025-10-04)
 
-This example has been **fully migrated** from deprecated `kaizen.mcp` to Kailash SDK's production-ready `kailash.mcp_server` implementation using BaseAgent helpers.
+This example has been **fully migrated** from deprecated `kaizen.mcp` to Kailash SDK's production-ready `kailash_mcp` implementation using BaseAgent helpers.
 
 ## Overview
 Demonstrates agents consuming external MCP (Model Context Protocol) tools using Kailash SDK's production-ready MCP implementation. This pattern uses BaseAgent helpers for simplified MCP integration with real JSON-RPC 2.0 protocol.
@@ -18,7 +18,7 @@ from kaizen.mcp import MCPConnection, MCPRegistry, AutoDiscovery
 
 # ✅ NEW (via BaseAgent helpers)
 from kaizen.core.base_agent import BaseAgent
-# kailash.mcp_server imported internally by BaseAgent
+# kailash_mcp imported internally by BaseAgent
 ```
 
 #### 2. **Connection Setup** - Manual → Helper-based
@@ -316,7 +316,7 @@ class MCPClientConfig:
 
 ### Dependencies
 ```bash
-pip install kailash  # Includes kailash.mcp_server
+pip install kailash  # Includes kailash_mcp
 ```
 
 ### Python Imports
@@ -477,7 +477,7 @@ npx @modelcontextprotocol/server-filesystem ./data
 
 ### Common Issues
 
-#### 1. Import Error: `kailash.mcp_server not available`
+#### 1. Import Error: `kailash_mcp not available`
 ```bash
 # Solution: Install full Kailash SDK
 pip install kailash --upgrade

--- a/packages/kailash-kaizen/examples/5-mcp-integration/agent-as-server/README.md
+++ b/packages/kailash-kaizen/examples/5-mcp-integration/agent-as-server/README.md
@@ -7,7 +7,7 @@
 This example demonstrates exposing Kaizen agent capabilities as MCP (Model Context Protocol) servers using Kailash SDK's production-ready MCP implementation via BaseAgent helpers.
 
 **Key Features**:
-- Real kailash.mcp_server.MCPServer (100% MCP spec compliant)
+- Real kailash_mcp.MCPServer (100% MCP spec compliant)
 - BaseAgent.expose_as_mcp_server() helper for automatic server creation
 - Real JSON-RPC 2.0 protocol (no mocking)
 - Multi-transport support (STDIO, HTTP, WebSocket, SSE)
@@ -45,10 +45,10 @@ def handle_mcp_request(self, tool_name, arguments):
     ...
 ```
 
-### After (Production kailash.mcp_server via BaseAgent)
+### After (Production kailash_mcp via BaseAgent)
 ```python
 from kaizen.core.base_agent import BaseAgent
-from kailash.mcp_server.auth import APIKeyAuth  # Only if auth needed
+from kailash_mcp.auth import APIKeyAuth  # Only if auth needed
 
 # Create auth provider (optional)
 auth = APIKeyAuth({"client1": {"permissions": ["tools.*"]}})
@@ -79,7 +79,7 @@ from kaizen.mcp import MCPServerConfig, MCPRegistry, EnterpriseFeatures
 
 # NEW (via BaseAgent)
 from kaizen.core.base_agent import BaseAgent
-# kailash.mcp_server imported internally by BaseAgent
+# kailash_mcp imported internally by BaseAgent
 ```
 
 ### 2. Server Setup
@@ -259,9 +259,9 @@ from kaizen.core.base_agent import BaseAgent, BaseAgentConfig
 from kaizen.signatures import Signature, InputField, OutputField
 
 # Authentication (optional)
-from kailash.mcp_server.auth import APIKeyAuth, JWTAuth, BearerTokenAuth
+from kailash_mcp.auth import APIKeyAuth, JWTAuth, BearerTokenAuth
 
-# NOTE: kailash.mcp_server imported internally by BaseAgent
+# NOTE: kailash_mcp imported internally by BaseAgent
 # No direct imports needed in agent code!
 ```
 
@@ -319,7 +319,7 @@ Agent Methods → BaseAgent.expose_as_mcp_server() → Production MCPServer
 
 ### API Key Authentication
 ```python
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp.auth import APIKeyAuth
 
 auth = APIKeyAuth({
     "demo-key": {
@@ -333,7 +333,7 @@ auth = APIKeyAuth({
 
 ### JWT Authentication
 ```python
-from kailash.mcp_server.auth import JWTAuth
+from kailash_mcp.auth import JWTAuth
 
 auth = JWTAuth(
     secret=os.getenv("JWT_SECRET", "your-secret"),
@@ -343,7 +343,7 @@ auth = JWTAuth(
 
 ### Bearer Token Authentication
 ```python
-from kailash.mcp_server.auth import BearerTokenAuth
+from kailash_mcp.auth import BearerTokenAuth
 
 auth = BearerTokenAuth(
     valid_tokens=["token1", "token2"]

--- a/packages/kailash-kaizen/examples/5-mcp-integration/auto-discovery-routing/README.md
+++ b/packages/kailash-kaizen/examples/5-mcp-integration/auto-discovery-routing/README.md
@@ -100,7 +100,7 @@ result = await agent.route_request(
 ### 1. Installation
 
 ```bash
-pip install kailash  # Includes kailash.mcp_server
+pip install kailash  # Includes kailash_mcp
 ```
 
 ### 2. Run the Example
@@ -374,7 +374,7 @@ config = AutoDiscoveryAgentConfig(
 ### 2. Service Mesh with Authentication
 
 ```python
-from kailash.mcp_server.auth import APIKeyAuth
+from kailash_mcp.auth import APIKeyAuth
 
 # Configure agent with auth
 config = AutoDiscoveryAgentConfig(
@@ -490,7 +490,7 @@ async def test_real_service_discovery():
 
 ## Comparison with Previous Implementation
 
-| Feature | Deprecated kaizen.mcp | Production kailash.mcp_server |
+| Feature | Deprecated kaizen.mcp | Production kailash_mcp |
 |---------|----------------------|-------------------------------|
 | Service Discovery | String matching | Real network discovery + registry |
 | Load Balancing | Manual | ServiceMesh with strategies |

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "kailash>=2.8.1",
+    "kailash-mcp>=0.2.3",
     "pydantic>=2.0.0",
     "typing-extensions>=4.5.0",
     "PyJWT>=2.8.0",

--- a/packages/kailash-nexus/docs/IMPLEMENTATION_GUIDE.md
+++ b/packages/kailash-nexus/docs/IMPLEMENTATION_GUIDE.md
@@ -37,7 +37,7 @@ self._gateway = create_gateway(
 ### 2. MCPClient (Production MCP)
 
 ```python
-from kailash.mcp_server.client import MCPClient
+from kailash_mcp.client import MCPClient
 
 # Use SDK's production MCP client
 mcp_client = MCPClient(

--- a/scripts/hooks/enforce-framework-first.js
+++ b/scripts/hooks/enforce-framework-first.js
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Hook: enforce-framework-first
+ * Event: PostToolUse
+ * Matcher: Write, Edit
+ * Purpose: Block raw library imports when a Kailash Engine/framework exists.
+ *          CC sees the block reason, rewrites using the framework, continues autonomously.
+ *
+ * Exit Codes:
+ *   0 = success (continue)
+ *   2 = blocking error (stop tool execution)
+ */
+
+const TIMEOUT_MS = 5000;
+const timeout = setTimeout(() => {
+  console.log(JSON.stringify({ continue: true }));
+  process.exit(1);
+}, TIMEOUT_MS);
+
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => (input += chunk));
+process.stdin.on("end", () => {
+  clearTimeout(timeout);
+  try {
+    const data = JSON.parse(input);
+    const result = checkForRawFrameworks(data);
+    console.log(JSON.stringify(result.output));
+    process.exit(result.exitCode);
+  } catch (error) {
+    console.log(JSON.stringify({ continue: true }));
+    process.exit(1);
+  }
+});
+
+const BLOCKED_IMPORTS = [
+  // ── Nexus: API endpoints, web services, HTTP servers ──
+  // Patterns include both imports AND framework-specific usage signatures, so
+  // an Edit that adds a new @app.get(...) route to an existing FastAPI file
+  // triggers the hook even when the import line is outside the diff. The
+  // import-only check missed this case (red team #445 finding 13).
+  {
+    patterns: [
+      // Imports (catch new files / file rewrites)
+      /\bfrom\s+fastapi\s+import\b/,
+      /\bimport\s+fastapi\b/,
+      /\bfrom\s+flask\s+import\b/,
+      /\bimport\s+flask\b/,
+      /\bfrom\s+starlette\b/,
+      /\bimport\s+starlette\b/,
+      /\bfrom\s+aiohttp\s+import\b/,
+      /\bimport\s+aiohttp\b/,
+      /\bfrom\s+sanic\s+import\b/,
+      /\bimport\s+sanic\b/,
+      // FastAPI usage signatures (catch edits that add new endpoints/routes)
+      /@app\.(get|post|put|delete|patch|head|options|websocket|middleware)\(/,
+      /@router\.(get|post|put|delete|patch|head|options|websocket)\(/,
+      /\bFastAPI\(/,
+      /\bAPIRouter\(/,
+    ],
+    framework: "Nexus",
+    specialist: "nexus-specialist",
+    guide: ".claude/skills/03-nexus/nexus-for-fastapi-users.md",
+    reason:
+      "Use Nexus for all API endpoints, web services, HTTP servers. " +
+      "Nexus() gives you API + CLI + MCP from a single handler registration. " +
+      "Consult nexus-specialist or read the translation guide.",
+  },
+
+  // ── DataFlow: database, SQL, ORM ──
+  {
+    patterns: [
+      /\bfrom\s+sqlalchemy\s+import\b/,
+      /\bimport\s+sqlalchemy\b/,
+      /\bfrom\s+psycopg2?\s+import\b/,
+      /\bimport\s+psycopg2?\b/,
+      /\bfrom\s+asyncpg\s+import\b/,
+      /\bimport\s+asyncpg\b/,
+      /\bimport\s+sqlite3\b/,
+      /\bfrom\s+sqlite3\s+import\b/,
+      /\bfrom\s+django\.db\s+import\b/,
+      /\bfrom\s+peewee\s+import\b/,
+      /\bimport\s+peewee\b/,
+      /\bfrom\s+tortoise\s+import\b/,
+      /\bimport\s+tortoise\b/,
+      /\bfrom\s+sqlmodel\s+import\b/,
+      /\bimport\s+sqlmodel\b/,
+      /\bfrom\s+databases\s+import\b/,
+      /\bimport\s+databases\b/,
+    ],
+    framework: "DataFlow",
+    specialist: "dataflow-specialist",
+    guide: ".claude/skills/02-dataflow/SKILL.md",
+    reason:
+      "Use DataFlow for all database operations. " +
+      "DataFlowEngine.builder() for production, db.express for CRUD, @db.model for schemas. " +
+      "Consult dataflow-specialist.",
+  },
+
+  // ── Kaizen: LLM calls, agents, completions ──
+  {
+    patterns: [
+      /\bfrom\s+openai\s+import\b/,
+      /\bimport\s+openai\b/,
+      /\bfrom\s+anthropic\s+import\b/,
+      /\bimport\s+anthropic\b/,
+      /\bfrom\s+google\.generativeai\b/,
+      /\bimport\s+google\.generativeai\b/,
+      /\bfrom\s+litellm\s+import\b/,
+      /\bimport\s+litellm\b/,
+      /\bfrom\s+langchain\b/,
+      /\bimport\s+langchain\b/,
+      /\bfrom\s+llama_index\b/,
+      /\bimport\s+llama_index\b/,
+      /\bfrom\s+dspy\b/,
+      /\bimport\s+dspy\b/,
+    ],
+    framework: "Kaizen",
+    specialist: "kaizen-specialist",
+    guide: ".claude/skills/04-kaizen/SKILL.md",
+    reason:
+      "Use Kaizen for all LLM calls, agents, and AI work. " +
+      "Delegate for autonomous agents, BaseAgent + Signature for custom logic. " +
+      "Consult kaizen-specialist.",
+  },
+
+  // ── ML: classical/deep learning ──
+  {
+    patterns: [
+      /\bfrom\s+sklearn\b/,
+      /\bimport\s+sklearn\b/,
+      /\bfrom\s+xgboost\s+import\b/,
+      /\bimport\s+xgboost\b/,
+      /\bfrom\s+lightgbm\s+import\b/,
+      /\bimport\s+lightgbm\b/,
+      /\bfrom\s+catboost\s+import\b/,
+      /\bimport\s+catboost\b/,
+      /\bfrom\s+torch\s+import\b/,
+      /\bimport\s+torch\b/,
+      /\bfrom\s+tensorflow\s+import\b/,
+      /\bimport\s+tensorflow\b/,
+    ],
+    framework: "Kailash ML",
+    specialist: "ml-specialist",
+    guide: ".claude/skills/34-kailash-ml/SKILL.md",
+    reason:
+      "Use Kailash ML for all ML training, inference, and feature work. " +
+      "AutoMLEngine for end-to-end, FeatureStore + ModelRegistry + TrainingPipeline for control. " +
+      "Consult ml-specialist.",
+  },
+
+  // ── Align: LLM fine-tuning, LoRA, alignment ──
+  {
+    patterns: [
+      /\bfrom\s+transformers\s+import\b/,
+      /\bimport\s+transformers\b/,
+      /\bfrom\s+peft\s+import\b/,
+      /\bimport\s+peft\b/,
+      /\bfrom\s+trl\s+import\b/,
+      /\bimport\s+trl\b/,
+    ],
+    framework: "Kailash Align",
+    specialist: "align-specialist",
+    guide: ".claude/skills/35-kailash-align/SKILL.md",
+    reason:
+      "Use Kailash Align for all fine-tuning, LoRA, and alignment work. " +
+      "align.train() + align.deploy() for end-to-end. " +
+      "Consult align-specialist.",
+  },
+];
+
+function checkForRawFrameworks(data) {
+  const filePath = data.tool_input?.file_path || "";
+  const content = data.tool_input?.content || data.tool_input?.new_string || "";
+
+  if (!content || !filePath) {
+    return { output: { continue: true }, exitCode: 0 };
+  }
+
+  if (isExcluded(filePath)) {
+    return { output: { continue: true }, exitCode: 0 };
+  }
+
+  for (const group of BLOCKED_IMPORTS) {
+    for (const pattern of group.patterns) {
+      if (pattern.test(content)) {
+        const lib = content.match(pattern)?.[0] || "raw import";
+        return {
+          output: {
+            continue: false,
+            reason:
+              `BLOCKED: ${lib} in ${filePath}. ` +
+              `${group.reason} ` +
+              `Guide: ${group.guide}`,
+          },
+          exitCode: 2,
+        };
+      }
+    }
+  }
+
+  return { output: { continue: true }, exitCode: 0 };
+}
+
+function isExcluded(filePath) {
+  // Test files — raw imports allowed for testing
+  if (
+    /[\\/]tests?[\\/]/.test(filePath) ||
+    /[\\/]__tests__[\\/]/.test(filePath) ||
+    /\.test\.[jt]sx?$/.test(filePath) ||
+    /\.spec\.[jt]sx?$/.test(filePath) ||
+    /test_[^/\\]+\.py$/.test(filePath) ||
+    /[^/\\]+_test\.py$/.test(filePath) ||
+    /conftest\.py$/.test(filePath)
+  )
+    return true;
+
+  // Config, docs, hooks, artifacts — not application code
+  if (
+    /[\\/]hooks[\\/]/.test(filePath) ||
+    /[\\/]\.claude[\\/]/.test(filePath) ||
+    /\.md$/.test(filePath) ||
+    /\.ya?ml$/.test(filePath) ||
+    /\.toml$/.test(filePath) ||
+    /\.json$/.test(filePath)
+  )
+    return true;
+
+  // BUILD repo — only the adapter/backend/transport/store layer uses raw imports.
+  // Engines, features, API, servers MUST use the SDK's own primitives.
+  if (
+    /[\\/]adapters[\\/]/.test(filePath) ||
+    /[\\/]backends[\\/]/.test(filePath) ||
+    /[\\/]transports[\\/]/.test(filePath) ||
+    /[\\/]providers[\\/]/.test(filePath) ||
+    /[\\/]drivers[\\/]/.test(filePath) ||
+    /[\\/]middleware[\\/]database[\\/]/.test(filePath) ||
+    /[\\/]middleware[\\/]gateway[\\/]event_store/.test(filePath) ||
+    /[\\/]trust[\\/].*store/.test(filePath) ||
+    /[\\/]trust[\\/]constraints[\\/]/.test(filePath) ||
+    /[\\/]trust[\\/]enforce[\\/]/.test(filePath) ||
+    /[\\/]crates[\\/]/.test(filePath) ||
+    /[\\/]src[\\/]lib\.rs$/.test(filePath) ||
+    /[\\/]src[\\/]main\.rs$/.test(filePath)
+  )
+    return true;
+
+  return false;
+}

--- a/specs/kaizen-core.md
+++ b/specs/kaizen-core.md
@@ -108,6 +108,17 @@ from kaizen import Signature, InputField, OutputField  # Signature system
 
 The deprecated sync `Agent` in `kaizen.agent` emits `DeprecationWarning` on import and will be removed in 3.0.0. Do not import from `kaizen.agent` directly.
 
+### Package Dependencies
+
+`kailash-kaizen` requires these Kailash packages at runtime:
+
+| Package              | Import name   | Required by                     | Reason                                   |
+| -------------------- | ------------- | ------------------------------- | ---------------------------------------- |
+| `kailash` (core SDK) | `kailash`     | Framework foundation            | Workflow, runtime, nodes                 |
+| `kailash-mcp`        | `kailash_mcp` | MCP tool integration (11 files) | `MCPClient`, `MCPServer`, auto-discovery |
+
+`kailash-mcp` is imported unconditionally in `base_agent.py`, `mcp_mixin.py`, `iterative_llm_agent.py`, `llm_agent.py`, and `mcp/builtin_server/server.py`. It MUST be a hard dependency, not optional.
+
 ---
 
 ## 3. BaseAgent

--- a/specs/kaizen-core.md
+++ b/specs/kaizen-core.md
@@ -112,12 +112,19 @@ The deprecated sync `Agent` in `kaizen.agent` emits `DeprecationWarning` on impo
 
 `kailash-kaizen` requires these Kailash packages at runtime:
 
-| Package              | Import name   | Required by                     | Reason                                   |
-| -------------------- | ------------- | ------------------------------- | ---------------------------------------- |
-| `kailash` (core SDK) | `kailash`     | Framework foundation            | Workflow, runtime, nodes                 |
-| `kailash-mcp`        | `kailash_mcp` | MCP tool integration (11 files) | `MCPClient`, `MCPServer`, auto-discovery |
+| Package              | Import name   | Required by                    | Reason                                   |
+| -------------------- | ------------- | ------------------------------ | ---------------------------------------- |
+| `kailash` (core SDK) | `kailash`     | Framework foundation           | Workflow, runtime, nodes                 |
+| `kailash-mcp`        | `kailash_mcp` | MCP tool integration (6 files) | `MCPClient`, `MCPServer`, auto-discovery |
 
-`kailash-mcp` is imported unconditionally in `base_agent.py`, `mcp_mixin.py`, `iterative_llm_agent.py`, `llm_agent.py`, and `mcp/builtin_server/server.py`. It MUST be a hard dependency, not optional.
+`kailash-mcp` is imported unconditionally at module load in **2 files** (verified by `rg '^from kailash_mcp|^import kailash_mcp' packages/kailash-kaizen/src/`):
+
+- `kaizen/core/base_agent.py` — base class for every Kaizen agent; the unconditional import here is what makes `kailash-mcp` a hard dependency rather than an optional extra.
+- `kaizen/mcp/builtin_server/server.py` — the bundled built-in MCP server.
+
+4 additional files (`mcp_mixin.py`, `iterative_llm_agent.py`, `llm_agent.py`, `mcp/builtin_server/tools/__init__.py`) use lazy imports inside method bodies. These would not, by themselves, force a hard dependency — but `base_agent.py` is the base class of every agent, so any `import kaizen` triggers the kailash-mcp import path.
+
+Verified by `tests/regression/test_issue_443_kaizen_mcp_dependency.py` which asserts `kailash-mcp` appears in `kailash-kaizen`'s install metadata via `importlib.metadata.requires()` AND exercises the actual import chain (`from kaizen.core.base_agent import BaseAgent` → `from kaizen_agents import Delegate`).
 
 ---
 

--- a/src/kailash/db/dialect.py
+++ b/src/kailash/db/dialect.py
@@ -34,6 +34,21 @@ _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _JSON_PATH_RE = re.compile(r"^[a-zA-Z0-9_.]+$")
 
 
+def _identifier_fingerprint(name: object) -> str:
+    """Return a 4-hex-digit fingerprint of *name* safe on unhashable inputs.
+
+    The fingerprint is a stable, non-reversible tag that lets operators
+    correlate errors in logs without echoing the raw (possibly malicious)
+    payload. Unhashable inputs (``dict``, ``list``, ``set``) that would
+    otherwise crash ``hash()`` are fingerprinted as ``"____"`` so the
+    caller can still raise a typed ``ValueError`` with a useful marker.
+    """
+    try:
+        return f"{hash(name) & 0xFFFF:04x}"
+    except TypeError:
+        return "____"
+
+
 def _validate_identifier(name: str, *, max_length: int = 128) -> None:
     """Validate a SQL identifier (table or column name).
 
@@ -48,25 +63,28 @@ def _validate_identifier(name: str, *, max_length: int = 128) -> None:
     Raises
     ------
     ValueError
-        If *name* contains characters that could enable SQL injection,
-        or exceeds the length limit.
+        If *name* is not a string, exceeds the length limit, or
+        contains characters that could enable SQL injection.
+        Unhashable non-string inputs (``dict``, ``list``, ``set``)
+        raise ``ValueError`` — NOT ``TypeError`` — because the
+        fingerprint helper is safe on unhashable values.
     """
     if not isinstance(name, str):
         raise ValueError(
             f"Invalid SQL identifier "
-            f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+            f"(fingerprint={_identifier_fingerprint(name)}): "
             f"must be a string, got {type(name).__name__}"
         )
     if len(name) > max_length:
         raise ValueError(
             f"Invalid SQL identifier "
-            f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+            f"(fingerprint={_identifier_fingerprint(name)}): "
             f"exceeds {max_length}-char limit (len={len(name)})"
         )
     if not _IDENTIFIER_RE.match(name):
         raise ValueError(
             f"Invalid SQL identifier "
-            f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+            f"(fingerprint={_identifier_fingerprint(name)}): "
             "must match [a-zA-Z_][a-zA-Z0-9_]*"
         )
 

--- a/src/kailash/db/dialect.py
+++ b/src/kailash/db/dialect.py
@@ -51,11 +51,17 @@ def _validate_identifier(name: str, *, max_length: int = 128) -> None:
         If *name* contains characters that could enable SQL injection,
         or exceeds the length limit.
     """
-    if not isinstance(name, str) or len(name) > max_length:
+    if not isinstance(name, str):
         raise ValueError(
             f"Invalid SQL identifier "
             f"(fingerprint={hash(name) & 0xFFFF:04x}): "
-            f"exceeds {max_length}-char limit or not a string"
+            f"must be a string, got {type(name).__name__}"
+        )
+    if len(name) > max_length:
+        raise ValueError(
+            f"Invalid SQL identifier "
+            f"(fingerprint={hash(name) & 0xFFFF:04x}): "
+            f"exceeds {max_length}-char limit (len={len(name)})"
         )
     if not _IDENTIFIER_RE.match(name):
         raise ValueError(

--- a/src/kailash/infrastructure/dlq.py
+++ b/src/kailash/infrastructure/dlq.py
@@ -68,6 +68,18 @@ class DBDeadLetterQueue:
         conn_manager: ConnectionManager,
         base_delay: float = DEFAULT_BASE_DELAY,
     ) -> None:
+        # Defense-in-depth per dataflow-identifier-safety.md Rule 5:
+        # `TABLE_NAME` is interpolated into 12+ DML strings on every
+        # operation. Validate at construction time so a subclass that
+        # overrides `TABLE_NAME` is rejected immediately, not when the
+        # first INSERT happens to fire. Validating once in `__init__`
+        # is the single enforcement point for every interpolation site.
+        from kailash.db.dialect import _validate_identifier
+
+        _validate_identifier(self.TABLE_NAME)
+        for suffix in ("status", "next_retry", "created"):
+            _validate_identifier(f"idx_{self.TABLE_NAME}_{suffix}")
+
         self._conn = conn_manager
         self._base_delay = base_delay
 
@@ -76,16 +88,6 @@ class DBDeadLetterQueue:
     # ------------------------------------------------------------------
     async def initialize(self) -> None:
         """Create the DLQ table and indices if they do not exist."""
-        # Defense-in-depth per dataflow-identifier-safety.md Rule 5: validate
-        # every identifier interpolated into DDL, even hardcoded ones, so a
-        # future refactor that makes TABLE_NAME configurable cannot bypass
-        # the gate by accident.
-        from kailash.db.dialect import _validate_identifier
-
-        _validate_identifier(self.TABLE_NAME)
-        for suffix in ("status", "next_retry", "created"):
-            _validate_identifier(f"idx_{self.TABLE_NAME}_{suffix}")
-
         await self._conn.execute(
             f"""
             CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (

--- a/src/kailash/infrastructure/dlq.py
+++ b/src/kailash/infrastructure/dlq.py
@@ -76,6 +76,16 @@ class DBDeadLetterQueue:
     # ------------------------------------------------------------------
     async def initialize(self) -> None:
         """Create the DLQ table and indices if they do not exist."""
+        # Defense-in-depth per dataflow-identifier-safety.md Rule 5: validate
+        # every identifier interpolated into DDL, even hardcoded ones, so a
+        # future refactor that makes TABLE_NAME configurable cannot bypass
+        # the gate by accident.
+        from kailash.db.dialect import _validate_identifier
+
+        _validate_identifier(self.TABLE_NAME)
+        for suffix in ("status", "next_retry", "created"):
+            _validate_identifier(f"idx_{self.TABLE_NAME}_{suffix}")
+
         await self._conn.execute(
             f"""
             CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (

--- a/src/kailash/workflow/dlq.py
+++ b/src/kailash/workflow/dlq.py
@@ -84,6 +84,21 @@ class PersistentDLQ:
         db_path: str = "./kailash_dlq.db",
         base_delay: float = DEFAULT_BASE_DELAY,
     ) -> None:
+        # Defense-in-depth per dataflow-identifier-safety.md Rule 5:
+        # validate every hardcoded identifier interpolated into DDL at
+        # construction time, BEFORE any subclass override of
+        # `_initialize_schema` could bypass the validator. This is the
+        # single enforcement point for every DDL/DML interpolation site.
+        from kailash.db.dialect import _validate_identifier
+
+        for ident in (
+            "dlq",
+            "idx_dlq_status",
+            "idx_dlq_next_retry",
+            "idx_dlq_created",
+        ):
+            _validate_identifier(ident)
+
         self._db_path = db_path
         self._base_delay = base_delay
         self._lock = threading.Lock()
@@ -112,20 +127,8 @@ class PersistentDLQ:
         self._conn.commit()
 
     def _initialize_schema(self) -> None:
-        # Defense-in-depth per dataflow-identifier-safety.md Rule 5: every
-        # hardcoded identifier interpolated into DDL MUST route through the
-        # validator at the call site. Hardcoded today; a future refactor that
-        # makes the table name configurable must not silently bypass the gate.
-        from kailash.db.dialect import _validate_identifier
-
-        for ident in (
-            "dlq",
-            "idx_dlq_status",
-            "idx_dlq_next_retry",
-            "idx_dlq_created",
-        ):
-            _validate_identifier(ident)
-
+        # Identifiers are validated in __init__ before this method is
+        # called; see the comment there for the rationale.
         cursor = self._conn.cursor()
         cursor.execute(
             """

--- a/src/kailash/workflow/dlq.py
+++ b/src/kailash/workflow/dlq.py
@@ -112,6 +112,20 @@ class PersistentDLQ:
         self._conn.commit()
 
     def _initialize_schema(self) -> None:
+        # Defense-in-depth per dataflow-identifier-safety.md Rule 5: every
+        # hardcoded identifier interpolated into DDL MUST route through the
+        # validator at the call site. Hardcoded today; a future refactor that
+        # makes the table name configurable must not silently bypass the gate.
+        from kailash.db.dialect import _validate_identifier
+
+        for ident in (
+            "dlq",
+            "idx_dlq_status",
+            "idx_dlq_next_retry",
+            "idx_dlq_created",
+        ):
+            _validate_identifier(ident)
+
         cursor = self._conn.cursor()
         cursor.execute(
             """

--- a/tests/regression/test_arbor_database_url_special_chars.py
+++ b/tests/regression/test_arbor_database_url_special_chars.py
@@ -608,10 +608,20 @@ class TestArborSharedMaskUrl:
         assert mask_url("sqlite:///tmp/app.db") == "sqlite:///tmp/app.db"
 
     def test_mask_url_none_and_empty(self):
-        from dataflow.utils.masking import mask_url
+        """None / empty input MUST return the unparseable sentinel.
 
-        assert mask_url(None) == ""
-        assert mask_url("") == ""
+        Updated 2026-04-14: the `mask_url` contract was hardened in PR #444
+        to return UNPARSEABLE_URL_SENTINEL for None, empty, and non-URL
+        inputs (defense-in-depth per observability rule 6.1). Returning ""
+        is BLOCKED because it conflates "no URL passed" with "URL has no
+        credentials to mask" — both produce empty strings, hiding bugs
+        where the helper was called with the wrong argument.
+        """
+        from dataflow.utils.masking import mask_url
+        from kailash.utils.url_credentials import UNPARSEABLE_URL_SENTINEL
+
+        assert mask_url(None) == UNPARSEABLE_URL_SENTINEL
+        assert mask_url("") == UNPARSEABLE_URL_SENTINEL
 
     def test_mask_url_multi_host_with_query_no_path(self):
         """Replica-set URL with query but NO path — query must still mask.

--- a/tests/regression/test_issue_443_kaizen_mcp_dependency.py
+++ b/tests/regression/test_issue_443_kaizen_mcp_dependency.py
@@ -61,17 +61,18 @@ def test_kailash_kaizen_declares_kailash_mcp_dependency():
     (per rules/testing.md) — it reads the actual install metadata that pip
     and uv use at install time.
     """
+    from packaging.requirements import Requirement
+
     requires = importlib.metadata.requires("kailash-kaizen")
     assert (
         requires is not None
     ), "kailash-kaizen has no requires metadata — package may be broken"
 
-    has_kailash_mcp = any(
-        req.split()[0].split(";")[0].split(">=")[0].split("==")[0].strip()
-        == "kailash-mcp"
-        for req in requires
-    )
-    assert has_kailash_mcp, (
+    # Use the canonical requirement parser instead of hand-rolled split()
+    # chains: handles >=, <=, ~=, !=, ==, extras, environment markers,
+    # and combined specifiers like "kailash-mcp>=0.2.3,<1.0".
+    declared_names = {Requirement(req).name for req in requires}
+    assert "kailash-mcp" in declared_names, (
         f"kailash-kaizen does NOT declare kailash-mcp as a dependency. "
-        f"Requirements: {requires}"
+        f"Declared: {sorted(declared_names)}"
     )

--- a/tests/regression/test_issue_443_kaizen_mcp_dependency.py
+++ b/tests/regression/test_issue_443_kaizen_mcp_dependency.py
@@ -1,0 +1,77 @@
+"""Regression tests for issue #443 — kailash-kaizen missing kailash-mcp dependency.
+
+Issue: https://github.com/terrene-foundation/kailash-py/issues/443
+
+kailash-kaizen >= 2.7.0 imports `from kailash_mcp.client import MCPClient` in
+`kaizen/core/base_agent.py` (top-level, unconditional). Without `kailash-mcp`
+declared as a dependency, fresh PyPI installs of kailash-kaizen fail with
+ModuleNotFoundError on `import kaizen`.
+
+These tests are behavioral (per rules/testing.md): they exercise the actual
+import path AND verify the dependency declaration via importlib.metadata
+(install-time config, not source-grep).
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+import pytest
+
+
+@pytest.mark.regression
+def test_kailash_mcp_module_imports():
+    """Issue #443: kailash_mcp must be importable in the kailash-kaizen runtime."""
+    import kailash_mcp  # noqa: F401
+
+    assert kailash_mcp is not None
+
+
+@pytest.mark.regression
+def test_kaizen_base_agent_imports():
+    """Issue #443: kaizen.core.base_agent imports kailash_mcp.client at top level.
+
+    If kailash-mcp is missing from the runtime, this import raises
+    ModuleNotFoundError because base_agent.py:34 imports MCPClient
+    unconditionally at module load time.
+    """
+    from kaizen.core.base_agent import BaseAgent
+
+    assert BaseAgent is not None
+
+
+@pytest.mark.regression
+def test_kaizen_agents_delegate_imports():
+    """Issue #443: kaizen_agents.Delegate is the canonical async agent entry point.
+
+    kaizen_agents.Delegate inherits from kaizen.core BaseAgent, so the same
+    import chain that broke base_agent broke every Delegate consumer.
+    """
+    from kaizen_agents import Delegate
+
+    assert Delegate is not None
+
+
+@pytest.mark.regression
+def test_kailash_kaizen_declares_kailash_mcp_dependency():
+    """Issue #443: kailash-kaizen's package metadata MUST list kailash-mcp.
+
+    Reading install-time requirements via importlib.metadata is the
+    canonical way to verify a dependency declaration. This is NOT source-grep
+    (per rules/testing.md) — it reads the actual install metadata that pip
+    and uv use at install time.
+    """
+    requires = importlib.metadata.requires("kailash-kaizen")
+    assert (
+        requires is not None
+    ), "kailash-kaizen has no requires metadata — package may be broken"
+
+    has_kailash_mcp = any(
+        req.split()[0].split(";")[0].split(">=")[0].split("==")[0].strip()
+        == "kailash-mcp"
+        for req in requires
+    )
+    assert has_kailash_mcp, (
+        f"kailash-kaizen does NOT declare kailash-mcp as a dependency. "
+        f"Requirements: {requires}"
+    )

--- a/tests/regression/test_issue_446_dlq_identifier_validation.py
+++ b/tests/regression/test_issue_446_dlq_identifier_validation.py
@@ -1,0 +1,107 @@
+"""Regression tests for issue #446 — DLQ hardcoded DDL identifiers must validate.
+
+Issue: https://github.com/terrene-foundation/kailash-py/issues/446
+
+The original issue framed `workflow/dlq.py`'s use of raw `sqlite3` as a
+framework-first violation. Analysis showed the DLQ is a legitimate
+resilience primitive that bootstraps before DataFlow, with the
+dialect-portable variant already living in `infrastructure/dlq.py`.
+
+Red team review revealed the real gap: the DLQ's hardcoded DDL
+identifiers (`dlq`, `idx_dlq_status`, etc.) were interpolated into DDL
+strings without routing through `_validate_identifier()`. Per
+`dataflow-identifier-safety.md` Rule 5, every identifier in DDL — even
+hardcoded ones — MUST route through the validator at the call site.
+This is defense-in-depth: hardcoded lists become dynamic lists during
+refactors, and the validator marks the intent permanently.
+
+These tests are behavioral (per `rules/testing.md`):
+
+1. ``PersistentDLQ`` initialization with default config succeeds —
+   proves the validator passes for all current hardcoded names.
+2. Patching the validator to reject the hardcoded name causes
+   initialization to fail — proves the validator is actually wired
+   into the path, not bypassed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.regression
+def test_persistent_dlq_initializes_with_validated_identifiers(tmp_path: Path) -> None:
+    """Issue #446: PersistentDLQ init succeeds — validator passes for hardcoded names."""
+    from kailash.workflow.dlq import PersistentDLQ
+
+    dlq_path = tmp_path / "dlq.sqlite"
+    dlq = PersistentDLQ(db_path=str(dlq_path))
+    try:
+        # If initialization completes, the validator accepted every hardcoded
+        # identifier (`dlq`, `idx_dlq_status`, `idx_dlq_next_retry`, `idx_dlq_created`).
+        stats = dlq.get_stats()
+        assert stats["total"] == 0
+    finally:
+        dlq.close()
+
+
+@pytest.mark.regression
+def test_persistent_dlq_initialization_calls_validator(tmp_path: Path) -> None:
+    """Issue #446: PersistentDLQ init MUST route every hardcoded identifier
+    through ``_validate_identifier()`` — proves the validator is actually
+    wired into the DDL path, not declared and then bypassed.
+
+    This is the load-bearing test: if a refactor accidentally drops the
+    validator call, this test fails.
+    """
+    from kailash.workflow import dlq as dlq_module
+    from kailash.db import dialect as dialect_module
+
+    # Capture the REAL validator before patching. Re-importing inside the
+    # spy would resolve to the patched object and recurse forever.
+    real_validator = dialect_module._validate_identifier
+
+    seen_identifiers: list[str] = []
+
+    def spy(name: str, *, max_length: int = 128) -> None:
+        seen_identifiers.append(name)
+        # Defer to the real validator so any invalid name still raises.
+        real_validator(name, max_length=max_length)
+
+    with patch.object(dialect_module, "_validate_identifier", side_effect=spy):
+        dlq_path = tmp_path / "dlq.sqlite"
+        dlq = dlq_module.PersistentDLQ(db_path=str(dlq_path))
+        dlq.close()
+
+    # The DLQ MUST validate at least the table name and its indices.
+    expected = {"dlq", "idx_dlq_status", "idx_dlq_next_retry", "idx_dlq_created"}
+    seen = set(seen_identifiers)
+    missing = expected - seen
+    assert not missing, (
+        f"PersistentDLQ initialization did not validate: {missing}. "
+        f"Hardcoded DDL identifiers MUST route through _validate_identifier "
+        f"per dataflow-identifier-safety.md Rule 5."
+    )
+
+
+@pytest.mark.regression
+def test_dlq_identifier_validator_rejects_injection_attempts() -> None:
+    """Issue #446: The validator used by the DLQ MUST reject SQL injection
+    payloads. Proves the validator is the right defense, not just a no-op.
+    """
+    from kailash.db.dialect import _validate_identifier
+
+    injection_payloads = [
+        'dlq"; DROP TABLE customers; --',
+        "dlq WITH DATA",
+        "1_starts_with_digit",
+        "dlq; SELECT * FROM users",
+        "",
+        "dlq with space",
+    ]
+    for payload in injection_payloads:
+        with pytest.raises(ValueError):
+            _validate_identifier(payload)

--- a/tests/regression/test_issue_446_dlq_identifier_validation.py
+++ b/tests/regression/test_issue_446_dlq_identifier_validation.py
@@ -105,3 +105,29 @@ def test_dlq_identifier_validator_rejects_injection_attempts() -> None:
     for payload in injection_payloads:
         with pytest.raises(ValueError):
             _validate_identifier(payload)
+
+
+@pytest.mark.regression
+def test_dlq_identifier_validator_raises_valueerror_on_unhashable_input() -> None:
+    """Issue #446 (round 4): unhashable non-string inputs MUST raise
+    ``ValueError`` — not ``TypeError``.
+
+    Regression guard: an earlier implementation called ``hash(name)``
+    inside the error-message f-string BEFORE the ``ValueError`` was
+    raised. For unhashable inputs (``dict``, ``list``, ``set``) the
+    ``hash()`` call itself raised ``TypeError: unhashable type``,
+    swallowing the typed ValueError contract and surfacing a
+    non-actionable error. The fingerprint helper must tolerate
+    unhashable inputs and return a fallback marker so the caller sees
+    the typed ValueError it expected.
+    """
+    from kailash.db.dialect import _validate_identifier
+
+    unhashable_payloads = [
+        {"a": 1},
+        [1, 2, 3],
+        {1, 2, 3},
+    ]
+    for payload in unhashable_payloads:
+        with pytest.raises(ValueError, match="must be a string"):
+            _validate_identifier(payload)  # type: ignore[arg-type]

--- a/uv.lock
+++ b/uv.lock
@@ -3009,7 +3009,7 @@ provides-extras = ["rlhf", "eval", "serve", "online", "all", "dev"]
 
 [[package]]
 name = "kailash-dataflow"
-version = "2.0.6"
+version = "2.0.7"
 source = { editable = "packages/kailash-dataflow" }
 dependencies = [
     { name = "aiomysql" },
@@ -3097,6 +3097,7 @@ dependencies = [
     { name = "gitpython" },
     { name = "google-genai" },
     { name = "kailash" },
+    { name = "kailash-mcp" },
     { name = "numpy" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
@@ -3131,6 +3132,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.21.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12" },
     { name = "kailash", specifier = ">=2.8.1" },
+    { name = "kailash-mcp", specifier = ">=0.2.3" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
@@ -3155,7 +3157,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "kailash-mcp"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/kailash-mcp" }
 dependencies = [
     { name = "kailash" },


### PR DESCRIPTION
## Summary

Fixes 2 of the 4 open GitHub issues (#443, #446 partial) plus 4 adjacent red-team-discovered gaps. #440 and #445 are addressed via issue comments and Nexus enhancement issues filed separately.

## Commits (6 atomic)

1. **fix(kaizen): declare kailash-mcp as hard dependency (#443)** — adds `kailash-mcp>=0.2.3` to packages/kailash-kaizen/pyproject.toml. Behavioral regression test verifies imports work AND the dep is declared via `importlib.metadata.requires()`. Cross-SDK inspection confirmed kailash-rs is already correct (Cargo enforces this at compile time; pip does not).
2. **docs(kaizen): replace stale kailash.mcp_server refs with kailash_mcp** — 123 references across 6 active reference docs replaced. Preserves 11 references in 4 historical/migration files (ADR-014, ADR-015, MIGRATION_AUDIT, TOOL_MIGRATION_PLAN).
3. **fix(workflow): validate hardcoded DLQ DDL identifiers (#446)** — adds `_validate_identifier()` calls to both `PersistentDLQ` (sync sqlite3) and `DBDeadLetterQueue` (async ConnectionManager) per dataflow-identifier-safety MUST Rule 5. Behavioral regression test patches the validator with a spy and asserts every expected identifier passes through it.
4. **fix(dataflow): enforce identifier length limit in dialect quote_identifier** — PostgreSQL/MySQL/SQLite dialects rejected regex-invalid names but silently accepted any length. A 200-char identifier passed validation. Adds `_MAX_IDENTIFIER_LENGTH` (63/64/128) and a length check before the regex check. Caught by `test_identifier_error_no_raw_echo.py` parametrized 200-char payload.
5. **fix(test): align mask_url None/empty test with PR #444 sentinel contract** — `test_mask_url_none_and_empty` was asserting the old empty-string contract that PR #444 hardened to `UNPARSEABLE_URL_SENTINEL`. Stale test from PR #444 sweep.
6. **feat(hooks): enforce-framework-first blocks FastAPI usage patterns (#445)** — hook only checked for import statements; an Edit that added new `@app.get` to an existing FastAPI file (with the import line outside the diff) passed through. Adds usage signatures (`@app.*`, `@router.*`, `FastAPI(`, `APIRouter(`) so new endpoint additions trigger the hook.

## Test results

```
$ uv run pytest tests/regression/ -q --timeout=60
206 passed, 9 warnings in 1.88s
```

7 new regression tests pass (4 for #443, 3 for #446). 3 pre-existing failures fixed in this branch (1 mask_url contract, 2 dialect length).

## Issues addressed in this PR

- ✅ **#443** — `Fixes #443` via commit 1 (dependency) + commit 2 (docs)
- ✅ **#446** (partial) — commit 3 fixes the identifier validation gap; broader carve-out reframing posted as issue comment

## Issues addressed via comments / spawned issues

- **#440** (loom COC template stale DriftMonitor API) — kailash-py runtime is correct (`set_reference_data` is the canonical API; kailash-ml has a test asserting `set_reference` was removed). Fix belongs in loom/.claude. Comment with the full file list (5-6 files including variants, not 3) and propagation chain to be posted.
- **#445** (raw FastAPI in 14 engine files) — multi-session epic. 3 Nexus enhancement issues filed as Wave 3 prerequisites: #447 (subapp mounting), #448 (custom WebSocket message handlers), #449 (composable middleware injection). Comment with corrected file count (14 not 9), 3-wave plan, and prerequisite links to be posted.

## Why this matters

- **#443 is BLOCKING**: users cannot import `kaizen-agents` from a fresh PyPI install today. This unblocks them.
- **Cross-SDK lesson**: Rust catches this at compile time (`cargo build` rejects un-declared crates); Python has no equivalent gate, which is why the regression slipped through. Future improvement: pre-publish dependency sweep that scans every production import against the declared manifest.

## Test plan

- [x] All 206 regression tests pass
- [x] 7 new regression tests added and passing
- [x] 3 pre-existing failures fixed
- [x] Hook fix tested with 4 cases (block, allow, comment-edit, adapter-exclusion)
- [x] CI will run full test matrix on Python 3.11/3.12/3.13 + PACT + CodeQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)