### PR TITLE
fix(kaizen): W6-001 — strip hardcoded models from CoreAgent + GovernedSupervisor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Kailash environment variable template.
+#
+# Copy this file to `.env` at the repo root and fill in real values.
+# `.env` is git-ignored; `.env.example` is the documented contract that
+# every Kailash deployment relies on for API keys and model identifiers.
+#
+# Per rules/env-models.md, model identifiers (and provider API keys)
+# MUST come from .env. Hardcoded model literals like "gpt-4" or
+# "claude-sonnet-4-6" in source code are BLOCKED — they lock deployments
+# to a single provider/version and prevent per-environment model
+# selection (cheap model in dev, capable model in prod).
+
+# -- Default model for kaizen agents -----------------------------------------
+# Used by CoreAgent (kaizen.core.agents.Agent) and GovernedSupervisor
+# (kaizen_agents.supervisor.GovernedSupervisor) when the caller does not
+# supply an explicit `model=` argument. If unset, those constructors raise
+# kaizen.errors.EnvModelMissing with an actionable message rather than
+# silently defaulting to a stale provider/version.
+#
+# Choose any model identifier supported by your configured provider
+# (gpt-4o-mini, gpt-4o, claude-3-5-sonnet, claude-3-5-haiku, gemini-1.5-pro,
+# llama3.1, ...). Pair it with the matching provider API key below.
+KAIZEN_DEFAULT_MODEL=
+
+# -- Provider API keys --------------------------------------------------------
+# Set whichever pair matches the provider implied by KAIZEN_DEFAULT_MODEL.
+# Per rules/env-models.md model-key pairings:
+#   gpt-* / o1-* / o3-* / o4-*   → OPENAI_API_KEY
+#   claude-*                     → ANTHROPIC_API_KEY
+#   gemini-*                     → GOOGLE_API_KEY (or GEMINI_API_KEY)
+#   deepseek-*                   → DEEPSEEK_API_KEY
+#   mistral-* / mixtral-*        → MISTRAL_API_KEY
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Removed hardcoded model strings from `CoreAgent` + `GovernedSupervisor`; both now read from `KAIZEN_DEFAULT_MODEL` env var (closes F-D-02 + F-D-50).** `CoreAgent` (`kaizen.core.agents.Agent`) and `GovernedSupervisor` (`kaizen_agents.supervisor.GovernedSupervisor`) previously defaulted to `"gpt-3.5-turbo"` and `"claude-sonnet-4-6"` respectively when the caller omitted `model=`. This violated `rules/env-models.md` (model identifiers MUST come from `.env`) and locked every default-API deployment to a single provider. Both constructors now resolve the default from `KAIZEN_DEFAULT_MODEL` and raise `kaizen.errors.EnvModelMissing` (new typed error) with an actionable message when the env var is unset. Existing callers passing explicit `model=<literal>` are unaffected. Tier-1 unit tests in `tests/unit/test_kaizen_default_model_env.py` cover env-set, caller-override, env-unset, and empty-string env paths for both constructors.
+
+### Added
+
+- **`kaizen.errors.EnvModelMissing`**: typed `RuntimeError` subclass for "model identifier required but `.env` did not provide it" failures. Carries `env_var` and `component` attributes so multi-call-site triage can disambiguate which entry point raised. Surfaces as a top-level export from `kaizen.errors`.
+- **`.env.example` at repo root**: documents `KAIZEN_DEFAULT_MODEL` plus the matching provider API-key entries per `rules/env-models.md` Model-Key Pairings table.
+
 ## [2.13.1] — 2026-04-25 — Fix clean-venv ImportError (post-2.13.0 hotfix)
 
 Patch — guards a pre-existing unconditional `import kaizen_agents.patterns.patterns` in `kaizen/orchestration/__init__.py` behind a `try/except ImportError`. The `kaizen-agents` package is NOT a declared dependency of `kailash-kaizen`; the proxies that consumed it were defensive `mock.patch` aliases for legacy test code. Without the guard, `from kaizen.orchestration import OrchestrationRuntime` (the new #602 surface in 2.13.0) raised `ModuleNotFoundError` for any clean-venv install of `kailash-kaizen` without `kaizen-agents` present. The proxy aliases are now installed only when `kaizen-agents` is co-installed.

--- a/packages/kailash-kaizen/src/kaizen/core/agents.py
+++ b/packages/kailash-kaizen/src/kaizen/core/agents.py
@@ -8,8 +8,11 @@ AI programming, built on Core SDK workflow patterns.
 import inspect
 import json
 import logging
+import os
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from kaizen.errors import EnvModelMissing
 
 # PERFORMANCE OPTIMIZATION: Lazy loading for Kailash imports
 # WorkflowBuilder imports can bring heavy dependencies
@@ -100,15 +103,30 @@ class Agent:
         return self.signature is not None
 
     def _set_default_config(self):
-        """Set default configuration values."""
-        defaults = {
-            "model": "gpt-3.5-turbo",
+        """Set default configuration values.
+
+        Per ``rules/env-models.md``, model identifiers MUST come from ``.env``
+        (``KAIZEN_DEFAULT_MODEL``) — hardcoded literals like ``"gpt-3.5-turbo"``
+        are BLOCKED. If the caller did not supply ``model`` AND the env var
+        is unset, raise :class:`kaizen.errors.EnvModelMissing` with an
+        actionable message rather than silently defaulting to a stale model.
+        Other defaults (temperature, max_tokens, timeout) remain hardcoded
+        because they are not provider-coupled.
+        """
+        if "model" not in self.config or self.config["model"] is None:
+            env_model = os.environ.get("KAIZEN_DEFAULT_MODEL")
+            if not env_model:
+                raise EnvModelMissing(
+                    env_var="KAIZEN_DEFAULT_MODEL", component="CoreAgent"
+                )
+            self.config["model"] = env_model
+
+        non_model_defaults = {
             "temperature": 0.7,
             "max_tokens": 1000,
             "timeout": 30,
         }
-
-        for key, value in defaults.items():
+        for key, value in non_model_defaults.items():
             if key not in self.config or self.config[key] is None:
                 self.config[key] = value
 
@@ -132,9 +150,11 @@ class Agent:
         WorkflowBuilder = _lazy_import_workflow_builder()
         workflow = WorkflowBuilder()
 
-        # Add LLM node using string-based pattern with Core SDK compatible parameters
+        # Add LLM node using string-based pattern with Core SDK compatible parameters.
+        # `_set_default_config` enforces `model` from KAIZEN_DEFAULT_MODEL env var
+        # (rules/env-models.md) — index access is correct here; no hardcoded fallback.
         node_params = {
-            "model": self.config.get("model", "gpt-3.5-turbo"),
+            "model": self.config["model"],
             "timeout": self.config.get("timeout", 30),
         }
 
@@ -496,10 +516,12 @@ class Agent:
             WorkflowBuilder = _lazy_import_workflow_builder()
             workflow = WorkflowBuilder()
 
-            # Build Core SDK compatible parameters with smart provider selection
+            # Build Core SDK compatible parameters with smart provider selection.
+            # Model defaulted from KAIZEN_DEFAULT_MODEL via `_set_default_config`
+            # (rules/env-models.md) — no hardcoded fallback permitted here.
             enhanced_params = {
                 "provider": self._get_provider_for_config(),  # Smart provider selection
-                "model": self.config.get("model", "gpt-3.5-turbo"),
+                "model": self.config["model"],
                 "timeout": self.config.get("timeout", 30),
             }
 
@@ -634,10 +656,12 @@ class Agent:
         WorkflowBuilder = _lazy_import_workflow_builder()
         workflow = WorkflowBuilder()
 
-        # Build LLM parameters for direct execution
+        # Build LLM parameters for direct execution. Model identifier comes from
+        # `_set_default_config` (KAIZEN_DEFAULT_MODEL env var) per
+        # rules/env-models.md — no hardcoded fallback permitted here.
         llm_params = {
             "provider": self._get_provider_for_config(),  # Smart provider selection
-            "model": self.config.get("model", "gpt-3.5-turbo"),
+            "model": self.config["model"],
             "timeout": self.config.get("timeout", 30),
         }
 
@@ -3016,9 +3040,11 @@ Continue this Thought-Action-Observation cycle until you reach a final answer. E
         WorkflowBuilder = _lazy_import_workflow_builder()
         workflow = WorkflowBuilder()
 
-        # Add communication node with target agent
+        # Add communication node with target agent. Target agent's model was
+        # validated at its `_set_default_config` (KAIZEN_DEFAULT_MODEL env var,
+        # rules/env-models.md) — index access is correct; no hardcoded fallback.
         communication_params = {
-            "model": target_agent.config.get("model", "gpt-3.5-turbo"),
+            "model": target_agent.config["model"],
             "generation_config": {
                 "temperature": target_agent.config.get("temperature", 0.7),
                 "max_tokens": target_agent.config.get("max_tokens", 500),

--- a/packages/kailash-kaizen/src/kaizen/errors.py
+++ b/packages/kailash-kaizen/src/kaizen/errors.py
@@ -1,0 +1,55 @@
+"""
+Kaizen top-level error types.
+
+This module hosts errors that span the kaizen package surface — not the
+LLM-provider-specific errors (`kaizen.llm.errors`) or the L3-runtime errors
+(`kaizen.l3.*.errors`). Place a typed error here when it is raised by a
+public-API entry point (CoreAgent, GovernedSupervisor, top-level pipelines)
+and consumers need to catch it without depending on a deep submodule.
+
+Errors:
+    EnvModelMissing — raised when a required model-name env var
+        (e.g. ``KAIZEN_DEFAULT_MODEL``) is unset and no caller-supplied
+        override is given. Per ``rules/env-models.md``, model strings
+        MUST come from ``.env``; hardcoded fallbacks are BLOCKED.
+"""
+
+from __future__ import annotations
+
+
+class EnvModelMissing(RuntimeError):
+    """A required model-name environment variable is unset.
+
+    Raised when an entry point (CoreAgent default config, GovernedSupervisor
+    default ``model`` argument, ...) needs a model identifier and neither the
+    caller nor any environment variable provided one. The default fallback to
+    a hardcoded literal (e.g. ``"gpt-3.5-turbo"``, ``"claude-sonnet-4-6"``)
+    is BLOCKED by ``rules/env-models.md`` because it locks deployments to a
+    single provider and prevents per-environment model selection.
+
+    The error message MUST name the env var the caller can set, so the user
+    sees a single actionable instruction instead of a generic missing-config
+    failure deep in the call stack.
+
+    Attributes:
+        env_var: Name of the environment variable that was checked and
+            found unset.
+        component: Short identifier for the component that raised
+            (e.g. ``"CoreAgent"``, ``"GovernedSupervisor"``) — used to
+            disambiguate when multiple call sites surface the same error.
+    """
+
+    def __init__(self, env_var: str, component: str = "") -> None:
+        self.env_var = env_var
+        self.component = component
+        location = f" ({component})" if component else ""
+        super().__init__(
+            f"{env_var} environment variable is required but not set{location}. "
+            f"Set {env_var} in your .env file (e.g. {env_var}=gpt-4o-mini) or "
+            f"pass an explicit model= argument. Per rules/env-models.md, "
+            f"hardcoded model strings are BLOCKED — model identifiers must "
+            f"come from .env."
+        )
+
+
+__all__ = ["EnvModelMissing"]

--- a/packages/kailash-kaizen/tests/unit/test_kaizen_default_model_env.py
+++ b/packages/kailash-kaizen/tests/unit/test_kaizen_default_model_env.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 1 — KAIZEN_DEFAULT_MODEL env var contract.
+
+Covers W6-001 / findings F-D-02 + F-D-50: model identifiers must come from
+``.env`` (rules/env-models.md). Two top-level public-API constructors —
+``CoreAgent`` (kaizen.core.agents.Agent) and ``GovernedSupervisor``
+(kaizen_agents.supervisor.GovernedSupervisor) — must read
+``KAIZEN_DEFAULT_MODEL`` when the caller did not supply ``model=`` and raise
+:class:`kaizen.errors.EnvModelMissing` when the env var is unset.
+
+Env-var test isolation (rules/testing.md § Env-Var Test Isolation MUST):
+every test that mutates ``KAIZEN_DEFAULT_MODEL`` acquires the module-scope
+``_ENV_LOCK`` via the ``_env_serialized`` fixture so xdist-parallel runs
+cannot observe a mid-monkeypatch state. ``monkeypatch.setenv`` /
+``monkeypatch.delenv`` restore at fixture teardown — the lock holds across
+the read-then-mutate so siblings cannot race in.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Iterator
+
+import pytest
+
+from kaizen.core.agents import Agent as CoreAgent
+from kaizen.errors import EnvModelMissing
+
+# Module-scope lock per rules/testing.md § Env-Var Test Isolation MUST.
+# Every test that mutates KAIZEN_DEFAULT_MODEL holds this lock across the
+# monkeypatch + body so xdist/pytest-parallel siblings cannot observe the
+# transient value or the unset window during teardown.
+_ENV_LOCK = threading.Lock()
+
+
+@pytest.fixture
+def _env_serialized() -> Iterator[None]:
+    """Acquire the module-scope env lock for the duration of the test body."""
+    with _ENV_LOCK:
+        yield
+
+
+# ---------------------------------------------------------------------------
+# CoreAgent (kaizen.core.agents.Agent) — F-D-02
+# ---------------------------------------------------------------------------
+
+
+def test_core_agent_uses_env_model_when_caller_omits_model(
+    monkeypatch: pytest.MonkeyPatch,
+    _env_serialized: None,
+) -> None:
+    """Caller did not supply model=; KAIZEN_DEFAULT_MODEL is set; agent
+    config["model"] reflects the env value (no hardcoded fallback)."""
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
+
+    agent = CoreAgent(agent_id="env-test-1", config={})
+
+    assert agent.config["model"] == "gpt-4o-mini"
+
+
+def test_core_agent_caller_explicit_model_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+    _env_serialized: None,
+) -> None:
+    """Caller-supplied model= beats KAIZEN_DEFAULT_MODEL; the env var is a
+    default, not an enforcer. This protects per-call provider routing."""
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
+
+    agent = CoreAgent(
+        agent_id="env-test-2",
+        config={"model": "claude-3-5-sonnet"},
+    )
+
+    assert agent.config["model"] == "claude-3-5-sonnet"
+
+
+def test_core_agent_raises_env_model_missing_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    _env_serialized: None,
+) -> None:
+    """No model= AND no env var — raise the typed error with an actionable
+    message naming the env var. Silent fallback to a hardcoded literal is
+    BLOCKED per rules/env-models.md."""
+    monkeypatch.delenv("KAIZEN_DEFAULT_MODEL", raising=False)
+
+    with pytest.raises(EnvModelMissing) as exc_info:
+        CoreAgent(agent_id="env-test-3", config={})
+
+    err = exc_info.value
+    assert err.env_var == "KAIZEN_DEFAULT_MODEL"
+    assert err.component == "CoreAgent"
+    assert "KAIZEN_DEFAULT_MODEL" in str(err)
+    # Message must instruct the user — not just name the gap.
+    assert ".env" in str(err)
+
+
+def test_core_agent_treats_empty_env_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    _env_serialized: None,
+) -> None:
+    """An empty-string value of KAIZEN_DEFAULT_MODEL is functionally unset —
+    sending an empty model identifier to a provider produces opaque
+    400/401 errors. Raise with the same actionable error."""
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "")
+
+    with pytest.raises(EnvModelMissing):
+        CoreAgent(agent_id="env-test-4", config={})
+
+
+# ---------------------------------------------------------------------------
+# GovernedSupervisor (kaizen_agents.supervisor.GovernedSupervisor) — F-D-50
+# ---------------------------------------------------------------------------
+#
+# GovernedSupervisor lives in the optional kaizen-agents sub-package; if it
+# is not editable-installed in the test venv, skip the supervisor block
+# rather than failing collection. Test runner per rules/python-environment.md
+# expects kaizen-agents installed alongside kaizen for the full suite.
+
+
+supervisor_module = pytest.importorskip(
+    "kaizen_agents.supervisor",
+    reason="kaizen-agents not installed; GovernedSupervisor tests skipped",
+)
+GovernedSupervisor = supervisor_module.GovernedSupervisor
+
+
+def test_governed_supervisor_uses_env_model_when_caller_omits_model(
+    monkeypatch: pytest.MonkeyPatch,
+    _env_serialized: None,
+) -> None:
+    """Caller did not supply model=; KAIZEN_DEFAULT_MODEL is set; supervisor
+    stores the env value (no hardcoded "claude-sonnet-4-6" fallback)."""
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
+
+    supervisor = GovernedSupervisor(budget_usd=1.0)
+
+    assert supervisor._model == "gpt-4o-mini"
+
+
+def test_governed_supervisor_caller_explicit_model_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+    _env_serialized: None,
+) -> None:
+    """Caller-supplied model= beats KAIZEN_DEFAULT_MODEL on supervisor."""
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
+
+    supervisor = GovernedSupervisor(model="claude-3-5-sonnet", budget_usd=1.0)
+
+    assert supervisor._model == "claude-3-5-sonnet"
+
+
+def test_governed_supervisor_raises_env_model_missing_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    _env_serialized: None,
+) -> None:
+    """No model= AND no env var — raise EnvModelMissing with component
+    set to "GovernedSupervisor" so multi-call-site triage can disambiguate."""
+    monkeypatch.delenv("KAIZEN_DEFAULT_MODEL", raising=False)
+
+    with pytest.raises(EnvModelMissing) as exc_info:
+        GovernedSupervisor(budget_usd=1.0)
+
+    err = exc_info.value
+    assert err.env_var == "KAIZEN_DEFAULT_MODEL"
+    assert err.component == "GovernedSupervisor"
+    assert "KAIZEN_DEFAULT_MODEL" in str(err)
+
+
+def test_governed_supervisor_treats_empty_env_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    _env_serialized: None,
+) -> None:
+    """Empty-string KAIZEN_DEFAULT_MODEL on supervisor is also unset."""
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "")
+
+    with pytest.raises(EnvModelMissing):
+        GovernedSupervisor(budget_usd=1.0)

