### PR TITLE
chore(release): kailash-ml 0.15.0 + kailash-mcp 0.2.6

### DIFF
--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the Kailash MCP package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-04-20 — elicitation/create sender half (#556)
+
+### Added
+
+- **`ElicitationSystem.__init__(send=...)` + `bind_transport(send)`** — injected async send-callable decouples `ElicitationSystem` from the `BaseTransport` class hierarchy. Testable with any `Callable[[dict], Awaitable[None]]`. Aligns with `rules/orphan-detection.md` §1 (facade with production call site) via `MCPServer.elicitation_system` + `_bind_elicitation_transport()` hook.
+- **MCP 2025-06-18 spec-compliant wire shape** — `_send_elicitation_request` now serializes `{"jsonrpc": "2.0", "id": request_id, "method": "elicitation/create", "params": {"requestId": ..., "message": prompt, "requestedSchema": schema}}` and dispatches through the bound send-fn. `ElicitResult.action == "accept"` routes to `provide_input`; `"decline"` / `"cancel"` raise `MCPError(REQUEST_CANCELLED)`.
+- **`specs/mcp-server.md §4.9`** expanded from 2 lines to full contract: construction (`send=` or `bind_transport`), wire shape, error semantics, security contract (schema validation before return-to-caller prevents prompt-injection-adjacent attacks).
+- **6 Tier 2 integration tests** at `tests/integration/mcp_server/test_elicitation_integration.py` covering in-process send/receive pair round-trip, unbound-send typed-error path, JSON-RPC wire-shape assertion, schema-validation-on-response, silent-send timeout, bind_transport idempotent replace.
+
+### Changed
+
+- **`_send_elicitation_request` error contract** — raises `MCPError(INVALID_REQUEST)` with actionable message naming `bind_transport` when no send is bound. Replaces the prior `NotImplementedError`.
+- **`ElicitationSystem` constructor** — now accepts optional `send: Callable[[Dict], Awaitable[None]] | None = None` (backward-compatible; existing callers passing no arg continue to work until they invoke `request_input`).
+
+### Fixed
+
+- Closes #556. Half-implemented public feature (receive half wired, sender half `NotImplementedError`) per `rules/orphan-detection.md` §2a (crypto-pair pattern applied to paired APIs).
+- Cross-SDK parity issue filed at `esperie-enterprise/kailash-rs#443` — Rust SDK has no elicitation surface; Python shape documented as reference for future Rust implementation.
+
 ## [0.2.5] - 2026-04-19 — oauth.py optional-extras gating (#514)
 
 ### Fixed

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.2.5"
+version = "0.2.6"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,42 @@
 # kailash-ml Changelog
 
+## [0.15.0] - 2026-04-20 — MLEngine Phase 3/4/5 complete (specs/ml-engines.md §12.1)
+
+Closes the full Phase 3/4/5 punch list from `specs/ml-engines.md §12.1`. All eight documented `MLEngine` methods (`setup`, `compare`, `fit`, `predict`, `finalize`, `evaluate`, `register`, `serve`) now have production implementations. Landed via four parallel worktree shards (PRs #561/#562/#563/#564) + prep commit (7 frozen result dataclasses in `_results.py`).
+
+### Added — Phase 3 (`setup` + `compare` + `finalize`)
+
+- **`MLEngine.setup()`** (PR #561): polars-native data profiling, `schema_hash` idempotency key per §2.1 MUST 6, task-type inference (classification/regression), deterministic holdout split, FeatureStore schema registration with tenant_id persistence. Phase 3.1 (kfold/stratified/walk_forward split strategies) deferred with a loud `NotImplementedError` naming the follow-up.
+- **`MLEngine.compare()`** (PR #562): multi-family Lightning sweep. Every family routed through `self.fit()` so Lightning-as-spine holds by construction per §2.1 MUST 7. Default family set derived from task_type (sklearn/xgboost/lightgbm for classification/regression). Best-first leaderboard via `_HIGHER_IS_BETTER_METRICS` / `_LOWER_IS_BETTER_METRICS` sets. Partial-result on timeout + structured WARN log. `ComparisonResult.tenant_id` propagates from engine, every inner `TrainingResult` echoes tenant_id.
+- **`MLEngine.finalize()`** (PR #562): retrain on train+holdout (`full_fit=True`) or re-wrap without retrain (`full_fit=False`). Accepts either a `TrainingResult` or a `models://name/v<N>` URI string.
+
+### Added — Phase 4 (`predict` + `evaluate` + `register`)
+
+- **`MLEngine.predict()`** (PR #563): registry hydration + three-channel dispatch (`direct` = in-process onnxruntime, `rest` = Nexus-bound endpoint, `mcp` = stdio transport). Typed `TenantRequiredError` when engine tenant_id does not match the registered model's tenant_id. `ModelNotFoundError` with actionable message when rest/mcp channels are requested without prior `serve()`. Structured entry/exit logs per `rules/observability.md`.
+- **`MLEngine.evaluate()`** (PR #562): three modes (holdout/shadow/live). Holdout = offline scoring with default metric set from task_type. Shadow = score + audit as `shadow_evaluate` without drift-monitor update. Live = score + audit as `evaluate` AND update DriftMonitor. Typed `TargetNotFoundError` when target column missing from data.
+- **`MLEngine.register()`** (PR #561): 6-framework ONNX-default export via existing `OnnxBridge` (sklearn/xgboost/lightgbm/catboost/torch/lightning). Typed `OnnxExportError` on default-path failure — silent pickle fallback BLOCKED per §4.2 MUST 4. Tenant-aware `(tenant_id, name, version)` primary key on `_kml_model_versions`. `§5.2` audit row written even on failure.
+
+### Added — Phase 5 (`serve`)
+
+- **`MLEngine.serve()`** (PR #563): REST + MCP + gRPC multi-channel bind from a single call per §2.1 MUST 10. REST channel via Nexus, MCP channel via kailash-mcp stdio transport. Per-channel URIs returned in `ServeResult.uris`. Partial-failure rollback — if MCP bind fails after REST bind succeeds, REST is shut down and a typed error is raised (no partial `ServeResult`). Tenant-id propagated to each channel's auth context. gRPC channel requires the `[grpc]` optional extra (loud-failure pattern per `rules/dependencies.md` § Exception).
+
+### Added — new infrastructure
+
+- **7 frozen result dataclasses** in `kailash_ml._results` (`SetupResult`, `ComparisonResult`, `PredictionResult`, `RegisterResult`, `EvaluationResult`, `ServeResult`, `FinalizeResult`). Field shapes are a contract — shards imported them rather than redefining, preventing the parallel-ownership race `rules/agents.md` § "Parallel-Worktree Package Ownership Coordination" documents.
+- **`kailash_ml.engines._engine_sql`** (PR #561): identifier-validated DDL helper module for MLEngine auxiliary tables (`_kml_engine_versions`, `_kml_engine_audit`) per `rules/dataflow-identifier-safety.md`.
+- **22 new Tier 2 integration test files** across four shards, covering idempotency, tenant propagation, ONNX matrix, export-failure → typed-error path, multi-family compare, shadow/live evaluate modes, direct/rest/mcp predict channels, multi-channel serve, partial-failure rollback, REST tenant-isolation.
+
+### Known deferrals (intentional)
+
+- **`split_strategy != "holdout"` in `setup()`**: kfold / stratified_kfold / walk_forward raise `NotImplementedError` naming Phase 3.1 as the follow-up. Tracked at `workspaces/kailash-ml-gpu-stack/journal/.pending/`.
+- **`serve(channels=["grpc"])`**: requires `pip install kailash-ml[grpc]`. Loud-failure `NotImplementedError` naming the extra per `rules/dependencies.md` § Exception.
+- **`PredictionResult.device`**: nullable; populated in kailash-ml 0.12.1+ only after fit → immediate-predict. Restored-from-registry predictions carry `None` until 0.15.1 per `specs/ml-engines.md §4.2 MUST 6`.
+
+### Changed
+
+- `kailash_ml.__all__` now exports the 7 new result dataclasses (eager-imported per `rules/orphan-detection.md` §6).
+- `MLEngine.engine.py` grew from 676 LOC → ~1800 LOC; helpers split across `_engine_sql.py` (267 LOC) + module-level serve/predict plumbing.
+
 ## [0.14.0] - 2026-04-20 — km.doctor + km.track spec completion (ml-backends.md §7, ml-tracking.md §2.4)
 
 Closes the two HIGH findings from the 2026-04-20 /redteam audit: km.doctor shipped 4 of 14 spec items (§7) and km.track persisted 10 of 17 auto-capture fields (§2.4). Both surfaces now ship the full spec-mandated coverage.

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.14.0"
+version = "0.15.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.14.0"
+__version__ = "0.15.0"


### PR DESCRIPTION
## Summary

Coordinated release for the four-shard MLEngine Phase 3/4/5 cycle plus the #556 MCP elicitation fix:

- **kailash-ml 0.14.0 → 0.15.0** — MLEngine full public surface implemented (setup/compare/fit/predict/finalize/evaluate/register/serve per §2.1 MUST 5)
- **kailash-mcp 0.2.5 → 0.2.6** — closes #556 (elicitation sender half)

## Shipped via

- **#561 (Shard A)** — setup + register
- **#562 (Shard B)** — compare + finalize + evaluate
- **#563 (Shard C)** — predict + serve
- **#564 (Shard D)** — MCP #556 elicitation transport
- Prep commit `04ff7dd3` — 7 frozen result dataclasses (`_results.py`)

## Known deferrals

- Non-holdout split strategies in `setup()` — Phase 3.1, loud `NotImplementedError` naming the follow-up
- `serve(channels=["grpc"])` — requires `pip install kailash-ml[grpc]` loud-failure pattern per `rules/dependencies.md` § Exception
- `PredictionResult.device` populated only immediate-after-fit — restored-from-registry predictions carry `None` until 0.15.1 per `specs/ml-engines.md §4.2 MUST 6`

## Post-merge

Push tags `ml-v0.15.0` and `mcp-v0.2.6` individually (one-tag-per-push per `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually") to trigger `Publish to PyPI`.

## Related issues

Phase 3/4/5 of `specs/ml-engines.md §12.1` punch list; closes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)