### PR TITLE
chore(codify): capture Python version bump playbook from PR #474

### DIFF
--- a/.claude/.proposals/archive/2026-04-14-kailash-py.yaml
+++ b/.claude/.proposals/archive/2026-04-14-kailash-py.yaml
@@ -1,0 +1,125 @@
+source_repo: kailash-py
+codify_date: "2026-04-14"
+codify_session: "fix(test): resolve all 63 unit test warnings + chore(release): coordinated patch release + security M1 follow-ups"
+sdk_version: 2.8.6
+coc_version: 1.0.3
+status: distributed
+distributed_date: 2026-04-14T15:43:44Z
+changes:
+  - file: rules/testing.md
+    action: modified
+    suggested_tier: global
+    reason: |
+      Added "Test Resource Cleanup Discipline" section with 4 new MUST rules
+      covering patterns surfaced by PR #466 (resolved 63 unit test warnings):
+      (1) Fixtures yield + cleanup, never return — for resources with __del__
+          ResourceWarning (CLIChannel, LocalRuntime, AsyncLocalRuntime,
+          AsyncSQLDatabaseNode);
+      (2) AsyncMock replaced by Mock(new_callable=Mock) when side_effect is
+          async def — prevents _execute_mock_call coroutine leak;
+      (3) Test helper classes without __init__ use Stub naming — avoids
+          PytestCollectionWarning for Test* classes with __init__;
+      (4) JWT test secrets ≥ 32 bytes per RFC 7518 §3.2 — eliminates
+          InsecureKeyLengthWarning false positives in CI.
+      All four are universal Python testing patterns; classify as global.
+    diff_lines: "+103"
+  - file: rules/deployment.md
+    action: modified
+    suggested_tier: variant-py
+    reason: |
+      Added 3 new MUST rules to the SDK release rules:
+      (1) Optional dependencies pin to PyPI-resolvable versions — extras MUST
+          NOT bump to the version being released, because CI installs from
+          PyPI before the release is published. Framework SDK pins inside
+          each sub-package's pyproject.toml ARE allowed to bump because they
+          resolve against the local editable install. Source: PR #467 fix
+          (commit a50d3119).
+      (2) All files imported by package __init__.py MUST be tracked in git —
+          editable installs see local working tree, but PyPI wheel only
+          includes git-tracked files. PR #459/#460 merged with nexus/__init__.py
+          importing untracked files; would have published a broken wheel.
+          Caught by /release audit and bundled in PR #467.
+      (3) Multi-package release tags MUST be pushed individually with ≥1s
+          pause between pushes. Batch pushes of 3+ tags trigger GitHub's
+          undocumented push.tags webhook rate-limiting — ZERO of 5 tags
+          triggered publish-pypi.yml on 2026-04-14. Recovery requires manual
+          workflow_dispatch per package. Validated empirically when the
+          single-tag push of nexus-v2.0.3 auto-triggered correctly. Source:
+          PR #469.
+      All three rules are Python/pyproject.toml/git-tag-specific. Classify
+      as variant-py. The Rust SDK has its own equivalent failure modes
+      (Cargo workspace pinning, mod declarations, crates.io release)
+      — separate rules needed for variants/rs.
+    diff_lines: "+93"
+  - file: .github/workflows/publish-pypi.yml
+    action: modified
+    suggested_tier: variant-py
+    reason: |
+      Added kailash-mcp to the PyPI publish workflow (4 places: tag pattern,
+      workflow_dispatch options, manual case statement, tag regex elif). The
+      mcp-v0.2.4 tag could not auto-publish because the workflow had never
+      been updated when kailash-mcp was added as a sub-package. Discovered
+      during the 2026-04-14 release when 4/5 packages auto-published but mcp
+      had to be manually triggered. Variant-py because the workflow is
+      Python-specific.
+    diff_lines: "+5"
+  - file: deploy/deployment-config.md
+    action: modified
+    suggested_tier: variant-py
+    reason: |
+      Added "Multi-Tag Release — Push Individually" section documenting the
+      batch-tag-push failure mode observed on 2026-04-14 (ZERO of 5 tags
+      triggered publish-pypi.yml from a single batch push). Includes DO/DO
+      NOT examples and recovery procedure (workflow_dispatch per package).
+      Also bumped kailash-nexus from 2.0.2 → 2.0.3 in the versions table.
+      Variant-py because deployment-config is Python/PyPI-specific.
+    diff_lines: "+27"
+production_changes:
+  - file: packages/kailash-mcp/src/kailash_mcp/advanced/subscriptions.py
+    change: "Replaced datetime.utcnow() with datetime.now(UTC) — Python 3.12+ deprecation fix"
+    pr: "#466"
+  - file: packages/kailash-nexus/src/nexus/auth/guards.py
+    change: "Added 277 LOC — was imported by nexus/__init__.py but never committed (PR #459/#460 oversight)"
+    pr: "#467"
+  - file: packages/kailash-nexus/src/nexus/errors.py
+    change: "Added 276 LOC — was imported by nexus/__init__.py but never committed (PR #459/#460 oversight)"
+    pr: "#467"
+  - file: packages/kailash-nexus/src/nexus/errors.py
+    change: |
+      Renamed PermissionError → ForbiddenError (canonical HTTP-status name).
+      Kept PermissionError = ForbiddenError as deprecated module-level alias
+      for backwards compatibility. Resolves security-review M1 finding
+      (shadowing stdlib PermissionError). Internal core.py guard-failure
+      raisers migrated to ForbiddenError. Public NexusPermissionError alias
+      retained.
+    pr: "#469"
+  - file: packages/kailash-nexus/src/nexus/__init__.py
+    change: "Added ForbiddenError to imports and __all__; kept NexusPermissionError deprecated alias"
+    pr: "#469"
+  - file: packages/kailash-nexus/src/nexus/core.py
+    change: "Migrated guard-failure raisers (both sync+async) from PermissionError to ForbiddenError"
+    pr: "#469"
+release_packages:
+  - { name: kailash, from: 2.8.5, to: 2.8.6 }
+  - { name: kailash-dataflow, from: 2.0.7, to: 2.0.8 }
+  - { name: kailash-kaizen, from: 2.7.3, to: 2.7.4 }
+  - { name: kailash-nexus, from: 2.0.1, to: 2.0.3 } # 2.0.2 released, then 2.0.3 for M1 fix
+  - { name: kailash-mcp, from: 0.2.3, to: 0.2.4 }
+notes: |
+  All changes validated and shipped to PyPI:
+  - 3309 unit tests pass with 0 warnings (was 63)
+  - security-reviewer APPROVED PR #467 with 1 MEDIUM finding (M1: PermissionError
+    shadowing) — resolved in PR #469 by renaming to ForbiddenError
+  - reviewer APPROVED (version consistency, SDK pin symmetry, CHANGELOG accuracy)
+  - PR #466 merged (warning fixes)
+  - PR #467 merged (coordinated release on main)
+  - PR #468 merged (initial codify)
+  - PR #469 merged (security M1 fix + batch-tag-push rule)
+  - 6 release tags pushed: v2.8.6, dataflow-v2.0.8, kaizen-v2.7.4, nexus-v2.0.2,
+    nexus-v2.0.3, mcp-v0.2.4
+  - 5/5 packages verified live on PyPI with new versions
+
+  Batch-tag-push rule validated empirically:
+  - 5-tag batch push (2026-04-14): triggered 0 workflow runs
+  - Single tag push of nexus-v2.0.3 (2026-04-14): auto-triggered correctly
+  - Rule in rules/deployment.md § "Multi-Package Release Tags Pushed Individually"

