### PR TITLE
chore(codify): 2 rule additions from clean-release cycle 2026-04-20

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -198,14 +198,140 @@ post_release_followups:
       DataFlow dialect contract into core OR amend specs/infra-sql.md
       to document the intentional split.
 
-summary_note: |
-  3 rule additions (2 HIGH, 1 MEDIUM), all targeting different files:
-  rules/testing.md, rules/orphan-detection.md, rules/specs-authority.md.
-  All 3 follow rule-authoring.md meta-rule (Loud/Linguistic/Layered).
-  Origin: Session 2026-04-20 /redteam full-specs sweep and
-  collection-gate unblock work. Cross-SDK applicable;
-  classification_suggestion: global for all 3.
+  - id: orphan-detection-stub-implementation-sweeps-deferral-tests
+    type: rule
+    severity: MEDIUM
+    target: rules/orphan-detection.md
+    section: "§4a: Stub Implementation MUST Sweep Deferral Tests In Same Commit"
+    summary: |
+      The mirror of existing §4 (API removal sweeps tests). When an
+      agent implements what was a NotImplementedError stub (Phase N
+      scaffold), the scaffold-era test that asserts
+      pytest.raises(NotImplementedError) flips from pass to fail the
+      moment the implementation lands — blocking the release PR's CI.
+      The implementation-author is uniquely positioned to grep for the
+      paired deferral test and delete it in the same commit. Adds the
+      DO/DO NOT pattern, BLOCKED rationalizations, and evidence from
+      the 2026-04-20 kailash-ml 0.13.0 release where
+      test_km_track_deferral_names_phase blocked 5 matrix jobs until
+      a follow-up commit removed it.
+    classification_suggestion: global
+    rationale: |
+      Cross-SDK applicable: Rust has the same pattern via
+      `todo!()` / `unimplemented!()` macros that scaffold-era tests
+      may assert-on with `should_panic`. The mirror-of-§4 framing
+      makes the rule symmetric: both api-removal and api-implementation
+      require a paired-test sweep in the same commit.
+    evidence:
+      session: "2026-04-20"
+      finding: |
+        kailash-ml 0.13.0 (PR #552, merge commit 767c9103) bundled
+        three spec-compliance closures (#546 ONNX matrix, #547
+        km.doctor, #548 km.track Phase 6). The km.track Phase 6
+        implementation replaced
+        `src/kailash_ml/__init__.py::track() -> raise NotImplementedError`
+        with a real async context manager. The scaffold test at
+        `packages/kailash-ml/tests/unit/test_mlengine_construction.py
+        ::TestMLEngineDeferredBodies::test_km_track_deferral_names_phase`
+        continued to call `track()` inside
+        `pytest.raises(NotImplementedError)`. CI surfaced this as
+        "DID NOT RAISE <class 'NotImplementedError'>" failing
+        across Base (Python 3.10/3.11/3.12/3.13/3.14) — 5 matrix jobs
+        red simultaneously. Fix: release/kailash-ml-0.13.0 commit
+        `ef8751c5` deleted the deferral test.
+      remediation: |
+        Implementation-author grep at implementation time:
+        `grep -rln 'NotImplementedError.*<symbol>\|<symbol>.*deferral' tests/`
+        costs ~1 second; catches the orphan before CI even starts.
 
-  Also logged: 5 post-release followups (11 HIGH findings from the
-  same /redteam session that require dedicated implementation
-  sessions, grouped into logical work units).
+  - id: agents-parallel-worktree-package-ownership
+    type: rule
+    severity: MEDIUM
+    target: rules/agents.md
+    section: "§: MUST Parallel-Worktree Package Ownership Coordination"
+    summary: |
+      When launching parallel worktree agents that touch the SAME
+      sub-package, the orchestrator MUST designate ONE agent as
+      version-owner (pyproject.toml + __init__.py::__version__ +
+      CHANGELOG) and tell every sibling agent explicitly NOT to edit
+      those files. Without the exclusion clause, agents race on the
+      same version bump and CHANGELOG header; the merge picks one
+      side and silently discards the other agent's CHANGELOG prose.
+      Adds DO/DO NOT with verbatim prompt fragments, BLOCKED
+      rationalizations, and the 2026-04-20 three-agent-parallel
+      success case as positive evidence.
+    classification_suggestion: global
+    rationale: |
+      Cross-SDK applicable: Rust has the same pattern with
+      `Cargo.toml [package] version` and per-crate CHANGELOG files.
+      The ownership contract is a multi-agent coordination primitive
+      independent of the build system — applies to any parallel
+      worktree setup where N agents produce commits into a single
+      release surface.
+    evidence:
+      session: "2026-04-20"
+      finding: |
+        Three parallel worktree agents resolved issues #546
+        (ONNX matrix), #547+#548 (km.doctor + km.track), and #550
+        (quote_identifier) in one session. kailash-ml 0.13.0 release:
+        Agent 1 was explicitly designated version-owner for
+        packages/kailash-ml/pyproject.toml +
+        __init__.py::__version__ + CHANGELOG.md. Agent 2's prompt
+        included the verbatim exclusion: "COORDINATION NOTE: A
+        parallel agent is resolving #546 (ONNX bridge matrix) in
+        another worktree and will ALSO bump version to 0.13.0 +
+        write CHANGELOG. To avoid merge conflicts, you (this agent)
+        MUST NOT edit packages/kailash-ml/pyproject.toml,
+        packages/kailash-ml/src/kailash_ml/__init__.py::__version__,
+        or packages/kailash-ml/CHANGELOG.md." Agent 3 worked on a
+        different package (core kailash/, 2.8.10). Result: merge
+        integration was mechanical — one CHANGELOG conflict on the
+        root file (trivial resolution), zero conflicts on package
+        pyproject.toml or package CHANGELOG. Integration step added
+        km-doctor console script + expanded CHANGELOG (which Agent 1
+        correctly seeded with ONNX entries only) to cover all three
+        issues.
+      counterfactual: |
+        Without the exclusion clause, Agent 2 would have independently
+        bumped 0.12.1 → 0.13.0 and written its own top-level
+        `## [0.13.0]` CHANGELOG entry. At merge time git would have
+        picked one agent's version field (arbitrary) and one agent's
+        CHANGELOG header (arbitrary), silently dropping the other's
+        prose. The cost of the exclusion clause is one sentence per
+        sibling prompt; the cost of the collision is manual CHANGELOG
+        reconciliation + risk of dropped coverage notes.
+
+  release_completion_update: |
+    All 5 post-release followups logged in the initial proposal
+    (ml-phase-6-implementation, ml-onnx-bridge-matrix-completion,
+    ml-km-doctor-console-script, kailash-trust-orphan-disposition,
+    dialect-quote-identifier-core-drift) are now COMPLETE as of
+    session 2026-04-20 (same day as the /redteam sweep that surfaced
+    them). Merged PRs: #551 (kailash-trust delete), #552
+    (kailash-ml 0.13.0 bundling #546+#547+#548), #553 (kailash 2.8.10
+    for #550). Published tags: v2.8.10, ml-v0.13.0. PyPI yank of
+    kailash-trust==0.1.1 completed by human maintainer.
+    These items can be marked done in loom's Gate-1 review.
+
+summary_note: |
+  5 rule additions + 5 completed implementation followups. Rule
+  additions: rules/testing.md (pytest plugin+marker pair),
+  rules/orphan-detection.md (§5a collect-only per-package AND §4a
+  stub-implementation sweeps deferral tests), rules/specs-authority.md
+  (full sweep on edit), rules/agents.md (parallel-worktree package
+  ownership). All 5 follow rule-authoring.md meta-rule
+  (Loud/Linguistic/Layered). Classification_suggestion: global for
+  all 5. Cross-SDK applicable in mechanism; Python-specific evidence
+  but the underlying patterns apply to Rust equivalents
+  (cargo features, per-crate CHANGELOG, todo!() scaffolds).
+
+  Implementation followups (all now COMPLETE): km.track Phase 6,
+  ONNX bridge matrix, km.doctor + km-doctor console script,
+  kailash-trust package deletion + PyPI yank, core quote_identifier
+  port. See release_completion_update for merge commits and tags.
+
+  Pre-existing: orphan-detection.md and agents.md now exceed the
+  200-line cap in rule-authoring.md MUST Rule (orphan-detection: 240,
+  agents: 288). Session 2026-04-20 notes already flagged this; future
+  codify cycle should extract reference material from both files into
+  guides or skills. Not blocking this proposal.

--- a/.claude/rules/agents.md
+++ b/.claude/rules/agents.md
@@ -217,6 +217,50 @@ result = Agent(prompt="Write src/feature.py with ...")
 
 **Why:** Session 2026-04-19 logged 2 occurrences (kaizen round 6, ml-specialist round 7) where an agent hit its budget mid-message and reported success with zero files on disk. The `ls` check is O(1) and converts silent no-op into loud retry. See `rules/worktree-isolation.md` MUST Rule 3 for the full protocol.
 
+## MUST: Parallel-Worktree Package Ownership Coordination
+
+When launching two or more parallel agents whose worktrees touch the SAME sub-package (same `packages/X/`), the orchestrator MUST designate ONE agent as the **version owner** for that package AND tell every other agent explicitly: "do NOT edit `packages/X/pyproject.toml`, `packages/X/src/X/__init__.py::__version__`, or `packages/X/CHANGELOG.md`". The final integration step belongs to the orchestrator, not to any agent.
+
+```python
+# DO — explicit ownership in the prompts
+Agent(  # version owner for kailash-ml
+    isolation="worktree",
+    prompt="""...resolve #546 ONNX matrix...
+    Version bump + CHANGELOG:
+    - packages/kailash-ml/pyproject.toml → 0.13.0
+    - packages/kailash-ml/src/kailash_ml/__init__.py::__version__
+    - packages/kailash-ml/CHANGELOG.md — add 0.13.0 entry""",
+)
+Agent(  # sibling, explicitly excluded from version bump
+    isolation="worktree",
+    prompt="""...resolve #547+#548 km.doctor + km.track...
+    COORDINATION NOTE: A parallel agent is bumping this package to
+    0.13.0. You MUST NOT edit packages/kailash-ml/pyproject.toml,
+    packages/kailash-ml/src/kailash_ml/__init__.py::__version__, or
+    packages/kailash-ml/CHANGELOG.md. Just deliver the functionality.""",
+)
+
+# DO NOT — silent parallel ownership, both agents touch pyproject.toml
+Agent(isolation="worktree", prompt="...resolve #546... bump to 0.13.0")
+Agent(isolation="worktree", prompt="...resolve #547+#548... bump to 0.13.0")
+# ↑ Both agents race to write the same pyproject.toml version field and
+#   the same CHANGELOG header; the merge-step hits a version conflict
+#   that the orchestrator resolves by picking one side — abandoning the
+#   other agent's CHANGELOG prose.
+```
+
+**BLOCKED rationalizations:**
+
+- "Both agents are smart enough to see the existing version"
+- "We'll resolve the conflict at merge time"
+- "The CHANGELOG entries are for different issues, they'll concat cleanly"
+- "Git's three-way merge handles this"
+- "Each agent owns a section of the CHANGELOG"
+
+**Why:** Parallel worktree agents see the same base SHA; each independently bumps `version = "0.12.1"` → `version = "0.13.0"` and writes a top-level `## [0.13.0]` CHANGELOG entry. At merge time git sees two "newest" versions of the same line and the orchestrator picks one — discarding the other agent's changelog prose silently. The integration-step post-hoc stitching is O(manual-labor); pre-declared ownership is O(one-line-in-prompt). Evidence: Session 2026-04-20 — three parallel worktree agents resolved #546/#547+#548/#550 cleanly because Agent 1 owned kailash-ml pyproject.toml, Agent 2 was explicitly excluded from it (delivered only code + tests), and Agent 3 owned core kailash/ (different package, no overlap). Without the exclusion clause, Agents 1 and 2 would have raced on `packages/kailash-ml/pyproject.toml` and `CHANGELOG.md`.
+
+Origin: Session 2026-04-20 kailash-ml 0.13.0 + kailash 2.8.10 parallel-release cycle (PRs #552, #553). Coordination worked because Agent 2's prompt included the exclusion clause verbatim.
+
 ## MUST NOT
 
 - Framework work without specialist

--- a/.claude/rules/orphan-detection.md
+++ b/.claude/rules/orphan-detection.md
@@ -95,6 +95,37 @@ Any PR that removes a public symbol (module, class, function, attribute) MUST de
 
 **Why:** Test files that fail at collection block the ENTIRE suite from running, not just themselves. One orphan test import takes down the 100 tests collected after it. Evidence: kailash-py commits `d3e7e0ef` + `5edc941f` deleted 9 orphan test files left behind by the DataFlow 2.0 refactor (`53dab715`) — integration collection had been failing since that refactor landed, but nobody noticed because the collection error was buried in the middle of a log.
 
+### 4a. Stub Implementation MUST Sweep Deferral Tests In Same Commit
+
+The mirror of Rule 4. Any PR that _implements_ a previously-deferred stub — replacing `NotImplementedError` / `raise NotImplementedError("Phase N — will implement")` / empty-body placeholder with a real implementation — MUST delete or rewrite every test that asserts the deferred behavior in the same commit. Scaffold-era tests like `test_foo_deferral_names_phase` that `pytest.raises(NotImplementedError)` on the now-implemented symbol flip from pass to fail the moment the implementation lands, and block the implementation's release CI.
+
+```python
+# DO — implementation + deferral-test sweep in one commit
+# git show <sha>:
+# M  src/pkg/tracking.py  (replaces NotImplementedError with real impl)
+# D  tests/unit/test_pkg_deferred_bodies.py::test_track_deferral_names_phase
+# A  tests/integration/test_pkg_tracking.py  (real coverage)
+
+# DO NOT — implement the symbol, leave the deferral test
+# git show <sha>:
+# M  src/pkg/tracking.py  (replaces NotImplementedError)
+# (tests/unit/test_pkg_deferred_bodies.py::test_track_deferral_names_phase
+#  still calls pkg.tracking.track() inside pytest.raises(NotImplementedError);
+#  CI fails with "DID NOT RAISE NotImplementedError" on every Python matrix job)
+```
+
+**BLOCKED rationalizations:**
+
+- "The deferral test was a scaffold; CI will surface it and we'll fix it then"
+- "The new test covers it; the old one is obviously obsolete"
+- "I'll clean up the scaffold tests in a follow-up"
+- "The deferral test is in a different file, out of scope"
+- "The Phase N naming means the test self-documents as obsolete"
+
+**Why:** CI-late discovery of the orphan deferral test blocks the release PR's matrix run, forcing an extra commit and an extra CI cycle at the worst possible moment (release gate). The implementation-author is uniquely positioned to spot the paired deferral test — they know exactly which symbol they un-deferred. A simple `grep -rln 'NotImplementedError.*<symbol>\|<symbol>.*deferral' tests/` at implementation time catches it in O(seconds); a CI re-run costs O(minutes) plus an extra reviewer cycle. Evidence: Session 2026-04-20 — kailash-ml 0.13.0 release (PR #552) landed real `km.track()` implementation (#548); `tests/unit/test_mlengine_construction.py::test_km_track_deferral_names_phase` was left behind and blocked CI on every Python 3.10/3.11/3.12/3.13/3.14 base job until the deferral test was deleted in a follow-up commit on the release branch.
+
+Origin: Session 2026-04-20 — kailash-ml 0.13.0 release CI surfaced the deferral-test orphan as a 5-job CI failure; fixed in release/kailash-ml-0.13.0 commit `ef8751c5`.
+
 ### 5. Collect-Only Is A Merge Gate
 
 `pytest --collect-only` across every test directory MUST return exit 0 before any PR merges. A collection error is a blocker in the same class as a test failure, regardless of which test file contains the error.

--- a/workspaces/kailash-ml-gpu-stack/journal/0010-DECISION-codify-release-cycle-2026-04-20.md
+++ b/workspaces/kailash-ml-gpu-stack/journal/0010-DECISION-codify-release-cycle-2026-04-20.md
@@ -1,0 +1,60 @@
+---
+type: DECISION
+status: final
+created: 2026-04-20
+session_id: clean-release-2026-04-20
+---
+
+# /codify — 2 rule additions from clean-release cycle 2026-04-20
+
+## Context
+
+Session resolved all 5 outstanding GH issues surfaced by the earlier `/redteam` sweep (2026-04-20 morning) in a single autonomous cycle:
+
+- **#546** — ONNX bridge matrix completion (torch/lightning/catboost) → kailash-ml 0.13.0
+- **#547** — `km.doctor()` + `km-doctor` console script → kailash-ml 0.13.0
+- **#548** — `km.track()` Phase 6 (NotImplementedError → async context manager) → kailash-ml 0.13.0
+- **#549** — `kailash-trust` package delete + PyPI yank
+- **#550** — `quote_identifier` port from DataFlow into core → kailash 2.8.10
+
+Four merged PRs (#551, #552, #553), two published tags (v2.8.10, ml-v0.13.0), one PyPI yank.
+
+## Decision
+
+Append two rule additions to `.claude/.proposals/latest.yaml` for loom Gate-1 review:
+
+1. **`rules/orphan-detection.md` §4a** — Stub Implementation MUST Sweep Deferral Tests In Same Commit. Mirror of existing §4 (API removal sweeps tests). The implementation-author grep (`grep -rln 'NotImplementedError.*<symbol>' tests/`) costs ~1s and catches the orphan before CI starts.
+
+2. **`rules/agents.md` §: MUST Parallel-Worktree Package Ownership Coordination** — when N parallel worktree agents touch the same sub-package, ONE is designated version-owner; sibling prompts include a verbatim exclusion clause for `pyproject.toml` / `__init__.py::__version__` / `CHANGELOG.md`. Prevents merge-time version-race with silent CHANGELOG drop.
+
+Also updated the proposal's existing 5 implementation followups (km.track Phase 6, ONNX matrix, km.doctor, kailash-trust orphan, dialect quote_identifier) to `COMPLETE` via a `release_completion_update` block. loom Gate-1 reviewer can mark them done.
+
+## Evidence
+
+### Rule 1 (orphan-detection §4a) — recovered failure
+
+kailash-ml 0.13.0 release PR #552 bundled #546+#547+#548. Agent 2 implemented `km.track()` replacing the `NotImplementedError` stub. CI surfaced the paired deferral test `test_km_track_deferral_names_phase` as failing across Base (Python 3.10/3.11/3.12/3.13/3.14) — 5 matrix jobs red simultaneously. Fix: delete the deferral test (`release/kailash-ml-0.13.0` commit `ef8751c5`). Cost: one extra CI cycle + one follow-up commit at release gate.
+
+### Rule 2 (agents parallel-worktree ownership) — positive evidence
+
+Three parallel agents launched with worktree isolation. Agent 1 designated version-owner for kailash-ml pyproject.toml + CHANGELOG. Agent 2's prompt included the verbatim exclusion: _"COORDINATION NOTE: A parallel agent is resolving #546 (ONNX bridge matrix) in another worktree and will ALSO bump version to 0.13.0 + write CHANGELOG. To avoid merge conflicts, you (this agent) MUST NOT edit packages/kailash-ml/pyproject.toml, packages/kailash-ml/src/kailash_ml/**init**.py::**version**, or packages/kailash-ml/CHANGELOG.md."_ Agent 3 worked on a different package (core kailash/ 2.8.10). Integration step: one trivial CHANGELOG.md root-file conflict, zero conflicts on package pyproject.toml. Without the exclusion clause, Agents 1 and 2 would have independently written `## [0.13.0]` headers and racey `version = "0.13.0"` fields.
+
+## Cross-SDK applicability
+
+Both rules apply to Rust (kailash-rs) with minor mechanism differences:
+
+- **Rule 1 (§4a mirror)**: Rust `todo!()` / `unimplemented!()` macros are the scaffold-equivalent of `NotImplementedError`. Scaffold tests may `should_panic` on the un-implemented path; implementation-author must sweep them in the same commit.
+- **Rule 2 (parallel ownership)**: Rust `Cargo.toml [package] version` and per-crate CHANGELOG files exhibit the same race. The ownership contract is build-system-independent.
+
+Classification_suggestion: `global` for both.
+
+## Also logged
+
+- Pre-existing rule-file size overflow: `rules/orphan-detection.md` (240 lines) and `rules/agents.md` (288 lines) both exceed the 200-line cap in `rules/rule-authoring.md` MUST Rule. Session 2026-04-20 morning notes already flagged this for future extraction into guides/skills. Not blocking this proposal.
+- `/wrapup` deferred to end of session.
+
+## Artifacts
+
+- Commits applied: none yet (rule files modified locally; commit pending).
+- Proposal: `.claude/.proposals/latest.yaml` — appended 2 new `changes:` entries + `release_completion_update` block + updated `summary_note`.
+- Next session handoff: loom Gate-1 reviews the 5 rule additions (3 from morning + 2 from this session) and the `release_completion_update` marker.


### PR DESCRIPTION
## Summary
- Append 2 rule additions to \`.claude/.proposals/latest.yaml\` for loom Gate-1 review
- Update proposal to mark 5 morning /redteam implementation followups COMPLETE
- Journal: 0010-DECISION-codify-release-cycle-2026-04-20.md

## Rule additions
1. **\`rules/orphan-detection.md\` §4a** — Stub Implementation MUST Sweep Deferral Tests In Same Commit. Mirror of §4. Evidence from PR #552 km.track deferral-test CI failure.
2. **\`rules/agents.md\`** — MUST Parallel-Worktree Package Ownership Coordination. Positive evidence from this session's 3-agent parallel release.

## Test plan
- [x] Pre-commit hooks pass when invoked directly
- [x] rule-authoring.md Loud/Linguistic/Layered test: MUST/MUST NOT, DO/DO NOT, BLOCKED phrases, Why, Origin present in both
- [x] Proposal append preserves all 8 prior entries (per rules/artifact-flow.md)

## Related
Closes no issues (codification only). Feeds loom Gate-1 for distribution to kailash-coc-claude-py template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)