### PR TITLE
feat(mcp): elicitation/create sender half via injected send-callable (#556)

### DIFF
--- a/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
@@ -72,7 +72,7 @@ from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Union
+from typing import Any, AsyncGenerator, Awaitable, Callable, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import jsonschema
@@ -80,6 +80,11 @@ from kailash_mcp.errors import MCPError, MCPErrorCode, ValidationError
 from kailash_mcp.protocol.protocol import ProgressToken, get_protocol_manager
 
 logger = logging.getLogger(__name__)
+
+# Type alias for the send-callable injected into ElicitationSystem.
+# A SendFn takes a JSON-RPC message dict and returns an awaitable that completes
+# once the message has been pushed through the underlying transport.
+SendFn = Callable[[Dict[str, Any]], Awaitable[None]]
 
 
 class ContentType(Enum):
@@ -754,12 +759,69 @@ class StreamingHandler:
 
 
 class ElicitationSystem:
-    """Interactive user input collection system."""
+    """Interactive user input collection system (MCP elicitation/create).
 
-    def __init__(self):
-        """Initialize elicitation system."""
+    Implements the MCP 2025-06-18 `elicitation/create` server-to-client request.
+    The system is split into two halves, both wired into the framework's hot
+    path per rules/orphan-detection.md §1:
+
+    - **Send half** (`_send_elicitation_request`): serializes an
+      `elicitation/create` JSON-RPC request and pushes it through an injected
+      send-callable bound to the active client transport.
+    - **Receive half** (`provide_input` / `cancel_request`): invoked by the
+      MCPServer's dispatch loop when an inbound `elicitation/response` with a
+      matching request_id arrives from the client.
+
+    Construction:
+
+        >>> from typing import Awaitable, Callable
+        >>> # Option A: pass send-callable at construction time
+        >>> system = ElicitationSystem(send=transport.send_message)
+        >>> # Option B: bind after construction (transport attaches later)
+        >>> system = ElicitationSystem()
+        >>> system.bind_transport(transport.send_message)
+
+    When `send is None`, the system is receive-only: `provide_input()` still
+    works (useful for in-process tests), but `request_input()` raises
+    `MCPError(INVALID_REQUEST)` with actionable guidance naming
+    `bind_transport`.
+
+    See specs/mcp-server.md §4.9 for the full contract.
+    """
+
+    def __init__(self, send: Optional[SendFn] = None):
+        """Initialize elicitation system.
+
+        Args:
+            send: Optional transport send-callable. When provided, the system
+                can issue `elicitation/create` requests. When None, the system
+                is receive-only — `request_input()` raises MCPError until
+                `bind_transport()` is called.
+        """
+        self._send: Optional[SendFn] = send
         self._pending_requests: Dict[str, Dict[str, Any]] = {}
         self._response_callbacks: Dict[str, Callable] = {}
+        self._cancel_callbacks: Dict[str, Callable] = {}
+
+    def bind_transport(self, send: SendFn) -> None:
+        """Bind a transport send-callable after construction.
+
+        Idempotent: a second call replaces the prior send-fn (used when a
+        transport reconnects). Does not affect pending requests.
+
+        Args:
+            send: Awaitable callable that accepts a JSON-RPC message dict and
+                pushes it through the underlying transport.
+        """
+        self._send = send
+        logger.debug(
+            "elicitation.transport.bound",
+            extra={"has_send": True},
+        )
+
+    def has_transport(self) -> bool:
+        """Return True when a send-callable has been bound."""
+        return self._send is not None
 
     async def request_input(
         self,
@@ -767,96 +829,261 @@ class ElicitationSystem:
         input_schema: Optional[Dict[str, Any]] = None,
         timeout: Optional[float] = 300.0,
     ) -> Any:
-        """Request input from user with schema validation.
+        """Request input from the connected client.
+
+        Emits an MCP `elicitation/create` JSON-RPC request, awaits the
+        matching `elicitation/response`, validates against `input_schema`,
+        and returns the validated payload.
 
         Args:
-            prompt: Input prompt for user
-            input_schema: JSON Schema for input validation
-            timeout: Request timeout in seconds
+            prompt: Prompt shown to the user by the client.
+            input_schema: Optional JSON Schema (Draft 7) for response
+                validation. When None, defaults to `{"type": "string"}` on the
+                wire (per MCP spec: `requestedSchema` is required in the
+                outbound message).
+            timeout: Seconds to wait for the response. When None, waits
+                indefinitely.
 
         Returns:
-            User input
-        """
-        request_id = str(uuid.uuid4())
+            The validated response payload from the client.
 
-        # Store request
+        Raises:
+            MCPError(INVALID_REQUEST): No send-transport is bound.
+            MCPError(REQUEST_TIMEOUT): Client did not respond within `timeout`.
+            MCPError(REQUEST_CANCELLED): Client returned a `decline` or
+                `cancel` action.
+            ValidationError: Response failed `input_schema` validation.
+        """
+        if self._send is None:
+            raise MCPError(
+                "ElicitationSystem has no send transport bound. Construct via "
+                "ElicitationSystem(send=transport.send_message) or call "
+                "system.bind_transport(transport.send_message) before "
+                "request_input(). See specs/mcp-server.md §4.9.",
+                error_code=MCPErrorCode.INVALID_REQUEST,
+            )
+
+        request_id = str(uuid.uuid4())
+        start_ts = time.monotonic()
+        logger.info(
+            "elicitation.request.start",
+            extra={
+                "elicitation_request_id": request_id,
+                "has_schema": input_schema is not None,
+                "timeout": timeout,
+            },
+        )
+
+        # Store request metadata
         self._pending_requests[request_id] = {
             "prompt": prompt,
             "schema": input_schema,
             "timestamp": time.time(),
         }
 
-        # Create future for response
-        response_future = asyncio.Future()
-        self._response_callbacks[request_id] = lambda data: response_future.set_result(
-            data
+        # Create futures for response / cancellation
+        response_future: "asyncio.Future[Any]" = asyncio.Future()
+        self._response_callbacks[request_id] = lambda data: (
+            response_future.set_result(data) if not response_future.done() else None
+        )
+        self._cancel_callbacks[request_id] = lambda reason: (
+            response_future.set_exception(
+                MCPError(
+                    f"Client cancelled elicitation request: {reason}",
+                    error_code=MCPErrorCode.REQUEST_CANCELLED,
+                )
+            )
+            if not response_future.done()
+            else None
         )
 
         try:
-            # Send elicitation request (would be sent to client in real implementation)
+            # Dispatch the elicitation/create request through the bound transport
             await self._send_elicitation_request(request_id, prompt, input_schema)
 
-            # Wait for response
+            # Wait for the matching response (or cancel / timeout)
             if timeout:
                 response = await asyncio.wait_for(response_future, timeout=timeout)
             else:
                 response = await response_future
 
-            # Validate response
+            # Validate the response against the declared schema. MUST happen
+            # BEFORE returning to the calling tool — skipping validation lets
+            # client-supplied payloads reach downstream tools as trusted input.
             if input_schema:
                 validator = SchemaValidator(input_schema)
                 validator.validate(response)
 
+            elapsed_ms = (time.monotonic() - start_ts) * 1000
+            logger.info(
+                "elicitation.request.ok",
+                extra={
+                    "elicitation_request_id": request_id,
+                    "elapsed_ms": elapsed_ms,
+                },
+            )
             return response
 
         except asyncio.TimeoutError:
-            raise MCPError(
-                "Input request timed out", error_code=MCPErrorCode.REQUEST_TIMEOUT
+            elapsed_ms = (time.monotonic() - start_ts) * 1000
+            logger.warning(
+                "elicitation.request.timeout",
+                extra={
+                    "elicitation_request_id": request_id,
+                    "elapsed_ms": elapsed_ms,
+                    "timeout": timeout,
+                },
             )
+            raise MCPError(
+                f"Elicitation request {request_id} timed out after {timeout}s",
+                error_code=MCPErrorCode.REQUEST_TIMEOUT,
+            )
+        except MCPError:
+            elapsed_ms = (time.monotonic() - start_ts) * 1000
+            logger.warning(
+                "elicitation.request.error",
+                extra={
+                    "elicitation_request_id": request_id,
+                    "elapsed_ms": elapsed_ms,
+                },
+            )
+            raise
         finally:
-            # Clean up
             self._pending_requests.pop(request_id, None)
             self._response_callbacks.pop(request_id, None)
+            self._cancel_callbacks.pop(request_id, None)
 
     async def provide_input(self, request_id: str, input_data: Any) -> bool:
-        """Provide input for pending request.
+        """Deliver an `accept`-action response to a pending elicitation.
+
+        Invoked by the MCPServer dispatch loop when an inbound
+        `elicitation/response` (action == "accept") with matching request_id
+        arrives from the client. Schema validation is intentionally NOT done
+        here — it happens in `request_input()` after the response future
+        resolves, so validation is a single-point concern.
 
         Args:
-            request_id: Request ID
-            input_data: User input data
+            request_id: Request ID from the client's response (matches the
+                `id` field of the original elicitation/create request).
+            input_data: The `content` payload from the client's ElicitResult.
 
         Returns:
-            True if input was accepted
+            True if a matching pending request existed and the callback was
+            invoked. False when the request_id is unknown (e.g., late
+            response arriving after timeout cleanup).
         """
         if request_id not in self._pending_requests:
+            logger.debug(
+                "elicitation.response.unknown",
+                extra={"elicitation_request_id": request_id},
+            )
             return False
 
         callback = self._response_callbacks.get(request_id)
         if callback:
             callback(input_data)
+            logger.debug(
+                "elicitation.response.delivered",
+                extra={"elicitation_request_id": request_id},
+            )
+            return True
+
+        return False
+
+    async def cancel_request(
+        self, request_id: str, reason: str = "client cancelled"
+    ) -> bool:
+        """Cancel a pending elicitation.
+
+        Invoked by the MCPServer dispatch loop when the client's
+        `elicitation/response` carries action "decline" or "cancel", OR when
+        the transport disconnects with pending elicitations. The calling
+        `request_input()` coroutine will raise
+        `MCPError(REQUEST_CANCELLED)`.
+
+        Args:
+            request_id: Request ID to cancel.
+            reason: Short reason string propagated into the raised MCPError.
+
+        Returns:
+            True if a matching pending request existed and was cancelled.
+            False when the request_id is unknown.
+        """
+        if request_id not in self._pending_requests:
+            return False
+
+        callback = self._cancel_callbacks.get(request_id)
+        if callback:
+            callback(reason)
+            logger.info(
+                "elicitation.response.cancelled",
+                extra={
+                    "elicitation_request_id": request_id,
+                    "reason": reason,
+                },
+            )
             return True
 
         return False
 
     async def _send_elicitation_request(
-        self, request_id: str, prompt: str, schema: Optional[Dict[str, Any]]
+        self,
+        request_id: str,
+        prompt: str,
+        schema: Optional[Dict[str, Any]],
     ) -> None:
-        """Send elicitation request to client.
+        """Serialize and dispatch an MCP elicitation/create request.
+
+        Builds a JSON-RPC 2.0 message per MCP 2025-06-18 and pushes it
+        through the bound send-callable. The client responds asynchronously
+        via the MCP transport's normal receive loop; the server's dispatch
+        layer routes the inbound `elicitation/response` back into
+        `provide_input()` or `cancel_request()`.
 
         Args:
-            request_id: Request ID
-            prompt: Input prompt
-            schema: Input schema
-        """
-        # In a real implementation, this would send the request to the MCP client
-        # via the MCP protocol transport layer.
-        logger.info(f"Elicitation request {request_id}: {prompt}")
+            request_id: Unique request ID (also used as the JSON-RPC `id`).
+            prompt: Prompt string shown to the user.
+            schema: Optional JSON Schema for the response. When None, the
+                outbound `requestedSchema` defaults to
+                `{"type": "string"}` per MCP spec requirement.
 
-        raise NotImplementedError(
-            "Elicitation request sending requires MCP client transport integration. "
-            "See #556 — tracked for completion. "
-            "Provide a concrete implementation that sends the request via the MCP protocol."
+        Raises:
+            MCPError(INVALID_REQUEST): No send-callable is bound. Callers
+                should normally hit this via `request_input()` which checks
+                the transport first; the check is duplicated here as
+                defense-in-depth against callers that invoke the private
+                method directly.
+        """
+        if self._send is None:
+            raise MCPError(
+                "ElicitationSystem has no send transport bound. Call "
+                "system.bind_transport(transport.send_message) before "
+                "invoking _send_elicitation_request(). See "
+                "specs/mcp-server.md §4.9.",
+                error_code=MCPErrorCode.INVALID_REQUEST,
+            )
+
+        requested_schema = schema if schema is not None else {"type": "string"}
+        message: Dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "elicitation/create",
+            "params": {
+                "requestId": request_id,
+                "message": prompt,
+                "requestedSchema": requested_schema,
+            },
+        }
+
+        logger.info(
+            "elicitation.send",
+            extra={
+                "elicitation_request_id": request_id,
+                "has_schema": schema is not None,
+                "mode": "real",
+            },
         )
+        await self._send(message)
 
 
 class ProgressReporter:

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -64,6 +64,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
+from kailash_mcp.advanced.features import ElicitationSystem
 from kailash_mcp.auth.providers import (
     AuthManager,
     AuthProvider,
@@ -566,6 +567,93 @@ class MCPServer:
 
         # Transport instance (for WebSocket and other transports)
         self._transport = None
+
+        # ElicitationSystem — server-to-client interactive-input subsystem
+        # (MCP 2025-06-18 elicitation/create). Constructed without a bound
+        # send-callable; the send-half is bound via `_bind_elicitation_transport`
+        # when the transport is established. Exposed as a public attribute
+        # so tools can call `server.elicitation_system.request_input(...)`.
+        # This is the production call site required by
+        # rules/orphan-detection.md §1 for the ElicitationSystem manager.
+        self.elicitation_system: ElicitationSystem = ElicitationSystem()
+
+    def _bind_elicitation_transport(self) -> None:
+        """Bind the active transport's send-callable to the elicitation system.
+
+        Called from transport-startup paths (`_run_websocket` etc.) once
+        `self._transport` has been established. Idempotent — safe to call
+        multiple times if the transport reconnects.
+        """
+        if self._transport is None:
+            return
+        send_message = getattr(self._transport, "send_message", None)
+        if send_message is None or not callable(send_message):
+            logger.warning(
+                "elicitation.transport.unavailable",
+                extra={"transport_type": type(self._transport).__name__},
+            )
+            return
+        self.elicitation_system.bind_transport(send_message)
+        logger.info(
+            "elicitation.transport.bound",
+            extra={"transport_type": type(self._transport).__name__},
+        )
+
+    async def _route_server_initiated_response(
+        self, request_id: Any, message: Dict[str, Any]
+    ) -> bool:
+        """Route an inbound JSON-RPC response to its originating pending request.
+
+        Server-initiated JSON-RPC requests (elicitation/create today;
+        sampling/createMessage in the future) expect a matching response
+        from the client. This method inspects `self.elicitation_system._pending_requests`
+        and other pending-request registries, routing the response to the
+        appropriate subsystem.
+
+        Args:
+            request_id: `id` field of the inbound response.
+            message: Full inbound message dict (with `result` or `error`).
+
+        Returns:
+            True when a matching pending request existed and was resolved.
+            False when no pending request matched — caller should fall
+            through to the regular request dispatch.
+        """
+        rid = str(request_id)
+
+        # Check pending elicitation requests
+        if rid in self.elicitation_system._pending_requests:
+            if "error" in message:
+                # Treat as cancellation with the error message as reason
+                err = message.get("error", {})
+                reason = (
+                    err.get("message", "client error")
+                    if isinstance(err, dict)
+                    else "client error"
+                )
+                await self.elicitation_system.cancel_request(rid, reason=reason)
+                return True
+            result = message.get("result", {})
+            # MCP 2025-06-18 ElicitResult: { action: "accept"|"decline"|"cancel", content?: {...} }
+            if isinstance(result, dict):
+                action = result.get("action", "accept")
+                if action == "accept":
+                    content = result.get("content")
+                    # If no content envelope, fall back to treating the whole
+                    # result as the payload (older client shape).
+                    payload = content if content is not None else result
+                    await self.elicitation_system.provide_input(rid, payload)
+                    return True
+                # decline / cancel
+                await self.elicitation_system.cancel_request(
+                    rid, reason=f"client action={action}"
+                )
+                return True
+            # Non-dict result — deliver as-is
+            await self.elicitation_system.provide_input(rid, result)
+            return True
+
+        return False
 
     def _init_mcp(self):
         """Initialize FastMCP server."""
@@ -1694,6 +1782,12 @@ class MCPServer:
                 f"WebSocket server started on {self.websocket_host}:{self.websocket_port}"
             )
 
+            # Bind the transport's send-callable to the elicitation system
+            # so tools that call `server.elicitation_system.request_input(...)`
+            # can actually dispatch elicitation/create requests through the
+            # active client transport.
+            self._bind_elicitation_transport()
+
             # Set up subscription notification callback
             if self.subscription_manager:
                 await self.subscription_manager.initialize()
@@ -1727,6 +1821,27 @@ class MCPServer:
 
             # Log request
             logger.debug(f"WebSocket request from {client_id}: {method}")
+
+            # Route inbound JSON-RPC responses (no `method` field, have `id`
+            # and either `result` or `error`) to any pending server-initiated
+            # request. This covers elicitation/create responses per MCP
+            # 2025-06-18 and is the production call site required by
+            # rules/orphan-detection.md §1 for ElicitationSystem.
+            if (
+                not method
+                and request_id is not None
+                and (
+                    "result" in decompressed_request or "error" in decompressed_request
+                )
+            ):
+                handled = await self._route_server_initiated_response(
+                    request_id, decompressed_request
+                )
+                if handled:
+                    # Response routed to originating pending request; no
+                    # further handler response needed (this is the client
+                    # replying to US, not a client-initiated request).
+                    return {}
 
             # Route to appropriate handler
             if method == "initialize":

--- a/specs/mcp-server.md
+++ b/specs/mcp-server.md
@@ -529,7 +529,111 @@ if ctx.is_cancelled():
 
 ### 4.9 ElicitationSystem
 
-Interactive user input system for tools that need to ask the user questions during execution.
+Interactive user input system for server-side tools that need to ask the connected client (and, by extension, the end-user) a question mid-execution. Implements the MCP 2025-06-18 `elicitation/create` server-to-client request. The system is split into two halves that are both wired into the framework hot path:
+
+1. **Send half** — `_send_elicitation_request()` serializes an MCP `elicitation/create` JSON-RPC request and pushes it through an injected send-callable bound to the active client transport.
+2. **Receive half** — `provide_input(request_id, input_data)` is invoked by the server's dispatch loop when an inbound `elicitation/response` (or a JSON-RPC response whose `id` matches a pending elicitation) arrives from the client.
+
+#### Construction
+
+```python
+from typing import Awaitable, Callable, Optional
+
+SendFn = Callable[[dict], Awaitable[None]]
+
+# Option A — pass the send-callable at construction time
+system = ElicitationSystem(send=transport.send_message)
+
+# Option B — bind after construction (when transport attaches later)
+system = ElicitationSystem()
+system.bind_transport(transport.send_message)
+```
+
+`bind_transport()` is idempotent; calling it a second time replaces the prior send-fn (used when a transport reconnects).
+
+When `send is None`, the system is **receive-only**: `provide_input()` still works (useful for in-process tests that pre-populate responses), but `request_input()` raises `MCPError(INVALID_REQUEST)` with actionable guidance naming `bind_transport`.
+
+#### `request_input(prompt, input_schema=None, timeout=300.0)`
+
+Sends an elicitation request, waits for the response, validates against the optional JSON Schema, and returns the validated payload.
+
+1. Generates a fresh `request_id` (UUIDv4).
+2. Records the request in `_pending_requests` and installs a response future in `_response_callbacks`.
+3. Emits structured log `elicitation.request.start` with `request_id`, `has_schema`, `timeout`.
+4. Calls `_send_elicitation_request(request_id, prompt, schema)` — raises `MCPError(INVALID_REQUEST, "ElicitationSystem has no send transport bound...")` if no send-callable is bound.
+5. Awaits the response future with `asyncio.wait_for(timeout)`.
+6. Validates response against `input_schema` via `SchemaValidator` (Draft 7). A validation failure raises `ValidationError`, not silent return of invalid data.
+7. On timeout: raises `MCPError(REQUEST_TIMEOUT)` with the correlation `request_id`.
+8. Cleans up `_pending_requests` and `_response_callbacks` in a `finally` block regardless of outcome.
+9. Emits `elicitation.request.ok` (or `elicitation.request.error`) with `request_id`, `elapsed_ms`.
+
+#### `provide_input(request_id, input_data)`
+
+Called by the MCPServer dispatch layer when an inbound elicitation response arrives. Returns `True` if a matching pending request existed and the callback was invoked, `False` otherwise.
+
+- Does NOT validate `input_data` against the schema — validation happens in `request_input()` after the response future resolves (single validation point).
+- Unknown `request_id` → `False`; the caller logs a `elicitation.response.unknown` WARN but does not error.
+
+#### JSON-RPC Wire Shape
+
+Outbound (server → client):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<request_id>",
+  "method": "elicitation/create",
+  "params": {
+    "requestId": "<request_id>",
+    "message": "<prompt>",
+    "requestedSchema": { "type": "string" }
+  }
+}
+```
+
+`requestedSchema` defaults to `{"type": "string"}` when the caller passes `input_schema=None`. The MCP specification requires `requestedSchema` to be present.
+
+Inbound (client → server) — the server's dispatch loop routes the response content into `provide_input(request_id, content)`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "<request_id>",
+  "result": {
+    "action": "accept",
+    "content": { "age": 25 }
+  }
+}
+```
+
+Per MCP 2025-06-18, `action` is one of `accept`, `decline`, or `cancel`. `content` is only meaningful for `accept`. A decline/cancel should be surfaced to the calling tool as a distinct value (or exception) — the current implementation treats any non-accept response as cancellation by raising `MCPError(REQUEST_CANCELLED)` to the tool caller.
+
+#### Server Dispatch Wiring
+
+The `MCPServer` constructor creates an `ElicitationSystem` instance and exposes it as `server.elicitation_system`. When the server's active transport is established, `server._bind_elicitation_transport()` calls `self.elicitation_system.bind_transport(transport.send_message)`. The dispatch loop (`_handle_websocket_message` and equivalents) routes inbound messages whose `id` matches a pending elicitation (via `server.elicitation_system._pending_requests`) into `provide_input()`.
+
+This wiring is the production call site required by `rules/orphan-detection.md` §1. Without it, `ElicitationSystem` would be a facade without a real consumer.
+
+#### Error Semantics
+
+| Condition                                        | Raised exception  | Error code          |
+| ------------------------------------------------ | ----------------- | ------------------- |
+| `request_input()` called with no transport bound | `MCPError`        | `INVALID_REQUEST`   |
+| Response timeout                                 | `MCPError`        | `REQUEST_TIMEOUT`   |
+| Schema validation failure on response            | `ValidationError` | (propagated)        |
+| Client declined / cancelled                      | `MCPError`        | `REQUEST_CANCELLED` |
+
+#### Security
+
+- Responses MUST be validated against `input_schema` before being returned to the calling tool. Skipping validation is BLOCKED — an unvalidated client response can carry prompt-injection-adjacent payloads that downstream tools consume as trusted input.
+- The `input_schema` defaults to `{"type": "string"}` when omitted; callers SHOULD supply a tight schema whenever the prompt asks for structured data.
+- Logs use structured fields (`request_id`, `has_schema`, `elapsed_ms`); raw prompt text is NOT logged at INFO (may contain sensitive context from the calling tool). Emit the prompt at DEBUG only if operator explicitly enables it.
+
+#### Reference
+
+- MCP specification 2025-06-18 `elicitation/create` feature: server-to-client request, client returns `ElicitResult { action, content? }`.
+- Implementation: `packages/kailash-mcp/src/kailash_mcp/advanced/features.py::ElicitationSystem`.
+- Tier 2 integration tests: `tests/integration/mcp_server/test_elicitation_integration.py`.
 
 ### 4.10 Resource Subscriptions
 

--- a/tests/integration/mcp_server/test_advanced_features.py
+++ b/tests/integration/mcp_server/test_advanced_features.py
@@ -7,7 +7,6 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from kailash_mcp.advanced.features import (
     BinaryResourceHandler,
     CancellationContext,
@@ -663,82 +662,97 @@ class TestStreamingHandler:
 
 
 class TestElicitationSystem:
-    """Test interactive user input system."""
+    """Test interactive user input system.
 
-    def setup_method(self):
-        """Set up test environment."""
-        self.elicitation = ElicitationSystem()
+    These tests exercise ElicitationSystem through an in-process
+    send/receive pair: a fake async send-callable captures the outbound
+    MCP `elicitation/create` message AND (in tests that need a response)
+    drives `provide_input` back into the system, round-tripping the
+    request just like the MCPServer dispatch layer would.
+
+    The in-process-pair pattern replaces the previous auto-response
+    mock that patched `_send_elicitation_request` — that pattern was
+    legacy scaffolding pre-dating the #556 design decision to inject a
+    send-callable at construction.
+    """
 
     @pytest.mark.asyncio
-    async def test_request_input_with_test_prompt(self):
-        """Test requesting input with test prompt (auto-response)."""
-        # The implementation auto-responds to prompts starting with "test"
-        result = await self.elicitation.request_input("test: What is your name?")
+    async def test_request_input_unbound_transport_raises_typed_error(self):
+        """With no send bound, request_input raises MCPError(INVALID_REQUEST).
 
-        assert result == "test response"
+        Regression guard for the un-stub: the old implementation raised
+        NotImplementedError, which is BLOCKED by rules/zero-tolerance.md
+        Rule 2. The new contract is a typed MCPError whose message names
+        bind_transport so the caller has an actionable fix.
+        """
+        system = ElicitationSystem()  # no send bound
 
-    @pytest.mark.asyncio
-    async def test_request_input_timeout(self):
-        """Test input request timeout."""
         with pytest.raises(MCPError) as exc_info:
-            await self.elicitation.request_input(
+            await system.request_input("Anything?")
+
+        assert exc_info.value.error_code == MCPErrorCode.INVALID_REQUEST
+        assert "bind_transport" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_request_input_timeout_with_silent_send(self):
+        """With a send that never triggers a response, request_input times out."""
+        captured_messages = []
+
+        async def silent_send(message):
+            captured_messages.append(message)
+            # deliberately never call provide_input
+
+        system = ElicitationSystem(send=silent_send)
+
+        with pytest.raises(MCPError) as exc_info:
+            await system.request_input(
                 "Enter something:",
-                timeout=0.1,  # Very short timeout
+                timeout=0.1,
             )
 
         assert exc_info.value.error_code == MCPErrorCode.REQUEST_TIMEOUT
+        assert len(captured_messages) == 1
+        assert captured_messages[0]["method"] == "elicitation/create"
 
     @pytest.mark.asyncio
     async def test_provide_input_manually(self):
-        """Test providing input manually."""
+        """In-process pair: provide_input round-trips an outbound request."""
+        system = ElicitationSystem()
 
-        # Start a request in background
-        async def background_request():
-            return await self.elicitation.request_input(
-                "Manual input test", timeout=1.0
-            )
+        async def responder_send(message):
+            # Schedule the provide_input on the next event-loop tick so the
+            # caller of request_input has a chance to install its future.
+            async def later():
+                await asyncio.sleep(0)
+                await system.provide_input(message["id"], "manual response")
 
-        task = asyncio.create_task(background_request())
+            asyncio.create_task(later())
 
-        # Give it a moment to start
-        await asyncio.sleep(0.1)
-
-        # Find the pending request and provide input
-        if self.elicitation._pending_requests:
-            request_id = list(self.elicitation._pending_requests.keys())[0]
-            success = await self.elicitation.provide_input(
-                request_id, "manual response"
-            )
-            assert success is True
-
-        result = await task
+        system.bind_transport(responder_send)
+        result = await system.request_input("Manual input test", timeout=1.0)
         assert result == "manual response"
 
     @pytest.mark.asyncio
     async def test_request_input_with_schema_validation(self):
-        """Test input request with schema validation."""
+        """Schema validation runs BEFORE returning to caller."""
         schema = {
             "type": "object",
             "properties": {"age": {"type": "integer", "minimum": 0}},
             "required": ["age"],
         }
 
-        # Mock valid input
-        with patch.object(self.elicitation, "_send_elicitation_request"):
+        async def valid_responder(message):
+            async def later():
+                await asyncio.sleep(0)
+                await self_elicitation.provide_input(message["id"], {"age": 25})
 
-            async def provide_valid_input():
-                await asyncio.sleep(0.1)
-                request_id = list(self.elicitation._pending_requests.keys())[0]
-                await self.elicitation.provide_input(request_id, {"age": 25})
+            asyncio.create_task(later())
 
-            task = asyncio.create_task(provide_valid_input())
-
-            result = await self.elicitation.request_input(
-                "Enter your age:", input_schema=schema, timeout=1.0
-            )
-
-            await task
-            assert result["age"] == 25
+        self_elicitation = ElicitationSystem(send=valid_responder)
+        result = await self_elicitation.request_input(
+            "Enter your age:", input_schema=schema, timeout=1.0
+        )
+        assert result["age"] == 25
 
 
 class TestProgressReporter:

--- a/tests/integration/mcp_server/test_elicitation_integration.py
+++ b/tests/integration/mcp_server/test_elicitation_integration.py
@@ -1,0 +1,327 @@
+"""Tier 2 integration tests for ElicitationSystem send/receive round-trips.
+
+These tests exercise ElicitationSystem through the public facade
+(ElicitationSystem, MCPServer.elicitation_system) with an in-process
+send/receive pair acting as the transport. No mocks, no monkeypatching —
+the only components substituted are the fake async send-callables that
+capture or echo messages, consistent with rules/testing.md Tier 2 contract
+(real infrastructure, no @patch / MagicMock / unittest.mock).
+
+Coverage:
+
+1. test_elicitation_in_process_pair_round_trip — happy path: fake send
+   captures outbound `elicitation/create`, immediately calls provide_input,
+   and request_input returns the round-tripped payload.
+2. test_elicitation_unbound_send_raises_typed_error — no transport bound:
+   request_input raises MCPError(INVALID_REQUEST) whose message names
+   bind_transport. NOT NotImplementedError, NOT AttributeError.
+3. test_elicitation_json_rpc_wire_shape — fake send records the outbound
+   dict; verifies spec-compliant JSON-RPC 2.0 + MCP 2025-06-18 shape.
+4. test_elicitation_schema_validation_on_response — fake send echoes an
+   invalid payload; verifies request_input raises ValidationError.
+5. test_elicitation_timeout_with_silent_send — fake send never triggers
+   provide_input; verifies TimeoutError -> MCPError(REQUEST_TIMEOUT).
+6. test_elicitation_bind_transport_replaces_prior — bind_transport called
+   twice; the second send-callable receives the message, the first does not.
+7. test_elicitation_cancel_request_surfaces_as_cancelled_error — fake send
+   calls cancel_request; request_input raises MCPError(REQUEST_CANCELLED).
+8. test_mcpserver_exposes_elicitation_system — structural invariant:
+   MCPServer constructor wires ElicitationSystem as a public attribute per
+   rules/orphan-detection.md §1.
+
+Rules satisfied:
+- rules/orphan-detection.md §2 (Tier 2 integration test for wired manager).
+- rules/orphan-detection.md §2a (paired-API round-trip through the facade).
+- rules/facade-manager-detection.md §1 (external-effect assertions, not mocks).
+- rules/testing.md Tier 2 (no mocks; real in-process infrastructure).
+- rules/zero-tolerance.md Rule 2 (confirms un-stub of _send_elicitation_request).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+from kailash_mcp.advanced.features import ElicitationSystem
+from kailash_mcp.errors import MCPError, MCPErrorCode, ValidationError
+from kailash_mcp.server import MCPServer
+
+
+@pytest.mark.asyncio
+async def test_elicitation_in_process_pair_round_trip() -> None:
+    """Happy path: fake send echoes a valid response via provide_input."""
+    system = ElicitationSystem()
+
+    async def echoing_send(message: Dict[str, Any]) -> None:
+        # Schedule provide_input on the next tick so the caller installs its
+        # response future before the callback fires.
+        async def later() -> None:
+            await asyncio.sleep(0)
+            await system.provide_input(message["id"], {"ok": True})
+
+        asyncio.create_task(later())
+
+    system.bind_transport(echoing_send)
+    result = await system.request_input("Confirm?", timeout=2.0)
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_elicitation_unbound_send_raises_typed_error() -> None:
+    """No transport bound: typed MCPError(INVALID_REQUEST), NOT NotImplementedError."""
+    system = ElicitationSystem()  # no send
+
+    with pytest.raises(MCPError) as exc_info:
+        await system.request_input("Anything?", timeout=0.1)
+
+    assert exc_info.value.error_code == MCPErrorCode.INVALID_REQUEST
+    # Actionable message must name bind_transport so callers know the fix.
+    assert "bind_transport" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_elicitation_json_rpc_wire_shape() -> None:
+    """Outbound message conforms to MCP 2025-06-18 elicitation/create."""
+    captured: List[Dict[str, Any]] = []
+    system = ElicitationSystem()
+
+    async def capturing_send(message: Dict[str, Any]) -> None:
+        captured.append(message)
+
+        # Feed a response so request_input returns instead of timing out.
+        async def later() -> None:
+            await asyncio.sleep(0)
+            await system.provide_input(message["id"], "done")
+
+        asyncio.create_task(later())
+
+    system.bind_transport(capturing_send)
+    schema = {"type": "string", "minLength": 1}
+    await system.request_input("Enter name:", input_schema=schema, timeout=1.0)
+
+    assert len(captured) == 1
+    msg = captured[0]
+    assert msg["jsonrpc"] == "2.0"
+    assert msg["method"] == "elicitation/create"
+    assert isinstance(msg["id"], str) and len(msg["id"]) > 0
+    params = msg["params"]
+    assert params["requestId"] == msg["id"]
+    assert params["message"] == "Enter name:"
+    assert params["requestedSchema"] == schema
+
+
+@pytest.mark.asyncio
+async def test_elicitation_requested_schema_defaults_when_omitted() -> None:
+    """When input_schema is None, outbound requestedSchema defaults to {type: string}."""
+    captured: List[Dict[str, Any]] = []
+    system = ElicitationSystem()
+
+    async def capturing_send(message: Dict[str, Any]) -> None:
+        captured.append(message)
+
+        async def later() -> None:
+            await asyncio.sleep(0)
+            await system.provide_input(message["id"], "hi")
+
+        asyncio.create_task(later())
+
+    system.bind_transport(capturing_send)
+    await system.request_input("Say hi:", timeout=1.0)
+
+    assert captured[0]["params"]["requestedSchema"] == {"type": "string"}
+
+
+@pytest.mark.asyncio
+async def test_elicitation_schema_validation_on_response() -> None:
+    """Invalid response payload raises ValidationError, NOT silent return."""
+    system = ElicitationSystem()
+    schema = {
+        "type": "object",
+        "properties": {"age": {"type": "integer", "minimum": 0}},
+        "required": ["age"],
+    }
+
+    async def invalid_echoer(message: Dict[str, Any]) -> None:
+        async def later() -> None:
+            await asyncio.sleep(0)
+            # Payload violates schema: `age` is a string, not an integer.
+            await system.provide_input(message["id"], {"age": "not-a-number"})
+
+        asyncio.create_task(later())
+
+    system.bind_transport(invalid_echoer)
+    with pytest.raises(ValidationError):
+        await system.request_input("Age?", input_schema=schema, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_elicitation_timeout_with_silent_send() -> None:
+    """Silent send that never calls provide_input surfaces as REQUEST_TIMEOUT."""
+
+    async def silent_send(message: Dict[str, Any]) -> None:
+        # Deliberately do nothing — no provide_input, no cancel_request.
+        return None
+
+    system = ElicitationSystem(send=silent_send)
+
+    with pytest.raises(MCPError) as exc_info:
+        await system.request_input("Waiting forever?", timeout=0.1)
+
+    assert exc_info.value.error_code == MCPErrorCode.REQUEST_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_elicitation_bind_transport_replaces_prior() -> None:
+    """bind_transport is idempotent-with-replace; second call wins."""
+    first_captured: List[Dict[str, Any]] = []
+    second_captured: List[Dict[str, Any]] = []
+
+    async def first_send(message: Dict[str, Any]) -> None:
+        first_captured.append(message)
+
+    async def second_send(message: Dict[str, Any]) -> None:
+        second_captured.append(message)
+
+        async def later() -> None:
+            await asyncio.sleep(0)
+            await system.provide_input(message["id"], "ok")
+
+        asyncio.create_task(later())
+
+    system = ElicitationSystem(send=first_send)
+    system.bind_transport(second_send)
+
+    result = await system.request_input("Bound?", timeout=1.0)
+    assert result == "ok"
+    assert len(first_captured) == 0  # first send replaced, never invoked
+    assert len(second_captured) == 1
+
+
+@pytest.mark.asyncio
+async def test_elicitation_cancel_request_surfaces_as_cancelled_error() -> None:
+    """Client decline/cancel -> MCPError(REQUEST_CANCELLED) at caller."""
+    system = ElicitationSystem()
+
+    async def cancelling_send(message: Dict[str, Any]) -> None:
+        async def later() -> None:
+            await asyncio.sleep(0)
+            await system.cancel_request(message["id"], reason="user declined")
+
+        asyncio.create_task(later())
+
+    system.bind_transport(cancelling_send)
+    with pytest.raises(MCPError) as exc_info:
+        await system.request_input("Proceed?", timeout=1.0)
+
+    assert exc_info.value.error_code == MCPErrorCode.REQUEST_CANCELLED
+    assert "user declined" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_elicitation_provide_input_unknown_request_id_returns_false() -> None:
+    """Unknown request_id on provide_input returns False, does NOT raise."""
+    system = ElicitationSystem()
+    result = await system.provide_input("no-such-id", {"whatever": True})
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_elicitation_cancel_request_unknown_request_id_returns_false() -> None:
+    """Unknown request_id on cancel_request returns False, does NOT raise."""
+    system = ElicitationSystem()
+    result = await system.cancel_request("no-such-id", reason="test")
+    assert result is False
+
+
+# -------------------------------------------------------------------------
+# Structural invariant tests — wire-up between MCPServer and ElicitationSystem
+# -------------------------------------------------------------------------
+
+
+def test_mcpserver_exposes_elicitation_system() -> None:
+    """MCPServer wires ElicitationSystem as a public attribute.
+
+    Orphan-detection guard: if a future refactor removes
+    `self.elicitation_system` from MCPServer.__init__, the manager becomes
+    an orphan (class exists, no production call site). This test is the
+    structural invariant.
+    """
+    server = MCPServer("test-server")
+    assert isinstance(server.elicitation_system, ElicitationSystem)
+    # No transport yet — has_transport must be False.
+    assert server.elicitation_system.has_transport() is False
+
+
+def test_mcpserver_bind_elicitation_transport_is_noop_without_transport() -> None:
+    """_bind_elicitation_transport handles missing transport without raising."""
+    server = MCPServer("test-server")
+    # _transport is None at construction; call must NOT raise.
+    server._bind_elicitation_transport()
+    assert server.elicitation_system.has_transport() is False
+
+
+@pytest.mark.asyncio
+async def test_mcpserver_route_server_initiated_response_accept_action() -> None:
+    """MCPServer._route_server_initiated_response delivers accept-action results."""
+    captured: List[Dict[str, Any]] = []
+    server = MCPServer("test-server")
+
+    async def capturing_send(message: Dict[str, Any]) -> None:
+        captured.append(message)
+
+        # Simulate the server's dispatch receiving the client's response.
+        async def later() -> None:
+            await asyncio.sleep(0)
+            # MCP 2025-06-18 ElicitResult with action=accept.
+            response = {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {"action": "accept", "content": {"choice": "blue"}},
+            }
+            await server._route_server_initiated_response(response["id"], response)
+
+        asyncio.create_task(later())
+
+    server.elicitation_system.bind_transport(capturing_send)
+    result = await server.elicitation_system.request_input("Pick a color:", timeout=1.0)
+    assert result == {"choice": "blue"}
+    # Verify wire shape captured by the fake transport.
+    assert captured[0]["method"] == "elicitation/create"
+
+
+@pytest.mark.asyncio
+async def test_mcpserver_route_server_initiated_response_decline_action() -> None:
+    """Decline/cancel action surfaces as MCPError(REQUEST_CANCELLED)."""
+    server = MCPServer("test-server")
+
+    async def declining_send(message: Dict[str, Any]) -> None:
+        async def later() -> None:
+            await asyncio.sleep(0)
+            response = {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {"action": "decline"},
+            }
+            await server._route_server_initiated_response(response["id"], response)
+
+        asyncio.create_task(later())
+
+    server.elicitation_system.bind_transport(declining_send)
+    with pytest.raises(MCPError) as exc_info:
+        await server.elicitation_system.request_input("Proceed?", timeout=1.0)
+    assert exc_info.value.error_code == MCPErrorCode.REQUEST_CANCELLED
+    assert "decline" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_mcpserver_route_returns_false_for_unknown_id() -> None:
+    """Response for an unknown id is NOT consumed — caller falls through."""
+    server = MCPServer("test-server")
+    response = {
+        "jsonrpc": "2.0",
+        "id": "no-pending-request",
+        "result": {"action": "accept", "content": "whatever"},
+    }
+    handled = await server._route_server_initiated_response(response["id"], response)
+    assert handled is False

--- a/workspaces/kailash-ml-gpu-stack/journal/.pending/0011-DISCOVERY-mcp-spec-sibling-sweep-shard-d.md
+++ b/workspaces/kailash-ml-gpu-stack/journal/.pending/0011-DISCOVERY-mcp-spec-sibling-sweep-shard-d.md
@@ -1,0 +1,67 @@
+# 0011 — DISCOVERY — MCP spec sibling-sweep (Shard D, #556)
+
+Date: 2026-04-20
+Scope: Parallel-release cycle Shard D — issue #556 un-stub `ElicitationSystem._send_elicitation_request`.
+
+## Trigger
+
+`specs/mcp-server.md` §4.9 expanded from 2 lines to ~105 lines documenting the `ElicitationSystem` construction contract, `request_input` / `provide_input` semantics, JSON-RPC wire shape, server dispatch wiring, error semantics, and security requirements. Per `rules/specs-authority.md` MUST Rule 5b, any spec edit triggers a FULL sibling-spec re-derivation sweep (not narrow-scope to the edited file).
+
+## Sibling set enumerated
+
+```bash
+ls specs/mcp-*.md
+# specs/mcp-auth.md
+# specs/mcp-client.md
+# specs/mcp-server.md  (edited)
+```
+
+Three-file domain. Sweep must re-derive assertions in the two unedited siblings (`mcp-auth.md`, `mcp-client.md`) against the expanded §4.9 contract.
+
+## Re-derivation
+
+Grep for cross-references the expansion might collide with:
+
+```bash
+grep -n "elicit\|Elicit\|interactive\|request_input\|elicitation/create" \
+     specs/mcp-client.md specs/mcp-auth.md
+# (empty — no prior references to the surface)
+```
+
+The expanded surface introduces:
+
+- `SendFn = Callable[[dict], Awaitable[None]]` type alias
+- `ElicitationSystem(send=...)` and `bind_transport(send)` APIs
+- MCP JSON-RPC `elicitation/create` method name
+- `ElicitResult { action, content }` wire shape per MCP 2025-06-18
+- Typed errors: `MCPError(INVALID_REQUEST)`, `MCPError(REQUEST_TIMEOUT)`, `MCPError(REQUEST_CANCELLED)`, `ValidationError`
+
+### mcp-client.md — assertions re-derived
+
+- `mcp-client.md` documents `MCPClient` (client-side), transport layer, service discovery, health checks, tool hydration. Elicitation is a **server-to-client** request; the client's role would be to RECEIVE `elicitation/create` and respond with `ElicitResult`. The spec currently does NOT describe an elicitation receive handler on the client side. **Disposition**: not a drift — `mcp-client.md` §1.2 (Transport Resolution) is silent on inbound server-to-client methods, which is consistent with the current kailash-mcp client surface. Future work to add a client-side elicitation-response builder would be a new section, not a correction.
+- No terminology collisions: `mcp-client.md` uses `request` / `response` exclusively for client-to-server request/response; the term `request_input` is namespaced to the server-side elicitation system.
+- No field-shape divergence: `MCPClient` does not expose an elicitation-related attribute.
+
+### mcp-auth.md — assertions re-derived
+
+- `mcp-auth.md` documents `AuthProvider`, `AuthManager`, `PermissionManager`, `RateLimiter`. Elicitation on the server side is authenticated via the transport's existing auth chain (client has already authenticated when the server issues `elicitation/create`). The security note in the expanded §4.9 ("schema validation MUST run before returning to the calling tool") is orthogonal to auth — it's input validation, not authorization.
+- No terminology collisions.
+- No field-shape divergence.
+
+### mcp-server.md — self-consistency
+
+- §4.8 `ProgressReporter` / `CancellationContext` uses `create_progress_reporter` / `create_cancellation_context` top-level factories. `ElicitationSystem` does NOT have an equivalent factory — it's constructed directly. Consistent with the existing §4.5 (`BinaryResourceHandler`) and §4.6 (`ResourceTemplate`) style where the class is the public surface.
+- §5 "Server-Side Edge Cases" has no existing elicitation-related note; the expanded §4.9 Server Dispatch Wiring subsection documents the MCPServer binding directly, avoiding a cross-reference that would need updating in §5.
+
+## Findings
+
+**0 HIGH, 0 MED, 0 LOW** — the expanded §4.9 surface is self-contained. The sibling specs describe orthogonal concerns (client surface, auth chain) and do not reference the elicitation system at all. No silent drift.
+
+## Action
+
+Continue with implementation (Shard D steps 2-5). No sibling-spec edits required.
+
+---
+
+Rule reference: `rules/specs-authority.md` MUST Rule 5b — full-sibling-spec re-derivation triggered by every spec edit.
+Cross-SDK: kailash-rs equivalent not yet inspected (tracked as Step 6 of Shard D).


### PR DESCRIPTION
## Summary

- `ElicitationSystem.__init__(send=...)` + `bind_transport(send)` — decouples from `BaseTransport` class hierarchy via async callable injection
- `_send_elicitation_request` now serializes MCP 2025-06-18 `elicitation/create` JSON-RPC request and dispatches through injected send-fn
- Typed `MCPError(INVALID_REQUEST)` with actionable message when no transport is bound (replaces NotImplementedError)
- `MCPServer` dispatch wiring routes `elicitation/response` back into `provide_input(request_id, content)`
- `specs/mcp-server.md` §4.9 expanded with wire shape, error semantics, security contract
- Tier 2 integration tests: in-process send/receive pair round-trip, unbound-send typed-error path, JSON-RPC wire-shape assertion, schema-validation-on-response, silent-send timeout, bind_transport idempotent replace
- Cross-SDK issue filed at https://github.com/esperie-enterprise/kailash-rs/issues/443 for Rust-side MCP elicitation parity

## Part of the Phase 3/4/5 parallel-release cycle

Sibling to #561 (Shard A) / #562 (Shard B) / #563 (Shard C). No file overlap with kailash-ml shards — clean merge.

## Test plan

- [x] 73 tests pass with warnings-as-errors (scoped: `test_advanced_features.py` + `test_elicitation_integration.py`)
- [x] `rg 'raise NotImplementedError' packages/kailash-mcp/src/kailash_mcp/advanced/features.py` — empty
- [x] Cross-SDK parity checked; kailash-rs has no elicitation surface, issue filed

## Related issues

Fixes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)