### PR TITLE
fix(nexus): ForbiddenError rename + batch-tag-push rule (nexus 2.0.3)

### DIFF
--- a/.claude/rules/deployment.md
+++ b/.claude/rules/deployment.md
@@ -115,3 +115,29 @@ done
 **Why:** Editable installs see the local working tree, including untracked files. PyPI users get only what's in the wheel, which is built from `git ls-files`. PR #459/#460 merged with `nexus/__init__.py` importing `.auth.guards` and `.errors` — both untracked. Tests passed because the local files existed. The wheel published to PyPI would have failed with `ImportError` on every fresh install. Caught by `/release` audit and fixed in PR #467.
 
 Origin: PR #467 (2026-04-14) — bundled the missing nexus/auth/guards.py and nexus/errors.py files that PR #459/#460 left untracked.
+
+## MUST: Multi-Package Release Tags Pushed Individually
+
+Coordinated multi-package releases MUST push each release tag in a separate `git push` command, with a brief pause between pushes. Batch-pushing 3+ tags in a single command is BLOCKED — GitHub's `push.tags` webhook drops workflow triggers silently.
+
+```bash
+# DO — one tag per push, trigger fires reliably
+for tag in v2.8.6 dataflow-v2.0.8 kaizen-v2.7.4 nexus-v2.0.2 mcp-v0.2.4; do
+  git push origin "$tag"
+  sleep 1
+done
+
+# DO NOT — batch push, workflows silently skipped
+git push origin v2.8.6 dataflow-v2.0.8 kaizen-v2.7.4 nexus-v2.0.2 mcp-v0.2.4
+# Observed 2026-04-14: ZERO of 5 tags triggered publish-pypi.yml.
+# Required manual workflow_dispatch for each package.
+```
+
+**BLOCKED rationalizations:**
+
+- "Batch push is faster"
+- "The workflow should handle multiple tag events"
+- "We can check for missing runs after"
+- "It worked last time with 2 tags"
+
+**Why:** GitHub Actions' `push.tags` webhook delivery has undocumented rate-limiting when multiple tags arrive in a single push event. Batch pushes of 3+ tags fail to trigger the workflow for most (or all) of the tags. The failure is silent — the tags are created successfully, but `publish-pypi.yml` runs never appear in the Actions tab. Recovery requires manual `workflow_dispatch` per package, which is error-prone (must remember every package) and leaves a paper-trail asymmetry. Source: 2026-04-14 release where `git push origin v2.8.6 dataflow-v2.0.8 kaizen-v2.7.4 nexus-v2.0.2 mcp-v0.2.4` triggered zero workflow runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### kailash-nexus 2.0.3 — 2026-04-14
+
+#### Added
+
+- **`ForbiddenError` canonical 403 class** (`kailash-nexus 2.0.3`): Added `nexus.ForbiddenError` as the canonical name for authorization failures. Avoids shadowing Python's stdlib `PermissionError` for any consumer that `from nexus.errors import *` or rebinds `PermissionError` locally. The previous `PermissionError` class is kept as a deprecated alias — `from nexus.errors import PermissionError` and `from nexus import NexusPermissionError` continue to work unchanged. Resolves security-review finding M1.
+
+#### Changed
+
+- **Internal `core.py` callers migrated to `ForbiddenError`** — the guard-failure code path (`_wrap_with_guard` for both sync and async) now raises `ForbiddenError` directly. The runtime class is identical (`PermissionError is ForbiddenError`), so existing `except nexus.NexusPermissionError` handlers continue to catch it.
+
 ### kailash 2.8.6 + kailash-dataflow 2.0.8 + kailash-kaizen 2.7.4 + kailash-nexus 2.0.2 + kailash-mcp 0.2.4 — 2026-04-14
 
 #### Fixed

--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -20,7 +20,7 @@
 | kailash (core)   | `v*`               | 2.8.6           |
 | kailash-dataflow | `dataflow-v*`      | 2.0.8           |
 | kailash-kaizen   | `kaizen-v*`        | 2.7.4           |
