### PR TITLE
feat(ml): kailash-ml 0.12.0 — GPU-first Phase 1 punch list complete

### DIFF
--- a/.claude/.proposals/archive/2026-04-19-kailash-py-round-10.yaml
+++ b/.claude/.proposals/archive/2026-04-19-kailash-py-round-10.yaml
@@ -1,256 +1,218 @@
 source_repo: kailash-py
 codify_date: "2026-04-19"
 codify_session: |
-  Session 2026-04-19 shipped 9 PRs (#502-#508 + #509 + #515 + #517 +
-  #518 + #519) and released 6 packages to PyPI (kailash 2.8.7,
-  kailash-kaizen 2.7.5, kailash-dataflow 2.0.10, kailash-nexus 2.1.0,
-  kailash-ml 0.10.0, kailash-mcp 0.2.5). Codify captures 9 recurring
-  institutional failure patterns:
-    1. Worktree isolation drift (ml / dataflow / kaizen / testing
-       specialists drifted back to main checkout, 4 occurrences).
-    2. Agent budget exhaustion mid-message ("Now let me write X…"
-       with no actual tool call) — 3 occurrences.
-    3. Scanner-surface symmetry variant: CodeQL `__all__` +
-       lazy `__getattr__` (PR #506 caught by #509 hotfix).
-    4. GPU-first kailash-ml architecture validated at
-       `workspaces/kailash-ml-gpu-stack/` — preserved here so it
-       survives workspace pruning.
-    5. Typed S2S client pattern (TypedServiceClient + DecoderRegistry)
-       introduced in PR #507 — now documented in nexus-specialist.
-    6. LogRecord reserved-attribute collision: `extra={"module": ...}`
-       raises `KeyError: "Attempt to overwrite 'module' in LogRecord"`
-       when mixed with kaizen-configured logging. Non-deterministic;
-       CI masks it via test-file isolation. (PR #506 → #509 hotfix)
-    7. Primitive-vs-orchestrator layer distinction for destructive
-       operations: per-DDL primitive `force_drop=True` + DropRefusedError
-       is DIFFERENT from per-migration orchestrator `force_downgrade=True`
-       + DowngradeRefusedError. Conflating the two inside one helper
-       (#508's `drop_confirmation.py`) required splitting in #517.
-    8. Cross-SDK citation audit pattern: 30 HITs / 5 MISSes across
-       `.claude/guides/deterministic-quality/` — MISSes concentrated in
-       one "aspirational prescriptive" file citing names that would
-       exist if the pattern were adopted. Fix: cite abstract pattern,
-       not literal-but-invented API. (rules/cross-sdk-inspection.md
-       MUST Rule 5 evidence)
-    9. TestPyPI trusted-publisher registration is PER-PACKAGE and
-       distinct from PyPI publisher config. Tag-triggered tag-push
-       releases bypass TestPyPI entirely; `workflow_dispatch` with
-       `publish_to=testpypi` requires the project already be
-       registered as a pending publisher on test.pypi.org (otherwise
-       400 "Non-user identities cannot create new projects").
-       kailash-ml hit this — registration is a one-time UI step per
-       package.
-  Prior proposal (2026-04-16 + 2026-04-19 append) archived to
-  archive/2026-04-19-kailash-py.yaml per rules/artifact-flow.md
-  "Archive Before Fresh" (status was distributed).
-sdk_version: 2.8.8
-coc_version: 1.0.3
+  Session 2026-04-19 rounds 9 + 10 shipped 3 bundle releases to PyPI
+  (kailash 2.8.8, kailash-dataflow 2.0.11 → 2.0.12, kailash-ml 0.11.0 →
+  0.11.1, kailash-align 0.3.2, kailash-pact 0.8.2, kailash-trust 0.1.1,
+  kaizen-agents 0.9.3), merged 9 PRs (#502-#530), and closed 4 cross-SDK
+  tickets (#510, #511, #512, #514) plus #516, #520, #525. Post-release
+  reviewer audit of the round-9 bundle caught 1 CRITICAL + 1 HIGH + 2
+  MEDIUM findings, fast-patched in round-10 (kailash-dataflow 2.0.12 +
+  kailash-ml 0.11.1). This codify captures 6 institutional patterns.
+
 status: distributed
+review_date: "2026-04-19"
+review_target_loom_version: "2.8.19"
 distributed_date: "2026-04-19"
 
 changes:
-  - file: rules/worktree-isolation.md
-    action: created
-    suggested_tier: global
-    reason: |
-      New rule file codifying the worktree drift and agent-budget-
-      exhaustion patterns. Three MUST rules:
-        - Rule 1: Orchestrator prompts MUST pin the worktree path
-          and include a "STEP 0 — verify isolation" instruction.
-          BLOCKED rationalizations enumerated verbatim ("the
-          isolation flag handles cwd for me", etc).
-        - Rule 2: Specialist agent files MUST include a self-check
-          (git rev-parse --show-toplevel at start) so the pinning
-          contract survives prompt compression.
-        - Rule 3: Parent MUST `ls`/`Read` to verify claimed files
-          exist after agent exit. Addresses budget-exhaustion mid-
-          message ("Now let me write X..." with no tool call).
-      Path-scoped to .claude/agents/**, .claude/commands/**,
-      **/agents/**. Cross-references rules/agents.md worktree
-      directive, zero-tolerance.md Rule 2, testing.md verified-
-      numerical-claims discipline.
-      Evidence: ml-specialist, dataflow-specialist, kaizen-specialist
-      each drifted back to the main tree during PRs #502-#508;
-      kaizen round 6 and ml-specialist round 7 reported completions
-      with no actual file writes.
-    diff_lines: "+127"
+  - id: keyspace-version-bump-invalidation-parity
+    type: rule
+    severity: HIGH
+    target: rules/tenant-isolation.md
+    section: "3a. Keyspace Version Bumps Require Invalidation-Path Sweep"
+    summary: |
+      When CacheKeyGenerator bumps default keyspace version (v1→v2 for
+      BP-049), EVERY invalidation path must be audited in same PR.
+      AsyncRedisCacheAdapter.invalidate_model was left pinned to v1 —
+      write-then-invalidate on Redis silently left v2 entries in place.
+      Fix: wildcard the version segment (dataflow:v*:*) to sweep both
+      legacy and current keyspace.
+    evidence:
+      pre_fix_pr: 522 # bumped v1→v2 in CacheKeyGenerator, left invalidator pinned
+      patch_pr: 529 # wildcard fix + 2 regression tests
+      bug_class: "cache keyspace producer bumps version, consumer-side invalidator left pinned"
+    classification_suggestion: global # applies to any cache-keyspace-versioning SDK work
+    review_notes:
+      classification: global
+      action: copy-section-from-BUILD
+      target_loom_path: .claude/rules/tenant-isolation.md
+      loom_section_anchor: "### 3a. Keyspace Version Bumps Require Invalidation-Path Sweep"
+      line_delta: +28
+      cross_sdk_flag: "kailash-rs parallel — if rs CacheKeyGenerator bumps keyspace, same sweep discipline applies"
+      notes: "Pattern is cache-keyspace-versioning generic. Python examples kept; no BUILD-internal path refs leaked."
 
-  - file: rules/agents.md
-    action: modified
-    suggested_tier: global
-    reason: |
-      Two additions:
-        - Cross-reference to new rules/worktree-isolation.md beneath
-          the existing "MUST: Worktree Isolation for Compiling
-          Agents" section ("isolation flag is necessary but not
-          sufficient without verification layer").
-        - New "MUST: Verify Agent Deliverables Exist After Exit"
-          section — parent orchestrator MUST ls/Read claimed files
-          before trusting completion. BLOCKED rationalizations
-          include "Now let me write the file..." (with no tool
-          call). Evidence: 2 occurrences this session.
-      Kept the file ≤200 lines (141 total) per rule-authoring
-      meta-rule.
-    diff_lines: "+25"
+  - id: multi-site-kwarg-plumbing-exhaustive-audit
+    type: rule
+    severity: HIGH
+    target: rules/security.md
+    section: "Multi-Site Kwarg Plumbing"
+    summary: |
+      When a security-relevant kwarg (policy, tenant scope, clearance
+      context, audit correlation) is plumbed through a helper, EVERY
+      call site MUST be updated in same PR. BP-049 added policy +
+      model_name to validate_model; Express site got it, engine site
+      was missed. Reviewer caught post-release; fast-patched.
+    evidence:
+      pre_fix_pr: 522 # plumbed validate_model, missed DataFlowEngine.validate_record
+      patch_pr: 529 # sibling site + regression test
+      bug_class: "security kwarg plumbing incomplete across sibling call sites"
+    classification_suggestion: global
+    review_notes:
+      classification: global
+      action: copy-section-from-BUILD
+      target_loom_path: .claude/rules/security.md
+      loom_section_anchor: "## Multi-Site Kwarg Plumbing"
+      line_delta: +35
+      cross_sdk_flag: "kailash-rs parallel — same grep-every-caller discipline on trust/policy plumbing"
+      notes: "Cross-language applicable. Trimmed example to keep cross-SDK neutral."
 
-  - file: rules/zero-tolerance.md
-    action: modified
-    suggested_tier: global
-    reason: |
-      Extended Rule 1a (Scanner-Surface Symmetry) with a second
-      concrete DO/DO NOT example covering the CodeQL
-      `py/modification-of-default-value` / `__all__` / lazy
-      `__getattr__` variant surfaced by PR #506:
-        - DO: eager-import new __all__ entries so CodeQL resolves
-          them at module scope.
-        - DO NOT: add to __all__ and resolve only via __getattr__
-          with the rationalization "the existing 8 entries do
-          this too".
-      The fix is to close the flag for this PR's additions;
-      grandfathered entries remain a separate workstream but are
-      NOT justification for adding more of the same.
-      Origin line updated to credit the 2026-04-19 extension.
-    diff_lines: "+23"
+  - id: all-hygiene-module-scope-public-imports
+    type: rule
+    severity: MEDIUM
+    target: rules/orphan-detection.md
+    section: "6. Module-Scope Public Imports Appear In `__all__`"
+    summary: |
+      Every module-scope public import in a package's __init__.py MUST
+      appear in __all__ unless explicitly private. kailash_ml 0.11.0
+      eagerly imported DeviceReport, device_report_from_backend_info,
+      device, use_device but omitted all four from __all__.
+      `from kailash_ml import *` dropped the advertised public API.
+    evidence:
+      pre_fix_pr: 523 # Phase 1 public API symbols added to imports
+      patch_pr: 529 # added to __all__
+      bug_class: "advertised-but-hidden public API via __all__ omission"
+    classification_suggestion: global # __all__ hygiene is universal Python discipline
+    review_notes:
+      classification: global
+      action: copy-section-from-BUILD-with-path-adaptation
+      target_loom_path: .claude/rules/orphan-detection.md
+      loom_section_anchor: "### 6. Module-Scope Public Imports Appear In `__all__`"
+      line_delta: +41
+      cross_sdk_flag: "no — Python-specific (`__all__` is Python); Rust has no equivalent (use `pub`/`pub use`). If kailash-rs needs `pub use` hygiene the rule is distinct."
+      notes: "Generalized kailash_ml → pkg placeholder to keep rule cross-package. Python-only pattern; OK as global because py is majority lang + rb variant follows same pattern."
 
-  - file: agents/frameworks/nexus-specialist.md
-    action: modified
-    suggested_tier: global
-    reason: |
-      Added "Typed Service Client (S2S)" section documenting
-      kailash.nexus.TypedServiceClient — thin wrapper over
-      ServiceClient with pluggable DecoderRegistry (introduced in
-      PR #507). Code example shows register() decoder, typed get()
-      with response_type, and get_raw() for untyped migration
-      paths. Cross-reference to rules/testing.md § Delegating
-      Primitives (typed/raw variants need direct test coverage
-      per BP-046 pattern).
-      Kept the file ≤400 lines (220 total) per cc-artifacts.md
-      MUST Rule 1 "no knowledge dumps".
-    diff_lines: "+17"
+  - id: cross-sdk-structural-api-divergence-disposition
+    type: rule
+    severity: MEDIUM
+    target: rules/cross-sdk-inspection.md
+    section: "3a. Structural API-Divergence Disposition"
+    summary: |
+      When sibling SDK reports a bug at an API surface this SDK doesn't
+      expose (kailash-rs#424 execute_raw(sql, params) vs Python's
+      execute_raw(sql)), disposition MUST include (a) Tier 2 test
+      through sibling binding path (Express bulk_create with shrinking
+      arity), (b) structural invariant test locking the signature so a
+      future refactor toward sibling shape fails loudly.
+    evidence:
+      issue: 525
+      pr: 528
+      bug_class: "cross-SDK structural divergence closed silently without test"
+    classification_suggestion: global
+    review_notes:
+      classification: global
+      action: author-new-section-from-proposal
+      target_loom_path: .claude/rules/cross-sdk-inspection.md
+      loom_section_anchor: "### 3a. Structural API-Divergence Disposition"
+      line_delta: +40
+      cross_sdk_flag: "kailash-rs parallel ticket — extend the sibling pattern bidirectionally when rs#424 closes"
+      notes: "Authored from proposal (no BUILD-side extension yet). Example uses Python-side Express/bulk_create but principle is cross-SDK; cross-sdk-inspection.md is itself a global cross-SDK rule so this placement is correct."
 
-  - file: workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md
-    action: preserved_reference
-    suggested_tier: skip
-    reason: |
-      Reference entry — NOT a sync candidate. The GPU-first
-      kailash-ml architecture validated this session (single
-      torch substrate, detect_backend() single routing point,
-      DeviceReport transparency contract, OOM fallback helper,
-      8 action items for ~3 implementation sessions) lives at
-      workspaces/kailash-ml-gpu-stack/ and would normally be
-      lost at workspace pruning.
-      This proposal entry exists to preserve a pointer to the
-      architecture in the institutional audit trail. The actual
-      content stays in the workspace; next implementation session
-      should open a follow-up GitHub issue referencing this
-      workspace path.
-      Key artifacts at workspaces/kailash-ml-gpu-stack/:
-        - briefs/01-user-constraints.md (user-side requirements)
-        - 01-analysis/ (original research)
-        - 04-validate/01-redteam-round1.md (1 CRITICAL + 5 HIGH)
-        - 04-validate/02-revised-stack.md (converged design)
-        - 04-validate/00-convergence.md (gap summary)
-        - journal/0001..0003 (per-finding RISK / GAP entries)
-      Convergence status: design-complete, implementation-pending
-      (cuML eviction + DeviceReport + sklearn Array API wrap +
-      OOM fallback + RL routing audit + CPU-native UMAP/HDBSCAN
-      + top-level helpers + regression tests).
-    diff_lines: "0 (reference only)"
+  - id: phantom-transitive-deps-uv-lock-upgrade
+    type: rule
+    severity: MEDIUM
+    target: rules/dependencies.md
+    section: "Phantom Transitive Deps — Resolve Via `uv lock --upgrade`, Not Local Caps"
+    summary: |
+      When pip check reports a conflict whose root is an unused
+      transitive dep, fix via uv lock --upgrade-package (lets solver
+      drop orphan) + uv sync. Adding a local cap on a package this
+      project does not import is BLOCKED. google-generativeai 0.8.6
+      installed but zero imports; held protobuf at old cap.
+    evidence:
+      patch_pr: 530
+      bug_class: "phantom transitive orphan constrains solver"
+    classification_suggestion: variant/py # uv-specific tooling; Rust/Ruby equivalents diverge
+    review_notes:
+      classification: global
+      action: author-new-section-multi-ecosystem
+      target_loom_path: .claude/rules/dependencies.md
+      loom_section_anchor: "## Phantom Transitive Deps — Resolve Via Lockfile Upgrade, Not Local Caps"
+      line_delta: +30
+      cross_sdk_flag: "Pattern is cross-ecosystem. Title generalized from `uv lock --upgrade` to `Lockfile Upgrade`; examples cover uv + cargo + npm. Kailash-rs should apply same discipline to Cargo.lock phantoms."
+      notes: "Override classification_suggestion=variant/py → global. The pattern (phantom transitive constrains solver, fix via lockfile-level upgrade not manifest cap) generalizes; only the tooling verbs differ. dependencies.md is already multi-language per frontmatter."
 
-  - file: rules/observability.md
-    action: amend
-    suggested_tier: global
-    reason: |
-      Add MUST rule §9 (or numbered after existing 8): "Never pass
-      reserved LogRecord attribute names via extra={}". Python's
-      logging.LogRecord reserves: msg, args, module, exc_info,
-      exc_text, stack_info, pathname, filename, name, levelname,
-      levelno, lineno, funcName, created, msecs, relativeCreated,
-      thread, threadName, processName, process. Passing any of
-      these via extra={} raises "KeyError: Attempt to overwrite 'X'
-      in LogRecord" when mixed with certain logging configurations.
-      DO: prefix domain-scoped field names (extra={"estimator_module":
-      X}). DO NOT: extra={"module": X}.
-      Why: Non-deterministic test failures (passed when isolated,
-      failed when mixed with kaizen tests). CI masks the bug.
-      Evidence: PR #506 shipped this bug; caught by round-2 redteam;
-      fixed in #509 hotfix (commit 717516f5).
-      Origin: kailash-py redteam round-2 (2026-04-19).
+  - id: post-release-reviewer-audit-gate
+    type: rule
+    severity: MEDIUM
+    target: rules/agents.md
+    section: "Quality Gates table — After release row"
+    summary: |
+      Add RECOMMENDED gate to run reviewer against the MERGED release
+      commit on main as a follow-up to the /release flow. Catches drift
+      pre-release gates missed (kwarg plumbing gaps, keyspace bumps with
+      missed invalidators). If CRIT/HIGH surfaces, patch same session
+      as x.y.z+1.
+    evidence:
+      round_9_bundle: "round-9 shipped clean pre-release; post-release reviewer found CRIT + HIGH + 2 MED"
+      round_10_patch: "dataflow 2.0.12 + ml 0.11.1 via PR #529 within 20min of round-9 merge"
+      bug_class: "pre-release gate blind spots discovered only post-ship"
+    classification_suggestion: global
+    review_notes:
+      classification: global
+      action: extend-existing-table
+      target_loom_path: .claude/rules/agents.md
+      loom_section_anchor: "Quality Gates (MUST — Gate-Level Review) — table row: After release"
+      line_delta: +1 # row added; column widths widened
+      cross_sdk_flag: "kailash-rs parallel — same post-release audit discipline applies"
+      notes: "Copied from BUILD verbatim into Quality Gates table. Pure process rule, no code adaptation needed."
 
-  - file: rules/dataflow-identifier-safety.md
-    action: amend
-    suggested_tier: global
-    reason: |
-      Add §4a "Primitive-vs-orchestrator layer distinction for
-      destructive operations". The primitive-layer rule (§4 DROP
-      statements require force_drop=True + raise DropRefusedError)
-      governs per-DDL callers. The NEW orchestrator-layer rule
-      (MigrationManager.apply_downgrade) requires force_downgrade=True
-      + raises DowngradeRefusedError because a downgrade runs
-      MULTIPLE DDL DROPs and needs a distinct refuse signal the caller
-      can catch separately. The two errors MUST NOT be subclasses of
-      each other — they represent different audit trails.
-      DO: per-method disposition ("1 DDL DROP = primitive, multi-DDL
-      sequence = orchestrator"). Existing call sites fixed in #508+#517:
-      VisualMigrationBuilder (primitive), NotNullHandler (primitive),
-      ColumnRemovalManager (orchestrator), RollbackManager (orchestrator),
-      AutoMigrationSystem (orchestrator).
-      Why: Conflating the two inside #508's drop_confirmation.py
-      required splitting in #517 (gh #510). Cross-SDK parity with
-      kailash-rs codify from 2026-04-19.
-      Origin: gh #510 + PR #517.
+  - id: framework-dispatch-method-drift-iterate-the-data
+    type: rule
+    severity: HIGH
+    target: rules/framework-first.md
+    section: "Framework version-stable integration — drive the data, not the method"
+    summary: |
+      kailash-nexus 2.1.0 shipped calling `app.router.startup()` +
+      `.shutdown()` as if they were stable FastAPI/Starlette coroutines.
+      FastAPI has shipped BOTH `.startup()` AND `._startup()` at
+      different versions; some production FastAPI builds exposed only
+      `_startup`. Every Nexus 2.1.0 service crashed at uvicorn lifespan
+      with AttributeError. Fix (2.1.1): iterate the `on_startup` /
+      `on_shutdown` LIST directly (what FastAPI's own _DefaultLifespan
+      does internally). The list is the stable surface; dispatch method
+      names drift.
 
-  - file: rules/testing.md
-    action: amend
-    suggested_tier: global
-    reason: |
-      Add §Test-Skip Triage Decision Tree (implements gh #512 /
-      skills/test-skip-discipline/SKILL.md):
-        - ACCEPTABLE: missing dep, infra unavailable, platform constraint
-          (keep skip with reason naming the constraint)
-        - BORDERLINE: real library limitation documenting known-failing
-          edge case (convert to @pytest.mark.xfail(strict=False) with
-          full reason — preserves test body, flips on fix)
-        - BLOCKED: "TODO", "needs refactoring", "flaky", "times out",
-          empty body — DELETE the test, not silent skip. If the
-          underlying bug matters, file an issue.
-      Applied this session: 1 converted to xfail (real PG ON CONFLICT
-      limitation), 2 deleted (TODO-style), 6 entire abandoned test
-      files deleted (test_migration_path_tester, test_model_registry,
-      test_edge_dataflow_unit, test_dataflow_bug_011_012_unit,
-      test_migration_trigger_system, test_dataflow_postgresql_parameter_conversion).
-      Origin: gh #512 / PR #518.
+      Rule extraction: when integrating with an external framework's
+      lifecycle hook, if both (a) a dispatch method name, and (b) a
+      list/dict of registered handlers are exposed, the data structure
+      is the stable surface across versions. Dispatch method names are
+      subject to underscore-prefix transitions and removal. Drive the
+      data; don't call the dispatch.
+    evidence:
+      issue: 531
+      pre_fix_pr: none # bug shipped in #501 which became nexus 2.1.0
+      patch_pr: 533 # iterate on_startup/on_shutdown lists
+      bug_class: "framework dispatch method name drift across versions"
+      regression_tests:
+        - test_workflow_server_lifespan_runs_on_startup_hooks
+        - test_lifespan_fires_handlers_even_when_dispatch_methods_missing
+    classification_suggestion: global # applies to any Python framework integration (FastAPI, Starlette, aiohttp, etc.)
+    review_notes:
+      classification: global
+      action: author-new-section-from-proposal-cross-language
+      target_loom_path: .claude/rules/framework-first.md
+      loom_section_anchor: "## Framework Version-Stable Integration — Drive The Data, Not The Dispatch"
+      line_delta: +44
+      cross_sdk_flag: "Pattern is cross-language (FastAPI/Starlette/aiohttp in Python; Axum/actix layers + Rails/Rack middleware analogs). Added Rust DO/DO NOT examples. Kailash-rs nexus-rs binding should mirror the same discipline."
+      notes: "Authored from proposal directly (BUILD has no extension yet). framework-first.md is already dual-path py/rs via frontmatter — global placement correct."
 
-  - file: rules/deployment.md
-    action: amend
-    suggested_tier: global
-    reason: |
-      Add MUST: "TestPyPI Trusted-Publisher Registration Is Per-Package".
-      Every package published via OIDC trusted-publishing MUST be
-      registered as a pending publisher on BOTH pypi.org AND
-      test.pypi.org separately. Tag-triggered publish (push of
-      `v*` / `<pkg>-v*`) goes direct to PyPI only. workflow_dispatch
-      with `publish_to=testpypi` requires the project to be
-      pre-registered on test.pypi.org (otherwise 400
-      "Non-user identities cannot create new projects"). Field values
-      MUST match exactly: Project name, Owner
-      (terrene-foundation), Repository (kailash-py), Workflow
-      (publish-pypi.yml), Environment (testpypi).
-      DO NOT assume TestPyPI registration carries over from PyPI.
-      Evidence: 2026-04-19 release — kailash-ml PyPI publish succeeded
-      via tag push, TestPyPI workflow_dispatch failed with 400 because
-      kailash_ml project wasn't pre-registered on test.pypi.org.
-      Origin: release round-8 (2026-04-19).
+summary_note: |
+  All 7 items derive from real failure modes shipped this session and
+  caught either by the post-release reviewer or by direct cross-SDK
+  inspection. Each has a concrete PR reference for loom Gate-1
+  classification. No synthetic patterns.
 
-audit_summary:
-  prs_this_session: 9
-  pr_numbers: "#502, #503, #504, #505, #506, #507, #508, #509, #513, #515, #517, #518, #519"
-  new_tests: "~250"
-  rules_added: 1
-  rules_amended: 6 # agents.md, zero-tolerance.md, observability.md, dataflow-identifier-safety.md, testing.md, deployment.md
-  agents_amended: 1 # nexus-specialist.md
-  workspace_architecture_captured: "kailash-ml-gpu-stack (design-complete)"
-  failure_patterns_codified: 5 # worktree drift, agent budget, CodeQL __all__, LogRecord collision, TestPyPI per-package config
-  pattern_references_preserved: 2
-  pypi_packages_released: 6
-  released_versions: "kailash 2.8.7, kaizen 2.7.5, dataflow 2.0.10, nexus 2.1.0, ml 0.10.0, mcp 0.2.5"
+  Distribution path: loom/ Gate-1 review classifies each as global vs
+  variant; Gate-2 distributes via /sync. BUILD repo changes (rule files
+  + proposal) live in this commit; no downstream sync happens from here.

--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1,218 +1,130 @@
 source_repo: kailash-py
 codify_date: "2026-04-19"
 codify_session: |
-  Session 2026-04-19 rounds 9 + 10 shipped 3 bundle releases to PyPI
-  (kailash 2.8.8, kailash-dataflow 2.0.11 → 2.0.12, kailash-ml 0.11.0 →
-  0.11.1, kailash-align 0.3.2, kailash-pact 0.8.2, kailash-trust 0.1.1,
-  kaizen-agents 0.9.3), merged 9 PRs (#502-#530), and closed 4 cross-SDK
-  tickets (#510, #511, #512, #514) plus #516, #520, #525. Post-release
-  reviewer audit of the round-9 bundle caught 1 CRITICAL + 1 HIGH + 2
-  MEDIUM findings, fast-patched in round-10 (kailash-dataflow 2.0.12 +
-  kailash-ml 0.11.1). This codify captures 6 institutional patterns.
+  Session 2026-04-19 ML GPU-first Phase 1 punch list (items 3/4/5/7/8) shipped
+  on feat/ml-gpu-phase1-integration with 13 commits. The implementation used
+  3 parallel ml-specialist agents in worktrees — and surfaced 3 institutional
+  failure modes that this codify captures as rule additions to rules/agents.md.
 
-status: distributed
-review_date: "2026-04-19"
-review_target_loom_version: "2.8.19"
-distributed_date: "2026-04-19"
+  Background: ml-specialist Shards A/B/C launched in parallel with
+  isolation="worktree" + absolute-path prompts. Shard A's agent truncated mid-
+  message before committing; the empty worktree was auto-cleaned and ~300 LOC
+  of SklearnTrainable Array-API rewrite was lost. Shard B's agent self-corrected
+  by detecting absolute-path leak to MAIN and rewriting against its worktree.
+  Shard C's agent truncated with uncommitted changes; orchestrator rescued via
+  WIP commit immediately on notification. Subsequent gate-level reviewer
+  APPROVED with minor fixes; /redteam mechanical sweep caught a HIGH spec-
+  compliance gap (TorchTrainable + LightningTrainable returning TrainingResult
+  without device=DeviceReport — 2 of 7 family adapters missed the wire-up
+  even though spec mandates "every fit returns one"). Fix landed inline; AST
+  regression invariant test added.
+
+status: pending_review
+review_date: null
+review_target_loom_version: "2.8.20"
+distributed_date: null
 
 changes:
-  - id: keyspace-version-bump-invalidation-parity
+  - id: worktree-prompts-relative-paths
     type: rule
     severity: HIGH
-    target: rules/tenant-isolation.md
-    section: "3a. Keyspace Version Bumps Require Invalidation-Path Sweep"
-    summary: |
-      When CacheKeyGenerator bumps default keyspace version (v1→v2 for
-      BP-049), EVERY invalidation path must be audited in same PR.
-      AsyncRedisCacheAdapter.invalidate_model was left pinned to v1 —
-      write-then-invalidate on Redis silently left v2 entries in place.
-      Fix: wildcard the version segment (dataflow:v*:*) to sweep both
-      legacy and current keyspace.
-    evidence:
-      pre_fix_pr: 522 # bumped v1→v2 in CacheKeyGenerator, left invalidator pinned
-      patch_pr: 529 # wildcard fix + 2 regression tests
-      bug_class: "cache keyspace producer bumps version, consumer-side invalidator left pinned"
-    classification_suggestion: global # applies to any cache-keyspace-versioning SDK work
-    review_notes:
-      classification: global
-      action: copy-section-from-BUILD
-      target_loom_path: .claude/rules/tenant-isolation.md
-      loom_section_anchor: "### 3a. Keyspace Version Bumps Require Invalidation-Path Sweep"
-      line_delta: +28
-      cross_sdk_flag: "kailash-rs parallel — if rs CacheKeyGenerator bumps keyspace, same sweep discipline applies"
-      notes: "Pattern is cache-keyspace-versioning generic. Python examples kept; no BUILD-internal path refs leaked."
-
-  - id: multi-site-kwarg-plumbing-exhaustive-audit
-    type: rule
-    severity: HIGH
-    target: rules/security.md
-    section: "Multi-Site Kwarg Plumbing"
-    summary: |
-      When a security-relevant kwarg (policy, tenant scope, clearance
-      context, audit correlation) is plumbed through a helper, EVERY
-      call site MUST be updated in same PR. BP-049 added policy +
-      model_name to validate_model; Express site got it, engine site
-      was missed. Reviewer caught post-release; fast-patched.
-    evidence:
-      pre_fix_pr: 522 # plumbed validate_model, missed DataFlowEngine.validate_record
-      patch_pr: 529 # sibling site + regression test
-      bug_class: "security kwarg plumbing incomplete across sibling call sites"
-    classification_suggestion: global
-    review_notes:
-      classification: global
-      action: copy-section-from-BUILD
-      target_loom_path: .claude/rules/security.md
-      loom_section_anchor: "## Multi-Site Kwarg Plumbing"
-      line_delta: +35
-      cross_sdk_flag: "kailash-rs parallel — same grep-every-caller discipline on trust/policy plumbing"
-      notes: "Cross-language applicable. Trimmed example to keep cross-SDK neutral."
-
-  - id: all-hygiene-module-scope-public-imports
-    type: rule
-    severity: MEDIUM
-    target: rules/orphan-detection.md
-    section: "6. Module-Scope Public Imports Appear In `__all__`"
-    summary: |
-      Every module-scope public import in a package's __init__.py MUST
-      appear in __all__ unless explicitly private. kailash_ml 0.11.0
-      eagerly imported DeviceReport, device_report_from_backend_info,
-      device, use_device but omitted all four from __all__.
-      `from kailash_ml import *` dropped the advertised public API.
-    evidence:
-      pre_fix_pr: 523 # Phase 1 public API symbols added to imports
-      patch_pr: 529 # added to __all__
-      bug_class: "advertised-but-hidden public API via __all__ omission"
-    classification_suggestion: global # __all__ hygiene is universal Python discipline
-    review_notes:
-      classification: global
-      action: copy-section-from-BUILD-with-path-adaptation
-      target_loom_path: .claude/rules/orphan-detection.md
-      loom_section_anchor: "### 6. Module-Scope Public Imports Appear In `__all__`"
-      line_delta: +41
-      cross_sdk_flag: "no — Python-specific (`__all__` is Python); Rust has no equivalent (use `pub`/`pub use`). If kailash-rs needs `pub use` hygiene the rule is distinct."
-      notes: "Generalized kailash_ml → pkg placeholder to keep rule cross-package. Python-only pattern; OK as global because py is majority lang + rb variant follows same pattern."
-
-  - id: cross-sdk-structural-api-divergence-disposition
-    type: rule
-    severity: MEDIUM
-    target: rules/cross-sdk-inspection.md
-    section: "3a. Structural API-Divergence Disposition"
-    summary: |
-      When sibling SDK reports a bug at an API surface this SDK doesn't
-      expose (kailash-rs#424 execute_raw(sql, params) vs Python's
-      execute_raw(sql)), disposition MUST include (a) Tier 2 test
-      through sibling binding path (Express bulk_create with shrinking
-      arity), (b) structural invariant test locking the signature so a
-      future refactor toward sibling shape fails loudly.
-    evidence:
-      issue: 525
-      pr: 528
-      bug_class: "cross-SDK structural divergence closed silently without test"
-    classification_suggestion: global
-    review_notes:
-      classification: global
-      action: author-new-section-from-proposal
-      target_loom_path: .claude/rules/cross-sdk-inspection.md
-      loom_section_anchor: "### 3a. Structural API-Divergence Disposition"
-      line_delta: +40
-      cross_sdk_flag: "kailash-rs parallel ticket — extend the sibling pattern bidirectionally when rs#424 closes"
-      notes: "Authored from proposal (no BUILD-side extension yet). Example uses Python-side Express/bulk_create but principle is cross-SDK; cross-sdk-inspection.md is itself a global cross-SDK rule so this placement is correct."
-
-  - id: phantom-transitive-deps-uv-lock-upgrade
-    type: rule
-    severity: MEDIUM
-    target: rules/dependencies.md
-    section: "Phantom Transitive Deps — Resolve Via `uv lock --upgrade`, Not Local Caps"
-    summary: |
-      When pip check reports a conflict whose root is an unused
-      transitive dep, fix via uv lock --upgrade-package (lets solver
-      drop orphan) + uv sync. Adding a local cap on a package this
-      project does not import is BLOCKED. google-generativeai 0.8.6
-      installed but zero imports; held protobuf at old cap.
-    evidence:
-      patch_pr: 530
-      bug_class: "phantom transitive orphan constrains solver"
-    classification_suggestion: variant/py # uv-specific tooling; Rust/Ruby equivalents diverge
-    review_notes:
-      classification: global
-      action: author-new-section-multi-ecosystem
-      target_loom_path: .claude/rules/dependencies.md
-      loom_section_anchor: "## Phantom Transitive Deps — Resolve Via Lockfile Upgrade, Not Local Caps"
-      line_delta: +30
-      cross_sdk_flag: "Pattern is cross-ecosystem. Title generalized from `uv lock --upgrade` to `Lockfile Upgrade`; examples cover uv + cargo + npm. Kailash-rs should apply same discipline to Cargo.lock phantoms."
-      notes: "Override classification_suggestion=variant/py → global. The pattern (phantom transitive constrains solver, fix via lockfile-level upgrade not manifest cap) generalizes; only the tooling verbs differ. dependencies.md is already multi-language per frontmatter."
-
-  - id: post-release-reviewer-audit-gate
-    type: rule
-    severity: MEDIUM
     target: rules/agents.md
-    section: "Quality Gates table — After release row"
+    section: "MUST: Worktree Prompts Use Relative Paths Only"
     summary: |
-      Add RECOMMENDED gate to run reviewer against the MERGED release
-      commit on main as a follow-up to the /release flow. Catches drift
-      pre-release gates missed (kwarg plumbing gaps, keyspace bumps with
-      missed invalidators). If CRIT/HIGH surfaces, patch same session
-      as x.y.z+1.
-    evidence:
-      round_9_bundle: "round-9 shipped clean pre-release; post-release reviewer found CRIT + HIGH + 2 MED"
-      round_10_patch: "dataflow 2.0.12 + ml 0.11.1 via PR #529 within 20min of round-9 merge"
-      bug_class: "pre-release gate blind spots discovered only post-ship"
+      Agents launched with isolation="worktree" + prompts referencing
+      absolute paths (/Users/...) silently write to the PARENT checkout
+      instead of their worktree. Empty worktrees auto-clean; the agent's
+      work is lost OR silently appears in main. Existing § "MUST: Worktree
+      Isolation" mentions the verification layer but does not flag the
+      absolute-path foot-gun. New section adds the relative-paths-only
+      directive with BLOCKED rationalizations + DO/DO NOT example.
     classification_suggestion: global
-    review_notes:
-      classification: global
-      action: extend-existing-table
-      target_loom_path: .claude/rules/agents.md
-      loom_section_anchor: "Quality Gates (MUST — Gate-Level Review) — table row: After release"
-      line_delta: +1 # row added; column widths widened
-      cross_sdk_flag: "kailash-rs parallel — same post-release audit discipline applies"
-      notes: "Copied from BUILD verbatim into Quality Gates table. Pure process rule, no code adaptation needed."
+    rationale: |
+      The failure mode is language-agnostic (Rust shards in kailash-rs would
+      hit the same write-to-main leak). Cross-SDK-applicable.
+    evidence:
+      session: "2026-04-19"
+      commit_sha: pending
+      occurrences: 2 of 3 parallel shards
+      lost_work_loc: "~300 (Shard A SklearnTrainable Array-API)"
 
-  - id: framework-dispatch-method-drift-iterate-the-data
+  - id: worktree-agents-commit-incremental
     type: rule
     severity: HIGH
-    target: rules/framework-first.md
-    section: "Framework version-stable integration — drive the data, not the method"
+    target: rules/agents.md
+    section: "MUST: Worktree Agents Commit Incremental Progress"
     summary: |
-      kailash-nexus 2.1.0 shipped calling `app.router.startup()` +
-      `.shutdown()` as if they were stable FastAPI/Starlette coroutines.
-      FastAPI has shipped BOTH `.startup()` AND `._startup()` at
-      different versions; some production FastAPI builds exposed only
-      `_startup`. Every Nexus 2.1.0 service crashed at uvicorn lifespan
-      with AttributeError. Fix (2.1.1): iterate the `on_startup` /
-      `on_shutdown` LIST directly (what FastAPI's own _DefaultLifespan
-      does internally). The list is the stable surface; dispatch method
-      names drift.
-
-      Rule extraction: when integrating with an external framework's
-      lifecycle hook, if both (a) a dispatch method name, and (b) a
-      list/dict of registered handlers are exposed, the data structure
-      is the stable surface across versions. Dispatch method names are
-      subject to underscore-prefix transitions and removal. Drive the
-      data; don't call the dispatch.
+      Agents in worktrees that don't `git commit` before exit lose 100% of
+      their output to worktree auto-cleanup. The existing § "MUST: Verify
+      Agent Deliverables" catches silent no-ops AFTER the fact but cannot
+      recover files that were only in a cleaned-up worktree. New section
+      mandates explicit "commit after each milestone" instruction in
+      worktree-agent prompts + orchestrator verification of ≥1 commit on
+      the branch before declaring work landed.
+    classification_suggestion: global
+    rationale: |
+      Same root cause as worktree-prompts-relative-paths but distinct
+      mitigation. Both apply to any language.
     evidence:
-      issue: 531
-      pre_fix_pr: none # bug shipped in #501 which became nexus 2.1.0
-      patch_pr: 533 # iterate on_startup/on_shutdown lists
-      bug_class: "framework dispatch method name drift across versions"
-      regression_tests:
-        - test_workflow_server_lifespan_runs_on_startup_hooks
-        - test_lifespan_fires_handlers_even_when_dispatch_methods_missing
-    classification_suggestion: global # applies to any Python framework integration (FastAPI, Starlette, aiohttp, etc.)
-    review_notes:
-      classification: global
-      action: author-new-section-from-proposal-cross-language
-      target_loom_path: .claude/rules/framework-first.md
-      loom_section_anchor: "## Framework Version-Stable Integration — Drive The Data, Not The Dispatch"
-      line_delta: +44
-      cross_sdk_flag: "Pattern is cross-language (FastAPI/Starlette/aiohttp in Python; Axum/actix layers + Rails/Rack middleware analogs). Added Rust DO/DO NOT examples. Kailash-rs nexus-rs binding should mirror the same discipline."
-      notes: "Authored from proposal directly (BUILD has no extension yet). framework-first.md is already dual-path py/rs via frontmatter — global placement correct."
+      session: "2026-04-19"
+      occurrences: 3 of 3 parallel shards truncated; 2 lost work
+      mitigation_proven: Shard B (commit-before-exit emphasis) + Shard C
+        (orchestrator WIP rescue commit)
+
+  - id: reviewer-mechanical-sweep
+    type: rule
+    severity: HIGH
+    target: rules/agents.md
+    section: "MUST: Reviewer Prompts Include Mechanical AST/Grep Sweep"
+    summary: |
+      Gate-level reviewer prompts that only show the diff miss orphans in
+      OLD lines that the spec also touches. New section mandates explicit
+      mechanical sweeps (parity greps, collect-only, pip check, __all__
+      verification) in every reviewer prompt BEFORE LLM judgment. The
+      sweeps catch what's missing from untouched code that the new public
+      surface implicitly required.
+    classification_suggestion: global
+    rationale: |
+      Mechanical sweeps complement (don't replace) LLM judgment review.
+      Cross-SDK-applicable: Rust gate reviewers face the same scope
+      limitation when reviewing diffs.
+    evidence:
+      session: "2026-04-19"
+      finding_caught_by_sweep: |
+        TorchTrainable + LightningTrainable missing device=DeviceReport in
+        return TrainingResult (2 of 7 return sites). Reviewer APPROVED;
+        /redteam parity grep caught it in 4 seconds. Fixed inline at commit
+        1e233dcd with AST regression invariant test.
+
+cross_sdk_parity:
+  - kailash-rs equivalent: |
+      kailash-rs has the SAME parallel-shard / worktree / reviewer patterns.
+      All 3 rule additions apply 1:1. After loom/ Gate-1 review classifies
+      as global, kailash-rs's coc-claude-rs template inherits via /sync.
+
+post_release_followups:
+  - id: predictions-device-field
+    severity: MEDIUM
+    target: kailash-ml 0.12.1
+    summary: |
+      Predictions class missing `device: Optional[DeviceReport]` field;
+      spec mandates "every predict returns one" but only the FIT half of
+      the transparency contract shipped in 0.12.0. Disclosed in CHANGELOG
+      Known Limitations + journal 0005-GAP. ~40 LOC + 150 LOC tests.
+
+  - id: rules-agents-md-length
+    severity: LOW
+    target: loom Gate-2
+    summary: |
+      rules/agents.md is now 244 lines — exceeds cc-artifacts.md cap of
+      200. Considered acceptable because the 3 new sections each follow
+      rule-authoring.md meta-rule (MUST + BLOCKED + DO/DO NOT + Why +
+      Origin). Future codify could extract worktree-isolation sections
+      into rules/worktree-isolation.md (already referenced by agents.md
+      §95 as a sibling rule).
 
 summary_note: |
-  All 7 items derive from real failure modes shipped this session and
-  caught either by the post-release reviewer or by direct cross-SDK
-  inspection. Each has a concrete PR reference for loom Gate-1
-  classification. No synthetic patterns.
-
-  Distribution path: loom/ Gate-1 review classifies each as global vs
-  variant; Gate-2 distributes via /sync. BUILD repo changes (rule files
-  + proposal) live in this commit; no downstream sync happens from here.
+  3 rule additions, all HIGH, all targeting rules/agents.md. All 3 follow
+  rule-authoring.md meta-rule (Loud/Linguistic/Layered). Origin: Session
+  2026-04-19 ML GPU-first Phase 1 parallel-shard experiment failure modes.
+  Cross-SDK applicable; classification_suggestion: global for all 3.

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -70,6 +70,41 @@ Agent({subagent_type: "security-reviewer", run_in_background: true, prompt: "Sec
 # Parent continues; reviews arrive as notifications
 ```
 
+### MUST: Reviewer Prompts Include Mechanical AST/Grep Sweep, Not Only Diff Review
+
+Every gate-level reviewer prompt MUST include explicit mechanical sweeps that verify ABSOLUTE state (not only the diff). LLM-judgment review of the diff catches what's wrong with the new code; mechanical sweeps catch what's missing from the OLD code that the spec also touched.
+
+```
+# DO — reviewer prompt enumerates mechanical sweeps to run
+Agent(subagent_type="reviewer", prompt="""
+... diff context ...
+
+Mechanical sweeps (run BEFORE LLM judgment):
+1. `grep -c "return TrainingResult(" src/...trainable.py` — must equal
+   `grep -cE "device=DeviceReport|device=device_report" src/...trainable.py`
+2. `pytest --collect-only -q` exit 0 across all test dirs
+3. `pip check` — no new conflicts vs main
+4. For every public symbol in __all__ added by this PR — verify
+   eager import (per orphan-detection §6)
+""")
+
+# DO NOT — reviewer prompt only includes diff context
+Agent(subagent_type="reviewer", prompt="Review the diff between main and feat/X.")
+# ↑ reviewer reads the diff, judges the new code, never runs the sweep.
+#   Orphan in untouched lines (TorchTrainable still missing device=) is invisible.
+```
+
+**BLOCKED rationalizations:**
+
+- "The reviewer is smart enough to spot orphans"
+- "Mechanical sweeps are /redteam's job, not the reviewer's"
+- "The diff IS the reviewer's scope"
+- "Adding sweeps to every reviewer prompt is repetitive"
+
+**Why:** Gate reviewers are constrained by the diff they're shown. The orphan failure mode of `rules/orphan-detection.md` §1 is invisible at diff-level — the new entries look complete; the OLD entries that were never updated for the new public surface stay invisible. A 4-second `grep -c` sweep catches what 5 minutes of LLM judgment misses. Without the sweep, the reviewer agent's APPROVE verdict is necessary but not sufficient. Evidence: Session 2026-04-19 — code reviewer APPROVED 0.12.0 with one minor finding (missing test); the subsequent `/redteam` mechanical sweep caught TorchTrainable + LightningTrainable missing `device=DeviceReport` (2 of 7 return sites). The reviewer never ran the parity grep.
+
+Origin: Session 2026-04-19 ML GPU-first Phase 1 codify cycle. See `workspaces/kailash-ml-gpu-stack/journal/0004-RISK-torch-lightning-deviceReport-orphan.md` § "Why it slipped past the round-3 reviewer."
+
 ## Zero-Tolerance
 
 Pre-existing failures MUST be fixed (see `rules/zero-tolerance.md` Rule 1). No workarounds for SDK bugs — deep dive and fix directly (Rule 4).
@@ -93,6 +128,71 @@ Agent(prompt: "implement feature Y...")  # Blocks waiting for X's build lock
 **Why:** Cargo uses an exclusive filesystem lock on `target/`. Two cargo processes in the same directory serialize completely, turning parallel agents into sequential execution. Worktrees give each agent its own `target/` directory.
 
 **See `rules/worktree-isolation.md`** for the orchestrator pinning contract, the specialist self-check, and the post-agent file-existence verification. The `isolation: "worktree"` flag is necessary but not sufficient — without the verification layer, agents drift back to the main checkout silently.
+
+## MUST: Worktree Prompts Use Relative Paths Only
+
+When prompting an agent with `isolation: "worktree"`, the orchestrator MUST reference files via paths RELATIVE to the repo root (`packages/kailash-ml/src/...`) — never absolute paths starting with `/Users/` or `/home/`. Agents resolve absolute paths against the filesystem root, which bypasses the worktree's copy and writes to the PARENT checkout instead.
+
+```python
+# DO — relative paths resolve to the worktree's cwd
+Agent(
+    isolation="worktree",
+    prompt="Edit packages/kailash-ml/src/kailash_ml/trainable.py at line 370..."
+)
+
+# DO NOT — absolute paths bypass worktree isolation
+Agent(
+    isolation="worktree",
+    prompt="Edit /Users/esperie/repos/loom/kailash-py/packages/kailash-ml/src/kailash_ml/trainable.py..."
+)
+# ↑ writes land in the MAIN checkout; the worktree stays empty; auto-cleanup
+#   deletes the empty worktree; agent's work is either silently on main OR lost.
+```
+
+**BLOCKED rationalizations:**
+
+- "Absolute paths are unambiguous"
+- "The agent should figure out its own cwd"
+- "This worked the one time I tested it"
+- "I included 'Repo root: /Users/...' at the top; the agent will use that"
+
+**Why:** `isolation: "worktree"` creates a nested git worktree under `.claude/worktrees/agent-XXXX/`, then runs the agent with cwd set to that worktree. Relative paths resolve correctly; absolute paths point back to the parent checkout the orchestrator is using, silently defeating isolation. Session 2026-04-19 logged: 2 of 3 parallel shards wrote to MAIN before self-correcting (Shard B) or losing work entirely (Shard A's 300+ LOC of sklearn array-API impl was lost when its empty worktree auto-cleaned). Only one self-corrected; the failure mode is not agent-detectable by default.
+
+Origin: Session 2026-04-19 ML GPU-first Phase 1 parallel-shard experiment. See `workspaces/kailash-ml-gpu-stack/journal/0004-RISK-torch-lightning-deviceReport-orphan.md` for the full post-mortem of the write-to-main leak AND the subsequent spec-compliance finding it masked.
+
+## MUST: Worktree Agents Commit Incremental Progress
+
+Every agent launched with `isolation: "worktree"` MUST receive an explicit instruction in its prompt to `git commit` after each major milestone (each file written, each test batch passed), NOT only at completion. The orchestrator MUST then verify the branch has ≥1 commit before declaring the agent's work landed.
+
+```python
+# DO — prompt includes incremental commit discipline
+Agent(
+    isolation="worktree",
+    prompt="""...
+**Commit discipline (MUST):**
+- After each file is complete, run `git add <file> && git commit -m "wip(shard-X): <what>"`.
+- Do NOT hold all work in the worktree's index until the final report.
+- If you exit without committing (budget exhaustion / crash / interruption),
+  the worktree is auto-cleaned and ALL work is lost.
+""",
+)
+
+# DO NOT — trust that the agent commits at completion
+Agent(isolation="worktree", prompt="Implement feature X. Report when done.")
+# ↑ agent writes 4 files, hits budget on file 5, emits truncated message,
+#   never reaches `git commit`, worktree auto-cleaned — all 5 files lost.
+```
+
+**BLOCKED rationalizations:**
+
+- "The agent will commit at the end"
+- "Splitting into commits adds overhead"
+- "The parent can recover from the worktree after the agent exits"
+- "Budget exhaustion is rare"
+
+**Why:** Worktree auto-cleanup silently deletes worktrees with zero commits on their branch. An agent that writes perfect code but truncates mid-message before committing loses 100% of its output. Post-hoc file-existence verification (see § Verify Agent Deliverables) catches orphan files in main but CANNOT recover files that were only in a cleaned-up worktree. Evidence: Session 2026-04-19 — Shard A's agent wrote a complete SklearnTrainable Array-API rewrite, then truncated on "Now let me rewrite fit:" with zero commits; worktree auto-deleted; ~300 LOC of load-bearing work had to be recovered serendipitously from Shard B's scope-creeped worktree. Shard C was rescued by an explicit WIP commit from the orchestrator immediately after notification. The only reliable defense is instructing the agent to commit as it goes.
+
+Origin: Session 2026-04-19 ML GPU-first Phase 1 parallel-shard experiment. Three of three parallel agents truncated at 250-370k tokens; two lost work to auto-cleanup; one (Shard B) self-corrected because its prompt happened to emphasize "commit before exit."
 
 ## MUST: Verify Agent Deliverables Exist After Exit
 

--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -22,7 +22,7 @@
 | kailash-kaizen   | `kaizen-v*`        | 2.7.5           |
 | kailash-nexus    | `nexus-v*`         | 2.1.1           |
 | kailash-pact     | `pact-v*`          | 0.8.2           |
-| kailash-ml       | `ml-v*`            | 0.11.0          |
+| kailash-ml       | `ml-v*`            | 0.12.0          |
 | kailash-align    | `align-v*`         | 0.3.2           |
 | kailash-mcp      | `mcp-v*`           | 0.2.5           |
 | kaizen-agents    | `kaizen-agents-v*` | 0.9.3           |

--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -23,10 +23,14 @@
 - **`HDBSCANTrainable.__init__` warning hygiene** — Pre-set `copy=True` so sklearn 1.5+ FutureWarning about the `copy` default change to 1.10 doesn't fire.
 - **`engines/dim_reduction.py::_reduce_umap` warning hygiene** — Same `n_jobs=1` preset (resolves a pre-existing warning that was outside the Phase 1 scope but caught under zero-tolerance Rule 1 ownership).
 
+### Known Limitations
+
+- **`Predictions.device` field not yet populated.** The spec's "Transparency contract" mandates that every `predict()` return carry a `DeviceReport`, but the `Predictions` class in 0.12.0 exposes only `raw` / `column` / `to_polars()`. Callers can inspect the FIT-time `TrainingResult.device` (wired across all 7 family adapters in this release) to identify the device that executed the model. Scheduled for 0.12.1 — requires an API addition to `Predictions` plus per-family `predict()` updates. See journal entry `0005-GAP-predictions-device-field-missing.md` for the 0.12.1 plan.
+
 ### Test counts
 
-- 943 passed / 1 skipped / 0 warnings in the unit suite.
-- 6 passed / 4 skipped in the new Tier 2 backend matrix on darwin-arm (XGBoost / LightGBM segfault on darwin-arm + py3.13 — Tier 2 ships on Linux CI; SCIPY_ARRAY_API=1 precondition skip when env-var unset).
+- 957 passed / 5 skipped / 0 warnings in the unit + regression + Tier 2 suites (943 unit + 6 Tier 2 + 2 new regression invariants + 6 new sklearn array-API).
+- 4 Tier 2 skips on darwin-arm (XGBoost / LightGBM segfault on darwin-arm + py3.13 — Tier 2 ships on Linux CI; SCIPY_ARRAY_API=1 precondition skip when env-var unset).
 
 ## [0.11.0] - 2026-04-19 — GPU-first Phase 1: DeviceReport + km.device()/use_device() (#523)
 

--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,33 @@
 # kailash-ml Changelog
 
+## [0.12.0] - 2026-04-19 — GPU-first Phase 1 punch list: Trainable adapters + transparency
+
+### Added
+
+- **`SklearnTrainable` Array-API auto-dispatch** — When the caller passes a non-CPU `TrainingContext.backend` AND the wrapped estimator is on the Phase 1 allowlist (`Ridge`, `LogisticRegression`, `LinearRegression`, `LinearDiscriminantAnalysis`, `KMeans`, `PCA`, `StandardScaler`, `MinMaxScaler`), the inner Lightning fit runs inside `sklearn.config_context(array_api_dispatch=True)` with X/y moved to a torch tensor on the resolved device. Emits INFO `sklearn.array_api.engaged` log. Off-allowlist estimators on a non-CPU backend log WARN `sklearn.array_api.offlist` and proceed on CPU numpy. (Item 3 of revised-stack.md)
+- **`SklearnTrainable` runtime fallback for scipy env-var gate** — `sklearn.config_context(array_api_dispatch=True)` requires `SCIPY_ARRAY_API=1` to be set BEFORE any sklearn/scipy import. When that precondition isn't met, the call raises at enter-time. The adapter now catches that and falls back to the CPU numpy path with WARN `sklearn.array_api.runtime_unavailable` so the deployment gap surfaces in log aggregators rather than as a hard failure.
+- **`XGBoostTrainable` GPU OOM single-retry fallback** — A GPU OOM during `trainer.fit` is intercepted; the adapter logs WARN `xgboost.gpu.oom_fallback`, rebuilds on CPU, and returns a `TrainingResult` whose `device.fallback_reason="oom"` and `device.backend="cpu"`. Non-OOM exceptions re-raise unchanged. (Item 4)
+- **`LightGBMTrainable` GPU OOM single-retry fallback** — Same pattern as XGBoost; logs WARN `lightgbm.gpu.oom_fallback` on the fallback path.
+- **`UMAPTrainable` (CPU-only Phase 1)** — New `kailash_ml.UMAPTrainable` wraps `umap-learn` as a Trainable. Phase 1 is CPU-only per the cuML eviction decision (revised-stack.md CRITICAL-1). When called with a non-CPU `TrainingContext.backend`, logs INFO `umap.cuml_eviction` (not WARN — this is the documented Phase 1 design) and runs on CPU. The returned `DeviceReport.fallback_reason="cuml_eviction"` so callers can distinguish this from an OOM or driver-missing fallback. Phase 2 adds torch-native UMAP across MPS/ROCm/XPU. (Item 5)
+- **`HDBSCANTrainable` (CPU-only Phase 1)** — New `kailash_ml.HDBSCANTrainable` wraps `sklearn.cluster.HDBSCAN` (sklearn 1.3+) as a Trainable. Same cuml_eviction logging contract as `UMAPTrainable`.
+- **`TrainingResult.device: Optional[DeviceReport]` field** — Append-only optional field that every Phase 1 Trainable family adapter populates. Carries family / backend / device_string / precision / fallback_reason / array_api so callers can distinguish a CUDA execution from a silent CPU fallback. Required for the orphan-detection §6 contract — `DeviceReport` is now wired into the production hot path of every Phase 1 family.
+- **Tier 2 backend-matrix tests** — `tests/integration/test_trainable_backend_matrix.py` exercises every Phase 1 Trainable across CPU + (where available) MPS / CUDA with real estimators, real Lightning Trainer, no mocking. (Item 7)
+
+### Removed
+
+- **`kailash-ml[rapids]` extra** — Verified absent. Phase 1 cuML eviction is complete; users who need cuML on NVIDIA install it themselves and swap it in via the Trainable layer. (Item 8)
+
+### Fixed
+
+- **`UMAPTrainable.__init__` warning hygiene** — Pre-set `n_jobs=1` so umap-learn's "n_jobs overridden by random_state" UserWarning doesn't fire.
+- **`HDBSCANTrainable.__init__` warning hygiene** — Pre-set `copy=True` so sklearn 1.5+ FutureWarning about the `copy` default change to 1.10 doesn't fire.
+- **`engines/dim_reduction.py::_reduce_umap` warning hygiene** — Same `n_jobs=1` preset (resolves a pre-existing warning that was outside the Phase 1 scope but caught under zero-tolerance Rule 1 ownership).
+
+### Test counts
+
+- 943 passed / 1 skipped / 0 warnings in the unit suite.
+- 6 passed / 4 skipped in the new Tier 2 backend matrix on darwin-arm (XGBoost / LightGBM segfault on darwin-arm + py3.13 — Tier 2 ships on Linux CI; SCIPY_ARRAY_API=1 precondition skip when env-var unset).
+
 ## [0.11.0] - 2026-04-19 — GPU-first Phase 1: DeviceReport + km.device()/use_device() (#523)
 
 ### Added

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -38,6 +38,13 @@ dependencies = [
     "scikit-learn>=1.5",
     "lightgbm>=4.0",
     "xgboost>=2.0",
+    # UMAP (umap-learn) is a base dep as of the cuML eviction (Phase 1).
+    # Per workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md
+    # CRITICAL-1 disposition: cuML is evicted; UMAPTrainable wraps the
+    # sklearn-native umap-learn package; sklearn.cluster.HDBSCAN covers
+    # HDBSCAN (already in scikit-learn>=1.5). Phase 2 roadmap: torch-native
+    # UMAP across MPS/ROCm/XPU.
+    "umap-learn>=0.5",
     # Lightning is the training spine for every family per ml-engines.md
     # §3 MUST 2 — every training call routes through lightning.pytorch.Trainer.
     # Therefore lightning + torch are base dependencies, not optional extras.

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.11.1"
+version = "0.12.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/__init__.py
+++ b/packages/kailash-ml/src/kailash_ml/__init__.py
@@ -24,8 +24,13 @@ from kailash_ml.engine import MLEngine
 from kailash_ml.engines.data_explorer import AlertConfig
 from kailash_ml.trainable import (
     HDBSCANTrainable,
+    LightGBMTrainable,
+    LightningTrainable,
+    SklearnTrainable,
+    TorchTrainable,
     Trainable,
     UMAPTrainable,
+    XGBoostTrainable,
 )
 from kailash_ml.types import (
     AgentInfusionProtocol,
@@ -246,8 +251,16 @@ __all__ = [
     "detect_backend",
     "TrainingResult",
     "Trainable",
-    # GPU-first Phase 1 Trainables — UMAP + HDBSCAN (cuML evicted per
-    # workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md).
+    # GPU-first Phase 1 — all 7 family adapters per specs/ml-engines.md §3.0.
+    # Pre-existing 5 (Sklearn/XGBoost/LightGBM/Torch/Lightning) were
+    # accessible via `from kailash_ml.trainable import ...` since 0.10.x
+    # but absent from kailash_ml.__all__ until 0.12.0 — fixed for spec
+    # parity per /redteam round-3 finding HIGH-3.
+    "SklearnTrainable",
+    "XGBoostTrainable",
+    "LightGBMTrainable",
+    "TorchTrainable",
+    "LightningTrainable",
     "UMAPTrainable",
     "HDBSCANTrainable",
     "train",

--- a/packages/kailash-ml/src/kailash_ml/__init__.py
+++ b/packages/kailash-ml/src/kailash_ml/__init__.py
@@ -22,7 +22,11 @@ from kailash_ml._result import TrainingResult
 from kailash_ml._version import __version__
 from kailash_ml.engine import MLEngine
 from kailash_ml.engines.data_explorer import AlertConfig
-from kailash_ml.trainable import Trainable
+from kailash_ml.trainable import (
+    HDBSCANTrainable,
+    Trainable,
+    UMAPTrainable,
+)
 from kailash_ml.types import (
     AgentInfusionProtocol,
     FeatureField,
@@ -242,6 +246,10 @@ __all__ = [
     "detect_backend",
     "TrainingResult",
     "Trainable",
+    # GPU-first Phase 1 Trainables — UMAP + HDBSCAN (cuML evicted per
+    # workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md).
+    "UMAPTrainable",
+    "HDBSCANTrainable",
     "train",
     "track",
     "resolve_torch_wheel",

--- a/packages/kailash-ml/src/kailash_ml/_result.py
+++ b/packages/kailash-ml/src/kailash_ml/_result.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field, fields
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type-checker only
+    from kailash_ml._device_report import DeviceReport
 
 __all__ = [
     "TrainingResult",
@@ -85,6 +88,11 @@ class TrainingResult:
     split_info: Optional[Any] = None
     calibration: Optional[Any] = None
     feature_importance: Optional[Mapping[str, float]] = None
+    # GPU-first Phase 1: per-call evidence of which backend / precision /
+    # fallback actually ran. Optional for back-compat; adapters populate
+    # this when they route through the device resolver. See
+    # kailash_ml._device_report.DeviceReport.
+    device: Optional["DeviceReport"] = None
 
     def __post_init__(self) -> None:
         # Populated-required-field check (§4.2 MUST 1).

--- a/packages/kailash-ml/src/kailash_ml/_result.py
+++ b/packages/kailash-ml/src/kailash_ml/_result.py
@@ -15,8 +15,10 @@ reader per `ml-engines.md` §10.1).
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from typing import Any, Mapping, Optional
+
+from kailash_ml._device_report import DeviceReport
 
 __all__ = [
     "TrainingResult",
@@ -85,6 +87,15 @@ class TrainingResult:
     split_info: Optional[Any] = None
     calibration: Optional[Any] = None
     feature_importance: Optional[Mapping[str, float]] = None
+    # --- Per-call device evidence (GPU-first Phase 1) ----------------------
+    # Populated by every family adapter (SklearnTrainable first — see
+    # `workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md` lines
+    # 54-78). Optional at the dataclass level so older callers (and
+    # from_dict payloads that pre-date this field) continue to validate;
+    # new family adapters MUST populate it. XGBoost / LightGBM adapters
+    # populate `.device.fallback_reason="oom"` when they survived a GPU
+    # OOM and retried on CPU (revised-stack.md § "Transparency contract").
+    device: Optional[DeviceReport] = None
 
     def __post_init__(self) -> None:
         # Populated-required-field check (§4.2 MUST 1).

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.11.1"
+__version__ = "0.12.0"

--- a/packages/kailash-ml/src/kailash_ml/engines/dim_reduction.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/dim_reduction.py
@@ -381,11 +381,16 @@ class DimReductionEngine:
         n_neighbors = kwargs.pop("n_neighbors", min(15, X.shape[0] - 1))
         min_dist = kwargs.pop("min_dist", 0.1)
 
+        # umap-learn warns that `random_state` forces `n_jobs=1`; pre-set
+        # the value so umap's "overridden to 1" UserWarning does not
+        # fire. See umap_.py:1952 (umap-learn 0.5+). Same pattern as
+        # UMAPTrainable in `trainable.py`.
         reducer = umap.UMAP(
             n_components=n_components,
             n_neighbors=n_neighbors,
             min_dist=min_dist,
             random_state=seed,
+            n_jobs=kwargs.pop("n_jobs", 1),
             **kwargs,
         )
         X_transformed = reducer.fit_transform(X)

--- a/packages/kailash-ml/src/kailash_ml/trainable.py
+++ b/packages/kailash-ml/src/kailash_ml/trainable.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:  # pragma: no cover - type-checker only
     import numpy as np  # noqa: F401 — referenced in string annotations
 
 from kailash_ml._device import UnsupportedFamily, detect_backend
+from kailash_ml._device_report import DeviceReport
 from kailash_ml._result import TrainingResult
 
 __all__ = [
@@ -286,6 +287,31 @@ def _artifact_dir() -> Path:
     return root
 
 
+def _is_gpu_oom_error(exc: BaseException) -> bool:
+    """Return True if ``exc`` looks like a GPU out-of-memory error.
+
+    Recognises the common messages across xgboost (``XGBoostError`` with
+    "out of memory"), torch (``torch.cuda.OutOfMemoryError``,
+    ``RuntimeError: CUDA out of memory``), and lightgbm
+    (``LightGBMError`` with OOM text). Per revised-stack.md § "No-config
+    contract" (xgboost / lightgbm rows) this is the signal that triggers
+    the single-retry CPU fallback; any non-OOM exception re-raises
+    unchanged (zero-tolerance.md Rule 3 — no silent swallow).
+    """
+    msg = str(exc).lower()
+    if (
+        "out of memory" in msg
+        or "cuda out of memory" in msg
+        or "cuda error: out of memory" in msg
+        or "oom" in msg
+    ):
+        return True
+    # Typed OOM classes without English messages (torch's
+    # CudaOutOfMemoryError subclasses on some builds expose an empty
+    # args tuple; catch by class name so the detection survives).
+    return type(exc).__name__ in ("OutOfMemoryError", "CudaOutOfMemoryError")
+
+
 # ---------------------------------------------------------------------------
 # Lightning adapter base — sklearn-style single-epoch wrapper
 # ---------------------------------------------------------------------------
@@ -363,17 +389,57 @@ def _make_single_epoch_module(
 
 
 # ---------------------------------------------------------------------------
-# SklearnTrainable (ml-backends.md §5.1 — CPU only)
+# SklearnTrainable (ml-backends.md §5.1 + GPU-first Phase 1 Array-API dispatch)
 # ---------------------------------------------------------------------------
+#
+# Per the revised-stack spec (workspaces/kailash-ml-gpu-stack/04-validate/
+# 02-revised-stack.md lines 84-89), sklearn is CPU-only via the stock numpy
+# path BUT can run on the detected device via scikit-learn's Array API
+# dispatch for a supported subset of estimators. We engage the Array API
+# context when the estimator is on the allowlist AND the caller requested
+# a non-CPU backend. Off-allowlist estimators fall back to CPU numpy and
+# emit `sklearn.array_api.offlist` at WARN with
+# ``fallback_reason="array_api_offlist"`` on the returned ``DeviceReport``.
+#
+# Allowlist membership is matched on ``type(estimator).__name__`` to keep
+# the import surface cheap — pulling in every allowlisted class at module
+# import time would defeat the "light sklearn baseline" Phase 3 decision.
+# The initial set is conservative (scikit-learn 1.5+ Array API dispatch
+# coverage; see the scikit-learn "Array API support" docs). Expansion is a
+# spec-level edit, not a code edit.
+_SKLEARN_ARRAY_API_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "Ridge",
+        "LogisticRegression",
+        "LinearRegression",
+        "LinearDiscriminantAnalysis",
+        "KMeans",
+        "PCA",
+        "StandardScaler",
+        "MinMaxScaler",
+    }
+)
 
 
 class SklearnTrainable:
     """Wraps any sklearn estimator as a Trainable.
 
-    Per `ml-backends.md` §5.1 sklearn is CPU-only; if the Engine resolved
-    a non-CPU accelerator we log a WARN (`sklearn.backend.ignored`) and
-    proceed on CPU. We still route through L.Trainer per `ml-engines.md`
-    §3 MUST 2.
+    Two device paths per revised-stack spec lines 84-89:
+
+    * **On allowlist + non-CPU requested** — engage
+      ``sklearn.config_context(array_api_dispatch=True)`` around the inner
+      estimator fit and move inputs to a torch tensor on
+      ``ctx.device_string``. Emits INFO ``sklearn.array_api.engaged``.
+      ``TrainingResult.device.array_api == True``.
+    * **Off allowlist OR CPU requested** — fall back to CPU numpy as in
+      pre-Phase-1 behavior. When the caller asked for a non-CPU backend
+      that we had to ignore, emit WARN ``sklearn.array_api.offlist``
+      with ``fallback_reason="array_api_offlist"``.
+
+    We still route through L.Trainer per ``ml-engines.md`` §3 MUST 2 for
+    both paths — Lightning is the enforcement point for accelerator /
+    precision resolution, even when the actual fit runs inside the
+    Array API context.
     """
 
     family_name = "sklearn"
@@ -443,11 +509,25 @@ class SklearnTrainable:
     ) -> TrainingResult:
         """Fit the sklearn estimator via a LightningModule wrapper.
 
+        Two device paths per revised-stack spec lines 84-89:
+
+        * **Array API engaged** (on-allowlist + non-CPU requested): wraps
+          the inner estimator fit in
+          ``sklearn.config_context(array_api_dispatch=True)`` and moves
+          X/y to a torch tensor on ``ctx.device_string``. The returned
+          ``TrainingResult.device.array_api`` is True.
+        * **CPU fallback** (off-allowlist, or CPU requested): inner
+          estimator fit runs on numpy as in pre-Phase-1 behavior. When a
+          non-CPU backend was requested but the estimator was
+          off-allowlist we emit WARN ``sklearn.array_api.offlist`` and
+          stamp the ``DeviceReport`` with
+          ``fallback_reason="array_api_offlist"``.
+
         Routes through ``lightning.pytorch.Trainer(accelerator="cpu",
         devices=1, precision="32-true", max_epochs=1)`` per
-        ``ml-engines.md`` §3 MUST 2. sklearn is CPU-only
-        (``ml-backends.md`` §5.1): if the Engine resolved a non-CPU
-        accelerator we log and override to CPU.
+        ``ml-engines.md`` §3 MUST 2 in both paths — Lightning is the
+        enforcement point for accelerator / precision resolution even
+        when the actual fit runs inside an Array API dispatch context.
         """
         if hyperparameters:
             # Apply any HP overrides to the underlying estimator.
@@ -456,15 +536,40 @@ class SklearnTrainable:
                     setattr(self._estimator, k, v)
 
         ctx = _effective_context(context)
-        if ctx.backend != "cpu":
-            logger.warning(
-                "sklearn.backend.ignored",
+        estimator_class = type(self._estimator).__name__
+        on_allowlist = estimator_class in _SKLEARN_ARRAY_API_ALLOWLIST
+        non_cpu_requested = ctx.backend != "cpu"
+        engage_array_api = on_allowlist and non_cpu_requested
+
+        if engage_array_api:
+            # INFO — normal transition: Array API dispatch is the expected
+            # code path for an allowlisted estimator on a detected GPU
+            # backend. No fallback, no degradation.
+            logger.info(
+                "sklearn.array_api.engaged",
                 extra={
-                    "requested_backend": ctx.backend,
                     "family": self.family_name,
-                    "reason": "sklearn is CPU-only per ml-backends.md §5.1",
+                    "estimator_class": estimator_class,
+                    "backend": ctx.backend,
+                    "device_string": ctx.device_string,
                 },
             )
+        elif non_cpu_requested:
+            # WARN — degraded path: caller asked for a GPU but the
+            # estimator is off-allowlist, so we fall back to CPU numpy.
+            logger.warning(
+                "sklearn.array_api.offlist",
+                extra={
+                    "family": self.family_name,
+                    "estimator_class": estimator_class,
+                    "requested_backend": ctx.backend,
+                    "fallback_reason": "array_api_offlist",
+                },
+            )
+
+        # The Lightning Trainer always runs on CPU — Array API is a
+        # data-path dispatch, not a Trainer-accelerator knob. This keeps
+        # the outer loop uniform across all non-DL families.
         cpu_ctx = TrainingContext(
             accelerator="cpu",
             precision="32-true",
@@ -479,10 +584,21 @@ class SklearnTrainable:
         X, y, feature_names = _split_xy(data, self._target)
         self._feature_names = feature_names
         metric_name, metric_fn = _resolve_metric(self._metric_kind, y)
+
+        if engage_array_api:
+            # Move inputs to torch tensors on the resolved device so the
+            # Array API dispatcher routes through torch's backend.
+            import torch  # noqa: PLC0415 — local to GPU path
+
+            X_fit = torch.as_tensor(X, device=ctx.device_string)
+            y_fit = torch.as_tensor(y, device=ctx.device_string)
+        else:
+            X_fit, y_fit = X, y
+
         module = _make_single_epoch_module(
             self._estimator,
-            X,
-            y,
+            X_fit,
+            y_fit,
             metric_name=metric_name,
             metric_fn=metric_fn,
             module_name="SklearnLightningAdapter",
@@ -493,7 +609,13 @@ class SklearnTrainable:
         trainer_kwargs = _log_backend_selection(cpu_ctx, max_epochs=1)
         trainer = pl_trainer.Trainer(**trainer_kwargs)
         t0 = time.monotonic()
-        trainer.fit(module)
+        if engage_array_api:
+            import sklearn  # noqa: PLC0415 — local to GPU path
+
+            with sklearn.config_context(array_api_dispatch=True):
+                trainer.fit(module)
+        else:
+            trainer.fit(module)
         elapsed = time.monotonic() - t0
 
         self._is_fitted = True
@@ -504,6 +626,29 @@ class SklearnTrainable:
         artifact_uri = _persist_native_artifact(
             self._estimator, prefix="sklearn", format="pickle"
         )
+
+        # DeviceReport carries POST-resolution evidence — what actually
+        # ran, not what was requested. Array API path points at the
+        # resolved GPU device; fallback path points at "cpu" with
+        # ``fallback_reason`` set when a non-CPU request was ignored.
+        if engage_array_api:
+            device_report = DeviceReport(
+                family=self.family_name,
+                backend=ctx.backend,
+                device_string=ctx.device_string,
+                precision=ctx.precision,
+                fallback_reason=None,
+                array_api=True,
+            )
+        else:
+            device_report = DeviceReport(
+                family=self.family_name,
+                backend="cpu",
+                device_string="cpu",
+                precision="32-true",
+                fallback_reason=("array_api_offlist" if non_cpu_requested else None),
+                array_api=False,
+            )
 
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
@@ -518,6 +663,7 @@ class SklearnTrainable:
             lightning_trainer_config=trainer_kwargs,
             family=self.family_name,
             hyperparameters=dict(hyperparameters or {}),
+            device=device_report,
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:
@@ -980,8 +1126,71 @@ class XGBoostTrainable:
 
         trainer_kwargs = _log_backend_selection(ctx, max_epochs=1)
         trainer = pl_trainer.Trainer(**trainer_kwargs)
+
+        # OOM fallback: GPU OOM on the xgboost path MUST degrade to CPU
+        # with a WARN log (revised-stack.md § "No-config contract" — xgboost
+        # row). Non-OOM exceptions re-raise unchanged per zero-tolerance.md
+        # Rule 3 (no silent swallow).
+        fallback_reason: Optional[str] = None
+        effective_ctx = ctx
+        effective_trainer_kwargs = trainer_kwargs
         t0 = time.monotonic()
-        trainer.fit(module)
+        try:
+            trainer.fit(module)
+        except Exception as exc:
+            if ctx.backend == "cpu" or not _is_gpu_oom_error(exc):
+                raise
+            logger.warning(
+                "xgboost.gpu.oom_fallback",
+                extra={
+                    "family": self.family_name,
+                    "requested_backend": ctx.backend,
+                    "fallback_backend": "cpu",
+                    "fallback_reason": "oom",
+                    "error_class": type(exc).__name__,
+                },
+            )
+            fallback_reason = "oom"
+            # Re-point the xgboost estimator at CPU before the retry so
+            # the inner fit inside `on_train_start` actually runs on CPU.
+            if hasattr(self._estimator, "set_params"):
+                try:
+                    self._estimator.set_params(device="cpu")
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "xgboost.device.set_failed",
+                        extra={
+                            "xgb_device": "cpu",
+                            "family": self.family_name,
+                        },
+                    )
+            # Rebuild module + Trainer for the retry — L.Trainer is
+            # single-shot, and the first module already exhausted state
+            # when trainer.fit raised.
+            cpu_ctx = TrainingContext(
+                accelerator="cpu",
+                precision="32-true",
+                devices=1,
+                device_string="cpu",
+                backend="cpu",
+                tenant_id=ctx.tenant_id,
+                tracker_run_id=ctx.tracker_run_id,
+                trial_number=ctx.trial_number,
+            )
+            cpu_module = _make_single_epoch_module(
+                self._estimator,
+                X,
+                y,
+                metric_name=metric_name,
+                metric_fn=metric_fn,
+                module_name="XGBoostLightningAdapter",
+            )
+            cpu_trainer_kwargs = _log_backend_selection(cpu_ctx, max_epochs=1)
+            cpu_trainer = pl_trainer.Trainer(**cpu_trainer_kwargs)
+            cpu_trainer.fit(cpu_module)
+            module = cpu_module
+            effective_ctx = cpu_ctx
+            effective_trainer_kwargs = cpu_trainer_kwargs
         elapsed = time.monotonic() - t0
 
         self._is_fitted = True
@@ -991,19 +1200,29 @@ class XGBoostTrainable:
             self._estimator, prefix="xgboost", format="pickle"
         )
 
+        device_report = DeviceReport(
+            family=self.family_name,
+            backend=effective_ctx.backend,
+            device_string=effective_ctx.device_string,
+            precision=effective_ctx.precision,
+            fallback_reason=fallback_reason,
+            array_api=False,
+        )
+
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             metrics={metric_name: module.metric},
-            device_used=ctx.device_string,
-            accelerator=ctx.accelerator,
-            precision=ctx.precision,
+            device_used=effective_ctx.device_string,
+            accelerator=effective_ctx.accelerator,
+            precision=effective_ctx.precision,
             elapsed_seconds=elapsed,
-            tracker_run_id=ctx.tracker_run_id,
-            tenant_id=ctx.tenant_id,
+            tracker_run_id=effective_ctx.tracker_run_id,
+            tenant_id=effective_ctx.tenant_id,
             artifact_uris={"native": artifact_uri},
-            lightning_trainer_config=trainer_kwargs,
+            lightning_trainer_config=effective_trainer_kwargs,
             family=self.family_name,
             hyperparameters=dict(hyperparameters or {}),
+            device=device_report,
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:
@@ -1159,8 +1378,70 @@ class LightGBMTrainable:
 
         trainer_kwargs = _log_backend_selection(ctx, max_epochs=1)
         trainer = pl_trainer.Trainer(**trainer_kwargs)
+
+        # OOM fallback: lightgbm GPU OOM MUST degrade to CPU with a
+        # WARN log (revised-stack.md § "No-config contract" — lightgbm
+        # row). ctx.backend in {"cuda", "rocm"} is the GPU path; "cpu"
+        # is already at the fallback target and re-raises unchanged
+        # per zero-tolerance.md Rule 3.
+        fallback_reason: Optional[str] = None
+        effective_ctx = ctx
+        effective_trainer_kwargs = trainer_kwargs
         t0 = time.monotonic()
-        trainer.fit(module)
+        try:
+            trainer.fit(module)
+        except Exception as exc:
+            if ctx.backend == "cpu" or not _is_gpu_oom_error(exc):
+                raise
+            logger.warning(
+                "lightgbm.gpu.oom_fallback",
+                extra={
+                    "family": self.family_name,
+                    "requested_backend": ctx.backend,
+                    "fallback_backend": "cpu",
+                    "fallback_reason": "oom",
+                    "error_class": type(exc).__name__,
+                },
+            )
+            fallback_reason = "oom"
+            # lightgbm uses `device_type="cpu"` (not `device=`). Re-point
+            # the estimator before the retry; debug-log any set_params
+            # failure (old lightgbm builds).
+            if hasattr(self._estimator, "set_params"):
+                try:
+                    self._estimator.set_params(device_type="cpu")
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "lightgbm.device.set_failed",
+                        extra={
+                            "lgb_device": "cpu",
+                            "family": self.family_name,
+                        },
+                    )
+            cpu_ctx = TrainingContext(
+                accelerator="cpu",
+                precision="32-true",
+                devices=1,
+                device_string="cpu",
+                backend="cpu",
+                tenant_id=ctx.tenant_id,
+                tracker_run_id=ctx.tracker_run_id,
+                trial_number=ctx.trial_number,
+            )
+            cpu_module = _make_single_epoch_module(
+                self._estimator,
+                X,
+                y,
+                metric_name=metric_name,
+                metric_fn=metric_fn,
+                module_name="LightGBMLightningAdapter",
+            )
+            cpu_trainer_kwargs = _log_backend_selection(cpu_ctx, max_epochs=1)
+            cpu_trainer = pl_trainer.Trainer(**cpu_trainer_kwargs)
+            cpu_trainer.fit(cpu_module)
+            module = cpu_module
+            effective_ctx = cpu_ctx
+            effective_trainer_kwargs = cpu_trainer_kwargs
         elapsed = time.monotonic() - t0
 
         self._is_fitted = True
@@ -1170,19 +1451,29 @@ class LightGBMTrainable:
             self._estimator, prefix="lightgbm", format="pickle"
         )
 
+        device_report = DeviceReport(
+            family=self.family_name,
+            backend=effective_ctx.backend,
+            device_string=effective_ctx.device_string,
+            precision=effective_ctx.precision,
+            fallback_reason=fallback_reason,
+            array_api=False,
+        )
+
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             metrics={metric_name: module.metric},
-            device_used=ctx.device_string,
-            accelerator=ctx.accelerator,
-            precision=ctx.precision,
+            device_used=effective_ctx.device_string,
+            accelerator=effective_ctx.accelerator,
+            precision=effective_ctx.precision,
             elapsed_seconds=elapsed,
-            tracker_run_id=ctx.tracker_run_id,
-            tenant_id=ctx.tenant_id,
+            tracker_run_id=effective_ctx.tracker_run_id,
+            tenant_id=effective_ctx.tenant_id,
             artifact_uris={"native": artifact_uri},
-            lightning_trainer_config=trainer_kwargs,
+            lightning_trainer_config=effective_trainer_kwargs,
             family=self.family_name,
             hyperparameters=dict(hyperparameters or {}),
+            device=device_report,
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:

--- a/packages/kailash-ml/src/kailash_ml/trainable.py
+++ b/packages/kailash-ml/src/kailash_ml/trainable.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:  # pragma: no cover - type-checker only
     import numpy as np  # noqa: F401 — referenced in string annotations
 
 from kailash_ml._device import UnsupportedFamily, detect_backend
+from kailash_ml._device_report import DeviceReport
 from kailash_ml._result import TrainingResult
 
 __all__ = [
@@ -65,6 +66,8 @@ __all__ = [
     "LightGBMTrainable",
     "TorchTrainable",
     "LightningTrainable",
+    "UMAPTrainable",
+    "HDBSCANTrainable",
 ]
 
 logger = logging.getLogger(__name__)
@@ -1195,6 +1198,439 @@ class LightGBMTrainable:
         )
         preds = self._estimator.predict(frame.to_numpy())
         return Predictions(preds, column="prediction")
+
+
+# ---------------------------------------------------------------------------
+# UMAPTrainable (Phase 1 — CPU only via umap-learn; cuML evicted per
+# workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md CRITICAL-1)
+# ---------------------------------------------------------------------------
+
+
+class UMAPTrainable:
+    """Wraps ``umap-learn``'s UMAP as a Trainable.
+
+    Phase 1 ships CPU-only via the ``umap-learn`` pip package. cuML is
+    evicted per the Phase 1 revised-stack decision (NVIDIA-only, fragile
+    wheels, blocks every other GPU backend). Users on NVIDIA accept the
+    slower path; users on every other backend gain a working path. Phase
+    2 adds torch-native UMAP across MPS/ROCm/XPU.
+
+    When ``TrainingContext.backend != "cpu"``, the adapter logs
+    ``umap.cuml_eviction`` at INFO (documented design, not degraded —
+    per ``rules/observability.md`` §3 INFO is the correct level) and
+    runs on CPU. The emitted ``DeviceReport.fallback_reason`` is
+    ``"cuml_eviction"`` so callers can distinguish this from an OOM or
+    driver-missing fallback.
+
+    UMAP is unsupervised: ``target`` is optional; when given, it is
+    split off so downstream pipelines can chain a supervised stage.
+    """
+
+    family_name = "umap"
+    _SUPPORTED_BACKENDS = ("cpu",)  # Phase 1 — CPU only
+
+    def __init__(
+        self,
+        *,
+        target: Optional[str] = None,
+        n_components: int = 2,
+        n_neighbors: int = 15,
+        random_state: int = 42,
+        **kwargs: Any,
+    ) -> None:
+        self._init_kwargs: dict[str, Any] = {
+            "n_components": n_components,
+            "n_neighbors": n_neighbors,
+            "random_state": random_state,
+            **kwargs,
+        }
+        self._target = target
+        self._reducer: Any = None
+        self._is_fitted = False
+        self._last_module: Any = None
+        self._feature_names: tuple[str, ...] = ()
+
+    def to_lightning_module(self) -> Any:
+        if self._last_module is None:
+            raise RuntimeError(
+                "UMAPTrainable.to_lightning_module() called before fit(). "
+                "Call fit(data) first."
+            )
+        return self._last_module
+
+    def get_param_distribution(self) -> HyperparameterSpace:
+        return HyperparameterSpace(
+            params=(
+                HyperparameterRange(name="n_components", kind="int", low=2, high=50),
+                HyperparameterRange(name="n_neighbors", kind="int", low=2, high=200),
+            )
+        )
+
+    def fit(
+        self,
+        data: pl.DataFrame,
+        *,
+        hyperparameters: Optional[Mapping[str, Any]] = None,
+        context: Optional[TrainingContext] = None,
+    ) -> TrainingResult:
+        import lightning.pytorch as pl_trainer
+        import numpy as np
+
+        try:
+            import umap  # umap-learn package
+        except ImportError as exc:  # pragma: no cover - declared base dep
+            raise ImportError(
+                "UMAPTrainable requires the 'umap-learn' package. "
+                "It is a base dependency of kailash-ml; reinstall via "
+                "'uv sync' or 'pip install kailash-ml'."
+            ) from exc
+
+        ctx = _effective_context(context)
+
+        # Phase 1: always CPU (cuML evicted). INFO per observability.md §3.
+        fallback_reason: Optional[str] = None
+        if ctx.backend != "cpu":
+            logger.info(
+                "umap.cuml_eviction",
+                extra={
+                    "family": self.family_name,
+                    "requested_backend": ctx.backend,
+                    "actual_backend": "cpu",
+                    "fallback_reason": "cuml_eviction",
+                },
+            )
+            fallback_reason = "cuml_eviction"
+
+        cpu_ctx = TrainingContext(
+            accelerator="cpu",
+            precision="32-true",
+            devices=1,
+            device_string="cpu",
+            backend="cpu",
+            tenant_id=ctx.tenant_id,
+            tracker_run_id=ctx.tracker_run_id,
+            trial_number=ctx.trial_number,
+        )
+
+        params = dict(self._init_kwargs)
+        if hyperparameters:
+            params.update(hyperparameters)
+        self._reducer = umap.UMAP(**params)
+
+        # UMAP is unsupervised — split off target if given, but do not require it.
+        if self._target is not None and self._target in data.columns:
+            X, _y, feature_names = _split_xy(data, self._target)
+            self._feature_names = feature_names
+        else:
+            X = data.to_numpy()
+            self._feature_names = tuple(data.columns)
+
+        X_arr = np.asarray(X)
+
+        # Build a single-epoch LightningModule that fits UMAP in
+        # on_train_start. Same pattern as XGBoost/LightGBM adapters;
+        # _make_single_epoch_module assumes supervised (y+metric), so we
+        # inline a minimal unsupervised adapter here.
+        import torch
+
+        reducer = self._reducer
+
+        class _UMAPLightningAdapter(pl_trainer.LightningModule):
+            def __init__(self) -> None:
+                super().__init__()
+                self._reducer = reducer
+                self._X = X_arr
+                self._fitted = False
+                self._bias = torch.nn.Parameter(torch.zeros(1, requires_grad=True))
+
+            def on_train_start(self) -> None:
+                self._reducer.fit(self._X)
+                self._fitted = True
+
+            def training_step(self, batch: Any, batch_idx: int) -> Any:
+                return self._bias.sum() * 0.0
+
+            def configure_optimizers(self) -> Any:
+                return torch.optim.SGD([self._bias], lr=1e-3)
+
+            def train_dataloader(self) -> Any:
+                ds = torch.utils.data.TensorDataset(
+                    torch.zeros(1, 1),
+                    torch.zeros(1, dtype=torch.long),
+                )
+                return torch.utils.data.DataLoader(ds, batch_size=1)
+
+        module = _UMAPLightningAdapter()
+
+        trainer_kwargs = _log_backend_selection(cpu_ctx, max_epochs=1)
+        trainer = pl_trainer.Trainer(**trainer_kwargs)
+        t0 = time.monotonic()
+        trainer.fit(module)
+        elapsed = time.monotonic() - t0
+
+        self._is_fitted = True
+        self._last_module = module
+
+        artifact_uri = _persist_native_artifact(
+            self._reducer, prefix="umap", format="pickle"
+        )
+
+        return TrainingResult(
+            model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
+            # UMAP is unsupervised; no supervised metric to report. We
+            # emit a placeholder 0.0 so the TrainingResult contract is
+            # satisfied. Downstream metrics (trustworthiness, silhouette
+            # against a target) belong to the engine, not the adapter.
+            metrics={"umap_embedding_components": float(params["n_components"])},
+            device_used=cpu_ctx.device_string,
+            accelerator=cpu_ctx.accelerator,
+            precision=cpu_ctx.precision,
+            elapsed_seconds=elapsed,
+            tracker_run_id=cpu_ctx.tracker_run_id,
+            tenant_id=cpu_ctx.tenant_id,
+            artifact_uris={"native": artifact_uri},
+            lightning_trainer_config=trainer_kwargs,
+            family=self.family_name,
+            hyperparameters=dict(hyperparameters or {}),
+            device=DeviceReport(
+                family=self.family_name,
+                backend="cpu",
+                device_string="cpu",
+                precision="32-true",
+                fallback_reason=fallback_reason,
+                array_api=False,
+            ),
+        )
+
+    def predict(self, X: pl.DataFrame) -> Predictions:
+        if not self._is_fitted:
+            raise RuntimeError("UMAPTrainable.predict() called before fit().")
+        # If target was used at fit time, drop it from X if present.
+        if self._target is not None and self._target in X.columns:
+            frame = X.drop(self._target)
+        else:
+            frame = X
+        embedding = self._reducer.transform(frame.to_numpy())
+        return Predictions(embedding, column="embedding")
+
+
+# ---------------------------------------------------------------------------
+# HDBSCANTrainable (Phase 1 — CPU only via sklearn.cluster.HDBSCAN;
+# cuML evicted per revised-stack.md CRITICAL-1)
+# ---------------------------------------------------------------------------
+
+
+class HDBSCANTrainable:
+    """Wraps ``sklearn.cluster.HDBSCAN`` as a Trainable.
+
+    Phase 1 ships CPU-only via sklearn 1.3+'s HDBSCAN (already in our
+    ``scikit-learn>=1.5`` base dep). cuML is evicted per the revised
+    stack decision. Phase 2 adds torch-native HDBSCAN across non-NVIDIA
+    backends.
+
+    Clustering note: HDBSCAN is transductive — ``.fit(X)`` exposes
+    ``labels_`` for the training data, but it has no canonical
+    ``.predict()`` for new points. ``HDBSCANTrainable.predict(X)``
+    re-runs ``.fit_predict(X)`` on ``X``, which clusters the new frame
+    independently. For approximate prediction on new points, fit with
+    ``prediction_data=True`` and use ``hdbscan.approximate_predict``
+    (not wrapped here — belongs in a downstream clustering engine).
+    """
+
+    family_name = "hdbscan"
+    _SUPPORTED_BACKENDS = ("cpu",)  # Phase 1 — CPU only
+
+    def __init__(
+        self,
+        *,
+        target: Optional[str] = None,
+        min_cluster_size: int = 5,
+        min_samples: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._init_kwargs: dict[str, Any] = {
+            "min_cluster_size": min_cluster_size,
+            **kwargs,
+        }
+        if min_samples is not None:
+            self._init_kwargs["min_samples"] = min_samples
+        self._target = target
+        self._clusterer: Any = None
+        self._is_fitted = False
+        self._last_module: Any = None
+        self._feature_names: tuple[str, ...] = ()
+
+    def to_lightning_module(self) -> Any:
+        if self._last_module is None:
+            raise RuntimeError(
+                "HDBSCANTrainable.to_lightning_module() called before fit(). "
+                "Call fit(data) first."
+            )
+        return self._last_module
+
+    def get_param_distribution(self) -> HyperparameterSpace:
+        return HyperparameterSpace(
+            params=(
+                HyperparameterRange(
+                    name="min_cluster_size", kind="int", low=2, high=100
+                ),
+                HyperparameterRange(name="min_samples", kind="int", low=1, high=50),
+            )
+        )
+
+    def fit(
+        self,
+        data: pl.DataFrame,
+        *,
+        hyperparameters: Optional[Mapping[str, Any]] = None,
+        context: Optional[TrainingContext] = None,
+    ) -> TrainingResult:
+        import lightning.pytorch as pl_trainer
+        import numpy as np
+        from sklearn.cluster import HDBSCAN
+
+        ctx = _effective_context(context)
+
+        fallback_reason: Optional[str] = None
+        if ctx.backend != "cpu":
+            logger.info(
+                "hdbscan.cuml_eviction",
+                extra={
+                    "family": self.family_name,
+                    "requested_backend": ctx.backend,
+                    "actual_backend": "cpu",
+                    "fallback_reason": "cuml_eviction",
+                },
+            )
+            fallback_reason = "cuml_eviction"
+
+        cpu_ctx = TrainingContext(
+            accelerator="cpu",
+            precision="32-true",
+            devices=1,
+            device_string="cpu",
+            backend="cpu",
+            tenant_id=ctx.tenant_id,
+            tracker_run_id=ctx.tracker_run_id,
+            trial_number=ctx.trial_number,
+        )
+
+        params = dict(self._init_kwargs)
+        if hyperparameters:
+            params.update(hyperparameters)
+        self._clusterer = HDBSCAN(**params)
+
+        # HDBSCAN is unsupervised — split off target if given.
+        if self._target is not None and self._target in data.columns:
+            X, _y, feature_names = _split_xy(data, self._target)
+            self._feature_names = feature_names
+        else:
+            X = data.to_numpy()
+            self._feature_names = tuple(data.columns)
+
+        X_arr = np.asarray(X)
+
+        import torch
+
+        clusterer = self._clusterer
+
+        class _HDBSCANLightningAdapter(pl_trainer.LightningModule):
+            def __init__(self) -> None:
+                super().__init__()
+                self._clusterer = clusterer
+                self._X = X_arr
+                self._fitted = False
+                self._n_clusters = 0
+                self._n_noise = 0
+                self._bias = torch.nn.Parameter(torch.zeros(1, requires_grad=True))
+
+            def on_train_start(self) -> None:
+                self._clusterer.fit(self._X)
+                self._fitted = True
+                labels = self._clusterer.labels_
+                # -1 is the HDBSCAN noise label; positive labels are clusters.
+                unique = set(int(x) for x in labels)
+                self._n_noise = int((labels == -1).sum())
+                self._n_clusters = len(unique - {-1})
+
+            def training_step(self, batch: Any, batch_idx: int) -> Any:
+                return self._bias.sum() * 0.0
+
+            def configure_optimizers(self) -> Any:
+                return torch.optim.SGD([self._bias], lr=1e-3)
+
+            def train_dataloader(self) -> Any:
+                ds = torch.utils.data.TensorDataset(
+                    torch.zeros(1, 1),
+                    torch.zeros(1, dtype=torch.long),
+                )
+                return torch.utils.data.DataLoader(ds, batch_size=1)
+
+            @property
+            def cluster_count(self) -> int:
+                return self._n_clusters
+
+            @property
+            def noise_count(self) -> int:
+                return self._n_noise
+
+        module = _HDBSCANLightningAdapter()
+
+        trainer_kwargs = _log_backend_selection(cpu_ctx, max_epochs=1)
+        trainer = pl_trainer.Trainer(**trainer_kwargs)
+        t0 = time.monotonic()
+        trainer.fit(module)
+        elapsed = time.monotonic() - t0
+
+        self._is_fitted = True
+        self._last_module = module
+
+        artifact_uri = _persist_native_artifact(
+            self._clusterer, prefix="hdbscan", format="pickle"
+        )
+
+        return TrainingResult(
+            model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
+            metrics={
+                "hdbscan_n_clusters": float(module.cluster_count),
+                "hdbscan_n_noise": float(module.noise_count),
+            },
+            device_used=cpu_ctx.device_string,
+            accelerator=cpu_ctx.accelerator,
+            precision=cpu_ctx.precision,
+            elapsed_seconds=elapsed,
+            tracker_run_id=cpu_ctx.tracker_run_id,
+            tenant_id=cpu_ctx.tenant_id,
+            artifact_uris={"native": artifact_uri},
+            lightning_trainer_config=trainer_kwargs,
+            family=self.family_name,
+            hyperparameters=dict(hyperparameters or {}),
+            device=DeviceReport(
+                family=self.family_name,
+                backend="cpu",
+                device_string="cpu",
+                precision="32-true",
+                fallback_reason=fallback_reason,
+                array_api=False,
+            ),
+        )
+
+    def predict(self, X: pl.DataFrame) -> Predictions:
+        if not self._is_fitted:
+            raise RuntimeError("HDBSCANTrainable.predict() called before fit().")
+        # HDBSCAN is transductive. For new data, re-cluster via fit_predict.
+        # See class docstring: for approximate_predict-style behavior on
+        # new points, instantiate sklearn.cluster.HDBSCAN upstream with
+        # appropriate settings — that path belongs in a clustering engine.
+        from sklearn.cluster import HDBSCAN
+
+        if self._target is not None and self._target in X.columns:
+            frame = X.drop(self._target)
+        else:
+            frame = X
+        new_clusterer = HDBSCAN(**self._init_kwargs)
+        labels = new_clusterer.fit_predict(frame.to_numpy())
+        return Predictions(labels, column="cluster_label")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kailash-ml/src/kailash_ml/trainable.py
+++ b/packages/kailash-ml/src/kailash_ml/trainable.py
@@ -611,10 +611,48 @@ class SklearnTrainable:
         trainer_kwargs = _log_backend_selection(cpu_ctx, max_epochs=1)
         trainer = pl_trainer.Trainer(**trainer_kwargs)
         t0 = time.monotonic()
+        # If engage_array_api was True but scipy's Array API support is
+        # not enabled at the env-var level (SCIPY_ARRAY_API=1 before any
+        # scipy/sklearn import), sklearn's config_context raises at
+        # enter-time. We catch that and fall back to the CPU numpy path
+        # with a WARN log so the deployment gap is visible in log
+        # aggregators. This is the documented failure mode of sklearn's
+        # array_api_dispatch — it requires a pre-import env-var switch
+        # that many production images do not yet set by default.
+        array_api_runtime_failed = False
         if engage_array_api:
             import sklearn  # noqa: PLC0415 — local to GPU path
 
-            with sklearn.config_context(array_api_dispatch=True):
+            try:
+                with sklearn.config_context(array_api_dispatch=True):
+                    trainer.fit(module)
+            except RuntimeError as exc:
+                # scipy array_api gate — "Scikit-learn array API support
+                # was enabled but scipy's own support is not enabled"
+                if "array API" not in str(exc) and "array_api" not in str(exc):
+                    raise
+                logger.warning(
+                    "sklearn.array_api.runtime_unavailable",
+                    extra={
+                        "family": self.family_name,
+                        "estimator_class": estimator_class,
+                        "requested_backend": ctx.backend,
+                        "fallback_reason": "array_api_runtime_unavailable",
+                        "hint": "set SCIPY_ARRAY_API=1 before any sklearn/scipy import",
+                    },
+                )
+                array_api_runtime_failed = True
+                # Retry CPU numpy path — rebuild module with un-tensor'd
+                # inputs so the estimator sees plain arrays.
+                module = _make_single_epoch_module(
+                    self._estimator,
+                    X,
+                    y,
+                    metric_name=metric_name,
+                    metric_fn=metric_fn,
+                    module_name="SklearnLightningAdapter",
+                )
+                trainer = pl_trainer.Trainer(**trainer_kwargs)
                 trainer.fit(module)
         else:
             trainer.fit(module)
@@ -633,7 +671,7 @@ class SklearnTrainable:
         # ran, not what was requested. Array API path points at the
         # resolved GPU device; fallback path points at "cpu" with
         # ``fallback_reason`` set when a non-CPU request was ignored.
-        if engage_array_api:
+        if engage_array_api and not array_api_runtime_failed:
             device_report = DeviceReport(
                 family=self.family_name,
                 backend=ctx.backend,
@@ -641,6 +679,18 @@ class SklearnTrainable:
                 precision=ctx.precision,
                 fallback_reason=None,
                 array_api=True,
+            )
+        elif engage_array_api and array_api_runtime_failed:
+            # Array API was ATTEMPTED but scipy's env-var gate blocked
+            # it; we fell back to CPU numpy. Report the failure shape
+            # so operators can grep for the deployment gap.
+            device_report = DeviceReport(
+                family=self.family_name,
+                backend="cpu",
+                device_string="cpu",
+                precision="32-true",
+                fallback_reason="array_api_runtime_unavailable",
+                array_api=False,
             )
         else:
             device_report = DeviceReport(
@@ -1532,6 +1582,10 @@ class UMAPTrainable:
             "n_components": n_components,
             "n_neighbors": n_neighbors,
             "random_state": random_state,
+            # umap-learn warns that `random_state` forces `n_jobs=1`; pre-set
+            # the value so umap's "overridden to 1" UserWarning does not
+            # fire. See umap_.py:1952 (umap-learn 0.5+).
+            "n_jobs": kwargs.pop("n_jobs", 1),
             **kwargs,
         }
         self._target = target
@@ -1740,6 +1794,10 @@ class HDBSCANTrainable:
     ) -> None:
         self._init_kwargs: dict[str, Any] = {
             "min_cluster_size": min_cluster_size,
+            # sklearn 1.5+ emits a FutureWarning that `copy` defaults are
+            # changing (False → True in sklearn 1.10). Pre-set the 1.10
+            # default so the upgrade is a no-op.
+            "copy": kwargs.pop("copy", True),
             **kwargs,
         }
         if min_samples is not None:

--- a/packages/kailash-ml/src/kailash_ml/trainable.py
+++ b/packages/kailash-ml/src/kailash_ml/trainable.py
@@ -886,6 +886,11 @@ class TorchTrainable:
 
         artifact_uri = _persist_native_artifact(inner, prefix="torch", format="pt")
 
+        # Per revised-stack.md § "Transparency contract": every fit
+        # returns a DeviceReport. Torch is the DL spine — backend
+        # reflects the actually-resolved Lightning accelerator (no
+        # eviction / OOM fallback path here; native multi-backend
+        # support via L.Trainer per ml-backends.md §5.4).
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             metrics={"train_loss": module.mean_loss},
@@ -899,6 +904,14 @@ class TorchTrainable:
             lightning_trainer_config=trainer_kwargs,
             family=self.family_name,
             hyperparameters={"learning_rate": lr, "max_epochs": max_epochs},
+            device=DeviceReport(
+                family=self.family_name,
+                backend=ctx.backend,
+                device_string=ctx.device_string,
+                precision=ctx.precision,
+                fallback_reason=None,
+                array_api=False,
+            ),
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:
@@ -1020,6 +1033,11 @@ class LightningTrainable:
         if not metrics:
             metrics["train_loss"] = 0.0
 
+        # Per revised-stack.md § "Transparency contract": every fit
+        # returns a DeviceReport. Lightning is the DL spine — backend
+        # reflects the actually-resolved Lightning accelerator (no
+        # eviction / OOM fallback path here; native multi-backend
+        # support via L.Trainer per ml-backends.md §5.5).
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             metrics=metrics,
@@ -1033,6 +1051,14 @@ class LightningTrainable:
             lightning_trainer_config=trainer_kwargs,
             family=self.family_name,
             hyperparameters={"max_epochs": max_epochs},
+            device=DeviceReport(
+                family=self.family_name,
+                backend=ctx.backend,
+                device_string=ctx.device_string,
+                precision=ctx.precision,
+                fallback_reason=None,
+                array_api=False,
+            ),
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:

--- a/packages/kailash-ml/tests/integration/test_trainable_backend_matrix.py
+++ b/packages/kailash-ml/tests/integration/test_trainable_backend_matrix.py
@@ -1,0 +1,346 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 backend-matrix tests across every Phase 1 Trainable family.
+
+Exercises each Trainable on CPU + (where available) MPS / CUDA with
+real estimators, real data, real Lightning Trainer. NO mocking per
+``rules/testing.md`` §"Tier 2 (Integration): Real infrastructure".
+
+Backend availability is detected at collection time:
+
+- ``cpu``  — always runs
+- ``mps``  — skipif ``not torch.backends.mps.is_available()``
+- ``cuda`` — skipif ``not torch.cuda.is_available()``
+
+Every test asserts:
+
+1. The fit completes without raising.
+2. ``TrainingResult.device`` is a populated ``DeviceReport`` (orphan-
+   detection §6 — the GPU-first Phase 1 public API symbols must be
+   exercised by Tier 2 per revised-stack.md § "Transparency contract").
+3. ``result.device.backend`` matches what actually ran (not what was
+   requested — e.g. UMAP on a CUDA request reports backend="cpu"
+   with ``fallback_reason="cuml_eviction"``).
+
+Per revised-stack.md § "Deliverables for a follow-up implementation
+session" item 7.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import sys
+
+import numpy as np
+import polars as pl
+import pytest
+import torch
+
+from kailash_ml._device_report import DeviceReport
+from kailash_ml.trainable import (
+    HDBSCANTrainable,
+    LightGBMTrainable,
+    SklearnTrainable,
+    TrainingContext,
+    UMAPTrainable,
+    XGBoostTrainable,
+)
+
+# ---------------------------------------------------------------------------
+# Backend availability gates
+# ---------------------------------------------------------------------------
+
+_MPS_AVAILABLE = torch.backends.mps.is_available()
+_CUDA_AVAILABLE = torch.cuda.is_available()
+_SCIPY_ARRAY_API = os.environ.get("SCIPY_ARRAY_API") == "1"
+
+requires_mps = pytest.mark.skipif(
+    not _MPS_AVAILABLE, reason="Test host does not expose Metal Performance Shaders."
+)
+requires_cuda = pytest.mark.skipif(
+    not _CUDA_AVAILABLE, reason="Test host does not expose a CUDA device."
+)
+requires_scipy_array_api = pytest.mark.skipif(
+    not _SCIPY_ARRAY_API,
+    reason=(
+        "Set SCIPY_ARRAY_API=1 before importing any sklearn/scipy module "
+        "to exercise the real Array API dispatch path."
+    ),
+)
+
+# XGBoost 2.x segfaults inside `_meta_from_numpy` on darwin-arm + py3.13
+# when fitting against a numpy ndarray (upstream XGBoost issue; same
+# class as the pre-existing `test_auto_logging.py` darwin-arm segfault
+# the conftest already excludes). Tier-2 coverage on Linux CI still
+# exercises the path. TODO: file upstream XGBoost issue with repro.
+_XGBOOST_SEGFAULT_HOST = (
+    sys.platform == "darwin"
+    and platform.machine() == "arm64"
+    and sys.version_info[:2] >= (3, 13)
+)
+xgboost_stable_only = pytest.mark.skipif(
+    _XGBOOST_SEGFAULT_HOST,
+    reason=(
+        "XGBoost 2.x segfaults on darwin-arm + py3.13 during _meta_from_numpy; "
+        "Tier 2 coverage deferred to Linux CI. Tier 1 OOM-fallback unit tests "
+        "exercise the XGBoostTrainable codepath without hitting the segfault."
+    ),
+)
+
+# LightGBM 4.x has the same numpy-dispatch segfault class on
+# darwin-arm + py3.13 (fires in `_lazy_init` → `__init_from_np2d`).
+# Same disposition: defer Tier 2 to Linux CI, keep Tier 1 OOM-fallback
+# unit tests that exercise the LightGBMTrainable codepath.
+lightgbm_stable_only = pytest.mark.skipif(
+    _XGBOOST_SEGFAULT_HOST,  # same host signature
+    reason=(
+        "LightGBM 4.x segfaults on darwin-arm + py3.13 during "
+        "__init_from_np2d; Tier 2 coverage deferred to Linux CI. Tier 1 "
+        "OOM-fallback unit tests exercise the LightGBMTrainable codepath."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures — real polars frames, deterministic, tiny
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def classification_frame() -> pl.DataFrame:
+    """50-row binary classification frame. Large enough for HDBSCAN."""
+    rng = np.random.default_rng(seed=42)
+    n = 50
+    x1 = rng.normal(0.0, 1.0, size=n)
+    x2 = rng.normal(0.0, 1.0, size=n)
+    # Linear separator — y=1 when 0.7*x1+0.3*x2>0
+    y = ((0.7 * x1 + 0.3 * x2) > 0).astype(int)
+    return pl.DataFrame({"feature1": x1, "feature2": x2, "target": y})
+
+
+@pytest.fixture(scope="module")
+def unsupervised_frame() -> pl.DataFrame:
+    """50-row 3-feature frame for UMAP / HDBSCAN (no target column)."""
+    rng = np.random.default_rng(seed=42)
+    n = 50
+    return pl.DataFrame(
+        {
+            "feature1": rng.normal(0.0, 1.0, size=n),
+            "feature2": rng.normal(1.0, 1.0, size=n),
+            "feature3": rng.normal(-1.0, 1.0, size=n),
+        }
+    )
+
+
+def _ctx(backend: str, device_string: str) -> TrainingContext:
+    """Construct a TrainingContext for the target backend."""
+    accelerator = "gpu" if backend in {"cuda", "mps"} else "cpu"
+    return TrainingContext(
+        accelerator=accelerator,
+        precision="32-true",
+        devices=1,
+        device_string=device_string,
+        backend=backend,
+        tenant_id=None,
+        tracker_run_id=None,
+        trial_number=None,
+    )
+
+
+def _cpu_ctx() -> TrainingContext:
+    return _ctx("cpu", "cpu")
+
+
+def _mps_ctx() -> TrainingContext:
+    return _ctx("mps", "mps")
+
+
+def _cuda_ctx() -> TrainingContext:
+    return _ctx("cuda", "cuda:0")
+
+
+# ---------------------------------------------------------------------------
+# Sklearn — CPU path + off-allowlist GPU request
+# ---------------------------------------------------------------------------
+
+
+def test_sklearn_cpu_fits_and_reports_cpu(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """Sklearn on CPU context — DeviceReport.backend=='cpu', array_api=False."""
+    from sklearn.ensemble import RandomForestClassifier
+
+    trainable = SklearnTrainable(
+        estimator=RandomForestClassifier(n_estimators=5, random_state=42),
+        target="target",
+    )
+    result = trainable.fit(classification_frame, context=_cpu_ctx())
+    assert isinstance(result.device, DeviceReport)
+    assert result.device.backend == "cpu"
+    assert result.device.family == "sklearn"
+    assert result.device.array_api is False
+    assert result.device.fallback_reason is None
+
+
+@requires_mps
+def test_sklearn_offlist_estimator_with_mps_request_falls_back(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """Off-allowlist + MPS request → WARN-fallback CPU path, device reflects it."""
+    from sklearn.ensemble import RandomForestClassifier
+
+    trainable = SklearnTrainable(
+        estimator=RandomForestClassifier(n_estimators=5, random_state=42),
+        target="target",
+    )
+    result = trainable.fit(classification_frame, context=_mps_ctx())
+    assert result.device.backend == "cpu"
+    assert result.device.array_api is False
+    assert result.device.fallback_reason == "array_api_offlist"
+
+
+@requires_mps
+@requires_scipy_array_api
+def test_sklearn_allowlisted_estimator_on_mps_engages_array_api(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """Allowlisted estimator + MPS + SCIPY_ARRAY_API=1 → array_api engaged.
+
+    Skipped when the test host does not have the scipy env-var set
+    before import; that's the production-deployment precondition and
+    this Tier-2 test is the checkpoint that the real path works when
+    the precondition holds.
+    """
+    from sklearn.linear_model import LogisticRegression
+
+    trainable = SklearnTrainable(
+        estimator=LogisticRegression(max_iter=200), target="target"
+    )
+    result = trainable.fit(classification_frame, context=_mps_ctx())
+    # When Array API engages cleanly, backend reflects MPS.
+    # When scipy's runtime gate trips (deployment env misses SCIPY_ARRAY_API),
+    # the CPU fallback path fires. Both are valid outcomes; the test
+    # asserts device is populated and the fallback is grep-able.
+    assert isinstance(result.device, DeviceReport)
+    if result.device.array_api:
+        assert result.device.backend == "mps"
+        assert result.device.device_string == "mps"
+        assert result.device.fallback_reason is None
+    else:
+        # Fallback path — either array_api_runtime_unavailable or
+        # array_api_offlist (if the allowlist check changed).
+        assert result.device.backend == "cpu"
+        assert result.device.fallback_reason in {
+            "array_api_runtime_unavailable",
+            "array_api_offlist",
+        }
+
+
+# ---------------------------------------------------------------------------
+# XGBoost — CPU path (CUDA unavailable on this host)
+# ---------------------------------------------------------------------------
+
+
+@xgboost_stable_only
+def test_xgboost_cpu_fits_and_reports_cpu(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """XGBoost on CPU context — no OOM fallback, DeviceReport.backend=='cpu'."""
+    trainable = XGBoostTrainable(target="target", task="classification")
+    result = trainable.fit(classification_frame, context=_cpu_ctx())
+    assert isinstance(result.device, DeviceReport)
+    assert result.device.backend == "cpu"
+    assert result.device.family == "xgboost"
+    assert result.device.fallback_reason is None
+
+
+@requires_cuda
+@xgboost_stable_only
+def test_xgboost_cuda_fits_and_reports_cuda(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """XGBoost on CUDA context — DeviceReport.backend=='cuda' when OOM not hit."""
+    trainable = XGBoostTrainable(target="target", task="classification")
+    result = trainable.fit(classification_frame, context=_cuda_ctx())
+    assert result.device.backend in {"cuda", "cpu"}  # cpu iff OOM fallback fired
+    if result.device.backend == "cpu":
+        assert result.device.fallback_reason == "oom"
+
+
+# ---------------------------------------------------------------------------
+# LightGBM — CPU path (CUDA unavailable on this host)
+# ---------------------------------------------------------------------------
+
+
+@lightgbm_stable_only
+def test_lightgbm_cpu_fits_and_reports_cpu(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """LightGBM on CPU context — standard path, DeviceReport.backend=='cpu'."""
+    trainable = LightGBMTrainable(target="target", task="classification")
+    result = trainable.fit(classification_frame, context=_cpu_ctx())
+    assert isinstance(result.device, DeviceReport)
+    assert result.device.backend == "cpu"
+    assert result.device.family == "lightgbm"
+    assert result.device.fallback_reason is None
+
+
+# ---------------------------------------------------------------------------
+# UMAP — Phase 1 CPU-only; CUDA request triggers cuml_eviction log path
+# ---------------------------------------------------------------------------
+
+
+def test_umap_cpu_fits_and_reports_cpu(
+    unsupervised_frame: pl.DataFrame,
+) -> None:
+    """UMAP on CPU context — no eviction log, DeviceReport.backend=='cpu'."""
+    trainable = UMAPTrainable(n_components=2, n_neighbors=5, random_state=42)
+    result = trainable.fit(unsupervised_frame, context=_cpu_ctx())
+    assert isinstance(result.device, DeviceReport)
+    assert result.device.backend == "cpu"
+    assert result.device.family == "umap"
+    assert result.device.fallback_reason is None
+
+
+def test_umap_cuda_request_reports_cuml_eviction_fallback(
+    unsupervised_frame: pl.DataFrame,
+) -> None:
+    """UMAP Phase 1 is CPU-only — CUDA request reports cuml_eviction.
+
+    Runs regardless of whether the host has CUDA, because the eviction
+    is unconditional in Phase 1 (cuML is evicted at the framework
+    level per revised-stack.md CRITICAL-1 disposition).
+    """
+    trainable = UMAPTrainable(n_components=2, n_neighbors=5, random_state=42)
+    result = trainable.fit(unsupervised_frame, context=_cuda_ctx())
+    assert result.device.backend == "cpu"
+    assert result.device.family == "umap"
+    assert result.device.fallback_reason == "cuml_eviction"
+
+
+# ---------------------------------------------------------------------------
+# HDBSCAN — Phase 1 CPU-only; CUDA request triggers cuml_eviction log path
+# ---------------------------------------------------------------------------
+
+
+def test_hdbscan_cpu_fits_and_reports_cpu(
+    unsupervised_frame: pl.DataFrame,
+) -> None:
+    """HDBSCAN on CPU context — standard path, DeviceReport.backend=='cpu'."""
+    trainable = HDBSCANTrainable(min_cluster_size=3)
+    result = trainable.fit(unsupervised_frame, context=_cpu_ctx())
+    assert isinstance(result.device, DeviceReport)
+    assert result.device.backend == "cpu"
+    assert result.device.family == "hdbscan"
+    assert result.device.fallback_reason is None
+
+
+def test_hdbscan_cuda_request_reports_cuml_eviction_fallback(
+    unsupervised_frame: pl.DataFrame,
+) -> None:
+    """HDBSCAN Phase 1 is CPU-only — CUDA request reports cuml_eviction."""
+    trainable = HDBSCANTrainable(min_cluster_size=3)
+    result = trainable.fit(unsupervised_frame, context=_cuda_ctx())
+    assert result.device.backend == "cpu"
+    assert result.device.family == "hdbscan"
+    assert result.device.fallback_reason == "cuml_eviction"

--- a/packages/kailash-ml/tests/regression/test_trainable_device_report_invariant.py
+++ b/packages/kailash-ml/tests/regression/test_trainable_device_report_invariant.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: every Trainable.fit MUST populate TrainingResult.device.
+
+Locks the spec invariant from
+``workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md``
+§ "Transparency contract" and orphan-detection §2: every fit returns
+a DeviceReport — the public ``DeviceReport`` symbol must be wired
+into the production hot path of every Trainable family.
+
+This is a structural guard. The actual fit logic + assertions are
+covered by per-family unit tests; this file mechanically asserts that
+no return-TrainingResult site drops the ``device`` kwarg.
+
+Origin: round-3 redteam (2026-04-19) found TorchTrainable + Lightning
+Trainable returning TrainingResult without ``device=DeviceReport(...)``
+— silent orphan of the GPU-first Phase 1 transparency contract.
+Fixed in commit-on-feat/ml-gpu-phase1-integration; this test prevents
+the next refactor from silently re-dropping it.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _trainable_module_path() -> Path:
+    """Path to packages/kailash-ml/src/kailash_ml/trainable.py."""
+    here = Path(__file__).resolve()
+    # tests/regression/test_*.py -> packages/kailash-ml
+    pkg_root = here.parent.parent.parent
+    return pkg_root / "src" / "kailash_ml" / "trainable.py"
+
+
+@pytest.mark.regression
+def test_every_return_trainingresult_has_device_kwarg() -> None:
+    """Every TrainingResult constructor in trainable.py MUST pass device=.
+
+    Mechanical AST guard against the round-3 redteam finding: lines
+    889 + 1023 (TorchTrainable + LightningTrainable) returned
+    TrainingResult without populating the device field, leaving the
+    GPU-first Phase 1 transparency contract orphan for those two
+    families. Fix landed inline; this test ensures any future refactor
+    that drops the kwarg fails loudly at test time.
+    """
+    src = _trainable_module_path().read_text()
+    tree = ast.parse(src)
+
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match `TrainingResult(...)` constructor calls (not module-
+        # qualified, since the file imports the symbol directly).
+        func = node.func
+        if not isinstance(func, ast.Name) or func.id != "TrainingResult":
+            continue
+        kwarg_names = {kw.arg for kw in node.keywords if kw.arg is not None}
+        if "device" not in kwarg_names:
+            # Capture call site context for the error message.
+            line_text = src.splitlines()[node.lineno - 1].strip()
+            offenders.append((node.lineno, line_text))
+
+    assert not offenders, (
+        "Every TrainingResult(...) constructor call in trainable.py MUST "
+        "populate the device=DeviceReport(...) kwarg per "
+        "workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md "
+        "§ 'Transparency contract'. Sites missing the device kwarg:\n"
+        + "\n".join(f"  line {ln}: {txt}" for ln, txt in offenders)
+    )
+
+
+@pytest.mark.regression
+def test_every_trainable_class_imports_device_report() -> None:
+    """trainable.py MUST import DeviceReport at module scope.
+
+    Belt-and-suspenders: an AST refactor that removes the
+    `from kailash_ml._device_report import DeviceReport` line would
+    break every device= construction silently (NameError at runtime),
+    but only when fit() is actually called. This test catches it at
+    import time.
+    """
+    src = _trainable_module_path().read_text()
+    tree = ast.parse(src)
+
+    has_device_report_import = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module == "kailash_ml._device_report":
+            for alias in node.names:
+                if alias.name == "DeviceReport":
+                    has_device_report_import = True
+                    break
+
+    assert has_device_report_import, (
+        "trainable.py MUST import DeviceReport at module scope from "
+        "kailash_ml._device_report. The orphan-detection §1 contract "
+        "requires every Trainable.fit() to construct a DeviceReport, "
+        "and dropping the import silently breaks every family adapter."
+    )

--- a/packages/kailash-ml/tests/regression/test_trainable_device_report_invariant.py
+++ b/packages/kailash-ml/tests/regression/test_trainable_device_report_invariant.py
@@ -73,6 +73,44 @@ def test_every_return_trainingresult_has_device_kwarg() -> None:
 
 
 @pytest.mark.regression
+def test_all_seven_phase_one_trainables_in_kailash_ml_all() -> None:
+    """specs/ml-engines.md §3.0 — all 7 family adapters MUST be in kailash_ml.__all__.
+
+    Origin: round-3 redteam spec-to-code sweep (2026-04-19) found only 2 of
+    7 Trainables (UMAP + HDBSCAN — the new ones from Shard C) were in
+    kailash_ml.__all__. The 5 pre-existing (Sklearn/XGBoost/LightGBM/
+    Torch/Lightning) were accessible via kailash_ml.trainable but absent
+    from the top-level export — silent spec violation that had been
+    accumulating since 0.10.x. Fixed in 0.12.0.
+    """
+    import kailash_ml
+
+    expected = {
+        "SklearnTrainable",
+        "XGBoostTrainable",
+        "LightGBMTrainable",
+        "TorchTrainable",
+        "LightningTrainable",
+        "UMAPTrainable",
+        "HDBSCANTrainable",
+    }
+    actual = {n for n in kailash_ml.__all__ if n.endswith("Trainable")}
+    missing = expected - actual
+    assert not missing, (
+        f"Per specs/ml-engines.md §3.0, all 7 Phase 1 family adapters MUST "
+        f"be in kailash_ml.__all__. Missing: {sorted(missing)}. "
+        f"Add eager imports to packages/kailash-ml/src/kailash_ml/__init__.py "
+        f"AND list them in __all__ (per orphan-detection §6)."
+    )
+    # Each MUST be reachable as kailash_ml.<X>
+    for name in expected:
+        assert hasattr(kailash_ml, name), (
+            f"{name} is in kailash_ml.__all__ but not on the kailash_ml "
+            f"module — eager import missing in __init__.py"
+        )
+
+
+@pytest.mark.regression
 def test_every_trainable_class_imports_device_report() -> None:
     """trainable.py MUST import DeviceReport at module scope.
 

--- a/packages/kailash-ml/tests/unit/test_hdbscan_trainable.py
+++ b/packages/kailash-ml/tests/unit/test_hdbscan_trainable.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for HDBSCANTrainable (GPU-first Phase 1, CPU-only).
+
+Phase 1 ships CPU-only via ``sklearn.cluster.HDBSCAN`` (sklearn ≥1.3,
+already in the ``scikit-learn>=1.5`` base dep). cuML is evicted per
+workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md
+CRITICAL-1 disposition. These tests verify:
+
+1. HDBSCAN fits on CPU and returns a populated DeviceReport.
+2. Requesting a CUDA backend logs ``hdbscan.cuml_eviction`` at INFO and
+   returns ``fallback_reason="cuml_eviction"`` in the DeviceReport.
+3. ``predict()`` returns cluster labels of the expected shape.
+4. HDBSCANTrainable is exported via ``kailash_ml.__all__``.
+"""
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import polars as pl
+import pytest
+
+import kailash_ml
+from kailash_ml import HDBSCANTrainable
+from kailash_ml.trainable import TrainingContext
+
+
+@pytest.fixture
+def clusterable_frame() -> pl.DataFrame:
+    """Synthetic frame with two well-separated Gaussian blobs.
+
+    HDBSCAN's default min_cluster_size=5 will find clusters in this data.
+    """
+    rng = np.random.default_rng(42)
+    blob1 = rng.normal(loc=0.0, scale=0.3, size=(20, 2))
+    blob2 = rng.normal(loc=5.0, scale=0.3, size=(20, 2))
+    points = np.vstack([blob1, blob2])
+    return pl.DataFrame({"x": points[:, 0].tolist(), "y": points[:, 1].tolist()})
+
+
+def _cpu_context() -> TrainingContext:
+    return TrainingContext(
+        accelerator="cpu",
+        precision="32-true",
+        devices=1,
+        device_string="cpu",
+        backend="cpu",
+    )
+
+
+def _cuda_context() -> TrainingContext:
+    """Pretend-CUDA context for eviction-path tests — HDBSCANTrainable
+    always runs on CPU, so this exercises the cuml_eviction sentinel."""
+    return TrainingContext(
+        accelerator="cuda",
+        precision="bf16-mixed",
+        devices=1,
+        device_string="cuda:0",
+        backend="cuda",
+    )
+
+
+def test_hdbscan_fits_on_cpu_returns_device_report(
+    clusterable_frame: pl.DataFrame,
+) -> None:
+    """HDBSCANTrainable.fit() on CPU populates DeviceReport.backend='cpu'."""
+    trainable = HDBSCANTrainable(min_cluster_size=5)
+    result = trainable.fit(clusterable_frame, context=_cpu_context())
+
+    assert result.device is not None
+    assert result.device.backend == "cpu"
+    assert result.device.family == "hdbscan"
+    assert result.device.device_string == "cpu"
+    assert result.device.precision == "32-true"
+    assert result.device.fallback_reason is None
+    assert result.device.array_api is False
+    assert result.family == "hdbscan"
+    assert "native" in result.artifact_uris
+
+    # External evidence the clusterer actually ran: two well-separated
+    # blobs should produce ≥1 cluster and finite metrics.
+    assert result.metrics["hdbscan_n_clusters"] >= 1.0
+    # Non-finite metrics are rejected by TrainingResult.__post_init__,
+    # so reaching here proves the metric values are finite.
+
+
+def test_hdbscan_logs_cuml_eviction_when_cuda_requested(
+    clusterable_frame: pl.DataFrame, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Requesting CUDA logs INFO-level cuml_eviction and sets fallback."""
+    trainable = HDBSCANTrainable(min_cluster_size=5)
+
+    with caplog.at_level(logging.INFO, logger="kailash_ml.trainable"):
+        result = trainable.fit(clusterable_frame, context=_cuda_context())
+
+    eviction_records = [
+        rec for rec in caplog.records if rec.message == "hdbscan.cuml_eviction"
+    ]
+    assert len(eviction_records) >= 1, (
+        "expected hdbscan.cuml_eviction INFO log, got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+    evict = eviction_records[0]
+    assert evict.levelno == logging.INFO
+    assert evict.requested_backend == "cuda"
+    assert evict.actual_backend == "cpu"
+    assert evict.fallback_reason == "cuml_eviction"
+
+    assert result.device is not None
+    assert result.device.backend == "cpu"
+    assert result.device.fallback_reason == "cuml_eviction"
+
+
+def test_hdbscan_predict_returns_cluster_labels(
+    clusterable_frame: pl.DataFrame,
+) -> None:
+    """predict() returns 1-D label array of length n_rows."""
+    trainable = HDBSCANTrainable(min_cluster_size=5)
+    trainable.fit(clusterable_frame, context=_cpu_context())
+
+    preds = trainable.predict(clusterable_frame)
+    assert preds.column == "cluster_label"
+    raw = preds.raw
+    # sklearn HDBSCAN.fit_predict returns ndarray of int labels.
+    assert raw.shape == (40,)
+
+
+def test_hdbscan_trainable_in_all() -> None:
+    """HDBSCANTrainable MUST be listed in kailash_ml.__all__ (orphan-detection §6)."""
+    assert "HDBSCANTrainable" in kailash_ml.__all__
+    assert HDBSCANTrainable is kailash_ml.HDBSCANTrainable

--- a/packages/kailash-ml/tests/unit/test_lightgbm_oom_fallback.py
+++ b/packages/kailash-ml/tests/unit/test_lightgbm_oom_fallback.py
@@ -1,0 +1,299 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for LightGBMTrainable GPU OOM → CPU fallback.
+
+Covers the Phase 1 punch list item 4 (revised-stack.md §"No-config
+contract" — lightgbm row): a GPU OOM inside ``trainer.fit`` MUST log a
+single WARN, retry on CPU, and return a TrainingResult whose
+``device.fallback_reason`` is ``"oom"`` with ``device.backend == "cpu"``.
+Non-OOM exceptions MUST re-raise unchanged. LightGBM probes the GPU
+build at ``set_params(device_type='gpu')`` time, so the test must stub
+that probe out.
+
+Tests patch ``lightning.pytorch.Trainer`` so no GPU / Lightning runtime
+is required (Tier 1 per rules/testing.md §"3-Tier Testing").
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import polars as pl
+import pytest
+from kailash_ml._device_report import DeviceReport
+from kailash_ml._result import TrainingResult
+from kailash_ml.trainable import LightGBMTrainable, TrainingContext, _is_gpu_oom_error
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_classification_data() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "feature1": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            "feature2": [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5],
+            "target": [0, 1, 0, 1, 0, 1, 0, 1],
+        }
+    )
+
+
+@pytest.fixture
+def cuda_context() -> TrainingContext:
+    return TrainingContext(
+        accelerator="gpu",
+        precision="32-true",
+        devices=1,
+        device_string="cuda:0",
+        backend="cuda",
+    )
+
+
+@pytest.fixture
+def cpu_context() -> TrainingContext:
+    return TrainingContext(
+        accelerator="cpu",
+        precision="32-true",
+        devices=1,
+        device_string="cpu",
+        backend="cpu",
+    )
+
+
+class _FakeLightGBMError(RuntimeError):
+    """Stand-in for lightgbm.basic.LightGBMError."""
+
+
+class _FakeOutOfMemoryError(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("")
+
+
+_FakeOutOfMemoryError.__name__ = "OutOfMemoryError"
+
+
+def _make_estimator() -> MagicMock:
+    """Build a lightgbm estimator stub.
+
+    The production path probes GPU support via ``set_params(device_type=
+    'gpu', gpu_use_dp=False)`` BEFORE the Lightning Trainer runs. For the
+    test we let set_params succeed so the fit path is reached; the
+    trainer stub then raises the OOM that triggers the fallback.
+    """
+    est = MagicMock(spec=["set_params", "fit", "predict"])
+    est.predict.return_value = [0, 1, 0, 1, 0, 1, 0, 1]
+    return est
+
+
+# ---------------------------------------------------------------------------
+# _is_gpu_oom_error helper — independent of Trainable
+# ---------------------------------------------------------------------------
+
+
+def test_oom_helper_recognizes_common_messages() -> None:
+    """_is_gpu_oom_error recognises the standard OOM phrasings (lgb variant)."""
+    assert _is_gpu_oom_error(_FakeLightGBMError("CUDA error: out of memory"))
+    assert _is_gpu_oom_error(RuntimeError("CUDA out of memory. Tried to allocate 2 GB"))
+    assert _is_gpu_oom_error(RuntimeError("lightgbm kernel OOM allocating GPU buffer"))
+    assert _is_gpu_oom_error(_FakeOutOfMemoryError())
+    assert not _is_gpu_oom_error(ValueError("missing column 'target'"))
+    assert not _is_gpu_oom_error(KeyError("foo"))
+    assert not _is_gpu_oom_error(RuntimeError("kernel launch failed"))
+
+
+# ---------------------------------------------------------------------------
+# LightGBMTrainable fit-path OOM fallback
+# ---------------------------------------------------------------------------
+
+
+def _install_oom_then_ok_trainer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    import lightning.pytorch as pl_trainer
+
+    state: dict[str, Any] = {"calls": 0, "instances": []}
+
+    def fit_side_effect(module: Any) -> None:
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise _FakeLightGBMError(
+                "Check failed: (size) >= ((alloc_size)) at cuda: out of memory"
+            )
+        module.on_train_start()
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name=f"Trainer#{len(state['instances']) + 1}")
+        trainer.fit.side_effect = fit_side_effect
+        state["instances"].append(trainer)
+        return trainer
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    return state
+
+
+def _install_non_oom_trainer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    import lightning.pytorch as pl_trainer
+
+    state: dict[str, Any] = {"calls": 0, "instances": []}
+
+    def fit_side_effect(module: Any) -> None:
+        state["calls"] += 1
+        raise RuntimeError("totally unrelated bug — missing column 'target'")
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name=f"Trainer#{len(state['instances']) + 1}")
+        trainer.fit.side_effect = fit_side_effect
+        state["instances"].append(trainer)
+        return trainer
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    return state
+
+
+def _install_always_oom_trainer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    import lightning.pytorch as pl_trainer
+
+    state: dict[str, Any] = {"calls": 0}
+
+    def fit_side_effect(module: Any) -> None:
+        state["calls"] += 1
+        raise _FakeLightGBMError("CUDA error: out of memory on CPU-path stub")
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name="Trainer")
+        trainer.fit.side_effect = fit_side_effect
+        return trainer
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    return state
+
+
+def test_oom_on_cuda_falls_back_to_cpu_with_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_classification_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """GPU OOM on lightgbm path → WARN log + CPU retry + device.backend=='cpu'."""
+    state = _install_oom_then_ok_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    estimator = _make_estimator()
+    trainable = LightGBMTrainable(
+        estimator=estimator, target="target", task="classification"
+    )
+    result = trainable.fit(sample_classification_data, context=cuda_context)
+
+    assert state["calls"] == 2, "expected one OOM + one CPU retry"
+    assert len(state["instances"]) == 2
+
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable" and r.levelno == logging.WARNING
+    ]
+    assert any(
+        "lightgbm.gpu.oom_fallback" in r.getMessage() for r in warn_records
+    ), f"missing lightgbm.gpu.oom_fallback in {[r.getMessage() for r in warn_records]}"
+    fallback_rec = next(
+        r for r in warn_records if "lightgbm.gpu.oom_fallback" in r.getMessage()
+    )
+    assert fallback_rec.fallback_reason == "oom"
+    assert fallback_rec.fallback_backend == "cpu"
+    assert fallback_rec.requested_backend == "cuda"
+    assert fallback_rec.error_class == "_FakeLightGBMError"
+
+    assert isinstance(result, TrainingResult)
+    assert result.device is not None
+    assert result.device.backend == "cpu"
+    assert result.device.fallback_reason == "oom"
+    assert result.device_used == "cpu"
+    assert result.accelerator == "cpu"
+    # Estimator was re-pointed at cpu for the retry.
+    estimator.set_params.assert_any_call(device_type="cpu")
+
+
+def test_non_oom_exception_does_not_trigger_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_classification_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """Non-OOM exceptions propagate; zero WARN log; no second Trainer."""
+    state = _install_non_oom_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    estimator = _make_estimator()
+    trainable = LightGBMTrainable(
+        estimator=estimator, target="target", task="classification"
+    )
+
+    with pytest.raises(RuntimeError, match="totally unrelated bug"):
+        trainable.fit(sample_classification_data, context=cuda_context)
+
+    assert state["calls"] == 1
+    assert len(state["instances"]) == 1
+    fallback_warns = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable"
+        and r.levelno == logging.WARNING
+        and "lightgbm.gpu.oom_fallback" in r.getMessage()
+    ]
+    assert fallback_warns == [], "no fallback WARN should fire on non-OOM"
+
+
+def test_cpu_request_oom_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_classification_data: pl.DataFrame,
+    cpu_context: TrainingContext,
+) -> None:
+    """If ctx.backend=='cpu' the fallback target is the same — propagate."""
+    state = _install_always_oom_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    estimator = _make_estimator()
+    trainable = LightGBMTrainable(
+        estimator=estimator, target="target", task="classification"
+    )
+
+    with pytest.raises(_FakeLightGBMError, match="out of memory"):
+        trainable.fit(sample_classification_data, context=cpu_context)
+
+    assert state["calls"] == 1, "CPU-requested OOM must NOT retry"
+    fallback_warns = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable"
+        and r.levelno == logging.WARNING
+        and "lightgbm.gpu.oom_fallback" in r.getMessage()
+    ]
+    assert fallback_warns == [], "no fallback WARN when already on CPU"
+
+
+def test_device_report_post_fallback_carries_oom_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_classification_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """Full DeviceReport shape after OOM→CPU fallback (revised-stack §54-78)."""
+    _install_oom_then_ok_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    estimator = _make_estimator()
+    trainable = LightGBMTrainable(
+        estimator=estimator, target="target", task="classification"
+    )
+    result = trainable.fit(sample_classification_data, context=cuda_context)
+
+    report = result.device
+    assert isinstance(report, DeviceReport)
+    assert report.family == "lightgbm"
+    assert report.backend == "cpu"
+    assert report.device_string == "cpu"
+    assert report.precision == "32-true"
+    assert report.fallback_reason == "oom"
+    assert report.array_api is False

--- a/packages/kailash-ml/tests/unit/test_sklearn_trainable_array_api.py
+++ b/packages/kailash-ml/tests/unit/test_sklearn_trainable_array_api.py
@@ -1,0 +1,394 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for SklearnTrainable Array-API allowlist + auto-context-wrap.
+
+Covers Phase 1 punch list item 3 (revised-stack.md §"No-config contract"
+— sklearn row, lines 84-89): when an allowlisted sklearn estimator is
+called with a non-CPU TrainingContext, ``SklearnTrainable.fit`` MUST
+wrap the inner ``trainer.fit`` in
+``sklearn.config_context(array_api_dispatch=True)``, move X/y to a
+torch tensor on the resolved device, log INFO ``sklearn.array_api.engaged``,
+and return ``TrainingResult.device.array_api == True``.
+
+Off-allowlist requests on a non-CPU backend MUST log WARN
+``sklearn.array_api.offlist`` with ``fallback_reason="array_api_offlist"``
+and proceed on CPU numpy.
+
+Tests patch ``lightning.pytorch.Trainer`` so no GPU / Lightning runtime
+is required (Tier 1 per rules/testing.md §"3-Tier Testing").
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import polars as pl
+import pytest
+from kailash_ml._device_report import DeviceReport
+from kailash_ml._result import TrainingResult
+from kailash_ml.trainable import (
+    _SKLEARN_ARRAY_API_ALLOWLIST,
+    SklearnTrainable,
+    TrainingContext,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_data() -> pl.DataFrame:
+    """Tiny deterministic frame for SklearnTrainable.fit()."""
+    return pl.DataFrame(
+        {
+            "feature1": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            "feature2": [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5],
+            "target": [0, 1, 0, 1, 0, 1, 0, 1],
+        }
+    )
+
+
+@pytest.fixture
+def cuda_context() -> TrainingContext:
+    """CUDA-resolved TrainingContext — engages Array API for allowlisted."""
+    return TrainingContext(
+        accelerator="gpu",
+        precision="32-true",
+        devices=1,
+        device_string="cuda:0",
+        backend="cuda",
+        tenant_id=None,
+        tracker_run_id=None,
+        trial_number=None,
+    )
+
+
+@pytest.fixture
+def cpu_context() -> TrainingContext:
+    """CPU TrainingContext — Array API never engaged."""
+    return TrainingContext(
+        accelerator="cpu",
+        precision="32-true",
+        devices=1,
+        device_string="cpu",
+        backend="cpu",
+        tenant_id=None,
+        tracker_run_id=None,
+        trial_number=None,
+    )
+
+
+def _install_recording_trainer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace ``pl_trainer.Trainer`` with a MagicMock; record fit calls.
+
+    Also stubs ``torch.as_tensor`` (no-op so the Array API engaged path
+    doesn't need a CUDA / MPS device on the test host) and
+    ``sklearn.config_context`` (no-op context manager so the test
+    doesn't trip scipy's ``SCIPY_ARRAY_API=1`` env-var precondition —
+    that's a deployment concern, not a control-flow concern). These
+    tests verify control-flow + log + DeviceReport, not tensor
+    movement or scipy integration.
+
+    Returns a state dict the test can inspect: ``{"calls": N,
+    "instances": [trainer], "config_context_calls": [...]}``.
+    """
+    import contextlib
+
+    import lightning.pytorch as pl_trainer
+    import sklearn
+    import torch
+
+    state: dict[str, Any] = {"calls": 0, "instances": [], "config_context_calls": []}
+
+    def fit_side_effect(module: Any) -> None:
+        state["calls"] += 1
+        # Drive on_train_start so the LightningModule sets module.metric.
+        module.on_train_start()
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name=f"Trainer#{len(state['instances']) + 1}")
+        trainer.fit.side_effect = fit_side_effect
+        state["instances"].append(trainer)
+        return trainer
+
+    def fake_as_tensor(arr: Any, device: Any = None, **_: Any) -> Any:
+        # Ignore the device kwarg — tests run on CPU regardless of what
+        # the cuda_context says.
+        return arr
+
+    @contextlib.contextmanager
+    def fake_config_context(**kwargs: Any) -> Any:
+        state["config_context_calls"].append(kwargs)
+        yield
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    monkeypatch.setattr(torch, "as_tensor", fake_as_tensor)
+    monkeypatch.setattr(sklearn, "config_context", fake_config_context)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Allowlist sanity
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_contains_expected_estimators() -> None:
+    """The Phase 1 conservative allowlist matches the spec rows."""
+    expected = {
+        "Ridge",
+        "LogisticRegression",
+        "LinearRegression",
+        "LinearDiscriminantAnalysis",
+        "KMeans",
+        "PCA",
+        "StandardScaler",
+        "MinMaxScaler",
+    }
+    assert _SKLEARN_ARRAY_API_ALLOWLIST == expected
+
+
+# ---------------------------------------------------------------------------
+# Array API engaged path (allowlist + non-CPU request)
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_estimator_engages_array_api_context(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """Allowlisted estimator + cuda backend → INFO log + DeviceReport.array_api=True."""
+    _install_recording_trainer(monkeypatch)
+    caplog.set_level(logging.INFO, logger="kailash_ml.trainable")
+
+    # MagicMock matched-by-class-name to "LogisticRegression" (an
+    # allowlist member). Returns deterministic int labels that survive
+    # the metric-type check sklearn does on accuracy_score.
+    estimator = MagicMock(spec=["fit", "predict", "set_params"])
+    estimator.predict.return_value = [0, 1, 0, 1, 0, 1, 0, 1]
+    type(estimator).__name__ = "LogisticRegression"
+
+    trainable = SklearnTrainable(estimator=estimator, target="target")
+    result = trainable.fit(sample_data, context=cuda_context)
+
+    info_records = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable" and r.levelno == logging.INFO
+    ]
+    engaged = [r for r in info_records if "sklearn.array_api.engaged" in r.getMessage()]
+    assert len(engaged) >= 1, (
+        f"missing sklearn.array_api.engaged INFO log; got "
+        f"{[r.getMessage() for r in info_records]}"
+    )
+    rec = engaged[0]
+    assert rec.estimator_class == "LogisticRegression"
+    assert rec.backend == "cuda"
+    assert rec.device_string == "cuda:0"
+
+    # DeviceReport reflects the engaged Array API path.
+    assert isinstance(result, TrainingResult)
+    assert result.device is not None
+    assert isinstance(result.device, DeviceReport)
+    assert result.device.array_api is True
+    assert result.device.backend == "cuda"
+    assert result.device.device_string == "cuda:0"
+    assert result.device.fallback_reason is None
+    assert result.device.family == "sklearn"
+
+
+# ---------------------------------------------------------------------------
+# Off-allowlist fallback (not on allowlist + non-CPU request)
+# ---------------------------------------------------------------------------
+
+
+def test_offlist_estimator_fallback_warns(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """Off-allowlist estimator + cuda backend → WARN + fallback_reason='array_api_offlist'."""
+    _install_recording_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    from sklearn.ensemble import RandomForestClassifier
+
+    trainable = SklearnTrainable(
+        estimator=RandomForestClassifier(n_estimators=5, random_state=42),
+        target="target",
+    )
+    result = trainable.fit(sample_data, context=cuda_context)
+
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable" and r.levelno == logging.WARNING
+    ]
+    offlist = [r for r in warn_records if "sklearn.array_api.offlist" in r.getMessage()]
+    assert len(offlist) >= 1, (
+        f"missing sklearn.array_api.offlist WARN log; got "
+        f"{[r.getMessage() for r in warn_records]}"
+    )
+    rec = offlist[0]
+    assert rec.estimator_class == "RandomForestClassifier"
+    assert rec.requested_backend == "cuda"
+    assert rec.fallback_reason == "array_api_offlist"
+
+    # DeviceReport reflects the CPU fallback path.
+    assert result.device is not None
+    assert result.device.array_api is False
+    assert result.device.backend == "cpu"
+    assert result.device.device_string == "cpu"
+    assert result.device.fallback_reason == "array_api_offlist"
+    assert result.device.family == "sklearn"
+
+
+# ---------------------------------------------------------------------------
+# CPU request never engages Array API
+# ---------------------------------------------------------------------------
+
+
+def test_cpu_request_does_not_engage_array_api(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_data: pl.DataFrame,
+    cpu_context: TrainingContext,
+) -> None:
+    """CPU backend request → no array_api log of any kind, fallback_reason is None."""
+    _install_recording_trainer(monkeypatch)
+    caplog.set_level(logging.DEBUG, logger="kailash_ml.trainable")
+
+    from sklearn.linear_model import LogisticRegression
+
+    trainable = SklearnTrainable(
+        estimator=LogisticRegression(max_iter=100), target="target"
+    )
+    result = trainable.fit(sample_data, context=cpu_context)
+
+    array_api_records = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable" and "sklearn.array_api" in r.getMessage()
+    ]
+    assert array_api_records == [], (
+        f"expected zero sklearn.array_api log records on CPU request; got "
+        f"{[r.getMessage() for r in array_api_records]}"
+    )
+
+    assert result.device is not None
+    assert result.device.array_api is False
+    assert result.device.backend == "cpu"
+    assert result.device.fallback_reason is None
+
+
+# ---------------------------------------------------------------------------
+# DeviceReport invariant (per orphan-detection §6 / Phase 1 transparency)
+# ---------------------------------------------------------------------------
+
+
+def test_device_report_populated_on_every_fit(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_data: pl.DataFrame,
+    cpu_context: TrainingContext,
+) -> None:
+    """SklearnTrainable.fit MUST always populate TrainingResult.device."""
+    _install_recording_trainer(monkeypatch)
+    from sklearn.linear_model import LogisticRegression
+
+    trainable = SklearnTrainable(
+        estimator=LogisticRegression(max_iter=100), target="target"
+    )
+    result = trainable.fit(sample_data, context=cpu_context)
+    assert result.device is not None
+    assert isinstance(result.device, DeviceReport)
+
+
+# ---------------------------------------------------------------------------
+# Reserved LogRecord field collision check (per observability.md §9)
+# ---------------------------------------------------------------------------
+
+
+def test_log_extra_keys_avoid_logrecord_collisions(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """Log records emitted by SklearnTrainable MUST NOT carry reserved LogRecord names.
+
+    Per observability.md MUST Rule 9: ``module``, ``class``, ``name``,
+    ``levelname`` etc. cannot be passed via ``extra=`` because they
+    collide with LogRecord's own attributes and raise a typed error in
+    some configurations. Domain-prefixed names (``estimator_class``,
+    ``estimator_module``) are required.
+    """
+    _install_recording_trainer(monkeypatch)
+    caplog.set_level(logging.DEBUG, logger="kailash_ml.trainable")
+
+    from sklearn.linear_model import LogisticRegression
+
+    trainable = SklearnTrainable(
+        estimator=LogisticRegression(max_iter=100), target="target"
+    )
+    trainable.fit(sample_data, context=cuda_context)
+
+    reserved = {
+        "msg",
+        "args",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "pathname",
+        "filename",
+        "name",
+        "levelname",
+        "levelno",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+    }
+    for r in caplog.records:
+        if r.name != "kailash_ml.trainable":
+            continue
+        # Inspect attributes set by `extra=` (everything not on the base
+        # LogRecord constructor signature).
+        record_attrs = set(r.__dict__.keys())
+        sklearn_extras = {
+            "family",
+            "estimator_class",
+            "backend",
+            "device_string",
+            "requested_backend",
+            "fallback_reason",
+        }
+        # Verify our extras landed.
+        present_extras = record_attrs & sklearn_extras
+        if "sklearn.array_api" in r.getMessage():
+            assert present_extras, (
+                f"sklearn.array_api log record missing expected extras; "
+                f"present attributes: {sorted(record_attrs)}"
+            )
+        # Verify we did NOT collide with reserved names by passing one
+        # in the extra dict (the assertion is implicit — Python's
+        # logging would have raised KeyError at .info() / .warning()
+        # call time, not here, so the test reaching this point already
+        # proves no collision occurred).
+        # Belt-and-suspenders: confirm record_attrs include reserved
+        # names ONLY in their LogRecord-built-in form, not as user-set
+        # extras.
+        assert "module" in record_attrs  # built-in, set by LogRecord ctor
+        # If we'd passed extra={"module": ...} it would have raised before
+        # this assertion ran. The fact that we're here proves the rule
+        # is held.

--- a/packages/kailash-ml/tests/unit/test_sklearn_trainable_array_api.py
+++ b/packages/kailash-ml/tests/unit/test_sklearn_trainable_array_api.py
@@ -249,6 +249,184 @@ def test_offlist_estimator_fallback_warns(
 
 
 # ---------------------------------------------------------------------------
+# Array-API runtime fallback (scipy SCIPY_ARRAY_API gate trips at runtime)
+# ---------------------------------------------------------------------------
+
+
+def _install_runtime_failing_array_api_trainer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, Any]:
+    """Install fakes such that ``sklearn.config_context`` raises the scipy gate.
+
+    Mirrors `_install_recording_trainer` but swaps `config_context` for
+    one that raises the exact `RuntimeError` shape sklearn emits when
+    ``SCIPY_ARRAY_API=1`` was not set before the scipy/sklearn import:
+    "Scikit-learn array API support was enabled but scipy's own support
+    is not enabled. ..."
+
+    Returns ``{"calls": N, "instances": [trainer1, trainer2],
+    "config_context_calls": [{"array_api_dispatch": True}]}`` — the
+    second trainer is the CPU-numpy retry that the fallback path
+    rebuilds.
+    """
+    import contextlib
+
+    import lightning.pytorch as pl_trainer
+    import sklearn
+    import torch
+
+    state: dict[str, Any] = {"calls": 0, "instances": [], "config_context_calls": []}
+
+    def fit_side_effect(module: Any) -> None:
+        state["calls"] += 1
+        module.on_train_start()
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name=f"Trainer#{len(state['instances']) + 1}")
+        trainer.fit.side_effect = fit_side_effect
+        state["instances"].append(trainer)
+        return trainer
+
+    def fake_as_tensor(arr: Any, device: Any = None, **_: Any) -> Any:
+        return arr
+
+    @contextlib.contextmanager
+    def failing_config_context(**kwargs: Any) -> Any:
+        state["config_context_calls"].append(kwargs)
+        # The exact text sklearn emits when scipy's array_api gate is
+        # not enabled. The substring `array API` (note casing) is
+        # what trainable.py's recovery branch matches against.
+        raise RuntimeError(
+            "Scikit-learn array API support was enabled but scipy's own "
+            "support is not enabled. Please set the SCIPY_ARRAY_API=1 "
+            "environment variable before importing sklearn or scipy."
+        )
+        yield  # unreachable — context manager raises at __enter__
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    monkeypatch.setattr(torch, "as_tensor", fake_as_tensor)
+    monkeypatch.setattr(sklearn, "config_context", failing_config_context)
+    return state
+
+
+def test_array_api_runtime_unavailable_falls_back_to_cpu_with_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """scipy env-var gate → WARN log + CPU retry + DeviceReport reflects fallback.
+
+    Regression guard for revised-stack.md § "Array-API runtime fallback":
+    when ``sklearn.config_context(array_api_dispatch=True)`` raises the
+    SCIPY_ARRAY_API gate ``RuntimeError`` at enter-time, the adapter
+    MUST catch it, emit one WARN
+    ``sklearn.array_api.runtime_unavailable``, rebuild the Lightning
+    Trainer on CPU numpy, and return a TrainingResult whose
+    ``device.fallback_reason == "array_api_runtime_unavailable"`` and
+    ``device.array_api is False``. Non-array-api ``RuntimeError``s MUST
+    re-raise unchanged (see test below).
+    """
+    state = _install_runtime_failing_array_api_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    estimator = MagicMock(spec=["fit", "predict", "set_params"])
+    estimator.predict.return_value = [0, 1, 0, 1, 0, 1, 0, 1]
+    type(estimator).__name__ = "LogisticRegression"
+
+    trainable = SklearnTrainable(estimator=estimator, target="target")
+    result = trainable.fit(sample_data, context=cuda_context)
+
+    # config_context was attempted exactly once (the engaged path).
+    assert state["config_context_calls"] == [{"array_api_dispatch": True}]
+    # Two trainer instances: first inside the failing config_context,
+    # second is the CPU numpy retry that the fallback path rebuilds.
+    assert len(state["instances"]) == 2, (
+        f"expected one engaged-attempt trainer + one CPU-retry trainer; "
+        f"got {len(state['instances'])}"
+    )
+    # Only the CPU-retry trainer's fit() actually completed (the first
+    # trainer's fit was inside the config_context that raised).
+    assert state["calls"] == 1
+
+    # WARN log fired exactly once with structured fallback fields.
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable" and r.levelno == logging.WARNING
+    ]
+    runtime_unavailable = [
+        r
+        for r in warn_records
+        if "sklearn.array_api.runtime_unavailable" in r.getMessage()
+    ]
+    assert len(runtime_unavailable) == 1, (
+        f"expected exactly one sklearn.array_api.runtime_unavailable WARN; "
+        f"got {[r.getMessage() for r in warn_records]}"
+    )
+    rec = runtime_unavailable[0]
+    assert rec.estimator_class == "LogisticRegression"
+    assert rec.requested_backend == "cuda"
+    assert rec.fallback_reason == "array_api_runtime_unavailable"
+    # The hint MUST be grep-able by operators triaging the deployment gap.
+    assert "SCIPY_ARRAY_API=1" in rec.hint
+
+    # DeviceReport reflects the CPU-numpy fallback, not the engaged path.
+    assert result.device is not None
+    assert result.device.array_api is False
+    assert result.device.backend == "cpu"
+    assert result.device.device_string == "cpu"
+    assert result.device.fallback_reason == "array_api_runtime_unavailable"
+    assert result.device.family == "sklearn"
+
+
+def test_non_array_api_runtime_error_re_raises_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """Unrelated RuntimeError inside config_context MUST NOT be swallowed.
+
+    Guards against a future refactor that loosens the substring match
+    (``"array API" not in str(exc) and "array_api" not in str(exc)``)
+    and silently swallows non-gate failures.
+    """
+    import contextlib
+
+    import lightning.pytorch as pl_trainer
+    import sklearn
+    import torch
+
+    def fit_side_effect(module: Any) -> None:
+        module.on_train_start()
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name="Trainer")
+        trainer.fit.side_effect = fit_side_effect
+        return trainer
+
+    def fake_as_tensor(arr: Any, device: Any = None, **_: Any) -> Any:
+        return arr
+
+    @contextlib.contextmanager
+    def unrelated_failing_config_context(**kwargs: Any) -> Any:
+        raise RuntimeError("totally unrelated bug — torch CUDA driver missing")
+        yield  # unreachable
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    monkeypatch.setattr(torch, "as_tensor", fake_as_tensor)
+    monkeypatch.setattr(sklearn, "config_context", unrelated_failing_config_context)
+
+    estimator = MagicMock(spec=["fit", "predict", "set_params"])
+    estimator.predict.return_value = [0, 1, 0, 1, 0, 1, 0, 1]
+    type(estimator).__name__ = "LogisticRegression"
+
+    trainable = SklearnTrainable(estimator=estimator, target="target")
+    with pytest.raises(RuntimeError, match="totally unrelated bug"):
+        trainable.fit(sample_data, context=cuda_context)
+
+
+# ---------------------------------------------------------------------------
 # CPU request never engages Array API
 # ---------------------------------------------------------------------------
 

--- a/packages/kailash-ml/tests/unit/test_umap_trainable.py
+++ b/packages/kailash-ml/tests/unit/test_umap_trainable.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for UMAPTrainable (GPU-first Phase 1, CPU-only).
+
+Phase 1 ships CPU-only via the ``umap-learn`` package. cuML is evicted
+per workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md
+CRITICAL-1 disposition. These tests verify:
+
+1. UMAP fits on CPU and returns a populated DeviceReport.
+2. Requesting a CUDA backend logs ``umap.cuml_eviction`` at INFO and
+   returns ``fallback_reason="cuml_eviction"`` in the DeviceReport.
+3. ``predict()`` returns an embedding of the expected shape.
+4. UMAPTrainable is exported via ``kailash_ml.__all__``.
+5. The ``[rapids]`` extra is absent from ``pyproject.toml``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+
+import kailash_ml
+from kailash_ml import UMAPTrainable
+from kailash_ml.trainable import TrainingContext
+
+
+@pytest.fixture
+def small_frame() -> pl.DataFrame:
+    """Synthetic numeric frame suitable for UMAP (≥ n_neighbors rows)."""
+    rng = np.random.default_rng(42)
+    return pl.DataFrame(
+        {
+            "f1": rng.standard_normal(30).tolist(),
+            "f2": rng.standard_normal(30).tolist(),
+            "f3": rng.standard_normal(30).tolist(),
+        }
+    )
+
+
+def _cpu_context() -> TrainingContext:
+    return TrainingContext(
+        accelerator="cpu",
+        precision="32-true",
+        devices=1,
+        device_string="cpu",
+        backend="cpu",
+    )
+
+
+def _cuda_context() -> TrainingContext:
+    """A pretend-CUDA context for eviction-path tests — we don't actually
+    require CUDA to be available because UMAPTrainable always runs on
+    CPU (cuml_eviction fires unconditionally for non-cpu)."""
+    return TrainingContext(
+        accelerator="cuda",
+        precision="bf16-mixed",
+        devices=1,
+        device_string="cuda:0",
+        backend="cuda",
+    )
+
+
+def test_umap_fits_on_cpu_returns_device_report(small_frame: pl.DataFrame) -> None:
+    """UMAPTrainable.fit() on CPU populates DeviceReport.backend='cpu'."""
+    trainable = UMAPTrainable(n_components=2, n_neighbors=5, random_state=0)
+    result = trainable.fit(small_frame, context=_cpu_context())
+
+    assert result.device is not None
+    assert result.device.backend == "cpu"
+    assert result.device.family == "umap"
+    assert result.device.device_string == "cpu"
+    assert result.device.precision == "32-true"
+    # No fallback when caller already on CPU.
+    assert result.device.fallback_reason is None
+    assert result.device.array_api is False
+    assert result.family == "umap"
+    assert "native" in result.artifact_uris
+
+
+def test_umap_logs_cuml_eviction_when_cuda_requested(
+    small_frame: pl.DataFrame, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Requesting CUDA logs INFO-level cuml_eviction and sets fallback."""
+    trainable = UMAPTrainable(n_components=2, n_neighbors=5, random_state=0)
+
+    with caplog.at_level(logging.INFO, logger="kailash_ml.trainable"):
+        result = trainable.fit(small_frame, context=_cuda_context())
+
+    # The log event name (grep-able sentinel).
+    eviction_records = [
+        rec for rec in caplog.records if rec.message == "umap.cuml_eviction"
+    ]
+    assert len(eviction_records) >= 1, (
+        "expected umap.cuml_eviction INFO log, got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+    evict = eviction_records[0]
+    assert evict.levelno == logging.INFO
+    assert evict.requested_backend == "cuda"
+    assert evict.actual_backend == "cpu"
+    assert evict.fallback_reason == "cuml_eviction"
+
+    # Runtime evidence the call ran on CPU with the eviction sentinel.
+    assert result.device is not None
+    assert result.device.backend == "cpu"
+    assert result.device.fallback_reason == "cuml_eviction"
+
+
+def test_umap_predict_returns_embedding(small_frame: pl.DataFrame) -> None:
+    """predict() returns a 2-D embedding of shape (n_rows, n_components)."""
+    trainable = UMAPTrainable(n_components=2, n_neighbors=5, random_state=0)
+    trainable.fit(small_frame, context=_cpu_context())
+
+    preds = trainable.predict(small_frame)
+    assert preds.column == "embedding"
+    raw = preds.raw
+    # umap.UMAP.transform returns ndarray (n_samples, n_components).
+    assert raw.shape == (30, 2)
+
+
+def test_umap_trainable_in_all() -> None:
+    """UMAPTrainable MUST be listed in kailash_ml.__all__ (rules/orphan-detection §6)."""
+    assert "UMAPTrainable" in kailash_ml.__all__
+    # Eager import — no lazy __getattr__ path.
+    assert UMAPTrainable is kailash_ml.UMAPTrainable
+
+
+def test_no_rapids_extra_in_pyproject() -> None:
+    """pyproject.toml MUST NOT expose a [rapids] extra (cuML evicted)."""
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:  # pragma: no cover - 3.10 fallback
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    # Find pyproject relative to this test file — works in worktrees + main checkout.
+    pkg_root = Path(__file__).resolve().parents[2]
+    pyproject = pkg_root / "pyproject.toml"
+    assert pyproject.exists(), f"pyproject.toml not found at {pyproject}"
+
+    with pyproject.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    extras = data.get("project", {}).get("optional-dependencies", {})
+    assert "rapids" not in extras, (
+        "[rapids] extra is BLOCKED — cuML was evicted per Phase 1 revised-stack.md; "
+        "use umap-learn + sklearn.cluster.HDBSCAN."
+    )
+    # The eviction is structural: no rapids, cuml, or cudf deps anywhere.
+    for extra_name, deps in extras.items():
+        for dep in deps:
+            lowered = dep.lower()
+            assert (
+                "rapids" not in lowered
+            ), f"extras[{extra_name}] contains '{dep}' — rapids is evicted."
+            assert (
+                "cuml" not in lowered
+            ), f"extras[{extra_name}] contains '{dep}' — cuml is evicted."
+            assert (
+                "cudf" not in lowered
+            ), f"extras[{extra_name}] contains '{dep}' — cudf is evicted."

--- a/packages/kailash-ml/tests/unit/test_xgboost_oom_fallback.py
+++ b/packages/kailash-ml/tests/unit/test_xgboost_oom_fallback.py
@@ -1,0 +1,312 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for XGBoostTrainable GPU OOM → CPU fallback.
+
+Covers the Phase 1 punch list item 4 (revised-stack.md §"No-config
+contract" — xgboost row): a GPU OOM inside ``trainer.fit`` MUST log a
+single WARN, retry on CPU, and return a TrainingResult whose
+``device.fallback_reason`` is ``"oom"`` with ``device.backend == "cpu"``.
+Non-OOM exceptions MUST re-raise unchanged.
+
+Tests patch ``lightning.pytorch.Trainer`` so no GPU / Lightning runtime
+is required (Tier 1 per rules/testing.md §"3-Tier Testing").
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import polars as pl
+import pytest
+from kailash_ml._device_report import DeviceReport
+from kailash_ml._result import TrainingResult
+from kailash_ml.trainable import TrainingContext, XGBoostTrainable, _is_gpu_oom_error
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_classification_data() -> pl.DataFrame:
+    """Tiny deterministic classification frame for XGBoost.fit()."""
+    return pl.DataFrame(
+        {
+            "feature1": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            "feature2": [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5],
+            "target": [0, 1, 0, 1, 0, 1, 0, 1],
+        }
+    )
+
+
+@pytest.fixture
+def cuda_context() -> TrainingContext:
+    """CUDA-resolved TrainingContext — starts the fit on the GPU path."""
+    return TrainingContext(
+        accelerator="gpu",
+        precision="32-true",
+        devices=1,
+        device_string="cuda:0",
+        backend="cuda",
+    )
+
+
+@pytest.fixture
+def cpu_context() -> TrainingContext:
+    """CPU-resolved TrainingContext — OOM here is NOT a fallback case."""
+    return TrainingContext(
+        accelerator="cpu",
+        precision="32-true",
+        devices=1,
+        device_string="cpu",
+        backend="cpu",
+    )
+
+
+class _FakeXGBoostError(RuntimeError):
+    """Stand-in for xgboost.core.XGBoostError (avoids xgboost import)."""
+
+
+# ---------------------------------------------------------------------------
+# _is_gpu_oom_error helper — independent of Trainable
+# ---------------------------------------------------------------------------
+
+
+class _FakeOutOfMemoryError(RuntimeError):
+    """Class-name-only detection — no English message needed."""
+
+    def __init__(self) -> None:
+        super().__init__("")
+
+
+_FakeOutOfMemoryError.__name__ = "OutOfMemoryError"
+
+
+def test_oom_helper_recognizes_common_messages() -> None:
+    """_is_gpu_oom_error recognises the standard OOM phrasings."""
+    assert _is_gpu_oom_error(_FakeXGBoostError("CUDA error: out of memory"))
+    assert _is_gpu_oom_error(RuntimeError("CUDA out of memory. Tried to allocate 2 GB"))
+    assert _is_gpu_oom_error(
+        RuntimeError("xgboost: out of memory allocating GPU buffer")
+    )
+    assert _is_gpu_oom_error(_FakeOutOfMemoryError())
+    # Non-OOM exceptions are NOT mistaken for OOM.
+    assert not _is_gpu_oom_error(ValueError("missing column 'target'"))
+    assert not _is_gpu_oom_error(KeyError("foo"))
+    assert not _is_gpu_oom_error(RuntimeError("kernel launch failed"))
+
+
+# ---------------------------------------------------------------------------
+# XGBoostTrainable fit-path OOM fallback
+# ---------------------------------------------------------------------------
+
+
+def _install_oom_then_ok_trainer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace ``pl_trainer.Trainer`` so first fit raises OOM, second succeeds.
+
+    Returns a state dict the test can inspect: ``{"calls": N,
+    "instances": [trainer1, trainer2]}`` — one Trainer is constructed
+    per attempt (the OOM fallback rebuilds on CPU).
+    """
+    import lightning.pytorch as pl_trainer
+
+    state: dict[str, Any] = {"calls": 0, "instances": []}
+
+    def fit_side_effect(module: Any) -> None:
+        state["calls"] += 1
+        # First call: raise GPU OOM. Second call: simulate success by
+        # invoking on_train_start so module.metric is set.
+        if state["calls"] == 1:
+            raise _FakeXGBoostError("CUDA error: out of memory allocating 1.2 GB")
+        module.on_train_start()
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name=f"Trainer#{len(state['instances']) + 1}")
+        trainer.fit.side_effect = fit_side_effect
+        state["instances"].append(trainer)
+        return trainer
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    return state
+
+
+def _install_non_oom_trainer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace the Trainer so fit raises a non-OOM RuntimeError."""
+    import lightning.pytorch as pl_trainer
+
+    state: dict[str, Any] = {"calls": 0, "instances": []}
+
+    def fit_side_effect(module: Any) -> None:
+        state["calls"] += 1
+        raise RuntimeError("totally unrelated bug — missing column 'target'")
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name=f"Trainer#{len(state['instances']) + 1}")
+        trainer.fit.side_effect = fit_side_effect
+        state["instances"].append(trainer)
+        return trainer
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    return state
+
+
+def _install_always_oom_trainer(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Trainer that always raises OOM — used to confirm CPU-start re-raises."""
+    import lightning.pytorch as pl_trainer
+
+    state: dict[str, Any] = {"calls": 0}
+
+    def fit_side_effect(module: Any) -> None:
+        state["calls"] += 1
+        raise _FakeXGBoostError("CUDA error: out of memory on CPU-path stub")
+
+    def fake_trainer_ctor(*args: Any, **kwargs: Any) -> MagicMock:
+        trainer = MagicMock(name="Trainer")
+        trainer.fit.side_effect = fit_side_effect
+        return trainer
+
+    monkeypatch.setattr(pl_trainer, "Trainer", fake_trainer_ctor)
+    return state
+
+
+def test_oom_on_cuda_falls_back_to_cpu_with_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_classification_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """GPU OOM on xgboost path → WARN log + CPU retry + device.backend=='cpu'."""
+    state = _install_oom_then_ok_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    # Minimal estimator stub — avoids xgboost import/fit cost. The real
+    # inner fit runs inside `on_train_start`; the Lightning module's
+    # fake metric path is exercised by the mocked trainer.
+    estimator = MagicMock(spec=["set_params", "fit", "predict"])
+    estimator.predict.return_value = [0, 1, 0, 1, 0, 1, 0, 1]
+
+    trainable = XGBoostTrainable(
+        estimator=estimator, target="target", task="classification"
+    )
+    result = trainable.fit(sample_classification_data, context=cuda_context)
+
+    # Two trainer instances: first raised OOM, second succeeded on CPU.
+    assert state["calls"] == 2, "expected one OOM + one CPU retry"
+    assert len(state["instances"]) == 2
+
+    # WARN log asserts — structured extra carries the fallback fields.
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable" and r.levelno == logging.WARNING
+    ]
+    assert any(
+        "xgboost.gpu.oom_fallback" in r.getMessage() for r in warn_records
+    ), f"missing xgboost.gpu.oom_fallback in {[r.getMessage() for r in warn_records]}"
+    fallback_rec = next(
+        r for r in warn_records if "xgboost.gpu.oom_fallback" in r.getMessage()
+    )
+    assert fallback_rec.fallback_reason == "oom"
+    assert fallback_rec.fallback_backend == "cpu"
+    assert fallback_rec.requested_backend == "cuda"
+    assert fallback_rec.error_class == "_FakeXGBoostError"
+
+    # Post-fallback TrainingResult reflects CPU execution.
+    assert isinstance(result, TrainingResult)
+    assert result.device is not None
+    assert result.device.backend == "cpu"
+    assert result.device.fallback_reason == "oom"
+    assert result.device_used == "cpu"
+    assert result.accelerator == "cpu"
+    # Estimator was re-pointed at cpu for the retry.
+    estimator.set_params.assert_any_call(device="cpu")
+
+
+def test_non_oom_exception_does_not_trigger_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_classification_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """Non-OOM exceptions propagate; zero WARN log; no second Trainer."""
+    state = _install_non_oom_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    estimator = MagicMock(spec=["set_params", "fit", "predict"])
+    trainable = XGBoostTrainable(
+        estimator=estimator, target="target", task="classification"
+    )
+
+    with pytest.raises(RuntimeError, match="totally unrelated bug"):
+        trainable.fit(sample_classification_data, context=cuda_context)
+
+    # Exactly one Trainer instance was built (no fallback retry).
+    assert state["calls"] == 1, "non-OOM must NOT trigger retry"
+    assert len(state["instances"]) == 1
+    # No OOM WARN line emitted.
+    fallback_warns = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable"
+        and r.levelno == logging.WARNING
+        and "xgboost.gpu.oom_fallback" in r.getMessage()
+    ]
+    assert fallback_warns == [], "no fallback WARN should fire on non-OOM"
+
+
+def test_cpu_request_oom_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_classification_data: pl.DataFrame,
+    cpu_context: TrainingContext,
+) -> None:
+    """If ctx.backend=='cpu' the fallback target is the same — propagate."""
+    state = _install_always_oom_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    estimator = MagicMock(spec=["set_params", "fit", "predict"])
+    trainable = XGBoostTrainable(
+        estimator=estimator, target="target", task="classification"
+    )
+
+    with pytest.raises(_FakeXGBoostError, match="out of memory"):
+        trainable.fit(sample_classification_data, context=cpu_context)
+
+    assert state["calls"] == 1, "CPU-requested OOM must NOT retry"
+    fallback_warns = [
+        r
+        for r in caplog.records
+        if r.name == "kailash_ml.trainable"
+        and r.levelno == logging.WARNING
+        and "xgboost.gpu.oom_fallback" in r.getMessage()
+    ]
+    assert fallback_warns == [], "no fallback WARN when already on CPU"
+
+
+def test_device_report_post_fallback_carries_oom_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    sample_classification_data: pl.DataFrame,
+    cuda_context: TrainingContext,
+) -> None:
+    """Full DeviceReport shape after OOM→CPU fallback (revised-stack §54-78)."""
+    _install_oom_then_ok_trainer(monkeypatch)
+    caplog.set_level(logging.WARNING, logger="kailash_ml.trainable")
+
+    estimator = MagicMock(spec=["set_params", "fit", "predict"])
+    estimator.predict.return_value = [0, 1, 0, 1, 0, 1, 0, 1]
+
+    trainable = XGBoostTrainable(
+        estimator=estimator, target="target", task="classification"
+    )
+    result = trainable.fit(sample_classification_data, context=cuda_context)
+
+    report = result.device
+    assert isinstance(report, DeviceReport)
+    assert report.family == "xgboost"
+    assert report.backend == "cpu"
+    assert report.device_string == "cpu"
+    assert report.precision == "32-true"
+    assert report.fallback_reason == "oom"
+    assert report.array_api is False

--- a/specs/ml-backends.md
+++ b/specs/ml-backends.md
@@ -17,14 +17,14 @@ This file is the domain truth for compute backend detection, selection, precisio
 
 Six first-class backends. Every engine that places tensors, invokes a Trainer, or serves inference MUST support this matrix. Backends not listed here (IPU, HPU, DirectML, Vulkan) are OUT OF SCOPE for 2.0 and MUST raise `UnsupportedFamily`.
 
-| Backend  | Vendor / line                      | Lightning `accelerator` | torch device string       | Install (PyPI)                                                         | Detection probe                                         | fp32 | fp16 | bf16 | int8 |
-| -------- | ---------------------------------- | ----------------------- | ------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------- | ---- | ---- | ---- | ---- |
-| **cpu**  | Any x86_64/ARM64 host              | `"cpu"`                 | `"cpu"`                   | Base `pip install kailash-ml`                                          | Always available                                        | yes  | no*  | no*  | yes  |
-| **cuda** | NVIDIA (A100, H100, L40S, V100, T4, RTX 30xx/40xx) | `"cuda"` (alias `"gpu"`) | `"cuda:{idx}"`           | `pip install kailash-ml[cuda]` (pulls `torch` CUDA wheel from PyPI)    | `torch.cuda.is_available()`                             | yes  | yes  | yes**| yes  |
-| **mps**  | Apple Silicon (M1/M2/M3/M4)        | `"mps"`                 | `"mps"`                   | Base install; `torch` universal2 wheel on Darwin ARM64                 | `torch.backends.mps.is_available()` AND `torch.backends.mps.is_built()` | yes  | yes  | no*** | no**** |
-| **rocm** | AMD Instinct (MI210, MI250, MI300) | `"cuda"` (HIP layer)    | `"cuda:{idx}"` (HIP→CUDA API source-compat) | `pip install kailash-ml[rocm]` (separate torch ROCm wheel index; MUST specify `--index-url https://download.pytorch.org/whl/rocm6.0`) | `torch.version.hip is not None` AND `torch.cuda.is_available()` | yes  | yes  | yes**| yes  |
-| **xpu**  | Intel Data Center GPU Max, Arc     | `"xpu"`                 | `"xpu:{idx}"`             | `pip install kailash-ml[xpu]` (pulls `intel-extension-for-pytorch`)    | `hasattr(torch, "xpu") and torch.xpu.is_available()`    | yes  | yes  | yes** | yes  |
-| **tpu**  | Google TPU v2/v3/v4/v5             | `"tpu"`                 | `xm.xla_device()`         | `pip install kailash-ml[tpu]` (pulls `torch_xla`; Linux only)          | Successful `import torch_xla.core.xla_model as xm` AND non-empty `xm.get_xla_supported_devices()` | yes  | no   | yes  | no   |
+| Backend  | Vendor / line                                      | Lightning `accelerator`  | torch device string                         | Install (PyPI)                                                                                                                        | Detection probe                                                                                   | fp32 | fp16 | bf16     | int8       |
+| -------- | -------------------------------------------------- | ------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---- | ---- | -------- | ---------- |
+| **cpu**  | Any x86_64/ARM64 host                              | `"cpu"`                  | `"cpu"`                                     | Base `pip install kailash-ml`                                                                                                         | Always available                                                                                  | yes  | no\* | no\*     | yes        |
+| **cuda** | NVIDIA (A100, H100, L40S, V100, T4, RTX 30xx/40xx) | `"cuda"` (alias `"gpu"`) | `"cuda:{idx}"`                              | `pip install kailash-ml[cuda]` (pulls `torch` CUDA wheel from PyPI)                                                                   | `torch.cuda.is_available()`                                                                       | yes  | yes  | yes\*\*  | yes        |
+| **mps**  | Apple Silicon (M1/M2/M3/M4)                        | `"mps"`                  | `"mps"`                                     | Base install; `torch` universal2 wheel on Darwin ARM64                                                                                | `torch.backends.mps.is_available()` AND `torch.backends.mps.is_built()`                           | yes  | yes  | no\*\*\* | no\*\*\*\* |
+| **rocm** | AMD Instinct (MI210, MI250, MI300)                 | `"cuda"` (HIP layer)     | `"cuda:{idx}"` (HIP→CUDA API source-compat) | `pip install kailash-ml[rocm]` (separate torch ROCm wheel index; MUST specify `--index-url https://download.pytorch.org/whl/rocm6.0`) | `torch.version.hip is not None` AND `torch.cuda.is_available()`                                   | yes  | yes  | yes\*\*  | yes        |
+| **xpu**  | Intel Data Center GPU Max, Arc                     | `"xpu"`                  | `"xpu:{idx}"`                               | `pip install kailash-ml[xpu]` (pulls `intel-extension-for-pytorch`)                                                                   | `hasattr(torch, "xpu") and torch.xpu.is_available()`                                              | yes  | yes  | yes\*\*  | yes        |
+| **tpu**  | Google TPU v2/v3/v4/v5                             | `"tpu"`                  | `xm.xla_device()`                           | `pip install kailash-ml[tpu]` (pulls `torch_xla`; Linux only)                                                                         | Successful `import torch_xla.core.xla_model as xm` AND non-empty `xm.get_xla_supported_devices()` | yes  | no   | yes      | no         |
 
 Notes on the precision matrix:
 
@@ -163,19 +163,19 @@ The resolver MUST return one of Lightning's concrete precision strings — `"32-
 
 Resolution order for `requested == "auto"`:
 
-| Backend  | Device capability     | Returned precision | Rationale                                                      |
-| -------- | --------------------- | ------------------ | -------------------------------------------------------------- |
-| cuda     | CC ≥ 8.0 (A100/H100/L40S/RTX 30+) | `"bf16-mixed"`     | bf16 dynamic range matches fp32; no loss scaling required      |
-| cuda     | CC 7.0–7.5 (V100/T4)  | `"16-mixed"`       | fp16 supported; bf16 is not                                    |
-| cuda     | CC < 7.0 (P100/K80)   | `"32-true"`        | no mixed-precision hardware                                    |
-| mps      | any Apple Silicon     | `"16-mixed"`       | bf16 op coverage incomplete (see § 1 footnote ***)             |
-| rocm     | MI300-class           | `"bf16-mixed"`     | bf16 available on MI300 series                                 |
-| rocm     | MI250-class           | `"16-mixed"`       | bf16 partial on MI250; fp16 is the reliable path               |
-| rocm     | older (MI100)         | `"32-true"`        | no mixed-precision hardware                                    |
-| xpu      | PVC-class             | `"bf16-mixed"`     | Data Center GPU Max supports bf16                              |
-| xpu      | Arc / older           | `"16-mixed"`       | fp16 is the reliable path                                      |
-| tpu      | any                   | `"bf16-true"`      | TPU XLA compiles bf16 natively; mixed-precision not needed     |
-| cpu      | any                   | `"32-true"`        | fp16/bf16 on CPU is slower than fp32                            |
+| Backend | Device capability                 | Returned precision | Rationale                                                  |
+| ------- | --------------------------------- | ------------------ | ---------------------------------------------------------- |
+| cuda    | CC ≥ 8.0 (A100/H100/L40S/RTX 30+) | `"bf16-mixed"`     | bf16 dynamic range matches fp32; no loss scaling required  |
+| cuda    | CC 7.0–7.5 (V100/T4)              | `"16-mixed"`       | fp16 supported; bf16 is not                                |
+| cuda    | CC < 7.0 (P100/K80)               | `"32-true"`        | no mixed-precision hardware                                |
+| mps     | any Apple Silicon                 | `"16-mixed"`       | bf16 op coverage incomplete (see § 1 footnote \*\*\*)      |
+| rocm    | MI300-class                       | `"bf16-mixed"`     | bf16 available on MI300 series                             |
+| rocm    | MI250-class                       | `"16-mixed"`       | bf16 partial on MI250; fp16 is the reliable path           |
+| rocm    | older (MI100)                     | `"32-true"`        | no mixed-precision hardware                                |
+| xpu     | PVC-class                         | `"bf16-mixed"`     | Data Center GPU Max supports bf16                          |
+| xpu     | Arc / older                       | `"16-mixed"`       | fp16 is the reliable path                                  |
+| tpu     | any                               | `"bf16-true"`      | TPU XLA compiles bf16 natively; mixed-precision not needed |
+| cpu     | any                               | `"32-true"`        | fp16/bf16 on CPU is slower than fp32                       |
 
 OPEN QUESTION: the exact MI250 vs MI300 / Arc vs PVC cutoff — MUST be validated against AMD ROCm 6.0 and Intel XPU docs before 2.0 locks. Flag as TODO until hardware CI lane confirms.
 
@@ -276,10 +276,15 @@ The Engine routes every training call through the Lightning wrapper (§ 4), but 
 
 ### 5.1 sklearn
 
-- **Backend support**: CPU only.
-- **TrainingResult.backend**: always `"cpu"`.
-- **Wrapping**: MUST be wrapped as `LightningModule` for metric/callback unification, but the inner `.fit()` runs on CPU regardless of `info.backend`.
-- **If caller specifies `prefer_backend="cuda"`**: MUST log WARN `"sklearn.backend.ignored"` and proceed on CPU; MUST NOT raise. (Rationale: sklearn's CPU-only is not a user error; it is the family's nature.)
+- **Backend support**: Lightning Trainer always runs on CPU; the inner estimator MAY route through the sklearn Array API on a non-CPU device per Phase 1.
+- **TrainingResult.backend** (legacy field): always `"cpu"`.
+- **DeviceReport (`TrainingResult.device`)** populates per the Phase 1 transparency contract:
+  - Allowlisted estimator + non-CPU `info.backend` → engage `sklearn.config_context(array_api_dispatch=True)`, move X/y to a torch tensor on `info.device_string`, log INFO `sklearn.array_api.engaged`. `device.array_api=True`, `device.backend=info.backend`.
+  - Off-allowlist estimator + non-CPU `info.backend` → CPU numpy fallback. Log WARN `sklearn.array_api.offlist`, set `device.fallback_reason="array_api_offlist"`.
+  - Allowlisted estimator + scipy env-var gate (`SCIPY_ARRAY_API` not set before sklearn import) raises `RuntimeError` at `config_context` enter-time → adapter catches the gate error, logs WARN `sklearn.array_api.runtime_unavailable` (with `hint` field naming `SCIPY_ARRAY_API=1`), retries on CPU numpy. `device.fallback_reason="array_api_runtime_unavailable"`. Non-array-api `RuntimeError`s MUST re-raise unchanged.
+- **Phase 1 Array API allowlist** (frozenset of `type(estimator).__name__` matches): `Ridge`, `LogisticRegression`, `LinearRegression`, `LinearDiscriminantAnalysis`, `KMeans`, `PCA`, `StandardScaler`, `MinMaxScaler`. Expansion is a spec amendment, not a code edit.
+- **Wrapping**: MUST be wrapped as `LightningModule` for metric/callback unification (`SklearnLightningAdapter`); the inner `.fit()` runs inside the Array API context when engaged.
+- **If caller specifies `prefer_backend="cuda"` with off-allowlist estimator**: MUST log WARN `"sklearn.array_api.offlist"` and proceed on CPU; MUST NOT raise. (sklearn's CPU-only is not a user error; it is the family's nature for off-allowlist estimators.)
 
 ### 5.2 xgboost
 
@@ -288,6 +293,7 @@ The Engine routes every training call through the Lightning wrapper (§ 4), but 
   - `info.backend == "cuda"` → pass `device="cuda"`
   - `info.backend == "cpu"` → pass `device="cpu"`
   - `info.backend in {"mps", "rocm", "xpu", "tpu"}` → MUST raise `UnsupportedFamily` naming the backend and the family. MUST NOT silently fall back to CPU.
+- **OOM single-retry fallback (Phase 1)**: A GPU OOM during `trainer.fit` (`_is_gpu_oom_error(exc)` matches `"out of memory"` / `"cuda out of memory"` / `OutOfMemoryError` / `CudaOutOfMemoryError`) MUST be intercepted exactly once. The adapter logs WARN `xgboost.gpu.oom_fallback` with structured fields `{family, requested_backend, fallback_backend, fallback_reason, error_class}`, calls `set_params(device="cpu")`, rebuilds the Lightning Trainer on a CPU TrainingContext, and retries. The returned `TrainingResult.device.backend="cpu"` and `device.fallback_reason="oom"`. Non-OOM exceptions re-raise unchanged. Re-raise also when `ctx.backend == "cpu"` (no fallback target).
 - **ROCm note**: xgboost does not ship a ROCm build as of 2.0.3; `device="cuda"` on a ROCm box raises at runtime. MUST detect this and raise `UnsupportedFamily` before the training call.
 
 ### 5.3 lightgbm
@@ -297,6 +303,7 @@ The Engine routes every training call through the Lightning wrapper (§ 4), but 
   - `info.backend == "cuda"` → probe lightgbm build; if GPU support present, pass `device_type="gpu"` + `gpu_use_dp=False`. If not, raise `UnsupportedFamily` with the install hint: `pip install lightgbm --config-settings=cmake.define.USE_GPU=1`.
   - `info.backend == "cpu"` → pass `device_type="cpu"`.
   - `info.backend in {"mps", "rocm", "xpu", "tpu"}` → MUST raise `UnsupportedFamily`.
+- **OOM single-retry fallback (Phase 1)**: Same shape as §5.2. WARN log key is `lightgbm.gpu.oom_fallback`. CPU rebuild uses `set_params(device_type="cpu")` (lightgbm idiom, not xgboost's `device=`). `device.fallback_reason="oom"` on the post-fallback `TrainingResult.device`.
 
 ### 5.4 catboost
 
@@ -312,6 +319,21 @@ The Engine routes every training call through the Lightning wrapper (§ 4), but 
 
 - **Backend support**: follows torch's device support — cuda, mps, cpu. TPU/XLA path exists in `torchrl` ≥ 0.5 but is experimental. Default to `"cuda"` / `"mps"` / `"cpu"`; treat `"tpu"`/`"rocm"`/`"xpu"` as OPEN QUESTION and raise `UnsupportedFamily` at 2.0 until validated.
 - **RL Engine wrapping**: RL trainers MUST use Lightning's accelerator for environment-rollout → learner transfers. The inner SB3/torchrl policy MUST be constructed with `device=info.device_string`.
+
+### 5.7 umap-learn (Phase 1)
+
+- **Backend support**: CPU only via the `umap-learn` pip package (base dependency; no `[umap]` extra).
+- **Mapping**:
+  - `info.backend == "cpu"` → standard CPU path. `device.fallback_reason=None`.
+  - `info.backend in {"cuda", "mps", "rocm", "xpu", "tpu"}` → cuML eviction is unconditional (Phase 1 design per `workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md` § "CRITICAL-1 disposition"). The adapter logs INFO `umap.cuml_eviction` (NOT WARN — this is the documented Phase 1 design, not a degraded path), runs on CPU, sets `device.fallback_reason="cuml_eviction"`. MUST NOT raise.
+- **No `[rapids]` extra**: Removed in 0.12.0 per CRITICAL-1 disposition. Users who require cuML on NVIDIA install it themselves and swap it in via `kailash_ml.register_trainable("umap", MyCustomCuMLUMAP)`.
+- **Phase 2 (planned)**: torch-native UMAP across MPS/ROCm/XPU. Spec amendment + new fallback codes (e.g., `oom`) will land with the Phase 2 implementation.
+
+### 5.8 sklearn.cluster.HDBSCAN (Phase 1)
+
+- **Backend support**: CPU only via `sklearn.cluster.HDBSCAN` (sklearn ≥ 1.3 — already required by base `scikit-learn>=1.5` dep).
+- **Mapping**: Same shape as §5.7. INFO log key `hdbscan.cuml_eviction`. `device.fallback_reason="cuml_eviction"` on non-CPU requests.
+- **Phase 3 (planned)**: torch-native HDBSCAN. Same spec-amendment process as UMAP Phase 2.
 
 ---
 

--- a/specs/ml-backends.md
+++ b/specs/ml-backends.md
@@ -338,8 +338,9 @@ The Engine routes every training call through the Lightning wrapper (§ 4), but 
 - **Backend support**: follows torch's device support — cuda, mps, cpu. TPU/XLA path exists in `torchrl` ≥ 0.5 but is experimental. Default to `"cuda"` / `"mps"` / `"cpu"`; treat `"tpu"`/`"rocm"`/`"xpu"` as OPEN QUESTION and raise `UnsupportedFamily` at 2.0 until validated.
 - **RL Engine wrapping**: RL trainers MUST use Lightning's accelerator for environment-rollout → learner transfers. The inner SB3/torchrl policy MUST be constructed with `device=info.device_string`.
 
-### 5.7 umap-learn (Phase 1)
+### 5.7 umap-learn (Phase 1) — `UMAPTrainable`
 
+- **Adapter class**: `kailash_ml.UMAPTrainable` (eagerly exported from `kailash_ml.__all__`; defined in `kailash_ml.trainable`).
 - **Backend support**: CPU only via the `umap-learn` pip package (base dependency; no `[umap]` extra).
 - **Mapping**:
   - `info.backend == "cpu"` → standard CPU path. `device.fallback_reason=None`.
@@ -347,8 +348,9 @@ The Engine routes every training call through the Lightning wrapper (§ 4), but 
 - **No `[rapids]` extra**: Removed in 0.12.0 per CRITICAL-1 disposition. Users who require cuML on NVIDIA install it themselves and swap it in via `kailash_ml.register_trainable("umap", MyCustomCuMLUMAP)`.
 - **Phase 2 (planned)**: torch-native UMAP across MPS/ROCm/XPU. Spec amendment + new fallback codes (e.g., `oom`) will land with the Phase 2 implementation.
 
-### 5.8 sklearn.cluster.HDBSCAN (Phase 1)
+### 5.8 sklearn.cluster.HDBSCAN (Phase 1) — `HDBSCANTrainable`
 
+- **Adapter class**: `kailash_ml.HDBSCANTrainable` (eagerly exported from `kailash_ml.__all__`; defined in `kailash_ml.trainable`).
 - **Backend support**: CPU only via `sklearn.cluster.HDBSCAN` (sklearn ≥ 1.3 — already required by base `scikit-learn>=1.5` dep).
 - **Mapping**: Same shape as §5.7. INFO log key `hdbscan.cuml_eviction`. `device.fallback_reason="cuml_eviction"` on non-CPU requests.
 - **Phase 3 (planned)**: torch-native HDBSCAN. Same spec-amendment process as UMAP Phase 2.

--- a/specs/ml-backends.md
+++ b/specs/ml-backends.md
@@ -264,9 +264,27 @@ trainer = pl.Trainer(accelerator="cuda")         # Trainer moves it again
 
 ### 4.3 MUST: `TrainingResult` Carries The Resolved Values
 
-Every `TrainingResult` returned by a Lightning-wrapped training path MUST populate `backend`, `accelerator`, `device_string`, `devices`, `precision`, and `cuda_capability` (when applicable). A TrainingResult with `backend="auto"` or `precision="auto"` is a contract violation.
+Every `TrainingResult` returned by a Lightning-wrapped training path MUST populate the following fields with concrete (never `"auto"`) values:
 
-**Why:** Downstream consumers (ExperimentTracker auto-logs, MLflow export, ModelRegistry metadata) rely on these fields for reproducibility. "auto" strings make the run impossible to replay.
+- **Top-level fields** (`accelerator`, `device_used`, `precision`, `lightning_trainer_config`) — defined in `specs/ml-engines.md` §4.1; these are the primary reproducibility envelope.
+- **`device: DeviceReport`** — the GPU-first Phase 1 transparency object; carries `family`, `backend`, `device_string`, `precision`, `fallback_reason`, `array_api`. The DeviceReport replaces what earlier drafts of this spec called the flat `backend` / `devices` / `cuda_capability` fields. CUDA capability (`major.minor`) lives on `BackendInfo`, NOT on `TrainingResult` directly — callers needing it inspect `engine.backend_info.cuda_capability`.
+
+A `TrainingResult` with `accelerator="auto"`, `precision="auto"`, or `device.backend="auto"` is a contract violation.
+
+```python
+# DO — concrete values + DeviceReport populated
+TrainingResult(
+    ..., accelerator="cuda", precision="bf16-mixed", device_used="cuda:0",
+    device=DeviceReport(family="lightning", backend="cuda",
+                         device_string="cuda:0", precision="bf16-mixed",
+                         fallback_reason=None, array_api=False),
+)
+
+# DO NOT — "auto" leak
+TrainingResult(..., accelerator="auto", precision="auto", device=None)
+```
+
+**Why:** Downstream consumers (ExperimentTracker auto-logs, MLflow export, ModelRegistry metadata) rely on these fields for reproducibility. "auto" strings make the run impossible to replay. The `device: DeviceReport` field is the Phase 1 transparency contract; without it callers cannot distinguish actual-CUDA-execution from silent-CPU-fallback (`fallback_reason="oom"` / `"cuml_eviction"` / `"array_api_offlist"` / `"array_api_runtime_unavailable"`).
 
 ---
 
@@ -277,7 +295,7 @@ The Engine routes every training call through the Lightning wrapper (§ 4), but 
 ### 5.1 sklearn
 
 - **Backend support**: Lightning Trainer always runs on CPU; the inner estimator MAY route through the sklearn Array API on a non-CPU device per Phase 1.
-- **TrainingResult.backend** (legacy field): always `"cpu"`.
+- **TrainingResult top-level fields**: `accelerator="cpu"`, `device_used="cpu"`. (The historical `TrainingResult.backend` field never existed; per §4.3 the canonical surface is `accelerator` + `device_used` + the GPU-first `device: DeviceReport` envelope.)
 - **DeviceReport (`TrainingResult.device`)** populates per the Phase 1 transparency contract:
   - Allowlisted estimator + non-CPU `info.backend` → engage `sklearn.config_context(array_api_dispatch=True)`, move X/y to a torch tensor on `info.device_string`, log INFO `sklearn.array_api.engaged`. `device.array_api=True`, `device.backend=info.backend`.
   - Off-allowlist estimator + non-CPU `info.backend` → CPU numpy fallback. Log WARN `sklearn.array_api.offlist`, set `device.fallback_reason="array_api_offlist"`.
@@ -362,9 +380,9 @@ Every per-backend file MUST exercise ALL of:
 
 1. `detect_backend(prefer=<that backend>)` returns a `BackendInfo` with correct fields.
 2. `resolve_precision(info, "auto")` returns the expected precision for that device class.
-3. A small `BoringModel`-style Lightning training run completes one epoch and produces a `TrainingResult` whose `backend`, `accelerator`, `devices`, `precision` match the resolution.
+3. A small `BoringModel`-style Lightning training run completes one epoch and produces a `TrainingResult` whose `accelerator`, `device_used`, `precision`, and `device.backend` (DeviceReport) match the resolution.
 4. The same run's `TrainingResult.device_used` reads back through `ModelRegistry.get_model()` unchanged (state-persistence verification per `rules/testing.md` § Tier 2).
-5. A non-Lightning family run (sklearn MUST be in every file) produces a `TrainingResult` with `backend="cpu"` regardless of hardware, and (for xgboost/lightgbm on cuda-only backends) an `UnsupportedFamily` is raised when the family cannot run on the backend.
+5. A non-Lightning family run (sklearn MUST be in every file) produces a `TrainingResult` with `accelerator="cpu"` and `device.backend="cpu"` regardless of hardware (DeviceReport may carry `array_api=True` + `device.backend=info.backend` when the Array-API path engaged for an allowlisted estimator on a non-CPU backend), and (for xgboost/lightgbm on cuda-only backends) an `UnsupportedFamily` is raised when the family cannot run on the backend.
 
 **Implementation status (verified 2026-04-17 — redteam):** Tier 1 coverage landed at `tests/unit/test_device_resolver.py` and `tests/unit/test_trainable_protocol.py`. Tier 2 hardware-contract landed at `tests/integration/test_backend_resolver_contract.py` and asserts clauses §2.2, §2.3, §3.3, §4.1, §5.1 on real hardware (no mocks). The per-backend integration files enumerated above are NOT all present — only the combined contract file exists at 2026-04-17. Splitting into `backends/test_<name>_backend.py` is Phase 5 (redesign proposal §9) once CI lanes are provisioned (§11 OPEN QUESTION 1). **RL + `agents/` subpackages do NOT consult the resolver** (pinned by `tests/regression/test_rl_orphan_guard.py`) — Phase 6 fix required.
 
@@ -497,7 +515,7 @@ This spec's semantics are shared with `kailash-rs`. Implementation details diffe
 - `resolve_precision(info, requested)` returning equivalent precision strings.
 - The error hierarchy: `BackendUnavailable`, `UnsupportedFamily`, `PrecisionUnsupported`.
 - `km.doctor()` equivalent (Rust: `kailash-ml-doctor` binary crate), with the same structured-JSON schema.
-- `TrainingResult` fields: `backend`, `device_string`, `devices`, `precision`, `cuda_capability`.
+- `TrainingResult` fields: top-level `accelerator`, `device_used`, `precision`, `lightning_trainer_config` PLUS the GPU-first `device: DeviceReport` envelope (family / backend / device_string / precision / fallback_reason / array_api). Both SDKs MUST converge on the DeviceReport shape; the legacy flat `backend` / `devices` / `cuda_capability` fields are NOT first-class on TrainingResult.
 
 ### 9.2 Python-Specific
 

--- a/specs/ml-engines.md
+++ b/specs/ml-engines.md
@@ -402,6 +402,22 @@ Every method on `MLEngine` MUST raise a typed exception from `kailash_ml.excepti
 
 Every model family that can be fitted by `MLEngine.fit()` MUST implement the `Trainable` protocol. This protocol is the single place where the Lightning-core invariant is enforced.
 
+### 3.0 Phase 1 Family Roster (kailash-ml ≥ 0.12.0)
+
+The Phase 1 GPU-first roster is fixed at seven public Trainable family adapters, all exported from `kailash_ml.trainable` and listed in `kailash_ml.__all__`:
+
+| Family    | Class                | Backend support                                                         | Notes                                           |
+| --------- | -------------------- | ----------------------------------------------------------------------- | ----------------------------------------------- |
+| sklearn   | `SklearnTrainable`   | CPU + Array API allowlist on non-CPU backends                           | See ml-backends.md §5.1                         |
+| xgboost   | `XGBoostTrainable`   | CPU + CUDA, OOM single-retry to CPU                                     | See ml-backends.md §5.2                         |
+| lightgbm  | `LightGBMTrainable`  | CPU + CUDA/ROCm, OOM single-retry to CPU                                | See ml-backends.md §5.3                         |
+| torch     | `TorchTrainable`     | All 6 (cuda/mps/rocm/xpu/tpu/cpu)                                       | DL spine; native multi-backend                  |
+| lightning | `LightningTrainable` | All 6 (cuda/mps/rocm/xpu/tpu/cpu)                                       | DL spine; native multi-backend                  |
+| umap      | `UMAPTrainable`      | CPU only (Phase 1) — non-CPU requests log `cuml_eviction` and fall back | See ml-backends.md §5.7. Phase 2 → torch-native |
+| hdbscan   | `HDBSCANTrainable`   | CPU only (Phase 1) — non-CPU requests log `cuml_eviction` and fall back | See ml-backends.md §5.8. Phase 3 → torch-native |
+
+Adding a new family is a spec amendment to this table AND a `tests/regression/test_trainable_device_report_invariant.py` AST update to enumerate the new class.
+
 ### 3.1 Protocol Definition
 
 ```python
@@ -542,7 +558,19 @@ class TrainingResult:
     split_info: SplitInfo | None = None   # which split strategy, seed, sizes
     calibration: CalibrationInfo | None = None
     feature_importance: dict[str, float] | None = None
+
+    # GPU-first Phase 1 transparency contract (kailash-ml ≥ 0.12.0)
+    device: DeviceReport | None = None    # per-call evidence; populated by every Phase 1 family
 ```
+
+`DeviceReport` is defined in `kailash_ml._device_report` and carries the post-resolution evidence of what backend / precision / fallback ACTUALLY ran (vs `device_used` which is only the device string). Fields:
+
+- `family: str` — `"sklearn"`, `"xgboost"`, `"torch"`, etc.
+- `backend: str` — concrete value from `_device.KNOWN_BACKENDS` (never `"auto"`)
+- `device_string: str` — torch device string actually used
+- `precision: str` — concrete precision string (never `"auto"`)
+- `fallback_reason: str | None` — `"oom"`, `"cuml_eviction"`, `"array_api_offlist"`, `"array_api_runtime_unavailable"`, `"driver_missing"`, `"unsupported_family"`, or `None`
+- `array_api: bool` — `True` iff sklearn's `config_context(array_api_dispatch=True)` engaged for this call
 
 ### 4.2 MUST Rules
 
@@ -604,6 +632,43 @@ return TrainingResult(..., lightning_trainer_config={"accelerator": "auto"})
 When the Engine's `register()` is called with `format="onnx"` (default) or `format="both"`, the returned `RegisterResult.artifact_uris` MUST contain `"onnx"`. If ONNX export failed, `register()` MUST raise `OnnxExportError` — silently returning without ONNX is BLOCKED.
 
 **Why:** See §6. "ONNX export failed, falling back to pickle" without a raised error is the v0.9.x bug pattern where the compatibility matrix claimed xgboost support but the code had no xgboost branch.
+
+#### 5. Every Phase 1 Family Adapter MUST Populate `device`
+
+Every `Trainable.fit()` implementation MUST construct and attach a `DeviceReport` to the returned `TrainingResult.device` field. The adapter MUST set `fallback_reason` to a machine-parseable string when a non-CPU request was downgraded:
+
+| Family    | Standard `fallback_reason` codes                         |
+| --------- | -------------------------------------------------------- |
+| sklearn   | `"array_api_offlist"`, `"array_api_runtime_unavailable"` |
+| xgboost   | `"oom"`                                                  |
+| lightgbm  | `"oom"`                                                  |
+| torch     | (none — native multi-backend; no fallback path)          |
+| lightning | (none — native multi-backend; no fallback path)          |
+| umap      | `"cuml_eviction"`                                        |
+| hdbscan   | `"cuml_eviction"`                                        |
+
+```python
+# DO — populate device on every return path
+return TrainingResult(
+    ..., device=DeviceReport(
+        family=self.family_name,
+        backend=resolved_backend,
+        device_string=resolved_device_string,
+        precision=resolved_precision,
+        fallback_reason=fallback_reason,  # None when no downgrade
+        array_api=array_api_engaged,
+    ),
+)
+
+# DO NOT — return TrainingResult without device=
+return TrainingResult(...)  # silently leaves device=None — orphan
+```
+
+**Why:** A `TrainingResult.device == None` from a family that the spec covers means callers cannot distinguish actual-CUDA-execution from silent-CPU-fallback. The orphan failure mode of `rules/orphan-detection.md` §1 applies at the field level: the public `DeviceReport` symbol must be wired into the production hot path of every Trainable family. `tests/regression/test_trainable_device_report_invariant.py` enforces this at AST level — every `TrainingResult(...)` constructor in `trainable.py` MUST carry `device=`. Origin: round-3 redteam (2026-04-19) caught TorchTrainable + LightningTrainable returning `TrainingResult` without `device=` even though the Phase 1 punch list assumed they were already wired.
+
+#### 6. `Predictions.device` — Deferred to 0.12.1
+
+The `Predictions` class shipped in 0.12.0 does NOT carry a `device` field. The spec mandate "every predict returns one" applies to the post-fit predict surface and is scheduled for kailash-ml 0.12.1. Callers in 0.12.0 MUST inspect the prior `TrainingResult.device` to determine the device the model was trained on; this is sufficient for the immediate-after-fit case but insufficient for serialized-then-restored model scenarios. Tracked in `workspaces/kailash-ml-gpu-stack/journal/0005-GAP-predictions-device-field-missing.md`.
 
 ---
 
@@ -853,15 +918,15 @@ See §6. Integration tests: `test_onnx_roundtrip_{sklearn,xgboost,lightgbm,catbo
 
 ### 7.2 Claim-to-Test Mapping
 
-| Claim                       | Integration Test File                                                    |
-| --------------------------- | ------------------------------------------------------------------------ |
-| Multi-channel serve         | `tests/integration/test_serve_multichannel.py`                           |
-| Polars-native pipelines     | `tests/integration/test_polars_native_pipeline.py`                       |
+| Claim                       | Integration Test File                                                     |
+| --------------------------- | ------------------------------------------------------------------------- |
+| Multi-channel serve         | `tests/integration/test_serve_multichannel.py`                            |
+| Polars-native pipelines     | `tests/integration/test_polars_native_pipeline.py`                        |
 | ONNX-default artifacts      | `tests/integration/test_onnx_roundtrip_{sklearn,xgboost,lightgbm,...}.py` |
-| Unified ML/DL/RL            | `tests/integration/test_unified_surface.py`                              |
-| Async tracker               | `tests/integration/test_tracker_async.py`                                |
-| Schema evolution            | `tests/integration/test_feature_store_evolve.py`                         |
-| MCP-native experiment query | `tests/integration/test_mcp_experiment_tools.py`                         |
+| Unified ML/DL/RL            | `tests/integration/test_unified_surface.py`                               |
+| Async tracker               | `tests/integration/test_tracker_async.py`                                 |
+| Schema evolution            | `tests/integration/test_feature_store_evolve.py`                          |
+| MCP-native experiment query | `tests/integration/test_mcp_experiment_tools.py`                          |
 
 ---
 
@@ -921,20 +986,20 @@ The legacy namespace MUST NOT be removed in any 2.x release. Removal happens at 
 
 The v0.9.x public symbols that are demoted to `kailash_ml.legacy.*` (and promoted callers MUST migrate to the 2.0 equivalents):
 
-| v0.9.x import                                  | v2.0 equivalent                    |
-| ---------------------------------------------- | ---------------------------------- |
-| `from kailash_ml import AutoMLEngine`          | `engine.compare() → .finalize()`   |
-| `from kailash_ml import TrainingPipeline`      | `engine.fit()`                     |
-| `from kailash_ml import HyperparameterSearch`  | `engine.compare(hp_search="...")`  |
-| `from kailash_ml import EnsembleEngine`        | `kailash_ml.primitives.Ensemble`   |
-| `from kailash_ml import ClusteringEngine`      | `kailash_ml.primitives.Transform`  |
-| `from kailash_ml import AnomalyDetectionEngine`| `kailash_ml.primitives.Transform`  |
-| `from kailash_ml import DimReductionEngine`    | `kailash_ml.primitives.Transform`  |
-| `from kailash_ml import PreprocessingPipeline` | `engine.setup()`                   |
-| `from kailash_ml import DataExplorer`          | `kailash_ml.primitives.Explorer`   |
-| `from kailash_ml import ModelVisualizer`       | `kailash_ml.primitives.Visualizer` |
-| `from kailash_ml import ModelExplainer`        | `kailash_ml.primitives.Explainer`  |
-| `from kailash_ml import FeatureEngineer`       | `kailash_ml.primitives.FeatureGen` |
+| v0.9.x import                                   | v2.0 equivalent                    |
+| ----------------------------------------------- | ---------------------------------- |
+| `from kailash_ml import AutoMLEngine`           | `engine.compare() → .finalize()`   |
+| `from kailash_ml import TrainingPipeline`       | `engine.fit()`                     |
+| `from kailash_ml import HyperparameterSearch`   | `engine.compare(hp_search="...")`  |
+| `from kailash_ml import EnsembleEngine`         | `kailash_ml.primitives.Ensemble`   |
+| `from kailash_ml import ClusteringEngine`       | `kailash_ml.primitives.Transform`  |
+| `from kailash_ml import AnomalyDetectionEngine` | `kailash_ml.primitives.Transform`  |
+| `from kailash_ml import DimReductionEngine`     | `kailash_ml.primitives.Transform`  |
+| `from kailash_ml import PreprocessingPipeline`  | `engine.setup()`                   |
+| `from kailash_ml import DataExplorer`           | `kailash_ml.primitives.Explorer`   |
+| `from kailash_ml import ModelVisualizer`        | `kailash_ml.primitives.Visualizer` |
+| `from kailash_ml import ModelExplainer`         | `kailash_ml.primitives.Explainer`  |
+| `from kailash_ml import FeatureEngineer`        | `kailash_ml.primitives.FeatureGen` |
 
 ### 8.3 Preserved Symbols
 
@@ -1011,14 +1076,14 @@ These clauses MUST be implemented identically in both SDKs:
 
 These clauses MUST be implemented with language-specific substitutions, semantics preserved:
 
-| Clause                  | Python (kailash-py)              | Rust (kailash-rs)                     |
-| ----------------------- | -------------------------------- | ------------------------------------- |
-| §2 Engine facade        | `kailash_ml.Engine`              | `kailash_ml::Engine` struct           |
-| §3 `Trainable` protocol | Python `Protocol` + `@runtime_checkable` | Rust `trait Trainable`        |
-| Lightning Trainer spine | `lightning.pytorch.Trainer`      | `burn::Trainer` or `tch::train::Trainer` |
-| ONNX export             | `skl2onnx` / `onnxmltools` / `torch.onnx.export` | `tract-onnx` / `ort` export |
-| MCP server              | `fastmcp` (Python)               | `mcp-rs` crate                        |
-| Async runtime           | asyncio / async-context-managers | tokio / async-trait                   |
+| Clause                  | Python (kailash-py)                              | Rust (kailash-rs)                        |
+| ----------------------- | ------------------------------------------------ | ---------------------------------------- |
+| §2 Engine facade        | `kailash_ml.Engine`                              | `kailash_ml::Engine` struct              |
+| §3 `Trainable` protocol | Python `Protocol` + `@runtime_checkable`         | Rust `trait Trainable`                   |
+| Lightning Trainer spine | `lightning.pytorch.Trainer`                      | `burn::Trainer` or `tch::train::Trainer` |
+| ONNX export             | `skl2onnx` / `onnxmltools` / `torch.onnx.export` | `tract-onnx` / `ort` export              |
+| MCP server              | `fastmcp` (Python)                               | `mcp-rs` crate                           |
+| Async runtime           | asyncio / async-context-managers                 | tokio / async-trait                      |
 
 ### 10.3 Python-Only Clauses
 

--- a/specs/ml-tracking.md
+++ b/specs/ml-tracking.md
@@ -128,22 +128,26 @@ for trial in trials:
 
 **MUST**: On run start, the tracker MUST capture the following fields without explicit user action. Missing any field is a HIGH finding in `/redteam`:
 
-| Field                      | Source                                                                                                       |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `start_time`               | `datetime.now(UTC)` at `__aenter__`                                                                          |
-| `end_time`                 | `datetime.now(UTC)` at `__aexit__`                                                                           |
-| `host`                     | `socket.gethostname()`                                                                                       |
-| `python_version`           | `sys.version_info` triple                                                                                    |
-| `kailash_ml_version`       | `kailash_ml.__version__`                                                                                     |
-| `lightning_version`        | `lightning.pytorch.__version__` (if importable)                                                              |
-| `torch_version`            | `torch.__version__` (if importable)                                                                          |
-| `cuda_version`             | `torch.version.cuda` (if torch and CUDA present)                                                             |
-| `git_sha`                  | `subprocess.run(["git", "rev-parse", "HEAD"])` if in a repo, else `None`. Failure logged, not raised.        |
-| `git_dirty`                | `True` if `git status --porcelain` is non-empty                                                              |
-| `device_used`              | From attached `TrainingResult.device_used` when `log_model(training_result=...)` is called                   |
-| `accelerator`              | From `TrainingResult.accelerator`                                                                            |
-| `precision`                | From `TrainingResult.precision`                                                                              |
-| `tenant_id`                | From constructor / `km.track(tenant_id=)` or raises `TenantRequiredError` when multi-tenant mode             |
+| Field                    | Source                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `start_time`             | `datetime.now(UTC)` at `__aenter__`                                                                                                                                                                                                                                                                                                            |
+| `end_time`               | `datetime.now(UTC)` at `__aexit__`                                                                                                                                                                                                                                                                                                             |
+| `host`                   | `socket.gethostname()`                                                                                                                                                                                                                                                                                                                         |
+| `python_version`         | `sys.version_info` triple                                                                                                                                                                                                                                                                                                                      |
+| `kailash_ml_version`     | `kailash_ml.__version__`                                                                                                                                                                                                                                                                                                                       |
+| `lightning_version`      | `lightning.pytorch.__version__` (if importable)                                                                                                                                                                                                                                                                                                |
+| `torch_version`          | `torch.__version__` (if importable)                                                                                                                                                                                                                                                                                                            |
+| `cuda_version`           | `torch.version.cuda` (if torch and CUDA present)                                                                                                                                                                                                                                                                                               |
+| `git_sha`                | `subprocess.run(["git", "rev-parse", "HEAD"])` if in a repo, else `None`. Failure logged, not raised.                                                                                                                                                                                                                                          |
+| `git_dirty`              | `True` if `git status --porcelain` is non-empty                                                                                                                                                                                                                                                                                                |
+| `device_used`            | From attached `TrainingResult.device_used` when `log_model(training_result=...)` is called                                                                                                                                                                                                                                                     |
+| `accelerator`            | From `TrainingResult.accelerator`                                                                                                                                                                                                                                                                                                              |
+| `precision`              | From `TrainingResult.precision`                                                                                                                                                                                                                                                                                                                |
+| `device_family`          | From `TrainingResult.device.family` (DeviceReport, kailash-ml ≥ 0.12.0). Family adapter that produced the run: `"sklearn"` / `"xgboost"` / `"lightgbm"` / `"torch"` / `"lightning"` / `"umap"` / `"hdbscan"`.                                                                                                                                  |
+| `device_backend`         | From `TrainingResult.device.backend`. The actually-resolved backend (never `"auto"`); distinct from the requested backend when `device.fallback_reason` is set.                                                                                                                                                                                |
+| `device_fallback_reason` | From `TrainingResult.device.fallback_reason` (nullable). One of `"oom"` / `"cuml_eviction"` / `"array_api_offlist"` / `"array_api_runtime_unavailable"` / `"driver_missing"` / `"unsupported_family"` / `None`. Critical for reproducibility — a run that "succeeded" with `fallback_reason="oom"` actually ran on CPU, not the requested GPU. |
+| `device_array_api`       | From `TrainingResult.device.array_api` (bool). `True` iff sklearn's `config_context(array_api_dispatch=True)` engaged for this call.                                                                                                                                                                                                           |
+| `tenant_id`              | From constructor / `km.track(tenant_id=)` or raises `TenantRequiredError` when multi-tenant mode                                                                                                                                                                                                                                               |
 
 **Why:** Every reproducibility failure in the field traces to missing one of these fields. MLflow makes the Python / CUDA / device fields optional and the top-N rule of thumb is that 1 in 20 runs reproduced by another person fails because of environment drift that would have been captured here.
 
@@ -216,13 +220,13 @@ assert isinstance(df, pl.DataFrame)
 
 **MUST**: `ExperimentTracker.open(store=...)` MUST accept the following backend URIs:
 
-| URI scheme         | Use case                                             | Notes                                                                                                   |
-| ------------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `sqlite:///:memory:` | Unit tests only — evicted on process exit           | Alias `sqlite+memory` accepted for readability                                                         |
-| `sqlite+memory`    | Notebook workflows with no persistence               | **MUST** be supported — closes the user-reported pain point #8 in `00-synthesis-redesign-proposal.md §3.6` |
-| `sqlite:///path/to/ml.db` | Local single-file store                        | Default when `store=None` in `km.track()` — resolves to `~/.kailash_ml/ml.db`                           |
-| `postgresql://...` | Multi-user, multi-host, prod                         | Recommended for any shared team                                                                         |
-| `mysql://...`      | Multi-user, multi-host, prod                         | Same contract as PostgreSQL                                                                             |
+| URI scheme                | Use case                                  | Notes                                                                                                      |
+| ------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `sqlite:///:memory:`      | Unit tests only — evicted on process exit | Alias `sqlite+memory` accepted for readability                                                             |
+| `sqlite+memory`           | Notebook workflows with no persistence    | **MUST** be supported — closes the user-reported pain point #8 in `00-synthesis-redesign-proposal.md §3.6` |
+| `sqlite:///path/to/ml.db` | Local single-file store                   | Default when `store=None` in `km.track()` — resolves to `~/.kailash_ml/ml.db`                              |
+| `postgresql://...`        | Multi-user, multi-host, prod              | Recommended for any shared team                                                                            |
+| `mysql://...`             | Multi-user, multi-host, prod              | Same contract as PostgreSQL                                                                                |
 
 **MUST**: The default `store` when `km.track()` is called with no arguments MUST be `f"sqlite:///{Path.home() / '.kailash_ml' / 'ml.db'}"`. The directory MUST be created if absent. Creation failure MUST raise a typed `TrackerStoreInitError`, not fall back to `:memory:`.
 
@@ -269,14 +273,14 @@ await registry.set_alias(name="churn", alias="production", version=5)  # moves p
 
 **MUST**: The aliases `production`, `staging`, `champion`, `challenger`, `canary`, and `shadow` MUST resolve with the following semantics when consumed by `engine.serve()` and the MCP surface:
 
-| Alias        | Meaning                                                               | Retention default           |
-| ------------ | --------------------------------------------------------------------- | --------------------------- |
-| `production` | The live-traffic model                                                | Retain indefinitely         |
-| `staging`    | Candidate for next promotion                                          | Retain last 10              |
-| `champion`   | Current best-performing model (synonym for production in A/B context) | Retain indefinitely         |
-| `challenger` | Candidate being evaluated against champion                            | Retain last 10              |
-| `canary`     | Gradually rolled-out candidate                                        | Retain last 10              |
-| `shadow`     | Receives mirrored traffic, no user-facing outputs                     | Retain last 10              |
+| Alias        | Meaning                                                               | Retention default   |
+| ------------ | --------------------------------------------------------------------- | ------------------- |
+| `production` | The live-traffic model                                                | Retain indefinitely |
+| `staging`    | Candidate for next promotion                                          | Retain last 10      |
+| `champion`   | Current best-performing model (synonym for production in A/B context) | Retain indefinitely |
+| `challenger` | Candidate being evaluated against champion                            | Retain last 10      |
+| `canary`     | Gradually rolled-out candidate                                        | Retain last 10      |
+| `shadow`     | Receives mirrored traffic, no user-facing outputs                     | Retain last 10      |
 
 **Why:** Mirror the semantics of production deployment tooling so platform teams can port their existing runbooks. Without reserved names, every team reinvents the same four aliases and the MCP tools can't render a meaningful status.
 
@@ -303,13 +307,13 @@ await registry.register(model, name="churn")  # BLOCKED — ModelSignatureRequir
 
 **MUST**: Every `ModelVersionInfo` MUST carry a non-null `lineage` dict with at least these keys:
 
-| Key                    | Type                  | Purpose                                                                                |
-| ---------------------- | --------------------- | -------------------------------------------------------------------------------------- |
-| `tracker_run_id`       | `str`                 | The ExperimentTracker run that produced the model                                      |
-| `parent_version`       | `Optional[int]`       | For fine-tuned or retrained models — the version this was derived from                 |
-| `training_data_uri`    | `Optional[str]`       | Pointer to the training dataset (S3 path, SQL query ID, DataFlow model+version)         |
-| `feature_store_version` | `Optional[str]`      | Schema version from the feature store (when the future `ml-features.md` lands)          |
-| `base_model_uri`       | `Optional[str]`       | For LoRA/alignment: the base model used                                                |
+| Key                     | Type            | Purpose                                                                         |
+| ----------------------- | --------------- | ------------------------------------------------------------------------------- |
+| `tracker_run_id`        | `str`           | The ExperimentTracker run that produced the model                               |
+| `parent_version`        | `Optional[int]` | For fine-tuned or retrained models — the version this was derived from          |
+| `training_data_uri`     | `Optional[str]` | Pointer to the training dataset (S3 path, SQL query ID, DataFlow model+version) |
+| `feature_store_version` | `Optional[str]` | Schema version from the feature store (when the future `ml-features.md` lands)  |
+| `base_model_uri`        | `Optional[str]` | For LoRA/alignment: the base model used                                         |
 
 Registration with missing `tracker_run_id` MUST raise `LineageRequiredError`.
 
@@ -410,14 +414,14 @@ async def delete_alias(
 
 **MUST**: `ArtifactStore` implementations MUST exist for each URI scheme below. `store.from_uri(uri)` is the factory:
 
-| Scheme           | Class                     | Use case                                                                |
-| ---------------- | ------------------------- | ----------------------------------------------------------------------- |
-| `file://`        | `LocalFileArtifactStore`  | Single-host dev, CI                                                     |
-| `sqlite://`      | `SqliteBlobArtifactStore` | Small artifacts (<10 MB), notebook-friendly, embedded with tracker DB   |
-| `s3://`          | `S3ArtifactStore`         | AWS prod, requires `boto3`                                              |
-| `gs://`          | `GCSArtifactStore`        | GCP prod, requires `google-cloud-storage`                               |
-| `azure://`       | `AzureBlobArtifactStore`  | Azure prod, requires `azure-storage-blob`                               |
-| `http://`, `https://` | `HTTPReadOnlyArtifactStore` | Read-only import path, used by MLflow migration                      |
+| Scheme                | Class                       | Use case                                                              |
+| --------------------- | --------------------------- | --------------------------------------------------------------------- |
+| `file://`             | `LocalFileArtifactStore`    | Single-host dev, CI                                                   |
+| `sqlite://`           | `SqliteBlobArtifactStore`   | Small artifacts (<10 MB), notebook-friendly, embedded with tracker DB |
+| `s3://`               | `S3ArtifactStore`           | AWS prod, requires `boto3`                                            |
+| `gs://`               | `GCSArtifactStore`          | GCP prod, requires `google-cloud-storage`                             |
+| `azure://`            | `AzureBlobArtifactStore`    | Azure prod, requires `azure-storage-blob`                             |
+| `http://`, `https://` | `HTTPReadOnlyArtifactStore` | Read-only import path, used by MLflow migration                       |
 
 **Why:** Each backend exists for a specific use case; missing `sqlite://` forces notebook users onto the filesystem and breaks in JupyterHub ephemeral containers. Explicit backend list prevents the "add custom backend" sprawl MLflow experienced.
 
@@ -469,13 +473,13 @@ if not key_available:
 
 **MUST**: Each store backend MUST expose `max_artifact_bytes` configured at construction. Default values:
 
-| Backend                  | Default `max_artifact_bytes` |
-| ------------------------ | ---------------------------- |
+| Backend                   | Default `max_artifact_bytes` |
+| ------------------------- | ---------------------------- |
 | `SqliteBlobArtifactStore` | 10 MB                        |
-| `LocalFileArtifactStore` | 10 GB                        |
-| `S3ArtifactStore`        | 5 TB (S3 object limit)       |
-| `GCSArtifactStore`       | 5 TB                         |
-| `AzureBlobArtifactStore` | 200 GB                       |
+| `LocalFileArtifactStore`  | 10 GB                        |
+| `S3ArtifactStore`         | 5 TB (S3 object limit)       |
+| `GCSArtifactStore`        | 5 TB                         |
+| `AzureBlobArtifactStore`  | 200 GB                       |
 
 Exceeding the limit MUST raise `ArtifactSizeExceededError` at `put()` time with the current size, limit, and a suggestion to reconfigure or switch backend.
 
@@ -531,16 +535,16 @@ await serve_mcp(server, transport="stdio")
 
 **MUST**: `TrackerMCPServer` MUST expose the following MCP tools. Each is an independently invocable method with a JSON schema documented in the server class:
 
-| Tool name             | Purpose                                                                                 |
-| --------------------- | --------------------------------------------------------------------------------------- |
-| `list_experiments`    | `(tenant_id, filter_expr, limit)` → `List[ExperimentInfo]`                              |
-| `get_run`             | `(run_id, tenant_id)` → full metadata + metrics + params + auto-captured environment    |
-| `search_runs`         | `(query, order_by, limit, tenant_id)` → `List[RunInfo]`                                 |
-| `get_model`           | `(name, alias_or_version, tenant_id)` → `ModelVersionInfo` with resolved artifact URIs  |
-| `list_models`         | `(name_pattern, tenant_id)` → `List[ModelVersionInfo]`                                  |
-| `diff_runs`           | `(run_a, run_b, tenant_id)` → `RunDiff` with per-key param/metric/env deltas            |
-| `list_aliases`        | `(name, tenant_id)` → `Dict[alias, version]`                                            |
-| `get_lineage`         | `(model_name, version, tenant_id)` → full lineage chain to training data               |
+| Tool name          | Purpose                                                                                |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| `list_experiments` | `(tenant_id, filter_expr, limit)` → `List[ExperimentInfo]`                             |
+| `get_run`          | `(run_id, tenant_id)` → full metadata + metrics + params + auto-captured environment   |
+| `search_runs`      | `(query, order_by, limit, tenant_id)` → `List[RunInfo]`                                |
+| `get_model`        | `(name, alias_or_version, tenant_id)` → `ModelVersionInfo` with resolved artifact URIs |
+| `list_models`      | `(name_pattern, tenant_id)` → `List[ModelVersionInfo]`                                 |
+| `diff_runs`        | `(run_a, run_b, tenant_id)` → `RunDiff` with per-key param/metric/env deltas           |
+| `list_aliases`     | `(name, tenant_id)` → `Dict[alias, version]`                                           |
+| `get_lineage`      | `(model_name, version, tenant_id)` → full lineage chain to training data               |
 
 **Why:** These eight tools are the smallest surface that lets an agent answer "which model is in production, how does it compare to the staging candidate, and what data was each trained on?" — the core MLflow use case. `diff_runs` is the killer feature MLflow does not provide.
 
@@ -569,14 +573,14 @@ class RunDiff:
 
 **MUST**: All primary keys MUST follow the shape `kailash_ml:v1:{tenant_id}:{resource}:{id}`:
 
-| Resource     | Key shape                                                |
-| ------------ | -------------------------------------------------------- |
-| Experiments  | `kailash_ml:v1:{tenant_id}:exp:{experiment_id}`          |
-| Runs         | `kailash_ml:v1:{tenant_id}:run:{run_id}`                 |
-| Models       | `kailash_ml:v1:{tenant_id}:model:{name}:{version}`       |
-| Aliases      | `kailash_ml:v1:{tenant_id}:alias:{name}:{alias}`         |
-| Artifacts    | `kailash_ml:v1:{tenant_id}:artifact:{sha256}`            |
-| Lineage      | `kailash_ml:v1:{tenant_id}:lineage:{model}:{version}`    |
+| Resource    | Key shape                                             |
+| ----------- | ----------------------------------------------------- |
+| Experiments | `kailash_ml:v1:{tenant_id}:exp:{experiment_id}`       |
+| Runs        | `kailash_ml:v1:{tenant_id}:run:{run_id}`              |
+| Models      | `kailash_ml:v1:{tenant_id}:model:{name}:{version}`    |
+| Aliases     | `kailash_ml:v1:{tenant_id}:alias:{name}:{alias}`      |
+| Artifacts   | `kailash_ml:v1:{tenant_id}:artifact:{sha256}`         |
+| Lineage     | `kailash_ml:v1:{tenant_id}:lineage:{model}:{version}` |
 
 **Why:** Same tenant-dimension-everywhere contract as `rules/tenant-isolation.md` MUST Rule 1. Any piece of state without a tenant dimension leaks across tenants as soon as two tenants happen to share a primary key (run IDs are UUIDs but model names are user-chosen strings — overlap is the norm, not the exception).
 
@@ -615,10 +619,10 @@ await tracker.log_metric("acc", 0.9)  # raises TenantRequiredError
 
 **MUST**: Every run, model, and artifact record MUST carry two fields:
 
-| Field             | Type             | Purpose                                                                          |
-| ----------------- | ---------------- | -------------------------------------------------------------------------------- |
-| `owner_tenant_id` | `str`            | The tenant that owns the record (always populated)                               |
-| `data_subject_ids` | `List[str]`     | Optional list of data subject IDs whose personal data may be present             |
+| Field              | Type        | Purpose                                                              |
+| ------------------ | ----------- | -------------------------------------------------------------------- |
+| `owner_tenant_id`  | `str`       | The tenant that owns the record (always populated)                   |
+| `data_subject_ids` | `List[str]` | Optional list of data subject IDs whose personal data may be present |
 
 Data subject IDs are typically user IDs, customer IDs, or patient IDs that appeared in the training data. Recording them is the caller's responsibility — `km.track(data_subject_ids=[...])` is the entry point.
 
@@ -726,14 +730,14 @@ This spec is **Python-Rust shared**. The API surface (method names, signatures m
 
 ### 10.2 Rust Translation
 
-| Clause                          | Python                                   | Rust                                                       |
-| ------------------------------- | ---------------------------------------- | ---------------------------------------------------------- |
-| Async context manager (§2.2)    | `async with km.track(...) as t:`         | `async_trait` + `tracker.with_run(|r| async { ... }).await` |
-| ONNX export (default format §2.5) | `format="onnx"` via `skl2onnx` / `torch.onnx` | `tract-onnx` as the export backend                     |
-| Storage backends (§4.1)         | `boto3`, `google-cloud-storage`, etc.    | `rust-s3`, `google-cloud-storage-rs`, `azure_storage`      |
-| MCP surface (§5)                | `kailash-mcp` (Python)                   | `mcp-rs` (Rust)                                            |
-| Polars return (§2.6)            | `polars.DataFrame`                       | `polars::DataFrame` (Rust polars)                          |
-| Storage key shape (§6)          | Same `kailash_ml:v1:{tenant_id}:...`     | Same — binary-identical keys allow cross-SDK read         |
+| Clause                            | Python                                        | Rust                                                  |
+| --------------------------------- | --------------------------------------------- | ----------------------------------------------------- | --- | --------------------- |
+| Async context manager (§2.2)      | `async with km.track(...) as t:`              | `async_trait` + `tracker.with_run(                    | r   | async { ... }).await` |
+| ONNX export (default format §2.5) | `format="onnx"` via `skl2onnx` / `torch.onnx` | `tract-onnx` as the export backend                    |
+| Storage backends (§4.1)           | `boto3`, `google-cloud-storage`, etc.         | `rust-s3`, `google-cloud-storage-rs`, `azure_storage` |
+| MCP surface (§5)                  | `kailash-mcp` (Python)                        | `mcp-rs` (Rust)                                       |
+| Polars return (§2.6)              | `polars.DataFrame`                            | `polars::DataFrame` (Rust polars)                     |
+| Storage key shape (§6)            | Same `kailash_ml:v1:{tenant_id}:...`          | Same — binary-identical keys allow cross-SDK read     |
 
 **MUST**: Rust reads of keys written by Python (and vice versa) MUST succeed without transformation. Cross-SDK interop tests (one written in Python, read in Rust; one written in Rust, read in Python) MUST live in `kailash-py/tests/cross_sdk/` and `kailash-rs/tests/cross_sdk/` respectively.
 
@@ -753,20 +757,20 @@ This spec is **Python-Rust shared**. The API surface (method names, signatures m
 
 **MUST**: All exceptions raised from `kailash_ml.tracker`, `kailash_ml.registry`, and `kailash_ml.artifacts` MUST inherit from `TrackingError`. Subclasses:
 
-| Exception                      | Raised when                                                                      |
-| ------------------------------ | -------------------------------------------------------------------------------- |
-| `TrackerStoreInitError`        | Store URI cannot be initialized (permission, disk full, invalid connection)     |
-| `TenantRequiredError`          | Multi-tenant mode without `tenant_id`                                            |
-| `InvalidTenantIdError`         | `tenant_id` fails the safety regex                                               |
-| `ModelSignatureRequiredError`  | `registry.register()` called without `signature`                                 |
-| `LineageRequiredError`         | `registry.register()` called without a tracker context (no `tracker_run_id`)    |
-| `ArtifactEncryptionError`      | Encrypt-then-store failed; includes `.reason` field                              |
-| `ArtifactSizeExceededError`    | Artifact exceeds backend `max_artifact_bytes`                                    |
-| `RunNotFoundError`             | `get_run(run_id)` with unknown run                                               |
-| `ModelNotFoundError`           | `registry.get(name, version)` with unknown version                               |
-| `AliasNotFoundError`           | `registry.get(name, alias=)` with unset alias                                    |
-| `ErasureRefusedError`          | `delete_data_subject()` blocked by production alias                              |
-| `MigrationImportError`         | MLflow import failed for a specific record (other records continue)              |
+| Exception                     | Raised when                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `TrackerStoreInitError`       | Store URI cannot be initialized (permission, disk full, invalid connection)  |
+| `TenantRequiredError`         | Multi-tenant mode without `tenant_id`                                        |
+| `InvalidTenantIdError`        | `tenant_id` fails the safety regex                                           |
+| `ModelSignatureRequiredError` | `registry.register()` called without `signature`                             |
+| `LineageRequiredError`        | `registry.register()` called without a tracker context (no `tracker_run_id`) |
+| `ArtifactEncryptionError`     | Encrypt-then-store failed; includes `.reason` field                          |
+| `ArtifactSizeExceededError`   | Artifact exceeds backend `max_artifact_bytes`                                |
+| `RunNotFoundError`            | `get_run(run_id)` with unknown run                                           |
+| `ModelNotFoundError`          | `registry.get(name, version)` with unknown version                           |
+| `AliasNotFoundError`          | `registry.get(name, alias=)` with unset alias                                |
+| `ErasureRefusedError`         | `delete_data_subject()` blocked by production alias                          |
+| `MigrationImportError`        | MLflow import failed for a specific record (other records continue)          |
 
 **Why:** Typed exceptions make error handling surgical. MLflow raises generic `Exception` in many paths, which forces downstream code to `except Exception: ...` and swallow unrelated errors.
 
@@ -785,14 +789,14 @@ Both `packages/kailash-ml/pyproject.toml` and `packages/kailash-ml/src/kailash_m
 
 ## Appendix A. MLflow Features Consciously NOT Matched
 
-| MLflow feature         | Decision  | Reason                                                                                                 |
-| ---------------------- | --------- | ------------------------------------------------------------------------------------------------------ |
-| `mlflow.projects`      | NOT MATCHED | Replaced by Kaizen workflow orchestration per `rules/framework-first.md`. Reimplementing projects-as-entrypoints duplicates Kaizen. |
-| `mlflow.evaluate`      | NOT MATCHED | Replaced by `engine.evaluate()` in `ml-engines.md`. Tracking records the run_id; evaluation is a training-spec concern. |
-| Model flavors (`mlflow.sklearn`, `mlflow.pytorch`, ...) | NOT MATCHED | Replaced by `format=` parameter on `log_model`. Flavor-as-module proliferates import paths; `format="onnx"` defaults enforce one canonical format. |
-| Model serving via MLflow REST | NOT MATCHED | Replaced by Nexus multi-channel serving (REST + MCP + CLI + WebSocket) per `nexus-channels.md`. |
-| AutoLog for 13 frameworks | NOT MATCHED | Auto-capture is scoped to environment fields (§2.4). Per-framework autologging is brittle (MLflow auto-log for XGBoost has been broken across 4 MLflow versions). Users call `log_metric` explicitly. |
-| System metrics (CPU, memory, GPU util) sampling | DEFERRED | Scope-deferred to a future `ml-observability.md`. Not worth coupling to tracking right now. |
+| MLflow feature                                          | Decision    | Reason                                                                                                                                                                                                |
+| ------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mlflow.projects`                                       | NOT MATCHED | Replaced by Kaizen workflow orchestration per `rules/framework-first.md`. Reimplementing projects-as-entrypoints duplicates Kaizen.                                                                   |
+| `mlflow.evaluate`                                       | NOT MATCHED | Replaced by `engine.evaluate()` in `ml-engines.md`. Tracking records the run_id; evaluation is a training-spec concern.                                                                               |
+| Model flavors (`mlflow.sklearn`, `mlflow.pytorch`, ...) | NOT MATCHED | Replaced by `format=` parameter on `log_model`. Flavor-as-module proliferates import paths; `format="onnx"` defaults enforce one canonical format.                                                    |
+| Model serving via MLflow REST                           | NOT MATCHED | Replaced by Nexus multi-channel serving (REST + MCP + CLI + WebSocket) per `nexus-channels.md`.                                                                                                       |
+| AutoLog for 13 frameworks                               | NOT MATCHED | Auto-capture is scoped to environment fields (§2.4). Per-framework autologging is brittle (MLflow auto-log for XGBoost has been broken across 4 MLflow versions). Users call `log_metric` explicitly. |
+| System metrics (CPU, memory, GPU util) sampling         | DEFERRED    | Scope-deferred to a future `ml-observability.md`. Not worth coupling to tracking right now.                                                                                                           |
 
 ## Appendix B. Open Questions
 

--- a/workspaces/kailash-ml-gpu-stack/journal/0004-RISK-torch-lightning-deviceReport-orphan.md
+++ b/workspaces/kailash-ml-gpu-stack/journal/0004-RISK-torch-lightning-deviceReport-orphan.md
@@ -1,0 +1,68 @@
+---
+type: RISK
+date: 2026-04-19
+created_at: 2026-04-19T22:50:00.000Z
+author: agent
+session_id: continue-session-2026-04-19
+project: kailash-ml-gpu-stack
+topic: TorchTrainable + LightningTrainable shipped without DeviceReport wire-up — caught by /redteam, fixed pre-merge
+phase: redteam
+tags: [orphan-detection, transparency-contract, deviceReport, redteam, phase-1]
+related_journal: [0002-GAP-device-report-and-stickiness-missing.md]
+---
+
+# Round-3 redteam — Torch + Lightning Trainables shipped without DeviceReport
+
+## What was found
+
+The `/redteam` spec-compliance audit on `feat/ml-gpu-phase1-integration` found that `TorchTrainable.fit` (line 889) and `LightningTrainable.fit` (line 1023) returned `TrainingResult` WITHOUT populating the `device=DeviceReport(...)` field, despite the round-1 spec at `04-validate/02-revised-stack.md` § "Transparency contract" stating:
+
+> This lands on:
+> - TrainingResult.device — every fit returns one
+> - Predictions.device — every predict returns one
+
+Pre-redteam grep counts:
+```
+return TrainingResult sites: 7
+device= kwarg sites:         5  ← 2 orphans
+```
+
+The two missing sites were the DL-spine families (Torch + Lightning), which were assumed-already-done because the punch list explicitly covered items 3/4/5/7/8 (sklearn array-API, xgboost/lightgbm OOM, UMAP/HDBSCAN, Tier 2 tests, [rapids] removal) — but the spec mandate "every fit returns one" applies to ALL 7 family adapters, not just the 5 explicitly named.
+
+This is the same orphan failure mode `rules/orphan-detection.md` §1 describes at the class level, scoped down to the field level: a public spec promise (`TrainingResult.device`) wired into the framework's hot path for 5 of 7 families and silently un-wired for 2.
+
+## Why it slipped past the round-3 reviewer
+
+The reviewer agent's APPROVE-WITH-MINOR-FIXES verdict listed H1 as "missing test for `array_api_runtime_unavailable` fallback" but did not flag the missing Torch/Lightning device wire-up. The reviewer's check was scoped to the diff (which added DeviceReport to the 5 NEW family adapters), not the absolute state of every TrainingResult call site. The mechanical AST sweep `grep -c "return TrainingResult(" + grep -cE "device=DeviceReport"` would have caught it in seconds; the reviewer didn't run it.
+
+Lesson: gate-level reviewers verify the diff; `/redteam` re-verifies the absolute state. Both are necessary; neither is sufficient alone.
+
+## Fix
+
+Same-PR fix on `feat/ml-gpu-phase1-integration` commit `1e233dcd`:
+- TorchTrainable.fit now constructs DeviceReport from the resolved Lightning context (no eviction/OOM fallback path — native multi-backend via L.Trainer per ml-backends.md §5.4).
+- LightningTrainable.fit — same pattern.
+- New regression test at `tests/regression/test_trainable_device_report_invariant.py` mechanically asserts every `TrainingResult(...)` constructor in trainable.py carries `device=`. Future refactors that drop the kwarg fail loudly at AST parse time.
+
+Post-fix counts:
+```
+return TrainingResult sites: 7
+device= kwarg sites:         7  ← parity
+```
+
+## Consequences
+
+- 0.12.0 release ships with the full transparency contract for `TrainingResult.device` across all 7 family adapters, not 5 of 7.
+- The regression invariant test prevents the next session from silently dropping the field via refactor.
+
+## Outstanding
+
+- `Predictions.device` field is still missing from the `Predictions` class entirely (see journal 0005-GAP). Out of scope for 0.12.0; tracked for 0.12.1.
+
+## For Discussion
+
+1. **Counterfactual**: If `/redteam` had not been run, the 0.12.0 wheel would have shipped with TorchTrainable + LightningTrainable returning `TrainingResult.device = None`. Downstream consumers of the GPU-first transparency surface would silently fail to distinguish actual-CUDA-execution from fell-back-to-CPU for the two DL-spine families — exactly the failure mode the Phase 1 spec was designed to prevent.
+
+2. **Data-referenced**: The reviewer agent ran in 5 minutes and produced a 5-finding report. The mechanical `/redteam` check that surfaced this finding ran in 4 seconds (two grep calls). What is the right division of labor between LLM-judgment review and mechanical AST/grep audit? Hypothesis: the mechanical sweep should be the FIRST gate (redteam phase 1), and the LLM reviewer should run AFTER it on the diff that's been mechanically pre-cleared.
+
+3. **Scope-creep counter-question**: Shard B's agent scope-crept into Shard A's territory (helpfully — caught a missing impl). But three of three agents missed the Torch/Lightning device wire-up because none was instructed to look at it. Should the task decomposition for parallel shards include a "spec-completeness check" todo that explicitly enumerates EVERY TrainingResult call site, not just the ones touched by the in-scope items?

--- a/workspaces/kailash-ml-gpu-stack/journal/0005-GAP-predictions-device-field-missing.md
+++ b/workspaces/kailash-ml-gpu-stack/journal/0005-GAP-predictions-device-field-missing.md
@@ -1,0 +1,81 @@
+---
+type: GAP
+date: 2026-04-19
+created_at: 2026-04-19T22:55:00.000Z
+author: agent
+session_id: continue-session-2026-04-19
+project: kailash-ml-gpu-stack
+topic: Predictions class has no device field; spec says "every predict returns one"
+phase: redteam
+tags: [transparency-contract, deviceReport, predictions, gap, phase-1, follow-up]
+related_journal: [0002-GAP-device-report-and-stickiness-missing.md, 0004-RISK-torch-lightning-deviceReport-orphan.md]
+---
+
+# `Predictions.device` field missing — spec violation, deferred to 0.12.1
+
+## What the spec requires
+
+`workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md` § "Transparency contract" lines 54-78:
+
+> Every call returns (or carries) a `DeviceReport`:
+> ```
+> @dataclass(frozen=True)
+> class DeviceReport: ...
+> ```
+>
+> This lands on:
+> - TrainingResult.device — every fit returns one
+> - Predictions.device — every predict returns one  ← THIS
+> - km.device() — top-level helper
+
+## What ships in 0.12.0
+
+`Predictions` (defined at `packages/kailash-ml/src/kailash_ml/trainable.py:128`) has only:
+
+```python
+class Predictions:
+    __slots__ = ("_raw", "_column")
+    def __init__(self, raw: Any, *, column: str = "prediction") -> None: ...
+    @property
+    def raw(self) -> Any: ...
+    @property
+    def column(self) -> str: ...
+    def to_polars(self) -> pl.DataFrame: ...
+```
+
+No `device` field. No `device` property. None of the 7 `predict()` methods construct or carry a DeviceReport.
+
+## Scope decision for 0.12.0
+
+Wiring `Predictions.device` requires:
+
+1. New `device: Optional[DeviceReport]` field on `Predictions` (with backwards-compat optional default for callers that already construct it).
+2. Update all 7 `Trainable.predict()` methods to construct and pass a DeviceReport (similar pattern to fit).
+3. Predictions tests for every family verifying `pred.device` populated correctly.
+4. Update `Predictions.__slots__` to include `_device`.
+
+This is ~40 LOC of code + ~150 LOC of tests + a structural API change to a public class. It's a bounded shard but distinctly bigger than the post-redteam HIGH-1 fix (which was 30 LOC + 100 LOC test).
+
+**Decision**: defer to 0.12.1. The 0.12.0 release ships the FIT half of the transparency contract complete (7/7 families) and the PREDICT half delegated to 0.12.1.
+
+## Consequences
+
+- 0.12.0 release notes MUST disclose that the predict-half of the transparency contract is incomplete. CHANGELOG `Known Limitations` section needed.
+- Downstream callers cannot programmatically distinguish a CUDA-resolved predict from a CPU-fallback predict in 0.12.0. They CAN inspect `result.device` from the prior fit — sufficient for the common case where predict runs immediately after fit, insufficient for callers that round-trip the model through serialization.
+
+## Plan for 0.12.1
+
+1. Add `device: Optional[DeviceReport] = None` to `Predictions.__init__` and `__slots__`.
+2. Update each Trainable.predict() to construct DeviceReport mirroring the fit-time call (cache `self._last_device_report` from fit, return it from predict).
+3. Add `tests/regression/test_predictions_device_invariant.py` — AST sweep asserting every `Predictions(...)` constructor in trainable.py carries `device=` (the same shape as the new TrainingResult invariant landed in 0.12.0).
+4. Tier 2 backend-matrix test additions for predict-time device assertions.
+
+Estimated capacity: 1 session shard, ~200 LOC total, single-file edits + tests.
+
+## For Discussion
+
+1. **Counterfactual**: If 0.12.0 had attempted to wire Predictions.device too, would the parallel-shard experiment have failed harder? Likely yes — predict() is per-family, so a 6th shard would have been needed (or one of the existing 3 would have scope-crept further). The deferral is the right call given the parallel-execution mode this session ran in.
+
+2. **Data-referenced**: How many downstream consumers actually need `Predictions.device`? Aether and aegis, the two known consumers, currently use TrainingResult fields immediately after fit. The Predictions surface is more relevant for inference-server scenarios (kailash-ml's `InferenceServer` engine) where predicts run hours/days after fit and the device may have changed. That's the audience to prioritize for 0.12.1.
+
+3. **Should the regression invariant test land in 0.12.0?** Argument for: the test would assert "no Predictions(...) with device= today" — it would fail until 0.12.1 lands the field. Argument against: an always-failing test is worse than no test. Decision: land the assertion test ALONGSIDE the 0.12.1 implementation, not before.

--- a/workspaces/kailash-ml-gpu-stack/journal/0006-DECISION-codify-three-parallel-agent-rules.md
+++ b/workspaces/kailash-ml-gpu-stack/journal/0006-DECISION-codify-three-parallel-agent-rules.md
@@ -1,0 +1,129 @@
+---
+type: DECISION
+date: 2026-04-19
+created_at: 2026-04-19T23:10:00.000Z
+author: agent
+session_id: continue-session-2026-04-19
+project: kailash-ml-gpu-stack
+topic: Codify three rule additions to rules/agents.md from this session's parallel-shard failure modes
+phase: codify
+tags:
+  [
+    codify,
+    parallel-agents,
+    worktree-isolation,
+    reviewer-discipline,
+    rules-update,
+  ]
+related_journal:
+  [
+    0004-RISK-torch-lightning-deviceReport-orphan.md,
+    0005-GAP-predictions-device-field-missing.md,
+  ]
+---
+
+# Codify — three rule additions for parallel-shard agent discipline
+
+## Decision
+
+Three rule additions land in `rules/agents.md`, all phrased per the
+`rules/rule-authoring.md` meta-rule (MUST clause + BLOCKED rationalizations
+
+- DO/DO NOT example + `**Why:**` + `Origin:` line):
+
+1. **§ "MUST: Worktree Prompts Use Relative Paths Only"** — agent prompts
+   referencing absolute paths bypass `isolation: "worktree"` and write to
+   the parent checkout.
+2. **§ "MUST: Worktree Agents Commit Incremental Progress"** — agents that
+   don't commit before exit lose 100% of work to worktree auto-cleanup.
+3. **§ "MUST: Reviewer Prompts Include Mechanical AST/Grep Sweep"** — gate
+   reviewers given only the diff miss orphans in OLD untouched lines that
+   the new public surface implicitly required.
+
+All 3 are classification_suggestion: global (cross-SDK-applicable to
+kailash-rs's parallel agent patterns) and live in `.claude/.proposals/latest.yaml`
+for loom/ Gate-1 review.
+
+## Alternatives considered
+
+**Alternative A — Extract worktree rules into a new `rules/worktree-isolation.md` file.**
+Pro: rules/agents.md goes from 244 lines back under the 200-line cap. Con: splits
+agent-orchestration discipline across two files; the existing `rules/agents.md`
+already references `rules/worktree-isolation.md` as a sibling at line 95, so
+the file split is a partial migration that future-codify cycles would need to
+finish. Decision: keep in agents.md; mark file-length as a LOW follow-up.
+
+**Alternative B — Codify only Pattern 3 (reviewer mechanical sweep) and leave
+the two worktree patterns implicit.** Pro: smaller surface change. Con: the
+worktree failure modes cost ~300 LOC of lost work this session; without rule-
+level enforcement they recur every parallel-shard cycle. Decision: codify all
+three.
+
+**Alternative C — Update the `reviewer` agent's knowledge instead of adding
+to `rules/agents.md`.** Pro: agent-level updates are more targeted. Con:
+agent-level guidance loads only when the reviewer agent is invoked; rule-level
+enforcement loads in every session that touches `rules/agents.md` paths. Per
+the rule-authoring meta-rule § "Layered" — the failure mode applies to ALL
+gate reviewers (reviewer, security-reviewer, gold-standards-validator),
+so rule-level is the right layer. Decision: rule-level.
+
+## Why this matters
+
+These 3 patterns are the institutional residue of three concrete dollar-cost
+failures this session:
+
+- ~300 LOC of Shard A's SklearnTrainable Array-API rewrite was lost.
+  Recovery happened serendipitously because Shard B scope-crept and
+  re-implemented it; without that, a 4th sequential agent run would have
+  been needed.
+- Shard C's UMAP/HDBSCAN work needed orchestrator-side WIP rescue commit
+  to survive notification arrival.
+- The reviewer's APPROVE verdict on a 940-LOC diff missed a HIGH spec-
+  compliance orphan that the `/redteam` mechanical sweep caught in
+  4 seconds. The 0.12.0 wheel would have shipped with TorchTrainable +
+  LightningTrainable returning `TrainingResult.device = None` for the
+  two DL-spine families.
+
+Each of these is now a one-line linguistic tripwire in the rule file.
+
+## Consequences
+
+- Future parallel-shard sessions in either kailash-py or kailash-rs will
+  receive worktree + reviewer discipline as part of session-start rule
+  loading.
+- Cross-SDK distribution via loom/ Gate-2 is gated on human classification.
+  The proposal explicitly tags all 3 rules as `classification_suggestion: global`.
+
+## Outstanding follow-ups (not blocking codify)
+
+- 0005-GAP: `Predictions.device` field missing — 0.12.1 work.
+- LOW: `rules/agents.md` is now 244 lines (over the 200-line cap from
+  `rules/cc-artifacts.md`). Future codify may extract the worktree sections
+  into `rules/worktree-isolation.md`.
+
+## For Discussion
+
+1. **Counterfactual**: If these 3 rules had been in `rules/agents.md` at
+   the start of this session, would Shard A's work have survived? Almost
+   certainly yes — the prompt would have included the relative-path
+   directive and the commit-before-exit directive. Net session cost would
+   have dropped by ~1 hour of recovery work.
+
+2. **Data-referenced**: This session ran 5 parallel ml-specialist agents
+   total (Shards A/B/C round 1, plus 2 background reviewers). 3 of 3 round-1
+   shards truncated at 250-370k tokens — a 100% truncation rate. The
+   `rules/autonomous-execution.md` capacity bands say ≤500 LOC load-bearing,
+   but each shard was ~300-400 LOC. The token budget exhausted before the
+   LOC budget. Question for next codify: should `autonomous-execution.md`
+   add a "context-token budget separate from LOC budget" clause? Filed as
+   open question; not part of this codify because the evidence base is one
+   session.
+
+3. **What would a 4th rule look like?** Spec-completeness in plan
+   decomposition — the punch list named items 3/4/5/7/8 covering 5 of 7
+   Trainable families; Torch + Lightning weren't called out but the spec
+   mandate "every fit returns one" applied to them too. Could become a
+   `rules/specs-authority.md` MUST: "Plans MUST enumerate EVERY existing
+   call site of each public surface the spec touches, not only the
+   sites in the explicit todo list." Decision: defer to next codify;
+   evidence base is one occurrence and the failure was caught by /redteam.

--- a/workspaces/kailash-ml-gpu-stack/journal/0007-DISCOVERY-full-specs-sweep-round.md
+++ b/workspaces/kailash-ml-gpu-stack/journal/0007-DISCOVERY-full-specs-sweep-round.md
@@ -1,0 +1,81 @@
+---
+type: DISCOVERY
+date: 2026-04-20
+created_at: 2026-04-20T00:30:00.000Z
+author: co-authored
+session_id: continue-session-2026-04-19
+project: kailash-ml-gpu-stack
+topic: Full-specs /redteam round caught cross-spec inconsistencies that ml-engines+ml-backends-only sweep missed
+phase: redteam
+tags:
+  [
+    redteam,
+    specs-authority,
+    cross-spec-consistency,
+    ml-tracking,
+    scope-discipline,
+  ]
+related_journal:
+  [
+    0004-RISK-torch-lightning-deviceReport-orphan.md,
+    0005-GAP-predictions-device-field-missing.md,
+  ]
+---
+
+# Discovery — full-specs sweep is structurally distinct from "specs I edited" sweep
+
+## What happened
+
+After the round-3 redteam-against-specs scope (which only verified `ml-engines.md` + `ml-backends.md` — the two specs I had just updated), the user explicitly asked: "do another /redteam against FULL specs and update specs as required." The full sweep caught two new findings that the narrow sweep missed:
+
+1. **HIGH (cross-spec inconsistency)** — `ml-backends.md` repeatedly referenced `TrainingResult.backend`, `TrainingResult.devices`, `TrainingResult.cuda_capability` as if they were top-level `TrainingResult` fields (lines 267, 365, 500). None of these exist — the actual shape per `ml-engines.md` §4.1 is `{accelerator, device_used, precision, lightning_trainer_config}` plus the new `device: DeviceReport` envelope. The drift had been silently accumulating since the spec was first drafted; the Phase 1 work just made it more visible because the new `device` field absorbed what these flat fields were trying to express.
+
+2. **MEDIUM (ml-tracking auto-capture gap)** — `ml-tracking.md` §2.4 mandatory auto-capture table listed `device_used` / `accelerator` / `precision` but not the new `TrainingResult.device: DeviceReport` fields. `ExperimentTracker.log_model(training_result=...)` is the reproducibility envelope; without capturing `fallback_reason` / `array_api` / `device.family` / `device.backend`, a run that "succeeded" with `fallback_reason="oom"` records as a normal CUDA run — exactly the bug the Phase 1 transparency contract was designed to prevent.
+
+## Why the narrow sweep missed both
+
+The narrow sweep was scoped to "specs I just edited" (ml-engines + ml-backends). That scope has a structural blind spot:
+
+- **Cross-spec inconsistencies** between the spec I edited and a sibling spec I didn't touch are invisible. `ml-backends.md` claimed `TrainingResult.backend` exists; my edits to `ml-engines.md` defined the actual `TrainingResult` shape. The contradiction was only visible by comparing them.
+- **Downstream specs that consume the changed surface** (here: `ml-tracking.md` consumes `TrainingResult.device` via `log_model(training_result=...)`) need updates too — but they're not part of "specs I edited."
+
+## Lesson for future /redteam
+
+A `/redteam` against specs MUST always scope to ALL specs in the project's domain (here: every `specs/ml-*.md` file), not just the specs the agent touched. Three categories of finding that only emerge from the full sweep:
+
+1. **Field-shape divergence** — sibling specs reference the changed dataclass differently.
+2. **Downstream consumer drift** — specs whose mandates depend on the changed surface are now stale.
+3. **Cross-spec terminology drift** — the same concept named two ways across files.
+
+The narrow scope is faster but produces false-confidence APPROVE verdicts. Future codify could add a `specs-authority.md` MUST clause: "Every spec edit triggers a re-derivation against the full sibling-spec set, not only the file edited."
+
+## What landed
+
+- Commit `cd9abde1` — ml-backends.md §4.3 + §5.1 + §6.6 + §9.1 rewritten around the actual `{accelerator, device_used, device: DeviceReport}` shape.
+- Commit `cd9abde1` — ml-tracking.md §2.4 added 4 new auto-capture rows mapping `device_family` / `device_backend` / `device_fallback_reason` / `device_array_api` to their `TrainingResult.device.<X>` sources.
+- Commit `11f31ba8` — ml-backends.md §5.7 + §5.8 added explicit `UMAPTrainable` / `HDBSCANTrainable` class names so spec-to-code grep can match directly.
+
+Spec-to-code parity table (now 14/14 green):
+
+- A1 ✓ 7/7 Trainables in `kailash_ml.__all__`
+- A2 ✓ TrainingResult.device field exists
+- A3 ✓ 7/7 return TrainingResult sites carry device=
+- A4 ✓ 8 estimators in Array API allowlist
+- A5 ✓ 3/3 sklearn fallback log keys present
+- A6 ✓ \_is_gpu_oom_error helper + xgb/lgbm fallback log keys
+- A7 ✓ UMAP + HDBSCAN cuml_eviction logs + fallback_reason
+- A8 ✓ no [rapids] extra
+- A9 ✓ Predictions.device deferred (matches 0.12.1 plan)
+- A10 ✓ AST regression invariants pass
+- A11 ✓ no dangling TrainingResult flat-field claims
+- A12 ✓ ml-tracking auto-capture covers Phase 1 DeviceReport fields
+- A14 ✓ round-2 re-verification — still no flat-field drift
+- A15 ✓ Phase 1 surface in 3/3 ml-\* specs
+
+## For Discussion
+
+1. **Counterfactual**: If you had not pushed for the full-specs sweep, the 0.12.0 release would have shipped with a HIGH cross-spec inconsistency (ml-backends.md → ml-engines.md) plus a MEDIUM downstream-spec gap (ml-tracking.md). Both would have surfaced as confused user reports months later ("the docs say `TrainingResult.backend` but my IDE doesn't autocomplete it"). What's the systematic version of "ask the user to push back on my scope"?
+
+2. **Data-referenced**: This /redteam round added 4 spec-coverage assertions (A11-A14) on top of the 10 from the prior round. The new ones came from the full-specs scope. Three rounds of /redteam, four findings each round. The asymptote is unclear; round 4 might find more or might find none. Question: is there a structural endpoint to /redteam, or does each round narrow the search but never reach zero?
+
+3. **`rules/specs-authority.md` extension**: Should MUST 5 ("Spec files are updated at first instance") be extended with a sibling clause MUST 5b ("Every spec edit triggers a re-derivation against the full sibling-spec set in the same domain, not only the edited file")? The narrow-vs-full scope ambiguity in this round is the evidence base. Defer to next codify if the pattern recurs in another session.


### PR DESCRIPTION
## Summary

Closes the GPU-first Phase 1 punch list (items 3/4/5/7/8 from `workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md`). All 7 family adapters now ship with the full transparency contract: `TrainingResult.device: DeviceReport` populated on every fit, OOM single-retry fallback for xgboost/lightgbm, sklearn Array-API auto-dispatch, UMAP/HDBSCAN CPU-only Trainables (cuML evicted).

- Bumps **kailash-ml 0.11.1 → 0.12.0** (minor — new public Trainables, new optional field on TrainingResult, new fallback log keys)
- 19 commits across implementation, tests, specs, journal, and release prep
- 4 audit rounds completed: implement → reviewer + security-reviewer → /redteam against narrow specs → /redteam against full specs

## What landed

**New code**:
- `SklearnTrainable` Array-API allowlist + auto-context-wrap + scipy env-var runtime fallback (item 3)
- `XGBoostTrainable` + `LightGBMTrainable` GPU OOM single-retry fallback (item 4)
- New `UMAPTrainable` + `HDBSCANTrainable` CPU-only Phase 1 wrappers (item 5)
- `TorchTrainable` + `LightningTrainable` retrofitted with `device=DeviceReport` (caught by /redteam)
- All 7 Trainables now top-level exported from `kailash_ml.__all__` (caught by full-specs sweep)
- `TrainingResult.device: Optional[DeviceReport]` field — populated by every Phase 1 family

**New tests** (27 total):
- 8 unit tests for sklearn array-API (allowlist, engaged path, off-allowlist fallback, scipy env-var fallback, non-array-api re-raise, CPU baseline, DeviceReport invariant, LogRecord field collision)
- 5 unit tests each for XGBoost OOM + LightGBM OOM
- 5 unit tests for UMAP, 4 for HDBSCAN
- 10 Tier-2 backend-matrix integration tests (6 pass + 4 documented platform skips)
- 3 AST regression invariants in `tests/regression/test_trainable_device_report_invariant.py`

**Specs updated** (`specs/ml-engines.md` + `specs/ml-backends.md` + `specs/ml-tracking.md`):
- New §3.0 family roster table enumerating all 7 Phase 1 adapters
- New §4.2.5 MUST: every Phase 1 family populates `device` field
- New §4.2.6 deferral note: `Predictions.device` → 0.12.1
- §5.1 sklearn rewritten with Array API allowlist + 3 log keys + scipy gate fallback
- §5.2/5.3 OOM single-retry fallback contract for xgb/lgbm
- New §5.7 (UMAPTrainable) + §5.8 (HDBSCANTrainable)
- §4.3 + §6.6 + §9.1 — cross-spec inconsistency fix (`TrainingResult.backend`/`.devices`/`.cuda_capability` flat fields removed; canonical surface is `accelerator + device_used + device:DeviceReport`)
- ml-tracking.md §2.4 — 4 new auto-capture rows for `device.family` / `device.backend` / `device.fallback_reason` / `device.array_api`

**Rule additions** (`rules/agents.md`, all classified `global` for cross-SDK distribution):
- MUST: Worktree Prompts Use Relative Paths Only (caught Shard A/C write-to-main leak)
- MUST: Worktree Agents Commit Incremental Progress (caught Shard A worktree auto-cleanup data loss)
- MUST: Reviewer Prompts Include Mechanical AST/Grep Sweep (caught Torch/Lightning DeviceReport orphan)

**Journal entries** (`workspaces/kailash-ml-gpu-stack/journal/`):
- `0004-RISK` — Torch/Lightning DeviceReport orphan + reviewer-vs-redteam division of labor
- `0005-GAP` — Predictions.device deferral plan for 0.12.1
- `0006-DECISION` — codify decision rationale for 3 rule additions
- `0007-DISCOVERY` — full-specs sweep lesson + 14/14 spec-to-code parity table

## Test plan
- [x] Unit suite: 951 pass / 1 skip / 0 warnings (excluding pre-existing darwin-arm `test_auto_logging.py` segfault per conftest)
- [x] Tier 2 backend-matrix: 6 pass / 4 documented platform skips (xgboost/lightgbm darwin-arm + py3.13 segfault → Linux CI; SCIPY_ARRAY_API=1 precondition skip)
- [x] Regression invariants: 7/7 pass (3 device-report AST guards + 4 prior)
- [x] Spec-to-code parity: 14/14 assertions verified via literal grep/AST commands

## Audit trail
1. `/implement` — 3 parallel ml-specialist agents (Shards A/B/C/D + integration)
2. Round 3 reviewers — code-reviewer (APPROVE w/ HIGH-1 fixed) + security-reviewer (APPROVE w/ tracked Phase 4 follow-up)
3. `/redteam` Round 3.5 — narrow scope (specs I edited) — found HIGH-1 (Torch/Lightning DeviceReport orphan)
4. `/redteam` Round 3.6 — full-specs scope (after user pushback) — found HIGH (cross-spec `TrainingResult.backend` inconsistency) + MEDIUM (ml-tracking auto-capture gap)
5. `/codify` — 3 rule additions + proposal at `.claude/.proposals/latest.yaml` for loom/ Gate-1 review

## Known limitations (disclosed in CHANGELOG)
- `Predictions.device` field not yet populated — scheduled for 0.12.1 (~40 LOC + 150 LOC tests). Workaround: inspect prior `TrainingResult.device`.

## Related issues
None (greenfield Phase 1 punch list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)