### PR TITLE
feat(ml): kailash-ml 0.14.0 — km.doctor + km.track spec completion

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,37 @@
 # kailash-ml Changelog
 
+## [0.14.0] - 2026-04-20 — km.doctor + km.track spec completion (ml-backends.md §7, ml-tracking.md §2.4)
+
+Closes the two HIGH findings from the 2026-04-20 /redteam audit: km.doctor shipped 4 of 14 spec items (§7) and km.track persisted 10 of 17 auto-capture fields (§2.4). Both surfaces now ship the full spec-mandated coverage.
+
+### Added — `km.doctor` full §7.1 diagnostic surface (closes #547 follow-up)
+
+- **XPU + TPU probes** — `km.doctor()` now probes all six first-class backends per `specs/ml-backends.md` §1 (adds `xpu` via native `torch.xpu` at torch ≥ 2.5, and `tpu` via `torch_xla`). Status `"missing"` on non-Intel / non-TPU hosts.
+- **`precision_matrix`** — per-backend auto-selected precision via `kailash_ml._device.detect_backend` + `resolve_precision`. Matches the concrete precision strings the training pipeline would pass to `L.Trainer(precision=...)`.
+- **`extras`** — installed status for `[cuda]`, `[rocm]`, `[xpu]`, `[tpu]`, `[dl]`, `[agents]`, `[explain]`, `[imbalance]` with per-module version probing so "why is this extra missing?" is answerable without shelling out to pip.
+- **`family_probes`** — `torch`, `lightning`, `sklearn`, `xgboost`, `lightgbm`, `catboost`, `onnxruntime`, `onnxruntime-gpu` each report installed version or `"not installed"`. `onnxruntime-gpu` uses `importlib.metadata.version` so it distinguishes CPU vs GPU wheel.
+- **`onnx_eps`** — enumerates `onnxruntime.get_available_providers()` (CoreML / CUDA / CPU / Azure EPs) when onnxruntime is importable.
+- **`sqlite_path`** — default `~/.kailash_ml/ml.db` (or `KAILASH_ML_STORE` override) with writability probe via a throwaway `.km-doctor-probe.sqlite` file; never touches a live ml.db.
+- **`cache_paths`** — data_root + cache directories with recursive byte size AND filesystem total/free via `shutil.disk_usage`.
+- **`tenant_mode`** — single-tenant vs multi-tenant, derived from `KAILASH_ML_DEFAULT_TENANT` (primary) with `KAILASH_TENANT_ID` fallback.
+- **`gotchas`** — `specs/ml-backends.md` §1.1 entries surfaced per detected `status=ok` backend so operators see backend-specific caveats (MPS CPU fallback, XLA 30s compile pause, CUDA_VISIBLE_DEVICES hint, etc.).
+- **`selected_default`** — the backend `detect_backend(None)` would return, derived from priority walk over ok-status probes.
+- **14 additional Tier 2 tests** at `tests/integration/test_km_doctor.py` verifying every new JSON section has the spec-required shape.
+
+### Added — `km.track` auto-capture completes §2.4 17-field envelope (closes #548 follow-up)
+
+- **7 new persisted columns** added to `experiment_runs`: `kailash_ml_version`, `lightning_version`, `torch_version`, `cuda_version`, `device_used`, `accelerator`, `precision`. Every `km.track()` run now persists the full reproducibility envelope `specs/ml-tracking.md` §2.4 mandates.
+- **`_capture_versions()` helper** — probes `kailash_ml.__version__` (always), `torch.__version__` + `torch.version.cuda` (when importable), `lightning.__version__` (when importable). Each probe is wrapped separately so a partial stack still yields as many fields as possible.
+- **`ExperimentRun.attach_training_result`** extended to mirror `TrainingResult.device_used` / `.accelerator` / `.precision` (top-level reproducibility fields) in addition to the existing `device.*` `DeviceReport` envelope. Never stores `"auto"` — fields pass through as concrete strings.
+- **Additive schema migration** — `initialize()` now probes `PRAGMA table_info(experiment_runs)` and runs `ALTER TABLE ADD COLUMN` for each 0.14 column missing from pre-0.14 databases. Existing `~/.kailash_ml/ml.db` files keep working; historical rows carry SQL `NULL` for the new fields.
+- **2 new Tier 2 tests** at `tests/integration/test_km_track.py`:
+  - `test_km_track_all_17_auto_capture_fields_present` — mechanical whitelist check that every §2.4 field is a persisted column.
+  - Extended trainable-integration test to assert `row["device_used"] == result.device_used`, `row["accelerator"] == result.accelerator`, `row["precision"] == result.precision` with the explicit "never `auto`" guard.
+
+### Fixed
+
+- **Partial-implementation orphans** — both km.doctor (`10/14` checks) and km.track (`10/17` fields) shipped as partial MVPs in 0.13.0. 0.14.0 closes each to the full spec-mandated surface; no deferred sub-items remain.
+
 ## [0.13.0] - 2026-04-20 — ONNX bridge matrix completion + km.track + km.doctor
 
 Three spec-compliance issues resolved in one minor release: #546 (ONNX matrix), #547 (km.doctor), #548 (km.track Phase 6).

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.13.0"
+version = "0.14.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/packages/kailash-ml/src/kailash_ml/doctor.py
+++ b/packages/kailash-ml/src/kailash_ml/doctor.py
@@ -8,11 +8,12 @@ Public surface:
 - :func:`main` — console-script entry point (``km-doctor``), parses argv
   and calls ``doctor`` with the effective flags.
 
-Probes the four first-class backends (``cpu``, ``cuda``, ``mps``,
-``rocm``) by attempting a torch-level availability check. Extension
-backends (``xpu``, ``tpu``) are handled in §7.1 of the spec but left
-out of the ``--require`` short-list for Phase 1 — they show up in the
-human-readable table when detected but are not required for exit 0.
+Probes all six first-class backends (``cpu``, ``cuda``, ``mps``,
+``rocm``, ``xpu``, ``tpu``) via the centralised ``_device.py``
+resolver where available, and reports per-backend precision
+auto-selection, installed extras, family module versions, ONNX
+runtime execution providers, default SQLite path + writability,
+cache directory + size, tenant mode, and the §1.1 gotchas list.
 
 Exit codes (spec §7.2):
 
@@ -25,9 +26,16 @@ Exit codes (spec §7.2):
 from __future__ import annotations
 
 import argparse
+import importlib
+import importlib.metadata
 import json
+import os
+import shutil
+import sqlite3
 import sys
+import tempfile
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Optional
 
 __all__ = ["doctor", "main"]
@@ -201,14 +209,444 @@ def _probe_rocm() -> BackendProbe:
         )
 
 
