### PR TITLE
fix(kaizen): guard kaizen_agents proxy imports — clean-venv hotfix (2.13.1)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.1] — 2026-04-25 — Fix clean-venv ImportError (post-2.13.0 hotfix)
+
+Patch — guards a pre-existing unconditional `import kaizen_agents.patterns.patterns` in `kaizen/orchestration/__init__.py` behind a `try/except ImportError`. The `kaizen-agents` package is NOT a declared dependency of `kailash-kaizen`; the proxies that consumed it were defensive `mock.patch` aliases for legacy test code. Without the guard, `from kaizen.orchestration import OrchestrationRuntime` (the new #602 surface in 2.13.0) raised `ModuleNotFoundError` for any clean-venv install of `kailash-kaizen` without `kaizen-agents` present. The proxy aliases are now installed only when `kaizen-agents` is co-installed.
+
+### Fixed
+
+- **`kaizen.orchestration` clean-venv import**: `import kaizen_agents.patterns.patterns` (and 3 sibling proxy imports) now wrapped in `try/except ImportError`. Surface unaffected when both packages co-installed; clean-venv `kailash-kaizen` install no longer breaks at module load.
+
+This is the structural defense for `rules/dependencies.md` § "Declared = Imported — No Silent Missing Dependencies" — a verification gap caught by the post-release clean-venv install check (per `rules/build-repo-release-discipline.md` Rule 2).
+
 ## [2.13.0] — 2026-04-25 — PlanSuspension parity (#598) + OrchestrationRuntime parity (#602)
 
 Minor bump — two cross-SDK parity surfaces land together: L3 plan suspension (PACT N3) and strategy-driven multi-agent orchestration runtime (kailash-rs ISS-27).

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.13.0"
+version = "2.13.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.13.0"
+__version__ = "2.13.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/orchestration/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/orchestration/__init__.py
@@ -21,15 +21,23 @@ keep working.
 
 import sys
 
-import kaizen_agents.patterns.patterns as _pp  # noqa: E402
-import kaizen_agents.patterns.patterns.blackboard as _bb  # noqa: E402
-import kaizen_agents.patterns.patterns.ensemble as _en  # noqa: E402
-import kaizen_agents.patterns.patterns.meta_controller as _mc  # noqa: E402
-
-sys.modules.setdefault("kaizen.orchestration.patterns", _pp)
-sys.modules.setdefault("kaizen.orchestration.patterns.blackboard", _bb)
-sys.modules.setdefault("kaizen.orchestration.patterns.ensemble", _en)
-sys.modules.setdefault("kaizen.orchestration.patterns.meta_controller", _mc)
+# Optional proxy aliases — only installed when kaizen-agents is present.
+# kaizen-agents is not a hard dependency of kailash-kaizen; the proxies exist
+# solely so legacy ``mock.patch("kaizen.orchestration.patterns.blackboard.…")``
+# call sites continue to resolve when both packages are co-installed. A clean
+# kailash-kaizen install (without kaizen-agents) MUST still import successfully.
+try:
+    import kaizen_agents.patterns.patterns as _pp  # noqa: E402
+    import kaizen_agents.patterns.patterns.blackboard as _bb  # noqa: E402
+    import kaizen_agents.patterns.patterns.ensemble as _en  # noqa: E402
+    import kaizen_agents.patterns.patterns.meta_controller as _mc  # noqa: E402
+except ImportError:
+    pass
+else:
+    sys.modules.setdefault("kaizen.orchestration.patterns", _pp)
+    sys.modules.setdefault("kaizen.orchestration.patterns.blackboard", _bb)
+    sys.modules.setdefault("kaizen.orchestration.patterns.ensemble", _en)
+    sys.modules.setdefault("kaizen.orchestration.patterns.meta_controller", _mc)
 
 # Public OrchestrationRuntime surface (issue #602 — cross-SDK parity with
 # kailash-rs kaizen-agents::orchestration::runtime). Eager imports so the

--- a/packages/kailash-kaizen/tests/regression/test_kaizen_2_13_1_clean_venv_import.py
+++ b/packages/kailash-kaizen/tests/regression/test_kaizen_2_13_1_clean_venv_import.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for kailash-kaizen 2.13.1.
+
+2.13.0 shipped with `kaizen/orchestration/__init__.py` unconditionally
+importing `kaizen_agents.patterns.patterns` — but `kaizen-agents` is not a
+declared dependency of `kailash-kaizen`. Clean-venv installs of the
+package raised `ModuleNotFoundError` at module load. The 2.13.1 patch
+guards the proxy import in a `try/except ImportError`.
+
+This test verifies that `from kaizen.orchestration import OrchestrationRuntime`
+succeeds even when `kaizen_agents` cannot be located.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.regression
+def test_orchestration_imports_without_kaizen_agents(monkeypatch):
+    """Reload `kaizen.orchestration` with `kaizen_agents` blocked from import.
+
+    The proxy aliases MUST be skipped silently; OrchestrationRuntime and the
+    accompanying public surface MUST still be importable.
+    """
+    # Drop any cached kaizen_agents modules + the orchestration module so
+    # the reload re-executes the guard branch.
+    for name in list(sys.modules):
+        if name == "kaizen_agents" or name.startswith("kaizen_agents."):
+            sys.modules.pop(name, None)
+        if name == "kaizen.orchestration" or name.startswith("kaizen.orchestration."):
+            sys.modules.pop(name, None)
+
+    # Block kaizen_agents at the importer level — any attempt to import
+    # MUST raise ImportError so the guard is exercised.
+    real_import = (
+        __builtins__["__import__"]
+        if isinstance(__builtins__, dict)
+        else __builtins__.__import__
+    )
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "kaizen_agents" or name.startswith("kaizen_agents."):
+            raise ImportError(f"blocked for regression test: {name}")
+        return real_import(name, *args, **kwargs)
+
+    if isinstance(__builtins__, dict):
+        monkeypatch.setitem(__builtins__, "__import__", _blocked_import)
+    else:
+        monkeypatch.setattr(__builtins__, "__import__", _blocked_import)
+
+    # Trigger the guard branch.
+    orch_module = importlib.import_module("kaizen.orchestration")
+
+    # The new public surface from #602 MUST still be reachable.
+    assert hasattr(orch_module, "OrchestrationRuntime")
+    assert hasattr(orch_module, "OrchestrationStrategy")
+    assert hasattr(orch_module, "OrchestrationResult")
+    assert hasattr(orch_module, "Coordinator")
+
+    # The legacy proxy aliases MUST NOT be present when kaizen_agents is
+    # unavailable — they are the optional surface.
+    assert "kaizen.orchestration.patterns" not in sys.modules


### PR DESCRIPTION
## Summary

Hotfix for `kailash-kaizen 2.13.0` — closes a clean-venv `ModuleNotFoundError` shipped in 2.13.0 (and predating it back to the structural-split refactor #75).

`kaizen/orchestration/__init__.py` unconditionally imported `kaizen_agents.patterns.patterns` + 3 sibling proxy modules. `kaizen-agents` is NOT a declared dep of `kailash-kaizen`; the proxies were defensive aliases for legacy `mock.patch` call sites.

**Caught by the post-2.13.0 clean-venv installability check** (per `rules/build-repo-release-discipline.md` Rule 2):

```
/tmp/verify-2.10.0/bin/python -c 'from kaizen.orchestration import OrchestrationRuntime'
→ ModuleNotFoundError: No module named 'kaizen_agents'
```

## Fix

Wrap the 4 proxy imports in `try/except ImportError`. The aliases now install only when `kaizen-agents` is co-installed; clean `kailash-kaizen` installs no longer break at module load.

## Test plan

- [x] Regression test added: `packages/kailash-kaizen/tests/regression/test_kaizen_2_13_1_clean_venv_import.py` — blocks `kaizen_agents` at the importer level and asserts `OrchestrationRuntime` + `Strategy` + `Result` + `Coordinator` remain reachable.
- [x] Local test pass.
- [ ] CI matrix passes.
- [ ] Post-merge: tag `kaizen-v2.13.1` + clean-venv re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)