### PR TITLE
security: JWT hardening — remove hardcoded api-gateway secret + require iss claim (#635, #636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.2] — 2026-04-26 — JWT security hardening (#635 + #636, Wave 5 audit)
+
+Patch bump — closes two security findings surfaced by Wave 5 portfolio spec audit (workspace `portfolio-spec-audit/04-validate/W5-C-findings.md`).
+
+### Security
+
+- **CRIT (closes #636)** — Remove hardcoded default JWT secret `"api-gateway-secret"` (18 chars) from `src/kailash/middleware/communication/api_gateway.py`. `APIGateway(enable_auth=True)` without an explicit `auth_manager=` now requires `KAILASH_API_GATEWAY_SECRET` environment variable (≥32 bytes per RFC 7518 §3.2). Missing env var raises typed `RuntimeError`; under-length raises typed `ValueError`. Aligns with `rules/env-models.md` (.env source-of-truth) and `rules/security.md` (no hardcoded secrets). Regression tests at `tests/regression/test_issue_636_api_gateway_default_secret.py` cover all paths including a structural invariant that greps the source for the hardcoded literal.
+- **HIGH (closes #635)** — Require `iss` claim presence when issuer is configured at `src/kailash/trust/auth/jwt.py::JWTValidator.verify_token`. PyJWT's `verify_iss` only enforces value equality WHEN the claim is present; tokens forged WITHOUT `iss` were silently accepted. Layered `options={"require": ["iss"]}` (and `aud` when audience is configured) closes the bypass. Cross-SDK companion to #625 (kailash-mcp 0.2.10) and kailash-rs#599 (v3.23.0). Regression tests at `tests/regression/test_issue_635_trust_jwt_iss_required.py` cover missing-iss-rejected, missing-iss-allowed-when-no-issuer, present-iss-validated, present-iss-matched, and missing-aud-rejected paths.
+
+### Cross-SDK alignment
+
+- kailash-rs#599 (v3.23.0) — Rust JWT iss-claim presence enforcement
+- #625 (kailash-mcp 0.2.10) — MCP layer iss-claim fix; this PR completes the same fix at the underlying trust JWT validator the MCP layer delegates to
+
 ## [2.11.1] — 2026-04-26 — Complete alg_id Layer-1 threading (#604 Wave 4)
 
 Patch bump — closes Wave 3 `/redteam` HIGH findings H1 + H2 on the `AlgorithmIdentifier` scaffold. Threads `alg_id` through the four remaining Layer-1 sites that PR #627 (kailash 2.11.0) deferred, and re-exports the canonical scaffold symbols from `kailash.trust` and `kailash.trust.signing`. Wire format remains gated on mint ISS-31 + cross-SDK align with `esperie/kailash-rs#33`; until then, all Layer-1 sites enforce `ed25519+sha256` only and raise `NotImplementedError` on any non-default value.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.11.1"
+version = "2.11.2"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.11.1"
+__version__ = "2.11.2"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/middleware/communication/api_gateway.py
+++ b/src/kailash/middleware/communication/api_gateway.py
@@ -8,6 +8,7 @@ frontend support capabilities.
 
 import asyncio
 import logging
+import os
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -159,12 +160,24 @@ class APIGateway:
         # Initialize auth manager if enabled
         if enable_auth:
             if auth_manager is None:
-                # Create default auth manager if none provided
-                # Import here to avoid circular dependency
+                secret_key = os.environ.get("KAILASH_API_GATEWAY_SECRET")
+                if not secret_key:
+                    raise RuntimeError(
+                        "APIGateway(enable_auth=True) without auth_manager requires "
+                        "KAILASH_API_GATEWAY_SECRET environment variable (>=32 bytes). "
+                        "Either set the env var, pass auth_manager=JWTAuthManager(...), "
+                        "or set enable_auth=False. See issue #636."
+                    )
+                if len(secret_key.encode("utf-8")) < 32:
+                    raise ValueError(
+                        "KAILASH_API_GATEWAY_SECRET must be at least 32 bytes "
+                        f"(got {len(secret_key.encode('utf-8'))}). See RFC 7518 §3.2 "
+                        "and JWTConfig.MIN_SECRET_LENGTH."
+                    )
                 from ..auth import JWTAuthManager
 
                 self.auth_manager = JWTAuthManager(
-                    secret_key="api-gateway-secret",
+                    secret_key=secret_key,
                     algorithm="HS256",
                     issuer="kailash-gateway",
                     audience="kailash-api",

--- a/src/kailash/trust/auth/jwt.py
+++ b/src/kailash/trust/auth/jwt.py
@@ -225,12 +225,24 @@ class JWTValidator:
             else:
                 key = self.config.public_key
 
-            # Build verification options
-            options = {
+            # Build verification options.
+            # SECURITY (#635, cross-SDK companion to #625): when an issuer is
+            # configured, the iss claim MUST be present. PyJWT's verify_iss
+            # only enforces value-equality WHEN the claim is present — a token
+            # forged without iss is silently accepted otherwise. Layering
+            # `require: ["iss"]` forces presence and closes the bypass.
+            options: Dict[str, Any] = {
                 "verify_exp": self.config.verify_exp,
                 "verify_iss": self.config.issuer is not None,
                 "verify_aud": self.config.audience is not None,
             }
+            require_claims: List[str] = []
+            if self.config.issuer is not None:
+                require_claims.append("iss")
+            if self.config.audience is not None:
+                require_claims.append("aud")
+            if require_claims:
+                options["require"] = require_claims
 
             # Decode and verify
             payload = jwt.decode(
@@ -240,7 +252,7 @@ class JWTValidator:
                 issuer=self.config.issuer,
                 audience=self.config.audience,
                 leeway=self.config.leeway,
-                options=options,
+                options=options,  # type: ignore[arg-type]  # PyJWT Options TypedDict
             )
 
             # SECURITY: Reject refresh tokens used as access tokens

--- a/tests/regression/test_issue_635_trust_jwt_iss_required.py
+++ b/tests/regression/test_issue_635_trust_jwt_iss_required.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #635 — trust JWT iss-claim presence enforcement.
+
+Cross-SDK companion to #625 (kailash-mcp 0.2.10) and kailash-rs#599 (v3.23.0).
+
+PyJWT's `verify_iss` only checks iss VALUE equality WHEN the claim is PRESENT.
+A token forged WITHOUT an iss claim was silently accepted by JWTValidator
+(and therefore by Nexus's JWTMiddleware which delegates to it). Layering
+`require: ["iss"]` forces presence.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import jwt as pyjwt
+import pytest
+
+from kailash.trust.auth.exceptions import InvalidTokenError
+from kailash.trust.auth.jwt import JWTConfig, JWTValidator
+
+JWT_TEST_SECRET = "test-secret-key-minimum-32-bytes!"
+
+
+def _encode(
+    claims: dict, secret: str = JWT_TEST_SECRET, algorithm: str = "HS256"
+) -> str:
+    """Encode a JWT with arbitrary claims for forgery scenarios."""
+    return pyjwt.encode(claims, secret, algorithm=algorithm)
+
+
+@pytest.mark.regression
+def test_missing_iss_rejected_when_issuer_configured():
+    """Token without iss claim MUST be rejected when validator has issuer configured."""
+    config = JWTConfig(
+        secret=JWT_TEST_SECRET, algorithm="HS256", issuer="trusted-issuer"
+    )
+    validator = JWTValidator(config)
+
+    # Forge a token that omits the iss claim entirely
+    exp = datetime.now(timezone.utc) + timedelta(minutes=5)
+    forged = _encode({"sub": "alice", "exp": exp.timestamp()})
+
+    with pytest.raises(InvalidTokenError):
+        validator.verify_token(forged)
+
+
+@pytest.mark.regression
+def test_missing_iss_accepted_when_issuer_not_configured():
+    """Token without iss claim MUST be accepted when validator has no issuer (preserves behaviour)."""
+    config = JWTConfig(secret=JWT_TEST_SECRET, algorithm="HS256", issuer=None)
+    validator = JWTValidator(config)
+
+    exp = datetime.now(timezone.utc) + timedelta(minutes=5)
+    token = _encode({"sub": "alice", "exp": exp.timestamp()})
+
+    payload = validator.verify_token(token)
+    assert payload["sub"] == "alice"
+    assert "iss" not in payload
+
+
+@pytest.mark.regression
+def test_present_iss_validated_against_configured_issuer():
+    """Existing behaviour preserved: iss-value mismatch still rejected."""
+    config = JWTConfig(
+        secret=JWT_TEST_SECRET, algorithm="HS256", issuer="trusted-issuer"
+    )
+    validator = JWTValidator(config)
+
+    exp = datetime.now(timezone.utc) + timedelta(minutes=5)
+    forged = _encode({"sub": "alice", "iss": "evil-issuer", "exp": exp.timestamp()})
+
+    with pytest.raises(InvalidTokenError):
+        validator.verify_token(forged)
+
+
+@pytest.mark.regression
+def test_present_iss_matching_configured_issuer_accepted():
+    """Happy path: iss present and matches configured issuer."""
+    config = JWTConfig(
+        secret=JWT_TEST_SECRET, algorithm="HS256", issuer="trusted-issuer"
+    )
+    validator = JWTValidator(config)
+
+    exp = datetime.now(timezone.utc) + timedelta(minutes=5)
+    token = _encode({"sub": "alice", "iss": "trusted-issuer", "exp": exp.timestamp()})
+
+    payload = validator.verify_token(token)
+    assert payload["sub"] == "alice"
+    assert payload["iss"] == "trusted-issuer"
+
+
+@pytest.mark.regression
+def test_missing_aud_rejected_when_audience_configured():
+    """Same hardening pattern for the aud claim — sibling enforcement."""
+    config = JWTConfig(
+        secret=JWT_TEST_SECRET,
+        algorithm="HS256",
+        issuer="trusted-issuer",
+        audience="kailash-api",
+    )
+    validator = JWTValidator(config)
+
+    exp = datetime.now(timezone.utc) + timedelta(minutes=5)
+    # Has iss, missing aud
+    forged = _encode({"sub": "alice", "iss": "trusted-issuer", "exp": exp.timestamp()})
+
+    with pytest.raises(InvalidTokenError):
+        validator.verify_token(forged)

--- a/tests/regression/test_issue_636_api_gateway_default_secret.py
+++ b/tests/regression/test_issue_636_api_gateway_default_secret.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #636 — APIGateway default JWT secret CRIT.
+
+CRIT: `src/kailash/middleware/communication/api_gateway.py` previously shipped
+a hardcoded default JWT signing key `"api-gateway-secret"` (18 chars, public OSS).
+Anyone calling `APIGateway(enable_auth=True)` without passing `auth_manager=`
+inherited a forgeable JWT auth chain.
+
+Fix: read secret from KAILASH_API_GATEWAY_SECRET env var; raise typed errors
+when missing or under-length. Aligns with `rules/env-models.md` (.env source-of-truth)
+and `rules/security.md` (no hardcoded secrets).
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from kailash.middleware.communication.api_gateway import APIGateway
+
+# Module-scope lock — env-var-mutating tests MUST serialize per
+# `rules/testing.md` § "Env-Var Test Isolation".
+_ENV_LOCK = threading.Lock()
+
+
+@pytest.fixture
+def env_serialized():
+    with _ENV_LOCK:
+        yield
+
+
+@pytest.mark.regression
+def test_no_hardcoded_default_secret_in_source():
+    """Structural invariant: the hardcoded "api-gateway-secret" literal MUST NOT recur."""
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "kailash"
+        / "middleware"
+        / "communication"
+        / "api_gateway.py"
+    )
+    text = src.read_text()
+    assert '"api-gateway-secret"' not in text, (
+        "Hardcoded default JWT secret reintroduced — see issue #636. "
+        "Default auth must read from KAILASH_API_GATEWAY_SECRET env var."
+    )
+
+
+@pytest.mark.regression
+def test_construction_without_env_var_raises_runtime_error(monkeypatch, env_serialized):
+    """APIGateway(enable_auth=True) without auth_manager + without env var -> RuntimeError."""
+    monkeypatch.delenv("KAILASH_API_GATEWAY_SECRET", raising=False)
+    with pytest.raises(RuntimeError, match="KAILASH_API_GATEWAY_SECRET"):
+        APIGateway(enable_auth=True)
+
+
+@pytest.mark.regression
+def test_construction_with_short_env_var_raises_value_error(
+    monkeypatch, env_serialized
+):
+    """Env var present but < 32 bytes -> ValueError (per RFC 7518 §3.2)."""
+    monkeypatch.setenv("KAILASH_API_GATEWAY_SECRET", "too-short")  # 9 bytes
+    with pytest.raises(ValueError, match="at least 32 bytes"):
+        APIGateway(enable_auth=True)
+
+
+@pytest.mark.regression
+def test_construction_with_valid_env_var_succeeds(monkeypatch, env_serialized):
+    """Env var >= 32 bytes -> APIGateway constructs cleanly with default JWT auth."""
+    monkeypatch.setenv(
+        "KAILASH_API_GATEWAY_SECRET",
+        "x" * 64,  # 64 bytes, well above the 32-byte minimum
+    )
+    gw = APIGateway(enable_auth=True)
+    assert gw.auth_manager is not None
+    assert gw.enable_auth is True
+
+
+@pytest.mark.regression
+def test_construction_with_explicit_auth_manager_ignores_env_var(
+    monkeypatch, env_serialized
+):
+    """When auth_manager is provided, env var is not required (caller owns secret)."""
+    monkeypatch.delenv("KAILASH_API_GATEWAY_SECRET", raising=False)
+
+    class _FakeAuthManager:
+        algorithm = "HS256"
+        issuer = "test-issuer"
+        audience = "test-aud"
+
+    fake = _FakeAuthManager()
+    gw = APIGateway(enable_auth=True, auth_manager=fake)
+    assert gw.auth_manager is fake
+
+
+@pytest.mark.regression
+def test_construction_without_auth_does_not_require_env_var(
+    monkeypatch, env_serialized
+):
+    """enable_auth=False bypasses the secret requirement entirely."""
+    monkeypatch.delenv("KAILASH_API_GATEWAY_SECRET", raising=False)
+    gw = APIGateway(enable_auth=False)
+    assert gw.auth_manager is None
+    assert gw.enable_auth is False


### PR DESCRIPTION
## Summary

Two security fixes from Wave 5 portfolio spec audit. Ships as kailash 2.11.2.

- **CRIT (#636)** — Remove hardcoded JWT default secret `"api-gateway-secret"` from `APIGateway`. Now requires `KAILASH_API_GATEWAY_SECRET` env var (≥32 bytes per RFC 7518 §3.2) when `enable_auth=True` without `auth_manager=`. Aligns with `rules/env-models.md` and `rules/security.md`.
- **HIGH (#635)** — Require `iss` claim presence in `JWTValidator.verify_token` when issuer configured. Cross-SDK companion to #625 (kailash-mcp 0.2.10) and kailash-rs#599 (v3.23.0); same fix at the underlying validator the MCP layer delegates to.

## Test plan

- [x] `tests/regression/test_issue_635_trust_jwt_iss_required.py` — 5 cases: missing iss rejected, missing iss allowed when issuer=None, present iss validated, present iss matched, missing aud rejected
- [x] `tests/regression/test_issue_636_api_gateway_default_secret.py` — 6 cases: source-grep invariant, env-var-missing → RuntimeError, env-var-too-short → ValueError, env-var-valid → success, explicit auth_manager bypass, enable_auth=False bypass
- [x] All 11 tests green locally (`.venv/bin/python -m pytest tests/regression/test_issue_63{5,6}*`)
- [ ] CI passes
- [ ] security-reviewer + reviewer gate per `rules/agents.md` § Quality Gates
- [ ] Hotfix release as kailash 2.11.2 after merge

## Related issues

Fixes #635
Fixes #636

## Cross-SDK alignment

- kailash-rs#599 (v3.23.0) — Rust JWT iss-claim presence
- #625 (kailash-mcp 0.2.10) — MCP layer iss-claim fix; this PR completes the same fix at the underlying trust JWT validator

## Audit provenance

Both findings surfaced by Wave 5 portfolio spec audit Shard C (nexus-specialist):

- W5-C-findings.md F-C-35 (CRIT) → #636
- W5-C-findings.md F-C-10 / F-C-40 (HIGH) → #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)