### PR TITLE
refactor(dataflow): W6-003 — rename MLTenantRequiredError → TenantRequiredError + alias

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,15 @@
 # DataFlow Changelog
 
+## [Unreleased] — DataFlow × ML error-name spec compliance (W6-003 / F-B-23)
+
+### Changed
+
+- **`dataflow.ml.MLTenantRequiredError` → `dataflow.ml.TenantRequiredError`** — renamed the ML-bridge tenant-required error to match `specs/dataflow-ml-integration.md` § 5 canonical name; spec-following users hit `ImportError` against the old name. Closes finding F-B-23.
+
+### Deprecated
+
+- **`MLTenantRequiredError`** — deprecated alias resolves to `TenantRequiredError` via module-level `__getattr__` on both `dataflow.ml` and `dataflow.ml._errors`; access emits a `DeprecationWarning`. The alias is intentionally absent from `__all__` so star-imports pick up only the canonical name. Slated for removal in **kailash-dataflow v3.0** — callers MUST migrate within the v2.x window. Per user `feedback_no_shims`, this is a 1-release back-compat bridge with an explicit removal milestone, NOT a permanent shim.
+
 ## [2.3.1] — 2026-04-26 — SecurityDefinerBuilder owner-pinning + COMMENT defense-in-depth (#607 follow-up)
 
 ### Security

--- a/packages/kailash-dataflow/src/dataflow/ml/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/ml/__init__.py
@@ -31,6 +31,8 @@ same canonicalized polars Arrow IPC stream across languages.
 
 from __future__ import annotations
 
