### PR TITLE
refactor(nexus): normalize engine-layer imports to Starlette (#445)

### DIFF
--- a/scripts/hooks/enforce-framework-first.js
+++ b/scripts/hooks/enforce-framework-first.js
@@ -226,16 +226,24 @@ function isExcluded(filePath) {
   )
     return true;
 
-  // BUILD repo — only the adapter/backend/transport/store layer uses raw imports.
-  // Engines, features, API, servers MUST use the SDK's own primitives.
+  // BUILD repo — only the adapter/backend/transport/store layer and the
+  // Nexus engine-foundation layer use raw imports.
+  // The servers/ and api/ directories are the engine layer that Nexus wraps
+  // via HTTPTransport._gateway → create_gateway(). They cannot import from
+  // nexus without creating a circular dependency (kailash → nexus → kailash).
+  // See #445 architectural analysis.
   if (
     /[\\/]adapters[\\/]/.test(filePath) ||
     /[\\/]backends[\\/]/.test(filePath) ||
     /[\\/]transports[\\/]/.test(filePath) ||
     /[\\/]providers[\\/]/.test(filePath) ||
     /[\\/]drivers[\\/]/.test(filePath) ||
+    // Nexus engine-foundation: server hierarchy + API gateway layer
+    /[\\/]servers[\\/]/.test(filePath) ||
+    /[\\/]src[\\/]kailash[\\/]api[\\/]/.test(filePath) ||
+    /[\\/]middleware[\\/]auth[\\/]/.test(filePath) ||
+    /[\\/]middleware[\\/]gateway[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]database[\\/]/.test(filePath) ||
-    /[\\/]middleware[\\/]gateway[\\/]event_store/.test(filePath) ||
     /[\\/]trust[\\/].*store/.test(filePath) ||
     /[\\/]trust[\\/]constraints[\\/]/.test(filePath) ||
     /[\\/]trust[\\/]enforce[\\/]/.test(filePath) ||

--- a/scripts/hooks/enforce-framework-first.js
+++ b/scripts/hooks/enforce-framework-first.js
@@ -239,7 +239,7 @@ function isExcluded(filePath) {
     /[\\/]providers[\\/]/.test(filePath) ||
     /[\\/]drivers[\\/]/.test(filePath) ||
     // Nexus engine-foundation: server hierarchy + API gateway layer
-    /[\\/]servers[\\/]/.test(filePath) ||
+    /[\\/]src[\\/]kailash[\\/]servers[\\/]/.test(filePath) ||
     /[\\/]src[\\/]kailash[\\/]api[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]auth[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]gateway[\\/]/.test(filePath) ||

--- a/src/kailash/api/gateway.py
+++ b/src/kailash/api/gateway.py
@@ -55,9 +55,11 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import httpx
-from fastapi import FastAPI, Request, Response, WebSocket
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import Response, StreamingResponse
+from starlette.websockets import WebSocket
 from pydantic import BaseModel, Field
 
 from ..runtime.local import LocalRuntime

--- a/src/kailash/api/workflow_api.py
+++ b/src/kailash/api/workflow_api.py
@@ -14,8 +14,10 @@ from typing import Any
 import uvicorn
 
 logger = logging.getLogger(__name__)
-from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi import BackgroundTasks, FastAPI
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from kailash.runtime.local import LocalRuntime

--- a/src/kailash/middleware/auth/auth_manager.py
+++ b/src/kailash/middleware/auth/auth_manager.py
@@ -14,8 +14,10 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
 import jwt
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
 
 from ...nodes.admin import PermissionCheckNode
 from ...nodes.data import AsyncSQLDatabaseNode

--- a/src/kailash/middleware/gateway/durable_gateway.py
+++ b/src/kailash/middleware/gateway/durable_gateway.py
@@ -13,8 +13,9 @@ import logging
 from datetime import UTC, datetime
 from typing import Any, Callable, Dict, List, Optional
 
-from fastapi import HTTPException, Request, Response
-from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
 
 from kailash.api.gateway import WorkflowAPIGateway
 

--- a/src/kailash/servers/durable_workflow_server.py
+++ b/src/kailash/servers/durable_workflow_server.py
@@ -12,8 +12,9 @@ import logging
 from datetime import UTC, datetime
 from typing import Any, Callable, Dict, List, Optional
 
-from fastapi import HTTPException, Request, Response
-from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
 
 from ..middleware.gateway.checkpoint_manager import CheckpointManager
 from ..middleware.gateway.deduplicator import RequestDeduplicator

--- a/src/kailash/servers/enterprise_workflow_server.py
+++ b/src/kailash/servers/enterprise_workflow_server.py
@@ -243,7 +243,7 @@ class EnterpriseWorkflowServer(DurableWorkflowServer):
                     ),
                 }
             except (KeyError, Exception) as e:
-                from fastapi import HTTPException
+                from starlette.exceptions import HTTPException
 
                 raise HTTPException(status_code=404, detail="Resource not found")
 
@@ -294,12 +294,12 @@ class EnterpriseWorkflowServer(DurableWorkflowServer):
         async def execute_workflow_async(workflow_id: str, request: dict):
             """Execute workflow asynchronously with resource resolution."""
             if not self.enable_async_execution:
-                from fastapi import HTTPException
+                from starlette.exceptions import HTTPException
 
                 raise HTTPException(status_code=503, detail="Async execution disabled")
 
             if workflow_id not in self.workflows:
-                from fastapi import HTTPException
+                from starlette.exceptions import HTTPException
 
                 raise HTTPException(
                     status_code=404, detail=f"Workflow '{workflow_id}' not found"
@@ -583,7 +583,7 @@ class EnterpriseWorkflowServer(DurableWorkflowServer):
         @self.app.websocket("/ws")
         async def websocket_endpoint(websocket):
             """WebSocket for real-time updates."""
-            from fastapi import WebSocket
+            from starlette.websockets import WebSocket
 
             await websocket.accept()
             try:

--- a/src/kailash/servers/workflow_server.py
+++ b/src/kailash/servers/workflow_server.py
@@ -11,8 +11,10 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import FastAPI, Request, WebSocket
-from fastapi.middleware.cors import CORSMiddleware
+from fastapi import FastAPI
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.websockets import WebSocket
 from pydantic import BaseModel, Field
 
 from ..api.workflow_api import WorkflowAPI


### PR DESCRIPTION
## Summary

- Exempts engine-layer directories (`servers/`, `api/`, `middleware/auth/`, `middleware/gateway/`) from the `enforce-framework-first.js` hook — these files form the server stack that Nexus wraps via `create_gateway()` and cannot import from nexus without creating a circular dependency
- Normalizes 7 engine-layer files to use direct Starlette imports (`Request`, `Response`, `HTTPException`, `WebSocket`, `CORSMiddleware`, `JSONResponse`, `StreamingResponse`) instead of FastAPI re-exports
- Keeps FastAPI-specific imports (`FastAPI`, `APIRouter`, `Depends`, `BackgroundTasks`, `HTTPBearer`) that have no Starlette equivalent

## Related issues

Partial fix for #445 (Tracks 1 + 2). Track 3 (migrating application-layer files to Nexus) will follow in separate PRs.

## Test plan

- [x] All modified module imports resolve (`python -c "from kailash.servers.workflow_server import ..."`)
- [x] 1536 Nexus unit tests pass, 0 failures
- [x] Engine-layer files now only import FastAPI for FastAPI-specific symbols
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)