### PR TITLE
feat(nexus): composable HTTP middleware injection (#449)

### DIFF
--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -1295,6 +1295,93 @@ Check the documentation or explore available resources.
         """List of registered middleware in application order."""
         return self._middleware_stack.copy()
 
+    def use_middleware(self, func: Callable) -> Callable:
+        """Decorator to register a function as HTTP middleware.
+
+        Provides a FastAPI-style ``@app.middleware("http")`` equivalent for
+        Nexus. The decorated function receives ``(request, call_next)`` and
+        must return a ``Response``. Internally wraps the function in a
+        Starlette :class:`~starlette.middleware.base.BaseHTTPMiddleware`
+        subclass and delegates to :meth:`add_middleware`.
+
+        The ``use_middleware`` name is used (instead of ``middleware``) to
+        avoid colliding with the :attr:`middleware` introspection property
+        that returns the registered middleware list.
+
+        Args:
+            func: An async function with signature
+                ``async def mw(request: Request, call_next) -> Response``.
+                Synchronous functions are rejected because the underlying
+                ``BaseHTTPMiddleware.dispatch`` contract requires an
+                awaitable — running a sync function on the event loop
+                would block all concurrent requests.
+
+        Returns:
+            The original function (unmodified) so the decorator can be
+            stacked or the function still called directly in tests.
+
+        Raises:
+            TypeError: If *func* is not callable, is a class (use
+                :meth:`add_middleware` for class-based middleware), or
+                is a synchronous function.
+
+        Example:
+            >>> @app.use_middleware
+            ... async def timing_middleware(request, call_next):
+            ...     import time
+            ...     t0 = time.monotonic()
+            ...     response = await call_next(request)
+            ...     response.headers["X-Process-Time"] = str(
+            ...         time.monotonic() - t0
+            ...     )
+            ...     return response
+        """
+        # Validate: reject non-callable
+        if not callable(func):
+            raise TypeError(
+                f"use_middleware expects an async function, got "
+                f"{type(func).__name__}"
+            )
+
+        # Validate: reject classes — use add_middleware for those
+        if isinstance(func, type):
+            raise TypeError(
+                "use_middleware expects a function, got a class. "
+                "Use add_middleware() to register a middleware class."
+            )
+
+        # Validate: reject sync functions — BaseHTTPMiddleware.dispatch
+        # must return an awaitable. A sync function would block the event
+        # loop and surface as a "coroutine expected" error at request time.
+        if not asyncio.iscoroutinefunction(func):
+            func_name = getattr(func, "__name__", repr(func))
+            raise TypeError(
+                f"use_middleware expects an async function, got sync "
+                f"function {func_name!r}. Define with "
+                f"'async def {func_name}(request, call_next): ...'"
+            )
+
+        from starlette.middleware.base import BaseHTTPMiddleware
+
+        # Build a middleware class that captures the user function.
+        # Each decorated function gets its own class so add_middleware's
+        # duplicate-class detection works correctly (two decorated
+        # functions produce two distinct classes).
+        class _FuncMiddleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):  # noqa: N805
+                return await func(request, call_next)
+
+        # Preserve the original function name for logging / introspection.
+        _FuncMiddleware.__name__ = f"FuncMiddleware[{func.__name__}]"
+        _FuncMiddleware.__qualname__ = _FuncMiddleware.__name__
+
+        logger.info(
+            "nexus.use_middleware.registered",
+            extra={"func": func.__name__},
+        )
+        self.add_middleware(_FuncMiddleware)
+        return func
+
     # =========================================================================
     # Public Router API (WS01 - TODO-300B)
     # =========================================================================

--- a/packages/kailash-nexus/tests/integration/test_middleware_api_integration.py
+++ b/packages/kailash-nexus/tests/integration/test_middleware_api_integration.py
@@ -9,9 +9,10 @@ import os
 
 import pytest
 from fastapi import APIRouter
-from nexus import Nexus
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.testclient import TestClient
+
+from nexus import Nexus
 
 # =============================================================================
 # Fixtures
