### PR TITLE
release(ml): 0.12.1 — Predictions.device field + kailash>=2.8.9 floor

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -22,7 +22,7 @@
 | kailash-kaizen   | `kaizen-v*`        | 2.7.5           |
 | kailash-nexus    | `nexus-v*`         | 2.1.1           |
 | kailash-pact     | `pact-v*`          | 0.8.2           |
-| kailash-ml       | `ml-v*`            | 0.12.0          |
+| kailash-ml       | `ml-v*`            | 0.12.1          |
 | kailash-align    | `align-v*`         | 0.3.2           |
 | kailash-mcp      | `mcp-v*`           | 0.2.5           |
 | kaizen-agents    | `kaizen-agents-v*` | 0.9.3           |

--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,21 @@
 # kailash-ml Changelog
 
+## [0.12.1] - 2026-04-20 — Predictions.device field + kailash>=2.8.9 floor bump
+
+### Added
+
+- **`Predictions.device: Optional[DeviceReport]` field** — Completes the predict-side half of the GPU-first Phase 1 transparency contract that 0.12.0 deferred. Every Phase 1 family adapter (`SklearnTrainable`, `XGBoostTrainable`, `LightGBMTrainable`, `TorchTrainable`, `LightningTrainable`, `UMAPTrainable`, `HDBSCANTrainable`) now caches the fit-time `DeviceReport` on `self._last_device_report` and stamps the same instance onto every `Predictions` returned until the next `fit()` call. Callers can now programmatically distinguish a CUDA-resolved predict from a CPU-fallback predict via `pred.device.backend` / `pred.device.fallback_reason` without inspecting the prior `TrainingResult`. Direct constructors that don't carry `device=` keep the backward-compat `None` default. Resolves `workspaces/kailash-ml-gpu-stack/journal/0005-GAP-predictions-device-field-missing.md`.
+- **`tests/regression/test_predictions_device_invariant.py`** — 3 mechanical AST guards that fail loudly if a future refactor drops the `device=` kwarg from a `Predictions(...)` constructor inside `predict()`, fails to cache `self._last_device_report` in `fit()`, or removes the `_device` slot / `device` property on `Predictions`.
+- **`tests/integration/test_predictions_device_matrix.py`** — 9 Tier 2 backend-matrix tests (7 pass on this host; 2 skipped per the darwin-arm XGBoost/LightGBM segfault pattern from 0.12.0) that exercise `fit → predict` end-to-end and assert `pred.device is result.device` (identity, not equality) for every family.
+
+### Changed
+
+- **`kailash>=2.8.9` floor bump** — Picks up the `app.router.startup()` / `.shutdown()` fix that shipped in kailash 2.8.9 via issue #538. Staggered adoption per issue #541 — each sibling package bumps its floor on its next natural minor release rather than a coordinated bundle. kailash-ml's floor bump lands here bundled with the `Predictions.device` work.
+
+### Fixed
+
+- **Removes the 0.12.0 Known Limitation for `Predictions.device`.** 0.12.0's changelog disclosed that the predict-side transparency contract was incomplete; 0.12.1 closes that gap.
+
 ## [0.12.0] - 2026-04-19 — GPU-first Phase 1 punch list: Trainable adapters + transparency
 
 ### Added

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.12.0"
+version = "0.12.1"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ classifiers = [
 readme = "README.md"
 keywords = ["ml", "machine-learning", "kailash", "automl", "feature-store", "model-registry"]
 dependencies = [
-    "kailash>=2.8.7",
+    "kailash>=2.8.9",
     "kailash-dataflow>=2.0.11",
     "kailash-nexus>=2.1.0",
     "polars>=1.0",

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/packages/kailash-ml/src/kailash_ml/trainable.py
+++ b/packages/kailash-ml/src/kailash_ml/trainable.py
@@ -126,13 +126,29 @@ class TrainingContext:
 
 
 class Predictions:
-    """Typed envelope around a model's prediction output."""
+    """Typed envelope around a model's prediction output.
 
-    __slots__ = ("_raw", "_column")
+    Carries a ``device: Optional[DeviceReport]`` — populated by every
+    Phase-1 family adapter — so callers can programmatically distinguish
+    a CUDA-resolved predict from a CPU-fallback predict. The adapter
+    caches the DeviceReport from its most-recent ``fit()`` call and
+    stamps it onto every ``Predictions`` it returns until the next
+    ``fit()`` overwrites it. See
+    ``workspaces/kailash-ml-gpu-stack/journal/0005-GAP-predictions-device-field-missing.md``.
+    """
 
-    def __init__(self, raw: Any, *, column: str = "prediction") -> None:
+    __slots__ = ("_raw", "_column", "_device")
+
+    def __init__(
+        self,
+        raw: Any,
+        *,
+        column: str = "prediction",
+        device: Optional[DeviceReport] = None,
+    ) -> None:
         self._raw = raw
         self._column = column
+        self._device = device
 
     @property
     def raw(self) -> Any:
@@ -141,6 +157,18 @@ class Predictions:
     @property
     def column(self) -> str:
         return self._column
+
+    @property
+    def device(self) -> Optional[DeviceReport]:
+        """Per-call device evidence for this predict, if the adapter fitted.
+
+        ``None`` is returned only by callers that construct ``Predictions``
+        directly without going through a fitted Trainable (rare;
+        typically only in unit tests). Every Phase-1 adapter's
+        ``predict()`` populates this from the device report cached at
+        fit-time.
+        """
+        return self._device
 
     def to_polars(self) -> pl.DataFrame:
         if isinstance(self._raw, pl.DataFrame):
@@ -702,6 +730,8 @@ class SklearnTrainable:
                 array_api=False,
             )
 
+        self._last_device_report = device_report
+
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             metrics={metric_name: module.metric},
@@ -732,7 +762,7 @@ class SklearnTrainable:
             frame = X
         arr = frame.to_numpy()
         preds = self._estimator.predict(arr)
-        return Predictions(preds, column="prediction")
+        return Predictions(preds, column="prediction", device=self._last_device_report)
 
 
 # ---------------------------------------------------------------------------
@@ -891,6 +921,16 @@ class TorchTrainable:
         # reflects the actually-resolved Lightning accelerator (no
         # eviction / OOM fallback path here; native multi-backend
         # support via L.Trainer per ml-backends.md §5.4).
+        device_report = DeviceReport(
+            family=self.family_name,
+            backend=ctx.backend,
+            device_string=ctx.device_string,
+            precision=ctx.precision,
+            fallback_reason=None,
+            array_api=False,
+        )
+        self._last_device_report = device_report
+
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             metrics={"train_loss": module.mean_loss},
@@ -904,14 +944,7 @@ class TorchTrainable:
             lightning_trainer_config=trainer_kwargs,
             family=self.family_name,
             hyperparameters={"learning_rate": lr, "max_epochs": max_epochs},
-            device=DeviceReport(
-                family=self.family_name,
-                backend=ctx.backend,
-                device_string=ctx.device_string,
-                precision=ctx.precision,
-                fallback_reason=None,
-                array_api=False,
-            ),
+            device=device_report,
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:
@@ -930,7 +963,11 @@ class TorchTrainable:
         self._model.eval()
         with torch.no_grad():
             preds = self._model(X_t)
-        return Predictions(preds.detach().cpu().numpy(), column="prediction")
+        return Predictions(
+            preds.detach().cpu().numpy(),
+            column="prediction",
+            device=self._last_device_report,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1038,6 +1075,16 @@ class LightningTrainable:
         # reflects the actually-resolved Lightning accelerator (no
         # eviction / OOM fallback path here; native multi-backend
         # support via L.Trainer per ml-backends.md §5.5).
+        device_report = DeviceReport(
+            family=self.family_name,
+            backend=ctx.backend,
+            device_string=ctx.device_string,
+            precision=ctx.precision,
+            fallback_reason=None,
+            array_api=False,
+        )
+        self._last_device_report = device_report
+
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             metrics=metrics,
@@ -1051,14 +1098,7 @@ class LightningTrainable:
             lightning_trainer_config=trainer_kwargs,
             family=self.family_name,
             hyperparameters={"max_epochs": max_epochs},
-            device=DeviceReport(
-                family=self.family_name,
-                backend=ctx.backend,
-                device_string=ctx.device_string,
-                precision=ctx.precision,
-                fallback_reason=None,
-                array_api=False,
-            ),
+            device=device_report,
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:
@@ -1077,7 +1117,11 @@ class LightningTrainable:
         self._module.eval()
         with torch.no_grad():
             preds = self._module(X_t)
-        return Predictions(preds.detach().cpu().numpy(), column="prediction")
+        return Predictions(
+            preds.detach().cpu().numpy(),
+            column="prediction",
+            device=self._last_device_report,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1286,6 +1330,7 @@ class XGBoostTrainable:
             fallback_reason=fallback_reason,
             array_api=False,
         )
+        self._last_device_report = device_report
 
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
@@ -1312,7 +1357,7 @@ class XGBoostTrainable:
             else X
         )
         preds = self._estimator.predict(frame.to_numpy())
-        return Predictions(preds, column="prediction")
+        return Predictions(preds, column="prediction", device=self._last_device_report)
 
 
 # ---------------------------------------------------------------------------
@@ -1537,6 +1582,7 @@ class LightGBMTrainable:
             fallback_reason=fallback_reason,
             array_api=False,
         )
