### PR TITLE
docs(specs): Wave 6.5 ml-automl + ml-feature-store v2 realignment

### DIFF
--- a/specs/dataflow-ml-integration.md
+++ b/specs/dataflow-ml-integration.md
@@ -10,6 +10,8 @@ Sibling specs: `specs/dataflow-core.md`, `specs/dataflow-express.md`, `specs/dat
 
 Origin: `ml-feature-store-draft.md` §2 mandates "DataFlow lineage integration" + `@feature` consuming `dataflow.transform`. `ml-registry-draft.md` mandates `lineage_dataset_hash` field on every model version. Round-1 theme T6 flagged spec-to-code drift where feature-store specs referenced a DataFlow binding that did not exist. This spec specifies the DataFlow-side surface kailash-ml 1.0.0 consumes.
 
+> **Wave 6.5 deferral note (2026-04-26):** Sections referencing the `@feature` decorator (§ 2.5, § 3) and `FeatureGroup` class as `kailash-ml`-side consumers describe **M2-deferred surfaces**, not 1.1.1-shipped behavior. Per `ml-feature-store.md` v2 § 11, the canonical 1.1.1 `FeatureStore` does NOT export `@feature`, `FeatureGroup`, `FeatureStore.materialize()`, or an online-store adapter. The `dataflow.ml_feature_source(...)` polars binding (§ 2 of this spec) IS shipped and consumed by `kailash_ml.features.FeatureStore.get_features(...)` end-to-end (verified positive at audit finding F-E2-23). When this spec graduates from `(draft)` to a versioned release, the `@feature` / `FeatureGroup` clauses MUST be revisited against ml-feature-store.md M2 deliverables.
+
 ---
 
 ## 1. Scope + Non-Goals

--- a/specs/kailash-core-ml-integration.md
+++ b/specs/kailash-core-ml-integration.md
@@ -244,7 +244,7 @@ Per approved-decisions.md Decision 12, cross-tenant admin operations raise `Mult
 **Inheritance:** `class MultiTenantOpError(MLError)` — directly under `MLError`, NOT under `ModelRegistryError` alone. The rationale is that cross-tenant admin ops surface across every kailash-ml domain:
 
 - **Registry** — `export_tenant_snapshot()` / `import_tenant_snapshot()` (see `ml-registry-draft.md §13`).
-- **Feature store** — `export_tenant_snapshot()` / `import_tenant_snapshot()` on a FeatureGroup (see `ml-feature-store-draft.md §12`).
+- **Feature store** — `export_tenant_snapshot()` / `import_tenant_snapshot()` on a FeatureGroup (M2-deferred — see `ml-feature-store.md` v2 § 11.1, the canonical 1.1.1 surface does not implement `FeatureGroup` yet).
 - **Serving** — cross-tenant `predict_with_shadow()` and cross-tenant model mirror without PACT D/T/R clearance (see `ml-serving-draft.md §12`).
 - **Tracking** — cross-tenant run compare in `kailash_ml.tracking` admin API (gated post-1.0).
 

--- a/specs/ml-automl.md
+++ b/specs/ml-automl.md
@@ -1,652 +1,830 @@
-# Kailash ML AutoML & Hyperparameter Search Specification (v1.0 Draft)
+# Kailash ML AutoML & Hyperparameter Search Specification
 
-Version: 1.0.0 (draft)
-Package: `kailash-ml`
-Parent domain: ML Lifecycle (see `ml-engines-v2-draft.md` for `MLEngine.compare` / `.fit`; `ml-tracking-draft.md` for run hierarchy; `ml-feature-store-draft.md` for data retrieval)
-License: Apache-2.0
-Python: >=3.11
-Owner: Terrene Foundation (Singapore CLG)
+**Version:** 1.1.1 (matches `kailash_ml.__version__`)
+**Status:** v2.0.0 (re-derived from implementation 2026-04-26 — supersedes v1.0.0)
+**Package:** `kailash-ml`
+**Parent domain:** ML Lifecycle (see `ml-engines.md` for `MLEngine.compare`/`.fit`; `ml-tracking.md` for run hierarchy; `ml-feature-store.md` for data retrieval)
+**License:** Apache-2.0
+**Python:** >=3.11
+**Owner:** Terrene Foundation (Singapore CLG)
 
-Status: DRAFT at `workspaces/kailash-ml-audit/specs-draft/ml-automl-draft.md`. Becomes `specs/ml-automl.md` after human review. Supersedes the AutoML/HPO sections of `ml-engines.md v0.9.x`.
+Origin: re-derivation of `specs/ml-automl.md` (v1.0.0) against the actual shipped surface in `packages/kailash-ml/src/kailash_ml/automl/`. The v1 spec OVERSTATES the implementation — Wave 5 portfolio audit at `workspaces/portfolio-spec-audit/04-validate/W5-E2-findings.md` recorded eight HIGH findings (F-E2-01..10) where spec ≠ code. v2 is the contract that matches what users actually receive when they `pip install kailash-ml==1.1.1`. Every capability the v1 spec asserted but the implementation does not deliver is enumerated under § "Deferred to M2 milestone" with a per-item rationale + sketch.
 
-Origin: Round-1 MLOps audit `workspaces/kailash-ml-audit/04-validate/round-1-mlops-production.md` HIGH "AutoMLEngine cannot distribute trials — serial only" + round-1 industry audit H-5 "No autolog()" M-1 "No sweeps / HPO UI" + round-1 SYNTHESIS T2 "0/18 engines auto-wire to km.track()". Closes three round-1 HIGHs by specifying: agent-augmented AutoML, distributed HPO, nested-run tracker wiring.
+This spec re-derives the assertions from scratch against the canonical surface at `packages/kailash-ml/src/kailash_ml/automl/__init__.py`.
 
 ---
 
 ## 1. Scope
 
-### 1.1 In Scope
+### 1.1 In Scope (v1.1.1)
 
-This spec is authoritative for three cooperating primitives, all exposed through `MLEngine`:
+This spec is authoritative for the AutoML primitives that ship in `kailash_ml.automl`:
 
-- **AutoMLEngine** — picks a model family AND hyperparameters jointly given data + a time budget; emits a leaderboard.
-- **HyperparameterSearch (HPO)** — searches a fixed family's hyperparameter space; standalone OR called by AutoMLEngine.
-- **Ensemble** — composes the top-N leaderboard entries into a single meta-model (weighted vote / stacking / bagging / boosting).
-
-The spec owns:
-
-1. Construction of each primitive (tenant-aware, tracker-aware, quota-aware).
-2. The `fit_auto()` entry point on `MLEngine` and the `engine.compare()` delegation.
-3. Trial-as-nested-run discipline with ambient tracker propagation.
-4. Distributed execution via `parallel_trials=N` (local) and `executor=` (Ray / Dask).
-5. Early-stopping, population-based training, and budget semantics.
-6. LLM-augmented AutoML: the Kaizen agent recommending the next trial (a kailash-ml uniqueness).
-7. Error taxonomy and test contract.
+- **`AutoMLEngine`** (canonical, at `kailash_ml.automl.engine:AutoMLEngine`) — orchestrates one search-strategy implementation over a user-supplied `ParamSpec` list, enforces a microdollar cost budget, consults PACT admission, persists a tenant-scoped audit row per trial.
+- **Four search strategies** at `kailash_ml.automl.strategies` — `GridSearchStrategy`, `RandomSearchStrategy`, `BayesianSearchStrategy`, `SuccessiveHalvingStrategy`.
+- **`CostTracker`** (microdollar-granularity budget accounting) at `kailash_ml.automl.cost_budget:CostTracker`.
+- **PACT admission wire-through** at `kailash_ml.automl.admission:check_trial_admission` — degrades gracefully when `kailash_pact` is absent or its `GovernanceEngine.check_trial_admission` is unimplemented.
+- **`MLEngine.compare()`** at `kailash_ml.engine:MLEngine.compare` — the documented entry point for "train and rank candidate families." It does NOT delegate to `AutoMLEngine` and is documented in `specs/ml-engines.md`; this spec only references it.
 
 ### 1.2 Out of Scope
 
-- **Feature engineering auto-search** — `FeatureEngineer` (under `kailash_ml.primitives`) owns the feature-generation search; AutoML consumes the output.
-- **Reward model search for RLHF** — lives in `kailash-align` (RLHF-specific HPO). AutoML here covers supervised families.
-- **Neural architecture search (NAS)** — deferred to a future `ml-nas.md`; Lightning NAS integrations are NOT in this spec.
+- **Feature engineering auto-search** — `FeatureEngineer` (under `kailash_ml.engines.feature_engineer`) owns the feature-generation search.
+- **Reward model search for RLHF** — lives in `kailash-align` (RLHF-specific HPO).
+- **Neural architecture search (NAS)** — not implemented.
 - **AutoML UI / leaderboard rendering** — covered by `MLDashboard`; this spec owns the data model.
+- **`MLEngine.fit_auto()`** — the v1 spec mandated this entry point; the canonical implementation does not provide it. See § "Deferred to M2 milestone" entry D-fitauto.
+
+### 1.3 Two Coexisting Surfaces (v1.0.0 → v1.1.1 Migration)
+
+Two `AutoMLEngine` classes ship in 1.1.1 and the user may encounter either:
+
+| Path                                                                 | Status     | Constructor signature                                                                                                                                               |
+| -------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kailash_ml.automl.engine.AutoMLEngine` (canonical M1 surface)       | preferred  | `AutoMLEngine(*, config, tenant_id, actor_id, connection=None, cost_tracker=None, governance_engine=None)`                                                          |
+| `kailash_ml.engines.automl_engine.AutoMLEngine` (legacy M0 scaffold) | deprecated | `AutoMLEngine(pipeline, search, *, registry=None)` — ALSO reachable as `kailash_ml.AutoMLEngine` via the module-level `__getattr__` in `kailash_ml/__init__.py:593` |
+
+Verified by direct read: top-level `kailash_ml.AutoMLEngine` resolves through `kailash_ml/__init__.py` `__getattr__` (lines 580-622) into `kailash_ml.engines.automl_engine` — i.e. the LEGACY scaffold. To use the canonical M1 surface, callers MUST `from kailash_ml.automl import AutoMLEngine`.
+
+This is a known transitional state. The legacy scaffold is retained for backwards compatibility until the W32 sweep removes it; the canonical surface is the spec authority for every contract below.
+
+**Wave 6 follow-up:** flip the `kailash_ml/__init__.py` `__getattr__` map entry (line 593) from `kailash_ml.engines.automl_engine` (legacy) to `kailash_ml.automl.engine` (canonical) so that `kailash_ml.AutoMLEngine` and `from kailash_ml.automl import AutoMLEngine` resolve to the same class. Until that lands, downstream code that follows the v1 spec's `from kailash_ml import AutoMLEngine` form receives the LEGACY scaffold; this is a user-hostile divergence that this spec documents but does not perpetuate.
 
 ---
 
 ## 2. Construction
 
-### 2.1 `AutoMLEngine`
+### 2.1 `AutoMLEngine` (canonical)
 
 ```python
-from kailash_ml import AutoMLEngine
-from kailash_ml.engines.automl_engine import AutoMLConfig
+from kailash_ml.automl import (
+    AutoMLConfig,
+    AutoMLEngine,
+    AutoMLResult,
+    CostTracker,
+    GovernanceEngineLike,
+    TrialRecord,
+)
 
 config = AutoMLConfig(
-    task_type="classification",   # "classification" | "regression" | "ranking" | "clustering"
+    task_type="classification",                      # "classification" | "regression" | "ranking" | "clustering"
+    metric_name="accuracy",
+    direction="maximize",                            # "maximize" | "minimize"
+    search_strategy="random",                        # "grid" | "random" | "bayesian" | "halving" | "successive_halving"
+    max_trials=30,
     time_budget_seconds=3600,
-    metric="roc_auc",
-    parallel_trials=4,            # local process pool parallelism
-    executor="local",             # "local" | "ray" | "dask"
-    max_trials=200,
-    early_stopping_patience=10,
-    agent=False,                  # opt-in LLM augmentation (requires kailash-ml[agents])
-    auto_approve=False,           # human approval gate for agent recommendations
+    total_budget_microdollars=0,                     # 0 => unbounded (explicit opt-out)
+    auto_approve_threshold_microdollars=0,
+    agent=False,                                     # double opt-in (caller flag + kailash-ml[agents] extra)
+    auto_approve=False,
     max_llm_cost_usd=5.0,
+    min_confidence=0.6,
+    seed=42,
 )
 
 engine = AutoMLEngine(
     config=config,
-    feature_store=fs,
-    model_registry=registry,
-    trials_store=None,            # None → canonical ~/.kailash_ml/ml.db per ml-tracking §2.2
     tenant_id="acme",
-    tracker=tracker,              # Optional[ExperimentRun]; ambient km.track() auto-wires via get_current_run() if None
+    actor_id="alice@acme",
+    connection=conn_mgr,                             # optional ConnectionManager for `_kml_automl_trials` audit
+    cost_tracker=None,                               # optional pre-built tracker; defaults from config
+    governance_engine=None,                          # optional PACT engine; degrades gracefully if missing
 )
 ```
 
-Store-URL resolution for the `trials_store=` kwarg routes through `kailash_ml._env.resolve_store_url(explicit=...)` per `ml-engines-v2.md §2.1 MUST 1b` (single shared helper; hand-rolled `os.environ.get(...)` is BLOCKED per `rules/security.md` § Multi-Site Kwarg Plumbing). The `trials_store=None` default delegates the `KAILASH_ML_STORE_URL` / `KAILASH_ML_TRACKER_DB` bridge / `~/.kailash_ml/ml.db` precedence chain to the helper — the same precedence `ExperimentTracker.create()` (see `ml-tracking.md §2.5`) uses — so `AutoMLEngine`'s trial history and the ambient `km.track()` parent run land in the same physical store without a separate resolution path.
+### 2.2 `AutoMLConfig` Fields (verified at `automl/engine.py:117-190`)
 
-### 2.2 `HyperparameterSearch`
+| Field                                 | Type    | Default            | Validated at `__post_init__`                                                                                                      |
+| ------------------------------------- | ------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `task_type`                           | `str`   | `"classification"` | MUST be one of `"classification" \| "regression" \| "ranking" \| "clustering"`                                                    |
+| `metric_name`                         | `str`   | `"accuracy"`       | non-empty                                                                                                                         |
+| `direction`                           | `str`   | `"maximize"`       | MUST be `"maximize" \| "minimize"`                                                                                                |
+| `search_strategy`                     | `str`   | `"random"`         | resolved by `resolve_strategy()`; valid: grid \| random \| bayesian \| halving \| successive_halving                              |
+| `max_trials`                          | `int`   | `30`               | MUST be positive                                                                                                                  |
+| `time_budget_seconds`                 | `int`   | `3600`             | MUST be positive finite                                                                                                           |
+| `total_budget_microdollars`           | `int`   | `0`                | MUST be ≥ 0 (0 = unbounded explicit opt-out)                                                                                      |
+| `auto_approve_threshold_microdollars` | `int`   | `0`                | MUST be ≥ 0                                                                                                                       |
+| `agent`                               | `bool`  | `False`            | flag only; the `kailash-ml[agents]` extra check is the engine's responsibility (see § 8)                                          |
+| `auto_approve`                        | `bool`  | `False`            | when `False`, any trial whose `budget_microdollars > auto_approve_threshold_microdollars` raises `PromotionRequiresApprovalError` |
+| `max_llm_cost_usd`                    | `float` | `5.0`              | MUST be finite + non-negative (`math.isfinite` enforces NaN/Inf rejection per `rules/zero-tolerance.md` Rule 2)                   |
+| `min_confidence`                      | `float` | `0.6`              | MUST be finite, in `[0.0, 1.0]`                                                                                                   |
+| `seed`                                | `int`   | `42`               | passed verbatim to strategy `__init__`                                                                                            |
 
-Standalone HPO over a fixed family/Trainable factory:
-
-```python
-from kailash_ml import HyperparameterSearch
-
-hpo = HyperparameterSearch(
-    trainable_factory=LightGBMTrainable,
-    space=HyperparameterSpace(
-        params=[
-            IntParam("n_estimators", low=100, high=1500),
-            FloatParam("learning_rate", low=1e-3, high=0.3, log=True),
-            IntParam("max_depth", low=3, high=16),
-        ],
-    ),
-    algorithm="bohb",             # "grid" | "random" | "bayesian" | "bohb" | "cmaes" | "halving"
-    metric="roc_auc",
-    mode="maximize",
-    max_trials=100,
-    parallel_trials=4,
-    tenant_id="acme",
-    tracker=tracker,
-)
-report = await hpo.search(train_df, target="churned")
-```
+`AutoMLConfig` is a regular `@dataclass` (not frozen). `to_dict()` returns a flat JSON-safe `dict[str, Any]`.
 
 ### 2.3 MUST Rules
 
-#### 1. Constructor Accepts Optional `tracker=`; Auto-Wires To Ambient `km.track()`
+#### MUST 1. Constructor Validates `tenant_id` And `actor_id`
 
-Both `AutoMLEngine` and `HyperparameterSearch` MUST accept `tracker: Optional[ExperimentRun] = None` (HIGH-8 — the user-visible async-context handle, NOT `Optional[ExperimentTracker]`). When `None`, the constructor MUST call `kailash_ml.tracking.get_current_run()` (the public accessor per `ml-tracking §10.1` — CRIT-4) to read the ambient run. If neither is present, the primitive operates without tracker (a plain algorithmic run) — but MUST log a WARN line stating "no tracker bound; trial history will not be recoverable". Direct access to `kailash_ml.tracking.runner._current_run` is BLOCKED for library callers.
+`AutoMLEngine.__init__` (verified `automl/engine.py:419-423`) raises `ValueError` when either is empty or non-string. The check is the single enforcement point for `rules/tenant-isolation.md` MUST Rule 5 across the AutoML surface — there is no public path that bypasses this check.
 
-```python
-# DO — constructor reads ambient
-async with km.track("automl-sweep") as parent:
-    automl = AutoMLEngine(config=cfg, ...)  # tracker = parent implicitly
-    await automl.run(schema=schema, data=df)
+#### MUST 2. Financial Field Validation
 
-# DO — explicit tracker (overrides ambient)
-explicit = MyMlflowTracker(...)
-automl = AutoMLEngine(config=cfg, tracker=explicit)
+`AutoMLConfig.max_llm_cost_usd`, `time_budget_seconds`, `min_confidence`, and every numeric budget MUST be validated via `math.isfinite()` at construction. `NaN` and `Inf` are rejected with `ValueError` (NOT `InvalidConfigError` — see § 10 deferral note). Negative budgets raise. This is the literal contract at `automl/engine.py:143-173`.
 
-# DO NOT — silent no-tracker without warning
-automl = AutoMLEngine(config=cfg)  # outside any km.track() — must WARN
-```
+#### MUST 3. Agent Mode Is Caller-Flag Only In v1.1.1
 
-**Why:** Round-1 audit found 0/18 engines auto-wire to `km.track()`. Ambient-contextvar resolution makes the 5-line newbie scenario ("enter `km.track()`, let AutoML log every trial as a child") work without manual threading, while still allowing explicit injection for advanced users.
+`config.agent=True` is a caller flag. The runtime extra check (`kailash-ml[agents]` installed, `kailash_kaizen` importable) is performed by callers that wire LLM suggestions into a `trial_fn`; the engine itself does NOT raise `MissingExtraError` because that error class is not in the package's typed-error set. Spec v1 § 2.3 MUST 3 ("`MissingExtraError` raised at `__init__` time") is NOT honoured by the canonical implementation. See § "Deferred to M2 milestone" entry D-missingextra.
 
-#### 2. Financial Field Validation
+#### MUST 4. Default Cost Ceiling Resolution
 
-`AutoMLConfig.max_llm_cost_usd`, `time_budget_seconds`, and every numeric budget MUST be validated via `math.isfinite()` at construction. `NaN` and `Inf` are rejected with `InvalidConfigError`. Negative budgets raise. Violations of this are a `rules/zero-tolerance.md` Rule 2 stub — unbounded budgets defeat cost guards.
+When `cost_tracker=None`, the engine constructs a `CostTracker` (`automl/engine.py:429-440`) using this precedence:
 
-#### 3. Agent Mode Is Double Opt-In
+1. If `config.total_budget_microdollars > 0` → `ceiling = config.total_budget_microdollars`
+2. Else if `config.agent and config.max_llm_cost_usd > 0` → `ceiling = usd_to_microdollars(config.max_llm_cost_usd)`
+3. Else → `ceiling = 0` (unbounded; explicit opt-out)
 
-`agent=True` MUST require BOTH:
-
-1. The kwarg is explicitly set by the caller (default `agent=False`).
-2. The optional extra `kailash-ml[agents]` is installed (providing `kailash_kaizen`); otherwise construction raises `MissingExtraError("kailash-ml[agents] required for agent=True")`.
-
-**Why:** LLM calls have cost. A silent default of `agent=True` would run up API bills in users' CI without consent.
+The constructed tracker is `tenant_id`-scoped and uses the default `max_ledger_entries=10_000` bound (see § 8.1).
 
 ---
 
-## 3. `MLEngine.fit_auto()` — The Canonical Entry Point
+## 3. Run Surface — `AutoMLEngine.run()`
 
-### 3.1 Signature
+### 3.1 Signature (verified `automl/engine.py:513-540`)
 
 ```python
-# on MLEngine
-async def fit_auto(
+async def run(
     self,
-    data: pl.DataFrame | pl.LazyFrame,
     *,
-    task: str = "auto",                     # "auto" | "classification" | "regression"
-    target: str,
-    time_budget: int = 3600,
-    metric: str | None = None,              # None => primary metric per task_type
-    families: list[str] | None = None,      # None => sensible default set
-    parallel_trials: int = 4,
-    executor: str = "local",                # "local" | "ray" | "dask"
-    max_trials: int = 200,
-    early_stopping_patience: int = 10,
-    agent: bool = False,
-    ensemble: bool = True,                  # build an ensemble from the top-k
-    top_k: int = 3,
-    seed: int = 42,
-) -> LeaderboardReport: ...
+    space: Sequence[ParamSpec],
+    trial_fn: Callable[[Trial], Awaitable[TrialOutcome]],
+    estimate_trial_cost_microdollars: Optional[Callable[[Trial], int]] = None,
+    strategy: SearchStrategy | None = None,
+    run_id: str | None = None,
+    source_tag: str = "baseline",                    # "baseline" | "agent"
+) -> AutoMLResult: ...
 ```
 
-### 3.2 `LeaderboardReport`
+The user owns the trainer (`trial_fn`). `AutoMLEngine` provides governance + audit + cost-budget enforcement only. There is no `data` / `target` / `families` / `parallel_trials` / `executor` / `early_stopping_patience` / `top_k` / `ensemble` kwarg on `run()` — users who want those abstractions use `MLEngine.compare()` (separate spec, separate surface) or call `run()` repeatedly themselves.
+
+(Engine module docstring at `automl/engine.py:7-12` mentions auto-deriving a `ParamSpec` from `FeatureSchema`; this is NOT implemented and should be stripped from the docstring as a Wave 6 follow-up. Until then the docstring is misleading; the canonical contract is the `space=` kwarg above.)
+
+### 3.2 `AutoMLResult` Shape (verified `automl/engine.py:243-285`)
 
 ```python
-@dataclass(frozen=True)
-class LeaderboardEntry:
-    rank: int
-    family: str
-    hyperparameters: dict
-    metrics: dict[str, float]
-    tracker_run_id: str                  # nested run under the AutoML parent
-    feature_versions: dict[str, str]
-    elapsed_seconds: float
-    trial_number: int
-
-@dataclass(frozen=True)
-class LeaderboardReport:
-    parent_run_id: str
-    task_type: str
-    primary_metric: str
-    entries: list[LeaderboardEntry]       # sorted by primary_metric, best first
-    ensemble_result: TrainingResult | None  # present when ensemble=True
+@dataclass
+class AutoMLResult:
+    run_id: str
+    tenant_id: str
+    actor_id: str
+    strategy: str
     total_trials: int
