### PR TITLE
docs(nexus): W6-009 — canonicalize ML mount on mount_ml_endpoints

### DIFF
--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Nexus Changelog
 
+## [Unreleased]
+
+### Documentation
+
+- **W6-009 — Canonicalized ML mount path on `mount_ml_endpoints()` (closes F-C-26)**: `specs/nexus-ml-integration.md` previously cited `nexus.register_service("inference", server.as_nexus_service())` and an `InferenceServer.as_nexus_service()` API that were never shipped. The canonical entry — verified at `packages/kailash-nexus/src/nexus/ml/__init__.py:222` — is `nexus.ml.mount_ml_endpoints(nexus, serve_handle, *, prefix="/ml")`. Spec sections §5.1, §5.2, §6 (error class), §7.2 (Tier-2 test name), §10 (Migration Path), and §12 (Cross-References) updated to reference the shipped surface; absent legacy names retracted per `rules/orphan-detection.md` §3 (Removed = Deleted, Not Deprecated).
+
+### Tests
+
+- **`tests/integration/test_mount_ml_endpoints.py` (new)**: structural-invariant Tier-2 regression test pinning `mount_ml_endpoints(nexus, serve_handle, *, prefix="/ml")` as the canonical entry. Asserts (a) signature shape; (b) absence of `Nexus.register_service` and `InferenceServer.as_nexus_service`; (c) end-to-end JWT-claim propagation into the predictor against a real Nexus + Protocol-satisfying ServeHandle (per `rules/testing.md` § Tier 2 "Protocol-Satisfying Deterministic Adapters" — no mocks). 7/7 passing locally.
+
+### Internal
+
+- `packages/kailash-nexus/pytest.ini` — register the `regression` marker (already in use by `tests/regression/test_issue_211.py`) to clear pre-existing `PytestUnknownMarkWarning` per `rules/zero-tolerance.md` Rule 1.
+
 ## [2.3.0] - 2026-04-25 — WebSocket per-connection unicast + on_message reply delivery (#618)
 
 ### Added

--- a/packages/kailash-nexus/pytest.ini
+++ b/packages/kailash-nexus/pytest.ini
@@ -2,3 +2,8 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 addopts = --import-mode=importlib
+markers =
+    unit: Unit tests (fast, isolated)
+    integration: Integration tests (real services)
+    e2e: End-to-end tests (complete flows)
+    regression: Regression tests pinning a specific bug or invariant (per rules/testing.md § Regression Testing)

