### PR TITLE
fix(deps): tighten kailash-nexus extras floor to >=2.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dataflow = [
     "kailash-dataflow>=2.0.12",
 ]
 nexus = [
-    "kailash-nexus>=2.1.0",
+    "kailash-nexus>=2.1.1",
 ]
 kaizen = [
     "kailash-kaizen>=2.7.5",
@@ -150,7 +150,7 @@ docs = [
 # Everything (core + all sub-packages with their optional deps)
 all = [
     "kailash-dataflow>=2.0.12",
-    "kailash-nexus>=2.1.0",
+    "kailash-nexus>=2.1.1",
     "kailash-kaizen>=2.7.5",
     "kaizen-agents>=0.9.3",
     "kailash-pact>=0.8.2",


### PR DESCRIPTION
## Summary

- `kailash-nexus 2.1.0` is a CRITICAL broken release (issue #531) — every production Nexus service crashed at uvicorn lifespan startup
- The `[nexus]` and `[all]` extras in root `pyproject.toml` still pointed at `>=2.1.0`, allowing pip to install the broken version
- Raises the floor to `>=2.1.1` now that 2.1.1 is published on PyPI (tagged `nexus-v2.1.1`)

## Related issues

Closes the follow-up item from the nexus-v2.1.1 hotfix release. Related to #531.