### PR TITLE
refactor(dataflow): split primitive force_drop from orchestrator force_downgrade (#510)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/migrations/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/__init__.py
@@ -18,6 +18,10 @@ from .auto_migration_system import (
     TableDefinition,
 )
 from .drop_confirmation import DropRefusedError, require_force_drop
+from .drop_confirmation_downgrade import (
+    DowngradeRefusedError,
+    require_force_downgrade,
+)
 from .fk_migration_operations import (
     CompositeFKOperation,
     FKChainUpdateOperation,
@@ -97,7 +101,10 @@ __all__ = [
     "FKChainUpdateOperation",
     "CompositeFKOperation",
     "FKOperationScenario",
-    # Destructive-operation confirmation
+    # Destructive-operation confirmation (primitive DDL layer)
     "DropRefusedError",
     "require_force_drop",
+    # Destructive-downgrade confirmation (migration-orchestrator layer)
+    "DowngradeRefusedError",
+    "require_force_downgrade",
 ]

--- a/packages/kailash-dataflow/src/dataflow/migrations/application_safe_rename_strategy.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/application_safe_rename_strategy.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import asyncpg
 
-from .drop_confirmation import require_force_drop
+from .drop_confirmation_downgrade import require_force_downgrade
 from .rename_coordination_engine import (
     CoordinationResult,
     RenameCoordinationEngine,
@@ -511,32 +511,34 @@ class RollbackManager:
         created_objects: List[str],
         connection: Optional[asyncpg.Connection] = None,
         *,
-        force_drop: bool = False,
+        force_downgrade: bool = False,
     ) -> RollbackExecutionResult:
         """
         Execute rollback for failed strategy.
 
-        Per rules/dataflow-identifier-safety.md MUST Rule 4, destructive DDL
-        requires explicit ``force_drop=True``. Rollback runs DROP TABLE /
-        DROP VIEW against the temp objects created during the failed
-        deployment; accidentally invoking it against wrong objects is
-        unrecoverable.
+        Per rules/schema-migration.md MUST Rule 7, destructive orchestrator-
+        layer migrations require explicit ``force_downgrade=True``. A
+        rollback replays a multi-statement destructive sequence (DROP TABLE
+        / DROP VIEW against every temp object created during the failed
+        deployment) — this is one **logical downgrade** of a failed
+        upgrade, not a single DDL primitive. Accidentally invoking it
+        against wrong objects is unrecoverable.
 
         Args:
             failed_strategy: Strategy that failed
             created_objects: Objects created during failed execution
             connection: Database connection
-            force_drop: Must be True to execute any DROP statements.
+            force_downgrade: Must be True to execute any DROP statements.
 
         Returns:
             RollbackExecutionResult with rollback details
 
         Raises:
-            DropRefusedError: if ``force_drop`` is False.
+            DowngradeRefusedError: if ``force_downgrade`` is False.
         """
-        require_force_drop(
+        require_force_downgrade(
             f"execute_rollback(strategy={failed_strategy.value})",
-            force_drop,
+            force_downgrade,
         )
         if connection is None:
             connection = await self.connection_manager.get_connection()

--- a/packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py
@@ -32,7 +32,7 @@ from kailash.runtime import AsyncLocalRuntime, LocalRuntime
 # Kailash imports for async workflow pattern
 from kailash.workflow.builder import WorkflowBuilder
 
-from .drop_confirmation import require_force_drop
+from .drop_confirmation_downgrade import require_force_downgrade
 
 logger = logging.getLogger(__name__)
 
@@ -1712,17 +1712,25 @@ class AutoMigrationSystem:
         interactive: bool = True,
         auto_confirm: bool = False,
         *,
-        force_drop: bool = False,
+        force_downgrade: bool = False,
     ) -> Tuple[bool, List[Migration]]:
         """
         Automatically generate and apply migrations to match target schema.
 
-        Per rules/dataflow-identifier-safety.md MUST Rule 4, if the generated
-        migration plan contains any destructive operation (DROP_TABLE,
-        DROP_COLUMN, DROP_INDEX, DROP_CONSTRAINT), ``force_drop=True`` MUST
-        be supplied. The flag is evaluated AFTER the diff is computed so
-        additive migrations (CREATE / ADD) remain ergonomic; destructive
-        migrations require deliberate acknowledgement.
+        Per rules/schema-migration.md MUST Rule 7, if the generated migration
+        plan contains any destructive operation (DROP_TABLE, DROP_COLUMN,
+        DROP_INDEX, DROP_CONSTRAINT), ``force_downgrade=True`` MUST be
+        supplied. This is the orchestrator layer — ``auto_migrate`` replays
+        a multi-statement plan as one **logical migration**; the destructive
+        subset of that plan constitutes a downgrade-equivalent operation
+        (dropping schema elements that previously existed). The primitive
+        layer's ``force_drop`` on individual DDL builders does NOT flow
+        through to this orchestrator-layer gate — each layer requires its
+        own deliberate acknowledgement.
+
+        The flag is evaluated AFTER the diff is computed so additive
+        migrations (CREATE / ADD) remain ergonomic; destructive migrations
+        require deliberate acknowledgement.
 
         ``dry_run=True`` is exempt: the plan is shown but nothing executes.
 
@@ -1731,16 +1739,17 @@ class AutoMigrationSystem:
             dry_run: If True, only show what would be done
             interactive: If True, prompt user for confirmation
             auto_confirm: If True, automatically confirm all changes
-            force_drop: Required (True) when the computed plan contains any
-                DROP_TABLE / DROP_COLUMN / DROP_INDEX / DROP_CONSTRAINT
+            force_downgrade: Required (True) when the computed plan contains
+                any DROP_TABLE / DROP_COLUMN / DROP_INDEX / DROP_CONSTRAINT
                 migration. Default False.
 
         Returns:
             Tuple of (success, list of applied migrations)
 
         Raises:
-            DropRefusedError: if the plan contains destructive migrations
-                and ``force_drop`` is False and ``dry_run`` is False.
+            DowngradeRefusedError: if the plan contains destructive
+                migrations and ``force_downgrade`` is False and ``dry_run``
+                is False.
         """
         logger.info("Starting auto-migration process")
 
@@ -1851,9 +1860,10 @@ class AutoMigrationSystem:
                 self._print_migration_preview(migration)
                 return True, [migration]
 
-            # rules/dataflow-identifier-safety.md MUST Rule 4: if any operation
-            # in the plan is destructive, require force_drop=True. Computed
-            # AFTER the diff so additive migrations stay ergonomic.
+            # rules/schema-migration.md MUST Rule 7: if any operation in the
+            # orchestrator-layer plan is destructive, require
+            # force_downgrade=True. Computed AFTER the diff so additive
+            # migrations stay ergonomic.
             _DESTRUCTIVE_TYPES = {
                 MigrationType.DROP_TABLE,
                 MigrationType.DROP_COLUMN,
@@ -1869,9 +1879,9 @@ class AutoMigrationSystem:
                 op_labels = ", ".join(
                     sorted({op.operation_type.value for op in destructive_ops})
                 )
-                require_force_drop(
+                require_force_downgrade(
                     f"auto_migrate(destructive ops: {op_labels})",
-                    force_drop,
+                    force_downgrade,
                 )
 
             # Apply migration while lock is still held

--- a/packages/kailash-dataflow/src/dataflow/migrations/column_removal_manager.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/column_removal_manager.py
@@ -35,7 +35,7 @@ from .dependency_analyzer import (
     TriggerDependency,
     ViewDependency,
 )
-from .drop_confirmation import require_force_drop
+from .drop_confirmation_downgrade import require_force_downgrade
 
 # Type alias for any column dependency
 ColumnDependency = Union[
@@ -529,16 +529,20 @@ class ColumnRemovalManager:
         plan: RemovalPlan,
         connection: Optional[asyncpg.Connection] = None,
         *,
-        force_drop: bool = False,
+        force_downgrade: bool = False,
     ) -> RemovalResult:
         """
         Execute safe column removal according to plan.
 
-        Per rules/dataflow-identifier-safety.md MUST Rule 4, destructive DDL
-        requires explicit ``force_drop=True``. A column removal is
-        irreversible; even with backup stages in the plan, dropped data is
-        restorable only within the backup retention window. The flag forces
-        the caller to acknowledge the action before any DROP statement runs.
+        Per rules/schema-migration.md MUST Rule 7, destructive orchestrator-
+        layer migrations require explicit ``force_downgrade=True``. A column
+        removal replays a multi-statement destructive sequence (savepoint
+        guard, dependency DROPs for triggers/views/constraints/indexes, then
+        the column DROP itself) — this is one **logical downgrade** of a
+        prior column addition, not a single DDL primitive. Even with backup
+        stages in the plan, dropped data is restorable only within the
+        backup retention window. The flag forces the caller to acknowledge
+        the action before any DROP statement runs.
 
         Dry-run plans (``plan.dry_run=True``) are exempt: they roll back to
         the pre-DDL savepoint and leave no persistent change.
@@ -546,19 +550,19 @@ class ColumnRemovalManager:
         Args:
             plan: Validated removal plan
             connection: Database connection (optional)
-            force_drop: Must be True to execute a non-dry-run removal.
+            force_downgrade: Must be True to execute a non-dry-run removal.
 
         Returns:
             RemovalResult with execution details and recovery information
 
         Raises:
-            DropRefusedError: if ``force_drop`` is False and the plan is not
-                a dry run.
+            DowngradeRefusedError: if ``force_downgrade`` is False and the
+                plan is not a dry run.
         """
         if not plan.dry_run:
-            require_force_drop(
+            require_force_downgrade(
                 f"execute_safe_removal(plan={plan.table_name}.{plan.column_name})",
-                force_drop,
+                force_downgrade,
             )
         start_time = datetime.now()
         self.logger.info(

--- a/packages/kailash-dataflow/src/dataflow/migrations/drop_confirmation.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/drop_confirmation.py
@@ -1,34 +1,42 @@
-"""Shared DROP confirmation helpers for migration builders.
+"""Shared DROP confirmation helpers for primitive-layer DDL APIs.
 
 Per `rules/dataflow-identifier-safety.md` MUST Rule 4, every public migration
-API that emits DROP TABLE / DROP COLUMN / DROP INDEX / DROP SCHEMA SQL MUST
-require an explicit ``force_drop=True`` flag on the calling API. The default
-MUST be to refuse.
+API that emits a single DROP TABLE / DROP COLUMN / DROP INDEX / DROP SCHEMA
+statement MUST require an explicit ``force_drop=True`` flag on the calling
+API. The default MUST be to refuse.
 
 Dropped data is unrecoverable. The explicit flag is the last human gate
 before destruction; without it, a typo or a mis-scoped operation takes the
 production table with it.
 
-Migration builders that expose destructive entry points should import
-``DropRefusedError`` + ``require_force_drop`` from this module so the
-message and error type are consistent across the whole migrations package.
+This module is the **primitive layer**: it guards individual DROP-emitting
+APIs (one method, one DDL DROP). Orchestrator-layer APIs that replay a
+multi-statement destructive plan gate at their own layer via
+``drop_confirmation_downgrade.DowngradeRefusedError`` + ``require_force_downgrade``
+(see `rules/schema-migration.md` MUST Rule 7).
 
-Related: ``schema-migration.md`` MUST Rule 7 (``force_downgrade`` on the
-migration-orchestrator layer). This module is the primitive-layer sibling:
-it guards individual DROP-emitting APIs; orchestrators that replay stored
-``down_sql`` gate at their own layer.
+The two layers are distinct on purpose: the primitive flag guards one DDL
+statement, the orchestrator flag guards one downgrade of an upgrade. The
+flag does NOT flow from one layer to the other — each layer requires its
+own deliberate acknowledgement.
 """
 
 from __future__ import annotations
 
 
 class DropRefusedError(RuntimeError):
-    """Raised when a destructive DROP API is called without ``force_drop=True``.
+    """Raised when a primitive-layer DROP API is called without ``force_drop=True``.
 
     Extends RuntimeError so callers catching ``RuntimeError`` (e.g. generic
     migration failure handlers) still see it, but the typed class enables
     precise handling in tests and for callers that explicitly anticipate the
     guard.
+
+    This is the **primitive-layer** error. Orchestrator-layer APIs raise
+    ``DowngradeRefusedError`` from ``drop_confirmation_downgrade`` — the two
+    classes are deliberately distinct (one is NOT a subclass of the other)
+    because they represent different layers of the destructive-operation
+    discipline.
     """
 
 
@@ -36,7 +44,7 @@ def require_force_drop(method_label: str, force_drop: bool) -> None:
     """Refuse the call with a typed error unless ``force_drop`` is True.
 
     ``method_label`` is the caller's API name (e.g. ``"drop_table('users')"``
-    or ``"execute_safe_removal(plan=users.email)"``) — used verbatim in the
+    or ``"drop_column('users', 'email')"``) — used verbatim in the
     error message so the caller sees exactly which action was refused.
 
     Does NOT echo raw user input that could be a stored XSS / log poisoning

--- a/packages/kailash-dataflow/src/dataflow/migrations/drop_confirmation_downgrade.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/drop_confirmation_downgrade.py
@@ -1,0 +1,69 @@
+"""Shared destructive-downgrade confirmation helpers for orchestrator-layer APIs.
+
+Per `rules/schema-migration.md` MUST Rule 7, every migration-orchestrator
+API that runs destructive DDL or irreversible data transforms as part of a
+multi-statement migration (downgrade, rollback, destructive auto-migrate
+plan) MUST require an explicit ``force_downgrade=True`` flag on the calling
+API. The default MUST be to refuse.
+
+Dropped data is unrecoverable, and the downgrade surface is strictly wider
+than the individual DROP primitive — a single ``apply_downgrade`` /
+``execute_rollback`` / destructive ``auto_migrate`` call can execute dozens
+of destructive statements in one transaction before the operator notices.
+Requiring the flag at every layer that can touch destructive DDL is the only
+structural defense against "I meant to roll back the schema, not destroy
+the data" incidents.
+
+This module is the **orchestrator layer**. Its sibling ``drop_confirmation``
+is the **primitive layer** — the two are distinct on purpose. The primitive
+flag (``force_drop``) guards one DDL statement; the orchestrator flag
+(``force_downgrade``) guards one downgrade of an upgrade. The flag does NOT
+flow from one layer to the other.
+
+The two error classes (``DropRefusedError`` and ``DowngradeRefusedError``)
+are deliberately **NOT** in a subclass relationship — each represents a
+different layer of the destructive-operation discipline, and callers that
+want to handle only one layer must be able to catch it precisely.
+"""
+
+from __future__ import annotations
+
+
+class DowngradeRefusedError(RuntimeError):
+    """Raised when an orchestrator-layer downgrade API is called without
+    ``force_downgrade=True``.
+
+    Extends RuntimeError so callers catching ``RuntimeError`` (e.g. generic
+    migration failure handlers) still see it, but the typed class enables
+    precise handling in tests and for callers that explicitly anticipate the
+    guard.
+
+    This is the **orchestrator-layer** error. Primitive-layer APIs raise
+    ``DropRefusedError`` from ``drop_confirmation`` — the two classes are
+    deliberately distinct (one is NOT a subclass of the other) because they
+    represent different layers of the destructive-operation discipline.
+    """
+
+
+def require_force_downgrade(method_label: str, force_downgrade: bool) -> None:
+    """Refuse the call with a typed error unless ``force_downgrade`` is True.
+
+    ``method_label`` is the caller's API name (e.g.
+    ``"apply_downgrade('0042')"`` or
+    ``"auto_migrate(destructive ops: DROP_TABLE, DROP_COLUMN)"``) — used
+    verbatim in the error message so the caller sees exactly which action
+    was refused.
+
+    Does NOT echo raw user input that could be a stored XSS / log poisoning
+    vector; the caller is responsible for sanitising ``method_label`` if it
+    includes caller-supplied strings.
+    """
+    if not force_downgrade:
+        raise DowngradeRefusedError(
+            f"{method_label} refused — pass force_downgrade=True to acknowledge "
+            f"destructive migration data loss is irreversible "
+            f"(see rules/schema-migration.md MUST Rule 7)."
+        )
+
+
+__all__ = ["DowngradeRefusedError", "require_force_downgrade"]

--- a/packages/kailash-dataflow/tests/regression/test_issue_510_force_downgrade_split.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_510_force_downgrade_split.py
@@ -1,0 +1,208 @@
+"""Regression: #510 — primitive force_drop vs orchestrator force_downgrade split.
+
+The primitive layer (`rules/dataflow-identifier-safety.md` MUST Rule 4) guards
+individual DDL DROP statements with ``force_drop=True`` + ``DropRefusedError``.
+The orchestrator layer (`rules/schema-migration.md` MUST Rule 7) guards
+multi-statement destructive downgrades with ``force_downgrade=True`` +
+``DowngradeRefusedError``.
+
+The two layers are deliberately distinct:
+
+- Two separate exception classes (neither is a subclass of the other).
+- Two separate helper functions (`require_force_drop`,
+  `require_force_downgrade`).
+- Two separate module homes (`drop_confirmation.py`,
+  `drop_confirmation_downgrade.py`).
+
+A caller that wants to catch only the primitive-layer failure MUST be able to
+do so without accidentally catching the orchestrator-layer failure, and vice
+versa. If a future refactor ever makes one a subclass of the other, this
+regression test breaks at import time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dataflow.migrations import (
+    DowngradeRefusedError,
+    DropRefusedError,
+    require_force_downgrade,
+    require_force_drop,
+)
+
+
+@pytest.mark.regression
+def test_issue_510_drop_refused_error_raised_from_require_force_drop():
+    """Primitive-layer helper raises DropRefusedError when force_drop is False."""
+    with pytest.raises(DropRefusedError) as excinfo:
+        require_force_drop("drop_table('users')", force_drop=False)
+    assert "drop_table('users')" in str(excinfo.value)
+    assert "force_drop=True" in str(excinfo.value)
+
+
+@pytest.mark.regression
+def test_issue_510_downgrade_refused_error_raised_from_require_force_downgrade():
+    """Orchestrator-layer helper raises DowngradeRefusedError when force_downgrade is False."""
+    with pytest.raises(DowngradeRefusedError) as excinfo:
+        require_force_downgrade("apply_downgrade('0042')", force_downgrade=False)
+    assert "apply_downgrade('0042')" in str(excinfo.value)
+    assert "force_downgrade=True" in str(excinfo.value)
+
+
+@pytest.mark.regression
+def test_issue_510_require_force_drop_silent_when_true():
+    """No error when the primitive flag is explicitly True."""
+    require_force_drop("drop_table('users')", force_drop=True)
+
+
+@pytest.mark.regression
+def test_issue_510_require_force_downgrade_silent_when_true():
+    """No error when the orchestrator flag is explicitly True."""
+    require_force_downgrade("apply_downgrade('0042')", force_downgrade=True)
+
+
+@pytest.mark.regression
+def test_issue_510_drop_and_downgrade_errors_are_distinct_classes():
+    """DropRefusedError and DowngradeRefusedError are NOT in a subclass relation.
+
+    Each represents a different layer of the destructive-operation discipline;
+    a caller catching only primitive failures must not accidentally swallow
+    orchestrator failures (and vice versa). If a future refactor makes one a
+    subclass of the other, this assertion fires immediately.
+    """
+    assert DropRefusedError is not DowngradeRefusedError
+    assert not issubclass(DropRefusedError, DowngradeRefusedError)
+    assert not issubclass(DowngradeRefusedError, DropRefusedError)
+
+
+@pytest.mark.regression
+def test_issue_510_drop_refused_error_not_caught_by_downgrade_except():
+    """A caller catching DowngradeRefusedError MUST NOT catch DropRefusedError."""
+    with pytest.raises(DropRefusedError):
+        try:
+            require_force_drop("drop_table('users')", force_drop=False)
+        except DowngradeRefusedError:
+            pytest.fail(
+                "DropRefusedError should not be caught as DowngradeRefusedError"
+            )
+
+
+@pytest.mark.regression
+def test_issue_510_downgrade_refused_error_not_caught_by_drop_except():
+    """A caller catching DropRefusedError MUST NOT catch DowngradeRefusedError."""
+    with pytest.raises(DowngradeRefusedError):
+        try:
+            require_force_downgrade("apply_downgrade('0042')", force_downgrade=False)
+        except DropRefusedError:
+            pytest.fail(
+                "DowngradeRefusedError should not be caught as DropRefusedError"
+            )
+
+
+@pytest.mark.regression
+def test_issue_510_both_errors_extend_runtimeerror():
+    """Both retain RuntimeError ancestry so generic migration handlers still see them."""
+    assert issubclass(DropRefusedError, RuntimeError)
+    assert issubclass(DowngradeRefusedError, RuntimeError)
+
+
+@pytest.mark.regression
+def test_issue_510_auto_migrate_refuses_without_force_downgrade():
+    """AutoMigrationSystem.auto_migrate on a destructive plan raises DowngradeRefusedError.
+
+    This is the orchestrator-layer behavioral regression: the renamed kwarg
+    MUST be ``force_downgrade`` (not ``force_drop``) and the refusal MUST be
+    ``DowngradeRefusedError`` (not ``DropRefusedError``). Verified via the
+    helper contract — the method signature is covered by import-time
+    inspection below so the test does not need a real database.
+    """
+    import inspect
+
+    from dataflow.migrations.auto_migration_system import AutoMigrationSystem
+
+    sig = inspect.signature(AutoMigrationSystem.auto_migrate)
+    params = sig.parameters
+    assert "force_downgrade" in params, (
+        "AutoMigrationSystem.auto_migrate must accept force_downgrade kwarg "
+        "(orchestrator layer per rules/schema-migration.md MUST Rule 7)"
+    )
+    assert "force_drop" not in params, (
+        "AutoMigrationSystem.auto_migrate must NOT accept force_drop kwarg — "
+        "that is the primitive-layer flag; the orchestrator layer uses "
+        "force_downgrade"
+    )
+
+
+@pytest.mark.regression
+def test_issue_510_execute_rollback_uses_force_downgrade():
+    """RollbackManager.execute_rollback uses force_downgrade (orchestrator layer)."""
+    import inspect
+
+    from dataflow.migrations.application_safe_rename_strategy import (
+        RollbackManager,
+    )
+
+    sig = inspect.signature(RollbackManager.execute_rollback)
+    params = sig.parameters
+    assert "force_downgrade" in params
+    assert "force_drop" not in params
+
+
+@pytest.mark.regression
+def test_issue_510_execute_safe_removal_uses_force_downgrade():
+    """ColumnRemovalManager.execute_safe_removal uses force_downgrade (orchestrator layer)."""
+    import inspect
+
+    from dataflow.migrations.column_removal_manager import (
+        ColumnRemovalManager,
+    )
+
+    sig = inspect.signature(ColumnRemovalManager.execute_safe_removal)
+    params = sig.parameters
+    assert "force_downgrade" in params
+    assert "force_drop" not in params
+
+
+@pytest.mark.regression
+def test_issue_510_visual_migration_builder_drops_keep_force_drop():
+    """VisualMigrationBuilder.drop_* methods KEEP force_drop (primitive layer).
+
+    Each drop_table / drop_column / drop_index appends one DDL DROP to the
+    plan — this is the primitive layer, so force_drop is correct.
+    """
+    import inspect
+
+    from dataflow.migrations.visual_migration_builder import (
+        VisualMigrationBuilder,
+    )
+
+    for method_name in ("drop_table", "drop_column", "drop_index"):
+        sig = inspect.signature(getattr(VisualMigrationBuilder, method_name))
+        params = sig.parameters
+        assert "force_drop" in params, (
+            f"VisualMigrationBuilder.{method_name} must keep force_drop "
+            f"(primitive layer per rules/dataflow-identifier-safety.md "
+            f"MUST Rule 4)"
+        )
+        assert "force_downgrade" not in params, (
+            f"VisualMigrationBuilder.{method_name} must NOT accept "
+            f"force_downgrade — that is the orchestrator-layer flag; "
+            f"each drop_* method appends one DDL DROP and is primitive"
+        )
+
+
+@pytest.mark.regression
+def test_issue_510_rollback_not_null_addition_keeps_force_drop():
+    """NotNullHandler.rollback_not_null_addition KEEPS force_drop (primitive layer).
+
+    The method runs one DDL DROP COLUMN — primitive layer, not orchestrator.
+    """
+    import inspect
+
+    from dataflow.migrations.not_null_handler import NotNullColumnHandler
+
+    sig = inspect.signature(NotNullColumnHandler.rollback_not_null_addition)
+    params = sig.parameters
+    assert "force_drop" in params
+    assert "force_downgrade" not in params


### PR DESCRIPTION
## Summary

- Split `drop_confirmation.py` (primitive layer, 1-DDL gate) from `drop_confirmation_downgrade.py` (orchestrator layer, multi-DDL migration gate).
- New orchestrator-layer exception `DowngradeRefusedError` and helper `require_force_downgrade`, distinct class from primitive-layer `DropRefusedError` (neither is a subclass of the other).
- Renamed 3 of the 5 call sites PR #508 introduced, per-caller classification by the "one DDL vs multi-DDL sequence" heuristic.

## Per-caller disposition

| Call site | Layer | Kwarg |
| --- | --- | --- |
| `VisualMigrationBuilder.drop_table/drop_column/drop_index` | PRIMITIVE | `force_drop` (unchanged) |
| `NotNullHandler.rollback_not_null_addition` | PRIMITIVE | `force_drop` (unchanged) |
| `ColumnRemovalManager.execute_safe_removal` | ORCHESTRATOR | `force_downgrade` (renamed) |
| `RollbackManager.execute_rollback` | ORCHESTRATOR | `force_downgrade` (renamed) |
| `AutoMigrationSystem.auto_migrate` | ORCHESTRATOR | `force_downgrade` (renamed) |

Orchestrator-layer methods replay multi-statement destructive plans (savepoint + chained DROP of triggers/views/constraints/indexes/columns, or a migration plan with many ops). These constitute one logical downgrade; the user authorizes the downgrade once, not per-statement.

## Test plan

- [x] 13 Tier-1 regression tests in `tests/regression/test_issue_510_force_downgrade_split.py` — all pass
- [x] Both errors raise separately; neither is a subclass of the other
- [x] Signature inspection proves the rename landed at every orchestrator site and the primitive sites kept `force_drop`
- [x] `pytest --collect-only packages/kailash-dataflow/tests/` → 5856 tests, 0 collection errors
- [x] Related auto_migrate unit tests still pass

## Related issues

Fixes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)