### PR TITLE
fix(kailash): 2.8.9 hotfix — cut core wheel containing #531 fix; closes #538

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### kailash 2.8.9 — 2026-04-20 (hotfix; closes #538)
+
+**Hotfix release.** Cuts the kailash core wheel containing commit `646c3d74` ("fix(nexus): release 2.1.1 — drive on_startup/on_shutdown lists directly (#531)"). Yesterday's release tagged `nexus-v2.1.1` published the kailash-nexus wheel but did NOT publish a new kailash core wheel — even though commit `646c3d74` modifies BOTH `packages/kailash-nexus/...` AND `src/kailash/servers/workflow_server.py` (which is shipped by the kailash core wheel). Result: every `pip install kailash-nexus==2.1.1` pulled `kailash>=2.8.7` (the broken core), and every Nexus 2.1.0/2.1.1 service crashed at uvicorn lifespan with `AttributeError: 'APIRouter' object has no attribute 'startup'`.
+
+**Fix shipped in this release**: `src/kailash/servers/workflow_server.py` lifespan now iterates the `on_startup` / `on_shutdown` lists directly instead of calling `app.router.startup()` / `app.router.shutdown()`. Closes #538.
+
+No other changes vs 2.8.8. Pure cross-package release-coordination fix.
+
+**Audit lesson** (codified in `rules/agents.md` MUST: Reviewer Prompts Include Mechanical AST/Grep Sweep): a mechanical sweep on the nexus-v2.1.1 release would have grep-noticed that the diff touched `src/kailash/...` AND flagged that a kailash core release was also required. Future cross-package releases MUST run the parity sweep before tagging.
+
 ### kailash 2.8.8 + kailash-dataflow 2.0.11 + kailash-ml 0.11.0 + kailash-align 0.3.2 + kailash-pact 0.8.2 + kailash-trust 0.1.1 + kaizen-agents 0.9.3 — 2026-04-19
 
 Bundle release: BP-049 classified-data leak security patch (DataFlow) + ML Phase 1 GPU-first foundation. See individual package changelogs for full entries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.8.8"
+version = "2.8.9"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.8.8"
+__version__ = "2.8.9"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Pure cross-package release-coordination hotfix. No code changes vs 2.8.8 — bumps version + ships the kailash core wheel from main (which already contains commit `646c3d74`, the #531 fix landed yesterday).

**Why this is a separate release**: commit `646c3d74` ("fix(nexus): release 2.1.1 — drive on_startup/on_shutdown lists directly (#531)") modifies BOTH `packages/kailash-nexus/...` AND `src/kailash/servers/workflow_server.py`. Yesterday's release tagged only `nexus-v2.1.1`, which built the nexus wheel but NOT the kailash core wheel. Latest kailash on PyPI was still 2.8.8, and every `pip install kailash-nexus==2.1.1` pulled `kailash>=2.8.7` (the broken core), crashing every Nexus 2.1.x service at uvicorn lifespan with `AttributeError: 'APIRouter' object has no attribute 'startup'`.

This release ships the kailash 2.8.9 wheel built from main (which contains the fix). Users upgrade to `kailash>=2.8.9` to get a working Nexus.

## What changed

- `pyproject.toml`: 2.8.8 → 2.8.9 (atomic per `zero-tolerance.md` Rule 5)
- `src/kailash/__init__.py`: `__version__` 2.8.8 → 2.8.9 (atomic)
- `CHANGELOG.md`: new release entry with #531 + #538 references and the audit lesson

## Audit lesson (codified)

Already codified in this branch family at `rules/agents.md` MUST: Reviewer Prompts Include Mechanical AST/Grep Sweep — a mechanical sweep on the nexus-v2.1.1 release diff would have grep-noticed `src/kailash/...` modifications and flagged that a kailash core release was also required. This release applies that rule retroactively before invoking it on `ml-v0.12.0` (PR #539, held).

## Verification plan
- [x] CI green on main-equivalent diff (only version + CHANGELOG changes)
- [ ] After merge: tag `v2.8.9` (single push per `rules/deployment.md` no-batch rule)
- [ ] PyPI Trusted Publisher auto-publishes
- [ ] Verify in fresh venv: `pip install kailash==2.8.9` then grep `app.router.startup()` returns 0
- [ ] Close #538 with delivered-code reference (commit + tag) per `rules/git.md`

## Related issues
Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)