+        self._last_device_report = device_report
 
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
@@ -1563,7 +1609,7 @@ class LightGBMTrainable:
             else X
         )
         preds = self._estimator.predict(frame.to_numpy())
-        return Predictions(preds, column="prediction")
+        return Predictions(preds, column="prediction", device=self._last_device_report)
 
 
 # ---------------------------------------------------------------------------
@@ -1745,6 +1791,16 @@ class UMAPTrainable:
             self._reducer, prefix="umap", format="pickle"
         )
 
+        device_report = DeviceReport(
+            family=self.family_name,
+            backend="cpu",
+            device_string="cpu",
+            precision="32-true",
+            fallback_reason=fallback_reason,
+            array_api=False,
+        )
+        self._last_device_report = device_report
+
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             # UMAP is unsupervised; no supervised metric to report. We
@@ -1762,14 +1818,7 @@ class UMAPTrainable:
             lightning_trainer_config=trainer_kwargs,
             family=self.family_name,
             hyperparameters=dict(hyperparameters or {}),
-            device=DeviceReport(
-                family=self.family_name,
-                backend="cpu",
-                device_string="cpu",
-                precision="32-true",
-                fallback_reason=fallback_reason,
-                array_api=False,
-            ),
+            device=device_report,
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:
@@ -1781,7 +1830,9 @@ class UMAPTrainable:
         else:
             frame = X
         embedding = self._reducer.transform(frame.to_numpy())
