### PR TITLE
feat(nexus): HttpClient + ServiceClient with SSRF-aware config (#464 #473)

### DIFF
--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -72,6 +72,23 @@ from .errors import (
     NexusError,
     NotFoundError,
 )
+from .http_client import (
+    HttpClient,
+    HttpClientConfig,
+    HttpClientError,
+    HttpResponse,
+    InvalidEndpointError,
+)
+from .service_client import (
+    ServiceClient,
+    ServiceClientDeserializeError,
+    ServiceClientError,
+    ServiceClientHttpError,
+    ServiceClientHttpStatusError,
+    ServiceClientInvalidHeaderError,
+    ServiceClientInvalidPathError,
+    ServiceClientSerializeError,
+)
 from .errors import PermissionError as NexusPermissionError  # deprecated alias
 from .errors import RateLimitError, ServiceUnavailableError
 from .errors import TimeoutError as NexusTimeoutError
@@ -149,4 +166,19 @@ __all__ = [
     "StreamingResponse",
     "WebSocket",
     "WebSocketDisconnect",
+    # Outbound HTTP primitive (issue #464 + cross-SDK kailash-rs#399)
+    "HttpClient",
+    "HttpClientConfig",
+    "HttpClientError",
+    "HttpResponse",
+    "InvalidEndpointError",
+    # Typed service-to-service client (issue #473 + cross-SDK kailash-rs#400)
+    "ServiceClient",
+    "ServiceClientError",
+    "ServiceClientHttpError",
+    "ServiceClientHttpStatusError",
+    "ServiceClientSerializeError",
+    "ServiceClientDeserializeError",
+    "ServiceClientInvalidPathError",
+    "ServiceClientInvalidHeaderError",
 ]

--- a/packages/kailash-nexus/src/nexus/http_client.py
+++ b/packages/kailash-nexus/src/nexus/http_client.py
@@ -1,0 +1,898 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Nexus outbound HttpClient — SSRF-aware typed HTTP client primitive.
+
+Nexus's inbound surface (handlers, routers, middleware) is extensive. Its
+outbound surface was absent: downstream applications that needed to call
+external services (webhooks, IdPs, agent forwarders, health probes) had to
+reach for `httpx` directly, bypassing Nexus's observability, security, and
+structured-logging guarantees.
+
+This module provides ``HttpClient`` and ``HttpClientConfig`` — the single
+supported construction path for Nexus outbound HTTP traffic.
+
+# SSRF defence
+
+Every outbound URL is validated at two points:
+
+1. ``HttpClient`` routes the URL through ``check_url`` at request-dispatch
+   time. That catches literal-IP SSRF, encoded-IP bypass forms, and DNS
+   rebinding attempts that resolve to a private / loopback / metadata IP at
+   parse time.
+2. ``HttpClient`` installs ``SafeDnsTransport`` on the underlying
+   ``httpx.AsyncClient``. The transport re-resolves the peer host at connect
+   time and rejects the connection before the TCP SYN fires. That closes the
+   TOCTOU window where a public hostname resolves to 1.2.3.4 at parse time
+   and to 127.0.0.1 at connect time.
+
+Both guards run. Removing either widens the surface.
+
+# Observability
+
+Every request emits three structured log lines
+(``nexus.http.request.start`` / ``.ok`` / ``.error``). Each carries a UUID
+``request_id`` correlation identifier that is injected as the
+``X-Request-ID`` header on the outgoing request, so a downstream service can
+trace the call back. The ``Authorization`` header value is NEVER logged;
+endpoint host is logged but NOT the full URL (some legacy providers carry
+credentials in query strings).
+
+# Cross-SDK parity
+
+Semantic match with ``kailash-rs#399`` HttpClient. Python uses ``httpx`` +
+``socket.getaddrinfo``; Rust uses ``reqwest`` + hyper's resolver. Public
+API shape is byte-identical: ``get`` / ``post`` / ``put`` / ``delete`` /
+``patch`` verb methods, ``request_id`` kwarg for correlation, ``json`` and
+``content`` kwargs mirroring httpx / reqwest semantics.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import logging
+import socket
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Mapping, Optional, Sequence
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class HttpClientError(Exception):
+    """Base class for HttpClient construction / dispatch errors.
+
+    Kept narrow: dispatch-layer ``httpx`` errors are not rewrapped by
+    ``HttpClient`` — they propagate to the caller unchanged. The higher-level
+    ``ServiceClient`` wrapper translates them into typed subclasses.
+    """
+
+
+class InvalidEndpointError(HttpClientError):
+    """The supplied URL failed SSRF validation.
+
+    ``reason`` is a short code from a fixed allowlist (``scheme``,
+    ``private_ipv4``, ``metadata_service``, ``malformed_url``, …). The URL
+    itself is stored only as a SHA-256 fingerprint so log pipelines never
+    echo a user-supplied URL verbatim.
+    """
+
+    _REASON_ALLOWLIST = frozenset(
+        {
+            "scheme",
+            "private_ipv4",
+            "private_ipv6",
+            "loopback",
+            "link_local",
+            "metadata_service",
+            "metadata_host",
+            "malformed_url",
+            "resolution_failed",
+            "ipv4_mapped",
+            "encoded_ip_bypass",
+            "host_not_allowlisted",
+        }
+    )
+
+    def __init__(self, reason: str, raw_url: Optional[str] = None) -> None:
+        if reason not in self._REASON_ALLOWLIST:
+            reason = "malformed_url"
+        self.reason = reason
+        self.url_fingerprint = _url_fingerprint(raw_url) if raw_url else None
+        if self.url_fingerprint is not None:
+            super().__init__(
+                f"invalid endpoint: reason={reason} "
+                f"url_fingerprint={self.url_fingerprint}"
+            )
+        else:
+            super().__init__(f"invalid endpoint: reason={reason}")
+
+
+# ---------------------------------------------------------------------------
+# URL fingerprinting (secrets-safe logging)
+# ---------------------------------------------------------------------------
+
+
+def _url_fingerprint(raw: Optional[str]) -> str:
+    """SHA-256 prefix of the raw URL. Matches cross-SDK 8-char contract."""
+    if not raw:
+        return "none"
+    return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()[:8]
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard — private / loopback / link-local / metadata detection
+# ---------------------------------------------------------------------------
+
+# IPv6 embedded-IPv4 ranges — an attacker can wrap a private IPv4 in one of
+# these forms to bypass a guard that only checks ``is_private`` on the IPv6
+# wrapper. Reject both ranges unconditionally — no legitimate external
+# service lives inside a translation-prefix range. Mirrors the kailash-rs
+# SafeDnsResolver check and the kaizen.llm.url_safety implementation.
+_IPV4_TRANSLATED_NETWORK = ipaddress.IPv6Network("::ffff:0:0:0/96")  # RFC 2765 SIIT
+_NAT64_WELLKNOWN_NETWORK = ipaddress.IPv6Network("64:ff9b::/96")  # RFC 6052
+
+# Cloud metadata IPs and hostnames — these are the most common SSRF
+# exfiltration targets on AWS / GCP / Azure. We reject both the numeric IP
+# and the convenience hostname the cloud provider ships to the guest OS.
+_METADATA_IPS = frozenset(
+    {
+        "169.254.169.254",
+        "fd00:ec2::254",
+    }
+)
+
+_METADATA_HOSTNAMES = frozenset(
+    {
+        "metadata.google.internal",
+        "metadata.azure.com",
+        "metadata.aws.internal",
+    }
+)
+
+
+def _is_private_ipv4(ip: ipaddress.IPv4Address) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _is_private_ipv6(ip: ipaddress.IPv6Address) -> bool:
+    if ip.is_private or ip.is_loopback or ip.is_link_local:
+        return True
+    if ip.is_multicast or ip.is_reserved or ip.is_unspecified:
+        return True
+    if ip.ipv4_mapped is not None:
+        return _is_private_ipv4(ip.ipv4_mapped)
+    if ip in _IPV4_TRANSLATED_NETWORK or ip in _NAT64_WELLKNOWN_NETWORK:
+        return True
+    return False
+
+
+def _ip_reason(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> str:
+    """Map an offending IP to an allowlisted ``InvalidEndpointError.reason``."""
+    ip_str = str(ip)
+    if ip_str in _METADATA_IPS:
+        return "metadata_service"
+    if isinstance(ip, ipaddress.IPv4Address):
+        if ip.is_loopback:
+            return "loopback"
+        if ip.is_link_local:
+            return "link_local"
+        return "private_ipv4"
+    # IPv6
+    if ip.ipv4_mapped is not None:
+        return "ipv4_mapped"
+    if ip in _IPV4_TRANSLATED_NETWORK or ip in _NAT64_WELLKNOWN_NETWORK:
+        return "ipv4_mapped"
+    if ip.is_loopback:
+        return "loopback"
+    if ip.is_link_local:
+        return "link_local"
+    return "private_ipv6"
+
+
+def _try_parse_ip(
+    candidate: str,
+) -> Optional[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    try:
+        return ipaddress.ip_address(candidate)
+    except (ValueError, TypeError):
+        return None
+
+
+def _try_inet_aton_shortform(candidate: str) -> Optional[ipaddress.IPv4Address]:
+    """Detect ``socket.inet_aton`` short-form IPv4 (``127.1`` -> 127.0.0.1).
+
+    ``ipaddress.ip_address`` rejects these, but libc resolves them, and a
+    guard that only checks the strict form is bypassable when the HTTP stack
+    forwards to the libc resolver.
+    """
+    if not candidate or not isinstance(candidate, str):
+        return None
+    if ":" in candidate:
+        return None
+    if _try_parse_ip(candidate) is not None:
+        return None
+    try:
+        packed = socket.inet_aton(candidate)
+    except (OSError, ValueError, TypeError):
+        return None
+    return ipaddress.IPv4Address(packed)
+
+
+def _detect_encoded_ip_bypass(host: str) -> bool:
+    """Reject decimal / octal / hex IPv4 encodings.
+
+    ``socket.gethostbyname("2130706433")`` returns ``127.0.0.1`` on many
+    libc implementations; the standard ``ipaddress`` parser rejects these,
+    so the guard needs its own detection.
+    """
+    if host.isdigit():
+        return True
+    for part in host.split("."):
+        if part.startswith("0x") or part.startswith("0X"):
+            return True
+        if len(part) > 1 and part.startswith("0") and part[1:].isdigit():
+            return True
+    return False
+
+
+def _iter_resolved_ips(
+    host: str,
+) -> "list[ipaddress.IPv4Address | ipaddress.IPv6Address]":
+    """Yield every IP ``socket.getaddrinfo`` associates with ``host``.
+
+    Returns an empty list on resolution failure so the caller can treat
+    that as ``resolution_failed``.
+    """
+    results: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        return results
+    seen: set[str] = set()
+    for info in infos:
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        ip_str = sockaddr[0]
+        if ip_str in seen:
+            continue
+        seen.add(ip_str)
+        parsed = _try_parse_ip(ip_str)
+        if parsed is not None:
+            results.append(parsed)
+    return results
+
+
+def check_url(
+    url: str,
+    *,
+    blocked_networks: Optional[Sequence[ipaddress._BaseNetwork]] = None,
+    host_allowlist: Optional[Sequence[str]] = None,
+    allow_loopback: bool = False,
+    resolve_dns: bool = True,
+) -> None:
+    """Validate ``url`` as an SSRF-safe outbound target.
+
+    Raises ``InvalidEndpointError`` on any rejection. ``reason`` is from a
+    fixed allowlist; the raw URL is hashed and stored only as a fingerprint
+    on the exception so audit logs never echo the user-supplied URL.
+
+    Ordering — per issue #473 non-negotiable 1: the private-IP / metadata
+    check runs BEFORE the host allowlist check. An allowlisted private IP is
+    still rejected. The allowlist ONLY narrows the already-safe set of
+    public hosts; it MUST NOT be a back-door past the SSRF guard.
+
+    ``allow_loopback=True`` is for tests against a local stub server. It
+    narrowly permits 127.0.0.1 / localhost / ::1. Every other private range
+    stays blocked.
+
+    ``blocked_networks`` lets callers add additional CIDR blocks on top of
+    the always-blocked set (e.g. a corporate internal block the attacker
+    shouldn't reach even if it passes the RFC1918 check).
+    """
+    if not isinstance(url, str) or not url:
+        raise InvalidEndpointError("malformed_url", raw_url=None)
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        raise InvalidEndpointError("malformed_url", raw_url=url)
+
+    scheme = (parsed.scheme or "").lower()
+    host = parsed.hostname or ""
+
+    # ---- Scheme check -----------------------------------------------------
+    # http / https only. Unknown schemes (file://, gopher://, ftp://) are
+    # BLOCKED before DNS lookup — they are the classic SSRF bypass surface.
+    # Run scheme check BEFORE the empty-host check because ``file:///path``
+    # parses with empty host; we want the rejection reason to surface as
+    # "scheme" so forensic aggregation can separate the file:// attempts
+    # from merely malformed URLs.
+    if scheme not in ("http", "https"):
+        raise InvalidEndpointError("scheme", raw_url=url)
+
+    if not host:
+        raise InvalidEndpointError("malformed_url", raw_url=url)
+
+    host_lc = host.lower()
+
+    # ---- Metadata hostname check ------------------------------------------
+    if host_lc in _METADATA_HOSTNAMES:
+        raise InvalidEndpointError("metadata_host", raw_url=url)
+
+    # ---- Encoded IP bypass check ------------------------------------------
+    parsed_ip = _try_parse_ip(host)
+    if parsed_ip is None and _detect_encoded_ip_bypass(host):
+        raise InvalidEndpointError("encoded_ip_bypass", raw_url=url)
+
+    # ---- inet_aton short-form check ---------------------------------------
+    if parsed_ip is None:
+        shortform = _try_inet_aton_shortform(host)
+        if shortform is not None:
+            if _is_private_ipv4(shortform) or str(shortform) in _METADATA_IPS:
+                raise InvalidEndpointError("encoded_ip_bypass", raw_url=url)
+            # Short-form IPv4 that resolves public: still reject — no
+            # legitimate external service is addressed via the inet_aton
+            # short-form, and accepting it widens the audit surface.
+            raise InvalidEndpointError("encoded_ip_bypass", raw_url=url)
+
+    # ---- Literal IP — private / metadata / extra-blocked ------------------
+    if parsed_ip is not None:
+        _validate_ip(parsed_ip, url, allow_loopback, blocked_networks, host_lc)
+        # Literal IP, passed checks — allowlist still applies if set.
+        _check_host_allowlist(host_lc, host_allowlist, url)
+        return
+
+    # ---- Host allowlist (layered AFTER SSRF per issue #473 NN1) -----------
+    _check_host_allowlist(host_lc, host_allowlist, url)
+
+    # ---- DNS resolution (rebinding defence) -------------------------------
+    if not resolve_dns:
+        return
+
+    any_resolved = False
+    loopback_hosts = {"localhost", "127.0.0.1", "::1"}
+    for ip in _iter_resolved_ips(host):
+        any_resolved = True
+        _validate_ip(ip, url, allow_loopback, blocked_networks, host_lc, loopback_hosts)
+
+    if not any_resolved and not (allow_loopback and host_lc in loopback_hosts):
+        raise InvalidEndpointError("resolution_failed", raw_url=url)
+
+
+def _validate_ip(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    url: str,
+    allow_loopback: bool,
+    blocked_networks: Optional[Sequence[ipaddress._BaseNetwork]],
+    host_lc: str,
+    loopback_hosts: Optional[set[str]] = None,
+) -> None:
+    """Validate a single IP against the blocklist.
+
+    Central routine used for both literal-IP URLs and DNS-resolved IPs. The
+    caller-supplied ``blocked_networks`` list is applied on top of the
+    always-blocked ranges so extra corporate / internal CIDRs cannot be
+    bypassed by a caller forgetting to mix them in.
+    """
+    loopback_hosts = loopback_hosts or {"localhost", "127.0.0.1", "::1"}
+    loopback_carveout = allow_loopback and ip.is_loopback and host_lc in loopback_hosts
+
+    # Metadata always blocked regardless of allow_loopback.
+    if str(ip) in _METADATA_IPS:
+        raise InvalidEndpointError("metadata_service", raw_url=url)
+
+    if isinstance(ip, ipaddress.IPv4Address):
+        if _is_private_ipv4(ip):
+            # Narrow allow_loopback carve-out: only 127.0.0.1 when the
+            # hostname is a known loopback label. Every other private range
+            # stays blocked so allow_loopback can't be used as a wildcard.
+            if not loopback_carveout:
+                raise InvalidEndpointError(_ip_reason(ip), raw_url=url)
+
+    if isinstance(ip, ipaddress.IPv6Address):
+        if _is_private_ipv6(ip):
+            if not loopback_carveout:
+                raise InvalidEndpointError(_ip_reason(ip), raw_url=url)
+
+    # Extra blocklist (corporate / internal ranges callers supply).
+    # When the loopback carve-out applies, skip the blocked_networks sweep
+    # as well — otherwise the default blocklist (which contains 127.0.0.0/8
+    # precisely because loopback is unsafe for production) re-rejects the
+    # IP the carve-out just permitted. The carve-out is still narrow: only
+    # literal loopback IPs under a known loopback hostname label are
+    # exempted, so no extra-blocklist CIDR a caller added can hit an IP
+    # that satisfies the carve-out anyway.
+    if blocked_networks and not loopback_carveout:
+        for net in blocked_networks:
+            try:
+                if ip in net:
+                    raise InvalidEndpointError("private_ipv4", raw_url=url)
+            except TypeError:
+                # Network family mismatch (v4 vs v6) is normal — skip.
+                continue
+
+
+def _check_host_allowlist(
+    host_lc: str,
+    host_allowlist: Optional[Sequence[str]],
+    url: str,
+) -> None:
+    """Enforce the optional host allowlist.
+
+    The allowlist is ONLY consulted AFTER the SSRF private-IP check has
+    passed (per issue #473 non-negotiable 1). The allowlist narrows the
+    already-safe public set — it is NOT a bypass path.
+    """
+    if host_allowlist is None:
+        return
+    normalized = {h.lower() for h in host_allowlist}
+    if host_lc not in normalized:
+        raise InvalidEndpointError("host_not_allowlisted", raw_url=url)
+
+
+# ---------------------------------------------------------------------------
+# SafeDnsTransport — connect-time SSRF re-check
+# ---------------------------------------------------------------------------
+
+
+class SafeDnsTransport(httpx.AsyncHTTPTransport):
+    """httpx transport that re-resolves the peer host at connect time.
+
+    ``check_url`` validates at URL-parse time. Between parse and connect
+    there is a TOCTOU window where a public hostname could resolve to a
+    public IP once and to 127.0.0.1 the next time (classic DNS rebinding).
+    This transport closes that window by re-checking every resolution
+    immediately before the TCP SYN.
+
+    Per issue #473 non-negotiable 1: the private-IP check runs BEFORE the
+    host allowlist, so an allowlisted private IP is still rejected at
+    connect time.
+    """
+
+    __slots__ = (
+        "_blocked_networks",
+        "_host_allowlist",
+        "_allow_loopback",
+    )
+
+    def __init__(
+        self,
+        *,
+        blocked_networks: Optional[Sequence[ipaddress._BaseNetwork]] = None,
+        host_allowlist: Optional[Sequence[str]] = None,
+        allow_loopback: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._blocked_networks = blocked_networks
+        self._host_allowlist = host_allowlist
+        self._allow_loopback = allow_loopback
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        host = request.url.host
+        # Re-run the full guard with DNS resolution active so a rebinding
+        # attack is caught before the connect. The URL is reconstructed from
+        # the request to keep fingerprints consistent with the caller-facing
+        # log line.
+        check_url(
+            str(request.url),
+            blocked_networks=self._blocked_networks,
+            host_allowlist=self._host_allowlist,
+            allow_loopback=self._allow_loopback,
+            resolve_dns=True,
+        )
+        return await super().handle_async_request(request)
+
+
+# ---------------------------------------------------------------------------
+# Configuration dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HttpClientConfig:
+    """Configuration for ``HttpClient``.
+
+    All defaults are SSRF-safe: follow_redirects defaults to False because
+    every redirect is a new SSRF surface; blocked_networks defaults to the
+    RFC1918 + loopback + link-local + IMDS set; host_allowlist defaults to
+    None (every public host is permitted, subject to the SSRF guard).
+    """
+
+    timeout_seconds: float = 30.0
+    connect_timeout_seconds: float = 10.0
+    follow_redirects: bool = False
+    blocked_networks: Optional[Sequence[ipaddress._BaseNetwork]] = None
+    host_allowlist: Optional[Sequence[str]] = None
+    structured_log_prefix: str = "nexus.http"
+    request_id_header: str = "X-Request-ID"
+    allow_loopback: bool = False
+    default_headers: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Fall back to the canonical always-blocked networks when the caller
+        # didn't supply a list. Frozen dataclass so we have to use
+        # object.__setattr__ to install the default.
+        if self.blocked_networks is None:
+            object.__setattr__(
+                self,
+                "blocked_networks",
+                _DEFAULT_BLOCKED_NETWORKS,
+            )
+
+
+# Baseline blocked networks. Applied on top of the per-IP private-range
+# check so extra IPv4 + IPv6 CIDRs are rejected even when a libc helper
+# somehow resolves them to look "public". RFC1918 + loopback + link-local +
+# IMDS + ULA + link-local-v6 + documentation ranges.
+_DEFAULT_BLOCKED_NETWORKS: tuple[ipaddress._BaseNetwork, ...] = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local + IMDS
+    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT — commonly internal
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),  # ULA
+    ipaddress.ip_network("fe80::/10"),  # link-local v6
+)
+
+
+# ---------------------------------------------------------------------------
+# HttpResponse — plain dataclass mirroring httpx.Response
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HttpResponse:
+    """Outbound HTTP response — minimal, framework-agnostic.
+
+    Exposed from raw methods (``get_raw`` etc.) so callers can inspect the
+    status code WITHOUT a status-check exception being raised. Typed JSON
+    methods (``get`` / ``post``) return decoded dicts directly.
+    """
+
+    status_code: int
+    headers: dict[str, str]
+    body: bytes
+    url: str
+    request_id: str
+
+
+# ---------------------------------------------------------------------------
+# HttpClient — the public primitive
+# ---------------------------------------------------------------------------
+
+
+class HttpClient:
+    """SSRF-aware outbound HTTP client for Nexus.
+
+    Every outbound request routes through ``check_url`` and
+    ``SafeDnsTransport``. The ``Authorization`` header is ALLOWED on
+    requests but NEVER logged; the endpoint hostname is logged, not the full
+    URL.
+
+    Use as an async context manager:
+
+        async with HttpClient(HttpClientConfig()) as client:
+            resp = await client.get("https://example.com/api")
+
+    Or close explicitly:
+
+        client = HttpClient(HttpClientConfig())
+        try:
+            await client.get(...)
+        finally:
+            await client.aclose()
+
+    The underlying ``httpx.AsyncClient`` is never exposed — every outbound
+    request goes through the observability-instrumented ``request()`` path.
+    """
+
+    __slots__ = ("_client", "_config", "_closed", "_transport")
+
+    def __init__(self, config: Optional[HttpClientConfig] = None) -> None:
+        self._config = config or HttpClientConfig()
+        self._transport = SafeDnsTransport(
+            blocked_networks=self._config.blocked_networks,
+            host_allowlist=self._config.host_allowlist,
+            allow_loopback=self._config.allow_loopback,
+        )
+        timeout = httpx.Timeout(
+            self._config.timeout_seconds,
+            connect=self._config.connect_timeout_seconds,
+        )
+        # follow_redirects is driven by config; the default is False because
+        # every redirect is a fresh SSRF surface and the caller should opt
+        # in consciously.
+        self._client = httpx.AsyncClient(
+            transport=self._transport,
+            timeout=timeout,
+            follow_redirects=self._config.follow_redirects,
+        )
+        self._closed = False
+
+    @property
+    def config(self) -> HttpClientConfig:
+        return self._config
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    async def __aenter__(self) -> "HttpClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying transport. Idempotent."""
+        if self._closed:
+            return
+        await self._client.aclose()
+        self._closed = True
+
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        json: Any = None,
+        content: Any = None,
+        params: Optional[Mapping[str, Any]] = None,
+        request_id: Optional[str] = None,
+        follow_redirects: Optional[bool] = None,
+    ) -> HttpResponse:
+        """Dispatch an HTTP request with full observability.
+
+        ``method`` is uppercased and validated against the standard verb set.
+        ``request_id`` is generated if not supplied and injected into the
+        request as the header named by ``config.request_id_header``.
+        """
+        if self._closed:
+            raise RuntimeError(
+                "HttpClient is closed; cannot dispatch new requests "
+                "(construct a new client or avoid aclose() before reuse)"
+            )
+
+        method_up = method.upper()
+
+        # SSRF guard at URL-parse time. SafeDnsTransport re-runs this at
+        # connect time — both layers fire per the defence-in-depth contract.
+        check_url(
+            url,
+            blocked_networks=self._config.blocked_networks,
+            host_allowlist=self._config.host_allowlist,
+            allow_loopback=self._config.allow_loopback,
+            resolve_dns=True,
+        )
+
+        if request_id is None:
+            request_id = str(uuid.uuid4())
+
+        # Merge default headers + per-call headers. The request_id header is
+        # added last so a caller-supplied value for it wins if present.
+        merged_headers: dict[str, str] = dict(self._config.default_headers)
+        if headers:
+            merged_headers.update(headers)
+        merged_headers.setdefault(self._config.request_id_header, request_id)
+
+        has_auth = any(k.lower() == "authorization" for k in merged_headers.keys())
+        endpoint_host = urlparse(url).hostname or "<unknown-host>"
+        url_fp = _url_fingerprint(url)
+        prefix = self._config.structured_log_prefix
+        t0 = time.monotonic()
+        logger.info(
+            f"{prefix}.request.start",
+            extra={
+                "request_id": request_id,
+                "method": method_up,
+                "endpoint_host": endpoint_host,
+                "url_fingerprint": url_fp,
+                "has_auth": has_auth,
+            },
+        )
+
+        # Raw redirects: caller may override config per-call. Still falls
+        # under the SafeDnsTransport guard because httpx follows redirects
+        # via the same transport, so every hop is re-validated.
+        effective_follow = (
+            self._config.follow_redirects
+            if follow_redirects is None
+            else follow_redirects
+        )
+
+        try:
+            resp = await self._client.request(
+                method_up,
+                url,
+                headers=merged_headers,
+                json=json,
+                content=content,
+                params=dict(params) if params else None,
+                follow_redirects=effective_follow,
+            )
+        except Exception as exc:
+            latency_ms = (time.monotonic() - t0) * 1000
+            logger.error(
+                f"{prefix}.request.error",
+                extra={
+                    "request_id": request_id,
+                    "method": method_up,
+                    "endpoint_host": endpoint_host,
+                    "url_fingerprint": url_fp,
+                    "has_auth": has_auth,
+                    "exception_class": type(exc).__name__,
+                    "latency_ms": latency_ms,
+                },
+            )
+            raise
+        latency_ms = (time.monotonic() - t0) * 1000
+        logger.info(
+            f"{prefix}.request.ok",
+            extra={
+                "request_id": request_id,
+                "method": method_up,
+                "endpoint_host": endpoint_host,
+                "url_fingerprint": url_fp,
+                "has_auth": has_auth,
+                "status_code": resp.status_code,
+                "latency_ms": latency_ms,
+            },
+        )
+        return HttpResponse(
+            status_code=resp.status_code,
+            headers={k: v for k, v in resp.headers.items()},
+            body=resp.content,
+            url=str(resp.url),
+            request_id=request_id,
+        )
+
+    # ---- Verb methods -----------------------------------------------------
+
+    async def get(self, url: str, **kwargs: Any) -> HttpResponse:
+        return await self.request("GET", url, **kwargs)
+
+    async def post(self, url: str, **kwargs: Any) -> HttpResponse:
+        return await self.request("POST", url, **kwargs)
+
+    async def put(self, url: str, **kwargs: Any) -> HttpResponse:
+        return await self.request("PUT", url, **kwargs)
+
+    async def delete(self, url: str, **kwargs: Any) -> HttpResponse:
+        return await self.request("DELETE", url, **kwargs)
+
+    async def patch(self, url: str, **kwargs: Any) -> HttpResponse:
+        return await self.request("PATCH", url, **kwargs)
+
+    # ---- Streaming --------------------------------------------------------
+
+    async def stream(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        json: Any = None,
+        content: Any = None,
+        params: Optional[Mapping[str, Any]] = None,
+        request_id: Optional[str] = None,
+        chunk_size: int = 8192,
+    ) -> AsyncIterator[bytes]:
+        """Stream response body in chunks.
+
+        Used for large webhook / health-probe response bodies where reading
+        the entire body into memory is undesirable. The SSRF guard still
+        runs; only the body-delivery mode differs.
+        """
+        if self._closed:
+            raise RuntimeError("HttpClient is closed; cannot stream")
+
+        method_up = method.upper()
+        check_url(
+            url,
+            blocked_networks=self._config.blocked_networks,
+            host_allowlist=self._config.host_allowlist,
+            allow_loopback=self._config.allow_loopback,
+            resolve_dns=True,
+        )
+        if request_id is None:
+            request_id = str(uuid.uuid4())
+
+        merged_headers: dict[str, str] = dict(self._config.default_headers)
+        if headers:
+            merged_headers.update(headers)
+        merged_headers.setdefault(self._config.request_id_header, request_id)
+
+        prefix = self._config.structured_log_prefix
+        has_auth = any(k.lower() == "authorization" for k in merged_headers.keys())
+        endpoint_host = urlparse(url).hostname or "<unknown-host>"
+        url_fp = _url_fingerprint(url)
+        t0 = time.monotonic()
+        logger.info(
+            f"{prefix}.stream.start",
+            extra={
+                "request_id": request_id,
+                "method": method_up,
+                "endpoint_host": endpoint_host,
+                "url_fingerprint": url_fp,
+                "has_auth": has_auth,
+            },
+        )
+
+        async def _generator() -> AsyncIterator[bytes]:
+            try:
+                async with self._client.stream(
+                    method_up,
+                    url,
+                    headers=merged_headers,
+                    json=json,
+                    content=content,
+                    params=dict(params) if params else None,
+                ) as resp:
+                    async for chunk in resp.aiter_bytes(chunk_size):
+                        yield chunk
+            except Exception as exc:
+                latency_ms = (time.monotonic() - t0) * 1000
+                logger.error(
+                    f"{prefix}.stream.error",
+                    extra={
+                        "request_id": request_id,
+                        "method": method_up,
+                        "endpoint_host": endpoint_host,
+                        "url_fingerprint": url_fp,
+                        "has_auth": has_auth,
+                        "exception_class": type(exc).__name__,
+                        "latency_ms": latency_ms,
+                    },
+                )
+                raise
+            else:
+                latency_ms = (time.monotonic() - t0) * 1000
+                logger.info(
+                    f"{prefix}.stream.ok",
+                    extra={
+                        "request_id": request_id,
+                        "method": method_up,
+                        "endpoint_host": endpoint_host,
+                        "url_fingerprint": url_fp,
+                        "has_auth": has_auth,
+                        "latency_ms": latency_ms,
+                    },
+                )
+
+        return _generator()
+
+
+__all__ = [
+    "HttpClient",
+    "HttpClientConfig",
+    "HttpResponse",
+    "HttpClientError",
+    "InvalidEndpointError",
+    "SafeDnsTransport",
+    "check_url",
+]

--- a/packages/kailash-nexus/src/nexus/service_client.py
+++ b/packages/kailash-nexus/src/nexus/service_client.py
@@ -1,0 +1,534 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed service-to-service HTTP client — ServiceClient.
+
+Built on top of ``HttpClient``. Adds:
+
+* A typed exception hierarchy (``ServiceClientError`` base + subclasses per
+  failure mode) so callers can ``except ServiceClientHttpStatusError`` and
+  recover without catching every other HTTP error.
+* Eager header + bearer-token validation at construction time. Invalid
+  headers fail fast, not at first request, and never silently pollute the
+  header map.
+* Convenient JSON-in / JSON-out methods (``get`` / ``post`` / ``put`` /
+  ``delete``) alongside raw variants (``get_raw`` / ``post_raw`` / …) that
+  return ``HttpResponse`` without status checking.
+* SSRF-on-by-default inherited from ``HttpClient``. Layer order is fixed
+  per issue #473 non-negotiable 1: the private-IP check runs BEFORE the
+  host allowlist, so an allowlisted private IP is still rejected.
+
+# Secrets hygiene
+
+The bearer token is stored privately and validated for CRLF injection at
+``__init__``. It is NEVER logged. Log lines derived from this client emit
+``has_auth=true`` only, never the token. Error messages for status failures
+truncate the response body to ~512 bytes so a provider echoing the submitted
+Authorization in a 4xx body is bounded in the resulting exception string.
+
+# Cross-SDK parity
+
+Semantic match with ``kailash-rs#400`` ServiceClient. The exception
+hierarchy names and triggers mirror the Rust ``ServiceClientError`` variants
+exactly so callers porting between SDKs hit the same ``isinstance`` checks.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import re
+from typing import Any, Mapping, Optional, Sequence
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from .http_client import (
+    HttpClient,
+    HttpClientConfig,
+    HttpResponse,
+    InvalidEndpointError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy — matches kailash-rs ServiceClientError variants
+# ---------------------------------------------------------------------------
+
+
+class ServiceClientError(Exception):
+    """Base class for ServiceClient failures.
+
+    Every typed subclass inherits from this, so a caller can
+    ``except ServiceClientError`` and catch every failure mode without
+    caring about the specific variant. New subclasses added in future
+    sessions MUST continue to inherit from this base.
+    """
+
+
+class ServiceClientHttpError(ServiceClientError):
+    """Transport-layer failure: SSRF blocked, timeout, connection error,
+    invalid URL, unsupported scheme.
+
+    Maps to ``kailash-rs::ServiceClientError::Http`` variant. The ``cause``
+    attribute carries the underlying exception (httpx.ConnectError,
+    httpx.TimeoutException, InvalidEndpointError) for callers that need to
+    inspect the low-level failure.
+    """
+
+    def __init__(self, message: str, *, cause: Optional[BaseException] = None) -> None:
+        self.cause = cause
+        super().__init__(message)
+
+
+class ServiceClientHttpStatusError(ServiceClientError):
+    """Non-2xx HTTP status received from the upstream service.
+
+    The response body is truncated to ~512 bytes in the exception message
+    so a provider that echoes the submitted Authorization header in its
+    4xx body does not leak the full token into ``str(err)`` / tracing
+    spans.
+    """
+
+    _BODY_LIMIT = 512
+
+    def __init__(self, status_code: int, body: bytes, url: str) -> None:
+        self.status_code = status_code
+        self.url = url
+        # Decode for message; keep raw bytes available on the attribute.
+        self.body = body
+        try:
+            decoded = body.decode("utf-8", errors="replace")
+        except Exception:
+            decoded = "<non-utf8 body>"
+        if len(decoded) > self._BODY_LIMIT:
+            decoded = decoded[: self._BODY_LIMIT] + "...[truncated]"
+        # Do NOT include the full URL in the message — the path may carry
+        # a sensitive query-string value; fingerprint it via its host only.
+        host = urlparse(url).hostname or "<unknown-host>"
+        super().__init__(f"HTTP {status_code} from {host}: {decoded!r}")
+
+
+class ServiceClientSerializeError(ServiceClientError):
+    """Request body could not be serialized to JSON.
+
+    Triggered when a caller passes a non-JSON-serializable value
+    (e.g. a custom object without ``__dict__``) to a typed JSON method.
+    """
+
+
+class ServiceClientDeserializeError(ServiceClientError):
+    """Response body was not valid JSON for the expected type."""
+
+
+class ServiceClientInvalidPathError(ServiceClientError):
+    """Base URL + path could not be joined into a valid URL.
+
+    Triggered when the path fails to produce a well-formed URL when joined
+    with the base (empty host after join, malformed path, unsupported
+    scheme). Separate from ``InvalidEndpointError`` which signals SSRF.
+    """
+
+
+class ServiceClientInvalidHeaderError(ServiceClientError):
+    """Header name/value rejected by eager validation.
+
+    Raised at ``__init__`` for headers supplied via the ``headers`` kwarg,
+    and for the bearer token. Catches CRLF injection (``X-Good: v\\r\\nX-Bad: 1``),
+    empty name/value, and control-byte injection.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Header validation
+# ---------------------------------------------------------------------------
+
+# HTTP header name: RFC 7230 — a ``token`` character set. Disallow
+# whitespace, control bytes, and the reserved separators so the header name
+# is always a safe grep target.
+_HEADER_NAME_REGEX = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+
+# Control-byte probe for header values. Rejects ``\r``, ``\n``, and every
+# other C0 control except HTAB (``\t`` is permitted in structured header
+# values). We match the Rust ``is_valid_header_value`` contract exactly.
+_HEADER_VALUE_BAD = re.compile(r"[\x00-\x08\x0A-\x1F\x7F]")
+
+
+def _validate_header_name(name: Any) -> str:
+    if not isinstance(name, str):
+        raise ServiceClientInvalidHeaderError(
+            f"header name must be a string (got {type(name).__name__})"
+        )
+    if not name:
+        raise ServiceClientInvalidHeaderError("header name must not be empty")
+    if not _HEADER_NAME_REGEX.match(name):
+        # Do NOT echo the raw name — it may carry an injection payload that
+        # would end up in log aggregators. Fingerprint length + a short
+        # prefix for forensic correlation.
+        prefix = name[:8].encode("unicode_escape").decode("ascii")
+        raise ServiceClientInvalidHeaderError(
+            f"header name failed RFC 7230 token validation "
+            f"(len={len(name)}, prefix={prefix!r})"
+        )
+    return name
+
+
+def _validate_header_value(name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise ServiceClientInvalidHeaderError(
+            f"header '{name}' value must be a string " f"(got {type(value).__name__})"
+        )
+    if not value:
+        raise ServiceClientInvalidHeaderError(
+            f"header '{name}' value must not be empty"
+        )
+    if _HEADER_VALUE_BAD.search(value):
+        # Don't echo the raw value — CRLF payload goes into logs otherwise.
+        raise ServiceClientInvalidHeaderError(
+            f"header '{name}' contains CRLF / control bytes " f"(len={len(value)})"
+        )
+    return value
+
+
+def _validate_bearer_token(token: str) -> str:
+    """Bearer-token validation shares the header-value rule set.
+
+    Same CRLF / control-byte rejection. Empty string permitted here only
+    to signal 'no auth' — callers pass ``None`` for that path; an empty
+    string is treated as an invalid explicit value.
+    """
+    if not isinstance(token, str):
+        raise ServiceClientInvalidHeaderError(
+            f"bearer_token must be a string (got {type(token).__name__})"
+        )
+    if not token:
+        raise ServiceClientInvalidHeaderError(
+            "bearer_token must not be empty; pass None for no auth"
+        )
+    if _HEADER_VALUE_BAD.search(token):
+        raise ServiceClientInvalidHeaderError(
+            f"bearer_token contains CRLF / control bytes (len={len(token)})"
+        )
+    return token
+
+
+# ---------------------------------------------------------------------------
+# ServiceClient
+# ---------------------------------------------------------------------------
+
+
+class ServiceClient:
+    """Typed service-to-service HTTP client.
+
+    Constructor validates every header and the bearer token eagerly.
+    Invalid inputs fail at construction, not at first request. This is
+    non-negotiable per issue #473 — CRLF injection in a header must never
+    silently reach the wire.
+
+    Usage::
+
+        client = ServiceClient(
+            "https://api.example.com",
+            bearer_token="...",
+            allowed_hosts=["api.example.com"],
+            timeout_secs=30.0,
+            headers={"X-Client": "my-app"},
+        )
+
+        user = await client.get("/users/42")          # typed JSON
+        resp = await client.get_raw("/healthz")        # HttpResponse, no status check
+
+    Layer order (issue #473 NN1): the SSRF private-IP / metadata check runs
+    BEFORE ``allowed_hosts`` is consulted. An allowlisted private IP is
+    still rejected. The allowlist narrows the already-safe public set, it
+    does NOT provide a bypass.
+    """
+
+    __slots__ = (
+        "_base_url",
+        "_http",
+        "_headers",
+        "_has_auth",
+    )
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        bearer_token: Optional[str] = None,
+        allowed_hosts: Optional[Sequence[str]] = None,
+        timeout_secs: float = 30.0,
+        connect_timeout_secs: float = 10.0,
+        headers: Optional[Mapping[str, str]] = None,
+        follow_redirects: bool = False,
+        allow_loopback: bool = False,
+    ) -> None:
+        # ---- Base URL validation ----------------------------------------
+        # httpx requires a well-formed absolute URL. Reject malformed base
+        # URLs eagerly so the first request doesn't surface a cryptic error.
+        if not isinstance(base_url, str) or not base_url:
+            raise ServiceClientInvalidPathError("base_url must be a non-empty string")
+        parsed = urlparse(base_url)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            raise ServiceClientInvalidPathError(
+                f"base_url must be an absolute http/https URL "
+                f"(scheme={parsed.scheme!r})"
+            )
+        # httpx's urljoin with a trailing-slash-less base URL strips the
+        # final segment on join. Normalise by ensuring exactly one trailing
+        # slash so path joins are intuitive (``/foo`` -> ``base/foo``).
+        if not base_url.endswith("/"):
+            base_url = base_url + "/"
+        self._base_url = base_url
+
+        # ---- Eager header validation ------------------------------------
+        merged: dict[str, str] = {}
+        if headers is not None:
+            for name, value in headers.items():
+                vname = _validate_header_name(name)
+                vvalue = _validate_header_value(vname, value)
+                merged[vname] = vvalue
+
+        # ---- Bearer-token validation ------------------------------------
+        self._has_auth = False
+        if bearer_token is not None:
+            token = _validate_bearer_token(bearer_token)
+            merged["Authorization"] = f"Bearer {token}"
+            self._has_auth = True
+
+        self._headers = merged
+
+        # ---- Build underlying HttpClient --------------------------------
+        config = HttpClientConfig(
+            timeout_seconds=timeout_secs,
+            connect_timeout_seconds=connect_timeout_secs,
+            follow_redirects=follow_redirects,
+            host_allowlist=list(allowed_hosts) if allowed_hosts else None,
+            allow_loopback=allow_loopback,
+            structured_log_prefix="nexus.service_client",
+            default_headers={
+                "Accept": "application/json",
+                "User-Agent": "kailash-nexus/service-client",
+            },
+        )
+        self._http = HttpClient(config)
+
+        logger.info(
+            "nexus.service_client.init",
+            extra={
+                "base_host": parsed.hostname,
+                "has_auth": self._has_auth,
+                "allowed_hosts_count": len(allowed_hosts) if allowed_hosts else 0,
+                "timeout_secs": timeout_secs,
+            },
+        )
+
+    # ---- Lifecycle --------------------------------------------------------
+
+    async def __aenter__(self) -> "ServiceClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def has_auth(self) -> bool:
+        return self._has_auth
+
+    # ---- Path joining -----------------------------------------------------
+
+    def _join(self, path: str) -> str:
+        if not isinstance(path, str) or not path:
+            raise ServiceClientInvalidPathError("path must be a non-empty string")
+        # Strip a leading slash so urljoin uses the full base URL path
+        # prefix. Example: base "https://api.example.com/v1/" + path
+        # "/users" should produce "https://api.example.com/v1/users", NOT
+        # "https://api.example.com/users".
+        if path.startswith("/"):
+            path = path.lstrip("/")
+        try:
+            joined = urljoin(self._base_url, path)
+        except Exception as exc:
+            raise ServiceClientInvalidPathError(
+                f"could not join base_url + path: {type(exc).__name__}"
+            ) from exc
+        parsed = urlparse(joined)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            raise ServiceClientInvalidPathError(
+                "joined URL is not a well-formed http/https URL"
+            )
+        return joined
+
+    # ---- Raw request — no status check -----------------------------------
+
+    async def _raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any = None,
+        extra_headers: Optional[Mapping[str, str]] = None,
+    ) -> HttpResponse:
+        url = self._join(path)
+        # Merge instance headers with per-call headers. Per-call values win.
+        headers: dict[str, str] = dict(self._headers)
+        if extra_headers is not None:
+            for name, value in extra_headers.items():
+                vname = _validate_header_name(name)
+                vvalue = _validate_header_value(vname, value)
+                headers[vname] = vvalue
+
+        # Serialise JSON up-front so a SerializeError surfaces cleanly
+        # distinct from an httpx-layer failure.
+        body_bytes: Optional[bytes] = None
+        if json is not None:
+            if "Content-Type" not in headers:
+                headers["Content-Type"] = "application/json"
+            try:
+                body_bytes = _json.dumps(json).encode("utf-8")
+            except (TypeError, ValueError) as exc:
+                raise ServiceClientSerializeError(
+                    f"request body is not JSON-serialisable: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
+
+        try:
+            return await self._http.request(
+                method,
+                url,
+                headers=headers,
+                content=body_bytes,
+            )
+        except InvalidEndpointError as exc:
+            # SSRF rejection at URL-parse or connect time. Translate into
+            # the transport-layer ServiceClientHttpError so callers get one
+            # typed surface for every "request did not reach upstream"
+            # condition.
+            raise ServiceClientHttpError(f"request blocked: {exc}", cause=exc) from exc
+        except httpx.TimeoutException as exc:
+            raise ServiceClientHttpError(
+                f"request timeout: {type(exc).__name__}", cause=exc
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise ServiceClientHttpError(
+                f"request error: {type(exc).__name__}", cause=exc
+            ) from exc
+
+    # ---- Public RAW variants — return HttpResponse, no status check ------
+
+    async def get_raw(
+        self,
+        path: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> HttpResponse:
+        return await self._raw_request("GET", path, extra_headers=headers)
+
+    async def post_raw(
+        self,
+        path: str,
+        body: Any = None,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> HttpResponse:
+        return await self._raw_request("POST", path, json=body, extra_headers=headers)
+
+    async def put_raw(
+        self,
+        path: str,
+        body: Any = None,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> HttpResponse:
+        return await self._raw_request("PUT", path, json=body, extra_headers=headers)
+
+    async def delete_raw(
+        self,
+        path: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> HttpResponse:
+        return await self._raw_request("DELETE", path, extra_headers=headers)
+
+    # ---- Public TYPED variants — status-checked, JSON in/out -------------
+
+    async def get(
+        self,
+        path: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        resp = await self.get_raw(path, headers=headers)
+        return self._ensure_ok_and_decode(resp)
+
+    async def post(
+        self,
+        path: str,
+        body: Any = None,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        resp = await self.post_raw(path, body, headers=headers)
+        return self._ensure_ok_and_decode(resp)
+
+    async def put(
+        self,
+        path: str,
+        body: Any = None,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        resp = await self.put_raw(path, body, headers=headers)
+        return self._ensure_ok_and_decode(resp)
+
+    async def delete(
+        self,
+        path: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        resp = await self.delete_raw(path, headers=headers)
+        return self._ensure_ok_and_decode(resp)
+
+    # ---- Response handling ------------------------------------------------
+
+    def _ensure_ok_and_decode(self, resp: HttpResponse) -> Any:
+        if 200 <= resp.status_code < 300:
+            # Empty-body 2xx (e.g. 204 No Content) returns None rather than
+            # raising a deserialize error. Callers that want a strict
+            # "body must be JSON" contract use the raw variant + decode.
+            if not resp.body:
+                return None
+            try:
+                return _json.loads(resp.body.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError) as exc:
+                raise ServiceClientDeserializeError(
+                    f"response body is not valid UTF-8 JSON: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
+        raise ServiceClientHttpStatusError(
+            status_code=resp.status_code,
+            body=resp.body,
+            url=resp.url,
+        )
+
+
+__all__ = [
+    "ServiceClient",
+    "ServiceClientError",
+    "ServiceClientHttpError",
+    "ServiceClientHttpStatusError",
+    "ServiceClientSerializeError",
+    "ServiceClientDeserializeError",
+    "ServiceClientInvalidPathError",
+    "ServiceClientInvalidHeaderError",
+]

--- a/packages/kailash-nexus/tests/integration/test_http_client_wiring.py
+++ b/packages/kailash-nexus/tests/integration/test_http_client_wiring.py
@@ -1,0 +1,233 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests (Tier 2) for ``nexus.http_client.HttpClient``.
+
+Uses ``pytest-httpserver`` to exercise every verb (GET/POST/PUT/DELETE/PATCH)
+plus streaming against a real HTTP server listening on 127.0.0.1. The
+``allow_loopback=True`` carve-out is exercised here — production callers
+would not set it, but tests against a local stub must.
+
+Contract exercised:
+
+* Full end-to-end wiring: HttpClient -> SafeDnsTransport -> httpx ->
+  pytest-httpserver -> response parsed and returned.
+* request_id injected as X-Request-ID header on the outgoing request.
+* Redirects NOT followed by default (SafeDnsTransport guard runs per hop
+  when enabled).
+* Body streaming returns chunks.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nexus.http_client import HttpClient, HttpClientConfig
+
+
+@pytest.fixture
+def loopback_client() -> HttpClient:
+    """HttpClient with allow_loopback=True for loopback-only tests."""
+    return HttpClient(
+        HttpClientConfig(
+            allow_loopback=True,
+            timeout_seconds=5.0,
+            connect_timeout_seconds=5.0,
+        )
+    )
+
+
+@pytest.mark.integration
+class TestHttpClientVerbs:
+    """Every verb round-trips against a real HTTP server."""
+
+    @pytest.mark.asyncio
+    async def test_get_returns_body(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        httpserver.expect_request("/api").respond_with_json({"ok": True})
+        try:
+            resp = await loopback_client.get(httpserver.url_for("/api"))
+            assert resp.status_code == 200
+            assert json.loads(resp.body) == {"ok": True}
+        finally:
+            await loopback_client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_post_sends_json_body(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        httpserver.expect_request("/users", method="POST").respond_with_json({"id": 42})
+        try:
+            resp = await loopback_client.post(
+                httpserver.url_for("/users"),
+                json={"name": "Alice"},
+            )
+            assert resp.status_code == 200
+            assert json.loads(resp.body) == {"id": 42}
+        finally:
+            await loopback_client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_put_updates_resource(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        httpserver.expect_request("/users/42", method="PUT").respond_with_json(
+            {"updated": True}
+        )
+        try:
+            resp = await loopback_client.put(
+                httpserver.url_for("/users/42"),
+                json={"name": "Bob"},
+            )
+            assert resp.status_code == 200
+            assert json.loads(resp.body) == {"updated": True}
+        finally:
+            await loopback_client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_204(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        httpserver.expect_request("/users/42", method="DELETE").respond_with_data(
+            "", status=204
+        )
+        try:
+            resp = await loopback_client.delete(httpserver.url_for("/users/42"))
+            assert resp.status_code == 204
+        finally:
+            await loopback_client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_patch_partial_update(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        httpserver.expect_request("/users/42", method="PATCH").respond_with_json(
+            {"patched": True}
+        )
+        try:
+            resp = await loopback_client.patch(
+                httpserver.url_for("/users/42"),
+                json={"name": "Charlie"},
+            )
+            assert resp.status_code == 200
+            assert json.loads(resp.body) == {"patched": True}
+        finally:
+            await loopback_client.aclose()
+
+
+@pytest.mark.integration
+class TestHttpClientHeaders:
+    """Header plumbing: correlation ID injection + per-call headers."""
+
+    @pytest.mark.asyncio
+    async def test_request_id_injected(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        from werkzeug.wrappers import Response
+
+        received_headers: dict[str, str] = {}
+
+        def handler(request) -> Response:
+            received_headers.update(request.headers)
+            return Response("", status=200)
+
+        httpserver.expect_request("/x").respond_with_handler(handler)
+        try:
+            resp = await loopback_client.get(
+                httpserver.url_for("/x"), request_id="test-abc-123"
+            )
+            assert resp.request_id == "test-abc-123"
+            assert received_headers.get("X-Request-Id") == "test-abc-123"
+        finally:
+            await loopback_client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_per_call_header_merged(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        from werkzeug.wrappers import Response
+
+        received_headers: dict[str, str] = {}
+
+        def handler(request) -> Response:
+            received_headers.update(request.headers)
+            return Response("", status=200)
+
+        httpserver.expect_request("/x").respond_with_handler(handler)
+        try:
+            await loopback_client.get(
+                httpserver.url_for("/x"),
+                headers={"X-Custom": "value-42"},
+            )
+            assert received_headers.get("X-Custom") == "value-42"
+        finally:
+            await loopback_client.aclose()
+
+
+@pytest.mark.integration
+class TestHttpClientStreaming:
+    @pytest.mark.asyncio
+    async def test_stream_returns_chunks(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        payload = b"x" * 32768  # 32 KiB — exceeds default chunk size
+        httpserver.expect_request("/big").respond_with_data(payload)
+        try:
+            stream = await loopback_client.stream(
+                "GET", httpserver.url_for("/big"), chunk_size=4096
+            )
+            collected = b""
+            async for chunk in stream:
+                collected += chunk
+            assert collected == payload
+        finally:
+            await loopback_client.aclose()
+
+
+@pytest.mark.integration
+class TestHttpClientRedirects:
+    """Default follow_redirects=False — caller must opt in."""
+
+    @pytest.mark.asyncio
+    async def test_default_does_not_follow_redirect(
+        self, httpserver, loopback_client: HttpClient
+    ) -> None:
+        httpserver.expect_request("/from").respond_with_data(
+            "",
+            status=302,
+            headers={"Location": httpserver.url_for("/to")},
+        )
+        httpserver.expect_request("/to").respond_with_json({"ok": True})
+        try:
+            resp = await loopback_client.get(httpserver.url_for("/from"))
+            # Redirect NOT followed by default.
+            assert resp.status_code == 302
+        finally:
+            await loopback_client.aclose()
+
+
+@pytest.mark.integration
+class TestHttpClientSsrfAtConnect:
+    """SafeDnsTransport runs at connect time — per-hop SSRF defence."""
+
+    @pytest.mark.asyncio
+    async def test_default_config_blocks_loopback(self, httpserver) -> None:
+        """Without allow_loopback, default config rejects 127.0.0.1.
+
+        Proves that the production default (allow_loopback=False) is
+        SSRF-safe out of the box. Loopback hostname resolution at connect
+        time is blocked even though the caller technically has access to
+        a local HTTP server. This is the expected shape for production
+        deployments where every HttpClient call targets external services.
+        """
+        client = HttpClient(HttpClientConfig())  # no allow_loopback
+        try:
+            from nexus.http_client import InvalidEndpointError
+
+            with pytest.raises(InvalidEndpointError):
+                await client.get(httpserver.url_for("/anything"))
+        finally:
+            await client.aclose()

--- a/packages/kailash-nexus/tests/integration/test_service_client_wiring.py
+++ b/packages/kailash-nexus/tests/integration/test_service_client_wiring.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests (Tier 2) for ``nexus.service_client.ServiceClient``.
+
+Exercises every typed JSON verb + every raw variant against a real HTTP
+server. Typed variants auto-deserialise 2xx responses and raise
+``ServiceClientHttpStatusError`` on non-2xx. Raw variants return the full
+``HttpResponse`` without status checking.
+
+These tests double as orphan-detection coverage per
+``rules/facade-manager-detection.md`` — ServiceClient is exercised through
+its public surface against a real server, proving the wiring is live.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.service_client import (
+    ServiceClient,
+    ServiceClientHttpStatusError,
+)
+
+
+@pytest.fixture
+def service(httpserver) -> "ServiceClient":
+    """ServiceClient pointing at the pytest-httpserver root.
+
+    Uses ``allow_loopback=True`` because the test server binds 127.0.0.1.
+    Production callers must never set this.
+    """
+    base = f"http://{httpserver.host}:{httpserver.port}"
+    return ServiceClient(
+        base,
+        bearer_token="test-token-xyz",
+        allow_loopback=True,
+        timeout_secs=5.0,
+    )
+
+
+@pytest.mark.integration
+class TestServiceClientTypedVerbs:
+    """Typed variants — JSON in, JSON out, 2xx asserted."""
+
+    @pytest.mark.asyncio
+    async def test_typed_get(self, httpserver, service: ServiceClient) -> None:
+        httpserver.expect_request("/users/42").respond_with_json(
+            {"id": 42, "name": "Alice"}
+        )
+        try:
+            result = await service.get("/users/42")
+            assert result == {"id": 42, "name": "Alice"}
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_typed_post(self, httpserver, service: ServiceClient) -> None:
+        httpserver.expect_request("/users", method="POST").respond_with_json(
+            {"id": 1, "created": True}
+        )
+        try:
+            result = await service.post(
+                "/users", {"name": "Alice", "email": "a@example.com"}
+            )
+            assert result == {"id": 1, "created": True}
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_typed_put(self, httpserver, service: ServiceClient) -> None:
+        httpserver.expect_request("/users/42", method="PUT").respond_with_json(
+            {"updated": True}
+        )
+        try:
+            result = await service.put("/users/42", {"name": "Alice Updated"})
+            assert result == {"updated": True}
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_typed_delete(self, httpserver, service: ServiceClient) -> None:
+        httpserver.expect_request("/users/42", method="DELETE").respond_with_json(
+            {"deleted": True}
+        )
+        try:
+            result = await service.delete("/users/42")
+            assert result == {"deleted": True}
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_typed_delete_204_returns_none(
+        self, httpserver, service: ServiceClient
+    ) -> None:
+        httpserver.expect_request("/users/42", method="DELETE").respond_with_data(
+            "", status=204
+        )
+        try:
+            result = await service.delete("/users/42")
+            assert result is None
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_typed_non_2xx_raises_status_error(
+        self, httpserver, service: ServiceClient
+    ) -> None:
+        httpserver.expect_request("/missing").respond_with_data(
+            "not found here", status=404
+        )
+        try:
+            with pytest.raises(ServiceClientHttpStatusError) as exc_info:
+                await service.get("/missing")
+            assert exc_info.value.status_code == 404
+            assert b"not found here" in exc_info.value.body
+        finally:
+            await service.aclose()
+
+
+@pytest.mark.integration
+class TestServiceClientRawVerbs:
+    """Raw variants — return HttpResponse, no status check."""
+
+    @pytest.mark.asyncio
+    async def test_get_raw_non_2xx_does_not_raise(
+        self, httpserver, service: ServiceClient
+    ) -> None:
+        httpserver.expect_request("/missing").respond_with_data("{}", status=404)
+        try:
+            resp = await service.get_raw("/missing")
+            assert resp.status_code == 404
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_post_raw(self, httpserver, service: ServiceClient) -> None:
+        httpserver.expect_request("/webhook", method="POST").respond_with_json(
+            {"received": True}
+        )
+        try:
+            resp = await service.post_raw("/webhook", {"event": "x"})
+            assert resp.status_code == 200
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_put_raw(self, httpserver, service: ServiceClient) -> None:
+        httpserver.expect_request("/users/42", method="PUT").respond_with_json(
+            {"updated": True}
+        )
+        try:
+            resp = await service.put_raw("/users/42", {"name": "Alice"})
+            assert resp.status_code == 200
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_delete_raw(self, httpserver, service: ServiceClient) -> None:
+        httpserver.expect_request("/users/42", method="DELETE").respond_with_data(
+            "", status=204
+        )
+        try:
+            resp = await service.delete_raw("/users/42")
+            assert resp.status_code == 204
+        finally:
+            await service.aclose()
+
+
+@pytest.mark.integration
+class TestServiceClientAuthHeader:
+    """Bearer token stored at construction must appear on every request."""
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_sent_on_request(
+        self, httpserver, service: ServiceClient
+    ) -> None:
+        from werkzeug.wrappers import Response
+
+        received_headers: dict[str, str] = {}
+
+        def handler(request) -> Response:
+            received_headers.update(request.headers)
+            return Response(
+                '{"ok": true}',
+                status=200,
+                content_type="application/json",
+            )
+
+        httpserver.expect_request("/auth-check").respond_with_handler(handler)
+        try:
+            await service.get("/auth-check")
+            assert received_headers.get("Authorization") == "Bearer test-token-xyz"
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_no_bearer_means_no_auth_header(self, httpserver) -> None:
+        from werkzeug.wrappers import Response
+
+        base = f"http://{httpserver.host}:{httpserver.port}"
+        client = ServiceClient(base, bearer_token=None, allow_loopback=True)
+        received_headers: dict[str, str] = {}
+
+        def handler(request) -> Response:
+            received_headers.update(request.headers)
+            return Response("{}", status=200, content_type="application/json")
+
+        httpserver.expect_request("/x").respond_with_handler(handler)
+        try:
+            await client.get_raw("/x")
+            assert "Authorization" not in received_headers
+        finally:
+            await client.aclose()
+
+
+@pytest.mark.integration
+class TestServiceClientAllowlistOrdering:
+    """Issue #473 NN1: allowlisted private IP STILL blocked."""
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_loopback_still_blocked_without_allow_loopback(
+        self, httpserver
+    ) -> None:
+        """The caller allowlists 127.0.0.1 but does NOT set allow_loopback.
+
+        Expected: the SSRF guard rejects first, before the allowlist is
+        consulted. No request reaches the server.
+        """
+        base = f"http://{httpserver.host}:{httpserver.port}"
+        client = ServiceClient(
+            base,
+            allowed_hosts=["127.0.0.1", httpserver.host],
+            allow_loopback=False,  # explicit — no carve-out
+        )
+        try:
+            from nexus.service_client import ServiceClientHttpError
+
+            with pytest.raises(ServiceClientHttpError):
+                await client.get_raw("/any")
+        finally:
+            await client.aclose()

--- a/packages/kailash-nexus/tests/unit/test_http_client.py
+++ b/packages/kailash-nexus/tests/unit/test_http_client.py
@@ -1,0 +1,434 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``nexus.http_client``.
+
+Coverage:
+
+* SSRF URL validation — every blocked pattern from the guard.
+* Config default shape — follow_redirects=False, blocked_networks defaults,
+  request_id_header naming.
+* InvalidEndpointError contract — reason allowlist, URL fingerprint only.
+* SSRF ordering — private-IP check runs BEFORE host allowlist per issue
+  #473 non-negotiable 1.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+import pytest
+
+from nexus.http_client import (
+    HttpClient,
+    HttpClientConfig,
+    InvalidEndpointError,
+    check_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientConfigDefaults:
+    """The config's defaults encode the SSRF posture.
+
+    Regression checkpoint: follow_redirects MUST default to False because
+    every redirect is a fresh SSRF surface. blocked_networks MUST include
+    the RFC1918 + loopback + link-local + IMDS set by default.
+    """
+
+    def test_follow_redirects_defaults_false(self) -> None:
+        config = HttpClientConfig()
+        assert config.follow_redirects is False
+
+    def test_blocked_networks_include_rfc1918(self) -> None:
+        config = HttpClientConfig()
+        networks = list(config.blocked_networks or ())
+        assert any(
+            ipaddress.IPv4Address("10.1.2.3") in n for n in networks
+        ), "RFC1918 10/8 must be in default blocklist"
+        assert any(
+            ipaddress.IPv4Address("172.20.0.1") in n for n in networks
+        ), "RFC1918 172.16/12 must be in default blocklist"
+        assert any(
+            ipaddress.IPv4Address("192.168.1.1") in n for n in networks
+        ), "RFC1918 192.168/16 must be in default blocklist"
+
+    def test_blocked_networks_include_loopback(self) -> None:
+        config = HttpClientConfig()
+        networks = list(config.blocked_networks or ())
+        assert any(ipaddress.IPv4Address("127.0.0.1") in n for n in networks)
+
+    def test_blocked_networks_include_link_local_and_imds(self) -> None:
+        config = HttpClientConfig()
+        networks = list(config.blocked_networks or ())
+        assert any(
+            ipaddress.IPv4Address("169.254.169.254") in n for n in networks
+        ), "AWS IMDS 169.254.169.254 must be in default blocklist"
+
+    def test_blocked_networks_include_ipv6_private(self) -> None:
+        config = HttpClientConfig()
+        networks = list(config.blocked_networks or ())
+        assert any(ipaddress.IPv6Address("::1") in n for n in networks)
+        assert any(
+            ipaddress.IPv6Address("fd00::1") in n for n in networks
+        ), "ULA fc00::/7 must be in default blocklist"
+
+    def test_request_id_header_default(self) -> None:
+        config = HttpClientConfig()
+        assert config.request_id_header == "X-Request-ID"
+
+    def test_structured_log_prefix_default(self) -> None:
+        config = HttpClientConfig()
+        assert config.structured_log_prefix == "nexus.http"
+
+
+# ---------------------------------------------------------------------------
+# SSRF rejection — blocked patterns
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUrlBlockedPatterns:
+    """Every blocked SSRF pattern must produce an InvalidEndpointError."""
+
+    def test_rfc1918_10_8_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://10.0.0.1/api")
+        assert exc_info.value.reason == "private_ipv4"
+
+    def test_rfc1918_172_16_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://172.16.0.1/api")
+        assert exc_info.value.reason == "private_ipv4"
+
+    def test_rfc1918_192_168_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://192.168.1.1/api")
+        assert exc_info.value.reason == "private_ipv4"
+
+    def test_loopback_127_0_0_1_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://127.0.0.1/api")
+        assert exc_info.value.reason == "loopback"
+
+    def test_aws_imds_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://169.254.169.254/latest/meta-data/")
+        assert exc_info.value.reason == "metadata_service"
+
+    def test_link_local_169_254_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://169.254.1.1/")
+        # Either link_local or metadata_service is acceptable — 169.254.169.254
+        # is metadata specifically; other link-local IPs surface as link_local.
+        assert exc_info.value.reason in ("link_local", "private_ipv4")
+
+    def test_ipv6_loopback_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://[::1]/api")
+        assert exc_info.value.reason == "loopback"
+
+    def test_ipv6_ula_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://[fd00::1]/api")
+        assert exc_info.value.reason == "private_ipv6"
+
+    def test_ipv6_link_local_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://[fe80::1]/api")
+        assert exc_info.value.reason == "link_local"
+
+    def test_ipv4_mapped_ipv6_loopback_rejected(self) -> None:
+        """``::ffff:127.0.0.1`` wraps loopback — must still reject."""
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://[::ffff:127.0.0.1]/api")
+        assert exc_info.value.reason == "ipv4_mapped"
+
+    def test_nat64_wellknown_rejected(self) -> None:
+        """RFC 6052 64:ff9b::/96 NAT64 wrapper — reject unconditionally."""
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://[64:ff9b::1]/api")
+        assert exc_info.value.reason == "ipv4_mapped"
+
+    def test_metadata_hostname_google_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://metadata.google.internal/computeMetadata/v1/")
+        assert exc_info.value.reason == "metadata_host"
+
+    def test_metadata_hostname_aws_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://metadata.aws.internal/")
+        assert exc_info.value.reason == "metadata_host"
+
+    def test_metadata_hostname_azure_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://metadata.azure.com/")
+        assert exc_info.value.reason == "metadata_host"
+
+    def test_decimal_encoded_ip_rejected(self) -> None:
+        """``2130706433`` = 127.0.0.1 in inet_aton decimal form."""
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://2130706433/")
+        assert exc_info.value.reason == "encoded_ip_bypass"
+
+    def test_octal_encoded_ip_rejected(self) -> None:
+        """``0177.0.0.1`` = 127.0.0.1 in inet_aton octal form."""
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://0177.0.0.1/")
+        assert exc_info.value.reason == "encoded_ip_bypass"
+
+    def test_hex_encoded_ip_rejected(self) -> None:
+        """``0x7f.0.0.1`` = 127.0.0.1 in inet_aton hex form."""
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://0x7f.0.0.1/")
+        assert exc_info.value.reason == "encoded_ip_bypass"
+
+    def test_inet_aton_shortform_loopback_rejected(self) -> None:
+        """``127.1`` resolves to 127.0.0.1 via libc. Guard must catch it."""
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://127.1/")
+        assert exc_info.value.reason == "encoded_ip_bypass"
+
+    def test_non_http_scheme_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("file:///etc/passwd")
+        assert exc_info.value.reason == "scheme"
+
+    def test_gopher_scheme_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("gopher://example.com/")
+        assert exc_info.value.reason == "scheme"
+
+    def test_ftp_scheme_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("ftp://example.com/")
+        assert exc_info.value.reason == "scheme"
+
+    def test_empty_url_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("")
+        assert exc_info.value.reason == "malformed_url"
+
+    def test_non_string_url_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError):
+            check_url(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# SSRF — public hosts pass
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUrlPublicHosts:
+    """Public hosts must NOT be rejected by the SSRF guard."""
+
+    def test_public_ip_allowed(self) -> None:
+        # 8.8.8.8 is Google DNS; a public IP. resolve_dns=False keeps this
+        # test offline and deterministic.
+        check_url("https://8.8.8.8/", resolve_dns=False)
+
+    def test_public_hostname_allowed_with_resolve_dns_off(self) -> None:
+        check_url("https://example.com/", resolve_dns=False)
+
+
+# ---------------------------------------------------------------------------
+# allow_loopback carve-out
+# ---------------------------------------------------------------------------
+
+
+class TestAllowLoopback:
+    """``allow_loopback=True`` permits ONLY 127.0.0.1 / localhost / ::1.
+
+    Every other private range stays blocked so allow_loopback cannot be
+    mis-used as a wildcard disable switch.
+    """
+
+    def test_loopback_permitted_when_enabled(self) -> None:
+        check_url(
+            "http://127.0.0.1:8080/x",
+            allow_loopback=True,
+            resolve_dns=False,
+        )
+
+    def test_private_ipv4_still_rejected_when_allow_loopback_set(
+        self,
+    ) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url("http://10.0.0.1/", allow_loopback=True, resolve_dns=False)
+        assert exc_info.value.reason == "private_ipv4"
+
+    def test_metadata_still_rejected_when_allow_loopback_set(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url(
+                "http://169.254.169.254/",
+                allow_loopback=True,
+                resolve_dns=False,
+            )
+        assert exc_info.value.reason == "metadata_service"
+
+
+# ---------------------------------------------------------------------------
+# SSRF ordering — issue #473 non-negotiable 1
+# ---------------------------------------------------------------------------
+
+
+class TestSsrfBeforeAllowlist:
+    """An allowlisted private IP must STILL be rejected.
+
+    Per issue #473 non-negotiable 1: the private-IP / metadata check runs
+    BEFORE the host allowlist. The allowlist narrows the already-safe
+    public set; it is NOT a bypass path.
+    """
+
+    def test_allowlisted_private_ip_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url(
+                "http://10.0.0.1/",
+                host_allowlist=["10.0.0.1"],
+                resolve_dns=False,
+            )
+        # private_ipv4, not host_not_allowlisted — ordering proof.
+        assert exc_info.value.reason == "private_ipv4"
+
+    def test_allowlisted_imds_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url(
+                "http://169.254.169.254/",
+                host_allowlist=["169.254.169.254"],
+                resolve_dns=False,
+            )
+        assert exc_info.value.reason == "metadata_service"
+
+    def test_allowlisted_loopback_rejected(self) -> None:
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url(
+                "http://127.0.0.1/",
+                host_allowlist=["127.0.0.1"],
+                resolve_dns=False,
+            )
+        assert exc_info.value.reason == "loopback"
+
+    def test_public_host_not_in_allowlist_rejected(self) -> None:
+        """Once SSRF passes, a non-allowlisted host is rejected."""
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url(
+                "https://attacker.example.com/",
+                host_allowlist=["api.example.com"],
+                resolve_dns=False,
+            )
+        assert exc_info.value.reason == "host_not_allowlisted"
+
+    def test_public_host_in_allowlist_allowed(self) -> None:
+        check_url(
+            "https://api.example.com/",
+            host_allowlist=["api.example.com"],
+            resolve_dns=False,
+        )
+
+    def test_allowlist_is_case_insensitive(self) -> None:
+        check_url(
+            "https://API.Example.Com/",
+            host_allowlist=["api.example.com"],
+            resolve_dns=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# InvalidEndpointError contract
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidEndpointErrorContract:
+    def test_reason_echoes_nothing_sensitive(self) -> None:
+        """Raw URL must NEVER appear in str(exc) — only the fingerprint."""
+        with pytest.raises(InvalidEndpointError) as exc_info:
+            check_url(
+                "http://127.0.0.1:8080/secret-token-abc123",
+                resolve_dns=False,
+            )
+        msg = str(exc_info.value)
+        assert "secret-token-abc123" not in msg
+        assert "url_fingerprint=" in msg
+
+    def test_unknown_reason_coerces_to_malformed(self) -> None:
+        """Defensive — if a future caller passes an off-allowlist reason."""
+        err = InvalidEndpointError("not_a_real_reason", raw_url="http://x/")
+        assert err.reason == "malformed_url"
+
+    def test_fingerprint_is_8_hex_chars(self) -> None:
+        err = InvalidEndpointError("scheme", raw_url="http://example.com/")
+        assert err.url_fingerprint is not None
+        assert len(err.url_fingerprint) == 8
+        # hex
+        int(err.url_fingerprint, 16)
+
+    def test_no_fingerprint_when_no_url(self) -> None:
+        err = InvalidEndpointError("malformed_url", raw_url=None)
+        assert err.url_fingerprint is None
+        assert "url_fingerprint" not in str(err)
+
+
+# ---------------------------------------------------------------------------
+# HttpClient lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientLifecycle:
+    @pytest.mark.asyncio
+    async def test_is_closed_false_initially(self) -> None:
+        client = HttpClient(HttpClientConfig())
+        try:
+            assert client.is_closed is False
+        finally:
+            await client.aclose()
+        assert client.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_aclose_is_idempotent(self) -> None:
+        client = HttpClient(HttpClientConfig())
+        await client.aclose()
+        await client.aclose()  # second call should not raise
+        assert client.is_closed is True
+
+    @pytest.mark.asyncio
+    async def test_use_after_close_raises(self) -> None:
+        client = HttpClient(HttpClientConfig())
+        await client.aclose()
+        with pytest.raises(RuntimeError):
+            await client.get("https://example.com/")
+
+    @pytest.mark.asyncio
+    async def test_context_manager_closes(self) -> None:
+        async with HttpClient(HttpClientConfig()) as client:
+            assert client.is_closed is False
+        assert client.is_closed is True
+
+
+# ---------------------------------------------------------------------------
+# HttpClient request validation
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientRequestValidation:
+    """Request-layer SSRF rejection is observable via InvalidEndpointError."""
+
+    @pytest.mark.asyncio
+    async def test_private_ip_raises_invalid_endpoint(self) -> None:
+        async with HttpClient(HttpClientConfig()) as client:
+            with pytest.raises(InvalidEndpointError):
+                await client.get("http://10.0.0.1/api")
+
+    @pytest.mark.asyncio
+    async def test_imds_raises_invalid_endpoint(self) -> None:
+        async with HttpClient(HttpClientConfig()) as client:
+            with pytest.raises(InvalidEndpointError):
+                await client.get("http://169.254.169.254/")
+
+    @pytest.mark.asyncio
+    async def test_scheme_raises_invalid_endpoint(self) -> None:
+        async with HttpClient(HttpClientConfig()) as client:
+            with pytest.raises(InvalidEndpointError):
+                await client.get("file:///etc/passwd")

--- a/packages/kailash-nexus/tests/unit/test_service_client.py
+++ b/packages/kailash-nexus/tests/unit/test_service_client.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``nexus.service_client``.
+
+Coverage:
+
+* Exception hierarchy — every typed subclass inherits from the base.
+* Eager header validation — CRLF / control bytes / empty / non-string
+  rejected at ``__init__``.
+* Bearer-token validation — CRLF / empty rejected at ``__init__``.
+* Path joining — malformed paths raise ServiceClientInvalidPathError.
+* SSRF propagation — a blocked URL from the underlying HttpClient surfaces
+  as ServiceClientHttpError.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.service_client import (
+    ServiceClient,
+    ServiceClientDeserializeError,
+    ServiceClientError,
+    ServiceClientHttpError,
+    ServiceClientHttpStatusError,
+    ServiceClientInvalidHeaderError,
+    ServiceClientInvalidPathError,
+    ServiceClientSerializeError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionHierarchy:
+    """Every typed failure mode inherits from ``ServiceClientError``.
+
+    Backwards-compat guarantee — a caller that catches
+    ``ServiceClientError`` MUST catch every subclass.
+    """
+
+    def test_http_error_is_service_client_error(self) -> None:
+        assert issubclass(ServiceClientHttpError, ServiceClientError)
+
+    def test_http_status_error_is_service_client_error(self) -> None:
+        assert issubclass(ServiceClientHttpStatusError, ServiceClientError)
+
+    def test_serialize_error_is_service_client_error(self) -> None:
+        assert issubclass(ServiceClientSerializeError, ServiceClientError)
+
+    def test_deserialize_error_is_service_client_error(self) -> None:
+        assert issubclass(ServiceClientDeserializeError, ServiceClientError)
+
+    def test_invalid_path_error_is_service_client_error(self) -> None:
+        assert issubclass(ServiceClientInvalidPathError, ServiceClientError)
+
+    def test_invalid_header_error_is_service_client_error(self) -> None:
+        assert issubclass(ServiceClientInvalidHeaderError, ServiceClientError)
+
+    def test_status_error_truncates_body(self) -> None:
+        """Body over 512 bytes must be truncated in the exception message.
+
+        This is defence against a provider that echoes the submitted
+        Authorization header in a 4xx body — the full token should not
+        appear in str(err).
+        """
+        long_body = b"x" * 2048
+        err = ServiceClientHttpStatusError(
+            status_code=403, body=long_body, url="https://api.example.com/x"
+        )
+        assert err.status_code == 403
+        assert err.body == long_body  # raw preserved
+        assert "...[truncated]" in str(err)
+        # Message length bounded.
+        assert len(str(err)) < 1024
+
+    def test_status_error_does_not_echo_full_url(self) -> None:
+        err = ServiceClientHttpStatusError(
+            status_code=500,
+            body=b"",
+            url="https://api.example.com/secret/path/xyz?token=abc123",
+        )
+        assert "secret" not in str(err)
+        assert "abc123" not in str(err)
+        assert "api.example.com" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Base URL validation
+# ---------------------------------------------------------------------------
+
+
+class TestBaseUrlValidation:
+    def test_empty_base_url_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidPathError):
+            ServiceClient("")
+
+    def test_non_http_base_url_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidPathError):
+            ServiceClient("file:///etc/passwd")
+
+    def test_no_host_base_url_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidPathError):
+            ServiceClient("https://")
+
+    def test_base_url_trailing_slash_normalised(self) -> None:
+        client = ServiceClient("https://api.example.com")
+        assert client.base_url == "https://api.example.com/"
+
+    def test_base_url_with_path_preserved(self) -> None:
+        client = ServiceClient("https://api.example.com/v1")
+        assert client.base_url == "https://api.example.com/v1/"
+
+
+# ---------------------------------------------------------------------------
+# Eager header validation — CRLF / control / empty
+# ---------------------------------------------------------------------------
+
+
+class TestEagerHeaderValidation:
+    """Non-negotiable per issue #473: invalid headers fail at __init__.
+
+    BLOCKED patterns: CRLF injection, empty name, empty value, control
+    bytes, non-string types. Every rejection must happen BEFORE the first
+    request dispatches.
+    """
+
+    def test_crlf_in_header_value_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X-Good": "value\r\nX-Bad: 1"},
+            )
+
+    def test_lone_lf_in_header_value_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X-Good": "value\nX-Bad: 1"},
+            )
+
+    def test_lone_cr_in_header_value_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X-Good": "value\rX-Bad: 1"},
+            )
+
+    def test_null_byte_in_header_value_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X-Good": "value\x00bypass"},
+            )
+
+    def test_empty_header_name_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"": "value"},
+            )
+
+    def test_empty_header_value_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X-Good": ""},
+            )
+
+    def test_space_in_header_name_rejected(self) -> None:
+        """RFC 7230 token — whitespace in names is injection bait."""
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X Bad": "value"},
+            )
+
+    def test_control_byte_in_header_name_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X-\x00Bad": "value"},
+            )
+
+    def test_non_string_header_name_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={42: "value"},  # type: ignore[dict-item]
+            )
+
+    def test_non_string_header_value_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X-Good": 42},  # type: ignore[dict-item]
+            )
+
+    def test_valid_headers_accepted(self) -> None:
+        client = ServiceClient(
+            "https://api.example.com",
+            headers={"X-Client": "my-app", "X-Request-Source": "test"},
+        )
+        assert client.base_url == "https://api.example.com/"
+
+    def test_header_error_message_does_not_echo_raw_value(self) -> None:
+        """The rejection message must not put the CRLF payload into logs."""
+        try:
+            ServiceClient(
+                "https://api.example.com",
+                headers={"X-Bad": "legit-value\r\nX-Sensitive-Token: abc123xyz"},
+            )
+            raise AssertionError("expected rejection")
+        except ServiceClientInvalidHeaderError as exc:
+            msg = str(exc)
+            assert "abc123xyz" not in msg
+            assert "X-Sensitive-Token" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Bearer-token validation — CRLF / empty
+# ---------------------------------------------------------------------------
+
+
+class TestBearerTokenValidation:
+    def test_crlf_in_bearer_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                bearer_token="good\r\nX-Injected: 1",
+            )
+
+    def test_empty_bearer_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                bearer_token="",
+            )
+
+    def test_null_byte_bearer_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                bearer_token="tok\x00bypass",
+            )
+
+    def test_non_string_bearer_rejected(self) -> None:
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            ServiceClient(
+                "https://api.example.com",
+                bearer_token=42,  # type: ignore[arg-type]
+            )
+
+    def test_valid_bearer_accepted(self) -> None:
+        client = ServiceClient(
+            "https://api.example.com", bearer_token="valid-token-xyz"
+        )
+        assert client.has_auth is True
+
+    def test_none_bearer_means_no_auth(self) -> None:
+        client = ServiceClient("https://api.example.com", bearer_token=None)
+        assert client.has_auth is False
+
+
+# ---------------------------------------------------------------------------
+# Path joining
+# ---------------------------------------------------------------------------
+
+
+class TestPathJoining:
+    @pytest.mark.asyncio
+    async def test_empty_path_rejected_at_request(self) -> None:
+        async with ServiceClient("https://api.example.com") as client:
+            with pytest.raises(ServiceClientInvalidPathError):
+                await client.get_raw("")
+
+    @pytest.mark.asyncio
+    async def test_non_string_path_rejected(self) -> None:
+        async with ServiceClient("https://api.example.com") as client:
+            with pytest.raises(ServiceClientInvalidPathError):
+                await client.get_raw(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# SSRF propagation — blocked URL surfaces as ServiceClientHttpError
+# ---------------------------------------------------------------------------
+
+
+class TestSsrfPropagation:
+    @pytest.mark.asyncio
+    async def test_private_ip_base_url_blocked(self) -> None:
+        async with ServiceClient("http://10.0.0.1") as client:
+            with pytest.raises(ServiceClientHttpError) as exc_info:
+                await client.get_raw("/api")
+            # Cause is the underlying InvalidEndpointError
+            assert exc_info.value.cause is not None
+
+    @pytest.mark.asyncio
+    async def test_imds_base_url_blocked(self) -> None:
+        async with ServiceClient("http://169.254.169.254") as client:
+            with pytest.raises(ServiceClientHttpError):
+                await client.get_raw("/latest/meta-data/")
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_private_ip_still_blocked(self) -> None:
+        """Issue #473 non-negotiable 1 — allowlist does not bypass SSRF."""
+        async with ServiceClient(
+            "http://10.0.0.1", allowed_hosts=["10.0.0.1"]
+        ) as client:
+            with pytest.raises(ServiceClientHttpError):
+                await client.get_raw("/api")
+
+
+# ---------------------------------------------------------------------------
+# Serialize error
+# ---------------------------------------------------------------------------
+
+
+class _Unserializable:
+    """An object whose `__dict__` contains a non-JSON-serialisable value."""
+
+    def __init__(self) -> None:
+        self.bad = object()
+
+
+class TestSerializeError:
+    @pytest.mark.asyncio
+    async def test_unserialisable_body_raises_serialize_error(self) -> None:
+        async with ServiceClient(
+            "https://api.example.com", allow_loopback=False
+        ) as client:
+            with pytest.raises(ServiceClientSerializeError):
+                # object() is not JSON-serialisable
+                await client.post_raw("/x", {"obj": object()})


### PR DESCRIPTION
## Summary

- **`nexus.HttpClient` (#464)** — SSRF-safe outbound HTTP primitive. Every URL passes through `check_url` at parse time; `SafeDnsTransport` re-validates the peer host at connect time, closing the TOCTOU window between parse and TCP SYN. `follow_redirects` defaults to `False` because every redirect is a fresh SSRF surface. Default `blocked_networks` covers RFC1918 + loopback + link-local + IMDS + ULA + v6 link-local + CGNAT. `request_id` is injected as `X-Request-ID` on every outgoing request.
- **`nexus.ServiceClient` (#473)** — typed service-to-service wrapper. Headers + bearer tokens validated eagerly at `__init__` (CRLF, control bytes, empty value all rejected fast). Exception hierarchy mirrors `kailash-rs#400`: `ServiceClientHttpError`, `HttpStatusError`, `SerializeError`, `DeserializeError`, `InvalidPathError`, `InvalidHeaderError` — all inheriting from `ServiceClientError` so legacy `except` clauses keep working. 4xx/5xx bodies truncate to ~512 B in the status-error message, bounding blast radius when a provider echoes the submitted `Authorization` in an error body.
- **SSRF ordering (non-negotiable 1)** — private-IP / metadata check runs BEFORE the host allowlist. An allowlisted private IP is still rejected. `TestSsrfBeforeAllowlist` proves this.
- **Secrets hygiene** — bearer tokens stored privately, never logged; log lines emit `has_auth=true` only. Raw URLs never in error messages; fingerprinted via 8-char SHA-256 prefix (cross-SDK parity with `kailash-rs#399` + `kaizen.llm.url_safety`).

## Test plan

- [x] 89 unit tests — every blocked SSRF pattern (RFC1918, loopback, IMDS, decimal/octal/hex bypass, `inet_aton` short-form, IPv6 loopback / ULA / link-local / IPv4-mapped / NAT64), every header validation path (CRLF, control bytes, empty, non-string), full exception-hierarchy `isinstance` sweep
- [x] 23 Tier 2 integration tests against `pytest-httpserver` — all five verbs (GET/POST/PUT/PATCH/DELETE), streaming, redirect-default-off, raw + typed variants exercised directly per `rules/testing.md § Delegating Primitives Need Direct Coverage`
- [x] Collect-only clean across `packages/kailash-nexus/tests/` (2156 tests collected, 0 errors)
- [x] No regression in the 1640-test Nexus unit suite
- [x] `pytest -W error::ResourceWarning` clean on the new tests

## Related issues

Fixes #464
Fixes #473

Cross-SDK alignment with `esperie-enterprise/kailash-rs#399` (HttpClient) and `esperie-enterprise/kailash-rs#400` (ServiceClient). Exception variant names + SSRF reason codes + URL-fingerprint shape are byte-identical so callers porting between SDKs hit the same `isinstance` checks and log aggregators correlate across languages.

Follow-up (out of scope): static OpenAPI→Python codegen — `#465`. Downstream aegis migration (11 httpx sites in `src/aegis/services/`) happens after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)