### PR TITLE
fix(trust): add kailash_trust package source + README for PyPI publish

### DIFF
--- a/packages/kailash-trust/README.md
+++ b/packages/kailash-trust/README.md
@@ -1,0 +1,27 @@
+# kailash-trust
+
+EATP trust plane integration for the [Kailash platform](https://github.com/terrene-foundation/kailash-py).
+
+This package re-exports the primary trust surface from `kailash.trust` for
+consumers who prefer the standalone install path.
+
+## Install
+
+```bash
+pip install kailash-trust
+```
+
+## Usage
+
+```python
+from kailash_trust import TrustOperations, GenesisRecord, TrustStore
+
+# Equivalent to: from kailash.trust import TrustOperations, GenesisRecord, TrustStore
+```
+
+The complete trust plane documentation is available in the
+[Kailash SDK docs](https://docs.terrene.foundation/kailash-trust).
+
+## License
+
+Apache 2.0 — Terrene Foundation

--- a/packages/kailash-trust/src/kailash_trust/__init__.py
+++ b/packages/kailash-trust/src/kailash_trust/__init__.py
@@ -1,0 +1,103 @@
+"""
+kailash-trust — EATP trust plane integration for the Kailash platform.
+
+The trust plane implementation lives in the core kailash package under
+``kailash.trust``. This package re-exports the primary public surface
+for consumers who prefer the standalone ``kailash-trust`` install path.
+
+Install:
+    pip install kailash-trust
+
+Usage:
+    from kailash_trust import TrustOperations, GenesisRecord, TrustStore
+    # Equivalent to: from kailash.trust import TrustOperations, GenesisRecord, TrustStore
+"""
+
+__version__ = "0.1.1"
+
+# Re-export the primary trust surface from the core kailash package.
+# The trust implementation lives in kailash.trust; this package is a
+# convenience install that brings kailash as a dependency and surfaces
+# the trust API at the kailash_trust namespace.
+try:
+    from kailash.trust import (  # noqa: F401
+        ALL_DIMENSIONS,
+        VALID_DIMENSION_NAMES,
+        ActionResult,
+        AuditAnchor,
+        AuthorityNotFoundError,
+        AuthorityPermission,
+        AuthorityType,
+        CapabilityAttestation,
+        CapabilityNotFoundError,
+        CapabilityRequest,
+        CapabilityType,
+        Constraint,
+        ConstraintEnvelope,
+        ConstraintType,
+        ConstraintViolationError,
+        DelegationError,
+        DelegationExpiredError,
+        DelegationLimits,
+        DelegationRecord,
+        GenesisRecord,
+        InMemoryTrustStore,
+        InvalidSignatureError,
+        InvalidTrustChainError,
+        LinkedHashChain,
+        LinkedHashEntry,
+        TrustChainNotFoundError,
+        TrustError,
+        TrustKeyManager,
+        TrustLineageChain,
+        TrustOperations,
+        TrustStore,
+        TrustStoreError,
+        VerificationFailedError,
+        VerificationLevel,
+        VerificationResult,
+    )
+except ImportError as exc:
+    raise ImportError(
+        "kailash-trust requires the kailash core package. "
+        "Install it with: pip install kailash>=2.8.7"
+    ) from exc
+
+__all__ = [
+    "__version__",
+    "ALL_DIMENSIONS",
+    "VALID_DIMENSION_NAMES",
+    "ActionResult",
+    "AuditAnchor",
+    "AuthorityNotFoundError",
+    "AuthorityPermission",
+    "AuthorityType",
+    "CapabilityAttestation",
+    "CapabilityNotFoundError",
+    "CapabilityRequest",
+    "CapabilityType",
+    "Constraint",
+    "ConstraintEnvelope",
+    "ConstraintType",
+    "ConstraintViolationError",
+    "DelegationError",
+    "DelegationExpiredError",
+    "DelegationLimits",
+    "DelegationRecord",
+    "GenesisRecord",
+    "InMemoryTrustStore",
+    "InvalidSignatureError",
+    "InvalidTrustChainError",
+    "LinkedHashChain",
+    "LinkedHashEntry",
+    "TrustChainNotFoundError",
+    "TrustError",
+    "TrustKeyManager",
+    "TrustLineageChain",
+    "TrustOperations",
+    "TrustStore",
+    "TrustStoreError",
+    "VerificationFailedError",
+    "VerificationLevel",
+    "VerificationResult",
+]


### PR DESCRIPTION
## Summary

- Adds `src/kailash_trust/__init__.py` — re-exports `kailash.trust` public surface at the `kailash_trust` namespace
- Adds `README.md` — required by `pyproject.toml` (was missing, causing `SetuptoolsWarning` during build)

## Context

After commit `eb1362a4` removed the `eatp.*` namespace shim, `packages/kailash-trust/src/` was empty (only a `.egg-info` artifact). The round-9 release tagged `trust-v0.1.1` but the publish build failed with:
```
error: error in 'egg_base' option: 'src' does not exist or is not a directory
ERROR Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```

The package is a thin convenience re-export: `kailash-trust` depends on `kailash` core and re-exports `TrustOperations`, `GenesisRecord`, `TrustStore`, etc. at the `kailash_trust` namespace.

## Related issues

Unblocks `trust-v0.1.1` PyPI publish for the round-9 bundled release.