### PR TITLE
fix(mcp): elicitation error codes emit MCP 2025-06-18 wire values (#572)

### DIFF
--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the Kailash MCP package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2026-04-21 — MCP elicitation error code cross-SDK parity (#572)
+
+### Fixed
+
+- **`ElicitationSystem` now emits MCP 2025-06-18 spec-compliant JSON-RPC error codes** on the wire — matching kailash-rs byte-for-byte per `rules/cross-sdk-inspection.md` (issue #572 / kailash-rs#471). Prior releases emitted positive application codes (`REQUEST_CANCELLED = 1007`, `REQUEST_TIMEOUT = 1006`) which are NOT valid JSON-RPC wire codes; MCP clients written against the spec did not recognize them as the documented conditions. Now:
+  - Client decline / cancel → `MCP_REQUEST_CANCELLED = -32800` (was `REQUEST_CANCELLED = 1007`)
+  - Response timeout → `MCP_ELICITATION_TIMEOUT = -32001` (was `REQUEST_TIMEOUT = 1006`)
+  - Schema validation failure → `MCP_SCHEMA_VALIDATION = -32602` (alias of existing `INVALID_PARAMS`, already correct)
+- **New `MCPErrorCode` enum members** for MCP wire parity: `MCP_REQUEST_CANCELLED`, `MCP_ELICITATION_TIMEOUT`, `MCP_TRANSPORT_REBOUND`, `MCP_SCHEMA_VALIDATION`. The legacy positive codes (`REQUEST_CANCELLED`, `REQUEST_TIMEOUT`) remain for non-wire application use; wire-path code paths MUST use the `MCP_*` prefix.
+- **Pin-value regression test** at `packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py` — nine assertions covering enum values, `MCPError` wire serialization, and a source-level grep that ElicitationSystem uses the `MCP_*` constants. If a future refactor reverts to `REQUEST_CANCELLED` / `REQUEST_TIMEOUT` on the wire the grep assertion fails loudly.
+
+### Cross-SDK
+
+- Canonical source: MCP specification 2025-06-18 / JSON-RPC 2.0 reserved ranges. kailash-rs landed these values first in PR #464 (Rust) with a pin-value regression test; kailash-py aligns here.
+- `specs/mcp-server.md` § "Error Semantics" now documents the four wire codes and the kailash-py ↔ kailash-rs constant mapping.
+
 ## [0.2.7] - 2026-04-20 — post-release audit hotfix (SPDX headers)
 
 Post-release `/redteam` audit of 0.2.6 (gold-standards-validator HIGH-1) surfaced missing SPDX license headers on the two files most heavily modified by the #556 ElicitationSystem redesign. 4-line docs-hygiene fix.

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.2.7"
+version = "0.2.8"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (

--- a/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
+++ b/packages/kailash-mcp/src/kailash_mcp/advanced/features.py
@@ -851,8 +851,8 @@ class ElicitationSystem:
 
         Raises:
             MCPError(INVALID_REQUEST): No send-transport is bound.
-            MCPError(REQUEST_TIMEOUT): Client did not respond within `timeout`.
-            MCPError(REQUEST_CANCELLED): Client returned a `decline` or
+            MCPError(MCP_ELICITATION_TIMEOUT, code=-32001): Client did not respond within `timeout`.
+            MCPError(MCP_REQUEST_CANCELLED, code=-32800): Client returned a `decline` or
                 `cancel` action.
             ValidationError: Response failed `input_schema` validation.
         """
@@ -892,7 +892,7 @@ class ElicitationSystem:
             response_future.set_exception(
                 MCPError(
                     f"Client cancelled elicitation request: {reason}",
-                    error_code=MCPErrorCode.REQUEST_CANCELLED,
+                    error_code=MCPErrorCode.MCP_REQUEST_CANCELLED,
                 )
             )
             if not response_future.done()
@@ -938,7 +938,7 @@ class ElicitationSystem:
             )
             raise MCPError(
                 f"Elicitation request {request_id} timed out after {timeout}s",
-                error_code=MCPErrorCode.REQUEST_TIMEOUT,
+                error_code=MCPErrorCode.MCP_ELICITATION_TIMEOUT,
             )
         except MCPError:
             elapsed_ms = (time.monotonic() - start_ts) * 1000

--- a/packages/kailash-mcp/src/kailash_mcp/errors.py
+++ b/packages/kailash-mcp/src/kailash_mcp/errors.py
@@ -75,6 +75,19 @@ class MCPErrorCode(Enum):
     REQUEST_TIMEOUT = 1006
     REQUEST_CANCELLED = 1007
 
+    # MCP 2025-06-18 elicitation/create wire codes — cross-SDK parity with
+    # kailash-rs (see issue #572 / kailash-rs#471). These are the values
+    # serialized into JSON-RPC error payloads sent to MCP clients and MUST
+    # match byte-for-byte across SDKs. MCP_ELICITATION_TIMEOUT and
+    # MCP_TRANSPORT_REBOUND are value-aliases of TRANSPORT_ERROR /
+    # AUTHENTICATION_FAILED under Python's Enum aliasing; the distinct name
+    # preserves call-site intent. MCP_SCHEMA_VALIDATION is an alias of
+    # INVALID_PARAMS (both are -32602 per JSON-RPC 2.0).
+    MCP_REQUEST_CANCELLED = -32800  # JSON-RPC 2.0 extension (cancellation)
+    MCP_ELICITATION_TIMEOUT = -32001  # alias of TRANSPORT_ERROR
+    MCP_TRANSPORT_REBOUND = -32002  # alias of AUTHENTICATION_FAILED
+    MCP_SCHEMA_VALIDATION = -32602  # alias of INVALID_PARAMS
+
 
 class MCPError(Exception):
     """Enhanced MCP error with structured information.

--- a/packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py
+++ b/packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py
@@ -1,0 +1,131 @@
+"""Pin-value regression test for MCP elicitation/create error codes.
+
+Cross-SDK parity with kailash-rs v3.x (issue #572 / kailash-rs#471). The four
+JSON-RPC error codes emitted by ``ElicitationSystem`` to MCP clients MUST
+match kailash-rs byte-for-byte — MCP is a wire-level protocol and clients
+written against one SDK's codes MUST handle the same errors when the server
+runs the other SDK.
+
+Canonical source: MCP specification 2025-06-18 / JSON-RPC 2.0 reserved range.
+"""
+
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Terrene Foundation
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+from kailash_mcp.errors import MCPError, MCPErrorCode
+
+
+@pytest.mark.unit
+class TestElicitationErrorCodeParity:
+    """Cross-SDK parity: the four MCP elicitation/create wire codes."""
+
+    def test_mcp_request_cancelled_pins_to_minus_32800(self) -> None:
+        assert MCPErrorCode.MCP_REQUEST_CANCELLED.value == -32800
+
+    def test_mcp_elicitation_timeout_pins_to_minus_32001(self) -> None:
+        assert MCPErrorCode.MCP_ELICITATION_TIMEOUT.value == -32001
+
+    def test_mcp_transport_rebound_pins_to_minus_32002(self) -> None:
+        assert MCPErrorCode.MCP_TRANSPORT_REBOUND.value == -32002
+
+    def test_mcp_schema_validation_pins_to_minus_32602(self) -> None:
+        assert MCPErrorCode.MCP_SCHEMA_VALIDATION.value == -32602
+
+    def test_all_four_codes_together(self) -> None:
+        """The four codes as a set — the cross-SDK contract."""
+        codes = {
+            "RequestCancelled": MCPErrorCode.MCP_REQUEST_CANCELLED.value,
+            "SchemaValidation": MCPErrorCode.MCP_SCHEMA_VALIDATION.value,
+            "ElicitationTimeout": MCPErrorCode.MCP_ELICITATION_TIMEOUT.value,
+            "TransportRebound": MCPErrorCode.MCP_TRANSPORT_REBOUND.value,
+        }
+        assert codes == {
+            "RequestCancelled": -32800,
+            "SchemaValidation": -32602,
+            "ElicitationTimeout": -32001,
+            "TransportRebound": -32002,
+        }
+
+
+@pytest.mark.unit
+class TestElicitationWireSerialization:
+    """MCPError wraps the MCP code on the wire — the value reaches the client."""
+
+    def test_request_cancelled_serializes_to_minus_32800(self) -> None:
+        err = MCPError(
+            "Client cancelled elicitation request: decline",
+            error_code=MCPErrorCode.MCP_REQUEST_CANCELLED,
+        )
+        assert err.error_code.value == -32800
+
+    def test_timeout_serializes_to_minus_32001(self) -> None:
+        err = MCPError(
+            "Elicitation request req-xyz timed out after 30s",
+            error_code=MCPErrorCode.MCP_ELICITATION_TIMEOUT,
+        )
+        assert err.error_code.value == -32001
+
+
+@pytest.mark.unit
+class TestElicitationSystemCallSites:
+    """Structural invariant: ElicitationSystem uses the MCP wire codes, not
+    the legacy positive application codes (1006/1007). If this regresses the
+    server will emit application codes to MCP clients, breaking cross-SDK
+    clients written against the spec.
+    """
+
+    def test_elicitation_features_uses_mcp_wire_codes(self) -> None:
+        features_path = (
+            Path(__file__).resolve().parents[2]
+            / "src"
+            / "kailash_mcp"
+            / "advanced"
+            / "features.py"
+        )
+        source = features_path.read_text()
+
+        # Locate the ElicitationSystem class body by text scan.
+        start = source.index("class ElicitationSystem")
+        end = source.index("class ", start + 1)
+        elicitation_src = source[start:end]
+
+        # Cancellation and timeout paths MUST use the MCP wire constants.
+        assert "MCPErrorCode.MCP_REQUEST_CANCELLED" in elicitation_src, (
+            "ElicitationSystem cancel callback must raise MCP_REQUEST_CANCELLED "
+            "(-32800) not REQUEST_CANCELLED (1007). See issue #572."
+        )
+        assert "MCPErrorCode.MCP_ELICITATION_TIMEOUT" in elicitation_src, (
+            "ElicitationSystem timeout path must raise MCP_ELICITATION_TIMEOUT "
+            "(-32001) not REQUEST_TIMEOUT (1006). See issue #572."
+        )
+
+        # Legacy positive application codes MUST NOT appear inside
+        # ElicitationSystem — they belong to non-wire application layers.
+        assert "MCPErrorCode.REQUEST_CANCELLED" not in elicitation_src, (
+            "ElicitationSystem must not use REQUEST_CANCELLED (1007) — "
+            "positive codes are not valid JSON-RPC wire codes. Use "
+            "MCP_REQUEST_CANCELLED (-32800) for client-decline / client-cancel."
+        )
+        assert "MCPErrorCode.REQUEST_TIMEOUT" not in elicitation_src, (
+            "ElicitationSystem must not use REQUEST_TIMEOUT (1006). Use "
+            "MCP_ELICITATION_TIMEOUT (-32001) for timeout on the wire."
+        )
+
+    def test_elicitation_system_constructor_signature_invariant(self) -> None:
+        """Locks the ElicitationSystem init signature so a future refactor
+        toward a different shape fails loudly.
+        """
+        from kailash_mcp.advanced.features import ElicitationSystem
+
+        sig = inspect.signature(ElicitationSystem.__init__)
+        params = [p for p in sig.parameters.values() if p.name != "self"]
+        assert [p.name for p in params] == ["send"], (
+            f"ElicitationSystem.__init__ signature drifted: {sig}. "
+            f"Cross-SDK parity relies on a fixed send-callable shape."
+        )

--- a/specs/mcp-server.md
+++ b/specs/mcp-server.md
@@ -616,12 +616,30 @@ This wiring is the production call site required by `rules/orphan-detection.md` 
 
 #### Error Semantics
 
-| Condition                                        | Raised exception  | Error code          |
-| ------------------------------------------------ | ----------------- | ------------------- |
-| `request_input()` called with no transport bound | `MCPError`        | `INVALID_REQUEST`   |
-| Response timeout                                 | `MCPError`        | `REQUEST_TIMEOUT`   |
-| Schema validation failure on response            | `ValidationError` | (propagated)        |
-| Client declined / cancelled                      | `MCPError`        | `REQUEST_CANCELLED` |
+Error codes emitted to MCP clients MUST match kailash-rs byte-for-byte (MCP 2025-06-18 / JSON-RPC 2.0). See cross-SDK parity notes below.
+
+| Condition                                        | Raised exception  | Error code (wire value)                        |
+| ------------------------------------------------ | ----------------- | ---------------------------------------------- |
+| `request_input()` called with no transport bound | `MCPError`        | `INVALID_REQUEST` (`-32600`)                   |
+| Response timeout                                 | `MCPError`        | `MCP_ELICITATION_TIMEOUT` (`-32001`)           |
+| Schema validation failure on response            | `ValidationError` | (propagated; `-32602` if wrapped as MCP error) |
+| Client declined / cancelled                      | `MCPError`        | `MCP_REQUEST_CANCELLED` (`-32800`)             |
+| Transport rebound mid-request (future)           | `MCPError`        | `MCP_TRANSPORT_REBOUND` (`-32002`)             |
+
+##### Cross-SDK Parity (kailash-rs)
+
+The four MCP wire codes used by `elicitation/create` MUST match kailash-rs byte-for-byte. Clients written against one SDK's codes MUST handle errors the same way when the server runs the other SDK.
+
+| Variant            | Wire code | kailash-py constant                                                     | kailash-rs constant  |
+| ------------------ | --------- | ----------------------------------------------------------------------- | -------------------- |
+| RequestCancelled   | `-32800`  | `MCPErrorCode.MCP_REQUEST_CANCELLED`                                    | `RequestCancelled`   |
+| SchemaValidation   | `-32602`  | `MCPErrorCode.INVALID_PARAMS` / `MCP_SCHEMA_VALIDATION` (alias)         | `SchemaValidation`   |
+| ElicitationTimeout | `-32001`  | `MCPErrorCode.MCP_ELICITATION_TIMEOUT` (alias of `TRANSPORT_ERROR`)     | `ElicitationTimeout` |
+| TransportRebound   | `-32002`  | `MCPErrorCode.MCP_TRANSPORT_REBOUND` (alias of `AUTHENTICATION_FAILED`) | `TransportRebound`   |
+
+Pin-value regression: `packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py`. A source-level grep asserts ElicitationSystem uses the `MCP_*` constants, not the legacy positive-code application variants (`REQUEST_CANCELLED = 1007`, `REQUEST_TIMEOUT = 1006`) which were invalid JSON-RPC wire values before issue #572.
+
+Related: kailash-rs#471, kailash-py#572.
 
 #### Security
 

--- a/tests/integration/mcp_server/test_advanced_features.py
+++ b/tests/integration/mcp_server/test_advanced_features.py
@@ -710,7 +710,9 @@ class TestElicitationSystem:
                 timeout=0.1,
             )
 
-        assert exc_info.value.error_code == MCPErrorCode.REQUEST_TIMEOUT
+        # Issue #572: elicitation timeout emits MCP 2025-06-18 wire code -32001.
+        assert exc_info.value.error_code == MCPErrorCode.MCP_ELICITATION_TIMEOUT
+        assert exc_info.value.error_code.value == -32001
         assert len(captured_messages) == 1
         assert captured_messages[0]["method"] == "elicitation/create"
 

--- a/tests/integration/mcp_server/test_elicitation_integration.py
+++ b/tests/integration/mcp_server/test_elicitation_integration.py
@@ -168,7 +168,10 @@ async def test_elicitation_timeout_with_silent_send() -> None:
     with pytest.raises(MCPError) as exc_info:
         await system.request_input("Waiting forever?", timeout=0.1)
 
-    assert exc_info.value.error_code == MCPErrorCode.REQUEST_TIMEOUT
+    # Issue #572: elicitation timeout now emits MCP wire code -32001 per
+    # MCP 2025-06-18 spec, not the legacy application code 1006.
+    assert exc_info.value.error_code == MCPErrorCode.MCP_ELICITATION_TIMEOUT
+    assert exc_info.value.error_code.value == -32001
 
 
 @pytest.mark.asyncio
@@ -200,7 +203,7 @@ async def test_elicitation_bind_transport_replaces_prior() -> None:
 
 @pytest.mark.asyncio
 async def test_elicitation_cancel_request_surfaces_as_cancelled_error() -> None:
-    """Client decline/cancel -> MCPError(REQUEST_CANCELLED) at caller."""
+    """Client decline/cancel -> MCPError(MCP_REQUEST_CANCELLED) at caller."""
     system = ElicitationSystem()
 
     async def cancelling_send(message: Dict[str, Any]) -> None:
@@ -214,7 +217,10 @@ async def test_elicitation_cancel_request_surfaces_as_cancelled_error() -> None:
     with pytest.raises(MCPError) as exc_info:
         await system.request_input("Proceed?", timeout=1.0)
 
-    assert exc_info.value.error_code == MCPErrorCode.REQUEST_CANCELLED
+    # Issue #572: cancellation emits MCP wire code -32800 per MCP 2025-06-18
+    # (JSON-RPC 2.0 cancellation extension), not the legacy app code 1007.
+    assert exc_info.value.error_code == MCPErrorCode.MCP_REQUEST_CANCELLED
+    assert exc_info.value.error_code.value == -32800
     assert "user declined" in str(exc_info.value)
 
 
@@ -310,7 +316,9 @@ async def test_mcpserver_route_server_initiated_response_decline_action() -> Non
     server.elicitation_system.bind_transport(declining_send)
     with pytest.raises(MCPError) as exc_info:
         await server.elicitation_system.request_input("Proceed?", timeout=1.0)
-    assert exc_info.value.error_code == MCPErrorCode.REQUEST_CANCELLED
+    # Issue #572: MCP 2025-06-18 wire code for cancellation.
+    assert exc_info.value.error_code == MCPErrorCode.MCP_REQUEST_CANCELLED
+    assert exc_info.value.error_code.value == -32800
     assert "decline" in str(exc_info.value)
 
 


### PR DESCRIPTION
## Summary

- `ElicitationSystem` now emits MCP 2025-06-18 spec-compliant JSON-RPC error codes on the wire, matching kailash-rs byte-for-byte.
- Four new `MCPErrorCode` enum members (`MCP_REQUEST_CANCELLED = -32800`, `MCP_ELICITATION_TIMEOUT = -32001`, `MCP_TRANSPORT_REBOUND = -32002`, `MCP_SCHEMA_VALIDATION = -32602`); legacy positive codes retained for non-wire application use.
- Pin-value regression test (9 assertions) + 4 downstream integration tests updated with explicit `.value` checks for grep-able parity; spec § Error Semantics now documents the kailash-py ↔ kailash-rs mapping.

## Why

MCP is a wire-level protocol. Prior kailash-py releases emitted positive application codes (`REQUEST_CANCELLED = 1007`, `REQUEST_TIMEOUT = 1006`) from `ElicitationSystem` to MCP clients. These are **not valid JSON-RPC wire codes** per MCP 2025-06-18 — clients written against the spec did not recognize them as the documented conditions, and cross-SDK clients written against kailash-rs (which emits the spec values per kailash-rs#471 / PR#464) could not handle errors uniformly.

The canonical source is the MCP 2025-06-18 specification; kailash-rs landed these values first with a pin-value regression test, kailash-py aligns here.

## Parity matrix (now)

| Variant              | Wire code | kailash-py constant                 | kailash-rs constant    |
| -------------------- | --------- | ----------------------------------- | ---------------------- |
| `RequestCancelled`   | `-32800`  | `MCPErrorCode.MCP_REQUEST_CANCELLED`  | `RequestCancelled`   |
| `SchemaValidation`   | `-32602`  | `MCPErrorCode.INVALID_PARAMS` / `MCP_SCHEMA_VALIDATION` (alias) | `SchemaValidation`   |
| `ElicitationTimeout` | `-32001`  | `MCPErrorCode.MCP_ELICITATION_TIMEOUT` (alias of `TRANSPORT_ERROR`) | `ElicitationTimeout` |
| `TransportRebound`   | `-32002`  | `MCPErrorCode.MCP_TRANSPORT_REBOUND` (alias of `AUTHENTICATION_FAILED`) | `TransportRebound`   |

## Test plan

- [x] `packages/kailash-mcp/tests/unit/test_elicitation_error_codes_parity.py` — 9/9 pass (enum values, wire serialization, source-grep invariant, constructor signature invariant)
- [x] `tests/integration/mcp_server/test_elicitation_integration.py` — 3 assertions migrated to MCP wire codes + explicit `.value` checks; passes
- [x] `tests/integration/mcp_server/test_advanced_features.py` — 1 assertion migrated; passes
- [x] `tests/unit/mcp_server/test_errors.py` (88 tests) — legacy constants `REQUEST_CANCELLED = 1007` / `REQUEST_TIMEOUT = 1006` retained for non-wire use; pass unchanged

## Related issues

Fixes #572. Cross-SDK mirror of kailash-rs#471 / kailash-rs#464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)