-    total_budget_seconds_used: float
+    completed_trials: int
+    denied_trials: int
+    failed_trials: int
+    best_trial: TrialRecord | None     # None when every trial failed/was denied
+    all_trials: list[TrialRecord]
+    elapsed_seconds: float
+    cumulative_cost_microdollars: int
     early_stopped: bool
-    tenant_id: str | None
+    early_stopped_reason: str | None   # one of "time_budget_exceeded" | "promotion_requires_approval" | "cost_budget_exhausted" | None
 ```
 
-### 3.3 MUST Rules
+`to_dict()` returns the result + an additional `cumulative_cost_usd` (presentation float).
 
-#### 1. Every Trial Is A Nested Run
+`AutoMLResult` is the canonical return type. The v1-spec'd `LeaderboardReport` is NOT implemented — it is enumerated under § "Deferred to M2 milestone" entry D-leaderboard.
 
-Every trial MUST be logged as a nested run under the AutoML parent run. The parent run holds the leaderboard; each child holds the trial's params, metrics, and artifacts.
+### 3.3 `TrialRecord` Shape (verified `automl/engine.py:193-240`, frozen dataclass)
 
 ```python
-# DO — nested-run discipline
-async with km.track("automl-churn") as parent:
-    automl_report = await engine.fit_auto(df, target="churned", time_budget=1800)
-    # Under the hood:
-    #   For each trial:
-    #     async with km.track("trial", parent_run_id=parent.run_id) as child:
-    #         await child.log_params(trial_hp)
-    #         await child.log_metrics({"roc_auc": 0.83, ...})
-
-# DO NOT — flat runs with no parent
-# Every trial as its own top-level run — leaderboard is orphaned from the parent
+@dataclass(frozen=True)
+class TrialRecord:
+    trial_id: str                                       # uuid4
+    run_id: str
+    tenant_id: str
+    actor_id: str
+    trial_number: int
+    strategy: str
+    params: dict[str, Any]
+    metric_name: str
+    metric_value: float | None                          # None when status != "completed" or metric is non-finite
+    cost_microdollars: int
+    started_at: datetime                                 # tz-aware UTC
+    finished_at: datetime | None
+    status: str                                         # "completed" | "failed" | "skipped" | "denied" | "approval_required"
+    admission_decision_id: str | None
+    admission_decision: str | None                      # "admitted" | "denied" | "skipped" | "unimplemented" | "error"
+    error: str | None = None
+    source: str = "baseline"                            # "baseline" | "agent"
+    fidelity: float = 1.0
+    rung: int = 0
 ```
 
-**Why:** Per `ml-tracking-draft.md`, nested runs are the standard MLflow-parity model. The AutoML UI renders the parent as a collapsible leaderboard; flat runs destroy that hierarchy.
+`to_dict()` returns a JSON-safe dict with `started_at` / `finished_at` already ISO-formatted.
 
-#### 2. Primary Metric MUST Be Deterministic Per Task Type
+### 3.4 Run-Loop Invariants
 
-When `metric=None`, the primary metric MUST be resolved deterministically:
+The `run()` loop enforces, in this order, on every iteration (verified `automl/engine.py:553-819`):
 
-| task               | default metric                                    |
-| ------------------ | ------------------------------------------------- |
-| `"classification"` | `"roc_auc"` (binary) or `"f1_macro"` (multiclass) |
-| `"regression"`     | `"neg_root_mean_squared_error"`                   |
-| `"ranking"`        | `"ndcg"`                                          |
-| `"clustering"`     | `"silhouette"`                                    |
+1. **Time budget check** (line 571): `time.monotonic() >= deadline` → set `early_stopped=True`, `early_stopped_reason="time_budget_exceeded"`, break.
+2. **Prompt-injection scan** (lines 583-619): every `trial.params` value of type `str` is matched against six regex patterns (`ignore previous instructions`, `disregard the above`, `system:`, `<system>` / `<instruction>` / `<prompt>` open/close, `DROP TABLE`, trailing `--`). On match: record a `status="skipped"` row with `error="prompt_injection: ..."`, advance to the next suggestion. Defense-in-depth — the params are typed (int/float/categorical) at trainer-call time, so this catches misuse before audit pollution.
+3. **Pre-flight cost estimate** (line 621): `estimated_cost = int(estimate_trial_cost_microdollars(trial))` if supplied else `0`.
+4. **PACT admission** (lines 626-700): `check_trial_admission(...)` is called. Three outcomes:
+   - Raises `PromotionRequiresApprovalError` → record `status="approval_required"`, set `early_stopped=True`, `early_stopped_reason="promotion_requires_approval"`, break.
+   - Returns `admission.admitted=False` → record `status="denied"`, advance.
+   - Returns `admission.admitted=True` → continue.
+5. **Pre-flight budget check** (lines 701-717): when `estimated_cost > 0` and `cost_tracker.check_would_exceed(estimated_cost)` is True → set `early_stopped=True`, `early_stopped_reason="cost_budget_exhausted"`, break BEFORE the trial runs.
+6. **Trial execution** (lines 718-761): `outcome = await trial_fn(trial)`. On exception: record `status="failed"` row with `error="<ExcClass>: <msg>"`, advance.
+7. **Post-trial cost record** (lines 762-789): the cost is `outcome.cost_microdollars` if positive else `estimated_cost`. Recording goes through `CostTracker.record(...)`. If the record raises `BudgetExceeded`, the engine sets `early_stopped=True`, `early_stopped_reason="cost_budget_exhausted"`, but STILL records the trial's actual outcome (the trial completed before the budget check fired).
+8. **Strategy observe + history** (lines 789-790): `strategy.observe(outcome); history.append(outcome)`.
+9. **Strategy stop check** (line 815): `strategy.should_stop(history)` → break.
 
-The resolved metric MUST be captured on `LeaderboardReport.primary_metric` so downstream consumers never need to re-derive it.
+The loop terminates when `strategy.suggest(history)` returns `None` (strategy exhaustion, e.g. grid finished or halving last rung) OR any of the breaks above fire.
 
-#### 3. Ensemble Build Is Opt-Out, Not Opt-In
+### 3.5 MUST Rules
 
-`ensemble=True` is the default. After the sweep completes, `MLEngine` MUST call `Ensemble.from_leaderboard(report, k=top_k)` and populate `LeaderboardReport.ensemble_result`. Setting `ensemble=False` skips it.
+#### MUST 1. Every Trial Persists An Audit Row
 
-**Why:** A bare leaderboard is research output; the user still has to pick one. Ensembling top-k is what MLflow AutoML, FLAML, H2O AutoML, and AutoGluon all do by default. Matching that default aligns kailash-ml with the industry baseline.
+Every iteration of the loop records exactly one `TrialRecord` via `_record_trial(...)`. The recorder appends to in-memory `_trials` AND, when the audit table is ready, INSERTs into `_kml_automl_trials`. Failure to INSERT (table-create failed, transient DB error) emits a WARN but does NOT block the run — the in-memory record is still appended. This is the documented "in-memory fallback" mode at `automl/engine.py:476-511`.
 
-#### 4. Time Budget Is A Hard Cap
+#### MUST 2. Best-Trial Selection Is Direction-Aware
 
-`time_budget` seconds is a hard deadline. Active trials are cooperatively terminated when the budget expires. Trials in progress at deadline are allowed to finish their current epoch (via Lightning callback) but no new trial starts. Violation raises `BudgetExhaustedError` from `fit_auto()` even if `max_trials` not reached.
+`_pick_best(...)` (`automl/engine.py:866-885`) returns the best `TrialRecord` among `status="completed"` rows whose `metric_value` is finite. Direction `"maximize"` sorts by `-metric_value`; `"minimize"` by `metric_value`. When zero completed/finite trials exist, `best_trial=None`.
+
+#### MUST 3. `source_tag` Is Persisted Verbatim
+
+Every `TrialRecord` carries `source` set to whatever `source_tag` the caller passed to `run()`. The orchestrator decides whether a particular `run()` invocation is `"agent"` or `"baseline"`; the engine itself does NOT split traffic between agent and baseline streams within a single `run()` call. See § "Deferred to M2 milestone" entry D-baselineparallel.
 
 ---
 
-## 4. Standalone HPO — `HyperparameterSearch.search()`
+## 4. Search Strategies
 
-### 4.1 Search Algorithms
+### 4.1 Implemented Strategies (verified at `automl/strategies/`)
 
-Each algorithm MUST be a concrete class implementing `HPOAlgorithm`:
+| Class                       | File                            | `name`       | Notes                                                                                                                                                      |
+| --------------------------- | ------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GridSearchStrategy`        | `automl/strategies/grid.py`     | `"grid"`     | Discretises `float` / `log_float` to `grid_resolution` evenly-spaced points; raises `HPOSpaceUnboundedError` (locally defined) when grid would be infinite |
+| `RandomSearchStrategy`      | `automl/strategies/random.py`   | `"random"`   | Deterministic under seed; bounded by `max_trials`                                                                                                          |
+| `BayesianSearchStrategy`    | `automl/strategies/bayesian.py` | `"bayesian"` | scikit-optimize when `kailash-ml[automl-bayes]` extra installed; deterministic local fallback otherwise                                                    |
+| `SuccessiveHalvingStrategy` | `automl/strategies/halving.py`  | `"halving"`  | Rung-aware; `initial_trials=9`, `reduction_factor=3`, `min_fidelity=1.0`, `max_fidelity=81.0` defaults                                                     |
 
-- `GridSearchAlgorithm` — exhaustive over discrete params; raises if space is unbounded.
-- `RandomSearchAlgorithm` — uniform / log-uniform per param spec.
-- `BayesianSearchAlgorithm` — GP + expected-improvement acquisition (via `scikit-optimize`).
-- `BOHBAlgorithm` — Bayesian + hyperband; strong for neural nets. REQUIRES `fidelity_param`, `min_fidelity`, `max_fidelity`, `reduction_factor` (see §4.2 MUST 4).
-- `CMAESAlgorithm` — evolutionary; good for non-separable continuous spaces.
-- `SuccessiveHalvingAlgorithm` — prune the worst half every round.
-- `ASHAAlgorithm` — Asynchronous Successive Halving; the default for `parallel_trials > 1` (see §4.2 MUST 5).
+`resolve_strategy(name: str, *, seed: int = 42, **kwargs: object) -> SearchStrategy` at `automl/strategies/__init__.py:39-62` is the factory; accepted names are `grid`, `random`, `bayesian`, `halving`, `successive_halving` (alias). Unknown names raise `ValueError`.
 
-### 4.2 MUST Rules
+### 4.2 `ParamSpec` (verified `automl/strategies/_base.py:18-61`)
 
-#### 1. Every Algorithm Implements The Same Protocol
+```python
+@dataclass(frozen=True)
+class ParamSpec:
+    name: str
+    kind: str                  # "int" | "float" | "log_float" | "categorical" | "bool"
+    low: float | int | None = None
+    high: float | int | None = None
+    choices: tuple[Any, ...] | None = None
+```
+
+Validation at `__post_init__`:
+
+- `kind` MUST be one of the five values above.
+- `int` / `float` / `log_float` REQUIRE `low` AND `high`, both finite, with `low <= high`.
+- `log_float` REQUIRES `low > 0`.
+- `categorical` REQUIRES non-empty `choices`.
+- `bool` is implemented internally as `categorical` with `choices=(False, True)` (object-set after init).
+
+### 4.3 `Trial` and `TrialOutcome` (verified `automl/strategies/_base.py:64-95`)
+
+```python
+@dataclass(frozen=True)
+class Trial:
+    trial_number: int
+    params: dict[str, Any]
+    fidelity: float = 1.0
+    rung: int = 0
+
+@dataclass
+class TrialOutcome:
+    trial_number: int
+    params: dict[str, Any]
+    metric: float
+    metric_name: str
+    direction: str             # "maximize" | "minimize"
+    duration_seconds: float = 0.0
+    cost_microdollars: int = 0
+    fidelity: float = 1.0
+    rung: int = 0
+    error: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_finite(self) -> bool: ...
+```
+
+### 4.4 `SearchStrategy` Protocol (verified `_base.py:98-120`)
 
 ```python
 @runtime_checkable
-class HPOAlgorithm(Protocol):
-    def suggest(self, history: list[Trial]) -> dict: ...
-    def observe(self, trial: Trial, result: TrainingResult) -> None: ...
-    def should_stop(self, history: list[Trial]) -> bool: ...
+class SearchStrategy(Protocol):
+    name: str
+    def suggest(self, history: list[TrialOutcome]) -> Trial | None: ...
+    def observe(self, outcome: TrialOutcome) -> None: ...
+    def should_stop(self, history: list[TrialOutcome]) -> bool: ...
 ```
 
-Swapping `algorithm="random"` for `algorithm="bayesian"` MUST NOT require any other code change in the caller.
+Adding a new strategy is one `@dataclass` + an entry in `resolve_strategy()`. Protocol conformance is checked at runtime by `isinstance(obj, SearchStrategy)`.
 
-**Why:** A protocol-based plugin surface matches `ml-tracking-draft.md`'s contract discipline and makes adding a new algorithm (e.g. population-based training) a one-class addition rather than a branch in every call site.
+### 4.5 MUST Rules
 
-#### 2. Population-Based Training Is A First-Class Variant
+#### MUST 1. Strategies Are Seed-Deterministic
 
-PBT-style HPO (trials that mutate their hyperparameters mid-run based on siblings' progress) MUST be available via `algorithm="pbt"`. The Lightning `PopulationBasedTraining` callback integrates via the Trainable's `LightningModule` adapter (see `ml-engines-v2-draft.md §3`).
+Every strategy's `__post_init__` constructs `random.Random(self.seed)` (or for bayesian, the same seed seeds skopt). Re-running with the same `seed` and the same `space` produces a byte-identical sequence of `suggest()` returns. This invariant is the test contract for `test_hpo_algorithm_random_suggest_determinism` (per § 11).
 
-#### 3. Early Stopping Is Per-Trial AND Population-Level
+#### MUST 2. SuccessiveHalving Is Rung-Aware
 
-A trial MUST be stopped early if its rolling validation metric fails to improve by `min_delta` over `patience` epochs. The sweep as a whole MUST stop if no improvement over `early_stopping_patience` trials is observed on the best-so-far primary metric.
+Promotion happens within a rung once `len(rung.outcomes) >= len(rung.trials) AND len(rung.trials) > 0`. Trials at different rungs are NOT compared. Higher-fidelity trials are NOT used to early-stop lower-fidelity siblings. (This is the v1 spec § 4.2 MUST 5 ASHA promotion rule, applied to non-async halving — async ASHA is deferred per § "Deferred to M2 milestone" entry D-asha.)
 
-#### 4. BOHB Multi-Fidelity Contract
+#### MUST 3. Bayesian Has Two Modes With Identical Protocol
 
-`algorithm="bohb"` REQUIRES four additional kwargs; omitting any raises `BOHBConfigError` at `search()` time:
-
-```python
-search = HyperparameterSearch(
-    algorithm="bohb",
-    fidelity_param="epochs",          # the HP that scales cost (neural net) or sample count (classical)
-    fidelity_min=1.0,                  # smallest fidelity tried (e.g. 1 epoch)
-    fidelity_max=81.0,                 # largest fidelity tried (e.g. 81 epochs)
-    reduction_factor=3,                # successive-halving ratio (default 3; η in the BOHB paper)
-)
-```
-
-Sane defaults per task type:
-
-| Task type                                  | `fidelity_param`     | `min` | `max`  | `reduction_factor` |
-| ------------------------------------------ | -------------------- | ----- | ------ | ------------------ |
-| `deep_learning`                            | `"epochs"`           | 1     | 81     | 3                  |
-| `classical_classification` / `_regression` | `"training_samples"` | 1000  | 100000 | 3                  |
-| `time_series`                              | `"n_bootstraps"`     | 10    | 1000   | 3                  |
-
-**Why:** Without a fidelity parameter, BOHB degenerates to Random + Hyperband promotion that isn't guided by Bayesian updates — 2-3× slower than well-configured Bayesian. The four-kwarg requirement forces users to think about what "cheap" vs "expensive" means for their task.
-
-#### 5. ASHA — Fidelity-Aware Promotion
-
-When `parallel_trials > 1`, the default promotion rule MUST be Async Successive Halving: trials are compared AT THE SAME fidelity rung, not across different fidelity tiers. A leaderboard entry `LeaderboardEntry` MUST carry `fidelity: float` and a `rung: int` (the halving rung where the entry was evaluated). Promotion is admitted only when N trials at the same rung complete.
-
-```python
-# DO — fidelity-aware comparison
-if len(entries_at_rung(rung=2)) >= min_samples_per_rung:
-    best_at_rung = max(entries_at_rung(rung=2), key=attr("metric"))
-    if best_at_rung.metric > current_best_next_rung:
-        promote(best_at_rung)
-
-# DO NOT — comparing across rungs
-best_any = max(all_entries, key=attr("metric"))   # trial-A at fidelity=81 vs trial-B at fidelity=3 — invalid
-```
-
-**MUST**: Cross-trial early-stopping rules (patience) apply only within a single rung. A 4-trial sweep where A runs at fidelity=81 while B/C/D run at fidelity=3 MUST NOT use A's score to early-stop B/C/D; they must first be promoted to A's fidelity.
-
-**Why:** A trial at higher fidelity has a mechanical advantage (more training budget); comparing its score to low-fidelity trials promotes by budget, not by hyperparameter quality. The ASHA-paper promotion rule is the structural correctness contract.
+When `scikit-optimize` is installed (`kailash-ml[automl-bayes]`), Bayesian routes through `skopt.Optimizer` with `acq_func="EI"`. When absent, a local mean+variance EI fallback runs. Both modes are deterministic under the seed and satisfy `SearchStrategy`. Switching is invisible to callers.
 
 ---
 
 ## 5. Parallel / Distributed Execution
 
-### 5.1 Local Parallelism (`executor="local"`)
+### 5.1 Single-Process Local Only (v1.1.1)
 
-Default. Uses a `ProcessPoolExecutor` sized to `parallel_trials`. Trials share the same offline feature store connection pool but run training in independent processes for GPU isolation.
+The canonical engine executes trials sequentially in the calling event loop. There is NO `parallel_trials` kwarg, NO `executor` kwarg, NO Ray/Dask integration, and NO `MissingExtraError` typed exception. Multi-process trial execution is the caller's responsibility (e.g. dispatch trials to a `ProcessPoolExecutor` and feed results back to `engine.run(strategy=preconfigured_strategy)`).
 
-### 5.2 Ray Executor (`executor="ray"`)
-
-Requires optional extra `kailash-ml[ray]` (`ray[tune]>=2.10`). Trials run as Ray actors; the AutoML driver consumes Tune's result stream and logs each completed trial to the shared tracker.
-
-```python
-result = await engine.fit_auto(
-    df,
-    target="churned",
-    time_budget=7200,
-    parallel_trials=32,
-    executor="ray",   # requires Ray cluster
-)
-```
-
-### 5.3 Dask Executor (`executor="dask"`)
-
-Requires optional extra `kailash-ml[dask]`. Similar to Ray but uses a Dask cluster for scheduling.
-
-### 5.4 MUST Rules
-
-#### 1. Executor Is Pluggable; Default Is Deterministic Local
-
-`executor="local"` is the default. Selecting `"ray"` or `"dask"` without the optional extra installed MUST raise `MissingExtraError("kailash-ml[ray] required for executor='ray'")` at `fit_auto()` time, not later.
-
-#### 2. Distributed Trials Propagate `tenant_id` + `parent_run_id`
-
-Every dispatched trial MUST carry the parent's `tenant_id` and the AutoML parent's `run_id`. Trials that lose this context (e.g. a Ray actor constructed without the parent env) MUST raise `ContextLostError` rather than silently logging under the wrong tenant.
-
-**Why:** Distributed execution is the #1 place tenant isolation breaks — workers pick up a default tenant instead of the caller's. Explicit propagation + loud failure on context loss is the structural defense per `rules/tenant-isolation.md` Rule 2.
-
-#### 3. Ray / Dask Are Not Required For Correctness
-
-A single-machine `parallel_trials=4` local run MUST produce identical results (within seed-determined variance) to a `parallel_trials=4` Ray run on one node. Divergence indicates executor bugs and is a regression blocker.
+This is a deliberate contraction of the v1 spec § 5 surface. See § "Deferred to M2 milestone" entry D-executor.
 
 ---
 
 ## 6. Early Stopping & Budget
 
-See §3.3 MUST 4 (time budget) + §4.2 MUST 3 (early stopping per trial + population).
+### 6.1 Time Budget Hard Cap
 
-### 6.1 MUST Rules
+`config.time_budget_seconds` is enforced via `time.monotonic()` against a deadline computed at `run()` start. When the deadline is reached, `early_stopped=True`, `early_stopped_reason="time_budget_exceeded"`. Trials in flight at the deadline are NOT pre-empted — the loop checks the deadline only at the top of the iteration, so an in-progress `trial_fn` runs to completion. The check fires BEFORE the next `strategy.suggest(history)` call.
 
-#### 1. `BudgetExhaustedError` Is Non-Fatal
+### 6.2 Cost Budget Hard Cap
 
-When `time_budget` expires, `fit_auto()` MUST return a `LeaderboardReport` with the completed trials and `early_stopped=True`, NOT raise. A separate `early_stopped_reason` field documents the cause.
+`CostTracker.check_would_exceed(estimated_cost)` is consulted pre-flight; on True, the run aborts with `early_stopped_reason="cost_budget_exhausted"` BEFORE the trial runs. When the actual cost (returned by `trial_fn` via `outcome.cost_microdollars`) exceeds the remaining budget after the trial completes, `CostTracker.record(...)` raises `BudgetExceeded` and the engine sets `early_stopped=True` but keeps the trial's audit row.
 
-**Why:** Users want partial leaderboards when the budget expires — research scenarios often "time-box" and accept the best-so-far. An exception discards useful state.
+### 6.3 No `BudgetExhaustedError` Raised From `run()`
 
-#### 2. Insufficient Trials Is An Error
+`run()` ALWAYS returns an `AutoMLResult` (possibly with `early_stopped=True`, possibly with `best_trial=None`). It does NOT raise `BudgetExhaustedError`, `InsufficientTrialsError`, or any AutoML-typed error from the AutoMLError family. Failures inside `trial_fn` are wrapped into per-trial `status="failed"` records and the run continues.
 
-If fewer than `min_trials=5` trials complete within the budget, `fit_auto()` MUST raise `InsufficientTrialsError(completed=N, min_required=5)`. A leaderboard of 1 entry is not a leaderboard.
+This diverges from v1 spec § 6.1 MUST 1 ("BudgetExhaustedError is non-fatal" — i.e., the v1 spec said it WOULD be raised but caught by `MLEngine.fit_auto`). In v1.1.1, the engine never raises an AutoMLError-family error; it returns an `AutoMLResult` whose `early_stopped_reason` field documents the cause. See § "Deferred to M2 milestone" entry D-typederrors.
+
+### 6.4 No Per-Trial Early-Stopping Patience
+
+The canonical engine has no `early_stopping_patience` field on `AutoMLConfig` and no per-trial early-stopping logic inside `run()`. Strategies own their own stop criteria via `should_stop(history)`. See § "Deferred to M2 milestone" entry D-earlystopping.
 
 ---
 
 ## 7. Ensemble Composition
 
-### 7.1 `Ensemble.from_leaderboard()`
+### 7.1 Current Surface — `EnsembleEngine` (Method-Style)
+
+`kailash_ml.engines.ensemble:EnsembleEngine` (verified, line 245) provides four ensemble methods as instance methods:
 
 ```python
-from kailash_ml import Ensemble
+from kailash_ml import EnsembleEngine
 
-ensemble = Ensemble.from_leaderboard(
-    report=leaderboard_report,
-    method="stacking",        # "weighted_vote" | "stacking" | "bagging" | "boosting"
-    k=5,                      # top-k to combine
-    meta_learner="logistic",  # only for stacking
-)
-result = await ensemble.fit(train_df, target="churned")  # returns TrainingResult
+engine = EnsembleEngine()
+result: BlendResult = engine.blend(models=[...], data=df, target="churned", weights=[...], method="soft", test_size=0.2, seed=42)
+result: StackResult = engine.stack(...)
+result: BagResult   = engine.bag(...)
+result: BoostResult = engine.boost(...)
 ```
 
-### 7.2 MUST Rules
+Each method returns a method-specific result dataclass (`BlendResult`, `StackResult`, `BagResult`, `BoostResult` — verified lines 45-163). Each result has its own `from_dict` classmethod for round-tripping but NOT a `from_leaderboard` constructor.
 
-#### 1. Ensemble Trains As A Single `TrainingResult`
+### 7.2 No `Ensemble.from_leaderboard()` In v1.1.1
 
-An ensemble fit MUST return a standard `TrainingResult` (per `ml-engines-v2-draft.md §4`) with:
+The v1 spec § 7.1 declared `Ensemble.from_leaderboard(report=, method=, k=, meta_learner=)` as the canonical entry point. In v1.1.1:
 
-- `model_uri` pointing to a registry entry of the stacked model;
-- `metrics` measured on the holdout set after the meta-learner is fit;
-- `feature_versions` aggregating all child groups;
-- a new audit field `base_models: list[str]` enumerating child model_uris.
+- `Ensemble` (the class name) is NOT exported from `kailash_ml.__init__`.
+- `EnsembleEngine` is exported (lazy via `__getattr__` per `kailash_ml/__init__.py:596`) but does NOT take a `LeaderboardReport` / `AutoMLResult` as input — its methods accept fitted estimators directly.
+- `EnsembleFailureError` IS in the typed-error hierarchy (`kailash.ml.errors:659`), but is not currently raised from any code path inside `EnsembleEngine` (the methods raise `ValueError` on bad inputs).
 
-**Why:** The Engine's `register()` / `serve()` must be able to treat an ensemble like any other trained model. Divergent result types would fork the registration path.
+See § "Deferred to M2 milestone" entries D-ensembleleaderboard and D-ensembleresult.
 
-#### 2. Ensemble Build Failures Surface As `EnsembleFailureError`
+### 7.3 MUST Rules
 
-If the meta-learner fails to fit (singular stacking matrix, dimensional mismatch), `Ensemble.fit()` MUST raise `EnsembleFailureError(method=, cause=, child_uris=)`. A silent fallback to the best-single-model is BLOCKED.
+#### MUST 1. Ensemble Methods Return Method-Specific Result Types
+
+`blend()` returns `BlendResult`; `stack()` returns `StackResult`; etc. The v1 spec mandate that ensembles return a `TrainingResult` (§ 7.2 MUST 1) is NOT implemented at the `EnsembleEngine` level. Conversion to a `TrainingResult` for downstream `MLEngine.register()` is the caller's responsibility.
 
 ---
 
-## 8. LLM-Augmented AutoML (Kailash-Unique)
+## 8. LLM-Augmented AutoML — v1.1.1 Behaviour
 
-### 8.1 Purpose
+### 8.1 Caller-Driven Wiring Only
 
-When `agent=True` and `kailash-ml[agents]` is installed, a Kaizen agent proposes the next hyperparameter configuration to try. This is a genuine product differentiator against FLAML / AutoGluon / H2O (none of which have LLM-driven suggestion).
+In v1.1.1 the engine itself does NOT manage an LLM. The `config.agent` flag is persisted on `AutoMLConfig` but is read only by callers who wire LLM suggestions into their own `trial_fn`. The legacy scaffold at `engines/automl_engine.py:201-230` (`LLMCostTracker`) implements POST-HOC cost summation (raises `LLMBudgetExceededError` AFTER the call when `_spent > _max_budget`); this is NOT wired into the canonical engine's `run()` loop.
 
-### 8.2 Operation
+### 8.2 Prompt-Injection Scan At Run-Loop Level
 
-```python
-report = await engine.fit_auto(
-    df,
-    target="churned",
-    time_budget=3600,
-    agent=True,
-    agent_config={
-        "model": "claude-opus-4",
-        "max_llm_cost_usd": 5.0,
-        "auto_approve": False,   # human confirms each recommendation
-    },
-)
-```
+The canonical engine scans every `trial.params` value of type `str` against six regex patterns (verified `automl/engine.py:82-109`). On a hit, the trial is recorded as `status="skipped"` with `error="prompt_injection: <offenders>"` and the run continues. This is defense-in-depth — not a primary security boundary, since `trial_fn` consumes typed (int/float/categorical) hyperparameters, not raw strings passed to a downstream LLM.
 
-### 8.3 MUST Rules
+### 8.3 Microdollar Cost Tracking (Atomic)
 
-#### 1. Baseline Runs In Parallel With Agent
+`CostTracker.record(...)` is the single atomic check+record entry point (verified `cost_budget.py:211-274`). It performs:
 
-When `agent=True`, a baseline pure-algorithmic search (Bayesian / BOHB) MUST run alongside the agent's suggestions. Both streams write trials to the same leaderboard. The final report MUST tag each trial with `source="agent" | "baseline"`.
+1. Type-check (`microdollars` MUST be `int`; floats raise `TypeError`).
+2. Acquire `asyncio.Lock`.
+3. If `microdollars > 0` and `check_would_exceed(...)` is True → emit WARN log, raise `BudgetExceeded(proposed, remaining, ceiling)`.
+4. Append `CostRecord(timestamp, microdollars, kind, trial_number, note)` to a bounded `deque[CostRecord]` with `maxlen=max_ledger_entries` (default 10,000).
+5. Update `_cumulative_microdollars` (clamped at 0 to permit negative-cost compensating entries without going below zero).
+6. Emit INFO log line `automl.cost_tracker.record`.
 
-**Why:** Without a baseline the user can't tell whether the agent helped or hurt. The baseline is cheap to run (it's trials that would have happened anyway), and it provides the counterfactual needed for fair evaluation.
+The check is race-free across concurrent `record()` calls within ONE event loop. Cross-process sharing is deferred (the in-memory ledger is per-instance).
 
