### PR TITLE
chore(release): kailash-mcp 0.2.10 — JWT iss-claim security fix release bump

### DIFF
--- a/packages/kailash-mcp/CHANGELOG.md
+++ b/packages/kailash-mcp/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the Kailash MCP package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.10] — 2026-04-26 — JWT iss-claim required when expected_issuer configured (#625)
+
+Patch bump — closes Wave 4 cross-SDK security finding #625 (kailash-rs#599 sibling). Per upstream PyJWT semantics, calling `decode(token, ..., issuer=allowlist)` enforces equality only when the `iss` claim is **present**. A forged token that omits `iss` entirely passes issuer validation regardless of the allowlist. Layering `options={"require": ["exp", "iss"]}` forces presence and closes the bypass.
+
+### Security
+
+- **HIGH (closes #625)** — `BearerTokenAuth.__init__` accepts new optional `expected_issuer` kwarg; `_validate_jwt_token` layers `options={"require": ["exp", "iss"]}` and `issuer=` when set. PyJWT exception handlers cover `MissingRequiredClaimError` + `InvalidIssuerError`.
+- **HIGH (closes #625)** — `JWTAuth.__init__` passes its `issuer` arg through to `BearerTokenAuth` as `expected_issuer`, so callers using `JWTAuth` automatically inherit the iss requirement.
+- **HIGH (closes #625)** — `JWTManager.verify_access_token` / `verify_refresh_token` layer the require-claims when `self.issuer is not None`.
+
+### Tests
+
+- 9/9 regression tests at `packages/kailash-mcp/tests/regression/test_issue_625_jwt_iss_required.py` (acceptance B + C + extra coverage + cross-SDK semantic-parity tests).
+- Registered `regression` pytest marker in `pyproject.toml`.
+
+### Cross-SDK
+
+- Originating issue: `esperie/kailash-rs#599`
+- Rust merging PR: `kailash-rs#602` (v3.23.0)
+- Python merging PR: kailash-py #632 (this release)
+
+### Origin
+
+- Initial fix shipped via PR #632 but was missed in the kailash-mcp version bump. This patch corrects the version to 0.2.10 so consumers can `pip install kailash-mcp==0.2.10` and receive the security fix. Per `rules/build-repo-release-discipline.md` § 1 (every src change triggers a release-cycle).
+
 ## [0.2.9] — 2026-04-24 — Security patch (issue #613)
 
 ### Changed

--- a/packages/kailash-mcp/pyproject.toml
+++ b/packages/kailash-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-mcp"
-version = "0.2.9"
+version = "0.2.10"
 description = "Production-ready Model Context Protocol (MCP) client, server, and platform for Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-mcp/src/kailash_mcp/__init__.py
+++ b/packages/kailash-mcp/src/kailash_mcp/__init__.py
@@ -7,7 +7,7 @@ Provides MCP client/server, authentication, service discovery, transports,
 and the Kailash Platform MCP Server for AI assistant introspection.
 """
 
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 
 # Advanced Features
 from kailash_mcp.advanced.features import (


### PR DESCRIPTION
## Summary

PR #632 shipped the JWT iss-claim security fix (#625) to `packages/kailash-mcp/src/` but missed bumping the `kailash-mcp` version. Without a version bump, consumers cannot install the security fix via PyPI.

This is a **release-discipline correction** — no source-code changes, only the atomicity guarantee from `rules/zero-tolerance.md` Rule 5 (pyproject.toml + `__version__` together) and `rules/build-repo-release-discipline.md` § 1 (every src change triggers a release cycle).

## Changes

- `packages/kailash-mcp/pyproject.toml::version` 0.2.9 → 0.2.10
- `packages/kailash-mcp/src/kailash_mcp/__init__.py::__version__` 0.2.9 → 0.2.10
- New CHANGELOG entry for 0.2.10 referencing #625 + #632 + cross-SDK origin

## Wave 4 release scope

Ships alongside:
- **kailash 2.11.1** — alg_id Layer-1 threading completion (#604 Wave 4) — PR #633
- **kailash-dataflow 2.3.1** — SecurityDefinerBuilder owner-pinning + COMMENT defense-in-depth (#607 Wave 4) — PR #631

## Test plan

No code changes. Tests are unchanged from PR #632 (9/9 regression tests at `packages/kailash-mcp/tests/regression/test_issue_625_jwt_iss_required.py`).

## Origin

`rules/build-repo-release-discipline.md` § 1 enforcement during Wave 4 release-scope detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)