### PR TITLE
fix(nexus): release 2.1.1 — drive on_startup/on_shutdown directly (#531)

### DIFF
--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.1.0"
+version = "2.1.1"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -96,7 +96,7 @@ from .errors import RateLimitError, ServiceUnavailableError
 from .errors import TimeoutError as NexusTimeoutError
 from .errors import UnauthorizedError, ValidationError
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 __all__ = [
     # Core
     "Nexus",

--- a/src/kailash/servers/workflow_server.py
+++ b/src/kailash/servers/workflow_server.py
@@ -5,6 +5,7 @@ WorkflowAPIGateway with clearer naming and better organization.
 """
 
 import asyncio
+import inspect
 import logging
 import time
 from collections import defaultdict, deque
@@ -220,7 +221,20 @@ class WorkflowServer:
                 extra={"title": title, "version": version},
             )
             try:
-                await app.router.startup()
+                # Iterate `router.on_startup` directly rather than
+                # calling a dispatch method. FastAPI has shipped both
+                # `.startup()` (older) and `._startup()` (newer) over
+                # the years and upgrades flip which one exists; the
+                # on_startup list itself is the only stable surface.
+                # Issue #531: nexus 2.1.0 shipped with `app.router.startup()`
+                # which crashed production FastAPI builds that only
+                # expose `_startup`. Driving the list directly matches
+                # what `_DefaultLifespan` does internally and survives
+                # FastAPI/Starlette version churn.
+                for handler in app.router.on_startup:
+                    result = handler()
+                    if inspect.iscoroutine(result):
+                        await result
                 # Run injected Nexus plugin startup hooks inside uvicorn's
                 # loop so any background tasks they spawn survive (#501).
                 if startup_hook is not None:
@@ -261,7 +275,11 @@ class WorkflowServer:
                             exc_info=True,
                         )
                 try:
-                    await app.router.shutdown()
+                    # Paired with the on_startup iteration above — see #531.
+                    for handler in app.router.on_shutdown:
+                        result = handler()
+                        if inspect.iscoroutine(result):
+                            await result
                 except Exception:
                     logger.warning(
                         "workflow_server.lifespan.router_shutdown_failed",

--- a/tests/regression/test_issue_531_nexus_lifespan_startup_shutdown.py
+++ b/tests/regression/test_issue_531_nexus_lifespan_startup_shutdown.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: issue #531 — Nexus 2.1.0 lifespan called non-existent
+``app.router.startup()`` / ``app.router.shutdown()`` on some FastAPI
+versions.
+
+The #500 fix shipped in kailash-nexus 2.1.0 (commit 1535f4be) invoked
+``app.router.startup()`` + ``app.router.shutdown()`` believing them to
+be stable Starlette coroutines. FastAPI has shipped both
+``.startup()`` and the underscore-prefixed ``._startup()`` at
+different points, and the version installed in some production
+deployments (per the issue reporter) exposed only ``_startup``. Every
+production Nexus service on 2.1.0 against that FastAPI version failed
+at uvicorn lifespan startup with
+``AttributeError: 'APIRouter' object has no attribute 'startup'``.
+
+The fix (2.1.1): iterate ``router.on_startup`` / ``router.on_shutdown``
+directly, awaiting any coroutine results. This is what FastAPI's own
+``_DefaultLifespan`` does internally and survives every FastAPI /
+Starlette version transition — there is no dispatch method name to
+drift.
+
+These tests:
+
+1. ``test_workflow_server_lifespan_runs_on_startup_hooks`` —
+   behavioural reproduction: construct a WorkflowServer, register
+   ``on_startup`` + ``on_shutdown`` handlers on the FastAPI router,
+   drive the lifespan context, assert both handlers fire. On 2.1.0
+   this raised ``AttributeError`` before the ``yield``; on 2.1.1+ it
+   completes cleanly.
+
+2. ``test_lifespan_survives_missing_startup_method`` — structural
+   pin: the lifespan implementation MUST NOT call any method named
+   ``startup`` / ``shutdown`` / ``_startup`` / ``_shutdown`` on
+   ``app.router``. Driving ``on_startup`` / ``on_shutdown`` lists is
+   the only version-stable surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+
+from kailash.servers.workflow_server import WorkflowServer
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_workflow_server_lifespan_runs_on_startup_hooks() -> None:
+    """Lifespan MUST run registered on_startup + on_shutdown handlers.
+
+    Reproduction of the #531 crash: constructing a WorkflowServer,
+    registering on_startup / on_shutdown handlers, and driving the
+    FastAPI lifespan context manager must fire both.
+    """
+    server = WorkflowServer(title="issue-531-regression", version="test")
+
+    startup_calls: list[str] = []
+    shutdown_calls: list[str] = []
+
+    async def _on_startup() -> None:
+        startup_calls.append("fired")
+
+    async def _on_shutdown() -> None:
+        shutdown_calls.append("fired")
+
+    app: FastAPI = server.app
+    app.router.on_startup.append(_on_startup)
+    app.router.on_shutdown.append(_on_shutdown)
+
+    # Drive the lifespan via FastAPI's bound context — the exact path
+    # uvicorn uses at boot. On 2.1.0 this raised AttributeError inside
+    # the context manager because `app.router.startup()` did not exist.
+    async with app.router.lifespan_context(app):
+        assert startup_calls == ["fired"], (
+            f"on_startup handler did not fire during lifespan; "
+            f"workflow_server.lifespan regressed "
+            f"(startup_calls={startup_calls!r})"
+        )
+
+    assert shutdown_calls == ["fired"], (
+        f"on_shutdown handler did not fire during lifespan teardown; "
+        f"workflow_server.lifespan shutdown regressed "
+        f"(shutdown_calls={shutdown_calls!r})"
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_lifespan_fires_handlers_even_when_dispatch_methods_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lifespan MUST fire on_startup / on_shutdown handlers even when
+    the FastAPI APIRouter exposes NEITHER ``.startup()`` NOR
+    ``._startup()``.
+
+    This is the structural defense against #531: FastAPI has shipped
+    both method names at different points, so the only version-stable
+    path is iterating the ``on_startup`` / ``on_shutdown`` lists. This
+    test patches BOTH dispatch method names off the APIRouter to prove
+    the lifespan never calls them — if the lifespan regresses to
+    calling either method, this test raises ``AttributeError`` inside
+    the context manager.
+    """
+    server = WorkflowServer(title="issue-531-no-dispatch", version="test")
+    app: FastAPI = server.app
+
+    # Poison both potential dispatch method names — if the lifespan
+    # calls either, the call raises and the test fails. Simulates
+    # the issue reporter's FastAPI version where one of the two
+    # raised AttributeError; confirms the fix doesn't depend on
+    # either method existing.
+    def _poisoned(*_args: object, **_kwargs: object) -> None:
+        raise AttributeError(
+            "workflow_server.lifespan called a version-drifting "
+            "dispatch method (startup/_startup/shutdown/_shutdown) — "
+            "it should iterate router.on_startup / router.on_shutdown "
+            "directly per #531."
+        )
+
+    for attr in ("startup", "shutdown", "_startup", "_shutdown"):
+        monkeypatch.setattr(app.router, attr, _poisoned, raising=False)
+
+    fired: list[str] = []
+
+    async def _on_startup() -> None:
+        fired.append("startup")
+
+    async def _on_shutdown() -> None:
+        fired.append("shutdown")
+
+    app.router.on_startup.append(_on_startup)
+    app.router.on_shutdown.append(_on_shutdown)
+
+    async with app.router.lifespan_context(app):
+        assert fired == ["startup"], (
+            f"on_startup did not fire when dispatch methods were "
+            f"removed — lifespan is calling a version-drifting method "
+            f"rather than iterating on_startup directly. See #531."
+        )
+
+    assert fired == ["startup", "shutdown"], (
+        f"on_shutdown did not fire when dispatch methods were "
+        f"removed — lifespan teardown is calling a version-drifting "
+        f"method. See #531."
+    )


### PR DESCRIPTION
## Summary

Nexus 2.1.0 crashes every production service at lifespan startup on FastAPI versions that don't expose `app.router.startup()` / `app.router.shutdown()`. FastAPI ships both `.startup()` and `._startup()` at different points; nexus 2.1.0 assumed the public form existed everywhere.

**Fix:** iterate `router.on_startup` / `router.on_shutdown` directly, awaiting coroutine results. This is what FastAPI's own `_DefaultLifespan` does internally and survives every version transition — no dispatch method name to drift.

## Regression tests

- \`test_workflow_server_lifespan_runs_on_startup_hooks\` — behavioural reproduction via FastAPI \`lifespan_context\`.
- \`test_lifespan_fires_handlers_even_when_dispatch_methods_missing\` — monkey-patches BOTH \`startup\` and \`_startup\` to raise; asserts lifespan still fires. If the fix regresses to calling either dispatch name, this test fails loudly.

Both tests pass locally against FastAPI 0.128.0. The second test would also pass against older FastAPI builds that only exposed `_startup` — that's the point.

## Test plan

- [x] 2 regression tests pass
- [x] kailash-nexus 2.1.0 → 2.1.1 atomic (pyproject + \`__version__\`)
- [x] No API change to WorkflowServer / Nexus public surface

## Related issues

Fixes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)