### PR TITLE
chore(artifacts): fix Rust symbol citations (#511)

### DIFF
--- a/.claude/guides/deterministic-quality/04-type-system-enforcement.md
+++ b/.claude/guides/deterministic-quality/04-type-system-enforcement.md
@@ -93,7 +93,7 @@ impl DataFlowBuilder {
 }
 ```
 
-**Scope**: `DataFlowEngine::builder()`, `NexusApp::builder()`, trust envelope construction. ~4 builders.
+**Scope**: `DataFlowEngine::builder()`, `NexusEngine::builder()`, trust envelope construction. ~4 builders.
 
 **Effort**: 1-2 sessions. Requires new generic type parameters but no algorithm changes.
 
@@ -132,7 +132,7 @@ impl TenantIdPy {
 }
 ```
 
-**Scope**: TenantId, UserId, CorrelationId, RequestId across PyO3, napi-rs, Magnus bindings.
+**Scope**: `TenantId` (exists in `crates/kailash-auth/src/tenant.rs`) + other identity/correlation newtypes to be introduced (user id, correlation id, request id) across PyO3, napi-rs, Magnus bindings.
 
 **Effort**: 2-3 sessions. Requires FFI specialist.
 
@@ -150,8 +150,9 @@ pub trait AuditEvent: private::Sealed { ... }
 
 mod private {
     pub trait Sealed {}
-    impl Sealed for super::QueryAudit {}
-    impl Sealed for super::MutationAudit {}
+    // Illustrative only — real audit-event type names TBD by the governance layer:
+    impl Sealed for super::AuditEventA {}
+    impl Sealed for super::AuditEventB {}
     // External types CANNOT implement Sealed
 }
 
@@ -160,7 +161,7 @@ pub trait AuditEvent { ... }
 // struct FakeAudit; impl AuditEvent for FakeAudit { ... }  ← undetectable
 ```
 
-**Scope**: AuditEntry, PolicyEnvelope, TrustToken, GovernanceDecision.
+**Scope**: `AuditEntry` (verified in kailash-rs audit layer) + related audit-event types, governance envelope types (not yet introduced).
 
 ## Python Patterns
 

--- a/.claude/guides/deterministic-quality/08-cross-sdk-parity.md
+++ b/.claude/guides/deterministic-quality/08-cross-sdk-parity.md
@@ -131,7 +131,8 @@ Beyond API surface matching, behavioral parity requires cross-SDK test suites:
 # tests/parity/test_product_mode.py
 """
 Cross-SDK behavioral parity test.
-Equivalent test exists in kailash-rs: crates/kailash-dataflow/tests/parity/test_product_mode.rs
+Equivalent test would live at: crates/kailash-dataflow/tests/parity/test_product_mode.rs
+(not yet created on the Rust side — see § "Where It Would Live" above).
 """
 
 @pytest.mark.parity


### PR DESCRIPTION
Audit + 5 fixes per rules/cross-sdk-inspection.md MUST Rule 5. 30 HITs verified, 5 MISSes fixed in 04-type-system-enforcement.md + 08-cross-sdk-parity.md. Fixes #511