### PR TITLE
fix(dataflow): quote identifiers in Express CRUD SQL for PostgreSQL

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -4855,8 +4855,15 @@ class DataFlow(DataFlowEventMixin):
         python_type = field_info["type"]
         sql_type = self._python_type_to_sql_type(python_type, database_type)
 
+        # Issue #480: quote the column identifier so reserved-word and
+        # mixed-case field names parse correctly. See
+        # rules/dataflow-identifier-safety.md MUST Rule 1.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect(database_type)
+
         # Start building column definition
-        definition_parts = [field_name, sql_type]
+        definition_parts = [dialect.quote_identifier(field_name), sql_type]
 
         # Handle nullable/required
         if field_info.get("required", True):
@@ -4937,8 +4944,20 @@ class DataFlow(DataFlowEventMixin):
                     validation_error="Model has no fields defined (missing type annotations)",
                 )
 
+        # Issue #480: quote table + column identifiers via the dialect
+        # helper so reserved-word and mixed-case field names survive
+        # PostgreSQL's unquoted-identifier lowercasing rule. See
+        # rules/dataflow-identifier-safety.md MUST Rule 1.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect(database_type)
+        quoted_table = dialect.quote_identifier(table_name)
+        quoted_id = dialect.quote_identifier("id")
+        quoted_created_at = dialect.quote_identifier("created_at")
+        quoted_updated_at = dialect.quote_identifier("updated_at")
+
         # Start building CREATE TABLE statement with safety protection
-        sql_parts = [f"CREATE TABLE IF NOT EXISTS {table_name} ("]
+        sql_parts = [f"CREATE TABLE IF NOT EXISTS {quoted_table} ("]
 
         # Check if model has a string ID field
         id_field = fields.get("id", {})
@@ -4948,20 +4967,20 @@ class DataFlow(DataFlowEventMixin):
         if id_type == str:
             # String ID models need user-provided IDs
             if database_type.lower() == "postgresql":
-                sql_parts.append("    id TEXT PRIMARY KEY,")
+                sql_parts.append(f"    {quoted_id} TEXT PRIMARY KEY,")
             elif database_type.lower() == "mysql":
                 # MySQL doesn't allow TEXT as primary key - use VARCHAR(255)
-                sql_parts.append("    id VARCHAR(255) PRIMARY KEY,")
+                sql_parts.append(f"    {quoted_id} VARCHAR(255) PRIMARY KEY,")
             else:  # sqlite
-                sql_parts.append("    id TEXT PRIMARY KEY,")
+                sql_parts.append(f"    {quoted_id} TEXT PRIMARY KEY,")
         else:
             # Integer ID models use auto-increment
             if database_type.lower() == "postgresql":
-                sql_parts.append("    id SERIAL PRIMARY KEY,")
+                sql_parts.append(f"    {quoted_id} SERIAL PRIMARY KEY,")
             elif database_type.lower() == "mysql":
-                sql_parts.append("    id INT AUTO_INCREMENT PRIMARY KEY,")
+                sql_parts.append(f"    {quoted_id} INT AUTO_INCREMENT PRIMARY KEY,")
             else:  # sqlite
-                sql_parts.append("    id INTEGER PRIMARY KEY AUTOINCREMENT,")
+                sql_parts.append(f"    {quoted_id} INTEGER PRIMARY KEY AUTOINCREMENT,")
 
         # Add model fields
         column_definitions = []
@@ -4978,21 +4997,25 @@ class DataFlow(DataFlowEventMixin):
         # Add created_at and updated_at timestamp columns
         if database_type.lower() == "postgresql":
             column_definitions.append(
-                "    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+                f"    {quoted_created_at} TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
             )
             column_definitions.append(
-                "    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+                f"    {quoted_updated_at} TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
             )
         elif database_type.lower() == "mysql":
             column_definitions.append(
-                "    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+                f"    {quoted_created_at} TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
             )
             column_definitions.append(
-                "    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
+                f"    {quoted_updated_at} TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"
             )
         else:  # sqlite
-            column_definitions.append("    created_at TEXT DEFAULT CURRENT_TIMESTAMP")
-            column_definitions.append("    updated_at TEXT DEFAULT CURRENT_TIMESTAMP")
+            column_definitions.append(
+                f"    {quoted_created_at} TEXT DEFAULT CURRENT_TIMESTAMP"
+            )
+            column_definitions.append(
+                f"    {quoted_updated_at} TEXT DEFAULT CURRENT_TIMESTAMP"
+            )
 
         # Join all column definitions
         sql_parts.extend([",\n".join(column_definitions)])