-#### 2. Cost Budget Is A Hard Cap — TOKEN-LEVEL Backpressure
+### 8.4 No Token-Level Backpressure
 
-`max_llm_cost_usd` MUST be enforced with TOKEN-LEVEL backpressure, NOT wall-clock OR post-hoc cost sum. The Kaizen signature used by the agent MUST set `max_prompt_tokens` and `max_completion_tokens` per call such that `(prompt_tokens + completion_tokens) × model_cost_per_token <= (remaining_budget_usd / safety_margin)` with `safety_margin = 1.2`.
+Spec v1 § 8.3 MUST 2 mandated TOKEN-LEVEL backpressure (compute `max_tokens_this_call` BEFORE the LLM call to prevent overrun). The v1.1.1 implementation has NO `max_prompt_tokens` / `max_completion_tokens` fields on `AutoMLConfig`. The caller's `estimate_trial_cost_microdollars` callback IS the pre-flight gate — but it is per-trial, not per-token. See § "Deferred to M2 milestone" entry D-tokenbackpressure.
 
-```python
-# DO — token-level cap per call
-remaining = config.max_llm_cost_usd - cumulative_cost_usd
-max_tokens_this_call = int(remaining / (model_cost_per_token * 1.2))
-max_prompt_tokens = min(config.max_prompt_tokens, max_tokens_this_call * 0.75)
-max_completion_tokens = min(config.max_completion_tokens, max_tokens_this_call * 0.25)
+### 8.5 No Baseline-Parallel-With-Agent Stream
 
-# DO NOT — post-hoc cap after overrun
-if cumulative_cost_usd >= max_llm_cost_usd:
-    suspend_agent()  # the call that pushed us over already ran — $4.99 → $7.50 in one call
-```
+The v1 spec § 8.3 MUST 1 mandated that, when `agent=True`, a baseline pure-algorithmic search runs in PARALLEL with the agent's suggestions. v1.1.1's `run()` executes ONE sequential stream per invocation; the orchestrator decides whether the stream is "baseline" or "agent" via the `source_tag` kwarg. See § "Deferred to M2 milestone" entry D-baselineparallel.
 
-#### 2a. Required Agent-Config Kwargs
+### 8.6 Approval Gate Before PACT
+
+The human-approval gate fires BEFORE PACT consultation (verified `admission.py:221-239`):
 
 ```python
-agent_config = {
-    "model": "claude-opus-4",
-    "max_llm_cost_usd": 5.0,
-    "max_prompt_tokens": 8000,         # MUST be set
-    "max_completion_tokens": 2000,     # MUST be set
-    "auto_approve": False,
-    "min_confidence": 0.6,             # MUST — from AgentGuardrailMixin
-}
+if not auto_approve and budget_microdollars > auto_approve_threshold_microdollars:
+    raise PromotionRequiresApprovalError(...)
 ```
 
-When remaining budget < one call's worth, the agent MUST be suspended, the baseline search continues, and a WARN `automl.agent.budget_exhausted` is emitted.
-
-**Why:** A single agent call under `auto_approve=True` can burn $5 in 30 seconds if the agent retries, expands context, reads its own audit trail, etc. The post-hoc cap fires AFTER the overrun; the token-level pre-cap prevents it.
-
-#### 2b. Cumulative Cost Tracking
-
-Cumulative LLM cost across all suggestions is tracked; when the per-call pre-cap reduces `max_tokens_this_call < 100`, subsequent trials revert to pure baseline (the agent cannot form a useful suggestion under that constraint). The cap MUST be reported in `LeaderboardReport.agent_cost_usd`.
-
-#### 3. Audit Trail Per `rules/event-payload-classification.md`
-
-Every agent decision (suggested HP, reasoning, cost) MUST be persisted to `_kml_automl_agent_audit` with `(tenant_id, actor_id, parent_run_id, trial_number, suggested_hp, llm_cost_microdollars, model, prompt_hash)`. PII-classified prompts are hashed, not raw-stored.
-
-#### 4. Approval Gate Default Is Human-In-Loop
-
-`auto_approve=False` is the default. The agent's suggestion is shown to a human reviewer (via Nexus / CLI) before the trial runs. Only when `auto_approve=True` does the agent run unattended. This matches `rules/autonomous-execution.md` "Human-on-the-Loop, not in-the-loop" for cost-bearing actions.
+The `auto_approve=False` default matches the v1 spec § 8.3 MUST 4 "human-on-the-loop" intent.
 
 ---
 
-## 8A. Schema DDL (AutoML Agent Audit)
+## 8A. Schema DDL
 
-Resolves Round-3 HIGH B15: the DDL block for `_kml_automl_agent_audit` the spec references in §8.3 MUST Rule 3 but did not define. Carries `tenant_id` per `rules/tenant-isolation.md` MUST Rule 5 and `actor_id` per `rules/event-payload-classification.md`.
+### 8A.1 `_kml_automl_trials` (implemented)
 
-### 8A.1 Identifier Discipline
-
-The `_kml_` table prefix (leading underscore marks these as internal tables users should not query directly) MUST be validated in the caller's `__init__` against the regex `^[a-zA-Z_][a-zA-Z0-9_]*$` per `rules/dataflow-identifier-safety.md` MUST Rule 2. Any dynamic identifier injected into DDL MUST route through `kailash.db.dialect.quote_identifier()` per `rules/dataflow-identifier-safety.md` MUST Rule 1. Table-name + prefix total length stays within the Postgres 63-char limit (Decision 2 approved).
-
-### 8A.2 Postgres DDL
+The canonical audit table is `_kml_automl_trials` (NOT `_kml_automl_agent_audit` — that name is from the v1 spec and is not implemented). DDL is emitted at first use by `_ensure_trials_table(conn)` (verified `automl/engine.py:296-348`):
 
 ```sql
--- _kml_automl_agent_audit
-CREATE TABLE _kml_automl_agent_audit (
-  id BIGSERIAL PRIMARY KEY,
-  tenant_id VARCHAR(255) NOT NULL,
-  automl_run_id UUID NOT NULL,  -- FK to the parent tracker run
+CREATE TABLE IF NOT EXISTS _kml_automl_trials (
+  trial_id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  actor_id TEXT NOT NULL,
   trial_number INTEGER NOT NULL,
-  agent_kind VARCHAR(64) NOT NULL,  -- 'llm_suggester' | 'baseline'
-  agent_model_id VARCHAR(255),
-  actor_id VARCHAR(255) NOT NULL,
-  pact_decision VARCHAR(16) NOT NULL,  -- 'admit' | 'reject' per PACT admission
-  pact_reason TEXT,
-  proposed_config JSONB NOT NULL,
-  budget_microdollars BIGINT NOT NULL,
-  actual_microdollars BIGINT,
-  outcome VARCHAR(16),  -- {FINISHED, FAILED, KILLED, PENDING} — Decision 1 status vocab
-  occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  strategy TEXT NOT NULL,
+  params_json TEXT NOT NULL,
+  metric_name TEXT NOT NULL,
+  metric_value REAL,
+  cost_microdollars INTEGER NOT NULL DEFAULT 0,
+  started_at TEXT NOT NULL,
+  finished_at TEXT,
+  status TEXT NOT NULL,
+  admission_decision_id TEXT,
+  admission_decision TEXT,
+  error TEXT,
+  source TEXT NOT NULL DEFAULT 'baseline',
+  fidelity REAL NOT NULL DEFAULT 1.0,
+  rung INTEGER NOT NULL DEFAULT 0
 );
-CREATE INDEX idx_automl_agent_tenant_run ON _kml_automl_agent_audit(tenant_id, automl_run_id, trial_number);
+CREATE INDEX IF NOT EXISTS idx_automl_trials_tenant_run
+  ON _kml_automl_trials(tenant_id, run_id, trial_number);
 ```
 
-### 8A.3 SQLite-Compatible Variant
+The DDL uses dialect-portable types (`TEXT` / `INTEGER` / `REAL`) that work for both Postgres and SQLite. Callers that want Postgres-native types (`UUID` / `JSONB` / `TIMESTAMPTZ` / `BIGSERIAL`) MUST land a numbered migration per `rules/schema-migration.md` MUST Rule 1 — the engine's own DDL is the lowest-common-denominator portable form.
 
-SQLite does not support `BIGSERIAL`, `UUID`, `JSONB`, `TIMESTAMPTZ`, or `BIGINT` as distinct types. The SQLite subset MUST substitute:
+### 8A.2 First-Use DDL Discipline
 
-- `BIGSERIAL` → `INTEGER PRIMARY KEY AUTOINCREMENT`
-- `UUID` → `TEXT` (canonical 36-char hyphenated string; caller generates via `uuid.uuid4()`)
-- `JSONB` → `TEXT` (JSON-serialized string; caller `json.dumps()` / `json.loads()`)
-- `TIMESTAMPTZ` → `TEXT` (ISO-8601 UTC string; caller normalizes to UTC before write)
-- `BIGINT` → `INTEGER`
-- `DEFAULT NOW()` → omitted; caller supplies ISO-8601 UTC string at insert
+`_ensure_trials_table(conn)` is called at most once per `AutoMLEngine` instance (tri-state cache `_audit_table_ready: bool | None`). On the first `_record_trial(...)` call:
 
-### 8A.4 Tier-2 Schema-Migration Test
+1. If `connection is None` → emit WARN `automl.engine.no_connection`, set cache to `False`, audit is in-memory only.
+2. Else → call `_ensure_trials_table(conn)`. On success, cache `True`. On exception, emit WARN `automl.audit.table_create_failed`, cache `False`.
+3. Subsequent INSERT failures emit WARN `automl.engine.audit_insert_failed` per row but do NOT block the run.
 
-- `test__kml_automl_agent_audit_schema_migration.py` — applies §8A.2 + §8A.3 DDL to a fresh Postgres (via `ConnectionManager`) AND a fresh SQLite (`:memory:`); asserts `pragma_table_info` / `information_schema.columns` match the declared shape; asserts `pact_decision` round-trips both `'admit'` and `'reject'`; asserts `outcome` accepts the Decision 1 status vocab `{FINISHED, FAILED, KILLED, PENDING}` and rejects `'INVALID'` when a CHECK constraint is registered; asserts the composite index `idx_automl_agent_tenant_run` is created; asserts `quote_identifier()` is the only path used to interpolate the table name in test fixtures per `rules/dataflow-identifier-safety.md` Rule 5.
+This is the documented "in-memory fallback" mode and is permitted per `rules/observability.md` Rule 7 (bulk-op partial failure WARN) + `rules/schema-migration.md` Rule 1 (first-use DDL is a degraded-mode development convenience; production deployments should land a numbered migration ahead of any sweep). The engine cannot install database migrations during a run, so emitting a WARN and continuing with in-memory persistence is the correct disposition. Wave 6 should ship a numbered migration that supersedes the lazy DDL path.
+
+### 8A.3 No Separate `_kml_automl_agent_audit` Table
+
+The v1 spec § 8A.2 declared a separate `_kml_automl_agent_audit` table with `(agent_kind, agent_model_id, pact_decision, pact_reason, proposed_config, budget_microdollars, actual_microdollars, outcome)` columns. v1.1.1's `_kml_automl_trials` carries `(admission_decision, admission_decision_id, source, cost_microdollars, params)` on the same row — agent-vs-baseline is split via the `source` column at query time.
+
+See § "Deferred to M2 milestone" entry D-agentaudit.
 
 ---
 
-## 9. Industry Parity
+## 9. Persistence
 
-| Capability                      | kailash-ml 1.0.0 | FLAML | AutoGluon | H2O AutoML | Ray Tune  | Optuna     | Katib   | SageMaker HPO |
-| ------------------------------- | ---------------- | ----- | --------- | ---------- | --------- | ---------- | ------- | ------------- |
-| Time-budget + leaderboard       | Y                | Y     | Y         | Y          | Y\*       | Y\*        | Y       | Y             |
-| Nested-run tracker wiring       | Y (km.track)     | P     | P         | P          | Y (TB/WB) | Y (MLflow) | Y       | Y             |
-| Parallel trials (local)         | Y                | Y     | Y         | Y          | Y         | Y          | Y       | Y             |
-| Distributed executor (Ray/Dask) | Y (plug-in)      | Y     | Y         | N          | Y (core)  | Y          | Y (K8s) | Y             |
-| Bayesian HPO                    | Y                | Y     | Y         | Y          | Y         | Y          | Y       | Y             |
-| BOHB / Hyperband                | Y                | Y     | Y         | N          | Y         | Y          | Y       | Y             |
-| CMA-ES                          | Y                | N     | N         | N          | Y         | Y          | N       | N             |
-| Population-based training       | Y                | N     | N         | N          | Y         | N          | N       | N             |
-| Ensemble build from leaderboard | Y (default)      | Y     | Y         | Y          | N         | N          | N       | Y             |
-| Stacking meta-learner           | Y                | Y     | Y         | Y          | N         | N          | N       | Y             |
-| Polars-native data input        | Y                | N     | N         | N          | N         | N          | N       | N             |
-| Multi-tenant keyspace           | Y                | N     | N         | N          | N         | N          | Y (K8s) | Y (IAM)       |
-| **LLM-augmented suggestions**   | **Y (unique)**   | N     | N         | N          | N         | N          | N       | N             |
-| PACT-governed trial admission   | Y (via `pact`)   | N     | N         | N          | N         | N          | N       | N             |
+### 9.1 In-Memory By Default
 
-**Position:** Parity with FLAML/AutoGluon/H2O on classical AutoML; ahead on (a) polars-native perf, (b) tenant isolation by construction, (c) LLM-augmented suggestion as a first-class option, (d) PACT governance over admission. The LLM-augmentation + baseline-counterfactual design is the category-defining delta.
+`AutoMLEngine(connection=None)` is supported and persists trial audit rows to `self._trials` only. The `AutoMLResult.all_trials` field is the in-memory snapshot returned to the caller. WARN line `automl.engine.no_connection` emits on first `_record_trial(...)` call so operators can see the audit is degraded.
+
+### 9.2 Database-Backed Audit
+
+Pass any object with `execute(sql: str, *args)` and `fetch(...)` coroutine methods (`kailash.db.connection.ConnectionManager` is the canonical type). The engine uses positional `?` placeholders that work for both `aiosqlite` and `asyncpg` adapters.
+
+### 9.3 No Cross-Process Cost Tracker (Yet)
+
+`CostTracker` is in-memory + per-instance. W32 32a (per the docstring at `cost_budget.py:5-11`) is the planned ConnectionManager-backed persister that survives process restart and shares state across workers. Until then, parallel/distributed AutoML runs MUST construct one tracker per worker.
 
 ---
 
 ## 10. Error Taxonomy
 
-Every AutoML / HPO / Ensemble error MUST be a typed exception under `kailash_ml.errors` (AutoMLError family per `ml-tracking-draft.md §9.1`). Cross-cutting errors (`UnsupportedTrainerError` per Decision 8, `MultiTenantOpError` per Decision 12, `ParamValueError` for HPO param-space validation) sit at the `MLError` root or `TrackingError` family and are re-exported from `kailash_ml.errors`.
+### 10.1 Errors Currently Raised From The AutoML Surface (v1.1.1)
 
