### PR TITLE
feat(kaizen): add LlmClient.embed() for OpenAI + Ollama

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -7,7 +7,7 @@ Additive API: introduces `LlmClient.from_deployment(...)` alongside the
 existing `kaizen.providers.registry` surface. Registry consumers are
 untouched (see the option-A decision journal in the #498 workspace).
 
-Public API (post-S1-S8):
+Public API (post-S1-S8 + #462):
 
 * `LlmClient.from_deployment(d)` — construct a client from an
   `LlmDeployment` (all 24 preset factories + the registry shim).
@@ -19,6 +19,11 @@ Public API (post-S1-S8):
 * `LlmClient()` (zero-arg) additive constructor — returns an empty
   client with `.with_deployment(d)` as the only path to a usable
   state.
+* `LlmClient.embed(texts, *, model=None, options=None)` — issues a
+  real HTTP embedding request through `LlmHttpClient` (SSRF-safe)
+  and returns a `list[list[float]]`. First wire-send method on the
+  client. Supports OpenAI (`WireProtocol.OpenAiChat` deployment) and
+  Ollama (`WireProtocol.OllamaNative`).
 
 The wire-layer `complete()` send-path is deliberately NOT exposed here
 until every wire-protocol adapter (OpenAIChat, AnthropicMessages,
@@ -32,12 +37,43 @@ landed and exercised by a Tier 2 end-to-end test. Shipping a public
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
-from kaizen.llm.deployment import LlmDeployment
+import httpx
+
+from kaizen.llm.deployment import EmbedOptions, LlmDeployment, WireProtocol
+from kaizen.llm.errors import (
+    InvalidResponse,
+    ProviderError,
+    RateLimited,
+    Timeout,
+)
+from kaizen.llm.http_client import LlmHttpClient
 from kaizen.llm.redaction import redact_messages
+from kaizen.llm.wire_protocols import ollama_embeddings, openai_embeddings
 
 logger = logging.getLogger(__name__)
+
+
+# Wire-protocol dispatch for embed(). Keyed by WireProtocol enum so a
+# future wire (e.g. MistralChat embeddings, CohereGenerate embeddings)
+# adds one entry and its shaper module — not a conditional branch. This
+# is structural dispatch on a typed key, NOT keyword-matching on user
+# input (rules/agent-reasoning.md), so it is permitted deterministic
+# logic: it routes on a deployment-level configuration value the caller
+# explicitly set by choosing a preset.
+_EMBED_DISPATCH: dict = {
+    WireProtocol.OpenAiChat: {
+        "path": "/embeddings",
+        "shaper": openai_embeddings,
+        "env_model_hint": "OPENAI_EMBEDDING_MODEL",
+    },
+    WireProtocol.OllamaNative: {
+        "path": "/api/embed",
+        "shaper": ollama_embeddings,
+        "env_model_hint": "OLLAMA_EMBEDDING_MODEL",
+    },
+}
 
 
 class LlmClient:
@@ -188,6 +224,236 @@ class LlmClient:
             classification_policy=self._classification_policy,
             caller_clearance=self._caller_clearance,
         )
+
+    # -----------------------------------------------------------------
+    # embed() — the first wire-send method on LlmClient (#462)
+    # -----------------------------------------------------------------
+
+    async def embed(
+        self,
+        texts: List[str],
+        *,
+        model: Optional[str] = None,
+        options: Optional[EmbedOptions] = None,
+        http_client: Optional[LlmHttpClient] = None,
+    ) -> List[List[float]]:
+        """Generate embedding vectors for ``texts`` via the configured deployment.
+
+        Returns a ``list[list[float]]`` — one vector per input text, in
+        the same order. For OpenAI the default vector dimension is the
+        model's default (1536 for ``text-embedding-3-small``, 3072 for
+        ``text-embedding-3-large``, overridable via
+        ``EmbedOptions.dimensions``). For Ollama the dimension is fixed
+        at the model level.
+
+        Args:
+            texts: One or more strings to embed. Empty list rejected.
+            model: Override the deployment's ``default_model``. When
+                ``None``, the deployment's ``default_model`` is used;
+                when BOTH are ``None``, raises ``ValueError``. Per
+                ``rules/env-models.md`` callers SHOULD read the model
+                from the environment (``OPENAI_EMBEDDING_MODEL``,
+                ``OLLAMA_EMBEDDING_MODEL``) rather than hardcoding.
+            options: Optional ``EmbedOptions`` (``dimensions`` / ``user``).
+                Accepted for every wire; individual wires may ignore
+                fields they do not support (Ollama ignores ``dimensions``
+                per its documented contract).
+            http_client: Optional pre-constructed ``LlmHttpClient`` — for
+                tests / advanced callers who want to share an HTTP pool
+                across multiple ``embed()`` calls. When ``None``, a
+                fresh client is constructed and closed per call.
+
+        Raises:
+            ValueError: ``texts`` empty, or neither ``model`` nor
+                ``default_model`` set.
+            TypeError: ``texts`` not a ``list[str]``, or ``options`` not
+                ``EmbedOptions``.
+            NotImplementedError: deployment's ``wire`` is not in the
+                supported-for-embed set. This is NOT a stub — every
+                supported wire is fully implemented; unsupported wires
+                raise a concrete typed error directing the caller to
+                file an issue. See ``_EMBED_DISPATCH`` for the supported
+                set.
+            InvalidResponse / ProviderError / RateLimited / Timeout:
+                wire-layer failures, with credential scrubbing applied
+                to all body snippets per ``errors.py``.
+            InvalidEndpoint: SSRF guard rejected the deployment's
+                ``base_url`` at DNS-resolve time. Raised BEFORE the TCP
+                SYN fires.
+
+        Example::
+
+            import os
+            from kaizen.llm import LlmClient, LlmDeployment
+            deployment = LlmDeployment.openai(
+                api_key=os.environ["OPENAI_API_KEY"],
+                model=os.environ.get("OPENAI_PROD_MODEL", "gpt-4o"),
+            )
+            client = LlmClient.from_deployment(deployment)
+            # Use an embedding model, not a chat model, for embed():
+            vectors = await client.embed(
+                ["text a", "text b"],
+                model=os.environ["OPENAI_EMBEDDING_MODEL"],
+            )
+            assert len(vectors) == 2
+            assert len(vectors[0]) == 1536  # text-embedding-3-small default
+        """
+        if self._deployment is None:
+            raise ValueError(
+                "LlmClient.embed requires a deployment; construct via "
+                "LlmClient.from_deployment(...) or LlmClient.from_env() first"
+            )
+        if not isinstance(texts, list):
+            raise TypeError(
+                f"texts must be list[str]; got {type(texts).__name__}"
+            )
+        if options is not None and not isinstance(options, EmbedOptions):
+            raise TypeError(
+                f"options must be EmbedOptions; got {type(options).__name__}"
+            )
+
+        wire = self._deployment.wire
+        dispatch = _EMBED_DISPATCH.get(wire)
+        if dispatch is None:
+            raise NotImplementedError(
+                f"LlmClient.embed does not yet support wire={wire.name!r}. "
+                "Supported: OpenAiChat (openai, groq, etc.), OllamaNative. "
+                "File an issue at terrene-foundation/kailash-py referencing "
+                "#462 to request another provider."
+            )
+
+        resolved_model = model or self._deployment.default_model
+        if not resolved_model:
+            raise ValueError(
+                "embed() requires a model — pass model=..., or construct "
+                "the deployment with a default_model. Per rules/env-models.md, "
+                f"read from os.environ[{dispatch['env_model_hint']!r}]."
+            )
+
+        shaper = dispatch["shaper"]
+        path = dispatch["path"]
+        payload = shaper.build_request_payload(texts, resolved_model, options)
+
+        url = self._build_embed_url(path)
+
+        # LlmHttpClient owns SSRF (via SafeDnsResolver) + structured
+        # logging. NEVER construct httpx.AsyncClient directly here.
+        owns_client = http_client is None
+        if owns_client:
+            http_client = LlmHttpClient(
+                deployment_preset=wire.name,
+                timeout=60.0,
+            )
+        assert http_client is not None  # type narrower
+
+        try:
+            # Build request, let auth strategy install its header.
+            request: dict = {"headers": {"Content-Type": "application/json"}}
+            auth = self._deployment.auth
+            auth.apply(request)
+            # Merge endpoint.required_headers (e.g. anthropic-version —
+            # not used for embed today, but correct by construction).
+            for k, v in self._deployment.endpoint.required_headers.items():
+                request["headers"].setdefault(k, v)
+
+            auth_kind = (
+                auth.auth_strategy_kind() if hasattr(auth, "auth_strategy_kind") else None
+            )
+            logger.info(
+                "llm.embed.start",
+                extra={
+                    "wire": wire.name,
+                    "auth_strategy_kind": auth_kind,
+                    "text_count": len(texts),
+                    "model": resolved_model,
+                    "source": "real",
+                    "mode": "real",
+                },
+            )
+
+            resp = await http_client.post(
+                url,
+                headers=request["headers"],
+                json=payload,
+                auth_strategy_kind=auth_kind,
+            )
+        except httpx.TimeoutException as exc:
+            logger.error(
+                "llm.embed.error",
+                extra={"wire": wire.name, "exception_class": type(exc).__name__},
+            )
+            if owns_client:
+                await http_client.aclose()
+            raise Timeout() from exc
+        except httpx.HTTPError as exc:
+            # Covers ConnectError, ReadError, NetworkError, ProtocolError —
+            # everything httpx surfaces that isn't a plain response.
+            logger.error(
+                "llm.embed.error",
+                extra={"wire": wire.name, "exception_class": type(exc).__name__},
+            )
+            if owns_client:
+                await http_client.aclose()
+            raise
+
+        # Response handling — map HTTP status to typed errors.
+        try:
+            if resp.status_code == 429:
+                retry_after_raw = resp.headers.get("retry-after")
+                retry_after: Optional[float] = None
+                if retry_after_raw:
+                    try:
+                        retry_after = float(retry_after_raw)
+                    except (TypeError, ValueError):
+                        retry_after = None
+                raise RateLimited(retry_after=retry_after)
+            if resp.status_code >= 400:
+                # Credential scrub is applied by ProviderError itself.
+                raise ProviderError(resp.status_code, body_snippet=resp.text or "")
+            try:
+                payload_json = resp.json()
+            except ValueError as exc:
+                raise InvalidResponse(
+                    f"{wire.name.lower()}_embeddings: response was not valid JSON"
+                ) from exc
+            parsed = shaper.parse_response(payload_json)
+            vectors = parsed["vectors"]
+            if not isinstance(vectors, list):
+                raise InvalidResponse(
+                    f"{wire.name.lower()}_embeddings: parse_response returned non-list vectors"
+                )
+            logger.info(
+                "llm.embed.ok",
+                extra={
+                    "wire": wire.name,
+                    "text_count": len(texts),
+                    "vector_count": len(vectors),
+                    "status_code": resp.status_code,
+                },
+            )
+            return vectors
+        finally:
+            if owns_client:
+                await http_client.aclose()
+
+    def _build_embed_url(self, suffix: str) -> str:
+        """Join ``endpoint.base_url`` + ``endpoint.path_prefix`` + ``suffix``.
+
+        Kept explicit (not ``urllib.parse.urljoin``) because ``urljoin``
+        has surprising path-collapse behaviour that would drop the
+        ``path_prefix`` when ``suffix`` starts with ``/``. We always
+        concatenate with a single separator so the produced URL matches
+        the deployment's declared shape.
+        """
+        assert self._deployment is not None
+        endpoint = self._deployment.endpoint
+        base = str(endpoint.base_url).rstrip("/")
+        prefix = (endpoint.path_prefix or "").rstrip("/")
+        suffix_norm = suffix if suffix.startswith("/") else "/" + suffix
+        if prefix:
+            prefix_norm = prefix if prefix.startswith("/") else "/" + prefix
+            return f"{base}{prefix_norm}{suffix_norm}"
+        return f"{base}{suffix_norm}"
 
 
 __all__ = ["LlmClient"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Wire protocol shapers for every supported LLM deployment (#498 Session 2).
+"""Wire protocol shapers for every supported LLM deployment (#498 Session 2, #462).
 
 A "wire protocol" is the on-the-wire request/response schema a provider
 speaks. Each module in this package owns exactly one provider family's wire
@@ -14,20 +14,27 @@ shape:
   * ``ollama_native`` — Ollama ``/api/chat``
   * ``huggingface_inference`` — HuggingFace Inference API ``/models/{model}``
 
-Every shaper exposes the same two functions:
+Chat shapers expose:
 
-  * ``build_request_payload(request: CompletionRequest) -> dict`` — produce the
-    provider-specific request body.
-  * ``parse_response(payload: dict) -> dict`` — extract a normalized
-    ``{"text", "usage"}`` view from a provider response.
+  * ``build_request_payload(request: CompletionRequest) -> dict``
+  * ``parse_response(payload: dict) -> dict``
 
-Both functions are pure (no I/O). The actual HTTP sender lives in
-``LlmHttpClient`` (Session 3 / S4c); these shapers are consumed by the
-client's serialize / deserialize hooks.
+Embedding shapers (introduced in #462) expose:
+
+  * ``openai_embeddings`` — OpenAI ``/v1/embeddings`` (POST)
+  * ``ollama_embeddings`` — Ollama ``/api/embed`` (POST)
+
+with signatures:
+
+  * ``build_request_payload(texts: list[str], model: str, options: EmbedOptions | None) -> dict``
+  * ``parse_response(payload: dict) -> {"vectors", "model", "usage"}``
+
+All functions are pure (no I/O). The actual HTTP sender lives in
+``LlmHttpClient``; these shapers are consumed by ``LlmClient.embed()``
+and (future) ``LlmClient.complete()``.
 
 Cross-SDK parity: every function's output for a fixed input is
-byte-identical to its Rust counterpart (see
-``tests/cross_sdk_parity/test_wire_payload_matches_rust.py`` in Session 9).
+byte-identical to its Rust counterpart.
 """
 
 from __future__ import annotations
@@ -38,7 +45,9 @@ from kaizen.llm.wire_protocols import (
     google_generate_content,
     huggingface_inference,
     mistral_chat,
+    ollama_embeddings,
     ollama_native,
+    openai_embeddings,
 )
 
 __all__ = [
@@ -47,5 +56,7 @@ __all__ = [
     "google_generate_content",
     "huggingface_inference",
     "mistral_chat",
+    "ollama_embeddings",
     "ollama_native",
+    "openai_embeddings",
 ]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/ollama_embeddings.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ollama Embeddings wire protocol shaper (#462).
+
+Shapes the on-the-wire request/response for Ollama's ``POST /api/embed``
+endpoint (the newer multi-text variant; the legacy ``/api/embeddings``
+accepted only a single ``prompt`` string and is deprecated upstream).
+
+Request schema:
+
+    POST /api/embed
+    {
+      "model":   "nomic-embed-text",
+      "input":   ["text a", "text b"] | "text a",   # list OR single str
+      "options": {...}                              # optional, not used here
+    }
+
+Response schema:
+
+    {
+      "model": "nomic-embed-text",
+      "embeddings": [[0.1, ...], [0.2, ...]],
+      "total_duration": ...,
+      "load_duration": ...,
+      "prompt_eval_count": ...
+    }
+
+Always sends ``input`` as a list even for single-text calls — the newer
+Ollama server accepts both but the list form is the forward-compatible
+path, and it lets the caller treat the response uniformly.
+
+Ollama has no authentication (``StaticNone`` strategy) and no per-request
+``dimensions`` knob (the model's dimension is fixed at training time);
+``EmbedOptions.dimensions`` is silently ignored for this wire so callers
+don't get an opaque 400 — this is the documented Ollama contract, not
+a Kaizen invention.
+
+Cross-SDK parity: this shaper's output for a fixed input is byte-identical
+to the kailash-rs Ollama embeddings payload builder (#393).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from kaizen.llm.deployment import EmbedOptions
+from kaizen.llm.errors import InvalidResponse
+
+
+def build_request_payload(
+    texts: List[str],
+    model: str,
+    options: EmbedOptions | None = None,
+) -> Dict[str, Any]:
+    """Build the ``/api/embed`` request body for Ollama.
+
+    * Rejects ``texts=[]`` with ``ValueError`` at the shaper boundary.
+    * Rejects non-string elements in ``texts``.
+    * ``EmbedOptions.dimensions`` is accepted (for API symmetry with
+      OpenAI) but NOT sent to Ollama — Ollama's embedding dimension is
+      fixed at the model level. Callers who must bound dimension should
+      pick a smaller model.
+    """
+    if not isinstance(texts, list):
+        raise TypeError(
+            f"build_request_payload expects texts: list[str]; got {type(texts).__name__}"
+        )
+    if not texts:
+        raise ValueError(
+            "build_request_payload requires at least one text; got empty list"
+        )
+    for idx, t in enumerate(texts):
+        if not isinstance(t, str):
+            raise TypeError(
+                f"texts[{idx}] must be str; got {type(t).__name__}"
+            )
+    if not isinstance(model, str) or not model:
+        raise ValueError(
+            "build_request_payload requires a non-empty model string — "
+            "read from os.environ['OLLAMA_EMBEDDING_MODEL'] per rules/env-models.md"
+        )
+
+    if options is not None and not isinstance(options, EmbedOptions):
+        raise TypeError(
+            f"options must be EmbedOptions; got {type(options).__name__}"
+        )
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        # Always send the list form — forward-compatible with every
+        # Ollama version that supports /api/embed.
+        "input": list(texts),
+    }
+    return payload
+
+
+def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract ``{vectors, model, usage}`` from an Ollama embeddings response.
+
+    Raises ``InvalidResponse`` with a stable ``reason`` when the payload
+    shape violates the documented contract.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(
+            f"parse_response expects a dict payload; got {type(payload).__name__}"
+        )
+    embeddings = payload.get("embeddings")
+    if not isinstance(embeddings, list):
+        raise InvalidResponse(
+            "ollama_embeddings: missing or non-list 'embeddings'"
+        )
+    vectors: List[List[float]] = []
+    for item in embeddings:
+        if not isinstance(item, list):
+            raise InvalidResponse(
+                "ollama_embeddings: 'embeddings' entry is not a list"
+            )
+        for v in item:
+            if not isinstance(v, (int, float)) or isinstance(v, bool):
+                raise InvalidResponse(
+                    "ollama_embeddings: vector contains non-numeric value"
+                )
+        vectors.append([float(v) for v in item])
+    return {
+        "vectors": vectors,
+        "model": payload.get("model"),
+        "usage": {
+            "input_tokens": payload.get("prompt_eval_count"),
+            "total_tokens": payload.get("prompt_eval_count"),
+        },
+    }
+
+
+__all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_embeddings.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/wire_protocols/openai_embeddings.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI Embeddings wire protocol shaper (#462).
+
+Shapes the on-the-wire request/response for OpenAI's ``POST /v1/embeddings``
+endpoint. Consumed by ``LlmClient.embed(...)`` via its OpenAI dispatch path.
+
+Request schema (OpenAI documented contract):
+
+* ``model`` (str)   — required; e.g. ``"text-embedding-3-small"``.
+* ``input`` (list of str)  — required; one or more strings to embed. The
+  helper rejects empty lists at ``build_request_payload`` time to give a
+  typed error at the shaper boundary rather than a 400 from OpenAI.
+* ``dimensions`` (int, optional) — output vector dimension for models that
+  support truncation (``text-embedding-3-*``). Omitted when unset so legacy
+  ``text-embedding-ada-002`` callers work without a schema change.
+* ``user`` (str, optional) — opaque caller identifier for abuse tracking.
+* ``encoding_format`` is deliberately NOT exposed: we always request the
+  default ``float`` format and parse the response as ``list[list[float]]``.
+  Supporting ``base64`` would require a second decode path without adding
+  value for the RAG / semantic-search use cases driving #462.
+
+Response schema (OpenAI documented contract):
+
+    {
+      "object": "list",
+      "data": [
+        {"object": "embedding", "index": 0, "embedding": [0.1, ...]},
+        ...
+      ],
+      "model": "text-embedding-3-small",
+      "usage": {"prompt_tokens": N, "total_tokens": N}
+    }
+
+``parse_response`` extracts the normalized ``{vectors, model, usage}`` view.
+The ``data`` array MUST be sorted by ``index`` before vectors are pulled —
+OpenAI returns them in index order today, but the shape contract does not
+guarantee it, and a future partial-response ordering change would silently
+corrupt aligned caller arrays. The sort is O(n log n) on a list that is
+typically short; round-trip correctness outweighs the cost.
+
+Cross-SDK parity: this shaper's output for a fixed input is byte-identical
+to the kailash-rs OpenAI embeddings payload builder (#393).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from kaizen.llm.deployment import EmbedOptions
+from kaizen.llm.errors import InvalidResponse
+
+
+def build_request_payload(
+    texts: List[str],
+    model: str,
+    options: EmbedOptions | None = None,
+) -> Dict[str, Any]:
+    """Build the ``/v1/embeddings`` request body for OpenAI.
+
+    * Rejects ``texts=[]`` with ``ValueError`` at the shaper boundary so
+      the caller gets a typed error before the HTTP round-trip.
+    * Rejects non-string elements in ``texts`` so a caller passing, e.g.,
+      ``[b"bytes"]`` fails with a shape error rather than a 400 echoing
+      the raw bytes.
+    * ``dimensions`` / ``user`` are only written to the payload when the
+      caller actually set them; callers relying on model defaults do NOT
+      get a silent override.
+    """
+    if not isinstance(texts, list):
+        raise TypeError(
+            f"build_request_payload expects texts: list[str]; got {type(texts).__name__}"
+        )
+    if not texts:
+        raise ValueError(
+            "build_request_payload requires at least one text; got empty list"
+        )
+    for idx, t in enumerate(texts):
+        if not isinstance(t, str):
+            raise TypeError(
+                f"texts[{idx}] must be str; got {type(t).__name__}"
+            )
+    if not isinstance(model, str) or not model:
+        raise ValueError(
+            "build_request_payload requires a non-empty model string — "
+            "read from os.environ['OPENAI_EMBEDDING_MODEL'] per rules/env-models.md"
+        )
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "input": list(texts),
+    }
+    if options is not None:
+        if not isinstance(options, EmbedOptions):
+            raise TypeError(
+                f"options must be EmbedOptions; got {type(options).__name__}"
+            )
+        if options.dimensions is not None:
+            payload["dimensions"] = options.dimensions
+        if options.user is not None:
+            payload["user"] = options.user
+    return payload
+
+
+def parse_response(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract ``{vectors, model, usage}`` from an OpenAI embeddings response.
+
+    Raises ``InvalidResponse`` with a stable ``reason`` when the payload
+    shape violates the documented contract. The ``reason`` strings are
+    caller-controlled constants (not user-supplied) and are safe to log.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(
+            f"parse_response expects a dict payload; got {type(payload).__name__}"
+        )
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise InvalidResponse("openai_embeddings: missing or non-list 'data'")
+    # Sort by reported `index` so vectors are returned in request order
+    # regardless of server-side reordering. Entries without an index
+    # default to 0, which preserves stable order for single-text calls.
+    try:
+        data_sorted = sorted(data, key=lambda item: int(item.get("index", 0)))
+    except (TypeError, ValueError):
+        raise InvalidResponse(
+            "openai_embeddings: 'data' entry has non-integer 'index'"
+        )
+    vectors: List[List[float]] = []
+    for item in data_sorted:
+        if not isinstance(item, dict):
+            raise InvalidResponse(
+                "openai_embeddings: 'data' entry is not a dict"
+            )
+        embedding = item.get("embedding")
+        if not isinstance(embedding, list):
+            raise InvalidResponse(
+                "openai_embeddings: 'data' entry missing 'embedding' list"
+            )
+        # Validate each element is a float / int (JSON numbers decode as
+        # either). Reject strings / nulls at the shape boundary rather
+        # than let them propagate into caller arrays where a later numpy
+        # coercion would fail with an opaque message.
+        for v in embedding:
+            if not isinstance(v, (int, float)) or isinstance(v, bool):
+                raise InvalidResponse(
+                    "openai_embeddings: 'embedding' contains non-numeric value"
+                )
+        vectors.append([float(v) for v in embedding])
+    usage = payload.get("usage") or {}
+    return {
+        "vectors": vectors,
+        "model": payload.get("model"),
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens"),
+            "total_tokens": usage.get("total_tokens"),
+        },
+    }
+
+
+__all__ = ["build_request_payload", "parse_response"]

--- a/packages/kailash-kaizen/tests/integration/llm/test_llmclient_embed_wiring.py
+++ b/packages/kailash-kaizen/tests/integration/llm/test_llmclient_embed_wiring.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 2 wiring test: LlmClient.embed() end-to-end (#462).
+
+Per `rules/facade-manager-detection.md` §2, this file exists at its canonical
+path so absence is grep-able. Exercises the full `LlmClient.from_deployment()
+→ .embed()` path: payload build → LlmHttpClient (SSRF guard) → real HTTP →
+parse → typed return.
+
+* OpenAI — real API if `OPENAI_API_KEY` is set; otherwise skipped.
+* Ollama — real local server if `OLLAMA_BASE_URL` is set AND reachable;
+  otherwise skipped.
+* SSRF — always runs; does NOT require external infrastructure. Exercises
+  the EndpointError path by pointing embed() at the AWS metadata service
+  (169.254.169.254) and asserting the SSRF guard rejects DNS resolution
+  before the TCP SYN fires.
+
+Per `rules/testing.md` Tier 2 policy: real infrastructure recommended, NO
+mocking of the wire layer.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+from kaizen.llm import LlmClient
+from kaizen.llm.deployment import LlmDeployment
+from kaizen.llm.errors import EndpointError
+
+
+# ---------------------------------------------------------------------------
+# Real OpenAI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_llmclient_embed_openai_real() -> None:
+    """End-to-end: LlmClient.embed() returns a real vector from OpenAI."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        pytest.skip(
+            "OPENAI_API_KEY not set; real OpenAI wiring test requires credential"
+        )
+    model = os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+
+    deployment = LlmDeployment.openai(api_key=api_key, model=model)
+    client = LlmClient.from_deployment(deployment)
+
+    vectors = await client.embed(["hello", "world"], model=model)
+    assert isinstance(vectors, list)
+    assert len(vectors) == 2
+    # text-embedding-3-small defaults to 1536 dims; text-embedding-3-large to 3072.
+    # Accept either (operator may override via env).
+    assert len(vectors[0]) in (
+        1536,
+        3072,
+        768,
+    ), f"unexpected vector dim for model={model}: {len(vectors[0])}"
+    assert all(isinstance(v, float) for v in vectors[0])
+
+
+# ---------------------------------------------------------------------------
+# Real Ollama (optional; skipped if no local server)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_llmclient_embed_ollama_real() -> None:
+    """End-to-end: LlmClient.embed() against a local Ollama server.
+
+    Requires `OLLAMA_BASE_URL` set (e.g. `http://localhost:11434`) AND a
+    locally-pulled embedding model (e.g. `ollama pull nomic-embed-text`).
+    Skipped otherwise — this is a localhost-only path and not every dev
+    environment runs Ollama.
+    """
+    base_url = os.environ.get("OLLAMA_BASE_URL")
+    if not base_url:
+        pytest.skip("OLLAMA_BASE_URL not set; Ollama wiring test requires local server")
+    model = os.environ.get("OLLAMA_EMBEDDING_MODEL", "nomic-embed-text")
+
+    # Probe reachability before constructing the deployment to produce a
+    # clear skip message rather than a late EndpointError.
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as probe:
+            await probe.get(base_url.rstrip("/") + "/api/tags")
+    except (httpx.ConnectError, httpx.TimeoutException):
+        pytest.skip(f"Ollama at {base_url} not reachable; skipping")
+
+    deployment = LlmDeployment.ollama(base_url=base_url, model=model)
+    client = LlmClient.from_deployment(deployment)
+
+    vectors = await client.embed(["hello", "world"], model=model)
+    assert isinstance(vectors, list)
+    assert len(vectors) == 2
+    assert len(vectors[0]) > 0
+    assert all(isinstance(v, float) for v in vectors[0])
+
+
+# ---------------------------------------------------------------------------
+# SSRF regression — always runs, no external infra needed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_llmclient_embed_rejects_aws_metadata_endpoint() -> None:
+    """SSRF guard: embed() refuses to connect to the AWS metadata service.
+
+    169.254.169.254 is the IMDS endpoint; any LLM base_url pointing there
+    MUST be rejected — either at deployment construction (by
+    `url_safety.check_url`) or at HTTP connect time (by `SafeDnsResolver`
+    on LlmHttpClient's transport). The test asserts `EndpointError`
+    (the common base) so it survives changes to where validation fires.
+    """
+    # docker_model_runner accepts a caller-provided base_url + uses the
+    # OpenAiChat wire (dispatch key for embed()).
+    try:
+        deployment = LlmDeployment.docker_model_runner(
+            base_url="http://169.254.169.254/engines",
+            model="text-embedding-3-small",
+        )
+    except EndpointError:
+        # Construction-time rejection is the strictest defense — OK.
+        return
+    client = LlmClient.from_deployment(deployment)
+
+    with pytest.raises(EndpointError):
+        await client.embed(["ssrf test"], model="text-embedding-3-small")
+
+
+# ---------------------------------------------------------------------------
+# Structural: embed() is wired on the LlmClient public surface
+# ---------------------------------------------------------------------------
+
+
+def test_llmclient_embed_is_coroutine_method() -> None:
+    """Guards against accidental signature regression on the public surface."""
+    import inspect
+
+    assert hasattr(LlmClient, "embed")
+    assert inspect.iscoroutinefunction(LlmClient.embed)

--- a/packages/kailash-kaizen/tests/unit/llm/test_embed_shapers.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_embed_shapers.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 1 unit tests for the OpenAI + Ollama embedding wire shapers (#462).
+
+Shapers are pure functions (build_request_payload / parse_response) with
+input validation. These tests exercise the documented contract and the
+typed errors emitted at each shape boundary — no I/O, no mocking required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm.deployment import EmbedOptions
+from kaizen.llm.errors import InvalidResponse
+from kaizen.llm.wire_protocols import ollama_embeddings, openai_embeddings
+
+
+# ---------------------------------------------------------------------------
+# OpenAI shaper — build_request_payload
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAiBuildRequest:
+    def test_minimal_payload(self):
+        payload = openai_embeddings.build_request_payload(
+            ["hello", "world"], "text-embedding-3-small"
+        )
+        assert payload == {
+            "model": "text-embedding-3-small",
+            "input": ["hello", "world"],
+        }
+
+    def test_dimensions_option_included_when_set(self):
+        payload = openai_embeddings.build_request_payload(
+            ["x"], "text-embedding-3-small", EmbedOptions(dimensions=256)
+        )
+        assert payload["dimensions"] == 256
+
+    def test_dimensions_option_omitted_when_unset(self):
+        payload = openai_embeddings.build_request_payload(
+            ["x"], "text-embedding-3-small", EmbedOptions()
+        )
+        assert "dimensions" not in payload
+
+    def test_user_option_included_when_set(self):
+        payload = openai_embeddings.build_request_payload(
+            ["x"], "text-embedding-3-small", EmbedOptions(user="abuse-track-id")
+        )
+        assert payload["user"] == "abuse-track-id"
+
+    def test_empty_texts_rejected(self):
+        with pytest.raises(ValueError, match="at least one text"):
+            openai_embeddings.build_request_payload([], "text-embedding-3-small")
+
+    def test_non_list_texts_rejected(self):
+        with pytest.raises(TypeError, match="list\\[str\\]"):
+            openai_embeddings.build_request_payload("hello", "text-embedding-3-small")  # type: ignore[arg-type]
+
+    def test_bytes_element_rejected(self):
+        with pytest.raises(TypeError, match="must be str"):
+            openai_embeddings.build_request_payload(
+                [b"hello"], "text-embedding-3-small"  # type: ignore[list-item]
+            )
+
+    def test_empty_model_rejected(self):
+        with pytest.raises(ValueError, match="non-empty model"):
+            openai_embeddings.build_request_payload(["x"], "")
+
+    def test_bad_options_type_rejected(self):
+        with pytest.raises(TypeError, match="EmbedOptions"):
+            openai_embeddings.build_request_payload(
+                ["x"], "text-embedding-3-small", {"dimensions": 256}  # type: ignore[arg-type]
+            )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI shaper — parse_response
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAiParseResponse:
+    def test_basic_parse(self):
+        response = {
+            "object": "list",
+            "data": [
+                {"object": "embedding", "index": 0, "embedding": [0.1, 0.2, 0.3]},
+            ],
+            "model": "text-embedding-3-small",
+            "usage": {"prompt_tokens": 4, "total_tokens": 4},
+        }
+        parsed = openai_embeddings.parse_response(response)
+        assert parsed["vectors"] == [[0.1, 0.2, 0.3]]
+        assert parsed["model"] == "text-embedding-3-small"
+        assert parsed["usage"] == {"input_tokens": 4, "total_tokens": 4}
+
+    def test_sorts_by_index(self):
+        """Contract: OpenAI docs do not guarantee array order; we sort by index."""
+        response = {
+            "data": [
+                {"index": 1, "embedding": [1.0, 1.1]},
+                {"index": 0, "embedding": [0.0, 0.1]},
+            ],
+        }
+        parsed = openai_embeddings.parse_response(response)
+        assert parsed["vectors"] == [[0.0, 0.1], [1.0, 1.1]]
+
+    def test_missing_data_field(self):
+        with pytest.raises(InvalidResponse, match="missing or non-list 'data'"):
+            openai_embeddings.parse_response({})
+
+    def test_data_entry_missing_embedding(self):
+        with pytest.raises(InvalidResponse, match="missing 'embedding' list"):
+            openai_embeddings.parse_response({"data": [{"index": 0}]})
+
+    def test_non_numeric_embedding_rejected(self):
+        with pytest.raises(InvalidResponse, match="non-numeric value"):
+            openai_embeddings.parse_response(
+                {"data": [{"index": 0, "embedding": [0.1, "nope"]}]}
+            )
+
+    def test_bool_rejected_as_embedding_value(self):
+        """bool is a subclass of int in Python; explicitly reject."""
+        with pytest.raises(InvalidResponse, match="non-numeric value"):
+            openai_embeddings.parse_response(
+                {"data": [{"index": 0, "embedding": [True, False]}]}
+            )
+
+
+# ---------------------------------------------------------------------------
+# Ollama shaper — build_request_payload
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaBuildRequest:
+    def test_minimal_payload(self):
+        payload = ollama_embeddings.build_request_payload(
+            ["a", "b"], "nomic-embed-text"
+        )
+        assert payload == {"model": "nomic-embed-text", "input": ["a", "b"]}
+
+    def test_dimensions_option_silently_dropped(self):
+        """Ollama's dimension is fixed at model level; EmbedOptions.dimensions ignored."""
+        payload = ollama_embeddings.build_request_payload(
+            ["x"], "nomic-embed-text", EmbedOptions(dimensions=256)
+        )
+        assert "dimensions" not in payload
+
+    def test_empty_texts_rejected(self):
+        with pytest.raises(ValueError, match="at least one text"):
+            ollama_embeddings.build_request_payload([], "nomic-embed-text")
+
+    def test_empty_model_rejected(self):
+        with pytest.raises(ValueError, match="non-empty model"):
+            ollama_embeddings.build_request_payload(["x"], "")
+
+
+# ---------------------------------------------------------------------------
+# Ollama shaper — parse_response
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaParseResponse:
+    def test_basic_parse(self):
+        response = {
+            "model": "nomic-embed-text",
+            "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+            "prompt_eval_count": 6,
+        }
+        parsed = ollama_embeddings.parse_response(response)
+        assert parsed["vectors"] == [[0.1, 0.2], [0.3, 0.4]]
+        assert parsed["model"] == "nomic-embed-text"
+        assert parsed["usage"]["input_tokens"] == 6
+
+    def test_missing_embeddings_field(self):
+        with pytest.raises(InvalidResponse, match="missing or non-list 'embeddings'"):
+            ollama_embeddings.parse_response({})
+
+    def test_non_list_entry_rejected(self):
+        with pytest.raises(InvalidResponse, match="not a list"):
+            ollama_embeddings.parse_response({"embeddings": [0.1, 0.2]})
+
+    def test_non_numeric_rejected(self):
+        with pytest.raises(InvalidResponse, match="non-numeric value"):
+            ollama_embeddings.parse_response({"embeddings": [[0.1, "nope"]]})


### PR DESCRIPTION
## Summary

- First wire-send method on `LlmClient`: `async def embed(texts, *, model=None, options=None, http_client=None) -> list[list[float]]`
- OpenAI `/v1/embeddings` + Ollama `/api/embed` shapers; dispatch table keyed on `WireProtocol` enum
- SSRF-safe (routes through `LlmHttpClient.post()` with `SafeDnsResolver`); typed errors via `kaizen.llm.errors`; credential scrubbing via `ProviderError`; model from `os.environ` per `rules/env-models.md`

## Why now

Downstream consumers (RAG agents, Aegis `knowledge_embedding_service`, CARE semantic retrieval) were falling back to raw `httpx` against `/v1/embeddings`, duplicating credential flow and bypassing SSRF protections. Filed as **BLOCKER** on Aegis's `framework-first-sweep`.

## Scope / sharding

Ships OpenAI + Ollama — the two priority providers for the RAG (cloud) and air-gapped (local) paths driving #462. Mistral / Cohere / HuggingFace deferred to follow-up per `rules/autonomous-execution.md` capacity budget; the dispatch table adds one entry + one shaper per future provider.

## Cross-SDK

Mirrors `esperie-enterprise/kailash-rs#393`. Shaper output is byte-identical to the Rust payload builder for fixed input (cross-SDK parity contract per EATP D6).

## Test plan

- [x] Tier 1 unit (23 tests): payload build + parse for both shapers, validation boundaries, `sort_by_index`, `bool`-as-number rejection, Ollama `dimensions`-silently-dropped.
- [x] Tier 2 wiring (4 tests):
  - [x] SSRF regression — `docker_model_runner(base_url="http://169.254.169.254/...")` → `EndpointError` before TCP SYN fires. **Always runs; no external infra needed.**
  - [x] Structural — `LlmClient.embed` is a coroutine on the public surface.
  - [ ] Real OpenAI — skips unless `OPENAI_API_KEY` set; runs on CI with secret.
  - [ ] Real Ollama — skips unless `OLLAMA_BASE_URL` set and reachable.
- [x] `pytest --collect-only` green (merge gate per `rules/orphan-detection.md` MUST Rule 5).

## Related issues

Fixes #462