### PR TITLE
chore(codify): round-9/10 — 6 rule extensions + fresh loom proposal

### DIFF
--- a/.claude/.proposals/archive/2026-04-19-kailash-py-round-10.yaml
+++ b/.claude/.proposals/archive/2026-04-19-kailash-py-round-10.yaml
@@ -1,0 +1,256 @@
+source_repo: kailash-py
+codify_date: "2026-04-19"
+codify_session: |
+  Session 2026-04-19 shipped 9 PRs (#502-#508 + #509 + #515 + #517 +
+  #518 + #519) and released 6 packages to PyPI (kailash 2.8.7,
+  kailash-kaizen 2.7.5, kailash-dataflow 2.0.10, kailash-nexus 2.1.0,
+  kailash-ml 0.10.0, kailash-mcp 0.2.5). Codify captures 9 recurring
+  institutional failure patterns:
+    1. Worktree isolation drift (ml / dataflow / kaizen / testing
+       specialists drifted back to main checkout, 4 occurrences).
+    2. Agent budget exhaustion mid-message ("Now let me write X…"
+       with no actual tool call) — 3 occurrences.
+    3. Scanner-surface symmetry variant: CodeQL `__all__` +
+       lazy `__getattr__` (PR #506 caught by #509 hotfix).
+    4. GPU-first kailash-ml architecture validated at
+       `workspaces/kailash-ml-gpu-stack/` — preserved here so it
+       survives workspace pruning.
+    5. Typed S2S client pattern (TypedServiceClient + DecoderRegistry)
+       introduced in PR #507 — now documented in nexus-specialist.
+    6. LogRecord reserved-attribute collision: `extra={"module": ...}`
+       raises `KeyError: "Attempt to overwrite 'module' in LogRecord"`
+       when mixed with kaizen-configured logging. Non-deterministic;
+       CI masks it via test-file isolation. (PR #506 → #509 hotfix)
+    7. Primitive-vs-orchestrator layer distinction for destructive
+       operations: per-DDL primitive `force_drop=True` + DropRefusedError
+       is DIFFERENT from per-migration orchestrator `force_downgrade=True`
+       + DowngradeRefusedError. Conflating the two inside one helper
+       (#508's `drop_confirmation.py`) required splitting in #517.
+    8. Cross-SDK citation audit pattern: 30 HITs / 5 MISSes across
+       `.claude/guides/deterministic-quality/` — MISSes concentrated in
+       one "aspirational prescriptive" file citing names that would
+       exist if the pattern were adopted. Fix: cite abstract pattern,
+       not literal-but-invented API. (rules/cross-sdk-inspection.md
+       MUST Rule 5 evidence)
+    9. TestPyPI trusted-publisher registration is PER-PACKAGE and
+       distinct from PyPI publisher config. Tag-triggered tag-push
+       releases bypass TestPyPI entirely; `workflow_dispatch` with
+       `publish_to=testpypi` requires the project already be
+       registered as a pending publisher on test.pypi.org (otherwise
+       400 "Non-user identities cannot create new projects").
+       kailash-ml hit this — registration is a one-time UI step per
+       package.
+  Prior proposal (2026-04-16 + 2026-04-19 append) archived to
+  archive/2026-04-19-kailash-py.yaml per rules/artifact-flow.md
+  "Archive Before Fresh" (status was distributed).
+sdk_version: 2.8.8
+coc_version: 1.0.3
+status: distributed
+distributed_date: "2026-04-19"
+
+changes:
+  - file: rules/worktree-isolation.md
+    action: created
+    suggested_tier: global
+    reason: |
+      New rule file codifying the worktree drift and agent-budget-
+      exhaustion patterns. Three MUST rules:
+        - Rule 1: Orchestrator prompts MUST pin the worktree path
+          and include a "STEP 0 — verify isolation" instruction.
+          BLOCKED rationalizations enumerated verbatim ("the
+          isolation flag handles cwd for me", etc).
+        - Rule 2: Specialist agent files MUST include a self-check
+          (git rev-parse --show-toplevel at start) so the pinning
+          contract survives prompt compression.
+        - Rule 3: Parent MUST `ls`/`Read` to verify claimed files
+          exist after agent exit. Addresses budget-exhaustion mid-
+          message ("Now let me write X..." with no tool call).
+      Path-scoped to .claude/agents/**, .claude/commands/**,
+      **/agents/**. Cross-references rules/agents.md worktree
+      directive, zero-tolerance.md Rule 2, testing.md verified-
+      numerical-claims discipline.
+      Evidence: ml-specialist, dataflow-specialist, kaizen-specialist
+      each drifted back to the main tree during PRs #502-#508;
+      kaizen round 6 and ml-specialist round 7 reported completions
+      with no actual file writes.
+    diff_lines: "+127"
+
+  - file: rules/agents.md
+    action: modified
+    suggested_tier: global
+    reason: |
+      Two additions:
+        - Cross-reference to new rules/worktree-isolation.md beneath
+          the existing "MUST: Worktree Isolation for Compiling
+          Agents" section ("isolation flag is necessary but not
+          sufficient without verification layer").
+        - New "MUST: Verify Agent Deliverables Exist After Exit"
+          section — parent orchestrator MUST ls/Read claimed files
+          before trusting completion. BLOCKED rationalizations
+          include "Now let me write the file..." (with no tool
+          call). Evidence: 2 occurrences this session.
+      Kept the file ≤200 lines (141 total) per rule-authoring
+      meta-rule.
+    diff_lines: "+25"
+
+  - file: rules/zero-tolerance.md
+    action: modified
+    suggested_tier: global
+    reason: |
+      Extended Rule 1a (Scanner-Surface Symmetry) with a second
+      concrete DO/DO NOT example covering the CodeQL
+      `py/modification-of-default-value` / `__all__` / lazy
+      `__getattr__` variant surfaced by PR #506:
+        - DO: eager-import new __all__ entries so CodeQL resolves
+          them at module scope.
+        - DO NOT: add to __all__ and resolve only via __getattr__
+          with the rationalization "the existing 8 entries do
+          this too".
+      The fix is to close the flag for this PR's additions;
+      grandfathered entries remain a separate workstream but are
+      NOT justification for adding more of the same.
+      Origin line updated to credit the 2026-04-19 extension.
+    diff_lines: "+23"
+
+  - file: agents/frameworks/nexus-specialist.md
+    action: modified
+    suggested_tier: global
+    reason: |
+      Added "Typed Service Client (S2S)" section documenting
+      kailash.nexus.TypedServiceClient — thin wrapper over
+      ServiceClient with pluggable DecoderRegistry (introduced in
+      PR #507). Code example shows register() decoder, typed get()
+      with response_type, and get_raw() for untyped migration
+      paths. Cross-reference to rules/testing.md § Delegating
+      Primitives (typed/raw variants need direct test coverage
+      per BP-046 pattern).
+      Kept the file ≤400 lines (220 total) per cc-artifacts.md
+      MUST Rule 1 "no knowledge dumps".
+    diff_lines: "+17"
+
+  - file: workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md
+    action: preserved_reference
+    suggested_tier: skip
+    reason: |
+      Reference entry — NOT a sync candidate. The GPU-first
+      kailash-ml architecture validated this session (single
+      torch substrate, detect_backend() single routing point,
+      DeviceReport transparency contract, OOM fallback helper,
+      8 action items for ~3 implementation sessions) lives at
+      workspaces/kailash-ml-gpu-stack/ and would normally be
+      lost at workspace pruning.
+      This proposal entry exists to preserve a pointer to the
+      architecture in the institutional audit trail. The actual
+      content stays in the workspace; next implementation session
+      should open a follow-up GitHub issue referencing this
+      workspace path.
+      Key artifacts at workspaces/kailash-ml-gpu-stack/:
+        - briefs/01-user-constraints.md (user-side requirements)
+        - 01-analysis/ (original research)
+        - 04-validate/01-redteam-round1.md (1 CRITICAL + 5 HIGH)
+        - 04-validate/02-revised-stack.md (converged design)
+        - 04-validate/00-convergence.md (gap summary)
+        - journal/0001..0003 (per-finding RISK / GAP entries)
+      Convergence status: design-complete, implementation-pending
+      (cuML eviction + DeviceReport + sklearn Array API wrap +
+      OOM fallback + RL routing audit + CPU-native UMAP/HDBSCAN
+      + top-level helpers + regression tests).
+    diff_lines: "0 (reference only)"
+
+  - file: rules/observability.md
+    action: amend
+    suggested_tier: global
+    reason: |
+      Add MUST rule §9 (or numbered after existing 8): "Never pass
+      reserved LogRecord attribute names via extra={}". Python's
+      logging.LogRecord reserves: msg, args, module, exc_info,
+      exc_text, stack_info, pathname, filename, name, levelname,
+      levelno, lineno, funcName, created, msecs, relativeCreated,
+      thread, threadName, processName, process. Passing any of
+      these via extra={} raises "KeyError: Attempt to overwrite 'X'
+      in LogRecord" when mixed with certain logging configurations.
+      DO: prefix domain-scoped field names (extra={"estimator_module":
+      X}). DO NOT: extra={"module": X}.
+      Why: Non-deterministic test failures (passed when isolated,
+      failed when mixed with kaizen tests). CI masks the bug.
+      Evidence: PR #506 shipped this bug; caught by round-2 redteam;
+      fixed in #509 hotfix (commit 717516f5).
+      Origin: kailash-py redteam round-2 (2026-04-19).
+
+  - file: rules/dataflow-identifier-safety.md
+    action: amend
+    suggested_tier: global
+    reason: |
+      Add §4a "Primitive-vs-orchestrator layer distinction for
+      destructive operations". The primitive-layer rule (§4 DROP
+      statements require force_drop=True + raise DropRefusedError)
+      governs per-DDL callers. The NEW orchestrator-layer rule
+      (MigrationManager.apply_downgrade) requires force_downgrade=True
+      + raises DowngradeRefusedError because a downgrade runs
+      MULTIPLE DDL DROPs and needs a distinct refuse signal the caller
+      can catch separately. The two errors MUST NOT be subclasses of
+      each other — they represent different audit trails.
+      DO: per-method disposition ("1 DDL DROP = primitive, multi-DDL
+      sequence = orchestrator"). Existing call sites fixed in #508+#517:
+      VisualMigrationBuilder (primitive), NotNullHandler (primitive),
+      ColumnRemovalManager (orchestrator), RollbackManager (orchestrator),
+      AutoMigrationSystem (orchestrator).
+      Why: Conflating the two inside #508's drop_confirmation.py
+      required splitting in #517 (gh #510). Cross-SDK parity with
+      kailash-rs codify from 2026-04-19.
+      Origin: gh #510 + PR #517.
+
+  - file: rules/testing.md
+    action: amend
+    suggested_tier: global
+    reason: |
+      Add §Test-Skip Triage Decision Tree (implements gh #512 /
+      skills/test-skip-discipline/SKILL.md):
+        - ACCEPTABLE: missing dep, infra unavailable, platform constraint
+          (keep skip with reason naming the constraint)
+        - BORDERLINE: real library limitation documenting known-failing
+          edge case (convert to @pytest.mark.xfail(strict=False) with
+          full reason — preserves test body, flips on fix)
+        - BLOCKED: "TODO", "needs refactoring", "flaky", "times out",
+          empty body — DELETE the test, not silent skip. If the
+          underlying bug matters, file an issue.
+      Applied this session: 1 converted to xfail (real PG ON CONFLICT
+      limitation), 2 deleted (TODO-style), 6 entire abandoned test
+      files deleted (test_migration_path_tester, test_model_registry,
+      test_edge_dataflow_unit, test_dataflow_bug_011_012_unit,
+      test_migration_trigger_system, test_dataflow_postgresql_parameter_conversion).
+      Origin: gh #512 / PR #518.
+
+  - file: rules/deployment.md
+    action: amend
+    suggested_tier: global
+    reason: |
+      Add MUST: "TestPyPI Trusted-Publisher Registration Is Per-Package".
+      Every package published via OIDC trusted-publishing MUST be
+      registered as a pending publisher on BOTH pypi.org AND
+      test.pypi.org separately. Tag-triggered publish (push of
+      `v*` / `<pkg>-v*`) goes direct to PyPI only. workflow_dispatch
+      with `publish_to=testpypi` requires the project to be
+      pre-registered on test.pypi.org (otherwise 400
+      "Non-user identities cannot create new projects"). Field values
+      MUST match exactly: Project name, Owner
+      (terrene-foundation), Repository (kailash-py), Workflow
+      (publish-pypi.yml), Environment (testpypi).
+      DO NOT assume TestPyPI registration carries over from PyPI.
+      Evidence: 2026-04-19 release — kailash-ml PyPI publish succeeded
+      via tag push, TestPyPI workflow_dispatch failed with 400 because
+      kailash_ml project wasn't pre-registered on test.pypi.org.
+      Origin: release round-8 (2026-04-19).
+
+audit_summary:
+  prs_this_session: 9
+  pr_numbers: "#502, #503, #504, #505, #506, #507, #508, #509, #513, #515, #517, #518, #519"
+  new_tests: "~250"
+  rules_added: 1
+  rules_amended: 6 # agents.md, zero-tolerance.md, observability.md, dataflow-identifier-safety.md, testing.md, deployment.md
+  agents_amended: 1 # nexus-specialist.md
+  workspace_architecture_captured: "kailash-ml-gpu-stack (design-complete)"
+  failure_patterns_codified: 5 # worktree drift, agent budget, CodeQL __all__, LogRecord collision, TestPyPI per-package config
+  pattern_references_preserved: 2
+  pypi_packages_released: 6
+  released_versions: "kailash 2.8.7, kaizen 2.7.5, dataflow 2.0.10, nexus 2.1.0, ml 0.10.0, mcp 0.2.5"

--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1,255 +1,127 @@
 source_repo: kailash-py
 codify_date: "2026-04-19"
 codify_session: |
-  Session 2026-04-19 shipped 9 PRs (#502-#508 + #509 + #515 + #517 +
-  #518 + #519) and released 6 packages to PyPI (kailash 2.8.7,
-  kailash-kaizen 2.7.5, kailash-dataflow 2.0.10, kailash-nexus 2.1.0,
-  kailash-ml 0.10.0, kailash-mcp 0.2.5). Codify captures 9 recurring
-  institutional failure patterns:
-    1. Worktree isolation drift (ml / dataflow / kaizen / testing
-       specialists drifted back to main checkout, 4 occurrences).
-    2. Agent budget exhaustion mid-message ("Now let me write X…"
-       with no actual tool call) — 3 occurrences.
-    3. Scanner-surface symmetry variant: CodeQL `__all__` +
-       lazy `__getattr__` (PR #506 caught by #509 hotfix).
-    4. GPU-first kailash-ml architecture validated at
-       `workspaces/kailash-ml-gpu-stack/` — preserved here so it
-       survives workspace pruning.
-    5. Typed S2S client pattern (TypedServiceClient + DecoderRegistry)
-       introduced in PR #507 — now documented in nexus-specialist.
-    6. LogRecord reserved-attribute collision: `extra={"module": ...}`
-       raises `KeyError: "Attempt to overwrite 'module' in LogRecord"`
-       when mixed with kaizen-configured logging. Non-deterministic;
-       CI masks it via test-file isolation. (PR #506 → #509 hotfix)
-    7. Primitive-vs-orchestrator layer distinction for destructive
-       operations: per-DDL primitive `force_drop=True` + DropRefusedError
-       is DIFFERENT from per-migration orchestrator `force_downgrade=True`
-       + DowngradeRefusedError. Conflating the two inside one helper
-       (#508's `drop_confirmation.py`) required splitting in #517.
-    8. Cross-SDK citation audit pattern: 30 HITs / 5 MISSes across
-       `.claude/guides/deterministic-quality/` — MISSes concentrated in
-       one "aspirational prescriptive" file citing names that would
-       exist if the pattern were adopted. Fix: cite abstract pattern,
-       not literal-but-invented API. (rules/cross-sdk-inspection.md
-       MUST Rule 5 evidence)
-    9. TestPyPI trusted-publisher registration is PER-PACKAGE and
-       distinct from PyPI publisher config. Tag-triggered tag-push
-       releases bypass TestPyPI entirely; `workflow_dispatch` with
-       `publish_to=testpypi` requires the project already be
-       registered as a pending publisher on test.pypi.org (otherwise
-       400 "Non-user identities cannot create new projects").
-       kailash-ml hit this — registration is a one-time UI step per
-       package.
-  Prior proposal (2026-04-16 + 2026-04-19 append) archived to
-  archive/2026-04-19-kailash-py.yaml per rules/artifact-flow.md
-  "Archive Before Fresh" (status was distributed).
-sdk_version: 2.8.8
-coc_version: 1.0.3
+  Session 2026-04-19 rounds 9 + 10 shipped 3 bundle releases to PyPI
+  (kailash 2.8.8, kailash-dataflow 2.0.11 → 2.0.12, kailash-ml 0.11.0 →
+  0.11.1, kailash-align 0.3.2, kailash-pact 0.8.2, kailash-trust 0.1.1,
+  kaizen-agents 0.9.3), merged 9 PRs (#502-#530), and closed 4 cross-SDK
+  tickets (#510, #511, #512, #514) plus #516, #520, #525. Post-release
+  reviewer audit of the round-9 bundle caught 1 CRITICAL + 1 HIGH + 2
+  MEDIUM findings, fast-patched in round-10 (kailash-dataflow 2.0.12 +
+  kailash-ml 0.11.1). This codify captures 6 institutional patterns.
+
 status: pending_review
 
 changes:
-  - file: rules/worktree-isolation.md
-    action: created
-    suggested_tier: global
-    reason: |
-      New rule file codifying the worktree drift and agent-budget-
-      exhaustion patterns. Three MUST rules:
-        - Rule 1: Orchestrator prompts MUST pin the worktree path
-          and include a "STEP 0 — verify isolation" instruction.
-          BLOCKED rationalizations enumerated verbatim ("the
-          isolation flag handles cwd for me", etc).
-        - Rule 2: Specialist agent files MUST include a self-check
-          (git rev-parse --show-toplevel at start) so the pinning
-          contract survives prompt compression.
-        - Rule 3: Parent MUST `ls`/`Read` to verify claimed files
-          exist after agent exit. Addresses budget-exhaustion mid-
-          message ("Now let me write X..." with no tool call).
-      Path-scoped to .claude/agents/**, .claude/commands/**,
-      **/agents/**. Cross-references rules/agents.md worktree
-      directive, zero-tolerance.md Rule 2, testing.md verified-
-      numerical-claims discipline.
-      Evidence: ml-specialist, dataflow-specialist, kaizen-specialist
-      each drifted back to the main tree during PRs #502-#508;
-      kaizen round 6 and ml-specialist round 7 reported completions
-      with no actual file writes.
-    diff_lines: "+127"
+  - id: keyspace-version-bump-invalidation-parity
+    type: rule
+    severity: HIGH
+    target: rules/tenant-isolation.md
+    section: "3a. Keyspace Version Bumps Require Invalidation-Path Sweep"
+    summary: |
+      When CacheKeyGenerator bumps default keyspace version (v1→v2 for
+      BP-049), EVERY invalidation path must be audited in same PR.
+      AsyncRedisCacheAdapter.invalidate_model was left pinned to v1 —
+      write-then-invalidate on Redis silently left v2 entries in place.
+      Fix: wildcard the version segment (dataflow:v*:*) to sweep both
+      legacy and current keyspace.
+    evidence:
+      pre_fix_pr: 522 # bumped v1→v2 in CacheKeyGenerator, left invalidator pinned
+      patch_pr: 529 # wildcard fix + 2 regression tests
+      bug_class: "cache keyspace producer bumps version, consumer-side invalidator left pinned"
+    classification_suggestion: global # applies to any cache-keyspace-versioning SDK work
 
-  - file: rules/agents.md
-    action: modified
-    suggested_tier: global
-    reason: |
-      Two additions:
-        - Cross-reference to new rules/worktree-isolation.md beneath
-          the existing "MUST: Worktree Isolation for Compiling
-          Agents" section ("isolation flag is necessary but not
-          sufficient without verification layer").
-        - New "MUST: Verify Agent Deliverables Exist After Exit"
-          section — parent orchestrator MUST ls/Read claimed files
-          before trusting completion. BLOCKED rationalizations
-          include "Now let me write the file..." (with no tool
-          call). Evidence: 2 occurrences this session.
-      Kept the file ≤200 lines (141 total) per rule-authoring
-      meta-rule.
-    diff_lines: "+25"
+  - id: multi-site-kwarg-plumbing-exhaustive-audit
+    type: rule
+    severity: HIGH
+    target: rules/security.md
+    section: "Multi-Site Kwarg Plumbing"
+    summary: |
+      When a security-relevant kwarg (policy, tenant scope, clearance
+      context, audit correlation) is plumbed through a helper, EVERY
+      call site MUST be updated in same PR. BP-049 added policy +
+      model_name to validate_model; Express site got it, engine site
+      was missed. Reviewer caught post-release; fast-patched.
+    evidence:
+      pre_fix_pr: 522 # plumbed validate_model, missed DataFlowEngine.validate_record
+      patch_pr: 529 # sibling site + regression test
+      bug_class: "security kwarg plumbing incomplete across sibling call sites"
+    classification_suggestion: global
 
-  - file: rules/zero-tolerance.md
-    action: modified
-    suggested_tier: global
-    reason: |
-      Extended Rule 1a (Scanner-Surface Symmetry) with a second
-      concrete DO/DO NOT example covering the CodeQL
-      `py/modification-of-default-value` / `__all__` / lazy
-      `__getattr__` variant surfaced by PR #506:
-        - DO: eager-import new __all__ entries so CodeQL resolves
-          them at module scope.
-        - DO NOT: add to __all__ and resolve only via __getattr__
-          with the rationalization "the existing 8 entries do
-          this too".
-      The fix is to close the flag for this PR's additions;
-      grandfathered entries remain a separate workstream but are
-      NOT justification for adding more of the same.
-      Origin line updated to credit the 2026-04-19 extension.
-    diff_lines: "+23"
+  - id: all-hygiene-module-scope-public-imports
+    type: rule
+    severity: MEDIUM
+    target: rules/orphan-detection.md
+    section: "6. Module-Scope Public Imports Appear In `__all__`"
+    summary: |
+      Every module-scope public import in a package's __init__.py MUST
+      appear in __all__ unless explicitly private. kailash_ml 0.11.0
+      eagerly imported DeviceReport, device_report_from_backend_info,
+      device, use_device but omitted all four from __all__.
+      `from kailash_ml import *` dropped the advertised public API.
+    evidence:
+      pre_fix_pr: 523 # Phase 1 public API symbols added to imports
+      patch_pr: 529 # added to __all__
+      bug_class: "advertised-but-hidden public API via __all__ omission"
+    classification_suggestion: global # __all__ hygiene is universal Python discipline
 
-  - file: agents/frameworks/nexus-specialist.md
-    action: modified
-    suggested_tier: global
-    reason: |
-      Added "Typed Service Client (S2S)" section documenting
-      kailash.nexus.TypedServiceClient — thin wrapper over
-      ServiceClient with pluggable DecoderRegistry (introduced in
-      PR #507). Code example shows register() decoder, typed get()
-      with response_type, and get_raw() for untyped migration
-      paths. Cross-reference to rules/testing.md § Delegating
-      Primitives (typed/raw variants need direct test coverage
-      per BP-046 pattern).
-      Kept the file ≤400 lines (220 total) per cc-artifacts.md
-      MUST Rule 1 "no knowledge dumps".
-    diff_lines: "+17"
+  - id: cross-sdk-structural-api-divergence-disposition
+    type: rule
+    severity: MEDIUM
+    target: rules/cross-sdk-inspection.md
+    section: "3a. Structural API-Divergence Disposition"
+    summary: |
+      When sibling SDK reports a bug at an API surface this SDK doesn't
+      expose (kailash-rs#424 execute_raw(sql, params) vs Python's
+      execute_raw(sql)), disposition MUST include (a) Tier 2 test
+      through sibling binding path (Express bulk_create with shrinking
+      arity), (b) structural invariant test locking the signature so a
+      future refactor toward sibling shape fails loudly.
+    evidence:
+      issue: 525
+      pr: 528
+      bug_class: "cross-SDK structural divergence closed silently without test"
+    classification_suggestion: global
 
-  - file: workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md
-    action: preserved_reference
-    suggested_tier: skip
-    reason: |
-      Reference entry — NOT a sync candidate. The GPU-first
-      kailash-ml architecture validated this session (single
-      torch substrate, detect_backend() single routing point,
-      DeviceReport transparency contract, OOM fallback helper,
-      8 action items for ~3 implementation sessions) lives at
-      workspaces/kailash-ml-gpu-stack/ and would normally be
-      lost at workspace pruning.
-      This proposal entry exists to preserve a pointer to the
-      architecture in the institutional audit trail. The actual
-      content stays in the workspace; next implementation session
-      should open a follow-up GitHub issue referencing this
-      workspace path.
-      Key artifacts at workspaces/kailash-ml-gpu-stack/:
-        - briefs/01-user-constraints.md (user-side requirements)
-        - 01-analysis/ (original research)
-        - 04-validate/01-redteam-round1.md (1 CRITICAL + 5 HIGH)
-        - 04-validate/02-revised-stack.md (converged design)
-        - 04-validate/00-convergence.md (gap summary)
-        - journal/0001..0003 (per-finding RISK / GAP entries)
-      Convergence status: design-complete, implementation-pending
-      (cuML eviction + DeviceReport + sklearn Array API wrap +
-      OOM fallback + RL routing audit + CPU-native UMAP/HDBSCAN
-      + top-level helpers + regression tests).
-    diff_lines: "0 (reference only)"
+  - id: phantom-transitive-deps-uv-lock-upgrade
+    type: rule
+    severity: MEDIUM
+    target: rules/dependencies.md
+    section: "Phantom Transitive Deps — Resolve Via `uv lock --upgrade`, Not Local Caps"
+    summary: |
+      When pip check reports a conflict whose root is an unused
+      transitive dep, fix via uv lock --upgrade-package (lets solver
+      drop orphan) + uv sync. Adding a local cap on a package this
+      project does not import is BLOCKED. google-generativeai 0.8.6
+      installed but zero imports; held protobuf at old cap.
+    evidence:
+      patch_pr: 530
+      bug_class: "phantom transitive orphan constrains solver"
+    classification_suggestion: variant/py # uv-specific tooling; Rust/Ruby equivalents diverge
 
-  - file: rules/observability.md
-    action: amend
-    suggested_tier: global
-    reason: |
-      Add MUST rule §9 (or numbered after existing 8): "Never pass
-      reserved LogRecord attribute names via extra={}". Python's
-      logging.LogRecord reserves: msg, args, module, exc_info,
-      exc_text, stack_info, pathname, filename, name, levelname,
-      levelno, lineno, funcName, created, msecs, relativeCreated,
-      thread, threadName, processName, process. Passing any of
-      these via extra={} raises "KeyError: Attempt to overwrite 'X'
-      in LogRecord" when mixed with certain logging configurations.
-      DO: prefix domain-scoped field names (extra={"estimator_module":
-      X}). DO NOT: extra={"module": X}.
-      Why: Non-deterministic test failures (passed when isolated,
-      failed when mixed with kaizen tests). CI masks the bug.
-      Evidence: PR #506 shipped this bug; caught by round-2 redteam;
-      fixed in #509 hotfix (commit 717516f5).
-      Origin: kailash-py redteam round-2 (2026-04-19).
+  - id: post-release-reviewer-audit-gate
+    type: rule
+    severity: MEDIUM
+    target: rules/agents.md
+    section: "Quality Gates table — After release row"
+    summary: |
+      Add RECOMMENDED gate to run reviewer against the MERGED release
+      commit on main as a follow-up to the /release flow. Catches drift
+      pre-release gates missed (kwarg plumbing gaps, keyspace bumps with
+      missed invalidators). If CRIT/HIGH surfaces, patch same session
+      as x.y.z+1.
+    evidence:
+      round_9_bundle: "round-9 shipped clean pre-release; post-release reviewer found CRIT + HIGH + 2 MED"
+      round_10_patch: "dataflow 2.0.12 + ml 0.11.1 via PR #529 within 20min of round-9 merge"
+      bug_class: "pre-release gate blind spots discovered only post-ship"
+    classification_suggestion: global
 
-  - file: rules/dataflow-identifier-safety.md
-    action: amend
-    suggested_tier: global
-    reason: |
-      Add §4a "Primitive-vs-orchestrator layer distinction for
-      destructive operations". The primitive-layer rule (§4 DROP
-      statements require force_drop=True + raise DropRefusedError)
-      governs per-DDL callers. The NEW orchestrator-layer rule
-      (MigrationManager.apply_downgrade) requires force_downgrade=True
-      + raises DowngradeRefusedError because a downgrade runs
-      MULTIPLE DDL DROPs and needs a distinct refuse signal the caller
-      can catch separately. The two errors MUST NOT be subclasses of
-      each other — they represent different audit trails.
-      DO: per-method disposition ("1 DDL DROP = primitive, multi-DDL
-      sequence = orchestrator"). Existing call sites fixed in #508+#517:
-      VisualMigrationBuilder (primitive), NotNullHandler (primitive),
-      ColumnRemovalManager (orchestrator), RollbackManager (orchestrator),
-      AutoMigrationSystem (orchestrator).
-      Why: Conflating the two inside #508's drop_confirmation.py
-      required splitting in #517 (gh #510). Cross-SDK parity with
-      kailash-rs codify from 2026-04-19.
-      Origin: gh #510 + PR #517.
+summary_note: |
+  All 6 items derive from real failure modes shipped this session and
+  caught either by the post-release reviewer or by direct cross-SDK
+  inspection. Each has a concrete PR reference for loom Gate-1
+  classification. No synthetic patterns.
 
-  - file: rules/testing.md
-    action: amend
-    suggested_tier: global
-    reason: |
-      Add §Test-Skip Triage Decision Tree (implements gh #512 /
-      skills/test-skip-discipline/SKILL.md):
-        - ACCEPTABLE: missing dep, infra unavailable, platform constraint
-          (keep skip with reason naming the constraint)
-        - BORDERLINE: real library limitation documenting known-failing
-          edge case (convert to @pytest.mark.xfail(strict=False) with
-          full reason — preserves test body, flips on fix)
-        - BLOCKED: "TODO", "needs refactoring", "flaky", "times out",
-          empty body — DELETE the test, not silent skip. If the
-          underlying bug matters, file an issue.
-      Applied this session: 1 converted to xfail (real PG ON CONFLICT
-      limitation), 2 deleted (TODO-style), 6 entire abandoned test
-      files deleted (test_migration_path_tester, test_model_registry,
-      test_edge_dataflow_unit, test_dataflow_bug_011_012_unit,
-      test_migration_trigger_system, test_dataflow_postgresql_parameter_conversion).
-      Origin: gh #512 / PR #518.
-
-  - file: rules/deployment.md
-    action: amend
-    suggested_tier: global
-    reason: |
-      Add MUST: "TestPyPI Trusted-Publisher Registration Is Per-Package".
-      Every package published via OIDC trusted-publishing MUST be
-      registered as a pending publisher on BOTH pypi.org AND
-      test.pypi.org separately. Tag-triggered publish (push of
-      `v*` / `<pkg>-v*`) goes direct to PyPI only. workflow_dispatch
-      with `publish_to=testpypi` requires the project to be
-      pre-registered on test.pypi.org (otherwise 400
-      "Non-user identities cannot create new projects"). Field values
-      MUST match exactly: Project name, Owner
-      (terrene-foundation), Repository (kailash-py), Workflow
-      (publish-pypi.yml), Environment (testpypi).
-      DO NOT assume TestPyPI registration carries over from PyPI.
-      Evidence: 2026-04-19 release — kailash-ml PyPI publish succeeded
-      via tag push, TestPyPI workflow_dispatch failed with 400 because
-      kailash_ml project wasn't pre-registered on test.pypi.org.
-      Origin: release round-8 (2026-04-19).
-
-audit_summary:
-  prs_this_session: 9
-  pr_numbers: "#502, #503, #504, #505, #506, #507, #508, #509, #513, #515, #517, #518, #519"
-  new_tests: "~250"
-  rules_added: 1
-  rules_amended: 6 # agents.md, zero-tolerance.md, observability.md, dataflow-identifier-safety.md, testing.md, deployment.md
-  agents_amended: 1 # nexus-specialist.md
-  workspace_architecture_captured: "kailash-ml-gpu-stack (design-complete)"
-  failure_patterns_codified: 5 # worktree drift, agent budget, CodeQL __all__, LogRecord collision, TestPyPI per-package config
-  pattern_references_preserved: 2
-  pypi_packages_released: 6
-  released_versions: "kailash 2.8.7, kaizen 2.7.5, dataflow 2.0.10, nexus 2.1.0, ml 0.10.0, mcp 0.2.5"
+  Distribution path: loom/ Gate-1 review classifies each as global vs
+  variant; Gate-2 distributes via /sync. BUILD repo changes (rule files
+  + proposal) live in this commit; no downstream sync happens from here.

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -44,22 +44,25 @@ Reviews happen at COC phase boundaries, not per-edit. Skip only when explicitly 
 
 **Why:** Skipping gate reviews lets analysis gaps, security holes, and naming violations propagate to downstream repos where they are far more expensive to fix. Evidence: 0052-DISCOVERY §3.3 — six commits shipped without a single review because gates were phrased as "recommended." Upgrading to MUST + background agents makes reviews nearly free.
 
-| Gate                | After Phase  | Enforcement | Review                                                                        |
-| ------------------- | ------------ | ----------- | ----------------------------------------------------------------------------- |
-| Analysis complete   | `/analyze`   | RECOMMENDED | **reviewer**: Are findings complete? Gaps?                                    |
-| Plan approved       | `/todos`     | RECOMMENDED | **reviewer**: Does plan cover requirements?                                   |
-| Implementation done | `/implement` | **MUST**    | **reviewer** + **security-reviewer**: Run as parallel background agents.      |
-| Validation passed   | `/redteam`   | RECOMMENDED | **reviewer**: Are red team findings addressed?                                |
-| Knowledge captured  | `/codify`    | RECOMMENDED | **gold-standards-validator**: Naming, licensing compliance.                   |
-| Before release      | `/release`   | **MUST**    | **reviewer** + **security-reviewer** + **gold-standards-validator**: Blocking. |
+| Gate                             | After Phase          | Enforcement | Review                                                                                                                                                                                                                                                                                         |
+| -------------------------------- | -------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Analysis complete                | `/analyze`           | RECOMMENDED | **reviewer**: Are findings complete? Gaps?                                                                                                                                                                                                                                                     |
+| Plan approved                    | `/todos`             | RECOMMENDED | **reviewer**: Does plan cover requirements?                                                                                                                                                                                                                                                    |
+| Implementation done              | `/implement`         | **MUST**    | **reviewer** + **security-reviewer**: Run as parallel background agents.                                                                                                                                                                                                                       |
+| Validation passed                | `/redteam`           | RECOMMENDED | **reviewer**: Are red team findings addressed?                                                                                                                                                                                                                                                 |
+| Knowledge captured               | `/codify`            | RECOMMENDED | **gold-standards-validator**: Naming, licensing compliance.                                                                                                                                                                                                                                    |
+| Before release                   | `/release`           | **MUST**    | **reviewer** + **security-reviewer** + **gold-standards-validator**: Blocking.                                                                                                                                                                                                                 |
+| After release (post-merge audit) | `/release` follow-up | RECOMMENDED | **reviewer** run against the MERGED release commit on main. Catches drift that pre-release review missed (e.g., a kwarg plumbing gap in a sibling call site, a keyspace bump with a missed invalidator). If CRIT/HIGH surfaces, open a patch branch in the SAME session and ship as `x.y.z+1`. |
 
 **BLOCKED responses when skipping MUST gates:**
+
 - "Skipping review to save time"
 - "Reviews will happen in a follow-up session"
 - "The changes are straightforward, no review needed"
 - "Already reviewed informally during implementation"
 
 **Background agent pattern for MUST gates** — the review costs nearly zero parent context:
+
 ```
 # At end of /implement, spawn reviews in background:
 Agent({subagent_type: "reviewer", run_in_background: true, prompt: "Review all changes since last gate..."})

--- a/.claude/rules/cross-sdk-inspection.md
+++ b/.claude/rules/cross-sdk-inspection.md
@@ -50,6 +50,52 @@ Per EATP SDK conventions (D6: independent implementation, matching semantics):
 
 **Why:** Semantic divergence between SDKs means code ported from Python to Rust (or vice versa) silently changes behavior, breaking user trust in the platform's cross-language promise.
 
+### 3a. Structural API-Divergence Disposition
+
+When the sibling SDK reports a bug at an API surface this SDK does NOT expose (e.g., the Rust `execute_raw(sql, params)` bug class requires a `params` arg that the Python `execute_raw(sql)` doesn't have), the disposition MUST include BOTH:
+
+1. **A Tier 2 test through the sibling path that DOES bind parameters** — the bug class may still manifest at a different API surface in this SDK (e.g., Express `bulk_create`, `update`, `upsert`). The test mirrors the sibling SDK's repro scenario through the equivalent parameter-binding path in this SDK.
+2. **A structural invariant test that pins the signature** — asserts the API signature that prevents the bug class from existing at this surface (e.g., `execute_raw` takes only `sql` as a positional arg, no `params`). If a future refactor grows the signature to match the sibling SDK's shape, the invariant test fails loudly and forces a re-audit.
+
+```python
+# DO — both tests; one exercises the sibling path, one locks the signature
+@pytest.mark.regression
+async def test_issue_XXX_cross_sdk_parity_via_sibling_path(test_suite):
+    # The Rust bug triggered at execute_raw(sql, params). Python execute_raw
+    # has no params. The parameter-binding path in Python is Express.bulk_create.
+    db = DataFlow(test_suite.config.url)
+    # ... exercise shrinking-arity bulk_create against real Postgres
+    assert poisoned_result.get("success") is True
+
+@pytest.mark.regression
+def test_issue_XXX_execute_raw_has_no_params_arg():
+    # Structural invariant: if this signature ever grows a `params` kwarg,
+    # the sibling bug class becomes reachable here and cross-SDK parity
+    # MUST be re-audited.
+    import inspect
+    from dataflow.core.pool_lightweight import LightweightPool
+    sig = inspect.signature(LightweightPool.execute_raw)
+    non_self = [p.name for n, p in sig.parameters.items() if n != "self"]
+    assert non_self == ["sql"], f"signature drifted: {sig}"
+
+# DO NOT — close the cross-SDK issue with only a hand-waving comment
+gh issue close XXX --comment "N/A — Python execute_raw has no params arg"
+# ↑ no test, no invariant; a future refactor silently reopens the bug class
+#   and the original sibling-report loses its correlation
+```
+
+**BLOCKED rationalizations:**
+
+- "The signatures are obviously different, no test needed"
+- "Our implementation can't have that bug"
+- "The structural invariant is enforced by the type system"
+- "Cross-SDK is belt-and-suspenders; one test is enough"
+- "We'll add the invariant test when the signature changes"
+
+**Why:** "Our signature doesn't have the arg" is true today and false the day someone ports a convenience method from the sibling SDK. The structural invariant test is the only mechanism that makes the signature _itself_ part of the contract — the moment the signature grows toward the sibling shape, the test fails and the agent reading the failure has a direct pointer back to the cross-SDK bug class. The sibling-path Tier 2 test proves the bug class does not manifest through the surface it COULD manifest through; without it, "different API" conceals a parallel bug the other SDK's API shape hid. Evidence: issue #525 (cross-SDK of kailash-rs#424) — Python `execute_raw(sql)` structurally cannot hit the Rust binding-layer UTF-8 corruption; disposition landed both an Express `bulk_create` sibling-path test AND a signature invariant test locking `LightweightPool.execute_raw(sql)` at PR #528.
+
+Origin: Issue #525 / PR #528 (2026-04-19) — kailash-rs#424 parity check.
+
 ### 4. Inspection Checklist
 
 When closing any issue, verify:

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -187,3 +187,42 @@ cargo check --quiet
 ```
 
 Any unmet, missing, or conflicting dependency BLOCKS the gate.
+
+### Phantom Transitive Deps — Resolve Via `uv lock --upgrade`, Not Local Caps
+
+When `pip check` reports a conflict whose root cause is a transitive package that no source file actually imports, the fix MUST be `uv lock --upgrade-package <phantom> <constrained_siblings>` followed by `uv sync` — which drops the unused dep and re-solves. Adding a local `<N` cap on a package this project does not directly import is BLOCKED (see § "No Caps on Transitive Dependencies" above).
+
+```bash
+# DO — diagnose the phantom, upgrade, drop
+$ uv pip check
+The package `grpcio-status` requires protobuf<6.0.dev0, but 6.33.6 is installed
+The package `google-ai-generativelanguage` requires protobuf<6.0.0.dev0, but 6.33.6 is installed
+
+# Trace the source (no src/ imports google.generativeai → phantom):
+$ grep -rln 'import google\.generativeai\|from google\.generativeai' src/ packages/ | head
+# (empty)
+
+$ uv lock --upgrade-package grpcio-status --upgrade-package google-ai-generativelanguage \
+          --upgrade-package google-generativeai --upgrade-package protobuf
+$ uv sync --extra dev  # or whichever extras you use
+$ uv pip check
+Checked 224 packages in 2ms. All installed packages are compatible
+
+# DO NOT — pin the transitive locally
+# pyproject.toml
+dependencies = [
+    ...,
+    "protobuf>=5.26,<6.0",   # capping a package we don't import
+]
+```
+
+**BLOCKED rationalizations:**
+
+- "A local cap is faster than chasing the transitive tree"
+- "Pinning protobuf keeps the tree stable"
+- "We'll drop the cap once upstream catches up"
+- "`uv lock --upgrade` is risky, could break other deps"
+
+**Why:** A local cap on a package this project does not directly import is purely speculative — no code could break if it upgrades, and the cap just blocks every downstream user from getting patches. Phantom-transitive conflicts almost always resolve by dropping the phantom (`uv lock --upgrade` lets the solver drop installs with zero consumers). When upstream actually holds the constraint legitimately, the solver will report that — which is the signal to upgrade THAT package, not to local-cap the transitive. Evidence: PR #530 (2026-04-19) — `google-generativeai 0.8.6` installed but zero imports; `uv lock --upgrade-package` dropped it + two transitive orphans (`google-ai-generativelanguage`, `grpcio-status 1.71.2`); `pip check` became clean without a local cap.
+
+Origin: PR #530 (2026-04-19) — phantom `google-generativeai` held protobuf solver at an old cap.

--- a/.claude/rules/orphan-detection.md
+++ b/.claude/rules/orphan-detection.md
@@ -110,6 +110,47 @@ Any PR that removes a public symbol (module, class, function, attribute) MUST de
 
 **Why:** Collection failures are invisible in "unit-only CI" setups yet become merge-blocking the moment someone runs the full suite locally. The only way to keep the full suite runnable is to gate every PR on collect-only-green.
 
+### 6. Module-Scope Public Imports Appear In `__all__`
+
+When a symbol is imported at module-scope into a package's `__init__.py` (not behind `_` / not lazy via `__getattr__`), it MUST appear in that module's `__all__` list unless the symbol itself is private (leading underscore). New `__all__` entries MUST land in the same PR as the import. Eagerly-imported-but-absent-from-`__all__` is BLOCKED.
+
+```python
+# DO — every public module-scope import appears in __all__
+# packages/kailash-ml/src/kailash_ml/__init__.py
+from kailash_ml._device_report import (
+    DeviceReport,
+    device_report_from_backend_info,
+)
+
+__all__ = [
+    "__version__",
+    "DeviceReport",
+    "device_report_from_backend_info",
+    ...
+]
+
+# DO NOT — public symbol imported but missing from __all__
+from kailash_ml._device_report import DeviceReport, device_report_from_backend_info
+
+__all__ = [
+    "__version__",
+    # DeviceReport, device_report_from_backend_info → absent
+    # Result: `from kailash_ml import *` drops the advertised public API
+]
+```
+
+**BLOCKED rationalizations:**
+
+- "The symbol is reachable via `kailash_ml.DeviceReport`, that's enough"
+- "Nobody uses `from pkg import *`"
+- "`__all__` is a convention, not a contract"
+- "We'll clean up `__all__` in a follow-up"
+- "The symbol is eagerly imported; the package re-exports it implicitly"
+
+**Why:** `__all__` is the package's public-API contract: documentation generators (Sphinx autodoc), linters, typing tools (`mypy --strict`), and `from pkg import *` consumers all read it as the canonical export list. A symbol that the agent "eagerly imports" but never lists is both advertised (via the import) AND hidden (via `__all__`) — that inconsistency is the exact failure shape the orphan pattern produces on the consumer side. The fix is a one-line addition in the same PR; deferring it means the advertised feature ships broken for every tool that respects `__all__`. Evidence: PR #523 (kailash-ml 0.11.0) eagerly imported `DeviceReport` / `device_report_from_backend_info` / `device` / `use_device` but omitted all four from `__all__`; caught by post-release reviewer; patched in PR #529 (kailash-ml 0.11.1).
+
+Origin: PR #523 / PR #529 (2026-04-19) — GPU-first Phase 1 public API symbols missed from `__all__`.
+
 ## MUST NOT
 
 - Land a `db.X` / `app.X` facade without the production call site in the same PR

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -174,6 +174,42 @@ Values of declared-safe types (`int`, `float`, `bool`, `Decimal`, `datetime`, `d
 
 Origin: GitHub issues #492 (bulk_upsert SQLi via string-escape) + #493 (sanitizer contract drift, 3 pre-existing failing tests). The contract above pins the decision so a future refactor doesn't swing back to quote-escape.
 
+## Multi-Site Kwarg Plumbing
+
+When a security-relevant kwarg (classification policy, tenant scope, clearance context, audit correlation ID) is plumbed through a helper, EVERY call site of that helper MUST be updated in the SAME PR. Updating the "primary" call site and deferring siblings is BLOCKED.
+
+```python
+# DO — grep every caller, update every sibling, same PR
+# Helper added `policy` + `model_name` kwargs for classification sanitisation.
+#
+# $ grep -rn 'validate_model(' src/ packages/
+# packages/kailash-dataflow/src/dataflow/features/express.py:_validate_if_enabled
+# packages/kailash-dataflow/src/dataflow/engine.py::validate_record
+# tests/...  (tests covered separately)
+#
+# Both production call sites get policy+model_name in this PR:
+engine.validate_record(instance) -> validate_model(instance, policy=..., model_name=...)
+express._validate_if_enabled(...) -> validate_model(instance, policy=..., model_name=...)
+
+# DO NOT — update primary site, skip the sibling
+express._validate_if_enabled(...) -> validate_model(instance, policy=..., model_name=...)
+engine.validate_record(instance)  -> validate_model(instance)   # bypasses sanitiser
+# ↑ The unpatched sibling surface still leaks classified field names / values in
+#   error messages; the sanitisation contract is broken on one public entry point.
+```
+
+**BLOCKED rationalizations:**
+
+- "The primary call site is the one users hit 99% of the time"
+- "The sibling is rarely used; we'll patch it in a follow-up"
+- "The helper signature is backwards-compatible, sibling can stay as-is"
+- "Test coverage will catch divergence later"
+- "The kwarg has a safe default — siblings still get baseline behaviour"
+
+**Why:** A helper that takes a security-relevant kwarg has the kwarg precisely because the unqualified call leaks or misbehaves. Leaving any sibling call site on the unqualified signature ships the exact failure mode the kwarg was introduced to fix; the "safe default" is by definition the insecure default (otherwise the kwarg would not exist). The fix is mechanical — `grep -rn 'helper_name(' .` and patch every hit in the same PR. Evidence: BP-049 (2026-04-19) landed `validate_model(policy=..., model_name=...)` in PR #522 but left `DataFlowEngine.validate_record(instance)` unqualified; post-release reviewer caught it; fast-patched in PR #529 (kailash-dataflow 2.0.12).
+
+Origin: PR #522 / PR #529 (2026-04-19) — BP-049 validation sanitiser plumbing missed one sibling.
+
 ## Kailash-Specific Security
 
 - **DataFlow**: Access controls on models, validate at model level, never expose internal IDs

--- a/.claude/rules/tenant-isolation.md
+++ b/.claude/rules/tenant-isolation.md
@@ -67,6 +67,34 @@ async def invalidate_model(self, model: str) -> int:
 
 **Why:** A user invalidating "their" cache should not clear every other tenant's cache. Tenant-scoped invalidation also enables targeted cache busting on tenant-specific events (a single tenant's password rotation, a single tenant's quota change).
 
+### 3a. Keyspace Version Bumps Require Invalidation-Path Sweep
+
+When the default keyspace version emitted by `CacheKeyGenerator` (or equivalent key-constructor) is bumped — e.g. `v1 → v2` for a cross-SDK parity change or a classification-hash format change — EVERY invalidation entry point in the codebase MUST be audited and updated in the same PR. The safest disposition is to match the version segment as a wildcard (`dataflow:v*:*`) so legacy keys AND current keys are swept in one call.
+
+```python
+# DO — version-wildcard sweep, future-proof
+if tenant_id is not None:
+    express_pattern = f"dataflow:v*:{tenant_id}:{model_name}:*"
+else:
+    express_pattern = f"dataflow:v*:{model_name}:*"
+query_pattern = f"dataflow:{model_name}:v*:*"
+
+# DO NOT — version-pinned sweep after the generator bumps
+express_pattern = f"dataflow:v1:{model_name}:*"   # misses every v2 entry
+query_pattern = f"dataflow:{model_name}:v1:*"
+```
+
+**BLOCKED rationalizations:**
+
+- "The invalidation path runs rarely, v1 entries will expire on their own TTL"
+- "We'll update the invalidation in a follow-up PR"
+- "The generator default can be reverted if it causes issues"
+- "Only one adapter pins the old version; the others are fine"
+
+**Why:** A cache keyspace bump is a producer-side change that silently breaks every consumer-side invalidator pinned to the old version. Write-then-invalidate leaves stale entries on the shared backend (Redis, Memcached, etc.) indefinitely; TTL-based eventual-expiry is not a substitute because TTLs are often multi-hour and users observe the stale reads in the meantime. Evidence: kailash-dataflow 2.0.11 shipped with `CacheKeyGenerator` default `v1→v2` but `AsyncRedisCacheAdapter.invalidate_model` left pinned at `v1`; post-release reviewer caught it and it was fast-patched in 2.0.12 via PR #529. Version-wildcard sweeps are the structural defense — the only invalidation code that survives the next keyspace bump unchanged.
+
+Origin: PR #522 / PR #529 (2026-04-19) — BP-049 keyspace bump `v1→v2`; Redis invalidator missed in the producer-side update.
+
 ### 4. Metric Labels Carry Tenant_id (Bounded)
 
 Metrics that count per-tenant operations (`requests_total`, `cache_hits_total`, `errors_total`) MAY include `tenant_id` as a label, BUT label cardinality MUST be bounded. Unbounded `tenant_id` labels in Prometheus produce a metric series per tenant which exhausts memory at scale.


### PR DESCRIPTION
## Summary

Codify pass capturing 6 institutional patterns from round-9 + round-10 (2026-04-19). Every rule addition cites concrete PR evidence.

## Rule changes

| # | File | Section | Evidence |
|---|---|---|---|
| 1 | \`rules/tenant-isolation.md\` | §3a Keyspace Version Bumps | PR #522 / #529 |
| 2 | \`rules/security.md\` | Multi-Site Kwarg Plumbing | PR #522 / #529 |
| 3 | \`rules/orphan-detection.md\` | §6 \`__all__\` hygiene | PR #523 / #529 |
| 4 | \`rules/cross-sdk-inspection.md\` | §3a Structural Divergence | Issue #525 / PR #528 |
| 5 | \`rules/dependencies.md\` | Phantom Transitive Deps | PR #530 |
| 6 | \`rules/agents.md\` | Quality Gates: Post-release row | round-9/10 |

## Proposal

- \`.claude/.proposals/archive/2026-04-19-kailash-py-round-10.yaml\` — round-8 proposal archived (was status: distributed)
- \`.claude/.proposals/latest.yaml\` — fresh \`pending_review\` with 6 entries + classification suggestions (5 global, 1 variant/py) for loom/ Gate-1

## Test plan

- [x] All rule additions follow \`rules/rule-authoring.md\` (MUST/BLOCKED/DO-DO NOT/Why/Origin)
- [x] No source code or public API changes
- [x] Proposal follows artifact-flow lifecycle (archive before fresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)