### PR TITLE
feat(trust): SLIP-0039 Shamir secret-sharing wrapper scaffold (#606)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,14 @@ ml = [
 align = [
     "kailash-align>=0.3.2",
 ]
+# Cryptographic extras (audited reference implementations)
+# Trust Vault SLIP-0039 Shamir secret-sharing wrapper — see issue #606.
+# Module import succeeds without this extra; call-site raises RuntimeError
+# with an actionable install hint per dependencies.md "loud failure at call
+# site" pattern.
+shamir = [
+    "shamir-mnemonic>=0.3",
+]
 # Secret backends (vendor-specific SDKs)
 vault = [
     "hvac>=2.1.0",

--- a/specs/security-data.md
+++ b/specs/security-data.md
@@ -347,6 +347,16 @@ In-memory audit log with configurable capacity.
 
 **Filtering:** `get_recent_events()` supports filtering by event_type, authority_id, and severity.
 
+### 10.X Trust Vault Backup -- Shamir Secret-Sharing
+
+Trust Vault key material is backed up via SLIP-0039 Shamir secret-sharing per Envoy Phase 01. The default ritual is **3-of-5** -- any three of five holders MUST agree to reconstruct a backed-up vault key. Operational guidance:
+
+- The wrapper API lives in `kailash.trust.vault.shamir`; full surface and contracts in `specs/trust-crypto.md` § Shamir Secret-Sharing.
+- The Trust Vault binding (`kailash.trust.vault.backup.back_up_vault_key`) is a gate-documented stub awaiting **mint ISS-37** (Trust Vault key clearance and rotation envelope). Until ISS-37 stabilises, callers reach `back_up_vault_key` and receive `NotImplementedError` referencing issue #606 + ISS-37; direct callers can use `kailash.trust.vault.shamir.generate(...)` against pre-resolved key bytes.
+- The audited reference library (`shamir-mnemonic>=0.3`) is shipped as the optional `shamir` extra: `pip install kailash[shamir]`. Module import succeeds without the extra; first call site fails loudly with an actionable install hint per `rules/dependencies.md`.
+- Shard contents are NEVER logged at any severity (per `rules/observability.md` MUST Rule 4). When ISS-37 lands, the binding will write an audit anchor capturing ritual parameters, holder distribution policy, and shard count -- but not the shards themselves.
+- The reference implementation is **not constant-time**; production deployments needing side-channel resistance MUST evaluate hardened alternatives before relying on the reference path. See `specs/trust-crypto.md` § Shamir Secret-Sharing for the full security caveat.
+
 ---
 
 ## 11. DataFlow Access Controls

--- a/specs/trust-crypto.md
+++ b/specs/trust-crypto.md
@@ -571,7 +571,94 @@ These invariants are enforced across the entire trust plane (per `rules/trust-pl
 
 ---
 
-## 30. Cross-SDK Alignment
+## 30. Shamir Secret-Sharing (SLIP-0039)
+
+Trust Vault key backup uses Shamir secret-sharing per SLIP-0039 (SatoshiLabs reference standard) via `kailash.trust.vault.shamir`. The wrapper composes the audited reference implementation `shamir-mnemonic` (PyPI) into an ergonomic ritual surface for splitting and reconstructing high-value Trust Vault key material.
+
+### Public Surface
+
+`kailash.trust.vault` re-exports the wrapper API:
+
+- **`ShamirRitual(threshold: int, total_shards: int)`** -- frozen dataclass capturing m-of-n parameters. Validation enforced in `__post_init__`:
+  - `1 <= threshold <= total_shards`
+  - `total_shards <= 16` (SLIP-0039 4-bit member-index field)
+  - `threshold >= 2` when `total_shards > 1` (trivial 1-of-n splits rejected pending mint ISS-37 governance review -- a 1-of-n ritual provides distribution but zero threshold protection, so the wrapper refuses by default)
+- **`generate(secret: bytes, ritual: ShamirRitual, *, passphrase: bytes = b"") -> List[List[str]]`** -- splits the secret into `ritual.total_shards` SLIP-0039 mnemonic shards. Single-group `m`-of-`n` configuration (`group_threshold=1`); multi-group rituals reserved for mint ISS-37.
+- **`reconstruct(shards: List[List[str]], *, passphrase: bytes = b"") -> bytes`** -- recombines threshold-many shards into the original secret.
+- **`serialize_shard(shard: List[str]) -> str`** -- canonical paper-print form (single space-joined dictionary words). Interop surface across SDKs and the form holders write to paper, engrave on metal, or print on cards.
+- **`deserialize_shard(shard: str) -> List[str]`** -- reverse operation, whitespace-tolerant for paper transcription.
+- **`rotate_holders(old_shards: List[List[str]], new_ritual: ShamirRitual, *, passphrase: bytes = b"") -> List[List[str]]`** -- recombine then re-shard. Used when the holder set changes (a holder leaves, a new holder joins, or the ritual is updated). The intermediate secret is `del`-eted before the function returns; rotation SHOULD run on an air-gapped host per Trust Vault operational guidance.
+- **`back_up_vault_key(vault_key: bytes, ritual: ShamirRitual) -> List[List[str]]`** -- Trust Vault binding stub. Awaits mint ISS-37 (Trust Vault key clearance and rotation envelope). The signature is published so callers can compile against it; the body raises `NotImplementedError` referencing issue #606 + ISS-37 until the binding spec lands.
+
+### Optional Extra
+
+Install via:
+
+```
+pip install kailash[shamir]
+```
+
+The audited reference library (`shamir-mnemonic>=0.3`) is shipped as an optional extra so the base `pip install kailash` does not pull in cryptographic mnemonic code most users do not need.
+
+### Lazy-Import Contract
+
+Module import of `kailash.trust.vault.shamir` MUST succeed even without the optional extra installed -- so `__all__` membership, `from kailash.trust.vault import *`, Sphinx autodoc, and static analysers all resolve. The audited library is imported lazily inside each public function via `_require_shamir_mnemonic()`. When the extra is absent, the FIRST call site raises:
+
+```
+RuntimeError: SLIP-0039 Shamir secret-sharing requires the 'shamir'
+optional extra. Install via: pip install kailash[shamir]
+```
+
+This is the "loud failure at call site" pattern from `rules/dependencies.md`. The silent `X = None` fallback anti-pattern is BLOCKED.
+
+### Threshold Convention
+
+The ritual is captured as `(threshold, total_shards)` -- m-of-n. Reconstruction requires AT LEAST `threshold` shards from the originally-generated set; fewer than `threshold` MUST refuse with the underlying SLIP-0039 library's typed exception (propagated unchanged through the wrapper).
+
+### Paper-Print Format
+
+`serialize_shard` produces a single-line whitespace-separated string of SLIP-0039 dictionary words. The format is the cross-SDK interop surface: a shard serialised by Python `kailash-py` round-trips through Rust `kailash-rs` (matching scaffold expected). `deserialize_shard` collapses any run of ASCII whitespace, so transcription artefacts (extra spaces, line breaks) survive the round-trip.
+
+### Rotation Protocol
+
+`rotate_holders(old_shards, new_ritual)`:
+
+1. Reconstruct the secret from `old_shards` via `reconstruct()`.
+2. Re-shard the secret via `generate(secret, new_ritual)`.
+3. `del` the intermediate secret reference before return.
+
+The intermediate secret is held in memory for the duration of the re-shard call. Hardened deployments SHOULD perform rotation in a process that exits immediately afterward to minimize the residence window. To rotate the passphrase as well as the holder set, call `reconstruct()` and `generate()` explicitly.
+
+### Trust Vault Binding (Awaiting Mint ISS-37)
+
+`back_up_vault_key` is published as a gate-documented stub -- the only permitted stub per `rules/zero-tolerance.md` Rule 2 (issue-linked, gate-documented). When mint ISS-37 stabilises:
+
+1. The body resolves the vault key by ID against the mint-issued clearance envelope, validating that the calling agent holds the required `backup` capability.
+2. The resolved key bytes are passed to `kailash.trust.vault.shamir.generate()` under the supplied ritual.
+3. An audit anchor is written to the canonical audit store (per `rules/eatp.md` audit-anchor contract) capturing ritual parameters, holder distribution policy, and shard count. Shard contents are NEVER logged (per `rules/observability.md` MUST Rule 4).
+
+The signature does NOT change when ISS-37 lands; only the body fills in. Callers can compile against `back_up_vault_key` today and observe `NotImplementedError` referencing issue #606 + mint ISS-37 until the binding spec lands.
+
+### Security Caveat
+
+The `shamir-mnemonic` reference implementation is **not constant-time** and is documented by its authors as suitable for correctness verification rather than handling of high-value secrets in adversarial settings. Trust Vault deployments that need side-channel resistance MUST evaluate hardened alternatives before production use. The wrapper exists today to (1) freeze the SLIP-0039 API surface so downstream callers can compile against it and (2) enable end-to-end ritual rehearsal.
+
+### Memory Hygiene
+
+Per `rules/trust-plane-security.md` MUST NOT Rule 3, callers MUST `del` returned secret bytes immediately after use. The wrapper itself does not log shard contents or passphrases at any level (`rules/observability.md` MUST Rule 4). The wrapper does not zeroize the bytes object (Python `bytes` is immutable; in-place clearing is not portable). Hardened deployments needing cryptographic zeroization MUST use a hardened secret-handling library above the wrapper.
+
+### Cross-SDK
+
+A matching scaffold is expected on the Rust SDK (`kailash-rs`) using a parallel audited Rust SLIP-0039 implementation. The serialised paper-print form is the cross-SDK interop surface. Per `rules/cross-sdk-inspection.md` a follow-up issue MUST be filed on `esperie/kailash-rs` if the matching scaffold is not yet present.
+
+### Tests
+
+- Tier 1 regression: `tests/regression/test_issue_606_shamir_wrapper.py` -- ritual validation, frozen invariant, lazy-import absence-path contract, stub error message.
+- Tier 2 integration: `tests/integration/trust/test_shamir_round_trip.py` -- real `shamir-mnemonic` round-trip across multiple shard subsets, threshold-minus-1 reconstruct refusal, paper-print round-trip, holder rotation 3-of-5 -> 2-of-3 + 3-of-5 -> 5-of-7 secret preservation. Per `rules/orphan-detection.md` Rule 2a (Crypto-Pair Round-Trip Through Facade), all crypto operations route through the public `kailash.trust.vault.shamir.<name>` surface, NOT the underlying library directly.
+
+---
+
+## 31. Cross-SDK Alignment
 
 Both Python (`kailash-py`) and Rust (`kailash-rs`) SDKs implement the EATP spec independently (D6). Convention names may differ (Python snake_case) but semantics MUST match. Key alignment points:
 

--- a/src/kailash/trust/vault/__init__.py
+++ b/src/kailash/trust/vault/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Trust Vault — SLIP-0039 Shamir backup scaffold (issue #606).
+
+The Trust Vault binding (mint ISS-37) is NOT YET STABLE. This package
+exposes the SLIP-0039 wrapper API + a gate-documented stub
+(:func:`back_up_vault_key`) that will fill in once the mint spec lands.
+
+See :mod:`kailash.trust.vault.shamir` for the ritual surface.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from kailash.trust.vault.backup import back_up_vault_key
+from kailash.trust.vault.shamir import (
+    ShamirRitual,
+    deserialize_shard,
+    generate,
+    reconstruct,
+    rotate_holders,
+    serialize_shard,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ShamirRitual",
+    "back_up_vault_key",
+    "deserialize_shard",
+    "generate",
+    "reconstruct",
+    "rotate_holders",
+    "serialize_shard",
+]

--- a/src/kailash/trust/vault/backup.py
+++ b/src/kailash/trust/vault/backup.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Trust Vault Shamir backup binding -- scaffold awaiting mint ISS-37.
+
+This module owns the binding between the SLIP-0039 wrapper in
+:mod:`kailash.trust.vault.shamir` and the Trust Vault key-management
+surface. The binding spec is gated on mint ISS-37 (Trust Vault key
+identity / clearance / rotation envelope) which is NOT YET STABLE.
+
+Scope today
+-----------
+
+The function signature :func:`back_up_vault_key` is published so callers
+can compile against it and the wrapper API surface is frozen. The body
+deliberately raises :class:`NotImplementedError` referencing issue #606
+and mint ISS-37 -- the ONE permitted stub per ``rules/zero-tolerance.md``
+Rule 2 (issue-linked, gate documented). When mint ISS-37 lands the body
+will fill in the binding; the public signature will not change.
+
+Forward path
+------------
+
+When ISS-37 stabilises:
+
+1. The body will resolve the vault key by ID against the mint-issued
+   clearance envelope, validating that the calling agent holds the
+   required ``backup`` capability.
+2. The resolved key bytes will be passed to
+   :func:`kailash.trust.vault.shamir.generate` under the supplied
+   ritual.
+3. An audit anchor will be written to the canonical audit store
+   (per ``rules/eatp.md`` audit anchor contract) capturing the ritual
+   parameters, the holder distribution policy, and the shard count.
+   Shard contents themselves are NEVER logged
+   (``rules/observability.md`` MUST Rule 4).
+
+Issue tracker
+-------------
+
+* GitHub issue: terrene-foundation/kailash-py#606
+* Mint spec: ISS-37 (Trust Vault key clearance and rotation envelope)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from kailash.trust.vault.shamir import ShamirRitual
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["back_up_vault_key"]
+
+
+def back_up_vault_key(
+    vault_key: bytes,
+    ritual: ShamirRitual,
+) -> List[List[str]]:
+    """Split a Trust Vault key into Shamir shards under ``ritual``.
+
+    .. warning::
+
+       This is a gated stub awaiting mint ISS-37. The signature is the
+       threading point that ISS-37 stabilises later -- the body fills in
+       once the binding spec lands. Callers reaching this stub today
+       receive :class:`NotImplementedError`.
+
+    Parameters
+    ----------
+    vault_key:
+        The raw vault key bytes resolved by the Trust Vault key manager.
+        When implemented, the function will accept either a key handle
+        or raw bytes; the signature evolution is in scope for ISS-37.
+    ritual:
+        The ``m``-of-``n`` ritual parameters captured by
+        :class:`ShamirRitual`.
+
+    Returns
+    -------
+    list[list[str]]
+        ``ritual.total_shards`` SLIP-0039 mnemonic shards.
+
+    Raises
+    ------
+    NotImplementedError
+        Until mint ISS-37 stabilises the Trust Vault binding.
+    """
+    raise NotImplementedError(
+        "back_up_vault_key: Trust Vault Shamir binding awaits mint ISS-37 "
+        "(see issue #606). The SLIP-0039 wrapper is available today via "
+        "kailash.trust.vault.shamir.generate(...) for direct callers."
+    )

--- a/src/kailash/trust/vault/shamir.py
+++ b/src/kailash/trust/vault/shamir.py
@@ -1,0 +1,535 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+SLIP-0039 Shamir secret-sharing wrapper for Trust Vault backup.
+
+This module wraps the audited reference implementation `shamir-mnemonic`
+(SLIP-0039 by SatoshiLabs) to expose an ergonomic ``ShamirRitual`` surface
+for splitting and reconstructing Trust Vault key material.
+
+Spec gate
+---------
+
+The Trust Vault binding (issue #606, mint ISS-37) is NOT YET STABLE. This
+module provides only the SLIP-0039 wrapper API and ritual scaffolding. The
+mint-specific binding lives in :mod:`kailash.trust.vault.backup` as a
+gate-documented stub awaiting ISS-37.
+
+Optional dependency
+-------------------
+
+The audited reference library is shipped as an optional extra so the base
+``pip install kailash`` does not pull in cryptographic mnemonic code that
+most users do not need. Install via::
+
+    pip install kailash[shamir]
+
+The library is imported lazily inside each public function so module import
+of ``kailash.trust.vault.shamir`` succeeds even without the extra; the call
+fails loudly with an actionable :class:`RuntimeError` instructing the user
+to install the extra. This is the "loud failure at call site" pattern from
+``rules/dependencies.md`` -- the silent ``X = None`` fallback is BLOCKED.
+
+Security caveat
+---------------
+
+The reference implementation is **not constant-time** and is documented by
+its authors as suitable for correctness verification rather than handling
+of high-value secrets in adversarial settings. Trust Vault deployments that
+need side-channel resistance MUST evaluate hardened alternatives before
+production use; the wrapper exists today to (1) freeze the SLIP-0039 API
+surface so downstream callers can compile against it and (2) enable the
+end-to-end ritual rehearsal.
+
+Public surface
+--------------
+
+* :class:`ShamirRitual` -- frozen dataclass capturing ``(threshold, total)``
+* :func:`generate` -- produces ``total`` shards from a secret
+* :func:`reconstruct` -- recombines ``threshold`` shards into the secret
+* :func:`serialize_shard` / :func:`deserialize_shard` -- paper-print form
+* :func:`rotate_holders` -- recombine then re-shard with a new ritual
+
+Memory hygiene
+--------------
+
+Per ``rules/trust-plane-security.md`` MUST NOT Rule 3, callers MUST ``del``
+returned secret bytes immediately after use. The wrapper itself does not
+log shard contents at any level (``rules/observability.md`` MUST Rule 4).
+
+Cross-SDK
+---------
+
+A matching scaffold is expected on the kailash-rs side using a parallel
+audited Rust SLIP-0039 implementation. The serialized paper-print form is
+the interop surface across SDKs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, List
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ShamirRitual",
+    "EntropySource",
+    "generate",
+    "reconstruct",
+    "serialize_shard",
+    "deserialize_shard",
+    "rotate_holders",
+]
+
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+#: Caller-supplied entropy source for shard generation. Receives the number
+#: of bytes requested and returns exactly that many. Defaults to
+#: :func:`os.urandom` when unset.
+EntropySource = Callable[[int], bytes]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: SLIP-0039 caps the number of shares per group at 16 (4-bit field).
+_MAX_TOTAL_SHARDS: int = 16
+
+#: Canonical paper-print delimiter. Single space matches the SLIP-0039
+#: mnemonic format, where each shard is rendered as a space-separated
+#: sequence of dictionary words.
+_SHARD_DELIM: str = " "
+
+#: Error message emitted when the optional ``shamir`` extra is absent.
+_EXTRA_HINT: str = (
+    "SLIP-0039 Shamir secret-sharing requires the 'shamir' optional extra. "
+    "Install via: pip install kailash[shamir]"
+)
+
+
+# ---------------------------------------------------------------------------
+# Lazy import helper
+# ---------------------------------------------------------------------------
+
+
+def _require_shamir_mnemonic():
+    """Lazy-import the audited SLIP-0039 reference library.
+
+    Returns the imported module on success. Raises :class:`RuntimeError`
+    with an actionable install hint if the optional extra is absent.
+
+    This is the "loud failure at call site" pattern from
+    ``rules/dependencies.md`` -- absence is surfaced at the FIRST call,
+    never silently as ``None``.
+    """
+    try:
+        import shamir_mnemonic  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise RuntimeError(_EXTRA_HINT) from exc
+    return shamir_mnemonic
+
+
+# ---------------------------------------------------------------------------
+# Ritual dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ShamirRitual:
+    """Parameters for an ``m``-of-``n`` Shamir ritual.
+
+    Attributes
+    ----------
+    threshold:
+        ``m`` -- the minimum number of shards required to reconstruct.
+    total_shards:
+        ``n`` -- the total number of shards generated.
+
+    Validation
+    ----------
+
+    Enforced in ``__post_init__``:
+
+    * ``1 <= threshold <= total_shards``
+    * ``total_shards <= 16`` (SLIP-0039 4-bit member-index field)
+    * ``threshold >= 2`` -- single-shard rituals provide no security beyond
+      simple possession of the secret and are rejected by default. Callers
+      that genuinely want the trivial ``1``-of-``n`` form (split-only, no
+      threshold protection) MUST pass ``allow_trivial=True`` explicitly --
+      not yet supported in this scaffold; opens later when mint ISS-37
+      lands and the trade-off can be reviewed.
+
+    The frozen dataclass form is mandated by
+    ``rules/trust-plane-security.md`` MUST Rule 4: ritual parameters
+    captured at governance approval time MUST NOT be mutable thereafter.
+    """
+
+    threshold: int
+    total_shards: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.threshold, int) or not isinstance(
+            self.total_shards, int
+        ):
+            raise TypeError(
+                "ShamirRitual.threshold and total_shards MUST be int; "
+                f"got threshold={type(self.threshold).__name__} "
+                f"total_shards={type(self.total_shards).__name__}"
+            )
+        if self.threshold < 1:
+            raise ValueError(
+                f"ShamirRitual.threshold must be >= 1 (got {self.threshold})"
+            )
+        if self.total_shards < 1:
+            raise ValueError(
+                f"ShamirRitual.total_shards must be >= 1 " f"(got {self.total_shards})"
+            )
+        if self.threshold > self.total_shards:
+            raise ValueError(
+                f"ShamirRitual.threshold ({self.threshold}) must be "
+                f"<= total_shards ({self.total_shards})"
+            )
+        if self.total_shards > _MAX_TOTAL_SHARDS:
+            raise ValueError(
+                f"ShamirRitual.total_shards ({self.total_shards}) exceeds "
+                f"SLIP-0039 limit of {_MAX_TOTAL_SHARDS}"
+            )
+        if self.threshold == 1 and self.total_shards > 1:
+            # 1-of-n means any single shard reconstructs the secret -- the
+            # ritual provides distribution but zero threshold protection.
+            # We reject by default; the gate to relax this opens with mint
+            # ISS-37 when the trade-off can be governance-reviewed.
+            raise ValueError(
+                "ShamirRitual rejects threshold=1 with total_shards>1 "
+                "(trivial split: any holder can recover unilaterally). "
+                "Use threshold>=2 or wait for mint ISS-37 governance "
+                "review if a trivial split is genuinely required."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Generate / reconstruct
+# ---------------------------------------------------------------------------
+
+
+def generate(
+    secret: bytes,
+    ritual: ShamirRitual,
+    *,
+    passphrase: bytes = b"",
+) -> List[List[str]]:
+    """Split ``secret`` into ``ritual.total_shards`` shards.
+
+    Parameters
+    ----------
+    secret:
+        The master secret to split. Per SLIP-0039 the secret length MUST
+        be 16, 32, or another multiple of 2 bytes that the underlying
+        library accepts; passing an invalid length surfaces as a
+        :class:`ValueError` from the library, propagated unchanged.
+    ritual:
+        The ``m``-of-``n`` parameters captured by :class:`ShamirRitual`.
+    passphrase:
+        Optional passphrase per SLIP-0039 spec. Empty by default.
+        Per ``rules/observability.md`` MUST Rule 4 the passphrase is
+        NEVER logged.
+
+    Returns
+    -------
+    list[list[str]]
+        A list of exactly ``ritual.total_shards`` shards. Each shard is
+        a list of SLIP-0039 dictionary words (the mnemonic).
+
+    Raises
+    ------
+    RuntimeError
+        If the ``shamir`` optional extra is not installed.
+    TypeError
+        If ``secret`` is not :class:`bytes`.
+    ValueError
+        If the SLIP-0039 library rejects the secret length or other
+        constraint (propagated from the underlying ``MnemonicError``).
+
+    Notes
+    -----
+
+    The wrapper uses a single-group ``m``-of-``n`` configuration
+    (``group_threshold=1``, ``groups=[(m, n)]``). Multi-group rituals
+    are an extension point reserved for the mint ISS-37 binding.
+
+    The function deliberately does NOT log the secret, the passphrase,
+    or any returned shard. Callers MUST ``del`` the returned list once
+    distribution is complete.
+    """
+    if not isinstance(secret, (bytes, bytearray)):
+        raise TypeError(
+            f"generate(secret=...) requires bytes; got {type(secret).__name__}"
+        )
+    if not isinstance(passphrase, (bytes, bytearray)):
+        raise TypeError(
+            f"generate(passphrase=...) requires bytes; got "
+            f"{type(passphrase).__name__}"
+        )
+
+    sm = _require_shamir_mnemonic()
+
+    # Single-group m-of-n: group_threshold=1, one group with (threshold, total).
+    groups = [(ritual.threshold, ritual.total_shards)]
+    mnemonics = sm.generate_mnemonics(
+        group_threshold=1,
+        groups=groups,
+        master_secret=bytes(secret),
+        passphrase=bytes(passphrase),
+    )
+
+    # The library returns List[List[str]] where the outer list is groups
+    # (length 1 for our single-group ritual) and the inner list is the
+    # mnemonics (one per shard, each as a single space-joined string).
+    # We split each mnemonic into its constituent words so callers can
+    # treat shards as word-lists per the wrapper contract.
+    if len(mnemonics) != 1:
+        raise RuntimeError(
+            "shamir_mnemonic.generate_mnemonics returned unexpected group "
+            f"count {len(mnemonics)} for single-group ritual"
+        )
+    group = mnemonics[0]
+    if len(group) != ritual.total_shards:
+        raise RuntimeError(
+            f"shamir_mnemonic.generate_mnemonics returned {len(group)} "
+            f"shards; ritual requested {ritual.total_shards}"
+        )
+    shards: List[List[str]] = [_words(m) for m in group]
+    logger.debug(
+        "shamir.generate: produced %d shards (threshold=%d)",
+        ritual.total_shards,
+        ritual.threshold,
+    )
+    return shards
+
+
+def reconstruct(
+    shards: List[List[str]],
+    *,
+    passphrase: bytes = b"",
+) -> bytes:
+    """Recombine threshold-many ``shards`` into the original secret.
+
+    Parameters
+    ----------
+    shards:
+        A list of at least ``ritual.threshold`` shards previously produced
+        by :func:`generate`. Each shard is a list of dictionary words.
+    passphrase:
+        The passphrase used at :func:`generate` time. MUST match exactly.
+
+    Returns
+    -------
+    bytes
+        The original master secret.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``shamir`` optional extra is not installed.
+    TypeError
+        If ``shards`` is not a list of lists of strings.
+    ValueError
+        If the SLIP-0039 library rejects the shard set (insufficient
+        threshold, mixed identifiers, checksum failures, etc.).
+        Propagated from the underlying ``MnemonicError``.
+
+    Memory hygiene
+    --------------
+
+    Per ``rules/trust-plane-security.md`` MUST NOT Rule 3, callers MUST
+    ``del`` the returned bytes immediately after use::
+
+        secret = reconstruct(shards)
+        try:
+            use_secret(secret)
+        finally:
+            del secret  # remove reference; GC collects backing buffer
+
+    The wrapper deliberately does NOT zeroize the bytes object (Python's
+    ``bytes`` is immutable; in-place clearing is not portable). Use a
+    hardened secret-handling library if zeroization is required.
+    """
+    if not isinstance(shards, list):
+        raise TypeError(
+            f"reconstruct(shards=...) requires list; got {type(shards).__name__}"
+        )
+    if not shards:
+        raise ValueError("reconstruct(shards=...) requires at least one shard")
+    for idx, shard in enumerate(shards):
+        if not isinstance(shard, list):
+            raise TypeError(
+                f"reconstruct: shard[{idx}] must be list[str]; got "
+                f"{type(shard).__name__}"
+            )
+        for widx, word in enumerate(shard):
+            if not isinstance(word, str):
+                raise TypeError(
+                    f"reconstruct: shard[{idx}][{widx}] must be str; got "
+                    f"{type(word).__name__}"
+                )
+    if not isinstance(passphrase, (bytes, bytearray)):
+        raise TypeError(
+            f"reconstruct(passphrase=...) requires bytes; got "
+            f"{type(passphrase).__name__}"
+        )
+
+    sm = _require_shamir_mnemonic()
+
+    # The library accepts mnemonics as space-joined strings.
+    mnemonics = [_join(words) for words in shards]
+    secret = sm.combine_mnemonics(mnemonics, passphrase=bytes(passphrase))
+    logger.debug("shamir.reconstruct: combined %d shards", len(shards))
+    return secret
+
+
+# ---------------------------------------------------------------------------
+# Serialization (paper-print form)
+# ---------------------------------------------------------------------------
+
+
+def serialize_shard(shard: List[str]) -> str:
+    """Serialize a shard to its paper-print form.
+
+    The paper-print form is the canonical SLIP-0039 mnemonic: dictionary
+    words separated by single spaces. This is the interop surface across
+    SDKs and the form holders write down on paper, engrave on metal, or
+    print on cards.
+
+    Raises
+    ------
+    TypeError
+        If ``shard`` is not a list of strings.
+    ValueError
+        If ``shard`` is empty.
+    """
+    if not isinstance(shard, list):
+        raise TypeError(
+            f"serialize_shard requires list[str]; got {type(shard).__name__}"
+        )
+    if not shard:
+        raise ValueError("serialize_shard: shard must be non-empty")
+    for idx, word in enumerate(shard):
+        if not isinstance(word, str):
+            raise TypeError(
+                f"serialize_shard: shard[{idx}] must be str; got "
+                f"{type(word).__name__}"
+            )
+        if not word or _SHARD_DELIM in word:
+            raise ValueError(
+                f"serialize_shard: shard[{idx}] is empty or contains the "
+                f"delimiter '{_SHARD_DELIM}'"
+            )
+    return _join(shard)
+
+
+def deserialize_shard(shard: str) -> List[str]:
+    """Reverse :func:`serialize_shard`.
+
+    Whitespace tolerant on input: any run of ASCII whitespace is treated
+    as a word separator, so shards copied from paper with extra spaces
+    or line breaks survive the round-trip.
+
+    Raises
+    ------
+    TypeError
+        If ``shard`` is not :class:`str`.
+    ValueError
+        If ``shard`` is empty after stripping.
+    """
+    if not isinstance(shard, str):
+        raise TypeError(f"deserialize_shard requires str; got {type(shard).__name__}")
+    words = shard.split()
+    if not words:
+        raise ValueError("deserialize_shard: shard is empty")
+    return words
+
+
+# ---------------------------------------------------------------------------
+# Holder rotation
+# ---------------------------------------------------------------------------
+
+
+def rotate_holders(
+    old_shards: List[List[str]],
+    new_ritual: ShamirRitual,
+    *,
+    passphrase: bytes = b"",
+) -> List[List[str]]:
+    """Recombine ``old_shards``, then re-shard under ``new_ritual``.
+
+    Use this when the holder set changes -- a holder leaves, a new
+    holder joins, or the ``(m, n)`` policy is updated. The reconstructed
+    secret is held in memory for the duration of the re-shard call;
+    callers SHOULD invoke this on an air-gapped or otherwise isolated
+    host per Trust Vault operational guidance.
+
+    Parameters
+    ----------
+    old_shards:
+        At least ``old_ritual.threshold`` shards from the previous
+        ritual. The old ritual itself is not required because SLIP-0039
+        encodes thresholds in the mnemonics.
+    new_ritual:
+        The ``(m, n)`` configuration for the rotated holder set.
+    passphrase:
+        The passphrase used at :func:`generate` time for ``old_shards``.
+        Re-emitted shards use the same passphrase by default. To rotate
+        the passphrase, call :func:`reconstruct` and :func:`generate`
+        explicitly.
+
+    Returns
+    -------
+    list[list[str]]
+        ``new_ritual.total_shards`` shards under the new ritual.
+
+    Memory hygiene
+    --------------
+
+    The intermediate secret is ``del``-eted before the function returns.
+    However, Python's garbage collector may retain the underlying buffer
+    until the next collection cycle, and the SLIP-0039 reference
+    implementation is not constant-time. Hardened deployments SHOULD
+    perform rotation in a process that exits immediately afterward to
+    minimize the residence window.
+    """
+    secret = reconstruct(old_shards, passphrase=passphrase)
+    try:
+        new_shards = generate(secret, new_ritual, passphrase=passphrase)
+    finally:
+        # Drop our reference. Python's GC collects the buffer on its own
+        # schedule; this is best-effort residence-time minimization, NOT
+        # cryptographic zeroization.
+        del secret
+    logger.debug(
+        "shamir.rotate_holders: re-sharded under threshold=%d total=%d",
+        new_ritual.threshold,
+        new_ritual.total_shards,
+    )
+    return new_shards
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _words(mnemonic: str) -> List[str]:
+    """Split a SLIP-0039 mnemonic into its constituent dictionary words."""
+    return mnemonic.split()
+
+
+def _join(words: List[str]) -> str:
+    """Join words back into a SLIP-0039 mnemonic string."""
+    return _SHARD_DELIM.join(words)

--- a/tests/integration/trust/test_shamir_round_trip.py
+++ b/tests/integration/trust/test_shamir_round_trip.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration: real SLIP-0039 round-trip + rotate-holders (issue #606).
+
+Tier 2 integration suite -- exercises the audited ``shamir-mnemonic``
+reference library through the public ``kailash.trust.vault.shamir`` facade.
+
+Per ``rules/orphan-detection.md`` Rule 2a (Crypto-Pair Round-Trip Through
+Facade): paired crypto operations (``generate``/``reconstruct``,
+``serialize_shard``/``deserialize_shard``) MUST have a Tier 2 test that
+round-trips through the public surface, NOT the underlying library
+directly. Isolated unit tests per half can drift silently; round-trip
+is the only structural guarantee that the wrapper's contract holds end
+to end.
+
+Per ``rules/testing.md`` § 3-Tier: NO mocks. The real ``shamir-mnemonic``
+library is used; the suite skips cleanly via :func:`pytest.importorskip`
+when the optional ``shamir`` extra is not installed.
+
+Cases:
+
+* 3-of-5 round-trip across multiple shard subsets (any 3 of 5 reconstruct)
+* Threshold-1 reconstruct fails (security invariant)
+* serialize_shard / deserialize_shard round-trip
+* rotate_holders 3-of-5 -> 2-of-3 preserves the secret
+* rotate_holders 3-of-5 -> 5-of-7 preserves the secret
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import pytest
+
+# Real shamir-mnemonic library -- skip cleanly if the optional extra is
+# not installed locally. The Tier 1 suite proves the absence-path
+# contract without the lib; this suite proves the cryptographic round
+# trip with the lib.
+shamir_mnemonic = pytest.importorskip("shamir_mnemonic")  # noqa: F841
+
+from kailash.trust.vault.shamir import (  # noqa: E402  -- import after skip gate
+    ShamirRitual,
+    deserialize_shard,
+    generate,
+    reconstruct,
+    rotate_holders,
+    serialize_shard,
+)
+
+
+# ---------------------------------------------------------------------------
+# Generate / reconstruct round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_shamir_3_of_5_round_trip():
+    """Any 3 of 5 shards reconstruct the original 32-byte secret.
+
+    SLIP-0039 reference correctness: the wrapper MUST preserve the
+    secret across any threshold-sized subset of the generated shards.
+    Tested with 3 different subsets to assert no shard is privileged.
+    """
+    secret = secrets.token_bytes(32)
+    ritual = ShamirRitual(threshold=3, total_shards=5)
+
+    shards = generate(secret, ritual)
+    assert len(shards) == 5
+    assert all(isinstance(shard, list) for shard in shards)
+    assert all(isinstance(word, str) for shard in shards for word in shard)
+
+    # Subset (0, 1, 2) reconstructs.
+    rec_a = reconstruct([shards[0], shards[1], shards[2]])
+    assert rec_a == secret
+
+    # Subset (1, 3, 4) reconstructs.
+    rec_b = reconstruct([shards[1], shards[3], shards[4]])
+    assert rec_b == secret
+
+    # Subset (0, 2, 4) reconstructs.
+    rec_c = reconstruct([shards[0], shards[2], shards[4]])
+    assert rec_c == secret
+
+
+@pytest.mark.integration
+def test_shamir_threshold_minus_one_fails():
+    """Reconstruction with threshold-1 shards raises (security invariant).
+
+    The Shamir threshold is the security boundary: fewer than ``threshold``
+    shards MUST NOT recover the secret. The underlying SLIP-0039 library
+    raises ``MnemonicError`` (subclass of ``Exception``); the wrapper does
+    not narrow this, so callers see the library's own typed exception.
+    """
+    secret = secrets.token_bytes(32)
+    ritual = ShamirRitual(threshold=3, total_shards=5)
+
+    shards = generate(secret, ritual)
+
+    # Only 2 shards -- below threshold; library MUST refuse.
+    with pytest.raises(Exception):  # noqa: B017 -- MnemonicError is a generic Exception
+        reconstruct([shards[0], shards[1]])
+
+
+# ---------------------------------------------------------------------------
+# Serialize / deserialize paper-print round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_shamir_serialize_deserialize_round_trip():
+    """Each generated shard round-trips through serialize/deserialize.
+
+    The paper-print form is the interop surface across SDKs and the
+    physical-medium form holders write to paper, engrave on metal, or
+    print on cards. Round-trip equality MUST hold for every shard.
+    """
+    secret = secrets.token_bytes(32)
+    ritual = ShamirRitual(threshold=3, total_shards=5)
+
+    shards = generate(secret, ritual)
+
+    for idx, shard in enumerate(shards):
+        paper = serialize_shard(shard)
+        assert isinstance(paper, str)
+        assert " " in paper  # multi-word mnemonic
+        recovered = deserialize_shard(paper)
+        assert recovered == shard, f"shard[{idx}] round-trip drift"
+
+    # And the round-tripped shards still reconstruct the secret.
+    paper_shards = [serialize_shard(s) for s in shards[:3]]
+    recovered_shards = [deserialize_shard(p) for p in paper_shards]
+    assert reconstruct(recovered_shards) == secret
+
+
+@pytest.mark.integration
+def test_shamir_serialize_deserialize_whitespace_tolerant():
+    """deserialize_shard tolerates extra whitespace from paper transcription."""
+    secret = secrets.token_bytes(32)
+    ritual = ShamirRitual(threshold=2, total_shards=3)
+
+    shards = generate(secret, ritual)
+    paper = serialize_shard(shards[0])
+
+    # Insert double-space + leading/trailing whitespace; .split() collapses.
+    transcribed = "  " + paper.replace(" ", "  ") + "  "
+    recovered = deserialize_shard(transcribed)
+    assert recovered == shards[0]
+
+
+# ---------------------------------------------------------------------------
+# Holder rotation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_rotate_holders_3_of_5_to_2_of_3():
+    """Rotation from 3-of-5 to 2-of-3 preserves the original secret.
+
+    Operational scenario: holder set shrinks (two holders depart, the
+    remaining three re-ritual under tighter threshold). Any 2 of the
+    new 3 shards MUST reconstruct the original secret.
+    """
+    secret = secrets.token_bytes(32)
+    old_ritual = ShamirRitual(threshold=3, total_shards=5)
+    new_ritual = ShamirRitual(threshold=2, total_shards=3)
+
+    old_shards = generate(secret, old_ritual)
+
+    # Take any 3 of the 5 old shards as input to rotation.
+    new_shards = rotate_holders(old_shards[:3], new_ritual)
+    assert len(new_shards) == 3
+
+    # Any 2 of the new 3 shards reconstruct the original secret.
+    assert reconstruct([new_shards[0], new_shards[1]]) == secret
+    assert reconstruct([new_shards[1], new_shards[2]]) == secret
+    assert reconstruct([new_shards[0], new_shards[2]]) == secret
+
+
+@pytest.mark.integration
+def test_rotate_holders_3_of_5_to_5_of_7():
+    """Rotation expanding holder set 3-of-5 -> 5-of-7 preserves the secret.
+
+    Operational scenario: governance approves expanding the holder
+    quorum. Reconstruction from any 5 of the 7 new shards MUST recover
+    the original secret.
+    """
+    secret = secrets.token_bytes(32)
+    old_ritual = ShamirRitual(threshold=3, total_shards=5)
+    new_ritual = ShamirRitual(threshold=5, total_shards=7)
+
+    old_shards = generate(secret, old_ritual)
+    new_shards = rotate_holders(old_shards[:3], new_ritual)
+    assert len(new_shards) == 7
+
+    # 5 shards reconstruct.
+    assert reconstruct(new_shards[:5]) == secret
+    # A different subset of 5 also reconstructs.
+    assert reconstruct(new_shards[2:7]) == secret
+
+
+@pytest.mark.integration
+def test_rotate_holders_below_old_threshold_fails():
+    """rotate_holders refuses below-threshold input from the OLD ritual.
+
+    Defense-in-depth: the recombine step inside rotation MUST refuse
+    fewer than ``old_ritual.threshold`` shards. Library raises an
+    exception; the wrapper propagates.
+    """
+    secret = secrets.token_bytes(32)
+    old_ritual = ShamirRitual(threshold=3, total_shards=5)
+    new_ritual = ShamirRitual(threshold=2, total_shards=3)
+
+    old_shards = generate(secret, old_ritual)
+
+    # Only 2 shards -- below the old threshold of 3; rotation MUST refuse.
+    with pytest.raises(Exception):  # noqa: B017 -- MnemonicError generic Exception
+        rotate_holders(old_shards[:2], new_ritual)

--- a/tests/regression/test_issue_606_shamir_wrapper.py
+++ b/tests/regression/test_issue_606_shamir_wrapper.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: SLIP-0039 Shamir wrapper scaffold (issue #606).
+
+Tier 1 regression suite for ``kailash.trust.vault.shamir``:
+
+* :class:`ShamirRitual` validation (threshold/total bounds, frozen invariant)
+* Lazy-import contract -- every public function MUST raise
+  :class:`RuntimeError` with an actionable install hint when the optional
+  ``shamir`` extra is absent (probed via ``sys.modules`` monkey-patch so the
+  test exercises the absence path even when ``shamir-mnemonic`` IS installed
+  locally for the Tier 2 round-trip suite).
+* :func:`back_up_vault_key` stub -- documents mint ISS-37 in the error.
+
+These tests run without the optional extra; they probe the absence-path
+contract that ``rules/dependencies.md`` calls out as the only acceptable form
+of "loud failure at call site" for optional dependencies. The Tier 2 suite
+under ``tests/integration/trust/test_shamir_round_trip.py`` exercises the
+real cryptographic round-trip with ``shamir-mnemonic`` installed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# ShamirRitual validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_shamir_ritual_default():
+    """Construction with valid (threshold, total_shards) succeeds."""
+    from kailash.trust.vault.shamir import ShamirRitual
+
+    ritual = ShamirRitual(threshold=3, total_shards=5)
+    assert ritual.threshold == 3
+    assert ritual.total_shards == 5
+
+
+@pytest.mark.regression
+def test_shamir_ritual_validation_threshold():
+    """Invalid (threshold, total) combinations raise ValueError."""
+    from kailash.trust.vault.shamir import ShamirRitual
+
+    # threshold > total
+    with pytest.raises(ValueError, match=r"threshold.*<= total_shards"):
+        ShamirRitual(threshold=4, total_shards=3)
+
+    # total exceeds SLIP-0039 4-bit limit (16)
+    with pytest.raises(ValueError, match=r"SLIP-0039 limit of 16"):
+        ShamirRitual(threshold=2, total_shards=17)
+
+    # threshold below 1
+    with pytest.raises(ValueError, match=r"threshold must be >= 1"):
+        ShamirRitual(threshold=0, total_shards=3)
+
+    # negative threshold
+    with pytest.raises(ValueError, match=r"threshold must be >= 1"):
+        ShamirRitual(threshold=-1, total_shards=3)
+
+    # negative total
+    with pytest.raises(ValueError, match=r"total_shards must be >= 1"):
+        ShamirRitual(threshold=1, total_shards=-1)
+
+    # trivial 1-of-n split (rejected pending mint ISS-37 governance review)
+    with pytest.raises(ValueError, match=r"trivial split"):
+        ShamirRitual(threshold=1, total_shards=5)
+
+
+@pytest.mark.regression
+def test_shamir_ritual_frozen():
+    """ShamirRitual is a frozen dataclass; attribute assignment raises."""
+    from dataclasses import FrozenInstanceError
+
+    from kailash.trust.vault.shamir import ShamirRitual
+
+    ritual = ShamirRitual(threshold=3, total_shards=5)
+    with pytest.raises(FrozenInstanceError):
+        ritual.threshold = 4  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        ritual.total_shards = 7  # type: ignore[misc]
+
+
+@pytest.mark.regression
+def test_shamir_ritual_type_validation():
+    """Non-int threshold/total raises TypeError."""
+    from kailash.trust.vault.shamir import ShamirRitual
+
+    with pytest.raises(TypeError, match=r"MUST be int"):
+        ShamirRitual(threshold="3", total_shards=5)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match=r"MUST be int"):
+        ShamirRitual(threshold=3, total_shards=5.0)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Lazy-import contract -- every public function raises with install hint
+# ---------------------------------------------------------------------------
+#
+# The pattern: monkey-patch ``sys.modules["shamir_mnemonic"]`` to ``None`` so
+# the lazy ``import shamir_mnemonic`` inside each function raises
+# ``ImportError`` even when the package is actually installed for the Tier 2
+# suite. ``rules/dependencies.md`` requires module import to succeed (so the
+# wrapper module itself stays in ``__all__``) AND the call site to fail
+# loudly with an actionable hint -- this test family proves both halves.
+
+
+@pytest.mark.regression
+def test_generate_optional_extra_absence_raises(monkeypatch):
+    """generate() raises RuntimeError citing the install hint."""
+    monkeypatch.setitem(sys.modules, "shamir_mnemonic", None)
+    from kailash.trust.vault.shamir import ShamirRitual, generate
+
+    with pytest.raises(RuntimeError, match=r"kailash\[shamir\]"):
+        generate(b"x" * 16, ShamirRitual(threshold=2, total_shards=3))
+
+
+@pytest.mark.regression
+def test_reconstruct_optional_extra_absence_raises(monkeypatch):
+    """reconstruct() raises RuntimeError citing the install hint."""
+    monkeypatch.setitem(sys.modules, "shamir_mnemonic", None)
+    from kailash.trust.vault.shamir import reconstruct
+
+    # Provide minimally well-typed shards so the type-checks in reconstruct
+    # do not preempt the lazy-import probe; the function must reach the
+    # ``_require_shamir_mnemonic`` call before raising.
+    shards = [["dummy", "words"], ["another", "shard"]]
+    with pytest.raises(RuntimeError, match=r"kailash\[shamir\]"):
+        reconstruct(shards)
+
+
+@pytest.mark.regression
+def test_serialize_shard_does_not_require_extra():
+    """serialize_shard is pure-Python; does NOT require the shamir extra."""
+    from kailash.trust.vault.shamir import serialize_shard
+
+    # serialize_shard does not import shamir_mnemonic; it is a pure
+    # paper-print formatter. Round-trips with deserialize_shard live in
+    # the Tier 2 suite. Here we only assert it works without the extra.
+    out = serialize_shard(["alpha", "beta", "gamma"])
+    assert out == "alpha beta gamma"
+
+
+@pytest.mark.regression
+def test_deserialize_shard_does_not_require_extra():
+    """deserialize_shard is pure-Python; does NOT require the shamir extra."""
+    from kailash.trust.vault.shamir import deserialize_shard
+
+    assert deserialize_shard("alpha beta gamma") == ["alpha", "beta", "gamma"]
+
+
+@pytest.mark.regression
+def test_rotate_holders_optional_extra_absence_raises(monkeypatch):
+    """rotate_holders() raises RuntimeError citing the install hint.
+
+    rotate_holders calls reconstruct(), which calls _require_shamir_mnemonic,
+    so the absence path surfaces at the first sub-call.
+    """
+    monkeypatch.setitem(sys.modules, "shamir_mnemonic", None)
+    from kailash.trust.vault.shamir import ShamirRitual, rotate_holders
+
+    old_shards = [["dummy", "words"], ["another", "shard"], ["third", "one"]]
+    new_ritual = ShamirRitual(threshold=2, total_shards=3)
+    with pytest.raises(RuntimeError, match=r"kailash\[shamir\]"):
+        rotate_holders(old_shards, new_ritual)
+
+
+# ---------------------------------------------------------------------------
+# back_up_vault_key stub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_back_up_vault_key_stub_raises():
+    """The stub raises NotImplementedError citing mint ISS-37."""
+    from kailash.trust.vault import ShamirRitual, back_up_vault_key
+
+    ritual = ShamirRitual(threshold=3, total_shards=5)
+    with pytest.raises(NotImplementedError, match=r"mint ISS-37"):
+        back_up_vault_key(b"x" * 16, ritual)
+
+
+@pytest.mark.regression
+def test_back_up_vault_key_stub_references_issue_606():
+    """The stub error message links to issue #606 for traceability."""
+    from kailash.trust.vault import ShamirRitual, back_up_vault_key
+
+    ritual = ShamirRitual(threshold=3, total_shards=5)
+    with pytest.raises(NotImplementedError, match=r"#606"):
+        back_up_vault_key(b"x" * 16, ritual)
+
+
+# ---------------------------------------------------------------------------
+# Public surface -- module import contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_public_surface_imports_without_extra(monkeypatch):
+    """Module import succeeds even when shamir_mnemonic is absent.
+
+    This is the inverse of the call-site loud-failure rule: the module
+    itself MUST import cleanly so static analysers, Sphinx autodoc, and
+    `from kailash.trust.vault import *` keep working without the extra.
+    """
+    monkeypatch.setitem(sys.modules, "shamir_mnemonic", None)
+    # Force re-import to exercise the absence path on module load.
+    monkeypatch.delitem(sys.modules, "kailash.trust.vault", raising=False)
+    monkeypatch.delitem(sys.modules, "kailash.trust.vault.shamir", raising=False)
+    monkeypatch.delitem(sys.modules, "kailash.trust.vault.backup", raising=False)
+
+    import kailash.trust.vault as vault_pkg
+
+    # Public surface is reachable via __all__ -- frozen dataclass + the five
+    # callables + the stub.
+    assert "ShamirRitual" in vault_pkg.__all__
+    assert "generate" in vault_pkg.__all__
+    assert "reconstruct" in vault_pkg.__all__
+    assert "serialize_shard" in vault_pkg.__all__
+    assert "deserialize_shard" in vault_pkg.__all__
+    assert "rotate_holders" in vault_pkg.__all__
+    assert "back_up_vault_key" in vault_pkg.__all__


### PR DESCRIPTION
## Summary

Scaffold for #606 — SLIP-0039 Shamir secret-sharing wrapper for Trust Vault key backup. The Trust Vault binding (`back_up_vault_key`) is gated on **mint ISS-37**; this PR ships the SLIP-0039 wrapper API + ritual scaffolding so downstream callers can compile against the surface today, and the binding body fills in cleanly when ISS-37 stabilises.

## Wrapper API

`kailash.trust.vault` re-exports:

- **`ShamirRitual(threshold, total_shards)`** — frozen dataclass capturing m-of-n. Validates `1 <= threshold <= total <= 16` (SLIP-0039 limit) and rejects trivial 1-of-n splits pending mint ISS-37 governance review.
- **`generate(secret, ritual, *, passphrase=b"")`** — produces `total_shards` SLIP-0039 mnemonic shards.
- **`reconstruct(shards, *, passphrase=b"")`** — recombines threshold-many shards into the secret.
- **`serialize_shard` / `deserialize_shard`** — canonical paper-print form (single-line space-separated dictionary words). Cross-SDK interop surface.
- **`rotate_holders(old_shards, new_ritual, *, passphrase=b"")`** — recombine then re-shard; intermediate secret `del`-eted before return.
- **`back_up_vault_key(vault_key, ritual)`** — Trust Vault binding **stub** raising `NotImplementedError("...mint ISS-37...")` per `rules/zero-tolerance.md` Rule 2 (issue-linked, gate-documented).

## Optional Extra — Lazy-Import Contract

```
pip install kailash[shamir]
```

Module import of `kailash.trust.vault.shamir` succeeds even without the optional extra installed (so `__all__` membership, Sphinx autodoc, and `from kailash.trust.vault import *` keep working). The audited `shamir-mnemonic` reference library is imported lazily inside each public function via `_require_shamir_mnemonic()`. When the extra is absent, the FIRST call site raises a `RuntimeError` with an actionable install hint:

```
RuntimeError: SLIP-0039 Shamir secret-sharing requires the 'shamir'
optional extra. Install via: pip install kailash[shamir]
```

This is the "loud failure at call site" pattern from `rules/dependencies.md`. The silent `X = None` fallback anti-pattern is BLOCKED.

## Cross-SDK

Per `rules/cross-sdk-inspection.md`: a matching SLIP-0039 scaffold is expected on the Rust SDK (`kailash-rs`) using a parallel audited Rust SLIP-0039 implementation. The serialised paper-print form is the cross-SDK interop surface — a shard serialised by Python `kailash-py` MUST round-trip through `kailash-rs`. **A follow-up issue should be filed on `esperie/kailash-rs` for the matching scaffold if not already present.**

## Test plan

- [x] **Tier 1 regression** — `tests/regression/test_issue_606_shamir_wrapper.py` (12 cases, all passing locally):
  - ShamirRitual frozen invariant + threshold/total validation (m>n, m=0, n>16, negative bounds, trivial 1-of-n rejection)
  - Lazy-import absence-path for `generate` / `reconstruct` / `rotate_holders` (probed via `sys.modules` monkey-patch so absence path exercises even when the lib is locally installed)
  - `serialize_shard` / `deserialize_shard` work without the extra (pure-Python)
  - `back_up_vault_key` stub raises `NotImplementedError` citing mint ISS-37 + issue #606
  - Module import contract — `kailash.trust.vault` imports cleanly without the extra
- [x] **Tier 2 integration** — `tests/integration/trust/test_shamir_round_trip.py` (7 cases, all passing locally with `shamir-mnemonic 0.3.0`):
  - 3-of-5 round-trip across 3 different shard subsets
  - threshold-minus-1 reconstruct fails (security boundary)
  - serialize/deserialize round-trip + whitespace tolerance for paper transcription
  - `rotate_holders` 3-of-5 → 2-of-3 preserves the secret
  - `rotate_holders` 3-of-5 → 5-of-7 preserves the secret
  - `rotate_holders` refuses below-old-threshold input
  - Suite skips cleanly via `pytest.importorskip` when `shamir-mnemonic` is not installed (CI without the extra)
- [x] Per `rules/orphan-detection.md` Rule 2a — all crypto operations route through the public `kailash.trust.vault.shamir.<name>` surface, NOT the underlying library directly.
- [x] Per `rules/testing.md` — Tier 2 uses real `shamir-mnemonic`; NO mocks (`@patch` / `MagicMock` / `unittest.mock`).

## Forward path

When mint ISS-37 stabilises, only `back_up_vault_key`'s body fills in:

1. Resolve the vault key by ID against the mint-issued clearance envelope; validate `backup` capability.
2. Pass resolved key bytes to `kailash.trust.vault.shamir.generate()` under the supplied ritual.
3. Write an audit anchor (per `rules/eatp.md`) capturing ritual parameters, holder distribution policy, and shard count. Shard contents are NEVER logged.

The signature does NOT change — callers compile against `back_up_vault_key` today and observe `NotImplementedError` until ISS-37 lands.

## Security caveat

The `shamir-mnemonic` reference implementation is **NOT constant-time** and is documented by its authors as suitable for correctness verification rather than handling of high-value secrets in adversarial settings. Trust Vault deployments needing side-channel resistance MUST evaluate hardened alternatives before production use. The wrapper exists today to (1) freeze the SLIP-0039 API surface so downstream callers can compile against it and (2) enable the end-to-end ritual rehearsal. Documented in `specs/trust-crypto.md` § Shamir Secret-Sharing.

## Specs

- `specs/trust-crypto.md` § Shamir Secret-Sharing (new)
- `specs/security-data.md` § 10.X Trust Vault Backup (new)

## Related issues

Refs #606