--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1,124 +1,42 @@
 source_repo: kailash-py
-codify_date: "2026-04-14"
-codify_session: "fix(test): resolve all 63 unit test warnings + chore(release): coordinated patch release + security M1 follow-ups"
+codify_date: "2026-04-15"
+codify_session: "feat(ci): declare Python 3.14 support across all packages (PR #474)"
 sdk_version: 2.8.6
 coc_version: 1.0.3
 status: pending_review
 changes:
-  - file: rules/testing.md
+  - file: skills/10-deployment-git/python-version-bump.md
+    action: created
+    suggested_tier: global
+    reason: |
+      New playbook capturing the end-to-end recipe for declaring support
+      for a new CPython minor release across the SDK. Validated by the
+      3.13 → 3.14 bump (PR #474, 2026-04-15). Three steps:
+        1. Add `Python :: 3.X` classifier to all 10 pyproject.toml files
+           (root + 9 sub-packages).
+        2. Append `"3.X"` to the 4 CI matrix files (unified-ci,
+           test-kailash-ml, test-kailash-align, trust-plane).
+        3. Verify locally with `uv venv --python 3.X` + per-package
+           `uv pip install --dry-run` BEFORE pushing — catches missing
+           ML-stack wheels (torch/transformers/accelerate) without
+           burning CI minutes.
+      Also documents the durable cross-surface version-test pattern
+      (assert SemVer regex AND `pkg.__version__ == _version.__version__`)
+      that prevents the recurring "stale literal version assertion"
+      failure mode caught in PR #474 (kailash-align test had been red
+      on main for two release bumps because fixture hardcoded "0.2.1"
+      after the package shipped 0.3.1).
+      Pure Python recipe — no language-specific content. Classify global
+      so the rs/rb variants can adapt for their own classifier/matrix
+      surfaces.
+    diff_lines: "+89"
+  - file: skills/10-deployment-git/SKILL.md
     action: modified
     suggested_tier: global
     reason: |