@@ -486,3 +487,73 @@ class TestCombinedFeatures:
         assert app.cors_config["allow_origins"] == ["http://example.com"]
         assert app.is_origin_allowed("http://example.com") is True
         assert app.is_origin_allowed("http://evil.com") is False
+
+
+# =============================================================================
+# Tests: @app.use_middleware (GH #449) — function-style middleware
+# =============================================================================
+
+
+class TestUseMiddlewareIntegration:
+    """Tier 2 integration tests: function-style middleware runs on real requests."""
+
+    def test_use_middleware_executes_in_request_path(self):
+        """A function decorated with @app.use_middleware runs on every request."""
+        execution_log = []
+
+        app = Nexus(enable_durability=False)
+
+        @app.use_middleware
+        async def tracking_middleware(request, call_next):
+            execution_log.append("before")
+            response = await call_next(request)
+            execution_log.append("after")
+            return response
+
+        client = _make_client(app)
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        assert execution_log == ["before", "after"]
+
+    def test_use_middleware_can_add_response_header(self):
+        """Decorated middleware can mutate the response (FastAPI-style timing header)."""
+        import time as _time
+
+        app = Nexus(enable_durability=False)
+
+        @app.use_middleware
+        async def timing_middleware(request, call_next):
+            t0 = _time.monotonic()
+            response = await call_next(request)
+            response.headers["X-Process-Time"] = f"{_time.monotonic() - t0:.6f}"
+            return response
+
+        client = _make_client(app)
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        assert "X-Process-Time" in response.headers
+        # It should be a non-negative number
+        assert float(response.headers["X-Process-Time"]) >= 0.0
+
+    def test_use_middleware_can_short_circuit(self):
+        """Decorated middleware can bail out without calling call_next."""
+        from starlette.responses import JSONResponse
+
+        app = Nexus(enable_durability=False)
+
+        @app.use_middleware
+        async def guard_middleware(request, call_next):
+            if request.headers.get("X-Block") == "yes":
+                return JSONResponse({"blocked": True}, status_code=418)
+            return await call_next(request)
+
+        client = _make_client(app)
+
+        ok = client.get("/health")
+        assert ok.status_code == 200
+
+        blocked = client.get("/health", headers={"X-Block": "yes"})
+        assert blocked.status_code == 418
+        assert blocked.json() == {"blocked": True}

--- a/packages/kailash-nexus/tests/unit/test_middleware_api.py
+++ b/packages/kailash-nexus/tests/unit/test_middleware_api.py
@@ -8,6 +8,7 @@ import logging
 from datetime import UTC, datetime
 
 import pytest
+
 from nexus import Nexus
 from nexus.core import MiddlewareInfo
 
@@ -394,3 +395,97 @@ class TestDuplicateMiddlewareDetection:
 
         # Both should be in the stack (warning is non-blocking)
         assert len(app.middleware) == 2
