### PR TITLE
fix(ci): add trust-v* tag support to publish-pypi.yml

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,6 +12,7 @@ on:
       - "ml-v*" # ML: ml-v0.1.0
       - "align-v*" # Align: align-v0.1.0
       - "mcp-v*" # MCP: mcp-v0.2.4
+      - "trust-v*" # Trust: trust-v0.1.0
   workflow_dispatch:
     inputs:
       package:
@@ -28,6 +29,7 @@ on:
           - kailash-ml
           - kailash-align
           - kailash-mcp
+          - kailash-trust
       publish_to:
         description: "Target registry"
         required: true
@@ -62,6 +64,7 @@ jobs:
               kailash-ml)       echo "package_dir=packages/kailash-ml" >> $GITHUB_OUTPUT ;;
               kailash-align)    echo "package_dir=packages/kailash-align" >> $GITHUB_OUTPUT ;;
               kailash-mcp)      echo "package_dir=packages/kailash-mcp" >> $GITHUB_OUTPUT ;;
+              kailash-trust)    echo "package_dir=packages/kailash-trust" >> $GITHUB_OUTPUT ;;
             esac
             echo "package=$PACKAGE" >> $GITHUB_OUTPUT
             echo "version=manual" >> $GITHUB_OUTPUT
@@ -98,6 +101,10 @@ jobs:
             elif [[ "$TAG" =~ ^mcp-v(.+)$ ]]; then
               echo "package=kailash-mcp" >> $GITHUB_OUTPUT
               echo "package_dir=packages/kailash-mcp" >> $GITHUB_OUTPUT
+              VERSION="${BASH_REMATCH[1]}"
+            elif [[ "$TAG" =~ ^trust-v(.+)$ ]]; then
+              echo "package=kailash-trust" >> $GITHUB_OUTPUT
+              echo "package_dir=packages/kailash-trust" >> $GITHUB_OUTPUT
               VERSION="${BASH_REMATCH[1]}"
             elif [[ "$TAG" =~ ^v(.+)$ ]]; then
               echo "package=kailash" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Adds `trust-v*` to `push.tags` triggers in `publish-pypi.yml`
- Adds `kailash-trust` to `workflow_dispatch` package choices
- Adds `trust-v*` case branch in the `determine-package` step
- Adds `kailash-trust` dispatch case mapping to `packages/kailash-trust/`

## Context

During the round-9 bundle release (PR #524), `trust-v0.1.1` was tagged but the workflow had no trigger pattern for it. The tag exists on remote but no publish run fired. This fix enables future tag-triggered publishes AND enables manual dispatch for the recovery publish of 0.1.1.

## Related issues

Fixes missing trust-v* publish trigger (round-9 release gap)