### PR TITLE
fix(redteam): collection-gate unblocks + 2 nexus __all__ orphans

### DIFF
--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -73,6 +73,7 @@ dev = [
     "ruff>=0.1.0",
     "fakeredis>=2.20.0",
     "respx>=0.21.0",
+    "pytest-benchmark>=4.0.0",
 ]
 # AWS Bedrock preset (#498 Session 3, S4b-i) -- botocore owns SigV4
 # canonicalization; inlined hmac.new in kaizen.llm.auth.aws is BLOCKED.
@@ -102,6 +103,7 @@ markers = [
     "requires_docker: Tests requiring Docker Model Runner",
     "requires_google: Tests requiring Google Gemini credentials",
     "regression: Regression tests for fixed bugs",
+    "benchmark: Performance benchmark tests (pytest-benchmark)",
 ]
 asyncio_mode = "auto"
 

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -48,7 +48,13 @@ from .presets import PRESETS, NexusConfig, PresetConfig, apply_preset, get_prese
 from .probes import ProbeManager, ProbeResponse, ProbeState
 from .registry import HandlerDef, HandlerParam, HandlerRegistry
 from .sse import register_sse_endpoint
-from .transports import HTTPTransport, MCPTransport, Transport
+from .transports import (
+    HTTPTransport,
+    MCPTransport,
+    Transport,
+    WebhookTransport,
+    WebSocketTransport,
+)
 from .websocket_handlers import Connection, MessageHandler, MessageHandlerRegistry
 
 with _warnings.catch_warnings():
@@ -72,6 +78,10 @@ from .errors import (
     NexusError,
     NotFoundError,
 )