+import warnings
+
 from dataflow.ml._classify import _kml_classify_actions
 from dataflow.ml._context import TrainingContext
 from dataflow.ml._errors import (
@@ -38,7 +40,7 @@ from dataflow.ml._errors import (
     DataFlowTransformError,
     FeatureSourceError,
     LineageHashError,
-    MLTenantRequiredError,
+    TenantRequiredError,
 )
 from dataflow.ml._events import (
     ML_TRAIN_END_EVENT,
@@ -74,5 +76,30 @@ __all__ = [
     "FeatureSourceError",
     "DataFlowTransformError",
     "LineageHashError",
-    "MLTenantRequiredError",
+    "TenantRequiredError",
+    # NOTE: ``MLTenantRequiredError`` is an intentional deprecated alias
+    # resolved through ``__getattr__`` below; it is intentionally absent
+    # from ``__all__`` so star-imports pick up only the canonical name,
+    # while ``from dataflow.ml import MLTenantRequiredError`` still works
+    # (with a DeprecationWarning) for the v2.x → v3.0 migration window.
 ]
+
+
+def __getattr__(name: str):
+    """Module-level ``__getattr__`` for deprecated aliases.
+
+    ``MLTenantRequiredError`` was renamed to :class:`TenantRequiredError`
+    in kailash-dataflow 2.3.2 (closes F-B-23) to match
+    ``specs/dataflow-ml-integration.md`` § 5. The old name resolves to
+    the new class with a one-shot ``DeprecationWarning`` per access. The
+    alias is slated for removal in kailash-dataflow v3.0.
+    """
+    if name == "MLTenantRequiredError":
+        warnings.warn(
+            "MLTenantRequiredError is deprecated; use TenantRequiredError. "
+            "Alias will be removed in kailash-dataflow v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return TenantRequiredError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/kailash-dataflow/src/dataflow/ml/_context.py
+++ b/packages/kailash-dataflow/src/dataflow/ml/_context.py
@@ -38,7 +38,7 @@ class TrainingContext:
         tenant_id: Tenant that owns the training data. ``None`` is
             permitted ONLY for single-tenant ``DataFlow`` instances;
             multi-tenant feature groups raise
-            :class:`MLTenantRequiredError` upstream before a
+            :class:`TenantRequiredError` upstream before a
             ``TrainingContext`` can be constructed with ``None``.
         dataset_hash: The ``dataflow.ml.hash()`` output for the training
             set. MUST start with ``"sha256:"`` and be 64 hex chars.

--- a/packages/kailash-dataflow/src/dataflow/ml/_errors.py
+++ b/packages/kailash-dataflow/src/dataflow/ml/_errors.py
@@ -9,6 +9,8 @@ to 2.1.0. See ``specs/dataflow-ml-integration.md`` § 5.
 
 from __future__ import annotations
 
+import warnings
+
 from dataflow.exceptions import DataFlowError
 
 __all__ = [
@@ -16,7 +18,12 @@ __all__ = [
     "FeatureSourceError",
     "DataFlowTransformError",
     "LineageHashError",
-    "MLTenantRequiredError",
+    "TenantRequiredError",
+    # ``MLTenantRequiredError`` is an intentional back-compat alias —
+    # see :func:`__getattr__` below. It is intentionally absent from
+    # ``__all__`` so ``from dataflow.ml._errors import *`` only picks up
+    # the canonical name, but ``from dataflow.ml._errors import
+    # MLTenantRequiredError`` still resolves (with a DeprecationWarning).
 ]
 
 
@@ -65,7 +72,7 @@ class LineageHashError(DataFlowMLIntegrationError):
     """
 
 
-class MLTenantRequiredError(DataFlowMLIntegrationError):
+class TenantRequiredError(DataFlowMLIntegrationError):
     """Raised when a multi_tenant=True feature group is accessed without
     a ``tenant_id``.
 
@@ -74,4 +81,30 @@ class MLTenantRequiredError(DataFlowMLIntegrationError):
     keeps the ML-bridge's error hierarchy self-contained while
     preserving the ``rules/tenant-isolation.md`` § 2 contract (missing
     tenant is a typed error, never a silent default).
+
+    .. note::
+       Renamed from ``MLTenantRequiredError`` in kailash-dataflow 2.3.2
+       to match ``specs/dataflow-ml-integration.md`` § 5 canonical name.
+       The old name remains as a deprecated back-compat alias slated for
+       removal in v3.0; access emits a ``DeprecationWarning`` once per
+       process. Closes finding F-B-23.
     """
+
+
+def __getattr__(name: str):
+    """Module-level ``__getattr__`` for the deprecated alias.
+
+    The ``MLTenantRequiredError`` alias resolves to
+    :class:`TenantRequiredError` and emits a ``DeprecationWarning`` on
+    first access per process. Any other unknown attribute raises
+    ``AttributeError`` so the alias does NOT silently mask typos.
+    """
+    if name == "MLTenantRequiredError":
+        warnings.warn(
+            "MLTenantRequiredError is deprecated; use TenantRequiredError. "
+            "Alias will be removed in kailash-dataflow v3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return TenantRequiredError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/kailash-dataflow/src/dataflow/ml/_feature_source.py
+++ b/packages/kailash-dataflow/src/dataflow/ml/_feature_source.py
@@ -13,7 +13,7 @@ Failure").
 Tenant isolation:
 
 * ``multi_tenant=True`` feature groups MUST receive a non-``None``
-  ``tenant_id``; omission raises :class:`MLTenantRequiredError`
+  ``tenant_id``; omission raises :class:`TenantRequiredError`
   (per ``rules/tenant-isolation.md`` § 2).
 * ``tenant_id`` is preserved on every cache key the helper constructs
   (see ``_cache_key`` below) so a tenant-scoped invalidation only
@@ -33,7 +33,7 @@ from typing import Any, List, Optional
 
 from dataflow.ml._errors import (
     FeatureSourceError,
-    MLTenantRequiredError,
+    TenantRequiredError,
 )
 
 logger = logging.getLogger(__name__)
@@ -184,7 +184,7 @@ def ml_feature_source(
         FeatureSourceError: kailash-ml is absent, the feature group's
             shape is invalid, or the underlying store refused to
             serve.
-        MLTenantRequiredError: ``multi_tenant=True`` without a
+        TenantRequiredError: ``multi_tenant=True`` without a
             ``tenant_id``.
         ValueError: Conflicting window arguments.
     """
@@ -214,7 +214,7 @@ def ml_feature_source(
     # Tenant strict mode — missing tenant on a multi-tenant group is a
     # typed error (`rules/tenant-isolation.md` § 2).
     if _is_multi_tenant_group(feature_group) and tenant_id is None:
-        raise MLTenantRequiredError(
+        raise TenantRequiredError(
             f"FeatureGroup {group_name!r} is multi_tenant=True; tenant_id is required"
         )
 
@@ -260,7 +260,7 @@ def ml_feature_source(
             until=until,
             limit=limit,
         )
-    except (FeatureSourceError, MLTenantRequiredError):
+    except (FeatureSourceError, TenantRequiredError):
         raise
     except TypeError as exc:
         # Older FeatureGroup implementations may not accept every kwarg;

--- a/packages/kailash-dataflow/tests/integration/test_dataflow_ml_feature_source_wiring.py
+++ b/packages/kailash-dataflow/tests/integration/test_dataflow_ml_feature_source_wiring.py
@@ -10,7 +10,7 @@ DataFlow instance and asserts the externally-observable contract:
 * ``materialize`` on a FeatureGroup implementation returns a
   ``polars.LazyFrame``.
 * Multi-tenant groups without ``tenant_id`` raise
-  ``MLTenantRequiredError`` with the exact message shape the
+  ``TenantRequiredError`` with the exact message shape the
   ``rules/tenant-isolation.md`` § 2 contract mandates.
 * Write-then-read persistence is verified end-to-end: rows written to
   the DataFlow table through ``db.express`` are retrievable through a
@@ -33,7 +33,7 @@ import pytest
 
 from dataflow import DataFlow
 from dataflow.ml import (
-    MLTenantRequiredError,
+    TenantRequiredError,
     ml_feature_source,
     transform,
 )
@@ -141,7 +141,7 @@ def single_tenant_db(tmp_path: Path):
 
 @pytest.fixture
 def multi_tenant_db(tmp_path: Path):
-    """Build a multi-tenant DataFlow for MLTenantRequiredError coverage."""
+    """Build a multi-tenant DataFlow for TenantRequiredError coverage."""
     db_path = tmp_path / "ml_mt_source.sqlite"
     df = DataFlow(f"sqlite:///{db_path}", auto_migrate=True, multi_tenant=True)
     df._ensure_connected()
@@ -224,7 +224,7 @@ def test_ml_feature_source_multi_tenant_without_tenant_id_raises(
 
     group = DataFlowTableFeatureGroup(db=db, model_name="SomeModel", multi_tenant=True)
 
-    with pytest.raises(MLTenantRequiredError, match="tenant_id is required"):
+    with pytest.raises(TenantRequiredError, match="tenant_id is required"):
         ml_feature_source(group)  # no tenant_id
 
 

--- a/packages/kailash-dataflow/tests/unit/ml/test_dataflow_ml_symbols.py
+++ b/packages/kailash-dataflow/tests/unit/ml/test_dataflow_ml_symbols.py
@@ -48,7 +48,7 @@ def test_public_api_symbols_present():
         "FeatureSourceError",
         "DataFlowTransformError",
         "LineageHashError",
-        "MLTenantRequiredError",
+        "TenantRequiredError",
     }
     missing = required - set(ml.__all__)
     assert not missing, f"dataflow.ml.__all__ missing symbols: {sorted(missing)}"
@@ -383,7 +383,7 @@ def test_error_hierarchy_all_inherit_dataflow_error():
         DataFlowTransformError,
         FeatureSourceError,
         LineageHashError,
-        MLTenantRequiredError,
+        TenantRequiredError,
     )
 
     for cls in (
@@ -391,7 +391,7 @@ def test_error_hierarchy_all_inherit_dataflow_error():
         FeatureSourceError,
         DataFlowTransformError,
         LineageHashError,
-        MLTenantRequiredError,
+        TenantRequiredError,
     ):
         assert issubclass(cls, DataFlowError), (
             f"{cls.__name__} must inherit from DataFlowError "

--- a/packages/kailash-dataflow/tests/unit/test_tenant_required_error_alias.py
+++ b/packages/kailash-dataflow/tests/unit/test_tenant_required_error_alias.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 1 — TenantRequiredError canonical name + MLTenantRequiredError
+back-compat alias coverage.
+
+Closes F-B-23 (W6-003). Renamed ``MLTenantRequiredError`` →
+``TenantRequiredError`` in kailash-dataflow 2.3.2 to match the spec's
+canonical name (``specs/dataflow-ml-integration.md`` § 5). The old name
+remains as a deprecated alias slated for removal in v3.0; access emits a
+``DeprecationWarning`` (per ``rules/zero-tolerance.md`` Rule 1 / user
+``feedback_no_shims`` — the alias is a 1-release migration bridge, NOT
+a permanent shim).
+
+This file is intentionally Tier 1: the alias resolution is a
+module-import-time concern with no infrastructure dependency.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+
+@pytest.mark.unit
+def test_tenant_required_error_canonical_import_succeeds():
+    """Canonical name imports without warning from both surfaces."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any DeprecationWarning would fail
+        from dataflow.ml import TenantRequiredError as Public  # noqa: F401
+        from dataflow.ml._errors import TenantRequiredError as Internal  # noqa: F401
+
+    # Both surfaces resolve to the same class object.
+    from dataflow.ml import TenantRequiredError as Public
+    from dataflow.ml._errors import TenantRequiredError as Internal
+
+    assert Public is Internal
+
+
+@pytest.mark.unit
+def test_alias_resolves_to_canonical_class_via_dataflow_ml():
+    """``dataflow.ml.MLTenantRequiredError`` IS ``dataflow.ml.TenantRequiredError``."""
+    import dataflow.ml as ml_mod
+
+    canonical = ml_mod.TenantRequiredError
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        alias = ml_mod.MLTenantRequiredError
+
+    assert alias is canonical, (
+        "MLTenantRequiredError MUST resolve to TenantRequiredError; "
+        "alias is intentional 1-release back-compat bridge, NOT a separate class"
+    )
+
+
+@pytest.mark.unit
+def test_alias_resolves_to_canonical_class_via__errors():
+    """``dataflow.ml._errors.MLTenantRequiredError`` IS the canonical class."""
+    import dataflow.ml._errors as errors_mod
+
+    canonical = errors_mod.TenantRequiredError
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("always")
+        alias = errors_mod.MLTenantRequiredError
+
+    assert alias is canonical
+
+
+@pytest.mark.unit
+def test_alias_emits_deprecation_warning_on_access():
+    """Accessing ``MLTenantRequiredError`` emits exactly one DeprecationWarning."""
+    import dataflow.ml as ml_mod
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # Trigger the __getattr__ once.
+        _ = ml_mod.MLTenantRequiredError
+
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert (
+        len(deprecation_warnings) == 1
+    ), f"expected exactly 1 DeprecationWarning, got {len(deprecation_warnings)}"
+    msg = str(deprecation_warnings[0].message)
+    assert "MLTenantRequiredError" in msg
+    assert "TenantRequiredError" in msg
+    assert "v3.0" in msg, "deprecation warning MUST cite removal milestone"
+
+
+@pytest.mark.unit
+def test_alias_emits_deprecation_warning_via__errors_module():
+    """The same DeprecationWarning fires when accessing through ``_errors``."""
+    import dataflow.ml._errors as errors_mod
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = errors_mod.MLTenantRequiredError
+
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert len(deprecation_warnings) == 1
+    assert "v3.0" in str(deprecation_warnings[0].message)
+
+
+@pytest.mark.unit
+def test_raise_via_alias_caught_by_canonical_except():
+    """Raising via either name is caught by ``except TenantRequiredError``."""
+    from dataflow.ml import TenantRequiredError
+
+    # Raise via canonical name.
+    with pytest.raises(TenantRequiredError, match="canonical"):
+        raise TenantRequiredError("canonical")
+
+    # Raise via the alias (ignoring the deprecation warning emitted on lookup).
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from dataflow.ml import MLTenantRequiredError as AliasCls
+
+    with pytest.raises(TenantRequiredError, match="via alias"):
+        raise AliasCls("via alias")
+
+
+@pytest.mark.unit
+def test_alias_absent_from_public_all():
+    """``MLTenantRequiredError`` is intentionally NOT in ``__all__``.
+
+    The alias is reachable via ``__getattr__`` for migration callers; star-
+    imports MUST pick up only the canonical name so new code does not
+    inherit the deprecated symbol.
+    """
+    import dataflow.ml as ml_mod
+    import dataflow.ml._errors as errors_mod
+
+    assert "TenantRequiredError" in ml_mod.__all__
+    assert "MLTenantRequiredError" not in ml_mod.__all__
+    assert "TenantRequiredError" in errors_mod.__all__
+    assert "MLTenantRequiredError" not in errors_mod.__all__
+
+
+@pytest.mark.unit
+def test_unknown_attribute_raises_attribute_error():
+    """``__getattr__`` MUST NOT swallow typos — only the documented alias resolves."""
+    import dataflow.ml as ml_mod
+
+    with pytest.raises(AttributeError, match="MLTenantRequired"):
+        # Plausible typo that MUST NOT be silently aliased.
+        _ = ml_mod.MLTenantRequired

--- a/specs/dataflow-ml-integration.md
+++ b/specs/dataflow-ml-integration.md
@@ -237,6 +237,10 @@ class TenantRequiredError(DataFlowMLIntegrationError):
     tenant_id. Per rules/tenant-isolation.md §2."""
 ```
 
+**Canonical name:** `TenantRequiredError` (since kailash-dataflow 2.3.2 — closes F-B-23). The class lives at `dataflow.ml._errors.TenantRequiredError` and is re-exported from `dataflow.ml` namespace; it is **distinct** from the sibling-but-unrelated `dataflow.core.multi_tenancy.TenantRequiredError` (Express-path tenant guard).
+
+**Deprecated alias:** `MLTenantRequiredError` resolves to `TenantRequiredError` via a module-level `__getattr__` on both `dataflow.ml._errors` and `dataflow.ml`; the alias emits a `DeprecationWarning` per access. Slated for removal in **kailash-dataflow v3.0**. Callers SHOULD migrate to the canonical name within the v2.x → v3.0 window. The alias is intentionally absent from `__all__` so star-imports pick up only the canonical name.
+
 The errors are DataFlow-side — the ML-side sees them wrapped via `FeatureStoreError(MLError)` when thrown through the `FeatureStore` API (per `kailash-core-ml-integration-draft.md` §3 hierarchy).
 
 ---


### PR DESCRIPTION
## Summary

Closes W5-B finding F-B-23. Renames \`MLTenantRequiredError\` → \`TenantRequiredError\` to match \`specs/dataflow-ml-integration.md\` § 5 canonical name. Adds 1-release deprecation-warning alias (NOT a permanent shim per \`feedback_no_shims\`).

- Definition site: \`dataflow.ml._errors\` — class renamed
- Module-level \`__getattr__\` returns the canonical class on \`MLTenantRequiredError\` access with \`DeprecationWarning\` (slated for removal in v3.0)
- Public re-export updated in \`dataflow.ml.__init__\` with same alias mechanism
- 4 internal raise/import sites swept
- 3 test files updated to canonical name (8 sites + 8 new alias tests)

## Test plan

- [x] 8/8 alias tests pass (0.54s)
- [x] 25/25 ML unit tests pass (1.86s)
- [x] 5964 tests collect (exit 0) across \`packages/kailash-dataflow/tests/\`
- [x] No-op for star-imports (alias absent from \`__all__\`)
- [x] Spec sibling re-derivation: grep returned empty before edit; only \`dataflow-ml-integration.md\` mentions deprecated name (in deprecation note)

## Commit-message correction note

Commit \`bb283bc3\` body claimed "alias for back-compat lands in next commit" but the diff already included the alias. Filed correction commit \`857ba432\` per \`rules/git.md\` § "Commit-Message Claim Accuracy" (amend BLOCKED — preserve audit trail).

## Related

- Closes F-B-23 from W5-B-findings
- Wave 6 todo: W6-003

🤖 Generated with [Claude Code](https://claude.com/claude-code)