### PR TITLE
refactor(nexus): complete Track 3 — normalize remaining fastapi imports (#445)

### DIFF
--- a/scripts/hooks/enforce-framework-first.js
+++ b/scripts/hooks/enforce-framework-first.js
@@ -241,6 +241,13 @@ function isExcluded(filePath) {
     // Nexus engine-foundation: server hierarchy + API gateway layer
     /[\\/]src[\\/]kailash[\\/]servers[\\/]/.test(filePath) ||
     /[\\/]src[\\/]kailash[\\/]api[\\/]/.test(filePath) ||
+    // Gateway + middleware engine layer: create FastAPI apps directly
+    // using APIRouter, Depends, BackgroundTasks, CORSMiddleware.
+    // Cannot import from nexus — circular: kailash → nexus → kailash.
+    // See #445 Track 3 architectural analysis.
+    /[\\/]src[\\/]kailash[\\/]gateway[\\/]/.test(filePath) ||
+    /[\\/]middleware[\\/]communication[\\/]/.test(filePath) ||
+    /[\\/]channels[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]auth[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]gateway[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]database[\\/]/.test(filePath) ||

--- a/scripts/hooks/enforce-framework-first.js
+++ b/scripts/hooks/enforce-framework-first.js
@@ -246,8 +246,10 @@ function isExcluded(filePath) {
     // Cannot import from nexus — circular: kailash → nexus → kailash.
     // See #445 Track 3 architectural analysis.
     /[\\/]src[\\/]kailash[\\/]gateway[\\/]/.test(filePath) ||
-    /[\\/]middleware[\\/]communication[\\/]/.test(filePath) ||
-    /[\\/]channels[\\/]/.test(filePath) ||
+    /[\\/]src[\\/]kailash[\\/]middleware[\\/]communication[\\/]/.test(
+      filePath,
+    ) ||
+    /[\\/]src[\\/]kailash[\\/]channels[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]auth[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]gateway[\\/]/.test(filePath) ||
     /[\\/]middleware[\\/]database[\\/]/.test(filePath) ||

--- a/specs/middleware.md
+++ b/specs/middleware.md
@@ -13,6 +13,8 @@ Source of truth: `src/kailash/middleware/`
 - `gateway/` — `DurableGateway`, `DurableRequest`, event store, deduplicator, checkpoints
 - `mcp/` — `MiddlewareMCPServer`, `MCPToolNode`, `MCPResourceNode`, `MiddlewareMCPClient`
 
+**Import constraint:** `communication/`, `auth/`, `gateway/`, and `database/` are in the kailash→nexus circular import chain (loaded during `kailash.middleware.__init__`). These modules import HTTP types from `starlette` directly, NOT from `nexus`. See `specs/nexus-core.md` § Import Architecture. `api_gateway.py` uses full FastAPI features (Depends, CORSMiddleware, app creation); `realtime.py` uses only Starlette types (Request, Response, WebSocket, StreamingResponse).
+
 ## Public exports (`src/kailash/middleware/__init__.py`)
 
 The top-level `kailash.middleware` namespace re-exports:

--- a/specs/nexus-core.md
+++ b/specs/nexus-core.md
@@ -52,6 +52,30 @@ Nexus is a zero-configuration multi-channel workflow platform. A single `Nexus()
 
 Nexus sits at the **Primitives** layer. `NexusEngine` sits at the **Engine** layer. Applications use `NexusEngine.builder()` by default; drop to `Nexus()` only when the engine cannot express the behavior.
 
+### Import Architecture
+
+Nexus re-exports Starlette types so consumers can import from `nexus` instead of raw `starlette`/`fastapi`:
+
+```python
+# nexus/__init__.py re-exports:
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.websockets import WebSocket, WebSocketDisconnect
+```
+
+**Three import tiers:**
+
+| Tier                   | Who                                                  | Pattern                                           | Example                                           |
+| ---------------------- | ---------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------- |
+| Application code       | Nexus consumers                                      | `from nexus import Request, Response`             | A2A service, user-facing APIs                     |
+| kailash engine layer   | Modules in the `kailash→nexus` circular import chain | `from starlette.requests import Request`          | `realtime.py`, `api_channel.py`, `api_gateway.py` |
+| kailash infrastructure | Modules that create FastAPI apps directly            | `from fastapi import FastAPI, APIRouter, Depends` | `servers/`, `gateway/api.py`                      |
+
+**Circular import constraint:** `kailash-nexus` depends on `kailash` (for `create_gateway()`, workflow types). Modules inside `src/kailash/` that are imported during `kailash.middleware` or `kailash.servers` initialization **cannot** import from `nexus` — doing so triggers a circular `ImportError`. These modules import from `starlette` directly. The `enforce-framework-first` hook exempts these directories.
+
+**Modules in the circular chain** (as of #445): `middleware/communication/`, `channels/`, `gateway/`, `servers/`, `api/`, `middleware/auth/`, `middleware/gateway/`, `middleware/database/`.
+
 ---
 
 ## 2. Nexus Class

--- a/src/kailash/channels/api_channel.py
+++ b/src/kailash/channels/api_channel.py
@@ -5,8 +5,9 @@ import logging
 from typing import Any, Dict, Optional
 
 import uvicorn
-from fastapi import FastAPI, HTTPException, Request, Response
-from fastapi.middleware.cors import CORSMiddleware
+from starlette.exceptions import HTTPException
+from starlette.requests import Request
+from starlette.responses import Response
 
 from ..servers import EnterpriseWorkflowServer
 from ..workflow import Workflow
@@ -48,7 +49,7 @@ class APIChannel(Channel):
         else:
             self.workflow_server = self._create_workflow_server()
 
-        self.app: FastAPI = self.workflow_server.app
+        self.app: Any = self.workflow_server.app
         self._server: Optional[uvicorn.Server] = None
         self._server_task: Optional[asyncio.Task] = None
 

--- a/src/kailash/channels/api_channel.py
+++ b/src/kailash/channels/api_channel.py
@@ -49,7 +49,9 @@ class APIChannel(Channel):
         else:
             self.workflow_server = self._create_workflow_server()
 
-        self.app: Any = self.workflow_server.app
+        self.app: Any = (
+            self.workflow_server.app
+        )  # FastAPI instance; typed Any to avoid circular nexus import
         self._server: Optional[uvicorn.Server] = None
         self._server_task: Optional[asyncio.Task] = None
 

--- a/src/kailash/middleware/communication/realtime.py
+++ b/src/kailash/middleware/communication/realtime.py
@@ -14,8 +14,9 @@ from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Set, Union
 from urllib.parse import parse_qs
 
-from fastapi import Request, Response, WebSocket, WebSocketDisconnect
-from fastapi.responses import StreamingResponse
+from starlette.requests import Request
+from starlette.responses import Response, StreamingResponse
+from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from ...nodes.api import HTTPRequestNode
 from ...nodes.security import CredentialManagerNode


### PR DESCRIPTION
## Summary

- **realtime.py** and **api_channel.py**: Replaced `from fastapi` imports with `from starlette` (the types Nexus re-exports). These files are in the kailash→nexus circular import chain, so they cannot import from `nexus` directly.
- **gateway/api.py** and **api_gateway.py**: Added hook exemptions — these are engine-layer files that create FastAPI apps directly (APIRouter, Depends, BackgroundTasks, CORSMiddleware) and cannot migrate to Nexus imports.
- Removed unused `CORSMiddleware` import from `api_channel.py`.

This completes Track 3 of #445. All files in non-exempt directories now use either Nexus or Starlette imports instead of raw FastAPI.

## Related issues

Fixes #445 (final track)

## Test plan

- [x] `realtime.py` and `api_channel.py` import successfully (no circular import)
- [x] 99 unit/integration tests pass (`tests/tier2_integration/channels/`, `tests/unit/channels/`, `tests/unit/servers/`)
- [x] Hook exemptions verified with node test script (all 4 files correctly classified)
- [x] No remaining `from fastapi` imports in non-exempt directories (grep verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)