-| kailash-nexus    | `nexus-v*`         | 2.0.2           |
+| kailash-nexus    | `nexus-v*`         | 2.0.3           |
 | kailash-pact     | `pact-v*`          | 0.8.1           |
 | kailash-ml       | `ml-v*`            | 0.9.0           |
 | kailash-align    | `align-v*`         | 0.3.1           |
@@ -66,3 +66,33 @@ git tag v2.5.0 -m "Release message"
 
 GitHub Actions `push.tags` webhook processing handles lightweight tags
 more reliably than annotated tags pushed after creation.
+
+## Multi-Tag Release — Push Individually
+
+When releasing multiple packages at once (coordinated patch release), tags
+MUST be pushed individually, NOT in a single batch. Batch pushes of 3+ tags
+fail to trigger the publish workflow reliably.
+
+```bash
+# CORRECT — push tags one at a time
+git push origin v2.8.6
+git push origin dataflow-v2.0.8
+git push origin kaizen-v2.7.4
+git push origin nexus-v2.0.2
+git push origin mcp-v0.2.4
+
+# WRONG — batch push silently skips workflow triggers
+git push origin v2.8.6 dataflow-v2.0.8 kaizen-v2.7.4 nexus-v2.0.2 mcp-v0.2.4
+# ↑ observed on 2026-04-14: ZERO of 5 tags triggered publish-pypi.yml.
+# Required manual workflow_dispatch for each package.
+```
+
+**Why:** GitHub Actions' `push.tags` webhook delivery has undocumented
+rate-limiting/batching behavior when multiple tags arrive in a single push
+event. The first observed failure mode (2026-04-14): 5 tags pushed at once
+triggered zero workflow runs. Individual pushes with a brief pause (≥1s)
+between them trigger reliably.
+
+**Recovery if a batch push was already done**: use `workflow_dispatch` to
+manually trigger publishing for each affected package. The tags themselves
+are still valid — only the auto-trigger was missed.

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.0.2"
+version = "2.0.3"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -65,13 +65,19 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
-from .errors import BadGatewayError, ConflictError, NexusError, NotFoundError
-from .errors import PermissionError as NexusPermissionError
+from .errors import (
+    BadGatewayError,
+    ConflictError,
+    ForbiddenError,
+    NexusError,
+    NotFoundError,
+)
+from .errors import PermissionError as NexusPermissionError  # deprecated alias
 from .errors import RateLimitError, ServiceUnavailableError
 from .errors import TimeoutError as NexusTimeoutError
 from .errors import UnauthorizedError, ValidationError
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __all__ = [
     # Core
     "Nexus",
@@ -129,7 +135,8 @@ __all__ = [
     "NotFoundError",
     "ConflictError",
     "UnauthorizedError",
-    "NexusPermissionError",
+    "ForbiddenError",  # canonical name for 403
+    "NexusPermissionError",  # deprecated alias for ForbiddenError
     "RateLimitError",
     "ServiceUnavailableError",
     "BadGatewayError",

--- a/packages/kailash-nexus/src/nexus/auth/guards.py
+++ b/packages/kailash-nexus/src/nexus/auth/guards.py
@@ -7,7 +7,7 @@ AuthGuard provides a declarative way to attach RBAC constraints to
 individual handlers rather than relying solely on route-scoped
 middleware. When a handler is registered with ``guard=``, the guard's
 ``check()`` method is called before the handler function executes. If
-the check fails, a ``PermissionError`` is raised and the handler never
+the check fails, a ``ForbiddenError`` is raised and the handler never
 runs.
 
 Usage::

--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -163,9 +163,9 @@ def _wrap_with_guard(func: Callable, guard: Any, handler_name: str) -> Callable:
             ctx = {"handler": handler_name}
             passed, reason = guard.check(user, ctx)
             if not passed:
-                from nexus.errors import PermissionError as NexusPermError
+                from nexus.errors import ForbiddenError
 
-                raise NexusPermError(reason or "Access denied")
+                raise ForbiddenError(reason or "Access denied")
             return await func(*args, **kwargs)
 
         return async_guarded
@@ -177,9 +177,9 @@ def _wrap_with_guard(func: Callable, guard: Any, handler_name: str) -> Callable:
             ctx = {"handler": handler_name}
             passed, reason = guard.check(user, ctx)
             if not passed:
-                from nexus.errors import PermissionError as NexusPermError
+                from nexus.errors import ForbiddenError
 
-                raise NexusPermError(reason or "Access denied")
+                raise ForbiddenError(reason or "Access denied")
             return func(*args, **kwargs)
 
         return sync_guarded

--- a/packages/kailash-nexus/src/nexus/errors.py
+++ b/packages/kailash-nexus/src/nexus/errors.py
@@ -41,7 +41,8 @@ __all__ = [
     "NotFoundError",
     "ConflictError",
     "UnauthorizedError",
-    "PermissionError",
+    "ForbiddenError",  # canonical name for 403
+    "PermissionError",  # deprecated alias for ForbiddenError (shadows stdlib)
     "RateLimitError",
     "ServiceUnavailableError",
     "BadGatewayError",
@@ -162,7 +163,7 @@ class UnauthorizedError(NexusError):
 
     Raised when the request has no credentials or the credentials are
     invalid.  Do NOT use for authorization failures (missing roles or
-    permissions) -- use ``PermissionError`` (403) instead.
+    permissions) -- use ``ForbiddenError`` (403) instead.
     """
 
     status_code: int = 401
@@ -177,13 +178,18 @@ class UnauthorizedError(NexusError):
         super().__init__(detail, context=context)
 
 
-class PermissionError(NexusError):
+class ForbiddenError(NexusError):
     """Authenticated but lacks required permission (403).
 
     The request was authenticated (valid JWT, API key, etc.) but the
     identity does not have the role or permission needed to access this
     resource.  The ``detail`` message intentionally does NOT reveal which
     permission is missing (information leakage).
+
+    .. note::
+        Renamed from ``PermissionError`` to avoid shadowing the stdlib
+        ``PermissionError`` exception. ``PermissionError`` remains as a
+        deprecated alias; use ``ForbiddenError`` for new code.
     """
 
     status_code: int = 403
@@ -196,6 +202,12 @@ class PermissionError(NexusError):
         context: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(detail, context=context)
+
+
+# Deprecated alias — shadows stdlib PermissionError. New code MUST use
+# ForbiddenError. Kept for backwards compatibility with code that imports
+# ``from nexus.errors import PermissionError`` directly.
+PermissionError = ForbiddenError
 
 
 class RateLimitError(NexusError):


### PR DESCRIPTION
## Summary

Resolves the three follow-ups from the 2026-04-14 release session.

### Security M1: PermissionError shadows stdlib — renamed to ForbiddenError

- `nexus.errors.PermissionError` renamed to `ForbiddenError` (canonical HTTP-status name)
- Kept `PermissionError = ForbiddenError` as module-level deprecated alias for backwards compat
- Internal `core.py` guard-failure raisers updated to `ForbiddenError`
- Public `NexusPermissionError` alias on `nexus/__init__.py` retained

Runtime behavior unchanged (same class, two names). Bumps **kailash-nexus 2.0.2 → 2.0.3**.

### Batch tag push rule

Documented the GitHub webhook rate-limiting that silently dropped all 5 publish-workflow triggers on 2026-04-14. Added MUST rule requiring individual tag pushes with ≥1s pause. Recovery procedure documented in `deploy/deployment-config.md`.

## Test plan
- [x] `pytest packages/kailash-nexus/tests/unit/test_nexus_bindings_459.py` — 15/15 pass
- [x] `pytest tests/unit/` — 3309 pass, 0 warnings
- [x] Pre-commit hooks pass
- [ ] CI passes

## Related
- Security review of PR #467 (finding M1)
- 2026-04-14 release session

🤖 Generated with [Claude Code](https://claude.com/claude-code)