### PR TITLE
chore(deploy): update deployment-config.md nexus version to 2.1.1

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -20,7 +20,7 @@
 | kailash (core)   | `v*`               | 2.8.8           |
 | kailash-dataflow | `dataflow-v*`      | 2.0.11          |
 | kailash-kaizen   | `kaizen-v*`        | 2.7.5           |
-| kailash-nexus    | `nexus-v*`         | 2.1.0           |
+| kailash-nexus    | `nexus-v*`         | 2.1.1           |
 | kailash-pact     | `pact-v*`          | 0.8.2           |
 | kailash-ml       | `ml-v*`            | 0.11.0          |
 | kailash-align    | `align-v*`         | 0.3.2           |


### PR DESCRIPTION
## Summary

- Updates the deployment config table to record kailash-nexus current version as 2.1.1
- 2.1.0 is a CRITICAL broken release (issue #531); 2.1.1 is now live on PyPI

## Related issues

Follow-up from #531, #533, #534, #535.