### PR TITLE
fix(ml+mcp): post-release audit hotfix — kailash-ml 0.15.1 + kailash-mcp 0.2.7

### DIFF
--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Kailash MCP package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-04-20 — post-release audit hotfix (SPDX headers)
+
+Post-release `/redteam` audit of 0.2.6 (gold-standards-validator HIGH-1) surfaced missing SPDX license headers on the two files most heavily modified by the #556 ElicitationSystem redesign. 4-line docs-hygiene fix.
+
+### Fixed
+
+- **`advanced/features.py` + `server.py` now carry `SPDX-License-Identifier: Apache-2.0` + `Copyright 2026 Terrene Foundation`** — matching the house convention already used by the other 20 kailash-mcp production modules. Both files previously started with a bare `"""..."""` docstring per `rules/terrene-naming.md` (Apache-2.0 labeling) violation. No behavior change.
+
 ## [0.2.6] - 2026-04-20 — elicitation/create sender half (#556)
 
 ### Added

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.2.6"
+version = "0.2.7"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
@@ -1,3 +1,5 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
 """
 Advanced MCP Features Implementation.
 

--- a/packages/kailash-mcp/src/kailash_mcp/server.py
+++ b/packages/kailash-mcp/src/kailash_mcp/server.py
@@ -1,3 +1,5 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
 """
 Enhanced MCP Server Framework with production-ready capabilities.
 

--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,17 @@
 # kailash-ml Changelog
 
