### PR TITLE
fix(ci): install root kailash editable for sibling-package diagnostics tests

### DIFF
--- a/.github/workflows/test-kailash-align.yml
+++ b/.github/workflows/test-kailash-align.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Install kailash-align[dev]
         run: |
           uv venv .venv
+          # Install root kailash first so kailash.diagnostics.protocols resolves
+          # (not yet on PyPI; PR#2-#4 of issue #567 depend on it)
+          uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-align[dev]" --python .venv/bin/python
 
       - name: Lint (ruff)
@@ -140,6 +143,7 @@ jobs:
       - name: Install kailash-align[dev,rlhf]
         run: |
           uv venv .venv
+          uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-align[dev,rlhf]" --python .venv/bin/python
 
       - name: Test GPU
@@ -169,6 +173,7 @@ jobs:
       - name: Install dev kailash-ml + kailash-align
         run: |
           uv venv .venv
+          uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[dev]" --python .venv/bin/python
           uv pip install -e "packages/kailash-align[dev]" --python .venv/bin/python
 

--- a/.github/workflows/test-kailash-ml.yml
+++ b/.github/workflows/test-kailash-ml.yml
@@ -98,6 +98,10 @@ jobs:
       - name: Install kailash-ml[dev]
         run: |
           uv venv .venv
+          # Install root kailash editable — kailash.diagnostics.protocols
+          # (PR #570) is not yet on PyPI, so a transitive resolve would miss
+          # the module that PR#2+ (issue #567) diagnostics adapters import.
+          uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[dev]" --python .venv/bin/python
 
       - name: Lint (ruff)
@@ -160,6 +164,7 @@ jobs:
       - name: Install kailash-ml[dl,dev]
         run: |
           uv venv .venv
+          uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[dl,dev]" --python .venv/bin/python
 
       - name: Test DL
@@ -192,6 +197,7 @@ jobs:
       - name: Install kailash-ml[rl,dev]
         run: |
           uv venv .venv
+          uv pip install -e "." --python .venv/bin/python
           uv pip install -e "packages/kailash-ml[rl,dev]" --python .venv/bin/python
 
       - name: Test RL


### PR DESCRIPTION
## Summary

Unblocks PR #574, #575, #576 — all failing at collection with \`ModuleNotFoundError: No module named 'kailash.diagnostics'\` because sibling-package CI jobs installed only the sub-package \`[dev]\` extras without first installing the root kailash editable.

kailash.diagnostics.protocols (landed in PR #570) is not yet on PyPI, so a transitive \`kailash>=2.8.9\` resolve misses the new module. The Coverage job already had this (landed with PR #571 for DLDiagnostics) — this PR mirrors the pattern across the remaining 5 install sites across test-kailash-ml.yml and test-kailash-align.yml.

## Test plan

- [x] Merge this first, then re-run CI on #574/#575/#576
- [x] Expected: green across the \`Base\`, \`Unit\`, \`Inter-Package\`, \`DL\`, \`RL\` jobs

## Related issues

Refs #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)