### PR TITLE
docs(specs): document import tiers, lazy connection triggers, and middleware dependencies

### DIFF
--- a/specs/dataflow-core.md
+++ b/specs/dataflow-core.md
@@ -148,6 +148,21 @@ DataFlow uses lazy connection initialization. The constructor (`__init__`) store
 4. Wires the audit backend (if enabled)
 5. Initializes the cache integration
 
+#### Operations That Trigger Connection
+
+| Operation | Triggers `_ensure_connected()`? | Notes |
+| --------- | ------------------------------- | ----- |
+| `db.express.create/read/update/delete/list/count` | YES | Accessing `db.express` or `db.express_sync` triggers connection before the first CRUD call. |
+| `@db.model` registration | NO | Model registration queues the model for deferred table creation. The actual DDL runs inside `_ensure_connected()` when the first database-touching operation occurs. |
+| `db.start()` | YES | Explicit fabric runtime start calls `_ensure_connected()` as part of initialization. |
+| `await db.initialize()` | YES | Async initialization explicitly calls `_ensure_connected()` before validating database connectivity. |
+| `db.create_tables()` | YES | Batch table creation calls `_ensure_connected()`. |
+| `db.health_check()` | YES | Health check requires an active connection. |
+| `db.execute_lightweight_query()` | YES | Lightweight queries (e.g., health probes) trigger connection. |
+| `db.audit_query()` | YES | Audit queries require an active connection. |
+
+**Design rationale:** Lazy connection means `DataFlow("sqlite:///app.db")` returns instantly with zero I/O. This allows `@db.model` decorators to register models at import time without blocking module loading. Connection is deferred until the application actually needs the database, which also means misconfigured connection URLs fail at first use, not at import time.
+
 ### 1.5 Runtime Detection
 
 DataFlow detects whether it is running in an async or sync context at construction time:

--- a/specs/middleware.md
+++ b/specs/middleware.md
@@ -116,6 +116,12 @@ class AgentUIMiddleware:
 
 There is NO `enable_event_streaming` parameter. Event streaming is always on — the constructor unconditionally creates `self.event_stream = EventStream(enable_batching=True)`.
 
+**Always-on streaming design:** Streaming is architecturally always-on because `AgentUIMiddleware` uses the `EventStream` internally for coordination between session management, workflow execution, and real-time transports. Disabling it would break internal event routing. To control event delivery without disabling the stream:
+
+- **Filter-based suppression:** Subscribe with an `EventFilter` that matches nothing (e.g., `EventFilter(event_types=[])`) to receive zero events while keeping the stream operational.
+- **Ignore the stream:** Simply do not call `subscribe_to_events()` — events are emitted but discarded when there are no subscribers.
+- **Verify streaming is working:** Subscribe with a permissive filter and check that `workflow.started` events arrive when `create_session()` is called. The `get_stats()` method reports `events_emitted` as a counter.
+
 **State initialized in `__init__`:**
 
 - `self.enable_dynamic_workflows`, `self.max_sessions`, `self.session_timeout_minutes`, `self.enable_workflow_sharing`
@@ -503,6 +509,33 @@ class AuthLevel(Enum):
 ### `MiddlewareAccessControlManager` / `MiddlewareAuthenticationMiddleware` (`auth/access_control.py`)
 
 Higher-level access control building on top of `MiddlewareAuthManager`. These are conditionally imported by `auth/__init__.py` (wrapped in a `try/except ImportError` to avoid circular dependencies with communication).
+
+#### Auth Dependencies and Conditional Imports
+
+The `auth/__init__.py` module uses a two-phase import strategy to handle circular dependencies:
+
+**Always available** (unconditional imports):
+
+| Import | Source | Required by |
+| ------ | ------ | ----------- |
+| `JWTAuthManager` | `auth/jwt_auth.py` | Core JWT operations (HS256/RS256, refresh tokens, blacklisting) |
+| `JWTConfig`, `TokenPayload`, `TokenPair`, `UserClaims`, `AuthenticationResult` | `auth/models.py` | Data models for auth operations |
+| `AuthenticationError`, `InvalidTokenError`, `TokenExpiredError`, `TokenBlacklistedError`, `PermissionDeniedError` | `auth/exceptions.py` | Exception hierarchy |
+| `generate_secret_key`, `generate_key_pair`, `parse_bearer_token` | `auth/utils.py` | Key generation and token parsing utilities |
+
+**Conditionally available** (wrapped in `try/except ImportError`):
+
+| Import | Source | Why conditional | What happens when missing |
+| ------ | ------ | --------------- | ------------------------ |
+| `MiddlewareAuthManager`, `AuthLevel` | `auth/auth_manager.py` | Imports `fastapi.Depends`, `fastapi.security.HTTPBearer`, and Kailash security nodes (`CredentialManagerNode`, `RotatingCredentialNode`, etc.). These may trigger circular imports when `auth/` is loaded during `kailash.middleware.__init__` before `communication/` is fully initialized. | `_has_access_control` is set to `False`. These symbols are omitted from `__all__`. Code that needs `MiddlewareAuthManager` should import it directly: `from kailash.middleware.auth.auth_manager import MiddlewareAuthManager`. |
+| `MiddlewareAccessControlManager`, `MiddlewareAuthenticationMiddleware` | `auth/access_control.py` | Same circular dependency chain — `access_control.py` imports from `communication/` which may not be fully initialized yet. | Same as above — omitted from `__all__` when unavailable. |
+
+**Runtime dependencies of `MiddlewareAuthManager`:**
+
+- `jwt` (PyJWT) — required, used directly for `jwt.encode()`/`jwt.decode()` with HS256
+- `fastapi` — required, used for `Depends`, `HTTPBearer`, `HTTPAuthorizationCredentials`
+- `starlette` — required, used for `HTTPException`, `Request`
+- Kailash SDK nodes: `CredentialManagerNode`, `RotatingCredentialNode`, `PermissionCheckNode`, `SecurityEventNode`, `AuditLogNode`, `AsyncSQLDatabaseNode`, `DataTransformer` — all from `kailash.nodes.*`
 
 ### Supporting models and utilities (`auth/models.py`, `auth/utils.py`)
 