+## [0.15.1] - 2026-04-20 — post-release audit hotfix (tenant-isolation + spec sync)
+
+Post-release `/redteam` audit of 0.15.0 (security-reviewer + reviewer + gold-standards-validator) surfaced one HIGH security finding and one HIGH spec-staleness finding. Both fixed in this patch.
+
+### Fixed
+
+- **Cross-tenant bypass in `_check_tenant_match`** (security-reviewer HIGH-1): `MLEngine._check_tenant_match` silently permitted an unscoped engine (`tenant_id=None`) to load a tenant-scoped model. Per `specs/ml-engines.md §5.1 MUST 3` and `rules/tenant-isolation.md` Rule 2 ("Missing tenant_id Is a Typed Error"), the unscoped-engine branch against a tenant-scoped model MUST raise `TenantRequiredError`, not pass silently. Fix: the check now raises with an actionable message naming `MLEngine(tenant_id=...)` as the fix. Regression test at `tests/regression/test_tenant_isolation_unscoped_engine.py` (5 cases) locks all four combinations of (engine tenant ∈ {None, "acme"}) × (model tenant ∈ {None, "acme"}).
+
+### Changed
+
+- **`specs/ml-engines.md §12.1` updated** (reviewer HIGH-1 / gold-standards MED-1): Phase status table now reflects shipped state — header bumped to "kailash-ml 0.15.0", 7-row Phase 3/4/5 table replaced with the 2 remaining intentional deferrals (non-holdout split strategies + grpc extras-guard). §12.2 2.0.0 gate items now marked `[x]` for the five satisfied by 0.15.0 (8-method surface, typed dataclass returns, TrainingResult 10-field contract, cache-key "default" forbidden, OnnxExportError on failure).
+
 ## [0.15.0] - 2026-04-20 — MLEngine Phase 3/4/5 complete (specs/ml-engines.md §12.1)
 
 Closes the full Phase 3/4/5 punch list from `specs/ml-engines.md §12.1`. All eight documented `MLEngine` methods (`setup`, `compare`, `fit`, `predict`, `finalize`, `evaluate`, `register`, `serve`) now have production implementations. Landed via four parallel worktree shards (PRs #561/#562/#563/#564) + prep commit (7 frozen result dataclasses in `_results.py`).

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "0.15.0"
+version = "0.15.1"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/packages/kailash-ml/src/kailash_ml/engine.py
+++ b/packages/kailash-ml/src/kailash_ml/engine.py
@@ -2130,10 +2130,24 @@ class MLEngine:
     def _check_tenant_match(self, model_tenant: Optional[str], model_name: str) -> None:
         """Enforce §5.1 MUST 3 — refuse cross-tenant access.
 
-        If the registered model carries a ``tenant_id`` AND the engine has
-        a ``tenant_id``, they MUST match. If either is None, we let it pass
-        (single-tenant mode / pre-shard-A rows).
+        Contract:
+        - model_tenant is None AND engine tenant is None → pass (single-tenant deployment)
+        - model_tenant is not None AND engine tenant is None → RAISE (unscoped engine
+          cannot access a tenant-scoped model; this is the silent-fallback bypass that
+          `tenant-isolation.md` Rule 2 BLOCKS)
+        - model_tenant is None AND engine tenant is not None → pass (multi-tenant engine
+          accessing a pre-multi-tenant model; rare, will disappear once all rows are
+          backfilled)
+        - both set, equal → pass
+        - both set, different → RAISE (cross-tenant access)
         """
+        if model_tenant is not None and self._tenant_id is None:
+            raise TenantRequiredError(
+                f"Model '{model_name}' belongs to tenant {model_tenant!r} but "
+                f"MLEngine was constructed without a tenant_id. Construct via "
+                f"MLEngine(tenant_id={model_tenant!r}) to access tenant-scoped models "
+                f"(specs/ml-engines.md §5.1 MUST 3, rules/tenant-isolation.md Rule 2)."
+            )
         if (
             model_tenant is not None
             and self._tenant_id is not None

--- a/packages/kailash-ml/tests/regression/test_tenant_isolation_unscoped_engine.py
+++ b/packages/kailash-ml/tests/regression/test_tenant_isolation_unscoped_engine.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: unscoped MLEngine MUST NOT access tenant-scoped models.
+
+Security review of kailash-ml 0.15.0 (post-release audit, commit bac2b3be)
+found that `MLEngine._check_tenant_match` silently allowed access to a
+tenant-scoped model when `MLEngine.tenant_id` was None — a cross-tenant
+bypass of `specs/ml-engines.md §5.1 MUST 3` and `rules/tenant-isolation.md`
+Rule 2 ("Missing tenant_id Is a Typed Error — Silent fallback to a default
+tenant or an unscoped key is BLOCKED").
+
+Fix shipped in kailash-ml 0.15.1 — the `model_tenant is not None AND
+self._tenant_id is None` branch now raises `TenantRequiredError`.
+
+This test LOCKS the fix: a future refactor that re-introduces the
+silent-pass path MUST fail this assertion loudly rather than ship a
+cross-tenant access bypass.
+"""
+from __future__ import annotations
+
+import pytest
+
+from kailash_ml import MLEngine
+from kailash_ml.engine import TenantRequiredError
+
+
+@pytest.mark.regression
+def test_unscoped_engine_refuses_tenant_scoped_model():
+    """Unscoped engine (tenant_id=None) + tenant-scoped model → TenantRequiredError."""
+    engine = MLEngine()  # unscoped — no tenant_id
+    assert engine.tenant_id is None
+
+    # Simulate a tenant-scoped model via the private check; production code
+    # reaches this via predict()/evaluate()/serve() loading from ModelRegistry.
+    with pytest.raises(TenantRequiredError) as exc_info:
+        engine._check_tenant_match(model_tenant="acme", model_name="User")
+
+    msg = str(exc_info.value)
+    # The error message MUST name the fix (`MLEngine(tenant_id=...)`) so a
+    # caller hitting this can act without consulting the spec.
+    assert "tenant_id" in msg, "error must tell caller how to scope the engine"
+    assert "acme" in msg, "error must name the tenant the model belongs to"
+
+
+@pytest.mark.regression
+def test_scoped_engine_refuses_cross_tenant_model():
+    """Engine tenant 'bob' + model tenant 'acme' → TenantRequiredError (pre-existing path)."""
+    engine = MLEngine(tenant_id="bob")
+    with pytest.raises(TenantRequiredError):
+        engine._check_tenant_match(model_tenant="acme", model_name="User")
+
+
+@pytest.mark.regression
+def test_scoped_engine_accepts_matching_tenant():
+    """Engine + model with same tenant → pass."""
+    engine = MLEngine(tenant_id="acme")
+    # No exception — matching tenants.
+    engine._check_tenant_match(model_tenant="acme", model_name="User")
+
+
+@pytest.mark.regression
+def test_unscoped_engine_accepts_unscoped_model():
+    """Single-tenant deployment — both engine and model have tenant_id=None."""
+    engine = MLEngine()
+    # No exception — legitimate single-tenant flow.
+    engine._check_tenant_match(model_tenant=None, model_name="User")
+
+
+@pytest.mark.regression
+def test_scoped_engine_accepts_pre_multi_tenant_model():
+    """Multi-tenant engine + pre-multi-tenant row (model_tenant=None) → pass.
+
+    This is the narrow permitted bypass: a row written before tenant_id
+    was a column on _kml_model_versions has no tenant, and a scoped engine
+    accessing it is not a security issue (the reverse is — blocked above).
+    """
+    engine = MLEngine(tenant_id="acme")
+    # No exception — pre-shard-A rows that don't carry tenant_id.
+    engine._check_tenant_match(model_tenant=None, model_name="User")

--- a/specs/ml-engines.md
+++ b/specs/ml-engines.md
@@ -1127,36 +1127,31 @@ Every reference below points to another spec or rule that this spec depends on b
 
 This checklist is the structural gate for kailash-ml **2.0.0** release. Every item MUST pass before tagging 2.0.0. Pre-2.0 releases satisfy the subset listed in §12.1 (Current Phase Status) and MUST NOT regress any already-green item.
 
-### 12.1 Current Phase Status (updated 2026-04-20 — kailash-ml 0.14.0)
+### 12.1 Current Phase Status (updated 2026-04-20 — kailash-ml 0.15.0)
 
-Pre-2.0 releases implement the phased punch list from the §9 redesign proposal. The §12 bottom-of-list "zero `NotImplementedError`" and "zero `TODO|FIXME`" gates are explicitly deferred to 2.0.0 — today's allowed deferrals are enumerated below with their phase marker. Any `NotImplementedError` in `packages/kailash-ml/src/kailash_ml/` NOT on this list is a HIGH finding.
+Phase 3/4/5 complete as of kailash-ml 0.15.0 (PRs #561/#562/#563, release #565). All seven `MLEngine` method bodies ship production implementations. Only two documented deferrals remain inside `packages/kailash-ml/src/kailash_ml/`:
 
-| Method / surface    | File:line       | Phase   | Tracking                                                                 |
-| ------------------- | --------------- | ------- | ------------------------------------------------------------------------ |
-| `MLEngine.setup`    | `engine.py:434` | Phase 3 | `_PHASE_3` marker — "Trainable adapters + Lightning Trainer integration" |
-| `MLEngine.compare`  | `engine.py:457` | Phase 3 | `_PHASE_3`                                                               |
-| `MLEngine.finalize` | `engine.py:581` | Phase 3 | `_PHASE_3`                                                               |
-| `MLEngine.predict`  | `engine.py:567` | Phase 4 | `_PHASE_4` — "inference path + ONNX export"                              |
-| `MLEngine.evaluate` | `engine.py:600` | Phase 4 | `_PHASE_4`                                                               |
-| `MLEngine.register` | `engine.py:626` | Phase 4 | `_PHASE_4`                                                               |
-| `MLEngine.serve`    | `engine.py:654` | Phase 5 | `_PHASE_5` — "InferenceServer + multi-channel serving"                   |
+| Deferral                             | File:line         | Scope          | Tracking                                                                                                                                     |
+| ------------------------------------ | ----------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setup(split_strategy != "holdout")` | `engine.py:~599`  | Phase 3.1      | kfold / stratified_kfold / walk_forward — journaled at `workspaces/kailash-ml-gpu-stack/journal/.pending/`                                   |
+| `serve(channels=["grpc"])`           | `engine.py:~2359` | `[grpc]` extra | Loud-failure pattern per `rules/dependencies.md` § Exception — requires `pip install kailash-ml[grpc]`; full gRPC channel tracked for 0.15.1 |
 
-All seven entries satisfy `rules/zero-tolerance.md` §2 Exception 2 ("iterative TODOs permitted when actively tracked"): each has a named phase marker, a documented body, and a dedicated upcoming session per the §9 redesign proposal.
+Any `NotImplementedError` in `packages/kailash-ml/src/kailash_ml/` NOT on this list is a HIGH finding.
 
-**Rule interaction:** `rules/orphan-detection.md` §4a mandates that the session implementing any of the seven stubs MUST sweep the paired deferral test in the same commit (evidence: kailash-ml 0.13.0 `test_km_track_deferral_names_phase` incident).
+**Rule interaction:** `rules/orphan-detection.md` §4a mandates that the session implementing any remaining stub (e.g. the Phase 3.1 split strategies) MUST sweep the paired deferral test in the same commit (evidence: kailash-ml 0.13.0 `test_km_track_deferral_names_phase` incident; validated again in 0.15.0 when Shard A swept `test_async_method_deferral_is_typed_error` in `dc2a6a8e`).
 
 ### 12.2 2.0.0 Gate Items
 
 - [ ] `kailash_ml.Engine()` constructs successfully with zero arguments on macOS (MPS), Linux (CUDA + CPU), and Windows (CPU)
-- [ ] `MLEngine` public surface is exactly eight methods (`setup`, `compare`, `fit`, `predict`, `finalize`, `evaluate`, `register`, `serve`)
-- [ ] Every `MLEngine` method returns a named dataclass (no raw dicts)
+- [x] `MLEngine` public surface is exactly eight methods (`setup`, `compare`, `fit`, `predict`, `finalize`, `evaluate`, `register`, `serve`) — kailash-ml 0.15.0
+- [x] Every `MLEngine` method returns a named dataclass (no raw dicts) — seven result dataclasses in `kailash_ml._results` + `TrainingResult` in `_result.py` (kailash-ml 0.15.0)
 - [ ] `Trainable` protocol has `LightningModule` adapters for sklearn, xgboost, lightgbm, catboost, torch, lightning
 - [ ] `training_pipeline.py` has zero fit loops outside `L.Trainer(**ctx_kwargs).fit(module, loader)`
-- [ ] `TrainingResult` dataclass has all ten required fields
-- [ ] `rg '"default"' src/` returns zero matches in cache key construction
+- [x] `TrainingResult` dataclass has all ten required fields — kailash-ml 0.12.0
+- [x] `rg '"default"' src/` returns zero matches in cache key construction — `SENTINEL_GLOBAL_TENANT="global"` used throughout (kailash-ml 0.15.0)
 - [ ] Every Primitive constructor accepts `tenant_id`
 - [ ] ONNX compatibility matrix entries all have round-trip tests passing
-- [ ] `register(format="onnx")` raises `OnnxExportError` on failure (no silent pickle fallback)
+- [x] `register(format="onnx")` raises `OnnxExportError` on failure (no silent pickle fallback) — kailash-ml 0.15.0, engine.py:2785
 - [ ] `kailash_ml.legacy.*` covers every demoted v0.9.x public symbol
 - [ ] Every legacy import emits `DeprecationWarning` on first use
 - [ ] Integration tests in §7.2 all pass on CPU; GPU-gated tests (`pytest.mark.gpu_*`) pass on CI GPU runners


### PR DESCRIPTION
## Summary

Post-release `/redteam` (reviewer + security-reviewer + gold-standards-validator) on yesterday's release (#565) surfaced three HIGH findings. All fixed here + regression-tested.

- **ML HIGH-1 (security)**: Cross-tenant bypass in `MLEngine._check_tenant_match` — unscoped engine (`tenant_id=None`) silently loaded tenant-scoped models. Now raises `TenantRequiredError` with actionable message. 5-case regression test in `tests/regression/test_tenant_isolation_unscoped_engine.py`.
- **MCP HIGH-1 (gold-standards)**: `features.py` + `server.py` missing `SPDX-License-Identifier: Apache-2.0` + copyright headers. Added.
- **Spec HIGH-1 (reviewer)**: `specs/ml-engines.md §12.1` still dated "0.14.0" with all 7 Phase 3/4/5 rows pending. Updated header, reduced table to the 2 intentional deferrals, marked 5 §12.2 checkboxes satisfied by 0.15.0.

## Test plan

- [x] `pytest tests/regression/test_tenant_isolation_unscoped_engine.py` — 5/5 green
- [x] `pytest --collect-only -q packages/kailash-ml/tests/ packages/kailash-mcp/tests/` — 1185 tests, exit 0
- [x] `pip check` — clean

## Post-merge

Push tags `ml-v0.15.1` and `mcp-v0.2.7` individually per `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually".

## Related issues

Post-release audit of #565 (kailash-ml 0.15.0 + kailash-mcp 0.2.6). Rule compliance: `rules/agents.md` § "After release" gate, `rules/tenant-isolation.md` Rule 2, `rules/terrene-naming.md` § License labels, `rules/specs-authority.md` §5 (first-instance updates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)