### PR TITLE
docs(specs): W6-005 — bulk update stale version headers

### DIFF
--- a/specs/dataflow-cache.md
+++ b/specs/dataflow-cache.md
@@ -1,6 +1,6 @@
 # Kailash DataFlow — Cache, Dialect, Record ID Coercion, Transactions, Pooling
 
-Version: 2.0.12
+Version: 2.3.1
 Package: `kailash-dataflow`
 Parent domain: DataFlow (split from `dataflow.md` per specs-authority Rule 8)
 Scope: Cache layer (backend selection, key format, TTL, invalidation, stats), dialect system (identifier quoting, placeholders, type mapping, feature matrix, upsert SQL, parameter conversion), record ID coercion, transaction manager, connection pooling

--- a/specs/dataflow-core.md
+++ b/specs/dataflow-core.md
@@ -1,6 +1,6 @@
 # Kailash DataFlow — Core (DataFlow Class, Engine, Exceptions, Trust, Fabric)
 
-Version: 2.0.7
+Version: 2.3.1
 Package: `kailash-dataflow`
 Parent domain: DataFlow (split from `dataflow.md` per specs-authority Rule 8)
 Scope: DataFlow class + constructor + connection URL + lazy/runtime detection, DataFlowEngine builder, exceptions, write events, Data Fabric Engine, derived models, retention engine, trust plane integration, versioning

--- a/specs/dataflow-express.md
+++ b/specs/dataflow-express.md
@@ -1,6 +1,6 @@
 # Kailash DataFlow — Express API (Async + Sync, Bulk, Validation, File Import)
 
-Version: 2.0.12
+Version: 2.3.1
 Package: `kailash-dataflow`
 Parent domain: DataFlow (split from `dataflow.md` per specs-authority Rule 8)
 Scope: Express async API (`db.express`), Express Sync API (`db.express_sync`), low-level bulk operations, validation framework (field validators invoked on write), file import

--- a/specs/dataflow-models.md
+++ b/specs/dataflow-models.md
@@ -1,6 +1,6 @@
 # Kailash DataFlow — Models, Classification, Multi-Tenant, Schema Management
 
-Version: 2.0.12
+Version: 2.3.1
 Package: `kailash-dataflow`
 Parent domain: DataFlow (split from `dataflow.md` per specs-authority Rule 8)
 Scope: `@db.model` decorator, field types, primary keys, auto-managed fields, table name mapping, model configuration, build-time validation, field classification/masking/retention, multi-tenant support, schema management (auto-migration, schema cache)

--- a/specs/kaizen-advanced.md
+++ b/specs/kaizen-advanced.md
@@ -1,6 +1,6 @@
 # Kailash Kaizen -- Domain Specification — Advanced Features
 
-Version: 2.7.3
+Version: 2.13.1
 Package: `kailash-kaizen`
 
 Parent domain: Kailash Kaizen AI agent framework. This file covers cost tracking, composition system, optimization system, audio support, configuration system, agent type presets, Google A2A protocol, permission system, hook system, and trust/posture. See also `kaizen-core.md`, `kaizen-signatures.md`, and `kaizen-providers.md`.

--- a/specs/kaizen-core.md
+++ b/specs/kaizen-core.md
@@ -1,6 +1,6 @@
 # Kailash Kaizen -- Domain Specification — Core
 
-Version: 2.7.3
+Version: 2.13.1
 Package: `kailash-kaizen`
 License: Apache-2.0
 Owner: Terrene Foundation (Singapore CLG)

--- a/specs/kaizen-interpretability.md
+++ b/specs/kaizen-interpretability.md
@@ -1,6 +1,6 @@
 # Kailash Kaizen Interpretability — Open-Weight LLM Diagnostics Adapter
 
-Version: 2.8.0
+Version: 2.13.1
 Package: `kailash-kaizen`
 Parent domain: Kaizen AI agent framework. This spec covers the post-hoc interpretability adapter that introspects local open-weight language models (Llama / Gemma / Phi / Mistral). It lives alongside other Diagnostic adapters (`specs/ml-diagnostics.md` for `DLDiagnostics`, forthcoming `kaizen-rag.md` for `RAGDiagnostics`, `kaizen-alignment.md` for `AlignmentDiagnostics`, etc.).
 Scope authority: `kaizen.interpretability.InterpretabilityDiagnostics` and the `kaizen.interpretability` facade module; the conformance contract against `kailash.diagnostics.protocols.Diagnostic`; the extras-gating contract for the `[interpretability]` extra.

--- a/specs/kaizen-providers.md
+++ b/specs/kaizen-providers.md
@@ -1,6 +1,6 @@
 # Kailash Kaizen -- Domain Specification — Providers, Strategies, Tools & Memory
 
-Version: 2.7.3
+Version: 2.13.1
 Package: `kailash-kaizen`
 
 Parent domain: Kailash Kaizen AI agent framework. This file covers the provider system, execution strategies, tool integration (MCP), memory system, error handling, and streaming support. See also `kaizen-core.md`, `kaizen-signatures.md`, and `kaizen-advanced.md`.

--- a/specs/kaizen-signatures.md
+++ b/specs/kaizen-signatures.md
@@ -1,6 +1,6 @@
 # Kailash Kaizen -- Domain Specification — Signatures & Structured Output
 
-Version: 2.7.3
+Version: 2.13.1
 Package: `kailash-kaizen`
 
 Parent domain: Kailash Kaizen AI agent framework. This file covers the signature system (InputField, OutputField, Signature, SignatureMeta, parser/compiler/validator, templates, enterprise extensions, multi-modal, execution patterns) and structured output (JSON schema generation). See also `kaizen-core.md`, `kaizen-providers.md`, and `kaizen-advanced.md`.


### PR DESCRIPTION
## Summary

Closes W5 LOW-bulk findings (~30 LOWs across dataflow + kaizen specs). Mechanical bulk update of stale \`Version: X.Y.Z\` headers to match each owning package's current \`__version__\`.

## Verified canonical version map

| Package | Version |
| --- | --- |
| kailash-dataflow | 2.3.1 |
| kailash-kaizen | 2.13.1 |
| kailash-ml | 1.1.1 |
| kailash-align | 0.6.0 |

\`pyproject.toml\` ↔ \`__version__\` parity verified; no Rule 5 violations surfaced.

## 9 spec files updated

**dataflow (4) → 2.3.1**: dataflow-cache (was 2.0.12), dataflow-core (2.0.7), dataflow-express (2.0.12), dataflow-models (2.0.12)

**kaizen (5) → 2.13.1**: kaizen-advanced (was 2.7.3), kaizen-core (2.7.3), kaizen-interpretability (2.8.0; "Status: LIVE" prose preserved), kaizen-providers (2.7.3), kaizen-signatures (2.7.3)

## Skipped (not stale)

- ml-automl, ml-feature-store: already at 1.1.1 (Wave 6.5 brought current)
- DRAFT-marked specs at 1.0.0 (15 ml/align/integration specs): version represents draft lineage, not stale package version

## Findings — substantive drift, NOT fixed in this PR

1. \`kaizen-agents-{core,governance,patterns}.md\` use sub-component versions (0.9.x) independent of parent kaizen 2.13.1 — convention call needed.
2. \`ml-rl-align-unification.md\` is cross-package (ml ↔ align), no clean owning package.
3. 15 DRAFT-marked specs should align to package version when promoted to AUTHORITATIVE.

## Test plan

- [x] Diff is purely mechanical (single-line \`Version:\` swaps, zero prose changes)
- [x] All 9 specs verified to match owning package's canonical version

## Related

- Wave 6 todo: W6-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)