### PR TITLE
feat(ml): MLEngine.setup() + register() — Phase 3/4 (shard A)

### DIFF
--- a/packages/kailash-ml/src/kailash_ml/__init__.py
+++ b/packages/kailash-ml/src/kailash_ml/__init__.py
@@ -19,6 +19,15 @@ from kailash_ml._device_report import (
 )
 from kailash_ml._gpu_setup import resolve_torch_wheel
 from kailash_ml._result import TrainingResult
+from kailash_ml._results import (
+    ComparisonResult,
+    EvaluationResult,
+    FinalizeResult,
+    PredictionResult,
+    RegisterResult,
+    ServeResult,
+    SetupResult,
+)
 from kailash_ml._version import __version__
 from kailash_ml.engine import MLEngine
 from kailash_ml.engines.data_explorer import AlertConfig
@@ -250,6 +259,17 @@ __all__ = [
     "BackendInfo",
     "detect_backend",
     "TrainingResult",
+    # MLEngine Phase 3/4/5 result dataclasses (§2.1 MUST 4 — typed dataclass per method).
+    # Fields are frozen contract per specs/ml-engines.md §4 precedent; shards
+    # implementing setup/compare/finalize/evaluate/register/predict/serve import
+    # these types rather than redefining them.
+    "SetupResult",
+    "ComparisonResult",
+    "PredictionResult",
+    "RegisterResult",
+    "EvaluationResult",
+    "ServeResult",
+    "FinalizeResult",
     "Trainable",
     # GPU-first Phase 1 — all 7 family adapters per specs/ml-engines.md §3.0.
     # Pre-existing 5 (Sklearn/XGBoost/LightGBM/Torch/Lightning) were

--- a/packages/kailash-ml/src/kailash_ml/_results.py
+++ b/packages/kailash-ml/src/kailash_ml/_results.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Result dataclasses for `MLEngine` Phase 3/4/5 methods.
+
+Per `specs/ml-engines.md` §2.1 MUST 4 every public method on `MLEngine`
+MUST return a typed dataclass — never a raw dict or tuple. This module
+hosts the seven non-TrainingResult envelopes (TrainingResult itself
+lives in `_result.py` for historical reasons and is re-exported here
+for convenience).
+
+The dataclasses are frozen and their field shapes are part of the
+public contract. Adding, renaming, or reordering fields requires a
+spec amendment (§4 sets the precedent for TrainingResult; the same
+applies to the seven types below). Shards implementing setup/compare/
+finalize/evaluate/register/predict/serve import these types; they do
+NOT redefine or mutate them.
+
+Tenant-id propagation (§5) is enforced by a `tenant_id` field on every
+result — nullable in single-tenant mode, required to echo
+`engine.tenant_id` in multi-tenant mode per §4.2 MUST 3.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional, Union
+
+from kailash_ml._result import TrainingResult
+
+__all__ = [
+    "SetupResult",
+    "ComparisonResult",
+    "PredictionResult",
+    "RegisterResult",
+    "EvaluationResult",
+    "ServeResult",
+    "FinalizeResult",
+    # Re-export for callers who want a single import point
+    "TrainingResult",
+]
+
+
+@dataclass(frozen=True)
+class SetupResult:
+    """Return envelope of `MLEngine.setup()` (ml-engines.md §2.2, §2.1 MUST 6).
+
+    Required fields describe the data profile + split outcome. The
+    `schema_hash` is the idempotency key per §2.1 MUST 6: two calls to
+    `setup()` with identical `(df_fingerprint, target, ignore,
+    feature_store_name)` MUST produce equal `schema_hash` values AND
+    equal `split_seed` values so downstream fit()/compare() calls see
+    the same split.
+    """
+
+    schema_hash: str  # idempotency key per §2.1 MUST 6
+    task_type: str  # "classification" | "regression" | "clustering" | "ranking"
+    target: str
+    feature_columns: tuple[str, ...]
+    ignored_columns: tuple[str, ...]
+    split_strategy: str  # "holdout" | "kfold" | "stratified_kfold" | "walk_forward"
+    split_seed: int
+    train_size: int
+    test_size: int
+    primary_metric: str  # inferred from task_type (accuracy/rmse/silhouette/…)
+    tenant_id: Optional[str]
+    feature_store_name: str  # auto-generated or user-supplied
+
+    # Optional extended profile; Phase 3 can attach richer schema info
+    # (dtype map, null counts, cardinalities) without churning the core
+    # required fields.
+    schema_info: Optional[Mapping[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class ComparisonResult:
+    """Return envelope of `MLEngine.compare()` (ml-engines.md §2.2).
+
+    The leaderboard is ordered best-first by `metric`. `best` is a
+    convenience pointer equal to `leaderboard[0]`. Every `TrainingResult`
+    in the leaderboard independently satisfies §4.2 MUST rules (device
+    populated, tenant_id echo, lightning_trainer_config captured).
+    """
+
+    leaderboard: tuple[TrainingResult, ...]  # best-first order
+    metric: str  # metric used for ranking
+    best: TrainingResult  # == leaderboard[0]
+    total_trials: int
+    elapsed_seconds: float
+    tenant_id: Optional[str]
+
+    # Optional diagnostics; useful for hp_search="bayesian"/"halving"
+    # runs where intermediate trial scores matter.
+    trial_log: Optional[tuple[Mapping[str, Any], ...]] = None
+
+
+@dataclass(frozen=True)
+class PredictionResult:
+    """Return envelope of `MLEngine.predict()` (ml-engines.md §2.2).
+
+    `predictions` holds the inference output — polars Series / DataFrame
+    for batch, dict for single-record. `channel` echoes the dispatch
+    path ("direct" for in-process, "rest"/"mcp" for endpoint round-
+    trip). `device` is deferred to 0.12.1+ per §4.2 MUST 6 (journal
+    0005); Phase 4 MAY attach it opportunistically but callers MUST NOT
+    depend on it being populated in 0.15.0.
+    """
+
+    predictions: Any  # polars Series/DataFrame, or dict for single-record
+    model_uri: str
+    model_version: Optional[int]
+    channel: str  # "direct" | "rest" | "mcp"
+    elapsed_ms: float
+    tenant_id: Optional[str]
+
+    # §4.2 MUST 6 deferred: may be None in 0.15.0, Phase 4.1+ populates
+    device: Optional[Any] = None  # Optional[DeviceReport] — late-bound
+
+
+@dataclass(frozen=True)
+class RegisterResult:
+    """Return envelope of `MLEngine.register()` (ml-engines.md §2.2, §6).
+
+    `artifact_uris` is a dict keyed by format; ONNX-default (§6.1 MUST 1)
+    means this dict MUST contain `"onnx"` when `register(format="onnx"|"both")`
+    succeeds. `model_uri` is the registry-relative URI
+    (`models://<name>/v<version>`) that downstream callers use as the
+    canonical identifier.
+    """
+
+    name: str
+    version: int
+    stage: str  # "staging" | "shadow" | "production"
+    artifact_uris: Mapping[str, str]  # {"onnx": "file://...", "pickle": "...", ...}
+    model_uri: str  # "models://User/v3"
+    registered_at: float  # epoch seconds (monotonic clock is NOT used per §5.2)
+    tenant_id: Optional[str]
+    alias: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    """Return envelope of `MLEngine.evaluate()` (ml-engines.md §2.2).
+
+    `metrics` is the {metric_name: value} dict produced by scoring the
+    model against the supplied data. `sample_count` is the number of
+    rows scored; `mode` records whether the evaluation was offline
+    ("holdout") or online ("shadow"/"live") per the shadow-deployment
+    contract in ml-tracking.md.
+    """
+
+    model_uri: str
+    model_version: Optional[int]
+    metrics: Mapping[str, float]
+    mode: str  # "holdout" | "shadow" | "live"
+    sample_count: int
+    elapsed_seconds: float
+    tenant_id: Optional[str]
+
+
+@dataclass(frozen=True)
+class ServeResult:
+    """Return envelope of `MLEngine.serve()` (ml-engines.md §2.2, §2.1 MUST 10).
+
+    Per §2.1 MUST 10 `engine.serve(model, channels=["rest", "mcp", "grpc"])`
+    MUST bring up ALL requested channels from a single call. `uris` is
+    keyed by the requested channel names and MUST contain one entry per
+    channel in `channels`.
+    """
+
+    uris: Mapping[str, str]  # {"rest": "http://...", "mcp": "mcp+stdio://...", ...}
+    channels: tuple[str, ...]
+    model_uri: str
+    model_version: Optional[int]
+    autoscale: bool
+    tenant_id: Optional[str]
+
+
+@dataclass(frozen=True)
+class FinalizeResult:
+    """Return envelope of `MLEngine.finalize()` (ml-engines.md §2.2).
+
+    `training_result` is the refitted `TrainingResult` produced by
+    running the chosen candidate on train + holdout combined (when
+    `full_fit=True`). `original_candidate` is preserved so the caller
+    can compare pre- and post-finalization metrics. Both independently
+    satisfy §4.2 MUST rules.
+    """
+
+    training_result: TrainingResult
+    original_candidate: Union[str, TrainingResult]  # model_uri or the pre-fit result
+    full_fit: bool
+    tenant_id: Optional[str]

--- a/packages/kailash-ml/src/kailash_ml/engine.py
+++ b/packages/kailash-ml/src/kailash_ml/engine.py
@@ -20,12 +20,20 @@ classes to `kailash_ml.legacy.*`. Phase 2 is additive.
 """
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
 import os
 import pathlib
+import pickle
+import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Union
 
 from kailash_ml._device import BackendInfo, detect_backend
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "MLEngine",
@@ -410,28 +418,201 @@ class MLEngine:
     ) -> Any:
         """Profile data, infer schema, detect task type, split train/test.
 
-        Phase 2 validates the target-column invariants (§2.3 table) and
-        defers the concrete schema + split work to Phase 3.
+        Per ``specs/ml-engines.md`` §2.1 MUST 6, ``setup()`` is
+        idempotent: two calls with identical
+        ``(df_fingerprint, target, ignore, feature_store_name)``
+        produce the same ``schema_hash`` and the same ``split_seed``.
+        The ``schema_hash`` doubles as the canonical cache/registry key
+        for every downstream ``fit()`` / ``compare()`` / ``finalize()``
+        reachable from this Engine instance.
+
+        Split strategies: Phase 3 implements ``"holdout"``; other
+        strategies (``"kfold"``, ``"stratified_kfold"``,
+        ``"walk_forward"``) raise a typed
+        :class:`NotImplementedError` naming the deferring phase so a
+        future session can complete them without reading the body.
+        See the phase 3.1 gap journal for the deferred roadmap.
         """
+        # Validate target argument shape before touching data so bad
+        # calls fail loud and fast (§2.3).
         if not isinstance(target, str) or not target:
             raise ValueError("setup(target=...) must be a non-empty string.")
 
-        # Validate target presence / target-not-in-features (§2.3).
-        columns = self._columns_of(data)
-        if columns is not None:
-            if target not in columns:
-                raise TargetNotFoundError(column=target, columns=columns)
-            feature_cols = tuple(
-                c
-                for c in columns
-                if c != target and (ignore is None or c not in ignore)
+        if split_strategy not in (
+            "holdout",
+            "kfold",
+            "stratified_kfold",
+            "walk_forward",
+        ):
+            raise ValueError(
+                f"setup(split_strategy=...) must be 'holdout', 'kfold', "
+                f"'stratified_kfold', or 'walk_forward'; got {split_strategy!r}."
             )
-            if target in feature_cols:
-                # Defensive — should be impossible given the filter
-                # above, but catch it explicitly per §2.3 semantics.
-                raise TargetInFeaturesError(column=target)
+        if not isinstance(test_size, (int, float)) or not (0 < float(test_size) < 1):
+            raise ValueError(
+                f"setup(test_size=...) must be a float in (0, 1); got {test_size!r}."
+            )
 
-        raise NotImplementedError(f"MLEngine.setup — {_PHASE_3}")
+        # Phase 3 implements holdout end-to-end; the other three
+        # strategies raise a typed deferral until Phase 3.1 lands. We
+        # check this BEFORE touching the DataFrame so unsupported
+        # strategies fail without side-effects.
+        if split_strategy != "holdout":
+            raise NotImplementedError(
+                f"split_strategy={split_strategy!r} — Phase 3 implements "
+                f"'holdout' end-to-end; stratified/kfold/walk_forward are "
+                f"tracked for Phase 3.1."
+            )
+
+        # Normalize polars-LazyFrame → DataFrame at the boundary so the
+        # rest of setup works against a materialized frame (§7.1 MUST 2
+        # — pandas is accepted via interop conversion; polars is native).
+        df = self._to_polars_dataframe(data)
+
+        # Validate target presence / target-not-in-features (§2.3).
+        columns = tuple(str(c) for c in df.columns)
+        if target not in columns:
+            raise TargetNotFoundError(column=target, columns=columns)
+
+        ignore_list = sorted(set(ignore or []))
+        feature_cols = tuple(c for c in columns if c != target and c not in ignore_list)
+        if target in feature_cols:
+            # Defensive — should be impossible given the filter above.
+            raise TargetInFeaturesError(column=target)
+        if not feature_cols:
+            raise ValueError(
+                f"setup(target={target!r}, ignore={ignore!r}) leaves zero "
+                f"feature columns. At least one feature is required."
+            )
+
+        # Resolve the feature store name so the idempotency key is
+        # deterministic across runs. When the caller supplies a
+        # FeatureStore object, we use its table prefix; when they pass
+        # a string, we use it directly; default is "engine_default".
+        fs_name = self._resolve_feature_store_name(feature_store)
+
+        # Compute the schema hash per §2.1 MUST 6. The inputs are
+        # canonicalised (sorted columns, sorted dtypes, sorted ignore)
+        # so permutations of the same DataFrame produce the same hash.
+        schema_hash = self._compute_schema_hash(
+            df=df,
+            target=target,
+            ignore=ignore_list,
+            feature_store_name=fs_name,
+        )
+
+        # Infer task type from target dtype + cardinality.
+        task_type = self._infer_task_type(df, target)
+        primary_metric = {
+            "classification": "accuracy",
+            "regression": "rmse",
+            "clustering": "silhouette",
+        }.get(task_type, "accuracy")
+
+        # Deterministic split per holdout strategy. We materialise sizes
+        # at setup() time so the SetupResult records EXACTLY what the
+        # downstream fit() will see.
+        n_total = int(df.height)
+        if n_total < 2:
+            raise ValueError(
+                f"setup() requires at least 2 rows to split; got {n_total}."
+            )
+        n_test = max(1, int(round(n_total * float(test_size))))
+        if n_test >= n_total:
+            n_test = n_total - 1
+        n_train = n_total - n_test
+
+        # Build the SetupResult (imported here to avoid circular imports
+        # at module load — _results is a lightweight module but we keep
+        # the import local for symmetry with the trainable.fit() path).
+        from kailash_ml._results import SetupResult
+
+        # Build the schema_info dict with concrete dtype + null-count
+        # per column (Phase 3 extended profile per §2.2 SetupResult).
+        schema_info = self._build_schema_info(df, feature_cols, target)
+
+        result = SetupResult(
+            schema_hash=schema_hash,
+            task_type=task_type,
+            target=target,
+            feature_columns=feature_cols,
+            ignored_columns=tuple(ignore_list),
+            split_strategy=split_strategy,
+            split_seed=seed,
+            train_size=n_train,
+            test_size=n_test,
+            primary_metric=primary_metric,
+            tenant_id=self._tenant_id,
+            feature_store_name=fs_name,
+            schema_info=schema_info,
+        )
+
+        # Idempotency (§2.1 MUST 6). Store the result on the engine so
+        # subsequent fit()/compare()/finalize() see the same split. If
+        # setup() was already called with the same schema_hash for this
+        # Engine instance, we return the cached result unchanged — no
+        # duplicate FeatureSchema registration, no new split seed.
+        cached = self._setup_result
+        if isinstance(cached, SetupResult) and cached.schema_hash == schema_hash:
+            logger.info(
+                "setup.idempotent_hit",
+                extra={
+                    "schema_hash": schema_hash,
+                    "tenant_id": self._tenant_id,
+                },
+            )
+            return cached
+
+        # Register the feature schema in the FeatureStore when one is
+        # available. When no feature_store was injected AND no default
+        # store is wired yet, we keep the SetupResult on the engine but
+        # do not raise — the Engine still works for the in-memory path
+        # fit() currently supports.
+        fs_impl = feature_store or self._feature_store
+        if fs_impl is not None and hasattr(fs_impl, "register_features"):
+            try:
+                from kailash_ml.types import FeatureField, FeatureSchema
+
+                schema = FeatureSchema(
+                    name=fs_name,
+                    features=[
+                        FeatureField(
+                            name=col,
+                            dtype=schema_info["columns"][col]["dtype"],
+                            nullable=bool(schema_info["columns"][col]["nullable"]),
+                        )
+                        for col in feature_cols
+                    ],
+                    entity_id_column=self._infer_entity_id_column(df),
+                )
+                await fs_impl.register_features(schema)
+            except Exception as exc:
+                # Re-register with the same hash is a no-op in the store;
+                # re-register with a different hash surfaces as ValueError
+                # — we let it propagate so drift is loud.
+                if isinstance(exc, ValueError):
+                    raise
+                logger.warning(
+                    "setup.feature_store_register_failed",
+                    extra={
+                        "schema_hash": schema_hash,
+                        "tenant_id": self._tenant_id,
+                        "error": str(exc),
+                    },
+                )
+
+        self._setup_result = result
+        logger.info(
+            "setup.complete",
+            extra={
+                "schema_hash": schema_hash,
+                "task_type": task_type,
+                "train_size": n_train,
+                "test_size": n_test,
+                "tenant_id": self._tenant_id,
+            },
+        )
+        return result
 
     async def compare(
         self,

--- a/packages/kailash-ml/src/kailash_ml/engine.py
+++ b/packages/kailash-ml/src/kailash_ml/engine.py
@@ -842,10 +842,7 @@ class MLEngine:
     def _columns_of(data: Any) -> Optional[tuple[str, ...]]:
         """Return column names of a polars / pandas / generic DataFrame.
 
-        None when the value isn't a recognized frame-shape object (the
-        Phase 3 schema inference will handle arbitrary inputs; Phase 2
-        restricts itself to the subset needed to validate target
-        semantics).
+        None when the value isn't a recognized frame-shape object.
         """
         cols = getattr(data, "columns", None)
         if cols is None:
@@ -854,3 +851,187 @@ class MLEngine:
             return tuple(str(c) for c in cols)
         except TypeError:
             return None
+
+    # ------------------------------------------------------------------
+    # setup() / register() internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_polars_dataframe(data: Any) -> Any:
+        """Coerce supported input shapes to a polars DataFrame.
+
+        Accepts ``pl.DataFrame``, ``pl.LazyFrame``, ``pandas.DataFrame``,
+        and list-of-dict / dict-of-list records. Per §7.1 MUST 2 the
+        Engine is polars-native; pandas is converted at the boundary.
+        """
+        import polars as pl
+
+        if isinstance(data, pl.DataFrame):
+            return data
+        if isinstance(data, pl.LazyFrame):
+            return data.collect()
+
+        # pandas DataFrame detection without importing pandas
+        # unconditionally (pandas is optional at the engine boundary).
+        pd_mod = type(data).__module__
+        if pd_mod.startswith("pandas."):
+            try:
+                return pl.from_pandas(data)
+            except Exception as exc:
+                raise ValueError(
+                    f"setup(data=...) pandas-to-polars conversion failed: {exc}. "
+                    f"Convert to polars.DataFrame before calling setup()."
+                ) from exc
+
+        if isinstance(data, (list, tuple)) and data and isinstance(data[0], dict):
+            return pl.from_dicts(list(data))
+        if isinstance(data, dict):
+            return pl.DataFrame(data)
+
+        raise ValueError(
+            f"setup(data=...) expected polars.DataFrame, polars.LazyFrame, "
+            f"pandas.DataFrame, or list[dict]; got {type(data).__name__}."
+        )
+
+    @staticmethod
+    def _resolve_feature_store_name(feature_store: Any) -> str:
+        """Resolve the feature-store name for the idempotency key.
+
+        When a ``FeatureStore`` instance is passed, use its ``table_prefix``
+        so two calls against the same store produce the same hash. When a
+        string is passed, use it directly. Otherwise use the stable
+        default ``"engine_default"``.
+        """
+        if feature_store is None:
+            return "engine_default"
+        if isinstance(feature_store, str):
+            return feature_store
+        prefix = getattr(feature_store, "_table_prefix", None)
+        if isinstance(prefix, str) and prefix:
+            return prefix.rstrip("_")
+        name = getattr(feature_store, "name", None)
+        if isinstance(name, str) and name:
+            return name
+        return f"fs_{type(feature_store).__name__.lower()}"
+
+    @staticmethod
+    def _compute_schema_hash(
+        *,
+        df: Any,
+        target: str,
+        ignore: list[str],
+        feature_store_name: str,
+    ) -> str:
+        """Deterministic schema hash per §2.1 MUST 6.
+
+        Inputs are canonicalised: columns are sorted, dtypes mapped to
+        stable strings, row count quantised to the whole integer. The
+        hash covers ``(sorted_columns + dtypes, row_count, target,
+        sorted(ignore), feature_store_name)`` so permutations of the
+        same DataFrame produce the same hash.
+        """
+        cols_sorted = sorted(str(c) for c in df.columns)
+        dtypes_map = {str(c): str(df.schema[c]) for c in df.columns}
+        dtypes_sorted = [(c, dtypes_map[c]) for c in cols_sorted]
+        canonical = {
+            "columns": dtypes_sorted,
+            "row_count": int(df.height),
+            "target": target,
+            "ignore": sorted(list(ignore)),
+            "feature_store": feature_store_name,
+        }
+        canonical_bytes = json.dumps(canonical, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(canonical_bytes).hexdigest()[:16]
+
+    @staticmethod
+    def _infer_task_type(df: Any, target: str) -> str:
+        """Infer classification/regression from the target column.
+
+        - Boolean / categorical / Utf8 / low-cardinality integers (<=10
+          distinct values) → classification.
+        - Floating-point → regression.
+        - Everything else → classification (integer labels commonly).
+        """
+        import polars as pl
+
+        dtype = df.schema[target]
+        if dtype in (pl.Boolean, pl.Utf8, pl.Categorical):
+            return "classification"
+        if dtype.is_float():
+            return "regression"
+        if dtype.is_integer():
+            # Low-cardinality integer target → classification;
+            # high-cardinality integer target → regression.
+            distinct = int(df[target].n_unique())
+            if distinct <= 10:
+                return "classification"
+            return "regression"
+        # Unknown dtype — default to classification so at least the
+        # sklearn path works without raising.
+        return "classification"
+
+    @staticmethod
+    def _build_schema_info(
+        df: Any,
+        feature_cols: tuple[str, ...],
+        target: str,
+    ) -> Mapping[str, Any]:
+        """Build the extended schema_info mapping (SetupResult).
+
+        Contains one entry per feature column with canonical dtype +
+        null count. The mapping is pickle-safe and JSON-safe so the
+        result can be persisted by the tracker without further
+        conversion.
+        """
+        import polars as pl
+
+        def _polars_to_feature_dtype(dt: Any) -> str:
+            # Map polars dtypes to the FeatureField dtype vocabulary
+            # used by FeatureStore's sql.dtype_to_sql() mapping.
+            if dt == pl.Boolean:
+                return "bool"
+            if dt == pl.Utf8:
+                return "utf8"
+            if dt == pl.Categorical:
+                return "categorical"
+            if dt.is_integer():
+                return "int64"
+            if dt.is_float():
+                return "float64"
+            if dt.is_temporal():
+                return "datetime"
+            return "utf8"
+
+        columns_info: dict[str, Any] = {}
+        for col in feature_cols:
+            polars_dtype = df.schema[col]
+            columns_info[col] = {
+                "dtype": _polars_to_feature_dtype(polars_dtype),
+                "polars_dtype": str(polars_dtype),
+                "nullable": int(df[col].null_count()) > 0,
+                "null_count": int(df[col].null_count()),
+            }
+        return {
+            "columns": columns_info,
+            "target": target,
+            "target_dtype": str(df.schema[target]),
+            "row_count": int(df.height),
+        }
+
+    @staticmethod
+    def _infer_entity_id_column(df: Any) -> str:
+        """Return a stable entity-id column name.
+
+        Prefer a column literally named ``"id"`` when present; otherwise
+        synthesise a pseudo-entity column name. The Phase 3 scope does
+        not require true entity resolution — setup() only needs a
+        consistent name for the FeatureStore schema row. Downstream
+        fit() paths ignore the entity column entirely for in-memory
+        training.
+        """
+        cols = [str(c) for c in df.columns]
+        if "id" in cols:
+            return "id"
+        if "entity_id" in cols:
+            return "entity_id"
+        return "_engine_entity_id"

--- a/packages/kailash-ml/src/kailash_ml/engine.py
+++ b/packages/kailash-ml/src/kailash_ml/engine.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Union
 
 from kailash_ml._device import BackendInfo, detect_backend
+from kailash_ml.engines import _engine_sql as _sql
 
 logger = logging.getLogger(__name__)
 
@@ -789,11 +790,25 @@ class MLEngine:
         format: str = "onnx",
         alias: Optional[str] = None,
     ) -> Any:
-        """Register a trained model in the registry.
+        """Register a trained model in the registry (ONNX-default, §6).
 
-        Phase 4 implements the ONNX export branches and the registry
-        persistence (ml-engines.md §6).
+        Exports the underlying model via
+        :mod:`kailash_ml.bridge.onnx_bridge` for formats ``"onnx"`` and
+        ``"both"`` — all six framework branches (sklearn, xgboost,
+        lightgbm, catboost, torch, lightning) are covered by the
+        bridge's existing dispatch per §6.1 MUST 2. ``format="onnx"``
+        (the default) MUST raise :class:`OnnxExportError` on export
+        failure per §4.2 MUST 4; silent fallback to pickle is
+        BLOCKED. ``format="both"`` tolerates partial ONNX failure
+        (pickle-only RegisterResult) per §6.1 MUST 5.
+
+        Tenant-aware: every version row persists ``tenant_id`` on
+        ``_kml_engine_versions`` (§5.1 MUST 4); ``(tenant_id, name,
+        version)`` is the primary key. Every ``register()`` call
+        writes an audit row per §5.2 with ``operation="register"``,
+        ``duration_ms``, ``outcome``.
         """
+        # Validate argument shape up-front so bad calls fail loud (§2.3).
         if stage not in ("staging", "shadow", "production"):
             raise ValueError(
                 f"register(stage=...) must be 'staging', 'shadow', or "
@@ -804,7 +819,194 @@ class MLEngine:
                 f"register(format=...) must be 'onnx', 'pickle', or 'both'; "
                 f"got {format!r}."
             )
-        raise NotImplementedError(f"MLEngine.register — {_PHASE_4}")
+
+        # result MUST be a TrainingResult per the spec §2.2 signature.
+        # We duck-type rather than strict isinstance so a lightweight
+        # TrainingResult-shaped object (useful for tests) is accepted
+        # provided it carries the fields register() actually reads.
+        for required_attr in ("family", "artifact_uris", "tenant_id"):
+            if not hasattr(result, required_attr):
+                raise ValueError(
+                    f"register(result=...) expected a TrainingResult-shaped "
+                    f"object with '{required_attr}'; got "
+                    f"{type(result).__name__}."
+                )
+
+        # tenant_id — Engine's tenant wins; a TrainingResult from a
+        # different Engine instance that drifts from self._tenant_id is
+        # caught here (multi-tenant safety: the Engine that registers
+        # owns the audit row).
+        tenant_id = self._tenant_id or result.tenant_id
+        effective_tenant = (
+            tenant_id if tenant_id is not None else (_sql.SENTINEL_GLOBAL_TENANT)
+        )
+
+        # Model-name synthesis: prefer explicit, then the training
+        # result's family + short hash of model_uri (stable across
+        # retries), then "model_<family>". Validated as an identifier
+        # before being interpolated into SQL paths.
+        model_name = name or self._synthesise_model_name(result)
+        from kailash.db.dialect import _validate_identifier
+
+        _validate_identifier(model_name)
+
+        # Retrieve the actual model object. Trainables attached via
+        # result._trainable are the canonical handle; some test paths
+        # may pass the model directly via result.model. We look in
+        # both slots and fall back to a helpful error if neither is
+        # populated.
+        model_obj = (
+            getattr(result, "model", None)
+            or getattr(result, "_model", None)
+            or getattr(getattr(result, "_trainable", None), "model", None)
+            or getattr(getattr(result, "trainable", None), "model", None)
+        )
+        if model_obj is None:
+            raise ValueError(
+                "register(result=...) could not locate the trained model. "
+                "Attach the fitted model on result.model or pass a "
+                "TrainingResult whose trainable exposes .model."
+            )
+
+        # Framework key for the ONNX bridge. Prefer the explicit
+        # result.family when present; otherwise infer from the model
+        # class module.
+        framework = self._resolve_onnx_framework(result, model_obj)
+
+        # Ensure the auxiliary engine tables exist. This is idempotent;
+        # a real bootstrap path initialises them at construction, but
+        # lazy creation here keeps the tests that construct an engine
+        # without a prior setup() working.
+        conn = await self._acquire_connection()
+        await _sql.create_engine_tables(conn)
+
+        # Monotonic version per (tenant_id, name). Read and insert
+        # must share a transaction to close the TOCTOU window.
+        t0 = time.monotonic()
+        registered_at = time.time()
+        audit_outcome = "failure"
+        audit_model_uri: Optional[str] = None
+
+        try:
+            async with conn.transaction() as tx:
+                version = await _sql.get_next_version(
+                    tx, tenant_id=effective_tenant, name=model_name
+                )
+                model_uri = f"models://{model_name}/v{version}"
+                audit_model_uri = model_uri
+
+                # Artifact persistence. The ArtifactStore primitive is
+                # shared with ModelRegistry so artifacts land in the
+                # same filesystem layout, giving downstream readers a
+                # uniform URI scheme.
+                artifact_uris: dict[str, str] = {}
+                store = self._resolve_artifact_store()
+
+                # ONNX export — default path. Failure on format="onnx"
+                # MUST raise OnnxExportError (§4.2 MUST 4); format="both"
+                # tolerates partial failure (§6.1 MUST 5).
+                if format in ("onnx", "both"):
+                    onnx_uri = await self._export_and_save_onnx(
+                        model=model_obj,
+                        framework=framework,
+                        name=model_name,
+                        version=version,
+                        artifact_store=store,
+                        format=format,
+                    )
+                    if onnx_uri is not None:
+                        artifact_uris["onnx"] = onnx_uri
+
+                # Pickle export — always for format="pickle" and "both";
+                # never for format="onnx" per §6.1 MUST 5.
+                if format in ("pickle", "both"):
+                    pickle_bytes = pickle.dumps(model_obj)
+                    pickle_uri = await store.save(
+                        model_name, version, pickle_bytes, "model.pkl"
+                    )
+                    artifact_uris["pickle"] = pickle_uri
+
+                # Persist the version row (§5.1 MUST 4: tenant_id on the
+                # model version table, indexed by the DDL helper).
+                await _sql.insert_version_row(
+                    tx,
+                    tenant_id=effective_tenant,
+                    name=model_name,
+                    version=version,
+                    model_uri=model_uri,
+                    stage=stage,
+                    alias=alias,
+                    artifact_uris_json=json.dumps(artifact_uris),
+                    registered_at=registered_at,
+                )
+
+            audit_outcome = "success"
+
+        except OnnxExportError:
+            # Let the typed ONNX error propagate; the audit row below
+            # still fires with outcome="failure".
+            raise
+        except Exception as exc:  # noqa: BLE001 — see logger.exception
+            logger.exception(
+                "engine.register.error",
+                extra={
+                    "name": model_name,
+                    "tenant_id": self._tenant_id,
+                    "error": str(exc),
+                },
+            )
+            raise
+        finally:
+            duration_ms = (time.monotonic() - t0) * 1000.0
+            # Audit row always writes — §5.2 mandates the row regardless
+            # of outcome so post-incident forensics can reconstruct
+            # who tried to register what.
+            try:
+                await _sql.insert_audit_row(
+                    conn,
+                    audit_id=str(uuid.uuid4()),
+                    tenant_id=effective_tenant,
+                    actor_id=None,
+                    model_uri=audit_model_uri,
+                    operation="register",
+                    occurred_at=registered_at,
+                    duration_ms=duration_ms,
+                    outcome=audit_outcome,
+                )
+            except Exception:  # noqa: BLE001 — audit write failure
+                # Log at WARN; never mask the primary exception.
+                logger.warning(
+                    "engine.register.audit_write_failed",
+                    extra={
+                        "name": model_name,
+                        "tenant_id": self._tenant_id,
+                    },
+                )
+
+        from kailash_ml._results import RegisterResult
+
+        result_envelope = RegisterResult(
+            name=model_name,
+            version=version,
+            stage=stage,
+            artifact_uris=artifact_uris,
+            model_uri=model_uri,
+            registered_at=registered_at,
+            tenant_id=tenant_id,
+            alias=alias,
+        )
+        logger.info(
+            "engine.register.ok",
+            extra={
+                "name": model_name,
+                "version": version,
+                "stage": stage,
+                "format": format,
+                "tenant_id": self._tenant_id,
+                "duration_ms": duration_ms,
+            },
+        )
+        return result_envelope
 
     async def serve(
         self,
@@ -1035,3 +1237,170 @@ class MLEngine:
         if "entity_id" in cols:
             return "entity_id"
         return "_engine_entity_id"
+
+    # ------------------------------------------------------------------
+    # register() internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _synthesise_model_name(result: Any) -> str:
+        """Generate a stable model name from a TrainingResult.
+
+        Prefers ``result.family`` when populated; falls back to a hash
+        of ``model_uri`` so two register() calls against the same
+        TrainingResult produce the same name. The returned name is
+        sanitised to the identifier allowlist so it can be interpolated
+        into SQL paths via ``_validate_identifier``.
+        """
+        family = getattr(result, "family", None)
+        if isinstance(family, str) and family.isidentifier():
+            base = family
+        else:
+            model_uri = getattr(result, "model_uri", None) or ""
+            digest = hashlib.sha256(model_uri.encode("utf-8")).hexdigest()[:8]
+            base = f"model_{digest}"
+        # Collapse any non-allowlist chars defensively — identifier
+        # allowlist is ^[a-zA-Z_][a-zA-Z0-9_]*$.
+        sanitised = "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in base)
+        if not sanitised or not (sanitised[0].isalpha() or sanitised[0] == "_"):
+            sanitised = f"_{sanitised or 'model'}"
+        return sanitised
+
+    @staticmethod
+    def _resolve_onnx_framework(result: Any, model_obj: Any) -> str:
+        """Resolve the ONNX bridge framework key from TrainingResult / model."""
+        explicit = getattr(result, "family", None)
+        if isinstance(explicit, str):
+            # Normalise family aliases to the ONNX bridge keys.
+            family_map = {
+                "sklearn": "sklearn",
+                "random_forest": "sklearn",
+                "rf": "sklearn",
+                "logreg": "sklearn",
+                "logistic": "sklearn",
+                "xgb": "xgboost",
+                "xgboost": "xgboost",
+                "lgbm": "lightgbm",
+                "lightgbm": "lightgbm",
+                "catboost": "catboost",
+                "torch": "torch",
+                "pytorch": "torch",
+                "lightning": "lightning",
+            }
+            if explicit.lower() in family_map:
+                return family_map[explicit.lower()]
+        module = type(model_obj).__module__.lower()
+        if module.startswith("sklearn"):
+            return "sklearn"
+        if module.startswith("xgboost"):
+            return "xgboost"
+        if module.startswith("lightgbm"):
+            return "lightgbm"
+        if module.startswith("catboost"):
+            return "catboost"
+        if module.startswith("lightning"):
+            return "lightning"
+        if module.startswith("torch"):
+            return "torch"
+        # Unknown framework — the bridge will return a "skipped" export
+        # result; register() promotes that to OnnxExportError on
+        # format="onnx".
+        return "sklearn"
+
+    async def _acquire_connection(self) -> Any:
+        """Return an initialised ConnectionManager for the engine's store.
+
+        When the engine was constructed with a ``ConnectionManager``
+        instance, return it as-is (DI override); otherwise build the
+        default SQLite connection on first use. The connection is
+        cached on the engine so repeated ``register()`` calls reuse
+        the pool.
+        """
+        from kailash.db.connection import ConnectionManager
+
+        if isinstance(self._connection_manager, ConnectionManager):
+            if getattr(self._connection_manager, "_pool", None) is None:
+                await self._connection_manager.initialize()
+            return self._connection_manager
+
+        # Default path: construct + initialise a ConnectionManager
+        # against the store URL. The store directory is created lazily
+        # here (NOT in __init__) so zero-arg construction stays pure.
+        if self._connection_manager is None:
+            url = self.store_url
+            # Ensure ~/.kailash_ml/ exists for the default SQLite case.
+            if url.startswith("sqlite:///"):
+                db_path = pathlib.Path(url[len("sqlite:///") :])
+                db_path.parent.mkdir(parents=True, exist_ok=True)
+            cm = ConnectionManager(url)
+            await cm.initialize()
+            self._connection_manager = cm
+        return self._connection_manager
+
+    def _resolve_artifact_store(self) -> Any:
+        """Return the ArtifactStore (DI override or default local file store)."""
+        if self._artifact_store is not None:
+            return self._artifact_store
+        from kailash_ml.engines.model_registry import LocalFileArtifactStore
+
+        root = pathlib.Path(
+            os.environ.get(
+                "KAILASH_ML_ARTIFACT_ROOT",
+                str(_DEFAULT_STORE_DIR / "artifacts"),
+            )
+        )
+        self._artifact_store = LocalFileArtifactStore(root_dir=root)
+        return self._artifact_store
+
+    async def _export_and_save_onnx(
+        self,
+        *,
+        model: Any,
+        framework: str,
+        name: str,
+        version: int,
+        artifact_store: Any,
+        format: str,
+    ) -> Optional[str]:
+        """Export the model to ONNX and persist via the artifact store.
+
+        Returns the artifact URI on success. On failure:
+        - format="onnx" raises :class:`OnnxExportError` (§4.2 MUST 4).
+        - format="both" returns ``None`` so pickle-only persistence
+          proceeds (§6.1 MUST 5).
+        """
+        import tempfile
+
+        from kailash_ml.bridge.onnx_bridge import OnnxBridge
+
+        bridge = OnnxBridge()
+        # torch / lightning exports require a sample input; tabular
+        # frameworks (sklearn/xgboost/lightgbm/catboost) only need the
+        # feature count. Phase 3 scope: we let the bridge's own
+        # n_features inference (`model.n_features_in_`) handle the
+        # tabular path; deep-learning sample_input plumbing is
+        # tracked for a subsequent phase.
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = pathlib.Path(tmp) / "model.onnx"
+            export_result = bridge.export(
+                model,
+                framework=framework,
+                output_path=output_path,
+            )
+            if not export_result.success:
+                cause = export_result.error_message or "unknown"
+                if format == "onnx":
+                    raise OnnxExportError(framework=framework, cause=cause)
+                # format="both" tolerates ONNX failure per §6.1 MUST 5.
+                logger.warning(
+                    "engine.register.onnx_partial_failure",
+                    extra={
+                        "name": name,
+                        "framework": framework,
+                        "cause": cause,
+                    },
+                )
+                return None
+            onnx_bytes = output_path.read_bytes()
+        uri = await artifact_store.save(name, version, onnx_bytes, "model.onnx")
+        return uri

--- a/packages/kailash-ml/src/kailash_ml/engine.py
+++ b/packages/kailash-ml/src/kailash_ml/engine.py
@@ -950,7 +950,7 @@ class MLEngine:
             logger.exception(
                 "engine.register.error",
                 extra={
-                    "name": model_name,
+                    "model_name": model_name,
                     "tenant_id": self._tenant_id,
                     "error": str(exc),
                 },
@@ -978,7 +978,7 @@ class MLEngine:
                 logger.warning(
                     "engine.register.audit_write_failed",
                     extra={
-                        "name": model_name,
+                        "model_name": model_name,
                         "tenant_id": self._tenant_id,
                     },
                 )
@@ -998,10 +998,10 @@ class MLEngine:
         logger.info(
             "engine.register.ok",
             extra={
-                "name": model_name,
-                "version": version,
+                "model_name": model_name,
+                "model_version": version,
                 "stage": stage,
-                "format": format,
+                "output_format": format,
                 "tenant_id": self._tenant_id,
                 "duration_ms": duration_ms,
             },
@@ -1395,7 +1395,7 @@ class MLEngine:
                 logger.warning(
                     "engine.register.onnx_partial_failure",
                     extra={
-                        "name": name,
+                        "model_name": name,
                         "framework": framework,
                         "cause": cause,
                     },

--- a/packages/kailash-ml/src/kailash_ml/engines/_engine_sql.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/_engine_sql.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Encapsulated SQL for :class:`~kailash_ml.engine.MLEngine`.
+
+Same discipline as :mod:`kailash_ml.engines._feature_sql`: every raw SQL
+string used by `MLEngine` lives here and nowhere else. `engine.py`
+delegates DDL and CRUD through this module so audits find every
+identifier-bearing statement in one place.
+
+Two tables:
+
+* ``_kml_engine_versions`` — tenant-aware model version ledger.
+  Augments :class:`kailash_ml.engines.ModelRegistry` (which stores the
+  registry-wide ``_kml_model_versions`` without a tenant column) by
+  carrying the tenant dimension mandated by
+  `specs/ml-engines.md` §5.1 MUST 4. Primary key is
+  ``(tenant_id, name, version)`` per the spec — ``tenant_id`` is part of
+  the identity scope, not a filter column bolted on later. The literal
+  ``"global"`` is used for single-tenant deployments (§5.1 MUST 2);
+  ``"default"`` is BLOCKED because
+  `rules/tenant-isolation.md` § MUST Rule 2 mandates a distinct sentinel.
+
+* ``_kml_engine_audit`` — operation audit trail per §5.2. Every
+  ``register()`` writes one row with ``tenant_id`` indexed (§5.2 column
+  list: ``tenant_id``, ``actor_id``, ``model_uri``, ``operation``,
+  ``occurred_at``, ``duration_ms``, ``outcome``).
+
+Rules applied:
+
+* ``rules/dataflow-identifier-safety.md`` — identifiers routed through
+  ``_validate_identifier``; SQL types through an allowlist.
+* ``rules/infrastructure-sql.md`` — ``?`` canonical placeholders,
+  ``dialect.blob_type()`` for BLOB portability, transactions for
+  multi-statement ops.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from kailash.db.connection import ConnectionManager
+from kailash.db.dialect import _validate_identifier
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "create_engine_tables",
+    "insert_version_row",
+    "get_next_version",
+    "fetch_version_row",
+    "insert_audit_row",
+    "count_versions",
+    "SENTINEL_GLOBAL_TENANT",
+]
+
+
+# ---------------------------------------------------------------------------
+# Tenant sentinel (specs/ml-engines.md §5.1 MUST 2)
+# ---------------------------------------------------------------------------
+
+# The literal string used in key construction and table rows when the
+# Engine is single-tenant. `"default"` is BLOCKED per rules/tenant-
+# isolation.md MUST Rule 2 — it silently merges every non-scoped read
+# into a shared cache slot.
+SENTINEL_GLOBAL_TENANT: str = "global"
+
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+
+async def create_engine_tables(conn: ConnectionManager) -> None:
+    """Create the MLEngine auxiliary tables if they do not exist.
+
+    Idempotent: safe to call on every ``register()`` invocation.
+    """
+    # The tables below use fixed identifiers — no user input is
+    # interpolated into the DDL. Defence-in-depth validation per
+    # rules/dataflow-identifier-safety.md MUST Rule 5 still applies:
+    # if a future refactor makes the name dynamic, the validator is
+    # already in place and catches the drift.
+    _validate_identifier("_kml_engine_versions")
+    _validate_identifier("_kml_engine_audit")
+    _validate_identifier("idx_kml_engine_versions_tenant_name")
+    _validate_identifier("idx_kml_engine_audit_tenant")
+
+    # `(tenant_id, name, version)` is the identity scope (§5.1 MUST 4).
+    # A UNIQUE constraint on `(tenant_id, name, version)` enforces the
+    # monotonic-per-tenant versioning contract.
+    await conn.execute(
+        "CREATE TABLE IF NOT EXISTS _kml_engine_versions ("
+        "  tenant_id TEXT NOT NULL,"
+        "  name TEXT NOT NULL,"
+        "  version INTEGER NOT NULL,"
+        "  model_uri TEXT NOT NULL,"
+        "  stage TEXT NOT NULL DEFAULT 'staging',"
+        "  alias TEXT,"
+        "  artifact_uris_json TEXT NOT NULL DEFAULT '{}',"
+        "  registered_at REAL NOT NULL,"
+        "  PRIMARY KEY (tenant_id, name, version)"
+        ")"
+    )
+
+    # Tenant-prefix index for the "which models did tenant X promote"
+    # post-incident query (rules/tenant-isolation.md § MUST Rule 5).
+    await conn.create_index(
+        "idx_kml_engine_versions_tenant_name",
+        "_kml_engine_versions",
+        "tenant_id, name",
+    )
+
+    # Audit-row schema per specs/ml-engines.md §5.2. `outcome` is a
+    # short enum string; `duration_ms` is a float (fractional ms is
+    # useful at training-cycle resolution).
+    await conn.execute(
+        "CREATE TABLE IF NOT EXISTS _kml_engine_audit ("
+        "  id TEXT PRIMARY KEY,"
+        "  tenant_id TEXT NOT NULL,"
+        "  actor_id TEXT,"
+        "  model_uri TEXT,"
+        "  operation TEXT NOT NULL,"
+        "  occurred_at REAL NOT NULL,"
+        "  duration_ms REAL NOT NULL,"
+        "  outcome TEXT NOT NULL"
+        ")"
+    )
+    await conn.create_index(
+        "idx_kml_engine_audit_tenant",
+        "_kml_engine_audit",
+        "tenant_id, occurred_at",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Version row CRUD
+# ---------------------------------------------------------------------------
+
+
+async def get_next_version(
+    tx: Any,
+    tenant_id: str,
+    name: str,
+) -> int:
+    """Return the next monotonic version for ``(tenant_id, name)``.
+
+    MUST be called inside a ``conn.transaction()`` — otherwise the
+    MAX-then-INSERT pattern has a TOCTOU race window where two
+    concurrent callers both read ``MAX(version)`` = N and both insert
+    N+1, yielding a UNIQUE constraint violation at best and a silent
+    collision at worst.
+    """
+    row = await tx.fetchone(
+        "SELECT MAX(version) AS max_v FROM _kml_engine_versions "
+        "WHERE tenant_id = ? AND name = ?",
+        tenant_id,
+        name,
+    )
+    max_v = row.get("max_v") if row else None
+    if max_v is None:
+        return 1
+    return int(max_v) + 1
+
+
+async def insert_version_row(
+    tx: Any,
+    *,
+    tenant_id: str,
+    name: str,
+    version: int,
+    model_uri: str,
+    stage: str,
+    alias: Optional[str],
+    artifact_uris_json: str,
+    registered_at: float,
+) -> None:
+    """Insert a version row into ``_kml_engine_versions``.
+
+    Must be called inside the same transaction as
+    :func:`get_next_version` so the MAX→INSERT pair is atomic.
+    """
+    await tx.execute(
+        "INSERT INTO _kml_engine_versions "
+        "(tenant_id, name, version, model_uri, stage, alias, "
+        " artifact_uris_json, registered_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        tenant_id,
+        name,
+        version,
+        model_uri,
+        stage,
+        alias,
+        artifact_uris_json,
+        registered_at,
+    )
+
+
+async def fetch_version_row(
+    conn: ConnectionManager,
+    *,
+    tenant_id: str,
+    name: str,
+    version: int,
+) -> Optional[dict[str, Any]]:
+    """Read a version row by ``(tenant_id, name, version)``.
+
+    Returns ``None`` when the row does not exist.
+    """
+    return await conn.fetchone(
+        "SELECT * FROM _kml_engine_versions "
+        "WHERE tenant_id = ? AND name = ? AND version = ?",
+        tenant_id,
+        name,
+        version,
+    )
+
+
+async def count_versions(
+    conn: ConnectionManager,
+    *,
+    tenant_id: str,
+    name: str,
+) -> int:
+    """Return the number of version rows for ``(tenant_id, name)``."""
+    row = await conn.fetchone(
+        "SELECT COUNT(*) AS n FROM _kml_engine_versions "
+        "WHERE tenant_id = ? AND name = ?",
+        tenant_id,
+        name,
+    )
+    if row is None:
+        return 0
+    return int(row.get("n", 0))
+
+
+# ---------------------------------------------------------------------------
+# Audit row write
+# ---------------------------------------------------------------------------
+
+
+async def insert_audit_row(
+    conn: ConnectionManager,
+    *,
+    audit_id: str,
+    tenant_id: str,
+    actor_id: Optional[str],
+    model_uri: Optional[str],
+    operation: str,
+    occurred_at: float,
+    duration_ms: float,
+    outcome: str,
+) -> None:
+    """Insert an audit row per specs/ml-engines.md §5.2."""
+    await conn.execute(
+        "INSERT INTO _kml_engine_audit "
+        "(id, tenant_id, actor_id, model_uri, operation, occurred_at, "
+        " duration_ms, outcome) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        audit_id,
+        tenant_id,
+        actor_id,
+        model_uri,
+        operation,
+        occurred_at,
+        duration_ms,
+        outcome,
+    )

--- a/packages/kailash-ml/tests/integration/test_engine_register_onnx_export_failure_raises.py
+++ b/packages/kailash-ml/tests/integration/test_engine_register_onnx_export_failure_raises.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 test for ONNX export failure semantics in ``register()``.
+
+Per ``specs/ml-engines.md`` §4.2 MUST 4 / §6.1 MUST 4: when
+``register(format="onnx")`` fails to export the model to ONNX, it MUST
+raise :class:`OnnxExportError`. Silent fallback to pickle under the
+default format is BLOCKED.
+
+``register(format="both")`` tolerates partial ONNX failure (§6.1 MUST 5).
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+
+import pytest
+
+
+def _training_result_with_unexportable_model() -> Any:
+    """Build a TrainingResult carrying a model the ONNX bridge cannot export.
+
+    We use a plain ``object()`` as the "model" — it matches no framework
+    in the bridge's ``_COMPAT_MATRIX`` so the export returns
+    ``OnnxExportResult(success=False, onnx_status="skipped")`` and
+    register() promotes that to :class:`OnnxExportError` per §6.1 MUST 4.
+    """
+    from kailash_ml._result import TrainingResult
+
+    result = TrainingResult(
+        model_uri="models://broken/v0",
+        metrics={"accuracy": 0.9},
+        device_used="cpu",
+        accelerator="cpu",
+        precision="32-true",
+        elapsed_seconds=0.01,
+        tracker_run_id=None,
+        tenant_id=None,
+        artifact_uris={},
+        lightning_trainer_config={},
+        family="unknown_family",
+    )
+    object.__setattr__(result, "model", object())
+    return result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_onnx_failure_raises_typed_error() -> None:
+    """format='onnx' (default) MUST raise OnnxExportError on failure."""
+    from kailash_ml import MLEngine
+    from kailash_ml.engine import OnnxExportError
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        os.environ["KAILASH_ML_ARTIFACT_ROOT"] = tmp
+
+        engine = MLEngine()
+        result = _training_result_with_unexportable_model()
+
+        with pytest.raises(OnnxExportError) as exc_info:
+            await engine.register(result, format="onnx")
+
+        # §4.2 MUST 4: the raised error names the framework + cause so
+        # operators can tell which branch failed without reading the log.
+        assert exc_info.value.framework is not None
+        assert exc_info.value.cause
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_format_both_tolerates_onnx_failure() -> None:
+    """format='both' returns RegisterResult with pickle-only artifact_uris (§6.1 MUST 5)."""
+    from kailash_ml import MLEngine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        os.environ["KAILASH_ML_ARTIFACT_ROOT"] = tmp
+
+        engine = MLEngine()
+        # Use a real sklearn model — ONNX export succeeds for sklearn so we
+        # need an unexportable shape. An ``object()`` with a valid pickle
+        # path: object() is picklable. ONNX fails (unknown framework),
+        # pickle succeeds, and format="both" returns pickle-only.
+        result = _training_result_with_unexportable_model()
+
+        reg = await engine.register(result, format="both")
+
+        # pickle artifact IS present; ONNX is NOT.
+        assert "pickle" in reg.artifact_uris
+        assert "onnx" not in reg.artifact_uris
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_audit_row_records_failure_outcome() -> None:
+    """§5.2 — failed register() still writes audit row with outcome='failure'."""
+    from kailash_ml import MLEngine
+    from kailash_ml.engine import OnnxExportError
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        os.environ["KAILASH_ML_ARTIFACT_ROOT"] = tmp
+
+        engine = MLEngine(tenant_id="acme")
+        result = _training_result_with_unexportable_model()
+
+        with pytest.raises(OnnxExportError):
+            await engine.register(result, format="onnx")
+
+        # Audit row MUST land even though register() raised.
+        conn = await engine._acquire_connection()
+        rows = await conn.fetch(
+            "SELECT * FROM _kml_engine_audit WHERE tenant_id = ? " "AND outcome = ?",
+            "acme",
+            "failure",
+        )
+        assert len(rows) >= 1
+        assert rows[0]["operation"] == "register"

--- a/packages/kailash-ml/tests/integration/test_engine_register_onnx_matrix.py
+++ b/packages/kailash-ml/tests/integration/test_engine_register_onnx_matrix.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 ONNX round-trip matrix through :meth:`MLEngine.register`.
+
+Per ``specs/ml-engines.md`` §6.1 MUST 2-3: every framework key in the
+ONNX compatibility matrix MUST have a Tier 2 round-trip regression
+test that trains a minimal model, exports via ``engine.register``,
+re-imports the ONNX artifact via ``onnxruntime.InferenceSession``, and
+asserts prediction parity against the native model.
+
+Optional frameworks (xgboost / lightgbm / catboost / torch / lightning)
+are skipped when their packages aren't installed on the host. The
+sklearn branch runs unconditionally because sklearn is a base dep.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("skl2onnx")
+pytest.importorskip("onnxruntime")
+
+
+# darwin-arm64 + Python 3.13 is a known segfault host for xgboost / lightgbm
+# 4.x — existing Tier 2 ONNX roundtrip tests already skipif on this combo.
+# See tests/integration/test_onnx_roundtrip_lightgbm.py for precedent.
+_SEGFAULT_HOST = (
+    sys.platform == "darwin"
+    and platform.machine() == "arm64"
+    and sys.version_info[:2] >= (3, 13)
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _training_result(model: Any, family: str) -> Any:
+    """Build a TrainingResult-shaped object carrying the fitted model."""
+    from kailash_ml._result import TrainingResult
+
+    result = TrainingResult(
+        model_uri="models://smoke/v0",
+        metrics={"accuracy": 0.9},
+        device_used="cpu",
+        accelerator="cpu",
+        precision="32-true",
+        elapsed_seconds=0.01,
+        tracker_run_id=None,
+        tenant_id=None,
+        artifact_uris={},
+        lightning_trainer_config={},
+        family=family,
+    )
+    # Frozen dataclass — attach the fitted model via object.__setattr__
+    # so register() can pick it up via the attribute lookup chain.
+    object.__setattr__(result, "model", model)
+    return result
+
+
+def _engine_in_tmp(tmp: str) -> Any:
+    """Construct an engine pointed at a throwaway SQLite store."""
+    os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+    os.environ["KAILASH_ML_ARTIFACT_ROOT"] = tmp
+
+    from kailash_ml import MLEngine
+
+    return MLEngine()
+
+
+def _onnx_inference_labels(onnx_uri: str, X: np.ndarray) -> np.ndarray:
+    """Load the ONNX artifact and return prediction labels on ``X``."""
+    import onnxruntime as ort
+
+    session = ort.InferenceSession(str(onnx_uri))
+    input_name = session.get_inputs()[0].name
+    outputs = session.run(None, {input_name: X.astype(np.float32)})
+    return np.asarray(outputs[0]).flatten()
+
+
+# ---------------------------------------------------------------------------
+# sklearn — unconditional
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_sklearn_onnx_roundtrip() -> None:
+    """sklearn RandomForest round-trips through engine.register(format='onnx')."""
+    from sklearn.datasets import make_classification
+    from sklearn.ensemble import RandomForestClassifier
+
+    with tempfile.TemporaryDirectory() as tmp:
+        engine = _engine_in_tmp(tmp)
+
+        X, y = make_classification(n_samples=100, n_features=6, random_state=42)
+        X = X.astype(np.float32)
+        model = RandomForestClassifier(n_estimators=5, random_state=42).fit(X, y)
+        result = _training_result(model, family="sklearn")
+
+        reg = await engine.register(result, format="onnx")
+
+        assert "onnx" in reg.artifact_uris
+        assert Path(reg.artifact_uris["onnx"]).exists()
+        onnx_labels = _onnx_inference_labels(reg.artifact_uris["onnx"], X[:20])
+        native_labels = model.predict(X[:20])
+        assert np.array_equal(onnx_labels, native_labels)
+        # Version monotonicity (§5.1 MUST 4 scope)
+        assert reg.version == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_sklearn_format_both_populates_both_artifacts() -> None:
+    """format='both' populates both onnx and pickle keys (§6.1 MUST 5)."""
+    from sklearn.datasets import make_classification
+    from sklearn.linear_model import LogisticRegression
+
+    with tempfile.TemporaryDirectory() as tmp:
+        engine = _engine_in_tmp(tmp)
+        X, y = make_classification(n_samples=80, n_features=4, random_state=0)
+        X = X.astype(np.float32)
+        model = LogisticRegression(max_iter=200).fit(X, y)
+        result = _training_result(model, family="sklearn")
+
+        reg = await engine.register(result, format="both")
+
+        assert "onnx" in reg.artifact_uris
+        assert "pickle" in reg.artifact_uris
+
+
+# ---------------------------------------------------------------------------
+# xgboost — optional
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    _SEGFAULT_HOST,
+    reason="xgboost segfaults on darwin-arm + py3.13; covered by Linux CI.",
+)
+async def test_register_xgboost_onnx_roundtrip() -> None:
+    """xgboost round-trips through engine.register(format='onnx')."""
+    pytest.importorskip("xgboost")
+    pytest.importorskip("onnxmltools")
+    import xgboost as xgb
+    from sklearn.datasets import make_classification
+
+    with tempfile.TemporaryDirectory() as tmp:
+        engine = _engine_in_tmp(tmp)
+        X, y = make_classification(n_samples=80, n_features=4, random_state=1)
+        X = X.astype(np.float32)
+        model = xgb.XGBClassifier(
+            n_estimators=5,
+            max_depth=3,
+            eval_metric="logloss",
+            random_state=1,
+        ).fit(X, y)
+        result = _training_result(model, family="xgboost")
+
+        reg = await engine.register(result, format="onnx")
+
+        assert "onnx" in reg.artifact_uris
+        assert Path(reg.artifact_uris["onnx"]).exists()
+
+
+# ---------------------------------------------------------------------------
+# lightgbm — optional (skip on darwin-arm + py3.13 segfault)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_lightgbm_onnx_roundtrip() -> None:
+    """lightgbm round-trips through engine.register(format='onnx')."""
+    import platform
+    import sys
+
+    pytest.importorskip("lightgbm")
+    pytest.importorskip("onnxmltools")
+
+    if (
+        sys.platform == "darwin"
+        and platform.machine() == "arm64"
+        and sys.version_info[:2] >= (3, 13)
+    ):
+        pytest.skip(
+            "LightGBM 4.x segfaults on darwin-arm + py3.13 — Tier 2 "
+            "coverage deferred to Linux CI (matches existing onnx "
+            "roundtrip test skipif)."
+        )
+
+    import lightgbm as lgb
+    from sklearn.datasets import make_classification
+
+    with tempfile.TemporaryDirectory() as tmp:
+        engine = _engine_in_tmp(tmp)
+        X, y = make_classification(n_samples=80, n_features=4, random_state=2)
+        X = X.astype(np.float32)
+        model = lgb.LGBMClassifier(n_estimators=5, random_state=2).fit(X, y)
+        result = _training_result(model, family="lightgbm")
+
+        reg = await engine.register(result, format="onnx")
+
+        assert "onnx" in reg.artifact_uris
+        assert Path(reg.artifact_uris["onnx"]).exists()
+
+
+# ---------------------------------------------------------------------------
+# catboost / torch / lightning — deep frameworks: optional, import-gated
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    _SEGFAULT_HOST,
+    reason="catboost + onnx deps unstable on darwin-arm + py3.13; Linux CI coverage.",
+)
+async def test_register_catboost_onnx_roundtrip() -> None:
+    """catboost round-trips through engine.register(format='onnx')."""
+    pytest.importorskip("catboost")
+    import catboost as cb
+    from sklearn.datasets import make_classification
+
+    with tempfile.TemporaryDirectory() as tmp:
+        engine = _engine_in_tmp(tmp)
+        X, y = make_classification(n_samples=80, n_features=4, random_state=3)
+        X = X.astype(np.float32)
+        model = cb.CatBoostClassifier(iterations=5, verbose=0).fit(X, y)
+        result = _training_result(model, family="catboost")
+
+        reg = await engine.register(result, format="onnx")
+
+        assert "onnx" in reg.artifact_uris
+        assert Path(reg.artifact_uris["onnx"]).exists()

--- a/packages/kailash-ml/tests/integration/test_engine_register_tenant_row.py
+++ b/packages/kailash-ml/tests/integration/test_engine_register_tenant_row.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 integration test for tenant_id persistence through register().
+
+Per ``specs/ml-engines.md`` §5.1 MUST 4: ``register()`` MUST persist
+``tenant_id`` on the model version row and the primary key MUST include
+it as ``(tenant_id, name, version)``. Two tenants registering a model
+with the same ``name`` MUST NOT collide.
+
+Per §5.2: every register() call MUST write an audit row carrying
+``tenant_id``, ``operation="register"``, ``duration_ms``, ``outcome``.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytest.importorskip("sklearn")
+pytest.importorskip("skl2onnx")
+
+
+def _training_result(model: Any, family: str) -> Any:
+    from kailash_ml._result import TrainingResult
+
+    result = TrainingResult(
+        model_uri="models://smoke/v0",
+        metrics={"accuracy": 0.9},
+        device_used="cpu",
+        accelerator="cpu",
+        precision="32-true",
+        elapsed_seconds=0.01,
+        tracker_run_id=None,
+        tenant_id=None,
+        artifact_uris={},
+        lightning_trainer_config={},
+        family=family,
+    )
+    object.__setattr__(result, "model", model)
+    return result
+
+
+def _fit_minimal_sklearn() -> Any:
+    from sklearn.datasets import make_classification
+    from sklearn.linear_model import LogisticRegression
+
+    X, y = make_classification(n_samples=60, n_features=4, random_state=42)
+    return LogisticRegression(max_iter=200).fit(X.astype(np.float32), y)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_persists_tenant_id_on_version_row() -> None:
+    """_kml_engine_versions row carries tenant_id and matches the engine."""
+    from kailash_ml import MLEngine
+    from kailash_ml.engines import _engine_sql as _sql
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        os.environ["KAILASH_ML_ARTIFACT_ROOT"] = tmp
+
+        engine = MLEngine(tenant_id="acme")
+        result = _training_result(_fit_minimal_sklearn(), family="sklearn")
+        reg = await engine.register(result, format="onnx")
+        assert reg.tenant_id == "acme"
+
+        # Read the row through the SQL helper.
+        conn = await engine._acquire_connection()
+        row = await _sql.fetch_version_row(
+            conn, tenant_id="acme", name=reg.name, version=reg.version
+        )
+        assert row is not None
+        assert row["tenant_id"] == "acme"
+        assert row["name"] == reg.name
+        assert row["version"] == reg.version
+        assert row["stage"] == "staging"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_two_tenants_independent_versions() -> None:
+    """(tenant_id, name, version) primary key — two tenants don't collide."""
+    from kailash_ml import MLEngine
+    from kailash_ml.engines import _engine_sql as _sql
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        os.environ["KAILASH_ML_ARTIFACT_ROOT"] = tmp
+
+        engine_a = MLEngine(tenant_id="acme")
+        engine_b = MLEngine(tenant_id="globex")
+        result_a = _training_result(_fit_minimal_sklearn(), family="sklearn")
+        result_b = _training_result(_fit_minimal_sklearn(), family="sklearn")
+
+        reg_a = await engine_a.register(result_a, name="sklearn", format="onnx")
+        reg_b = await engine_b.register(result_b, name="sklearn", format="onnx")
+
+        # Both tenants start at version 1 — no cross-tenant collision.
+        assert reg_a.version == 1
+        assert reg_b.version == 1
+
+        # Second register in tenant "acme" increments.
+        reg_a2 = await engine_a.register(result_a, name="sklearn", format="onnx")
+        assert reg_a2.version == 2
+
+        # Counts are tenant-scoped.
+        conn = await engine_a._acquire_connection()
+        n_acme = await _sql.count_versions(conn, tenant_id="acme", name="sklearn")
+        n_globex = await _sql.count_versions(conn, tenant_id="globex", name="sklearn")
+        assert n_acme == 2
+        assert n_globex == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_writes_audit_row_with_tenant_id() -> None:
+    """§5.2 audit row — tenant_id + operation + outcome persisted."""
+    from kailash_ml import MLEngine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        os.environ["KAILASH_ML_ARTIFACT_ROOT"] = tmp
+
+        engine = MLEngine(tenant_id="acme")
+        result = _training_result(_fit_minimal_sklearn(), family="sklearn")
+        await engine.register(result, format="onnx")
+
+        conn = await engine._acquire_connection()
+        rows = await conn.fetch(
+            "SELECT * FROM _kml_engine_audit WHERE tenant_id = ? " "AND operation = ?",
+            "acme",
+            "register",
+        )
+        assert len(rows) >= 1
+        row = rows[0]
+        assert row["tenant_id"] == "acme"
+        assert row["operation"] == "register"
+        assert row["outcome"] == "success"
+        assert row["duration_ms"] > 0
+        assert row["model_uri"].startswith("models://")

--- a/packages/kailash-ml/tests/integration/test_engine_setup_idempotency.py
+++ b/packages/kailash-ml/tests/integration/test_engine_setup_idempotency.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 integration test for :meth:`MLEngine.setup` idempotency.
+
+Per ``specs/ml-engines.md`` §2.1 MUST 6: calling ``setup()`` twice with
+identical ``(df_fingerprint, target, ignore, feature_store_name)`` MUST
+produce equal ``schema_hash`` AND equal ``split_seed`` values, and MUST
+NOT create a duplicate FeatureSchema registration.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import polars as pl
+import pytest
+
+pytest.importorskip("polars")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_engine_setup_is_idempotent_on_repeated_calls() -> None:
+    """Two setup() calls with the same inputs yield the same SetupResult."""
+    from kailash_ml import MLEngine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        engine = MLEngine()
+        df = pl.DataFrame(
+            {
+                "id": list(range(50)),
+                "x1": [float(i) for i in range(50)],
+                "x2": [float(i * 2) for i in range(50)],
+                "y": [i % 2 for i in range(50)],
+            }
+        )
+        r1 = await engine.setup(df, target="y")
+        r2 = await engine.setup(df, target="y")
+
+        # §2.1 MUST 6 — same hash, same split seed, equal sizes.
+        assert r1.schema_hash == r2.schema_hash
+        assert r1.split_seed == r2.split_seed
+        assert r1.train_size == r2.train_size
+        assert r1.test_size == r2.test_size
+
+        # Same target + task + feature columns.
+        assert r1.target == r2.target == "y"
+        assert r1.task_type == r2.task_type == "classification"
+        assert r1.feature_columns == r2.feature_columns
+
+        # r2 is the cached result (idempotent hit returns the stored object).
+        assert r2 is r1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_engine_setup_ignore_permutation_yields_same_hash() -> None:
+    """Ignore-list ordering does NOT affect the schema hash."""
+    from kailash_ml import MLEngine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        engine_a = MLEngine()
+        engine_b = MLEngine()
+        df = pl.DataFrame(
+            {
+                "id": list(range(30)),
+                "extra": list(range(30)),
+                "x1": [float(i) for i in range(30)],
+                "y": [i % 2 for i in range(30)],
+            }
+        )
+        r_a = await engine_a.setup(df, target="y", ignore=["extra", "id"])
+        r_b = await engine_b.setup(df, target="y", ignore=["id", "extra"])
+        assert r_a.schema_hash == r_b.schema_hash
+        assert r_a.ignored_columns == r_b.ignored_columns == ("extra", "id")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_engine_setup_different_data_yields_different_hash() -> None:
+    """Different row counts produce different schema_hash values."""
+    from kailash_ml import MLEngine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        engine = MLEngine()
+        df_small = pl.DataFrame({"x": list(range(10)), "y": [i % 2 for i in range(10)]})
+        df_big = pl.DataFrame({"x": list(range(100)), "y": [i % 2 for i in range(100)]})
+        r_small = await engine.setup(df_small, target="y")
+        # reset the cached _setup_result so a second shape can be tested.
+        engine._setup_result = None
+        r_big = await engine.setup(df_big, target="y")
+        assert r_small.schema_hash != r_big.schema_hash

--- a/packages/kailash-ml/tests/integration/test_engine_setup_tenant_propagation.py
+++ b/packages/kailash-ml/tests/integration/test_engine_setup_tenant_propagation.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 integration test for tenant_id propagation through setup().
+
+Per ``specs/ml-engines.md`` §5.1: every primitive MUST be tenant-aware,
+and the Engine MUST propagate its ``tenant_id`` into every result
+envelope it produces. SetupResult.tenant_id MUST echo
+``engine.tenant_id``.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import polars as pl
+import pytest
+
+pytest.importorskip("polars")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_engine_setup_echoes_tenant_id_in_result() -> None:
+    """``SetupResult.tenant_id`` == ``engine.tenant_id``."""
+    from kailash_ml import MLEngine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        engine = MLEngine(tenant_id="acme")
+        df = pl.DataFrame(
+            {
+                "id": list(range(20)),
+                "x": [float(i) for i in range(20)],
+                "y": [i % 2 for i in range(20)],
+            }
+        )
+        result = await engine.setup(df, target="y")
+        assert result.tenant_id == "acme"
+        assert engine.tenant_id == "acme"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_engine_setup_single_tenant_mode_returns_none_tenant() -> None:
+    """Zero-arg engine propagates ``tenant_id=None`` into SetupResult."""
+    from kailash_ml import MLEngine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        engine = MLEngine()
+        df = pl.DataFrame({"x": list(range(20)), "y": [i % 2 for i in range(20)]})
+        result = await engine.setup(df, target="y")
+        # Single-tenant mode — echoed as None, NOT "default" (§5.1 MUST 2).
+        assert result.tenant_id is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_engine_setup_two_tenants_have_independent_results() -> None:
+    """Two engines with different tenants have different SetupResult.tenant_id."""
+    from kailash_ml import MLEngine
+
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["KAILASH_ML_STORE_URL"] = f"sqlite:///{tmp}/ml.db"
+        engine_a = MLEngine(tenant_id="acme")
+        engine_b = MLEngine(tenant_id="globex")
+        df = pl.DataFrame({"x": list(range(20)), "y": [i % 2 for i in range(20)]})
+        r_a = await engine_a.setup(df, target="y")
+        r_b = await engine_b.setup(df, target="y")
+        assert r_a.tenant_id == "acme"
+        assert r_b.tenant_id == "globex"
+        # Schema hash depends on data, not tenant, so hashes match:
+        assert r_a.schema_hash == r_b.schema_hash

--- a/packages/kailash-ml/tests/unit/test_mlengine_construction.py
+++ b/packages/kailash-ml/tests/unit/test_mlengine_construction.py
@@ -64,17 +64,34 @@ class TestMLEngineMethodSurface:
 
 
 class TestMLEngineDeferredBodies:
-    """Phase 2 scaffold pattern — methods raise NotImplementedError with phase pointer."""
+    """Remaining deferral sweep — only the 5 sibling-shard methods still defer.
+
+    Shard-A (setup + register) has been un-stubbed per specs/ml-engines.md
+    §2.1 MUST 6 / §6. The earlier ``test_async_method_deferral_is_typed_error``
+    that asserted ``pytest.raises(NotImplementedError)`` against ``setup()``
+    was deleted in the same commit per rules/orphan-detection.md §4a.
+    """
 
     @pytest.mark.asyncio
-    async def test_async_method_deferral_is_typed_error(self):
-        """A deferred async method MUST raise NotImplementedError (not AttributeError)."""
+    async def test_setup_returns_typed_result_on_minimal_input(self):
+        """Shard-A: setup() returns a populated SetupResult (replaces the
+        deferral test that asserted NotImplementedError).
+        """
+        import polars as pl
+        from kailash_ml import SetupResult
+
         engine = MLEngine()
-        with pytest.raises(NotImplementedError) as exc_info:
-            await engine.setup(data=None, target="x")
-        # The message SHOULD name the phase so the next session knows what to finish
-        msg = str(exc_info.value).lower()
-        assert "phase" in msg or "mlengine" in msg
+        df = pl.DataFrame({"x1": list(range(20)), "y": [i % 2 for i in range(20)]})
+        result = await engine.setup(df, target="y")
+        assert isinstance(result, SetupResult)
+        assert result.target == "y"
+        assert result.task_type == "classification"
+        assert result.feature_columns == ("x1",)
+        assert result.train_size + result.test_size == 20
+        assert result.tenant_id is None  # engine has no tenant_id
+        # Idempotency (§2.1 MUST 6) — second call returns the same hash
+        result2 = await engine.setup(df, target="y")
+        assert result2.schema_hash == result.schema_hash
 
     def test_km_train_three_line_hello_world_works(self):
         """Top-level `km.train(df, target='y')` runs end-to-end per spec §5.1."""


### PR DESCRIPTION
## Summary

- `MLEngine.setup()` — polars-native, schema-hash idempotency key, task-type inference, deterministic holdout split, tenant-id propagation per `specs/ml-engines.md` §2.1 MUST 6
- `MLEngine.register()` — 6-framework ONNX-default export via existing `OnnxBridge`, typed `OnnxExportError` (silent pickle fallback BLOCKED), tenant-aware `(tenant_id, name, version)` primary key, §5.2 audit row writes even on failure
- New `engines/_engine_sql.py` — sole SQL touchpoint for MLEngine auxiliary tables (`_kml_engine_versions`, `_kml_engine_audit`), identifier-validated DDL per `rules/dataflow-identifier-safety.md`
- 5 Tier 2 integration test files (17 test cases) + deferral-test sweep per `rules/orphan-detection.md` §4a

One internal Phase 3.1 deferral inside `setup()` for `split_strategy != "holdout"` — kfold/stratified/walk_forward tracked for follow-up.

## Part of the Phase 3/4/5 parallel-release cycle

- Shard A (this PR): setup + register
- Shard B: compare + finalize + evaluate
- Shard C: predict + serve
- Shard D: MCP #556 elicitation sender half

Version bump + CHANGELOG consolidation happens in a separate release PR after all 4 shards merge.

## Test plan

- [x] Tier 1: `pytest packages/kailash-ml/tests/unit/test_mlengine_construction.py` — 7/7 green
- [x] Tier 2: 5 new integration files — 14 green, 3 xgb/lgbm/catboost skipped per platform precedent
- [x] `pytest --collect-only -q packages/kailash-ml/tests/` — exit 0
- [x] `rg 'raise NotImplementedError'` in engine.py — only sibling-shard stubs remain

## Related issues

Phase 3/4 of `specs/ml-engines.md` §12.1 punch list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)