### PR TITLE
feat: bundled resolution of 5 issues (#598/#600/#602/#603/#618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased — issue-603]
+## [2.10.0] — 2026-04-25 — MCP transports (#600) + BudgetTracker threshold callback (#603)
+
+Minor bump — two new public API surfaces in kailash core. Ships with `kailash-nexus 2.3.0` (#618 per-connection unicast) and `kailash-kaizen 2.13.0` (#598 PlanSuspension + #602 OrchestrationRuntime parity).
 
 ### Added
 
@@ -28,7 +30,7 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
-### kailash [Unreleased — issue-600] — MCP transport primitives (stdio / SSE / HTTP)
+### kailash 2.10.0 — 2026-04-25 — MCP transport primitives (stdio / SSE / HTTP) (#600)
 
 **Added** — closes #600
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased — issue-603]
+
+### Added
+
+- **`BudgetTracker.set_threshold_callback(threshold_pct, callback)`** at `src/kailash/trust/constraints/budget_tracker.py` — public API for registering a one-shot callback that fires when budget utilization first reaches a caller-supplied fraction of allocated budget. Distinct from the existing `on_threshold()` (which fires only at hardcoded 80/95/100% marks). Callback fires when `(committed + reserved) / allocated >= threshold_pct` after a successful `reserve()` or `record()` call. Multiple callbacks may be registered at the same threshold (registration order preserved); each (threshold, handle) fires AT MOST ONCE per BudgetTracker instance. Returns an integer handle for symmetric removal via `unregister_threshold_callback(handle)`. Thread-safe under existing `self._lock`; predicate evaluated under lock, callbacks dispatched outside the lock to prevent re-entrancy deadlock. Callback exceptions are logged at WARNING via `logger.exception` and never propagate to `record()`/`reserve()` callers. Motivation: Envoy Phase 01 Grant Moment trigger — operator wires "you've used 80% of your budget" notification to drive escalation. Cross-SDK alignment with `kailash-rs#30`.
+- **`BudgetEvent` payload extended** with optional `threshold_pct: Optional[float]`, `committed_microdollars: Optional[int]`, `reserved_microdollars: Optional[int]` fields. Custom-threshold events carry the registered fraction; legacy `threshold_80` / `threshold_95` / `exhausted` events now also carry their corresponding fraction (0.80 / 0.95 / 1.00) for cross-callback uniformity. `to_dict()` / `from_dict()` are backward-compatible — older payloads without these keys deserialize cleanly with the new fields set to `None`.
+- **Tier 1 unit tests** at `tests/trust/unit/test_budget_tracker_callbacks.py` (27 tests) covering happy path, registration order, multi-threshold ordering, exception isolation, once-only firing, threshold-pct validation (NaN/Inf/0/1/boundary), claimed-amount predicate, unregister semantics, allocated-zero edge case, and `_max_callbacks` limit.
+- **Tier 2 integration tests** at `tests/trust/integration/test_budget_tracker_callbacks.py` (5 tests) exercising callback dispatch under concurrent `reserve()`/`record()` workers (16-thread + 50-thread scenarios), callback-exception isolation under load, multi-threshold independence under load, and end-to-end Grant Moment scenario. NO mocking — all tests use real `threading` primitives.
+
+### Related
+
+- Cross-SDK: `esperie/kailash-rs#30` (Rust `BudgetTracker::set_threshold_callback`).
+
 ## Note: Changelog Reorganized
 
 The changelog has been reorganized into individual files for better management. Please see:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ The changelog has been reorganized into individual files for better management. 
 
 ## Recent Releases
 
+### kailash [Unreleased — issue-600] — MCP transport primitives (stdio / SSE / HTTP)
+
+**Added** — closes #600
+
+- **`kailash.channels.mcp.Transport`** — abstract base for MCP client transports. Three concrete implementations ship in this module:
+  - **`StdioTransport`** — bidirectional JSON-RPC over a local subprocess (LSP-style `Content-Length` framing). Allowlist gate on the spawned command; `allowed_commands=` parameter enforces explicit allowlist; spawning falls back to `TransportError` if the executable is not in the list.
+  - **`SseTransport`** — HTTP POST + Server-Sent Events stream. Connects to a remote SSE-exposed MCP server. POSTs requests to `{base}/message`; reads inline JSON OR `data: <json>` SSE events. Per-message reply path supported.
+  - **`HttpTransport`** — single-shot request/response. POSTs the JSON-RPC body and parses the JSON response inline. `receive()` raises `NotImplementedError` because HTTP has no unsolicited server-push.
+- **`validate_url(raw_url, *, allow_private=False)`** — SSRF guard shared across all HTTP-class transports. Rejects non-`http`/`https` schemes; rejects loopback, link-local, multicast, and RFC-1918 private hosts unless `allow_private=True` is passed (intended for trusted internal endpoints). Raises `TransportError`.
+- **Exception hierarchy:** `TransportError` (base) and `ProtocolError` (framing/format errors). All transport methods raise these — never bare `Exception`.
+
+**Tier 1 + Tier 2 coverage:**
+
+- 35 unit tests at `tests/unit/channels/test_mcp_transports.py` cover URL validation, exception hierarchy, transport construction guards, and per-transport contract.
+- 4 integration tests at `tests/integration/channels/test_mcp_transports_real.py` execute against real infrastructure (subprocess echo for stdio, `aiohttp` test server for sse + http) — NO mocking per `rules/testing.md` § 3-Tier Testing.
+
+**Cross-SDK parity:** mirrors `kailash-rs/crates/kailash-mcp/src/transport/{stdio,sse}.rs` semantic shape for parity (kailash-rs ISS-20 / EATP D6).
+
 ### kailash 2.9.2 — 2026-04-25 — 1.1.2 patch wave (docstring + cross-SDK)
 
 **Docstring + docstring-only changes** — no behavior change in `src/kailash/`. Ships alongside `kailash-dataflow 2.2.0` (public API expose, #601) + `kailash-kaizen 2.12.3` (security sweep, #614 + #617).

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.0] — 2026-04-25 — PlanSuspension cross-SDK parity (#598)
+
+Minor bump — new public API surface for L3 plan suspension. PACT N3 mandates resumable plan suspension; the kailash-rs SDK has shipped `SuspensionReason` + `SuspensionRecord` since the L3 landing, but the Python SDK had no equivalent and any cross-SDK plan serialization round-trip lost the suspension cause and resume frontier. This release closes that gap.
+
+### Added
+
+- **`kaizen.l3.plan.suspension` module** — five-variant `SuspensionReason` tagged union (frozen dataclasses + `Literal` `kind` discriminator) plus `SuspensionRecord` capturing the resume frontier:
+  - `HumanApprovalGateReason(held_node, reason)` — node entered Held gradient zone
+  - `CircuitBreakerTrippedReason(breaker_id, triggering_node)` — downstream dependency tripped
+  - `BudgetExceededReason(dimension, usage_pct, triggering_node)` — envelope dimension hit threshold (default 90%)
+  - `EnvelopeViolationReason(dimension, detail, triggering_node)` — envelope check rejected for non-budget reason (clearance, classification, dimension policy). Python-only today; cross-SDK parity for the 5th variant tracked in a sibling kailash-rs issue.
+  - `ExplicitCancellationReason(reason, resume_hint)` — caller-initiated cancel
+- **`SuspensionRecord.from_plan(reason, plan)`** — partitions plan node states into `running_nodes` / `ready_nodes` / `pending_nodes` (sorted lex for cross-SDK comparison stability), captures `suspended_at` UTC timestamp, and accepts an opaque `resume_context` payload.
+- **`Plan.suspension: Optional[SuspensionRecord]`** — present while the plan is in `SUSPENDED` state, cleared on `resume()`. Round-trips through `Plan.to_dict` / `Plan.from_dict`.
+- **`PlanExecutor.suspend(plan, reason=...)` / `AsyncPlanExecutor.suspend(plan, reason=...)`** — optional `reason` kwarg attaches the record at suspend time.
+- **`PlanExecutor.suspend_for_circuit_breaker(plan, breaker_id, triggering_node)`** + async variant — convenience wrapper for the `CircuitBreakerTripped` variant; required because the breaker-trip signal originates outside the executor's hot loop.
+- **`PlanExecutor.cancel(plan, reason="...", resume_hint="...")`** + async variant — always attaches `ExplicitCancellationReason` BEFORE cascading node-skip transitions, so `running_nodes` / `ready_nodes` / `pending_nodes` capture the pre-cancel snapshot.
+- **Wire format helpers** — `suspension_reason_to_dict` / `suspension_reason_from_dict` / `suspension_reason_label` matching Rust serde `#[serde(tag = "kind", rename_all = "snake_case")]`. Cross-SDK forensic correlation works without a third-party tagged-union library.
+
+### Changed
+
+- **`PlanExecutor.resume(plan)` / `AsyncPlanExecutor.resume(plan)`** — now clears `plan.suspension` (PACT N3: the suspension record is consumed by resume; downstream callers that need the record for audit MUST capture it before calling `resume()`).
+- **`AsyncPlanExecutor._execute_node` BLOCKED-verdict path** — classifies the suspension cause as `BudgetExceededReason` when the verdict reports a numeric overflow (`requested > available` on a known dimension) and `EnvelopeViolationReason` otherwise (structural rejection: clearance, classification, dimension policy).
+- **Both executors' `_determine_terminal_state`** — when the loop ends with one or more HELD nodes, attaches `HumanApprovalGateReason` for the lexicographically-first HELD node. Takes precedence over a previously-recorded `EnvelopeViolation` because the actionable resume path is the human-approval gate.
+
+### Cross-SDK Parity
+
+Wire-format `kind` tags (`human_approval_gate`, `circuit_breaker_tripped`, `budget_exceeded`, `envelope_violation`, `explicit_cancellation`) are reserved across SDKs. Field shapes match `kailash-rs/crates/kailash-kaizen/src/l3/core/plan/types.rs:267-396`. The `envelope_violation` variant is the Python SDK's 5th; a follow-up kailash-rs issue tracks adding it for full parity.
+
+### Tests
+
+- 30 Tier 1 unit tests at `tests/unit/l3/plan/test_suspension.py` — variant construction, frozen-dataclass invariant, label stability, wire-format round-trip, parametrized cross-SDK vector table.
+- 12 Tier 2 integration tests at `tests/integration/l3/test_suspension_emission.py` — drives each of the 5 trigger conditions end-to-end through `PlanExecutor` / `AsyncPlanExecutor`, asserts `plan.suspension.reason` is the right variant, asserts `Plan.to_dict` / `from_dict` round-trips the suspension field.
+
 ## [2.12.3] — 2026-04-25 — Security sweep (#614 + #617)
 
 Patch bump — defense-in-depth tightening of tenant-id log hygiene and credential-adjacent fingerprinting. No API changes.

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased — issue-602]
+
+### Added
+
+- **`kaizen.orchestration.OrchestrationRuntime`** (issue #602 / kailash-rs ISS-27 cross-SDK parity) — strategy-driven multi-agent coordinator mirroring the Rust `kaizen-agents::orchestration::runtime::OrchestrationRuntime` shape. Builder-style `add_agent` / `strategy` / `coordinator` / `config` setters; async `run(input)` returns `OrchestrationResult` with the same five-field shape as the Rust struct (`agent_results`, `final_output`, `total_iterations`, `total_tokens`, `duration_ms`). Sequential / Parallel / Hierarchical / Pipeline strategies dispatch through a single `agent_invoker` seam — Protocol-conforming agents need only implement `name` + `run_async` to participate. New surface: `OrchestrationRuntime`, `OrchestrationStrategy` (frozen dataclass + `sequential() / parallel() / hierarchical(name) / pipeline(steps)` factories), `OrchestrationStrategyKind` StrEnum (lowercase values match Rust serde), `OrchestrationConfig`, `OrchestrationResult`, `OrchestrationError`, `Coordinator` Protocol, `AgentLike` Protocol, `SharedMemoryCoordinator` (default in-memory backed by `SharedMemoryPool`), `PipelineStep`, `PipelineInputSource`. Coexists with — does NOT replace — `kaizen_agents.patterns.OrchestrationRuntime` (registry/lifecycle runtime for 10-100 agent fleets) and `kaizen.trust.orchestration.TrustAwareOrchestrationRuntime` (trust-policy enforcement). Tier-1: 37 unit tests in `tests/unit/orchestration/test_runtime.py`. Tier-2: 9 integration tests in `tests/integration/orchestration/test_runtime_e2e.py` exercising the runtime end-to-end through the real `SharedMemoryPool` coordinator + `TestCrossSdkShapeParity` locking the result-field set against the Rust struct shape. Spec: `specs/kaizen-agents-governance.md` § 19.6.
+
 ## [2.12.3] — 2026-04-25 — Security sweep (#614 + #617)
 
 Patch bump — defense-in-depth tightening of tenant-id log hygiene and credential-adjacent fingerprinting. No API changes.

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.12.3"
+version = "2.13.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.12.3"
+__version__ = "2.13.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/l3/plan/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/l3/plan/__init__.py
@@ -12,6 +12,18 @@ from kaizen.l3.plan.errors import (
 )
 from kaizen.l3.plan.executor import AsyncPlanExecutor, PlanExecutor
 from kaizen.l3.plan.modification import apply_modification, apply_modifications
+from kaizen.l3.plan.suspension import (
+    BudgetExceededReason,
+    CircuitBreakerTrippedReason,
+    EnvelopeViolationReason,
+    ExplicitCancellationReason,
+    HumanApprovalGateReason,
+    SuspensionReason,
+    SuspensionRecord,
+    suspension_reason_from_dict,
+    suspension_reason_label,
+    suspension_reason_to_dict,
+)
 from kaizen.l3.plan.types import (
     EdgeType,
     Plan,
@@ -51,4 +63,15 @@ __all__ = [
     # Modification
     "apply_modification",
     "apply_modifications",
+    # Suspension (PACT N3)
+    "BudgetExceededReason",
+    "CircuitBreakerTrippedReason",
+    "EnvelopeViolationReason",
+    "ExplicitCancellationReason",
+    "HumanApprovalGateReason",
+    "SuspensionReason",
+    "SuspensionRecord",
+    "suspension_reason_from_dict",
+    "suspension_reason_label",
+    "suspension_reason_to_dict",
 ]

--- a/packages/kailash-kaizen/src/kaizen/l3/plan/executor.py
+++ b/packages/kailash-kaizen/src/kaizen/l3/plan/executor.py
@@ -23,6 +23,15 @@ import uuid
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from kaizen.l3.plan.errors import ExecutionError
+from kaizen.l3.plan.suspension import (
+    BudgetExceededReason,
+    CircuitBreakerTrippedReason,
+    EnvelopeViolationReason,
+    ExplicitCancellationReason,
+    HumanApprovalGateReason,
+    SuspensionReason,
+    SuspensionRecord,
+)
 from kaizen.l3.plan.types import (
     EdgeType,
     Plan,
@@ -138,10 +147,24 @@ class PlanExecutor:
         events.extend(self._determine_terminal_state(plan))
         return events
 
-    def suspend(self, plan: Plan) -> list[PlanEvent]:
+    def suspend(
+        self,
+        plan: Plan,
+        reason: SuspensionReason | None = None,
+    ) -> list[PlanEvent]:
         """Suspend an executing plan.
 
         Precondition: plan.state must be EXECUTING.
+
+        Args:
+            plan: The plan to suspend.
+            reason: Optional :class:`SuspensionReason` explaining why
+                the plan is being suspended. When supplied, the
+                executor attaches a :class:`SuspensionRecord` to
+                ``plan.suspension`` capturing the resume frontier
+                (PACT N3). When omitted, ``plan.suspension`` is left
+                untouched — useful for callers whose terminal-state
+                logic emits the record (HumanApprovalGate path).
         """
         if plan.state != PlanState.EXECUTING:
             raise ExecutionError(
@@ -149,13 +172,39 @@ class PlanExecutor:
                 details={"plan_id": plan.plan_id, "state": plan.state.value},
             )
 
+        if reason is not None:
+            plan.suspension = SuspensionRecord.from_plan(reason, plan)
         plan.state = PlanState.SUSPENDED
         return [PlanEvent.plan_suspended()]
+
+    def suspend_for_circuit_breaker(
+        self,
+        plan: Plan,
+        breaker_id: str,
+        triggering_node: str,
+    ) -> list[PlanEvent]:
+        """Suspend an executing plan because a circuit breaker tripped.
+
+        Convenience wrapper around :meth:`suspend` for the
+        ``CircuitBreakerTripped`` variant. Required because the
+        breaker-trip signal originates outside the executor's hot
+        loop (downstream tool/agent registry) — the caller emits
+        the suspension with the breaker id so the resume path knows
+        which breaker to re-check.
+        """
+        reason: SuspensionReason = CircuitBreakerTrippedReason(
+            breaker_id=breaker_id,
+            triggering_node=triggering_node,
+        )
+        return self.suspend(plan, reason=reason)
 
     def resume(self, plan: Plan) -> list[PlanEvent]:
         """Resume a suspended plan.
 
-        Precondition: plan.state must be SUSPENDED.
+        Precondition: plan.state must be SUSPENDED. Clears
+        ``plan.suspension`` (PACT N3: the suspension record is consumed
+        by resume; downstream callers that need the record for audit
+        MUST capture it before calling ``resume()``).
         """
         if plan.state != PlanState.SUSPENDED:
             raise ExecutionError(
@@ -164,12 +213,32 @@ class PlanExecutor:
             )
 
         plan.state = PlanState.EXECUTING
+        plan.suspension = None
         return [PlanEvent.plan_resumed()]
 
-    def cancel(self, plan: Plan) -> list[PlanEvent]:
+    def cancel(
+        self,
+        plan: Plan,
+        reason: str = "caller-initiated",
+        resume_hint: str = "",
+    ) -> list[PlanEvent]:
         """Cancel a plan (executing or suspended).
 
-        Terminal states (Completed, Failed, Cancelled) raise error.
+        Always attaches an :class:`ExplicitCancellationReason`
+        :class:`SuspensionRecord` to ``plan.suspension`` BEFORE
+        transitioning to Cancelled (PACT N3: cancellation is one of
+        the five suspension reasons; the record persists post-cancel
+        for audit).
+
+        Args:
+            plan: The plan to cancel.
+            reason: Human-readable cancellation reason (default
+                ``"caller-initiated"``).
+            resume_hint: Hint describing when/why a resume could
+                happen, even though the plan is now Cancelled
+                (default empty string for no-hint).
+
+        Terminal states (Completed, Failed, Cancelled) raise.
         """
         terminal_states = {PlanState.COMPLETED, PlanState.FAILED, PlanState.CANCELLED}
         if plan.state in terminal_states:
@@ -177,6 +246,14 @@ class PlanExecutor:
                 f"Cannot cancel a plan in terminal state {plan.state.value}",
                 details={"plan_id": plan.plan_id, "state": plan.state.value},
             )
+
+        # PACT N3: attach SuspensionRecord BEFORE the cascade so
+        # running/ready/pending lists capture the pre-cancel snapshot.
+        cancel_reason: SuspensionReason = ExplicitCancellationReason(
+            reason=reason,
+            resume_hint=resume_hint,
+        )
+        plan.suspension = SuspensionRecord.from_plan(cancel_reason, plan)
 
         events: list[PlanEvent] = []
 
@@ -286,6 +363,13 @@ class PlanExecutor:
             events.append(
                 PlanEvent.node_blocked(node.node_id, dimension="envelope", detail=error)
             )
+            # PACT N3: capture EnvelopeViolation snapshot as soon as the
+            # block fires. The terminal-state path may overwrite this with
+            # a HumanApprovalGate record if HELD nodes are present after
+            # the cascade — that is intentional: HELD takes precedence in
+            # the suspension classification because the human-approval
+            # gate is the actionable resume path.
+            self._record_envelope_violation(plan, node, error or "")
             # Cascade: skip downstream data-dependent nodes
             events.extend(self._cascade_block(plan, node.node_id))
         elif retryable:
@@ -298,6 +382,58 @@ class PlanExecutor:
             )
 
         return events
+
+    def _record_envelope_violation(
+        self,
+        plan: Plan,
+        node: PlanNode,
+        detail: str,
+    ) -> None:
+        """Attach an :class:`EnvelopeViolationReason` SuspensionRecord.
+
+        Called when a node's envelope-violation result fires.
+        Does NOT change plan state — that is the
+        :meth:`_determine_terminal_state` responsibility.
+        """
+        reason: SuspensionReason = EnvelopeViolationReason(
+            dimension="envelope",
+            detail=detail,
+            triggering_node=node.node_id,
+        )
+        plan.suspension = SuspensionRecord.from_plan(reason, plan)
+
+    def _record_budget_exceeded(
+        self,
+        plan: Plan,
+        node: PlanNode,
+        dimension: str,
+        usage_pct: float,
+    ) -> None:
+        """Attach a :class:`BudgetExceededReason` SuspensionRecord."""
+        reason: SuspensionReason = BudgetExceededReason(
+            dimension=dimension,
+            usage_pct=usage_pct,
+            triggering_node=node.node_id,
+        )
+        plan.suspension = SuspensionRecord.from_plan(reason, plan)
+
+    def _record_human_approval_gate(
+        self,
+        plan: Plan,
+        held_node: PlanNode,
+    ) -> None:
+        """Attach a :class:`HumanApprovalGateReason` SuspensionRecord.
+
+        Called by :meth:`_determine_terminal_state` when the plan
+        finishes its execution loop with at least one HELD node.
+        ``held_node`` is the first lexicographic HELD node; the record
+        names it as the resume gate.
+        """
+        reason: SuspensionReason = HumanApprovalGateReason(
+            held_node=held_node.node_id,
+            reason=held_node.error or "Held — awaiting human approval",
+        )
+        plan.suspension = SuspensionRecord.from_plan(reason, plan)
 
     def _handle_retryable_failure(
         self,
@@ -516,6 +652,7 @@ class PlanExecutor:
 
         - All required completed -> COMPLETED
         - Any node HELD (none FAILED/SKIPPED among required) -> SUSPENDED
+          (attaches HumanApprovalGate SuspensionRecord)
         - Required nodes FAILED or SKIPPED -> FAILED
         - Otherwise (pending nodes, no running) -> SUSPENDED
         """
@@ -549,6 +686,12 @@ class PlanExecutor:
             if held_nodes:
                 # HELD nodes take precedence — plan is suspended awaiting resolution
                 plan.state = PlanState.SUSPENDED
+                # PACT N3: HumanApprovalGate variant. HELD takes
+                # precedence over a previously recorded
+                # EnvelopeViolation because the actionable resume
+                # path is the human-approval gate, not the envelope.
+                first_held = sorted(held_nodes, key=lambda n: n.node_id)[0]
+                self._record_human_approval_gate(plan, first_held)
                 events.append(PlanEvent.plan_suspended())
             elif failed_nodes:
                 plan.state = PlanState.FAILED
@@ -681,10 +824,20 @@ class AsyncPlanExecutor:
         await self._emit_many(terminal_events, events)
         return events
 
-    async def suspend(self, plan: Plan) -> list[PlanEvent]:
+    async def suspend(
+        self,
+        plan: Plan,
+        reason: SuspensionReason | None = None,
+    ) -> list[PlanEvent]:
         """Suspend an executing plan.
 
         Precondition: plan.state must be EXECUTING.
+
+        Args:
+            plan: The plan to suspend.
+            reason: Optional :class:`SuspensionReason`. When supplied,
+                attaches a :class:`SuspensionRecord` capturing the
+                resume frontier (PACT N3).
         """
         if plan.state != PlanState.EXECUTING:
             raise ExecutionError(
@@ -692,15 +845,34 @@ class AsyncPlanExecutor:
                 details={"plan_id": plan.plan_id, "state": plan.state.value},
             )
 
+        if reason is not None:
+            plan.suspension = SuspensionRecord.from_plan(reason, plan)
         plan.state = PlanState.SUSPENDED
         events: list[PlanEvent] = []
         await self._emit(PlanEvent.plan_suspended(), events)
         return events
 
+    async def suspend_for_circuit_breaker(
+        self,
+        plan: Plan,
+        breaker_id: str,
+        triggering_node: str,
+    ) -> list[PlanEvent]:
+        """Suspend an executing plan because a circuit breaker tripped.
+
+        Convenience wrapper for the ``CircuitBreakerTripped`` variant.
+        """
+        reason: SuspensionReason = CircuitBreakerTrippedReason(
+            breaker_id=breaker_id,
+            triggering_node=triggering_node,
+        )
+        return await self.suspend(plan, reason=reason)
+
     async def resume(self, plan: Plan) -> list[PlanEvent]:
         """Resume a suspended plan.
 
-        Precondition: plan.state must be SUSPENDED.
+        Precondition: plan.state must be SUSPENDED. Clears
+        ``plan.suspension`` (PACT N3).
         """
         if plan.state != PlanState.SUSPENDED:
             raise ExecutionError(
@@ -709,12 +881,22 @@ class AsyncPlanExecutor:
             )
 
         plan.state = PlanState.EXECUTING
+        plan.suspension = None
         events: list[PlanEvent] = []
         await self._emit(PlanEvent.plan_resumed(), events)
         return events
 
-    async def cancel(self, plan: Plan) -> list[PlanEvent]:
+    async def cancel(
+        self,
+        plan: Plan,
+        reason: str = "caller-initiated",
+        resume_hint: str = "",
+    ) -> list[PlanEvent]:
         """Cancel a plan (executing or suspended).
+
+        Always attaches an :class:`ExplicitCancellationReason`
+        :class:`SuspensionRecord` to ``plan.suspension`` BEFORE
+        transitioning to Cancelled (PACT N3).
 
         Terminal states (Completed, Failed, Cancelled) raise error.
         """
@@ -728,6 +910,14 @@ class AsyncPlanExecutor:
                 f"Cannot cancel a plan in terminal state {plan.state.value}",
                 details={"plan_id": plan.plan_id, "state": plan.state.value},
             )
+
+        # PACT N3: attach SuspensionRecord BEFORE the cascade so
+        # running/ready/pending lists capture the pre-cancel snapshot.
+        cancel_reason: SuspensionReason = ExplicitCancellationReason(
+            reason=reason,
+            resume_hint=resume_hint,
+        )
+        plan.suspension = SuspensionRecord.from_plan(cancel_reason, plan)
 
         events: list[PlanEvent] = []
 
@@ -848,6 +1038,38 @@ class AsyncPlanExecutor:
                 node.transition_to(PlanNodeState.RUNNING)
                 node.transition_to(PlanNodeState.FAILED)
                 node.error = f"Envelope blocked: {verdict.detail}"
+                # PACT N3: classify the BLOCKED suspension cause —
+                # if the verdict reports a numeric budget overflow
+                # (requested > available with a known dimension),
+                # it is a BudgetExceeded suspension; otherwise it is
+                # a structural EnvelopeViolation (classification,
+                # clearance, dimension-policy mismatch).
+                is_budget_overflow = (
+                    verdict.requested is not None
+                    and verdict.available is not None
+                    and verdict.requested > verdict.available
+                    and verdict.dimension is not None
+                )
+                if is_budget_overflow:
+                    # Pre-block usage_pct may be slightly under 1.0;
+                    # compute requested/available ratio as a proxy.
+                    usage_pct = (
+                        verdict.requested / verdict.available
+                        if verdict.available > 0
+                        else 1.0
+                    )
+                    self._record_budget_exceeded(
+                        plan,
+                        node,
+                        verdict.dimension or "financial",
+                        usage_pct,
+                    )
+                else:
+                    self._record_envelope_violation(
+                        plan,
+                        node,
+                        verdict.detail or "envelope blocked",
+                    )
                 await self._emit(
                     PlanEvent.node_blocked(
                         node.node_id,
@@ -863,6 +1085,20 @@ class AsyncPlanExecutor:
             if verdict.tag == "HELD":
                 node.transition_to(PlanNodeState.RUNNING)
                 node.transition_to(PlanNodeState.HELD)
+                # PACT N3: HELD on the envelope path means a budget
+                # threshold was hit — record BudgetExceeded with the
+                # verdict's reported usage. The terminal-state path
+                # may overwrite this with HumanApprovalGate (HELD
+                # nodes always trigger that variant) — both signals
+                # are operationally meaningful; precedence is owned
+                # by _determine_terminal_state.
+                if verdict.dimension is not None and verdict.current_usage is not None:
+                    self._record_budget_exceeded(
+                        plan,
+                        node,
+                        verdict.dimension,
+                        verdict.current_usage,
+                    )
                 await self._emit(
                     PlanEvent.node_held(
                         node.node_id,
@@ -902,6 +1138,11 @@ class AsyncPlanExecutor:
             # G8: Envelope violation -> ALWAYS Blocked
             node.transition_to(PlanNodeState.FAILED)
             node.error = error
+            # PACT N3: callback-reported envelope violation —
+            # classify as EnvelopeViolation. The terminal-state path
+            # may upgrade to HumanApprovalGate if the cascade leaves
+            # HELD nodes.
+            self._record_envelope_violation(plan, node, error or "")
             await self._emit(
                 PlanEvent.node_blocked(
                     node.node_id, dimension="envelope", detail=error
@@ -1148,11 +1389,53 @@ class AsyncPlanExecutor:
 
         return events
 
+    def _record_envelope_violation(
+        self,
+        plan: Plan,
+        node: PlanNode,
+        detail: str,
+    ) -> None:
+        """Attach an :class:`EnvelopeViolationReason` SuspensionRecord."""
+        reason: SuspensionReason = EnvelopeViolationReason(
+            dimension="envelope",
+            detail=detail,
+            triggering_node=node.node_id,
+        )
+        plan.suspension = SuspensionRecord.from_plan(reason, plan)
+
+    def _record_budget_exceeded(
+        self,
+        plan: Plan,
+        node: PlanNode,
+        dimension: str,
+        usage_pct: float,
+    ) -> None:
+        """Attach a :class:`BudgetExceededReason` SuspensionRecord."""
+        reason: SuspensionReason = BudgetExceededReason(
+            dimension=dimension,
+            usage_pct=usage_pct,
+            triggering_node=node.node_id,
+        )
+        plan.suspension = SuspensionRecord.from_plan(reason, plan)
+
+    def _record_human_approval_gate(
+        self,
+        plan: Plan,
+        held_node: PlanNode,
+    ) -> None:
+        """Attach a :class:`HumanApprovalGateReason` SuspensionRecord."""
+        reason: SuspensionReason = HumanApprovalGateReason(
+            held_node=held_node.node_id,
+            reason=held_node.error or "Held — awaiting human approval",
+        )
+        plan.suspension = SuspensionRecord.from_plan(reason, plan)
+
     def _determine_terminal_state(self, plan: Plan) -> list[PlanEvent]:
         """Determine the final state of the plan after execution loop ends.
 
         - All required completed -> COMPLETED
         - Any node HELD (none FAILED/SKIPPED among required) -> SUSPENDED
+          (attaches HumanApprovalGate SuspensionRecord)
         - Required nodes FAILED or SKIPPED -> FAILED
         - Otherwise (pending nodes, no running) -> SUSPENDED
         """
@@ -1186,6 +1469,12 @@ class AsyncPlanExecutor:
             if held_nodes:
                 # HELD nodes take precedence — plan is suspended awaiting resolution
                 plan.state = PlanState.SUSPENDED
+                # PACT N3: HumanApprovalGate variant. HELD takes
+                # precedence over a previously recorded
+                # EnvelopeViolation because the actionable resume
+                # path is the human-approval gate, not the envelope.
+                first_held = sorted(held_nodes, key=lambda n: n.node_id)[0]
+                self._record_human_approval_gate(plan, first_held)
                 events.append(PlanEvent.plan_suspended())
             elif failed_nodes:
                 plan.state = PlanState.FAILED

--- a/packages/kailash-kaizen/src/kaizen/l3/plan/suspension.py
+++ b/packages/kailash-kaizen/src/kaizen/l3/plan/suspension.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Plan suspension types — PACT N3 (resumable plan suspension).
+
+PACT Normative Requirement N3 mandates that any plan which suspends
+execution MUST be resumable from the exact suspension point. This module
+provides the wire-level types that capture WHY a plan suspended and the
+execution frontier needed to resume.
+
+Cross-SDK parity reference:
+``/Users/esperie/repos/loom/kailash-rs/crates/kailash-kaizen/src/l3/core/plan/types.rs``
+lines 267-396 (``SuspensionReason`` + ``SuspensionRecord``). Field
+shapes, tag spelling, and label strings MUST match the Rust contract for
+a serialized SuspensionRecord round-tripped between SDKs to compare
+equal modulo the timestamp.
+
+Per issue #598, the Python SDK implements **five** suspension variants:
+
+1. ``HumanApprovalGate`` — a node entered the Held gradient zone and an
+   approver must act before it can proceed.
+2. ``CircuitBreakerTripped`` — a downstream dependency circuit broke and
+   execution paused while the breaker cools down.
+3. ``BudgetExceeded`` — an envelope dimension hit its configured
+   threshold (default 90%) and planning must decide whether to continue,
+   re-plan, or escalate.
+4. ``EnvelopeViolation`` — an envelope check returned BLOCKED for a
+   reason other than budget threshold (clearance, classification,
+   dimension policy). Distinct from ``BudgetExceeded`` because remediation
+   differs (re-plan vs. escalate-and-cancel).
+5. ``ExplicitCancellation`` — caller requested a graceful pause with a
+   resume hint.
+
+Spec reference: PACT envelope governance + EATP D6 cross-SDK semantic
+parity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal, Union
+
+__all__ = [
+    "BudgetExceededReason",
+    "CircuitBreakerTrippedReason",
+    "EnvelopeViolationReason",
+    "ExplicitCancellationReason",
+    "HumanApprovalGateReason",
+    "SuspensionReason",
+    "SuspensionRecord",
+    "suspension_reason_label",
+    "suspension_reason_to_dict",
+    "suspension_reason_from_dict",
+]
+
+
+# ---------------------------------------------------------------------------
+# SuspensionReason variants
+#
+# Each variant is a frozen dataclass with a Literal ``kind`` discriminator.
+# The Union type alias ``SuspensionReason`` ties them together as a tagged
+# union. Serialization uses ``suspension_reason_to_dict`` /
+# ``suspension_reason_from_dict`` which match the Rust serde contract
+# ``#[serde(tag = "kind", rename_all = "snake_case")]``.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HumanApprovalGateReason:
+    """Human approval required (Held gradient zone).
+
+    Mirrors Rust ``SuspensionReason::HumanApprovalGate { held_node, reason }``.
+    """
+
+    held_node: str
+    reason: str
+    kind: Literal["human_approval_gate"] = "human_approval_gate"
+
+
+@dataclass(frozen=True)
+class CircuitBreakerTrippedReason:
+    """Circuit breaker for a tool, agent, or downstream service tripped.
+
+    Mirrors Rust ``SuspensionReason::CircuitBreakerTripped { breaker_id,
+    triggering_node }``.
+    """
+
+    breaker_id: str
+    triggering_node: str
+    kind: Literal["circuit_breaker_tripped"] = "circuit_breaker_tripped"
+
+
+@dataclass(frozen=True)
+class BudgetExceededReason:
+    """Budget exceeded on one or more envelope dimensions.
+
+    Mirrors Rust ``SuspensionReason::BudgetExceeded { dimension,
+    usage_pct, triggering_node }``.
+
+    ``usage_pct`` is on the 0.0..=1.0 scale (NOT 0..=100).
+    """
+
+    dimension: str
+    usage_pct: float
+    triggering_node: str
+    kind: Literal["budget_exceeded"] = "budget_exceeded"
+
+
+@dataclass(frozen=True)
+class EnvelopeViolationReason:
+    """Envelope check returned BLOCKED for a non-budget reason.
+
+    Distinct from :class:`BudgetExceededReason`: this variant covers
+    clearance failures, classification mismatches, dimension policy
+    violations, and any other envelope-rejected execution where the cause
+    is structural rather than threshold-driven. The L3 EnvelopeEnforcer
+    emits this when a verdict tags BLOCKED with a non-budget dimension.
+
+    Per issue #598, this is the Python-SDK 5th variant. The Rust SDK has
+    four variants today; cross-SDK parity for ``EnvelopeViolation`` is
+    tracked in the sibling kailash-rs issue. When Rust adds the variant,
+    the wire-format ``kind`` tag MUST remain ``envelope_violation``.
+    """
+
+    dimension: str
+    detail: str
+    triggering_node: str
+    kind: Literal["envelope_violation"] = "envelope_violation"
+
+
+@dataclass(frozen=True)
+class ExplicitCancellationReason:
+    """Explicit cancellation with a resume hint.
+
+    Mirrors Rust ``SuspensionReason::ExplicitCancellation { reason,
+    resume_hint }``.
+    """
+
+    reason: str
+    resume_hint: str
+    kind: Literal["explicit_cancellation"] = "explicit_cancellation"
+
+
+# Type alias for the tagged union. Callers MUST use isinstance to
+# discriminate the variant rather than inspecting ``.kind`` (the kind
+# string is a wire-format detail; isinstance is the structural form).
+SuspensionReason = Union[
+    HumanApprovalGateReason,
+    CircuitBreakerTrippedReason,
+    BudgetExceededReason,
+    EnvelopeViolationReason,
+    ExplicitCancellationReason,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_VARIANT_BY_KIND: dict[str, type] = {
+    "human_approval_gate": HumanApprovalGateReason,
+    "circuit_breaker_tripped": CircuitBreakerTrippedReason,
+    "budget_exceeded": BudgetExceededReason,
+    "envelope_violation": EnvelopeViolationReason,
+    "explicit_cancellation": ExplicitCancellationReason,
+}
+
+
+def suspension_reason_label(reason: SuspensionReason) -> str:
+    """Return the snake_case label for metrics / logs.
+
+    Mirrors Rust ``SuspensionReason::label()`` so cross-SDK metric
+    cardinality matches.
+    """
+    return reason.kind
+
+
+def suspension_reason_to_dict(reason: SuspensionReason) -> dict[str, Any]:
+    """Serialize a SuspensionReason to the cross-SDK wire format.
+
+    Output shape matches the Rust serde contract
+    ``#[serde(tag = "kind", rename_all = "snake_case")]``: a single
+    flat object with a ``kind`` field plus the variant's data fields.
+
+    Example::
+
+        >>> r = HumanApprovalGateReason(held_node="n7", reason="manual review")
+        >>> suspension_reason_to_dict(r)
+        {'kind': 'human_approval_gate', 'held_node': 'n7', 'reason': 'manual review'}
+    """
+    if isinstance(reason, HumanApprovalGateReason):
+        return {
+            "kind": "human_approval_gate",
+            "held_node": reason.held_node,
+            "reason": reason.reason,
+        }
+    if isinstance(reason, CircuitBreakerTrippedReason):
+        return {
+            "kind": "circuit_breaker_tripped",
+            "breaker_id": reason.breaker_id,
+            "triggering_node": reason.triggering_node,
+        }
+    if isinstance(reason, BudgetExceededReason):
+        return {
+            "kind": "budget_exceeded",
+            "dimension": reason.dimension,
+            "usage_pct": reason.usage_pct,
+            "triggering_node": reason.triggering_node,
+        }
+    if isinstance(reason, EnvelopeViolationReason):
+        return {
+            "kind": "envelope_violation",
+            "dimension": reason.dimension,
+            "detail": reason.detail,
+            "triggering_node": reason.triggering_node,
+        }
+    if isinstance(reason, ExplicitCancellationReason):
+        return {
+            "kind": "explicit_cancellation",
+            "reason": reason.reason,
+            "resume_hint": reason.resume_hint,
+        }
+    raise TypeError(f"unknown SuspensionReason variant: {type(reason).__name__!r}")
+
+
+def suspension_reason_from_dict(data: dict[str, Any]) -> SuspensionReason:
+    """Deserialize a SuspensionReason from the cross-SDK wire format.
+
+    Raises:
+        ValueError: If ``kind`` is missing or not a known variant.
+        TypeError: If a required field for the variant is missing.
+    """
+    if "kind" not in data:
+        raise ValueError(
+            "SuspensionReason payload missing required 'kind' discriminator"
+        )
+    kind = data["kind"]
+    if kind == "human_approval_gate":
+        return HumanApprovalGateReason(
+            held_node=data["held_node"],
+            reason=data["reason"],
+        )
+    if kind == "circuit_breaker_tripped":
+        return CircuitBreakerTrippedReason(
+            breaker_id=data["breaker_id"],
+            triggering_node=data["triggering_node"],
+        )
+    if kind == "budget_exceeded":
+        return BudgetExceededReason(
+            dimension=data["dimension"],
+            usage_pct=float(data["usage_pct"]),
+            triggering_node=data["triggering_node"],
+        )
+    if kind == "envelope_violation":
+        return EnvelopeViolationReason(
+            dimension=data["dimension"],
+            detail=data["detail"],
+            triggering_node=data["triggering_node"],
+        )
+    if kind == "explicit_cancellation":
+        return ExplicitCancellationReason(
+            reason=data["reason"],
+            resume_hint=data["resume_hint"],
+        )
+    raise ValueError(
+        f"unknown SuspensionReason kind: {kind!r}; "
+        f"expected one of {sorted(_VARIANT_BY_KIND)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# SuspensionRecord
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SuspensionRecord:
+    """Full suspension record captured when a plan enters Suspended state.
+
+    Mirrors Rust ``SuspensionRecord`` (kailash-rs
+    crates/kailash-kaizen/src/l3/core/plan/types.rs:340-396).
+
+    Frozen: a SuspensionRecord captures the suspension snapshot and MUST
+    NOT be mutated. Resume callers construct a fresh Plan state from the
+    record's frontier; the record itself is discarded only when
+    ``Plan.transition_to(Executing)`` succeeds (resume path) or
+    ``Plan.transition_to(Cancelled)`` (cancel-from-suspended).
+
+    Attributes:
+        reason: Why the plan was suspended (tagged-union variant).
+        suspended_at: Timestamp at which suspension was recorded
+            (timezone-aware UTC; defaults to ``datetime.now(UTC)``).
+        running_nodes: Nodes that were ``Running`` at suspension time.
+            On resume these nodes retain their state and the executor
+            will not re-spawn them. Sorted lexicographically for
+            deterministic comparison across SDKs.
+        ready_nodes: Nodes that were ``Ready`` at suspension time. These
+            are the first candidates for re-scheduling on resume.
+        pending_nodes: Nodes that were ``Pending`` at suspension time.
+            Their gating relationships are preserved; they become Ready
+            once their predecessors complete.
+        resume_context: Opaque serialized context that re-entry callers
+            may use to reconstitute extra state (e.g. conversation
+            history, retry counter, external workflow id). Deserialized
+            by the caller.
+    """
+
+    reason: SuspensionReason
+    suspended_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    running_nodes: list[str] = field(default_factory=list)
+    ready_nodes: list[str] = field(default_factory=list)
+    pending_nodes: list[str] = field(default_factory=list)
+    resume_context: Any | None = None
+
+    @classmethod
+    def from_plan(
+        cls,
+        reason: SuspensionReason,
+        plan: Any,  # Plan; typed Any to avoid circular import
+        *,
+        resume_context: Any | None = None,
+    ) -> SuspensionRecord:
+        """Construct a record from the reason and plan-node snapshot.
+
+        Mirrors Rust ``SuspensionRecord::new(reason, plan)``: enumerates
+        node states, partitions into running/ready/pending lists, sorts
+        each list lexicographically for cross-SDK comparison stability.
+
+        Args:
+            reason: Tagged-union variant identifying why the plan
+                suspended.
+            plan: A :class:`kaizen.l3.plan.types.Plan` instance.
+                Typed ``Any`` to avoid a circular import; the function
+                only requires ``plan.nodes`` (a mapping of node_id to a
+                node with a ``.state`` attribute) and the
+                :class:`PlanNodeState` enum values RUNNING / READY /
+                PENDING.
+            resume_context: Optional opaque payload that resume callers
+                may use to reconstitute side-state.
+        """
+        # Local import to avoid cycle: types.py imports nothing from
+        # suspension.py at module load; suspension.py defers its
+        # PlanNodeState lookup to runtime.
+        from kaizen.l3.plan.types import PlanNodeState
+
+        running: list[str] = []
+        ready: list[str] = []
+        pending: list[str] = []
+        for node_id, node in plan.nodes.items():
+            if node.state == PlanNodeState.RUNNING:
+                running.append(node_id)
+            elif node.state == PlanNodeState.READY:
+                ready.append(node_id)
+            elif node.state == PlanNodeState.PENDING:
+                pending.append(node_id)
+        running.sort()
+        ready.sort()
+        pending.sort()
+        return cls(
+            reason=reason,
+            suspended_at=datetime.now(UTC),
+            running_nodes=running,
+            ready_nodes=ready,
+            pending_nodes=pending,
+            resume_context=resume_context,
+        )
+
+    def with_resume_context(self, ctx: Any) -> SuspensionRecord:
+        """Return a copy with ``resume_context`` set.
+
+        Frozen-dataclass-friendly builder; mirrors Rust
+        ``SuspensionRecord::with_resume_context``.
+        """
+        return SuspensionRecord(
+            reason=self.reason,
+            suspended_at=self.suspended_at,
+            running_nodes=list(self.running_nodes),
+            ready_nodes=list(self.ready_nodes),
+            pending_nodes=list(self.pending_nodes),
+            resume_context=ctx,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the cross-SDK JSON-compatible wire format."""
+        return {
+            "reason": suspension_reason_to_dict(self.reason),
+            "suspended_at": self.suspended_at.isoformat(),
+            "running_nodes": list(self.running_nodes),
+            "ready_nodes": list(self.ready_nodes),
+            "pending_nodes": list(self.pending_nodes),
+            "resume_context": self.resume_context,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SuspensionRecord:
+        """Deserialize from the cross-SDK JSON-compatible wire format."""
+        suspended_at_raw = data.get("suspended_at")
+        if isinstance(suspended_at_raw, datetime):
+            suspended_at = suspended_at_raw
+        elif isinstance(suspended_at_raw, str):
+            suspended_at = datetime.fromisoformat(suspended_at_raw)
+        else:
+            suspended_at = datetime.now(UTC)
+        return cls(
+            reason=suspension_reason_from_dict(data["reason"]),
+            suspended_at=suspended_at,
+            running_nodes=list(data.get("running_nodes", [])),
+            ready_nodes=list(data.get("ready_nodes", [])),
+            pending_nodes=list(data.get("pending_nodes", [])),
+            resume_context=data.get("resume_context"),
+        )

--- a/packages/kailash-kaizen/src/kaizen/l3/plan/types.py
+++ b/packages/kailash-kaizen/src/kaizen/l3/plan/types.py
@@ -304,6 +304,12 @@ class Plan:
     """A directed acyclic graph of agent tasks with dependency edges.
 
     The plan is the unit of L3 execution.
+
+    PACT N3: when the plan transitions to ``SUSPENDED`` state, the
+    executor MUST attach a :class:`SuspensionRecord` (cross-SDK parity
+    with kailash-rs ``Plan.suspension`` field) capturing why the plan
+    suspended and the execution frontier needed to resume from the
+    exact suspension point. The field is cleared on successful resume.
     """
 
     plan_id: str
@@ -315,6 +321,10 @@ class Plan:
     state: PlanState
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     modified_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    # PACT N3: present while the plan is suspended; cleared on resume.
+    # Typed ``Any`` to avoid a circular import — concrete type is
+    # ``kaizen.l3.plan.suspension.SuspensionRecord | None``.
+    suspension: Any = None
 
     def transition_to(self, new_state: PlanState) -> None:
         """Validate and apply a plan state transition.
@@ -333,6 +343,12 @@ class Plan:
         self.modified_at = datetime.now(UTC)
 
     def to_dict(self) -> dict[str, Any]:
+        # Local import to avoid circular dependency
+        # (suspension.py imports PlanNodeState from this module).
+        suspension_dict: dict[str, Any] | None = None
+        if self.suspension is not None:
+            # SuspensionRecord has a to_dict() method
+            suspension_dict = self.suspension.to_dict()
         return {
             "plan_id": self.plan_id,
             "name": self.name,
@@ -343,10 +359,17 @@ class Plan:
             "state": self.state.value,
             "created_at": self.created_at.isoformat(),
             "modified_at": self.modified_at.isoformat(),
+            "suspension": suspension_dict,
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Plan:
+        suspension_payload = data.get("suspension")
+        suspension: Any = None
+        if suspension_payload is not None:
+            from kaizen.l3.plan.suspension import SuspensionRecord
+
+            suspension = SuspensionRecord.from_dict(suspension_payload)
         return cls(
             plan_id=data["plan_id"],
             name=data["name"],
@@ -365,6 +388,7 @@ class Plan:
                 if isinstance(data.get("modified_at"), str)
                 else data.get("modified_at", datetime.now(UTC))
             ),
+            suspension=suspension,
         )
 
 

--- a/packages/kailash-kaizen/src/kaizen/orchestration/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/orchestration/__init__.py
@@ -1,11 +1,22 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """
-Proxy module: kaizen.orchestration -> kaizen_agents.patterns
+kaizen.orchestration — multi-agent orchestration surface.
 
-Registers sys.modules aliases so that mock.patch targets like
-``kaizen.orchestration.patterns.blackboard.A2A_AVAILABLE``
-resolve to the real kaizen_agents.patterns.patterns module.
+This module hosts:
+
+- ``OrchestrationRuntime`` (cross-SDK parity with kailash-rs
+  ``kaizen-agents::orchestration::runtime``) — strategy-driven multi-agent
+  coordination with Sequential / Parallel / Hierarchical / Pipeline
+  strategies. See ``kaizen.orchestration.runtime``.
+- Re-exports + ``sys.modules`` aliases that point
+  ``kaizen.orchestration.patterns.*`` at the real
+  ``kaizen_agents.patterns.patterns.*`` modules so existing ``mock.patch``
+  targets continue to resolve.
+
+The proxy aliases predate the runtime module; they are preserved verbatim
+so tests that patch ``kaizen.orchestration.patterns.blackboard.A2A_AVAILABLE``
+keep working.
 """
 
 import sys
@@ -19,3 +30,35 @@ sys.modules.setdefault("kaizen.orchestration.patterns", _pp)
 sys.modules.setdefault("kaizen.orchestration.patterns.blackboard", _bb)
 sys.modules.setdefault("kaizen.orchestration.patterns.ensemble", _en)
 sys.modules.setdefault("kaizen.orchestration.patterns.meta_controller", _mc)
+
+# Public OrchestrationRuntime surface (issue #602 — cross-SDK parity with
+# kailash-rs kaizen-agents::orchestration::runtime). Eager imports so the
+# symbols satisfy `from kaizen.orchestration import *` and Sphinx autodoc per
+# rules/orphan-detection.md §6.
+from kaizen.orchestration.runtime import (  # noqa: E402
+    AgentLike,
+    Coordinator,
+    OrchestrationConfig,
+    OrchestrationError,
+    OrchestrationResult,
+    OrchestrationRuntime,
+    OrchestrationStrategy,
+    OrchestrationStrategyKind,
+    PipelineInputSource,
+    PipelineStep,
+    SharedMemoryCoordinator,
+)
+
+__all__ = [
+    "AgentLike",
+    "Coordinator",
+    "OrchestrationConfig",
+    "OrchestrationError",
+    "OrchestrationResult",
+    "OrchestrationRuntime",
+    "OrchestrationStrategy",
+    "OrchestrationStrategyKind",
+    "PipelineInputSource",
+    "PipelineStep",
+    "SharedMemoryCoordinator",
+]

--- a/packages/kailash-kaizen/src/kaizen/orchestration/runtime.py
+++ b/packages/kailash-kaizen/src/kaizen/orchestration/runtime.py
@@ -1,0 +1,1003 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+OrchestrationRuntime — cross-SDK parity with kailash-rs `OrchestrationEngine`.
+
+This module ships the Python equivalent of the Rust
+`kaizen-agents::orchestration::runtime::OrchestrationRuntime` shape (issue #602
+/ kailash-rs ISS-27). The Python ``OrchestrationRuntime`` is constructed with a
+strategy + coordinator and exposes both async (``.run``) and sync
+(``.run_sync``) entry points. Same input -> same observable result on both
+SDKs (modulo determinism), per EATP D6.
+
+The class is intentionally a thin orchestrator over four strategies
+(``Sequential`` / ``Parallel`` / ``Hierarchical`` / ``Pipeline``) and mirrors
+the Rust enum. Agents are registered by name in insertion order, which
+determines execution order for the Sequential and Pipeline strategies (also
+mirroring Rust's ``IndexMap``-backed registry).
+
+Existing Kaizen orchestration components — ``kaizen_agents.patterns.runtime``
+(registry-based, multi-agent SaaS shape) and
+``kaizen.trust.orchestration.runtime`` (trust-aware runtime) — are NOT replaced
+by this class. They serve different problems:
+
+- ``kaizen_agents.patterns.OrchestrationRuntime`` — registry/lifecycle/health/
+  budget/circuit-breaker pattern for 10-100 agent fleets.
+- ``kaizen.trust.orchestration.TrustAwareOrchestrationRuntime`` — trust-policy
+  enforcement on top of orchestration.
+- ``kaizen.orchestration.runtime.OrchestrationRuntime`` (THIS module) —
+  strategy-driven multi-agent coordination matching the Rust API shape, used
+  for cross-SDK parity and as the canonical shape downstream consumers
+  reference (e.g., ``OrchestrationRuntime`` examples in
+  ``kaizen.signatures``).
+
+Usage
+-----
+.. code-block:: python
+
+    from kaizen.orchestration import (
+        OrchestrationRuntime,
+        OrchestrationStrategy,
+        SharedMemoryCoordinator,
+    )
+
+    runtime = (
+        OrchestrationRuntime(
+            strategy=OrchestrationStrategy.sequential(),
+            coordinator=SharedMemoryCoordinator(),
+        )
+        .add_agent("researcher", researcher_agent)
+        .add_agent("writer", writer_agent)
+    )
+    result = await runtime.run("Summarize Q3 revenue trends")
+    # result.final_output == writer_agent's response
+    # result.agent_results["researcher"] == per-agent dict
+
+Cross-SDK contract (mirrors ``orchestration/runtime.rs``)
+---------------------------------------------------------
+- Constructor: ``OrchestrationRuntime(strategy, coordinator=None, config=None)``
+  + builder-style ``.add_agent(name, agent)``, ``.strategy(s)``, ``.config(c)``,
+  ``.coordinator(c)``.
+- Execution: ``await runtime.run(input)`` returns ``OrchestrationResult``.
+  Sync convenience: ``runtime.run_sync(input)`` (uses ``asyncio.run`` — only
+  call from non-async contexts; see ``rules/patterns.md`` § Paired Public
+  Surface).
+- Strategies: ``Sequential`` / ``Parallel`` / ``Hierarchical`` / ``Pipeline``
+  are constructed via ``OrchestrationStrategy.<name>(...)`` factories so the
+  enum surface is a typed dataclass, not an opaque string.
+- Result fields match the Rust struct: ``agent_results`` (dict by name),
+  ``final_output`` (str), ``total_iterations`` (int), ``total_tokens`` (int),
+  ``duration_ms`` (int).
+- Errors: empty-runtime / unknown-coordinator / pipeline-step-references-
+  unknown-agent / max-agent-calls all raise ``OrchestrationError`` (see
+  ``exceptions``). No silent fallbacks (per ``rules/zero-tolerance.md``
+  Rule 3).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Tuple,
+    Union,
+    runtime_checkable,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AgentLike",
+    "Coordinator",
+    "OrchestrationConfig",
+    "OrchestrationError",
+    "OrchestrationResult",
+    "OrchestrationRuntime",
+    "OrchestrationStrategy",
+    "OrchestrationStrategyKind",
+    "PipelineInputSource",
+    "PipelineStep",
+    "SharedMemoryCoordinator",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class OrchestrationError(RuntimeError):
+    """Typed error for orchestration runtime failures.
+
+    Subclass of ``RuntimeError`` (not a custom ``Exception`` hierarchy) so it
+    composes cleanly with ``asyncio.TimeoutError`` and matches the
+    ``AgentError::Config`` shape used on the Rust side without forcing the
+    caller into a kaizen-specific exception import.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Protocols
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AgentLike(Protocol):
+    """Minimal duck-type for agents the runtime can drive.
+
+    Mirrors the Rust ``BaseAgent`` trait surface with the methods the strategy
+    dispatcher actually invokes. Either ``run`` or ``run_async`` MUST be
+    implemented; the runtime prefers ``run_async`` when available.
+
+    Real ``kaizen.core.base_agent.BaseAgent`` instances satisfy this Protocol
+    out of the box (their ``run`` returns ``Dict[str, Any]`` whose ``.get(
+    "response")`` or first ``OutputField`` value the runtime treats as the
+    string response). Test adapters / Rust-port shims need only provide the
+    minimal pair.
+    """
+
+    @property
+    def name(self) -> str:  # pragma: no cover - Protocol surface
+        ...
+
+    async def run_async(
+        self, **inputs: Any
+    ) -> Mapping[str, Any]:  # pragma: no cover - Protocol surface
+        ...
+
+
+@runtime_checkable
+class Coordinator(Protocol):
+    """Minimal duck-type for the orchestration coordinator.
+
+    Mirrors Rust's ``Arc<dyn AgentMemory>`` shared-memory integration point.
+    A coordinator is the cross-agent state surface — agents write findings via
+    ``store(...)`` and read peers' findings via ``retrieve(...)``. The
+    Sequential and Hierarchical strategies forward the coordinator into each
+    agent's per-call kwargs as ``coordinator=`` so the agent can opt into
+    shared-state reads/writes.
+
+    A ``None`` coordinator is permitted; the runtime then runs each agent in
+    isolation (matches Rust's ``Option<Arc<dyn AgentMemory>>`` shape).
+    """
+
+    async def store(
+        self, key: str, value: Any
+    ) -> None:  # pragma: no cover - Protocol surface
+        ...
+
+    async def retrieve(
+        self, key: str
+    ) -> Optional[Any]:  # pragma: no cover - Protocol surface
+        ...
+
+
+class SharedMemoryCoordinator:
+    """Default in-memory coordinator backed by ``SharedMemoryPool``.
+
+    Wraps ``kaizen.memory.shared_memory.SharedMemoryPool`` (the synchronous,
+    thread-safe insight pool) into the async ``Coordinator`` Protocol the
+    runtime expects. Round-trips ``store(key, value)`` / ``retrieve(key)`` via
+    a single-tag insight write/filter so the same pool can be observed from
+    other Kaizen agents that already integrate with ``SharedMemoryPool``.
+
+    For deployments that require a persistent, distributed, or trust-aware
+    coordinator (e.g., DataFlow-backed insight stores), implement the
+    ``Coordinator`` Protocol directly — this class is a convenience default,
+    not a production primitive.
+    """
+
+    def __init__(self, agent_id: str = "orchestration-runtime") -> None:
+        # Local import — keeps the runtime module importable even if the
+        # memory subpackage's heavier imports drift.
+        from kaizen.memory.shared_memory import SharedMemoryPool
+
+        self._pool = SharedMemoryPool()
+        self._agent_id = agent_id
+
+    async def store(self, key: str, value: Any) -> None:
+        # Encode value as the insight content; tag with the key so retrieve
+        # can filter exactly by tag.
+        self._pool.write_insight(
+            {
+                "agent_id": self._agent_id,
+                "content": str(value),
+                "tags": [f"orch:{key}"],
+                "importance": 0.5,
+                "segment": "orchestration",
+                "metadata": {"key": key, "raw": value},
+            }
+        )
+
+    async def retrieve(self, key: str) -> Optional[Any]:
+        # Read the most recent insight tagged with this key. ``read_all`` is
+        # synchronous; the async signature is for Protocol-compliance.
+        insights = self._pool.read_all()
+        for insight in reversed(insights):
+            if f"orch:{key}" in insight.get("tags", []):
+                meta = insight.get("metadata", {}) or {}
+                return meta.get("raw", insight.get("content"))
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Strategy dataclasses
+# ---------------------------------------------------------------------------
+
+
+class OrchestrationStrategyKind(str, Enum):
+    """Strategy discriminator — mirrors the Rust ``OrchestrationStrategy`` enum."""
+
+    SEQUENTIAL = "sequential"
+    PARALLEL = "parallel"
+    HIERARCHICAL = "hierarchical"
+    PIPELINE = "pipeline"
+
+
+@dataclass(frozen=True)
+class PipelineInputSource:
+    """Where a pipeline step fetches its input from (mirrors Rust enum).
+
+    One of ``initial`` (use the run-level input), ``agent_output`` (use a
+    previously-executed step's response by name), or ``template`` (interpolate
+    ``{{agent_name.response}}`` placeholders against prior results).
+
+    Only one of ``initial``, ``agent_name``, ``template`` is set at a time;
+    construct via the classmethods so misconstruction is impossible at the
+    Python level.
+    """
+
+    initial: bool = False
+    agent_name: Optional[str] = None
+    template: Optional[str] = None
+
+    @classmethod
+    def from_initial(cls) -> "PipelineInputSource":
+        return cls(initial=True)
+
+    @classmethod
+    def from_agent_output(cls, agent_name: str) -> "PipelineInputSource":
+        if not agent_name:
+            raise ValueError(
+                "PipelineInputSource.from_agent_output requires a non-empty agent_name"
+            )
+        return cls(agent_name=agent_name)
+
+    @classmethod
+    def from_template(cls, template: str) -> "PipelineInputSource":
+        if template is None:
+            raise ValueError(
+                "PipelineInputSource.from_template requires a non-None template"
+            )
+        return cls(template=template)
+
+
+@dataclass(frozen=True)
+class PipelineStep:
+    """One step in a pipeline strategy."""
+
+    agent_name: str
+    input_from: PipelineInputSource
+
+
+@dataclass(frozen=True)
+class OrchestrationStrategy:
+    """Strategy descriptor — mirrors the Rust ``OrchestrationStrategy`` enum.
+
+    Construct via the classmethods (``sequential()``, ``parallel()``,
+    ``hierarchical(coordinator_name=...)``, ``pipeline(steps=...)``) so the
+    enum cannot be misconstructed (e.g., a Hierarchical without a coordinator
+    name).
+    """
+
+    kind: OrchestrationStrategyKind = OrchestrationStrategyKind.SEQUENTIAL
+    coordinator_name: Optional[str] = None
+    steps: Optional[Tuple[PipelineStep, ...]] = None
+
+    @classmethod
+    def sequential(cls) -> "OrchestrationStrategy":
+        return cls(kind=OrchestrationStrategyKind.SEQUENTIAL)
+
+    @classmethod
+    def parallel(cls) -> "OrchestrationStrategy":
+        return cls(kind=OrchestrationStrategyKind.PARALLEL)
+
+    @classmethod
+    def hierarchical(cls, coordinator_name: str) -> "OrchestrationStrategy":
+        if not coordinator_name:
+            raise ValueError(
+                "OrchestrationStrategy.hierarchical requires a non-empty coordinator_name"
+            )
+        return cls(
+            kind=OrchestrationStrategyKind.HIERARCHICAL,
+            coordinator_name=coordinator_name,
+        )
+
+    @classmethod
+    def pipeline(cls, steps: List[PipelineStep]) -> "OrchestrationStrategy":
+        if not steps:
+            raise ValueError(
+                "OrchestrationStrategy.pipeline requires a non-empty list of PipelineStep"
+            )
+        return cls(
+            kind=OrchestrationStrategyKind.PIPELINE,
+            steps=tuple(steps),
+        )
+
+    @property
+    def name(self) -> str:
+        return self.kind.value
+
+
+# ---------------------------------------------------------------------------
+# Config + result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OrchestrationConfig:
+    """Configuration for an orchestration run.
+
+    Field semantics match the Rust ``OrchestrationConfig`` struct so the same
+    config dict round-trips between SDKs.
+    """
+
+    max_total_iterations: int = 50
+    max_agent_calls: int = 100
+    timeout_secs: Optional[float] = None
+    fail_fast: bool = True
+    share_conversation_history: bool = False
+
+
+@dataclass
+class OrchestrationResult:
+    """Result of a single orchestration run.
+
+    Field semantics match the Rust ``OrchestrationResult`` struct.
+    ``agent_results`` is keyed by agent name and ordered by execution; the
+    insertion-ordered ``dict`` provides the same observable order as the
+    Rust ``IndexMap``.
+    """
+
+    agent_results: Dict[str, Mapping[str, Any]] = field(default_factory=dict)
+    final_output: str = ""
+    total_iterations: int = 0
+    total_tokens: int = 0
+    duration_ms: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "agent_results": {k: dict(v) for k, v in self.agent_results.items()},
+            "final_output": self.final_output,
+            "total_iterations": self.total_iterations,
+            "total_tokens": self.total_tokens,
+            "duration_ms": self.duration_ms,
+        }
+
+
+# ---------------------------------------------------------------------------
+# OrchestrationRuntime
+# ---------------------------------------------------------------------------
+
+
+# Type alias for the pluggable agent invoker. Tests / port shims may pass any
+# callable matching ``(agent, input, coordinator) -> Awaitable[Mapping]``.
+AgentInvoker = Callable[[Any, str, Optional[Coordinator]], Awaitable[Mapping[str, Any]]]
+
+
+class OrchestrationRuntime:
+    """Multi-agent orchestration runtime with cross-SDK parity.
+
+    Mirrors the Rust ``kaizen-agents::orchestration::runtime::OrchestrationRuntime``
+    builder + dispatch shape. Construct with a strategy and (optional)
+    coordinator, then chain ``add_agent`` calls and invoke ``run``.
+
+    Per ``rules/agent-reasoning.md``: this class is a transport / dispatch
+    layer; it does NOT make agent decisions in code (no keyword routing, no
+    if-else over input content). Strategy selection is configured up-front
+    and any per-task routing inside Hierarchical / Pipeline strategies
+    happens through agent names declared at build time, not through runtime
+    classification of the input string.
+    """
+
+    def __init__(
+        self,
+        strategy: Optional[OrchestrationStrategy] = None,
+        coordinator: Optional[Coordinator] = None,
+        config: Optional[OrchestrationConfig] = None,
+        *,
+        agent_invoker: Optional[AgentInvoker] = None,
+    ) -> None:
+        """Initialize an orchestration runtime.
+
+        Args:
+            strategy: Coordination strategy. Defaults to Sequential when
+                ``None`` is passed (matches Rust's ``OrchestrationRuntime::new``
+                + ``OrchestrationStrategy::default``).
+            coordinator: Optional shared-state object (``Coordinator``
+                Protocol). If ``None``, agents run in isolation.
+            config: Optional orchestration config (caps + timeouts +
+                fail-fast). Defaults to ``OrchestrationConfig()``.
+            agent_invoker: Optional dependency-injection seam — the
+                ``async`` callable the runtime uses to invoke a single
+                ``(agent, input, coordinator) -> Mapping`` step. Defaults to
+                ``OrchestrationRuntime._default_invoker`` which prefers
+                ``agent.run_async(input=...)`` and falls back to
+                ``agent.run(input=...)`` in a thread. Tests inject this to
+                avoid spinning up real LLM agents.
+        """
+        self._strategy: OrchestrationStrategy = (
+            strategy if strategy is not None else OrchestrationStrategy.sequential()
+        )
+        self._coordinator: Optional[Coordinator] = coordinator
+        self._config: OrchestrationConfig = (
+            config if config is not None else OrchestrationConfig()
+        )
+        # Insertion-ordered dict — matches Rust IndexMap.
+        self._agents: Dict[str, Any] = {}
+        self._agent_invoker: AgentInvoker = (
+            agent_invoker if agent_invoker is not None else self._default_invoker
+        )
+
+    # -----------------------------------------------------------------------
+    # Builder API
+    # -----------------------------------------------------------------------
+
+    def add_agent(self, name: str, agent: Any) -> "OrchestrationRuntime":
+        """Register an agent under ``name``.
+
+        Insertion order determines execution order for the Sequential and
+        Pipeline strategies (matches Rust's ``IndexMap`` behavior). Re-adding
+        the same name replaces the previous agent.
+
+        Returns ``self`` so calls chain.
+        """
+        if not name:
+            raise ValueError("OrchestrationRuntime.add_agent requires a non-empty name")
+        self._agents[name] = agent
+        return self
+
+    def strategy(self, strategy: OrchestrationStrategy) -> "OrchestrationRuntime":
+        """Replace the orchestration strategy. Returns ``self``."""
+        if strategy is None:
+            raise ValueError(
+                "OrchestrationRuntime.strategy requires a non-None strategy"
+            )
+        self._strategy = strategy
+        return self
+
+    def coordinator(self, coordinator: Optional[Coordinator]) -> "OrchestrationRuntime":
+        """Replace the coordinator (may be ``None``). Returns ``self``."""
+        self._coordinator = coordinator
+        return self
+
+    def config(self, config: OrchestrationConfig) -> "OrchestrationRuntime":
+        """Replace the orchestration config. Returns ``self``."""
+        if config is None:
+            raise ValueError("OrchestrationRuntime.config requires a non-None config")
+        self._config = config
+        return self
+
+    # -----------------------------------------------------------------------
+    # Introspection
+    # -----------------------------------------------------------------------
+
+    @property
+    def agent_count(self) -> int:
+        return len(self._agents)
+
+    @property
+    def agent_names(self) -> List[str]:
+        return list(self._agents.keys())
+
+    @property
+    def current_strategy(self) -> OrchestrationStrategy:
+        return self._strategy
+
+    @property
+    def current_coordinator(self) -> Optional[Coordinator]:
+        return self._coordinator
+
+    @property
+    def current_config(self) -> OrchestrationConfig:
+        return self._config
+
+    # -----------------------------------------------------------------------
+    # Run
+    # -----------------------------------------------------------------------
+
+    async def run(self, input: str) -> OrchestrationResult:
+        """Run the orchestration with the given input.
+
+        Async by parity with Rust ``async fn run``. Use ``run_sync`` for sync
+        contexts (CLI scripts, tests) — see ``rules/patterns.md`` § Paired
+        Public Surface for the trade-off.
+
+        Raises:
+            OrchestrationError: when no agents are registered, when the
+                strategy references an unknown agent / coordinator, or when
+                the underlying agent invocation fails and ``fail_fast`` is
+                set.
+            asyncio.TimeoutError: when ``config.timeout_secs`` is set and
+                exceeded. The Rust SDK wraps this as ``AgentError::Config``;
+                Python preserves the standard library type so callers can
+                rely on existing ``except asyncio.TimeoutError`` handlers.
+        """
+        if not self._agents:
+            raise OrchestrationError(
+                "OrchestrationRuntime.run: no agents registered (call .add_agent() first)"
+            )
+
+        run_id = uuid.uuid4().hex[:8]
+        logger.info(
+            "orchestration.run.start",
+            extra={
+                "run_id": run_id,
+                "strategy": self._strategy.name,
+                "agent_count": len(self._agents),
+                "agent_names": list(self._agents.keys()),
+                "has_coordinator": self._coordinator is not None,
+                "timeout_secs": self._config.timeout_secs,
+            },
+        )
+
+        start = time.perf_counter()
+
+        try:
+            if self._config.timeout_secs is not None:
+                result = await asyncio.wait_for(
+                    self._dispatch(input, run_id=run_id),
+                    timeout=self._config.timeout_secs,
+                )
+            else:
+                result = await self._dispatch(input, run_id=run_id)
+        except asyncio.TimeoutError:
+            logger.exception(
+                "orchestration.run.timeout",
+                extra={
+                    "run_id": run_id,
+                    "timeout_secs": self._config.timeout_secs,
+                },
+            )
+            raise
+        except OrchestrationError:
+            logger.exception("orchestration.run.error", extra={"run_id": run_id})
+            raise
+        except Exception:
+            logger.exception("orchestration.run.error", extra={"run_id": run_id})
+            raise
+
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        result.duration_ms = elapsed_ms
+        logger.info(
+            "orchestration.run.ok",
+            extra={
+                "run_id": run_id,
+                "strategy": self._strategy.name,
+                "duration_ms": elapsed_ms,
+                "total_iterations": result.total_iterations,
+                "total_tokens": result.total_tokens,
+            },
+        )
+        return result
+
+    def run_sync(self, input: str) -> OrchestrationResult:
+        """Synchronous convenience wrapper around ``run``.
+
+        WARNING: Calls ``asyncio.run()`` internally. Per
+        ``rules/patterns.md`` § "Paired Public Surface — Consistent Async-ness",
+        sync-wrapping ``asyncio.run`` raises ``RuntimeError: This event loop is
+        already running`` when called from inside an active event loop
+        (pytest-asyncio, Nexus handlers, Jupyter, any Kaizen agent). This
+        method is a CLI/script convenience — production code should
+        ``await runtime.run(input)`` directly.
+        """
+        return asyncio.run(self.run(input))
+
+    # -----------------------------------------------------------------------
+    # Dispatch
+    # -----------------------------------------------------------------------
+
+    async def _dispatch(self, input: str, *, run_id: str) -> OrchestrationResult:
+        kind = self._strategy.kind
+        if kind is OrchestrationStrategyKind.SEQUENTIAL:
+            return await self._run_sequential(input, run_id=run_id)
+        if kind is OrchestrationStrategyKind.PARALLEL:
+            return await self._run_parallel(input, run_id=run_id)
+        if kind is OrchestrationStrategyKind.HIERARCHICAL:
+            return await self._run_hierarchical(input, run_id=run_id)
+        if kind is OrchestrationStrategyKind.PIPELINE:
+            return await self._run_pipeline(input, run_id=run_id)
+        # Defensive: every strategy variant is enumerated above; any new
+        # variant must add a branch. This is reached only if a future
+        # contributor extends ``OrchestrationStrategyKind`` without updating
+        # the dispatch — fail loudly per zero-tolerance Rule 3.
+        raise OrchestrationError(
+            f"OrchestrationRuntime: unknown strategy kind {kind!r}"
+        )
+
+    # -----------------------------------------------------------------------
+    # Strategies
+    # -----------------------------------------------------------------------
+
+    async def _run_sequential(self, input: str, *, run_id: str) -> OrchestrationResult:
+        agent_results: Dict[str, Mapping[str, Any]] = {}
+        current_input = input
+        total_tokens = 0
+        total_iterations = 0
+
+        for name, agent in self._agents.items():
+            if total_iterations >= self._config.max_agent_calls:
+                raise OrchestrationError(
+                    f"OrchestrationRuntime: max_agent_calls={self._config.max_agent_calls} reached"
+                )
+            result = await self._invoke_one(
+                agent, current_input, name=name, run_id=run_id
+            )
+            current_input = _extract_response(result)
+            total_tokens += _extract_tokens(result)
+            total_iterations += 1
+            agent_results[name] = result
+
+        return OrchestrationResult(
+            agent_results=agent_results,
+            final_output=current_input,
+            total_iterations=total_iterations,
+            total_tokens=total_tokens,
+        )
+
+    async def _run_parallel(self, input: str, *, run_id: str) -> OrchestrationResult:
+        # Spawn all agents concurrently with the SAME input.
+        tasks: Dict[str, asyncio.Task[Mapping[str, Any]]] = {}
+        for name, agent in self._agents.items():
+            tasks[name] = asyncio.create_task(
+                self._invoke_one(agent, input, name=name, run_id=run_id)
+            )
+
+        agent_results: Dict[str, Mapping[str, Any]] = {}
+        first_error: Optional[BaseException] = None
+
+        # Drain every task; ``fail_fast`` short-circuits collection but still
+        # cancels in-flight tasks, matching Rust's ``join_set.abort_all``.
+        for name, task in tasks.items():
+            try:
+                agent_results[name] = await task
+            except Exception as exc:
+                if self._config.fail_fast:
+                    for other_name, other in tasks.items():
+                        if other_name != name and not other.done():
+                            other.cancel()
+                    raise OrchestrationError(
+                        f"OrchestrationRuntime: parallel agent {name!r} failed: {exc}"
+                    ) from exc
+                # Collect-all mode: log + remember first error, continue.
+                if first_error is None:
+                    first_error = exc
+                logger.warning(
+                    "orchestration.parallel.agent_failed",
+                    extra={
+                        "run_id": run_id,
+                        "agent_name": name,
+                        "error": str(exc),
+                    },
+                )
+
+        if not agent_results:
+            # All agents failed in collect-all mode — surface the first error
+            # rather than returning an empty result.
+            if first_error is not None:
+                raise OrchestrationError(
+                    f"OrchestrationRuntime: all parallel agents failed; first error: {first_error}"
+                ) from first_error
+            raise OrchestrationError(
+                "OrchestrationRuntime: no parallel agent produced a result"
+            )
+
+        total_tokens = sum(_extract_tokens(r) for r in agent_results.values())
+        final_output = _build_parallel_output(agent_results)
+        return OrchestrationResult(
+            agent_results=agent_results,
+            final_output=final_output,
+            total_iterations=len(agent_results),
+            total_tokens=total_tokens,
+        )
+
+    async def _run_hierarchical(
+        self, input: str, *, run_id: str
+    ) -> OrchestrationResult:
+        coord_name = self._strategy.coordinator_name
+        if not coord_name:
+            raise OrchestrationError(
+                "OrchestrationRuntime: hierarchical strategy missing coordinator_name"
+            )
+        if coord_name not in self._agents:
+            raise OrchestrationError(
+                f"OrchestrationRuntime: coordinator agent {coord_name!r} not registered"
+            )
+
+        agent_results: Dict[str, Mapping[str, Any]] = {}
+        total_tokens = 0
+        total_iterations = 0
+
+        coord_result = await self._invoke_one(
+            self._agents[coord_name], input, name=coord_name, run_id=run_id
+        )
+        coord_output = _extract_response(coord_result)
+        total_tokens += _extract_tokens(coord_result)
+        total_iterations += 1
+        agent_results[coord_name] = coord_result
+
+        for name, agent in self._agents.items():
+            if name == coord_name:
+                continue
+            if total_iterations >= self._config.max_agent_calls:
+                break
+            try:
+                sub_result = await self._invoke_one(
+                    agent, coord_output, name=name, run_id=run_id
+                )
+            except Exception as exc:
+                if self._config.fail_fast:
+                    raise OrchestrationError(
+                        f"OrchestrationRuntime: hierarchical sub-agent {name!r} failed: {exc}"
+                    ) from exc
+                logger.warning(
+                    "orchestration.hierarchical.sub_agent_failed",
+                    extra={
+                        "run_id": run_id,
+                        "agent_name": name,
+                        "error": str(exc),
+                    },
+                )
+                continue
+            total_tokens += _extract_tokens(sub_result)
+            total_iterations += 1
+            agent_results[name] = sub_result
+
+        return OrchestrationResult(
+            agent_results=agent_results,
+            final_output=coord_output,
+            total_iterations=total_iterations,
+            total_tokens=total_tokens,
+        )
+
+    async def _run_pipeline(self, input: str, *, run_id: str) -> OrchestrationResult:
+        steps = self._strategy.steps or ()
+        if not steps:
+            raise OrchestrationError(
+                "OrchestrationRuntime: pipeline strategy requires at least one step"
+            )
+
+        agent_results: Dict[str, Mapping[str, Any]] = {}
+        result_map: Dict[str, str] = {}
+        total_tokens = 0
+        total_iterations = 0
+
+        for step in steps:
+            if total_iterations >= self._config.max_agent_calls:
+                raise OrchestrationError(
+                    f"OrchestrationRuntime: max_agent_calls={self._config.max_agent_calls} reached"
+                )
+            if step.agent_name not in self._agents:
+                raise OrchestrationError(
+                    f"OrchestrationRuntime: pipeline step references unknown agent {step.agent_name!r}"
+                )
+            step_input = _resolve_pipeline_input(step.input_from, input, result_map)
+            result = await self._invoke_one(
+                self._agents[step.agent_name],
+                step_input,
+                name=step.agent_name,
+                run_id=run_id,
+            )
+            response = _extract_response(result)
+            result_map[step.agent_name] = response
+            agent_results[step.agent_name] = result
+            total_tokens += _extract_tokens(result)
+            total_iterations += 1
+
+        # Final output is the last step's response (Rust uses last value of
+        # the IndexMap; this preserves insertion order).
+        final_output = next(reversed(result_map.values())) if result_map else ""
+
+        return OrchestrationResult(
+            agent_results=agent_results,
+            final_output=final_output,
+            total_iterations=total_iterations,
+            total_tokens=total_tokens,
+        )
+
+    # -----------------------------------------------------------------------
+    # Invocation seams
+    # -----------------------------------------------------------------------
+
+    async def _invoke_one(
+        self, agent: Any, input: str, *, name: str, run_id: str
+    ) -> Mapping[str, Any]:
+        """Invoke a single agent via the configured ``agent_invoker``.
+
+        The default invoker prefers ``agent.run_async(input=input,
+        coordinator=...)`` then falls back to a thread-pooled
+        ``agent.run(input=input, ...)``. The ``coordinator`` kwarg is only
+        passed when a coordinator is registered AND the agent's signature
+        accepts it — the runtime never injects keys the agent didn't ask for
+        (per ``rules/agent-reasoning.md`` § "Pre-filter input before LLM
+        sees it" — the runtime is plumbing, not pre-classification).
+        """
+        logger.info(
+            "orchestration.agent.invoke",
+            extra={
+                "run_id": run_id,
+                "agent_name": name,
+                "strategy": self._strategy.name,
+            },
+        )
+        try:
+            result = await self._agent_invoker(agent, input, self._coordinator)
+        except Exception:
+            logger.exception(
+                "orchestration.agent.error",
+                extra={"run_id": run_id, "agent_name": name},
+            )
+            raise
+
+        if not isinstance(result, Mapping):
+            raise OrchestrationError(
+                f"OrchestrationRuntime: agent {name!r} returned {type(result).__name__}, expected Mapping"
+            )
+        return result
+
+    @staticmethod
+    async def _default_invoker(
+        agent: Any, input: str, coordinator: Optional[Coordinator]
+    ) -> Mapping[str, Any]:
+        """Default agent invoker.
+
+        Tries ``agent.run_async(input=input)`` first, then falls back to
+        ``await asyncio.to_thread(agent.run, input=input)``. The coordinator
+        is forwarded as a kwarg only when the target callable's signature
+        accepts ``coordinator`` — keeps the default invoker compatible with
+        ``BaseAgent`` (whose signature does NOT accept a coordinator) and
+        with bespoke test agents (which can opt in by declaring the kwarg).
+        """
+        # Async path
+        run_async = getattr(agent, "run_async", None)
+        if callable(run_async):
+            kwargs: Dict[str, Any] = {"input": input}
+            if coordinator is not None and _accepts_coordinator(run_async):
+                kwargs["coordinator"] = coordinator
+            return await run_async(**kwargs)
+
+        # Sync fallback path
+        run_sync = getattr(agent, "run", None)
+        if callable(run_sync):
+            kwargs = {"input": input}
+            if coordinator is not None and _accepts_coordinator(run_sync):
+                kwargs["coordinator"] = coordinator
+            return await asyncio.to_thread(run_sync, **kwargs)
+
+        raise OrchestrationError(
+            f"OrchestrationRuntime: agent {agent!r} has neither run_async nor run"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_response(result: Mapping[str, Any]) -> str:
+    """Extract the response string from an agent result mapping.
+
+    Tries (in order): ``response`` (Rust ``AgentResult.response`` parity),
+    ``output``, ``answer``, ``result``, then the first value if it's a string.
+    Falls back to ``str(result)`` so the orchestration never silently drops
+    output (per ``rules/zero-tolerance.md`` Rule 3).
+    """
+    for key in ("response", "output", "answer", "result"):
+        value = result.get(key)
+        if isinstance(value, str):
+            return value
+    # First string value wins (matches BaseAgent's signature-output dict shape).
+    for value in result.values():
+        if isinstance(value, str):
+            return value
+    return str(result)
+
+
+def _extract_tokens(result: Mapping[str, Any]) -> int:
+    """Extract the total-tokens count from an agent result mapping.
+
+    Tries ``total_tokens`` then ``tokens``; falls back to 0. Non-int values
+    are coerced via ``int()`` (raises ``TypeError`` if non-numeric — that's
+    intentional; silent zero-coercion would mask a bug).
+    """
+    for key in ("total_tokens", "tokens"):
+        value = result.get(key)
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            # Defensive: bool is a subclass of int; do not silently coerce.
+            continue
+        if isinstance(value, (int, float)):
+            return int(value)
+    return 0
+
+
+def _build_parallel_output(results: Mapping[str, Mapping[str, Any]]) -> str:
+    """Format the combined output for parallel execution.
+
+    Mirrors Rust ``build_parallel_output``: single-result returns the lone
+    response; multi-result joins with ``--- name ---`` headers.
+    """
+    if len(results) == 1:
+        only = next(iter(results.values()))
+        return _extract_response(only)
+    parts = []
+    for name, result in results.items():
+        parts.append(f"--- {name} ---\n{_extract_response(result)}")
+    return "\n\n".join(parts)
+
+
+def _resolve_pipeline_input(
+    source: PipelineInputSource,
+    initial_input: str,
+    result_map: Mapping[str, str],
+) -> str:
+    """Resolve a pipeline step's input string from its source descriptor."""
+    if source.initial:
+        return initial_input
+    if source.agent_name is not None:
+        if source.agent_name not in result_map:
+            raise OrchestrationError(
+                f"OrchestrationRuntime: pipeline step references output from "
+                f"{source.agent_name!r} which has not run yet or does not exist"
+            )
+        return result_map[source.agent_name]
+    if source.template is not None:
+        return _interpolate_template(source.template, result_map)
+    raise OrchestrationError(
+        "OrchestrationRuntime: PipelineInputSource has no source set"
+    )
+
+
+def _interpolate_template(template: str, result_map: Mapping[str, str]) -> str:
+    """Replace ``{{name.response}}`` placeholders with the named response.
+
+    Mirrors Rust ``interpolate_template``: unknown placeholders are left as-is
+    so failures are visible in the resulting prompt rather than silently
+    swallowed.
+    """
+    out = template
+    for name, response in result_map.items():
+        out = out.replace(f"{{{{{name}.response}}}}", response)
+    return out
+
+
+def _accepts_coordinator(func: Callable[..., Any]) -> bool:
+    """True iff ``func`` declares a ``coordinator`` keyword argument.
+
+    Used by the default invoker to forward the coordinator only when the
+    target callable opted in. This is structural plumbing (signature
+    inspection), NOT runtime classification — permitted by
+    ``rules/agent-reasoning.md`` § "Permitted Deterministic Logic".
+    """
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+    if "coordinator" in sig.parameters:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())

--- a/packages/kailash-kaizen/tests/integration/l3/test_suspension_emission.py
+++ b/packages/kailash-kaizen/tests/integration/l3/test_suspension_emission.py
@@ -1,0 +1,401 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 integration tests for L3 executor SuspensionRecord emission.
+
+Issue #598 — drives each of the 5 PACT N3 trigger conditions
+end-to-end through the L3 PlanExecutor / AsyncPlanExecutor and
+asserts that ``plan.suspension`` carries the correct variant.
+
+These are Tier 2 integration tests — no mocking of the framework
+hot path. The agent ``node_callback`` is a thin in-process function
+(no LLM, no network) because the L3 executor's contract is purely
+synchronous-callback / async-callback driven; "real infrastructure"
+for L3 means the real executor running over real Plan dataclasses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kaizen.l3.plan.executor import AsyncPlanExecutor, PlanExecutor
+from kaizen.l3.plan.suspension import (
+    BudgetExceededReason,
+    CircuitBreakerTrippedReason,
+    EnvelopeViolationReason,
+    ExplicitCancellationReason,
+    HumanApprovalGateReason,
+    SuspensionRecord,
+)
+from kaizen.l3.plan.types import (
+    EdgeType,
+    Plan,
+    PlanEdge,
+    PlanNode,
+    PlanNodeState,
+    PlanState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_node(
+    node_id: str,
+    agent_spec_id: str = "spec_1",
+    optional: bool = False,
+) -> PlanNode:
+    return PlanNode(
+        node_id=node_id,
+        agent_spec_id=agent_spec_id,
+        input_mapping={},
+        state=PlanNodeState.PENDING,
+        instance_id=None,
+        optional=optional,
+        retry_count=0,
+        output=None,
+        error=None,
+    )
+
+
+def _make_edge(from_node: str, to_node: str) -> PlanEdge:
+    return PlanEdge(
+        from_node=from_node,
+        to_node=to_node,
+        edge_type=EdgeType.DATA_DEPENDENCY,
+    )
+
+
+def _make_plan(
+    nodes: list[PlanNode],
+    edges: list[PlanEdge] | None = None,
+    gradient: dict[str, Any] | None = None,
+) -> Plan:
+    return Plan(
+        plan_id="test-plan-598",
+        name="suspension emission test",
+        envelope={"financial": {"max_cost": 100.0}},
+        gradient=gradient or {},
+        nodes={n.node_id: n for n in nodes},
+        edges=edges or [],
+        state=PlanState.VALIDATED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trigger 1: HumanApprovalGate
+# ---------------------------------------------------------------------------
+
+
+def test_sync_human_approval_gate_on_required_node_held():
+    """G5: required node fails non-retryable -> HELD -> SuspensionRecord.
+
+    The terminal-state path attaches a HumanApprovalGateReason because
+    the execution loop exits with a HELD node.
+    """
+    plan = _make_plan(
+        [_make_node("required_n")],
+        gradient={"retry_budget": 0},  # no retries; first failure -> HELD
+    )
+
+    def callback(node_id: str, agent_spec_id: str) -> dict:
+        return {"output": None, "error": "boom", "retryable": False}
+
+    executor = PlanExecutor(callback)
+    events = executor.execute(plan)
+
+    # Plan ended in SUSPENDED with at least one HELD node
+    assert plan.state == PlanState.SUSPENDED
+    assert any(n.state == PlanNodeState.HELD for n in plan.nodes.values())
+
+    # SuspensionRecord attached with HumanApprovalGate variant
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension, SuspensionRecord)
+    assert isinstance(plan.suspension.reason, HumanApprovalGateReason)
+    assert plan.suspension.reason.held_node == "required_n"
+    # The held node's error is captured in the reason
+    assert "boom" in plan.suspension.reason.reason
+
+
+def test_sync_human_approval_gate_picks_lexicographic_first():
+    """When multiple HELD nodes, the lex-first node id wins (deterministic
+    cross-SDK comparison)."""
+    plan = _make_plan(
+        [_make_node("z_held"), _make_node("a_held")],
+        gradient={"retry_budget": 0},
+    )
+
+    def callback(node_id: str, agent_spec_id: str) -> dict:
+        return {"output": None, "error": "fail", "retryable": False}
+
+    executor = PlanExecutor(callback)
+    executor.execute(plan)
+
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension.reason, HumanApprovalGateReason)
+    assert plan.suspension.reason.held_node == "a_held"
+
+
+# ---------------------------------------------------------------------------
+# Trigger 2: CircuitBreakerTripped
+# ---------------------------------------------------------------------------
+
+
+def test_sync_circuit_breaker_tripped():
+    """suspend_for_circuit_breaker attaches the right variant."""
+    plan = _make_plan([_make_node("n1")])
+    plan.state = PlanState.EXECUTING
+
+    executor = PlanExecutor(lambda nid, sid: {"output": None, "error": None})
+    events = executor.suspend_for_circuit_breaker(
+        plan,
+        breaker_id="openai-rate-limit",
+        triggering_node="n1",
+    )
+
+    assert plan.state == PlanState.SUSPENDED
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension.reason, CircuitBreakerTrippedReason)
+    assert plan.suspension.reason.breaker_id == "openai-rate-limit"
+    assert plan.suspension.reason.triggering_node == "n1"
+
+
+@pytest.mark.asyncio
+async def test_async_circuit_breaker_tripped():
+    plan = _make_plan([_make_node("n1")])
+    plan.state = PlanState.EXECUTING
+
+    async def callback(nid, sid):
+        return {"output": None, "error": None}
+
+    executor = AsyncPlanExecutor(callback)
+    await executor.suspend_for_circuit_breaker(
+        plan,
+        breaker_id="anthropic-quota",
+        triggering_node="n1",
+    )
+
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension.reason, CircuitBreakerTrippedReason)
+    assert plan.suspension.reason.breaker_id == "anthropic-quota"
+
+
+# ---------------------------------------------------------------------------
+# Trigger 3: BudgetExceeded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_budget_exceeded_via_blocked_verdict():
+    """Async executor with enforcer: BLOCKED verdict whose requested >
+    available is classified as BudgetExceeded."""
+    from kaizen.l3.envelope.types import Verdict
+
+    plan = _make_plan(
+        [_make_node("expensive_node")],
+        gradient={"retry_budget": 0},
+    )
+
+    class StubEnforcer:
+        async def check_action(self, ctx):
+            return Verdict(
+                tag="BLOCKED",
+                dimension="financial",
+                detail="budget exceeded",
+                requested=150.0,
+                available=100.0,
+            )
+
+    async def callback(nid, sid):
+        # Should never be reached because BLOCKED short-circuits
+        return {"output": None, "error": None}
+
+    executor = AsyncPlanExecutor(callback, enforcer=StubEnforcer())
+    await executor.execute(plan)
+
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension.reason, BudgetExceededReason)
+    assert plan.suspension.reason.dimension == "financial"
+    assert plan.suspension.reason.usage_pct == pytest.approx(1.5)
+    assert plan.suspension.reason.triggering_node == "expensive_node"
+
+
+# ---------------------------------------------------------------------------
+# Trigger 4: EnvelopeViolation
+# ---------------------------------------------------------------------------
+
+
+def test_sync_envelope_violation_via_callback_result():
+    """Sync executor: callback returns envelope_violation=True ->
+    EnvelopeViolation SuspensionRecord."""
+    plan = _make_plan(
+        [_make_node("classified_read")],
+        gradient={"retry_budget": 0},
+    )
+
+    def callback(node_id: str, agent_spec_id: str) -> dict:
+        return {
+            "output": None,
+            "error": "clearance level mismatch",
+            "retryable": False,
+            "envelope_violation": True,
+        }
+
+    executor = PlanExecutor(callback)
+    executor.execute(plan)
+
+    # The execution path: envelope_violation -> NodeBlocked -> cascade.
+    # No HELD nodes, so terminal-state does NOT overwrite with
+    # HumanApprovalGate.
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension.reason, EnvelopeViolationReason)
+    assert plan.suspension.reason.detail == "clearance level mismatch"
+    assert plan.suspension.reason.triggering_node == "classified_read"
+
+
+@pytest.mark.asyncio
+async def test_async_envelope_violation_via_blocked_verdict_no_overflow():
+    """Async executor with enforcer: BLOCKED verdict without numeric
+    overflow is classified as EnvelopeViolation."""
+    from kaizen.l3.envelope.types import Verdict
+
+    plan = _make_plan(
+        [_make_node("classified_read")],
+        gradient={"retry_budget": 0},
+    )
+
+    class StubEnforcer:
+        async def check_action(self, ctx):
+            # No requested/available numerics -> structural violation
+            return Verdict(
+                tag="BLOCKED",
+                dimension="data_access",
+                detail="clearance fail",
+            )
+
+    async def callback(nid, sid):
+        return {"output": None, "error": None}
+
+    executor = AsyncPlanExecutor(callback, enforcer=StubEnforcer())
+    await executor.execute(plan)
+
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension.reason, EnvelopeViolationReason)
+    assert plan.suspension.reason.detail == "clearance fail"
+
+
+# ---------------------------------------------------------------------------
+# Trigger 5: ExplicitCancellation
+# ---------------------------------------------------------------------------
+
+
+def test_sync_explicit_cancellation_attaches_record():
+    plan = _make_plan([_make_node("n1"), _make_node("n2")])
+    plan.state = PlanState.EXECUTING
+
+    executor = PlanExecutor(lambda nid, sid: {"output": None, "error": None})
+    executor.cancel(
+        plan,
+        reason="user pressed stop",
+        resume_hint="resume after data-quality review",
+    )
+
+    assert plan.state == PlanState.CANCELLED
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension.reason, ExplicitCancellationReason)
+    assert plan.suspension.reason.reason == "user pressed stop"
+    assert plan.suspension.reason.resume_hint == "resume after data-quality review"
+    # All nodes were skipped; pending_nodes captured pre-cancel
+    assert plan.suspension.pending_nodes == ["n1", "n2"]
+
+
+@pytest.mark.asyncio
+async def test_async_explicit_cancellation_attaches_record():
+    plan = _make_plan([_make_node("n1")])
+    plan.state = PlanState.EXECUTING
+
+    async def callback(nid, sid):
+        return {"output": None, "error": None}
+
+    executor = AsyncPlanExecutor(callback)
+    await executor.cancel(
+        plan,
+        reason="quota exhausted",
+        resume_hint="next billing cycle",
+    )
+
+    assert plan.suspension is not None
+    assert isinstance(plan.suspension.reason, ExplicitCancellationReason)
+    assert plan.suspension.reason.reason == "quota exhausted"
+
+
+# ---------------------------------------------------------------------------
+# resume() clears the record
+# ---------------------------------------------------------------------------
+
+
+def test_sync_resume_clears_suspension():
+    plan = _make_plan([_make_node("n1")])
+    plan.state = PlanState.EXECUTING
+
+    executor = PlanExecutor(lambda nid, sid: {"output": None, "error": None})
+    executor.suspend(
+        plan,
+        reason=ExplicitCancellationReason(
+            reason="pause", resume_hint="resume immediately"
+        ),
+    )
+    assert plan.suspension is not None
+
+    executor.resume(plan)
+    assert plan.suspension is None
+    assert plan.state == PlanState.EXECUTING
+
+
+@pytest.mark.asyncio
+async def test_async_resume_clears_suspension():
+    plan = _make_plan([_make_node("n1")])
+    plan.state = PlanState.EXECUTING
+
+    async def callback(nid, sid):
+        return {"output": None, "error": None}
+
+    executor = AsyncPlanExecutor(callback)
+    await executor.suspend(
+        plan,
+        reason=CircuitBreakerTrippedReason(breaker_id="openai", triggering_node="n1"),
+    )
+    assert plan.suspension is not None
+
+    await executor.resume(plan)
+    assert plan.suspension is None
+
+
+# ---------------------------------------------------------------------------
+# Suspension survives Plan.to_dict / from_dict round-trip
+#
+# This is the cross-SDK wire test: a Python plan in the SUSPENDED state
+# round-trips through dict and the SuspensionRecord is reconstructed.
+# A Rust subscriber reading the dict MUST see the same field shapes.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_dict_roundtrip_preserves_suspension():
+    plan = _make_plan([_make_node("n1"), _make_node("n2")])
+    plan.state = PlanState.EXECUTING
+
+    executor = PlanExecutor(lambda nid, sid: {"output": None, "error": None})
+    executor.cancel(plan, reason="audit", resume_hint="rerun next quarter")
+
+    # Round-trip
+    d = plan.to_dict()
+    plan2 = Plan.from_dict(d)
+
+    assert plan2.suspension is not None
+    assert isinstance(plan2.suspension.reason, ExplicitCancellationReason)
+    assert plan2.suspension.reason.reason == "audit"
+    # Pre-cancel snapshot preserved
+    assert sorted(plan2.suspension.pending_nodes) == ["n1", "n2"]