+def _probe_xpu() -> BackendProbe:
+    """Intel XPU probe — native ``torch.xpu`` (torch ≥ 2.5)."""
+    torch = _probe_torch_module()
+    if torch is None:
+        return BackendProbe(
+            backend="xpu",
+            status="missing",
+            failures=["torch not installed"],
+        )
+    try:
+        xpu = getattr(torch, "xpu", None)
+        if xpu is None:
+            return BackendProbe(
+                backend="xpu",
+                status="missing",
+                version=getattr(torch, "__version__", None),
+                failures=["torch.xpu missing (requires torch>=2.5)"],
+            )
+        if not bool(xpu.is_available()):
+            return BackendProbe(
+                backend="xpu",
+                status="missing",
+                version=getattr(torch, "__version__", None),
+                failures=["torch.xpu.is_available() == False"],
+            )
+        try:
+            count = int(xpu.device_count())
+        except Exception:  # noqa: BLE001
+            count = 0
+        return BackendProbe(
+            backend="xpu",
+            status="ok",
+            version=getattr(torch, "__version__", None),
+            devices=count,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return BackendProbe(
+            backend="xpu",
+            status="fail",
+            failures=[f"xpu probe raised {type(exc).__name__}: {exc}"],
+        )
+
+
+def _probe_tpu() -> BackendProbe:
+    """Google TPU probe — requires ``torch_xla`` from the ``[tpu]`` extra."""
+    try:
+        xm = importlib.import_module("torch_xla.core.xla_model")
+    except ImportError:
+        return BackendProbe(
+            backend="tpu",
+            status="missing",
+            failures=["torch_xla not installed (pip install kailash-ml[tpu])"],
+        )
+    except Exception as exc:  # noqa: BLE001
+        return BackendProbe(
+            backend="tpu",
+            status="fail",
+            failures=[f"torch_xla import raised {type(exc).__name__}: {exc}"],
+        )
+    try:
+        devices = xm.get_xla_supported_devices() or []
+        if not devices:
+            return BackendProbe(
+                backend="tpu",
+                status="missing",
+                failures=["xm.get_xla_supported_devices() returned empty"],
+            )
+        version = None
+        try:
+            version = importlib.metadata.version("torch_xla")
+        except importlib.metadata.PackageNotFoundError:
+            pass
+        return BackendProbe(
+            backend="tpu",
+            status="ok",
+            version=version,
+            devices=len(devices),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return BackendProbe(
+            backend="tpu",
+            status="fail",
+            failures=[f"tpu probe raised {type(exc).__name__}: {exc}"],
+        )
+
+
 _PROBES: dict[str, Any] = {
     "cpu": _probe_cpu,
     "cuda": _probe_cuda,
     "mps": _probe_mps,
     "rocm": _probe_rocm,
+    "xpu": _probe_xpu,
+    "tpu": _probe_tpu,
 }
 
-_BACKEND_ORDER: tuple[str, ...] = ("cpu", "cuda", "mps", "rocm")
+_BACKEND_ORDER: tuple[str, ...] = ("cpu", "cuda", "mps", "rocm", "xpu", "tpu")
+
+
+# ---------------------------------------------------------------------------
+# Precision auto-selection per backend (spec §3.2)
+# ---------------------------------------------------------------------------
+
+
+def _precision_for_backend(probe: BackendProbe) -> Optional[str]:
+    """Return the auto-selected precision for a detected backend.
+
+    Uses :mod:`kailash_ml._device` when the backend probed ``ok`` so we
+    match the exact values produced at training time. For non-ok
+    probes, return ``None`` so the report does not claim a precision
+    for a backend the system cannot execute.
+    """
+    if probe.status != "ok":
+        return None
+    # Reuse the centralised resolver when possible — keeps the doctor
+    # output identical to what TrainingPipeline / InferenceServer would
+    # report at runtime.
+    try:
+        from kailash_ml._device import (
+            detect_backend,
+            resolve_precision,
+        )  # noqa: PLC0415
+
+        info = detect_backend(prefer=probe.backend)
+        return resolve_precision(info, requested="auto")
+    except Exception:  # noqa: BLE001
+        # Fallback to the spec §3.2 defaults — conservative matches for
+        # hosts where detect_backend can't resolve (e.g. probe says xpu
+        # is present but _device.py returns BackendUnavailable).
+        defaults = {
+            "cpu": "32-true",
+            "cuda": "bf16-mixed",
+            "mps": "16-mixed",
+            "rocm": "16-mixed",
+            "xpu": "bf16-mixed",
+            "tpu": "bf16-true",
+        }
+        return defaults.get(probe.backend)
+
+
+# ---------------------------------------------------------------------------
+# Installed extras enumeration (spec §7.1 "Installed extras")
+# ---------------------------------------------------------------------------
+
+
+# Maps ``[extra]`` name -> "probe module import path". Each entry's
+# presence is derived by attempting ``importlib.import_module`` on the
+# probe — an install is considered present iff the probe imports.
+_EXTRA_PROBES: dict[str, tuple[str, ...]] = {
+    # Hardware backends
+    "cuda": ("torch",),
+    "rocm": ("torch",),
+    "xpu": ("intel_extension_for_pytorch",),
+    "tpu": ("torch_xla",),
+    # Framework feature extras
+    "dl": ("torch", "lightning", "transformers"),
+    "agents": ("kaizen",),
+    "explain": ("shap",),
+    "imbalance": ("imblearn",),
+}
+
+
+def _probe_extras() -> dict[str, dict[str, Any]]:
+    """Return a structured report of which ``[extras]`` are installed.
+
+    Each value is ``{"installed": bool, "modules": {module: version?}}``
+    so the JSON output surfaces WHICH modules were checked (answering
+    "why is this extra missing?" without shelling out to pip).
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for extra, modules in _EXTRA_PROBES.items():
+        module_report: dict[str, Optional[str]] = {}
+        all_present = True
+        for module_name in modules:
+            try:
+                mod = importlib.import_module(module_name)
+                module_report[module_name] = getattr(mod, "__version__", None)
+            except ImportError:
+                module_report[module_name] = None
+                all_present = False
+            except Exception as exc:  # noqa: BLE001
+                module_report[module_name] = f"probe_failed: {type(exc).__name__}"
+                all_present = False
+        out[extra] = {
+            "installed": all_present,
+            "modules": module_report,
+        }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Family probes (spec §7.1 "Family probes")
+# ---------------------------------------------------------------------------
+
+
+_FAMILY_PROBES: tuple[tuple[str, str], ...] = (
+    ("torch", "torch"),
+    ("lightning", "lightning"),
+    ("sklearn", "sklearn"),
+    ("xgboost", "xgboost"),
+    ("lightgbm", "lightgbm"),
+    ("catboost", "catboost"),
+    ("onnxruntime", "onnxruntime"),
+    # onnxruntime-gpu is installed as the package name ``onnxruntime-gpu``
+    # but imports as ``onnxruntime``. We probe via importlib.metadata so
+    # the report can distinguish the CPU vs GPU wheel.
+    ("onnxruntime-gpu", "__metadata__:onnxruntime-gpu"),
+)
+
+
+def _probe_families() -> dict[str, Optional[str]]:
+    """Return ``{family: version_or_None_if_missing}``."""
+    out: dict[str, Optional[str]] = {}
+    for label, target in _FAMILY_PROBES:
+        if target.startswith("__metadata__:"):
+            pkg_name = target.removeprefix("__metadata__:")
+            try:
+                out[label] = importlib.metadata.version(pkg_name)
+            except importlib.metadata.PackageNotFoundError:
+                out[label] = None
+            continue
+        try:
+            mod = importlib.import_module(target)
+            out[label] = getattr(mod, "__version__", None)
+        except ImportError:
+            out[label] = None
+        except Exception as exc:  # noqa: BLE001
+            out[label] = f"probe_failed: {type(exc).__name__}"
+    return out
+
+
+# ---------------------------------------------------------------------------
+# ONNX execution providers (spec §7.1 "ONNX runtime availability")
+# ---------------------------------------------------------------------------
+
+
+def _probe_onnx_eps() -> dict[str, Any]:
+    """Enumerate onnxruntime execution providers when available."""
+    try:
+        import onnxruntime as ort  # noqa: PLC0415
+    except ImportError:
+        return {"installed": False, "providers": [], "version": None}
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "installed": False,
+            "providers": [],
+            "version": None,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    version = getattr(ort, "__version__", None)
+    try:
+        providers = list(ort.get_available_providers())
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "installed": True,
+            "version": version,
+            "providers": [],
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    return {"installed": True, "version": version, "providers": providers}
+
+
+# ---------------------------------------------------------------------------
+# SQLite path / cache / tenant helpers (spec §7.1)
+# ---------------------------------------------------------------------------
+
+
+def _default_sqlite_path() -> Path:
+    """Return the configured or default kailash-ml SQLite path.
+
+    Honours ``KAILASH_ML_STORE`` env var when set (paths starting with
+    ``sqlite:///`` have that prefix stripped). Defaults to
+    ``~/.kailash_ml/ml.db`` per spec §7.1.
+    """
+    configured = os.environ.get("KAILASH_ML_STORE")
+    if configured:
+        if configured.startswith("sqlite:///"):
+            return Path(configured[len("sqlite:///") :])
+        return Path(configured)
+    return Path.home() / ".kailash_ml" / "ml.db"
+
+
+def _probe_sqlite_path() -> dict[str, Any]:
+    """Probe the default/configured SQLite path for writability.
+
+    Creates the parent directory if missing and opens a temporary
+    connection to verify the process can actually write. Returns a
+    structured report; does NOT touch the production ml.db.
+    """
+    path = _default_sqlite_path()
+    source = "KAILASH_ML_STORE" if os.environ.get("KAILASH_ML_STORE") else "default"
+    out: dict[str, Any] = {
+        "path": str(path),
+        "source": source,
+        "writable": False,
+        "exists": path.exists(),
+        "error": None,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Probe in a separate file so we never touch the production
+        # ml.db (which could be locked by a live run).
+        probe_path = path.parent / ".km-doctor-probe.sqlite"
+        try:
+            conn = sqlite3.connect(str(probe_path))
+            conn.execute("CREATE TABLE IF NOT EXISTS probe (id INTEGER PRIMARY KEY)")
+            conn.close()
+            probe_path.unlink(missing_ok=True)
+            out["writable"] = True
+        except Exception as exc:  # noqa: BLE001
+            out["error"] = f"{type(exc).__name__}: {exc}"
+        finally:
+            if probe_path.exists():
+                try:
+                    probe_path.unlink()
+                except OSError:
+                    pass
+    except Exception as exc:  # noqa: BLE001
+        out["error"] = f"{type(exc).__name__}: {exc}"
+    return out
+
+
+def _probe_cache_paths() -> dict[str, Any]:
+    """Probe the kailash-ml cache directories with current disk usage.
+
+    Reports both ``~/.kailash_ml`` (the data root) and the artifact
+    cache (``~/.kailash_ml/cache``) when present. Sizes use
+    ``shutil.disk_usage`` for the filesystem and a recursive walk for
+    the kailash-ml-owned portion.
+    """
+    root = Path.home() / ".kailash_ml"
+    cache = root / "cache"
+    try:
+        fs_usage = shutil.disk_usage(str(root.parent if not root.exists() else root))
+        fs_total = int(fs_usage.total)
+        fs_free = int(fs_usage.free)
+    except Exception as exc:  # noqa: BLE001
+        fs_total = 0
+        fs_free = 0
+        fs_err: Optional[str] = f"{type(exc).__name__}: {exc}"
+    else:
+        fs_err = None
+
+    def _walk_size(p: Path) -> int:
+        if not p.exists():
+            return 0
+        total = 0
+        for sub in p.rglob("*"):
+            if sub.is_file():
+                try:
+                    total += sub.stat().st_size
+                except OSError:
+                    continue
+        return total
+
+    return {
+        "data_root": {
+            "path": str(root),
+            "exists": root.exists(),
+            "size_bytes": _walk_size(root),
+        },
+        "cache": {
+            "path": str(cache),
+            "exists": cache.exists(),
+            "size_bytes": _walk_size(cache),
+        },
+        "filesystem": {
+            "total_bytes": fs_total,
+            "free_bytes": fs_free,
+            "error": fs_err,
+        },
+    }
+
+
+def _probe_tenant_mode() -> dict[str, Any]:
+    """Report tenant mode derived from ``KAILASH_ML_DEFAULT_TENANT``.
+
+    Spec §7.1 "Tenant mode" — the operator-facing diagnostic answers
+    "am I running this process in multi-tenant mode?". We look at the
+    canonical env var and return a human-readable mode + the raw
+    value. ``KAILASH_TENANT_ID`` is also checked (same effect in
+    ``km.track``).
+    """
+    # ``KAILASH_ML_DEFAULT_TENANT`` is the canonical spec name. Some
+    # downstream code also honours ``KAILASH_TENANT_ID`` (tracker runner);
+    # both are checked so the doctor output covers either convention.
+    primary = os.environ.get("KAILASH_ML_DEFAULT_TENANT")
+    alt = os.environ.get("KAILASH_TENANT_ID")
+    value = primary if primary else alt
+    return {
+        "mode": "multi-tenant" if value else "single-tenant",
+        "tenant_id": value,
+        "env_var_set": (
+            "KAILASH_ML_DEFAULT_TENANT"
+            if primary
+            else ("KAILASH_TENANT_ID" if alt else None)
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# §1.1 gotchas — surfaced per detected backend
+# ---------------------------------------------------------------------------
+
+
+_GOTCHAS_BY_BACKEND: dict[str, tuple[str, ...]] = {
+    "cpu": (),
+    "cuda": (
+        "CUDA honours CUDA_VISIBLE_DEVICES='' — set this env var to disable detection.",
+    ),
+    "mps": (
+        "MPS op coverage is incomplete in torch 2.4; some ops emit UserWarning "
+        "on silent CPU fallback. Check logs for 'cpu fallback' lines.",
+        "MPS bf16 is experimental — default precision is fp16 per spec §1 footnote.",
+    ),
+    "rocm": (
+        "ROCm and CUDA share torch.cuda.is_available(); distinguished only by "
+        "torch.version.hip. Some ops are missing on ROCm < 6.0.",
+    ),
+    "xpu": (
+        "XPU requires intel-extension-for-pytorch at torch 2.x (open question "
+        "whether torch ≥ 2.5 native XPU suffices).",
+    ),
+    "tpu": (
+        "XLA compiles lazily — the first training step pauses ~30s while the "
+        "graph is compiled. Not a hang.",
+    ),
+}
+
+
+def _probe_gotchas(probes: list[BackendProbe]) -> list[dict[str, Any]]:
+    """Return the §1.1 gotchas for every detected (status=ok) backend."""
+    out: list[dict[str, Any]] = []
+    for probe in probes:
+        if probe.status != "ok":
+            continue
+        for message in _GOTCHAS_BY_BACKEND.get(probe.backend, ()):
+            out.append({"backend": probe.backend, "hint": message})
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -275,44 +713,166 @@ def doctor(
         elif match.status != "ok":
             exit_code = 2
 
+    # Selected default — the backend that detect_backend(None) would
+    # return. Probe each in priority order; first ok wins. Matches
+    # _device.py priority per spec §2.2.
+    selected_default: Optional[str] = None
+    for name in ("cuda", "mps", "rocm", "xpu", "tpu", "cpu"):
+        p = next((q for q in probes if q.backend == name), None)
+        if p is not None and p.status == "ok":
+            selected_default = name
+            break
+
+    # Per-backend precision auto-selection (spec §3.2).
+    precision_matrix: dict[str, Optional[str]] = {
+        p.backend: _precision_for_backend(p)
+        for p in probes
+        if p.backend in _BACKEND_ORDER
+    }
+
+    extras = _probe_extras()
+    family_probes = _probe_families()
+    onnx_eps = _probe_onnx_eps()
+    sqlite_report = _probe_sqlite_path()
+    cache_paths = _probe_cache_paths()
+    tenant_mode = _probe_tenant_mode()
+    gotchas = _probe_gotchas(probes)
+
     # Emit output
     if as_json:
         payload = {
             "require": require,
             "exit_code": exit_code,
             "backends": [asdict(p) for p in probes],
+            "selected_default": selected_default,
+            "precision_matrix": precision_matrix,
+            "extras": extras,
+            "family_probes": family_probes,
+            "onnx_eps": onnx_eps,
+            "sqlite_path": sqlite_report,
+            "cache_paths": cache_paths,
+            "tenant_mode": tenant_mode,
+            "gotchas": gotchas,
         }
         print(json.dumps(payload, indent=2, sort_keys=True), file=out)
     else:
-        _emit_human_readable(probes, exit_code, require, out=out)
+        _emit_human_readable(
+            probes=probes,
+            exit_code=exit_code,
+            require=require,
+            selected_default=selected_default,
+            precision_matrix=precision_matrix,
+            extras=extras,
+            family_probes=family_probes,
+            onnx_eps=onnx_eps,
+            sqlite_report=sqlite_report,
+            cache_paths=cache_paths,
+            tenant_mode=tenant_mode,
+            gotchas=gotchas,
+            out=out,
+        )
 
     return exit_code
 
 
 def _emit_human_readable(
+    *,
     probes: list[BackendProbe],
     exit_code: int,
     require: Optional[str],
-    *,
+    selected_default: Optional[str],
+    precision_matrix: dict[str, Optional[str]],
+    extras: dict[str, dict[str, Any]],
+    family_probes: dict[str, Optional[str]],
+    onnx_eps: dict[str, Any],
+    sqlite_report: dict[str, Any],
+    cache_paths: dict[str, Any],
+    tenant_mode: dict[str, Any],
+    gotchas: list[dict[str, Any]],
     out,
 ) -> None:
     """Human-readable table. Not machine-parseable; use ``--json`` for that."""
     print("kailash-ml doctor", file=out)
-    print("=" * 48, file=out)
-    header = f"{'backend':<8} {'status':<8} {'devices':>7}  version"
+    print("=" * 64, file=out)
+
+    # Backend table
+    header = f"{'backend':<8} {'status':<8} {'devices':>7}  {'precision':<12}  version"
     print(header, file=out)
-    print("-" * 48, file=out)
+    print("-" * 64, file=out)
     for p in probes:
         version = p.version or "-"
+        precision = precision_matrix.get(p.backend) or "-"
         print(
-            f"{p.backend:<8} {p.status:<8} {p.devices:>7}  {version}",
+            f"{p.backend:<8} {p.status:<8} {p.devices:>7}  {precision:<12}  {version}",
             file=out,
         )
         for w in p.warnings:
             print(f"  warn: {w}", file=out)
         for f in p.failures:
             print(f"  fail: {f}", file=out)
-    print("-" * 48, file=out)
+    print("-" * 64, file=out)
+
+    print(f"selected_default = {selected_default or '-'}", file=out)
+
+    # Installed extras
+    print("\nInstalled extras:", file=out)
+    for name, report in extras.items():
+        state = "installed" if report["installed"] else "missing"
+        print(f"  [{name}] {state}", file=out)
+
+    # Family probes
+    print("\nFamily probes (module version or 'not installed'):", file=out)
+    for fam, ver in family_probes.items():
+        display = ver if ver is not None else "not installed"
+        print(f"  {fam:<20} {display}", file=out)
+
+    # ONNX EPs
+    print("\nONNX runtime execution providers:", file=out)
+    if onnx_eps["installed"]:
+        version = onnx_eps.get("version") or "-"
+        providers = onnx_eps.get("providers") or []
+        print(f"  onnxruntime {version}", file=out)
+        for ep in providers:
+            print(f"    - {ep}", file=out)
+    else:
+        print("  onnxruntime not installed", file=out)
+
+    # SQLite path
+    print("\nDefault SQLite path:", file=out)
+    print(f"  path    = {sqlite_report['path']}", file=out)
+    print(f"  source  = {sqlite_report['source']}", file=out)
+    print(f"  exists  = {sqlite_report['exists']}", file=out)
+    print(f"  writable= {sqlite_report['writable']}", file=out)
+    if sqlite_report.get("error"):
+        print(f"  error   = {sqlite_report['error']}", file=out)
+
+    # Cache paths
+    print("\nCache paths:", file=out)
+    for label, entry in (
+        ("data_root", cache_paths["data_root"]),
+        ("cache", cache_paths["cache"]),
+    ):
+        print(
+            f"  {label:<10} {entry['path']} (exists={entry['exists']}, "
+            f"size={entry['size_bytes']} bytes)",
+            file=out,
+        )
+
+    # Tenant mode
+    print(f"\nTenant mode: {tenant_mode['mode']}", file=out)
+    if tenant_mode.get("env_var_set"):
+        print(
+            f"  {tenant_mode['env_var_set']} = {tenant_mode.get('tenant_id')}",
+            file=out,
+        )
+
+    # Gotchas
+    if gotchas:
+        print("\nKnown gotchas (spec §1.1):", file=out)
+        for entry in gotchas:
+            print(f"  [{entry['backend']}] {entry['hint']}", file=out)
+
+    print("-" * 64, file=out)
     if require:
         print(f"require = {require}", file=out)
     print(f"exit_code = {exit_code}", file=out)

--- a/packages/kailash-ml/src/kailash_ml/tracking/runner.py
+++ b/packages/kailash-ml/src/kailash_ml/tracking/runner.py
@@ -7,7 +7,13 @@ clauses for the Phase 6 tracker entry point:
 
 - §2.1 construction via ``async with km.track(...) as run:``
 - §2.2 auto-set status: RUNNING / COMPLETED / FAILED / KILLED
-- §2.4 16 mandatory auto-capture fields on run start
+- §2.4 17 mandatory auto-capture fields on run start
+
+As of kailash-ml 0.14.0 the auto-capture surface expands from 10 to
+17 fields (adding ``kailash_ml_version`` / ``lightning_version`` /
+``torch_version`` / ``cuda_version`` / ``device_used`` /
+``accelerator`` / ``precision``) so every run carries the full
+reproducibility envelope §2.4 mandates.
 
 This module is async-first and does NOT depend on the 1.x
 ``kailash_ml.engines.experiment_tracker.ExperimentTracker`` — the
@@ -16,11 +22,9 @@ older engine is preserved for back-compat; new callers use
 """
 from __future__ import annotations
 
-import asyncio
 import contextvars
 import logging
 import os
-import platform
 import signal
 import socket
 import subprocess
@@ -149,6 +153,56 @@ def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _capture_versions() -> dict[str, Optional[str]]:
+    """Return the four library/runtime versions per ``ml-tracking.md`` §2.4.
+
+    - ``kailash_ml_version`` — always ``kailash_ml.__version__`` (package is
+      imported by definition here).
+    - ``torch_version`` — ``torch.__version__`` when torch importable, else None.
+    - ``cuda_version`` — ``torch.version.cuda`` when torch importable AND CUDA
+      is reported; None otherwise (includes MPS/CPU-only hosts).
+    - ``lightning_version`` — ``lightning.__version__`` when lightning is
+      importable, else None.
+
+    Every probe is wrapped separately so a partial stack (torch without
+    CUDA, lightning missing) still yields as many fields as possible.
+    """
+    # kailash_ml — always present at this point (we're inside its package).
+    try:
+        from kailash_ml import __version__ as kml_version  # noqa: PLC0415
+    except Exception:  # noqa: BLE001 — probe must not raise
+        kml_version = None
+
+    torch_version: Optional[str] = None
+    cuda_version: Optional[str] = None
+    try:
+        import torch  # noqa: PLC0415
+
+        torch_version = getattr(torch, "__version__", None)
+        cuda_version = getattr(getattr(torch, "version", None), "cuda", None)
+    except ImportError:
+        pass
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("tracking.torch.probe_failed", extra={"error": str(exc)})
+
+    lightning_version: Optional[str] = None
+    try:
+        import lightning  # noqa: PLC0415
+
+        lightning_version = getattr(lightning, "__version__", None)
+    except ImportError:
+        pass
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("tracking.lightning.probe_failed", extra={"error": str(exc)})
+
+    return {
+        "kailash_ml_version": kml_version,
+        "torch_version": torch_version,
+        "cuda_version": cuda_version,
+        "lightning_version": lightning_version,
+    }
+
+
 # ---------------------------------------------------------------------------
 # ExperimentRun — the async context manager yielded by km.track()
 # ---------------------------------------------------------------------------
@@ -198,6 +252,25 @@ class ExperimentRun:
         self._device_backend: Optional[str] = None
         self._device_fallback_reason: Optional[str] = None
         self._device_array_api: Optional[bool] = None
+        # Top-level TrainingResult mirrors — populated by
+        # attach_training_result when the caller wires a Trainable. The
+        # field names mirror TrainingResult's own surface per
+        # ``specs/ml-tracking.md`` §2.4 — ``device_used`` / ``accelerator``
+        # / ``precision`` live here alongside the ``device.*`` DeviceReport
+        # fields so both surfaces persist and a stale-read never conflates
+        # them.
+        self._device_used: Optional[str] = None
+        self._accelerator: Optional[str] = None
+        self._precision: Optional[str] = None
+        # Library/runtime versions — captured eagerly at construction
+        # because they are process-wide constants. Probed at
+        # ``__aenter__`` because construction order vs import order is
+        # not guaranteed; deferring until the context opens gives
+        # torch/lightning their best chance of being importable.
+        self._kailash_ml_version: Optional[str] = None
+        self._lightning_version: Optional[str] = None
+        self._torch_version: Optional[str] = None
+        self._cuda_version: Optional[str] = None
         # Wall-clock fields populated at __aenter__ / __aexit__.
         self._wall_clock_start: Optional[datetime] = None
         self._wall_clock_end: Optional[datetime] = None
@@ -247,6 +320,16 @@ class ExperimentRun:
             # backend so the tracker row is not empty.
             self._device_backend = result.device_used
             self._device_family = result.family
+        # Top-level TrainingResult fields — always populate when
+        # non-empty (spec §2.4 rows 11-13: ``device_used`` /
+        # ``accelerator`` / ``precision`` come from TrainingResult's
+        # own fields, not the DeviceReport envelope).
+        if result.device_used:
+            self._device_used = result.device_used
+        if result.accelerator:
+            self._accelerator = result.accelerator
+        if result.precision:
+            self._precision = result.precision
 
     # ------------------------------------------------------------------
     # Lifecycle: async context manager
@@ -261,6 +344,13 @@ class ExperimentRun:
             if parent is not None:
                 self.parent_run_id = parent.run_id
 
+        # Library/runtime version probes (spec §2.4 rows 5-8).
+        versions = _capture_versions()
+        self._kailash_ml_version = versions["kailash_ml_version"]
+        self._lightning_version = versions["lightning_version"]
+        self._torch_version = versions["torch_version"]
+        self._cuda_version = versions["cuda_version"]
+
         row = {
             "run_id": self.run_id,
             "experiment": self.experiment,
@@ -268,6 +358,10 @@ class ExperimentRun:
             "status": RunStatus.RUNNING,
             "host": socket.gethostname(),
             "python_version": sys.version.split()[0],
+            "kailash_ml_version": self._kailash_ml_version,
+            "lightning_version": self._lightning_version,
+            "torch_version": self._torch_version,
+            "cuda_version": self._cuda_version,
             "git_sha": sha,
             "git_branch": branch,
             "git_dirty": dirty,
@@ -275,6 +369,9 @@ class ExperimentRun:
             "wall_clock_end": None,
             "duration_seconds": None,
             "tenant_id": self.tenant_id,
+            "device_used": self._device_used,
+            "accelerator": self._accelerator,
+            "precision": self._precision,
             "device_family": self._device_family,
             "device_backend": self._device_backend,
             "device_fallback_reason": self._device_fallback_reason,
@@ -375,6 +472,9 @@ class ExperimentRun:
                 "status": status,
                 "wall_clock_end": self._wall_clock_end.isoformat(),
                 "duration_seconds": duration,
+                "device_used": self._device_used,
+                "accelerator": self._accelerator,
+                "precision": self._precision,
                 "device_family": self._device_family,
                 "device_backend": self._device_backend,
                 "device_fallback_reason": self._device_fallback_reason,

--- a/packages/kailash-ml/src/kailash_ml/tracking/sqlite_backend.py
+++ b/packages/kailash-ml/src/kailash_ml/tracking/sqlite_backend.py
@@ -38,6 +38,10 @@ CREATE TABLE IF NOT EXISTS experiment_runs (
     status                   TEXT NOT NULL,
     host                     TEXT,
     python_version           TEXT,
+    kailash_ml_version       TEXT,
+    lightning_version        TEXT,
+    torch_version            TEXT,
+    cuda_version             TEXT,
     git_sha                  TEXT,
     git_branch               TEXT,
     git_dirty                INTEGER,
@@ -45,6 +49,9 @@ CREATE TABLE IF NOT EXISTS experiment_runs (
     wall_clock_end           TEXT,
     duration_seconds         REAL,
     tenant_id                TEXT,
+    device_used              TEXT,
+    accelerator              TEXT,
+    precision                TEXT,
     device_family            TEXT,
     device_backend           TEXT,
     device_fallback_reason   TEXT,
@@ -59,6 +66,22 @@ _INDEX_SQL = """
 CREATE INDEX IF NOT EXISTS idx_experiment_runs_experiment
     ON experiment_runs (experiment);
 """
+
+# Pre-0.14 databases carried a narrower schema. On first access we probe
+# ``PRAGMA table_info`` and ALTER TABLE any missing columns so existing
+# ``~/.kailash_ml/ml.db`` files keep working after the 0.14 schema
+# expansion. Column names MUST match the 0.14 schema exactly; the list
+# is hardcoded so the migration cannot inject an identifier from user
+# input (``rules/dataflow-identifier-safety.md`` §5).
+_COLUMNS_ADDED_IN_0_14: tuple[tuple[str, str], ...] = (
+    ("kailash_ml_version", "TEXT"),
+    ("lightning_version", "TEXT"),
+    ("torch_version", "TEXT"),
+    ("cuda_version", "TEXT"),
+    ("device_used", "TEXT"),
+    ("accelerator", "TEXT"),
+    ("precision", "TEXT"),
+)
 
 
 class SQLiteTrackerBackend:
@@ -100,7 +123,15 @@ class SQLiteTrackerBackend:
         self._initialized = False
 
     async def initialize(self) -> None:
-        """Create the schema if absent. Idempotent."""
+        """Create the schema if absent. Idempotent.
+
+        Also migrates pre-0.14 databases by adding any columns that
+        landed in 0.14 (seven additional reproducibility fields —
+        ``kailash_ml_version``, ``lightning_version``, ``torch_version``,
+        ``cuda_version``, ``device_used``, ``accelerator``, ``precision``).
+        The migration is additive (ALTER TABLE ADD COLUMN) so existing
+        rows stay readable; new columns default to SQL NULL.
+        """
         if self._initialized:
             return
 
@@ -108,6 +139,16 @@ class SQLiteTrackerBackend:
             with self._conn_lock:
                 self._conn.execute(_SCHEMA_SQL)
                 self._conn.execute(_INDEX_SQL)
+                # Detect pre-0.14 databases and add missing columns.
+                cur = self._conn.execute("PRAGMA table_info(experiment_runs)")
+                existing = {row[1] for row in cur.fetchall()}
+                for name, sql_type in _COLUMNS_ADDED_IN_0_14:
+                    if name not in existing:
+                        # Identifier hardcoded; SQL type pinned to
+                        # ``TEXT`` per §5 of dataflow-identifier-safety.
+                        self._conn.execute(
+                            f"ALTER TABLE experiment_runs ADD COLUMN {name} {sql_type}"
+                        )
 
         await asyncio.to_thread(_init)
         self._initialized = True
@@ -136,12 +177,14 @@ class SQLiteTrackerBackend:
         sql = (
             "INSERT INTO experiment_runs ("
             "run_id, experiment, parent_run_id, status, host, python_version, "
+            "kailash_ml_version, lightning_version, torch_version, cuda_version, "
             "git_sha, git_branch, git_dirty, wall_clock_start, wall_clock_end, "
-            "duration_seconds, tenant_id, device_family, device_backend, "
-            "device_fallback_reason, device_array_api, params, error_type, "
-            "error_message"
+            "duration_seconds, tenant_id, device_used, accelerator, precision, "
+            "device_family, device_backend, device_fallback_reason, "
+            "device_array_api, params, error_type, error_message"
             ") VALUES ("
-            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?"
+            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+            "?, ?, ?, ?, ?, ?, ?"
             ")"
         )
         values = (
@@ -151,6 +194,10 @@ class SQLiteTrackerBackend:
             row["status"],
             row.get("host"),
             row.get("python_version"),
+            row.get("kailash_ml_version"),
+            row.get("lightning_version"),
+            row.get("torch_version"),
+            row.get("cuda_version"),
             row.get("git_sha"),
             row.get("git_branch"),
             _bool_to_int(row.get("git_dirty")),
@@ -158,6 +205,9 @@ class SQLiteTrackerBackend:
             row.get("wall_clock_end"),
             row.get("duration_seconds"),
             row.get("tenant_id"),
+            row.get("device_used"),
+            row.get("accelerator"),
+            row.get("precision"),
             row.get("device_family"),
             row.get("device_backend"),
             row.get("device_fallback_reason"),
@@ -275,6 +325,10 @@ _COLUMNS = (
     "status",
     "host",
     "python_version",
+    "kailash_ml_version",
+    "lightning_version",
+    "torch_version",
+    "cuda_version",
     "git_sha",
     "git_branch",
     "git_dirty",
@@ -282,6 +336,9 @@ _COLUMNS = (
     "wall_clock_end",
     "duration_seconds",
     "tenant_id",
+    "device_used",
+    "accelerator",
+    "precision",
     "device_family",
     "device_backend",
     "device_fallback_reason",

--- a/packages/kailash-ml/tests/integration/test_km_doctor.py
+++ b/packages/kailash-ml/tests/integration/test_km_doctor.py
@@ -60,14 +60,16 @@ def test_doctor_cpu_available() -> None:
 
 
 def test_doctor_json_output_shape() -> None:
-    """``--json`` output exposes the 4 probed backends with required keys."""
+    """``--json`` output exposes the 6 probed backends with required keys."""
     buf = io.StringIO()
     code = doctor(as_json=True, out=buf)
     payload = json.loads(buf.getvalue())
     assert payload["exit_code"] == code
     assert payload["require"] is None
     backends = {p["backend"] for p in payload["backends"]}
-    assert backends == {"cpu", "cuda", "mps", "rocm"}
+    # All six first-class backends per spec §1 — v0.14.0 adds xpu + tpu
+    # to the 0.13.0 probe set.
+    assert backends == {"cpu", "cuda", "mps", "rocm", "xpu", "tpu"}
     for entry in payload["backends"]:
         # Mandatory structured fields per spec §7.2
         assert "status" in entry
@@ -111,6 +113,211 @@ def test_km_doctor_is_public_symbol() -> None:
 # ---------------------------------------------------------------------------
 # Console-script / subprocess path
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# v0.14.0 expansion — all 10 additional diagnostic checks (spec §7.1)
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_json_includes_spec_7_1_sections() -> None:
+    """Every spec §7.1 diagnostic section is present as a top-level key.
+
+    Mechanical whitelist check: the report MUST include the 10 sections
+    the spec mandates (selected_default, precision_matrix, extras,
+    family_probes, onnx_eps, sqlite_path, cache_paths, tenant_mode,
+    gotchas) alongside the existing ``backends`` + ``exit_code``.
+    """
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    required_keys = {
+        "backends",
+        "exit_code",
+        "require",
+        "selected_default",
+        "precision_matrix",
+        "extras",
+        "family_probes",
+        "onnx_eps",
+        "sqlite_path",
+        "cache_paths",
+        "tenant_mode",
+        "gotchas",
+    }
+    missing = required_keys - set(payload.keys())
+    assert not missing, f"spec §7.1 sections missing from JSON: {sorted(missing)}"
+
+
+def test_doctor_precision_matrix_covers_all_6_backends() -> None:
+    """Every probed backend has a precision entry (value may be None)."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    matrix = payload["precision_matrix"]
+    # Six backends MUST appear as keys — value is None when the backend
+    # is unavailable on this host, concrete precision string otherwise.
+    for backend in ("cpu", "cuda", "mps", "rocm", "xpu", "tpu"):
+        assert backend in matrix, f"precision_matrix missing {backend}"
+    # CPU always available -> always has a precision
+    assert matrix["cpu"] is not None, "cpu must always have a precision"
+
+
+def test_doctor_selected_default_matches_detect_backend() -> None:
+    """``selected_default`` resolves to the highest-priority ``ok`` backend."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    selected = payload["selected_default"]
+    assert selected is not None, "cpu always present, selected_default MUST be non-null"
+    # The selected default MUST correspond to a probe whose status=ok
+    ok_backends = {p["backend"] for p in payload["backends"] if p["status"] == "ok"}
+    assert selected in ok_backends
+
+
+def test_doctor_extras_enumerate_spec_set() -> None:
+    """``extras`` enumerates every spec §7.1 extras bucket."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    extras = payload["extras"]
+    # Spec §7.1 Installed extras: [cuda], [rocm], [xpu], [tpu], [dl],
+    # [agents], [explain], [imbalance]
+    for extra in ("cuda", "rocm", "xpu", "tpu", "dl", "agents", "explain", "imbalance"):
+        assert extra in extras, f"extras missing '{extra}'"
+        assert "installed" in extras[extra]
+        assert "modules" in extras[extra]
+
+
+def test_doctor_family_probes_report_base_deps() -> None:
+    """Base dep families report a concrete version; optional families report None."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    families = payload["family_probes"]
+    # Base deps (always installed in the [dev] test venv)
+    for fam in ("torch", "lightning", "sklearn", "xgboost", "lightgbm", "onnxruntime"):
+        assert fam in families, f"family_probes missing '{fam}'"
+    # sklearn is a base dep -> MUST report a version
+    assert families["sklearn"] is not None
+
+
+def test_doctor_onnx_eps_enumerates_providers() -> None:
+    """``onnx_eps.providers`` is a non-empty list when onnxruntime is installed."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    onnx = payload["onnx_eps"]
+    # onnxruntime is a base dep so must be installed.
+    assert onnx["installed"] is True
+    assert onnx["version"] is not None
+    assert isinstance(onnx["providers"], list)
+    assert len(onnx["providers"]) >= 1
+    # CPUExecutionProvider is the mandatory fallback EP on every platform.
+    assert "CPUExecutionProvider" in onnx["providers"]
+
+
+def test_doctor_sqlite_path_probe(tmp_path) -> None:
+    """SQLite path is reported with writable=True on a fresh tmp home."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    sqlite = payload["sqlite_path"]
+    # Every run populates the shape, regardless of writability
+    assert "path" in sqlite
+    assert "source" in sqlite
+    assert "exists" in sqlite
+    assert "writable" in sqlite
+    assert sqlite["source"] in {"default", "KAILASH_ML_STORE"}
+
+
+def test_doctor_sqlite_path_honours_env(monkeypatch, tmp_path) -> None:
+    """``KAILASH_ML_STORE`` overrides the default SQLite path."""
+    override = tmp_path / "custom.db"
+    monkeypatch.setenv("KAILASH_ML_STORE", f"sqlite:///{override}")
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    sqlite = payload["sqlite_path"]
+    assert sqlite["source"] == "KAILASH_ML_STORE"
+    assert sqlite["path"] == str(override)
+    # Tmp dir is writable — the probe should confirm.
+    assert sqlite["writable"] is True
+
+
+def test_doctor_cache_paths_report_disk_usage() -> None:
+    """Cache paths section populates data_root + cache + filesystem stats."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    cache = payload["cache_paths"]
+    assert "data_root" in cache
+    assert "cache" in cache
+    assert "filesystem" in cache
+    # data_root has a path + exists + size_bytes triple
+    for field in ("path", "exists", "size_bytes"):
+        assert field in cache["data_root"]
+        assert field in cache["cache"]
+    # filesystem has total + free bytes
+    assert "total_bytes" in cache["filesystem"]
+    assert "free_bytes" in cache["filesystem"]
+
+
+def test_doctor_tenant_mode_single_default(monkeypatch) -> None:
+    """No tenant env var -> single-tenant mode."""
+    monkeypatch.delenv("KAILASH_ML_DEFAULT_TENANT", raising=False)
+    monkeypatch.delenv("KAILASH_TENANT_ID", raising=False)
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    tenant = payload["tenant_mode"]
+    assert tenant["mode"] == "single-tenant"
+    assert tenant["tenant_id"] is None
+
+
+def test_doctor_tenant_mode_multi(monkeypatch) -> None:
+    """``KAILASH_ML_DEFAULT_TENANT`` triggers multi-tenant mode."""
+    monkeypatch.setenv("KAILASH_ML_DEFAULT_TENANT", "acme-42")
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    tenant = payload["tenant_mode"]
+    assert tenant["mode"] == "multi-tenant"
+    assert tenant["tenant_id"] == "acme-42"
+
+
+def test_doctor_gotchas_are_emitted_for_detected_backends() -> None:
+    """``gotchas`` contains one entry per ``(backend, hint)`` pair for ok backends."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    gotchas = payload["gotchas"]
+    # Each entry has ``backend`` + ``hint`` keys.
+    for entry in gotchas:
+        assert "backend" in entry
+        assert "hint" in entry
+        # Only ok-status backends contribute gotchas (don't mislead
+        # operators about backends they can't actually use).
+        ok_backends = {p["backend"] for p in payload["backends"] if p["status"] == "ok"}
+        assert entry["backend"] in ok_backends
+
+
+def test_doctor_xpu_probe_present_in_json() -> None:
+    """XPU probe is always reported (status may be missing on non-Intel hosts)."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    xpu = next(p for p in payload["backends"] if p["backend"] == "xpu")
+    assert xpu["status"] in {"ok", "warn", "fail", "missing"}
+
+
+def test_doctor_tpu_probe_present_in_json() -> None:
+    """TPU probe is always reported (status missing on non-TPU hosts)."""
+    buf = io.StringIO()
+    doctor(as_json=True, out=buf)
+    payload = json.loads(buf.getvalue())
+    tpu = next(p for p in payload["backends"] if p["backend"] == "tpu")
+    assert tpu["status"] in {"ok", "warn", "fail", "missing"}
 
 
 def test_km_doctor_console_script_or_module_json() -> None:

--- a/packages/kailash-ml/tests/integration/test_km_track.py
+++ b/packages/kailash-ml/tests/integration/test_km_track.py
@@ -17,27 +17,12 @@ the row through the backend's public API. This matches
 from __future__ import annotations
 
 import asyncio
-import os
 import signal
-import tempfile
-import threading
-import time
 from pathlib import Path
-from typing import Any
 
 import polars as pl
 import pytest
-
-import kailash_ml as km
-from kailash_ml._device_report import DeviceReport
-from kailash_ml._result import TrainingResult
-from kailash_ml.tracking import (
-    ExperimentRun,
-    RunStatus,
-    SQLiteTrackerBackend,
-    track,
-)
-
+from kailash_ml.tracking import RunStatus, SQLiteTrackerBackend, track
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
@@ -68,7 +53,7 @@ async def backend(tmp_path: Path) -> SQLiteTrackerBackend:
 
 
 async def test_km_track_round_trip(backend: SQLiteTrackerBackend) -> None:
-    """The 16 auto-capture fields survive a write/read round trip."""
+    """The 17 auto-capture fields survive a write/read round trip."""
     async with track("round-trip-exp", backend=backend, lr=0.01, depth=5) as run:
         await run.log_param("batch_size", 128)
         run_id = run.run_id
@@ -77,12 +62,20 @@ async def test_km_track_round_trip(backend: SQLiteTrackerBackend) -> None:
     row = await backend.get_run(run_id)
     assert row is not None, "run should be persisted after context exit"
 
-    # 16 auto-capture fields (spec §2.4)
+    # 17 auto-capture fields (spec §2.4)
     assert row["run_id"] == run_id
     assert row["experiment"] == experiment
     assert row["status"] == RunStatus.COMPLETED
     assert row["host"] is not None and row["host"] != ""
     assert row["python_version"].startswith("3.")
+    # Library/runtime versions (spec §2.4 rows 5-8) — kailash_ml always
+    # populated; torch / lightning populated when importable (they are
+    # base deps so always True in this test's venv). cuda_version is
+    # None on non-CUDA hosts.
+    assert row["kailash_ml_version"] is not None and row["kailash_ml_version"] != ""
+    assert row["torch_version"] is not None and row["torch_version"].startswith("2.")
+    assert row["lightning_version"] is not None
+    assert "cuda_version" in row
     # git fields — tolerate absence in CI / non-git checkouts
     assert "git_sha" in row
     assert "git_branch" in row
@@ -95,6 +88,9 @@ async def test_km_track_round_trip(backend: SQLiteTrackerBackend) -> None:
     # parent_run_id explicitly None for a top-level run
     assert row["parent_run_id"] is None
     # device fields None until attach_training_result is called
+    assert row["device_used"] is None
+    assert row["accelerator"] is None
+    assert row["precision"] is None
     assert row["device_family"] is None
     assert row["device_backend"] is None
     assert row["device_fallback_reason"] is None
@@ -102,6 +98,52 @@ async def test_km_track_round_trip(backend: SQLiteTrackerBackend) -> None:
 
     # Params preserved through round trip
     assert row["params"] == {"lr": 0.01, "depth": 5, "batch_size": 128}
+
+
+async def test_km_track_all_17_auto_capture_fields_present(
+    backend: SQLiteTrackerBackend,
+) -> None:
+    """Explicit whitelist check: every spec §2.4 field column exists.
+
+    Mechanical AST-style assertion — iterate the spec's 17-field list
+    and assert each is a persisted column on the row. Catches a future
+    refactor that silently drops a column (e.g. during the 0.14 → 1.0
+    schema bump).
+    """
+    expected_fields = {
+        # From spec §2.4 table, plus the core run_id/experiment/status
+        # keys that are part of the same surface.
+        "run_id",
+        "experiment",
+        "status",
+        "parent_run_id",
+        "tenant_id",
+        "host",
+        "python_version",
+        "kailash_ml_version",
+        "lightning_version",
+        "torch_version",
+        "cuda_version",
+        "git_sha",
+        "git_branch",
+        "git_dirty",
+        "wall_clock_start",
+        "wall_clock_end",
+        "duration_seconds",
+        "device_used",
+        "accelerator",
+        "precision",
+        "device_family",
+        "device_backend",
+        "device_fallback_reason",
+        "device_array_api",
+    }
+    async with track("all-fields-exp", backend=backend) as run:
+        run_id = run.run_id
+    row = await backend.get_run(run_id)
+    assert row is not None
+    missing = expected_fields - set(row.keys())
+    assert not missing, f"spec §2.4 fields not persisted: {sorted(missing)}"
 
 
 # ---------------------------------------------------------------------------
@@ -276,3 +318,14 @@ async def test_km_track_integrates_trainable_device_report(
     # device_array_api is a bool: True when Array API engaged, False
     # otherwise. The sklearn adapter populates it deterministically.
     assert row["device_array_api"] in {True, False}
+    # Top-level TrainingResult mirrors (spec §2.4 rows 11-13) — every
+    # trainable adapter populates these as concrete strings (never
+    # "auto"). device_used is the torch device string; accelerator is
+    # the Lightning accelerator label; precision is the concrete
+    # Lightning precision.
+    assert row["device_used"] == result.device_used
+    assert row["accelerator"] == result.accelerator
+    assert row["precision"] == result.precision
+    assert row["device_used"] and row["device_used"] != "auto"
+    assert row["accelerator"] and row["accelerator"] != "auto"
+    assert row["precision"] and row["precision"] != "auto"


### PR DESCRIPTION
## Summary

kailash-ml 0.13.0 shipped minimum-viable \`km.doctor\` (4 of 14 checks) and \`km.track\` auto-capture (10 of 17 fields). Today's /redteam against full specs (\`ml-backends.md §7.1\`, \`ml-tracking.md §2.4\`) flagged both as spec-code drift. This PR closes the gap.

Resolves 2 HIGH findings from the 2026-04-20 /redteam audit:

- **HIGH 4 — km.doctor full §7.1 surface**: 10 new checks added — XPU/TPU probes, per-backend precision auto, extras enumeration (\`cuda\`/\`rocm\`/\`xpu\`/\`tpu\`/\`dl\`/\`agents\`/\`explain\`/\`imbalance\`), family probes (torch/lightning/sklearn/xgboost/lightgbm/catboost/onnxruntime), ONNX EP detection, SQLite path writability, cache disk usage, tenant-mode detection, per-backend gotchas.
- **HIGH 5 — km.track 17-field capture**: 7 missing fields added — \`kailash_ml_version\`, \`lightning_version\`, \`torch_version\`, \`cuda_version\`, \`device_used\`, \`accelerator\`, \`precision\`. Schema migration is additive via \`PRAGMA table_info\`+\`ALTER TABLE ADD COLUMN\`.

## Tests

- 21/21 \`test_km_doctor\` integration tests green (7 pre-existing + 14 new)
- 10/10 \`test_km_track\` integration tests green
- Combined: **31/31 in 5.14s**

## Test plan

- [x] All integration tests green on MPS (darwin-arm)
- [x] \`km-doctor --json\` exposes all 14 spec keys
- [x] \`km.track\` persists all 17 fields in \`experiment_runs\`
- [x] Additive schema migration validated against pre-0.14 DB
- [x] Version bump: \`packages/kailash-ml/pyproject.toml\` + \`_version.py\` → 0.14.0
- [x] CHANGELOG entry

## Related issues

Follow-up to #546/#547/#548 (kailash-ml 0.13.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)