-        return Predictions(embedding, column="embedding")
+        return Predictions(
+            embedding, column="embedding", device=self._last_device_report
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1963,6 +2014,16 @@ class HDBSCANTrainable:
             self._clusterer, prefix="hdbscan", format="pickle"
         )
 
+        device_report = DeviceReport(
+            family=self.family_name,
+            backend="cpu",
+            device_string="cpu",
+            precision="32-true",
+            fallback_reason=fallback_reason,
+            array_api=False,
+        )
+        self._last_device_report = device_report
+
         return TrainingResult(
             model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
             metrics={
@@ -1979,14 +2040,7 @@ class HDBSCANTrainable:
             lightning_trainer_config=trainer_kwargs,
             family=self.family_name,
             hyperparameters=dict(hyperparameters or {}),
-            device=DeviceReport(
-                family=self.family_name,
-                backend="cpu",
-                device_string="cpu",
-                precision="32-true",
-                fallback_reason=fallback_reason,
-                array_api=False,
-            ),
+            device=device_report,
         )
 
     def predict(self, X: pl.DataFrame) -> Predictions:
@@ -2004,7 +2058,9 @@ class HDBSCANTrainable:
             frame = X
         new_clusterer = HDBSCAN(**self._init_kwargs)
         labels = new_clusterer.fit_predict(frame.to_numpy())
-        return Predictions(labels, column="cluster_label")
+        return Predictions(
+            labels, column="cluster_label", device=self._last_device_report
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/kailash-ml/tests/integration/test_predictions_device_matrix.py
+++ b/packages/kailash-ml/tests/integration/test_predictions_device_matrix.py
@@ -1,0 +1,315 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 backend-matrix tests for the predict-side transparency contract.
+
+Sibling of ``test_trainable_backend_matrix.py`` — that file asserts
+``fit()`` populates ``TrainingResult.device``; this file asserts
+``predict()`` populates ``Predictions.device`` with the same
+``DeviceReport`` cached at fit-time.
+
+Per revised-stack.md § "Transparency contract" and
+``workspaces/kailash-ml-gpu-stack/journal/0005-GAP-predictions-device-field-missing.md``:
+every predict returns a Predictions carrying a DeviceReport, so
+callers can programmatically distinguish a CUDA-resolved predict from
+a CPU-fallback predict without inspecting the prior TrainingResult.
+
+Backend availability gates mirror test_trainable_backend_matrix.py.
+XGBoost / LightGBM are gated by the same darwin-arm segfault skip.
+"""
+from __future__ import annotations
+
+import platform
+import sys
+
+import numpy as np
+import polars as pl
+import pytest
+import torch
+
+from kailash_ml._device_report import DeviceReport
+from kailash_ml.trainable import (
+    HDBSCANTrainable,
+    LightGBMTrainable,
+    Predictions,
+    SklearnTrainable,
+    TrainingContext,
+    UMAPTrainable,
+    XGBoostTrainable,
+)
+
+_XGBOOST_SEGFAULT_HOST = (
+    sys.platform == "darwin"
+    and platform.machine() == "arm64"
+    and sys.version_info[:2] >= (3, 13)
+)
+xgboost_stable_only = pytest.mark.skipif(
+    _XGBOOST_SEGFAULT_HOST,
+    reason=(
+        "XGBoost 2.x segfaults on darwin-arm + py3.13 during _meta_from_numpy; "
+        "Tier 2 coverage deferred to Linux CI."
+    ),
+)
+lightgbm_stable_only = pytest.mark.skipif(
+    _XGBOOST_SEGFAULT_HOST,
+    reason=(
+        "LightGBM 4.x segfaults on darwin-arm + py3.13 during __init_from_np2d; "
+        "Tier 2 coverage deferred to Linux CI."
+    ),
+)
+
+
+@pytest.fixture(scope="module")
+def classification_frame() -> pl.DataFrame:
+    rng = np.random.default_rng(seed=42)
+    n = 50
+    x1 = rng.normal(0.0, 1.0, size=n)
+    x2 = rng.normal(0.0, 1.0, size=n)
+    y = ((0.7 * x1 + 0.3 * x2) > 0).astype(int)
+    return pl.DataFrame({"feature1": x1, "feature2": x2, "target": y})
+
+
+@pytest.fixture(scope="module")
+def unsupervised_frame() -> pl.DataFrame:
+    rng = np.random.default_rng(seed=42)
+    n = 50
+    return pl.DataFrame(
+        {
+            "feature1": rng.normal(0.0, 1.0, size=n),
+            "feature2": rng.normal(1.0, 1.0, size=n),
+            "feature3": rng.normal(-1.0, 1.0, size=n),
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def torch_frame() -> pl.DataFrame:
+    """Small regression frame for TorchTrainable / LightningTrainable."""
+    rng = np.random.default_rng(seed=42)
+    n = 64
+    x1 = rng.normal(0.0, 1.0, size=n).astype(np.float32)
+    x2 = rng.normal(0.0, 1.0, size=n).astype(np.float32)
+    y = (0.5 * x1 + 0.3 * x2).astype(np.float32)
+    return pl.DataFrame({"feature1": x1, "feature2": x2, "target": y})
+
+
+def _cpu_ctx() -> TrainingContext:
+    return TrainingContext(
+        accelerator="cpu",
+        precision="32-true",
+        devices=1,
+        device_string="cpu",
+        backend="cpu",
+        tenant_id=None,
+        tracker_run_id=None,
+        trial_number=None,
+    )
+
+
+def _cuda_ctx() -> TrainingContext:
+    return TrainingContext(
+        accelerator="gpu",
+        precision="32-true",
+        devices=1,
+        device_string="cuda:0",
+        backend="cuda",
+        tenant_id=None,
+        tracker_run_id=None,
+        trial_number=None,
+    )
+
+
+def _assert_device_round_trip(result_device: DeviceReport, pred: Predictions) -> None:
+    """Core invariant: pred.device is the same DeviceReport fit() returned.
+
+    Not just "not None" and not just "same values" — the adapter caches
+    the exact instance to ``self._last_device_report`` and stamps it on
+    every subsequent predict until the next fit. Verifying object
+    identity catches a refactor that would accidentally rebuild a new
+    DeviceReport in predict().
+    """
+    assert isinstance(
+        pred.device, DeviceReport
+    ), f"pred.device must be a DeviceReport; got {type(pred.device).__name__}"
+    assert pred.device is result_device, (
+        "pred.device MUST be the exact DeviceReport instance cached from fit(); "
+        "constructing a fresh one in predict() breaks cache-invalidation semantics."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sklearn — CPU predict carries fit's DeviceReport
+# ---------------------------------------------------------------------------
+
+
+def test_sklearn_predict_carries_fit_device_report(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """SklearnTrainable.predict() Predictions.device is the fit-time DeviceReport."""
+    from sklearn.ensemble import RandomForestClassifier
+
+    trainable = SklearnTrainable(
+        estimator=RandomForestClassifier(n_estimators=5, random_state=42),
+        target="target",
+    )
+    result = trainable.fit(classification_frame, context=_cpu_ctx())
+    pred = trainable.predict(classification_frame.drop("target"))
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.family == "sklearn"
+    assert pred.device.backend == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# XGBoost — CPU predict carries fit's DeviceReport
+# ---------------------------------------------------------------------------
+
+
+@xgboost_stable_only
+def test_xgboost_predict_carries_fit_device_report(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """XGBoostTrainable.predict() Predictions.device is the fit-time DeviceReport."""
+    trainable = XGBoostTrainable(target="target", task="classification")
+    result = trainable.fit(classification_frame, context=_cpu_ctx())
+    pred = trainable.predict(classification_frame.drop("target"))
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.family == "xgboost"
+    assert pred.device.backend == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# LightGBM — CPU predict carries fit's DeviceReport
+# ---------------------------------------------------------------------------
+
+
+@lightgbm_stable_only
+def test_lightgbm_predict_carries_fit_device_report(
+    classification_frame: pl.DataFrame,
+) -> None:
+    """LightGBMTrainable.predict() Predictions.device is the fit-time DeviceReport."""
+    trainable = LightGBMTrainable(target="target", task="classification")
+    result = trainable.fit(classification_frame, context=_cpu_ctx())
+    pred = trainable.predict(classification_frame.drop("target"))
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.family == "lightgbm"
+    assert pred.device.backend == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Torch — CPU predict carries fit's DeviceReport
+# ---------------------------------------------------------------------------
+
+
+def test_torch_predict_carries_fit_device_report(torch_frame: pl.DataFrame) -> None:
+    """TorchTrainable.predict() Predictions.device is the fit-time DeviceReport."""
+    from kailash_ml.trainable import TorchTrainable
+
+    class _Linear(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 1)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.linear(x).squeeze(-1)
+
+    trainable = TorchTrainable(
+        model=_Linear(),
+        target="target",
+        loss_fn=torch.nn.MSELoss(),
+    )
+    result = trainable.fit(torch_frame, context=_cpu_ctx())
+    pred = trainable.predict(torch_frame.drop("target"))
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.family == "torch"
+
+
+# ---------------------------------------------------------------------------
+# Lightning — CPU predict carries fit's DeviceReport
+# ---------------------------------------------------------------------------
+
+
+def test_lightning_predict_carries_fit_device_report(
+    torch_frame: pl.DataFrame,
+) -> None:
+    """LightningTrainable.predict() Predictions.device is the fit-time DeviceReport."""
+    import lightning.pytorch as pl_trainer
+
+    from kailash_ml.trainable import LightningTrainable
+
+    class _LitModel(pl_trainer.LightningModule):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 1)
+            self.loss_fn = torch.nn.MSELoss()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.linear(x).squeeze(-1)
+
+        def training_step(self, batch, batch_idx):  # type: ignore[no-untyped-def]
+            x, y = batch
+            y_hat = self(x)
+            return self.loss_fn(y_hat, y.reshape(y_hat.shape))
+
+        def configure_optimizers(self):  # type: ignore[no-untyped-def]
+            return torch.optim.Adam(self.parameters(), lr=1e-2)
+
+    trainable = LightningTrainable(module=_LitModel(), target="target")
+    result = trainable.fit(torch_frame, context=_cpu_ctx())
+    pred = trainable.predict(torch_frame.drop("target"))
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.family == "lightning"
+
+
+# ---------------------------------------------------------------------------
+# UMAP — CPU predict + cuml_eviction fallback on CUDA request
+# ---------------------------------------------------------------------------
+
+
+def test_umap_predict_carries_fit_device_report(
+    unsupervised_frame: pl.DataFrame,
+) -> None:
+    """UMAPTrainable.predict() Predictions.device is the fit-time DeviceReport."""
+    trainable = UMAPTrainable(n_components=2, n_neighbors=5, random_state=42)
+    result = trainable.fit(unsupervised_frame, context=_cpu_ctx())
+    pred = trainable.predict(unsupervised_frame)
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.family == "umap"
+    assert pred.device.fallback_reason is None
+
+
+def test_umap_cuda_request_predict_carries_eviction_fallback(
+    unsupervised_frame: pl.DataFrame,
+) -> None:
+    """UMAP Phase 1 CUDA request — predict carries fallback_reason='cuml_eviction'."""
+    trainable = UMAPTrainable(n_components=2, n_neighbors=5, random_state=42)
+    result = trainable.fit(unsupervised_frame, context=_cuda_ctx())
+    pred = trainable.predict(unsupervised_frame)
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.fallback_reason == "cuml_eviction"
+
+
+# ---------------------------------------------------------------------------
+# HDBSCAN — CPU predict + cuml_eviction fallback on CUDA request
+# ---------------------------------------------------------------------------
+
+
+def test_hdbscan_predict_carries_fit_device_report(
+    unsupervised_frame: pl.DataFrame,
+) -> None:
+    """HDBSCANTrainable.predict() Predictions.device is the fit-time DeviceReport."""
+    trainable = HDBSCANTrainable(min_cluster_size=3)
+    result = trainable.fit(unsupervised_frame, context=_cpu_ctx())
+    pred = trainable.predict(unsupervised_frame)
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.family == "hdbscan"
+    assert pred.device.fallback_reason is None
+
+
+def test_hdbscan_cuda_request_predict_carries_eviction_fallback(
+    unsupervised_frame: pl.DataFrame,
+) -> None:
+    """HDBSCAN Phase 1 CUDA request — predict carries fallback_reason='cuml_eviction'."""
+    trainable = HDBSCANTrainable(min_cluster_size=3)
+    result = trainable.fit(unsupervised_frame, context=_cuda_ctx())
+    pred = trainable.predict(unsupervised_frame)
+    _assert_device_round_trip(result.device, pred)
+    assert pred.device.fallback_reason == "cuml_eviction"

--- a/packages/kailash-ml/tests/regression/test_predictions_device_invariant.py
+++ b/packages/kailash-ml/tests/regression/test_predictions_device_invariant.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: every Trainable.predict MUST return Predictions carrying device=.
+
+Sibling invariant of ``test_trainable_device_report_invariant.py`` for
+the predict-side half of the GPU-first Phase 1 transparency contract
+(see ``workspaces/kailash-ml-gpu-stack/journal/0005-GAP-predictions-device-field-missing.md``).
+
+Spec: ``workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md``
+§ "Transparency contract" — every predict returns a Predictions whose
+``device`` attribute is the DeviceReport cached at fit-time. Adapters
+MUST construct ``Predictions(..., device=self._last_device_report)``
+and MUST cache ``self._last_device_report = device_report`` right
+before returning TrainingResult from fit().
+
+This is a mechanical AST guard — no per-family unit test can catch
+"the fit() site dropped the cache" or "the predict() site dropped the
+kwarg" structurally. Each drop is a silent orphan of the predict-side
+transparency contract.
+
+Origin: kailash-ml 0.12.1 — Predictions.device field landed in this
+release; the 0.12.0 punch list deferred it to 0.12.1.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _trainable_module_path() -> Path:
+    """Path to packages/kailash-ml/src/kailash_ml/trainable.py."""
+    here = Path(__file__).resolve()
+    # tests/regression/test_*.py -> packages/kailash-ml
+    pkg_root = here.parent.parent.parent
+    return pkg_root / "src" / "kailash_ml" / "trainable.py"
+
+
+@pytest.mark.regression
+def test_every_return_predictions_has_device_kwarg() -> None:
+    """Every Predictions() constructor inside a predict() method MUST pass device=.
+
+    Mechanical AST guard: a refactor that drops the ``device=`` kwarg
+    silently ships Predictions with ``device=None``, which breaks every
+    downstream caller that inspects ``pred.device.backend`` /
+    ``pred.device.fallback_reason``. This test catches the drop at
+    test-collection time.
+
+    Scope: Predictions() calls appear in 7 predict() methods (one per
+    family). This test walks the AST, filters to Predictions calls that
+    are inside a function whose name is 'predict', and asserts each one
+    passes device= as a kwarg.
+    """
+    src = _trainable_module_path().read_text()
+    tree = ast.parse(src)
+
+    offenders: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if node.name != "predict":
+            continue
+        # Walk the predict body looking for Predictions(...) constructor calls.
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Call):
+                continue
+            func = inner.func
+            if not isinstance(func, ast.Name) or func.id != "Predictions":
+                continue
+            kwarg_names = {kw.arg for kw in inner.keywords if kw.arg is not None}
+            if "device" not in kwarg_names:
+                line_text = src.splitlines()[inner.lineno - 1].strip()
+                offenders.append((inner.lineno, line_text))
+
+    assert not offenders, (
+        "Every Predictions(...) constructor inside a predict() method in "
+        "trainable.py MUST pass device=<DeviceReport> per "
+        "workspaces/kailash-ml-gpu-stack/04-validate/02-revised-stack.md "
+        "§ 'Transparency contract'. Sites missing the device kwarg:\n"
+        + "\n".join(f"  line {ln}: {txt}" for ln, txt in offenders)
+    )
+
+
+@pytest.mark.regression
+def test_every_fit_caches_last_device_report() -> None:
+    """Every Trainable.fit MUST assign self._last_device_report before returning.
+
+    The predict() path references ``self._last_device_report`` — that
+    attribute is set ONLY by fit(). A fit() path that constructs a
+    DeviceReport but never caches it leaves predict() reading a stale
+    or missing attribute.
+
+    Mechanical AST guard: walk each fit() FunctionDef; assert there is
+    at least one ``self._last_device_report = ...`` Assign statement in
+    its body (including nested blocks).
+    """
+    src = _trainable_module_path().read_text()
+    tree = ast.parse(src)
+
+    fit_functions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "fit"
+    ]
+
+    # Phase 1 ships 7 families; each class has one fit(). Protocol definition
+    # Trainable.fit (a `...` body) brings the total to 8 — filter it out.
+    real_fits = [
+        f
+        for f in fit_functions
+        if not (
+            len(f.body) == 1
+            and isinstance(f.body[0], ast.Expr)
+            and isinstance(f.body[0].value, ast.Constant)
+        )
+    ]
+    assert len(real_fits) == 7, (
+        f"Expected 7 concrete fit() methods (one per Phase 1 family); "
+        f"found {len(real_fits)}. If a family was added/removed, update "
+        f"this invariant."
+    )
+
+    missing: list[tuple[int, str]] = []
+    for fit in real_fits:
+        found = False
+        for inner in ast.walk(fit):
+            if not isinstance(inner, ast.Assign):
+                continue
+            for target in inner.targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                    and target.attr == "_last_device_report"
+                ):
+                    found = True
+                    break
+            if found:
+                break
+        if not found:
+            missing.append((fit.lineno, fit.name))
+
+    assert not missing, (
+        "Every Trainable.fit() method MUST cache the DeviceReport via "
+        "``self._last_device_report = device_report`` before returning "
+        "TrainingResult. Without it, predict() reads a missing attribute. "
+        f"Fits missing the cache: {missing}"
+    )
+
+
+@pytest.mark.regression
+def test_predictions_class_has_device_slot_and_property() -> None:
+    """Predictions MUST declare _device in __slots__ and expose a device property.
+
+    Belt-and-suspenders: the field addition is both a slots entry
+    (runtime enforcement) and a property (API surface). A refactor that
+    drops either half silently breaks the contract — slots drop makes
+    assignment fail with AttributeError at construction time; property
+    drop makes ``pred.device`` inaccessible.
+    """
+    from kailash_ml.trainable import Predictions
+
+    # __slots__ MUST contain _device
+    assert "_device" in Predictions.__slots__, (
+        "Predictions.__slots__ MUST include '_device' for the device "
+        "field. Current __slots__: " + repr(Predictions.__slots__)
+    )
+
+    # .device property MUST be accessible
+    assert hasattr(
+        Predictions, "device"
+    ), "Predictions MUST expose a public 'device' attribute/property."
+
+    # Constructing without device gives None (optional at API level)
+    p = Predictions([0, 1, 2])
+    assert p.device is None, (
+        "Predictions() with no device kwarg MUST return device=None "
+        "(backward-compat for direct callers; Phase 1 adapters always "
+        "populate device via self._last_device_report)."
+    )


### PR DESCRIPTION
## Summary

- Close the predict-side half of the GPU-first Phase 1 transparency contract that 0.12.0 deferred (journal 0005-GAP). Every Phase 1 family adapter (Sklearn/XGBoost/LightGBM/Torch/Lightning/UMAP/HDBSCAN) now caches the fit-time `DeviceReport` on `self._last_device_report` and stamps the same instance onto every `Predictions` returned until the next `fit()`. Callers can now distinguish a CUDA-resolved predict from a CPU-fallback predict via `pred.device.backend` / `pred.device.fallback_reason` without inspecting the prior `TrainingResult`.
- Bump `kailash>=2.8.7 → >=2.8.9` (issue #541 staggered floor for kailash-ml; the remaining 8 sibling packages adopt the floor on their next natural minor release per the issue's disposition).
- Remove the 0.12.0 "Known Limitation" disclosure about `Predictions.device` — closed in this release.

## Changes

| File | Change |
|---|---|
| `packages/kailash-ml/src/kailash_ml/trainable.py` | `Predictions.__slots__` gains `_device`; `__init__` gains `device=` kwarg; new `.device` property. Each of 7 `fit()` methods caches `self._last_device_report = device_report`. Each of 7 `predict()` methods passes `device=self._last_device_report`. |
| `packages/kailash-ml/src/kailash_ml/_version.py` | 0.12.0 → 0.12.1 |
| `packages/kailash-ml/pyproject.toml` | version bump + `kailash>=2.8.9` floor |
| `packages/kailash-ml/CHANGELOG.md` | 0.12.1 entry |
| `packages/kailash-ml/tests/regression/test_predictions_device_invariant.py` (NEW) | 3 AST-sweep guards |
| `packages/kailash-ml/tests/integration/test_predictions_device_matrix.py` (NEW) | 9 Tier 2 backend-matrix tests |
| `deploy/deployment-config.md` | version table bump |

## Test plan

- [x] 3/3 new regression invariants pass
- [x] 7/9 new Tier 2 tests pass (2 skipped: XGBoost/LightGBM darwin-arm+py3.13 segfault — covered on Linux CI)
- [x] 48/48 Trainable/DeviceReport-related unit tests pass
- [x] `.venv/bin/python -m pytest --collect-only packages/kailash-ml/tests/` exit 0
- [x] `import kailash_ml; kailash_ml.__version__ == "0.12.1"`

## Related issues

- Closes the `Predictions.device` deferral from journal `workspaces/kailash-ml-gpu-stack/journal/0005-GAP-predictions-device-field-missing.md`
- Addresses issue #541 for `kailash-ml` (staggered per-package floor bump; 8 siblings remain on their own cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)