--- a/packages/kailash-kaizen/tests/integration/orchestration/__init__.py
+++ b/packages/kailash-kaizen/tests/integration/orchestration/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/kailash-kaizen/tests/integration/orchestration/test_runtime_e2e.py
+++ b/packages/kailash-kaizen/tests/integration/orchestration/test_runtime_e2e.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tier-2 end-to-end integration tests for kaizen.orchestration.OrchestrationRuntime.
+
+Per ``rules/testing.md`` § "Protocol Adapters", a deterministic
+Protocol-conforming agent + the real ``SharedMemoryPool``-backed coordinator
+are an acceptable Tier-2 surface for transport-only modules. The runtime
+contains zero LLM calls and zero external infrastructure — its full
+contract is exercised end-to-end through the public ``run`` entry point with
+the default invoker, the real coordinator, and multi-strategy compositions.
+
+For LLM-driven coverage of the same surface, see Tier-3 e2e suites that
+plug live ``BaseAgent`` instances into this runtime — out of scope for the
+runtime's parity tests.
+
+Mirrors the Rust ``orchestration::runtime::tests`` shared-memory and
+multi-strategy integration tests one-for-one (issue #602 / EATP D6).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+import pytest
+
+from kaizen.orchestration import (
+    OrchestrationConfig,
+    OrchestrationRuntime,
+    OrchestrationStrategy,
+    PipelineInputSource,
+    PipelineStep,
+    SharedMemoryCoordinator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Real coordinator-aware agents
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StoreAgent:
+    name: str
+    key: str
+    value: str
+
+    async def run_async(
+        self, *, input: str = "", coordinator: Optional[Any] = None
+    ) -> Mapping[str, Any]:
+        if coordinator is None:
+            raise RuntimeError(f"{self.name}: coordinator required")
+        await coordinator.store(self.key, self.value)
+        return {
+            "response": f"stored {self.key}",
+            "total_tokens": 5,
+        }
+
+
+@dataclass
+class _LoadAgent:
+    name: str
+    key: str
+
+    async def run_async(
+        self, *, input: str = "", coordinator: Optional[Any] = None
+    ) -> Mapping[str, Any]:
+        if coordinator is None:
+            raise RuntimeError(f"{self.name}: coordinator required")
+        value = await coordinator.retrieve(self.key)
+        return {"response": str(value), "total_tokens": 5}
+
+
+@dataclass
+class _UppercaseAgent:
+    name: str
+
+    async def run_async(self, **inputs: Any) -> Mapping[str, Any]:
+        text = inputs.get("input", "")
+        return {"response": text.upper(), "total_tokens": 7}
+
+
+@dataclass
+class _ReverseAgent:
+    name: str
+
+    async def run_async(self, **inputs: Any) -> Mapping[str, Any]:
+        text = inputs.get("input", "")
+        return {"response": text[::-1], "total_tokens": 7}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pipelines
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeEndToEnd:
+    @pytest.mark.asyncio
+    async def test_sequential_with_real_shared_memory(self) -> None:
+        """Writer -> Reader through the real SharedMemoryPool-backed coordinator."""
+        coord = SharedMemoryCoordinator()
+        runtime = (
+            OrchestrationRuntime(coordinator=coord)
+            .add_agent("store", _StoreAgent("store", "research", "Q3 trend"))
+            .add_agent("load", _LoadAgent("load", "research"))
+        )
+        result = await runtime.run("seed")
+        # The reader's view of shared memory IS the final output.
+        assert result.final_output == "Q3 trend"
+        # Both agents executed; total_iterations covers them.
+        assert result.total_iterations == 2
+
+    @pytest.mark.asyncio
+    async def test_pipeline_template_chains_two_real_transformations(self) -> None:
+        """Pipeline with a real Template step chaining two transformations."""
+        runtime = (
+            OrchestrationRuntime(
+                strategy=OrchestrationStrategy.pipeline(
+                    [
+                        PipelineStep("upper", PipelineInputSource.from_initial()),
+                        PipelineStep(
+                            "reverse",
+                            PipelineInputSource.from_template(
+                                "transform: {{upper.response}}"
+                            ),
+                        ),
+                    ]
+                )
+            )
+            .add_agent("upper", _UppercaseAgent("upper"))
+            .add_agent("reverse", _ReverseAgent("reverse"))
+        )
+        result = await runtime.run("hello world")
+        # upper("hello world") -> "HELLO WORLD"
+        # template -> "transform: HELLO WORLD"
+        # reverse(template) -> reversed string
+        assert result.final_output == "transform: HELLO WORLD"[::-1]
+
+    @pytest.mark.asyncio
+    async def test_parallel_aggregates_real_responses(self) -> None:
+        runtime = (
+            OrchestrationRuntime(strategy=OrchestrationStrategy.parallel())
+            .add_agent("upper", _UppercaseAgent("upper"))
+            .add_agent("reverse", _ReverseAgent("reverse"))
+        )
+        result = await runtime.run("kaizen")
+        assert result.agent_results["upper"]["response"] == "KAIZEN"
+        assert result.agent_results["reverse"]["response"] == "neziak"
+        assert "--- upper ---" in result.final_output
+        assert "--- reverse ---" in result.final_output
+
+    @pytest.mark.asyncio
+    async def test_hierarchical_with_real_workers(self) -> None:
+        runtime = (
+            OrchestrationRuntime(strategy=OrchestrationStrategy.hierarchical("upper"))
+            .add_agent("upper", _UppercaseAgent("upper"))
+            .add_agent("reverse", _ReverseAgent("reverse"))
+        )
+        result = await runtime.run("kaizen")
+        # Coordinator runs first → "KAIZEN"
+        assert result.final_output == "KAIZEN"
+        # Worker receives the coordinator's output → reverse("KAIZEN")
+        assert result.agent_results["reverse"]["response"] == "NEZIAK"
+
+    @pytest.mark.asyncio
+    async def test_max_agent_calls_caps_sequential(self) -> None:
+        from kaizen.orchestration import OrchestrationError
+
+        runtime = (
+            OrchestrationRuntime(
+                config=OrchestrationConfig(max_agent_calls=1),
+            )
+            .add_agent("a", _UppercaseAgent("a"))
+            .add_agent("b", _UppercaseAgent("b"))
+        )
+        with pytest.raises(OrchestrationError, match="max_agent_calls"):
+            await runtime.run("x")
+
+    @pytest.mark.asyncio
+    async def test_run_emits_duration_ms(self) -> None:
+        runtime = OrchestrationRuntime().add_agent("u", _UppercaseAgent("u"))
+        result = await runtime.run("x")
+        assert result.duration_ms >= 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-SDK shape parity (kailash-rs ISS-27 — observable contract test)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSdkShapeParity:
+    """Observable-shape parity with kailash-rs `OrchestrationResult`.
+
+    These assertions lock the field shape of OrchestrationResult so a future
+    refactor cannot rename / drop a field that the Rust SDK also emits. EATP
+    D6 mandates semantic parity; these tests are the structural defense.
+    """
+
+    @pytest.mark.asyncio
+    async def test_result_field_shape(self) -> None:
+        runtime = OrchestrationRuntime().add_agent("u", _UppercaseAgent("u"))
+        result = await runtime.run("hi")
+        d = result.to_dict()
+        # Same five keys as the Rust struct.
+        assert set(d.keys()) == {
+            "agent_results",
+            "final_output",
+            "total_iterations",
+            "total_tokens",
+            "duration_ms",
+        }
+        assert isinstance(d["agent_results"], dict)
+        assert isinstance(d["final_output"], str)
+        assert isinstance(d["total_iterations"], int)
+        assert isinstance(d["total_tokens"], int)
+        assert isinstance(d["duration_ms"], int)
+
+    @pytest.mark.asyncio
+    async def test_strategy_kind_round_trips_via_string_value(self) -> None:
+        # Cross-SDK serde: Rust serializes the strategy enum as a string
+        # variant. Python's StrEnum yields the same lowercase value.
+        assert OrchestrationStrategy.sequential().kind.value == "sequential"
+        assert OrchestrationStrategy.parallel().kind.value == "parallel"
+        assert OrchestrationStrategy.hierarchical("c").kind.value == "hierarchical"
+        assert (
+            OrchestrationStrategy.pipeline(
+                [PipelineStep("a", PipelineInputSource.from_initial())]
+            ).kind.value
+            == "pipeline"
+        )

--- a/packages/kailash-kaizen/tests/unit/l3/plan/test_suspension.py
+++ b/packages/kailash-kaizen/tests/unit/l3/plan/test_suspension.py
@@ -1,0 +1,488 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 1 unit tests for kaizen.l3.plan.suspension.
+
+Issue #598 — PlanSuspension parity (5-variant SuspensionReason)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from kaizen.l3.plan.suspension import (
+    BudgetExceededReason,
+    CircuitBreakerTrippedReason,
+    EnvelopeViolationReason,
+    ExplicitCancellationReason,
+    HumanApprovalGateReason,
+    SuspensionRecord,
+    suspension_reason_from_dict,
+    suspension_reason_label,
+    suspension_reason_to_dict,
+)
+from kaizen.l3.plan.types import (
+    Plan,
+    PlanNode,
+    PlanNodeState,
+    PlanState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Variant construction
+# ---------------------------------------------------------------------------
+
+
+def test_human_approval_gate_construction():
+    r = HumanApprovalGateReason(held_node="n7", reason="manual review")
+    assert r.kind == "human_approval_gate"
+    assert r.held_node == "n7"
+    assert r.reason == "manual review"
+
+
+def test_circuit_breaker_tripped_construction():
+    r = CircuitBreakerTrippedReason(
+        breaker_id="openai-rate-limit",
+        triggering_node="rag_query",
+    )
+    assert r.kind == "circuit_breaker_tripped"
+    assert r.breaker_id == "openai-rate-limit"
+    assert r.triggering_node == "rag_query"
+
+
+def test_budget_exceeded_construction():
+    r = BudgetExceededReason(
+        dimension="financial",
+        usage_pct=0.95,
+        triggering_node="expensive_agent",
+    )
+    assert r.kind == "budget_exceeded"
+    assert r.dimension == "financial"
+    assert r.usage_pct == 0.95
+    assert r.triggering_node == "expensive_agent"
+
+
+def test_envelope_violation_construction():
+    r = EnvelopeViolationReason(
+        dimension="data_access",
+        detail="clearance level mismatch",
+        triggering_node="classified_doc_read",
+    )
+    assert r.kind == "envelope_violation"
+    assert r.dimension == "data_access"
+    assert r.detail == "clearance level mismatch"
+    assert r.triggering_node == "classified_doc_read"
+
+
+def test_explicit_cancellation_construction():
+    r = ExplicitCancellationReason(
+        reason="caller-initiated",
+        resume_hint="resume after human review of dataset",
+    )
+    assert r.kind == "explicit_cancellation"
+    assert r.reason == "caller-initiated"
+    assert r.resume_hint == "resume after human review of dataset"
+
+
+def test_variants_are_frozen():
+    """Frozen dataclass blocks mutation — important for the audit trail."""
+    r = HumanApprovalGateReason(held_node="n1", reason="x")
+    with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+        r.held_node = "n2"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Labels
+# ---------------------------------------------------------------------------
+
+
+def test_label_matches_kind_for_all_5_variants():
+    """Cross-SDK metric cardinality stability — labels must equal kind."""
+    cases = [
+        (
+            HumanApprovalGateReason(held_node="n", reason="r"),
+            "human_approval_gate",
+        ),
+        (
+            CircuitBreakerTrippedReason(breaker_id="b", triggering_node="n"),
+            "circuit_breaker_tripped",
+        ),
+        (
+            BudgetExceededReason(dimension="d", usage_pct=0.9, triggering_node="n"),
+            "budget_exceeded",
+        ),
+        (
+            EnvelopeViolationReason(dimension="d", detail="x", triggering_node="n"),
+            "envelope_violation",
+        ),
+        (
+            ExplicitCancellationReason(reason="r", resume_hint="h"),
+            "explicit_cancellation",
+        ),
+    ]
+    for reason, expected_label in cases:
+        assert suspension_reason_label(reason) == expected_label
+
+
+# ---------------------------------------------------------------------------
+# Wire-format round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_human_approval_gate_round_trip():
+    r = HumanApprovalGateReason(held_node="n7", reason="manual review")
+    d = suspension_reason_to_dict(r)
+    assert d == {
+        "kind": "human_approval_gate",
+        "held_node": "n7",
+        "reason": "manual review",
+    }
+    r2 = suspension_reason_from_dict(d)
+    assert r2 == r
+
+
+def test_circuit_breaker_round_trip():
+    r = CircuitBreakerTrippedReason(breaker_id="b", triggering_node="n")
+    d = suspension_reason_to_dict(r)
+    assert d == {
+        "kind": "circuit_breaker_tripped",
+        "breaker_id": "b",
+        "triggering_node": "n",
+    }
+    r2 = suspension_reason_from_dict(d)
+    assert r2 == r
+
+
+def test_budget_exceeded_round_trip():
+    r = BudgetExceededReason(dimension="financial", usage_pct=0.92, triggering_node="n")
+    d = suspension_reason_to_dict(r)
+    assert d == {
+        "kind": "budget_exceeded",
+        "dimension": "financial",
+        "usage_pct": 0.92,
+        "triggering_node": "n",
+    }
+    r2 = suspension_reason_from_dict(d)
+    assert r2 == r
+
+
+def test_envelope_violation_round_trip():
+    r = EnvelopeViolationReason(
+        dimension="data_access", detail="clearance fail", triggering_node="n"
+    )
+    d = suspension_reason_to_dict(r)
+    assert d == {
+        "kind": "envelope_violation",
+        "dimension": "data_access",
+        "detail": "clearance fail",
+        "triggering_node": "n",
+    }
+    r2 = suspension_reason_from_dict(d)
+    assert r2 == r
+
+
+def test_explicit_cancellation_round_trip():
+    r = ExplicitCancellationReason(reason="r", resume_hint="h")
+    d = suspension_reason_to_dict(r)
+    assert d == {
+        "kind": "explicit_cancellation",
+        "reason": "r",
+        "resume_hint": "h",
+    }
+    r2 = suspension_reason_from_dict(d)
+    assert r2 == r
+
+
+def test_from_dict_rejects_missing_kind():
+    with pytest.raises(ValueError, match="missing required 'kind'"):
+        suspension_reason_from_dict({"held_node": "n", "reason": "r"})
+
+
+def test_from_dict_rejects_unknown_kind():
+    with pytest.raises(ValueError, match="unknown SuspensionReason kind"):
+        suspension_reason_from_dict({"kind": "made_up_variant"})
+
+
+def test_from_dict_rejects_missing_required_field():
+    # human_approval_gate variant requires held_node + reason
+    with pytest.raises(KeyError):
+        suspension_reason_from_dict({"kind": "human_approval_gate"})
+
+
+# ---------------------------------------------------------------------------
+# SuspensionRecord
+# ---------------------------------------------------------------------------
+
+
+def _make_plan_with_states(
+    state_map: dict[str, PlanNodeState],
+) -> Plan:
+    """Build a Plan with nodes in the given states."""
+    nodes: dict[str, PlanNode] = {}
+    for node_id, state in state_map.items():
+        nodes[node_id] = PlanNode(
+            node_id=node_id,
+            agent_spec_id="dummy",
+            input_mapping={},
+            state=state,
+            instance_id=None,
+            optional=False,
+            retry_count=0,
+            output=None,
+            error=None,
+        )
+    return Plan(
+        plan_id="p1",
+        name="test",
+        envelope={},
+        gradient={},
+        nodes=nodes,
+        edges=[],
+        state=PlanState.EXECUTING,
+    )
+
+
+def test_record_from_plan_partitions_node_states():
+    plan = _make_plan_with_states(
+        {
+            "n_running1": PlanNodeState.RUNNING,
+            "n_running2": PlanNodeState.RUNNING,
+            "n_ready": PlanNodeState.READY,
+            "n_pending": PlanNodeState.PENDING,
+            "n_completed": PlanNodeState.COMPLETED,
+            "n_failed": PlanNodeState.FAILED,
+        }
+    )
+    reason = HumanApprovalGateReason(held_node="x", reason="y")
+    record = SuspensionRecord.from_plan(reason, plan)
+    assert record.running_nodes == ["n_running1", "n_running2"]
+    assert record.ready_nodes == ["n_ready"]
+    assert record.pending_nodes == ["n_pending"]
+
+
+def test_record_lists_are_sorted_for_cross_sdk_stability():
+    plan = _make_plan_with_states(
+        {
+            "z_run": PlanNodeState.RUNNING,
+            "a_run": PlanNodeState.RUNNING,
+            "m_run": PlanNodeState.RUNNING,
+        }
+    )
+    record = SuspensionRecord.from_plan(
+        ExplicitCancellationReason(reason="r", resume_hint="h"),
+        plan,
+    )
+    assert record.running_nodes == ["a_run", "m_run", "z_run"]
+
+
+def test_record_default_suspended_at_is_utc():
+    plan = _make_plan_with_states({"n": PlanNodeState.PENDING})
+    record = SuspensionRecord.from_plan(
+        ExplicitCancellationReason(reason="r", resume_hint="h"),
+        plan,
+    )
+    assert record.suspended_at.tzinfo is not None
+    assert record.suspended_at.utcoffset().total_seconds() == 0
+
+
+def test_record_with_resume_context_returns_copy():
+    plan = _make_plan_with_states({"n": PlanNodeState.PENDING})
+    record = SuspensionRecord.from_plan(
+        ExplicitCancellationReason(reason="r", resume_hint="h"),
+        plan,
+    )
+    record2 = record.with_resume_context({"retry": 3})
+    assert record2.resume_context == {"retry": 3}
+    assert record.resume_context is None  # original untouched
+    assert record2.reason == record.reason
+    assert record2.suspended_at == record.suspended_at
+
+
+def test_record_to_dict_has_iso_suspended_at():
+    plan = _make_plan_with_states({"n": PlanNodeState.PENDING})
+    fixed = datetime(2026, 4, 25, 10, 30, 0, tzinfo=UTC)
+    record = SuspensionRecord(
+        reason=ExplicitCancellationReason(reason="r", resume_hint="h"),
+        suspended_at=fixed,
+        running_nodes=[],
+        ready_nodes=[],
+        pending_nodes=["n"],
+        resume_context=None,
+    )
+    d = record.to_dict()
+    assert d["suspended_at"] == "2026-04-25T10:30:00+00:00"
+    assert d["pending_nodes"] == ["n"]
+    assert d["reason"]["kind"] == "explicit_cancellation"
+
+
+def test_record_round_trip_through_dict():
+    plan = _make_plan_with_states(
+        {"a": PlanNodeState.RUNNING, "b": PlanNodeState.PENDING}
+    )
+    record = SuspensionRecord.from_plan(
+        BudgetExceededReason(
+            dimension="financial", usage_pct=0.95, triggering_node="a"
+        ),
+        plan,
+        resume_context={"agent_state": "awaiting_quota_lift"},
+    )
+    d = record.to_dict()
+    record2 = SuspensionRecord.from_dict(d)
+    assert record2.reason == record.reason
+    assert record2.suspended_at == record.suspended_at
+    assert record2.running_nodes == record.running_nodes
+    assert record2.ready_nodes == record.ready_nodes
+    assert record2.pending_nodes == record.pending_nodes
+    assert record2.resume_context == record.resume_context
+
+
+# ---------------------------------------------------------------------------
+# Plan.suspension field
+# ---------------------------------------------------------------------------
+
+
+def test_plan_suspension_defaults_to_none():
+    plan = _make_plan_with_states({"n": PlanNodeState.PENDING})
+    assert plan.suspension is None
+
+
+def test_plan_to_dict_round_trips_suspension():
+    plan = _make_plan_with_states({"n": PlanNodeState.PENDING})
+    plan.suspension = SuspensionRecord(
+        reason=ExplicitCancellationReason(reason="r", resume_hint="h"),
+        suspended_at=datetime(2026, 4, 25, 12, 0, 0, tzinfo=UTC),
+        running_nodes=[],
+        ready_nodes=[],
+        pending_nodes=["n"],
+        resume_context=None,
+    )
+    d = plan.to_dict()
+    assert d["suspension"] is not None
+    assert d["suspension"]["reason"]["kind"] == "explicit_cancellation"
+
+    plan2 = Plan.from_dict(d)
+    assert plan2.suspension is not None
+    assert plan2.suspension.reason == plan.suspension.reason
+    assert plan2.suspension.pending_nodes == ["n"]
+
+
+def test_plan_to_dict_with_no_suspension_field():
+    plan = _make_plan_with_states({"n": PlanNodeState.PENDING})
+    d = plan.to_dict()
+    assert d["suspension"] is None
+    plan2 = Plan.from_dict(d)
+    assert plan2.suspension is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-SDK parity vectors
+#
+# These vectors are the canonical wire-format payloads. The sister Rust
+# SDK (kailash-rs/crates/kailash-kaizen/src/l3/core/plan/types.rs) MUST
+# produce the same shapes for the same logical inputs (modulo the
+# suspended_at timestamp). Any field-name drift between SDKs MUST land
+# in a single coordinated PR; this test is the structural contract.
+# ---------------------------------------------------------------------------
+
+
+CROSS_SDK_VECTORS = [
+    # (description, wire_payload, expected_python_record_attrs)
+    (
+        "human_approval_gate canonical",
+        {
+            "kind": "human_approval_gate",
+            "held_node": "n7",
+            "reason": "manual review",
+        },
+        ("HumanApprovalGateReason", "n7", "manual review"),
+    ),
+    (
+        "circuit_breaker_tripped canonical",
+        {
+            "kind": "circuit_breaker_tripped",
+            "breaker_id": "openai-rate-limit",
+            "triggering_node": "rag_query",
+        },
+        ("CircuitBreakerTrippedReason", "openai-rate-limit", "rag_query"),
+    ),
+    (
+        "budget_exceeded canonical",
+        {
+            "kind": "budget_exceeded",
+            "dimension": "financial",
+            "usage_pct": 0.95,
+            "triggering_node": "expensive_agent",
+        },
+        ("BudgetExceededReason", "financial", 0.95, "expensive_agent"),
+    ),
+    (
+        "envelope_violation canonical (Python-only today, Rust follow-up)",
+        {
+            "kind": "envelope_violation",
+            "dimension": "data_access",
+            "detail": "clearance level mismatch",
+            "triggering_node": "classified_doc_read",
+        },
+        ("EnvelopeViolationReason", "data_access", "clearance level mismatch"),
+    ),
+    (
+        "explicit_cancellation canonical",
+        {
+            "kind": "explicit_cancellation",
+            "reason": "caller-initiated",
+            "resume_hint": "resume after human review of dataset",
+        },
+        (
+            "ExplicitCancellationReason",
+            "caller-initiated",
+            "resume after human review of dataset",
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("description,payload,expected_attrs", CROSS_SDK_VECTORS)
+def test_cross_sdk_parity_vector(
+    description: str,
+    payload: dict,
+    expected_attrs: tuple,
+):
+    """Each canonical wire payload deserializes to the right variant."""
+    reason = suspension_reason_from_dict(payload)
+    assert type(reason).__name__ == expected_attrs[0], (
+        f"{description}: kind {payload['kind']!r} did NOT deserialize to "
+        f"{expected_attrs[0]} (got {type(reason).__name__})"
+    )
+    # Round-trip back to dict — bytes-stable
+    assert suspension_reason_to_dict(reason) == payload, (
+        f"{description}: round-trip lost data; before={payload!r} "
+        f"after={suspension_reason_to_dict(reason)!r}"
+    )
+
+
+def test_cross_sdk_full_record_vector():
+    """A complete SuspensionRecord wire-format vector round-trips."""
+    payload = {
+        "reason": {
+            "kind": "human_approval_gate",
+            "held_node": "approval_node",
+            "reason": "ML model output requires expert review",
+        },
+        "suspended_at": "2026-04-25T12:34:56+00:00",
+        "running_nodes": ["a", "b"],
+        "ready_nodes": ["c"],
+        "pending_nodes": ["d", "e"],
+        "resume_context": {"reviewer_id": "alice@example.com"},
+    }
+    record = SuspensionRecord.from_dict(payload)
+    assert isinstance(record.reason, HumanApprovalGateReason)
+    assert record.reason.held_node == "approval_node"
+    assert record.suspended_at == datetime(2026, 4, 25, 12, 34, 56, tzinfo=UTC)
+    assert record.running_nodes == ["a", "b"]
+    assert record.ready_nodes == ["c"]
+    assert record.pending_nodes == ["d", "e"]
+    assert record.resume_context == {"reviewer_id": "alice@example.com"}
+    # Round-trip
+    assert record.to_dict() == payload

--- a/packages/kailash-kaizen/tests/unit/orchestration/__init__.py
+++ b/packages/kailash-kaizen/tests/unit/orchestration/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/kailash-kaizen/tests/unit/orchestration/test_runtime.py
+++ b/packages/kailash-kaizen/tests/unit/orchestration/test_runtime.py
@@ -1,0 +1,547 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+Tier-1 unit tests for kaizen.orchestration.runtime.OrchestrationRuntime.
+
+Cross-SDK parity test surface — mirrors the Rust
+``crates/kaizen-agents/src/orchestration/runtime.rs::tests`` module test
+list one-for-one. Every Rust test has a Python equivalent here so the
+``OrchestrationRuntime`` shapes stay observably identical (issue #602 /
+kailash-rs ISS-27 / EATP D6).
+
+Tests use Protocol-conforming deterministic agents (per ``rules/testing.md``
+§ "Protocol Adapters") rather than real LLM agents, so unit runs are
+hermetic and fast.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
+
+import pytest
+
+from kaizen.orchestration import (
+    OrchestrationConfig,
+    OrchestrationError,
+    OrchestrationRuntime,
+    OrchestrationStrategy,
+    OrchestrationStrategyKind,
+    PipelineInputSource,
+    PipelineStep,
+    SharedMemoryCoordinator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test agents
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _EchoAgent:
+    """Minimal Protocol-conforming agent that echoes input with a prefix."""
+
+    name: str
+    description: str = ""
+    tokens: int = 10
+
+    async def run_async(self, **inputs: Any) -> Mapping[str, Any]:
+        text = inputs.get("input", "")
+        return {
+            "response": f"[{self.name}] {text}",
+            "total_tokens": self.tokens,
+            "iterations": 1,
+        }
+
+
+@dataclass
+class _FailingAgent:
+    """Agent that raises on every invocation."""
+
+    name: str
+
+    async def run_async(self, **inputs: Any) -> Mapping[str, Any]:
+        raise RuntimeError(f"{self.name} failed intentionally")
+
+
+@dataclass
+class _SlowAgent:
+    """Agent that sleeps for ``delay_ms`` before responding."""
+
+    name: str
+    delay_ms: int
+
+    async def run_async(self, **inputs: Any) -> Mapping[str, Any]:
+        import asyncio
+
+        await asyncio.sleep(self.delay_ms / 1000.0)
+        return {"response": f"[{self.name}] slow", "total_tokens": 5}
+
+
+@dataclass
+class _MemoryReaderAgent:
+    """Agent that reads ``key`` from the coordinator and reports it."""
+
+    name: str
+    key: str
+
+    async def run_async(
+        self, *, input: str = "", coordinator: Optional[Any] = None
+    ) -> Mapping[str, Any]:
+        if coordinator is None:
+            return {"response": f"{self.key}=<no coordinator>", "total_tokens": 1}
+        value = await coordinator.retrieve(self.key)
+        if value is None:
+            return {"response": f"{self.key}=<not found>", "total_tokens": 1}
+        return {"response": f"{self.key}={value}", "total_tokens": 1}
+
+
+@dataclass
+class _MemoryWriterAgent:
+    """Agent that writes ``(key, value)`` to the coordinator."""
+
+    name: str
+    key: str
+    value: str
+
+    async def run_async(
+        self, *, input: str = "", coordinator: Optional[Any] = None
+    ) -> Mapping[str, Any]:
+        if coordinator is not None:
+            await coordinator.store(self.key, self.value)
+        return {"response": f"stored {self.key}={self.value}", "total_tokens": 1}
+
+
+# ---------------------------------------------------------------------------
+# Builder API
+# ---------------------------------------------------------------------------
+
+
+class TestBuilder:
+    def test_new_creates_empty_runtime(self) -> None:
+        runtime = OrchestrationRuntime()
+        assert runtime.agent_count == 0
+        assert runtime.agent_names == []
+        assert runtime.current_strategy.kind is OrchestrationStrategyKind.SEQUENTIAL
+        assert runtime.current_coordinator is None
+
+    def test_add_agent_increases_count(self) -> None:
+        runtime = (
+            OrchestrationRuntime()
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("b", _EchoAgent("b"))
+        )
+        assert runtime.agent_count == 2
+        assert runtime.agent_names == ["a", "b"]
+
+    def test_add_agent_preserves_insertion_order(self) -> None:
+        runtime = (
+            OrchestrationRuntime()
+            .add_agent("z", _EchoAgent("z"))
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("m", _EchoAgent("m"))
+        )
+        assert runtime.agent_names == ["z", "a", "m"]
+
+    def test_add_agent_duplicate_name_replaces(self) -> None:
+        runtime = (
+            OrchestrationRuntime()
+            .add_agent("a", _EchoAgent("a1"))
+            .add_agent("a", _EchoAgent("a2"))
+        )
+        assert runtime.agent_count == 1
+
+    def test_add_agent_rejects_empty_name(self) -> None:
+        with pytest.raises(ValueError, match="non-empty name"):
+            OrchestrationRuntime().add_agent("", _EchoAgent("a"))
+
+    def test_strategy_setter(self) -> None:
+        runtime = OrchestrationRuntime().strategy(OrchestrationStrategy.parallel())
+        assert runtime.current_strategy.kind is OrchestrationStrategyKind.PARALLEL
+
+    def test_strategy_setter_rejects_none(self) -> None:
+        with pytest.raises(ValueError, match="non-None strategy"):
+            OrchestrationRuntime().strategy(None)  # type: ignore[arg-type]
+
+    def test_config_setter(self) -> None:
+        cfg = OrchestrationConfig(
+            max_total_iterations=10,
+            max_agent_calls=20,
+            timeout_secs=60.0,
+            fail_fast=False,
+            share_conversation_history=True,
+        )
+        runtime = OrchestrationRuntime().config(cfg)
+        assert runtime.current_config.max_total_iterations == 10
+        assert runtime.current_config.fail_fast is False
+
+    def test_config_setter_rejects_none(self) -> None:
+        with pytest.raises(ValueError, match="non-None config"):
+            OrchestrationRuntime().config(None)  # type: ignore[arg-type]
+
+    def test_default_config_values(self) -> None:
+        cfg = OrchestrationConfig()
+        assert cfg.max_total_iterations == 50
+        assert cfg.max_agent_calls == 100
+        assert cfg.timeout_secs is None
+        assert cfg.fail_fast is True
+        assert cfg.share_conversation_history is False
+
+    def test_coordinator_setter(self) -> None:
+        coord = SharedMemoryCoordinator()
+        runtime = OrchestrationRuntime().coordinator(coord)
+        assert runtime.current_coordinator is coord
+
+    def test_coordinator_setter_accepts_none(self) -> None:
+        runtime = OrchestrationRuntime().coordinator(None)
+        assert runtime.current_coordinator is None
+
+
+# ---------------------------------------------------------------------------
+# Strategy enum
+# ---------------------------------------------------------------------------
+
+
+class TestStrategy:
+    def test_strategy_names(self) -> None:
+        assert OrchestrationStrategy.sequential().name == "sequential"
+        assert OrchestrationStrategy.parallel().name == "parallel"
+        assert OrchestrationStrategy.hierarchical("coord").name == "hierarchical"
+        assert (
+            OrchestrationStrategy.pipeline(
+                [PipelineStep("a", PipelineInputSource.from_initial())]
+            ).name
+            == "pipeline"
+        )
+
+    def test_hierarchical_requires_coordinator_name(self) -> None:
+        with pytest.raises(ValueError, match="coordinator_name"):
+            OrchestrationStrategy.hierarchical("")
+
+    def test_pipeline_requires_steps(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            OrchestrationStrategy.pipeline([])
+
+    def test_pipeline_input_source_factories(self) -> None:
+        a = PipelineInputSource.from_initial()
+        assert a.initial is True
+
+        b = PipelineInputSource.from_agent_output("upstream")
+        assert b.agent_name == "upstream"
+
+        c = PipelineInputSource.from_template("Summarize: {{x.response}}")
+        assert c.template == "Summarize: {{x.response}}"
+
+    def test_pipeline_input_source_validation(self) -> None:
+        with pytest.raises(ValueError):
+            PipelineInputSource.from_agent_output("")
+        with pytest.raises(ValueError):
+            PipelineInputSource.from_template(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Run errors
+# ---------------------------------------------------------------------------
+
+
+class TestRunErrors:
+    @pytest.mark.asyncio
+    async def test_run_empty_runtime_raises(self) -> None:
+        runtime = OrchestrationRuntime()
+        with pytest.raises(OrchestrationError, match="no agents registered"):
+            await runtime.run("hello")
+
+    @pytest.mark.asyncio
+    async def test_hierarchical_missing_coordinator_raises(self) -> None:
+        runtime = OrchestrationRuntime(
+            strategy=OrchestrationStrategy.hierarchical("nonexistent")
+        ).add_agent("worker", _EchoAgent("worker"))
+        with pytest.raises(OrchestrationError, match="coordinator agent"):
+            await runtime.run("test")
+
+    @pytest.mark.asyncio
+    async def test_pipeline_missing_agent_raises(self) -> None:
+        runtime = OrchestrationRuntime(
+            strategy=OrchestrationStrategy.pipeline(
+                [PipelineStep("nonexistent", PipelineInputSource.from_initial())]
+            )
+        ).add_agent("a", _EchoAgent("a"))
+        with pytest.raises(OrchestrationError, match="unknown agent"):
+            await runtime.run("test")
+
+    @pytest.mark.asyncio
+    async def test_pipeline_agent_output_unresolved_raises(self) -> None:
+        # Step 1 references the OUTPUT of "a" but "a" has not run yet.
+        runtime = (
+            OrchestrationRuntime(
+                strategy=OrchestrationStrategy.pipeline(
+                    [
+                        PipelineStep(
+                            "b",
+                            PipelineInputSource.from_agent_output("a"),
+                        ),
+                    ]
+                )
+            )
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("b", _EchoAgent("b"))
+        )
+        with pytest.raises(OrchestrationError, match="has not run"):
+            await runtime.run("test")
+
+
+# ---------------------------------------------------------------------------
+# Sequential
+# ---------------------------------------------------------------------------
+
+
+class TestSequential:
+    @pytest.mark.asyncio
+    async def test_sequential_single_agent(self) -> None:
+        runtime = OrchestrationRuntime().add_agent("echo", _EchoAgent("echo"))
+        result = await runtime.run("hello")
+        assert result.final_output == "[echo] hello"
+        assert "echo" in result.agent_results
+        assert result.total_iterations == 1
+        assert result.duration_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_sequential_chains_output(self) -> None:
+        runtime = (
+            OrchestrationRuntime()
+            .add_agent("researcher", _EchoAgent("researcher"))
+            .add_agent("writer", _EchoAgent("writer"))
+        )
+        result = await runtime.run("topic")
+        assert result.final_output == "[writer] [researcher] topic"
+        assert result.total_iterations == 2
+        assert result.total_tokens == 20  # 10 per agent
+
+    @pytest.mark.asyncio
+    async def test_sequential_three_agents(self) -> None:
+        runtime = (
+            OrchestrationRuntime()
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("b", _EchoAgent("b"))
+            .add_agent("c", _EchoAgent("c"))
+        )
+        result = await runtime.run("input")
+        assert result.final_output == "[c] [b] [a] input"
+        assert result.total_iterations == 3
+
+
+# ---------------------------------------------------------------------------
+# Parallel
+# ---------------------------------------------------------------------------
+
+
+class TestParallel:
+    @pytest.mark.asyncio
+    async def test_parallel_all_agents_receive_same_input(self) -> None:
+        runtime = (
+            OrchestrationRuntime(strategy=OrchestrationStrategy.parallel())
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("b", _EchoAgent("b"))
+        )
+        result = await runtime.run("hello")
+        assert result.agent_results["a"]["response"] == "[a] hello"
+        assert result.agent_results["b"]["response"] == "[b] hello"
+
+    @pytest.mark.asyncio
+    async def test_parallel_aggregates_tokens(self) -> None:
+        runtime = (
+            OrchestrationRuntime(strategy=OrchestrationStrategy.parallel())
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("b", _EchoAgent("b"))
+            .add_agent("c", _EchoAgent("c"))
+        )
+        result = await runtime.run("test")
+        assert result.total_tokens == 30  # 10 per agent
+
+    @pytest.mark.asyncio
+    async def test_parallel_fail_fast_propagates_error(self) -> None:
+        runtime = (
+            OrchestrationRuntime(
+                strategy=OrchestrationStrategy.parallel(),
+                config=OrchestrationConfig(fail_fast=True),
+            )
+            .add_agent("ok", _EchoAgent("ok"))
+            .add_agent("fail", _FailingAgent("fail"))
+        )
+        with pytest.raises(OrchestrationError, match="parallel agent"):
+            await runtime.run("test")
+
+    @pytest.mark.asyncio
+    async def test_parallel_no_fail_fast_collects_successes(self) -> None:
+        runtime = (
+            OrchestrationRuntime(
+                strategy=OrchestrationStrategy.parallel(),
+                config=OrchestrationConfig(fail_fast=False),
+            )
+            .add_agent("ok", _EchoAgent("ok"))
+            .add_agent("fail", _FailingAgent("fail"))
+        )
+        result = await runtime.run("test")
+        assert "ok" in result.agent_results
+        assert "fail" not in result.agent_results
+
+    @pytest.mark.asyncio
+    async def test_parallel_single_agent_unwrapped_output(self) -> None:
+        runtime = OrchestrationRuntime(
+            strategy=OrchestrationStrategy.parallel()
+        ).add_agent("solo", _EchoAgent("solo"))
+        result = await runtime.run("hi")
+        # Single-result form: lone response, no header decoration.
+        assert result.final_output == "[solo] hi"
+
+    @pytest.mark.asyncio
+    async def test_parallel_multi_agent_headered_output(self) -> None:
+        runtime = (
+            OrchestrationRuntime(strategy=OrchestrationStrategy.parallel())
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("b", _EchoAgent("b"))
+        )
+        result = await runtime.run("hi")
+        assert "--- a ---" in result.final_output
+        assert "[a] hi" in result.final_output
+        assert "--- b ---" in result.final_output
+        assert "[b] hi" in result.final_output
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestPipeline:
+    @pytest.mark.asyncio
+    async def test_pipeline_basic(self) -> None:
+        runtime = (
+            OrchestrationRuntime(
+                strategy=OrchestrationStrategy.pipeline(
+                    [
+                        PipelineStep("a", PipelineInputSource.from_initial()),
+                        PipelineStep(
+                            "b",
+                            PipelineInputSource.from_agent_output("a"),
+                        ),
+                    ]
+                )
+            )
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("b", _EchoAgent("b"))
+        )
+        result = await runtime.run("start")
+        assert result.final_output == "[b] [a] start"
+
+    @pytest.mark.asyncio
+    async def test_pipeline_with_template(self) -> None:
+        runtime = (
+            OrchestrationRuntime(
+                strategy=OrchestrationStrategy.pipeline(
+                    [
+                        PipelineStep("a", PipelineInputSource.from_initial()),
+                        PipelineStep(
+                            "b",
+                            PipelineInputSource.from_template(
+                                "Summarize: {{a.response}}"
+                            ),
+                        ),
+                    ]
+                )
+            )
+            .add_agent("a", _EchoAgent("a"))
+            .add_agent("b", _EchoAgent("b"))
+        )
+        result = await runtime.run("research topic")
+        assert result.final_output == "[b] Summarize: [a] research topic"
+
+
+# ---------------------------------------------------------------------------
+# Hierarchical
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchical:
+    @pytest.mark.asyncio
+    async def test_hierarchical_runs_coordinator_then_workers(self) -> None:
+        runtime = (
+            OrchestrationRuntime(strategy=OrchestrationStrategy.hierarchical("coord"))
+            .add_agent("coord", _EchoAgent("coord"))
+            .add_agent("worker_a", _EchoAgent("worker_a"))
+            .add_agent("worker_b", _EchoAgent("worker_b"))
+        )
+        result = await runtime.run("plan")
+        assert result.total_iterations == 3
+        # Final output is the coordinator's response (the "synthesis").
+        assert result.final_output == "[coord] plan"
+        # Both workers received the coordinator's output as input.
+        assert result.agent_results["worker_a"]["response"] == "[worker_a] [coord] plan"
+        assert result.agent_results["worker_b"]["response"] == "[worker_b] [coord] plan"
+
+
+# ---------------------------------------------------------------------------
+# Timeout
+# ---------------------------------------------------------------------------
+
+
+class TestTimeout:
+    @pytest.mark.asyncio
+    async def test_run_with_timeout_succeeds_when_fast_enough(self) -> None:
+        runtime = OrchestrationRuntime(
+            config=OrchestrationConfig(timeout_secs=5.0),
+        ).add_agent("fast", _SlowAgent("fast", delay_ms=10))
+        result = await runtime.run("test")
+        assert result.final_output == "[fast] slow"
+
+    @pytest.mark.asyncio
+    async def test_run_with_timeout_fails_when_too_slow(self) -> None:
+        import asyncio
+
+        runtime = OrchestrationRuntime(
+            config=OrchestrationConfig(timeout_secs=0.05),
+        ).add_agent("slow", _SlowAgent("slow", delay_ms=2000))
+        with pytest.raises(asyncio.TimeoutError):
+            await runtime.run("test")
+
+
+# ---------------------------------------------------------------------------
+# Coordinator integration (Tier-1 — uses default in-memory coordinator)
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinator:
+    @pytest.mark.asyncio
+    async def test_sequential_with_coordinator(self) -> None:
+        coord = SharedMemoryCoordinator()
+        runtime = (
+            OrchestrationRuntime(coordinator=coord)
+            .add_agent("writer", _MemoryWriterAgent("writer", "research", "findings"))
+            .add_agent("reader", _MemoryReaderAgent("reader", "research"))
+        )
+        result = await runtime.run("start")
+        assert result.final_output == "research=findings"
+
+    @pytest.mark.asyncio
+    async def test_no_coordinator_means_isolated_agents(self) -> None:
+        # No coordinator passed — the reader sees `<no coordinator>`.
+        runtime = (
+            OrchestrationRuntime()
+            .add_agent("writer", _MemoryWriterAgent("writer", "research", "findings"))
+            .add_agent("reader", _MemoryReaderAgent("reader", "research"))
+        )
+        result = await runtime.run("start")
+        assert result.final_output == "research=<no coordinator>"
+
+
+# ---------------------------------------------------------------------------
+# Sync convenience
+# ---------------------------------------------------------------------------
+
+
+class TestRunSync:
+    def test_run_sync_executes_outside_event_loop(self) -> None:
+        runtime = OrchestrationRuntime().add_agent("echo", _EchoAgent("echo"))
+        result = runtime.run_sync("hi")
+        assert result.final_output == "[echo] hi"

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Nexus Changelog
 
+## [2.3.0] - 2026-04-25 — WebSocket per-connection unicast + on_message reply delivery (#618)
+
+### Added
+
+- **`MessageHandler.on_message` / `on_text` return values are auto-delivered (#618)**: when a class-based WebSocket handler returns a non-`None` value from `on_message` or `on_text`, the registry sends it back to the originating client on the same connection — no need for the handler to call `await conn.send_json(...)` explicitly. Type contract: `dict`/`list` → JSON via `send_json`, `str` → raw text via `send_text`, `bytes` → UTF-8 decoded then `send_text` (invalid UTF-8 logged at WARN and dropped), `None` → no auto-reply (handler-owned send). Tenant-safe by construction — the auto-reply CAN ONLY reach the originating socket. Cross-SDK parity with `kailash-rs#589`.
+- **`Nexus.websocket_send_to(path, connection_id, payload) -> bool` (#618)**: per-connection unicast push from external publishers. Use this when an external producer (DataFlow change stream, message-queue consumer, scheduled job) needs to address ONE specific client by its `connection_id`, not the broadcast set. Dispatch is scoped to the named connection — no other client receives the frame, so per-tenant push is safe by construction. Returns `False` (no raise) for unknown path, unknown `connection_id`, or already-closed socket. Mirrors `MessageHandlerRegistry.send_to` with the same name on the `Nexus` facade for parity with `websocket_broadcast`.
+- **`MessageHandlerRegistry.send_to(path, connection_id, payload)`**: the registry-level primitive. Reuses `Connection.send_json` / `send_text` so the wire frame matches `on_message` auto-replies bit-for-bit.
+
+### Changed
+
+- `MessageHandler.on_message` / `on_text` return type widened from `None` to `Any` (with documented per-shape delivery semantics). Backward-compatible — handlers returning `None` continue to behave as before.
+
+### Migration
+
+- 2.2.x → 2.3.0 is additive. No required handler changes. Handlers that already call `await conn.send_json(...)` and return `None` keep working unchanged. Handlers that previously had to duplicate their reply payload (return + explicit send) MAY now drop the explicit send and rely on the return-value contract.
+
 ## [2.2.0] - 2026-04-23 — ML bridge: tenant/actor ContextVars, MLDashboard auth, ml-endpoint mount (W31.c)
 
 ### Added

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.2.0"
+version = "2.3.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -102,7 +102,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 __all__ = [
     # Core
     "Nexus",

--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -686,6 +686,37 @@ class Nexus:
         """
         await self._ws_message_handlers.broadcast_event(path, event)
 
+    async def websocket_send_to(
+        self, path: str, connection_id: str, payload: Any
+    ) -> bool:
+        """Send ``payload`` to a single tracked WebSocket connection.
+
+        Issue #618 — per-connection unicast push from external
+        publishers. Use this when an external producer (DataFlow
+        change stream, message-queue consumer, scheduled job) needs
+        to address ONE specific client by its
+        :attr:`~nexus.websocket_handlers.Connection.connection_id`,
+        not the broadcast set. Dispatch is scoped to the named
+        connection — no other client receives the frame, so per-
+        tenant push is safe by construction.
+
+        Args:
+            path: URL path the target connection was registered on.
+            connection_id: ``connection_id`` returned to the handler's
+                ``on_connect``.
+            payload: JSON-serializable dict/list, raw ``str``, or
+                UTF-8 ``bytes``.
+
+        Returns:
+            ``True`` if the frame was sent; ``False`` if the path has
+            no registered handler, the connection_id is unknown, or
+            the socket is already closed / the send failed.
+
+        Cross-SDK parity: kailash-rs#589 ships the equivalent Rust
+        primitive.
+        """
+        return await self._ws_message_handlers.send_to(path, connection_id, payload)
+
     @property
     def websocket_handlers(self):
         """Read-only access to the class-based message handler registry."""

--- a/packages/kailash-nexus/src/nexus/websocket_handlers.py
+++ b/packages/kailash-nexus/src/nexus/websocket_handlers.py
@@ -286,20 +286,40 @@ class MessageHandler:
         """
         return None
 
-    async def on_message(self, conn: Connection, msg: Dict[str, Any]) -> None:
+    async def on_message(self, conn: Connection, msg: Dict[str, Any]) -> Any:
         """Called for each JSON-decoded message from the client.
 
         ``msg`` is a dict parsed from the client's JSON frame. For
         non-JSON text frames :meth:`on_text` is called instead.
         Override in subclass.
+
+        **Return value handling (issue #618):** If this method returns a
+        non-``None`` value, the registry sends it back to the same
+        client on the same connection as a unicast reply:
+
+        - ``dict`` / ``list`` → JSON-encoded text frame via
+          :meth:`Connection.send_json`.
+        - ``str`` → raw text frame via :meth:`Connection.send_text`.
+        - ``bytes`` → decoded as UTF-8 and sent as text frame; raises
+          :class:`UnicodeDecodeError` only if the bytes are not valid
+          UTF-8 (logged at WARN, frame dropped).
+        - ``None`` → no auto-reply; the handler is free to call
+          ``await conn.send_*`` explicitly.
+
+        Cross-SDK parity: kailash-rs#589 implements the same
+        return-value-as-reply contract on the Rust side.
         """
         return None
 
-    async def on_text(self, conn: Connection, text: str) -> None:
+    async def on_text(self, conn: Connection, text: str) -> Any:
         """Called for each non-JSON text frame from the client.
 
         Default implementation logs at DEBUG and drops the frame.
         Override to handle raw text protocols.
+
+        **Return value handling (issue #618):** Same contract as
+        :meth:`on_message` — non-``None`` return values are auto-sent
+        back to the same client.
         """
         logger.debug(
             "ws.handler.text_frame_dropped",
@@ -584,7 +604,7 @@ class MessageHandlerRegistry:
         handler: MessageHandler, conn: Connection, msg: Dict[str, Any]
     ) -> None:
         try:
-            await handler.on_message(conn, msg)
+            reply = await handler.on_message(conn, msg)
         except Exception:  # noqa: BLE001
             logger.exception(
                 "ws.handler.on_message_error",
@@ -593,19 +613,83 @@ class MessageHandlerRegistry:
                     "connection_id": conn.connection_id,
                 },
             )
+            return
+        await MessageHandlerRegistry._deliver_reply(conn, reply)
 
     @staticmethod
     async def _safe_on_text(
         handler: MessageHandler, conn: Connection, text: str
     ) -> None:
         try:
-            await handler.on_text(conn, text)
+            reply = await handler.on_text(conn, text)
         except Exception:  # noqa: BLE001
             logger.exception(
                 "ws.handler.on_text_error",
                 extra={
                     "path": conn.path,
                     "connection_id": conn.connection_id,
+                },
+            )
+            return
+        await MessageHandlerRegistry._deliver_reply(conn, reply)
+
+    # ------------------------------------------------------------------
+    # on_message return-value delivery (issue #618 + cross-SDK kailash-rs#589)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def _deliver_reply(conn: Connection, reply: Any) -> None:
+        """Deliver a non-None ``on_message`` / ``on_text`` return value.
+
+        Tenant-safe by construction: dispatch is scoped to ``conn`` —
+        the same socket the client sent the request on. No broadcast
+        leakage; the reply CAN ONLY reach the originating client.
+
+        Type contract:
+        - ``None``  → no-op (handler did its own send, or doesn't reply)
+        - ``dict`` / ``list`` → JSON via ``send_json``
+        - ``str`` → raw text via ``send_text``
+        - ``bytes`` → UTF-8 decoded then ``send_text``; on
+          ``UnicodeDecodeError`` log WARN and drop
+        - any other type → ``send_json`` (best-effort
+          ``json.dumps(default=str)``); ``TypeError`` logged at WARN.
+        """
+        if reply is None:
+            return
+        if isinstance(reply, (dict, list)):
+            await conn.send_json(reply)
+            return
+        if isinstance(reply, str):
+            await conn.send_text(reply)
+            return
+        if isinstance(reply, (bytes, bytearray)):
+            try:
+                text = bytes(reply).decode("utf-8")
+            except UnicodeDecodeError as exc:
+                logger.warning(
+                    "ws.handler.reply_bytes_not_utf8",
+                    extra={
+                        "path": conn.path,
+                        "connection_id": conn.connection_id,
+                        "error": str(exc),
+                    },
+                )
+                return
+            await conn.send_text(text)
+            return
+        # Fallback for arbitrary serializable objects (numbers, bools,
+        # custom dataclasses with default=str). Same shape as send_json
+        # so handlers that return a typed object behave like dict.
+        try:
+            await conn.send_json(reply)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "ws.handler.reply_unserializable",
+                extra={
+                    "path": conn.path,
+                    "connection_id": conn.connection_id,
+                    "type": type(reply).__name__,
+                    "error": str(exc),
                 },
             )
 
@@ -622,6 +706,67 @@ class MessageHandlerRegistry:
         if handler is None:
             raise KeyError(f"no websocket handler registered at {path!r}")
         await handler.broadcast_event(event)
+
+    async def send_to(self, path: str, connection_id: str, payload: Any) -> bool:
+        """Send ``payload`` to a single tracked connection (issue #618).
+
+        External-publisher unicast: scoped to the exact connection
+        identified by (``path``, ``connection_id``). Tenant-safe by
+        construction — the dispatch reaches ONLY the named socket;
+        every other connection on the same path is unaffected.
+
+        Args:
+            path: URL path the connection was registered on (e.g.
+                ``"/events"``). MUST match a registered handler.
+            connection_id: The :attr:`Connection.connection_id`
+                returned by ``on_connect`` for the target client.
+            payload: JSON-serializable value (sent via
+                :meth:`Connection.send_json`), :class:`str` (sent via
+                :meth:`Connection.send_text`), or :class:`bytes`
+                (UTF-8 decoded then sent as text frame).
+
+        Returns:
+            ``True`` if the frame was successfully handed to the
+            socket; ``False`` if the path has no registered handler,
+            the connection_id is unknown, the connection is already
+            closed, or the send raised. The registry prunes dead
+            connections on the next receive cycle in either case.
+        """
+        path_conns = self._connections_by_path.get(path)
+        if path_conns is None:
+            logger.debug(
+                "ws.send_to.unknown_path",
+                extra={"path": path, "connection_id": connection_id},
+            )
+            return False
+        conn = path_conns.get(connection_id)
+        if conn is None:
+            logger.debug(
+                "ws.send_to.unknown_connection_id",
+                extra={"path": path, "connection_id": connection_id},
+            )
+            return False
+        if not conn.alive:
+            return False
+        # Reuse the shared delivery contract so external send_to and
+        # on_message return-value reply produce identical wire frames.
+        if isinstance(payload, str):
+            return await conn.send_text(payload)
+        if isinstance(payload, (bytes, bytearray)):
+            try:
+                text = bytes(payload).decode("utf-8")
+            except UnicodeDecodeError as exc:
+                logger.warning(
+                    "ws.send_to.bytes_not_utf8",
+                    extra={
+                        "path": path,
+                        "connection_id": connection_id,
+                        "error": str(exc),
+                    },
+                )
+                return False
+            return await conn.send_text(text)
+        return await conn.send_json(payload)
 
     # ------------------------------------------------------------------
     # Internals used by MessageHandler

--- a/packages/kailash-nexus/tests/integration/test_websocket_unicast.py
+++ b/packages/kailash-nexus/tests/integration/test_websocket_unicast.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 2 integration tests for issue #618 — WebSocket unicast.
+
+Two empirically-verified gaps in kailash-nexus 2.2.x (cross-SDK with
+``kailash-rs#589``) are closed:
+
+1. ``MessageHandler.on_message`` return value was discarded by
+   :meth:`MessageHandlerRegistry._safe_on_message`. A handler that
+   returned ``"echo: foo"`` silently never reached the originating
+   client; the client timed out waiting on the reply unless the
+   handler also called ``await conn.send_json(...)`` explicitly,
+   duplicating the value.
+
+2. Per-connection unicast push from EXTERNAL publishers (e.g., a
+   DataFlow change stream that knows the target ``connection_id``)
+   had no entry point. ``websocket_broadcast`` fans out to every
+   connection via ``on_event``; there was no equivalent
+   ``send_to(path, connection_id, payload)``.
+
+These tests run a real ``websockets`` server under
+:class:`WebSocketTransport` and drive it from a real ``websockets``
+client. Per ``rules/testing.md`` § 3-Tier Testing, NO mocking.
+Per ``rules/facade-manager-detection.md`` MUST Rule 1, the registry
+is exercised through the ``app.websocket_handlers`` /
+``app.websocket_send_to`` facade rather than direct class imports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import socket
+from typing import Any, List
+
+import pytest
+import websockets
+
+from nexus import Nexus
+from nexus.registry import HandlerRegistry
+from nexus.transports.websocket import WebSocketTransport
+from nexus.websocket_handlers import Connection, MessageHandler
+
+
+def _free_port() -> int:
+    """Bind to port 0 to let the kernel pick a free port, then release."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+async def ws_server():
+    """Start a WebSocketTransport wired to a fresh Nexus's registry.
+
+    Mirrors the fixture in ``test_websocket_message_handlers.py`` so the
+    integration setup matches what users write.
+    """
+    app = Nexus(enable_auth=False, enable_monitoring=False)
+    port = _free_port()
+    transport = WebSocketTransport(
+        host="127.0.0.1",
+        port=port,
+        path="/legacy-ws",  # legacy JSON-RPC path, not used by these tests
+        ping_interval=5.0,
+        ping_timeout=5.0,
+    )
+    app.add_transport(transport)
+
+    registry = HandlerRegistry()
+    await transport.start(registry)
+
+    for _ in range(50):
+        if transport.is_running:
+            break
+        await asyncio.sleep(0.02)
+    assert transport.is_running, "WebSocketTransport did not start in time"
+
+    yield app, port
+
+    await transport.stop()
+
+
+# ---------------------------------------------------------------------------
+# 1. on_message return-value delivery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_on_message_dict_return_delivered_to_sender(ws_server):
+    """Returning a dict from on_message echoes back to the same client."""
+    app, port = ws_server
+
+    @app.websocket("/echo-dict")
+    class EchoDict(MessageHandler):
+        async def on_message(self, conn: Connection, msg: Any) -> Any:
+            return {"echo": msg.get("hello")}
+
+    uri = f"ws://127.0.0.1:{port}/echo-dict"
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"hello": "world"}))
+        reply = await asyncio.wait_for(ws.recv(), timeout=2.0)
+        assert json.loads(reply) == {"echo": "world"}
+
+
+@pytest.mark.integration
+async def test_on_message_str_return_delivered_as_text_frame(ws_server):
+    """Returning a str sends a raw text frame (not JSON-encoded)."""
+    app, port = ws_server
+
+    @app.websocket("/echo-str")
+    class EchoStr(MessageHandler):
+        async def on_message(self, conn: Connection, msg: Any) -> Any:
+            return f"echo: {msg.get('hello')}"
+
+    uri = f"ws://127.0.0.1:{port}/echo-str"
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"hello": "world"}))
+        reply = await asyncio.wait_for(ws.recv(), timeout=2.0)
+        # str returns produce a raw text frame, not a JSON-encoded one
+        assert reply == "echo: world"
+
+
+@pytest.mark.integration
+async def test_on_message_bytes_return_decoded_as_utf8(ws_server):
+    """Returning bytes decodes as UTF-8 and sends as text frame."""
+    app, port = ws_server
+
+    @app.websocket("/echo-bytes")
+    class EchoBytes(MessageHandler):
+        async def on_message(self, conn: Connection, msg: Any) -> Any:
+            return f"bytes: {msg.get('hello')}".encode("utf-8")
+
+    uri = f"ws://127.0.0.1:{port}/echo-bytes"
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"hello": "world"}))
+        reply = await asyncio.wait_for(ws.recv(), timeout=2.0)
+        assert reply == "bytes: world"
+
+
+@pytest.mark.integration
+async def test_on_message_none_return_no_auto_reply(ws_server):
+    """Returning None means handler-owned send: no auto-reply is generated."""
+    app, port = ws_server
+
+    @app.websocket("/no-reply")
+    class NoReply(MessageHandler):
+        async def on_message(self, conn: Connection, msg: Any) -> Any:
+            return None  # explicit no-reply
+
+    uri = f"ws://127.0.0.1:{port}/no-reply"
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"hello": "world"}))
+        # No frame should arrive within a short window
+        with contextlib.suppress(asyncio.TimeoutError):
+            unexpected = await asyncio.wait_for(ws.recv(), timeout=0.3)
+            raise AssertionError(
+                f"on_message returned None but client received {unexpected!r}"
+            )
+
+
+@pytest.mark.integration
+async def test_on_message_return_only_reaches_sender_not_other_clients(
+    ws_server,
+):
+    """Return value is unicast — sibling clients do NOT receive it."""
+    app, port = ws_server
+
+    @app.websocket("/private-echo")
+    class PrivateEcho(MessageHandler):
+        async def on_message(self, conn: Connection, msg: Any) -> Any:
+            return {"echo": msg.get("hello"), "to": conn.connection_id}
+
+    uri = f"ws://127.0.0.1:{port}/private-echo"
+    async with websockets.connect(uri) as alice:
+        async with websockets.connect(uri) as bob:
+            # Drain Bob's side so anything that leaks would be observable.
+            await alice.send(json.dumps({"hello": "alice-says"}))
+            alice_reply = await asyncio.wait_for(alice.recv(), timeout=2.0)
+            assert json.loads(alice_reply)["echo"] == "alice-says"
+
+            with contextlib.suppress(asyncio.TimeoutError):
+                leaked = await asyncio.wait_for(bob.recv(), timeout=0.3)
+                raise AssertionError(f"alice's reply leaked to bob: {leaked!r}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Nexus.websocket_send_to(path, connection_id, payload)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_websocket_send_to_targets_one_connection(ws_server):
+    """``app.websocket_send_to`` reaches only the named connection."""
+    app, port = ws_server
+    seen_ids: List[str] = []
+
+    @app.websocket("/named")
+    class NamedTargets(MessageHandler):
+        async def on_connect(self, conn: Connection) -> None:
+            seen_ids.append(conn.connection_id)
+
+    uri = f"ws://127.0.0.1:{port}/named"
+    async with websockets.connect(uri) as alice:
+        async with websockets.connect(uri) as bob:
+            # Wait until both connections have been recorded.
+            handler = app.websocket_handlers.get("/named")
+            assert handler is not None
+            for _ in range(100):
+                if handler.connection_count == 2 and len(seen_ids) == 2:
+                    break
+                await asyncio.sleep(0.02)
+            assert handler.connection_count == 2
+            alice_id, bob_id = seen_ids[0], seen_ids[1]
+
+            # Push a frame to ALICE only.
+            ok = await app.websocket_send_to("/named", alice_id, {"ping": "alice-only"})
+            assert ok is True
+
+            alice_reply = await asyncio.wait_for(alice.recv(), timeout=2.0)
+            assert json.loads(alice_reply) == {"ping": "alice-only"}
+
+            # BOB must NOT have received the frame.
+            with contextlib.suppress(asyncio.TimeoutError):
+                leaked = await asyncio.wait_for(bob.recv(), timeout=0.3)
+                raise AssertionError(
+                    f"send_to targeted alice but bob received {leaked!r}"
+                )
+
+
+@pytest.mark.integration
+async def test_websocket_send_to_unknown_path_returns_false(ws_server):
+    """Unknown path returns False and does not raise."""
+    app, _port = ws_server
+    ok = await app.websocket_send_to("/no-such-path", "deadbeef", {"x": 1})
+    assert ok is False
+
+
+@pytest.mark.integration
+async def test_websocket_send_to_unknown_connection_id_returns_false(
+    ws_server,
+):
+    """Known path + unknown connection_id returns False, no raise."""
+    app, port = ws_server
+
+    @app.websocket("/has-handler")
+    class _H(MessageHandler):
+        pass
+
+    # Connect once so the path has a registered handler with at least
+    # one tracked connection — the unknown id we pass MUST still miss.
+    uri = f"ws://127.0.0.1:{port}/has-handler"
+    async with websockets.connect(uri):
+        ok = await app.websocket_send_to(
+            "/has-handler", "deadbeef-not-a-real-id", {"x": 1}
+        )
+        assert ok is False
+
+
+@pytest.mark.integration
+async def test_websocket_send_to_str_payload_sends_text_frame(ws_server):
+    """A str payload is delivered as a raw text frame, not JSON-encoded."""
+    app, port = ws_server
+    captured: List[str] = []
+
+    @app.websocket("/text-frame")
+    class TextFrame(MessageHandler):
+        async def on_connect(self, conn: Connection) -> None:
+            captured.append(conn.connection_id)
+
+    uri = f"ws://127.0.0.1:{port}/text-frame"
+    async with websockets.connect(uri) as ws:
+        for _ in range(100):
+            if captured:
+                break
+            await asyncio.sleep(0.02)
+        assert captured
+
+        ok = await app.websocket_send_to("/text-frame", captured[0], "hello-text")
+        assert ok is True
+
+        reply = await asyncio.wait_for(ws.recv(), timeout=2.0)
+        assert reply == "hello-text"
+
+
+# ---------------------------------------------------------------------------
+# 3. Regression guard — broadcast still works
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_broadcast_event_still_works_after_send_to(ws_server):
+    """``websocket_broadcast`` pre-existing fanout is unaffected.
+
+    Guards against a refactor that wires ``send_to`` and accidentally
+    breaks the broadcast path.
+    """
+    app, port = ws_server
+
+    @app.websocket("/broadcast-still-works")
+    class FanoutEverybody(MessageHandler):
+        async def on_event(self, event: Any) -> None:
+            for c in self.connections:
+                await c.send_json(event)
+
+    uri = f"ws://127.0.0.1:{port}/broadcast-still-works"
+    async with websockets.connect(uri) as a:
+        async with websockets.connect(uri) as b:
+            handler = app.websocket_handlers.get("/broadcast-still-works")
+            assert handler is not None
+            for _ in range(100):
+                if handler.connection_count == 2:
+                    break
+                await asyncio.sleep(0.02)
+            assert handler.connection_count == 2
+
+            await app.websocket_broadcast("/broadcast-still-works", {"event": "ping"})
+
+            a_reply = await asyncio.wait_for(a.recv(), timeout=2.0)
+            b_reply = await asyncio.wait_for(b.recv(), timeout=2.0)
+            assert json.loads(a_reply) == {"event": "ping"}
+            assert json.loads(b_reply) == {"event": "ping"}

--- a/packages/kailash-nexus/tests/unit/test_websocket_handlers.py
+++ b/packages/kailash-nexus/tests/unit/test_websocket_handlers.py
@@ -583,3 +583,286 @@ class TestConnectionSend:
         ok = await conn.send_text("pong")
         assert ok is True
         assert ws.sent == ["pong"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #618 — on_message return-value delivery
+# ---------------------------------------------------------------------------
+
+
+class TestOnMessageReturnDelivery:
+    """Tier 1 coverage of the on_message return -> auto-reply contract."""
+
+    @pytest.mark.asyncio
+    async def test_dict_return_sent_as_json(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_message(self, conn, msg):
+                return {"echo": msg.get("hello")}
+
+        reg.register("/echo", H)
+        ws = FakeWebSocket([json.dumps({"hello": "world"})])
+        await reg.handle_connection(ws, "/echo")
+
+        # Two frames sent: handshake "connected" event is NOT (the
+        # registry doesn't emit one — only the transport does). So the
+        # only outbound frame here is the auto-reply.
+        assert ws.sent == ['{"echo": "world"}']
+
+    @pytest.mark.asyncio
+    async def test_list_return_sent_as_json(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_message(self, conn, msg):
+                return [1, 2, msg["n"]]
+
+        reg.register("/echo", H)
+        ws = FakeWebSocket([json.dumps({"n": 3})])
+        await reg.handle_connection(ws, "/echo")
+
+        assert ws.sent == ["[1, 2, 3]"]
+
+    @pytest.mark.asyncio
+    async def test_str_return_sent_as_text_frame(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_message(self, conn, msg):
+                return f"echo: {msg.get('hello')}"
+
+        reg.register("/echo", H)
+        ws = FakeWebSocket([json.dumps({"hello": "world"})])
+        await reg.handle_connection(ws, "/echo")
+
+        assert ws.sent == ["echo: world"]
+
+    @pytest.mark.asyncio
+    async def test_bytes_return_decoded_as_utf8(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_message(self, conn, msg):
+                return f"bytes: {msg.get('hello')}".encode("utf-8")
+
+        reg.register("/echo", H)
+        ws = FakeWebSocket([json.dumps({"hello": "world"})])
+        await reg.handle_connection(ws, "/echo")
+
+        assert ws.sent == ["bytes: world"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_utf8_bytes_logged_and_dropped(self, caplog):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_message(self, conn, msg):
+                return b"\xff\xfe\xfa"  # invalid UTF-8
+
+        reg.register("/echo", H)
+        ws = FakeWebSocket([json.dumps({"x": 1})])
+        with caplog.at_level("WARNING"):
+            await reg.handle_connection(ws, "/echo")
+
+        # Invalid bytes are NOT sent on the wire — silently dropped
+        # except for the WARN log line.
+        assert ws.sent == []
+        assert any(
+            "ws.handler.reply_bytes_not_utf8" in rec.message for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_none_return_no_auto_reply(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_message(self, conn, msg):
+                return None  # explicit no-reply
+
+        reg.register("/echo", H)
+        ws = FakeWebSocket([json.dumps({"hello": "world"})])
+        await reg.handle_connection(ws, "/echo")
+
+        assert ws.sent == []
+
+    @pytest.mark.asyncio
+    async def test_handler_can_still_send_explicitly_when_returning_none(self):
+        """Backward compatibility: existing handlers keep working."""
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_message(self, conn, msg):
+                await conn.send_json({"explicit": msg.get("hello")})
+                return None
+
+        reg.register("/echo", H)
+        ws = FakeWebSocket([json.dumps({"hello": "world"})])
+        await reg.handle_connection(ws, "/echo")
+
+        # Only the explicit send went out; no duplicate auto-reply.
+        assert ws.sent == ['{"explicit": "world"}']
+
+    @pytest.mark.asyncio
+    async def test_handler_raises_no_reply_sent(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_message(self, conn, msg):
+                raise RuntimeError("boom")
+
+        reg.register("/echo", H)
+        ws = FakeWebSocket([json.dumps({"hello": "world"})])
+        await reg.handle_connection(ws, "/echo")
+
+        # Exception is logged in _safe_on_message; no auto-reply.
+        assert ws.sent == []
+
+    @pytest.mark.asyncio
+    async def test_on_text_return_value_also_delivered(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            async def on_text(self, conn, text):
+                return f"got-text:{text}"
+
+        reg.register("/text", H)
+        ws = FakeWebSocket(["ping"])
+        await reg.handle_connection(ws, "/text")
+
+        assert ws.sent == ["got-text:ping"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #618 — MessageHandlerRegistry.send_to(path, connection_id, payload)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrySendTo:
+    """External-publisher unicast push to a single tracked connection."""
+
+    @pytest.mark.asyncio
+    async def test_send_to_known_connection_returns_true(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            pass
+
+        reg.register("/named", H)
+
+        # Inject a Connection directly (mimics handle_connection's setup
+        # without driving the receive loop).
+        ws = FakeWebSocket([])
+        conn = Connection(ws, "conn-1", "/named")
+        reg._connections_by_path["/named"]["conn-1"] = conn
+
+        ok = await reg.send_to("/named", "conn-1", {"ping": True})
+        assert ok is True
+        assert ws.sent == ['{"ping": true}']
+
+    @pytest.mark.asyncio
+    async def test_send_to_unknown_path_returns_false(self):
+        reg = MessageHandlerRegistry()
+        ok = await reg.send_to("/no-such-path", "conn-1", {"x": 1})
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_send_to_unknown_connection_id_returns_false(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            pass
+
+        reg.register("/named", H)
+        ok = await reg.send_to("/named", "no-such-id", {"x": 1})
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_send_to_dead_connection_returns_false(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            pass
+
+        reg.register("/named", H)
+        ws = FakeWebSocket([])
+        conn = Connection(ws, "conn-1", "/named")
+        conn._alive = False  # already disconnected
+        reg._connections_by_path["/named"]["conn-1"] = conn
+
+        ok = await reg.send_to("/named", "conn-1", {"ping": True})
+        assert ok is False
+        assert ws.sent == []  # no send attempted
+
+    @pytest.mark.asyncio
+    async def test_send_to_str_payload_uses_text_frame(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            pass
+
+        reg.register("/named", H)
+        ws = FakeWebSocket([])
+        conn = Connection(ws, "conn-1", "/named")
+        reg._connections_by_path["/named"]["conn-1"] = conn
+
+        ok = await reg.send_to("/named", "conn-1", "raw-text")
+        assert ok is True
+        assert ws.sent == ["raw-text"]
+
+    @pytest.mark.asyncio
+    async def test_send_to_bytes_payload_decoded_utf8(self):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            pass
+
+        reg.register("/named", H)
+        ws = FakeWebSocket([])
+        conn = Connection(ws, "conn-1", "/named")
+        reg._connections_by_path["/named"]["conn-1"] = conn
+
+        ok = await reg.send_to("/named", "conn-1", b"hello-bytes")
+        assert ok is True
+        assert ws.sent == ["hello-bytes"]
+
+    @pytest.mark.asyncio
+    async def test_send_to_only_targets_named_connection(self):
+        """Three connections; send_to reaches exactly one of them."""
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            pass
+
+        reg.register("/named", H)
+
+        sockets = {}
+        for cid in ["c1", "c2", "c3"]:
+            ws = FakeWebSocket([])
+            sockets[cid] = ws
+            conn = Connection(ws, cid, "/named")
+            reg._connections_by_path["/named"][cid] = conn
+
+        ok = await reg.send_to("/named", "c2", {"only-for": "c2"})
+        assert ok is True
+        assert sockets["c1"].sent == []
+        assert sockets["c2"].sent == ['{"only-for": "c2"}']
+        assert sockets["c3"].sent == []
+
+    @pytest.mark.asyncio
+    async def test_send_to_invalid_utf8_bytes_returns_false(self, caplog):
+        reg = MessageHandlerRegistry()
+
+        class H(MessageHandler):
+            pass
+
+        reg.register("/named", H)
+        ws = FakeWebSocket([])
+        conn = Connection(ws, "conn-1", "/named")
+        reg._connections_by_path["/named"]["conn-1"] = conn
+
+        with caplog.at_level("WARNING"):
+            ok = await reg.send_to("/named", "conn-1", b"\xff\xfe")
+        assert ok is False
+        assert ws.sent == []
+        assert any("ws.send_to.bytes_not_utf8" in rec.message for rec in caplog.records)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.9.2"
+version = "2.10.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/specs/kaizen-agents-governance.md
+++ b/specs/kaizen-agents-governance.md
@@ -1,6 +1,6 @@
 # Kailash Kaizen Agents Specification — Governance & Orchestration
 
-Version: 0.9.2
+Version: 0.9.3
 
 Parent domain: Kailash `kaizen-agents` package (Layer 2 — ENGINES). This file covers GovernedSupervisor, PACT governance subsystems, audit integration, event system, journey orchestration, agent lifecycle management, message transport, session management, runtime adapters, orchestration layer, and DataFlow integration. See also `kaizen-agents-core.md` and `kaizen-agents-patterns.md`.
 
@@ -453,6 +453,43 @@ Tool mapping submodules (`runtime_adapters/tool_mapping/`) handle provider-speci
 ### 19.5 Monitor
 
 `orchestration/monitor.py` — Monitors orchestration progress and health.
+
+### 19.6 Strategy-Driven Runtime — Cross-SDK Parity
+
+The `kaizen.orchestration.OrchestrationRuntime` class (added 2026-04-25, issue #602) ships the Python equivalent of the Rust `kaizen-agents::orchestration::runtime::OrchestrationRuntime` shape (kailash-rs ISS-27). This is the canonical strategy-driven multi-agent coordinator and is distinct from `kaizen_agents.patterns.OrchestrationRuntime` (registry/lifecycle/health-monitoring runtime for 10-100 agent fleets) and `kaizen.trust.orchestration.TrustAwareOrchestrationRuntime` (trust-policy enforcement).
+
+**Public surface (`kaizen.orchestration`):**
+
+- `OrchestrationRuntime(strategy, coordinator=None, config=None)` — strategy-driven runtime; builder-style `.add_agent(name, agent)`, `.strategy(s)`, `.coordinator(c)`, `.config(c)` setters all return `self`.
+- `OrchestrationStrategy` — frozen dataclass + classmethod factories: `sequential()`, `parallel()`, `hierarchical(coordinator_name)`, `pipeline(steps)`. Mirrors the Rust enum without exposing an opaque string surface.
+- `OrchestrationStrategyKind` — `StrEnum`; lowercase string values (`"sequential"`, `"parallel"`, `"hierarchical"`, `"pipeline"`) match the Rust serde discriminator.
+- `PipelineStep(agent_name, input_from)` + `PipelineInputSource` — pipeline strategy step descriptors; `PipelineInputSource.from_initial()`, `from_agent_output(name)`, `from_template(template)`.
+- `OrchestrationConfig(max_total_iterations=50, max_agent_calls=100, timeout_secs=None, fail_fast=True, share_conversation_history=False)` — field shape parity with Rust struct.
+- `OrchestrationResult(agent_results, final_output, total_iterations, total_tokens, duration_ms)` — field shape parity with Rust struct; `to_dict()` returns the cross-SDK-stable mapping.
+- `Coordinator` Protocol — `async store(key, value)` / `async retrieve(key) -> Optional`. Mirrors Rust's `Arc<dyn AgentMemory>`.
+- `AgentLike` Protocol — `name` property + `async run_async(**inputs) -> Mapping`. Real `kaizen.core.base_agent.BaseAgent` instances satisfy this Protocol; test/port shims may implement the minimum.
+- `SharedMemoryCoordinator` — default in-memory coordinator backed by `kaizen.memory.shared_memory.SharedMemoryPool`.
+- `OrchestrationError` — typed error subclassing `RuntimeError` for empty-runtime / unknown-coordinator / pipeline-step-references-unknown-agent / max-agent-calls.
+
+**Execution contract:**
+
+- `await runtime.run(input)` returns `OrchestrationResult`. Async-first to match the Rust `async fn run`.
+- `runtime.run_sync(input)` — synchronous convenience that calls `asyncio.run` internally. Per `rules/patterns.md` § "Paired Public Surface — Consistent Async-ness", this MUST NOT be called from inside an active event loop (raises `RuntimeError: This event loop is already running`); CLI/script use only.
+- `OrchestrationConfig.timeout_secs` enforced via `asyncio.wait_for`; on expiry `asyncio.TimeoutError` is raised (preserves the standard library type so existing `except asyncio.TimeoutError` handlers compose).
+- `fail_fast=True` (default) — Sequential / Hierarchical / Pipeline raise `OrchestrationError` on the first agent failure; Parallel cancels in-flight tasks and raises. `fail_fast=False` — Parallel collects all successes and surfaces the first error only when every agent failed.
+
+**Strategy semantics (mirrors Rust `_run_*` helpers):**
+
+| Strategy       | Input handling                                     | Final output                                                          |
+| -------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
+| Sequential     | Each agent receives prior agent's `response`.      | Last agent's response.                                                |
+| Parallel       | Every agent receives the same input.               | Single agent: lone response. Multi-agent: `--- name ---\n` headers.   |
+| Hierarchical   | Coordinator first; sub-agents receive its response | Coordinator's response (the synthesis).                               |
+| Pipeline       | Per-step input from `PipelineInputSource`          | Last step's response (preserves insertion order).                     |
+
+**Coordinator forwarding:** The default agent invoker forwards the registered `Coordinator` as a `coordinator=` kwarg ONLY when the target callable's signature accepts it (`inspect.signature` opt-in). This is structural plumbing (signature inspection), NOT runtime classification — agents that do not declare the kwarg run in isolation.
+
+**Cross-SDK parity tests:** `tests/integration/orchestration/test_runtime_e2e.py::TestCrossSdkShapeParity` locks the `OrchestrationResult` field set + `OrchestrationStrategyKind` lowercase values against the Rust struct shape. Field divergence between SDKs is caught at test-collection time, not at the wire.
 
 ---
 

--- a/specs/nexus-channels.md
+++ b/specs/nexus-channels.md
@@ -154,6 +154,32 @@ Server push:
 
 **Resource cleanup:** `__del__` emits `ResourceWarning` if transport was not stopped.
 
+#### 4.4.1 Class-based MessageHandler API
+
+For per-connection state, subscription fanout, or any pattern that exceeds stateless request/response, register a `MessageHandler` subclass at a path via `Nexus.websocket(path)` decorator or `Nexus.register_websocket(path, handler_cls)`. The `MessageHandlerRegistry` (`app.websocket_handlers`) routes incoming frames to the handler's lifecycle hooks and tracks `Connection` objects with isolated `state: SimpleNamespace`.
+
+**Lifecycle hooks (override in subclass, all async):**
+
+- `async on_connect(self, conn)` — fired after handshake; initialize `conn.state.*`.
+- `async on_message(self, conn, msg) -> Any` — fired per JSON-decoded frame; **return value contract** (issue #618):
+  - `None` → no auto-reply (handler-owned `await conn.send_*`).
+  - `dict` / `list` → auto-sent as JSON text frame via `conn.send_json`.
+  - `str` → auto-sent as raw text frame via `conn.send_text`.
+  - `bytes` → UTF-8 decoded then `conn.send_text`; invalid UTF-8 logged at WARN and dropped.
+  - any other → best-effort `conn.send_json` with `default=str`; `TypeError`/`ValueError` logged at WARN.
+- `async on_text(self, conn, text) -> Any` — same return-value contract as `on_message`.
+- `async on_disconnect(self, conn)` — fired after socket close; `conn` already removed from `self.connections`.
+- `async on_event(self, event)` — fanout hook called by `broadcast_event` (NOT by the framework directly).
+
+**Tenant safety:** `on_message` auto-replies are scoped to the originating socket — no broadcast leakage. Per-connection unicast push from external publishers uses `Nexus.websocket_send_to(path, connection_id, payload)` (issue #618), which scopes dispatch to one tracked connection.
+
+**Server-originated dispatch entry points (on `Nexus`):**
+
+- `await app.websocket_broadcast(path, event)` — fires `on_event` on the handler at `path`; raises `KeyError` if no handler is registered. The handler decides which connections receive the event (typically by iterating `self.connections` and filtering by `conn.state`).
+- `await app.websocket_send_to(path, connection_id, payload) -> bool` (issue #618) — sends `payload` to a single tracked connection. Returns `True` on successful send; `False` if path has no handler, `connection_id` is unknown, or the socket is closed / send failed. Payload typing: `dict`/`list` → JSON, `str` → text frame, `bytes` → UTF-8 decoded text frame.
+
+**Cross-SDK parity (issue #618):** Both the `on_message` return-value contract and the `send_to(path, connection_id, payload)` primitive match the Rust kailash-rs#589 surface semantically per EATP D6.
+
 ### 4.5 WebhookTransport
 
 **Module:** `nexus.transports.webhook`

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.9.2"
+__version__ = "2.10.0"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/channels/mcp/__init__.py
+++ b/src/kailash/channels/mcp/__init__.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""MCP transport primitives — client side.
+
+Three concrete transports speak the JSON-RPC wire protocol over
+different physical layers:
+
+- :class:`StdioTransport` — bidirectional stdin/stdout JSON-RPC framing
+  (LSP ``Content-Length`` framing) against a local subprocess MCP
+  server.
+- :class:`SseTransport` — HTTP POST + Server-Sent Events stream
+  against a remote SSE-exposed MCP server.
+- :class:`HttpTransport` — single-shot HTTP POST request/response
+  against a remote HTTP MCP endpoint (no server-push).
+
+All transports satisfy the :class:`Transport` ABC and may be passed
+to any consumer that accepts a ``Transport`` instance (kaizen, the
+MCP client utilities, etc.).
+
+This module mirrors the Rust SDK's ``kailash-mcp/src/transport/``
+crate for cross-SDK parity (EATP D6: independent implementation,
+matching wire semantics).
+"""
+
+from kailash.channels.mcp.base import (
+    ProtocolError,
+    Transport,
+    TransportError,
+    validate_url,
+)
+from kailash.channels.mcp.http import HttpTransport
+from kailash.channels.mcp.sse import SseTransport
+from kailash.channels.mcp.stdio import StdioTransport
+
+__all__ = [
+    "HttpTransport",
+    "ProtocolError",
+    "SseTransport",
+    "StdioTransport",
+    "Transport",
+    "TransportError",
+    "validate_url",
+]

--- a/src/kailash/channels/mcp/base.py
+++ b/src/kailash/channels/mcp/base.py
@@ -1,0 +1,205 @@
+"""Transport abstractions for MCP client-server communication.
+
+The :class:`Transport` abstract base hides the physical wire (stdio
+subprocess, HTTP, SSE, in-memory test queue) behind a single async
+``send`` call. The MCP client dispatches JSON-RPC requests through any
+implementation; the underlying I/O is an implementation detail.
+
+This mirrors the Rust SDK's ``McpTransport`` trait (see
+``kailash-rs/crates/kailash-mcp/src/transport/mod.rs``) for cross-SDK
+parity (EATP D6: independent implementation, matching semantics).
+
+Three concrete transports ship in this package:
+
+- :class:`~kailash.channels.mcp.stdio.StdioTransport` — bidirectional
+  stdin/stdout JSON-RPC framing (LSP-style ``Content-Length`` headers).
+- :class:`~kailash.channels.mcp.sse.SseTransport` — Server-Sent Events
+  client (HTTP POST for client→server, SSE for server→client).
+- :class:`~kailash.channels.mcp.http.HttpTransport` — HTTP POST request /
+  response (single-shot per-message).
+
+All transports validate user-supplied URLs for SSRF before connecting.
+See :func:`validate_url` for the policy.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from abc import ABC, abstractmethod
+from typing import Optional
+from urllib.parse import urlparse
+
+
+class TransportError(Exception):
+    """Base class for transport-layer failures.
+
+    Raised by :class:`Transport` implementations when the underlying I/O
+    fails (connection refused, EOF, framing error, malformed response).
+    Subclasses :class:`ConnectionError` so callers can ``except
+    ConnectionError`` if they prefer the stdlib base.
+    """
+
+
+class ProtocolError(TransportError):
+    """JSON-RPC framing or HTTP-status protocol violation.
+
+    Distinct from :class:`TransportError` for callers that want to
+    distinguish "transport down" (retry) from "server returned a 4xx /
+    5xx" (don't retry).
+    """
+
+
+class Transport(ABC):
+    """Abstract MCP transport.
+
+    Implementations send a JSON-encoded JSON-RPC request and return the
+    JSON-encoded response. The transport layer is responsible only for
+    framing and delivery — JSON parsing and method dispatch live in the
+    MCP client / server layer above.
+
+    All implementations MUST be safe to share across asyncio tasks; the
+    concrete transports use locks where needed (stdio's stdin/stdout)
+    or stateless HTTP clients (sse/http).
+    """
+
+    @abstractmethod
+    async def send(self, message: str) -> str:
+        """Send a JSON-RPC request and return the JSON-RPC response.
+
+        Args:
+            message: JSON-encoded JSON-RPC request string.
+
+        Returns:
+            JSON-encoded JSON-RPC response string.
+
+        Raises:
+            TransportError: If the underlying I/O fails.
+            ProtocolError: If the framing or HTTP status indicates a
+                protocol-level violation.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def receive(self) -> str:
+        """Receive a single JSON-RPC message from the server.
+
+        Used by transports that support server→client push (SSE event
+        stream, stdio out-of-band notifications). Transports that are
+        strictly request/response (plain HTTP) MAY raise
+        :class:`NotImplementedError` from ``receive``.
+
+        Returns:
+            JSON-encoded JSON-RPC message string.
+
+        Raises:
+            TransportError: If the underlying I/O fails.
+            NotImplementedError: If the transport does not support
+                unsolicited server messages.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Close the transport and release underlying resources.
+
+        Idempotent — calling :meth:`close` after the transport is
+        already closed is a no-op.
+        """
+        raise NotImplementedError
+
+    async def __aenter__(self) -> "Transport":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+
+# ---------------------------------------------------------------------------
+# SSRF validation — shared by HTTP and SSE transports.
+#
+# Mirrors the Rust ``transport::validate_url`` policy: only ``http`` and
+# ``https`` schemes; reject private / loopback / link-local addresses
+# unless the caller opts in via ``allow_private=True`` (intended for
+# internal service-mesh use).
+# ---------------------------------------------------------------------------
+
+
+def validate_url(raw_url: str, *, allow_private: bool = False) -> str:
+    """Validate ``raw_url`` for outbound MCP transport use.
+
+    Rules:
+
+    - Only ``http`` and ``https`` schemes are allowed.
+    - Unless ``allow_private`` is True, hosts that resolve syntactically
+      to a private, loopback, or link-local address are rejected.
+
+    DNS rebinding caveat: this check validates the URL **syntactically**
+    but does not resolve DNS. A hostname that DNS-resolves to a private
+    IP at connect time bypasses this check; pair with a DNS-aware
+    resolver if defense-in-depth is required.
+
+    Args:
+        raw_url: The candidate endpoint URL.
+        allow_private: If True, skip the private/loopback/link-local
+            check. Use only for endpoints from a trusted server-managed
+            source (admin-configured registry, internal service mesh).
+
+    Returns:
+        The normalized URL string (``parsed.geturl()`` form).
+
+    Raises:
+        TransportError: If the URL fails validation.
+    """
+    if not isinstance(raw_url, str) or not raw_url:
+        raise TransportError("URL must be a non-empty string")
+
+    try:
+        parsed = urlparse(raw_url)
+    except ValueError as exc:
+        raise TransportError(f"invalid URL: {exc}") from exc
+
+    if parsed.scheme not in ("http", "https"):
+        raise TransportError(
+            f"unsupported URL scheme {parsed.scheme!r}: only http and https are allowed"
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise TransportError("URL has no host")
+
+    if not allow_private and _is_private_host(host):
+        raise TransportError("URL points to private network")
+
+    return parsed.geturl()
+
+
+def _is_private_host(host: str) -> bool:
+    """Return True if ``host`` is a private/loopback/link-local address.
+
+    Handles raw IPv4, raw IPv6 (with brackets stripped by urlparse), and
+    well-known loopback hostnames (``localhost`` / ``*.localhost``).
+    Real hostnames that are not loopback fall through to False — DNS
+    rebinding is the caller's responsibility (see :func:`validate_url`).
+    """
+    # Try parsing as IP first.
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+
+    if ip is not None:
+        return ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_unspecified
+
+    lower = host.lower()
+    if lower == "localhost" or lower.endswith(".localhost"):
+        return True
+
+    return False
+
+
+__all__ = [
+    "Transport",
+    "TransportError",
+    "ProtocolError",
+    "validate_url",
+]

--- a/src/kailash/channels/mcp/http.py
+++ b/src/kailash/channels/mcp/http.py
@@ -1,0 +1,139 @@
+"""HTTP transport for MCP client communication.
+
+:class:`HttpTransport` sends JSON-RPC requests to an MCP server via
+HTTP POST. Each request is a single ``POST`` with
+``Content-Type: application/json`` and the response body contains the
+JSON-RPC response.
+
+This mirrors the Rust SDK's ``HttpTransport`` (see
+``kailash-rs/crates/kailash-mcp/src/transport/http.rs``) for cross-SDK
+parity. The wire format is identical — a Python client speaks to a
+Rust-served HTTP MCP endpoint and vice versa.
+
+The primary constructor :meth:`HttpTransport.__init__` validates the
+endpoint URL via :func:`kailash.channels.mcp.base.validate_url` to
+prevent SSRF; only ``http`` and ``https`` schemes are allowed and
+private/loopback addresses are rejected unless ``allow_private=True``
+is passed (intended for trusted internal endpoints).
+
+HTTP is a request/response transport — :meth:`receive` raises
+:class:`NotImplementedError` because the protocol does not support
+unsolicited server-push.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import aiohttp
+
+from .base import ProtocolError, Transport, TransportError, validate_url
+
+
+class HttpTransport(Transport):
+    """MCP client transport that sends JSON-RPC requests via HTTP POST.
+
+    Attributes:
+        endpoint_url: The validated endpoint URL.
+    """
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        *,
+        session: Optional[aiohttp.ClientSession] = None,
+        allow_private: bool = False,
+        timeout: float = 30.0,
+        headers: Optional[dict] = None,
+    ) -> None:
+        """Create an HTTP transport.
+
+        Args:
+            endpoint_url: Full MCP endpoint URL.
+            session: Optional pre-built :class:`aiohttp.ClientSession`.
+                If ``None`` a session is created lazily on first use and
+                owned/closed by this transport.
+            allow_private: Skip the SSRF check (use only when the URL
+                comes from a trusted server-managed source — admin
+                registry, internal service mesh).
+            timeout: Per-request timeout in seconds.
+            headers: Optional default headers added to every POST
+                (in addition to ``Content-Type: application/json``).
+        """
+        validated = validate_url(endpoint_url, allow_private=allow_private)
+        self.endpoint_url = validated
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session = session
+        self._owns_session = session is None
+        self._extra_headers = dict(headers or {})
+        self._closed = False
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
+            self._owns_session = True
+        return self._session
+
+    # ------------------------------------------------------------------
+    # Transport protocol
+    # ------------------------------------------------------------------
+
+    async def send(self, message: str) -> str:
+        """POST ``message`` to the endpoint and return the response body.
+
+        Raises:
+            TransportError: On connection failure / timeout.
+            ProtocolError: On HTTP 4xx / 5xx response.
+        """
+        if self._closed:
+            raise TransportError("transport is closed")
+
+        session = await self._ensure_session()
+        request_headers = {"Content-Type": "application/json"}
+        request_headers.update(self._extra_headers)
+
+        try:
+            async with session.post(
+                self.endpoint_url,
+                data=message,
+                headers=request_headers,
+            ) as response:
+                body = await response.text()
+                if response.status >= 400:
+                    raise ProtocolError(f"HTTP {response.status}: {body}")
+                return body
+        except asyncio.TimeoutError as exc:
+            raise TransportError(
+                f"HTTP request to {self.endpoint_url} timed out"
+            ) from exc
+        except aiohttp.ClientConnectionError as exc:
+            raise TransportError(
+                f"failed to connect to {self.endpoint_url}: {exc}"
+            ) from exc
+        except aiohttp.ClientError as exc:
+            raise TransportError(
+                f"HTTP request to {self.endpoint_url} failed: {exc}"
+            ) from exc
+
+    async def receive(self) -> str:
+        """HTTP transport does not support unsolicited server messages."""
+        raise NotImplementedError(
+            "HttpTransport does not support receive() — HTTP is "
+            "request/response only. Use SseTransport for server-push."
+        )
+
+    async def close(self) -> None:
+        """Close the HTTP session if owned."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._owns_session and self._session is not None:
+            try:
+                await self._session.close()
+            except Exception:
+                pass
+            self._session = None
+
+
+__all__ = ["HttpTransport"]

--- a/src/kailash/channels/mcp/sse.py
+++ b/src/kailash/channels/mcp/sse.py
@@ -1,0 +1,249 @@
+"""Server-Sent Events (SSE) transport — client side.
+
+:class:`SseTransport` connects to a remote MCP server exposing its
+JSON-RPC messages over a bidirectional HTTP-POST + SSE stream. The
+client POSTs requests to ``{base_url}/message`` and reads responses
+either inline (for synchronous servers) or from a Server-Sent Events
+stream at ``{base_url}/sse``.
+
+This mirrors the Rust SDK's ``SseClientTransport`` (see
+``kailash-rs/crates/kailash-mcp/src/transport/sse.rs``) for cross-SDK
+parity.
+
+All constructors validate the base URL via
+:func:`kailash.channels.mcp.base.validate_url` to prevent SSRF; only
+``http`` and ``https`` schemes are allowed and private/loopback
+addresses are rejected unless ``allow_private=True`` is passed.
+
+The full nexus SSE *server* (route registration, middleware, tool
+catalogue) lives in ``kailash.middleware.mcp``; this module hosts only
+the *client* side so any consumer (kaizen, mcp_executor, etc.) can speak
+to remote SSE-exposed MCP servers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Optional
+
+import aiohttp
+
+from .base import ProtocolError, Transport, TransportError, validate_url
+
+
+class SseTransport(Transport):
+    """MCP client transport over Server-Sent Events.
+
+    The client does an HTTP POST to ``{base}/message`` for each request.
+    The response body may be either:
+
+    - A plain JSON document (a server that answers synchronously).
+    - A single ``data: <json>`` SSE event line — the leading ``data:``
+      prefix is stripped before returning to the caller.
+
+    For unsolicited server-push notifications, call :meth:`receive` to
+    iterate the ``{base}/sse`` event stream.
+
+    Attributes:
+        base_url: The validated base URL (no trailing slash).
+        message_path: Endpoint path for POSTed requests (default
+            ``/message``).
+        sse_path: Endpoint path for the SSE event stream (default
+            ``/sse``).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        message_path: str = "/message",
+        sse_path: str = "/sse",
+        session: Optional[aiohttp.ClientSession] = None,
+        allow_private: bool = False,
+        timeout: float = 30.0,
+    ) -> None:
+        """Create an SSE transport.
+
+        Args:
+            base_url: Base URL of the remote MCP server.
+            message_path: Path for client→server POSTs.
+            sse_path: Path for the SSE event stream.
+            session: Optional pre-built :class:`aiohttp.ClientSession`.
+                If ``None`` a session is created lazily on first use and
+                owned/closed by this transport.
+            allow_private: Skip the SSRF check (intended for trusted
+                internal endpoints).
+            timeout: Request timeout in seconds.
+        """
+        validated = validate_url(base_url, allow_private=allow_private)
+        self.base_url = validated.rstrip("/")
+        self.message_path = (
+            message_path if message_path.startswith("/") else f"/{message_path}"
+        )
+        self.sse_path = sse_path if sse_path.startswith("/") else f"/{sse_path}"
+        self._timeout = aiohttp.ClientTimeout(total=timeout)
+        self._session = session
+        self._owns_session = session is None
+        self._closed = False
+        self._sse_response: Optional[aiohttp.ClientResponse] = None
+        self._sse_lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
+            self._owns_session = True
+        return self._session
+
+    @property
+    def message_url(self) -> str:
+        return f"{self.base_url}{self.message_path}"
+
+    @property
+    def sse_url(self) -> str:
+        return f"{self.base_url}{self.sse_path}"
+
+    # ------------------------------------------------------------------
+    # Transport protocol
+    # ------------------------------------------------------------------
+
+    async def send(self, message: str) -> str:
+        """POST ``message`` to ``{base}/message`` and return the body."""
+        if self._closed:
+            raise TransportError("transport is closed")
+
+        session = await self._ensure_session()
+        try:
+            async with session.post(
+                self.message_url,
+                data=message,
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                },
+            ) as response:
+                text = await response.text()
+                if response.status >= 400:
+                    raise ProtocolError(
+                        f"SSE POST returned HTTP {response.status}: {text}"
+                    )
+        except aiohttp.ClientError as exc:
+            raise TransportError(
+                f"SSE POST to {self.message_url} failed: {exc}"
+            ) from exc
+        except asyncio.TimeoutError as exc:
+            raise TransportError(f"SSE POST to {self.message_url} timed out") from exc
+
+        return _strip_sse_data_prefix(text)
+
+    async def receive(self) -> str:
+        """Read the next event from the ``{base}/sse`` event stream.
+
+        Opens the SSE connection lazily on first call. Subsequent calls
+        consume successive events from the same stream. The raw
+        ``data:`` line is returned (already stripped of the prefix).
+
+        Raises:
+            TransportError: On connection failure or stream EOF.
+            ProtocolError: On malformed SSE framing.
+        """
+        if self._closed:
+            raise TransportError("transport is closed")
+
+        async with self._sse_lock:
+            session = await self._ensure_session()
+            if self._sse_response is None or self._sse_response.closed:
+                try:
+                    self._sse_response = await session.get(
+                        self.sse_url,
+                        headers={"Accept": "text/event-stream"},
+                    )
+                except aiohttp.ClientError as exc:
+                    raise TransportError(
+                        f"failed to open SSE stream at {self.sse_url}: {exc}"
+                    ) from exc
+                if self._sse_response.status >= 400:
+                    text = await self._sse_response.text()
+                    self._sse_response.release()
+                    self._sse_response = None
+                    raise ProtocolError(
+                        f"SSE GET returned HTTP {self._sse_response.status if self._sse_response else '???'}: {text}"
+                    )
+
+            data_lines: list[str] = []
+            async for raw_line in self._sse_response.content:
+                line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+                if line == "":
+                    if data_lines:
+                        return "\n".join(data_lines)
+                    continue
+                if line.startswith(":"):
+                    # SSE comment line — ignore.
+                    continue
+                if line.startswith("data:"):
+                    data_lines.append(line[len("data:") :].lstrip())
+                # Any other field (event:, id:, retry:) is ignored for
+                # the JSON-RPC payload purposes.
+
+            raise TransportError("SSE stream closed before delivering an event")
+
+    async def close(self) -> None:
+        """Close the SSE stream and (if owned) the HTTP session."""
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._sse_response is not None and not self._sse_response.closed:
+            try:
+                self._sse_response.release()
+            except Exception:
+                pass
+            self._sse_response = None
+
+        if self._owns_session and self._session is not None:
+            try:
+                await self._session.close()
+            except Exception:
+                pass
+            self._session = None
+
+
+def _strip_sse_data_prefix(text: str) -> str:
+    """If ``text`` looks like a single SSE ``data:`` event, strip the prefix.
+
+    Accepts both forms:
+
+    - ``data: {"jsonrpc": ...}\\n\\n``  → strips ``data:`` + whitespace.
+    - ``{"jsonrpc": ...}``             → returned unchanged.
+
+    Multi-line SSE events (multiple ``data:`` lines) are joined with
+    newlines, matching the SSE spec's concatenation rule.
+    """
+    trimmed = text.strip()
+    if not trimmed:
+        return trimmed
+
+    # Plain JSON path: starts with `{` or `[`.
+    if trimmed[0] in "{[":
+        return trimmed
+
+    if not trimmed.startswith("data:"):
+        return trimmed
+
+    data_lines: list[str] = []
+    for raw_line in trimmed.splitlines():
+        line = raw_line.rstrip("\r\n")
+        if line.startswith(":"):
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[len("data:") :].lstrip())
+        elif line == "":
+            break
+    return "\n".join(data_lines)
+
+
+__all__ = ["SseTransport"]

--- a/src/kailash/channels/mcp/stdio.py
+++ b/src/kailash/channels/mcp/stdio.py
@@ -1,0 +1,307 @@
+"""Stdio transport for MCP client communication.
+
+:class:`StdioTransport` spawns an MCP server subprocess and exchanges
+JSON-RPC messages with it via stdin/stdout using LSP-style
+``Content-Length`` framing.
+
+Framing format (one message)::
+
+    Content-Length: <N>\\r\\n
+    \\r\\n
+    <JSON body of exactly N bytes>
+
+This mirrors the Rust SDK's ``StdioTransport`` (see
+``kailash-rs/crates/kailash-mcp/src/transport/stdio.rs``) for cross-SDK
+parity. Both implementations are wire-level compatible — a Python
+client can speak to a Rust-spawned MCP server and vice versa.
+
+Security: subprocess spawning never invokes a shell (``shell=False``),
+so the command/args are not interpreted by ``/bin/sh``. The caller is
+responsible for the executable allowlist; supply ``allowed_commands``
+to enforce one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+from asyncio.subprocess import Process
+from typing import Optional, Sequence
+
+from .base import ProtocolError, Transport, TransportError
+
+CONTENT_LENGTH_PREFIX = "Content-Length: "
+
+# 64 MiB cap on a single message body — matches the Rust limit and
+# guards against malicious / runaway peers that would otherwise drive
+# us to OOM by sending an outsized Content-Length header.
+MAX_MESSAGE_SIZE = 64 * 1024 * 1024
+
+
+class StdioTransport(Transport):
+    """MCP client transport over a subprocess's stdin/stdout.
+
+    Spawns a child process (no shell) and frames JSON-RPC messages with
+    LSP-style ``Content-Length`` headers. Only one request is in flight
+    at a time per transport instance — :meth:`send` serializes
+    write/read pairs through an :class:`asyncio.Lock`.
+
+    Construct via :meth:`spawn` (async classmethod) or
+    :meth:`from_process` (already-spawned process).
+
+    Attributes:
+        process: The child :class:`asyncio.subprocess.Process`.
+    """
+
+    def __init__(self, process: Process) -> None:
+        if process.stdin is None:
+            raise TransportError("child process stdin not available")
+        if process.stdout is None:
+            raise TransportError("child process stdout not available")
+        self.process = process
+        self._stdin = process.stdin
+        self._stdout = process.stdout
+        self._send_lock = asyncio.Lock()
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def spawn(
+        cls,
+        command: str,
+        args: Optional[Sequence[str]] = None,
+        *,
+        allowed_commands: Optional[Sequence[str]] = None,
+        env: Optional[dict] = None,
+        cwd: Optional[str] = None,
+    ) -> "StdioTransport":
+        """Spawn an MCP server subprocess and connect a transport.
+
+        Args:
+            command: Path or basename of the executable to spawn. Path
+                traversal sequences (``..``) are rejected.
+            args: Optional list of arguments to pass to the executable.
+            allowed_commands: If provided, the command's basename MUST
+                appear in this list — otherwise a :class:`TransportError`
+                is raised. Use this to enforce a strict allowlist for
+                user-supplied input.
+            env: Optional environment mapping (passed to the subprocess).
+            cwd: Optional working directory for the subprocess.
+
+        Returns:
+            A connected :class:`StdioTransport`.
+
+        Raises:
+            TransportError: If the command fails validation or spawning
+                fails.
+        """
+        cls._validate_command(command, allowed_commands)
+        cmd_args: list[str] = list(args or [])
+        try:
+            process = await asyncio.create_subprocess_exec(
+                command,
+                *cmd_args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+                env=env,
+                cwd=cwd,
+            )
+        except (OSError, FileNotFoundError) as exc:
+            raise TransportError(f"failed to spawn {command!r}: {exc}") from exc
+        return cls(process)
+
+    @classmethod
+    def from_process(cls, process: Process) -> "StdioTransport":
+        """Create a transport from an already-spawned subprocess.
+
+        The process MUST have been spawned with ``stdin=PIPE`` and
+        ``stdout=PIPE``. Useful when the caller wants control over
+        spawning (e.g., custom rlimits, namespace setup).
+        """
+        return cls(process)
+
+    @staticmethod
+    def _validate_command(command: str, allowed: Optional[Sequence[str]]) -> None:
+        if not isinstance(command, str) or not command:
+            raise TransportError("command must be a non-empty string")
+        if ".." in command.split(os.sep):
+            raise TransportError(f"command rejected (path traversal): {command!r}")
+        if allowed is not None:
+            basename = os.path.basename(command)
+            if basename not in allowed and command not in allowed:
+                allowed_str = ", ".join(repr(c) for c in allowed)
+                raise TransportError(
+                    f"command {command!r} not in the allowlist [{allowed_str}]"
+                )
+
+    # ------------------------------------------------------------------
+    # Transport protocol
+    # ------------------------------------------------------------------
+
+    async def send(self, message: str) -> str:
+        """Send a framed request, return the framed response."""
+        if self._closed:
+            raise TransportError("transport is closed")
+        async with self._send_lock:
+            await write_framed_message(self._stdin, message)
+            return await read_framed_message(self._stdout)
+
+    async def receive(self) -> str:
+        """Read a single unsolicited message from the subprocess.
+
+        For request/response use, prefer :meth:`send`. ``receive`` is
+        provided for transports / clients that subscribe to server-side
+        notifications.
+        """
+        if self._closed:
+            raise TransportError("transport is closed")
+        return await read_framed_message(self._stdout)
+
+    async def close(self) -> None:
+        """Close stdin/stdout and terminate the subprocess.
+
+        Idempotent. Sends EOF on stdin first to give a well-behaved
+        server a chance to exit cleanly; if it does not exit within a
+        short grace period the process is killed.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        try:
+            if self._stdin and not self._stdin.is_closing():
+                self._stdin.close()
+        except Exception:
+            pass
+
+        if self.process.returncode is None:
+            try:
+                await asyncio.wait_for(self.process.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                try:
+                    self.process.terminate()
+                except ProcessLookupError:
+                    pass
+                try:
+                    await asyncio.wait_for(self.process.wait(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    try:
+                        self.process.kill()
+                    except ProcessLookupError:
+                        pass
+                    try:
+                        await self.process.wait()
+                    except Exception:
+                        pass
+
+
+# ---------------------------------------------------------------------------
+# Framing helpers — exposed publicly so other transport-shaped consumers
+# (test fixtures, alternate stdio wrappers) can reuse the same wire
+# format without re-implementing it.
+# ---------------------------------------------------------------------------
+
+
+async def write_framed_message(writer: asyncio.StreamWriter, body: str) -> None:
+    """Write ``body`` to ``writer`` with LSP-style framing.
+
+    Format: ``Content-Length: <N>\\r\\n\\r\\n<body>``.
+
+    Raises:
+        TransportError: On underlying I/O failure.
+    """
+    body_bytes = body.encode("utf-8")
+    header = f"{CONTENT_LENGTH_PREFIX}{len(body_bytes)}\r\n\r\n".encode("ascii")
+    try:
+        writer.write(header)
+        writer.write(body_bytes)
+        await writer.drain()
+    except (ConnectionError, BrokenPipeError, OSError) as exc:
+        raise TransportError(f"failed to write framed message: {exc}") from exc
+
+
+async def read_framed_message(reader: asyncio.StreamReader) -> str:
+    """Read a single framed message from ``reader``.
+
+    Reads header lines until a blank line, parses the
+    ``Content-Length``, then reads exactly that many bytes for the
+    body.
+
+    Raises:
+        TransportError: On EOF or I/O error.
+        ProtocolError: If ``Content-Length`` is missing, malformed, or
+            exceeds :data:`MAX_MESSAGE_SIZE`, or if the body is not
+            valid UTF-8.
+    """
+    content_length: Optional[int] = None
+
+    while True:
+        try:
+            line = await reader.readline()
+        except (ConnectionError, OSError) as exc:
+            raise TransportError(f"failed to read header line: {exc}") from exc
+
+        if not line:
+            raise TransportError("EOF while reading headers")
+
+        try:
+            decoded = line.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise ProtocolError(f"non-ASCII byte in header line: {exc}") from exc
+
+        trimmed = decoded.rstrip("\r\n")
+        if trimmed == "":
+            break
+
+        if trimmed.startswith(CONTENT_LENGTH_PREFIX):
+            value = trimmed[len(CONTENT_LENGTH_PREFIX) :].strip()
+            try:
+                content_length = int(value)
+            except ValueError as exc:
+                raise ProtocolError(
+                    f"invalid Content-Length value {value!r}: {exc}"
+                ) from exc
+
+    if content_length is None:
+        raise ProtocolError("missing Content-Length header")
+    if content_length < 0:
+        raise ProtocolError(f"Content-Length {content_length} is negative")
+    if content_length > MAX_MESSAGE_SIZE:
+        raise ProtocolError(
+            f"Content-Length {content_length} exceeds maximum allowed size "
+            f"({MAX_MESSAGE_SIZE} bytes)"
+        )
+
+    try:
+        body = await reader.readexactly(content_length)
+    except asyncio.IncompleteReadError as exc:
+        raise TransportError(
+            f"failed to read message body ({content_length} bytes, "
+            f"got {len(exc.partial)})"
+        ) from exc
+    except (ConnectionError, OSError) as exc:
+        raise TransportError(f"failed to read message body: {exc}") from exc
+
+    try:
+        return body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ProtocolError(f"message body is not valid UTF-8: {exc}") from exc
+
+
+def _quote_for_log(command: str, args: Sequence[str]) -> str:
+    """Render a spawn command + args for log output (debug only)."""
+    return shlex.join([command, *args])
+
+
+__all__ = [
+    "StdioTransport",
+    "write_framed_message",
+    "read_framed_message",
+    "MAX_MESSAGE_SIZE",
+    "CONTENT_LENGTH_PREFIX",
+]

--- a/src/kailash/trust/constraints/budget_tracker.py
+++ b/src/kailash/trust/constraints/budget_tracker.py
@@ -23,7 +23,7 @@ import threading
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, ClassVar, Dict, List, Optional
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 from kailash.trust.exceptions import TrustError
 
@@ -60,7 +60,9 @@ class BudgetTrackerError(TrustError):
 # Dataclasses
 # ---------------------------------------------------------------------------
 
-_VALID_EVENT_TYPES = frozenset({"threshold_80", "threshold_95", "exhausted"})
+_VALID_EVENT_TYPES = frozenset(
+    {"threshold_80", "threshold_95", "exhausted", "custom_threshold"}
+)
 
 
 @dataclass
@@ -175,13 +177,29 @@ class BudgetEvent:
     """Event emitted when a budget threshold is crossed.
 
     ``event_type`` is one of ``"threshold_80"``, ``"threshold_95"``,
-    or ``"exhausted"``.
+    ``"exhausted"`` (fired by :meth:`BudgetTracker.on_threshold` callbacks
+    at the hardcoded 80%/95%/100% utilization marks), or
+    ``"custom_threshold"`` (fired by callbacks registered via
+    :meth:`BudgetTracker.set_threshold_callback` at a caller-supplied
+    fraction of allocated budget).
+
+    For ``"custom_threshold"`` events, ``threshold_pct`` is set to the
+    fractional threshold (e.g. ``0.80`` for 80%). For the hardcoded event
+    types, ``threshold_pct`` is set to the corresponding fraction
+    (``0.80`` / ``0.95`` / ``1.00``) for cross-callback uniformity.
+
+    ``committed_microdollars`` and ``reserved_microdollars`` capture the
+    point-in-time values at the moment the threshold was observed, so
+    callbacks can correlate the event with budget state without re-locking.
     """
 
     event_type: str
     remaining_microdollars: int
     allocated_microdollars: int
     timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    threshold_pct: Optional[float] = None
+    committed_microdollars: Optional[int] = None
+    reserved_microdollars: Optional[int] = None
 
     def __post_init__(self) -> None:
         if self.event_type not in _VALID_EVENT_TYPES:
@@ -189,15 +207,27 @@ class BudgetEvent:
                 f"Invalid event_type {self.event_type!r}; expected one of {sorted(_VALID_EVENT_TYPES)}",
                 details={"event_type": self.event_type},
             )
+        if self.threshold_pct is not None and not math.isfinite(self.threshold_pct):
+            raise BudgetTrackerError(
+                f"threshold_pct must be finite, got {self.threshold_pct!r}",
+                details={"threshold_pct": str(self.threshold_pct)},
+            )
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize to a plain dict. Datetime is ISO-8601 string."""
-        return {
+        out: Dict[str, Any] = {
             "event_type": self.event_type,
             "remaining_microdollars": self.remaining_microdollars,
             "allocated_microdollars": self.allocated_microdollars,
             "timestamp": self.timestamp.isoformat(),
         }
+        if self.threshold_pct is not None:
+            out["threshold_pct"] = self.threshold_pct
+        if self.committed_microdollars is not None:
+            out["committed_microdollars"] = self.committed_microdollars
+        if self.reserved_microdollars is not None:
+            out["reserved_microdollars"] = self.reserved_microdollars
+        return out
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> BudgetEvent:
@@ -228,11 +258,23 @@ class BudgetEvent:
                 f"Cannot parse timestamp: {ts_raw!r}",
                 details={"timestamp_raw": str(ts_raw)},
             )
+        threshold_pct_raw = data.get("threshold_pct")
+        committed_raw = data.get("committed_microdollars")
+        reserved_raw = data.get("reserved_microdollars")
         return cls(
             event_type=data["event_type"],
             remaining_microdollars=int(data["remaining_microdollars"]),
             allocated_microdollars=int(data["allocated_microdollars"]),
             timestamp=ts,
+            threshold_pct=(
+                float(threshold_pct_raw) if threshold_pct_raw is not None else None
+            ),
+            committed_microdollars=(
+                int(committed_raw) if committed_raw is not None else None
+            ),
+            reserved_microdollars=(
+                int(reserved_raw) if reserved_raw is not None else None
+            ),
         )
 
 
@@ -321,11 +363,22 @@ class BudgetTracker:
         )
         self._threshold_callbacks: List[Callable[[BudgetEvent], None]] = []
         self._record_callbacks: List[Callable[[], None]] = []
+        # Custom-threshold callbacks keyed by fractional threshold (0.0-1.0).
+        # Within a single key, callbacks fire in registration order.
+        # An auto-incremented handle is paired with each callback so the
+        # caller can pass it back to unregister_threshold_callback().
+        self._custom_threshold_callbacks: Dict[
+            float, List[Tuple[int, Callable[[BudgetEvent], None]]]
+        ] = {}
+        # Each (threshold_pct, handle) fires at most once per tracker.
+        self._fired_custom_handles: set[int] = set()
+        # Monotonic handle counter; never reused so unregister is unambiguous.
+        self._next_callback_handle: int = 1
         self._max_callbacks: int = 100
         self._store = store
         self._tracker_id = tracker_id
 
-        # Track which thresholds have already fired so we don't re-fire
+        # Track which hardcoded thresholds have already fired so we don't re-fire
         self._fired_thresholds: set[str] = set()
 
         # Auto-restore from store if available
@@ -375,6 +428,9 @@ class BudgetTracker:
         if microdollars == 0:
             return True
 
+        custom_dispatch: List[
+            Tuple[BudgetEvent, List[Callable[[BudgetEvent], None]]]
+        ] = []
         try:
             with self._lock:
                 available = self._allocated - self._committed - self._reserved
@@ -414,13 +470,21 @@ class BudgetTracker:
                     self._reserved,
                     self._allocated - self._committed - self._reserved,
                 )
-                return True
+                # Issue #603: collect custom-threshold dispatch list while
+                # still holding the lock; reserve() also crosses thresholds
+                # because (committed + reserved) just increased.
+                custom_dispatch = self._collect_custom_threshold_events()
         except Exception:
             # Fail-closed: any unexpected error -> deny
             logger.exception(
                 "Unexpected error in reserve() -- fail-closed, returning False"
             )
             return False
+
+        # Issue #603: dispatch outside the lock. Callback failure isolation
+        # is handled inside _dispatch_custom_threshold_callbacks.
+        self._dispatch_custom_threshold_callbacks(custom_dispatch)
+        return True
 
     def record(self, reserved_microdollars: int, actual_microdollars: int) -> None:
         """Finalize a reservation: release the reserved amount and commit the actual.
@@ -456,6 +520,9 @@ class BudgetTracker:
             )
 
         events_to_fire: List[BudgetEvent] = []
+        custom_dispatch: List[
+            Tuple[BudgetEvent, List[Callable[[BudgetEvent], None]]]
+        ] = []
         snapshot_to_save: Optional[BudgetSnapshot] = None
 
         with self._lock:
@@ -487,6 +554,10 @@ class BudgetTracker:
 
             # C1: Collect threshold events inside the lock but do NOT fire callbacks here
             events_to_fire = self._collect_threshold_events()
+            # Issue #603: collect custom-threshold dispatch list under the
+            # same lock so the rising-edge predicate is evaluated against a
+            # consistent (committed, reserved) pair.
+            custom_dispatch = self._collect_custom_threshold_events()
 
             # C3: Capture a consistent snapshot while still holding the lock
             if self._store is not None:
@@ -506,6 +577,11 @@ class BudgetTracker:
                         "Threshold callback raised exception for event %s -- ignoring",
                         event.event_type,
                     )
+
+        # Issue #603: dispatch custom-threshold callbacks OUTSIDE the lock.
+        # Failure of one callback MUST NOT prevent siblings from firing,
+        # and MUST NOT propagate to the record() caller.
+        self._dispatch_custom_threshold_callbacks(custom_dispatch)
 
         # C3: Save the snapshot that was captured consistently inside the lock.
         if (
@@ -654,6 +730,147 @@ class BudgetTracker:
             )
         self._record_callbacks.append(callback)
 
+    def set_threshold_callback(
+        self,
+        threshold_pct: float,
+        callback: Callable[[BudgetEvent], None],
+    ) -> int:
+        """Register a callback to fire when budget utilization crosses ``threshold_pct``.
+
+        Unlike :meth:`on_threshold`, which fires at hardcoded 80%, 95%, and
+        100% utilization marks, this method registers a callback at any
+        caller-supplied fraction of allocated budget.  The callback fires
+        once -- and only once -- per registration when the predicate
+
+            (committed + reserved) / allocated >= threshold_pct
+
+        first becomes true after a successful :meth:`record` or
+        :meth:`reserve` call.  State oscillation (committed/reserved
+        decreasing below the threshold and crossing it again) does NOT
+        re-fire the callback.
+
+        Multiple callbacks MAY be registered for the same threshold.
+        Within a single threshold, callbacks fire in registration order.
+        Callbacks for distinct thresholds fire in ascending threshold
+        order when a single mutation crosses several thresholds at once.
+
+        If a callback raises, the exception is logged at WARNING level via
+        ``logger.exception`` and execution continues to the next registered
+        callback for the same event.  The triggering :meth:`record` /
+        :meth:`reserve` call NEVER propagates a callback exception to its
+        caller -- this preserves the budget-accounting hot path.
+
+        Args:
+            threshold_pct: Fractional threshold in the half-open range
+                ``(0.0, 1.0]``.  ``0.80`` fires at 80% utilization;
+                ``1.0`` fires when ``committed + reserved >= allocated``.
+                Values outside this range, NaN, or infinite raise
+                :class:`BudgetTrackerError`.
+            callback: Callable accepting a :class:`BudgetEvent`.  The event
+                carries ``event_type="custom_threshold"``, the registered
+                ``threshold_pct``, and a snapshot of
+                ``committed_microdollars`` / ``reserved_microdollars`` /
+                ``remaining_microdollars`` at the moment of crossing.
+
+        Returns:
+            An opaque integer handle that can be passed to
+            :meth:`unregister_threshold_callback` to symmetrically remove
+            this registration.  Handles are unique within a tracker
+            instance and are never reused.
+
+        Raises:
+            BudgetTrackerError: If ``threshold_pct`` is not finite, is
+                ``<= 0.0``, or is ``> 1.0``.  Also raised if the maximum
+                callback limit (100) has been reached across the union of
+                all custom-threshold callbacks.
+
+        Example::
+
+            tracker = BudgetTracker(allocated_microdollars=10_000_000)
+            fired = []
+            tracker.set_threshold_callback(
+                0.80,
+                lambda evt: fired.append(evt.threshold_pct),
+            )
+            tracker.reserve(8_500_000)  # 85% -- callback fires once
+            tracker.record(8_500_000, 1_000_000)  # back to 10% -- no re-fire
+            tracker.reserve(9_500_000)  # back to 95% -- still no re-fire
+            assert fired == [0.80]
+        """
+        if not callable(callback):
+            raise BudgetTrackerError(
+                f"callback must be callable, got {type(callback).__name__}",
+                details={"callback_type": type(callback).__name__},
+            )
+        if not isinstance(threshold_pct, (int, float)) or isinstance(
+            threshold_pct, bool
+        ):
+            raise BudgetTrackerError(
+                f"threshold_pct must be a number, got {type(threshold_pct).__name__}",
+                details={"threshold_pct_type": type(threshold_pct).__name__},
+            )
+        threshold = float(threshold_pct)
+        if not math.isfinite(threshold):
+            raise BudgetTrackerError(
+                f"threshold_pct must be finite, got {threshold_pct!r}",
+                details={"threshold_pct": str(threshold_pct)},
+            )
+        if threshold <= 0.0 or threshold > 1.0:
+            raise BudgetTrackerError(
+                f"threshold_pct must satisfy 0.0 < pct <= 1.0, got {threshold!r}",
+                details={"threshold_pct": threshold},
+            )
+
+        with self._lock:
+            total = sum(len(v) for v in self._custom_threshold_callbacks.values())
+            if total >= self._max_callbacks:
+                raise BudgetTrackerError(
+                    f"Maximum custom-threshold callback limit ({self._max_callbacks}) reached",
+                    details={
+                        "callback_type": "custom_threshold",
+                        "limit": self._max_callbacks,
+                    },
+                )
+            handle = self._next_callback_handle
+            self._next_callback_handle += 1
+            self._custom_threshold_callbacks.setdefault(threshold, []).append(
+                (handle, callback)
+            )
+            return handle
+
+    def unregister_threshold_callback(self, handle: int) -> bool:
+        """Remove a callback previously registered via :meth:`set_threshold_callback`.
+
+        Args:
+            handle: The handle returned from :meth:`set_threshold_callback`.
+
+        Returns:
+            True if a callback with the given handle was removed; False if
+            the handle was not found (already unregistered or never valid).
+
+        Note:
+            Unregistering a callback after it has already fired does NOT
+            re-arm the registration.  Once a custom-threshold callback has
+            fired its one-shot, it stays fired even if its registration
+            slot is reused by a subsequent ``set_threshold_callback`` call
+            -- the new registration receives a fresh handle and a fresh
+            one-shot opportunity.
+        """
+        if not isinstance(handle, int) or isinstance(handle, bool):
+            return False
+        with self._lock:
+            for threshold, entries in list(self._custom_threshold_callbacks.items()):
+                for idx, (h, _cb) in enumerate(entries):
+                    if h == handle:
+                        del entries[idx]
+                        if not entries:
+                            del self._custom_threshold_callbacks[threshold]
+                        # Leave _fired_custom_handles entry in place so a
+                        # re-registration with a new handle gets a fresh
+                        # one-shot rather than re-firing on the old crossing.
+                        return True
+            return False
+
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------
@@ -705,11 +922,22 @@ class BudgetTracker:
         remaining = max(0, self._allocated - self._committed - self._reserved)
         # Float only for logging display
         utilization_pct_display = (self._committed / self._allocated) * 100
+        # Map hardcoded event_type -> threshold fraction for cross-callback
+        # uniformity; consumers may filter by threshold_pct regardless of
+        # whether the event came from on_threshold or set_threshold_callback.
+        _PCT_FOR_TYPE: Dict[str, float] = {
+            "threshold_80": 0.80,
+            "threshold_95": 0.95,
+            "exhausted": 1.00,
+        }
         for event_type in thresholds_to_fire:
             event = BudgetEvent(
                 event_type=event_type,
                 remaining_microdollars=remaining,
                 allocated_microdollars=self._allocated,
+                threshold_pct=_PCT_FOR_TYPE.get(event_type),
+                committed_microdollars=self._committed,
+                reserved_microdollars=self._reserved,
             )
             logger.info(
                 "Budget threshold crossed: %s (committed=%d, allocated=%d, %.1f%%)",
@@ -720,6 +948,103 @@ class BudgetTracker:
             )
             events.append(event)
         return events
+
+    def _collect_custom_threshold_events(
+        self,
+    ) -> List[Tuple[BudgetEvent, List[Callable[[BudgetEvent], None]]]]:
+        """Collect custom-threshold events that crossed since last evaluation.
+
+        Called under lock from both :meth:`record` and :meth:`reserve`. For
+        each threshold whose predicate
+        ``(committed + reserved) / allocated >= threshold_pct`` is now true
+        AND whose handle has not yet fired, this method:
+
+        1. Marks every callback at that threshold as fired (one-shot).
+        2. Builds one :class:`BudgetEvent` describing the crossing.
+        3. Returns ``(event, callbacks_in_registration_order)`` so the
+           caller can dispatch OUTSIDE the lock (avoids re-entrancy
+           deadlock when callbacks call back into the tracker).
+
+        Thresholds are visited in ascending order so that a single
+        mutation crossing both 0.50 and 0.80 fires the 0.50 callbacks
+        first.
+
+        Returns:
+            List of ``(event, callbacks)`` tuples, possibly empty. Each
+            tuple's callbacks list is a stable copy that survives
+            concurrent unregistration.
+        """
+        if self._allocated == 0 or not self._custom_threshold_callbacks:
+            return []
+
+        # claimed/allocated >= pct  <=>  claimed >= pct * allocated.
+        # Use float comparison; thresholds are bounded in (0,1] so
+        # float precision at the boundary matches the documented contract.
+        claimed = self._committed + self._reserved
+        allocated_f = float(self._allocated)
+
+        out: List[Tuple[BudgetEvent, List[Callable[[BudgetEvent], None]]]] = []
+        remaining = max(0, self._allocated - self._committed - self._reserved)
+        for threshold in sorted(self._custom_threshold_callbacks.keys()):
+            entries = self._custom_threshold_callbacks.get(threshold, [])
+            if not entries:
+                continue
+            # Predicate check
+            if (claimed / allocated_f) < threshold:
+                continue
+            unfired = [
+                (h, cb) for (h, cb) in entries if h not in self._fired_custom_handles
+            ]
+            if not unfired:
+                continue
+            # Mark fired NOW (still under lock) so concurrent
+            # reserve/record cannot double-collect the same handle.
+            for h, _cb in unfired:
+                self._fired_custom_handles.add(h)
+            event = BudgetEvent(
+                event_type="custom_threshold",
+                remaining_microdollars=remaining,
+                allocated_microdollars=self._allocated,
+                threshold_pct=threshold,
+                committed_microdollars=self._committed,
+                reserved_microdollars=self._reserved,
+            )
+            logger.info(
+                "Budget custom threshold crossed: %.4f "
+                "(committed=%d, reserved=%d, allocated=%d, claimed=%d)",
+                threshold,
+                self._committed,
+                self._reserved,
+                self._allocated,
+                claimed,
+            )
+            out.append((event, [cb for (_h, cb) in unfired]))
+        return out
+
+    def _dispatch_custom_threshold_callbacks(
+        self,
+        dispatch: List[Tuple[BudgetEvent, List[Callable[[BudgetEvent], None]]]],
+    ) -> None:
+        """Dispatch custom-threshold callbacks OUTSIDE the lock.
+
+        Issue #603: callback failures MUST NOT propagate to the caller of
+        :meth:`record` or :meth:`reserve`, AND MUST NOT prevent siblings
+        from firing. Each callback runs in its own try/except; raises are
+        logged at WARNING via ``logger.exception`` (which captures stack
+        trace). The ordering is: events in threshold-ascending order
+        (established in :meth:`_collect_custom_threshold_events`),
+        callbacks within an event in registration order.
+        """
+        for event, callbacks in dispatch:
+            for cb in callbacks:
+                try:
+                    cb(event)
+                except Exception:
+                    logger.exception(
+                        "Custom threshold callback raised exception for "
+                        "threshold_pct=%s -- ignoring",
+                        event.threshold_pct,
+                    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/channels/test_mcp_transports_real.py
+++ b/tests/integration/channels/test_mcp_transports_real.py
@@ -76,7 +76,7 @@ class TestStdioTransportReal:
         transport = await StdioTransport.spawn(
             command=sys.executable,
             args=[str(echo_script)],
-            allowed=[sys.executable, "python3", "python"],
+            allowed_commands=[sys.executable, "python3", "python"],
         )
         try:
             request = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "ping"})
@@ -91,8 +91,8 @@ class TestStdioTransportReal:
 
 
 @pytest.fixture
-async def http_echo_server(aiohttp_unused_port):
-    port = aiohttp_unused_port()
+async def http_echo_server(unused_tcp_port_factory):
+    port = unused_tcp_port_factory()
 
     async def handler(request: web.Request) -> web.Response:
         body = await request.text()
@@ -136,8 +136,8 @@ class TestHttpTransportReal:
 
 
 @pytest.fixture
-async def sse_server(aiohttp_unused_port):
-    port = aiohttp_unused_port()
+async def sse_server(unused_tcp_port_factory):
+    port = unused_tcp_port_factory()
 
     async def message_handler(request: web.Request) -> web.Response:
         body = await request.text()

--- a/tests/integration/channels/test_mcp_transports_real.py
+++ b/tests/integration/channels/test_mcp_transports_real.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 integration tests for MCP transport primitives — issue #600.
+
+NO mocking per rules/testing.md § 3-Tier Testing — every transport is
+exercised against real infrastructure (real subprocess for stdio, real
+aiohttp test server for sse/http).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import textwrap
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from kailash.channels.mcp import (
+    HttpTransport,
+    SseTransport,
+    StdioTransport,
+    TransportError,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+# ----- StdioTransport against a real subprocess ----------------------------
+
+
+_ECHO_SERVER_SOURCE = textwrap.dedent(
+    """\
+    import sys
+
+    def _read_message(stream):
+        # Read LSP-style framed message: Content-Length: N\\r\\n\\r\\n<body>
+        header_bytes = b""
+        while not header_bytes.endswith(b"\\r\\n\\r\\n"):
+            byte = stream.buffer.read(1)
+            if not byte:
+                return None
+            header_bytes += byte
+        header = header_bytes.decode("utf-8")
+        for line in header.split("\\r\\n"):
+            if line.lower().startswith("content-length:"):
+                length = int(line.split(":", 1)[1].strip())
+                break
+        else:
+            return None
+        return stream.buffer.read(length).decode("utf-8")
+
+    def _write_message(stream, body):
+        encoded = body.encode("utf-8")
+        stream.buffer.write(f"Content-Length: {len(encoded)}\\r\\n\\r\\n".encode("ascii"))
+        stream.buffer.write(encoded)
+        stream.buffer.flush()
+
+    while True:
+        msg = _read_message(sys.stdin)
+        if msg is None:
+            break
+        _write_message(sys.stdout, msg)  # echo
+    """
+)
+
+
+class TestStdioTransportReal:
+    @pytest.mark.asyncio
+    async def test_send_receive_echo(self, tmp_path) -> None:
+        echo_script = tmp_path / "echo_server.py"
+        echo_script.write_text(_ECHO_SERVER_SOURCE)
+        transport = await StdioTransport.spawn(
+            command=sys.executable,
+            args=[str(echo_script)],
+            allowed=[sys.executable, "python3", "python"],
+        )
+        try:
+            request = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+            response = await transport.send(request)
+            # Echo server returns whatever we sent.
+            assert json.loads(response) == json.loads(request)
+        finally:
+            await transport.close()
+
+
+# ----- HttpTransport against a real aiohttp server -------------------------
+
+
+@pytest.fixture
+async def http_echo_server(aiohttp_unused_port):
+    port = aiohttp_unused_port()
+
+    async def handler(request: web.Request) -> web.Response:
+        body = await request.text()
+        # Pretend to be an MCP server: echo the request payload.
+        return web.json_response(json.loads(body))
+
+    app = web.Application()
+    app.router.add_post("/mcp", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    try:
+        yield f"http://127.0.0.1:{port}/mcp"
+    finally:
+        await runner.cleanup()
+
+
+class TestHttpTransportReal:
+    @pytest.mark.asyncio
+    async def test_send_round_trip(self, http_echo_server) -> None:
+        transport = HttpTransport(http_echo_server, allow_private=True)
+        try:
+            request = json.dumps({"jsonrpc": "2.0", "id": 7, "method": "echo"})
+            response = await transport.send(request)
+            assert json.loads(response) == json.loads(request)
+        finally:
+            await transport.close()
+
+    @pytest.mark.asyncio
+    async def test_receive_raises(self, http_echo_server) -> None:
+        transport = HttpTransport(http_echo_server, allow_private=True)
+        try:
+            with pytest.raises(NotImplementedError):
+                await transport.receive()
+        finally:
+            await transport.close()
+
+
+# ----- SseTransport against a real aiohttp server -------------------------
+
+
+@pytest.fixture
+async def sse_server(aiohttp_unused_port):
+    port = aiohttp_unused_port()
+
+    async def message_handler(request: web.Request) -> web.Response:
+        body = await request.text()
+        return web.json_response(json.loads(body))
+
+    async def sse_handler(request: web.Request) -> web.StreamResponse:
+        resp = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream"},
+        )
+        await resp.prepare(request)
+        await resp.write(
+            b"data: " + json.dumps({"event": "hello"}).encode("utf-8") + b"\n\n"
+        )
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/message", message_handler)
+    app.router.add_get("/sse", sse_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        await runner.cleanup()
+
+
+class TestSseTransportReal:
+    @pytest.mark.asyncio
+    async def test_send_receive_echo(self, sse_server) -> None:
+        transport = SseTransport(sse_server, allow_private=True)
+        try:
+            request = json.dumps({"jsonrpc": "2.0", "id": 42, "method": "echo"})
+            response = await transport.send(request)
+            assert json.loads(response) == json.loads(request)
+        finally:
+            await transport.close()

--- a/tests/trust/integration/test_budget_tracker_callbacks.py
+++ b/tests/trust/integration/test_budget_tracker_callbacks.py
@@ -1,0 +1,239 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tier 2 integration tests for BudgetTracker.set_threshold_callback (issue #603).
+
+These tests exercise the threshold-callback API under realistic concurrent
+load using real Python ``threading`` primitives (NO mocks per
+``rules/testing.md``). The goal is to prove that:
+
+1. Under contention, a custom-threshold callback fires EXACTLY ONCE for a
+   given (threshold, handle) -- the lock + fired-handle set must
+   serialize the rising-edge correctly.
+2. Concurrent reserve()/record() workers cannot starve threshold dispatch.
+3. Callback exceptions raised from worker threads do not corrupt budget
+   accounting or block siblings.
+4. The full reserve -> record cycle preserves the once-only guarantee
+   even when the predicate transitions true -> false -> true.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, wait
+from typing import List
+
+import pytest
+
+from kailash.trust.constraints.budget_tracker import (
+    BudgetEvent,
+    BudgetTracker,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Thread-safe append-only event recorder."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.events: List[BudgetEvent] = []
+
+    def __call__(self, event: BudgetEvent) -> None:
+        with self._lock:
+            self.events.append(event)
+
+
+# ---------------------------------------------------------------------------
+# Concurrent contention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestConcurrentThresholdFiring:
+    def test_concurrent_reserves_fire_callback_exactly_once(self) -> None:
+        """16 threads racing across the 80% threshold; one fire only."""
+        # Budget = 16M; each thread reserves 1M. The 13th successful reserve
+        # is the first to push claimed >= 12.8M (80% of 16M).
+        tracker = BudgetTracker(allocated_microdollars=16_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.80, rec)
+
+        barrier = threading.Barrier(16)
+
+        def worker() -> bool:
+            barrier.wait()
+            return tracker.reserve(1_000_000)
+
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            futs = [pool.submit(worker) for _ in range(16)]
+            wait(futs)
+            successes = sum(1 for f in futs if f.result() is True)
+
+        # All 16 reservations of 1M each fit in 16M budget.
+        assert successes == 16
+        assert tracker.remaining_microdollars() == 0
+        # Critical invariant: exactly one fire under contention.
+        assert (
+            len(rec.events) == 1
+        ), f"expected single fire, got {len(rec.events)} events"
+
+    def test_concurrent_reserve_record_oscillation_one_fire(self) -> None:
+        """50 threads run reserve+record cycles; threshold fires once."""
+        tracker = BudgetTracker(allocated_microdollars=10_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.50, rec)
+
+        # Each cycle reserves 100k, records actual 100k -- net committed
+        # increases by 100k per successful cycle. After 50 cycles the
+        # committed reaches 5M = 50% threshold, somewhere mid-stream.
+        # Concurrent workers will race to the rising edge.
+
+        def worker() -> None:
+            for _ in range(10):
+                if tracker.reserve(100_000):
+                    tracker.record(100_000, 100_000)
+
+        threads = [threading.Thread(target=worker) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Total budget consumed: 50 * 10 * 100k = 50M attempted, 10M cap.
+        # By the time all join, committed = 10M (full budget) and reserved=0.
+        assert tracker.remaining_microdollars() == 0
+        # Threshold MUST have fired exactly once despite oscillation pressure.
+        assert len(rec.events) == 1, f"expected one fire, got {len(rec.events)} events"
+        evt = rec.events[0]
+        assert evt.event_type == "custom_threshold"
+        assert evt.threshold_pct == pytest.approx(0.50)
+
+    def test_concurrent_callback_exceptions_isolated(self) -> None:
+        """A callback that always raises does not corrupt budget state."""
+        tracker = BudgetTracker(allocated_microdollars=10_000_000)
+        order: List[str] = []
+        order_lock = threading.Lock()
+
+        def bomb(_evt: BudgetEvent) -> None:
+            with order_lock:
+                order.append("bomb")
+            raise RuntimeError("intentional")
+
+        def survivor(_evt: BudgetEvent) -> None:
+            with order_lock:
+                order.append("survivor")
+
+        tracker.set_threshold_callback(0.50, bomb)
+        tracker.set_threshold_callback(0.50, survivor)
+
+        # Many threads attempt to reserve -- at least one will cross 50%
+        # and trigger callback dispatch. Any callback raising MUST NOT
+        # propagate to the worker thread or block the sibling.
+        results: List[bool] = []
+        results_lock = threading.Lock()
+
+        def worker() -> None:
+            ok = tracker.reserve(700_000)
+            with results_lock:
+                results.append(ok)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # No worker thread crashed.
+        assert len(results) == 20
+        # bomb + survivor both ran exactly once each (one-shot per handle).
+        assert order.count("bomb") == 1
+        assert order.count("survivor") == 1
+        # Order: bomb fired first because registered first, then survivor.
+        # Find the indices.
+        bomb_idx = order.index("bomb")
+        surv_idx = order.index("survivor")
+        assert bomb_idx < surv_idx
+
+    def test_multiple_thresholds_fire_independently_under_contention(
+        self,
+    ) -> None:
+        """Distinct thresholds each fire once under concurrent load."""
+        tracker = BudgetTracker(allocated_microdollars=10_000_000)
+        rec_50 = _Recorder()
+        rec_80 = _Recorder()
+        rec_95 = _Recorder()
+        tracker.set_threshold_callback(0.50, rec_50)
+        tracker.set_threshold_callback(0.80, rec_80)
+        tracker.set_threshold_callback(0.95, rec_95)
+
+        # Workers consume the full budget through reserve+record cycles.
+        def worker() -> None:
+            for _ in range(20):
+                if tracker.reserve(50_000):
+                    tracker.record(50_000, 50_000)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All three thresholds fired exactly once (rising-edge per handle).
+        assert len(rec_50.events) == 1, f"50% expected 1, got {len(rec_50.events)}"
+        assert len(rec_80.events) == 1, f"80% expected 1, got {len(rec_80.events)}"
+        assert len(rec_95.events) == 1, f"95% expected 1, got {len(rec_95.events)}"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end Grant Moment scenario (Envoy Phase 01 motivation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestGrantMomentScenario:
+    """Smoke test: caller registers a 'budget warning' handler, gets one event."""
+
+    def test_full_lifecycle_register_consume_get_warning(self) -> None:
+        # Budget: $5 = 5_000_000 microdollars
+        tracker = BudgetTracker(allocated_microdollars=5_000_000)
+        warnings: List[BudgetEvent] = []
+        warn_lock = threading.Lock()
+
+        def on_budget_warning(evt: BudgetEvent) -> None:
+            with warn_lock:
+                warnings.append(evt)
+
+        # Operator wires a Grant Moment trigger at 80% utilization.
+        tracker.set_threshold_callback(0.80, on_budget_warning)
+
+        # Simulate a stream of LLM calls. Each "call" reserves 200k
+        # ($0.20) then records actual 200k.
+        for _i in range(25):
+            if tracker.reserve(200_000):
+                tracker.record(200_000, 200_000)
+
+        # 25 * 200k = 5M (full budget).
+        # Warning fires when committed first reaches 4M (80% of 5M).
+        # Verify exactly one warning.
+        assert len(warnings) == 1
+        evt = warnings[0]
+        assert evt.event_type == "custom_threshold"
+        assert evt.threshold_pct == pytest.approx(0.80)
+        assert evt.allocated_microdollars == 5_000_000
+        # At fire time the *claimed* amount (committed + reserved) must be
+        # >= 4M (80% of 5M). The predicate fires on `claimed`, not on
+        # `committed` alone, so a snapshot might show committed=3.8M and
+        # reserved=0.2M (claimed=4.0M) at the rising edge.
+        assert evt.committed_microdollars is not None
+        assert evt.reserved_microdollars is not None
+        claimed = evt.committed_microdollars + evt.reserved_microdollars
+        assert claimed >= 4_000_000
+        # Final state: budget exhausted
+        assert tracker.remaining_microdollars() == 0

--- a/tests/trust/unit/test_budget_tracker_callbacks.py
+++ b/tests/trust/unit/test_budget_tracker_callbacks.py
@@ -1,0 +1,425 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tier 1 unit tests for BudgetTracker.set_threshold_callback (issue #603).
+
+Covers:
+- Happy path: single threshold, single callback, fires once on crossing
+- Multiple callbacks at the same threshold preserve registration order
+- Multiple distinct thresholds fire in ascending order on a single mutation
+- Callback exception isolation: raise in one does not block siblings, does
+  not propagate to record()/reserve()
+- Once-only firing: state oscillation does not re-fire
+- Threshold-pct edge cases: 0.0 rejected, negative rejected, > 1.0 rejected,
+  NaN/Inf rejected, exactly 1.0 accepted, 0.999... near-boundary
+- Reserve path also fires (not just record)
+- Predicate uses committed + reserved (the "claimed" amount)
+- Unregister removes from callback list; unregister-after-fire does not
+  re-arm (re-registration with new handle gets fresh one-shot)
+- BudgetEvent payload carries threshold_pct, committed/reserved/remaining
+- Custom-threshold limit shares quota with on_threshold via _max_callbacks
+- Allocated == 0 special case: no fires
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from typing import List
+
+import pytest
+
+from kailash.trust.constraints.budget_tracker import (
+    BudgetEvent,
+    BudgetTracker,
+    BudgetTrackerError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: collect events into a list (callable, thread-safe)
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Thread-safe append-only event recorder for tests."""
+
+    def __init__(self) -> None:
+        self.events: List[BudgetEvent] = []
+        self._lock = threading.Lock()
+
+    def __call__(self, event: BudgetEvent) -> None:
+        with self._lock:
+            self.events.append(event)
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_callback_fires_once_when_threshold_crossed_via_record(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=10_000_000)
+        rec = _Recorder()
+        handle = tracker.set_threshold_callback(0.80, rec)
+        assert isinstance(handle, int) and handle > 0
+
+        # 70% via record -- below threshold
+        assert tracker.reserve(7_000_000) is True
+        tracker.record(7_000_000, 7_000_000)
+        assert len(rec.events) == 0
+
+        # Push committed to 85% via additional record
+        # (reserve 1.5M, then record actual 1.5M -> committed = 8.5M = 85%)
+        assert tracker.reserve(1_500_000) is True
+        # Reserve already brings claimed to 8.5M, fires.
+        assert len(rec.events) == 1
+        evt = rec.events[0]
+        assert evt.event_type == "custom_threshold"
+        assert evt.threshold_pct == pytest.approx(0.80)
+        assert evt.allocated_microdollars == 10_000_000
+        assert evt.committed_microdollars == 7_000_000
+        assert evt.reserved_microdollars == 1_500_000
+
+    def test_callback_fires_via_reserve_path(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.50, rec)
+
+        assert tracker.reserve(400_000) is True  # 40% -- no fire
+        assert len(rec.events) == 0
+        assert tracker.reserve(200_000) is True  # 60% -- fires
+        assert len(rec.events) == 1
+
+    def test_callback_returns_handle_unique_per_registration(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        h1 = tracker.set_threshold_callback(0.5, lambda e: None)
+        h2 = tracker.set_threshold_callback(0.5, lambda e: None)
+        h3 = tracker.set_threshold_callback(0.7, lambda e: None)
+        assert len({h1, h2, h3}) == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Multiple callbacks per threshold
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleCallbacks:
+    def test_registration_order_preserved_within_same_threshold(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        order: List[str] = []
+
+        def make_cb(name: str):
+            def cb(_evt: BudgetEvent) -> None:
+                order.append(name)
+
+            return cb
+
+        tracker.set_threshold_callback(0.50, make_cb("first"))
+        tracker.set_threshold_callback(0.50, make_cb("second"))
+        tracker.set_threshold_callback(0.50, make_cb("third"))
+
+        assert tracker.reserve(600_000) is True  # 60% -- fires all
+        assert order == ["first", "second", "third"]
+
+    def test_multiple_thresholds_fire_in_ascending_order(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        order: List[float] = []
+
+        def cb_for(pct: float):
+            def cb(evt: BudgetEvent) -> None:
+                assert evt.threshold_pct == pytest.approx(pct)
+                order.append(pct)
+
+            return cb
+
+        # Register in non-sorted order; firing order must be ascending.
+        tracker.set_threshold_callback(0.90, cb_for(0.90))
+        tracker.set_threshold_callback(0.50, cb_for(0.50))
+        tracker.set_threshold_callback(0.75, cb_for(0.75))
+
+        # One mutation crosses all three at once
+        assert tracker.reserve(950_000) is True
+        assert order == [0.50, 0.75, 0.90]
+
+
+# ---------------------------------------------------------------------------
+# 3. Once-only firing
+# ---------------------------------------------------------------------------
+
+
+class TestOnceOnly:
+    def test_sustained_above_threshold_does_not_re_fire(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.50, rec)
+
+        assert tracker.reserve(600_000) is True  # 60% -- fires once
+        assert len(rec.events) == 1
+
+        # Subsequent mutations still above threshold -- no re-fire
+        assert tracker.reserve(100_000) is True  # 70%
+        tracker.record(100_000, 100_000)  # commit 100k
+        assert tracker.reserve(50_000) is True  # 75%
+        assert len(rec.events) == 1
+
+    def test_oscillation_below_and_back_does_not_re_fire(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.50, rec)
+
+        # Cross via reserve
+        assert tracker.reserve(600_000) is True
+        assert len(rec.events) == 1
+
+        # Drop below: record actual 0 releases the reservation entirely
+        tracker.record(600_000, 0)
+        # claimed = 0+0; well below 50%. No re-fire (one-shot is one-shot).
+        assert len(rec.events) == 1
+
+        # Cross again -- must NOT re-fire
+        assert tracker.reserve(700_000) is True
+        assert len(rec.events) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Failure isolation
+# ---------------------------------------------------------------------------
+
+
+class TestFailureIsolation:
+    def test_callback_exception_does_not_propagate_via_reserve(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+
+        def bomb(_evt: BudgetEvent) -> None:
+            raise RuntimeError("boom")
+
+        tracker.set_threshold_callback(0.50, bomb)
+
+        # Reserve must succeed despite callback raising.
+        assert tracker.reserve(700_000) is True
+        # Bookkeeping unaffected
+        assert tracker.remaining_microdollars() == 300_000
+
+    def test_callback_exception_does_not_propagate_via_record(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+
+        def bomb(_evt: BudgetEvent) -> None:
+            raise ValueError("fail")
+
+        tracker.set_threshold_callback(0.50, bomb)
+
+        assert tracker.reserve(400_000) is True  # 40% -- no fire
+        # Record an overage that pushes committed to 700k -> 70% -- fires
+        tracker.record(400_000, 700_000)
+        # No exception propagated; record() returned normally.
+        # Bookkeeping reflects the record.
+        assert tracker.remaining_microdollars() == 1_000_000 - 700_000
+
+    def test_first_callback_raises_second_still_fires(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        order: List[str] = []
+
+        def bomb(_evt: BudgetEvent) -> None:
+            order.append("bomb")
+            raise RuntimeError("first cb crash")
+
+        def survivor(_evt: BudgetEvent) -> None:
+            order.append("survivor")
+
+        tracker.set_threshold_callback(0.50, bomb)
+        tracker.set_threshold_callback(0.50, survivor)
+
+        assert tracker.reserve(700_000) is True
+        # Both callbacks ran; bomb first (registration order), survivor second.
+        assert order == ["bomb", "survivor"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Threshold-pct validation
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdValidation:
+    def test_zero_threshold_rejected(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback(0.0, lambda e: None)
+
+    def test_negative_threshold_rejected(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback(-0.1, lambda e: None)
+
+    def test_above_one_threshold_rejected(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback(1.1, lambda e: None)
+
+    def test_nan_threshold_rejected(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback(math.nan, lambda e: None)
+
+    def test_inf_threshold_rejected(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback(math.inf, lambda e: None)
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback(-math.inf, lambda e: None)
+
+    def test_exactly_one_accepted_and_fires_at_full_claim(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(1.0, rec)
+
+        assert tracker.reserve(999_999) is True  # 99.9999% -- below 100%
+        assert len(rec.events) == 0
+        assert tracker.reserve(1) is True  # exactly 100% -- fires
+        assert len(rec.events) == 1
+        assert rec.events[0].threshold_pct == pytest.approx(1.0)
+
+    def test_threshold_just_above_999_nines_fires_at_exact_match(self) -> None:
+        # threshold 0.999_999 against budget 1_000_000 fires at claimed 999_999
+        # because 999_999 / 1_000_000 = 0.999_999 >= 0.999_999.
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.999_999, rec)
+
+        assert tracker.reserve(999_998) is True  # 99.9998% -- below
+        assert len(rec.events) == 0
+        assert tracker.reserve(1) is True  # 99.9999% -- fires
+        assert len(rec.events) == 1
+
+    def test_callback_must_be_callable(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback(0.5, "not_callable")  # type: ignore[arg-type]
+
+    def test_threshold_must_be_number(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback("0.5", lambda e: None)  # type: ignore[arg-type]
+        with pytest.raises(BudgetTrackerError):
+            # bool is a subclass of int in Python; explicitly reject it
+            # because True/False as threshold is a programming error.
+            tracker.set_threshold_callback(True, lambda e: None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 6. Predicate uses committed + reserved
+# ---------------------------------------------------------------------------
+
+
+class TestPredicateClaimedAmount:
+    def test_predicate_includes_in_flight_reservations(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.50, rec)
+
+        # Reserve 600k WITHOUT recording: claimed = 600k = 60%, must fire.
+        assert tracker.reserve(600_000) is True
+        assert len(rec.events) == 1
+
+    def test_predicate_uses_record_path_overage(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.80, rec)
+
+        assert tracker.reserve(100_000) is True  # 10%
+        assert len(rec.events) == 0
+        # Record overage: committed jumps to 850k -> 85%
+        tracker.record(100_000, 850_000)
+        assert len(rec.events) == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. Unregister
+# ---------------------------------------------------------------------------
+
+
+class TestUnregister:
+    def test_unregister_before_fire_prevents_callback(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        handle = tracker.set_threshold_callback(0.50, rec)
+        assert tracker.unregister_threshold_callback(handle) is True
+
+        assert tracker.reserve(700_000) is True
+        assert len(rec.events) == 0  # unregistered -- never fires
+
+    def test_unregister_unknown_handle_returns_false(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        assert tracker.unregister_threshold_callback(99999) is False
+
+    def test_unregister_one_callback_leaves_siblings_intact(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec1 = _Recorder()
+        rec2 = _Recorder()
+        h1 = tracker.set_threshold_callback(0.50, rec1)
+        _h2 = tracker.set_threshold_callback(0.50, rec2)
+
+        assert tracker.unregister_threshold_callback(h1) is True
+
+        assert tracker.reserve(700_000) is True
+        assert len(rec1.events) == 0
+        assert len(rec2.events) == 1
+
+    def test_unregister_after_fire_does_not_re_arm_at_same_handle(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        rec = _Recorder()
+        handle = tracker.set_threshold_callback(0.50, rec)
+
+        # Cross threshold and fire
+        assert tracker.reserve(700_000) is True
+        assert len(rec.events) == 1
+
+        # Unregister AFTER fire
+        assert tracker.unregister_threshold_callback(handle) is True
+        # Re-register at SAME threshold -- this gets a NEW handle and
+        # therefore a fresh one-shot opportunity. Since predicate is still
+        # true, the next reserve/record will fire it on the very next call.
+        rec2 = _Recorder()
+        new_handle = tracker.set_threshold_callback(0.50, rec2)
+        assert new_handle != handle
+        # Trigger any reserve to force predicate evaluation.
+        assert tracker.reserve(50_000) is True
+        # rec2 fires because the new handle has not yet fired.
+        assert len(rec2.events) == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. Allocated zero edge case
+# ---------------------------------------------------------------------------
+
+
+class TestAllocatedZero:
+    def test_allocated_zero_never_fires(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=0)
+        rec = _Recorder()
+        tracker.set_threshold_callback(0.50, rec)
+
+        # Zero-amount reserve always succeeds; cannot reserve > 0.
+        assert tracker.reserve(0) is True
+        # No mutation happened, no fire.
+        assert len(rec.events) == 0
+
+
+# ---------------------------------------------------------------------------
+# 9. Limit
+# ---------------------------------------------------------------------------
+
+
+class TestLimit:
+    def test_max_callback_limit_enforced(self) -> None:
+        tracker = BudgetTracker(allocated_microdollars=1_000_000)
+        # Default max is 100; register 100 callbacks at varying thresholds.
+        for i in range(100):
+            # Use distinct thresholds so each fires at a distinct point;
+            # the limit applies to the union across all thresholds.
+            tracker.set_threshold_callback(0.001 * (i + 1), lambda e: None)
+
+        with pytest.raises(BudgetTrackerError):
+            tracker.set_threshold_callback(0.5, lambda e: None)

--- a/tests/unit/channels/test_mcp_transports.py
+++ b/tests/unit/channels/test_mcp_transports.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 1 unit tests for MCP transport primitives — issue #600."""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.channels.mcp import (
+    HttpTransport,
+    ProtocolError,
+    SseTransport,
+    StdioTransport,
+    Transport,
+    TransportError,
+    validate_url,
+)
+
+
+# ----- validate_url SSRF guard ---------------------------------------------
+
+
+class TestValidateUrl:
+    def test_accepts_https(self) -> None:
+        assert (
+            validate_url("https://example.com/mcp", allow_private=False)
+            == "https://example.com/mcp"
+        )
+
+    def test_accepts_http(self) -> None:
+        assert (
+            validate_url("http://example.com/mcp", allow_private=False)
+            == "http://example.com/mcp"
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "ws://example.com",
+            "data:text/plain;,abc",
+        ],
+    )
+    def test_rejects_non_http_scheme(self, url: str) -> None:
+        with pytest.raises(ValueError, match="scheme"):
+            validate_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/mcp",
+            "http://localhost/mcp",
+            "http://10.0.0.1/mcp",
+            "http://192.168.1.1/mcp",
+            "http://172.16.0.1/mcp",
+            "http://[::1]/mcp",
+        ],
+    )
+    def test_rejects_private_by_default(self, url: str) -> None:
+        with pytest.raises(ValueError):
+            validate_url(url, allow_private=False)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/mcp",
+            "http://10.0.0.1/mcp",
+        ],
+    )
+    def test_allow_private_unblocks(self, url: str) -> None:
+        # Should not raise — caller opted in.
+        assert validate_url(url, allow_private=True) == url
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError):
+            validate_url("")
+
+    def test_rejects_no_host(self) -> None:
+        with pytest.raises(ValueError):
+            validate_url("http:///path")
+
+
+# ----- HttpTransport --------------------------------------------------------
+
+
+class TestHttpTransport:
+    def test_construct_with_validated_url(self) -> None:
+        t = HttpTransport("https://example.com/mcp")
+        assert t.endpoint_url == "https://example.com/mcp"
+
+    def test_construct_rejects_private_by_default(self) -> None:
+        with pytest.raises(ValueError):
+            HttpTransport("http://127.0.0.1/mcp")
+
+    def test_construct_allow_private(self) -> None:
+        t = HttpTransport("http://127.0.0.1/mcp", allow_private=True)
+        assert t.endpoint_url == "http://127.0.0.1/mcp"
+
+    def test_construct_rejects_non_http_scheme(self) -> None:
+        with pytest.raises(ValueError):
+            HttpTransport("file:///etc/passwd")
+
+    def test_is_transport_subclass(self) -> None:
+        assert issubclass(HttpTransport, Transport)
+
+    @pytest.mark.asyncio
+    async def test_receive_raises_not_implemented(self) -> None:
+        t = HttpTransport("https://example.com/mcp")
+        with pytest.raises(NotImplementedError):
+            await t.receive()
+        await t.close()
+
+
+# ----- SseTransport ---------------------------------------------------------
+
+
+class TestSseTransport:
+    def test_construct_with_base_url(self) -> None:
+        t = SseTransport("https://example.com")
+        assert t.base_url == "https://example.com"
+
+    def test_strips_trailing_slash(self) -> None:
+        t = SseTransport("https://example.com/")
+        assert t.base_url == "https://example.com"
+
+    def test_message_url_default(self) -> None:
+        t = SseTransport("https://example.com")
+        assert t.message_url == "https://example.com/message"
+
+    def test_sse_url_default(self) -> None:
+        t = SseTransport("https://example.com")
+        assert t.sse_url == "https://example.com/sse"
+
+    def test_construct_rejects_non_http_scheme(self) -> None:
+        with pytest.raises(ValueError):
+            SseTransport("ftp://example.com")
+
+    def test_construct_rejects_private_by_default(self) -> None:
+        with pytest.raises(ValueError):
+            SseTransport("http://127.0.0.1")
+
+    def test_is_transport_subclass(self) -> None:
+        assert issubclass(SseTransport, Transport)
+
+
+# ----- StdioTransport -------------------------------------------------------
+
+
+class TestStdioTransport:
+    def test_is_transport_subclass(self) -> None:
+        assert issubclass(StdioTransport, Transport)
+
+    @pytest.mark.asyncio
+    async def test_spawn_rejects_disallowed_command(self) -> None:
+        with pytest.raises(ValueError):
+            await StdioTransport.spawn(
+                command="/bin/bash",
+                args=["-c", "echo pwned"],
+                allowed=["python3", "node"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_spawn_validates_empty_command(self) -> None:
+        with pytest.raises(ValueError):
+            await StdioTransport.spawn(command="", args=[])
+
+
+# ----- exception hierarchy --------------------------------------------------
+
+
+class TestExceptions:
+    def test_protocol_error_is_transport_error(self) -> None:
+        assert issubclass(ProtocolError, TransportError)
+
+    def test_transport_error_is_exception(self) -> None:
+        assert issubclass(TransportError, Exception)

--- a/tests/unit/channels/test_mcp_transports.py
+++ b/tests/unit/channels/test_mcp_transports.py
@@ -44,7 +44,7 @@ class TestValidateUrl:
         ],
     )
     def test_rejects_non_http_scheme(self, url: str) -> None:
-        with pytest.raises(ValueError, match="scheme"):
+        with pytest.raises(TransportError, match="scheme"):
             validate_url(url)
 
     @pytest.mark.parametrize(
@@ -59,7 +59,7 @@ class TestValidateUrl:
         ],
     )
     def test_rejects_private_by_default(self, url: str) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             validate_url(url, allow_private=False)
 
     @pytest.mark.parametrize(
@@ -74,11 +74,11 @@ class TestValidateUrl:
         assert validate_url(url, allow_private=True) == url
 
     def test_rejects_empty(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             validate_url("")
 
     def test_rejects_no_host(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             validate_url("http:///path")
 
 
@@ -91,7 +91,7 @@ class TestHttpTransport:
         assert t.endpoint_url == "https://example.com/mcp"
 
     def test_construct_rejects_private_by_default(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             HttpTransport("http://127.0.0.1/mcp")
 
     def test_construct_allow_private(self) -> None:
@@ -99,7 +99,7 @@ class TestHttpTransport:
         assert t.endpoint_url == "http://127.0.0.1/mcp"
 
     def test_construct_rejects_non_http_scheme(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             HttpTransport("file:///etc/passwd")
 
     def test_is_transport_subclass(self) -> None:
@@ -134,11 +134,11 @@ class TestSseTransport:
         assert t.sse_url == "https://example.com/sse"
 
     def test_construct_rejects_non_http_scheme(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             SseTransport("ftp://example.com")
 
     def test_construct_rejects_private_by_default(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             SseTransport("http://127.0.0.1")
 
     def test_is_transport_subclass(self) -> None:
@@ -154,16 +154,16 @@ class TestStdioTransport:
 
     @pytest.mark.asyncio
     async def test_spawn_rejects_disallowed_command(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             await StdioTransport.spawn(
                 command="/bin/bash",
                 args=["-c", "echo pwned"],
-                allowed=["python3", "node"],
+                allowed_commands=["python3", "node"],
             )
 
     @pytest.mark.asyncio
     async def test_spawn_validates_empty_command(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(TransportError):
             await StdioTransport.spawn(command="", args=[])
 
 


### PR DESCRIPTION
## Summary

Bundled resolution of 5 of the 11 open issues identified at session start (the other 6 were dispositioned: 2 spec-gated on mint, 2 deferred-with-brief, 2 retained as multi-shard / coordination-gated).

| Issue | Title | Package | Bump |
|-------|-------|---------|------|
| #618 | Nexus WS: per-connection unicast + on_message reply | kailash-nexus | 2.2.0 → 2.3.0 |
| #598 | PlanSuspension cross-SDK parity (5-variant SuspensionReason) | kailash-kaizen | 2.12.3 → 2.13.0 |
| #602 | OrchestrationRuntime parity (kailash-rs ISS-27) | kailash-kaizen | (same bump) |
| #600 | MCP transport primitives (stdio/SSE/HTTP) | kailash | 2.9.2 → 2.10.0 |
| #603 | BudgetTracker threshold-breach callback API | kailash | (same bump) |

## Implementation summary

- **5 worktree-isolated agents** (3 in Wave 1, 2 in Wave 2) per `rules/worktree-isolation.md` Rule 4 (waves of ≤3).
- **Pre-flight merge-base check** verified for all 5 worktrees from base `92619069`.
- **Cross-SDK parity** — every shipped surface mirrors the kailash-rs reference implementation (kailash-nexus websocket, kailash-kaizen l3/plan/types, kaizen-agents/orchestration/runtime, kailash-mcp/transport, kailash-kaizen/cost/budget). Field shapes and method signatures match.

## Test coverage

- **173 unit tests pass** (62 + 68 + 43 across the 3 affected packages).
- **40+ Tier 2 integration tests** (real WS server, real subprocess for stdio MCP, real aiohttp test server for HTTP/SSE, real threading primitives for budget callbacks). NO mocking per `rules/testing.md` § 3-Tier Testing.
- **Cross-SDK shape parity tests** added for `OrchestrationResult` and `SuspensionReason` wire format.

## Disposition of remaining issues

| Issue | Disposition |
|-------|-------------|
| #604 | Blocked on mint ISS-31 + kailash-rs ISS-33 (cross-SDK convergence required) |
| #605 | Retained as multi-shard workstream (HIGH; PACT N4/N5 conformance runner; 2-3 sessions) |
| #606 | Retained — single shard, cross-SDK coordination-gated (SLIP-0039 Shamir wire format) |
| #607 | Retained — full-shard scope (≥500 LOC + Tier 2 Postgres RLS) |
| #599 | Blocked on mint ISS-17 (PACT-enforced MCP middleware spec) |
| #596 | Blocked on mint ISS-06 (TieredAuditDispatcher spec) |

## Test plan

- [ ] CI matrix passes across Python 3.11/3.12/3.13
- [ ] Tier 1 tests pass (verified locally — 173 pass)
- [ ] Tier 2 tests pass against real infrastructure (verified locally per agent reports)
- [ ] Post-merge: `/release` for kailash 2.10.0 + kailash-nexus 2.3.0 + kailash-kaizen 2.13.0
- [ ] Post-release: clean-venv installability verification per `rules/build-repo-release-discipline.md` Rule 2

## Related issues

Closes #598, #600, #602, #603, #618.

Cross-SDK parity:
- kailash-rs#589 (per #618)
- kailash-rs ISS-27 (per #602)
- kailash-rs ISS-20 (per #600)
- kailash-rs ISS-30 (per #603)
- kailash-rs `crates/kailash-kaizen/src/l3/core/plan/types.rs` (per #598)

🤖 Generated with [Claude Code](https://claude.com/claude-code)