### PR TITLE
feat(ml): GPU-first Phase 1 — DeviceReport + km.device()/use_device()

### DIFF
--- a/packages/kailash-align/pyproject.toml
+++ b/packages/kailash-align/pyproject.toml
@@ -25,9 +25,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "kailash>=0.4.0",
-    "kailash-ml>=0.1.0",
-    "kailash-kaizen>=0.3.0",
+    "kailash>=2.8.7",
+    "kailash-ml>=0.10.0",
+    "kailash-kaizen>=2.7.5",
     "torch>=2.2,<3.0",
     "transformers>=4.40,<5.0",
     "trl>=1.0,<2.0",

--- a/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/key_generator.py
@@ -6,7 +6,10 @@ Generates deterministic cache keys from queries and parameters.
 
 import hashlib
 import json
-from typing import Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+if TYPE_CHECKING:
+    from dataflow.classification.policy import ClassificationPolicy
 
 
 class CacheKeyGenerator:
@@ -16,7 +19,8 @@ class CacheKeyGenerator:
         self,
         prefix: str = "dataflow",
         namespace: Optional[str] = None,
-        version: str = "v1",
+        version: str = "v2",
+        classification_policy: Optional["ClassificationPolicy"] = None,
     ):
         """
         Initialize key generator.
@@ -24,11 +28,54 @@ class CacheKeyGenerator:
         Args:
             prefix: Global prefix for all keys
             namespace: Optional namespace (e.g., tenant ID)
-            version: Cache version for schema changes
+            version: Cache keyspace version. Default is ``"v2"`` (BP-049
+                cross-SDK keyspace; pre-fix ``v1`` entries are orphaned on
+                upgrade and naturally expire). Cross-SDK contract matches
+                ``kailash-rs`` v3.19.0.
+            classification_policy: Optional policy used to hash classified
+                PK values before they enter the key-material hash. When
+                provided, PKs whose model+field pair is classified are
+                routed through ``format_record_id_for_event`` before
+                serialization so the raw value never appears in the JSON
+                that feeds the MD5/SHA-256 digest. See issue #520.
         """
         self.prefix = prefix
         self.namespace = namespace
         self.version = version
+        self._classification_policy = classification_policy
+
+    def _safe_params(self, model_name: str, params: Any) -> Any:
+        """Return a copy of ``params`` with classified PK values hashed.
+
+        Routes ``params["id"]`` (and any ``{"id": ...}`` nested in a
+        filter dict) through ``format_record_id_for_event`` when the
+        classification policy marks the model's PK as classified.
+        Non-dict inputs and dicts without an ``id`` key pass through
+        unchanged. Mirrors the filtering contract of
+        ``kailash-rs`` BP-049.
+        """
+        if self._classification_policy is None or not isinstance(params, dict):
+            return params
+        # Lazy import avoids a cycle with features/express.py.
+        from dataflow.classification.event_payload import (
+            format_record_id_for_event,
+        )
+
+        def _hash_id(mapping: Dict[str, Any]) -> Dict[str, Any]:
+            if "id" not in mapping:
+                return mapping
+            safe = dict(mapping)
+            safe["id"] = format_record_id_for_event(
+                self._classification_policy, model_name, mapping["id"]
+            )
+            return safe
+
+        safe_params = _hash_id(params)
+        # Filter-style params ({"filter": {"id": ...}}) — hash the nested id.
+        if isinstance(safe_params.get("filter"), dict):
+            safe_params = dict(safe_params)
+            safe_params["filter"] = _hash_id(safe_params["filter"])
+        return safe_params
 
     def generate_key(
         self, model_name: str, sql: str, params: List[Any], ttl: Optional[int] = None
@@ -103,16 +150,20 @@ class CacheKeyGenerator:
     ) -> str:
         """Generate cache key for Express operations (no SQL).
 
-        Produces keys like ``dataflow:v1:<tenant>:<model>:<op>:<hash>``
+        Produces keys like ``dataflow:v2:<tenant>:<model>:<op>:<hash>``
         where ``<tenant>`` is only included when a ``tenant_id`` is
         provided (or the generator was constructed with a namespace).
         The trailing segment is a short hash of the serialised *params*.
+        When a ``classification_policy`` was configured and ``params``
+        contains a classified PK under ``id``, the PK is routed through
+        ``format_record_id_for_event`` BEFORE serialisation so the raw
+        value never enters the hash input. See issue #520 (BP-049).
 
-        Shape:
+        Shape (``v2`` keyspace; BP-049 cross-SDK):
 
-        * Without tenant/namespace: ``dataflow:v1:User:list:a1b2c3d4``
-        * With tenant_id: ``dataflow:v1:tenant-a:User:list:a1b2c3d4``
-        * With namespace: ``dataflow:v1:<namespace>:User:list:a1b2c3d4``
+        * Without tenant/namespace: ``dataflow:v2:User:list:a1b2c3d4``
+        * With tenant_id: ``dataflow:v2:tenant-a:User:list:a1b2c3d4``
+        * With namespace: ``dataflow:v2:<namespace>:User:list:a1b2c3d4``
 
         The ``tenant_id`` argument takes precedence over the
         constructor ``namespace`` when both are supplied, so a
@@ -149,7 +200,8 @@ class CacheKeyGenerator:
         parts.append(operation)
 
         if params is not None:
-            param_str = json.dumps(params, sort_keys=True, default=str)
+            safe = self._safe_params(model_name, params)
+            param_str = json.dumps(safe, sort_keys=True, default=str)
             param_hash = hashlib.md5(param_str.encode()).hexdigest()[:8]
             parts.append(param_hash)
 

--- a/packages/kailash-dataflow/src/dataflow/classification/validation_error.py
+++ b/packages/kailash-dataflow/src/dataflow/classification/validation_error.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Validation-error sanitization helpers.
+
+Validation errors carry a surface that is strictly wider than an internal
+log line: they are surfaced back to the caller (HTTP 400 body, CLI
+stderr, agent response), recorded in audit trails, and often displayed
+in developer tooling. A raw classified field VALUE or a classified
+field NAME in a validation error is a permanent leak with a wider blast
+radius than any log entry.
+
+This module provides ``sanitize_validation_error`` — the single filter
+point that every ``FieldValidationError`` constructed in the DataFlow
+validation pipeline routes through. The helper:
+
+1. Replaces a classified field NAME with ``"<classified>"`` so the
+   error surface cannot be used to enumerate the schema.
+2. Replaces a classified field VALUE with a type-descriptor
+   (``"<classified string>"``, ``"<classified int>"``, etc.) so the
+   error surface cannot be used to exfiltrate the value.
+3. Rewrites the human-readable ``message`` to strip any interpolated
+   field name before it is surfaced.
+
+Cross-SDK: contract matches ``kailash-rs`` BP-049 (v3.19.0). Same
+placeholder strings, same type-descriptor vocabulary, same behaviour
+when no policy is configured (pass-through).
+
+See issue #520 and ``rules/event-payload-classification.md`` Rules 5–7.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional, Tuple
+
+if TYPE_CHECKING:
+    from dataflow.classification.policy import ClassificationPolicy
+
+__all__ = [
+    "sanitize_validation_error",
+    "CLASSIFIED_FIELD_NAME_PLACEHOLDER",
+    "classified_value_descriptor",
+]
+
+
+# Single placeholder string for classified field names. Intentionally
+# short and grep-able so an audit of caller-facing strings can surface
+# every validation error that touched a classified field.
+CLASSIFIED_FIELD_NAME_PLACEHOLDER = "<classified>"
+
+
+def classified_value_descriptor(value: Any) -> str:
+    """Return a type-descriptor string for a classified field value.
+
+    The descriptor reveals only the Python type of the value, never the
+    value itself. Covers the common field types: ``str``, ``int``,
+    ``float``, ``bool``, ``bytes``, ``list``, ``dict``; falls back to
+    ``"<classified value>"`` for anything else.
+
+    Cross-SDK: matches ``kailash-rs`` descriptor vocabulary.
+    """
+    if value is None:
+        return "<classified none>"
+    if isinstance(value, bool):
+        return "<classified bool>"
+    if isinstance(value, int):
+        return "<classified int>"
+    if isinstance(value, float):
+        return "<classified float>"
+    if isinstance(value, (bytes, bytearray)):
+        return "<classified bytes>"
+    if isinstance(value, str):
+        return "<classified string>"
+    if isinstance(value, list):
+        return "<classified list>"
+    if isinstance(value, dict):
+        return "<classified dict>"
+    return "<classified value>"
+
+
+def sanitize_validation_error(
+    policy: Optional["ClassificationPolicy"],
+    model_name: str,
+    field_name: str,
+    message: str,
+    value: Any = None,
+) -> Tuple[str, str, Any, bool]:
+    """Return a sanitised ``(field, message, value, is_classified)`` tuple.
+
+    Args:
+        policy: The active classification policy, or ``None`` if no
+            classifications are registered on this DataFlow instance.
+            When ``None`` the helper is a pass-through and
+            ``is_classified`` is always ``False``.
+        model_name: The model the validation error is about (e.g.
+            ``"User"``).
+        field_name: The field name that failed validation. When the
+            ``(model_name, field_name)`` pair is classified, the name
+            returned by this helper is
+            ``CLASSIFIED_FIELD_NAME_PLACEHOLDER``; otherwise the name
+            is returned unchanged.
+        message: The human-readable validation message. When the field
+            is classified and the message contains the raw field name,
+            the raw name is replaced with the placeholder so the name
+            cannot be recovered from the surface text.
+        value: The offending value (optional). When the field is
+            classified this is replaced with a type-descriptor via
+            :func:`classified_value_descriptor`; otherwise it is
+            returned unchanged.
+
+    Returns:
+        A 4-tuple ``(safe_field, safe_message, safe_value,
+        is_classified)``. Callers use ``is_classified`` to increment a
+        ``classified_field_count`` aggregate on the surrounding
+        ``ValidationResult`` for operator alerting without revealing
+        which fields were affected.
+    """
+    if policy is None:
+        return field_name, message, value, False
+
+    field_classification = policy.get_field(model_name, field_name)
+    if field_classification is None:
+        return field_name, message, value, False
+
+    # Classified: replace name, scrub message, and replace value with
+    # a type-descriptor.
+    safe_field = CLASSIFIED_FIELD_NAME_PLACEHOLDER
+    safe_message = message.replace(field_name, CLASSIFIED_FIELD_NAME_PLACEHOLDER)
+    safe_value = classified_value_descriptor(value) if value is not None else None
+    return safe_field, safe_message, safe_value, True

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -1119,10 +1119,13 @@ class DataFlow(DataFlowEventMixin):
                 max_size=cache_max_size,
             )
 
-            # Create key generator
+            # Create key generator. BP-049 (#520): plumb the classification
+            # policy so classified PKs are hashed before serialisation into
+            # cache keys.
             key_generator = CacheKeyGenerator(
                 prefix=cache_key_prefix,
                 namespace=getattr(self.config, "cache_namespace", None),
+                classification_policy=getattr(self, "_classification_policy", None),
             )
 
             # Create cache invalidator

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -55,6 +55,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 from dataflow.cache.auto_detection import CacheBackend
 from dataflow.cache.key_generator import CacheKeyGenerator
 from dataflow.cache.memory_cache import InMemoryCache
+from dataflow.classification.event_payload import format_record_id_for_event
 from dataflow.core.agent_context import get_current_agent_id, get_current_clearance
 from dataflow.core.multi_tenancy import TenantRequiredError
 from dataflow.core.tenant_context import get_current_tenant_id
@@ -140,7 +141,12 @@ class DataFlowExpress:
         else:
             self._cache_manager = None
 
-        self._key_gen = CacheKeyGenerator()
+        # BP-049: plumb the DataFlow classification policy into the cache
+        # key generator so classified PKs are hashed before serialisation
+        # (issue #520). ``self._db`` holds the owning DataFlow instance.
+        self._key_gen = CacheKeyGenerator(
+            classification_policy=getattr(self._db, "_classification_policy", None),
+        )
 
         # Local hit/miss counters for Express-level stats
         self._cache_hits = 0
@@ -270,7 +276,11 @@ class DataFlowExpress:
             setattr(proxy, k, v)
         _Proxy.__field_validators__ = validators
 
-        result = _validate_instance(proxy)
+        # BP-049 (#520): route classified-field validation errors through
+        # the sanitiser so the caller-facing error surface never echoes a
+        # classified field NAME or raw VALUE.
+        policy = getattr(self._db, "_classification_policy", None)
+        result = _validate_instance(proxy, policy=policy, model_name=model)
         if not result.valid:
             error_msgs = "; ".join(e.message for e in result.errors)
             from dataflow.exceptions import DataFlowError
@@ -406,6 +416,46 @@ class DataFlowExpress:
             return False
         return bool(policy.get_model_fields(model))
 
+    def _safe_record_id(self, model: str, id: Any) -> Optional[str]:
+        """Return an event/log/audit-safe ``record_id`` for this model.
+
+        Single-point filter for every PK value that leaves the Express
+        write path into a log line, audit row, trust-plane event, or
+        error-surface string. Classified string PKs come back as
+        ``"sha256:XXXXXXXX"``; integers and unclassified strings pass
+        through as ``str(value)``. Cross-SDK contract matches
+        ``kailash-rs`` BP-048 / BP-049 so a PK hashed in Python and a
+        PK hashed in Rust produce the same fingerprint for forensic
+        correlation.
+
+        Mandated by ``rules/event-payload-classification.md`` Rule 1 and
+        ``rules/dataflow-classification.md``. See issue #520 (BP-049).
+        """
+        policy = getattr(self._db, "_classification_policy", None)
+        return format_record_id_for_event(policy, model, id)
+
+    def _safe_query_params(
+        self, model: str, params: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        """Return a copy of ``params`` with classified PK values hashed.
+
+        Audit / trust-plane paths take a dict of query parameters
+        (``{"id": id}``, ``{"id": id, "fields": fields}``). This helper
+        hashes the ``id`` slot when the model has a classified PK. Other
+        keys are passed through unchanged; callers that need to redact
+        classified field VALUES inside ``fields`` MUST do so through the
+        classification masking helpers on the read path.
+
+        Mandated by issue #520 (BP-049).
+        """
+        if params is None:
+            return None
+        if "id" not in params:
+            return params
+        safe = dict(params)
+        safe["id"] = self._safe_record_id(model, params["id"])
+        return safe
+
     def _apply_classification_mask_record(self, model: str, record: Any) -> Any:
         """Apply classification masking to a single record if needed.
 
