### PR TITLE
release: kailash 2.8.10 — quote_identifier parity with DataFlow (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### kailash 2.8.10 — 2026-04-20 (closes #550)
+
+**Identifier-safety parity with DataFlow.** `kailash.db.dialect` now ships a canonical `quote_identifier(name)` helper on `PostgresDialect` / `MySQLDialect` / `SQLiteDialect` that BOTH validates against the allowlist regex AND wraps in the dialect's quote character. Previously, core DDL paths (notably `ConnectionManager.create_index()` and every `src/kailash/infrastructure/*` bootstrap-table CREATE) validated the identifier via `_validate_identifier` but then interpolated the raw name into DDL — an injection vector per `rules/dataflow-identifier-safety.md` MUST Rule 1 that DataFlow's own `dataflow.adapters.dialect` had already closed.
+
+**What changed:**
+
+- `kailash.db.dialect` adds `IdentifierError` (a `ValueError` subclass) and `quote_identifier` on every dialect. Contract matches DataFlow: PG/SQLite use `"`, MySQL uses backtick; length limits 63 / 64 / 128; error messages never echo the raw input (fingerprint only).
+- `ConnectionManager.create_index()` now quotes `index_name`, `table`, and each column via `dialect.quote_identifier()`.
+- Every `src/kailash/infrastructure/*.py` bootstrap table (`task_queue`, `worker_registry`, `dlq`, `checkpoint_store`, `event_store`, `idempotency_store`, `execution_store`) routes its `TABLE_NAME` / `self._table` through `dialect.quote_identifier()` in the `CREATE TABLE IF NOT EXISTS` DDL. DML sites are unchanged — `_validate_identifier` already vets the identifier at `__init__` per Rule 5 defense-in-depth.
+- `_validate_identifier` is retained for validate-only call sites (upsert SET-clause column interpolation, hardcoded-list defense-in-depth). It now raises `IdentifierError` instead of `ValueError`; existing callers that `except ValueError` continue to work because `IdentifierError` subclasses `ValueError`.
+- `specs/infra-sql.md` updated to document the quote+validate contract.
+- 64 new regression tests — 54 unit (injection payloads, length limits, dialect-appropriate quoting, fingerprint-no-echo across all three dialects) + 10 Tier 2 (real SQLite, `ConnectionManager.create_index()` rejects unsafe identifiers before DDL reaches the driver, DDL-is-quoted reflection).
+
+Closes #550.
+
 ### kailash 2.8.9 — 2026-04-20 (hotfix; closes #538)
 
 **Hotfix release.** Cuts the kailash core wheel containing commit `646c3d74` ("fix(nexus): release 2.1.1 — drive on_startup/on_shutdown lists directly (#531)"). Yesterday's release tagged `nexus-v2.1.1` published the kailash-nexus wheel but did NOT publish a new kailash core wheel — even though commit `646c3d74` modifies BOTH `packages/kailash-nexus/...` AND `src/kailash/servers/workflow_server.py` (which is shipped by the kailash core wheel). Result: every `pip install kailash-nexus==2.1.1` pulled `kailash>=2.8.7` (the broken core), and every Nexus 2.1.0/2.1.1 service crashed at uvicorn lifespan with `AttributeError: 'APIRouter' object has no attribute 'startup'`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.8.9"
+version = "2.8.10"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/specs/infra-sql.md
+++ b/specs/infra-sql.md
@@ -45,21 +45,50 @@ The SDK-wide canonical SQL placeholder is `?` (SQLite style). Every SQL string a
 | PostgreSQL | `$1`, `$2`, ...    | `?` -> `$N` (1-indexed) |
 | MySQL      | `%s`               | `?` -> `%s`             |
 
-### Identifier Validation
+### Identifier Safety
 
-`_validate_identifier(name: str, *, max_length: int = 128) -> None`
+The core SDK ships two paired helpers for identifier safety. Every dynamic-identifier DDL path MUST use `quote_identifier` (validate AND quote); validate-only callers use `_validate_identifier`.
 
-Validates SQL identifiers (table names, column names, index names) against injection. Raises `ValueError` on failure.
+This mirrors the canonical contract established by `dataflow.adapters.dialect` (see `packages/kailash-dataflow/src/dataflow/adapters/dialect.py`) and is mandated by `rules/dataflow-identifier-safety.md` MUST Rules 1-2.
+
+#### `dialect.quote_identifier(name: str) -> str`
+
+Validates AND wraps _name_ in dialect-appropriate identifier quotes. Returns the quoted form suitable for interpolation into DDL.
 
 Contract:
 
-- Input must be a string.
-- Maximum length: 128 characters (default; PostgreSQL limit is 63, MySQL is 64).
+- Input must be a string; non-strings raise `IdentifierError`.
 - Must match regex `^[a-zA-Z_][a-zA-Z0-9_]*$`.
-- Error messages include a fingerprint hash (`hash(name) & 0xFFFF`), not the raw input, to prevent log poisoning.
-- Does NOT attempt to escape -- rejects invalid inputs outright.
+- Length limit: PostgreSQL 63, MySQL 64, SQLite 128.
+- Quote character: `"` for PostgreSQL/SQLite, `` ` `` for MySQL.
+- Raises `IdentifierError` (subclass of `ValueError`) on failure. Error message never echoes the raw identifier — only a fingerprint hash (`hash(name) & 0xFFFF`) is emitted, to prevent log poisoning and stored XSS via error-message paths.
+- MUST NOT attempt to escape embedded quote characters — invalid inputs are rejected outright.
 
-Used by: every `CREATE TABLE`, `CREATE INDEX`, table name constructor, and DDL path in the SDK.
+```python
+from kailash.db.dialect import PostgresDialect
+
+dialect = PostgresDialect()
+quoted = dialect.quote_identifier("users")        # '"users"'
+dialect.quote_identifier('"; DROP TABLE x; --')   # raises IdentifierError
+```
+
+Used by: every `CREATE TABLE`, `CREATE INDEX`, `ALTER TABLE`, `DROP` site that interpolates a dynamic identifier. Specifically, `ConnectionManager.create_index()` and all `src/kailash/infrastructure/*.py` bootstrap-table DDL paths route table / index / column names through `quote_identifier`.
+
+#### `_validate_identifier(name: str, *, max_length: int = 128) -> None`
+
+Validate-only primitive for sites that interpolate an identifier WITHOUT dialect quoting. Raises `IdentifierError` (`ValueError` subclass) on failure. Contract identical to `quote_identifier` (regex, length, fingerprint error message), minus the quoting step.
+
+Used by:
+
+- Upsert column-list interpolation where the SET clause embeds bare column names (`col = EXCLUDED.col`).
+- Hardcoded-identifier defense-in-depth validation at construction time (per `rules/dataflow-identifier-safety.md` Rule 5).
+- Test fixtures.
+
+`_validate_identifier` MUST NOT be used in DDL paths that need quoting — use `quote_identifier` there instead. Per Rule 1, skipping the quote step on a dynamic-identifier DDL is an injection vector even when validation passes.
+
+#### `IdentifierError`
+
+Typed exception raised by `quote_identifier` and `_validate_identifier` when an identifier fails safety validation. Subclasses `ValueError` so existing call sites that catch `ValueError` continue to work. Error messages use a fingerprint hash; they never echo the raw input.
 
 ### JSON Path Validation
 
@@ -583,7 +612,7 @@ All stores and the ConnectionManager follow these error handling patterns:
 
 - `RuntimeError` when `ConnectionManager.execute/fetch/fetchone` is called before `initialize()`.
 - `RuntimeError` from `stamp_schema_version` when the database has a newer schema than the running code (downgrade protection).
-- `ValueError` from `_validate_identifier` when a table name, column name, or index name fails the allowlist regex.
+- `IdentifierError` (a `ValueError` subclass) from `quote_identifier` and `_validate_identifier` when a table name, column name, or index name fails the allowlist regex, length check, or type check. Error messages use a fingerprint hash — the raw identifier is never echoed.
 - `ImportError` with actionable install instructions when a required async driver is missing.
 - `ValueError` from `decode_userinfo_or_raise` when decoded credentials contain null bytes.
 

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.8.9"
+__version__ = "2.8.10"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/db/connection.py
+++ b/src/kailash/db/connection.py
@@ -16,7 +16,6 @@ from typing import Any, Dict, List, Optional
 from kailash.db.dialect import (
     DatabaseType,
     QueryDialect,
-    _validate_identifier,
     detect_dialect,
 )
 
@@ -99,14 +98,22 @@ class ConnectionManager:
         Uses ``CREATE INDEX IF NOT EXISTS`` on PostgreSQL/SQLite and
         catches duplicate-index errors on MySQL (which does not support
         ``IF NOT EXISTS`` for indexes).
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, every
+        dynamic identifier interpolated into DDL MUST route through
+        ``dialect.quote_identifier()`` — which both validates against
+        the allowlist regex AND wraps in dialect-appropriate quotes.
         """
-        _validate_identifier(index_name)
-        _validate_identifier(table)
-        for col in (c.strip() for c in columns.split(",")):
-            _validate_identifier(col)
+        quoted_index = self.dialect.quote_identifier(index_name)
+        quoted_table = self.dialect.quote_identifier(table)
+        quoted_cols = ", ".join(
+            self.dialect.quote_identifier(c.strip()) for c in columns.split(",")
+        )
         if self.dialect.database_type == DatabaseType.MYSQL:
             try:
-                await self.execute(f"CREATE INDEX {index_name} ON {table}({columns})")
+                await self.execute(
+                    f"CREATE INDEX {quoted_index} ON {quoted_table}({quoted_cols})"
+                )
             except Exception:
                 # MySQL raises error 1061 if index already exists
                 logger.warning(
@@ -116,7 +123,8 @@ class ConnectionManager:
                 )
         else:
             await self.execute(
-                f"CREATE INDEX IF NOT EXISTS {index_name} ON {table}({columns})"
+                f"CREATE INDEX IF NOT EXISTS {quoted_index} "
+                f"ON {quoted_table}({quoted_cols})"
             )
 
     # ------------------------------------------------------------------

--- a/src/kailash/db/dialect.py
+++ b/src/kailash/db/dialect.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "DatabaseType",
+    "IdentifierError",
     "QueryDialect",
     "PostgresDialect",
     "MySQLDialect",
@@ -32,6 +33,25 @@ __all__ = [
 
 _IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _JSON_PATH_RE = re.compile(r"^[a-zA-Z0-9_.]+$")
+
+
+class IdentifierError(ValueError):
+    """Raised when a SQL identifier fails safety validation.
+
+    Subclasses ``ValueError`` so existing call sites that catch
+    ``ValueError`` (e.g. `_validate_identifier` raisers) continue to
+    work. Error messages NEVER echo the raw input verbatim — they
+    use a fingerprint hash (`hash(name) & 0xFFFF:04x`) to prevent
+    log poisoning / stored-XSS-via-error-message.
+
+    Per ``rules/dataflow-identifier-safety.md`` MUST Rule 2, the
+    quote-identifier contract requires distinct typed error surfaces
+    so DDL-layer callers can distinguish identifier-validation
+    failures from unrelated ``ValueError`` raises in surrounding
+    code.
+    """
+
+    pass
 
 
 def _identifier_fingerprint(name: object) -> str:
@@ -52,6 +72,19 @@ def _identifier_fingerprint(name: object) -> str:
 def _validate_identifier(name: str, *, max_length: int = 128) -> None:
     """Validate a SQL identifier (table or column name).
 
+    This is the validate-only primitive for sites that interpolate
+    an identifier into SQL WITHOUT wrapping it in dialect quotes —
+    for example, `upsert` column lists where the SET clause embeds
+    bare column names (`col = EXCLUDED.col`), or hardcoded-identifier
+    lists that defense-in-depth validate per
+    ``rules/dataflow-identifier-safety.md`` Rule 5.
+
+    DDL paths that interpolate dynamic identifiers into statements
+    like ``CREATE INDEX``, ``CREATE TABLE``, ``ALTER TABLE``, or
+    ``DROP`` MUST use ``dialect.quote_identifier(name)`` instead —
+    which both validates AND wraps in dialect-appropriate quotes
+    (per ``rules/dataflow-identifier-safety.md`` MUST Rule 1).
+
     Parameters
     ----------
     name
@@ -62,31 +95,74 @@ def _validate_identifier(name: str, *, max_length: int = 128) -> None:
 
     Raises
     ------
-    ValueError
-        If *name* is not a string, exceeds the length limit, or
-        contains characters that could enable SQL injection.
-        Unhashable non-string inputs (``dict``, ``list``, ``set``)
-        raise ``ValueError`` — NOT ``TypeError`` — because the
-        fingerprint helper is safe on unhashable values.
+    IdentifierError
+        (``ValueError`` subclass) if *name* is not a string,
+        exceeds the length limit, or contains characters that
+        could enable SQL injection. Unhashable non-string inputs
+        (``dict``, ``list``, ``set``) raise ``IdentifierError`` —
+        NOT ``TypeError`` — because the fingerprint helper is
+        safe on unhashable values.
     """
     if not isinstance(name, str):
-        raise ValueError(
+        raise IdentifierError(
             f"Invalid SQL identifier "
             f"(fingerprint={_identifier_fingerprint(name)}): "
             f"must be a string, got {type(name).__name__}"
         )
     if len(name) > max_length:
-        raise ValueError(
+        raise IdentifierError(
             f"Invalid SQL identifier "
             f"(fingerprint={_identifier_fingerprint(name)}): "
             f"exceeds {max_length}-char limit (len={len(name)})"
         )
     if not _IDENTIFIER_RE.match(name):
-        raise ValueError(
+        raise IdentifierError(
             f"Invalid SQL identifier "
             f"(fingerprint={_identifier_fingerprint(name)}): "
             "must match [a-zA-Z_][a-zA-Z0-9_]*"
         )
+
+
+def _quote_identifier_impl(
+    name: str,
+    *,
+    max_length: int,
+    quote_char: str,
+) -> str:
+    """Validate *name* against the allowlist regex AND wrap it in
+    *quote_char* for dialect-appropriate identifier quoting.
+
+    Contract per ``rules/dataflow-identifier-safety.md`` MUST Rule 2:
+
+    1. **Validate** against ``^[a-zA-Z_][a-zA-Z0-9_]*$`` (baseline).
+    2. **Reject** — the raise does NOT echo the raw input; only a
+       fingerprint hash is emitted for forensic correlation.
+    3. **Check length** against *max_length* (PG 63 / MySQL 64 /
+       SQLite 128).
+    4. **Quote** with *quote_char* (``"`` for PG/SQLite, ``\u0060``
+       for MySQL).
+    5. **Do NOT escape** embedded quote characters — invalid
+       inputs are rejected outright.
+    """
+    if not isinstance(name, str):
+        raise IdentifierError(
+            f"Invalid SQL identifier "
+            f"(fingerprint={_identifier_fingerprint(name)}): "
+            f"must be a string, got {type(name).__name__}"
+        )
+    if len(name) > max_length:
+        raise IdentifierError(
+            f"Invalid SQL identifier "
+            f"(fingerprint={_identifier_fingerprint(name)}): "
+            f"exceeds {max_length}-char limit (len={len(name)})"
+        )
+    if not _IDENTIFIER_RE.match(name):
+        raise IdentifierError(
+            f"Invalid SQL identifier "
+            f"(fingerprint={_identifier_fingerprint(name)}): "
+            "must match [a-zA-Z_][a-zA-Z0-9_]*"
+        )
+    return f"{quote_char}{name}{quote_char}"
 
 
 def _validate_json_path(path: str) -> None:
@@ -138,6 +214,24 @@ class QueryDialect(ABC):
         PostgreSQL: ``$1``, ``$2``, ...
         MySQL: ``%s``
         SQLite: ``?``
+        """
+
+    @abstractmethod
+    def quote_identifier(self, name: str) -> str:
+        """Validate *name* and return it wrapped in dialect-appropriate
+        identifier quotes.
+
+        This is the canonical helper for every DDL path that
+        interpolates a dynamic identifier — ``CREATE TABLE``,
+        ``CREATE INDEX``, ``ALTER TABLE``, ``DROP`` — per
+        ``rules/dataflow-identifier-safety.md`` MUST Rule 1.
+
+        Contract per MUST Rule 2:
+
+        - PostgreSQL / SQLite: wraps in ``"``; max length 63 / 128.
+        - MySQL: wraps in ``\u0060`` (backtick); max length 64.
+        - Raises :class:`IdentifierError` on invalid input; error
+          message does NOT echo the raw identifier.
         """
 
     def translate_query(self, query: str) -> str:
@@ -284,12 +378,22 @@ class QueryDialect(ABC):
 class PostgresDialect(QueryDialect):
     """PostgreSQL dialect — uses ``$1, $2, ...`` numbered placeholders."""
 
+    _MAX_IDENTIFIER_LENGTH = 63  # PostgreSQL NAMEDATALEN - 1
+    _QUOTE_CHAR = '"'
+
     @property
     def database_type(self) -> DatabaseType:
         return DatabaseType.POSTGRESQL
 
     def placeholder(self, index: int) -> str:
         return f"${index + 1}"
+
+    def quote_identifier(self, name: str) -> str:
+        return _quote_identifier_impl(
+            name,
+            max_length=self._MAX_IDENTIFIER_LENGTH,
+            quote_char=self._QUOTE_CHAR,
+        )
 
     # translate_query inherited from base — replaces ? with $N
 
@@ -351,12 +455,22 @@ class PostgresDialect(QueryDialect):
 class MySQLDialect(QueryDialect):
     """MySQL dialect — uses ``%s`` positional placeholders."""
 
+    _MAX_IDENTIFIER_LENGTH = 64  # MySQL identifier length limit
+    _QUOTE_CHAR = "`"
+
     @property
     def database_type(self) -> DatabaseType:
         return DatabaseType.MYSQL
 
     def placeholder(self, index: int) -> str:
         return "%s"
+
+    def quote_identifier(self, name: str) -> str:
+        return _quote_identifier_impl(
+            name,
+            max_length=self._MAX_IDENTIFIER_LENGTH,
+            quote_char=self._QUOTE_CHAR,
+        )
 
     # translate_query inherited from base — replaces ? with %s
 
@@ -436,12 +550,22 @@ class MySQLDialect(QueryDialect):
 class SQLiteDialect(QueryDialect):
     """SQLite dialect — uses ``?`` positional placeholders (canonical)."""
 
+    _MAX_IDENTIFIER_LENGTH = 128  # SQLite practical limit
+    _QUOTE_CHAR = '"'
+
     @property
     def database_type(self) -> DatabaseType:
         return DatabaseType.SQLITE
 
     def placeholder(self, index: int) -> str:
         return "?"
+
+    def quote_identifier(self, name: str) -> str:
+        return _quote_identifier_impl(
+            name,
+            max_length=self._MAX_IDENTIFIER_LENGTH,
+            quote_char=self._QUOTE_CHAR,
+        )
 
     def translate_query(self, query: str) -> str:
         """SQLite uses ``?`` natively — identity translation."""

--- a/src/kailash/infrastructure/checkpoint_store.py
+++ b/src/kailash/infrastructure/checkpoint_store.py
@@ -52,10 +52,16 @@ class DBCheckpointStore:
     # Lifecycle
     # ------------------------------------------------------------------
     async def initialize(self) -> None:
-        """Create the checkpoints table if it does not exist."""
+        """Create the checkpoints table if it does not exist.
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, the
+        table name is routed through ``dialect.quote_identifier()``
+        for the DDL interpolation.
+        """
+        quoted_table = self._conn.dialect.quote_identifier(self.TABLE_NAME)
         await self._conn.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+            CREATE TABLE IF NOT EXISTS {quoted_table} (
                 checkpoint_key {self._conn.dialect.text_column(indexed=True)} PRIMARY KEY,
                 data {self._conn.dialect.blob_type()} NOT NULL,
                 size_bytes INTEGER NOT NULL,

--- a/src/kailash/infrastructure/dlq.py
+++ b/src/kailash/infrastructure/dlq.py
@@ -87,10 +87,17 @@ class DBDeadLetterQueue:
     # Lifecycle
     # ------------------------------------------------------------------
     async def initialize(self) -> None:
-        """Create the DLQ table and indices if they do not exist."""
+        """Create the DLQ table and indices if they do not exist.
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, the
+        table name is routed through ``dialect.quote_identifier()``
+        for the DDL interpolation. ``create_index()`` separately quotes
+        its own identifier arguments.
+        """
+        quoted_table = self._conn.dialect.quote_identifier(self.TABLE_NAME)
         await self._conn.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+            CREATE TABLE IF NOT EXISTS {quoted_table} (
                 id {self._conn.dialect.text_column(indexed=True)} PRIMARY KEY,
                 workflow_id TEXT NOT NULL,
                 error TEXT NOT NULL,

--- a/src/kailash/infrastructure/event_store.py
+++ b/src/kailash/infrastructure/event_store.py
@@ -55,10 +55,16 @@ class DBEventStoreBackend:
     # Lifecycle
     # ------------------------------------------------------------------
     async def initialize(self) -> None:
-        """Create the events table if it does not exist."""
+        """Create the events table if it does not exist.
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, the
+        table name is quoted via ``dialect.quote_identifier()`` for
+        the DDL interpolation.
+        """
+        quoted_table = self._conn.dialect.quote_identifier(self.TABLE_NAME)
         await self._conn.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+            CREATE TABLE IF NOT EXISTS {quoted_table} (
                 {self._conn.dialect.auto_id_column()},
                 stream_key {self._conn.dialect.text_column(indexed=True)} NOT NULL,
                 sequence INTEGER NOT NULL,

--- a/src/kailash/infrastructure/execution_store.py
+++ b/src/kailash/infrastructure/execution_store.py
@@ -65,10 +65,16 @@ class DBExecutionStore:
     # Lifecycle
     # ------------------------------------------------------------------
     async def initialize(self) -> None:
-        """Create the executions table and indices if they do not exist."""
+        """Create the executions table and indices if they do not exist.
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, the
+        table name is quoted via ``dialect.quote_identifier()`` for
+        the DDL interpolation.
+        """
+        quoted_table = self._conn.dialect.quote_identifier(self.TABLE_NAME)
         await self._conn.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+            CREATE TABLE IF NOT EXISTS {quoted_table} (
                 run_id {self._conn.dialect.text_column(indexed=True)} PRIMARY KEY,
                 workflow_id {self._conn.dialect.text_column(indexed=True)},
                 status {self._conn.dialect.text_column(indexed=True)} NOT NULL DEFAULT 'pending',

--- a/src/kailash/infrastructure/idempotency_store.py
+++ b/src/kailash/infrastructure/idempotency_store.py
@@ -61,10 +61,16 @@ class DBIdempotencyStore:
     # Lifecycle
     # ------------------------------------------------------------------
     async def initialize(self) -> None:
-        """Create the idempotency table and indices if they do not exist."""
+        """Create the idempotency table and indices if they do not exist.
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, the
+        table name is quoted via ``dialect.quote_identifier()`` for
+        the DDL interpolation.
+        """
+        quoted_table = self._conn.dialect.quote_identifier(self.TABLE_NAME)
         await self._conn.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+            CREATE TABLE IF NOT EXISTS {quoted_table} (
                 idempotency_key {self._conn.dialect.text_column(indexed=True)} PRIMARY KEY,
                 fingerprint TEXT NOT NULL,
                 response_data TEXT NOT NULL,

--- a/src/kailash/infrastructure/task_queue.py
+++ b/src/kailash/infrastructure/task_queue.py
@@ -124,13 +124,21 @@ class SQLTaskQueue:
         """Create the task queue table if it does not exist.
 
         Safe to call multiple times (idempotent).
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, the
+        dynamic table name is routed through ``dialect.quote_identifier()``
+        for the DDL interpolation (validates + quotes). DML sites
+        below reuse the validated ``self._table`` as-is since the
+        identifier was already vetted by ``_validate_identifier`` in
+        ``__init__`` (Rule 5 defense-in-depth).
         """
         if self._initialized:
             return
 
         _tc = self._conn.dialect.text_column(indexed=True)
+        quoted_table = self._conn.dialect.quote_identifier(self._table)
         await self._conn.execute(
-            f"CREATE TABLE IF NOT EXISTS {self._table} ("
+            f"CREATE TABLE IF NOT EXISTS {quoted_table} ("
             f"task_id {_tc} PRIMARY KEY, "
             f"queue_name {_tc} NOT NULL DEFAULT 'default', "
             "payload TEXT NOT NULL, "

--- a/src/kailash/infrastructure/worker_registry.py
+++ b/src/kailash/infrastructure/worker_registry.py
@@ -70,13 +70,18 @@ class SQLWorkerRegistry:
         """Create the worker registry table if it does not exist.
 
         Safe to call multiple times (idempotent).
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, the
+        table name is quoted via ``dialect.quote_identifier()`` for
+        the DDL interpolation.
         """
         if self._initialized:
             return
 
         _tc = self._conn.dialect.text_column(indexed=True)
+        quoted_table = self._conn.dialect.quote_identifier(self._table)
         await self._conn.execute(
-            f"CREATE TABLE IF NOT EXISTS {self._table} ("
+            f"CREATE TABLE IF NOT EXISTS {quoted_table} ("
             f"worker_id {_tc} PRIMARY KEY, "
             f"queue_name {_tc} NOT NULL, "
             f"status {_tc} NOT NULL DEFAULT 'active', "

--- a/tests/regression/test_create_index_identifier_safety.py
+++ b/tests/regression/test_create_index_identifier_safety.py
@@ -1,0 +1,161 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: ``ConnectionManager.create_index()`` rejects unsafe identifiers
+via ``dialect.quote_identifier()`` before the DB driver sees anything.
+
+Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1, every DDL that
+interpolates a dynamic identifier MUST route through
+``dialect.quote_identifier()``. This test exercises the real DDL hot path:
+``ConnectionManager.create_index()`` on a live SQLite database, asserting
+that malicious table / index names raise :class:`IdentifierError` BEFORE
+any SQL reaches aiosqlite.
+
+This closes #550 — core SDK parity with DataFlow's canonical
+``quote_identifier`` contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.db.connection import ConnectionManager
+from kailash.db.dialect import IdentifierError
+
+
+@pytest.fixture
+async def conn():
+    """Real aiosqlite-backed ConnectionManager against an in-memory db.
+
+    Uses a real connection (Tier 2 discipline — no mocking of the
+    adapter). The test asserts that ``create_index`` rejects unsafe
+    identifiers at the quote_identifier boundary BEFORE issuing any
+    DDL to the driver; the real connection is needed to prove the
+    rejection is not driver-side.
+    """
+    mgr = ConnectionManager("sqlite:///:memory:")
+    await mgr.initialize()
+    # Pre-create a table so a malicious-index-on-valid-table scenario
+    # doesn't fail for the wrong reason.
+    await mgr.execute("CREATE TABLE test_users (id INTEGER, name TEXT)")
+    try:
+        yield mgr
+    finally:
+        await mgr.close()
+
+
+class TestCreateIndexRejectsUnsafeTable:
+    """``create_index(table=...)`` MUST reject malicious table names."""
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_table_name_with_injection_rejected(self, conn):
+        with pytest.raises(IdentifierError):
+            await conn.create_index(
+                "idx_name",
+                'users"; DROP TABLE customers; --',
+                "col",
+            )
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_table_name_with_semicolon_rejected(self, conn):
+        with pytest.raises(IdentifierError):
+            await conn.create_index("idx_name", "users;drop", "col")
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_table_name_with_space_rejected(self, conn):
+        with pytest.raises(IdentifierError):
+            await conn.create_index("idx_name", "users WHERE 1=1", "col")
+
+
+class TestCreateIndexRejectsUnsafeIndexName:
+    """``create_index(index_name=...)`` MUST reject malicious index names."""
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_index_name_injection_rejected(self, conn):
+        with pytest.raises(IdentifierError):
+            await conn.create_index(
+                'idx"; DROP TABLE test_users; --',
+                "test_users",
+                "id",
+            )
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_index_name_with_backtick_rejected(self, conn):
+        with pytest.raises(IdentifierError):
+            await conn.create_index("`injected`", "test_users", "id")
+
+
+class TestCreateIndexRejectsUnsafeColumn:
+    """``create_index(columns=...)`` MUST reject malicious column names."""
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_column_injection_rejected(self, conn):
+        with pytest.raises(IdentifierError):
+            await conn.create_index(
+                "idx_name",
+                "test_users",
+                "id); DROP TABLE test_users; --",
+            )
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_multi_column_injection_on_second_rejected(self, conn):
+        with pytest.raises(IdentifierError):
+            await conn.create_index(
+                "idx_name",
+                "test_users",
+                "id, name; DROP TABLE test_users",
+            )
+
+
+class TestCreateIndexSucceedsForValidIdentifiers:
+    """Sanity: valid identifiers still work end-to-end on a real DB."""
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_create_valid_index(self, conn):
+        # If the index were NOT created, a second call without IF NOT EXISTS
+        # would raise. SQLite uses IF NOT EXISTS, so we verify creation via
+        # sqlite_master reflection.
+        await conn.create_index("idx_test_users_name", "test_users", "name")
+        rows = await conn.fetch(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name = ?",
+            "idx_test_users_name",
+        )
+        assert len(rows) == 1, f"Expected idx_test_users_name to exist, got: {rows}"
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_create_composite_index(self, conn):
+        await conn.create_index("idx_test_users_composite", "test_users", "id, name")
+        rows = await conn.fetch(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name = ?",
+            "idx_test_users_composite",
+        )
+        assert len(rows) == 1
+
+
+class TestCreateIndexUsesDialectQuoting:
+    """The DDL produced by ``create_index`` wraps identifiers in the
+    SQLite quote char (``"``). Reflection via ``sqlite_master.sql``
+    confirms ``quote_identifier`` was applied, not a naive f-string."""
+
+    @pytest.mark.regression
+    @pytest.mark.asyncio
+    async def test_generated_ddl_is_quoted(self, conn):
+        await conn.create_index("idx_quoted_check", "test_users", "name")
+        rows = await conn.fetch(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name = ?",
+            "idx_quoted_check",
+        )
+        assert len(rows) == 1
+        sql = rows[0]["sql"] or ""
+        # The DDL MUST contain dialect quotes around the identifiers.
+        assert '"idx_quoted_check"' in sql, f"DDL missing quoted index name. Got: {sql}"
+        assert '"test_users"' in sql, f"DDL missing quoted table name. Got: {sql}"
+        assert '"name"' in sql, f"DDL missing quoted column name. Got: {sql}"

--- a/tests/regression/test_identifier_error_core.py
+++ b/tests/regression/test_identifier_error_core.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: core SDK ``dialect.quote_identifier()`` contract.
+
+Mirrors the DataFlow-side contract (`packages/kailash-dataflow/tests/unit/
+adapters/test_safe_identifier.py` and
+`tests/regression/test_identifier_error_no_raw_echo.py`) for the core
+SDK port at ``kailash.db.dialect``. Per ``rules/dataflow-identifier-safety.md``
+MUST Rule 2, every dialect's ``quote_identifier`` MUST:
+
+1. Validate against the allowlist regex ``^[a-zA-Z_][a-zA-Z0-9_]*$``.
+2. Reject with a typed ``IdentifierError`` whose message does NOT echo
+   the raw input verbatim — only a fingerprint hash is emitted.
+3. Check length against the dialect limit (PG 63 / MySQL 64 / SQLite 128).
+4. Quote with the dialect's quote char (``"`` for PG/SQLite, ``\u0060`` for MySQL).
+5. Not attempt to escape embedded quote characters.
+
+Closes #550 (cross-SDK parity with kailash-dataflow's canonical
+``quote_identifier`` helper).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from kailash.db.dialect import (
+    IdentifierError,
+    MySQLDialect,
+    PostgresDialect,
+    SQLiteDialect,
+)
+
+_FINGERPRINT_RE = re.compile(r"fingerprint=[0-9a-f]{4}")
+
+
+# ======================================================================
+# Validation — the regex allowlist rejects injection payloads
+# ======================================================================
+class TestQuoteIdentifierRejectsSQLInjection:
+    """Every dialect MUST reject standard injection payloads via IdentifierError."""
+
+    @pytest.fixture(params=[PostgresDialect(), MySQLDialect(), SQLiteDialect()])
+    def dialect(self, request):
+        return request.param
+
+    @pytest.mark.regression
+    def test_drop_table_injection(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier('users"; DROP TABLE customers; --')
+
+    @pytest.mark.regression
+    def test_name_with_spaces(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("name WITH DATA")
+
+    @pytest.mark.regression
+    def test_starts_with_digit(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("123_starts_with_digit")
+
+    @pytest.mark.regression
+    def test_empty_string(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("")
+
+    @pytest.mark.regression
+    def test_whitespace_only(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("   ")
+
+    @pytest.mark.regression
+    def test_null_byte(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("table\x00drop")
+
+    @pytest.mark.regression
+    def test_backtick(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("`injected`")
+
+    @pytest.mark.regression
+    def test_double_quote(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier('"injected"')
+
+    @pytest.mark.regression
+    def test_dot(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("schema.table")
+
+    @pytest.mark.regression
+    def test_hyphen(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("table-name")
+
+    @pytest.mark.regression
+    def test_semicolon(self, dialect):
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier("table;drop")
+
+    @pytest.mark.regression
+    def test_non_string_raises_identifier_error(self, dialect):
+        # The contract says IdentifierError (ValueError subclass), not TypeError.
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier(None)  # type: ignore[arg-type]
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier(42)  # type: ignore[arg-type]
+
+
+# ======================================================================
+# Length limits — PG 63, MySQL 64, SQLite 128
+# ======================================================================
+class TestQuoteIdentifierEnforcesDialectLengthLimit:
+    @pytest.mark.regression
+    def test_postgres_rejects_64_chars(self):
+        dialect = PostgresDialect()
+        # 63 allowed, 64 rejected
+        ok = "a" * 63
+        bad = "a" * 64
+        assert dialect.quote_identifier(ok) == f'"{ok}"'
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier(bad)
+
+    @pytest.mark.regression
+    def test_mysql_rejects_65_chars(self):
+        dialect = MySQLDialect()
+        ok = "a" * 64
+        bad = "a" * 65
+        assert dialect.quote_identifier(ok) == f"`{ok}`"
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier(bad)
+
+    @pytest.mark.regression
+    def test_sqlite_rejects_129_chars(self):
+        dialect = SQLiteDialect()
+        ok = "a" * 128
+        bad = "a" * 129
+        assert dialect.quote_identifier(ok) == f'"{ok}"'
+        with pytest.raises(IdentifierError):
+            dialect.quote_identifier(bad)
+
+
+# ======================================================================
+# Dialect-appropriate quoting — PG/SQLite use `"`, MySQL uses backtick
+# ======================================================================
+class TestQuoteIdentifierProducesDialectQuoting:
+    @pytest.mark.regression
+    def test_postgres_uses_double_quotes(self):
+        assert PostgresDialect().quote_identifier("users") == '"users"'
+
+    @pytest.mark.regression
+    def test_mysql_uses_backticks(self):
+        assert MySQLDialect().quote_identifier("users") == "`users`"
+
+    @pytest.mark.regression
+    def test_sqlite_uses_double_quotes(self):
+        assert SQLiteDialect().quote_identifier("users") == '"users"'
+
+    @pytest.mark.regression
+    def test_valid_identifiers_round_trip(self):
+        # Common valid forms accepted across every dialect.
+        names = [
+            "users",
+            "user_profiles",
+            "_private",
+            "UserProfiles",
+            "a",
+            "_",
+            "table123",
+        ]
+        for d in (PostgresDialect(), MySQLDialect(), SQLiteDialect()):
+            for n in names:
+                out = d.quote_identifier(n)
+                assert n in out  # wrapped but not mangled
+
+
+# ======================================================================
+# Error-message hygiene — fingerprint ONLY, never the raw payload
+# ======================================================================
+class TestQuoteIdentifierErrorFingerprintNoEcho:
+    """The raw (possibly malicious) input MUST NOT appear in the error message.
+
+    Per ``rules/dataflow-identifier-safety.md`` MUST Rule 2: the error
+    message uses a fingerprint hash to prevent log-poisoning / stored
+    XSS. This is the exact same contract the DataFlow helper already
+    enforces; tests mirror that parity.
+    """
+
+    @pytest.fixture(params=[PostgresDialect(), MySQLDialect(), SQLiteDialect()])
+    def dialect(self, request):
+        return request.param
+
+    @pytest.mark.regression
+    def test_sql_injection_not_echoed(self, dialect):
+        payload = 'users"; DROP TABLE customers; --'
+        with pytest.raises(IdentifierError) as exc_info:
+            dialect.quote_identifier(payload)
+        msg = str(exc_info.value)
+        assert (
+            payload not in msg
+        ), f"Error message MUST NOT echo the raw payload. Got: {msg}"
+        assert _FINGERPRINT_RE.search(
+            msg
+        ), f"Error message must include a hex fingerprint. Got: {msg}"
+
+    @pytest.mark.regression
+    def test_xss_payload_not_echoed(self, dialect):
+        payload = '<script>alert("xss")</script>'
+        with pytest.raises(IdentifierError) as exc_info:
+            dialect.quote_identifier(payload)
+        msg = str(exc_info.value)
+        assert payload not in msg
+        assert _FINGERPRINT_RE.search(msg)
+
+    @pytest.mark.regression
+    def test_long_payload_not_echoed(self, dialect):
+        # Exceed every dialect's length limit.
+        payload = "bad_ident_" + ("a" * 500)
+        with pytest.raises(IdentifierError) as exc_info:
+            dialect.quote_identifier(payload)
+        msg = str(exc_info.value)
+        assert payload not in msg
+        assert _FINGERPRINT_RE.search(msg)
+
+
+# ======================================================================
+# IdentifierError IS a ValueError — backward-compat with pre-existing
+# callers that catch ValueError on invalid identifiers.
+# ======================================================================
+class TestIdentifierErrorIsValueError:
+    @pytest.mark.regression
+    def test_identifier_error_subclasses_value_error(self):
+        assert issubclass(IdentifierError, ValueError)
+
+    @pytest.mark.regression
+    def test_existing_value_error_callers_still_work(self):
+        """Callers that wrote ``except ValueError`` continue to catch
+        the new typed ``IdentifierError`` without modification."""
+        dialect = PostgresDialect()
+        try:
+            dialect.quote_identifier('" OR 1=1 --')
+        except ValueError:
+            return  # Caught correctly.
+        pytest.fail("Expected ValueError (IdentifierError) to be raised")


### PR DESCRIPTION
## Summary
- Ports DataFlow's canonical \`dialect.quote_identifier(name)\` into core \`src/kailash/db/dialect.py\` with matching contract (validate + quote, typed \`IdentifierError\`, no raw-input echo in errors).
- Migrates every core DDL call site to the new helper:
  - \`ConnectionManager.create_index()\` — quotes \`index_name\`, \`table\`, each column
  - \`src/kailash/infrastructure/{task_queue, worker_registry, dlq, checkpoint_store, event_store, idempotency_store, execution_store}.py\` — \`CREATE TABLE IF NOT EXISTS\` DDL routes through \`quote_identifier\`
- \`specs/infra-sql.md\` updated to document the quote+validate contract.
- 64 new regression tests (54 Tier 1 + 10 Tier 2) covering every dialect, injection payloads, length limits, fingerprint-no-echo.

## Test plan
- [x] \`pytest tests/regression/test_identifier_error_core.py tests/regression/test_create_index_identifier_safety.py\` — 64/64 pass
- [x] \`rg 'def quote_identifier' src/kailash/db/\` — 4 matches (abstract + 3 concrete dialects)
- [x] \`_validate_identifier\` retained as documented validate-only primitive per rules/dataflow-identifier-safety.md Rule 5; now raises \`IdentifierError\` (subclass of \`ValueError\` for backwards compat).
- [ ] CI matrix (Python 3.11-3.14 + PACT) — awaits this PR

## Related issues
Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)