--- a/specs/nexus-core.md
+++ b/specs/nexus-core.md
@@ -76,6 +76,33 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 
 **Modules in the circular chain** (as of #445): `middleware/communication/`, `channels/`, `gateway/`, `servers/`, `api/`, `middleware/auth/`, `middleware/gateway/`, `middleware/database/`.
 
+#### Import Tier Enumeration
+
+The `enforce-framework-first` hook (see `scripts/hooks/enforce-framework-first.js`) classifies every source file into one of three tiers. The hook exempts Tier 1 modules from the "import from `nexus`, not raw `starlette`/`fastapi`" rule.
+
+**Tier 1 — Engine/Foundation layer** (raw `starlette`/`fastapi` imports required):
+
+| Exempted directory            | Reason                                                                                                                                  |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/kailash/servers/`        | Server hierarchy creates FastAPI apps directly via `create_gateway()`. Importing from `nexus` would create `kailash -> nexus -> kailash` circular import. |
+| `src/kailash/api/`            | API route definitions consumed during `kailash` init; same circular import chain as `servers/`.                                         |
+| `src/kailash/gateway/`        | Gateway layer creates FastAPI apps and uses `APIRouter`, `Depends`, `BackgroundTasks`, `CORSMiddleware` directly. Circular: `kailash -> nexus -> kailash`. |
+| `src/kailash/middleware/communication/` | `APIGateway` and `RealtimeMiddleware` are loaded during `kailash.middleware.__init__`. `api_gateway.py` uses full FastAPI features; `realtime.py` uses Starlette types (`Request`, `Response`, `WebSocket`, `StreamingResponse`). |
+| `src/kailash/middleware/auth/` | Auth middleware is loaded during `kailash.middleware.__init__`. Uses `fastapi.Depends`, `HTTPBearer`, `starlette.requests.Request`, `starlette.exceptions.HTTPException`. |
+| `src/kailash/middleware/gateway/` | Durable gateway layer uses Starlette types directly. Loaded as part of the middleware init chain.                                     |
+| `src/kailash/middleware/database/` | Database middleware uses FastAPI dependency injection (`get_middleware_db_session`). Part of the middleware init chain.                |
+| `src/kailash/channels/`      | Channel implementations are loaded during `kailash` init; circular chain through `kailash.middleware -> nexus -> kailash`.               |
+| `adapters/`, `backends/`, `transports/`, `providers/`, `drivers/` | Infrastructure layer: database adapters, cache backends, transport implementations. These are below the framework abstraction and use raw driver imports. |
+| `trust/*store`, `trust/constraints/`, `trust/enforce/` | Trust plane persistence and enforcement layer operates below the framework boundary.                                                |
+
+**Tier 2 — Framework layer** (imports from `nexus` re-exports):
+
+Modules inside `packages/kailash-nexus/src/nexus/` that compose the Nexus framework itself. These import from `starlette`/`fastapi` at the definition site but re-export types through `nexus/__init__.py` for consumers.
+
+**Tier 3 — Application layer** (imports from `nexus` only):
+
+All other code — user applications, A2A services, test files, examples. These MUST import HTTP types from `nexus`, not from `starlette` or `fastapi` directly. The `enforce-framework-first` hook flags violations.
+
 ---
 
 ## 2. Nexus Class


### PR DESCRIPTION
## Summary
- Add Import Tier Enumeration table to `nexus-core.md` — maps every exempted directory to its tier and circular import reason
- Add "Operations That Trigger Connection" table to `dataflow-core.md` — documents which operations trigger lazy `_ensure_connected()`
- Expand `middleware.md` with always-on streaming design notes and auth conditional import documentation

## Related issues
Red-team findings from spec-vs-implementation audit (session 2026-04-14).

## Test plan
- [ ] Spec content verified against source code
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)