--- a/packages/kailash-nexus/tests/integration/test_mount_ml_endpoints.py
+++ b/packages/kailash-nexus/tests/integration/test_mount_ml_endpoints.py
@@ -1,0 +1,262 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""W6-009 — Canonical-entry Tier-2 test for ``nexus.ml.mount_ml_endpoints``.
+
+This file pins the canonical public-API shape declared in
+`specs/nexus-ml-integration.md` §5.2 + §10 + §12 after the W5-C
+finding F-C-26 spec/code reconciliation. The companion file
+`test_nexus_ml_endpoints_wiring.py` exercises the mounted REST + MCP
+routes end-to-end; this file's job is the *structural-invariant*
+regression that locks the public surface so a future refactor cannot
+silently re-introduce the legacy ``register_service`` /
+``InferenceServer.as_nexus_service`` names without flipping a loud
+test.
+
+Per `rules/orphan-detection.md` §3 (Removed = Deleted, Not Deprecated),
+the prior draft spec mentioned two surfaces that were never shipped:
+``Nexus.register_service(...)`` and ``InferenceServer.as_nexus_service()``.
+The shipped path is exclusively ``nexus.ml.mount_ml_endpoints`` per
+`packages/kailash-nexus/src/nexus/ml/__init__.py:222`. This test
+locks that fact:
+
+  1. ``mount_ml_endpoints`` is importable from ``nexus.ml``.
+  2. Its signature is exactly ``(nexus, serve_handle, *, prefix="/ml")``.
+  3. The absent legacy names are NOT attributes of ``Nexus`` /
+     ``InferenceServer`` (when ml is installed) — guarded so the test
+     does not require kailash-ml to be installed in every CI shard.
+  4. Mounted endpoints reach the predictor end-to-end against a real
+     Nexus + JWT + Protocol-satisfying ``ServeHandle`` (per
+     `rules/testing.md` § Tier 2 "Protocol-Satisfying Deterministic
+     Adapters").
+
+The Tier-2 test uses a real Nexus instance + real FastAPI TestClient +
+real JWT middleware — no ``unittest.mock`` (per `rules/testing.md`
+§ "Tier 2 (Integration): NO mocking").
+"""
+
+from __future__ import annotations
+
+import inspect
+import socket
+from contextlib import closing
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import jwt as pyjwt
+import pytest
+from fastapi.testclient import TestClient
+
+from nexus import Nexus
+from nexus.auth.jwt import JWTConfig, JWTMiddleware
+from nexus.ml import mount_ml_endpoints
+
+JWT_TEST_SECRET = "test-secret-key-minimum-32-bytes!"
+
+
+def _free_port(start: int = 18600) -> int:
+    for port in range(start, start + 200):
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            try:
+                s.bind(("", port))
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("no free port")
+
+
+def _make_token(sub: str, tenant_id: Optional[str] = None) -> str:
+    now = datetime.now(timezone.utc)
+    payload: Dict[str, Any] = {
+        "sub": sub,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=1)).timestamp()),
+    }
+    if tenant_id is not None:
+        payload["tenant_id"] = tenant_id
+    return pyjwt.encode(payload, JWT_TEST_SECRET, algorithm="HS256")
+
+
+class DeterministicServeHandle:
+    """Protocol-satisfying ``ServeHandle`` adapter for Tier-2 testing.
+
+    Per `rules/testing.md` Tier 2 exception: a class that satisfies a
+    structural Protocol at runtime AND produces deterministic output is
+    NOT a mock. This adapter records every ``predict`` call so the test
+    can assert the propagated tenant/actor reached the predictor.
+    """
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    async def predict(
+        self,
+        inputs: Any,
+        *,
+        tenant_id: Optional[str] = None,
+        actor_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        self.calls.append(
+            {"inputs": inputs, "tenant_id": tenant_id, "actor_id": actor_id}
+        )
+        score = float(inputs.get("x", 0)) if isinstance(inputs, dict) else 0.0
+        return {"score": score, "seen_tenant": tenant_id, "seen_actor": actor_id}
+
+    def describe(self) -> Dict[str, Any]:
+        return {"model": "w6-009-canonical-entry", "version": "1.0.0"}
+
+
+@pytest.fixture
+def nexus_with_ml():
+    """Real Nexus + JWT middleware + mounted ml endpoints.
+
+    Yields ``(client, handle)``. No mocks: real Nexus, real FastAPI
+    TestClient, real JWT validation, real Protocol-satisfying handle.
+    """
+    port = _free_port()
+    app = Nexus(api_port=port, auto_discovery=False)
+    # Narrow `Optional[FastAPI]` → `FastAPI` for the type checker AND
+    # assert the gateway built successfully. Per `rules/zero-tolerance.md`
+    # § 3a (Typed Delegate Guards For None Backing Objects).
+    fastapi_app = app.fastapi_app
+    assert fastapi_app is not None, (
+        "Nexus.fastapi_app is None — the HTTP transport gateway did not build. "
+        "Construct Nexus with default api_port + auto_discovery=False before mounting."
+    )
+    fastapi_app.add_middleware(
+        JWTMiddleware,
+        config=JWTConfig(
+            secret=JWT_TEST_SECRET,
+            algorithm="HS256",
+            exempt_paths=["/ml/healthz", "/health"],
+        ),
+    )
+    handle = DeterministicServeHandle()
+    mount_ml_endpoints(app, handle, prefix="/ml")
+    client = TestClient(fastapi_app)
+    try:
+        yield client, handle
+    finally:
+        try:
+            app.stop()
+        except Exception:  # noqa: BLE001 — fixture teardown best-effort
+            pass
+
+
+# --------------------------------------------------------------------------
+# Structural invariant tests — lock the public-API shape that F-C-26 fixed.
+# --------------------------------------------------------------------------
+
+
+class TestMountMlEndpointsSignature:
+    """Spec §5.2 — ``mount_ml_endpoints`` is the canonical mount entry."""
+
+    def test_mount_ml_endpoints_is_importable_from_nexus_ml(self) -> None:
+        """The canonical entry MUST be reachable as ``nexus.ml.mount_ml_endpoints``."""
+        from nexus.ml import mount_ml_endpoints as imported
+
+        assert callable(imported), "mount_ml_endpoints must be a callable"
+
+    def test_mount_ml_endpoints_signature_is_locked(self) -> None:
+        """Locks ``mount_ml_endpoints(nexus, serve_handle, *, prefix='/ml') -> None``.
+
+        If the signature drifts, the test fails loudly and the
+        cross-spec contract (`specs/nexus-ml-integration.md` §5.2) MUST
+        be re-derived per `rules/specs-authority.md` §5b.
+        """
+        sig = inspect.signature(mount_ml_endpoints)
+        params = list(sig.parameters.values())
+        # Positional: nexus, serve_handle
+        assert params[0].name == "nexus"
+        assert params[1].name == "serve_handle"
+        # Keyword-only: prefix with default "/ml"
+        assert params[2].name == "prefix"
+        assert params[2].kind is inspect.Parameter.KEYWORD_ONLY
+        assert params[2].default == "/ml"
+
+    def test_nexus_class_does_not_expose_register_service(self) -> None:
+        """Spec §10 retraction — ``Nexus.register_service`` does NOT exist.
+
+        Per `rules/orphan-detection.md` §3 (Removed = Deleted, Not
+        Deprecated): the legacy ``register_service`` overload was never
+        shipped; if a future refactor reintroduces it, the test forces
+        a re-audit of the cross-SDK contract per
+        `rules/cross-sdk-inspection.md` §3a.
+        """
+        assert not hasattr(Nexus, "register_service"), (
+            "Nexus.register_service was retracted per F-C-26 / spec §10. "
+            "If this attribute is reintroduced, re-derive "
+            "specs/nexus-ml-integration.md §5.1 + §10 + §12 per "
+            "rules/specs-authority.md §5b."
+        )
+
+    def test_inference_server_does_not_expose_as_nexus_service(self) -> None:
+        """Spec §5.1 retraction — ``InferenceServer.as_nexus_service`` does NOT exist.
+
+        The test imports kailash-ml lazily so the file passes when the
+        ``[ml]`` extra is absent. When ml IS installed the assertion
+        runs and locks the absent surface.
+        """
+        try:
+            from kailash_ml.serving.server import InferenceServer
+        except ImportError:
+            pytest.skip("kailash-ml not installed; absent-surface check skipped")
+        assert not hasattr(InferenceServer, "as_nexus_service"), (
+            "InferenceServer.as_nexus_service was retracted per F-C-26 / "
+            "spec §5.1. If reintroduced, re-derive "
+            "specs/nexus-ml-integration.md §5 + §12 per "
+            "rules/specs-authority.md §5b."
+        )
+
+
+# --------------------------------------------------------------------------
+# Tier-2 end-to-end mount path test (real Nexus + real ServeHandle).
+# --------------------------------------------------------------------------
+
+
+class TestMountMlEndpointsEndToEnd:
+    """Spec §5.1 — every request hitting ``POST /ml/predict`` reaches the
+    predictor with ambient tenant/actor propagated from the JWT claims."""
+
+    def test_canonical_mount_propagates_jwt_claims_to_predict(
+        self, nexus_with_ml
+    ) -> None:
+        client, handle = nexus_with_ml
+        token = _make_token(sub="user-w6-009", tenant_id="tenant-canonical")
+        resp = client.post(
+            "/ml/predict",
+            json={"x": 7},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Predictor saw the JWT-derived tenant + actor.
+        assert body["seen_tenant"] == "tenant-canonical"
+        assert body["seen_actor"] == "user-w6-009"
+        # Read-back verification per rules/testing.md § State Persistence:
+        assert len(handle.calls) == 1
+        assert handle.calls[0]["tenant_id"] == "tenant-canonical"
+        assert handle.calls[0]["actor_id"] == "user-w6-009"
+        assert handle.calls[0]["inputs"] == {"x": 7}
+
+    def test_canonical_mount_describe_returns_handle_metadata(
+        self, nexus_with_ml
+    ) -> None:
+        client, _ = nexus_with_ml
+        token = _make_token(sub="meta-reader")
+        resp = client.get(
+            "/ml/describe",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["model"] == "w6-009-canonical-entry"
+        assert body["version"] == "1.0.0"
+
+    def test_canonical_mount_healthz_is_unauthenticated(self, nexus_with_ml) -> None:
+        """Spec §5.2 — healthz is exempt from auth (liveness probe)."""
+        client, _ = nexus_with_ml
+        resp = client.get("/ml/healthz")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"

--- a/specs/nexus-ml-integration.md
+++ b/specs/nexus-ml-integration.md
@@ -231,33 +231,54 @@ Frozen (per PACT MUST Rule 1 discipline) + the scopes tuple is immutable.
 
 ### 5.1 Contract
 
-When `InferenceServer` (kailash-ml) is registered as a Nexus service:
+When a kailash-ml `ServeHandle` (returned by `km.serve(...)` or constructed directly from an `InferenceServer`) is mounted behind Nexus:
 
 ```python
-from kailash_nexus import Nexus
-from kailash_ml import InferenceServer
+from nexus import Nexus
+from nexus.ml import mount_ml_endpoints
+import kailash_ml as km
 
 nexus = Nexus(...)
-server = InferenceServer(model_name="churn_v3")
-nexus.register_service("inference", server.as_nexus_service())
+serve_handle = await km.serve(model_name="churn_v3")
+mount_ml_endpoints(nexus, serve_handle, prefix="/ml")
 ```
 
-Every request hitting `POST /services/inference/predict` MUST:
+Every request hitting `POST /ml/predict` (or the optional MCP / WebSocket variants — see §5.2) MUST:
 
 1. Pass through `JWTMiddleware` (sets `_current_tenant_id`, `_current_actor_id`).
-2. `InferenceServer.as_nexus_service()` wraps its `predict()` handler such that it reads `get_current_tenant_id()` / `get_current_actor_id()` and forwards them into the `predict(request, *, tenant_id=..., actor_id=...)` call.
+2. `mount_ml_endpoints` wraps the registered `ServeHandle.predict` so the handler reads `get_current_tenant_id()` / `get_current_actor_id()` at the request boundary and forwards them as keyword arguments into `predict(inputs, *, tenant_id=..., actor_id=...)` when the predictor's signature accepts them. Predictors that do NOT accept the kwargs still see the propagated tenant via `get_current_tenant_id()` directly through the kailash-ml compat layer (`§2.3`).
 3. The predictor appends the tenant/actor to the inference audit row.
 
-### 5.2 `InferenceServer.as_nexus_service()` API
+### 5.2 `mount_ml_endpoints` API (canonical)
 
 ```python
-# packages/kailash-ml/src/kailash_ml/serving/server.py
-def as_nexus_service(self) -> "NexusServiceAdapter":
-    """Adapter that exposes this InferenceServer as a Nexus service.
-    Propagates ambient tenant_id + actor_id into every predict() call."""
+# packages/kailash-nexus/src/nexus/ml/__init__.py
+def mount_ml_endpoints(
+    nexus: Any,
+    serve_handle: Any,
+    *,
+    prefix: str = "/ml",
+) -> None:
+    """Mount REST + MCP + WebSocket routes for a kailash-ml ``ServeHandle``.
+
+    Routes registered (relative to ``prefix``, default ``/ml``):
+        - ``POST {prefix}/predict``       — REST prediction endpoint
+        - ``GET  {prefix}/describe``      — model metadata (signature, version)
+        - ``GET  {prefix}/healthz``       — liveness probe (no auth)
+        - ``POST {prefix}/mcp/predict``   — MCP-compatible prediction endpoint
+        - WebSocket ``{prefix}/ws``       — streaming predictions (when the
+          underlying Nexus exposes ``register_websocket``)
+    """
 ```
 
-The adapter is a thin wrapper — kailash-ml does NOT take a hard dependency on Nexus. The adapter is only instantiated when `as_nexus_service()` is called, and that method imports Nexus lazily (import-time deferral per `rules/dependencies.md` discipline).
+**Canonical contract** (verified at `packages/kailash-nexus/src/nexus/ml/__init__.py:222`):
+
+- `serve_handle` MUST expose a `predict(inputs, *, tenant_id=None, actor_id=None) -> dict` callable. Predictors whose signatures lack the kwargs are still supported — `mount_ml_endpoints` introspects `inspect.signature(predict)` and only forwards kwargs the callable accepts.
+- `serve_handle` MAY expose `describe() -> dict` for model metadata; absent, `GET {prefix}/describe` returns `{"prefix": prefix}`.
+- The `[ml]` extra is required (`pip install kailash-nexus[ml]`); `mount_ml_endpoints` raises `ImportError` at call time when `kailash_ml` is not installed.
+- WebSocket registration is best-effort: when the Nexus instance exposes `register_websocket`, a class-based `MessageHandler` is registered at `{prefix}/ws` per `skills/03-nexus/nexus-multi-channel.md`. Errors during streaming send a generic `{"error": "prediction failed"}` body without leaking exception details (per `rules/security.md` § Output Encoding).
+
+The mount function is a thin wrapper — kailash-ml does NOT take a hard dependency on Nexus. The Nexus-side import of `kailash_ml` is deferred to call time inside `_require_ml_extra(...)` per `rules/dependencies.md` § "Exception: Optional Extras with Loud Failure".
 
 ### 5.3 Auto-audit
 
@@ -283,9 +304,10 @@ class NexusContextError(NexusError):
     """New. Raised when a caller tries to reset a contextvar with a token
     that doesn't belong to them, or when contextvar state is corrupt."""
 
-class NexusServiceAdapterError(NexusError):
-    """New. Raised when InferenceServer.as_nexus_service() fails to
-    construct (missing optional extra, misconfigured nexus instance)."""
+class NexusMLMountError(NexusError):
+    """New. Raised when ``nexus.ml.mount_ml_endpoints`` cannot register
+    routes (missing ``[ml]`` extra, ``serve_handle`` lacks ``predict``,
+    or the underlying Nexus HTTP transport is uninitialised)."""
 ```
 
 Missing `sub` claim → 401 `invalid_token` (existing behavior in `specs/nexus-auth.md` §9.1).
@@ -307,7 +329,8 @@ File naming:
 
 - `tests/integration/test_jwt_middleware_tenant_propagation_wiring.py` — real FastAPI app + real JWTMiddleware + ML engine reads `get_current_tenant_id()` → matches JWT `tenant_id` claim.
 - `tests/integration/test_dashboard_nexus_auth_wiring.py` — real Nexus instance issues JWT → `MLDashboard(auth="nexus")` validates it → principal carries `actor_id` + `tenant_id`.
-- `tests/integration/test_inference_server_as_nexus_service_wiring.py` — Nexus-served `InferenceServer` → JWT-authenticated request → audit row in the inference audit table carries the JWT's `sub` + `tenant_id`.
+- `tests/integration/test_nexus_ml_endpoints_wiring.py` — Nexus instance + `mount_ml_endpoints` + Protocol-satisfying `ServeHandle` (per `rules/testing.md` § Tier 2 "Protocol-Satisfying Deterministic Adapters") + JWT-authenticated request → assertions: (a) `POST {prefix}/predict` returns 200; (b) the predictor saw the propagated `tenant_id` + `actor_id`; (c) `GET {prefix}/healthz` is reachable without auth; (d) `POST {prefix}/mcp/predict` unwraps the MCP tool envelope; (e) two sequential requests with different JWTs do NOT bleed tenant context.
+- `tests/integration/test_mount_ml_endpoints.py` — Canonical-entry regression locking the shipped public-API shape: (1) `mount_ml_endpoints` signature is exactly `(nexus, serve_handle, *, prefix="/ml") -> None` (structural invariant test per `rules/cross-sdk-inspection.md` §3a); (2) the absent legacy names `Nexus.register_service` and `InferenceServer.as_nexus_service` are NOT present on the Nexus or kailash-ml public surfaces — if a future refactor reintroduces them, the test fails loudly and forces re-audit per `rules/orphan-detection.md` §3.
 
 Each test asserts state persistence per `rules/testing.md` § "State Persistence Verification" — every write is read back.
 
@@ -350,7 +373,7 @@ Cross-SDK follow-up is deferred until kailash-rs scopes a Rust-side Nexus ML inf
 - `JWTMiddleware.__init__` — unchanged.
 - `JWTValidator` — unchanged; constructed directly via `JWTValidator(JWTConfig(...))`. Dashboard reuse runs through `nexus.ml.MLDashboard.from_nexus(nexus)` which extracts the already-configured JWTConfig from the live JWTMiddleware on the Nexus instance.
 - `nexus.ml` — new module: `MLDashboard` auth adapter + `mount_ml_endpoints` helper.
-- `Nexus` — gains `register_service()` overload that accepts a `NexusServiceAdapter` (backward-compatible).
+- `Nexus` — UNCHANGED. The ML serving surface mounts via the standalone helper `nexus.ml.mount_ml_endpoints(nexus, serve_handle)` rather than a method on the `Nexus` class itself. No `register_service()` overload and no `NexusServiceAdapter` class are introduced; the prior draft's mention of those names is RETRACTED in favor of the canonical `mount_ml_endpoints` entry per §5.2.
 
 Users relying on `specs/nexus-auth.md` §9.1 behavior are unaffected. Optional migration: switch from manual `request.state.user.tenant_id` extraction to `get_current_tenant_id()` (simpler, same value, but NOT required).
 
@@ -373,7 +396,7 @@ Part of the kailash-ml 1.0.0 wave release (see `pact-ml-integration-draft.md` §
 - kailash-ml specs consuming this surface:
   - `ml-tracking-draft.md` §10 — `get_current_run()` contextvar (ml-side mirror).
   - `ml-dashboard-draft.md` §5 — `MLDashboard(auth="nexus")`.
-  - `ml-serving-draft.md` — `InferenceServer.as_nexus_service()`.
+  - `ml-serving.md` — `InferenceServer` runtime that produces the `ServeHandle` instance fed to `mount_ml_endpoints` (the bridge module is owned by `nexus-ml-integration.md` §5; ml-serving owns only the runtime).
   - `ml-engines-v2-draft.md` §3 — every engine reads `get_current_tenant_id()` via the compat layer.
 - Nexus companion specs:
   - `specs/nexus-auth.md` §9.1 — JWTMiddleware (unchanged).


### PR DESCRIPTION
## Summary

Closes W5-C finding F-C-26. Spec advertised \`nexus.register_service()\` + \`InferenceServer.as_nexus_service()\`; code uses \`mount_ml_endpoints()\`. Reconciled to single canonical path.

## Mount signature (verified)

\`mount_ml_endpoints(nexus, serve_handle, *, prefix="/ml") -> None\`
Routes: POST /ml/predict, GET /ml/describe, GET /ml/healthz, POST /ml/mcp/predict, WS /ml/ws

## Changes

- Spec § 4 canonicalized; absent surfaces removed
- Tier-2 test \`tests/integration/test_mount_ml_endpoints.py\` (7 tests, 2.09s)
- \`pytest.ini\` registers \`regression\` marker (closes pre-existing PytestUnknownMarkWarning per zero-tolerance Rule 1)

## Sibling re-derivation

\`grep\` across all specs for absent symbols returns only nexus-ml-integration.md — no cross-spec drift.

## Test plan

- [x] 7/7 Tier-2 tests pass
- [x] 2256 tests collect (exit 0), 0 warnings
- [x] Pyright clean (Optional[FastAPI] narrowed with typed assert per zero-tolerance §3a)
- [x] Structural invariant tests lock the absent-surface contract

## Related

- Closes F-C-26; Wave 6 todo W6-009

🤖 Generated with [Claude Code](https://claude.com/claude-code)