-      Added "Test Resource Cleanup Discipline" section with 4 new MUST rules
-      covering patterns surfaced by PR #466 (resolved 63 unit test warnings):
-      (1) Fixtures yield + cleanup, never return — for resources with __del__
-          ResourceWarning (CLIChannel, LocalRuntime, AsyncLocalRuntime,
-          AsyncSQLDatabaseNode);
-      (2) AsyncMock replaced by Mock(new_callable=Mock) when side_effect is
-          async def — prevents _execute_mock_call coroutine leak;
-      (3) Test helper classes without __init__ use Stub naming — avoids
-          PytestCollectionWarning for Test* classes with __init__;
-      (4) JWT test secrets ≥ 32 bytes per RFC 7518 §3.2 — eliminates
-          InsecureKeyLengthWarning false positives in CI.
-      All four are universal Python testing patterns; classify as global.
-    diff_lines: "+103"
-  - file: rules/deployment.md
-    action: modified
-    suggested_tier: variant-py
-    reason: |
-      Added 3 new MUST rules to the SDK release rules:
-      (1) Optional dependencies pin to PyPI-resolvable versions — extras MUST
-          NOT bump to the version being released, because CI installs from
-          PyPI before the release is published. Framework SDK pins inside
-          each sub-package's pyproject.toml ARE allowed to bump because they
-          resolve against the local editable install. Source: PR #467 fix
-          (commit a50d3119).
-      (2) All files imported by package __init__.py MUST be tracked in git —
-          editable installs see local working tree, but PyPI wheel only
-          includes git-tracked files. PR #459/#460 merged with nexus/__init__.py
-          importing untracked files; would have published a broken wheel.
-          Caught by /release audit and bundled in PR #467.
-      (3) Multi-package release tags MUST be pushed individually with ≥1s
-          pause between pushes. Batch pushes of 3+ tags trigger GitHub's
-          undocumented push.tags webhook rate-limiting — ZERO of 5 tags
-          triggered publish-pypi.yml on 2026-04-14. Recovery requires manual
-          workflow_dispatch per package. Validated empirically when the
-          single-tag push of nexus-v2.0.3 auto-triggered correctly. Source:
-          PR #469.
-      All three rules are Python/pyproject.toml/git-tag-specific. Classify
-      as variant-py. The Rust SDK has its own equivalent failure modes
-      (Cargo workspace pinning, mod declarations, crates.io release)
-      — separate rules needed for variants/rs.
-    diff_lines: "+93"
-  - file: .github/workflows/publish-pypi.yml
-    action: modified
-    suggested_tier: variant-py
-    reason: |
-      Added kailash-mcp to the PyPI publish workflow (4 places: tag pattern,
-      workflow_dispatch options, manual case statement, tag regex elif). The
-      mcp-v0.2.4 tag could not auto-publish because the workflow had never
-      been updated when kailash-mcp was added as a sub-package. Discovered
-      during the 2026-04-14 release when 4/5 packages auto-published but mcp
-      had to be manually triggered. Variant-py because the workflow is
-      Python-specific.
-    diff_lines: "+5"
-  - file: deploy/deployment-config.md
-    action: modified
-    suggested_tier: variant-py
-    reason: |
-      Added "Multi-Tag Release — Push Individually" section documenting the
-      batch-tag-push failure mode observed on 2026-04-14 (ZERO of 5 tags
-      triggered publish-pypi.yml from a single batch push). Includes DO/DO
-      NOT examples and recovery procedure (workflow_dispatch per package).
-      Also bumped kailash-nexus from 2.0.2 → 2.0.3 in the versions table.
-      Variant-py because deployment-config is Python/PyPI-specific.
-    diff_lines: "+27"
-production_changes:
-  - file: packages/kailash-mcp/src/kailash_mcp/advanced/subscriptions.py
-    change: "Replaced datetime.utcnow() with datetime.now(UTC) — Python 3.12+ deprecation fix"
-    pr: "#466"
-  - file: packages/kailash-nexus/src/nexus/auth/guards.py
-    change: "Added 277 LOC — was imported by nexus/__init__.py but never committed (PR #459/#460 oversight)"
-    pr: "#467"
-  - file: packages/kailash-nexus/src/nexus/errors.py
-    change: "Added 276 LOC — was imported by nexus/__init__.py but never committed (PR #459/#460 oversight)"
-    pr: "#467"
-  - file: packages/kailash-nexus/src/nexus/errors.py
-    change: |
-      Renamed PermissionError → ForbiddenError (canonical HTTP-status name).
-      Kept PermissionError = ForbiddenError as deprecated module-level alias
-      for backwards compatibility. Resolves security-review M1 finding
-      (shadowing stdlib PermissionError). Internal core.py guard-failure
-      raisers migrated to ForbiddenError. Public NexusPermissionError alias
-      retained.
-    pr: "#469"
-  - file: packages/kailash-nexus/src/nexus/__init__.py
-    change: "Added ForbiddenError to imports and __all__; kept NexusPermissionError deprecated alias"
-    pr: "#469"
-  - file: packages/kailash-nexus/src/nexus/core.py
-    change: "Migrated guard-failure raisers (both sync+async) from PermissionError to ForbiddenError"
-    pr: "#469"
-release_packages:
-  - { name: kailash, from: 2.8.5, to: 2.8.6 }
-  - { name: kailash-dataflow, from: 2.0.7, to: 2.0.8 }
-  - { name: kailash-kaizen, from: 2.7.3, to: 2.7.4 }
-  - { name: kailash-nexus, from: 2.0.1, to: 2.0.3 } # 2.0.2 released, then 2.0.3 for M1 fix
-  - { name: kailash-mcp, from: 0.2.3, to: 0.2.4 }
-notes: |
-  All changes validated and shipped to PyPI:
-  - 3309 unit tests pass with 0 warnings (was 63)
-  - security-reviewer APPROVED PR #467 with 1 MEDIUM finding (M1: PermissionError
-    shadowing) — resolved in PR #469 by renaming to ForbiddenError
-  - reviewer APPROVED (version consistency, SDK pin symmetry, CHANGELOG accuracy)
-  - PR #466 merged (warning fixes)
-  - PR #467 merged (coordinated release on main)
-  - PR #468 merged (initial codify)
-  - PR #469 merged (security M1 fix + batch-tag-push rule)
-  - 6 release tags pushed: v2.8.6, dataflow-v2.0.8, kaizen-v2.7.4, nexus-v2.0.2,
-    nexus-v2.0.3, mcp-v0.2.4
-  - 5/5 packages verified live on PyPI with new versions
-
-  Batch-tag-push rule validated empirically:
-  - 5-tag batch push (2026-04-14): triggered 0 workflow runs
-  - Single tag push of nexus-v2.0.3 (2026-04-14): auto-triggered correctly
-  - Rule in rules/deployment.md § "Multi-Package Release Tags Pushed Individually"
+      Added an index entry for the new python-version-bump playbook
+      under the Deployment Lifecycle section, between deployment-ci
+      and the Docker section. Five-line entry with the trigger,
+      3-step summary, and gotcha headline so the playbook is
+      discoverable from the skill's main TOC.
+    diff_lines: "+7"