--- a/packages/kaizen-agents/src/kaizen_agents/supervisor.py
+++ b/packages/kaizen-agents/src/kaizen_agents/supervisor.py
@@ -5,12 +5,13 @@
 Hides the 20-concept L3 surface area behind three layers:
 
 Layer 1 (simple):
-    supervisor = GovernedSupervisor(model="claude-sonnet-4-6", budget_usd=10.0)
+    # KAIZEN_DEFAULT_MODEL=<your-chosen-model> in .env supplies the default.
+    supervisor = GovernedSupervisor(budget_usd=10.0)
     result = await supervisor.run("Analyze this codebase")
 
 Layer 2 (configured):
     supervisor = GovernedSupervisor(
-        model="claude-sonnet-4-6",
+        model=os.environ["KAIZEN_DEFAULT_MODEL"],  # explicit env override
         budget_usd=10.0,
         tools=["read_file", "grep", "write_report"],
         data_clearance="restricted",
@@ -32,10 +33,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import os
 import threading
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
-from typing import Any, Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from kaizen.errors import EnvModelMissing
 
 try:
     from kailash.trust.pact.agent import GovernanceHeldError
@@ -48,27 +53,22 @@ except ImportError:
             super().__init__(*args)
 
 
-from kaizen_agents.audit.trail import AuditTrail
-from kaizen_agents.governance.accountability import AccountabilityTracker
-from kaizen_agents.governance.budget import BudgetTracker
-from kaizen_agents.governance.bypass import BypassManager
-from kaizen_agents.governance.cascade import CascadeManager
-from kaizen_agents.governance.cost_model import CostModel
 from kailash.trust import ConfidentialityLevel
-
-from kaizen_agents.governance.clearance import (
-    ClassificationAssigner,
-    ClearanceEnforcer,
-)
-from kaizen_agents.governance.dereliction import DerelictionDetector
-from kaizen_agents.governance.vacancy import VacancyManager
 from kailash.trust.pact.config import (
     ConstraintEnvelopeConfig,
     FinancialConstraintConfig,
     OperationalConstraintConfig,
     TemporalConstraintConfig,
 )
-
+from kaizen_agents.audit.trail import AuditTrail
+from kaizen_agents.governance.accountability import AccountabilityTracker
+from kaizen_agents.governance.budget import BudgetTracker
+from kaizen_agents.governance.bypass import BypassManager
+from kaizen_agents.governance.cascade import CascadeManager
+from kaizen_agents.governance.clearance import ClassificationAssigner, ClearanceEnforcer
+from kaizen_agents.governance.cost_model import CostModel
+from kaizen_agents.governance.dereliction import DerelictionDetector
+from kaizen_agents.governance.vacancy import VacancyManager
 from kaizen_agents.types import (
     AgentSpec,
     ConstraintEnvelope,
@@ -85,7 +85,12 @@ from kaizen_agents.types import (
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["GovernanceHeldError", "GovernedSupervisor", "HoldRecord", "SupervisorResult"]
+__all__ = [
+    "GovernanceHeldError",
+    "GovernedSupervisor",
+    "HoldRecord",
+    "SupervisorResult",
+]
 
 
 @dataclass
@@ -119,7 +124,9 @@ class _ReadOnlyView:
         object.__setattr__(self, "_allowed", allowed_methods)
 
     def __getattr__(self, name: str) -> Any:
-        if name.startswith("_") or name not in object.__getattribute__(self, "_allowed"):
+        if name.startswith("_") or name not in object.__getattribute__(
+            self, "_allowed"
+        ):
             target = object.__getattribute__(self, "_target")
             raise AttributeError(
                 f"'{type(target).__name__}' read-only view has no attribute '{name}'"
@@ -203,6 +210,9 @@ class GovernedSupervisor:
 
     Args:
         model: Model identifier string (informational, passed to AgentSpecs).
+            When ``None`` (default), resolves from the ``KAIZEN_DEFAULT_MODEL``
+            environment variable; if that is also unset, raises
+            :class:`kaizen.errors.EnvModelMissing` per ``rules/env-models.md``.
         budget_usd: Maximum budget in USD. Default $1.00.
         tools: Allowed tool names. Default empty (default-deny per PACT Rule 5).
         data_clearance: Clearance level string. Default "public".
@@ -218,7 +228,7 @@ class GovernedSupervisor:
 
     def __init__(
         self,
-        model: str = "claude-sonnet-4-6",
+        model: str | None = None,
         budget_usd: float = 1.0,
         tools: list[str] | None = None,
         data_clearance: str = "public",
@@ -229,13 +239,34 @@ class GovernedSupervisor:
         policy_source: str = "",
         cost_model: CostModel | None = None,
     ) -> None:
+        # Resolve model identifier. Per rules/env-models.md, model strings MUST
+        # come from .env (KAIZEN_DEFAULT_MODEL); a hardcoded literal default
+        # like "claude-sonnet-4-6" is BLOCKED because it locks every supervisor
+        # deployment to one provider/version. If the caller passed model=None,
+        # fall back to the env var; if that is unset too, raise the typed
+        # EnvModelMissing error so the failure surfaces with an actionable
+        # instruction instead of silently sending a stale model on the wire.
+        if model is None:
+            env_model = os.environ.get("KAIZEN_DEFAULT_MODEL")
+            if not env_model:
+                raise EnvModelMissing(
+                    env_var="KAIZEN_DEFAULT_MODEL", component="GovernedSupervisor"
+                )
+            model = env_model
+
         # Validate inputs
         if not math.isfinite(budget_usd) or budget_usd < 0:
-            raise ValueError(f"budget_usd must be finite and non-negative, got {budget_usd}")
+            raise ValueError(
+                f"budget_usd must be finite and non-negative, got {budget_usd}"
+            )
         if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
-            raise ValueError(f"timeout_seconds must be finite and positive, got {timeout_seconds}")
+            raise ValueError(
+                f"timeout_seconds must be finite and positive, got {timeout_seconds}"
+            )
         if not math.isfinite(warning_threshold):
-            raise ValueError(f"warning_threshold must be finite, got {warning_threshold}")
+            raise ValueError(
+                f"warning_threshold must be finite, got {warning_threshold}"
+            )
         if data_clearance not in _CLEARANCE_MAP:
             raise ValueError(
                 f"data_clearance must be one of {sorted(_CLEARANCE_MAP.keys())}, "
@@ -440,13 +471,21 @@ class GovernedSupervisor:
                     hold_record = HoldRecord(
                         node_id=node_id,
                         reason=hold_reason,
-                        details=getattr(held, "details", {}) if hasattr(held, "details") else {},
-                        held_at=datetime.now(timezone.utc),
+                        details=(
+                            getattr(held, "details", {})
+                            if hasattr(held, "details")
+                            else {}
+                        ),
+                        held_at=datetime.now(UTC),
                     )
                     with self._held_lock:
                         # Evict resolved holds if at capacity
                         if len(self._held_nodes) >= self._max_held_nodes:
-                            resolved = [k for k, v in self._held_nodes.items() if v.event.is_set()]
+                            resolved = [
+                                k
+                                for k, v in self._held_nodes.items()
+                                if v.event.is_set()
+                            ]
                             for k in resolved:
                                 del self._held_nodes[k]
                         self._held_nodes[node_id] = hold_record
@@ -457,7 +496,9 @@ class GovernedSupervisor:
                             reason=f"governance: {hold_reason}",
                         )
                     )
-                    self._audit.record_held("root", node_id, f"governance: {hold_reason}")
+                    self._audit.record_held(
+                        "root", node_id, f"governance: {hold_reason}"
+                    )
                     continue
 
                 except (KeyboardInterrupt, SystemExit):
@@ -496,7 +537,9 @@ class GovernedSupervisor:
         events.append(
             PlanEvent(
                 event_type=(
-                    PlanEventType.PLAN_COMPLETED if all_completed else PlanEventType.PLAN_FAILED
+                    PlanEventType.PLAN_COMPLETED
+                    if all_completed
+                    else PlanEventType.PLAN_FAILED
                 ),
                 results=node_results if all_completed else None,
             )
@@ -600,13 +643,21 @@ class GovernedSupervisor:
                     hold_record = HoldRecord(
                         node_id=node_id,
                         reason=hold_reason,
-                        details=getattr(held, "details", {}) if hasattr(held, "details") else {},
-                        held_at=datetime.now(timezone.utc),
+                        details=(
+                            getattr(held, "details", {})
+                            if hasattr(held, "details")
+                            else {}
+                        ),
+                        held_at=datetime.now(UTC),
                     )
                     with self._held_lock:
                         # Evict resolved holds if at capacity
                         if len(self._held_nodes) >= self._max_held_nodes:
-                            resolved = [k for k, v in self._held_nodes.items() if v.event.is_set()]
+                            resolved = [
+                                k
+                                for k, v in self._held_nodes.items()
+                                if v.event.is_set()
+                            ]
                             for k in resolved:
                                 del self._held_nodes[k]
                         self._held_nodes[node_id] = hold_record
@@ -617,7 +668,9 @@ class GovernedSupervisor:
                             reason=f"governance: {hold_reason}",
                         )
                     )
-                    self._audit.record_held("root", node_id, f"governance: {hold_reason}")
+                    self._audit.record_held(
+                        "root", node_id, f"governance: {hold_reason}"
+                    )
                     continue
 
                 except (KeyboardInterrupt, SystemExit):
@@ -867,7 +920,9 @@ class GovernedSupervisor:
                 and completion_tokens >= 0
             ):
                 model_name = output.get("model", self._model)
-                computed = self._cost_model.compute(model_name, prompt_tokens, completion_tokens)
+                computed = self._cost_model.compute(
+                    model_name, prompt_tokens, completion_tokens
+                )
                 if math.isfinite(computed) and computed >= 0:
                     return computed
 


### PR DESCRIPTION
## Summary

Closes W5-D findings F-D-02 + F-D-50 (hardcoded model strings in kaizen). Both CoreAgent and GovernedSupervisor now read from \`KAIZEN_DEFAULT_MODEL\` env var per \`rules/env-models.md\`.

- New typed error: \`EnvModelMissing\` in \`kaizen.errors\`
- 5 sites updated in \`kaizen.core.agents\` (CoreAgent _set_default_config + 4 downstream config["model"] sites)
- GovernedSupervisor \`__init__\` + module docstring
- 8 Tier-1 unit tests cover env-set / caller-override / env-unset / empty-string-env across both agents
- Tests serialize via module-scope \`threading.Lock\` per \`rules/testing.md\` § Env-Var Test Isolation
- \`.env.example\` documents \`KAIZEN_DEFAULT_MODEL\`

## Test plan

- [x] 8/8 unit tests pass
- [x] No hardcoded \`gpt-*\` / \`claude-*\` literal in \`packages/kailash-kaizen/src/\`
- [x] CHANGELOG entry added

## Pre-existing issues (NOT introduced)

Documented in todo W6-001 for /redteam follow-up:
- Pre-existing kaizen \`pytest --collect-only\` errors from missing test deps (verified on main HEAD)
- Pre-existing test failures in \`tests/unit/core/test_base_agent_defaults.py\` (verified on main HEAD)

## Related

- Closes F-D-02 + F-D-50 from \`workspaces/portfolio-spec-audit/04-validate/W5-D-findings.md\`
- Wave 6 todo: \`workspaces/portfolio-spec-audit/todos/active/W6-001-strip-hardcoded-models-kaizen.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)