### PR TITLE
release: v2.8.7 + package bundle (2026-04-19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,34 @@ The changelog has been reorganized into individual files for better management. 
 - **[sdk-users/6-reference/changelogs/unreleased/](sdk-users/6-reference/changelogs/unreleased/)** - Unreleased changes
 - **[sdk-users/6-reference/changelogs/releases/](sdk-users/6-reference/changelogs/releases/)** - Individual release changelogs
 
-## Unreleased
+## Recent Releases
 
-### kailash-kaizen — #498 LLM Deployment Abstraction (Sessions 1-8 complete)
+### kailash 2.8.7 + kailash-kaizen 2.7.5 + kailash-dataflow 2.0.10 + kailash-nexus 2.1.0 + kailash-ml 0.10.0 + kailash-mcp 0.2.5 — 2026-04-19
+
+#### kailash-kaizen 2.7.5
+
+- **`LlmClient.embed()` for OpenAI + Ollama (#462, PR #502)**: `LlmClient.embed(texts, *, model)` exposes a first-class embedding API on the existing `LlmClient` surface. Supports OpenAI (`text-embedding-3-small`, `text-embedding-3-large`, `text-embedding-ada-002`) and Ollama (`nomic-embed-text` and any Ollama-hosted embedding model). Returns a `List[List[float]]` consistent with OpenAI's embedding response shape.
+- **LLM endpoint trust migration identifier validation fix (#499, PR #504)**: The trust migration module in `kaizen.llm.migration` used f-string interpolation for identifier names in several log and error message paths, which was flagged as a medium-severity finding in the #499 defense-in-depth audit. All identifier-containing paths now route through `_validate_identifier()` before use.
+
+#### kailash-dataflow 2.0.10
+
+- See `packages/kailash-dataflow/CHANGELOG.md` for full entry.
+
+#### kailash-nexus 2.1.0
+
+- See `packages/kailash-nexus/CHANGELOG.md` for full entry.
+
+#### kailash-ml 0.10.0
+
+- See `packages/kailash-ml/CHANGELOG.md` for full entry.
+
+#### kailash-mcp 0.2.5
+
+- **`oauth.py` optional-extras gating (#514, PR #518)**: `kailash_mcp/auth/oauth.py` had module-level `import aiohttp`, `import jwt`, and `from cryptography...` — all declared as optional under the `[auth-oauth]` extra. These are now wrapped in `try/except ImportError` blocks with a `_require_oauth_extras()` loud-failure helper. The module now imports cleanly on a bare `pip install kailash-mcp` and raises a descriptive `ImportError` naming the required extra when OAuth classes are instantiated without the extra installed. Aligns with `rules/dependencies.md` § "Declared = Gated Consistently".
+
+---
+
+## kailash-kaizen — #498 LLM Deployment Abstraction (Sessions 1-8 complete)
 
 Four-axis LLM deployment abstraction: 24 preset factories spanning direct providers (OpenAI, Anthropic, Google, 13 others), AWS Bedrock (5 families), GCP Vertex (Claude + Gemini), and Azure OpenAI — all with cross-SDK byte-parity to `kailash-rs#406`. Additive API: existing `kaizen.providers.registry` continues to work unchanged (39 consumer files verified via regression test).
 

--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -17,14 +17,14 @@
 
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
-| kailash (core)   | `v*`               | 2.8.6           |
-| kailash-dataflow | `dataflow-v*`      | 2.0.8           |
-| kailash-kaizen   | `kaizen-v*`        | 2.7.4           |
-| kailash-nexus    | `nexus-v*`         | 2.0.3           |
+| kailash (core)   | `v*`               | 2.8.7           |
+| kailash-dataflow | `dataflow-v*`      | 2.0.10          |
+| kailash-kaizen   | `kaizen-v*`        | 2.7.5           |
+| kailash-nexus    | `nexus-v*`         | 2.1.0           |
 | kailash-pact     | `pact-v*`          | 0.8.1           |
-| kailash-ml       | `ml-v*`            | 0.9.0           |
+| kailash-ml       | `ml-v*`            | 0.10.0          |
 | kailash-align    | `align-v*`         | 0.3.1           |
-| kailash-mcp      | `mcp-v*`           | 0.2.4           |
+| kailash-mcp      | `mcp-v*`           | 0.2.5           |
 | kaizen-agents    | `kaizen-agents-v*` | 0.9.2           |
 
 ## Release Runbook

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,16 @@
 # DataFlow Changelog
 
+## [2.0.10] - 2026-04-19 — Identifier quoting + defense-in-depth hardening + force_downgrade split (#480 #499 #510)
+
+### Security
+
+- **Express CRUD PG identifier quoting (#480, PR #503)**: `DataFlowExpress` CRUD methods (`create`, `read`, `update`, `delete`, `list`, `count`) now route all table and column name interpolations in PostgreSQL DDL and DML through `dialect.quote_identifier()`. Prior to this fix, Express CRUD SQL used unquoted identifiers in PostgreSQL, allowing model names with reserved words or special characters to produce syntax errors or (in adversarial contexts) injection via crafted model names.
+- **9 defense-in-depth MED findings (#499, PRs #504 #508)**: batch close of medium-severity findings from the post-convergence security audit. Includes: constant-time comparison enforcement in credential validators, structured-error sanitization to avoid leaking DB internals in error messages, input length guards on several public API entry points, and tightening of exception handler scopes that were too broad.
+
+### Changed
+
+- **`force_drop` vs `force_downgrade` split (#510, PR #517)**: The `force_drop=True` flag on `dialect.drop_table()` (primitive DDL layer) is now distinct from the new `force_downgrade=True` flag on `MigrationManager.apply_downgrade()` (orchestrator layer). Before this refactor, `force_drop` was overloaded to mean both "acknowledge this individual DROP" and "acknowledge this destructive migration rollback." They now carry independent semantics per `rules/schema-migration.md` MUST Rule 7 and `rules/dataflow-identifier-safety.md` MUST Rule 4.
+
 ## [2.0.9] - 2026-04-18 — Security hardening + Python 3.14 compatibility (#477 #478)
 
 ### Security

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.0.9"
+version = "2.0.10"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -107,7 +107,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.0.9"
+__version__ = "2.0.10"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.7.5] - 2026-04-15 — Python 3.14 compatibility
+## [2.7.5] - 2026-04-19 — LlmClient.embed() + trust migration fix + Python 3.14 compatibility (#462 #499 #477)
+
+### Added
+
+- **`LlmClient.embed()` for OpenAI + Ollama (#462, PR #502)**: `LlmClient.embed(texts, *, model)` exposes a first-class embedding API on the existing `LlmClient` surface. Supports OpenAI (`text-embedding-3-small`, `text-embedding-3-large`, `text-embedding-ada-002`) and Ollama (`nomic-embed-text` and any Ollama-hosted embedding model). Returns a `List[List[float]]` consistent with OpenAI's embedding response shape.
 
 ### Fixed
+
+- **LLM endpoint trust migration identifier validation (#499, PR #504)**: `kaizen.llm.migration` used f-string interpolation for identifier names in log and error message paths. All identifier-containing paths now route through `_validate_identifier()` before use.
+- **Python 3.14 (PEP 649 / PEP 749) silently broke every class-based `Signature`.**
 
 - **Python 3.14 (PEP 649 / PEP 749) silently broke every class-based `Signature`.** `SignatureMeta.__new__` read `namespace.get("__annotations__", {})` to discover `InputField` / `OutputField` declarations. On 3.14 the compiler emits `namespace["__annotate__"]` (a lazy callable) instead of populating `__annotations__` directly, so the metaclass saw `{}`, produced signatures with zero fields, and every dependent `BaseAgent` refused to construct. The fix routes the read through the new shared helper `kailash.utils.annotations.get_namespace_annotations`, which evaluates `__annotate__` (preferring `Format.VALUE`, falling back to `Format.FORWARDREF` on unresolved names) on 3.14 and reads the eager dict on 3.13 and earlier.
 - **`kaizen.deploy.introspect.build_card_for`** previously called `getattr(signature_cls, "__annotations__", {})`, which can raise `NameError` instead of returning a default on 3.14 if the signature has any string forward reference. Replaced with `kailash.utils.annotations.get_class_annotations(signature_cls)` so every annotation read in the SDK flows through the one-place handler for 3.13/3.14 differences.

--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -1,0 +1,24 @@
+# kailash-mcp Changelog
+
+All notable changes to the Kailash MCP package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.5] - 2026-04-19 — oauth.py optional-extras gating (#514)
+
+### Fixed
+
+- **`oauth.py` module-level imports of optional extras (#514, PR #518)**: `kailash_mcp/auth/oauth.py` imported `aiohttp`, `PyJWT`, and `cryptography` at module scope. All three are declared optional under `[project.optional-dependencies] auth-oauth`. On a bare `pip install kailash-mcp` (no oauth extra), any `import kailash_mcp` transitioned to an `ImportError` through the auth sub-package. Fix: wrap the three imports in `try/except ImportError` with `None` fallbacks; add `_require_oauth_extras()` helper that raises a descriptive `ImportError` naming `pip install 'kailash-mcp[auth-oauth]'` when OAuth classes are instantiated without the extra. Module now imports cleanly without the oauth extra; OAuth classes fail loudly with an actionable error instead of silently. Aligns with `rules/dependencies.md` § "Declared = Gated Consistently" and cross-SDK parity with kailash-rs#417.
+
+## [0.2.4] - 2026-04-14
+
+### Fixed
+
+- All 63 unit test warnings resolved (combined with kailash 2.8.6 release).
+
+## [0.2.3] - 2026-04-08
+
+### Added
+
+- Initial platform server, auth JWT/OAuth, and MCP client/server implementations.

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.2.4"
+version = "0.2.5"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,12 @@
 # kailash-ml Changelog
 
+## [0.10.0] - 2026-04-19 — Pipeline, FeatureUnion, ColumnTransformer + register_estimator (#479 #488)
+
+### Added
+
+- **`Pipeline` + `FeatureUnion` + `ColumnTransformer` estimators (#479 #488, PR #506)**: Three sklearn-compatible compositing estimators now ship in `kailash_ml.estimators`. `Pipeline` chains ordered `(name, estimator)` steps where each step's `transform` output feeds the next step's input; the final step may be a classifier or regressor and exposes `fit`, `predict`, `predict_proba`. `FeatureUnion` runs multiple transformers in parallel and concatenates their outputs column-wise. `ColumnTransformer` applies per-column transformer lists and handles remainder columns via `passthrough` or `drop`. All three are registered with the `kailash_ml` estimator registry and exported from `kailash_ml.__init__`.
+- **`register_estimator` / `unregister_estimator` public API (#488)**: `kailash_ml.register_estimator(name, cls)` and `unregister_estimator(name)` expose the estimator registry for user-defined or third-party sklearn-compatible estimators. Registered estimators are reachable by name inside `Pipeline` / `FeatureUnion` / `ColumnTransformer` step lists and via `AutoMLEngine` hyperparameter search. `register_estimator` raises `ValueError` on name collision unless `force=True` is passed.
+
 ## [0.7.0] - 2026-04-07
 
 ### Added

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.9.0"
+version = "0.10.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Nexus Changelog
 
-## [Unreleased]
+## [2.1.0] - 2026-04-19 — HttpClient + ServiceClient + TypedServiceClient + lifespan hooks (#464 #465 #473 #500 #501)
+
+### Added
+
+- **`HttpClient` + `ServiceClient` with SSRF-aware config (#464 #473, PR #505)**: `nexus.HttpClient` is a thin wrapper around `httpx.AsyncClient` with a `HttpClientConfig` that enforces SSRF-aware defaults (no private IP ranges, connection timeouts, redirect limits). `nexus.ServiceClient` builds on `HttpClient` and provides a named-service abstraction with structured error types (`ServiceClientError`, `ServiceClientHttpError`, `ServiceClientHttpStatusError`, `ServiceClientDeserializeError`, `ServiceClientInvalidHeaderError`, `ServiceClientInvalidPathError`).
+- **`TypedServiceClient` wrapper for S2S JSON APIs (#465, PR #507)**: `nexus.TypedServiceClient` adds Pydantic-model-driven request/response serialization on top of `ServiceClient`. Callers declare `RequestModel` and `ResponseModel` types; `TypedServiceClient` validates, serializes, deserializes, and raises typed errors on schema mismatch. Covers the common S2S JSON API pattern without manual `json.loads` / Pydantic `.model_validate`.
+- **`post_webhook` + `probe_remote_health` outbound helpers (PR #509)**: `nexus.post_webhook(url, payload, *, secret)` fires a signed outbound webhook using HMAC-SHA256 over the raw JSON bytes (not re-serialized). `nexus.probe_remote_health(url, *, timeout)` performs a lightweight GET health probe and returns a structured `RemoteHealthResult`.
 
 ### Fixed
 

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.0.3"
+version = "2.1.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -96,7 +96,7 @@ from .errors import RateLimitError, ServiceUnavailableError
 from .errors import TimeoutError as NexusTimeoutError
 from .errors import UnauthorizedError, ValidationError
 
-__version__ = "2.0.3"
+__version__ = "2.1.0"
 __all__ = [
     # Core
     "Nexus",


### PR DESCRIPTION
## Summary

- kailash core 2.8.7 — already on main (tag + publish only)
- kailash-kaizen 2.7.5 — already on main (tag + publish only)
- kailash-dataflow 2.0.9 → 2.0.10 — Express CRUD PG identifier quoting, 9 defense-in-depth MED findings, force_drop/force_downgrade split
- kailash-nexus 2.0.3 → 2.1.0 (MINOR) — HttpClient + ServiceClient + TypedServiceClient + lifespan hooks
- kailash-ml 0.9.0 → 0.10.0 (MINOR) — Pipeline + FeatureUnion + ColumnTransformer + register_estimator
- kailash-mcp 0.2.4 → 0.2.5 — oauth.py optional-extras gating (fix bare-install ImportError)

## Changes

- Version bumps in pyproject.toml + __init__.py (or _version.py for ml) for dataflow, nexus, ml, mcp
- CHANGELOG entries for all 6 packages
- Root CHANGELOG.md bundle entry
- deploy/deployment-config.md version table updated

## Test plan

- [ ] CI passes on this branch
- [ ] TestPyPI workflow_dispatch for nexus-2.1.0 (MINOR)
- [ ] TestPyPI workflow_dispatch for ml-0.10.0 (MINOR)
- [ ] Tags pushed individually after merge: v2.8.7, kaizen-v2.7.5, dataflow-v2.0.10, nexus-v2.1.0, ml-v0.10.0, mcp-v0.2.5
- [ ] publish-pypi.yml triggered for each tag
- [ ] Clean venv install verification for each package

## Related issues

Closes #480 #499 #464 #465 #473 #500 #501 #479 #488 #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)