--- a/.claude/skills/10-deployment-git/SKILL.md
+++ b/.claude/skills/10-deployment-git/SKILL.md
@@ -29,7 +29,7 @@ SDK release and development infrastructure patterns for:
   - Create deployment-config.md
 
 - **[release-runbook](release-runbook.md)** - SDK release runbook (detailed procedures)
-  - Version locations for all packages (pyproject.toml + __init__.py)
+  - Version locations for all packages (pyproject.toml + **init**.py)
   - SDK dependency pin rules
   - Version consistency verification commands
   - Pre-release, build, publish, post-release step-by-step procedures
@@ -49,6 +49,13 @@ SDK release and development infrastructure patterns for:
   - Tag-triggered publishing pipeline
   - Documentation deployment (ReadTheDocs, GitHub Pages)
   - Self-hosted runner management
+
+- **[python-version-bump](python-version-bump.md)** - Python minor-version bump playbook
+  - When to declare a new CPython release (3.X stable + ≥1 patch)
+  - 3-step recipe: pyproject classifiers → CI matrices → `uv pip install --dry-run --python 3.X` verification
+  - Concrete file list for all 10 packages and 4 CI matrix files
+  - Common gotcha: stale literal version assertions in test fixtures (durable cross-surface contract pattern)
+  - ML stack wheel-lag guidance (torch / transformers / accelerate)
 
 ### Docker
 