-| Exception                      | When raised                                                                                                                                                                                                                                                                                                                           |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BudgetExhaustedError`         | Wall-clock budget expired before user-requested `max_trials` reached (WARN, not fatal).                                                                                                                                                                                                                                               |
-| `InsufficientTrialsError`      | Fewer than `min_trials=5` trials completed — leaderboard not meaningful.                                                                                                                                                                                                                                                              |
-| `EnsembleFailureError`         | Meta-learner failed; child_uris + cause included.                                                                                                                                                                                                                                                                                     |
-| `TrialFailureError`            | A single trial raised uncaught; wrapped with parent context.                                                                                                                                                                                                                                                                          |
-| `MissingExtraError`            | `executor="ray"` / `agent=True` without the optional extra installed.                                                                                                                                                                                                                                                                 |
-| `ContextLostError`             | Distributed worker launched without parent `tenant_id` / `parent_run_id`.                                                                                                                                                                                                                                                             |
-| `InvalidConfigError`           | Non-finite budget, negative trial count, unknown algorithm name.                                                                                                                                                                                                                                                                      |
-| `HPOSpaceUnboundedError`       | `algorithm="grid"` invoked with an unbounded param space.                                                                                                                                                                                                                                                                             |
-| `AgentCostBudgetExceededError` | Cumulative LLM cost ≥ `max_llm_cost_usd`; subsequent trials revert to baseline.                                                                                                                                                                                                                                                       |
-| `ParamValueError`              | (cross-cutting, TrackingError family) HPO proposal contained a numeric hyperparameter with NaN or ±Inf — sampled point fails `math.isfinite()`. Re-exported from `kailash_ml.errors`. Multi-inherits `ValueError` so `except ValueError` continues to catch. See `ml-engines-v2-draft.md §3.2 MUST 3a` + `ml-tracking-draft.md §9.1`. |
-| `UnsupportedTrainerError`      | (cross-cutting, direct MLError child) A trial's Trainable bypasses `L.Trainer` during AutoML dispatch (Decision 8). Re-exported from `kailash_ml.errors`. See `ml-engines-v2-draft.md §3.2 MUST 2`.                                                                                                                                   |
+Verified by direct read of the canonical surface AND `kailash.ml.errors` (re-exported via `kailash_ml.errors`):
+
+| Error                            | Source module                                | When raised                                                                                                                                                                                |
+| -------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ValueError`                     | `automl/engine.py` `__post_init__` + `run()` | Non-finite budgets, negative trial count, unknown task_type/direction, empty `space`, empty/non-string tenant_id/actor_id                                                                  |
+| `BudgetExceeded`                 | `automl/cost_budget.py:77`                   | Proposed spend would push cumulative cost over the configured ceiling. NOT a subclass of `MLError`/`AutoMLError` — it is a plain `Exception`.                                              |
+| `PromotionRequiresApprovalError` | `automl/admission.py:58`                     | (a) `auto_approve=False` AND `budget_microdollars > auto_approve_threshold_microdollars`; (b) PACT engine raises any non-(`AttributeError`/`NotImplementedError`) exception (fail-CLOSED). |
+| `HPOSpaceUnboundedError`         | `automl/strategies/grid.py:32`               | `GridSearchStrategy` invoked with an unbounded continuous dimension. Local class; NOT in `kailash.ml.errors` taxonomy.                                                                     |
+| `TypeError`                      | `automl/cost_budget.py:64,228`               | Non-numeric USD input to `usd_to_microdollars`; non-int microdollars to `CostTracker.record`.                                                                                              |
+
+### 10.2 Errors From `kailash_ml.errors` (Available But Not Currently Raised By AutoML)
+
+Verified at `src/kailash/ml/errors.py`:
+
+- `BudgetExhaustedError` (line 649) — `AutoMLError` subclass; spec'd for `MLEngine.fit_auto()` use.
+- `InsufficientTrialsError` (line 654) — `AutoMLError` subclass; spec'd for `MLEngine.fit_auto()` use.
+- `EnsembleFailureError` (line 659) — `AutoMLError` subclass; not currently raised by `EnsembleEngine`.
+- `ParamValueError` (line 378) — `TrackingError, ValueError` multi-inherit; spec'd for HPO param validation.
+- `UnsupportedTrainerError` (line 334) — direct `MLError` subclass; spec'd for Trainable-bypass detection.
+
+These five are part of the typed taxonomy but the canonical AutoML surface does not raise them in v1.1.1. They are reserved for the M2 milestone surface (`MLEngine.fit_auto`, `Ensemble.from_leaderboard`).
+
+### 10.3 Errors Named In v1 Spec But Absent From Both Surfaces
+
+The v1 spec § 10 enumerated 11 typed exceptions. Six are absent from `kailash.ml.errors` AND not raised by the canonical AutoML surface:
+
+- `TrialFailureError` — trial failures wrap into `TrialRecord(status="failed", error=...)` instead.
+- `MissingExtraError` — caller-side responsibility; not raised by AutoMLEngine.
+- `ContextLostError` — distributed execution is not implemented; the error has no call site.
+- `InvalidConfigError` — `AutoMLConfig.__post_init__` raises plain `ValueError` instead.
+- `AgentCostBudgetExceededError` — agent-baseline split is not implemented; cost-overrun raises `BudgetExceeded` (not `AgentCostBudgetExceededError`).
+- (`HPOSpaceUnboundedError` exists locally in `automl/strategies/grid.py` but is NOT in the canonical `kailash.ml.errors` hierarchy.)
+
+See § "Deferred to M2 milestone" entry D-typederrors.
+
+### 10.4 MUST Rule
+
+#### MUST 1. Cross-Cutting Errors Re-Exported From `kailash_ml.errors`
+
+`kailash_ml.errors` re-exports the entire `kailash.ml.errors` hierarchy (verified `errors.py:21-94`). Identity is preserved: `kailash_ml.errors.MLError is kailash.ml.errors.MLError` is `True`. Callers MAY catch on either name. Per `rules/orphan-detection.md §6` every entry in `kailash_ml.errors.__all__` is eagerly imported (no lazy `__getattr__`).
 
 ---
 
 ## 11. Test Contract
 
-### 11.1 Tier 1 (Unit)
+### 11.1 Tier 1 + Tier 2 — Files Actually Present
 
-- `test_leaderboard_rank_ordering` — entries sorted by primary metric.
-- `test_hpo_algorithm_random_suggest_determinism` — same seed → same suggestions.
-- `test_hpo_algorithm_bayesian_observes_history` — `observe()` updates the GP.
-- `test_hpo_algorithm_bohb_halving` — trials prune at correct budget levels.
-- `test_ensemble_from_leaderboard_respects_k` — top-k selection is correct.
-- `test_automl_config_budget_non_finite_rejected` — `time_budget=float('inf')` raises.
-- `test_automl_config_llm_cost_nan_rejected` — `max_llm_cost_usd=nan` raises.
-- One test per error taxonomy entry.
+Test files verified by `find packages/kailash-ml/tests -name 'test_automl*'`:
 
-### 11.2 Tier 2 (Integration)
+| File                                             | Tier   | Purpose                                                                                    |
+| ------------------------------------------------ | ------ | ------------------------------------------------------------------------------------------ |
+| `tests/unit/test_automl_engine.py`               | Tier 1 | Engine behaviour with stubbed connection + stubbed governance                              |
+| `tests/unit/test_automl_engine_unit.py`          | Tier 1 | Engine helper internals (`_record_trial`, time-budget logic, `_select_best`)               |
+| `tests/unit/test_automl_admission.py`            | Tier 1 | PACT admission decision matrix (skipped / unimplemented / approval_required / fail-closed) |
+| `tests/unit/test_automl_cost_budget.py`          | Tier 1 | `CostTracker.record` atomicity, negative-compensation, `check_would_exceed` lock-free      |
+| `tests/unit/test_automl_strategies.py`           | Tier 1 | `ParamSpec` validation, strategy protocol conformance, `resolve_strategy` factory          |
+| `tests/integration/test_automl_engine_wiring.py` | Tier 2 | Real Postgres / SQLite, end-to-end run with audit row persistence — see § 11.3             |
 
-- `test_automl_ray_executor_wiring.py` — **only when `[ray]` installed**: `executor="ray"` runs 8 trials on a local Ray cluster; tracker captures each as nested run.
-- `test_automl_dask_executor_wiring.py` — **only when `[dask]` installed**.
-- `test_automl_nested_run_tracking.py` — real SQLite tracker; `fit_auto(df, ...)` produces N+1 runs (1 parent + N trials); `tracker.list_runs(parent_id=...)` returns N children.
-- `test_automl_tenant_propagation.py` — distributed trials inherit `tenant_id="acme"`; cross-tenant audit query returns only acme's trials.
-- `test_automl_budget_hard_cap.py` — `time_budget=5` returns a report before wall-clock exceeds 10s; `early_stopped=True`.
-- `test_automl_ensemble_default_on.py` — no `ensemble=` kwarg → report.ensemble_result is not None.
-- `test_hpo_search_polars_native.py` — search against a polars DataFrame, no pandas conversion happens internally.
-- `test_automl_agent_mode_double_optin.py` — `agent=True` without `[agents]` extra raises `MissingExtraError`.
-- `test_automl_agent_baseline_parallel.py` — `agent=True` with fake LLM → report contains both `source="agent"` and `source="baseline"` trials.
-- `test_automl_agent_cost_cap.py` — `max_llm_cost_usd=0.01` with expensive fake LLM → audit row records cap hit; trials continue via baseline.
+The exact assertions per file are owned by the test code, not this spec. To enumerate the cases run:
 
-### 11.3 Tier 3 (E2E via `MLEngine`)
+```bash
+pytest --collect-only -q packages/kailash-ml/tests/unit/test_automl_engine.py \
+                        packages/kailash-ml/tests/unit/test_automl_engine_unit.py \
+                        packages/kailash-ml/tests/unit/test_automl_admission.py \
+                        packages/kailash-ml/tests/unit/test_automl_cost_budget.py \
+                        packages/kailash-ml/tests/unit/test_automl_strategies.py \
+                        packages/kailash-ml/tests/integration/test_automl_engine_wiring.py
+```
 
-- `test_mlengine_fit_auto_churn_e2e.py` — `engine.fit_auto(df, target="churned", time_budget=120)` produces leaderboard; best entry's `tracker_run_id` points to a real run; `engine.register(result.entries[0])` succeeds.
+### 11.2 Tier 3 (E2E)
+
+No Tier 3 e2e file exists for the canonical `kailash_ml.automl.engine.AutoMLEngine` surface as of v1.1.1. The legacy scaffold has e2e coverage under `kailash-ml`'s broader test pyramid; the canonical surface relies on the Tier 2 wiring test (§ 11.3) for end-to-end coverage with real infrastructure. Wave 6 follow-up: add `test_automl_engine_e2e_with_real_trainer.py` exercising the canonical surface against a real model family.
+
+### 11.3 Wiring Test Per `rules/facade-manager-detection.md`
+
+Per the docstring at `automl/engine.py:29-32`, `AutoMLEngine` is a manager-shape class. The wiring test lives at `packages/kailash-ml/tests/integration/test_automl_engine_wiring.py` (verified to exist) and constructs the engine through the public facade (`from kailash_ml.automl import AutoMLEngine`) with real `AutoMLConfig` + real `ConnectionManager`.
 
 ---
 
 ## 12. Cross-References
 