@@ -6909,7 +6932,18 @@ class DataFlow(DataFlowEventMixin):
             # If table inspection fails, use model fields only
             all_columns = field_names
 
-        columns_str = ", ".join(all_columns)
+        # Issue #480: quote every identifier via the dialect helper so
+        # reserved words (order, user, desc, group...) and mixed-case
+        # column names survive PostgreSQL's unquoted-identifier
+        # lowercasing rule. DialectManager also validates identifiers
+        # against the strict allowlist regex — see
+        # rules/dataflow-identifier-safety.md MUST Rule 1.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect(database_type)
+        quoted_table = dialect.quote_identifier(table_name)
+        quoted_id = dialect.quote_identifier("id")
+        columns_str = ", ".join(dialect.quote_identifier(c) for c in all_columns)
 
         # Database-specific parameter placeholders
         if database_type.lower() == "postgresql":
@@ -6923,12 +6957,12 @@ class DataFlow(DataFlowEventMixin):
             filter_placeholder = "?"
 
         return {
-            "select_by_id": f"SELECT {columns_str} FROM {table_name} WHERE id = {id_placeholder}",
-            "select_all": f"SELECT {columns_str} FROM {table_name}",
-            "select_with_filter": f"SELECT {columns_str} FROM {table_name} WHERE {{filter_condition}}",
-            "select_with_pagination": f"SELECT {columns_str} FROM {table_name} ORDER BY id LIMIT {{limit}} OFFSET {{offset}}",
-            "count_all": f"SELECT COUNT(*) FROM {table_name}",
-            "count_with_filter": f"SELECT COUNT(*) FROM {table_name} WHERE {{filter_condition}}",
+            "select_by_id": f"SELECT {columns_str} FROM {quoted_table} WHERE {quoted_id} = {id_placeholder}",
+            "select_all": f"SELECT {columns_str} FROM {quoted_table}",
+            "select_with_filter": f"SELECT {columns_str} FROM {quoted_table} WHERE {{filter_condition}}",
+            "select_with_pagination": f"SELECT {columns_str} FROM {quoted_table} ORDER BY {quoted_id} LIMIT {{limit}} OFFSET {{offset}}",
+            "count_all": f"SELECT COUNT(*) FROM {quoted_table}",
+            "count_with_filter": f"SELECT COUNT(*) FROM {quoted_table} WHERE {{filter_condition}}",
         }
 
     def _generate_update_sql(
@@ -6965,22 +6999,42 @@ class DataFlow(DataFlowEventMixin):
         except Exception:
             has_updated_at = False
 
+        # Issue #480: quote identifiers via the dialect helper so
+        # reserved-word and mixed-case field names survive PostgreSQL's
+        # unquoted-identifier lowercasing rule. See
+        # rules/dataflow-identifier-safety.md MUST Rule 1.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect(database_type)
+        quoted_table = dialect.quote_identifier(table_name)
+        quoted_id = dialect.quote_identifier("id")
+        quoted_updated_at = dialect.quote_identifier("updated_at")
+
         # Database-specific parameter placeholders and SET clauses
         if database_type.lower() == "postgresql":
-            set_clauses = [f"{name} = ${i + 1}" for i, name in enumerate(field_names)]
-            where_clause = f"WHERE id = ${len(field_names) + 1}"
+            set_clauses = [
+                f"{dialect.quote_identifier(name)} = ${i + 1}"
+                for i, name in enumerate(field_names)
+            ]
+            where_clause = f"WHERE {quoted_id} = ${len(field_names) + 1}"
             updated_at_clause = (
-                "updated_at = CURRENT_TIMESTAMP" if has_updated_at else None
+                f"{quoted_updated_at} = CURRENT_TIMESTAMP" if has_updated_at else None
             )
         elif database_type.lower() == "mysql":
-            set_clauses = [f"{name} = %s" for name in field_names]
-            where_clause = "WHERE id = %s"
-            updated_at_clause = "updated_at = NOW()" if has_updated_at else None
-        else:  # sqlite
-            set_clauses = [f"{name} = ?" for name in field_names]
-            where_clause = "WHERE id = ?"
+            set_clauses = [
+                f"{dialect.quote_identifier(name)} = %s" for name in field_names
+            ]
+            where_clause = f"WHERE {quoted_id} = %s"
             updated_at_clause = (
-                "updated_at = CURRENT_TIMESTAMP" if has_updated_at else None
+                f"{quoted_updated_at} = NOW()" if has_updated_at else None
+            )
+        else:  # sqlite
+            set_clauses = [
+                f"{dialect.quote_identifier(name)} = ?" for name in field_names
+            ]
+            where_clause = f"WHERE {quoted_id} = ?"
+            updated_at_clause = (
+                f"{quoted_updated_at} = CURRENT_TIMESTAMP" if has_updated_at else None
             )
 
         # Combine SET clauses (only include updated_at if the column exists)
@@ -6989,7 +7043,7 @@ class DataFlow(DataFlowEventMixin):
             all_set_clauses.append(updated_at_clause)
         set_clause = ", ".join(all_set_clauses)
 
-        sql = f"UPDATE {table_name} SET {set_clause} {where_clause}"
+        sql = f"UPDATE {quoted_table} SET {set_clause} {where_clause}"
 
         # Add RETURNING clause for PostgreSQL to get all fields back
         if database_type.lower() == "postgresql":
@@ -7011,7 +7065,7 @@ class DataFlow(DataFlowEventMixin):
                 # If table inspection fails, use model fields only
                 all_columns = ["id"] + list(fields.keys())
 
-            sql += f" RETURNING {', '.join(all_columns)}"
+            sql += f" RETURNING {', '.join(dialect.quote_identifier(c) for c in all_columns)}"
 
         return sql
 
@@ -7034,6 +7088,13 @@ class DataFlow(DataFlowEventMixin):
             model_name
         )
 