--- a/.claude/skills/10-deployment-git/python-version-bump.md
+++ b/.claude/skills/10-deployment-git/python-version-bump.md
@@ -1,0 +1,119 @@
+# Python Version Bump Playbook
+
+When CPython ships a new stable release (~yearly, October), declare support across the SDK in three steps. Verified end-to-end on the 3.13 → 3.14 bump (PR #474, 2026-04-15).
+
+## Trigger
+
+A new CPython minor version has been stable on python.org for at least one release patch (3.X.0 → 3.X.1). Earlier than that, ML stack wheels (torch, transformers) typically aren't published yet.
+
+## The 3-Step Recipe
+
+### 1. Add the classifier to every `pyproject.toml`
+
+Edit the trove classifier list in **all 10** package manifests (root + 9 sub-packages). Append `Python :: 3.X` after the highest existing version.
+
+```toml
+classifiers = [
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",   # <-- add this
+]
+```
+
+Files (current as of 2026-04-15):
+
+```
+pyproject.toml
+packages/kailash-dataflow/pyproject.toml
+packages/kailash-nexus/pyproject.toml
+packages/kailash-kaizen/pyproject.toml
+packages/kailash-mcp/pyproject.toml
+packages/kailash-pact/pyproject.toml
+packages/kailash-trust/pyproject.toml
+packages/kaizen-agents/pyproject.toml
+packages/kailash-ml/pyproject.toml
+packages/kailash-align/pyproject.toml
+```
+
+`requires-python = ">=3.11"` floor stays unchanged — we are widening declared support, not narrowing the minimum.
+
+### 2. Add `"3.X"` to every per-version CI matrix
+
+Four workflow files have `python-version` matrices that test multiple versions:
+
+```
+.github/workflows/unified-ci.yml          # core kailash matrix
+.github/workflows/test-kailash-ml.yml     # ML stack matrix
+.github/workflows/test-kailash-align.yml  # Align stack matrix
+.github/workflows/trust-plane.yml         # trust plane × ubuntu/windows
+```
+
+Append `"3.X"` to each matrix array. **Do not** change single-version utility jobs (`publish-pypi.yml` builds wheels on 3.12 and that is correct — pure-Python wheels are forward-compatible).
+
+### 3. Verify locally with `uv` BEFORE pushing
+
+This catches missing wheels (especially in the ML stack) before CI burns time on it.
+
+```bash
+# Create a throwaway 3.X venv (uv auto-downloads the interpreter if needed)
+uv venv --python 3.X /tmp/py3X-resolve
+
+# Dry-run resolution per package — fails loudly if any wheel is missing for cp3X
+for pkg in . packages/*/; do
+  echo "=== $pkg ==="
+  uv pip install --dry-run --python /tmp/py3X-resolve/bin/python "$pkg" 2>&1 | tail -3
+done
+
+# Confirm ML chain explicitly (highest-risk deps)
+uv pip install --dry-run --python /tmp/py3X-resolve/bin/python packages/kailash-align \
+  | grep -iE "^\s*\+ (torch|transformers|trl|accelerate|peft|datasets|polars|numpy|scikit-learn)"
+
+# Optional: real install + smoke test of root kailash
+uv pip install --python /tmp/py3X-resolve/bin/python .
+/tmp/py3X-resolve/bin/python -c "import kailash; print(kailash.__version__)"
+
+# Cleanup
+rm -rf /tmp/py3X-resolve
+```
+
+If every package returns dependency lines (no `error:` or `No matching distribution`), 3.X is safe to declare.
+
+## Common Gotchas
+
+### Stale literal version assertions in test fixtures
+
+Per-package version tests that hardcode the version string (e.g. `assert __version__ == "0.2.1"`) silently rot on every release bump and only surface when the matrix runs them. The 3.14 PR surfaced exactly this in `packages/kailash-align/tests/test_package.py` — the fixture had been red on `main` for two release bumps.
+
+**Durable pattern** (no literal coupling to a specific version):
+
+```python
+import re
+
+class TestVersion:
+    _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
+
+    def test_version_accessible(self):
+        from mypkg._version import __version__
+        assert self._SEMVER_RE.match(__version__), __version__
+
+    def test_version_from_package(self):
+        import mypkg
+        from mypkg._version import __version__ as canonical
+        assert mypkg.__version__ == canonical  # cross-surface contract
+```
+
+**Why:** Asserting a literal couples the test to a moving target. Asserting the contract (PEP 440 format AND `mypkg.__version__ == _version.__version__`) survives every release bump and would have caught the original drift that caused the staleness.
+
+### Wheel build version
+
+`publish-pypi.yml` hard-codes `python-version: "3.12"` for the wheel build job. Leave it alone unless the build itself needs newer syntax — pure-Python wheels (`Requires-Python: >=3.11`) install cleanly on 3.13 and 3.14 regardless of the build interpreter.
+
+### ML stack wheel lag
+
+`torch`, `transformers`, `accelerate` typically publish cp3X wheels 3-6 months after CPython 3.X.0 stable. If Step 3 shows missing wheels for any of those, do not add 3.X to the `kailash-ml` / `kailash-align` matrices — wait for upstream. The other 8 packages can still ship 3.X support.
+
+## Reference
+
+PR #474 (2026-04-15) — first end-to-end execution of this recipe. Two commits:
+
+- `44c00dc7` — classifier + matrix changes (15 files, +24 / -6)
+- `bad6f505` — collateral fix for stale align version-test literal


### PR DESCRIPTION
## Summary

Codifies the 3-step recipe for declaring SDK support for new CPython minor releases, validated end-to-end by the 3.13 → 3.14 bump in #474.

## What's added

- **`skills/10-deployment-git/python-version-bump.md`** (new, ~120 lines) — the playbook itself
  - When to trigger (CPython 3.X stable + ≥1 patch released)
  - Step 1: trove classifiers in all 10 `pyproject.toml` files (concrete file list)
  - Step 2: `python-version` matrices in 4 CI workflows (concrete file list)
  - Step 3: `uv venv --python 3.X` + `uv pip install --dry-run` verification command (with the ML-chain explicit grep that surfaces torch/transformers wheel availability)
  - Common gotchas: stale-literal version-test fixtures, wheel build version, ML wheel lag
- **`skills/10-deployment-git/SKILL.md`** — index entry under Deployment Lifecycle, between `deployment-ci` and the Docker section
- **`.claude/.proposals/latest.yaml`** — fresh `pending_review` proposal recording the addition (suggested tier: global)
- **`.claude/.proposals/archive/2026-04-14-kailash-py.yaml`** — archived prior `distributed` proposal per `artifact-flow.md` MUST: Archive Before Fresh

## Why now

PR #474 was the first end-to-end execution of this recipe. Two specific friction points are worth not re-discovering next year:

1. The `uv pip install --dry-run --python 3.X` verification step caught zero issues this time, but it's the cheapest insurance against an ML wheel-lag surprise that would otherwise burn a full CI cycle to discover
2. The kailash-align test fixture (`assert __version__ == "0.2.1"`) had been red on `main` for two release bumps — surfaced only when the matrix expansion ran the suite. The cross-surface contract pattern documented in the playbook structurally prevents the recurring failure mode

## Test plan

- [ ] Pre-commit hooks pass (already verified locally)
- [ ] Skill loads on `/sdk` and other deployment-related queries via 10-deployment-git's existing trigger keywords
- [ ] Proposal manifest is valid YAML (verified locally)
- [ ] Next `/sync` at loom can pick up the proposal and propagate (manual gate)

## Related

- Codifies learnings from #474 (Python 3.14 support — merged at commit `05dd1283`)
- Follows `artifact-flow.md` proposal lifecycle (archive → fresh `pending_review`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)