+
+
+# =============================================================================
+# Tests: @app.use_middleware decorator (GH #449)
+# =============================================================================
+
+
+class TestUseMiddlewareDecorator:
+    """Tests for the @app.use_middleware function-style middleware decorator."""
+
+    def test_use_middleware_registers_async_function(self):
+        """@app.use_middleware registers an async function as middleware."""
+        app = Nexus(enable_durability=False)
+
+        @app.use_middleware
+        async def timing_middleware(request, call_next):
+            response = await call_next(request)
+            return response
+
+        # The decorator should register a BaseHTTPMiddleware subclass
+        # that wraps the function. The stack should grow by exactly one.
+        assert len(app._middleware_stack) >= 1
+        # Find our wrapper (name includes the function name)
+        names = [m.name for m in app.middleware]
+        assert any("timing_middleware" in n for n in names)
+
+    def test_use_middleware_rejects_sync_function(self):
+        """Sync functions are rejected — BaseHTTPMiddleware.dispatch requires async."""
+        app = Nexus(enable_durability=False)
+
+        def sync_middleware(request, call_next):  # not async
+            return call_next(request)
+
+        with pytest.raises(TypeError, match="async function"):
+            app.use_middleware(sync_middleware)
+
+    def test_use_middleware_rejects_non_callable(self):
+        """Non-callable inputs are rejected."""
+        app = Nexus(enable_durability=False)
+
+        with pytest.raises(TypeError, match="async function"):
+            app.use_middleware("not a function")  # type: ignore[arg-type]
+
+        with pytest.raises(TypeError, match="async function"):
+            app.use_middleware(42)  # type: ignore[arg-type]
+
+    def test_use_middleware_rejects_class(self):
+        """Classes are rejected — use add_middleware() for class-based middleware."""
+        app = Nexus(enable_durability=False)
+
+        with pytest.raises(TypeError, match="class"):
+            app.use_middleware(DummyMiddleware)
+
+    def test_use_middleware_returns_original_function(self):
+        """Decorator returns the original function unmodified so it can be called/stacked."""
+        app = Nexus(enable_durability=False)
+
+        async def my_middleware(request, call_next):
+            return await call_next(request)
+
+        result = app.use_middleware(my_middleware)
+
+        assert result is my_middleware
+        assert result.__name__ == "my_middleware"
+
+    def test_use_middleware_wrapper_has_readable_name(self):
+        """The generated wrapper class carries the original function name for introspection."""
+        app = Nexus(enable_durability=False)
+
+        @app.use_middleware
+        async def cors_inject(request, call_next):
+            return await call_next(request)
+
+        # The wrapper class name should be grep-able for the original fn name
+        names = [m.name for m in app.middleware]
+        assert any(
+            "cors_inject" in n for n in names
+        ), f"Expected a middleware whose name references 'cors_inject'; got {names}"
+
+    def test_use_middleware_two_functions_produce_distinct_wrappers(self):
+        """Two decorated functions produce two distinct middleware entries."""
+        app = Nexus(enable_durability=False)
+
+        @app.use_middleware
+        async def first(request, call_next):
+            return await call_next(request)
+
+        @app.use_middleware
+        async def second(request, call_next):
+            return await call_next(request)
+
+        names = [m.name for m in app.middleware]
+        assert sum(1 for n in names if "first" in n) == 1
+        assert sum(1 for n in names if "second" in n) == 1


### PR DESCRIPTION
## Summary

Adds `@app.use_middleware` — a FastAPI-style decorator that lets downstream
Nexus apps register function-style HTTP middleware with one line instead of
hand-rolling a `BaseHTTPMiddleware` subclass for every observability hook,
header injector, or per-request timer.

```python
@app.use_middleware
async def timing_middleware(request, call_next):
    t0 = time.monotonic()
    response = await call_next(request)
    response.headers["X-Process-Time"] = f"{time.monotonic() - t0:.6f}"
    return response
```

## What's in this PR

- `Nexus.use_middleware(func)` decorator on the public Nexus class
- Per-function `BaseHTTPMiddleware` subclass wrapping so existing
  duplicate-detection and ordering logic in `add_middleware` continues to work
- Typed `TypeError` rejection of: non-callables, classes (redirected to
  `add_middleware`), and sync functions (would block the event loop because
  `BaseHTTPMiddleware.dispatch` must return an awaitable)
- Returns the original function unmodified so it can still be called directly
  or stacked with other decorators
- 7 Tier 1 unit tests covering every validation branch and the introspection
  contract
- 3 Tier 2 integration tests that exercise the decorator through a real
  `TestClient` gateway — response header injection, execution ordering
  (before/after), and short-circuit via early `JSONResponse` return

## Why `use_middleware` and not `middleware`

The existing `middleware` property on `Nexus` returns the registered-middleware
list for introspection. Using `@app.middleware(...)` would shadow that
property. `use_middleware` keeps both surfaces clean.

## Test results

```
10 passed in 0.65s  (use_middleware tests specifically)
49 passed, 21 warnings in 4.96s  (full middleware test file)
```

The 21 warnings are pre-existing `Nexus._gateway` deprecation warnings
from the test helper `_make_client`, not introduced here.

## Related issues

Closes #449

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>