+from .errors import PermissionError as NexusPermissionError  # deprecated alias
+from .errors import RateLimitError, ServiceUnavailableError
+from .errors import TimeoutError as NexusTimeoutError
+from .errors import UnauthorizedError, ValidationError
 from .http_client import (
     HttpClient,
     HttpClientConfig,
@@ -79,6 +89,7 @@ from .http_client import (
     HttpResponse,
     InvalidEndpointError,
 )
+from .outbound import post_webhook, probe_remote_health
 from .service_client import (
     ServiceClient,
     ServiceClientDeserializeError,
@@ -90,11 +101,6 @@ from .service_client import (
     ServiceClientSerializeError,
 )
 from .typed_service_client import Decoder, TypedServiceClient
-from .outbound import post_webhook, probe_remote_health
-from .errors import PermissionError as NexusPermissionError  # deprecated alias
-from .errors import RateLimitError, ServiceUnavailableError
-from .errors import TimeoutError as NexusTimeoutError
-from .errors import UnauthorizedError, ValidationError
 
 __version__ = "2.1.1"
 __all__ = [
@@ -105,6 +111,8 @@ __all__ = [
     "Transport",
     "HTTPTransport",
     "MCPTransport",
+    "WebhookTransport",
+    "WebSocketTransport",
     # Handler Registry
     "HandlerDef",
     "HandlerParam",

--- a/uv.lock
+++ b/uv.lock
@@ -2758,7 +2758,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.8.8"
+version = "2.8.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -2993,7 +2993,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.0" },
     { name = "gguf", marker = "extra == 'serve'", specifier = ">=0.10" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "kailash", specifier = ">=2.8.7" },
+    { name = "kailash", specifier = ">=2.8.9" },
     { name = "kailash-align", extras = ["rlhf", "eval", "serve", "online"], marker = "extra == 'all'" },
     { name = "kailash-kaizen", specifier = ">=2.7.5" },
     { name = "kailash-ml", specifier = ">=0.11.0" },
@@ -3058,7 +3058,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'cloud'", specifier = ">=2.18" },
     { name = "httpx", marker = "extra == 'fabric'", specifier = ">=0.27" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
-    { name = "kailash", specifier = ">=2.8.6" },
+    { name = "kailash", specifier = ">=2.8.9" },
     { name = "kailash-dataflow", extras = ["fabric", "cloud", "excel", "parquet", "streaming"], marker = "extra == 'fabric-all'" },
     { name = "motor", specifier = ">=3.3.0" },
     { name = "msgpack", marker = "extra == 'fabric'", specifier = ">=1.0" },
@@ -3139,7 +3139,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.21.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12" },
-    { name = "kailash", specifier = ">=2.8.6" },
+    { name = "kailash", specifier = ">=2.8.9" },
     { name = "kailash-mcp", specifier = ">=0.2.4" },
     { name = "numpy", specifier = ">=1.24.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
@@ -3183,7 +3183,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'platform'", specifier = ">=0.115.12" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115.12" },
     { name = "httpx", marker = "extra == 'http'", specifier = ">=0.25.0" },
-    { name = "kailash", specifier = ">=2.8.6" },
+    { name = "kailash", specifier = ">=2.8.9" },
     { name = "kailash-mcp", extras = ["http", "sse", "websocket", "auth-jwt", "auth-oauth", "server", "platform"], marker = "extra == 'full'" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.23.0" },
     { name = "pydantic", specifier = ">=2.6" },
@@ -3200,7 +3200,7 @@ provides-extras = ["http", "sse", "websocket", "auth-jwt", "auth-oauth", "server
 
 [[package]]
 name = "kailash-ml"
-version = "0.11.1"
+version = "0.12.1"
 source = { editable = "packages/kailash-ml" }
 dependencies = [
     { name = "kailash" },
@@ -3218,6 +3218,7 @@ dependencies = [
     { name = "scipy" },
     { name = "skl2onnx" },
     { name = "torch" },
+    { name = "umap-learn" },
     { name = "xgboost" },
 ]
 
@@ -3252,7 +3253,7 @@ requires-dist = [
     { name = "gymnasium", marker = "extra == 'rl'", specifier = ">=0.29" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.98" },
     { name = "imbalanced-learn", marker = "extra == 'imbalance'", specifier = ">=0.12" },
-    { name = "kailash", specifier = ">=2.8.7" },
+    { name = "kailash", specifier = ">=2.8.9" },
     { name = "kailash-dataflow", specifier = ">=2.0.11" },
     { name = "kailash-kaizen", marker = "extra == 'agents'", specifier = ">=2.7.5" },
     { name = "kailash-ml", extras = ["dl"], marker = "extra == 'dl-gpu'" },
@@ -3291,6 +3292,7 @@ requires-dist = [
     { name = "torchaudio", marker = "extra == 'dl'", specifier = ">=2.2" },
     { name = "torchvision", marker = "extra == 'dl'", specifier = ">=0.17" },
     { name = "transformers", marker = "extra == 'dl'", specifier = ">=4.40" },
+    { name = "umap-learn", specifier = ">=0.5" },
     { name = "uvicorn", marker = "extra == 'dashboard'", specifier = ">=0.27" },
     { name = "xgboost", specifier = ">=2.0" },
     { name = "xgboost", marker = "extra == 'xgb'", specifier = ">=2.0" },
@@ -3314,7 +3316,7 @@ dependencies = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "janus", specifier = ">=1.0" },
-    { name = "kailash", specifier = ">=2.8.6" },
+    { name = "kailash", specifier = ">=2.8.9" },
     { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
@@ -3346,7 +3348,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.109" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.98" },
-    { name = "kailash", specifier = ">=2.8.7" },
+    { name = "kailash", specifier = ">=2.8.9" },
     { name = "kailash-kaizen", specifier = ">=2.7.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.0" },
@@ -3377,7 +3379,7 @@ dependencies = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "kailash", specifier = ">=2.8.7" },
+    { name = "kailash", specifier = ">=2.8.9" },
     { name = "kailash-kaizen", specifier = ">=2.7.5" },
     { name = "kailash-pact", specifier = ">=0.8.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
@@ -6318,6 +6320,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pynndescent"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "llvmlite" },
+    { name = "numba" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/fb/7f58c397fb31666756457ee2ac4c0289ef2daad57f4ae4be8dec12f80b03/pynndescent-0.6.0.tar.gz", hash = "sha256:7ffde0fb5b400741e055a9f7d377e3702e02250616834231f6c209e39aac24f5", size = 2992987, upload-time = "2026-01-08T21:29:58.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl", hash = "sha256:dc8c74844e4c7f5cbd1e0cd6909da86fdc789e6ff4997336e344779c3d5538ef", size = 73511, upload-time = "2026-01-08T21:29:57.306Z" },
+]
+
+[[package]]
 name = "pyotp"
 version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -8525,6 +8543,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "umap-learn"
+version = "0.5.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/ee/af4171241117f85c74b5ca6448ea1033cc28d599c13651d67289bacd4083/umap_learn-0.5.12.tar.gz", hash = "sha256:6aff02ecac5f2aad9f3c65ee518d7ae93e1a985ae38721fdcffceee4232c33c7", size = 96672, upload-time = "2026-04-08T20:03:54.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/98/f63318ccbe75c810011fe9233884c5d348d94d90005de1b79e5f93bef9c0/umap_learn-0.5.12-py3-none-any.whl", hash = "sha256:f2a85d2a2adcb52b541bed9b27a23ca169b56bb1b23283abeebfb8dfb8a42fe5", size = 91849, upload-time = "2026-04-08T20:03:52.561Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Red-team sweep against full specs surfaced 13 HIGH findings; this PR lands the 2 that were in-scope for inline fix.

- **Collection gate** (orphan-detection.md §5) unblocked for kaizen: declares `pytest-benchmark>=4.0.0` in kaizen `[dev]` extras + registers the `benchmark` pytest marker. Prior state blocked 11,917 tests from collection in the root venv.
- **Two orphan-detection §6 violations in `nexus/__init__.py`**: `WebSocketTransport` and `WebhookTransport` exist in `transports/__init__.__all__` AND are documented in `specs/nexus-channels.md §4.4` and §4.5, but the package root `__init__.py` never imported or re-exported them. `from nexus import WebSocketTransport` raised `ImportError` despite the spec advertising it.

## What else the sweep found (flagged, NOT in this PR)

11 additional HIGH findings require dedicated implementation sessions:
- 9 ML findings — ONNX bridge matrix (torch/lightning/catboost branches), `km.doctor` console script absent, `km.track` still raises NotImplementedError (Phase 6 spec-code contradiction)
- 2 governance/infra findings — `packages/kailash-trust` is a publication orphan (zero tests), `dialect.quote_identifier()` drift between core and dataflow layers

Full audit artifacts: `workspaces/kailash-ml-gpu-stack/04-validate/0[5-7]-specs-gap-audit-*.md`
Journal: `workspaces/kailash-ml-gpu-stack/journal/0008-GAP-full-specs-redteam-2026-04-20-findings.md`

## Test plan

- [x] `.venv/bin/python -m pytest --collect-only -q packages/kailash-kaizen/tests/` → 11917 tests collected, 0 errors
- [x] `.venv/bin/python -c "from nexus import WebSocketTransport, WebhookTransport"` → OK
- [x] Pre-commit hooks pass (black, isort, ruff, tier-1 unit tests)

## Related issues

None open. Fixes discovered by /redteam full-specs sweep 2026-04-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)