-- `ml-engines-v2-draft.md §2.1 MUST 5` — the eight-method Engine surface; `fit_auto` is a convenience on top of `compare() → finalize()`.
-- `ml-engines-v2-draft.md §5` — tenant propagation; every AutoML trial inherits the Engine's `tenant_id`.
-- `ml-tracking-draft.md` — nested-run semantics; `log_metric`, `log_params` on child runs.
-- `ml-feature-store-draft.md` — AutoML consumes feature groups as candidate inputs; every trial logs `feature_versions`.
-- `rules/tenant-isolation.md` — MUST Rules 1-5; every storage key and audit row tenant-scoped.
-- `rules/autonomous-execution.md` — "Human-on-the-Loop" shapes the agent-mode approval gate.
-- `rules/event-payload-classification.md` — agent audit rows hash PII prompts.
-- `rules/zero-tolerance.md` Rule 2 — non-finite budgets treated as stubs and blocked.
-- `kailash-pact` — `PACT.GovernanceEngine.check_trial_admission()` consulted before every trial when `pact_enforcement=True`; a trial that exceeds a PACT dimension (cost, latency, fairness) is skipped before spin-up.
+- `specs/ml-engines.md` — `MLEngine.compare()` is the high-level "train and rank candidate families" surface; this spec covers `AutoMLEngine` as the lower-level orchestration primitive.
+- `specs/ml-tracking.md` — nested-run semantics for tracking AutoML parents + per-trial children.
+- `specs/ml-feature-store.md` — feature retrieval; out of scope for this spec.
+- `specs/pact-ml-integration.md` §2.1 — upstream `GovernanceEngine.check_trial_admission` contract that `kailash_ml.automl.admission` wires against.
+- `rules/tenant-isolation.md` MUST 5 — every audit row carries `tenant_id`.
+- `rules/event-payload-classification.md` — agent-side payload hashing applies to `_record_trial` rows when classified params are involved.
+- `rules/zero-tolerance.md` Rule 2 — non-finite budgets rejected at construction.
+- `rules/dataflow-identifier-safety.md` — `_kml_automl_trials` table name routes through dialect quoting at the connection layer (callers' responsibility; the engine emits the literal name).
+- `rules/schema-migration.md` MUST 1 — production deployments SHOULD land a numbered migration that creates `_kml_automl_trials` ahead of first use; the first-use DDL is degraded-mode for development only.
+- `rules/orphan-detection.md` § 6 — every error in `kailash_ml.errors.__all__` is eagerly imported.
+- `rules/facade-manager-detection.md` MUST 1 — `AutoMLEngine` wiring test exists at `tests/integration/test_automl_engine_wiring.py`.
 
 ---
 
-## 13. Conformance Checklist
+## 13. Examples
 
-- [ ] `AutoMLEngine` constructor accepts `tracker=None` and reads ambient `km.track()` context.
-- [ ] `HyperparameterSearch` constructor signature matches §2.2.
-- [ ] `fit_auto()` returns `LeaderboardReport` with both parent + nested trial runs logged.
-- [ ] Primary metric resolution is deterministic per §3.3 MUST 2.
-- [ ] `ensemble=True` is the default; `ensemble_result` populated for non-empty leaderboards.
-- [ ] `time_budget` is a hard cap; deadline-hit returns report with `early_stopped=True`.
-- [ ] `executor="ray"` / `"dask"` raise `MissingExtraError` if extra not installed.
-- [ ] Distributed trials carry `tenant_id` + `parent_run_id`; loss raises `ContextLostError`.
-- [ ] `agent=True` is double opt-in; baseline runs in parallel; cost cap is hard.
-- [ ] Every error is a typed exception per §10.
-- [ ] Tier 2 tests in §11.2 all named and passing.
-- [ ] `rg 'NotImplementedError' packages/kailash-ml/src/kailash_ml/engines/automl_engine.py` returns zero matches.
-- [ ] `rg 'tenant_id' packages/kailash-ml/src/kailash_ml/engines/automl_engine.py` matches every trial emission.
+### 13.1 Minimal Sweep (No PACT, No Connection, In-Memory)
+
+```python
+import asyncio
+from kailash_ml.automl import (
+    AutoMLConfig, AutoMLEngine, ParamSpec, Trial, TrialOutcome,
+)
+
+config = AutoMLConfig(
+    task_type="classification",
+    metric_name="accuracy",
+    direction="maximize",
+    search_strategy="random",
+    max_trials=10,
+    time_budget_seconds=60,
+    seed=42,
+)
+
+engine = AutoMLEngine(
+    config=config,
+    tenant_id="acme",
+    actor_id="alice@acme",
+)
+
+space = [
+    ParamSpec(name="n_estimators", kind="int", low=10, high=200),
+    ParamSpec(name="max_depth", kind="int", low=2, high=12),
+    ParamSpec(name="learning_rate", kind="log_float", low=1e-3, high=0.3),
+]
+
+async def trial_fn(trial: Trial) -> TrialOutcome:
+    # User-owned trainer; e.g. fit a LightGBM and return validation accuracy
+    accuracy = await my_train_and_eval(trial.params)
+    return TrialOutcome(
+        trial_number=trial.trial_number,
+        params=dict(trial.params),
+        metric=accuracy,
+        metric_name=config.metric_name,
+        direction=config.direction,
+    )
+
+result = asyncio.run(engine.run(space=space, trial_fn=trial_fn))
+print(result.best_trial.metric_value, result.best_trial.params)
+```
+
+### 13.2 With Cost Budget + PACT Stub
+
+```python
+from kailash_ml.automl import (
+    AutoMLConfig, AutoMLEngine, CostTracker, ParamSpec,
+)
+
+config = AutoMLConfig(
+    task_type="regression",
+    metric_name="rmse",
+    direction="minimize",
+    search_strategy="bayesian",
+    max_trials=50,
+    time_budget_seconds=1800,
+    total_budget_microdollars=10_000_000,             # $10
+    auto_approve=False,                                # require approval over threshold
+    auto_approve_threshold_microdollars=1_000_000,    # $1 per-trial threshold
+)
+
+engine = AutoMLEngine(
+    config=config,
+    tenant_id="acme",
+    actor_id="alice@acme",
+    connection=conn_mgr,                               # writes _kml_automl_trials
+    cost_tracker=CostTracker(
+        ceiling_microdollars=10_000_000,
+        tenant_id="acme",
+    ),
+    governance_engine=None,                            # PACT degrades to "skipped"
+)
+
+def estimate_cost(trial):
+    return 500_000  # $0.50 per trial
+
+result = await engine.run(
+    space=space,
+    trial_fn=trial_fn,
+    estimate_trial_cost_microdollars=estimate_cost,
+)
+
+if result.early_stopped:
+    print(f"stopped: {result.early_stopped_reason}")
+print(f"spent: ${result.cumulative_cost_microdollars/1_000_000:.2f}")
+```
+
+### 13.3 Standalone Strategy Use (Without `AutoMLEngine`)
+
+```python
+from kailash_ml.automl import resolve_strategy, ParamSpec, Trial, TrialOutcome
+
+strategy = resolve_strategy(
+    "halving",
+    space=[ParamSpec("lr", "log_float", low=1e-4, high=1.0)],
+    initial_trials=9,
+    reduction_factor=3,
+    seed=42,
+)
+history: list[TrialOutcome] = []
+while (trial := strategy.suggest(history)) is not None:
+    outcome = my_evaluate(trial)
+    strategy.observe(outcome)
+    history.append(outcome)
+    if strategy.should_stop(history):
+        break
+```
 
 ---
 
-_End of ml-automl-draft.md_
+## Deferred to M2 milestone
+
+The v1 spec promises 12 capabilities the v1.1.1 implementation does not provide. Each is enumerated here with the spec citation, current behaviour, deferral rationale, and a 1-2 sentence implementation sketch.
+
+### D-bohb. BOHB / CMA-ES / PBT Search Strategies
+
+- **v1 spec citation:** § 4.1 ("`BOHBAlgorithm`, `CMAESAlgorithm`, `ASHAAlgorithm`, plus `pbt` algorithm") + § 4.2 MUST 4 (BOHB multi-fidelity contract) + MUST 2 (PBT first-class).
+- **Current behaviour:** Only four strategies (grid/random/bayesian/halving). `automl/strategies/__init__.py` docstring (verified line 11) acknowledges "BOHB / CMA-ES / PBT / ASHA are deferred to post-M1 milestones." `resolve_strategy("bohb")` raises `ValueError`.
+- **Deferral rationale:** Each is a substantial new strategy class with its own protocol-conformant `suggest`/`observe`/`should_stop` plus specific required kwargs (BOHB needs `fidelity_param`/`fidelity_min`/`fidelity_max`/`reduction_factor`); shipping all four together would double the strategy surface area without a proven user pull.
+- **Sketch:** Add four new files under `automl/strategies/{bohb,cmaes,pbt,asha}.py`, each a `@dataclass` implementing `SearchStrategy`. BOHB wraps `hpbandster` (or local fallback). CMA-ES wraps `cma`. PBT extends `SuccessiveHalvingStrategy` with a per-trial mutation step. ASHA is the async variant of halving (rung promotion is event-driven, not population-complete). Add each name to `resolve_strategy()`.
+
+### D-asha. ASHA As Default For `parallel_trials > 1`
+
+- **v1 spec citation:** § 4.2 MUST 5 — ASHA is the default promotion rule when `parallel_trials > 1`.
+- **Current behaviour:** No `parallel_trials` kwarg exists; `SuccessiveHalvingStrategy` is the closest analogue but is synchronous.
+- **Deferral rationale:** Depends on D-executor (parallel/distributed execution).
+- **Sketch:** Add `ASHAStrategy` class that promotes trials event-driven (as outcomes land) instead of waiting for the rung to fill. Default `search_strategy="asha"` when `parallel_trials > 1` is detected. Requires D-executor first.
+
+### D-executor. `executor=` Kwarg (Local / Ray / Dask)
+
+- **v1 spec citation:** § 5.1-5.4 — `executor: str = "local"` with `"ray"` / `"dask"` values; § 5.4 MUST 1 mandates `MissingExtraError` when extra missing; § 5.4 MUST 2 mandates `tenant_id` + `parent_run_id` propagation; `ContextLostError` on lost context.
+- **Current behaviour:** Single-process sequential only. No `executor` / `parallel_trials` kwarg on `AutoMLEngine.__init__` or `run()`. `MissingExtraError` and `ContextLostError` are not in the typed-error set.
+- **Deferral rationale:** Distributed trial execution is a substantial architectural addition (worker dispatch, result-stream consumption, tenant-scoped Redis or worker registry); high-leverage but high-cost. The single-process surface in v1.1.1 satisfies the critical-path use cases (CLI, single-host tutorials, CI runs).
+- **Sketch:** Add `executor: str = "local"` and `parallel_trials: int = 1` fields to `AutoMLConfig`. Implement three executor classes: `LocalExecutor` (uses `ProcessPoolExecutor`), `RayExecutor` (requires `kailash-ml[ray]` extra), `DaskExecutor` (requires `kailash-ml[dask]` extra). Add `MissingExtraError` and `ContextLostError` to `kailash.ml.errors`. Every dispatched task carries `(tenant_id, parent_run_id)` as bound context; missing on the worker → `ContextLostError`.
+
+### D-ensembleleaderboard. `Ensemble.from_leaderboard()` Classmethod
+
+- **v1 spec citation:** § 7.1 — `Ensemble.from_leaderboard(report=, method=, k=, meta_learner=)` as the canonical entry point + § 3.3 MUST 3 (ensemble build is opt-out with `ensemble=True` default).
+- **Current behaviour:** `EnsembleEngine` exposes `blend()` / `stack()` / `bag()` / `boost()` instance methods that take fitted estimators directly. There is no `Ensemble` class with a `from_leaderboard` classmethod. `AutoMLConfig` has no `ensemble: bool` or `top_k: int` field.
+- **Deferral rationale:** Requires a `LeaderboardReport` type (D-leaderboard) before it has anything to consume; cycles with D-fitauto.
+- **Sketch:** Introduce `Ensemble` (or rename `EnsembleEngine`) with `from_leaderboard(report: LeaderboardReport, *, method: str, k: int = 3, meta_learner: str = "logistic") -> Ensemble`. Add `ensemble: bool = True` and `top_k: int = 3` fields to a new (M2-era) config class. Wire a call to `Ensemble.from_leaderboard(...)` into `MLEngine.fit_auto()` (D-fitauto) when `config.ensemble=True`.
+
+### D-ensembleresult. `Ensemble.fit()` Returns `TrainingResult`
+
+- **v1 spec citation:** § 7.2 MUST 1 — ensemble fit returns standard `TrainingResult` with `model_uri`, `metrics`, `feature_versions`, plus a new `base_models: list[str]` field.
+- **Current behaviour:** Each ensemble method returns its method-specific result dataclass (`BlendResult` / `StackResult` / `BagResult` / `BoostResult`). None return a `TrainingResult`. None populate a `base_models` list.
+- **Deferral rationale:** Requires both a `TrainingResult` shape that accommodates ensembles AND a downstream `MLEngine.register(ensemble_result)` path. The v1 spec also adds a new audit field that is a schema change.
+- **Sketch:** Add `Ensemble.fit(...) -> TrainingResult` as the canonical entry point that internally calls the appropriate `EnsembleEngine.{blend,stack,bag,boost}`. Convert the method-specific result into a `TrainingResult` with `base_models=[r.model_uri for r in inputs]`. Raise `EnsembleFailureError` (already in `kailash.ml.errors:659`) on meta-learner failure.
+
+### D-fitauto. `MLEngine.fit_auto()` Convenience Method
+
+- **v1 spec citation:** § 3.1 — `MLEngine.fit_auto(data, *, task, target, time_budget, metric, families, parallel_trials, executor, max_trials, early_stopping_patience, agent, ensemble, top_k, seed) -> LeaderboardReport`.
+- **Current behaviour:** `MLEngine` has `compare()` (verified `engine.py:994`) which is similar but NOT identical: `compare(*, families, n_trials, hp_search, metric, early_stopping, timeout_seconds, data, target) -> ComparisonResult`. The kwargs `task`, `time_budget`, `parallel_trials`, `executor`, `early_stopping_patience`, `top_k`, `agent`, `ensemble`, `seed` are NOT exposed. The return type is `ComparisonResult`, not `LeaderboardReport`.
+- **Deferral rationale:** A new entry point with a different return type would fork `MLEngine`'s public surface without a corresponding implementation underneath. Until D-leaderboard, D-executor, D-ensembleleaderboard land, `fit_auto` would be a documentation lie.
+- **Sketch:** Add `fit_auto(...)` to `MLEngine` once the prerequisites land. It composes `setup() → compare(hp_search="bayesian", n_trials=...) → finalize() → Ensemble.from_leaderboard(...)`, returning a `LeaderboardReport` whose entries reference per-trial nested run IDs.
+
+### D-leaderboard. `LeaderboardReport` Typed Result
+
+- **v1 spec citation:** § 3.2 — `LeaderboardReport` dataclass with `parent_run_id`, `task_type`, `primary_metric`, `entries: list[LeaderboardEntry]`, `ensemble_result: TrainingResult | None`, `total_trials`, `total_budget_seconds_used`, `early_stopped`, `tenant_id`. `LeaderboardEntry` has `rank`, `family`, `hyperparameters`, `metrics`, `tracker_run_id`, `feature_versions`, `elapsed_seconds`, `trial_number`.
+- **Current behaviour:** The canonical result type is `AutoMLResult` (verified `automl/engine.py:243-285`); the field set is described in § 3.2 above. There is no `family` field (single-family sweeps), no `tracker_run_id` (the engine doesn't bind to `kailash_ml.tracking`), no `feature_versions` (feature-store integration is the caller's responsibility), no `ensemble_result`. `MLEngine.compare()` returns `ComparisonResult`, a separate type owned by `specs/ml-engines.md`.
+- **Deferral rationale:** Two divergent result types (`AutoMLResult` for the engine, `ComparisonResult` for `MLEngine.compare()`) plus the v1-spec'd `LeaderboardReport` makes three. Reconciliation is a separate work item.
+- **Sketch:** Define `LeaderboardReport` and `LeaderboardEntry` in a new module `kailash_ml/automl/report.py`. Add a converter `LeaderboardReport.from_automl_result(result, families, ensemble_result=None) -> LeaderboardReport`. Reserve `AutoMLResult` for the low-level engine; `LeaderboardReport` for the `MLEngine.fit_auto()` surface.
+
+### D-tokenbackpressure. Token-Level LLM Backpressure
+
+- **v1 spec citation:** § 8.3 MUST 2 — `max_llm_cost_usd` enforced via TOKEN-LEVEL backpressure (compute `max_tokens_this_call` BEFORE the call to prevent overrun); § 8.3 MUST 2a mandates `max_prompt_tokens` / `max_completion_tokens` agent-config kwargs; `min_confidence` from `AgentGuardrailMixin`.
+- **Current behaviour:** `AutoMLConfig` has `min_confidence` but NOT `max_prompt_tokens` / `max_completion_tokens`. The legacy `LLMCostTracker.record(...)` (`engines/automl_engine.py:215-230`) performs POST-HOC summation: it records cost AFTER the call and raises `LLMBudgetExceededError` only when `_spent > _max_budget`. The exact "$4.99 → $7.50 in one call" failure mode the v1 spec forbids is the implementation's actual behaviour.
+- **Deferral rationale:** Token-level backpressure requires per-model pricing tables AND per-call computation of max_tokens — significant complexity that depends on D-baselineparallel before it has a meaningful enforcement seat.
+- **Sketch:** Add `max_prompt_tokens` and `max_completion_tokens` to a new `AgentConfig` dataclass under `kailash_ml/automl/agent.py`. Compute `max_tokens_this_call = remaining_budget / (model_cost_per_token * safety_margin=1.2)`. Wire into the agent-side `trial_fn` factory (the engine itself stays neutral about LLM; the agent factory enforces). Also re-route `LLMCostTracker` to call the canonical `CostTracker` so cost tracking is unified.
+
+### D-baselineparallel. Baseline-Parallel-With-Agent Stream
+
+- **v1 spec citation:** § 8.3 MUST 1 — when `agent=True`, a baseline pure-algorithmic search runs in PARALLEL with the agent's suggestions; final report tags each trial `source="agent" | "baseline"`.
+- **Current behaviour:** The canonical engine runs ONE stream per `run()` invocation. The orchestrator chooses `source_tag="baseline"` or `source_tag="agent"`. The legacy scaffold's `engines/automl_engine.py:529` says "Agent augmentation (not implemented in v1 -- requires kaizen agents)" and proceeds without parallelism.
+- **Deferral rationale:** Depends on D-executor (parallel infrastructure) AND D-fitauto (the high-level surface that would orchestrate the two streams).
+- **Sketch:** Inside `MLEngine.fit_auto(agent=True)`, dispatch two `AutoMLEngine.run(...)` invocations (one with `source_tag="baseline"`, one with `source_tag="agent"`) to the configured executor and merge results into one `LeaderboardReport`. Trials in both streams write to the same `_kml_automl_trials` table — `source` column is the partitioning key.
+
+### D-agentaudit. `_kml_automl_agent_audit` Separate Audit Table
+
+- **v1 spec citation:** § 8A.2 / § 8A.3 — separate `_kml_automl_agent_audit` table with `(tenant_id, automl_run_id, trial_number, agent_kind, agent_model_id, actor_id, pact_decision, pact_reason, proposed_config, budget_microdollars, actual_microdollars, outcome, occurred_at)` columns; SQLite + Postgres variants. § 8A.4 mandates `test__kml_automl_agent_audit_schema_migration.py`.
+- **Current behaviour:** A single `_kml_automl_trials` table carries all the columns (including agent-relevant fields like `admission_decision_id`, `admission_decision`, `cost_microdollars`, `source`); the `source` column is the agent/baseline split. There is no separate `_kml_automl_agent_audit` table and no schema-migration test for it.
+- **Deferral rationale:** A separate agent-audit table is justified IF the column set diverges meaningfully from the trial-audit table (e.g., per-call LLM telemetry that would bloat trial rows). Until LLM telemetry is wired (D-tokenbackpressure), the unified table is sufficient.
+- **Sketch:** Add `_kml_automl_agent_audit` as a numbered migration when token-level LLM telemetry lands. Schema: `(id BIGSERIAL, tenant_id, automl_run_id UUID, trial_number, agent_kind, agent_model_id, actor_id, pact_decision, pact_reason, proposed_config JSONB, prompt_tokens INTEGER, completion_tokens INTEGER, budget_microdollars BIGINT, actual_microdollars BIGINT, outcome, occurred_at TIMESTAMPTZ)`. Add SQLite-portable variant. Add `test__kml_automl_agent_audit_schema_migration.py` per `rules/schema-migration.md` MUST 5.
+
+### D-typederrors. Six Missing Typed Errors
+
+- **v1 spec citation:** § 10 enumerates 11 typed exceptions; v1.1.1 has six of them (`BudgetExhaustedError`, `InsufficientTrialsError`, `EnsembleFailureError`, `ParamValueError`, `UnsupportedTrainerError`, plus `HPOSpaceUnboundedError` defined locally in `automl/strategies/grid.py`). Six are missing entirely from `kailash.ml.errors`: `TrialFailureError`, `MissingExtraError`, `ContextLostError`, `InvalidConfigError`, `AgentCostBudgetExceededError`. (HPOSpaceUnboundedError exists locally but is not in the canonical taxonomy.)
+- **Current behaviour:** The canonical engine raises `ValueError` (for InvalidConfig-class scenarios), `BudgetExceeded` (cost overruns), `PromotionRequiresApprovalError` (approval gate). Trial failures wrap into `TrialRecord(status="failed", error=...)` instead of raising `TrialFailureError`. There is no `MissingExtraError` raised for missing optional extras (caller is expected to handle).
+- **Deferral rationale:** Adding the missing six is straightforward but must be done deliberately — each new error class is a public-API commitment, and the v1 spec's `ContextLostError` only makes sense alongside D-executor.
+- **Sketch:** Add five typed exceptions to `kailash.ml.errors`: `TrialFailureError(AutoMLError)`, `MissingExtraError(MLError)`, `ContextLostError(AutoMLError)`, `InvalidConfigError(AutoMLError, ValueError)`, `AgentCostBudgetExceededError(AutoMLError, BudgetExhaustedError)`. Promote `HPOSpaceUnboundedError` from `automl/strategies/grid.py` to `kailash.ml.errors` and re-export from the local module for backwards compatibility. Replace `ValueError` raises in `AutoMLConfig.__post_init__` with `InvalidConfigError`. Re-export all from `kailash_ml.errors`.
+
+### D-trackerwiring. Constructor `tracker=` Kwarg + Ambient `km.track()`
+
+- **v1 spec citation:** § 2.3 MUST 1 — `AutoMLEngine.__init__` accepts `tracker: Optional[ExperimentRun] = None` and auto-wires to `kailash_ml.tracking.get_current_run()` when `None`. Emits WARN when no tracker is bound.
+- **Current behaviour:** `AutoMLEngine.__init__` does NOT accept `tracker=`. There is no auto-wire to `kailash_ml.tracking.get_current_run()`. There is no WARN line "no tracker bound; trial history will not be recoverable" — the audit row goes to `_kml_automl_trials` directly via `connection`, decoupled from the tracking system.
+- **Deferral rationale:** Trial-as-nested-run discipline is a separate concern from trial-audit-row persistence. The v1 spec's design coupled them; the canonical implementation chose to keep them independent (tracker for `MLEngine.compare/fit`; audit table for `AutoMLEngine.run`).
+- **Sketch:** Either (a) reconcile by adding `tracker=` to `AutoMLEngine.__init__` and emitting nested-run children inside `_record_trial`, OR (b) document the decoupling explicitly and provide a helper `tracker.attach(automl_engine)` that subscribes to trial events. Option (b) is the cleaner architecture; option (a) is the v1-spec-aligned path.
+
+### D-earlystopping. `early_stopping_patience` Field
+
+- **v1 spec citation:** § 3.1 — `MLEngine.fit_auto(... early_stopping_patience: int = 10 ...)`; § 4.2 MUST 3 — sweep-level early stopping when no improvement over N trials.
+- **Current behaviour:** `AutoMLConfig` has no `early_stopping_patience` field. Sweep-level early stopping is the strategy's `should_stop(history)` responsibility; no patience mechanism is bundled into `AutoMLEngine`.
+- **Deferral rationale:** A patience mechanism is genuinely useful but adds non-trivial state (best-so-far tracking, generation counter). Until D-fitauto, it has no high-level entry point to enforce.
+- **Sketch:** Add `early_stopping_patience: int = 0` (0 = disabled) to `AutoMLConfig`. In `run()`, after each completed trial, track `trials_since_best_improved` and break with `early_stopped_reason="no_improvement"` when ≥ patience.
+
+---
+
+_End of ml-automl-v2-draft.md_

--- a/specs/ml-engines-v2-addendum.md
+++ b/specs/ml-engines-v2-addendum.md
@@ -9,6 +9,8 @@ Status: DRAFT at `workspaces/kailash-ml-audit/specs-draft/ml-engines-v2-addendum
 
 Origin: `workspaces/kailash-ml-audit/04-validate/round-1-SYNTHESIS.md` themes T2 (0/18 engines auto-wire tracker) + T3 (tenant isolation absent from 13/13 engines) + T5 (two model registries) + T7 (industry parity sub-MLflow-1.0); `round-1-mlops-production.md` 13×Tracker + 13×Tenant matrices; `round-1-industry-competitive.md` §C scorecard. Split per `rules/specs-authority.md §8` (base file already >300 LOC — an addendum keeps each shard ≤500 LOC rather than ballooning the parent).
 
+> **Wave 6.5 deferral note (2026-04-26):** This addendum cites `engine.fit_auto(...)` as a five-line Quick Start surface (§ E2.1, line 109). Per the Wave 6.5 spec realignment, `MLEngine.fit_auto()` is **not implemented** in kailash-ml 1.1.1 — see `ml-automl.md` § "Deferred to M2 milestone" entry D-fitauto. Callers today use `MLEngine.compare()` for family ranking and instantiate `kailash_ml.automl.AutoMLEngine` directly for HPO. The fit_auto facade lands in M2.
+
 ---
 
 ## Enrichment 1 — The 18-Engine × Tracker × Tenant × Actor Matrix

--- a/specs/ml-feature-store.md
+++ b/specs/ml-feature-store.md
@@ -1,734 +1,538 @@
-# Kailash ML Feature Store Specification (v1.0 Draft)
+# Kailash ML Feature Store Specification
 
-Version: 1.0.0 (draft)
-Package: `kailash-ml`
-Parent domain: ML Lifecycle (see `ml-engines-v2-draft.md` for `MLEngine` composition; `ml-tracking-draft.md` for runs/registry; `ml-drift-draft.md` for monitoring)
-License: Apache-2.0
-Python: >=3.11
-Owner: Terrene Foundation (Singapore CLG)
+**Version:** 1.1.1 (verified at `packages/kailash-ml/src/kailash_ml/_version.py`)
+**Status:** v2.0.0 (re-derived from filesystem mechanical sweeps 2026-04-26 — supersedes v1.0.0)
+**Package:** `kailash-ml`
+**Canonical module:** `kailash_ml.features` (1.0+ surface)
+**Legacy module:** `kailash_ml.engines.feature_store` (0.x surface, retained for 0.x callers; not specified here)
+**Parent domain:** ML Lifecycle. See `ml-engines.md` (MLEngine), `ml-tracking.md` (runs/registry), `ml-drift.md` (monitoring), `dataflow-ml-integration.md §1.1` (the `ml_feature_source` polars binding this spec consumes).
+**License:** Apache-2.0
+**Python:** >=3.11
+**Owner:** Terrene Foundation (Singapore CLG)
 
-Status: DRAFT at `workspaces/kailash-ml-audit/specs-draft/ml-feature-store-draft.md`. Becomes `specs/ml-feature-store.md` after human review. Supersedes the feature-store sections of `ml-engines.md v0.9.x §1.1`.
+## Re-Derivation Note
 
-Origin: Round-1 MLOps audit `workspaces/kailash-ml-audit/04-validate/round-1-mlops-production.md` HIGH "FeatureStore single-tenant only, no online/offline split, no feature-group concept" + industry-competitive audit Section C #13 "Feature store with offline+online parity". Closes round-1 CRIT T3 (tenant isolation absent from 13/13 engines) for the feature-store primitive.
+This v2 round 2 draft replaces the v1 outline (`specs/ml-feature-store.md`) AND supersedes round 1 (which retained too much v1 inertia and shipped two CRIT-class fabrications). Section structure is re-derived directly from the canonical 1.0+ surface at `packages/kailash-ml/src/kailash_ml/features/`. v1 capabilities not present in 1.0+ are consolidated under § 11 "Deferred to M2".
+
+Every "is implemented" claim below cites a file:line range read in this session. Every error class cited in § 6 is verified present in `src/kailash/ml/errors.py` via the round-2 mechanical sweep. Every test file cited in § 7 is verified present in `packages/kailash-ml/tests/`.
+
+Origin: Wave 5 portfolio audit findings F-E2-18..24 + Wave 6.5 round-2 re-derivation (2026-04-26).
 
 ---
 
 ## 1. Scope
 
-### 1.1 In Scope
+### 1.1 What FeatureStore Does in 1.0+
 
-This spec is authoritative for:
+`kailash_ml.features.FeatureStore` is a thin polars-native DataFlow-bridge: it wraps a live `DataFlow` instance and routes every feature read through `dataflow.ml_feature_source(...)`. The store does NOT own a connection pool, does NOT own DDL, does NOT own a registry table — those concerns belong to the parent `DataFlow` and to numbered migrations per `rules/schema-migration.md`.
 
-- **Offline feature store** — bulk historical storage backed by a SQL dialect (Postgres, DuckDB, SQLite) for training/backtesting reads.
-- **Online feature store** — low-latency key-value storage (Redis default; DynamoDB and MemoryDB acceptable adapters) for serving reads (sub-10ms p95).
-- **Point-in-time joins** — training retrieval that returns the feature value correct `as_of` a supplied timestamp, per entity, without leakage.
-- **Feature definition** — `@feature` decorator wrapping polars expressions; type-inferred; version-pinned; TTL; lineage capture.
-- **Feature groups** — named collections of features sharing an entity key, access control, and ownership — the primitive AutoML and Training read against.
-- **Materialization** — batch compute from source (DataFlow query, polars DataFrame, file) to offline store; streaming sync offline → online.
-- **Feature versioning** — every feature spec change produces a new version pinned by content SHA and tracked in the registry.
-- **Tenant isolation** — storage keys, query filters, audit rows all carry `tenant_id`; cross-tenant reads raise `TenantRequiredError`.
-- **Drift integration** — feature distributions hooked into `DriftMonitor` so monitoring runs against live online-store snapshots.
-- **Lineage** — every TrainingResult carries `feature_version` + `entity_snapshot_hash` for reproducibility.
+Concretely, the canonical surface ships:
 
-### 1.2 Out of Scope
+- A frozen, content-addressed `FeatureSchema` + `FeatureField` dataclass pair (`features/schema.py:122-280`).
+- A polars-native `FeatureStore.get_features(schema, timestamp, *, tenant_id, entity_ids)` retrieval method that delegates to `dataflow.ml_feature_source(point_in_time=...)` (`features/store.py:134-257`).
+- Tenant-isolation primitives — `validate_tenant_id`, `make_feature_cache_key`, `make_feature_group_wildcard` — under `features/cache_keys.py`.
+- Two read-path helpers on `FeatureStore` — `cache_key_for_row` and `invalidation_pattern` — that route through the cache_keys helpers (`features/store.py:263-308`).
+- A loud `ImportError` when the DataFlow polars binding is absent (`features/store.py:329-361`), per `rules/dependencies.md` § "Declared = Imported".
 
-- **Feature engineering DSL** beyond polars expressions — advanced window / rolling / aggregate semantics live in `kailash-dataflow`.
-- **Streaming infrastructure** (Kafka, Flink) — the online store consumes materialization writes; upstream streaming is user's concern.
-- **Data cataloging UI** — covered by `MLDashboard` (ml-tracking/dashboard) at the inventory tab; this spec owns the API, not the UI shell.
-- **ETL / bulk ingestion** — `DataFlow` owns that; `FeatureStore.ingest(df)` accepts a pre-computed DataFrame.
+### 1.2 What FeatureStore Does NOT Do in 1.0+
+
+The 1.0+ canonical surface does NOT provide: `@feature` decorator, `FeatureGroup` class, registry persistence, materialization scheduling, online-vs-offline split, GDPR `erase_tenant`, feature evolution, version immutability enforcement at the FeatureStore layer, or industry-parity adapters. Each is enumerated under § 11 "Deferred to M2".
+
+### 1.3 Source-File Surface
+
+`packages/kailash-ml/src/kailash_ml/features/`:
+
+- `__init__.py` — public re-exports (6 symbols, see § 2.1)
+- `schema.py` — `FeatureField`, `FeatureSchema`, `ALLOWED_DTYPES`
+- `store.py` — `FeatureStore` class + `_import_ml_feature_source()` helper
+- `cache_keys.py` — tenant-isolation helpers + canonical key shape
 
 ---
 
 ## 2. Construction
 
-### 2.1 MUST Rules
+### 2.1 Public Re-Exports (`features/__init__.py:12-27`)
 
-#### 1. Single-Line Construction With Explicit Stores
-
-`FeatureStore` MUST accept both offline and online store URLs at construction. Zero-arg construction is BLOCKED for this primitive — feature storage location is a deliberate operational choice.
+`kailash_ml.features.__all__` exports exactly six symbols:
 
 ```python
-# DO — explicit stores, tenant explicit
-from kailash_ml import FeatureStore
-
-fs = FeatureStore(
-    store="postgresql://user:pass@host:5432/ml",  # offline
-    online="redis://cache:6379/0",                # online (optional)
-    tenant_id="acme",
-)
-await fs.initialize()
-
-# DO — engine propagates tenant
-engine = km.Engine(store="postgresql://...", tenant_id="acme")
-# engine.feature_store has tenant_id="acme" automatically
-
-# DO NOT — zero-arg on the bare primitive
-fs = FeatureStore()  # TypeError; operator must state the store explicitly
+__all__ = [
+    "CANONICAL_SINGLE_TENANT_SENTINEL",
+    "FeatureField",
+    "FeatureSchema",
+    "FeatureStore",
+    "make_feature_cache_key",
+    "make_feature_group_wildcard",
+]
 ```
 
-**Why:** The v0.9.x `FeatureStore(conn, table_prefix="kml_feat_")` shape required a pre-built `ConnectionManager`, discouraged tenant passage, and hid that online/offline parity was not supported. Explicit `store=` + `online=` makes every deployment answer both questions at construction.
+Every entry has a corresponding eager module-scope import in `__init__.py` (lines 12-18), satisfying `rules/orphan-detection.md` MUST 6.
 
-Store-URL resolution for BOTH the `store=` (offline) and `online=` (online) kwargs routes through `kailash_ml._env.resolve_store_url(explicit=...)` per `ml-engines-v2.md §2.1 MUST 1b` (single shared helper; hand-rolled `os.environ.get(...)` is BLOCKED per `rules/security.md` § Multi-Site Kwarg Plumbing). When the caller passes an explicit URL (e.g. `store="postgresql://..."`, `online="redis://..."`), the helper returns it unchanged; when the caller passes `None` (offline store) or omits `online=`, the helper applies the `KAILASH_ML_STORE_URL` / per-backend env var / canonical default precedence chain so offline and online URL resolution share the same single enforcement point and cannot drift.
+### 2.2 `FeatureStore.__init__` Signature
 
-#### 2. Constructor Signature
+Verified at `features/store.py:98-114`:
 
 ```python
-class FeatureStore:
-    def __init__(
-        self,
-        store: str | ConnectionManager,         # REQUIRED: offline store URL
-        *,
-        online: str | OnlineStoreAdapter | None = None,  # Redis URL or adapter
-        tenant_id: str | None = None,
-        table_prefix: str = "_kml_feat_",
-        registry: FeatureRegistry | None = None,
-        ttl_online_seconds: int = 86400,        # default 24h TTL on online rows
-    ) -> None: ...
-
-    async def initialize(self) -> None: ...   # idempotent; creates tables/keys
-```
-
-#### 3. `initialize()` MUST Be Idempotent
-
-Calling `initialize()` on a fresh instance MUST create required SQL tables + Redis key namespaces. Calling it again on an already-initialized store MUST be a no-op.
-
-**Why:** Notebook users re-run setup cells; non-idempotent initialize throws on the second call and blocks the happy path.
-
----
-
-## 3. Feature Definition
-
-### 3.1 `@feature` Decorator
-
-Every feature MUST be defined via `@feature` on a Python function that returns a polars `Expr` or `Series`. The decorator captures dtype, dependencies, version (content SHA), and TTL.
-
-```python
-# DO — polars-native feature definition
-from kailash_ml import feature
-import polars as pl
-
-@feature(
-    entity="user_id",
-    dtype=pl.Float64,
-    ttl=3600,           # seconds; online-store eviction target
-    description="Mean purchase value over the user's trailing 30 days.",
-)
-def avg_purchase_30d(df: pl.LazyFrame) -> pl.Expr:
-    return (
-        df.filter(pl.col("event_time") >= pl.col("as_of") - pl.duration(days=30))
-        .group_by("user_id")
-        .agg(pl.col("amount").mean().alias("avg_purchase_30d"))
-    )
-
-# DO NOT — pandas expressions
-@feature(entity="user_id", dtype="float64")
-def avg_purchase_30d(df: pd.DataFrame) -> pd.Series:  # BLOCKED
-    return df.groupby("user_id")["amount"].mean()
-```
-
-**Why:** Polars is the internal data currency of kailash-ml (`ml-engines-v2-draft.md §1.1`). Accepting pandas would force a conversion boundary inside the feature pipeline, doubling memory for the largest operation in the system.
-
-### 3.2 MUST Rules
-
-#### 1. Every Feature Has An Entity Key
-
-Every `@feature` MUST declare `entity="..."` naming the primary entity column (e.g. `user_id`, `session_id`, `device_id`). Features without entity keys are BLOCKED — they cannot participate in point-in-time joins.
-
-#### 2. Feature Version Is Content-Addressed
-
-The feature version MUST be the first 12 hex chars of `sha256(decorator_kwargs || inspect.getsource(fn) || py_version || polars_version || numpy_version || blas_backend)`. Two feature specs with byte-identical source, decorator kwargs, AND numeric library versions MUST produce the same version; any source OR library change MUST produce a new version.
-
-```python
-# DO — deterministic versioning including the numeric-library stack
-feature_version = sha256(
-    f"{sorted(decorator_kwargs)}"
-    f"|{getsource(fn)}"
-    f"|{sys.version_info[:2]}"
-    f"|polars={polars.__version__}"
-    f"|numpy={numpy.__version__}"
-    f"|blas={detected_blas_backend}"        # "openblas" | "mkl" | "accelerate" | None
-    .encode()
-).hexdigest()[:12]
-# avg_purchase_30d@a3f1c2d9b4e5
-```
-
-**Why:** Registry lineage (`TrainingResult.feature_versions`) must be reproducible. Source+kwargs alone miss BLAS-backend drift (OpenBLAS vs MKL changes sum-of-product order → 1-ULP float drift on 1B-row aggregates) and polars/numpy version drift (aggregation algorithm changes between minor versions). The expanded hash input binds the feature-version to the exact numeric substrate — matching `km.seed()` SeedReport fields (`ml-engines-v2.md §11.2 MUST 5`).
-
-#### 3. TTL Applies To Online Store, Not Offline
-
-`ttl=3600` means the online-store row expires after 3600 seconds. Offline rows are retained until an explicit `retention_days` policy expires them (see §8). Mixing TTL semantics between stores is BLOCKED.
-
----
-
-## 4. Feature Groups
-
-### 4.1 Purpose
-
-A `FeatureGroup` is a named collection of features sharing an entity, ownership, and access policy. Training reads a group; serving reads a group. Groups — not individual features — are the atomic unit of versioning and access control.
-
-```python
-from kailash_ml import FeatureGroup
-
-group = FeatureGroup(
-    name="user_signals",
-    entity="user_id",
-    features=[avg_purchase_30d, login_count_7d, churn_risk_score],
-    owner="growth-team",
-    classification="PII",   # per kailash-dataflow classification
-)
-await fs.register_group(group, tenant_id="acme")
-```
-
-### 4.2 MUST Rules
-
-#### 1. Group Registration Persists `tenant_id`
-
-`register_group()` MUST persist `tenant_id` as a column on `_kml_feature_groups` row; the primary key is `(tenant_id, name, version)`. Two tenants MAY register a group with the same `name`.
-
-**Why:** Per `rules/tenant-isolation.md` Rule 5 — per-tenant audit queries without a full table scan require the tenant column indexed on every metadata row.
-
-#### 2. Classification Propagates To Training Rows
-
-When a group is marked `classification="PII"`, every feature value served from that group MUST be classified in the TrainingResult's audit trail (per `rules/event-payload-classification.md`). A downstream inference that leaks a PII feature value into a log WARN is auditable back to the group declaration.
-
-#### 3. Removing A Feature From A Group Requires A New Group Version
-
-`FeatureGroup.evolve()` is the ONLY mutation path. Removing, renaming, or changing a feature's dtype produces a new group version with a distinct version SHA. Silent in-place edit is BLOCKED.
-
----
-
-## 5. Materialization
-
-### 5.1 Batch Materialization (offline)
-
-`fs.materialize(group, source)` reads the source (a polars LazyFrame or DataFlow query), computes every feature, and writes to the offline store. Writes are tenant-scoped.
-
-```python
-# DO — materialize a group from a polars LazyFrame
-events = pl.scan_parquet("s3://events/*.parquet")
-await fs.materialize(group, source=events, tenant_id="acme")
-
-# DO — materialize from a DataFlow query
-result = await fs.materialize(group, source=db.express.query("User"), tenant_id="acme")
-# result.rows_written: int
-# result.feature_version: str
-# result.entity_snapshot_hash: str
-```
-
-### 5.2 Streaming Sync offline → online
-
-`fs.sync_to_online(group)` reads every materialized row from offline, upserts into the online store with the group's TTL. Tenant scoping applies.
-
-### 5.3 MUST Rules
-
-#### 1. Materialization Writes To Offline Only; Sync Writes Online
-
-`materialize()` MUST NOT write to the online store. `sync_to_online()` MUST NOT compute features. Conflating them is BLOCKED — the offline compute path can take minutes/hours; the online sync must stay snappy.
-
-#### 2. Materialization MUST Record Materialized-At Timestamp
-
-Every offline row MUST carry a `_materialized_at` TIMESTAMP column. Point-in-time joins use this column in addition to event timestamps to provide reproducibility.
-
-#### 2a. `_materialized_at` MUST Be Indexed
-
-Every offline feature group table MUST carry a composite index `(tenant_id, entity_id, _materialized_at DESC)`. On tables with 10B+ rows, an unindexed `WHERE _materialized_at <= as_of` is a full scan; the index converts point-in-time joins to logarithmic lookups.
-
-```sql
--- DO — index for point-in-time joins + late-arrival filter
-CREATE INDEX idx_kml_feat_user_signals_pit
-  ON _kml_feat_user_signals (tenant_id, user_id, _materialized_at DESC);
-
--- DO NOT — unindexed _materialized_at
--- (scan cost linear in row count; point-in-time queries stall at scale)
-```
-
-The index ordering (`DESC` on `_materialized_at`) matches the "latest-value-as-of-as_of" access pattern. The DAL MUST route every PIT query through this index via explicit ORDER BY + LIMIT 1 on the column.
-
-#### 3. Streaming Sync Is Tenant-Scoped
-
-`sync_to_online(group, tenant_id=...)` MUST restrict sync to keys matching `kailash_ml:v1:{tenant_id}:feature:{group}:*`. Cross-tenant accidental syncs are blocked by the key shape.
-
----
-
-## 6. Offline Retrieval (Training)
-
-### 6.1 `get_training_features()` — Point-In-Time-Correct
-
-```python
-# DO — point-in-time retrieval with as_of per entity
-entity_df = pl.DataFrame({
-    "user_id": ["u1", "u2", "u3"],
-    "as_of":   [datetime(2026, 3, 15), datetime(2026, 3, 20), datetime(2026, 3, 21)],
-    "label":   [0, 1, 0],
-})
-
-training = await fs.get_training_features(
-    entity_df=entity_df,
-    groups=["user_signals", "device_signals"],
-    tenant_id="acme",
-)
-# training is a polars DataFrame: entity_df + joined feature columns
-# Each row's features are the value correct as_of that row's as_of timestamp
-```
-
-### 6.2 MUST Rules
-
-#### 1. No Future Leakage — Strict `as_of` Correctness
-
-For every `(entity_id, as_of)` tuple in `entity_df`, the returned feature values MUST be computed from source events with `event_time <= as_of`. An event at `as_of + epsilon` MUST NOT influence the feature value. Violations are caught by `test_feature_store_no_future_leakage`.
-
-```python
-# DO — strict upper-bound
-# For avg_purchase_30d joining with as_of=2026-03-15:
-#   include events: 2026-02-13 <= event_time <= 2026-03-15
-#   exclude events: event_time > 2026-03-15
-
-# DO NOT — off-by-one upper bound
-#   include event_time <= as_of + 1 second   (leakage)
-```
-
-**Why:** Future leakage is the #1 failure mode of training pipelines; a model that trains on features computed from future events appears to have uncanny predictive power in backtest and immediately regresses in production.
-
-#### 2. Missing Feature Values Raise `StaleFeatureError` OR Return NaN (User Configurable)
-
-```python
-training = await fs.get_training_features(
-    entity_df=entity_df,
-    groups=["user_signals"],
-    missing_feature_policy="raise",  # "raise" | "null" | "exclude" | "default"
-    tenant_id="acme",
-)
-```
-
-`missing_feature_policy`:
-
-- `"raise"` (default) — raise `StaleFeatureError(entity_id=, feature=, as_of=, reason=)` naming the first missing cell.
-- `"null"` — fill missing cells with `null`; the column remains nullable.
-- `"exclude"` — drop the entire entity-row from the training DataFrame when ANY feature is missing at `as_of` (conservative; prevents training on partial records).
-- `"default"` — use the `@feature(default=...)` value declared on the feature definition.
-
-Silent NaN is BLOCKED as the default because it masks training bugs.
-
-#### 2a. Late-Arriving Data Policy (Point-In-Time Correctness)
-
-Events with `event_time < as_of <= _materialized_at` (late-arriving data — the event belongs to the past but materialised AFTER the query's as_of reference) require a defensible semantic choice. Feast includes them ("as-of-event-time"); Tecton excludes them when the materialization window is closed ("as-of-materialization-time"). kailash-ml picks the CONSERVATIVE default:
-
-```python
-training = await fs.get_training_features(
-    entity_df=entity_df,
-    groups=["user_signals"],
-    late_arrival_policy="exclude",  # "include" | "exclude" | "warn" — default "exclude"
-    tenant_id="acme",
-)
-```
-
-| Policy    | Behaviour                                                                                                                                     | Use case                                               |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `exclude` | (default) Late events IGNORED at query time — only events with `_materialized_at <= as_of` included. Matches training-serving-skew tolerance. | Most production models; conservative default.          |
-| `include` | Late events INCLUDED — matches Feast "as-of-event-time". Use when backfill is part of the feature pipeline.                                   | Backfill-heavy pipelines; research environments.       |
-| `warn`    | Late events INCLUDED but every late-cell is emitted to the tracker as `feature_store.late_arrival.{feature}`.                                 | Initial rollout — observe before choosing the default. |
-
-**MUST 1**: The default is `"exclude"` — explicit opt-in required for `"include"`. BLOCKED rationalization: "we want as-of-event-time to maximise data" — use `"include"` with an explicit kwarg; silent default change is a correctness regression.
-
-**MUST 2**: Two Tier 2 tests — `test_feature_store_late_arrival_exclude.py` AND `test_feature_store_late_arrival_include.py` — MUST exist and assert divergent behavior on the same dataset.
-
-**Why:** Without a documented policy, different calls return different numbers for the same `(entity_id, as_of)` pair depending on when the call ran. Making the policy explicit with a conservative default makes backtest results reproducible across re-runs.
-
-#### 3. Return Type Is Always `polars.DataFrame`
-
-`get_training_features` MUST return `pl.DataFrame`. Returning pandas, dict-of-arrays, or a generator is BLOCKED.
-
-#### 4. Training-Serving Skew Detection — `FeatureStore.detect_skew`
-
-```python
-async def detect_skew(
+def __init__(
     self,
+    dataflow: "DataFlow",
     *,
-    model_name: str,
-    tenant_id: str,
-    window: timedelta = timedelta(days=7),
-    sample_size: int = 1000,
-) -> SkewReport: ...
-
-@dataclass(frozen=True)
-class SkewReport:
-    model_name: str
-    sampled_at: datetime
-    n_entities_sampled: int
-    per_feature: "polars.DataFrame"        # columns: feature, ks_statistic, ks_p_value, l1_distance, online_mean, offline_mean
-    severity: Literal["healthy", "warning", "critical"]
-    recommendation: str
+    default_tenant_id: str | None = None,
+) -> None:
 ```
 
-Samples N entities at random, fetches the online-served feature value AND the offline-materialised value at the same `event_time`, computes per-feature divergence statistics (KS, L1). Emits `feature_store.skew.{feature}` metrics and appears as a default tile in `MLDashboard`.
+Behaviour:
 
-**MUST 1**: `detect_skew` MUST be called automatically by `MLDashboard` every 24h for every tenant's every active model. An operator can cron-disable via config.
+- `dataflow is None` → raises `TypeError` with the actionable message: `"FeatureStore(dataflow=...) is required — construct via DataFlow(...) and pass the instance in. See rules/facade-manager-detection.md Rule 3."` (`store.py:104-109`).
+- `default_tenant_id is not None` → eagerly invokes `validate_tenant_id(default_tenant_id, operation="FeatureStore.__init__")` to fail loudly at construction (`store.py:111-114`).
+- `default_tenant_id is None` → store is constructed; every method call MUST then specify `tenant_id` explicitly or `TenantRequiredError` is raised at the call site.
 
-**MUST 2**: Severity thresholds — `ks_p_value < 0.01` → CRITICAL (training-serving skew detected); `< 0.05` → WARNING.
+#### MUST 1 — Construction Receives the Live DataFlow Instance
 
-**Why:** Training-serving skew is the #1 cause of model degradation in production after deployment. Without a first-class primitive, users write one-off scripts that drift from reality. Feast ships `feast materialize-incremental` followed by a skew check; Tecton ships `skew_analysis`. Kailash-ml's `detect_skew` is the parity surface with a conservative default cadence.
+`FeatureStore` MUST receive the parent `DataFlow` instance via the positional `dataflow` argument. Self-construction (`FeatureStore(db_url=...)`) and global-lookup are BLOCKED — see `rules/facade-manager-detection.md` Rule 3.
+
+### 2.3 Read-Only Properties
+
+Verified at `features/store.py:314-321`:
+
+- `fs.dataflow` returns the bound `DataFlow` instance (read-only).
+- `fs.default_tenant_id` returns the `default_tenant_id` supplied at construction (read-only, may be `None`).
+
+There are no other public attributes on `FeatureStore`.
 
 ---
 
-## 7. Online Retrieval (Serving)
+## 3. Schema (FeatureField + FeatureSchema)
 
-### 7.1 `get_online_features()` — Sub-10ms p95
+### 3.1 `FeatureField` (`features/schema.py:122-166`)
+
+`@dataclass(frozen=True, slots=True)` with four fields:
+
+| Field         | Type | Default | Validation                                                                                              |
+| ------------- | ---- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `name`        | str  | —       | Validated against `^[a-zA-Z_][a-zA-Z0-9_]*$` (`schema.py:82`); `_validate_name` does NOT echo raw value |
+| `dtype`       | str  | —       | Normalised via `_normalise_dtype` against `ALLOWED_DTYPES` allowlist + synonym table                    |
+| `nullable`    | bool | `True`  | —                                                                                                       |
+| `description` | str  | `""`    | —                                                                                                       |
+
+`__post_init__` calls `object.__setattr__(self, "dtype", _normalise_dtype(self.dtype))` because the dataclass is frozen.
+
+### 3.2 Dtype Allowlist (`features/schema.py:35-79`)
+
+`ALLOWED_DTYPES` is a `frozenset` containing 19 polars-native dtypes: integer (8), float (2), text (2), bool, temporal (4), binary, categorical. `_DTYPE_SYNONYMS` maps 8 numpy/numpy-style aliases (`float`, `double`, `int`, `long`, `str`, `text`, `string`, `boolean`) to canonical forms.
+
+#### MUST 2 — Dtype Strings Are Polars-Native
+
+`FeatureField.dtype` MUST resolve (after synonym normalisation) to a member of `ALLOWED_DTYPES`. Pandas-style dtype strings outside the synonym table fail at construction with a `ValueError` whose message lists the allowed set (`schema.py:93-98`).
+
+### 3.3 `FeatureSchema` (`features/schema.py:174-280`)
+
+`@dataclass(frozen=True, slots=True)` with five caller-visible fields plus one derived field:
+
+| Field              | Type                     | Default       | Notes                                                          |
+| ------------------ | ------------------------ | ------------- | -------------------------------------------------------------- |
+| `name`             | str                      | —             | Validated against the SQL identifier regex                     |
+| `version`          | int                      | `1`           | MUST be `>= 1`; `bool` rejected via explicit check             |
+| `fields`           | tuple[FeatureField, ...] | `()`          | MUST contain ≥1 field; duplicate names rejected                |
+| `entity_id_column` | str                      | `"entity_id"` | Validated against the SQL identifier regex                     |
+| `timestamp_column` | str \| None              | `None`        | If present, validated against the SQL identifier regex         |
+| `content_hash`     | str (init=False)         | derived       | sha256 first-16-hex of canonical payload (`schema.py:248-251`) |
+
+`_canonical_payload` (`schema.py:253-260`) serialises `{name, version, entity_id_column, timestamp_column, fields=[FeatureField.to_dict() ...]}` via `json.dumps(..., sort_keys=True)`, then sha256 → first 16 hex chars.
+
+#### MUST 3 — `content_hash` Stability
+
+`FeatureSchema.content_hash` MUST be deterministic across processes and machines for byte-identical input. Two `FeatureSchema` instances constructed with identical `(name, version, fields, entity_id_column, timestamp_column)` MUST yield the same `content_hash`.
+
+---
+
+## 4. Retrieval
+
+### 4.1 `get_features` Signature
+
+Verified at `features/store.py:134-141`:
 
 ```python
-# DO — online lookup for a single entity
-features = await fs.get_online_features(
-    entity_id="u1",
-    groups=["user_signals"],
-    tenant_id="acme",
-)
-# features: dict[str, Any]; {"avg_purchase_30d": 42.10, "login_count_7d": 5, ...}
+async def get_features(
+    self,
+    schema: FeatureSchema,
+    timestamp: datetime | None = None,
+    *,
+    tenant_id: str | None = None,
+    entity_ids: list[str] | None = None,
+) -> pl.DataFrame:
+```
 
-# DO — batch online lookup
-features_batch = await fs.get_online_features_batch(
+#### MUST 4 — `get_features` Returns `polars.DataFrame`, Not `LazyFrame`
+
+The public-API boundary returns a concrete `polars.DataFrame`. If `dataflow.ml_feature_source` returns a `LazyFrame`, `get_features` collects it (`store.py:204`). If the binding returns any other type, `FeatureStoreError` is raised with the offending type name in `reason` (`store.py:205-214`).
+
+#### MUST 5 — Point-in-Time Join Delegates to DataFlow
+
+When `timestamp` is supplied, `get_features` MUST pass it through unchanged as `point_in_time=timestamp` to `ml_feature_source` (`store.py:197-201`). The store does NOT compute the as-of join itself — that contract belongs to `dataflow-ml-integration.md §1.1`. `timestamp` MUST be a `datetime`; non-`datetime` raises `TypeError` (`store.py:172-176`).
+
+This is the F-E2-23 positive: PIT join via `dataflow.ml_feature_source(point_in_time=timestamp)` is wired end-to-end.
+
+#### MUST 6 — Tenant Validation Precedes Every Read
+
+`get_features` MUST resolve `tenant_id` via `_resolve_tenant` (`store.py:120-128`) before any read. The resolver returns `tenant_id if tenant_id is not None else self._default_tenant_id`, then passes the result to `validate_tenant_id`. A missing tenant raises `TenantRequiredError`; the read does NOT proceed.
+
+### 4.2 Error Pass-Through
+
+The `try` block at `store.py:193-257` distinguishes three error families:
+
+1. `TenantRequiredError` — re-raised unchanged (`store.py:232-236`). The contract is "tenant is a hard gate"; the store MUST NOT reclassify this as `FeatureStoreError`.
+2. `ImportError` — re-raised unchanged (`store.py:237-240`). Operators MUST see the dependency gap clearly.
+3. Any other `Exception` — wrapped as `FeatureStoreError(reason="get_features failed: <ExcClassName>", tenant_id=effective_tenant) from exc` (`store.py:241-257`). The `from exc` preserves the original cause for `__cause__` chaining.
+
+### 4.3 Entity-ID Filter
+
+When `entity_ids` is supplied, the returned DataFrame is post-filtered via `df.filter(pl.col(schema.entity_id_column).is_in(entity_ids))` (`store.py:215-216`). This is a polars in-memory filter applied AFTER the binding returns; it does not push down to DataFlow.
+
+### 4.4 Structured Logging
+
+Three structured INFO/EXCEPTION lines, all carrying `source="dataflow"`, `mode="real"`, plus `tenant_id`, `schema` (= `FeatureSchema.name`), `version` (`store.py:181-253`):
+
+| Event                              | Level     | Additional fields               |
+| ---------------------------------- | --------- | ------------------------------- |
+| `feature_store.get_features.start` | INFO      | `has_timestamp`, `entity_count` |
+| `feature_store.get_features.ok`    | INFO      | `row_count`, `latency_ms`       |
+| `feature_store.get_features.error` | EXCEPTION | `latency_ms`                    |
+
+#### MUST 7 — INFO-Level Logs MUST NOT Carry Field-Level Schema Identifiers
+
+Per `rules/observability.md` Rule 8 the INFO lines emit the schema NAME (`schema.name` — a logical model identifier) and `version` only. Individual COLUMN names from `FeatureSchema.fields` MUST NOT appear at INFO+ level. The DEBUG path is the only acceptable destination if column-level diagnostics are needed.
+
+---
+
+## 5. Tenant Isolation
+
+This is the F-E2-24 positive set, implemented at `features/cache_keys.py`.
+
+### 5.1 Canonical Cache Key Shape
+
+Verified at `features/cache_keys.py:196-199`:
+
+```
+kailash_ml:{FEATURE_KEY_VERSION}:{tenant_id}:feature:{schema_name}:{version}:{row_key}
+```
+
+With `FEATURE_KEY_VERSION = "v1"` (`cache_keys.py:42`), the concrete shape today is:
+
+```
+kailash_ml:v1:{tenant_id}:feature:{schema_name}:{version}:{row_key}
+```
+
+#### MUST 8 — Cache Keys Embed `tenant_id` As The Second Dimension
+
+Every cache key emitted by `make_feature_cache_key` MUST embed `tenant_id` between `FEATURE_KEY_VERSION` and the `feature` literal. This satisfies `rules/tenant-isolation.md` MUST 1 (cache keys include tenant_id for multi-tenant models).
+
+### 5.2 `validate_tenant_id` Contract
+
+Verified at `cache_keys.py:67-126`. The validator rejects:
+
+| Input class                                    | Outcome                               | Site                |
+| ---------------------------------------------- | ------------------------------------- | ------------------- |
+| `tenant_id is None`                            | `TenantRequiredError`                 | `cache_keys.py:91`  |
+| `not isinstance(tenant_id, str)`               | `TenantRequiredError`                 | `cache_keys.py:100` |
+| `tenant_id in {"default", "global", ""}`       | `TenantRequiredError`                 | `cache_keys.py:107` |
+| `not _TENANT_RE.match(tenant_id)` (regex fail) | `TenantRequiredError` (fingerprinted) | `cache_keys.py:117` |
+
+Tenant-id regex (`cache_keys.py:56`): `^[A-Za-z_][A-Za-z0-9_\-]*$`. Colons are rejected because they would split the key shape; the validator's error message uses a 16-bit hash fingerprint to avoid echoing the rejected raw input.
+
+#### MUST 9 — Forbidden Sentinels Raise, Not Default
+
+`FORBIDDEN_TENANT_SENTINELS = frozenset({"default", "global", ""})` (`cache_keys.py:50`). Single-tenant deployments MUST use the canonical sentinel `CANONICAL_SINGLE_TENANT_SENTINEL = "_single"` (`cache_keys.py:46`); the validator accepts `"_single"` because the leading-underscore form satisfies `_TENANT_RE`.
+
+Silent fallback to a default tenant is BLOCKED — this satisfies `rules/tenant-isolation.md` MUST 2 (multi-tenant strict mode — missing `tenant_id` is a typed error).
+
+### 5.3 Invalidation Pattern (Version-Wildcard)
+
+`make_feature_group_wildcard` (`cache_keys.py:202-224`) emits patterns matching the `v*` keyspace-version wildcard so a future `FEATURE_KEY_VERSION` bump (e.g. `v1 → v2`) does not strand legacy keys.
+
+| Args                                            | Pattern                          |
+| ----------------------------------------------- | -------------------------------- |
+| `tenant_id="t1", schema_name="s", version=None` | `kailash_ml:v*:t1:feature:s:*`   |
+| `tenant_id="t1", schema_name="s", version=2`    | `kailash_ml:v*:t1:feature:s:2:*` |
+
+Tenant-scoped invalidation is REQUIRED — `make_feature_group_wildcard` calls `validate_tenant_id` first, so a missing tenant raises before any pattern is built. This satisfies `rules/tenant-isolation.md` MUST 3 (tenant-scoped invalidation) AND MUST 3a (keyspace-version wildcard sweep).
+
+### 5.4 `row_key` Validation Contract
+
+Verified at `cache_keys.py:186-195`. The contract for `row_key`:
+
+- MUST be a non-empty string (`cache_keys.py:186-189`).
+- MUST NOT contain `:` (`cache_keys.py:192-195`).
+- No further regex is applied — `row_key` is opaque to the helper. It is NOT interpolated into SQL; it only goes into the Redis-compatible cache key namespace.
+
+The `row_key` is rejected (not escaped) to keep key shape unambiguous.
+
+### 5.5 Schema-Name Validation
+
+`_validate_schema_name` (`cache_keys.py:129-140`) requires `schema_name` to match `^[a-zA-Z_][a-zA-Z0-9_]*$`. Failure raises `ValueError` with a 16-bit fingerprint, not the raw input.
+
+### 5.6 Version Validation
+
+`_validate_version` (`cache_keys.py:143-153`) requires `version` to be `int` (NOT `bool`) AND `>= 1`.
+
+### 5.7 `FeatureStore.cache_key_for_row` and `invalidation_pattern`
+
+These read-path helpers on the store delegate directly to the cache_keys module after resolving tenant via `_resolve_tenant` (`store.py:263-308`):
+
+- `fs.cache_key_for_row(schema, row_key, *, tenant_id=None) -> str` calls `make_feature_cache_key(...)`.
+- `fs.invalidation_pattern(schema, *, tenant_id=None, all_versions=False) -> str` calls `make_feature_group_wildcard(version=None if all_versions else schema.version)`.
+
+Centralising the call sites here means a future keyspace-version bump patches one method per concern, not the entire codebase.
+
+---
+
+## 6. Errors
+
+This section enumerates ONLY error classes that (a) exist in `src/kailash/ml/errors.py` AND (b) are reachable from the `kailash_ml.features.FeatureStore` surface in 1.0+.
+
+### 6.1 Exception Classes Raised From The Canonical Surface
+
+| Class                   | Defined in `errors.py`                                                                                | Raised at                                       | When                                                                    |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------- |
+| `TypeError` (builtin)   | n/a (builtin)                                                                                         | `store.py:104-109`                              | `FeatureStore(None)` — missing dataflow positional argument             |
+| `TypeError` (builtin)   | n/a (builtin)                                                                                         | `store.py:165-168`                              | `get_features(schema, ...)` where schema is not `FeatureSchema`         |
+| `TypeError` (builtin)   | n/a (builtin)                                                                                         | `store.py:172-176`                              | `get_features(..., timestamp=...)` where timestamp is not `datetime`    |
+| `TypeError` (builtin)   | n/a (builtin)                                                                                         | `schema.py:88-90`, `:104-105`, `:213-217`       | `FeatureField.dtype` not str; `FeatureSchema.version` not int           |
+| `ValueError` (builtin)  | n/a (builtin)                                                                                         | `schema.py:93-98`, `:106-114`, `:218-225`       | dtype not allowed; identifier regex fail; empty fields                  |
+| `ValueError` (builtin)  | n/a (builtin)                                                                                         | `cache_keys.py:131-139`, `:149-152`, `:186-195` | `schema_name`/`version`/`row_key` validation failures                   |
+| `TenantRequiredError`   | `errors.py:389` (line of `class TenantRequiredError`) — declared at the canonical TrackingError home. | `cache_keys.py:91`, `:100`, `:107`, `:117`      | Missing/non-str/forbidden-sentinel/regex-fail tenant_id                 |
+| `ImportError` (builtin) | n/a (builtin)                                                                                         | `store.py:354-361`                              | `dataflow.ml_feature_source` not importable from either resolution path |
+| `FeatureStoreError`     | `errors.py:315` (`class FeatureStoreError(MLError)`)                                                  | `store.py:208-214`, `:254-257`                  | Binding returned non-DataFrame; or any other `Exception` from binding   |
+
+`FeatureStoreError` is constructed with kwarg-only `reason=` per `MLError.__init__` (`errors.py:245-259`). The full kwargs surface is `reason=`, `tenant_id=`, `actor_id=`, `resource_id=`, `**context`.
+
+### 6.2 Exception Classes Defined But NOT Raised From The Canonical FeatureStore Surface
+
+Three subclasses of `FeatureStoreError` exist in `errors.py:632-643` but are NOT reached by any code path in `kailash_ml.features.FeatureStore` today:
+
+| Class                       | Defined in `errors.py` | 1.0+ FeatureStore call sites |
+| --------------------------- | ---------------------- | ---------------------------- |
+| `FeatureNotFoundError`      | `errors.py:632`        | none                         |
+| `StaleFeatureError`         | `errors.py:636`        | none                         |
+| `PointInTimeViolationError` | `errors.py:641`        | none                         |
+
+These typed exceptions are part of the M2 surface (see § 11). The 1.0+ FeatureStore does NOT raise them — feature-not-found at the polars-binding level surfaces as a `FeatureStoreError` wrapper with the original exception preserved via `from exc`. Downstream code that catches `FeatureStoreError` will continue to catch the M2 subclasses once the wiring lands; but downstream code MUST NOT today `try/except` against `FeatureNotFoundError` etc. expecting it to surface from `kailash_ml.features.FeatureStore` — those paths do not raise these classes today.
+
+### 6.3 NOT Defined Anywhere — Do Not Reference
+
+The following classes do NOT appear in `src/kailash/ml/errors.py` (verified via round-2 grep). v1 (and round 1 of this v2) referred to them; downstream code MUST NOT `try/except` against them.
+
+`FeatureGroupNotFoundError`, `FeatureVersionNotFoundError`, `FeatureEvolutionError`, `OnlineStoreUnavailableError`, `CrossTenantReadError`, `FeatureVersionImmutableError`.
+
+These are M2 placeholders to be defined IF and WHEN the corresponding surfaces (feature groups, evolution, online store, cross-tenant read guard, version immutability) ship — see § 11.
+
+---
+
+## 7. Test Contract
+
+### 7.1 Tests That DO Exist (Verified Via `find`)
+
+Filesystem sweep: `find packages/kailash-ml/tests -name 'test_feature*'` yields six files. Three of these exercise the canonical 1.0+ surface (verified via grep for `from kailash_ml.features` imports):
+
+| File                                          | Tier | Surface exercised                                                                                                                                   |
+| --------------------------------------------- | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tests/unit/test_feature_store_unit.py`       | T1   | Canonical (`from kailash_ml.features import FeatureStore`) — constructor validation, tenant resolution, cache helpers, deferred-import loud failure |
+| `tests/unit/test_feature_store_schema.py`     | T1   | Canonical (`from kailash_ml.features import FeatureField, FeatureSchema`)                                                                           |
+| `tests/unit/test_feature_store_cache_keys.py` | T1   | Canonical (`from kailash_ml.features import ...`)                                                                                                   |
+| `tests/integration/test_feature_store.py`     | T2   | **LEGACY** (`from kailash_ml.engines.feature_store import FeatureStore`) — exercises the 0.x engine, NOT the 1.0+ canonical surface                 |
+| `tests/unit/test_feature_engineer.py`         | T1   | Out-of-scope (feature-engineering primitive, not FeatureStore)                                                                                      |
+| `tests/unit/test_feature_sql.py`              | T1   | Out-of-scope (legacy SQL builder)                                                                                                                   |
+
+### 7.2 Test The Canonical FeatureStore Currently Lacks
+
+The canonical 1.0+ `kailash_ml.features.FeatureStore` has **zero Tier-2 wiring tests** — the existing `tests/integration/test_feature_store.py` exercises the LEGACY `kailash_ml.engines.feature_store` module (verified by reading line 15: `from kailash_ml.engines.feature_store import FeatureStore`).
+
+Per `rules/facade-manager-detection.md` MUST 1 (every `*Store` manager exposed via the public surface MUST have a Tier-2 test imported through the framework facade) AND MUST 2 (the test file MUST be named `test_<lowercase_manager_name>_wiring.py` so the absence is grep-able), this is a gap.
+
+#### Wave 6 follow-up: create `packages/kailash-ml/tests/integration/test_feature_store_wiring.py` exercising `kailash_ml.features.FeatureStore` via a real `DataFlow(...)` instance + real Postgres + the `dataflow.ml_feature_source` binding. The wiring test SHOULD cover the conformance assertions in § 10.
+
+Until that test lands, the canonical FeatureStore surface MUST be marked as having a Tier-2 wiring gap in any release notes that announce it as production-ready.
+
+### 7.3 Source-Comment Drift To Clean Up In Wave 6
+
+The runtime `ImportError` message at `features/store.py:354-361` references "W31 31b" — a workspace artifact, not a durable cross-spec citation. Per `rules/specs-authority.md` § 1, user-facing strings MUST cite specs, not workspace history. Wave 6 follow-up: replace "tracked as W31 31b in specs/dataflow-ml-integration.md §1.1" with "see specs/dataflow-ml-integration.md §1.1" in the `ImportError` message body. (Do NOT edit in this round — out of spec scope.)
+
+---
+
+## 8. Examples
+
+DOCS-EXACT code that runs against the canonical 1.0+ surface.
+
+### 8.1 Schema Definition
+
+```python
+from datetime import datetime, timezone
+from kailash_ml.features import FeatureField, FeatureSchema
+
+schema = FeatureSchema(
+    name="user_churn",
+    version=1,
+    fields=(
+        FeatureField(name="login_count_7d", dtype="int64"),
+        FeatureField(name="purchase_amount_30d", dtype="float64"),
+        FeatureField(name="is_premium", dtype="bool", nullable=False),
+    ),
+    entity_id_column="user_id",
+    timestamp_column="event_time",
+)
+
+print(schema.content_hash)  # 16-hex deterministic fingerprint
+print(schema.field_names)   # ['login_count_7d', 'purchase_amount_30d', 'is_premium']
+```
+
+### 8.2 Feature Retrieval (Multi-Tenant)
+
+```python
+from datetime import datetime, timezone
+from dataflow import DataFlow
+from kailash_ml.features import FeatureStore
+
+db = DataFlow("postgresql://...")  # caller owns the lifecycle
+fs = FeatureStore(db)
+
+# Latest values, scoped to tenant "acme":
+df_latest = await fs.get_features(schema, tenant_id="acme")
+
+# Point-in-time correct (as-of 2026-04-01T00:00:00Z), scoped to tenant "acme",
+# filtered to 3 entities:
+as_of = datetime(2026, 4, 1, tzinfo=timezone.utc)
+df_pit = await fs.get_features(
+    schema,
+    timestamp=as_of,
+    tenant_id="acme",
     entity_ids=["u1", "u2", "u3"],
-    groups=["user_signals"],
-    tenant_id="acme",
-)
-# features_batch: dict[entity_id -> dict[feature -> value]]
-```
-
-### 7.2 MUST Rules
-
-#### 1. Target p95 Latency ≤ 10ms For Cache-Hit Reads
-
-With Redis as online store on the same VPC, p95 of `get_online_features(entity_id)` MUST be ≤ 10ms. This is the InferenceServer budget constraint — features must arrive in <10ms so the end-to-end predict() budget ≤ 50ms is achievable.
-
-**Why:** Every real-time inference (fraud, recommendation, routing) has a tight budget. An online store that takes 100ms blows the latency SLO before the model even sees the features.
-
-#### 2. Stale Value Behavior Is Explicit
-
-If an online-store row has aged past its TTL, the reader MUST raise `StaleFeatureError` OR return NaN OR return the default — user-selectable via `on_stale=` kwarg. Silent return of stale values is BLOCKED.
-
-```python
-# DO — explicit handling
-features = await fs.get_online_features(entity_id="u1", groups=["..."], on_stale="raise")
-# Raises StaleFeatureError if any feature's row is past TTL
-```
-
-#### 3. Tenant Isolation — Missing `tenant_id` Raises `TenantRequiredError`
-
-Per `rules/tenant-isolation.md` MUST Rule 2. The online store key shape is `kailash_ml:v1:{tenant_id}:feature:{group}:{entity_id}` — a missing `tenant_id` produces a malformed key that MUST be rejected at the API, not constructed as `kailash_ml:v1::feature:...` and read silently.
-
----
-
-## 8. Versioning & Retention
-
-### 8.1 Feature Version Lineage
-
-Every `TrainingResult` carries `feature_versions: dict[group_name, version_sha]`. Re-training against the same feature versions reproduces the exact feature values (given materialization is deterministic on the same source).
-
-### 8.1a Feature Versions Are Monotonic AND Immutable Post-Materialisation
-
-Once a feature version `sha_v1 = sha256(decorator_kwargs || inspect.getsource(fn) || py_version || polars.__version__ || numpy.__version__ || blas_backend)` has been materialised to `_kml_feature_group_history`, it MUST NOT be mutated. A source-level change produces a NEW version; the old version persists untouched.
-
-```python
-# DO — version bump creates a new row, old persists
-@feature(name="avg_purchase_30d", group="user_signals", version=1)
-def avg_purchase_30d(tx_df): ...
-# Materialised → sha_abc123 written to _kml_feature_group_history
-
-# User edits the function body (reformat or rename variable)
-# → new sha_def456 auto-computed on next materialisation
-# → two rows now exist in history: (sha_abc123, sha_def456)
-# → ModelVersion.feature_versions pinned to abc123 still resolves
-
-# DO NOT — overwrite existing version
-# UPDATE _kml_feature_group_history SET fn_source = ? WHERE sha = 'abc123'  # BLOCKED
-```
-
-#### MUST 1. History Table Append-Only
-
-`_kml_feature_group_history` is append-only. Writes with an existing `(tenant_id, group, version_sha)` composite key MUST raise `FeatureVersionImmutableError`. The table MUST NOT have an `UPDATE` path in any DAL method.
-
-#### MUST 2. ModelVersion Pins Exact SHAs, Not `@latest`
-
-`ModelVersion.feature_versions: dict[str, str]` stores the EXACT `(group, version_sha)` pairs the model was trained on. Consumers asking for `group@abc123` get the exact definition — resurrected from history.
-
-#### MUST 3. Version Bump Forces New Row
-
-A user who updates a `@feature` body triggers automatic version bump on next materialisation — kailash-ml computes the new SHA and INSERTs a fresh history row. The prior version remains live.
-
-#### MUST 4. `get_feature_version(group, version)` Is Immutable Post-Materialisation
-
-`FeatureStore.get_feature_version(group, version_sha) -> FeatureVersion` MUST always resolve, even for superseded versions (as long as retention hasn't purged them per §8.2).
-
-#### MUST 5. Tier 2 Test
-
-`tests/integration/test_feature_version_immutability.py` MUST:
-
-1. Train model M1 at feature group G version v1 (sha_abc).
-2. Edit G's source → new version v2 (sha_def).
-3. Assert M1's inference still fetches v1 features correctly.
-4. Assert attempting to UPDATE v1's source in history raises `FeatureVersionImmutableError`.
-
-**Why:** Downstream models pin to exact feature SHAs. A mutable feature version silently changes the semantic meaning of every model that pinned it, retrospectively invalidating every cached prediction. Append-only history is the structural defense. See Tecton / Feast for similar immutability contracts.
-
-### 8.2 Retention
-
-```python
-fs = FeatureStore(
-    store="postgresql://...",
-    online="redis://...",
-    tenant_id="acme",
-    offline_retention_days=365,    # default None = forever
-    online_ttl_seconds=86400,      # default 24h
 )
 ```
 
-`offline_retention_days` triggers a background compaction that truncates offline rows older than N days. `online_ttl_seconds` is enforced by Redis EXPIRE on every write.
-
-### 8.3 MUST Rules
-
-#### 1. Retention Is Tenant-Scoped
-
-Per-tenant retention overrides are accepted via `fs.set_retention(tenant_id="acme", days=90)`. A tenant-level GDPR erasure request triggers `fs.erase_tenant(tenant_id="acme", reason="GDPR article 17")` which drops every `_materialized_*` row AND every online key for that tenant. Erasure writes an audit row with `actor_id` + `occurred_at`.
-
----
-
-## 9. Tenant Isolation (Binding to `rules/tenant-isolation.md`)
-
-### 9.1 Keyspace
-
-```
-kailash_ml:v1:{tenant_id}:feature:{group_name}:{entity_id}:{feature_version}
-```
-
-Single-tenant deployments MUST use the literal `"_single"` for `{tenant_id}` per `ml-tracking.md §7.2` (the canonical cross-spec sentinel). The strings `"default"` and `"global"` are BLOCKED (see `rules/tenant-isolation.md` Rule 2 for "default"; `ml-tracking.md §7.2` for the canonical-sentinel authority).
-
-### 9.2 MUST Rules
-
-#### 1. Every SQL Query Filters By `tenant_id`
-
-SQL reads (`SELECT * FROM _kml_feat_user_signals WHERE user_id = ...`) MUST include `AND tenant_id = $N`. Missing filter raises `TenantFilterMissingError` at the DAL — tested in `test_feature_store_tenant_filter_enforced`.
-
-#### 2. Cross-Tenant Reads Raise
-
-A read for `tenant_id="acme"` that would return a row with `tenant_id="bob"` MUST raise `CrossTenantReadError`. Regression test: two tenants store features with the same entity ID; one tenant's read sees zero rows of the other's data.
-
-#### 3. Audit Rows Persist `tenant_id`
-
-Every `_kml_feature_audit` row (materialize, register_group, sync, erase) MUST persist `tenant_id` indexed per Rule 5. Forensic queries "what did tenant X materialize last week" are O(index-scan).
-
----
-
-## 10. Drift Integration
-
-### 10.1 Hooks Into `DriftMonitor`
+### 8.3 Single-Tenant Default
 
 ```python
-# DO — attach feature distributions as drift baselines
-await drift_monitor.set_reference_from_feature_group(
-    group_name="user_signals",
-    feature_version="a3f1c2d9b4e5",
-    tenant_id="acme",
-)
-# DriftMonitor pulls baseline distribution from offline store rows
-# at the group's feature_version; live snapshots pulled periodically from online
+from kailash_ml.features import CANONICAL_SINGLE_TENANT_SENTINEL, FeatureStore
 
-report = await drift_monitor.check_drift(
-    group_name="user_signals",
-    tenant_id="acme",
-)
-# report.drift_per_feature: {"avg_purchase_30d": 0.12, ...}
+# Single-tenant deployment: bind the sentinel at construction; method calls
+# can omit tenant_id thereafter.
+fs = FeatureStore(db, default_tenant_id=CANONICAL_SINGLE_TENANT_SENTINEL)
+df = await fs.get_features(schema)  # tenant_id omitted; default applies
 ```
 
-### 10.2 MUST Rules
+### 8.4 Cache Key + Invalidation
 
-#### 1. Feature Monitoring Consumes `FeatureGroup`, Not Ad-Hoc Columns
+```python
+key = fs.cache_key_for_row(schema, row_key="u1", tenant_id="acme")
+# → 'kailash_ml:v1:acme:feature:user_churn:1:u1'
 
-`DriftMonitor` MUST accept `set_reference_from_feature_group(group, version, tenant_id)` as a first-class method. A drift baseline pinned to a feature version survives schema evolution: if the group evolves to v2, the v1 baseline is still valid for v1 models, and the v2 baseline is auto-computed on next materialization.
+pattern = fs.invalidation_pattern(schema, tenant_id="acme")
+# → 'kailash_ml:v*:acme:feature:user_churn:1:*'
 
-**Why:** Ad-hoc column-list drift baselines go stale the moment the feature catalog evolves, forcing manual re-baselining. Group-linked baselines auto-track the lineage.
-
----
-
-## 10A. Schema DDL (Feature Store Tables)
-
-Resolves Round-3 HIGH B7: DDL blocks for the four feature-store tables the spec references (`_kml_feature_groups`, `_kml_feature_versions`, `_kml_feature_materialization`, `_kml_feature_audit`) but did not define. All four carry `tenant_id` per `rules/tenant-isolation.md` MUST Rule 5 where the data is tenant-scoped; the audit table additionally carries `actor_id` per `rules/event-payload-classification.md`.
-
-### 10A.1 Identifier Discipline
-
-All dynamic table names written by DDL-emitting code MUST route through `kailash.db.dialect.quote_identifier()` per `rules/dataflow-identifier-safety.md` MUST Rule 1. The `_kml_` table prefix (leading underscore marks these as internal metadata tables users should not query directly — distinct from the user-configurable per-tenant feature-table prefix `table_prefix="kml_feat_"` in `FeatureStore.__init__`) MUST be validated in the caller's `__init__` against the regex `^[a-zA-Z_][a-zA-Z0-9_]*$` per `rules/dataflow-identifier-safety.md` MUST Rule 2; table-name + prefix total length stays within the Postgres 63-char limit (Decision 2 approved).
-
-Polars expression sources (`polars_expr_src`) are stored as inert TEXT — never interpolated into executable SQL. When a feature-version materializes, the polars expression is evaluated by the polars engine against the offline store, never handed to the SQL interpolator.
-
-### 10A.2 Postgres DDL
-
-```sql
--- _kml_feature_groups
-CREATE TABLE _kml_feature_groups (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id VARCHAR(255) NOT NULL,
-  name VARCHAR(255) NOT NULL,
-  entity VARCHAR(255) NOT NULL,
-  owner VARCHAR(255),
-  description TEXT,
-  ttl_seconds INTEGER,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE (tenant_id, name)
-);
-
--- _kml_feature_versions
-CREATE TABLE _kml_feature_versions (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  feature_group_id UUID NOT NULL REFERENCES _kml_feature_groups(id),
-  version_sha VARCHAR(72) NOT NULL,  -- sha256 of the feature definition
-  polars_expr_src TEXT NOT NULL,  -- polars expression source (inert; never interpolated into SQL)
-  schema_json JSONB NOT NULL,
-  registered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE (feature_group_id, version_sha)
-);
-
--- _kml_feature_materialization
-CREATE TABLE _kml_feature_materialization (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  feature_version_id UUID NOT NULL REFERENCES _kml_feature_versions(id),
-  kind VARCHAR(16) NOT NULL,  -- 'offline' | 'online'
-  last_run_at TIMESTAMPTZ,
-  row_count BIGINT,
-  status VARCHAR(16) NOT NULL DEFAULT 'IDLE'
-);
-
--- _kml_feature_audit
-CREATE TABLE _kml_feature_audit (
-  id BIGSERIAL PRIMARY KEY,
-  tenant_id VARCHAR(255) NOT NULL,
-  feature_group_id UUID NOT NULL,
-  actor_id VARCHAR(255) NOT NULL,
-  action VARCHAR(32) NOT NULL,  -- register | update | promote | delete | materialize
-  prev_state JSONB,
-  new_state JSONB,
-  occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-CREATE INDEX idx_feature_audit_tenant_time ON _kml_feature_audit(tenant_id, occurred_at DESC);
+pattern_all_versions = fs.invalidation_pattern(schema, tenant_id="acme", all_versions=True)
+# → 'kailash_ml:v*:acme:feature:user_churn:*'
 ```
 
-### 10A.3 SQLite-Compatible Variant
+---
 
-SQLite does not support `UUID`, `JSONB`, `TIMESTAMPTZ`, `BIGSERIAL`, or `BIGINT` as distinct types. The SQLite subset MUST substitute:
+## 9. Cross-References
 
-- `UUID` → `TEXT` (canonical 36-char hyphenated string; caller generates via `uuid.uuid4()`)
-- `JSONB` → `TEXT` (JSON-serialized string; caller `json.dumps()` / `json.loads()`)
-- `TIMESTAMPTZ` → `TEXT` (ISO-8601 UTC string, e.g. `2026-04-21T12:34:56.789Z`; caller normalizes to UTC before write)
-- `BIGSERIAL` → `INTEGER PRIMARY KEY AUTOINCREMENT`
-- `BIGINT` → `INTEGER`
-- `DEFAULT gen_random_uuid()` → omitted; caller supplies UUID at insert
-- `DEFAULT NOW()` → omitted; caller supplies ISO-8601 UTC string at insert
-- `REFERENCES ... (id)` → kept verbatim (SQLite supports FK syntax; enforcement requires `PRAGMA foreign_keys = ON`)
+Sibling specs that interact with the FeatureStore surface:
 
-### 10A.4 Tier-2 Schema-Migration Tests
-
-- `test__kml_feature_groups_schema_migration.py` — applies §10A.2 + §10A.3 DDL to a fresh Postgres (via `ConnectionManager`) AND a fresh SQLite (`:memory:`); asserts `pragma_table_info` / `information_schema.columns` match the declared shape; asserts the `UNIQUE(tenant_id, name)` constraint rejects a duplicate row on both backends.
-- `test__kml_feature_versions_schema_migration.py` — same contract; additionally asserts the `UNIQUE(feature_group_id, version_sha)` constraint and the FK to `_kml_feature_groups(id)` on both backends; asserts that `polars_expr_src` round-trips a large expression verbatim (never SQL-interpolated at read).
-- `test__kml_feature_materialization_schema_migration.py` — same contract; additionally asserts the `kind` column round-trips both `'offline'` and `'online'` values; asserts the FK to `_kml_feature_versions(id)`.
-- `test__kml_feature_audit_schema_migration.py` — same contract; additionally asserts the composite index `idx_feature_audit_tenant_time` exists; asserts the `action` vocab round-trips `register | update | promote | delete | materialize`.
-
-Each test MUST use `quote_identifier()` when referencing the table name by string for validation queries, closing the `rules/dataflow-identifier-safety.md` Rule 5 loop even for hardcoded test fixtures.
+- **`dataflow-ml-integration.md §1.1`** — owner of `dataflow.ml_feature_source(feature_group, *, tenant_id, point_in_time)`. The canonical FeatureStore retrieval path (§ 4.1) DOES NOT implement the polars binding; it delegates. Any change to `ml_feature_source`'s signature or semantics requires this spec to re-derive § 4. Per `rules/specs-authority.md` § 5b a sibling-spec re-derivation sweep is mandatory when this spec changes.
+- **`ml-engines.md`** — `MLEngine` may consume features via `FeatureStore` for `fit_auto`/`compare`. Today's `MLEngine` does not import the canonical `FeatureStore`; an integration is M2.
+- **`ml-tracking.md`** — `tenant_id` semantics + `CANONICAL_SINGLE_TENANT_SENTINEL` ("\_single") originate in `ml-tracking.md §7.2`. This spec re-uses that sentinel verbatim.
+- **`ml-drift.md`** — drift monitoring (M2) will consume materialised feature snapshots; today no integration.
+- **`rules/tenant-isolation.md`** MUST 1, 2, 3, 3a — satisfied at `cache_keys.py` (see § 5.1, § 5.2, § 5.3 above).
+- **`rules/facade-manager-detection.md`** MUST 1, 2, 3 — partially satisfied (constructor takes parent framework instance per Rule 3; Tier-2 wiring test absent per Rule 1, see § 7.2).
+- **`rules/orphan-detection.md`** MUST 6 — satisfied (`__init__.py:12-27` imports every `__all__` entry eagerly).
+- **`rules/dependencies.md`** § "Declared = Imported" — satisfied by loud `ImportError` at `store.py:354-361`.
+- **`rules/observability.md`** Rule 8 — satisfied (INFO logs emit schema NAME, never field names).
+- **`rules/schema-migration.md`** — FeatureStore owns NO DDL. Any feature-table DDL belongs to numbered migrations under `dataflow-ml-integration.md §1.1`.
 
 ---
 
-## 11. Industry Parity
+## 10. Conformance Checklist
 
-| Capability                         | kailash-ml 1.0.0 | Feast | Hopsworks | Tecton | SageMaker FS | ClearML |
-| ---------------------------------- | ---------------- | ----- | --------- | ------ | ------------ | ------- |
-| Offline store (Postgres / DuckDB)  | Y                | Y     | Y         | Y      | Y            | Y\*     |
-| Online store (Redis / DynamoDB)    | Y                | Y     | Y         | Y      | Y            | Y\*     |
-| Point-in-time correctness          | Y (native)       | Y     | Y         | Y      | Y            | N       |
-| Polars-native                      | Y                | N     | N         | N      | N            | N       |
-| Feature groups                     | Y                | Y     | Y         | Y      | Y            | Y       |
-| TTL on online rows                 | Y                | Y     | Y         | Y      | Y            | Y       |
-| Schema evolution without rewrite   | Y (`evolve()`)   | Y     | Y         | Y\*    | Y\*          | N       |
-| Per-tenant isolation (multi-CLG)   | Y (native)       | N     | Y\*       | Y\*    | Y (IAM)      | N       |
-| DataFlow lineage integration       | Y (unique)       | N     | N         | N      | N            | N       |
-| Classification-aware (PII tagging) | Y (unique)       | N     | Y\*       | Y\*    | N            | N       |
-| Drift-baseline hooks built-in      | Y                | N     | Y         | Y      | Y            | Y       |
+A feature-store implementation claiming "1.0+ canonical surface" MUST satisfy ALL of:
 
-**Position:** Polars-native + DataFlow-integrated + PACT/tenant-native. Parity with Feast/Tecton on table-stakes (point-in-time, online/offline split, feature groups); ahead on polars-native (3-5x perf on typical reads), ahead on DataFlow lineage (feature spec carries the exact source query), and uniquely integrated with `kailash-dataflow` classification for PII-aware feature groups.
-
----
-
-## 12. Error Taxonomy
-
-Every error from the feature-store surface MUST be a typed exception under `kailash_ml.errors` (FeatureStoreError family per `ml-tracking-draft.md §9.1`). Cross-domain errors (`TenantRequiredError`) live under `TrackingError` and are re-exported. Cross-cutting errors sitting at the `MLError` root (`MultiTenantOpError` per Decision 12) are ALSO re-exported from `kailash_ml.errors` so feature-store callers may write `except MultiTenantOpError` without importing the `kailash.ml.errors` module directly.
-
-| Exception                     | When raised                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FeatureNotFoundError`        | `get_*_features()` names a feature not in any registered group.                                                                                                                                                                                                                                                                                                                                                                                   |
-| `FeatureGroupNotFoundError`   | Group name not registered for the requested `tenant_id`.                                                                                                                                                                                                                                                                                                                                                                                          |
-| `FeatureVersionNotFoundError` | `feature_version=` parameter doesn't exist in the registry.                                                                                                                                                                                                                                                                                                                                                                                       |
-| `StaleFeatureError`           | Online row past TTL with `on_stale="raise"`; offline missing with `on_missing="raise"`.                                                                                                                                                                                                                                                                                                                                                           |
-| `PointInTimeViolationError`   | Internal audit detects a row in `get_training_features` result that was materialized after its `as_of`.                                                                                                                                                                                                                                                                                                                                           |
-| `TenantRequiredError`         | Multi-tenant store called without `tenant_id`.                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `CrossTenantReadError`        | Query with `tenant_id="acme"` resolves a row with different `tenant_id`.                                                                                                                                                                                                                                                                                                                                                                          |
-| `TenantQuotaExceededError`    | Tenant exceeds per-tenant storage / read QPS quota (see `ml-engines-v2-draft.md §5.3`).                                                                                                                                                                                                                                                                                                                                                           |
-| `FeatureEvolutionError`       | `FeatureGroup.evolve()` requested a schema change that would break an active model signature.                                                                                                                                                                                                                                                                                                                                                     |
-| `OnlineStoreUnavailableError` | Online store unreachable; caller may fallback to offline OR raise, user-selectable via `on_online_miss=` kwarg.                                                                                                                                                                                                                                                                                                                                   |
-| `MultiTenantOpError`          | (Decision 12, cross-cutting, post-1.0) `export_tenant_snapshot()` / `import_tenant_snapshot()` on a feature group called without PACT D/T/R clearance for cross-tenant admin export/import. Root inherits `MLError`, NOT `FeatureStoreError`, so `except MLError` catches uniformly across registry + feature-store + serving + tracking. See `ml-tracking-draft.md §9.1.1` + `supporting-specs-draft/kailash-core-ml-integration-draft.md §3.3`. |
+- [ ] `kailash_ml.features.__all__` lists exactly the six symbols in § 2.1, every one with a corresponding eager import.
+- [ ] `FeatureStore.__init__(dataflow, *, default_tenant_id=None)` signature matches § 2.2 exactly.
+- [ ] `FeatureStore(None)` raises `TypeError` with the actionable message at `store.py:104-109`.
+- [ ] `default_tenant_id` is eager-validated at construction via `validate_tenant_id`.
+- [ ] `fs.dataflow` and `fs.default_tenant_id` are read-only properties.
+- [ ] `FeatureSchema.content_hash` is sha256 first-16-hex of the canonical payload, deterministic across processes.
+- [ ] `FeatureField.dtype` rejects non-allowlist values at construction.
+- [ ] `get_features(schema, timestamp=None, *, tenant_id=None, entity_ids=None) -> pl.DataFrame` matches § 4.1 exactly.
+- [ ] `get_features` re-raises `TenantRequiredError` and `ImportError` unchanged; wraps every other `Exception` as `FeatureStoreError(reason=..., tenant_id=...) from exc`.
+- [ ] Cache key shape matches `kailash_ml:v1:{tenant_id}:feature:{schema_name}:{version}:{row_key}`.
+- [ ] `validate_tenant_id` rejects `None`, non-`str`, the three forbidden sentinels, and any tenant*id failing `^[A-Za-z*][A-Za-z0-9_\-]\*$`.
+- [ ] `make_feature_group_wildcard` emits `v*` so a future keyspace-version bump does not strand legacy keys.
+- [ ] `_import_ml_feature_source` raises a loud `ImportError` whose message names the upstream binding requirement and points to `dataflow-ml-integration.md §1.1`.
+- [ ] Three structured INFO/EXCEPTION lines emitted on every `get_features` call: `feature_store.get_features.{start,ok,error}`.
+- [ ] No column names from `FeatureSchema.fields` appear at INFO+ log level.
+- [ ] The error classes raised from this surface are exactly the eight in § 6.1; classes in § 6.3 are NEVER raised.
 
 ---
 
-## 13. Test Contract
+## 11. Deferred to M2
 
-### 13.1 Tier 1 (Unit)
+Each entry below was specified in v1 and does NOT exist in 1.0+. The Wave 5 audit (F-E2-18..22) flagged these. Each entry: what was specified, what's in 1.0+, M2 disposition.
 
-- `test_feature_decorator_versioning` — content SHA is deterministic for identical source; changes for mutated source.
-- `test_point_in_time_upper_bound` — synthetic events with known `event_time`, `as_of` placements, strict upper-bound assertion.
-- `test_key_shape_formatter` — `kailash_ml:v1:{tenant_id}:feature:...` produced correctly; "default" tenant raises.
-- One test per error taxonomy entry (12 tests).
+### 11.1 Feature Groups (was § 4 in v1; F-E2-19)
 
-### 13.2 Tier 2 (Integration, Real Postgres + Real Redis)
+V1 specified a `FeatureGroup` class with online + offline views, materialisation policies, and online-store backends.
 
-Per `rules/facade-manager-detection.md` Rule 1, these tests MUST import via the framework facade (`engine.feature_store.X`, not `from kailash_ml.engines.feature_store import FeatureStore`):
+1.0+ ships only `FeatureSchema` (the schema definition) plus `FeatureStore.get_features` (a single retrieval surface). There is no `FeatureGroup` class. Online vs offline split is collapsed into "whatever `dataflow.ml_feature_source` returns".
 
-- `test_feature_store_point_in_time_wiring.py` — real Postgres; materialize 10k events; assert `get_training_features(entity_df, as_of=...)` returns values with strict upper-bound; mutate a row and re-check.
-- `test_feature_store_online_latency.py` — real Redis; p95 `get_online_features` under 10ms over 1000 reads.
-- `test_feature_store_tenant_isolation.py` — two tenants materialize the same group name with different entities; cross-tenant reads raise; invalidation is scoped.
-- `test_feature_store_sync_offline_to_online.py` — materialize then sync; verify online returns the same value.
-- `test_feature_store_evolve.py` — `evolve(add=[...], drop=[...])` produces a new group version; old version remains readable.
-- `test_feature_store_retention_gdpr_erase.py` — `erase_tenant()` drops offline + online + records audit row.
-- `test_feature_store_drift_baseline_hook.py` — `DriftMonitor.set_reference_from_feature_group()` reads feature values at the pinned version; live snapshot reads from online store.
-- `test_feature_store_classification_propagation.py` — PII-classified group values do NOT appear raw in log lines (`rules/event-payload-classification.md`).
+**M2 disposition:** Re-introduce `FeatureGroup` if and only if a downstream Engine surfaces a need that `FeatureSchema + ml_feature_source(...)` cannot express. If introduced, define `FeatureGroupNotFoundError` in `errors.py` (currently absent — see § 6.3) at the same time the class lands.
 
-### 13.3 Tier 3 (E2E, via `MLEngine`)
+### 11.2 `@feature` Decorator + Materialization (was § 5 in v1; F-E2-18)
 
-- `test_mlengine_train_reads_feature_group.py` — `engine.fit(group="user_signals", target="churned")` trains against the feature store; `TrainingResult.feature_versions` contains the exact SHA.
-- `test_mlengine_serve_reads_online_store.py` — `engine.serve(model, channels=["rest"])` + POST /predict reads online features sub-10ms.
+V1 specified `@feature` for declarative materialisation pipelines + scheduling.
+
+1.0+ ships nothing in this surface. Materialisation is a DataFlow concern; scheduling lives in workflow primitives.
+
+**M2 disposition:** Defer until DataFlow ships a materialisation primitive that the FeatureStore can wrap. The decorator surface is a UX concern best deferred until the underlying mechanism ships.
+
+### 11.3 Feature Versioning + Immutability Enforcement (was § 7 in v1; F-E2-20)
+
+V1 specified that registered feature versions are immutable; mutation attempts raise `FeatureVersionImmutableError`.
+
+1.0+ ships `FeatureSchema.version: int` (`schema.py:203`) which is part of the content-addressed hash, but there is NO registry-backed immutability check at the `FeatureStore` layer. `FeatureVersionImmutableError` does NOT exist in `errors.py` (verified § 6.3).
+
+**M2 disposition:** Define `FeatureVersionImmutableError` in `errors.py` AND wire the immutability check at the registry-mutation site (M2 — when the registry-backed feature group lands, see § 11.1). Today, immutability is content-addressed only — two callers writing `FeatureSchema(name="x", version=1, fields=A)` and `FeatureSchema(name="x", version=1, fields=B)` produce different `content_hash` values, but the FeatureStore has no DDL-level `UNIQUE(name, version)` enforcement to reject the second registration.
+
+### 11.4 Storage / Retention / Eraser (was § 8 in v1; F-E2-21)
+
+V1 specified online-store backends (Redis, DynamoDB) + retention policies + GDPR `erase_tenant`.
+
+1.0+ ships none of this. The cache-key helpers in § 5 produce keys SUITABLE for a Redis backend, but no Redis adapter is shipped at the FeatureStore layer.
+
+**M2 disposition:** Defer. GDPR erasure is a cross-cutting concern — `ml-tracking.md §8.4` already defines `ErasureRefusedError` (canonical home: `TrackingError`) — when the FeatureStore lands a registry-backed online surface, GDPR erasure plumbs through that path.
+
+### 11.5 Industry Parity Adapters (was § 15 in v1)
+
+V1 enumerated parity adapters for sibling feature-store products.
+
+1.0+ ships none of this. Per `rules/independence.md` no commercial-product comparisons appear in the spec.
+
+**M2 disposition:** Defer indefinitely. If users request a migration adapter, ship an external `kailash-feature-store-migrate` package.
+
+### 11.6 Constructor Kwargs Subset (F-E2-18)
+
+V1 implied a richer constructor surface (e.g. `FeatureStore(connection_manager=..., online_store=..., retention=...)`).
+
+1.0+ ships exactly two kwargs: `dataflow` (positional) + `default_tenant_id=` (kwarg-only). The 1.0+ surface is intentionally narrow per `rules/facade-manager-detection.md` Rule 3.
+
+**M2 disposition:** Defer constructor expansion. If new kwargs are needed, prefer composition (separate `FeatureMaterialiser`, `FeatureRegistry`) over constructor-flag bloat.
+
+### 11.7 Typed Exceptions Absent At The Surface (F-E2-22)
+
+The five exception classes referenced in v1 (and falsely cited by round 1 of this draft) do NOT exist in `errors.py` today (§ 6.3): `FeatureGroupNotFoundError`, `FeatureVersionNotFoundError`, `FeatureEvolutionError`, `OnlineStoreUnavailableError`, `CrossTenantReadError`.
+
+**M2 disposition:** Each will land in `errors.py` at the same PR that lands the corresponding surface (§ 11.1, § 11.2, § 11.3, § 11.4). Until then, downstream code MUST NOT `try/except` against any of these classes.
 
 ---
 
-## 14. Cross-References
-
-- `ml-engines-v2-draft.md §5` — tenant propagation contract; `FeatureStore` inherits the Engine's `tenant_id`.
-- `ml-tracking-draft.md` — `ExperimentTracker` reads `feature_versions` from every `TrainingResult`; run detail page renders the group/version lineage.
-- `ml-drift-draft.md` — drift baseline hooks; feature groups as first-class drift targets.
-- `ml-automl-draft.md` — AutoML reads feature groups as candidate feature sets; HPO trials log group+version per trial.
-- `rules/tenant-isolation.md` — MUST Rules 1-5, cache key shape, invalidation scoping, audit row discipline. Binding.
-- `rules/event-payload-classification.md` — classified PII feature values never appear raw in event payloads.
-- `rules/facade-manager-detection.md` — FeatureStore is a `*Store` manager-shape class; MUST have `test_feature_store_*_wiring.py` tests through the Engine facade.
-- `kailash-dataflow` classification model — `FeatureGroup.classification` propagates from dataflow's `@classify` decorator when features derive from classified columns.
-
----
-
-## 15. Conformance Checklist
-
-- [ ] `FeatureStore(store=..., online=..., tenant_id=...)` constructs zero-arg-free; `initialize()` is idempotent.
-- [ ] Every feature has `entity=`, `dtype=`, content-addressed version.
-- [ ] `@feature` accepts polars expressions only; pandas raises at decorator time.
-- [ ] `FeatureGroup` versioning via `evolve()`; in-place mutation BLOCKED.
-- [ ] `materialize()` writes offline; `sync_to_online()` writes online; conflating raises.
-- [ ] `get_training_features(entity_df, as_of=...)` is point-in-time correct; no future leakage.
-- [ ] `get_online_features()` p95 ≤ 10ms on same-VPC Redis; Tier 2 latency test passes.
-- [ ] `tenant_id` required on every read; missing raises `TenantRequiredError`.
-- [ ] Storage keys use `kailash_ml:v1:{tenant_id}:feature:...` with `"_single"` canonical sentinel for single-tenant per `ml-tracking.md §7.2`.
-- [ ] Every error is a typed exception per §12.
-- [ ] Every Tier 2 test in §13.2 is named and imports via the facade.
-- [ ] `rg tenant_id packages/kailash-ml/src/kailash_ml/engines/feature_store.py` returns matches on every public method signature.
-
----
-
-_End of ml-feature-store-draft.md_
+**End of v2 round 2 draft. Mechanical sweeps performed: 5. All "is implemented" claims cite a file:line range read in this session. The fabricated symbols flagged by the round-1 reviewer have been deleted and consolidated under § 6.3 + § 11.7 as "deferred + not yet defined".**


### PR DESCRIPTION
## Summary

Wave 6.5 spec realignment closes 13 HIGH findings from the [Wave 5 portfolio audit](workspaces/portfolio-spec-audit/04-validate/W5-E2-findings.md) — 8 AutoML (F-E2-01..10) + 5 FeatureStore (F-E2-18..22) — by re-deriving both specs from the actual shipped 1.1.1 surface rather than implementing-to-stale-spec.

- **`specs/ml-automl.md`** — v2.0.0 (+178 LOC). Two-surface reality (canonical `kailash_ml.automl.engine` + legacy `kailash_ml.engines.automl_engine` reachable via `__getattr__`), 4-strategy lineup (BOHB/CMAES/ASHA/PBT deferred to M2), unified `_kml_automl_trials` audit table, post-hoc cost cap (token-level pre-cap deferred), 13 explicit M2 deferral entries with implementation sketches.
- **`specs/ml-feature-store.md`** — v2.0.0 (-196 LOC, 540 line target met). DataFlow-bridge constructor (`FeatureStore(dataflow, *, default_tenant_id=None)`), preserved positives (PIT join F-E2-23 wired end-to-end via `dataflow.ml_feature_source(point_in_time=...)`; tenant isolation F-E2-24 with canonical key shape and forbidden sentinels), 7 M2 deferrals (online store, `@feature` decorator, `FeatureGroup`, materialization API, etc.). Six exception classes the v1 spec referenced are confirmed ABSENT from `errors.py` and now flagged "MUST NOT try/except against".
- **3 sibling specs** carry one-paragraph deferral acknowledgments per `rules/specs-authority.md` § 5b (full-sibling re-derivation): `ml-engines-v2-addendum.md` (`fit_auto` clause), `dataflow-ml-integration.md` (`@feature` + `FeatureGroup` clauses), `kailash-core-ml-integration.md` (FeatureGroup snapshot reference).

Verification: every "is implemented" assertion in v2 cites a verified file:line range in `packages/kailash-ml/src/kailash_ml/`. Reviewer report at `workspaces/portfolio-spec-audit/04-validate/W6.5-v2-draft-review.md` confirmed AutoML 17/17 mechanical sweeps PASS; FeatureStore round 2 closed both round-1 CRITs (5 fabricated exception classes + 1 fabricated wiring test path).

## Wave 6 follow-ups (file as separate issues, not part of this PR)

1. Flip `kailash_ml/__init__.py:593` `__getattr__` map: `engines.automl_engine` → `automl.engine` so top-level `kailash_ml.AutoMLEngine` resolves to the canonical class.
2. Strip stale FeatureSchema auto-derivation language from `automl/engine.py:7-12` docstring.
3. Land numbered migration for `_kml_automl_trials` (supersede lazy first-use DDL).
4. Add Tier-3 e2e for canonical `kailash_ml.automl.engine.AutoMLEngine` against a real model trainer.
5. Create `packages/kailash-ml/tests/integration/test_feature_store_wiring.py` for canonical 1.0+ `FeatureStore` (closes `rules/facade-manager-detection.md` MUST 1 violation).
6. Strip "W31 31b" workspace-artifact reference from the `ImportError` message at `features/store.py:354-361`.
7. Reconcile `dataflow-ml-integration.md` from `(draft)` to a versioned release once M2 `@feature` + `FeatureGroup` land.

## Test plan

- [x] Pre-commit on staged files — Trim trailing whitespace, EOF fixer, Tier 1 unit, doc style — all PASS
- [x] Cross-sibling sweep per `rules/specs-authority.md` § 5b — three siblings reconciled (`ml-engines-v2-addendum.md`, `dataflow-ml-integration.md`, `kailash-core-ml-integration.md`)
- [x] Mechanical sweeps verified: every error class in v2 § 6 appears in `errors.py`; every test file cited in v2 § 7/§ 11 exists on disk; six fabricated exception classes confirmed ABSENT and explicitly flagged "MUST NOT try/except"
- [x] Confirmed-positive behaviors (F-E2-23 PIT join, F-E2-24 tenant isolation) preserved verbatim
- [ ] Reviewer second pass against merged main (post-merge gate per `rules/agents.md` § Quality Gates)

## Related issues

Closes Wave 5 audit HIGHs F-E2-01, F-E2-02, F-E2-03, F-E2-04, F-E2-05, F-E2-06, F-E2-08, F-E2-09 (AutoML); F-E2-18, F-E2-19, F-E2-20, F-E2-21, F-E2-22 (FeatureStore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)