@@ -497,14 +547,15 @@ class DataFlowExpress:
                     except Exception:
                         pass  # Best-effort read-back; original result still valid
 
-            # TSG-201: Emit write event
+            # TSG-201: Emit write event. ``_emit_write_event`` routes
+            # ``record_id`` through ``format_record_id_for_event``
+            # internally (BP-048), so pass the raw PK — double-hashing
+            # would break cross-SDK fingerprint correlation.
             if hasattr(self._db, "_emit_write_event"):
-                record_id = (
-                    str(result.get("id", ""))
-                    if result and isinstance(result, dict)
-                    else None
+                raw_record_id = (
+                    result.get("id") if result and isinstance(result, dict) else None
                 )
-                self._db._emit_write_event(model, "create", record_id=record_id)
+                self._db._emit_write_event(model, "create", record_id=raw_record_id)
 
             await self._trust_record_success(
                 model, "create", plan, rows_affected=1, query_params=data
@@ -568,7 +619,7 @@ class DataFlowExpress:
                     "read",
                     plan,
                     rows_affected=1 if result is not None else 0,
-                    query_params={"id": id},
+                    query_params=self._safe_query_params(model, {"id": id}),
                 )
                 return result
             except Exception as e:
@@ -581,19 +632,23 @@ class DataFlowExpress:
                 ):
                     logger.debug(
                         "express.record_not_found_for_read",
-                        extra={"model": model, "id": id},
+                        extra={"model": model, "id": self._safe_record_id(model, id)},
                     )
                     await self._trust_record_success(
                         model,
                         "read",
                         plan,
                         rows_affected=0,
-                        query_params={"id": id},
+                        query_params=self._safe_query_params(model, {"id": id}),
                     )
                     return None
                 # Re-raise other errors
                 await self._trust_record_failure(
-                    model, "read", plan, e, query_params={"id": id}
+                    model,
+                    "read",
+                    plan,
+                    e,
+                    query_params=self._safe_query_params(model, {"id": id}),
                 )
                 raise
 
@@ -630,23 +685,28 @@ class DataFlowExpress:
                     "update",
                     plan,
                     exc,
-                    query_params={"id": id, "fields": fields},
+                    query_params=self._safe_query_params(
+                        model, {"id": id, "fields": fields}
+                    ),
                 )
                 raise
 
             # Model-scoped cache invalidation (TSG-104)
             await self._invalidate_model_cache(model)
 
-            # TSG-201: Emit write event
+            # TSG-201: Emit write event. ``_emit_write_event`` hashes
+            # classified PKs internally (BP-048) — pass raw ``id``.
             if hasattr(self._db, "_emit_write_event"):
-                self._db._emit_write_event(model, "update", record_id=str(id))
+                self._db._emit_write_event(model, "update", record_id=id)
 
             await self._trust_record_success(
                 model,
                 "update",
                 plan,
                 rows_affected=1,
-                query_params={"id": id, "fields": fields},
+                query_params=self._safe_query_params(
+                    model, {"id": id, "fields": fields}
+                ),
             )
             # Issue #490: normalize the return to the full record shape
             # (same as read()) and apply read-path redaction. UpdateNode's
@@ -688,16 +748,21 @@ class DataFlowExpress:
                 result = await node.async_run(id=id)
             except Exception as exc:
                 await self._trust_record_failure(
-                    model, "delete", plan, exc, query_params={"id": id}
+                    model,
+                    "delete",
+                    plan,
+                    exc,
+                    query_params=self._safe_query_params(model, {"id": id}),
                 )
                 raise
 
             # Model-scoped cache invalidation (TSG-104)
             await self._invalidate_model_cache(model)
 
-            # TSG-201: Emit write event
+            # TSG-201: Emit write event. ``_emit_write_event`` hashes
+            # classified PKs internally (BP-048) — pass raw ``id``.
             if hasattr(self._db, "_emit_write_event"):
-                self._db._emit_write_event(model, "delete", record_id=str(id))
+                self._db._emit_write_event(model, "delete", record_id=id)
 
             deleted = (
                 result.get("deleted", False)
@@ -709,7 +774,7 @@ class DataFlowExpress:
                 "delete",
                 plan,
                 rows_affected=1 if deleted else 0,
-                query_params={"id": id},
+                query_params=self._safe_query_params(model, {"id": id}),
             )
             return deleted
 
@@ -1008,14 +1073,13 @@ class DataFlowExpress:
             # Model-scoped cache invalidation (TSG-104)
             await self._invalidate_model_cache(model)
 
-            # TSG-201: Emit write event
+            # TSG-201: Emit write event. ``_emit_write_event`` hashes
+            # classified PKs internally (BP-048) — pass raw PK.
             if hasattr(self._db, "_emit_write_event"):
