### PR TITLE
feat(nexus): typed service-to-service client wrapper (#465)

### DIFF
--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -89,6 +89,7 @@ from .service_client import (
     ServiceClientInvalidPathError,
     ServiceClientSerializeError,
 )
+from .typed_service_client import Decoder, TypedServiceClient
 from .errors import PermissionError as NexusPermissionError  # deprecated alias
 from .errors import RateLimitError, ServiceUnavailableError
 from .errors import TimeoutError as NexusTimeoutError
@@ -181,4 +182,7 @@ __all__ = [
     "ServiceClientDeserializeError",
     "ServiceClientInvalidPathError",
     "ServiceClientInvalidHeaderError",
+    # Typed-model service client (issue #465 + cross-SDK kailash-rs#400)
+    "TypedServiceClient",
+    "Decoder",
 ]

--- a/packages/kailash-nexus/src/nexus/typed_service_client.py
+++ b/packages/kailash-nexus/src/nexus/typed_service_client.py
@@ -1,0 +1,435 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed-model service-to-service HTTP client — ``TypedServiceClient``.
+
+A thin wrapper around :class:`nexus.service_client.ServiceClient` that adds
+model-typed request/response variants. The base class already guarantees:
+
+* SSRF-on-by-default (private-IP / metadata-endpoint rejection before
+  allowlist, per issue #473 non-negotiable 1).
+* Eager CRLF / control-byte rejection on every header and the bearer token.
+* Typed exception hierarchy rooted at ``ServiceClientError``.
+* Bounded response-body truncation on non-2xx to prevent token echo into
+  exception strings.
+
+This module adds — and nothing else:
+
+* ``get_typed`` / ``post_typed`` / ``put_typed`` / ``delete_typed`` — each
+  parameterised by a response model class. The JSON body returned from the
+  base client's typed verb is fed through a decoder to produce a concrete
+  model instance.
+* A default decoder that assumes the target class is a plain ``@dataclass``
+  (or any class whose ``__init__`` takes the JSON field names as keyword
+  arguments) and invokes ``cls(**payload)``. Missing-field and wrong-type
+  failures are translated into
+  :class:`~nexus.service_client.ServiceClientDeserializeError`.
+* :meth:`TypedServiceClient.register_decoder` — a per-instance override that
+  lets downstream users plug in pydantic, msgspec, attrs, or any other
+  deserialiser without Nexus taking a hard dependency. Registration is
+  instance-scoped (not a process global), so two clients in the same
+  process can disagree about the decoder for the same class.
+
+# Out of scope
+
+OpenAPI → Python code generation is *explicitly* deferred until a concrete
+consumer arrives (matches the kailash-rs BP-044 decision journal on the
+Rust side). The current scope is: give downstream generators and
+hand-written dataclass owners a uniform typed surface to call.
+
+# Cross-SDK parity
+
+Semantic match with kailash-rs #400. The four typed verb names
+(``get_typed`` / ``post_typed`` / ``put_typed`` / ``delete_typed``) and
+the ``ServiceClientDeserializeError`` trigger condition mirror the
+Rust surface exactly so callers porting between SDKs hit the same
+``isinstance`` checks.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import typing
+from typing import Any, Callable, Mapping, Optional, Type, TypeVar
+
+from .service_client import (
+    ServiceClient,
+    ServiceClientDeserializeError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Decoder protocol
+# ---------------------------------------------------------------------------
+
+# A decoder converts a decoded JSON value (dict / list / str / int / …) into
+# an instance of the target model class. The signature is intentionally
+# minimal so pydantic / msgspec / attrs / hand-rolled dataclasses can all
+# plug in without adapter shims.
+Decoder = Callable[[Any, Type[Any]], Any]
+
+# Type variable that lets static type checkers narrow the return type of
+# ``get_typed(... , User)`` to ``User``. At runtime the hints are
+# advisory — deserialisation errors surface as ``ServiceClientDeserializeError``.
+M = TypeVar("M")
+
+
+def _default_decode(payload: Any, model_cls: Type[M]) -> M:
+    """Default decoder — assumes a dataclass-like ``__init__(**fields)``.
+
+    The fallback path works for any class whose constructor accepts the
+    JSON object's keys as keyword arguments. This covers:
+
+    * ``@dataclass(frozen=True)`` classes (the OpenAPI-generator target).
+    * Plain classes with an explicit ``__init__`` accepting keyword args.
+    * ``typing.NamedTuple`` — ``NT(**payload)`` works natively.
+
+    Anything else (pydantic ``BaseModel``, msgspec ``Struct``, attrs class
+    with custom ``__init__``) MUST register its own decoder via
+    :meth:`TypedServiceClient.register_decoder` to avoid ``TypeError``
+    bubbling up from an unsupported constructor signature.
+
+    Failure modes collapsed into ``ServiceClientDeserializeError``:
+
+    * JSON object missing a required field → ``TypeError`` caught → raise.
+    * Wrong scalar type for a declared dataclass field (we check this
+      explicitly for ``@dataclass`` targets because ``cls(**payload)``
+      does NOT validate types by itself, and silently wrong-typed fields
+      are the #1 drift source in cross-SDK JSON contracts).
+    * Target class constructor raises (e.g. ``__post_init__`` validator) →
+      error chained from the original exception so the caller can see
+      both the wrapper and the root cause.
+    """
+    # Only the JSON-object case makes sense for "call cls(**payload)". A
+    # top-level JSON array or scalar is a contract mismatch with any
+    # @dataclass model and should surface as a deserialize error with a
+    # clear message rather than a cryptic ``TypeError`` from cls(**payload)
+    # invoked on a non-mapping.
+    if not isinstance(payload, Mapping):
+        raise ServiceClientDeserializeError(
+            f"cannot decode {type(payload).__name__} into "
+            f"{getattr(model_cls, '__name__', str(model_cls))}: "
+            f"expected a JSON object"
+        )
+
+    # Structural dataclass validation — catch wrong-type fields before they
+    # land in the instance. ``cls(**payload)`` for a dataclass does NOT
+    # type-check; an ``email: str`` field receiving an integer constructs
+    # fine and surfaces as a string-formatting bug far from the API
+    # boundary. We check dataclass fields against resolved annotations so
+    # drift is caught at the deserialisation step.
+    if dataclasses.is_dataclass(model_cls):
+        try:
+            hints = typing.get_type_hints(model_cls)
+        except Exception:
+            # If PEP 563 / forward-ref resolution fails, fall through and
+            # let cls(**payload) do its best. We do NOT silently swallow
+            # the eventual TypeError — it becomes a DeserializeError below.
+            hints = {}
+        fields = dataclasses.fields(model_cls)
+        required_names = {
+            f.name
+            for f in fields
+            if f.default is dataclasses.MISSING
+            and f.default_factory is dataclasses.MISSING  # type: ignore[misc]
+        }
+        known_names = {f.name for f in fields}
+
+        missing = required_names - set(payload.keys())
+        if missing:
+            raise ServiceClientDeserializeError(
+                f"cannot decode into {model_cls.__name__}: missing "
+                f"required field(s) {sorted(missing)!r}"
+            )
+
+        # Type-narrowing — only checks simple, non-generic types. We do NOT
+        # attempt to validate List[int] / Dict[str, X] / Union[...]; that
+        # is a pydantic / msgspec-scale feature and callers who need it
+        # MUST register a decoder. Scalar-type mismatches cover >90% of
+        # contract drift in practice and are the bug class that surfaces
+        # weeks later as an ``AttributeError``.
+        for fname, declared in hints.items():
+            if fname not in payload:
+                continue
+            if fname not in known_names:
+                # Type hint for a field the dataclass doesn't expose (e.g.
+                # ClassVar, inherited from a non-dataclass base). Skip.
+                continue
+            value = payload[fname]
+            expected = _unwrap_optional(declared)
+            if expected is None or not isinstance(expected, type):
+                # Generic, Union, ForwardRef, etc. — out of scope for the
+                # default decoder. A caller who needs validation for these
+                # registers a decoder.
+                continue
+            if value is None:
+                # ``None`` is only acceptable if the declared type itself
+                # was ``Optional[X]`` (already unwrapped above, so we only
+                # reach here when the annotation permits None).
+                if _is_optional(declared):
+                    continue
+                raise ServiceClientDeserializeError(
+                    f"cannot decode into {model_cls.__name__}: field "
+                    f"{fname!r} is null but declared as "
+                    f"{getattr(expected, '__name__', str(expected))}"
+                )
+            # bool is a subclass of int; reject `True` arriving for an
+            # `int` field because it's almost always a JSON-contract bug.
+            if expected is int and isinstance(value, bool):
+                raise ServiceClientDeserializeError(
+                    f"cannot decode into {model_cls.__name__}: field "
+                    f"{fname!r} expected int but received bool"
+                )
+            if not isinstance(value, expected):
+                raise ServiceClientDeserializeError(
+                    f"cannot decode into {model_cls.__name__}: field "
+                    f"{fname!r} expected "
+                    f"{getattr(expected, '__name__', str(expected))} "
+                    f"but received {type(value).__name__}"
+                )
+
+    try:
+        return model_cls(**payload)
+    except TypeError as exc:
+        # Unexpected keyword (extra field in server response) or missing
+        # required keyword that the dataclass-pre-check missed (e.g. the
+        # target class is not a dataclass). Translate to DeserializeError
+        # so the caller gets a uniform surface.
+        raise ServiceClientDeserializeError(
+            f"cannot decode into "
+            f"{getattr(model_cls, '__name__', str(model_cls))}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+    except ServiceClientDeserializeError:
+        raise
+    except Exception as exc:
+        # Target class constructor or __post_init__ raised. Surface the
+        # original error via chained exception but keep the typed surface.
+        raise ServiceClientDeserializeError(
+            f"cannot decode into "
+            f"{getattr(model_cls, '__name__', str(model_cls))}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _is_optional(annotation: Any) -> bool:
+    """Return True if the annotation is ``Optional[X]`` / ``X | None``."""
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union or origin is getattr(__import__("types"), "UnionType", None):
+        args = typing.get_args(annotation)
+        return type(None) in args
+    return False
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    """Return ``X`` for ``Optional[X]`` / ``X | None``, else the annotation."""
+    if _is_optional(annotation):
+        args = [a for a in typing.get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+        # ``Union[A, B, None]`` — not a scalar; caller falls through to no-check.
+        return None
+    return annotation
+
+
+# ---------------------------------------------------------------------------
+# TypedServiceClient
+# ---------------------------------------------------------------------------
+
+
+class TypedServiceClient(ServiceClient):
+    """Service-to-service client with model-typed request/response verbs.
+
+    Inherits every guarantee of :class:`ServiceClient`:
+
+    * SSRF-on-by-default, layer order per issue #473 NN1.
+    * Eager CRLF / control-byte rejection of headers and the bearer token.
+    * Typed exception hierarchy (``ServiceClientError`` + variants).
+
+    Adds four model-typed variants that run the base client's JSON verb
+    and feed the decoded payload through a decoder keyed by the target
+    model class:
+
+    .. code-block:: python
+
+        from dataclasses import dataclass
+        from nexus import TypedServiceClient
+
+        @dataclass(frozen=True)
+        class User:
+            id: int
+            name: str
+            email: str
+
+        async with TypedServiceClient(
+            "https://api.internal",
+            bearer_token="...",
+            allowed_hosts=["api.internal"],
+        ) as client:
+            user = await client.get_typed("/users/42", User)
+            # user: User
+            created = await client.post_typed(
+                "/users",
+                {"name": "Alice", "email": "alice@example.com"},
+                User,
+            )
+
+    Downstream users with a pydantic / msgspec / attrs model can plug in
+    their own decoder without Nexus taking a hard dependency:
+
+    .. code-block:: python
+
+        import pydantic
+
+        class User(pydantic.BaseModel):
+            id: int
+            name: str
+            email: str
+
+        client = TypedServiceClient("https://api.internal")
+        client.register_decoder(User, lambda payload, cls: cls.model_validate(payload))
+        user = await client.get_typed("/users/42", User)
+
+    Decoder registration is **instance-scoped** — two clients in the
+    same process can disagree about how to decode the same class.
+    """
+
+    # Instance-scoped decoder map — NOT a class-level dict. A class-level
+    # dict would leak state between clients and make the "per-client
+    # decoder" guarantee false. __slots__ extends the base class's
+    # __slots__.
+    __slots__ = ("_decoders",)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # Map from model class -> decoder callable. Class objects are
+        # hashable by identity, which is exactly the semantics we want
+        # (two dataclasses with the same name in different modules are
+        # distinct keys).
+        self._decoders: dict[Type[Any], Decoder] = {}
+
+    # ---- Decoder registration --------------------------------------------
+
+    def register_decoder(
+        self, model_cls: Type[M], decoder: Decoder
+    ) -> "TypedServiceClient":
+        """Plug in a custom decoder for ``model_cls``.
+
+        The registered decoder receives ``(json_payload, model_cls)`` and
+        MUST return an instance of ``model_cls``. Any exception raised by
+        the decoder is wrapped in ``ServiceClientDeserializeError`` when
+        surfaced to the caller (so the typed exception hierarchy stays
+        uniform regardless of the underlying deserialisation library).
+
+        Returns ``self`` so registrations can chain::
+
+            client = (
+                TypedServiceClient("https://api.internal")
+                .register_decoder(User, pydantic_decoder)
+                .register_decoder(Order, msgspec_decoder)
+            )
+        """
+        if not isinstance(model_cls, type):
+            raise TypeError(
+                f"model_cls must be a class (got {type(model_cls).__name__})"
+            )
+        if not callable(decoder):
+            raise TypeError(
+                f"decoder must be callable (got {type(decoder).__name__})"
+            )
+        self._decoders[model_cls] = decoder
+        logger.debug(
+            "nexus.typed_service_client.register_decoder",
+            extra={"model_cls": getattr(model_cls, "__name__", str(model_cls))},
+        )
+        return self
+
+    def _decode(self, payload: Any, model_cls: Type[M]) -> M:
+        """Dispatch to the registered decoder for ``model_cls``, or default."""
+        decoder = self._decoders.get(model_cls, _default_decode)
+        try:
+            return decoder(payload, model_cls)
+        except ServiceClientDeserializeError:
+            raise
+        except Exception as exc:
+            # Custom decoders do not know about ServiceClientDeserializeError.
+            # Convert their exceptions into the typed surface so callers
+            # can ``except ServiceClientDeserializeError`` uniformly.
+            raise ServiceClientDeserializeError(
+                f"decoder for "
+                f"{getattr(model_cls, '__name__', str(model_cls))} raised "
+                f"{type(exc).__name__}: {exc}"
+            ) from exc
+
+    # ---- Typed verbs — status-checked, JSON in, model out -----------------
+
+    async def get_typed(
+        self,
+        path: str,
+        model_cls: Type[M],
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> M:
+        """GET ``path`` and decode the JSON body into ``model_cls``."""
+        payload = await self.get(path, headers=headers)
+        return self._decode(payload, model_cls)
+
+    async def post_typed(
+        self,
+        path: str,
+        body: Any,
+        model_cls: Type[M],
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> M:
+        """POST ``body`` as JSON; decode the 2xx JSON body into ``model_cls``.
+
+        ``body`` is forwarded verbatim to :meth:`ServiceClient.post`, which
+        serialises it with ``json.dumps``. Callers whose ``body`` is a
+        dataclass / pydantic model MUST convert to a dict first
+        (``asdict`` / ``model_dump``) or register a request encoder at a
+        layer above this client. Handling arbitrary request-model types
+        is out of scope until a concrete consumer arrives.
+        """
+        payload = await self.post(path, body, headers=headers)
+        return self._decode(payload, model_cls)
+
+    async def put_typed(
+        self,
+        path: str,
+        body: Any,
+        model_cls: Type[M],
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> M:
+        """PUT ``body`` as JSON; decode the 2xx JSON body into ``model_cls``."""
+        payload = await self.put(path, body, headers=headers)
+        return self._decode(payload, model_cls)
+
+    async def delete_typed(
+        self,
+        path: str,
+        model_cls: Type[M],
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> M:
+        """DELETE ``path`` and decode the JSON body into ``model_cls``.
+
+        Note — a 204 No Content response from the base client returns
+        ``None``. Feeding ``None`` into a dataclass decoder yields a
+        ``ServiceClientDeserializeError`` ("expected a JSON object");
+        that is the intended behaviour. Callers who want "delete returns
+        the deleted resource on 200, nothing on 204" semantics MUST
+        use :meth:`ServiceClient.delete` directly.
+        """
+        payload = await self.delete(path, headers=headers)
+        return self._decode(payload, model_cls)
+
+
+__all__ = [
+    "TypedServiceClient",
+    "Decoder",
+]

--- a/packages/kailash-nexus/tests/integration/test_typed_service_client_wiring.py
+++ b/packages/kailash-nexus/tests/integration/test_typed_service_client_wiring.py
@@ -1,0 +1,286 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests (Tier 2) for ``nexus.typed_service_client``.
+
+Exercises every typed-model verb against a real HTTP server. Demonstrates:
+
+* Happy-path round trip for GET / POST / PUT / DELETE → dataclass instance.
+* Deserialize-error surface when the upstream response is missing a field
+  or returns a wrong-typed scalar.
+* Custom decoder registration (simulating pydantic / msgspec) dispatched
+  against a real response.
+* HTTP status errors bubble through unchanged — the typed wrapper does
+  NOT mask ``ServiceClientHttpStatusError``.
+
+Runs against ``pytest_httpserver`` which gives us a real httpx → HTTP →
+werkzeug round trip — no mocks, real network stack.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from nexus.service_client import (
+    ServiceClientDeserializeError,
+    ServiceClientHttpStatusError,
+)
+from nexus.typed_service_client import TypedServiceClient
+
+
+@dataclass(frozen=True)
+class User:
+    id: int
+    name: str
+    email: str
+
+
+@pytest.fixture
+def service(httpserver) -> TypedServiceClient:
+    """TypedServiceClient pointing at pytest-httpserver.
+
+    Uses ``allow_loopback=True`` because the test server binds 127.0.0.1.
+    Production callers never set this flag.
+    """
+    base = f"http://{httpserver.host}:{httpserver.port}"
+    return TypedServiceClient(
+        base,
+        bearer_token="test-token-xyz",
+        allow_loopback=True,
+        timeout_secs=5.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy paths — every typed verb round-trips a User through a real server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestTypedVerbsRoundTrip:
+    @pytest.mark.asyncio
+    async def test_get_typed_returns_user(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        httpserver.expect_request("/users/42").respond_with_json(
+            {"id": 42, "name": "Alice", "email": "alice@example.com"}
+        )
+        try:
+            user = await service.get_typed("/users/42", User)
+            assert isinstance(user, User)
+            assert user == User(id=42, name="Alice", email="alice@example.com")
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_post_typed_returns_user(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        httpserver.expect_request("/users", method="POST").respond_with_json(
+            {"id": 1, "name": "Alice", "email": "alice@example.com"}
+        )
+        try:
+            user = await service.post_typed(
+                "/users",
+                {"name": "Alice", "email": "alice@example.com"},
+                User,
+            )
+            assert isinstance(user, User)
+            assert user.id == 1
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_put_typed_returns_user(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        httpserver.expect_request("/users/42", method="PUT").respond_with_json(
+            {"id": 42, "name": "Alice Updated", "email": "alice@example.com"}
+        )
+        try:
+            user = await service.put_typed(
+                "/users/42",
+                {"name": "Alice Updated"},
+                User,
+            )
+            assert user.name == "Alice Updated"
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_delete_typed_returns_user(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        httpserver.expect_request("/users/42", method="DELETE").respond_with_json(
+            {"id": 42, "name": "Alice", "email": "alice@example.com"}
+        )
+        try:
+            user = await service.delete_typed("/users/42", User)
+            assert user.id == 42
+        finally:
+            await service.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Deserialize errors — upstream payload does not match the model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestTypedDeserializeErrors:
+    @pytest.mark.asyncio
+    async def test_missing_field_raises_deserialize_error(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        httpserver.expect_request("/users/42").respond_with_json(
+            {"id": 42, "name": "Alice"}  # no email
+        )
+        try:
+            with pytest.raises(ServiceClientDeserializeError) as exc_info:
+                await service.get_typed("/users/42", User)
+            assert "email" in str(exc_info.value)
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_wrong_scalar_type_raises_deserialize_error(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        httpserver.expect_request("/users/42").respond_with_json(
+            {"id": "not-an-int", "name": "Alice", "email": "a@x.com"}
+        )
+        try:
+            with pytest.raises(ServiceClientDeserializeError) as exc_info:
+                await service.get_typed("/users/42", User)
+            assert "id" in str(exc_info.value)
+        finally:
+            await service.aclose()
+
+    @pytest.mark.asyncio
+    async def test_top_level_list_raises_deserialize_error(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        httpserver.expect_request("/users/42").respond_with_json(
+            [{"id": 42, "name": "Alice", "email": "a@x.com"}]
+        )
+        try:
+            with pytest.raises(ServiceClientDeserializeError):
+                await service.get_typed("/users/42", User)
+        finally:
+            await service.aclose()
+
+
+# ---------------------------------------------------------------------------
+# HTTP status errors bubble through the typed wrapper unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestTypedStatusErrors:
+    @pytest.mark.asyncio
+    async def test_404_surfaces_http_status_error(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        httpserver.expect_request("/users/404").respond_with_data(
+            "not found", status=404
+        )
+        try:
+            with pytest.raises(ServiceClientHttpStatusError) as exc_info:
+                await service.get_typed("/users/404", User)
+            assert exc_info.value.status_code == 404
+        finally:
+            await service.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Custom decoder — simulates pydantic / msgspec integration
+# ---------------------------------------------------------------------------
+
+
+class PydanticLikeUser:
+    """Stand-in for a pydantic BaseModel — strict custom __init__."""
+
+    def __init__(self, *, id: int, name: str, email: str) -> None:
+        # Mimic pydantic v2 strict coercion (string "42" → int 42).
+        self.id = int(id)
+        self.name = name
+        self.email = email
+
+    @classmethod
+    def validate(cls, payload: dict) -> "PydanticLikeUser":
+        return cls(**payload)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PydanticLikeUser):
+            return NotImplemented
+        return (
+            self.id == other.id
+            and self.name == other.name
+            and self.email == other.email
+        )
+
+
+@pytest.mark.integration
+class TestCustomDecoderRoundTrip:
+    @pytest.mark.asyncio
+    async def test_custom_decoder_dispatches_on_typed_get(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        """Register a pydantic-style decoder and verify it runs end-to-end.
+
+        This proves the decoder plug-in path is live against a real
+        server, not just a unit-level contract.
+        """
+        httpserver.expect_request("/users/42").respond_with_json(
+            # `id` as string — pydantic-like decoder coerces, default
+            # decoder would reject with ``expected int``. This is the
+            # exact reason the custom-decoder path exists.
+            {"id": "42", "name": "Alice", "email": "alice@example.com"}
+        )
+
+        service.register_decoder(
+            PydanticLikeUser, lambda payload, cls: cls.validate(payload)
+        )
+        try:
+            user = await service.get_typed("/users/42", PydanticLikeUser)
+            assert isinstance(user, PydanticLikeUser)
+            assert user == PydanticLikeUser(
+                id=42, name="Alice", email="alice@example.com"
+            )
+        finally:
+            await service.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Bearer-token propagation via typed verbs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestTypedVerbsAuth:
+    @pytest.mark.asyncio
+    async def test_bearer_token_sent_on_typed_get(
+        self, httpserver, service: TypedServiceClient
+    ) -> None:
+        from werkzeug.wrappers import Response
+
+        received_headers: dict[str, str] = {}
+
+        def handler(request) -> Response:
+            received_headers.update(request.headers)
+            return Response(
+                '{"id": 1, "name": "A", "email": "a@x.com"}',
+                status=200,
+                content_type="application/json",
+            )
+
+        httpserver.expect_request("/users/1").respond_with_handler(handler)
+        try:
+            await service.get_typed("/users/1", User)
+            assert (
+                received_headers.get("Authorization") == "Bearer test-token-xyz"
+            )
+        finally:
+            await service.aclose()

--- a/packages/kailash-nexus/tests/unit/test_typed_service_client.py
+++ b/packages/kailash-nexus/tests/unit/test_typed_service_client.py
@@ -1,0 +1,390 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests (Tier 1) for ``nexus.typed_service_client.TypedServiceClient``.
+
+Coverage:
+
+* The default dataclass decoder produces instances for well-formed JSON.
+* Missing required fields, wrong scalar types, and non-object top-level
+  payloads collapse into ``ServiceClientDeserializeError``.
+* Custom decoder registration dispatches per-model and is instance-scoped.
+* ``register_decoder`` returns ``self`` for chained registration.
+* Custom decoder exceptions are wrapped in ``ServiceClientDeserializeError``.
+* Type-annotation edge cases — ``Optional[X]`` accepts ``None``, plain
+  ``X`` rejects ``None``, ``bool`` is NOT accepted where ``int`` declared.
+
+These tests exercise the decoder surface in isolation. End-to-end round
+trips against a real HTTP server live in the Tier 2 wiring suite at
+``tests/integration/test_typed_service_client_wiring.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from nexus.service_client import ServiceClientDeserializeError
+from nexus.typed_service_client import (
+    Decoder,
+    TypedServiceClient,
+    _default_decode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test dataclasses — plain, frozen, with defaults, with optional fields
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class User:
+    id: int
+    name: str
+    email: str
+
+
+@dataclass
+class UserWithDefault:
+    id: int
+    name: str
+    active: bool = True
+
+
+@dataclass
+class UserWithOptional:
+    id: int
+    name: str
+    email: Optional[str] = None
+
+
+@dataclass
+class UserWithPostInit:
+    id: int
+    name: str
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("name must not be empty")
+
+
+@dataclass
+class UserWithListField:
+    id: int
+    name: str
+    # Generic containers fall through the default type-check; they are
+    # accepted as-is and the caller registers a decoder if they want
+    # deep validation.
+    tags: list = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Default decoder — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultDecoderHappyPath:
+    def test_simple_dataclass_round_trip(self) -> None:
+        user = _default_decode(
+            {"id": 42, "name": "Alice", "email": "a@example.com"}, User
+        )
+        assert user == User(id=42, name="Alice", email="a@example.com")
+
+    def test_dataclass_with_default_uses_default_when_absent(self) -> None:
+        user = _default_decode({"id": 1, "name": "Alice"}, UserWithDefault)
+        assert user.active is True
+
+    def test_dataclass_with_default_accepts_override(self) -> None:
+        user = _default_decode(
+            {"id": 1, "name": "Alice", "active": False}, UserWithDefault
+        )
+        assert user.active is False
+
+    def test_optional_field_accepts_none(self) -> None:
+        user = _default_decode(
+            {"id": 1, "name": "Alice", "email": None}, UserWithOptional
+        )
+        assert user.email is None
+
+    def test_optional_field_accepts_value(self) -> None:
+        user = _default_decode(
+            {"id": 1, "name": "Alice", "email": "a@x.com"}, UserWithOptional
+        )
+        assert user.email == "a@x.com"
+
+    def test_optional_field_absent_uses_default(self) -> None:
+        user = _default_decode({"id": 1, "name": "Alice"}, UserWithOptional)
+        assert user.email is None
+
+    def test_list_field_accepted_as_is(self) -> None:
+        """Generic ``list`` annotation falls through the scalar type-check.
+
+        Callers who want deep validation register a decoder.
+        """
+        user = _default_decode(
+            {"id": 1, "name": "Alice", "tags": ["admin", "vip"]},
+            UserWithListField,
+        )
+        assert user.tags == ["admin", "vip"]
+
+
+# ---------------------------------------------------------------------------
+# Default decoder — failure modes
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultDecoderFailures:
+    def test_missing_required_field_raises(self) -> None:
+        with pytest.raises(ServiceClientDeserializeError) as exc_info:
+            _default_decode({"id": 42, "name": "Alice"}, User)  # no email
+        assert "email" in str(exc_info.value)
+        assert "missing required field" in str(exc_info.value)
+
+    def test_wrong_scalar_type_raises(self) -> None:
+        with pytest.raises(ServiceClientDeserializeError) as exc_info:
+            _default_decode(
+                {"id": "not-an-int", "name": "Alice", "email": "a@x.com"}, User
+            )
+        assert "id" in str(exc_info.value)
+        assert "expected int" in str(exc_info.value)
+
+    def test_bool_rejected_for_int_field(self) -> None:
+        """bool is a subclass of int; rejected explicitly to catch drift."""
+        with pytest.raises(ServiceClientDeserializeError) as exc_info:
+            _default_decode(
+                {"id": True, "name": "Alice", "email": "a@x.com"}, User
+            )
+        assert "bool" in str(exc_info.value)
+
+    def test_null_rejected_for_non_optional_field(self) -> None:
+        with pytest.raises(ServiceClientDeserializeError) as exc_info:
+            _default_decode(
+                {"id": 42, "name": None, "email": "a@x.com"}, User
+            )
+        assert "null" in str(exc_info.value) or "None" in str(exc_info.value)
+
+    def test_non_mapping_payload_raises(self) -> None:
+        with pytest.raises(ServiceClientDeserializeError) as exc_info:
+            _default_decode([{"id": 1, "name": "A", "email": "a@x"}], User)
+        assert "expected a JSON object" in str(exc_info.value)
+
+    def test_scalar_payload_raises(self) -> None:
+        with pytest.raises(ServiceClientDeserializeError):
+            _default_decode("just a string", User)
+
+    def test_post_init_failure_wrapped(self) -> None:
+        with pytest.raises(ServiceClientDeserializeError) as exc_info:
+            _default_decode({"id": 1, "name": ""}, UserWithPostInit)
+        # Original ValueError is chained.
+        assert exc_info.value.__cause__ is not None
+        assert "name must not be empty" in str(exc_info.value)
+
+    def test_extra_unknown_field_raises(self) -> None:
+        """``cls(**payload)`` with an unknown key raises ``TypeError``.
+
+        The default decoder translates it into
+        ``ServiceClientDeserializeError`` rather than letting ``TypeError``
+        leak into the caller's error-handling plane.
+        """
+        with pytest.raises(ServiceClientDeserializeError):
+            _default_decode(
+                {"id": 1, "name": "A", "email": "a@x", "unknown": "x"}, User
+            )
+
+
+# ---------------------------------------------------------------------------
+# Non-dataclass target — extra fields reach cls(**payload) → typed error
+# ---------------------------------------------------------------------------
+
+
+class PlainKwargsClass:
+    """Not a dataclass; takes **kwargs to prove the fallback path."""
+
+    def __init__(self, **kwargs: object) -> None:
+        self.fields = kwargs
+
+
+class StrictKwargsClass:
+    """Not a dataclass; rejects unknown kwargs."""
+
+    def __init__(self, id: int, name: str) -> None:
+        self.id = id
+        self.name = name
+
+
+class TestNonDataclassTargets:
+    def test_plain_kwargs_class_accepts_any_payload(self) -> None:
+        obj = _default_decode({"a": 1, "b": 2}, PlainKwargsClass)
+        assert isinstance(obj, PlainKwargsClass)
+        assert obj.fields == {"a": 1, "b": 2}
+
+    def test_strict_kwargs_class_rejects_unknown_field(self) -> None:
+        with pytest.raises(ServiceClientDeserializeError):
+            _default_decode(
+                {"id": 1, "name": "A", "extra": True}, StrictKwargsClass
+            )
+
+    def test_strict_kwargs_class_rejects_missing_required(self) -> None:
+        with pytest.raises(ServiceClientDeserializeError):
+            _default_decode({"name": "A"}, StrictKwargsClass)
+
+
+# ---------------------------------------------------------------------------
+# TypedServiceClient — register_decoder, dispatch, chaining
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client() -> TypedServiceClient:
+    """A minimal TypedServiceClient — no network calls in these tests."""
+    return TypedServiceClient("https://api.example.com")
+
+
+class TestRegisterDecoder:
+    def test_register_returns_self_for_chaining(
+        self, client: TypedServiceClient
+    ) -> None:
+        def _fake_decoder(payload, cls):
+            return cls()
+
+        class X:
+            pass
+
+        class Y:
+            pass
+
+        result = client.register_decoder(X, _fake_decoder).register_decoder(
+            Y, _fake_decoder
+        )
+        assert result is client
+
+    def test_register_rejects_non_class(
+        self, client: TypedServiceClient
+    ) -> None:
+        with pytest.raises(TypeError):
+            client.register_decoder("not a class", lambda p, c: None)  # type: ignore[arg-type]
+
+    def test_register_rejects_non_callable_decoder(
+        self, client: TypedServiceClient
+    ) -> None:
+        with pytest.raises(TypeError):
+            client.register_decoder(User, "not-a-callable")  # type: ignore[arg-type]
+
+    def test_custom_decoder_dispatched(
+        self, client: TypedServiceClient
+    ) -> None:
+        sentinel = object()
+
+        def custom(payload, cls):
+            assert payload == {"id": 99}
+            assert cls is User
+            return sentinel
+
+        client.register_decoder(User, custom)
+        assert client._decode({"id": 99}, User) is sentinel
+
+    def test_custom_decoder_exception_wrapped_in_deserialize_error(
+        self, client: TypedServiceClient
+    ) -> None:
+        def bad_decoder(payload, cls):
+            raise RuntimeError("decoder blew up")
+
+        client.register_decoder(User, bad_decoder)
+        with pytest.raises(ServiceClientDeserializeError) as exc_info:
+            client._decode({"id": 1, "name": "A", "email": "a@x"}, User)
+        assert "decoder blew up" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    def test_deserialize_error_from_decoder_not_double_wrapped(
+        self, client: TypedServiceClient
+    ) -> None:
+        """If the decoder itself raises ``ServiceClientDeserializeError``,
+        the wrapper must re-raise it unchanged, NOT wrap it again."""
+
+        original = ServiceClientDeserializeError("decoder-raised")
+
+        def raising(payload, cls):
+            raise original
+
+        client.register_decoder(User, raising)
+        with pytest.raises(ServiceClientDeserializeError) as exc_info:
+            client._decode({"id": 1}, User)
+        assert exc_info.value is original
+
+    def test_decoder_scope_is_per_instance(self) -> None:
+        """Two clients in the same process MUST have independent decoder maps."""
+        c1 = TypedServiceClient("https://api1.example.com")
+        c2 = TypedServiceClient("https://api2.example.com")
+
+        sentinel = object()
+
+        def decoder_for_c1(payload, cls):
+            return sentinel
+
+        c1.register_decoder(User, decoder_for_c1)
+        # c1 dispatches to the custom decoder.
+        assert (
+            c1._decode({"id": 1, "name": "A", "email": "a@x"}, User) is sentinel
+        )
+        # c2 falls back to the default decoder and produces a real User.
+        assert c2._decode(
+            {"id": 1, "name": "A", "email": "a@x"}, User
+        ) == User(id=1, name="A", email="a@x")
+
+    def test_unknown_class_uses_default_decoder(
+        self, client: TypedServiceClient
+    ) -> None:
+        """Registering a decoder for class A MUST NOT affect decoding of class B."""
+
+        @dataclass
+        class OtherModel:
+            id: int
+            value: str
+
+        def bad_decoder(payload, cls):
+            raise AssertionError("must not be called for OtherModel")
+
+        client.register_decoder(User, bad_decoder)
+        other = client._decode({"id": 7, "value": "x"}, OtherModel)
+        assert other == OtherModel(id=7, value="x")
+
+
+# ---------------------------------------------------------------------------
+# Construction — TypedServiceClient inherits ServiceClient's validation
+# ---------------------------------------------------------------------------
+
+
+class TestConstructionInheritance:
+    def test_empty_base_url_rejected(self) -> None:
+        from nexus.service_client import ServiceClientInvalidPathError
+
+        with pytest.raises(ServiceClientInvalidPathError):
+            TypedServiceClient("")
+
+    def test_crlf_in_header_rejected(self) -> None:
+        from nexus.service_client import ServiceClientInvalidHeaderError
+
+        with pytest.raises(ServiceClientInvalidHeaderError):
+            TypedServiceClient(
+                "https://api.example.com",
+                headers={"X-Bad": "v\r\nX-Injected: 1"},
+            )
+
+    def test_decoders_initially_empty(self) -> None:
+        client = TypedServiceClient("https://api.example.com")
+        assert client._decoders == {}
+
+    def test_is_subclass_of_service_client(self) -> None:
+        from nexus.service_client import ServiceClient
+
+        assert issubclass(TypedServiceClient, ServiceClient)
+
+    def test_decoder_type_alias_callable(self) -> None:
+        """``Decoder`` is a ``Callable[[Any, Type[Any]], Any]`` alias.
+
+        Covered here so the symbol has a test-site reference and the
+        default-collection test suite exercises it.
+        """
+        assert Decoder is not None


### PR DESCRIPTION
## Summary

Adds `TypedServiceClient` — a thin generic subclass of `ServiceClient` (merged in #505) that enables model-typed request/response variants for service-to-service calls between Nexus applications.

Per issue #465 scope and the BP-044 decision journal on the kailash-rs side, full OpenAPI→Python codegen is **deferred** until a concrete consumer arrives. This PR ships only the wrapper layer that an OpenAPI-generator output (or a hand-written `@dataclass` owner) can target today.

### Public API

```python
from dataclasses import dataclass
from nexus import TypedServiceClient

@dataclass(frozen=True)
class User:
    id: int
    name: str
    email: str

async with TypedServiceClient(
    "https://api.internal",
    bearer_token="...",
    allowed_hosts=["api.internal"],
) as client:
    user = await client.get_typed("/users/42", User)
    created = await client.post_typed("/users", {"name": "Alice"}, User)
```

- `get_typed` / `post_typed` / `put_typed` / `delete_typed` — each parameterised by a response model class via a `TypeVar[M]` so type checkers narrow the return type.
- Default decoder handles any `@dataclass` or kwargs-`__init__` class; missing required fields, wrong scalar types, and non-object top-level payloads collapse into `ServiceClientDeserializeError`.
- `register_decoder(model_cls, decoder)` — **instance-scoped** plug-in for pydantic / msgspec / attrs, with no hard Nexus dependency on any of them. Decoder exceptions are wrapped in `ServiceClientDeserializeError` so the typed exception surface stays uniform.

### Inherited guarantees (from base `ServiceClient`)

- SSRF-on-by-default with issue #473 NN1 layer order (private-IP check BEFORE allowlist).
- Eager CRLF / control-byte rejection on every header and the bearer token.
- Typed exception hierarchy rooted at `ServiceClientError`.
- Response-body truncation in status-error strings (prevents token echo).

### Cross-SDK parity

Semantic match with `esperie-enterprise/kailash-rs#400`. The four typed-verb names and the `ServiceClientDeserializeError` trigger conditions mirror the Rust surface exactly (rules/cross-sdk-inspection.md D6).

## Test plan

- [x] 31 unit tests in `packages/kailash-nexus/tests/unit/test_typed_service_client.py` (default decoder happy paths, failure modes, non-dataclass targets, decoder dispatch, instance scoping, chaining, construction inheritance)
- [x] 10 integration tests in `packages/kailash-nexus/tests/integration/test_typed_service_client_wiring.py` against `pytest_httpserver` (real httpx → HTTP → werkzeug round trip): typed verb round-trip for all 4 verbs, deserialize errors for missing field / wrong type / top-level list, HTTP status errors bubble through, custom decoder (pydantic-style) end-to-end, bearer-token propagation on typed GET
- [x] Full existing `service_client` suite (50 tests) still green — no regression
- [x] `pip check` clean; no new dependency

## Related issues

Fixes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)