### PR TITLE
chore(codify): rules, mcp publish workflow, proposal — 2026-04-14

### DIFF
--- a/.claude/.proposals/archive/2026-04-14-kailash-py-nexus-bindings.yaml
+++ b/.claude/.proposals/archive/2026-04-14-kailash-py-nexus-bindings.yaml
@@ -1,0 +1,20 @@
+source_repo: kailash-py
+codify_date: '2026-04-14'
+codify_session: 'feat(nexus): middleware decorator, subapp mounting, WebSocket message
+  handlers'
+sdk_version: 2.6.0
+coc_version: 1.0.3
+status: distributed
+changes:
+- file: agents/frameworks/nexus-specialist.md
+  action: modified
+  suggested_tier: global
+  reason: Added Essential Patterns for use_middleware decorator (#449), mount() subapp
+    composition (#447), and class-based WebSocket MessageHandler with per-connection
+    state (#448)
+  diff_lines: '+25'
+reviewed_date: '2026-04-14'
+reviewed_notes: "Classified as variant-py (not global per proposal) \u2014 the 3 new\
+  \ Nexus patterns (use_middleware, mount, @app.websocket class) are Python-specific;\
+  \ rs binding parity tracked in kailash-rs#386 and kailash-rs#387."
+distributed_date: '2026-04-14T13:30:00Z'

--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1,20 +1,89 @@
 source_repo: kailash-py
-codify_date: '2026-04-14'
-codify_session: 'feat(nexus): middleware decorator, subapp mounting, WebSocket message
-  handlers'
-sdk_version: 2.6.0
+codify_date: "2026-04-14"
+codify_session: "fix(test): resolve all 63 unit test warnings + chore(release): coordinated patch release"
+sdk_version: 2.8.6
 coc_version: 1.0.3
-status: distributed
+status: pending_review
 changes:
-- file: agents/frameworks/nexus-specialist.md
-  action: modified
-  suggested_tier: global
-  reason: Added Essential Patterns for use_middleware decorator (#449), mount() subapp
-    composition (#447), and class-based WebSocket MessageHandler with per-connection
-    state (#448)
-  diff_lines: '+25'
-reviewed_date: '2026-04-14'
-reviewed_notes: "Classified as variant-py (not global per proposal) \u2014 the 3 new\
-  \ Nexus patterns (use_middleware, mount, @app.websocket class) are Python-specific;\
-  \ rs binding parity tracked in kailash-rs#386 and kailash-rs#387."
-distributed_date: '2026-04-14T13:30:00Z'
+  - file: rules/testing.md
+    action: modified
+    suggested_tier: global
+    reason: |
+      Added "Test Resource Cleanup Discipline" section with 4 new MUST rules
+      covering patterns surfaced by PR #466 (resolved 63 unit test warnings):
+      (1) Fixtures yield + cleanup, never return — for resources with __del__
+          ResourceWarning (CLIChannel, LocalRuntime, AsyncLocalRuntime,
+          AsyncSQLDatabaseNode);
+      (2) AsyncMock replaced by Mock(new_callable=Mock) when side_effect is
+          async def — prevents _execute_mock_call coroutine leak;
+      (3) Test helper classes without __init__ use Stub naming — avoids
+          PytestCollectionWarning for Test* classes with __init__;
+      (4) JWT test secrets ≥ 32 bytes per RFC 7518 §3.2 — eliminates
+          InsecureKeyLengthWarning false positives in CI.
+      All four are universal Python testing patterns; classify as global.
+    diff_lines: "+103"
+  - file: rules/deployment.md
+    action: modified
+    suggested_tier: variant-py
+    reason: |
+      Added 2 new MUST rules to the SDK release rules:
+      (1) Optional dependencies pin to PyPI-resolvable versions — extras MUST
+          NOT bump to the version being released, because CI installs from
+          PyPI before the release is published. Framework SDK pins inside
+          each sub-package's pyproject.toml ARE allowed to bump because they
+          resolve against the local editable install. Source: PR #467 fix
+          (commit a50d3119).
+      (2) All files imported by package __init__.py MUST be tracked in git —
+          editable installs see local working tree, but PyPI wheel only
+          includes git-tracked files. PR #459/#460 merged with nexus/__init__.py
+          importing untracked files; would have published a broken wheel.
+          Caught by /release audit and bundled in PR #467.
+      Both rules are Python/pyproject.toml-specific. Classify as variant-py.
+      The Rust SDK has its own equivalent failure modes (Cargo workspace
+      pinning, mod declarations) — separate rule needed for variants/rs.
+    diff_lines: "+74"
+  - file: .github/workflows/publish-pypi.yml
+    action: modified
+    suggested_tier: variant-py
+    reason: |
+      Added kailash-mcp to the PyPI publish workflow (4 places: tag pattern,
+      workflow_dispatch options, manual case statement, tag regex elif). The
+      mcp-v0.2.4 tag could not auto-publish because the workflow had never
+      been updated when kailash-mcp was added as a sub-package. Discovered
+      during the 2026-04-14 release when 4/5 packages auto-published but mcp
+      had to be manually triggered. Variant-py because the workflow is
+      Python-specific.
+    diff_lines: "+5"
+production_changes:
+  - file: packages/kailash-mcp/src/kailash_mcp/advanced/subscriptions.py
+    change: "Replaced datetime.utcnow() with datetime.now(UTC) — Python 3.12+ deprecation fix"
+    pr: "#466"
+  - file: packages/kailash-nexus/src/nexus/auth/guards.py
+    change: "Added 277 LOC — was imported by nexus/__init__.py but never committed (PR #459/#460 oversight)"
+    pr: "#467"
+  - file: packages/kailash-nexus/src/nexus/errors.py
+    change: "Added 276 LOC — was imported by nexus/__init__.py but never committed (PR #459/#460 oversight)"
+    pr: "#467"
+release_packages:
+  - { name: kailash, from: 2.8.5, to: 2.8.6 }
+  - { name: kailash-dataflow, from: 2.0.7, to: 2.0.8 }
+  - { name: kailash-kaizen, from: 2.7.3, to: 2.7.4 }
+  - { name: kailash-nexus, from: 2.0.1, to: 2.0.2 }
+  - { name: kailash-mcp, from: 0.2.3, to: 0.2.4 }
+notes: |
+  All changes validated and shipped:
+  - 3309 unit tests pass with 0 warnings (was 63)
+  - security-reviewer APPROVED (1 MEDIUM finding non-blocking — PermissionError
+    shadowing; mitigated by NexusPermissionError alias in __init__.py)
+  - reviewer APPROVED (version consistency, SDK pin symmetry, CHANGELOG accuracy)
+  - PR #466 merged (warning fixes)
+  - PR #467 merged (release commit on main)
+  - 5 release tags pushed: v2.8.6, dataflow-v2.0.8, kaizen-v2.7.4, nexus-v2.0.2, mcp-v0.2.4
+  - 4/5 packages publishing via workflow_dispatch (tag-triggered failed due to
+    GitHub batch-push behavior — not the lightweight/annotated issue, but
+    multi-tag push at once)
+  - kailash-mcp publish workflow added in this PR (separate concern)
+
+  Outstanding follow-ups (post-distribute):
+  - PermissionError → ForbiddenError rename in nexus/errors.py (M1 from security review)
+  - Investigate why batch tag push didn't trigger workflows individually

--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -47,3 +47,71 @@ python -m venv /tmp/verify --clear
 Every SDK MUST have `deploy/deployment-config.md`. Run `/deploy` to create it.
 
 **Why:** Without a deployment config, release agents guess at package names, registries, and credentials, leading to failed or misdirected publishes.
+
+## MUST: Optional Dependencies Pin to PyPI-Resolvable Versions
+
+`[project.optional-dependencies]` extras MUST pin to versions already on PyPI at the time of the commit. Bumping an extras pin to the version being released in the same commit is BLOCKED — CI installs from PyPI before the release is published, so the pin fails to resolve.
+
+```toml
+# DO — extras pin to currently-published minimum compatible version
+[project.optional-dependencies]
+dataflow = ["kailash-dataflow>=2.0.3"]   # 2.0.3 is on PyPI; 2.0.8 is being released
+nexus    = ["kailash-nexus>=2.0.0"]
+kaizen   = ["kailash-kaizen>=2.7.1"]
+
+# DO NOT — extras pin to the version being released
+[project.optional-dependencies]
+dataflow = ["kailash-dataflow>=2.0.8"]   # 2.0.8 is not on PyPI yet → pip resolution fails
+```
+
+**BLOCKED rationalizations:**
+
+- "The version will exist by the time CI runs"
+- "We can fix CI after the release lands"
+- "The lockfile pins the right version anyway"
+
+**Why:** CI for the release PR runs `pip install -e ".[dev]"` against PyPI, which has the OLD versions. Pinning to the unreleased version produces `ERROR: No matching distribution found for kailash-mcp>=0.2.4` and the release CI fails. The framework SDK pins inside each package's own pyproject.toml (`kailash>=2.8.6` in `packages/kailash-dataflow/pyproject.toml`) ARE allowed to bump because they resolve against the local editable install of kailash, not PyPI. Source: PR #467 fix (commit a50d3119).
+
+## MUST: All Files Imported By package `__init__.py` Tracked In Git
+
+Before tagging a release, every `from .X import Y` and `from .pkg import Z` in any package's `__init__.py` MUST resolve to a file tracked in git. Imports that resolve to local-only files (untracked, .gitignored, generated) are BLOCKED — the published wheel will `ImportError` from a clean checkout.
+
+```bash
+# DO — verify all package imports are tracked
+for init in packages/*/src/*/__init__.py; do
+  pkg_dir="$(dirname "$init")"
+  python -c "import ast, pathlib
+init = pathlib.Path('$init')
+tree = ast.parse(init.read_text())
+for node in ast.walk(tree):
+    if isinstance(node, ast.ImportFrom) and node.level > 0 and node.module:
+        candidate = init.parent / node.module.replace('.', '/')
+        for path in (candidate.with_suffix('.py'), candidate / '__init__.py'):
+            if path.exists():
+                rel = path.relative_to(pathlib.Path.cwd())
+                import subprocess
+                tracked = subprocess.run(['git', 'ls-files', '--error-unmatch', str(rel)],
+                                         capture_output=True).returncode == 0
+                if not tracked:
+                    print(f'UNTRACKED: {rel} imported by {init}')
+                break
+"
+done
+
+# DO NOT — release with untracked files imported by __init__.py
+# packages/kailash-nexus/src/nexus/__init__.py:
+#   from .auth.guards import AuthGuard          # auth/guards.py UNTRACKED
+#   from .errors import NexusError              # errors.py UNTRACKED
+# Result: pip install kailash-nexus → ImportError on first import
+```
+
+**BLOCKED rationalizations:**
+
+- "The file exists on my machine, the test passed"
+- "It was supposed to be in the previous PR"
+- "We'll add it in the next release"
+- "The CI passed because it uses editable install"
+
+**Why:** Editable installs see the local working tree, including untracked files. PyPI users get only what's in the wheel, which is built from `git ls-files`. PR #459/#460 merged with `nexus/__init__.py` importing `.auth.guards` and `.errors` — both untracked. Tests passed because the local files existed. The wheel published to PyPI would have failed with `ImportError` on every fresh install. Caught by `/release` audit and fixed in PR #467.
+
+Origin: PR #467 (2026-04-14) — bundled the missing nexus/auth/guards.py and nexus/errors.py files that PR #459/#460 left untracked.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -130,6 +130,115 @@ Any numerical claim about test counts, file counts, or coverage in session notes
 
 Origin: `workspaces/arbor-upstream-fixes/.session-notes` (2026-04-12)
 
+## Test Resource Cleanup Discipline
+
+The unit test suite is a leading indicator of production hygiene. Warnings emitted during `pytest` are not "noise" — every `ResourceWarning`, `RuntimeWarning`, or `DeprecationWarning` is a real bug in either the test or the code-under-test that will surface as a production incident in a different shape.
+
+### MUST: Fixtures Yield + Cleanup, Never Return
+
+Any fixture that constructs a resource (channel, runtime, server, connection, pool) MUST use `yield` and call the resource's cleanup method after `yield`. `return` in a fixture that creates a stateful resource is BLOCKED.
+
+```python
+# DO — yield + cleanup, resource closed when test exits
+@pytest.fixture
+def cli_channel(channel_config, mock_input_stream, mock_output_stream):
+    channel = CLIChannel(
+        config=channel_config,
+        input_stream=mock_input_stream,
+        output_stream=mock_output_stream,
+    )
+    yield channel
+    channel.close()
+
+# DO NOT — return without cleanup, resource leaks until GC
+@pytest.fixture
+def cli_channel(channel_config, mock_input_stream, mock_output_stream):
+    return CLIChannel(
+        config=channel_config,
+        input_stream=mock_input_stream,
+        output_stream=mock_output_stream,
+    )
+```
+
+**BLOCKED rationalizations:**
+
+- "The class has a `__del__` so the GC will clean it up"
+- "It's a unit test, the process exits anyway"
+- "The mock makes the resource fake, no real cleanup needed"
+
+**Why:** Resource classes that emit `ResourceWarning` from `__del__` (CLIChannel, LocalRuntime, AsyncLocalRuntime, AsyncSQLDatabaseNode) flood the test runner with warnings that hide real signals. Fixtures using `return` accumulate orphan resources across the test session — 36 unclosed channels in `test_cli_channel_comprehensive.py` produced 36 warnings before this rule landed (PR #466).
+
+### MUST: AsyncMock Replaced By Mock When side_effect Is `async def`
+
+When patching an awaitable function (e.g. `asyncio.open_connection`, `asyncio.wait_for`) with a side_effect that is itself an `async def`, MUST use `Mock(new_callable=Mock)` not the default `AsyncMock`. The `async def` side_effect already returns the coroutine — `AsyncMock` wraps it again and the inner wrapper is never awaited.
+
+```python
+# DO — Mock with async side_effect, no double-wrap
+async def fake_open(*args, **kwargs):
+    return (mock_reader, mock_writer)
+
+with patch("asyncio.open_connection", new_callable=Mock) as mock_oc:
+    mock_oc.side_effect = fake_open
+    # production code awaits mock_oc(...) → fake_open() → coroutine awaited
+    await production_code()
+
+# DO NOT — AsyncMock + async side_effect, leaks _execute_mock_call coroutine
+async def fake_open(*args, **kwargs):
+    return (mock_reader, mock_writer)
+
+with patch("asyncio.open_connection") as mock_oc:  # default = AsyncMock for awaitables
+    mock_oc.side_effect = fake_open
+    # AsyncMock._execute_mock_call wraps fake_open() into another coroutine that's never awaited
+    # → RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
+```
+
+**Why:** `AsyncMock` introspects the patched target; if it's a coroutine function, every `__call__` creates an internal `_execute_mock_call` coroutine that wraps the side_effect. When the side_effect itself is `async def`, the wrapper coroutine is created but never awaited — the warning surfaces during garbage collection, hours after the test passed. Source: PR #466 fix in `tests/unit/mcp_server/test_discovery.py`.
+
+### MUST: Test Helper Classes Without `__init__` Use Stub Naming
+
+Classes in test files that act as helper implementations (subclasses of production base classes) MUST NOT use the `Test` prefix. pytest collects every class matching `python_classes = Test*`, and a helper class with `__init__(self, **kwargs)` raises `PytestCollectionWarning: cannot collect test class because it has a __init__ constructor`.
+
+```python
+# DO — Stub naming bypasses pytest collection
+class ConditionalRuntimeStub(BaseRuntime, ConditionalExecutionMixin):
+    """Helper runtime for testing the mixin in isolation."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.executed_nodes = []
+
+# DO NOT — Test prefix triggers collection warning + skipped tests
+class TestConditionalRuntime(BaseRuntime, ConditionalExecutionMixin):
+    """Helper runtime — but pytest tries to collect it as a test class."""
+
+    def __init__(self, **kwargs):  # <-- triggers PytestCollectionWarning
+        super().__init__(**kwargs)
+```
+
+**Why:** A `Test*` class with `__init__` is silently dropped from collection AND pollutes the warning summary. The `Stub` / `Helper` / `Fake` suffix signals intent and stays out of pytest's collection path. Source: PR #466 fix in `tests/unit/runtime/mixins/test_conditional_execution_mixin.py`.
+
+### MUST: JWT Test Secrets ≥ 32 Bytes (RFC 7518 §3.2)
+
+JWT test fixtures using HS256 / HS384 / HS512 MUST use a secret of at least 32 bytes. Short test secrets trigger `InsecureKeyLengthWarning` from PyJWT and produce false-positive security signals in CI logs.
+
+```python
+# DO — 32-byte test secret per RFC 7518
+class TestJWTAuth:
+    JWT_TEST_SECRET = "test-secret-key-minimum-32-bytes!"
+
+    def test_create_token(self):
+        auth = JWTAuth(self.JWT_TEST_SECRET, algorithm="HS256")
+        # ...
+
+# DO NOT — short test secret
+def test_create_token():
+    auth = JWTAuth("secret_key", algorithm="HS256")  # 10 bytes → InsecureKeyLengthWarning
+```
+
+**Why:** Short HMAC keys reduce brute-force resistance and are the same code path as production. A test that ships with a 10-byte key teaches the next contributor that 10 bytes is acceptable. Source: PR #466 fix in `tests/unit/mcp_server/test_auth.py`.
+
+Origin: PR #466 (2026-04-14) — eliminated 63 unit test warnings across 10 categories. Each pattern above resolves a category that recurred until the rule was added.
+
 ## 3-Tier Testing
 
 ### Tier 1 (Unit): Mocking allowed, <1s per test

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,6 +11,7 @@ on:
       - "kaizen-agents-v*" # Kaizen Agents: kaizen-agents-v0.3.0
       - "ml-v*" # ML: ml-v0.1.0
       - "align-v*" # Align: align-v0.1.0
+      - "mcp-v*" # MCP: mcp-v0.2.4
   workflow_dispatch:
     inputs:
       package:
@@ -26,6 +27,7 @@ on:
           - kaizen-agents
           - kailash-ml
           - kailash-align
+          - kailash-mcp
       publish_to:
         description: "Target registry"
         required: true
@@ -59,6 +61,7 @@ jobs:
               kaizen-agents)    echo "package_dir=packages/kaizen-agents" >> $GITHUB_OUTPUT ;;
               kailash-ml)       echo "package_dir=packages/kailash-ml" >> $GITHUB_OUTPUT ;;
               kailash-align)    echo "package_dir=packages/kailash-align" >> $GITHUB_OUTPUT ;;
+              kailash-mcp)      echo "package_dir=packages/kailash-mcp" >> $GITHUB_OUTPUT ;;
             esac
             echo "package=$PACKAGE" >> $GITHUB_OUTPUT
             echo "version=manual" >> $GITHUB_OUTPUT
@@ -91,6 +94,10 @@ jobs:
             elif [[ "$TAG" =~ ^align-v(.+)$ ]]; then
               echo "package=kailash-align" >> $GITHUB_OUTPUT
               echo "package_dir=packages/kailash-align" >> $GITHUB_OUTPUT
+              VERSION="${BASH_REMATCH[1]}"
+            elif [[ "$TAG" =~ ^mcp-v(.+)$ ]]; then
+              echo "package=kailash-mcp" >> $GITHUB_OUTPUT
+              echo "package_dir=packages/kailash-mcp" >> $GITHUB_OUTPUT
               VERSION="${BASH_REMATCH[1]}"
             elif [[ "$TAG" =~ ^v(.+)$ ]]; then
               echo "package=kailash" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Codification of institutional knowledge from the 2026-04-14 release session (PR #466 + PR #467).

### Rules updated

- **rules/testing.md** — 4 new MUST clauses for test resource cleanup discipline (fixtures yield+cleanup, AsyncMock vs Mock for async side_effects, Stub naming for helper classes, JWT 32-byte minimum)
- **rules/deployment.md** — 2 new MUST clauses for SDK release (extras pin to PyPI-resolvable versions, all __init__.py imports tracked in git)

### Workflow fix

- **.github/workflows/publish-pypi.yml** — Added kailash-mcp support (4 places). Caught when mcp-v0.2.4 tag could not auto-publish.

### Proposal

- **.claude/.proposals/latest.yaml** — Fresh proposal for loom/ Gate 1 review
- **.claude/.proposals/archive/2026-04-14-kailash-py-nexus-bindings.yaml** — archived previous distributed proposal

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes
- [ ] Loom Gate 1 review (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)