+        # Issue #480: quote identifiers via the dialect helper.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect(database_type)
+        quoted_table = dialect.quote_identifier(table_name)
+        quoted_id = dialect.quote_identifier("id")
+
         # Database-specific parameter placeholders
         if database_type.lower() == "postgresql":
             id_placeholder = "$1"
@@ -7043,9 +7104,9 @@ class DataFlow(DataFlowEventMixin):
             id_placeholder = "?"
 
         return {
-            "delete_by_id": f"DELETE FROM {table_name} WHERE id = {id_placeholder}",
-            "delete_with_filter": f"DELETE FROM {table_name} WHERE {{filter_condition}}",
-            "delete_all": f"DELETE FROM {table_name}",
+            "delete_by_id": f"DELETE FROM {quoted_table} WHERE {quoted_id} = {id_placeholder}",
+            "delete_with_filter": f"DELETE FROM {quoted_table} WHERE {{filter_condition}}",
+            "delete_all": f"DELETE FROM {quoted_table}",
         }
 
     def _generate_bulk_sql(

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -1451,7 +1451,18 @@ class NodeGenerator:
                         table_name = self.dataflow_instance._get_table_name(
                             self.model_name
                         )
-                        columns = ", ".join(field_names)
+
+                        # Issue #480: quote identifiers via the dialect helper
+                        # so reserved-word and mixed-case field names survive
+                        # PostgreSQL's unquoted-identifier lowercasing rule.
+                        # See rules/dataflow-identifier-safety.md MUST Rule 1.
+                        from ..adapters.dialect import DialectManager
+
+                        dialect = DialectManager.get_dialect(database_type)
+                        quoted_table = dialect.quote_identifier(table_name)
+                        columns = ", ".join(
+                            dialect.quote_identifier(name) for name in field_names
+                        )
 
                         # Database-specific parameter placeholders
                         if database_type.lower() == "postgresql":
@@ -1466,13 +1477,19 @@ class NodeGenerator:
                                 returning_fields.append("created_at")
                             if "updated_at" in model_fields:
                                 returning_fields.append("updated_at")
-                            query = f"INSERT INTO {table_name} ({columns}) VALUES ({placeholders}) RETURNING {', '.join(returning_fields)}"
+                            quoted_returning = ", ".join(
+                                dialect.quote_identifier(f) for f in returning_fields
+                            )
+                            query = (
+                                f"INSERT INTO {quoted_table} ({columns}) "
+                                f"VALUES ({placeholders}) RETURNING {quoted_returning}"
+                            )
                         elif database_type.lower() == "mysql":
                             placeholders = ", ".join(["%s"] * len(field_names))
-                            query = f"INSERT INTO {table_name} ({columns}) VALUES ({placeholders})"
+                            query = f"INSERT INTO {quoted_table} ({columns}) VALUES ({placeholders})"
                         else:  # sqlite
                             placeholders = ", ".join(["?"] * len(field_names))
-                            query = f"INSERT INTO {table_name} ({columns}) VALUES ({placeholders})"
+                            query = f"INSERT INTO {quoted_table} ({columns}) VALUES ({placeholders})"
 
                         # ADR-002: Changed from WARNING to DEBUG - SQL generation tracing
                         logger.debug(
@@ -1632,7 +1649,8 @@ class NodeGenerator:
                                 )
                                 if has_timestamps:
                                     readback_query = (
-                                        f"SELECT * FROM {table_name} WHERE id = ?"
+                                        f"SELECT * FROM {quoted_table} "
+                                        f"WHERE {dialect.quote_identifier('id')} = ?"
                                     )
                                     readback_result = await sql_node.async_run(
                                         query=readback_query,
@@ -2274,16 +2292,30 @@ class NodeGenerator:
                         except Exception:
                             has_updated_at = False
 
+                        # Issue #480: quote identifiers via the dialect
+                        # helper so reserved-word and mixed-case field names
+                        # survive PostgreSQL's unquoted-identifier lowercasing
+                        # rule. See rules/dataflow-identifier-safety.md MUST
+                        # Rule 1.
+                        from ..adapters.dialect import DialectManager
+
+                        dialect = DialectManager.get_dialect(database_type)
+                        quoted_table = dialect.quote_identifier(table_name)
+                        quoted_id = dialect.quote_identifier("id")
+                        quoted_updated_at = dialect.quote_identifier("updated_at")
+
                         # Build dynamic UPDATE query for only the fields being updated
                         field_names = list(updates.keys())
                         if database_type.lower() == "postgresql":
                             set_clauses = [
-                                f"{name} = ${i + 1}"
+                                f"{dialect.quote_identifier(name)} = ${i + 1}"
                                 for i, name in enumerate(field_names)
                             ]
-                            where_clause = f"WHERE id = ${len(field_names) + 1}"
+                            where_clause = (
+                                f"WHERE {quoted_id} = ${len(field_names) + 1}"
+                            )
                             updated_at_clause = (
-                                "updated_at = CURRENT_TIMESTAMP"
+                                f"{quoted_updated_at} = CURRENT_TIMESTAMP"
                                 if has_updated_at
                                 else None
                             )
@@ -2316,25 +2348,22 @@ class NodeGenerator:
                             if updated_at_clause:
                                 all_set_clauses.append(updated_at_clause)
 
-                            query = f"UPDATE {table_name} SET {', '.join(all_set_clauses)} {where_clause} RETURNING {', '.join(all_columns)}"
-                        elif database_type.lower() == "mysql":
-                            set_clauses = [f"{name} = %s" for name in field_names]
-                            where_clause = "WHERE id = %s"
-                            updated_at_clause = (
-                                "updated_at = NOW()" if has_updated_at else None
+                            returning_str = ", ".join(
+                                dialect.quote_identifier(c) for c in all_columns
                             )
-
-                            # Build SET clause (only include updated_at if column exists)
-                            all_set_clauses = set_clauses
-                            if updated_at_clause:
-                                all_set_clauses.append(updated_at_clause)
-
-                            query = f"UPDATE {table_name} SET {', '.join(all_set_clauses)} {where_clause}"
-                        else:  # sqlite
-                            set_clauses = [f"{name} = ?" for name in field_names]
-                            where_clause = "WHERE id = ?"
+                            query = (
+                                f"UPDATE {quoted_table} "
+                                f"SET {', '.join(all_set_clauses)} "
+                                f"{where_clause} RETURNING {returning_str}"
+                            )
+                        elif database_type.lower() == "mysql":
+                            set_clauses = [
+                                f"{dialect.quote_identifier(name)} = %s"
+                                for name in field_names
+                            ]
+                            where_clause = f"WHERE {quoted_id} = %s"
                             updated_at_clause = (
-                                "updated_at = CURRENT_TIMESTAMP"
+                                f"{quoted_updated_at} = NOW()"
                                 if has_updated_at
                                 else None
                             )
@@ -2344,7 +2373,25 @@ class NodeGenerator:
                             if updated_at_clause:
                                 all_set_clauses.append(updated_at_clause)
 
-                            query = f"UPDATE {table_name} SET {', '.join(all_set_clauses)} {where_clause}"
+                            query = f"UPDATE {quoted_table} SET {', '.join(all_set_clauses)} {where_clause}"
+                        else:  # sqlite
+                            set_clauses = [
+                                f"{dialect.quote_identifier(name)} = ?"
+                                for name in field_names
+                            ]
+                            where_clause = f"WHERE {quoted_id} = ?"
+                            updated_at_clause = (
+                                f"{quoted_updated_at} = CURRENT_TIMESTAMP"
+                                if has_updated_at
+                                else None
+                            )
+
+                            # Build SET clause (only include updated_at if column exists)
+                            all_set_clauses = set_clauses
+                            if updated_at_clause:
+                                all_set_clauses.append(updated_at_clause)
+
+                            query = f"UPDATE {quoted_table} SET {', '.join(all_set_clauses)} {where_clause}"
 
                         # Prepare parameters: field values first, then ID
                         # BUG #515 FIX: Serialize dict/list values for SQL binding
@@ -2510,14 +2557,21 @@ class NodeGenerator:
                     # Get the table name directly
                     table_name = self.dataflow_instance._get_table_name(self.model_name)
 
+                    # Issue #480: quote identifiers via the dialect helper.
+                    from ..adapters.dialect import DialectManager
+
+                    dialect = DialectManager.get_dialect(database_type)
+                    quoted_table = dialect.quote_identifier(table_name)
+                    quoted_id = dialect.quote_identifier("id")
+
                     # Database-specific DELETE query
                     # PostgreSQL/SQLite support RETURNING, MySQL does not
                     if database_type.lower() == "mysql":
-                        query = f"DELETE FROM {table_name} WHERE id = %s"
+                        query = f"DELETE FROM {quoted_table} WHERE {quoted_id} = %s"
                     elif database_type.lower() == "postgresql":
-                        query = f"DELETE FROM {table_name} WHERE id = $1 RETURNING id"
+                        query = f"DELETE FROM {quoted_table} WHERE {quoted_id} = $1 RETURNING {quoted_id}"
                     else:  # sqlite
-                        query = f"DELETE FROM {table_name} WHERE id = ? RETURNING id"
+                        query = f"DELETE FROM {quoted_table} WHERE {quoted_id} = ? RETURNING {quoted_id}"
 
                     # Debug log
                     import logging

--- a/packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py
@@ -766,11 +766,18 @@ class PostgreSQLMigrationGenerator:
 
     def _create_table_sql(self, table: TableDefinition) -> str:
         """Generate CREATE TABLE SQL."""
+        # Issue #480: quote table + column identifiers so reserved words
+        # (order, user, desc...) and mixed-case names survive PostgreSQL's
+        # unquoted-identifier lowercasing rule. See
+        # rules/dataflow-identifier-safety.md MUST Rule 1.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect("postgresql")
         columns_sql = []
         for column in table.columns:
             columns_sql.append(self._column_definition_sql(column))
 
-        sql = f"CREATE TABLE {table.name} (\n"
+        sql = f"CREATE TABLE {dialect.quote_identifier(table.name)} (\n"
         sql += ",\n".join(f"    {col_sql}" for col_sql in columns_sql)
         sql += "\n);"
 
@@ -778,7 +785,12 @@ class PostgreSQLMigrationGenerator:
 
     def _column_definition_sql(self, column: ColumnDefinition) -> str:
         """Generate column definition SQL."""
-        parts = [column.name, column.type]
+        # Issue #480: quote the column name so reserved-word columns
+        # (order, user, desc, group...) parse correctly on PostgreSQL.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect("postgresql")
+        parts = [dialect.quote_identifier(column.name), column.type]
 
         if column.max_length and column.type.upper() in ("VARCHAR", "CHAR"):
             parts[1] = f"{column.type}({column.max_length})"
@@ -1436,11 +1448,15 @@ class SQLiteMigrationGenerator:
 
     def _create_table_sql(self, table: TableDefinition) -> str:
         """Generate CREATE TABLE SQL for SQLite."""
+        # Issue #480: quote identifiers via the dialect helper.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect("sqlite")
         columns_sql = []
         for column in table.columns:
             columns_sql.append(self._column_definition_sql(column))
 
-        sql = f"CREATE TABLE {table.name} (\n"
+        sql = f"CREATE TABLE {dialect.quote_identifier(table.name)} (\n"
         sql += ",\n".join(f"    {col_sql}" for col_sql in columns_sql)
         sql += "\n);"
 
@@ -1448,7 +1464,15 @@ class SQLiteMigrationGenerator:
 
     def _column_definition_sql(self, column: ColumnDefinition) -> str:
         """Generate column definition SQL for SQLite."""
-        parts = [column.name, self._map_type_to_sqlite(column.type)]
+        # Issue #480: quote column name so reserved-word columns
+        # (order, user, desc, group...) parse correctly.
+        from ..adapters.dialect import DialectManager
+
+        dialect = DialectManager.get_dialect("sqlite")
+        parts = [
+            dialect.quote_identifier(column.name),
+            self._map_type_to_sqlite(column.type),
+        ]
 
         if column.primary_key:
             parts.append("PRIMARY KEY")

--- a/packages/kailash-dataflow/tests/integration/test_issue_480_express_pg_identifier_quoting.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_480_express_pg_identifier_quoting.py
@@ -1,0 +1,262 @@
+"""
+Regression tests for issue #480.
+
+DataFlowExpress previously generated malformed PostgreSQL for
+``create`` / ``list`` / ``read`` / ``update`` / ``delete`` when the model
+contained reserved-word column names (``order``, ``desc``, ``group``,
+``user`` ...) or mixed-case column names (``firstName``). The root cause
+was that every SQL generator interpolated table and column identifiers
+raw into the query string, so PostgreSQL either raised a syntax error
+(reserved words) or silently lowercased the column name (mixed case).
+
+Fix: route every dynamic identifier through ``DialectManager.get_dialect
+(database_type).quote_identifier(...)`` before interpolation. See
+``rules/dataflow-identifier-safety.md`` MUST Rule 1.
+
+These tests are SQLite-invisible: SQLite accepts the unquoted DDL as a
+synonym and the unquoted DML as a lookup against the stored (case-
+insensitive) identifier. PostgreSQL does not — which is why the bug
+escaped the pre-existing SQLite test suite.
+
+Cross-SDK parity: mirrors ``esperie-enterprise/kailash-rs#403``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from dataflow import DataFlow
+
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+
+@pytest.fixture
+async def test_suite():
+    """Create the standard integration test suite against real PostgreSQL."""
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+@pytest.fixture
+async def _clean_tables(test_suite):
+    """Drop bug-specific tables before AND after each test."""
+
+    tables = [
+        "issue480_items",
+        "issue480_ledgers",
+        "issue480_customers",
+    ]
+
+    async def _wipe():
+        async with test_suite.get_connection() as conn:
+            for t in tables:
+                try:
+                    await conn.execute(f'DROP TABLE IF EXISTS "{t}" CASCADE')
+                except Exception:  # pragma: no cover — best-effort teardown
+                    pass
+            # Reset DataFlow's bookkeeping tables so auto-migrate doesn't
+            # think the schema is already up-to-date.
+            for bookkeeping in (
+                "dataflow_migrations",
+                "dataflow_model_registry",
+                "dataflow_migration_history",
+            ):
+                try:
+                    await conn.execute(f"TRUNCATE {bookkeeping}")
+                except Exception:  # pragma: no cover — missing table is fine
+                    pass
+
+    await _wipe()
+    yield
+    await _wipe()
+
+
+@pytest.mark.integration
+@pytest.mark.regression
+@pytest.mark.timeout(30)
+class TestIssue480ExpressPostgresIdentifierQuoting:
+    """Regression: DataFlowExpress must quote identifiers on PostgreSQL."""
+
+    async def test_issue_480_exact_reproduction_from_issue_body(
+        self, test_suite, _clean_tables
+    ):
+        """The exact repro from #480 body — create/list/read an `Item` model.
+
+        Pre-fix: INSERT/SELECT interpolate the table name unquoted, the
+        behaviour works on SQLite but fails on PostgreSQL when the table
+        name or column name is a reserved word or mixed-case.  The issue
+        body's ``Item`` uses only safe identifiers, so this test asserts
+        the basic smoke-test path still works — it's the entry point any
+        user hits first.
+        """
+        db = DataFlow(test_suite.config.url, auto_migrate=True, pool_size=2)
+
+        # Use a unique table_name to avoid colliding with other tests.
+        @db.model
+        class Issue480Item:
+            __tablename__ = "issue480_items"
+            id: str
+            name: str
+
+        await db.initialize()
+
+        rid = f"x-{uuid.uuid4().hex[:8]}"
+        created = await db.express.create("Issue480Item", {"id": rid, "name": "test"})
+        assert created["id"] == rid
+        assert created["name"] == "test"
+
+        # State-persistence read-back — mandatory by rules/testing.md.
+        fetched = await db.express.read("Issue480Item", rid)
+        assert fetched is not None
+        assert fetched["id"] == rid
+        assert fetched["name"] == "test"
+
+        # list returns at least the one row we created.
+        rows = await db.express.list("Issue480Item")
+        assert len(rows) >= 1
+        assert any(r["id"] == rid for r in rows)
+
+        await db.close_async()
+
+    async def test_issue_480_reserved_word_columns_create_list_read(
+        self, test_suite, _clean_tables
+    ):
+        """Reserved PG keywords as column names MUST round-trip.
+
+        Pre-fix: ``CREATE TABLE ledgers (order INTEGER, desc TEXT, ...)``
+        raises ``syntax error at or near "order"`` on PostgreSQL because
+        ``order`` is a reserved word.  The SDK's auto-migration DDL and
+        every CRUD SQL generator must quote the identifier so the reserved
+        word is parsed as an identifier.
+        """
+        db = DataFlow(test_suite.config.url, auto_migrate=True, pool_size=2)
+
+        @db.model
+        class Issue480Ledger:
+            __tablename__ = "issue480_ledgers"
+            id: str
+            order: int  # reserved word
+            desc: str  # reserved word
+
+        await db.initialize()
+        rid = f"L-{uuid.uuid4().hex[:8]}"
+
+        created = await db.express.create(
+            "Issue480Ledger", {"id": rid, "order": 1, "desc": "initial"}
+        )
+        assert created["id"] == rid
+        assert created["order"] == 1
+        assert created["desc"] == "initial"
+
+        fetched = await db.express.read("Issue480Ledger", rid)
+        assert fetched is not None
+        assert fetched["order"] == 1
+        assert fetched["desc"] == "initial"
+
+        rows = await db.express.list("Issue480Ledger")
+        assert any(r["id"] == rid for r in rows)
+
+        await db.close_async()
+
+    async def test_issue_480_reserved_word_update_and_delete(
+        self, test_suite, _clean_tables
+    ):
+        """UPDATE and DELETE also MUST quote reserved-word identifiers.
+
+        Separate test because UPDATE has its own SQL-generation path in
+        ``dataflow.core.nodes`` that diverged from the read/create path.
+        See rules/testing.md § "Delegating Primitives Need Direct
+        Coverage".
+        """
+        db = DataFlow(test_suite.config.url, auto_migrate=True, pool_size=2)
+
+        @db.model
+        class Issue480Ledger:
+            __tablename__ = "issue480_ledgers"
+            id: str
+            order: int
+            desc: str
+
+        await db.initialize()
+        rid = f"L-{uuid.uuid4().hex[:8]}"
+
+        await db.express.create(
+            "Issue480Ledger", {"id": rid, "order": 1, "desc": "initial"}
+        )
+        updated = await db.express.update(
+            "Issue480Ledger", rid, {"order": 42, "desc": "patched"}
+        )
+        assert updated["order"] == 42
+        assert updated["desc"] == "patched"
+
+        # State-persistence verification: read-back after update.
+        post = await db.express.read("Issue480Ledger", rid)
+        assert post["order"] == 42
+        assert post["desc"] == "patched"
+
+        deleted = await db.express.delete("Issue480Ledger", rid)
+        assert deleted is True
+
+        after = await db.express.read("Issue480Ledger", rid)
+        assert after is None
+
+        await db.close_async()
+
+    async def test_issue_480_camel_case_column_names_preserved(
+        self, test_suite, _clean_tables
+    ):
+        """Mixed-case column names MUST round-trip identically.
+
+        Pre-fix: ``CREATE TABLE customers (firstName TEXT, ...)`` stores
+        the column as ``firstname`` because PostgreSQL lowercases
+        unquoted identifiers.  The INSERT then returns
+        ``{"firstname": ...}`` to the caller instead of ``{"firstName":
+        ...}``, breaking round-tripping with user code that expects the
+        camelCase key it passed in.
+        """
+        db = DataFlow(test_suite.config.url, auto_migrate=True, pool_size=2)
+
+        @db.model
+        class Issue480Customer:
+            __tablename__ = "issue480_customers"
+            id: str
+            firstName: str
+
+        await db.initialize()
+        rid = f"c-{uuid.uuid4().hex[:8]}"
+
+        created = await db.express.create(
+            "Issue480Customer", {"id": rid, "firstName": "Alice"}
+        )
+        # Caller's camelCase key MUST survive the round-trip.
+        assert (
+            "firstName" in created
+        ), f"firstName key lost in return (got keys: {list(created.keys())})"
+        assert created["firstName"] == "Alice"
+
+        fetched = await db.express.read("Issue480Customer", rid)
+        assert fetched is not None
+        assert fetched["firstName"] == "Alice"
+
+        rows = await db.express.list("Issue480Customer")
+        assert any(r.get("firstName") == "Alice" for r in rows)
+
+        # Verify the actual column name stored in PostgreSQL is the
+        # mixed-case form — this is what DataFlow's dialect-aware
+        # identifier quoting guarantees.
+        async with test_suite.get_connection() as conn:
+            columns = await conn.fetch(
+                """
+                SELECT column_name FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'issue480_customers'
+                """
+            )
+        column_names = {row["column_name"] for row in columns}
+        assert (
+            "firstName" in column_names
+        ), f"mixed-case column lowercased by PostgreSQL (got: {column_names})"
+
+        await db.close_async()


### PR DESCRIPTION
## Summary

- Every DataFlowExpress `create` / `list` / `read` / `update` / `delete` SQL generator interpolated table + column identifiers raw. SQLite tolerates this; PostgreSQL rejects reserved words (`order`, `desc`) and silently lowercases mixed-case columns (`firstName` → `firstname`).
- All dynamic identifiers now route through `DialectManager.get_dialect(...).quote_identifier(...)` (per `rules/dataflow-identifier-safety.md` MUST Rule 1 — validates against allowlist regex AND dialect-quotes).
- Touches `engine.py` CRUD SQL generators, `nodes.py` Create/Update/Delete inline SQL, and `auto_migration_system.py` DDL for both PG and SQLite paths.

## Why now

Filed as **P0 bug** blocking downstream PG consumers. The workaround they were forced into — `df.execute_raw(sql, [params])` with `$N` — is exactly the pattern `rules/zero-tolerance.md` Rule 4 forbids.

## Cross-SDK

Mirrors `esperie-enterprise/kailash-rs#403` per EATP D6. Same root cause + same fix shape (dialect-quoted identifiers at every SQL-generation site).

## Test plan

- [x] New Tier 2 regression file `packages/kailash-dataflow/tests/integration/test_issue_480_express_pg_identifier_quoting.py` (4 tests, all pass against real PostgreSQL on port 5434):
  - [x] Exact reproduction from issue body (`Item` with `id` + `name`)
  - [x] Reserved-word columns (`Ledger` with `order: int`, `desc: str`) — CREATE + READ + LIST
  - [x] Reserved-word columns — UPDATE + DELETE (separate paths per `rules/testing.md` delegating-primitives rule)
  - [x] Mixed-case columns (`Customer` with `firstName`) — round-trip key preservation AND `information_schema.columns` verifies mixed-case on disk
- [x] SQLite path unchanged (adjacent `test_dataflow_async_lifecycle.py` still green)

## Out-of-scope follow-ups (flagged by specialist during sampling, all pre-existing on main, verified via `git stash`)

1. `tests/integration/test_bug_3_reserved_fields_fix.py` — 4/5 tests timeout at 10s (WorkflowBuilder `id`-injection; perf / pool regression)
2. `tests/integration/database/test_sqlite_integration.py::test_auto_generated_nodes` — `no such table: dataflow_migration_locks`
3. `tests/integration/database/test_sqlite_integration.py::test_schema_migration` — DF-501
4. `DataFlow('sqlite:///:memory:')` cross-task threading error — `SQLite objects created in a thread can only be used in that same thread`

Each deserves its own shard per the capacity budget.

## Related issues

Fixes #480