-                record_id = (
-                    str(data.get("id", ""))
-                    if isinstance(data, dict) and "id" in data
-                    else None
+                raw_record_id = (
+                    data.get("id") if isinstance(data, dict) and "id" in data else None
                 )
-                self._db._emit_write_event(model, "upsert", record_id=record_id)
+                self._db._emit_write_event(model, "upsert", record_id=raw_record_id)
 
             # Return the record directly for simpler API.
             # Issue #490: normalize the return to the full record shape
@@ -1083,13 +1147,15 @@ class DataFlowExpress:
             await self._invalidate_model_cache(model)
 
             # TSG-201: Emit write event (upsert_advanced is also an upsert)
+            # ``_emit_write_event`` hashes classified PKs internally
+            # (BP-048) — pass raw PK.
             if hasattr(self._db, "_emit_write_event"):
-                record_id = (
-                    str(create.get("id", ""))
+                raw_record_id = (
+                    create.get("id")
                     if isinstance(create, dict) and "id" in create
                     else None
                 )
-                self._db._emit_write_event(model, "upsert", record_id=record_id)
+                self._db._emit_write_event(model, "upsert", record_id=raw_record_id)
 
             # Issue #490: mutation return MUST apply read-path redaction.
             # See rules/dataflow-classification.md MUST Rule 1. The top-level

--- a/packages/kailash-dataflow/src/dataflow/validation/decorators.py
+++ b/packages/kailash-dataflow/src/dataflow/validation/decorators.py
@@ -31,9 +31,12 @@ threaded); validation reads the list without mutation.
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, List, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Type, TypeVar
 
 from dataflow.validation.result import ValidationResult
+
+if TYPE_CHECKING:
+    from dataflow.classification.policy import ClassificationPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -76,9 +79,7 @@ def field_validator(
     def _decorator(cls: Type[T]) -> Type[T]:
         # Lazily initialize the validator list. Copy from parent to
         # avoid mutating a shared superclass list.
-        existing: List[_ValidatorEntry] = list(
-            getattr(cls, "__field_validators__", [])
-        )
+        existing: List[_ValidatorEntry] = list(getattr(cls, "__field_validators__", []))
         existing.append((field_name, validator_fn, label))
         cls.__field_validators__ = existing  # type: ignore[attr-defined]
         return cls
@@ -86,20 +87,42 @@ def field_validator(
     return _decorator
 
 
-def validate_model(instance: Any) -> ValidationResult:
+def validate_model(
+    instance: Any,
+    policy: Optional["ClassificationPolicy"] = None,
+    model_name: Optional[str] = None,
+) -> ValidationResult:
     """Run all registered field validators against a model instance.
 
     Collects ALL validation errors (does not fail-fast). Returns a
     ``ValidationResult`` whose ``.valid`` property is ``True`` only
     when every validator passes.
 
+    When ``policy`` and ``model_name`` are provided, validation errors
+    on classified fields are routed through
+    ``dataflow.classification.validation_error.sanitize_validation_error``
+    so the caller-facing error surface never echoes a classified field
+    NAME or raw VALUE back to the caller. ``ValidationResult.classified_field_count``
+    tracks the aggregate for operator alerting. See issue #520 and
+    ``rules/event-payload-classification.md`` Rules 5–7.
+
     Args:
         instance: A DataFlowModel instance (or any object whose class
             has a ``__field_validators__`` attribute).
+        policy: Optional classification policy. When ``None`` the
+            helper is a pass-through and errors contain raw field
+            names / values (backwards-compatible behaviour for
+            unclassified models).
+        model_name: Optional model name used by the sanitiser to look
+            up per-field classification. Required when ``policy`` is
+            supplied; ignored otherwise.
 
     Returns:
         A ``ValidationResult`` aggregating all errors.
     """
+    # Lazy import avoids a cycle with classification.policy.
+    from dataflow.classification.validation_error import sanitize_validation_error
+
     result = ValidationResult()
     validators: List[_ValidatorEntry] = getattr(
         type(instance), "__field_validators__", []
@@ -111,22 +134,39 @@ def validate_model(instance: Any) -> ValidationResult:
             is_valid = validator_fn(value)
         except Exception as exc:
             # Validator raised — treat as validation failure, not crash.
-            logger.warning(
-                "Validator %s raised %s for field %s: %s",
-                label,
-                type(exc).__name__,
-                field_name,
-                exc,
+            # Classified field names stay at DEBUG per
+            # rules/observability.md Rule 8; the WARN-level signal is
+            # carried by the ValidationResult aggregate.
+            logger.debug(
+                "validator.raised",
+                extra={
+                    "validator": label,
+                    "exc_type": type(exc).__name__,
+                    "field": field_name,
+                    "error": str(exc),
+                },
             )
             is_valid = False
 
         if not is_valid:
+            raw_message = (
+                f"Validation failed for field '{field_name}' " f"(validator: {label})"
+            )
+            safe_field, safe_message, safe_value, is_classified = (
+                sanitize_validation_error(
+                    policy=policy,
+                    model_name=model_name or "",
+                    field_name=field_name,
+                    message=raw_message,
+                    value=value,
+                )
+            )
             result.add_error(
-                field_name=field_name,
-                message=f"Validation failed for field '{field_name}' "
-                f"(validator: {label})",
+                field_name=safe_field,
+                message=safe_message,
                 validator=label,
-                value=value,
+                value=safe_value,
+                is_classified=is_classified,
             )
 
     return result

--- a/packages/kailash-dataflow/src/dataflow/validation/result.py
+++ b/packages/kailash-dataflow/src/dataflow/validation/result.py
@@ -68,9 +68,17 @@ class ValidationResult:
 
     Attributes:
         errors: List of individual field validation failures.
+        classified_field_count: Count of validation errors that
+            occurred on a classified field. Surfaced for operator
+            alerting ("a classified field failed validation on this
+            record") without revealing which field — the field name is
+            already sanitised to ``"<classified>"`` via
+            ``sanitize_validation_error`` (issue #520 / BP-049 cross-SDK
+            with kailash-rs).
     """
 
     errors: List[FieldValidationError] = field(default_factory=list)
+    classified_field_count: int = 0
 
     @property
     def valid(self) -> bool:
@@ -83,14 +91,25 @@ class ValidationResult:
         message: str,
         validator: str,
         value: Any = None,
+        is_classified: bool = False,
     ) -> None:
         """Append a validation error to the result.
 
         Args:
-            field_name: Name of the field that failed.
-            message: Human-readable description.
+            field_name: Name of the field that failed. Callers are
+                expected to have already routed the field name through
+                ``dataflow.classification.validation_error.sanitize_validation_error``
+                so classified names arrive as ``"<classified>"``.
+            message: Human-readable description. Same sanitisation
+                contract applies.
             validator: Name of the validator that produced this error.
-            value: The offending value (optional).
+            value: The offending value (optional). Classified values
+                MUST be type-descriptor strings, never raw values.
+            is_classified: ``True`` when the sanitiser replaced the
+                field name / value because the field was classified.
+                Increments ``classified_field_count`` for operator
+                alerting. Does NOT appear on ``FieldValidationError``
+                itself — the aggregate count lives on the result.
         """
         self.errors.append(
             FieldValidationError(
@@ -100,16 +119,20 @@ class ValidationResult:
                 value=value,
             )
         )
+        if is_classified:
+            self.classified_field_count += 1
 
     def merge(self, other: ValidationResult) -> None:
         """Merge errors from another ``ValidationResult`` into this one."""
         self.errors.extend(other.errors)
+        self.classified_field_count += other.classified_field_count
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to dictionary."""
         return {
             "valid": self.valid,
             "errors": [e.to_dict() for e in self.errors],
+            "classified_field_count": self.classified_field_count,
         }
 
     @classmethod
@@ -117,4 +140,5 @@ class ValidationResult:
         """Deserialize from dictionary."""
         return cls(
             errors=[FieldValidationError.from_dict(e) for e in data.get("errors", [])],
+            classified_field_count=data.get("classified_field_count", 0),
         )

--- a/packages/kailash-dataflow/tests/integration/security/test_bp_049_classification_leaks_wiring.py
+++ b/packages/kailash-dataflow/tests/integration/security/test_bp_049_classification_leaks_wiring.py
@@ -1,0 +1,470 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 integration tests for BP-049 classification-leak surfaces.
+
+Issue #520 — cross-SDK alignment with kailash-rs v3.19.0. Three DataFlow
+surfaces leaked classified field values / field names:
+
+* **M1 — NotFound / trust-audit error paths.** ``express.read`` /
+  ``express.update`` / ``express.delete`` routed raw PK values into
+  ``_trust_record_failure`` / ``_trust_record_success`` as
+  ``query_params={"id": id}`` AND into the
+  ``"express.record_not_found_for_read"`` structured-log event. The fix
+  wraps every PK-emitting site in ``_safe_record_id`` /
+  ``_safe_query_params`` so classified string PKs are SHA-256 hashed
+  before reaching the audit / log surface.
+
+* **M2 — Cache key construction.** ``CacheKeyGenerator`` accepted a raw
+  PK dict as ``params`` and serialised it through ``json.dumps`` before
+  hashing. When a cache backend persisted the pre-hash JSON (any
+  backend without at-rest encryption) the raw PK value was visible on
+  disk. The fix passes a ``ClassificationPolicy`` into the generator
+  and routes classified PKs through ``format_record_id_for_event``
+  BEFORE JSON serialisation. The cache keyspace version also bumps
+  ``v1 → v2`` for cross-SDK parity with kailash-rs.
+
+* **M3 — Validation error messages.** ``FieldValidationError.value``
+  stored the offending raw value, and ``message`` interpolated the
+  classified field NAME. The fix adds the
+  ``dataflow.classification.validation_error.sanitize_validation_error``
+  helper and routes every validation error through it;
+  ``ValidationResult.classified_field_count`` carries the aggregate
+  count for operator alerting without revealing which field was
+  affected.
+
+These tests pin the contract. Each test:
+
+1. Constructs a real ``DataFlow`` against PostgreSQL via the shared
+   ``IntegrationTestSuite`` fixture.
+2. Registers a model with a classified PK (``DataClassification.PII``
+   on ``id``).
+3. Exercises the production hot path.
+4. Asserts the externally-observable surface (event payload, cache
+   key, validation error) does NOT contain the raw PK value.
+
+Cross-SDK: the reference test file is
+``crates/kailash-dataflow/tests/bp_049_classification_leaks_wiring.rs``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.cache.key_generator import CacheKeyGenerator
+from dataflow.classification import (
+    DataClassification,
+    MaskingStrategy,
+    classify,
+)
+from dataflow.classification.policy import ClassificationPolicy
+from dataflow.classification.validation_error import (
+    CLASSIFIED_FIELD_NAME_PLACEHOLDER,
+    classified_value_descriptor,
+    sanitize_validation_error,
+)
+from dataflow.validation.decorators import field_validator, validate_model
+from dataflow.validation.result import ValidationResult
+
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+pytestmark = [pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def test_suite():
+    """Shared Tier-2 fixture: real PostgreSQL on port 5434."""
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+@pytest.fixture
+def unique_model_name() -> str:
+    """Unique model name per test to avoid registry collisions."""
+    return f"Bp049{uuid.uuid4().hex[:10]}"
+
+
+def _make_db_with_classified_pk(db_url: str, model_name: str) -> DataFlow:
+    """Model keyed by a classified string ``id``.
+
+    This is the exact shape that triggered the leak on every BP-049
+    surface: a model keyed by a classified PK (email, SSN, external
+    reference ID).
+    """
+    db = DataFlow(db_url, auto_migrate=True, pool_size=2, max_overflow=2)
+    cls = type(
+        model_name,
+        (),
+        {
+            "__annotations__": {"id": str, "label": str},
+            "id": "",
+            "label": "",
+        },
+    )
+    cls = classify("id", DataClassification.PII, masking=MaskingStrategy.REDACT)(cls)
+    db.model(cls)
+    return db
+
+
+def _expected_hash(raw: str) -> str:
+    return f"sha256:{hashlib.sha256(raw.encode()).hexdigest()[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# M1 — error messages / trust-audit paths
+# ---------------------------------------------------------------------------
+
+
+async def test_m1_read_not_found_audit_does_not_leak_classified_pk(
+    test_suite, unique_model_name
+):
+    """``express.read`` for a missing classified PK MUST NOT emit the raw
+    value to the trust-audit / log surface.
+
+    Reads the ``_safe_query_params`` result via the write event the
+    audit path emits on the cache-miss → not-found branch. If the raw
+    PK appears anywhere in the event payload ``repr`` the test fails.
+    """
+    db = _make_db_with_classified_pk(test_suite.config.url, unique_model_name)
+    events = []
+    try:
+        await db.initialize()
+        db.on_model_change(unique_model_name, lambda evt: events.append(evt))
+        raw_pk = f"alice-{uuid.uuid4().hex[:8]}@leak.example"
+        # Read a PK that doesn't exist — exercises the not-found +
+        # _safe_query_params path.
+        result = await db.express.read(unique_model_name, raw_pk)
+        assert result is None
+        # The event bus does NOT emit on read; the contract is that the
+        # trust-audit and log surfaces scrub the PK. Directly exercise
+        # the helper on the DataFlowExpress instance to pin the contract.
+        safe = db.express._safe_record_id(unique_model_name, raw_pk)
+        assert safe == _expected_hash(raw_pk), (
+            f"Classified PK MUST be hashed before it reaches the audit "
+            f"surface. Got {safe!r}, expected {_expected_hash(raw_pk)!r}."
+        )
+        safe_params = db.express._safe_query_params(unique_model_name, {"id": raw_pk})
+        assert safe_params == {"id": _expected_hash(raw_pk)}
+        assert raw_pk not in repr(
+            safe_params
+        ), f"Raw PK leaked into audit query_params: {safe_params!r}"
+    finally:
+        db.close()
+
+
+async def test_m1_create_event_hashes_classified_pk(test_suite, unique_model_name):
+    """``express.create`` event payload MUST carry ``sha256:`` for a
+    classified PK — the combined fix for BP-048 + BP-049.
+    """
+    db = _make_db_with_classified_pk(test_suite.config.url, unique_model_name)
+    events = []
+    try:
+        await db.initialize()
+        db.on_model_change(unique_model_name, lambda evt: events.append(evt))
+        raw_pk = f"alice-{uuid.uuid4().hex[:8]}@leak.example"
+        await db.express.create(unique_model_name, {"id": raw_pk, "label": "hi"})
+        creates = [
+            e for e in events if e.event_type.endswith(f".{unique_model_name}.create")
+        ]
+        assert len(creates) == 1
+        record_id = creates[0].payload["record_id"]
+        assert record_id is not None
+        assert record_id.startswith(
+            "sha256:"
+        ), f"Classified PK MUST be hashed in create event; got {record_id!r}"
+        assert raw_pk not in repr(
+            creates[0].payload
+        ), f"Raw PK leaked into event payload: {creates[0].payload!r}"
+    finally:
+        db.close()
+
+
+async def test_m1_update_event_hashes_classified_pk(test_suite, unique_model_name):
+    """``express.update`` event payload MUST carry ``sha256:`` for a
+    classified PK — pre-BP-049 shipped ``str(id)`` verbatim.
+    """
+    db = _make_db_with_classified_pk(test_suite.config.url, unique_model_name)
+    events = []
+    try:
+        await db.initialize()
+        raw_pk = f"alice-{uuid.uuid4().hex[:8]}@leak.example"
+        await db.express.create(unique_model_name, {"id": raw_pk, "label": "initial"})
+        # Subscribe AFTER create so we only capture the update event.
+        db.on_model_change(unique_model_name, lambda evt: events.append(evt))
+        await db.express.update(unique_model_name, raw_pk, {"label": "updated"})
+        updates = [
+            e for e in events if e.event_type.endswith(f".{unique_model_name}.update")
+        ]
+        assert len(updates) == 1
+        record_id = updates[0].payload["record_id"]
+        assert record_id is not None
+        assert record_id.startswith(
+            "sha256:"
+        ), f"Classified PK MUST be hashed in update event; got {record_id!r}"
+        assert raw_pk not in repr(updates[0].payload)
+    finally:
+        db.close()
+
+
+async def test_m1_delete_event_hashes_classified_pk(test_suite, unique_model_name):
+    """``express.delete`` event payload MUST carry ``sha256:`` for a
+    classified PK — closes the last mutation primitive.
+    """
+    db = _make_db_with_classified_pk(test_suite.config.url, unique_model_name)
+    events = []
+    try:
+        await db.initialize()
+        raw_pk = f"alice-{uuid.uuid4().hex[:8]}@leak.example"
+        await db.express.create(unique_model_name, {"id": raw_pk, "label": "initial"})
+        db.on_model_change(unique_model_name, lambda evt: events.append(evt))
+        await db.express.delete(unique_model_name, raw_pk)
+        deletes = [
+            e for e in events if e.event_type.endswith(f".{unique_model_name}.delete")
+        ]
+        assert len(deletes) == 1
+        record_id = deletes[0].payload["record_id"]
+        assert record_id is not None
+        assert record_id.startswith(
+            "sha256:"
+        ), f"Classified PK MUST be hashed in delete event; got {record_id!r}"
+        assert raw_pk not in repr(deletes[0].payload)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# M2 — cache key construction
+# ---------------------------------------------------------------------------
+
+
+def test_m2_default_version_is_v2():
+    """Cross-SDK parity: default keyspace is ``v2`` per BP-049."""
+    kg = CacheKeyGenerator()
+    assert (
+        kg.version == "v2"
+    ), f"BP-049 cross-SDK contract requires v2 keyspace; got {kg.version!r}"
+
+
+def test_m2_cache_key_does_not_embed_raw_classified_pk():
+    """Cache key for a classified-PK read MUST NOT contain the raw value
+    anywhere in its key material (including the pre-hash JSON).
+    """
+    policy = ClassificationPolicy()
+    policy.set_field(
+        "Account",
+        "id",
+        DataClassification.PII,
+        masking=MaskingStrategy.REDACT,
+    )
+    kg = CacheKeyGenerator(classification_policy=policy)
+    raw_pk = "alice@leak.example"
+
+    # The final key is md5-hashed so the raw value isn't literally
+    # visible, but the pre-hash JSON IS the leak surface for any cache
+    # backend that persists key material / debug-logs key inputs. The
+    # sanitiser substitutes the hash BEFORE serialisation.
+    safe = kg._safe_params("Account", {"id": raw_pk})
+    assert safe["id"] == _expected_hash(raw_pk)
+
+    # Unclassified model: value passes through unchanged.
+    passthrough = kg._safe_params("NotClassified", {"id": raw_pk})
+    assert passthrough == {"id": raw_pk}
+
+
+def test_m2_cache_key_classified_pk_produces_stable_different_key():
+    """Two different raw classified PKs produce two different cache
+    keys (the hashing does not collapse values)."""
+    policy = ClassificationPolicy()
+    policy.set_field(
+        "Account",
+        "id",
+        DataClassification.PII,
+        masking=MaskingStrategy.REDACT,
+    )
+    kg = CacheKeyGenerator(classification_policy=policy)
+
+    key_a = kg.generate_express_key(
+        "Account", "read", params={"id": "alice@leak.example"}
+    )
+    key_b = kg.generate_express_key(
+        "Account", "read", params={"id": "bob@leak.example"}
+    )
+    assert key_a != key_b, "Distinct raw PKs MUST produce distinct keys"
+    assert "alice@leak.example" not in key_a
+    assert "bob@leak.example" not in key_b
+    # v2 keyspace
+    assert ":v2:" in key_a
+
+
+def test_m2_cache_key_filter_nested_id_is_hashed():
+    """Filter-style params (``{"filter": {"id": ...}}``) have the
+    nested ``id`` hashed too."""
+    policy = ClassificationPolicy()
+    policy.set_field(
+        "Account",
+        "id",
+        DataClassification.PII,
+        masking=MaskingStrategy.REDACT,
+    )
+    kg = CacheKeyGenerator(classification_policy=policy)
+    raw = "carol@leak.example"
+    safe = kg._safe_params("Account", {"filter": {"id": raw}})
+    assert safe == {"filter": {"id": _expected_hash(raw)}}
+
+
+def test_m2_no_policy_means_no_hashing():
+    """Backwards-compat: a key generator built without a policy acts
+    identically to pre-BP-049. Callers of DataFlow that have no
+    classifications MUST NOT see a behaviour change."""
+    kg = CacheKeyGenerator()  # no policy
+    raw = {"id": "alice@leak.example"}
+    assert kg._safe_params("Account", raw) == raw
+
+
+# ---------------------------------------------------------------------------
+# M3 — validation error sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_m3_sanitize_validation_error_unclassified_passthrough():
+    """Pass-through when no policy or field is unclassified."""
+    # No policy at all.
+    sf, sm, sv, ic = sanitize_validation_error(
+        None, "User", "email", "bad email", "x@y"
+    )
+    assert (sf, sm, sv, ic) == ("email", "bad email", "x@y", False)
+
+    # Policy present but field not classified.
+    policy = ClassificationPolicy()
+    sf, sm, sv, ic = sanitize_validation_error(
+        policy, "User", "email", "bad email", "x@y"
+    )
+    assert (sf, sm, sv, ic) == ("email", "bad email", "x@y", False)
+
+
+def test_m3_sanitize_validation_error_classified_redacts():
+    """Classified field → name placeholder, value type-descriptor,
+    message scrubbed of the raw field name."""
+    policy = ClassificationPolicy()
+    policy.set_field(
+        "User",
+        "email",
+        DataClassification.PII,
+        masking=MaskingStrategy.REDACT,
+    )
+    sf, sm, sv, ic = sanitize_validation_error(
+        policy,
+        "User",
+        "email",
+        "Validation failed for field 'email' (validator: is_email)",
+        "alice@leak.example",
+    )
+    assert sf == CLASSIFIED_FIELD_NAME_PLACEHOLDER
+    assert "email" not in sm or CLASSIFIED_FIELD_NAME_PLACEHOLDER in sm
+    assert sv == "<classified string>"
+    assert ic is True
+    assert (
+        "alice@leak.example" not in sm
+    ), "Raw classified value MUST NOT leak into the sanitised message"
+
+
+def test_m3_classified_value_descriptor_covers_common_types():
+    """Type-descriptor vocabulary matches the cross-SDK contract."""
+    assert classified_value_descriptor("x") == "<classified string>"
+    assert classified_value_descriptor(42) == "<classified int>"
+    assert classified_value_descriptor(1.5) == "<classified float>"
+    assert classified_value_descriptor(True) == "<classified bool>"
+    assert classified_value_descriptor(b"x") == "<classified bytes>"
+    assert classified_value_descriptor([1, 2]) == "<classified list>"
+    assert classified_value_descriptor({"k": "v"}) == "<classified dict>"
+    assert classified_value_descriptor(None) == "<classified none>"
+
+
+def _reject_all(value):
+    """Named validator so the derived label stays grep-able."""
+    return False
+
+
+def test_m3_validate_model_sanitises_classified_errors():
+    """End-to-end via validate_model: a validator that rejects a
+    classified field produces a sanitised ValidationResult with the
+    classified_field_count aggregate set."""
+
+    @field_validator("email", _reject_all)
+    class M3ClassifiedModel:
+        email: str = ""
+
+    policy = ClassificationPolicy()
+    policy.set_field(
+        "M3ClassifiedModel",
+        "email",
+        DataClassification.PII,
+        masking=MaskingStrategy.REDACT,
+    )
+
+    instance = M3ClassifiedModel()
+    instance.email = "alice@leak.example"
+
+    result = validate_model(instance, policy=policy, model_name="M3ClassifiedModel")
+    assert not result.valid
+    assert len(result.errors) == 1
+    err = result.errors[0]
+    assert err.field == CLASSIFIED_FIELD_NAME_PLACEHOLDER
+    assert "alice@leak.example" not in err.message
+    assert err.value == "<classified string>"
+    assert result.classified_field_count == 1
+
+
+def test_m3_validate_model_unclassified_preserves_raw_values():
+    """Backwards-compat: unclassified field retains raw error value."""
+
+    @field_validator("name", _reject_all)
+    class M3UnclassifiedModel:
+        name: str = ""
+
+    policy = ClassificationPolicy()  # empty
+    instance = M3UnclassifiedModel()
+    instance.name = "bad value"
+    result = validate_model(instance, policy=policy, model_name="M3UnclassifiedModel")
+    assert not result.valid
+    assert result.errors[0].field == "name"
+    assert result.errors[0].value == "bad value"
+    assert result.classified_field_count == 0
+
+
+def test_m3_validation_result_merge_aggregates_classified_count():
+    """merge() sums classified_field_count across results."""
+    r1 = ValidationResult()
+    r1.add_error("f1", "m", "v", value="x", is_classified=True)
+    r2 = ValidationResult()
+    r2.add_error("f2", "m", "v", value="y", is_classified=True)
+    r2.add_error("f3", "m", "v", value="z", is_classified=False)
+    r1.merge(r2)
+    assert r1.classified_field_count == 2
+    assert len(r1.errors) == 3
+
+
+def test_m3_validation_result_to_dict_includes_classified_count():
+    """Serialised form includes the aggregate for operator alerting."""
+    vr = ValidationResult()
+    vr.add_error(
+        CLASSIFIED_FIELD_NAME_PLACEHOLDER,
+        "msg",
+        "val",
+        value="<classified string>",
+        is_classified=True,
+    )
+    d = vr.to_dict()
+    assert d["classified_field_count"] == 1
+    # Round-trip.
+    vr2 = ValidationResult.from_dict(d)
+    assert vr2.classified_field_count == 1

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 readme = "README.md"
 keywords = ["ml", "machine-learning", "kailash", "automl", "feature-store", "model-registry"]
 dependencies = [
-    "kailash>=2.8.1",
-    "kailash-dataflow>=1.0",
-    "kailash-nexus>=1.0",
+    "kailash>=2.8.7",
+    "kailash-dataflow>=2.0.10",
+    "kailash-nexus>=2.1.0",
     "polars>=1.0",
     "pyarrow>=14.0",
     "numpy>=1.24",
@@ -73,7 +73,7 @@ rl = [
     "gymnasium>=0.29",
 ]
 agents = [
-    "kailash-kaizen>=1.0",
+    "kailash-kaizen>=2.7.5",
 ]
 explain = ["shap>=0.44"]
 imbalance = ["imbalanced-learn>=0.12"]

--- a/packages/kailash-ml/src/kailash_ml/__init__.py
+++ b/packages/kailash-ml/src/kailash_ml/__init__.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
     from kailash_ml.engines.drift_monitor import DriftCallback as DriftCallback
 
 from kailash_ml._device import BackendInfo, detect_backend
+from kailash_ml._device_report import (
+    DeviceReport,
+    device_report_from_backend_info,
+)
 from kailash_ml._gpu_setup import resolve_torch_wheel
 from kailash_ml._result import TrainingResult
 from kailash_ml._version import __version__
@@ -77,6 +81,98 @@ def train(
     engine = MLEngine()
     # engine.fit is async; synchronous wrapper for the three-line form
     return asyncio.run(engine.fit(df, target=target, family=family, **kwargs))
+
+
+# ---------------------------------------------------------------------------
+# GPU-first convenience (Phase 1): km.device() + km.use_device()
+# ---------------------------------------------------------------------------
+#
+# Per workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md.
+# Users interact through ``import kailash_ml as km`` so the top-level
+# surface keeps every adapter transparent to device selection: no
+# ``device="..."`` or ``accelerator="..."`` parameter plumbed through
+# the API; instead the resolver decides, and callers who need to pin a
+# backend (offline / deterministic / CPU-only runs) enter a small
+# context manager.
+
+import contextvars as _contextvars
+from contextlib import contextmanager as _contextmanager
+from typing import Iterator as _Iterator, Optional as _Optional
+
+
+# Thread-safe and asyncio-safe override consumed by detect_backend()
+# callers. A value of None means "no override — use the priority
+# resolver". A string value pins detection to that backend for the
+# duration of the ``with km.use_device(...)`` block.
+_device_override: _contextvars.ContextVar[_Optional[str]] = _contextvars.ContextVar(
+    "kailash_ml_device_override", default=None
+)
+
+
+def device(prefer: _Optional[str] = None) -> BackendInfo:
+    """Return the resolved ``BackendInfo`` without training anything.
+
+    Inspection-only entry point: users who want to know which backend
+    the next training call would pick MUST NOT call ``detect_backend``
+    directly (that's the engine-internal API). ``km.device()`` honours
+    any ``with km.use_device(...)`` scope in effect and otherwise runs
+    the priority resolver.
+
+        import kailash_ml as km
+        print(km.device())  # BackendInfo(backend='cuda', precision='bf16-mixed', ...)
+        with km.use_device("cpu"):
+            print(km.device().backend)  # "cpu"
+
+    Args:
+        prefer: Optional explicit backend. When omitted, honours any
+            ``use_device`` scope in effect; when provided, overrides the
+            scope for this single call. Same vocabulary as
+            ``_device.KNOWN_BACKENDS`` ("cuda" / "mps" / "rocm" /
+            "xpu" / "tpu" / "cpu") or "auto".
+
+    Returns:
+        A pre-resolved :class:`BackendInfo` (concrete precision, never
+        "auto").
+    """
+    effective = prefer if prefer is not None else _device_override.get()
+    return detect_backend(prefer=effective)
+
+
+@_contextmanager
+def use_device(name: str) -> _Iterator[BackendInfo]:
+    """Pin backend selection to ``name`` for the duration of the block.
+
+    Intended for offline / deterministic / CPU-only runs where a
+    surrounding test or notebook needs a single backend regardless of
+    the host's capabilities. The pin is contextvar-scoped so it is
+    thread-safe and asyncio-safe.
+
+        import kailash_ml as km
+        with km.use_device("cpu"):
+            result = km.train(df, target="y")  # runs on CPU
+        # pin released; the next call uses the priority resolver again
+
+    Args:
+        name: One of ``_device.KNOWN_BACKENDS`` or ``"auto"``. Unknown
+            strings raise :class:`ValueError` immediately (same
+            vocabulary as ``detect_backend``). If the named backend is
+            not available on this host, :class:`BackendUnavailable` is
+            raised when entering the block — a deterministic failure
+            surface beats silently running on the wrong backend.
+
+    Yields:
+        The :class:`BackendInfo` resolved inside the scope, so callers
+        can destructure it if useful.
+    """
+    # Validate eagerly: resolving now surfaces BackendUnavailable at
+    # ``with`` time, not at the first ``km.train(...)`` call inside the
+    # block — the latter is much harder to reason about.
+    info = detect_backend(prefer=name)
+    token = _device_override.set(name)
+    try:
+        yield info
+    finally:
+        _device_override.reset(token)
 
 
 def track(experiment: str, **kwargs):

--- a/packages/kailash-ml/src/kailash_ml/_device_report.py
+++ b/packages/kailash-ml/src/kailash_ml/_device_report.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""DeviceReport dataclass for kailash-ml GPU-first Phase 1.
+
+Every call that trains or predicts via a ``Trainable`` MUST return (or
+carry) a ``DeviceReport`` so callers can distinguish between a run that
+actually executed on a GPU and a run that fell back to CPU silently.
+The report also captures the pre-resolved precision and whether the
+sklearn Array API dispatch was engaged on the call.
+
+Implements `workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md`
+§ "DeviceReport contract" (lines 54-78 of the revised-stack doc).
+
+Surface contract:
+
+    DeviceReport.family              "sklearn" | "xgboost" | "torch" | "rl" | ...
+    DeviceReport.backend             "cuda" | "mps" | "rocm" | "xpu" | "tpu" | "cpu"
+    DeviceReport.device_string       "cuda:0" | "mps" | "cpu"
+    DeviceReport.precision           "fp32" | "bf16" | "fp16" | Lightning shortcut
+    DeviceReport.fallback_reason     non-None when GPU -> CPU fallback fired
+    DeviceReport.array_api           True if sklearn Array API was engaged
+
+Lives alongside ``BackendInfo`` (``_device.py``). The two differ by
+scope: ``BackendInfo`` is environment-level (what the host CAN do),
+``DeviceReport`` is call-level (what this specific fit/predict ACTUALLY
+did).
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+from kailash_ml._device import BackendInfo
+
+__all__ = [
+    "DeviceReport",
+    "device_report_from_backend_info",
+]
+
+
+@dataclass(frozen=True)
+class DeviceReport:
+    """Per-call evidence of what backend / precision / path ran.
+
+    Attributes:
+        family: The Trainable family label (e.g. ``"sklearn"``,
+            ``"xgboost"``, ``"torch"``, ``"rl"``). Free-form string so
+            new families can add themselves without a registry hop.
+        backend: One of the detected backends from ``_device.KNOWN_BACKENDS``
+            (``"cuda"``, ``"mps"``, ``"rocm"``, ``"xpu"``, ``"tpu"``,
+            ``"cpu"``). Matches the value that actually executed, not
+            the value requested.
+        device_string: Torch device string (``"cuda:0"``, ``"mps"``,
+            ``"cpu"``). Echoes the string that was actually passed to
+            ``.to(...)`` / Trainer ``devices=`` on the hot path.
+        precision: Concrete precision string (``"fp32"``, ``"bf16"``,
+            ``"fp16"``, or a Lightning shortcut like ``"bf16-mixed"``).
+            Never ``"auto"``; callers that start with ``"auto"`` MUST
+            resolve to a concrete value before constructing this
+            report.
+        fallback_reason: ``None`` when the call ran on the initially
+            requested backend. A short machine-parseable string when a
+            GPU → CPU (or higher-tier → lower-tier) fallback fired:
+
+              * ``"oom"``                 OOM on the GPU path; retried CPU.
+              * ``"cuml_eviction"``       UMAP/HDBSCAN on CPU because cuML
+                                          was evicted in Phase 1.
+              * ``"array_api_offlist"``   sklearn estimator not on the
+                                          Array API allowlist; CPU numpy path.
+              * ``"driver_missing"``      runtime driver probe failed.
+              * ``"unsupported_family"``  family cannot run on the detected
+                                          backend.
+        array_api: ``True`` iff the sklearn Array API dispatch was
+            engaged for this call (``sklearn.config_context(array_api_dispatch=True)``).
+            ``False`` for non-sklearn families and for sklearn calls
+            that fell off the allowlist.
+    """
+
+    family: str
+    backend: str
+    device_string: str
+    precision: str
+    fallback_reason: Optional[str] = None
+    array_api: bool = False
+
+    def __post_init__(self) -> None:  # type: ignore[override]
+        # Concrete values only (mirrors TrainingResult.__post_init__ §4.2
+        # MUST 2). Runtime reports MUST carry evidence, not intent.
+        if not isinstance(self.family, str) or not self.family:
+            raise ValueError(
+                "DeviceReport.family must be a non-empty string "
+                "(e.g. 'sklearn', 'xgboost', 'torch')."
+            )
+        if not isinstance(self.backend, str) or not self.backend:
+            raise ValueError(
+                "DeviceReport.backend must be a non-empty string "
+                "(e.g. 'cuda', 'cpu')."
+            )
+        if self.backend == "auto":
+            raise ValueError(
+                "DeviceReport.backend='auto' is BLOCKED. Resolve 'auto' "
+                "to a concrete value via detect_backend() before "
+                "constructing the report."
+            )
+        if not isinstance(self.device_string, str) or not self.device_string:
+            raise ValueError(
+                "DeviceReport.device_string must be a non-empty string "
+                "(e.g. 'cuda:0', 'mps', 'cpu')."
+            )
+        if not isinstance(self.precision, str) or not self.precision:
+            raise ValueError(
+                "DeviceReport.precision must be a non-empty string "
+                "(e.g. 'fp32', 'bf16', '16-mixed')."
+            )
+        if self.precision == "auto":
+            raise ValueError(
+                "DeviceReport.precision='auto' is BLOCKED. Resolve 'auto' "
+                "to a concrete value via resolve_precision() before "
+                "constructing the report."
+            )
+        if self.fallback_reason is not None and not isinstance(
+            self.fallback_reason, str
+        ):
+            raise ValueError(
+                "DeviceReport.fallback_reason must be None or a short "
+                "machine-parseable string."
+            )
+        if not isinstance(self.array_api, bool):
+            raise ValueError(
+                "DeviceReport.array_api must be a bool."
+            )
+
+    def as_log_extra(self) -> dict[str, Any]:
+        """Return a dict suitable for ``logger.info(..., extra=...)``.
+
+        The six fields are the minimum structured log payload every
+        adapter emits on fit/predict, per the revised-stack spec. Using
+        ``asdict`` keeps this deterministic as new optional fields are
+        added to the contract.
+        """
+        return asdict(self)
+
+
+def device_report_from_backend_info(
+    info: BackendInfo,
+    *,
+    family: str,
+    fallback_reason: Optional[str] = None,
+    array_api: bool = False,
+) -> DeviceReport:
+    """Construct a ``DeviceReport`` from a ``BackendInfo`` plus family.
+
+    Convenience for the 90% case where the adapter just ran on the
+    resolved backend and wants to hand the report to its
+    ``TrainingResult``. Callers that had a fallback should pass the
+    POST-fallback ``BackendInfo`` (typically a CPU info) plus the
+    ``fallback_reason`` describing why — the report captures what
+    ACTUALLY ran, not what was requested.
+    """
+    return DeviceReport(
+        family=family,
+        backend=info.backend,
+        device_string=info.device_string,
+        precision=info.precision,
+        fallback_reason=fallback_reason,
+        array_api=array_api,
+    )

--- a/packages/kailash-ml/tests/unit/test_device_report.py
+++ b/packages/kailash-ml/tests/unit/test_device_report.py
@@ -1,0 +1,335 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for DeviceReport + km.device() / km.use_device().
+
+Pins the contract established in
+``workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md``
+for the GPU-first Phase 1 rollout:
+
+* DeviceReport validates its inputs and refuses "auto" values.
+* DeviceReport produces a deterministic structured-log extra dict.
+* km.device() honours a surrounding km.use_device(...) scope.
+* km.use_device() is contextvar-scoped (asyncio-safe).
+* Unknown backend names raise ValueError at pin time, not at first use.
+
+These tests run on plain CPU hosts — they do NOT require a GPU. GPU /
+MPS / TPU paths are exercised in the matrix-level Tier 2 regression
+tests added by item 8.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import kailash_ml as km
+from kailash_ml import (
+    BackendInfo,
+    DeviceReport,
+    detect_backend,
+    device_report_from_backend_info,
+)
+from kailash_ml._device import KNOWN_BACKENDS, BackendUnavailable
+
+
+# ---------------------------------------------------------------------------
+# DeviceReport — validation contract
+# ---------------------------------------------------------------------------
+
+
+def test_device_report_construction_happy_path():
+    """Concrete values -> frozen report with all six fields."""
+    report = DeviceReport(
+        family="sklearn",
+        backend="cpu",
+        device_string="cpu",
+        precision="32-true",
+    )
+    assert report.family == "sklearn"
+    assert report.backend == "cpu"
+    assert report.device_string == "cpu"
+    assert report.precision == "32-true"
+    assert report.fallback_reason is None
+    assert report.array_api is False
+
+
+def test_device_report_is_frozen():
+    """Reports are immutable — callers MUST construct a new one."""
+    report = DeviceReport(
+        family="sklearn",
+        backend="cpu",
+        device_string="cpu",
+        precision="32-true",
+    )
+    with pytest.raises(Exception):  # dataclass(frozen=True) raises FrozenInstanceError
+        report.backend = "cuda"  # type: ignore[misc]
+
+
+def test_device_report_rejects_auto_backend():
+    """Runtime reports MUST carry evidence; ``"auto"`` is intent."""
+    with pytest.raises(ValueError, match="auto"):
+        DeviceReport(
+            family="sklearn",
+            backend="auto",
+            device_string="cpu",
+            precision="32-true",
+        )
+
+
+def test_device_report_rejects_auto_precision():
+    """Precision must be pre-resolved before the report is built."""
+    with pytest.raises(ValueError, match="auto"):
+        DeviceReport(
+            family="sklearn",
+            backend="cpu",
+            device_string="cpu",
+            precision="auto",
+        )
+
+
+@pytest.mark.parametrize("field", ["family", "backend", "device_string", "precision"])
+def test_device_report_rejects_empty_strings(field: str):
+    """Every string field MUST be non-empty."""
+    kwargs = {
+        "family": "sklearn",
+        "backend": "cpu",
+        "device_string": "cpu",
+        "precision": "32-true",
+    }
+    kwargs[field] = ""
+    with pytest.raises(ValueError):
+        DeviceReport(**kwargs)
+
+
+def test_device_report_rejects_non_bool_array_api():
+    """array_api is a bool, not a truthy string."""
+    with pytest.raises(ValueError, match="array_api"):
+        DeviceReport(
+            family="sklearn",
+            backend="cpu",
+            device_string="cpu",
+            precision="32-true",
+            array_api="yes",  # type: ignore[arg-type]
+        )
+
+
+def test_device_report_fallback_reason_must_be_string_or_none():
+    """fallback_reason is either None or a short string."""
+    # None — ok.
+    DeviceReport(
+        family="sklearn",
+        backend="cpu",
+        device_string="cpu",
+        precision="32-true",
+        fallback_reason=None,
+    )
+    # String — ok.
+    DeviceReport(
+        family="xgboost",
+        backend="cpu",
+        device_string="cpu",
+        precision="32-true",
+        fallback_reason="oom",
+    )
+    # Non-string non-None — rejected.
+    with pytest.raises(ValueError, match="fallback_reason"):
+        DeviceReport(
+            family="sklearn",
+            backend="cpu",
+            device_string="cpu",
+            precision="32-true",
+            fallback_reason=42,  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# DeviceReport — log payload contract
+# ---------------------------------------------------------------------------
+
+
+def test_device_report_as_log_extra_carries_all_fields():
+    """The log payload every adapter emits carries all six fields."""
+    report = DeviceReport(
+        family="xgboost",
+        backend="cuda",
+        device_string="cuda:0",
+        precision="bf16-mixed",
+        fallback_reason=None,
+        array_api=False,
+    )
+    extra = report.as_log_extra()
+    assert extra == {
+        "family": "xgboost",
+        "backend": "cuda",
+        "device_string": "cuda:0",
+        "precision": "bf16-mixed",
+        "fallback_reason": None,
+        "array_api": False,
+    }
+
+
+def test_device_report_log_extra_with_fallback():
+    """Fallback reason surfaces in the log payload."""
+    report = DeviceReport(
+        family="xgboost",
+        backend="cpu",
+        device_string="cpu",
+        precision="32-true",
+        fallback_reason="oom",
+    )
+    assert report.as_log_extra()["fallback_reason"] == "oom"
+    assert report.as_log_extra()["backend"] == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# device_report_from_backend_info
+# ---------------------------------------------------------------------------
+
+
+def test_device_report_from_backend_info_uses_post_fallback_info():
+    """The helper is a convenience over the BackendInfo that ACTUALLY ran."""
+    cpu_info = detect_backend(prefer="cpu")
+    report = device_report_from_backend_info(
+        cpu_info, family="sklearn", fallback_reason="cuml_eviction"
+    )
+    assert report.backend == "cpu"
+    assert report.device_string == "cpu"
+    assert report.precision == cpu_info.precision
+    assert report.family == "sklearn"
+    assert report.fallback_reason == "cuml_eviction"
+    assert report.array_api is False
+
+
+def test_device_report_from_backend_info_array_api_flag():
+    """array_api flag propagates unchanged."""
+    cpu_info = detect_backend(prefer="cpu")
+    report = device_report_from_backend_info(
+        cpu_info, family="sklearn", array_api=True
+    )
+    assert report.array_api is True
+
+
+# ---------------------------------------------------------------------------
+# km.device()
+# ---------------------------------------------------------------------------
+
+
+def test_km_device_returns_backend_info():
+    """Inspection-only: km.device() returns the resolved BackendInfo."""
+    info = km.device()
+    assert isinstance(info, BackendInfo)
+    assert info.backend in KNOWN_BACKENDS
+    # Precision was pre-resolved, never "auto".
+    assert info.precision != "auto"
+
+
+def test_km_device_accepts_explicit_prefer():
+    """km.device('cpu') forces a specific resolver."""
+    info = km.device("cpu")
+    assert info.backend == "cpu"
+    assert info.device_string == "cpu"
+
+
+def test_km_device_rejects_unknown_backend():
+    """Unknown backend names raise ValueError, not silent fallback."""
+    with pytest.raises(ValueError, match="Unknown backend"):
+        km.device("nvidia")  # not in KNOWN_BACKENDS
+
+
+# ---------------------------------------------------------------------------
+# km.use_device()
+# ---------------------------------------------------------------------------
+
+
+def test_km_use_device_pins_backend_for_scope():
+    """Inside the block, km.device() returns the pinned backend."""
+    with km.use_device("cpu"):
+        assert km.device().backend == "cpu"
+
+
+def test_km_use_device_releases_pin_on_exit():
+    """Outside the block, km.device() returns the resolver's pick."""
+    # Default pin is None; check the pin is cleared on exit.
+    with km.use_device("cpu"):
+        pass
+    info_after = km.device()
+    # The default resolver still runs — not guaranteed to be "cpu" on
+    # every host. Just assert a valid backend came back.
+    assert info_after.backend in KNOWN_BACKENDS
+
+
+def test_km_use_device_yields_the_backend_info():
+    """The context manager yields the resolved info for destructuring."""
+    with km.use_device("cpu") as info:
+        assert isinstance(info, BackendInfo)
+        assert info.backend == "cpu"
+
+
+def test_km_use_device_rejects_unknown_backend_at_entry():
+    """Unknown backends raise at ``with`` time, not first use."""
+    with pytest.raises(ValueError, match="Unknown backend"):
+        with km.use_device("nvidia"):  # noqa: SIM117
+            pass
+
+
+def test_km_use_device_raises_backend_unavailable_for_missing_gpu():
+    """On a CPU-only host, ``use_device('cuda')`` fails fast.
+
+    Skipped when CUDA actually IS available (GPU runners); run the
+    regression on CI CPU runners. The check happens at ``with`` time so
+    the error surface is deterministic regardless of when the first
+    training call fires.
+    """
+    # Probe availability up front.
+    try:
+        detect_backend(prefer="cuda")
+        cuda_available = True
+    except BackendUnavailable:
+        cuda_available = False
+
+    if cuda_available:
+        pytest.skip("CUDA is available on this host; fail-fast path not exercised")
+    with pytest.raises(BackendUnavailable):
+        with km.use_device("cuda"):  # noqa: SIM117
+            pass
+
+
+def test_km_use_device_is_contextvar_scoped_in_asyncio():
+    """Contextvar scope: two concurrent tasks see independent pins."""
+
+    results: dict[str, str] = {}
+
+    async def task_cpu():
+        with km.use_device("cpu"):
+            await asyncio.sleep(0)  # force a scheduling boundary
+            results["cpu"] = km.device().backend
+
+    async def task_default():
+        await asyncio.sleep(0)  # force a scheduling boundary
+        results["default"] = km.device().backend
+
+    async def main():
+        await asyncio.gather(task_cpu(), task_default())
+
+    asyncio.run(main())
+    assert results["cpu"] == "cpu"
+    # The default-task result is whatever the resolver picks; it MUST
+    # NOT be polluted by the other task's pin on hosts where the
+    # resolver would normally pick a non-cpu backend. On CPU-only hosts
+    # both are "cpu" which is fine — the test asserts independence, not
+    # divergence.
+    assert results["default"] in KNOWN_BACKENDS
+
+
+def test_km_use_device_nesting_restores_outer_pin():
+    """Nested ``use_device`` calls restore the outer pin on exit."""
+    with km.use_device("cpu") as outer_info:
+        assert km.device().backend == "cpu"
+        # Inner pin; on a CPU-only host "cpu" is the only valid option,
+        # so just re-pin "cpu" to exercise the stack mechanic.
+        with km.use_device("cpu") as inner_info:
+            assert km.device().backend == "cpu"
+            assert inner_info.backend == "cpu"
+        # Outer pin restored.
+        assert km.device().backend == outer_info.backend

--- a/packages/kailash-pact/pyproject.toml
+++ b/packages/kailash-pact/pyproject.toml
@@ -27,12 +27,12 @@ classifiers = [
 readme = "README.md"
 keywords = ["governance", "pact", "agent", "trust", "D/T/R", "envelopes", "clearance", "EATP", "AI"]
 dependencies = [
-    "kailash>=2.8.1",
+    "kailash>=2.8.7",
     "click>=8.0",
     "fastapi>=0.109",
     "slowapi>=0.1.9",
     # Kaizen integration
-    "kailash-kaizen>=2.0.0",
+    "kailash-kaizen>=2.7.5",
     # PostgreSQL
     "psycopg[binary]>=3.0",
     "psycopg_pool>=3.0",

--- a/packages/kailash-trust/pyproject.toml
+++ b/packages/kailash-trust/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "kailash>=2.7.0",
+    "kailash>=2.8.7",
 ]
 
 [project.optional-dependencies]

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -23,9 +23,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "kailash>=2.8.1",
-    "kailash-kaizen>=2.3.2",
-    "kailash-pact>=0.4.1",
+    "kailash>=2.8.7",
+    "kailash-kaizen>=2.7.5",
+    "kailash-pact>=0.8.1",
     "httpx>=0.27.0",
     "openai>=1.30.0",
     "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,23 +80,23 @@ dependencies = [
 # Pins are MINIMUM compatible versions, not "latest" — bumping to unreleased
 # versions breaks CI which installs from PyPI before the release is published.
 dataflow = [
-    "kailash-dataflow>=2.0.3",
+    "kailash-dataflow>=2.0.10",
 ]
 nexus = [
-    "kailash-nexus>=2.0.0",
+    "kailash-nexus>=2.1.0",
 ]
 kaizen = [
-    "kailash-kaizen>=2.7.1",
-    "kaizen-agents>=0.9.0",
+    "kailash-kaizen>=2.7.5",
+    "kaizen-agents>=0.9.2",
 ]
 pact = [
     "kailash-pact>=0.8.1",
 ]
 ml = [
-    "kailash-ml>=0.9.0",
+    "kailash-ml>=0.10.0",
 ]
 align = [
-    "kailash-align>=0.3.0",
+    "kailash-align>=0.3.1",
 ]
 # Secret backends (vendor-specific SDKs)
 vault = [
@@ -149,13 +149,13 @@ docs = [
 ]
 # Everything (core + all sub-packages with their optional deps)
 all = [
-    "kailash-dataflow>=2.0.3",
-    "kailash-nexus>=2.0.0",
-    "kailash-kaizen>=2.7.1",
-    "kaizen-agents>=0.9.0",
+    "kailash-dataflow>=2.0.10",
+    "kailash-nexus>=2.1.0",
+    "kailash-kaizen>=2.7.5",
+    "kaizen-agents>=0.9.2",
     "kailash-pact>=0.8.1",
-    "kailash-ml[all]>=0.8.1",
-    "kailash-align[all]>=0.3.0",
+    "kailash-ml[all]>=0.10.0",
+    "kailash-align[all]>=0.3.1",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2758,7 +2758,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.8.6"
+version = "2.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -2989,10 +2989,10 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.0" },
     { name = "gguf", marker = "extra == 'serve'", specifier = ">=0.10" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "kailash", specifier = ">=0.4.0" },
+    { name = "kailash", specifier = ">=2.8.7" },
     { name = "kailash-align", extras = ["rlhf", "eval", "serve", "online"], marker = "extra == 'all'" },
-    { name = "kailash-kaizen", specifier = ">=0.3.0" },
-    { name = "kailash-ml", specifier = ">=0.1.0" },
+    { name = "kailash-kaizen", specifier = ">=2.7.5" },
+    { name = "kailash-ml", specifier = ">=0.10.0" },
     { name = "llama-cpp-python", marker = "extra == 'serve'", specifier = ">=0.3" },
     { name = "lm-eval", marker = "extra == 'eval'", specifier = ">=0.4,<1.0" },
     { name = "peft", specifier = ">=0.10" },
@@ -3009,7 +3009,7 @@ provides-extras = ["rlhf", "eval", "serve", "online", "all", "dev"]
 
 [[package]]
 name = "kailash-dataflow"
-version = "2.0.8"
+version = "2.0.10"
 source = { editable = "packages/kailash-dataflow" }
 dependencies = [
     { name = "aiomysql" },
@@ -3081,7 +3081,7 @@ provides-extras = ["fabric", "cloud", "excel", "parquet", "streaming", "fabric-a
 
 [[package]]
 name = "kailash-kaizen"
-version = "2.7.4"
+version = "2.7.5"
 source = { editable = "packages/kailash-kaizen" }
 dependencies = [
     { name = "aiohttp" },
@@ -3096,6 +3096,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "gitpython" },
     { name = "google-genai" },
+    { name = "httpx" },
     { name = "kailash" },
     { name = "kailash-mcp" },
     { name = "numpy" },
@@ -3125,11 +3126,14 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.15.0" },
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0" },
+    { name = "botocore", marker = "extra == 'bedrock'", specifier = ">=1.34" },
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.20.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "gitpython", specifier = ">=3.1.0" },
+    { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0" },
     { name = "google-genai", specifier = ">=1.21.0" },
+    { name = "httpx", specifier = ">=0.25.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12" },
     { name = "kailash", specifier = ">=2.8.6" },
     { name = "kailash-mcp", specifier = ">=0.2.4" },
@@ -3153,11 +3157,11 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "bedrock", "vertex"]
 
 [[package]]
 name = "kailash-mcp"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "packages/kailash-mcp" }
 dependencies = [
     { name = "kailash" },
@@ -3192,13 +3196,14 @@ provides-extras = ["http", "sse", "websocket", "auth-jwt", "auth-oauth", "server
 
 [[package]]
 name = "kailash-ml"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "packages/kailash-ml" }
 dependencies = [
     { name = "kailash" },
     { name = "kailash-dataflow" },
     { name = "kailash-nexus" },
     { name = "lightgbm" },
+    { name = "lightning" },
     { name = "numpy" },
     { name = "onnxmltools" },
     { name = "onnxruntime" },
@@ -3208,6 +3213,8 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "skl2onnx" },
+    { name = "torch" },
+    { name = "xgboost" },
 ]
 
 [package.optional-dependencies]
@@ -3241,16 +3248,17 @@ requires-dist = [
     { name = "gymnasium", marker = "extra == 'rl'", specifier = ">=0.29" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.98" },
     { name = "imbalanced-learn", marker = "extra == 'imbalance'", specifier = ">=0.12" },
-    { name = "kailash", specifier = ">=2.8.1" },
-    { name = "kailash-dataflow", specifier = ">=1.0" },
-    { name = "kailash-kaizen", marker = "extra == 'agents'", specifier = ">=1.0" },
+    { name = "kailash", specifier = ">=2.8.7" },
+    { name = "kailash-dataflow", specifier = ">=2.0.10" },
+    { name = "kailash-kaizen", marker = "extra == 'agents'", specifier = ">=2.7.5" },
+    { name = "kailash-ml", extras = ["dl"], marker = "extra == 'dl-gpu'" },
     { name = "kailash-ml", extras = ["dl"], marker = "extra == 'rl'" },
     { name = "kailash-ml", extras = ["dl", "xgb", "catboost", "stats", "rl", "agents", "hpo", "mlflow", "huggingface", "dashboard", "interop", "imbalance", "explain"], marker = "extra == 'all'" },
     { name = "kailash-ml", extras = ["dl-gpu", "xgb", "catboost", "stats", "rl", "agents", "hpo", "mlflow", "huggingface", "dashboard", "interop", "imbalance", "explain"], marker = "extra == 'all-gpu'" },
-    { name = "kailash-nexus", specifier = ">=1.0" },
+    { name = "kailash-nexus", specifier = ">=2.1.0" },
     { name = "lightgbm", specifier = ">=4.0" },
+    { name = "lightning", specifier = ">=2.2" },
     { name = "lightning", marker = "extra == 'dl'", specifier = ">=2.2" },
-    { name = "lightning", marker = "extra == 'dl-gpu'", specifier = ">=2.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "onnxmltools", specifier = ">=1.12" },
@@ -3274,23 +3282,20 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'dashboard'", specifier = ">=0.35" },
     { name = "statsmodels", marker = "extra == 'stats'", specifier = ">=0.14" },
     { name = "timm", marker = "extra == 'dl'", specifier = ">=1.0" },
-    { name = "timm", marker = "extra == 'dl-gpu'", specifier = ">=1.0" },
+    { name = "torch", specifier = ">=2.2" },
     { name = "torch", marker = "extra == 'dl'", specifier = ">=2.2" },
-    { name = "torch", marker = "extra == 'dl-gpu'", specifier = ">=2.2" },
     { name = "torchaudio", marker = "extra == 'dl'", specifier = ">=2.2" },
-    { name = "torchaudio", marker = "extra == 'dl-gpu'", specifier = ">=2.2" },
     { name = "torchvision", marker = "extra == 'dl'", specifier = ">=0.17" },
-    { name = "torchvision", marker = "extra == 'dl-gpu'", specifier = ">=0.17" },
     { name = "transformers", marker = "extra == 'dl'", specifier = ">=4.40" },
-    { name = "transformers", marker = "extra == 'dl-gpu'", specifier = ">=4.40" },
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.27" },
+    { name = "xgboost", specifier = ">=2.0" },
     { name = "xgboost", marker = "extra == 'xgb'", specifier = ">=2.0" },
 ]
 provides-extras = ["dl", "dl-gpu", "rl", "agents", "explain", "imbalance", "xgb", "catboost", "stats", "hpo", "mlflow", "huggingface", "dashboard", "interop", "all", "all-gpu", "dev"]
 
 [[package]]
 name = "kailash-nexus"
-version = "2.0.3"
+version = "2.1.0"
 source = { editable = "packages/kailash-nexus" }
 dependencies = [
     { name = "fastapi" },
@@ -3336,8 +3341,8 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.109" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.98" },
-    { name = "kailash", specifier = ">=2.8.1" },
-    { name = "kailash-kaizen", specifier = ">=2.0.0" },
+    { name = "kailash", specifier = ">=2.8.7" },
+    { name = "kailash-kaizen", specifier = ">=2.7.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.0" },
     { name = "psycopg-pool", specifier = ">=3.0" },
@@ -3351,7 +3356,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "kaizen-agents"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "packages/kaizen-agents" }
 dependencies = [
     { name = "httpx" },
@@ -3367,9 +3372,9 @@ dependencies = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "kailash", specifier = ">=2.8.1" },
-    { name = "kailash-kaizen", specifier = ">=2.3.2" },
-    { name = "kailash-pact", specifier = ">=0.4.1" },
+    { name = "kailash", specifier = ">=2.8.7" },
+    { name = "kailash-kaizen", specifier = ">=2.7.5" },
+    { name = "kailash-pact", specifier = ">=0.8.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "openai", specifier = ">=1.30.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.2.0" },


### PR DESCRIPTION
## Summary

Foundational layer for the GPU-first punch list at \(internal workspace). Lands items 2 and 7 from the 8-item list; items 3-6 (sklearn Array-API, XGBoost/LightGBM OOM fallback, RL audit, UMAP/HDBSCAN adapters) build on this foundation in a follow-up session.

## Items shipped

- **Item 1 — \`[rapids]\` extra**: confirmed already absent from \`packages/kailash-ml/pyproject.toml\`; no-op.
- **Item 2 — DeviceReport**: new frozen dataclass at \`kailash_ml/_device_report.py\` carrying per-call evidence (family, backend, device_string, precision, fallback_reason, array_api). Validates that \`\"auto\"\` is BLOCKED at construction time. Helper \`device_report_from_backend_info()\` is the 90% convenience.
- **Item 7 — km.device() + km.use_device()**: top-level inspection helper and context manager. Contextvar-scoped so thread-safe and asyncio-safe. Unknown backends raise at pin time (not first use). BackendUnavailable fires eagerly when the pinned backend is not present on the host.

## Follow-up (next session)

- **Item 3**: sklearn Array-API allowlist + auto-context-wrapping
- **Item 4**: OOM fallback helper + XGBoost/LightGBM wiring
- **Item 5**: RL device routing audit
- **Item 6**: CPU-native UMAP/HDBSCAN adapters (Phase 1; torch-native is Phase 2/3)
- **Item 8**: per-family per-backend regression test matrix

Each of items 3-6 will consume the DeviceReport contract landed here.

## Test plan

- [x] 24 unit tests added (\`test_device_report.py\`) covering validation contract, log payload shape, contextvar scope in asyncio, nesting semantics
- [x] All pass on CPU-only host (\`24 passed in 3.11s\`)

## Related

Tracks GPU-first ML Phase 1 — \(internal workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
