### PR TITLE
feat(ml): W6-013 — implement CatBoostTrainable adapter

### DIFF
--- a/packages/kailash-ml/src/kailash_ml/__init__.py
+++ b/packages/kailash-ml/src/kailash_ml/__init__.py
@@ -140,6 +140,7 @@ from kailash_ml.estimators import (
     unregister_estimator,
 )
 from kailash_ml.trainable import (
+    CatBoostTrainable,
     HDBSCANTrainable,
     LightGBMTrainable,
     LightningTrainable,
@@ -658,6 +659,7 @@ __all__ = [
     "SklearnTrainable",
     "XGBoostTrainable",
     "LightGBMTrainable",
+    "CatBoostTrainable",
     "TorchTrainable",
     "LightningTrainable",
     "UMAPTrainable",
@@ -717,6 +719,7 @@ _ = (
     register_estimator,
     registered_estimators,
     unregister_estimator,
+    CatBoostTrainable,
     HDBSCANTrainable,
     LightGBMTrainable,
     LightningTrainable,

--- a/packages/kailash-ml/src/kailash_ml/engine.py
+++ b/packages/kailash-ml/src/kailash_ml/engine.py
@@ -302,6 +302,8 @@ _FAMILY_ALIASES = {
     "xgboost": "xgboost",
     "lgbm": "lightgbm",
     "lightgbm": "lightgbm",
+    "catboost": "catboost",
+    "cb": "catboost",
     "torch": "torch",
     "pytorch": "torch",
     "lightning": "lightning",
@@ -333,6 +335,8 @@ def _build_trainable_from_family(family: str, *, target: str) -> Any:
         return _tr.XGBoostTrainable(target=target)
     if canonical == "lightgbm":
         return _tr.LightGBMTrainable(target=target)
+    if canonical == "catboost":
+        return _tr.CatBoostTrainable(target=target)
     if canonical == "torch":
         raise ValueError(
             "family='torch' requires `trainable=TorchTrainable(model=…, "

--- a/packages/kailash-ml/src/kailash_ml/trainable.py
+++ b/packages/kailash-ml/src/kailash_ml/trainable.py
@@ -64,6 +64,7 @@ __all__ = [
     "SklearnTrainable",
     "XGBoostTrainable",
     "LightGBMTrainable",
+    "CatBoostTrainable",
     "TorchTrainable",
     "LightningTrainable",
     "UMAPTrainable",
@@ -1671,6 +1672,290 @@ class LightGBMTrainable:
     def predict(self, X: pl.DataFrame) -> Predictions:
         if not self._is_fitted:
             raise RuntimeError("LightGBMTrainable.predict() called before fit().")
+        frame = (
+            X.select([c for c in self._feature_names if c in X.columns])
+            if self._feature_names
+            else X
+        )
+        preds = self._estimator.predict(frame.to_numpy())
+        return Predictions(preds, column="prediction", device=self._last_device_report)
+
+
+# ---------------------------------------------------------------------------
+# CatBoostTrainable (W6-013 / F-E1-01 — Phase 1 family adapter)
+# ---------------------------------------------------------------------------
+
+
+class CatBoostTrainable:
+    """Wraps catboost's sklearn-style estimator as a Trainable.
+
+    Per ``specs/ml-engines-v2.md §3`` + ``ml-engines-v2-addendum.md``
+    Classical-ML surface, CatBoost is one of the four non-Torch
+    Phase-1 families (sklearn / xgboost / lightgbm / catboost). The
+    ``[catboost]`` extra ships in ``pyproject.toml``; importing this
+    adapter without the extra raises :class:`ImportError` with an
+    actionable message naming the extra (per
+    ``rules/dependencies.md`` § "Optional Extras with Loud Failure").
+
+    Device mapping per ``ml-backends.md`` §5 + CatBoost docs:
+
+    - backend == "cuda" → ``task_type="GPU"`` + ``devices="0"``
+    - backend == "cpu"  → ``task_type="CPU"``
+    - backend in {"mps", "rocm", "xpu", "tpu"} → ``UnsupportedFamily``
+
+    CatBoost's iterative boosting fit runs in
+    ``on_train_start`` of the LightningModule wrapper, mirroring the
+    XGBoost/LightGBM pattern (Lightning Hard Lock-In, Decision 8).
+    """
+
+    family_name = "catboost"
+    _SUPPORTED_BACKENDS = ("cuda", "cpu")
+
+    def __init__(
+        self,
+        estimator: Any = None,
+        *,
+        target: str = "target",
+        task: str = "classification",
+        **kwargs: Any,
+    ) -> None:
+        if estimator is None:
+            try:
+                import catboost as _cb
+            except ImportError as exc:  # pragma: no cover — exercised w/o extra
+                raise ImportError(
+                    "CatBoostTrainable requires the [catboost] extra: "
+                    "pip install kailash-ml[catboost]"
+                ) from exc
+
+            if task == "classification":
+                defaults = {
+                    "iterations": 20,
+                    "depth": 3,
+                    "random_seed": 42,
+                    "verbose": False,
+                }
+                defaults.update(kwargs)
+                estimator = _cb.CatBoostClassifier(**defaults)
+            else:
+                defaults = {
+                    "iterations": 20,
+                    "depth": 3,
+                    "random_seed": 42,
+                    "verbose": False,
+                }
+                defaults.update(kwargs)
+                estimator = _cb.CatBoostRegressor(**defaults)
+        self._estimator = estimator
+        self._target = target
+        self._task = task
+        self._is_fitted = False
+        self._last_module: Any = None
+        self._last_device_report: Optional[DeviceReport] = None
+        self._feature_names: tuple[str, ...] = ()
+
+    @property
+    def model(self) -> Any:
+        """Fitted model handle per W33c / `ml-registry.md` §5.6.1.
+
+        For CatBoost the model IS the sklearn-compatible estimator.
+        """
+        return self._estimator
+
+    def to_lightning_module(self) -> Any:
+        if self._last_module is None:
+            raise RuntimeError(
+                "CatBoostTrainable.to_lightning_module() called before fit(). "
+                "Call fit(data) first."
+            )
+        return self._last_module
+
+    def get_param_distribution(self) -> HyperparameterSpace:
+        return HyperparameterSpace(
+            params=(
+                HyperparameterRange(name="iterations", kind="int", low=10, high=500),
+                HyperparameterRange(name="depth", kind="int", low=2, high=10),
+                HyperparameterRange(
+                    name="learning_rate", kind="log_float", low=1e-3, high=1.0
+                ),
+            )
+        )
+
+    def fit(
+        self,
+        data: pl.DataFrame,
+        *,
+        hyperparameters: Optional[Mapping[str, Any]] = None,
+        context: Optional[TrainingContext] = None,
+    ) -> TrainingResult:
+        import lightning.pytorch as pl_trainer
+
+        ctx = _effective_context(context)
+
+        # Device mapping per ml-backends.md §5 — enforce supported
+        # backend BEFORE any training call. Raises UnsupportedFamily on
+        # MPS / ROCm / XPU / TPU with an actionable message.
+        if ctx.backend not in self._SUPPORTED_BACKENDS:
+            raise UnsupportedFamily(
+                f"catboost cannot run on backend '{ctx.backend}'. "
+                f"catboost supports only {list(self._SUPPORTED_BACKENDS)}. "
+                f"Use accelerator='cpu' or install on a CUDA host; or select "
+                f"a different family (lightgbm supports CUDA+ROCm; torch "
+                f"supports all 6 backends).",
+                family=self.family_name,
+                backend=ctx.backend,
+                supported_backends_for_family=self._SUPPORTED_BACKENDS,
+            )
+
+        if hyperparameters:
+            for k, v in hyperparameters.items():
+                if hasattr(self._estimator, k):
+                    try:
+                        self._estimator.set_params(**{k: v})
+                    except Exception:  # noqa: BLE001 — fall back to attribute set
+                        setattr(self._estimator, k, v)
+
+        # Set CatBoost task_type per §5 (CatBoost idiom). The set_params
+        # call may fail on builds without GPU support — surface as
+        # UnsupportedFamily on the GPU path; tolerate on the CPU path
+        # (the default task_type is already CPU).
+        cb_task_type = "GPU" if ctx.backend == "cuda" else "CPU"
+        if cb_task_type == "GPU":
+            try:
+                self._estimator.set_params(task_type="GPU", devices="0")
+            except Exception as exc:  # noqa: BLE001
+                raise UnsupportedFamily(
+                    f"catboost GPU support not present in the installed build "
+                    f"(requested backend='{ctx.backend}'). "
+                    f"Install a GPU-capable build of catboost, or use "
+                    f"accelerator='cpu'.",
+                    family=self.family_name,
+                    backend=ctx.backend,
+                    supported_backends_for_family=("cpu",),
+                ) from exc
+        else:
+            try:
+                self._estimator.set_params(task_type="CPU")
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "catboost.device.set_failed",
+                    extra={"cb_task_type": "CPU", "family": self.family_name},
+                )
+
+        X, y, feature_names = _split_xy(data, self._target)
+        self._feature_names = feature_names
+        metric_name, metric_fn = _resolve_metric("auto", y, task_hint=self._task)
+        module = _make_single_epoch_module(
+            self._estimator,
+            X,
+            y,
+            metric_name=metric_name,
+            metric_fn=metric_fn,
+            module_name="CatBoostLightningAdapter",
+        )
+
+        trainer_kwargs = _log_backend_selection(ctx, max_epochs=1)
+        trainer = pl_trainer.Trainer(**trainer_kwargs)
+
+        # OOM fallback: GPU OOM on the catboost path MUST degrade to CPU
+        # with a WARN log mirroring xgboost / lightgbm (revised-stack.md
+        # § "No-config contract"). Non-OOM exceptions re-raise unchanged
+        # per zero-tolerance.md Rule 3 (no silent swallow).
+        fallback_reason: Optional[str] = None
+        effective_ctx = ctx
+        effective_trainer_kwargs = trainer_kwargs
+        t0 = time.monotonic()
+        try:
+            trainer.fit(module)
+        except Exception as exc:
+            if ctx.backend == "cpu" or not _is_gpu_oom_error(exc):
+                raise
+            logger.warning(
+                "catboost.gpu.oom_fallback",
+                extra={
+                    "family": self.family_name,
+                    "requested_backend": ctx.backend,
+                    "fallback_backend": "cpu",
+                    "fallback_reason": "oom",
+                    "error_class": type(exc).__name__,
+                },
+            )
+            fallback_reason = "oom"
+            # Re-point catboost at CPU before the retry so the inner fit
+            # inside on_train_start actually runs on CPU.
+            try:
+                self._estimator.set_params(task_type="CPU")
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "catboost.device.set_failed",
+                    extra={
+                        "cb_task_type": "CPU",
+                        "family": self.family_name,
+                    },
+                )
+            cpu_ctx = TrainingContext(
+                accelerator="cpu",
+                precision="32-true",
+                devices=1,
+                device_string="cpu",
+                backend="cpu",
+                tenant_id=ctx.tenant_id,
+                tracker_run_id=ctx.tracker_run_id,
+                trial_number=ctx.trial_number,
+            )
+            cpu_module = _make_single_epoch_module(
+                self._estimator,
+                X,
+                y,
+                metric_name=metric_name,
+                metric_fn=metric_fn,
+                module_name="CatBoostLightningAdapter",
+            )
+            cpu_trainer_kwargs = _log_backend_selection(cpu_ctx, max_epochs=1)
+            cpu_trainer = pl_trainer.Trainer(**cpu_trainer_kwargs)
+            cpu_trainer.fit(cpu_module)
+            module = cpu_module
+            effective_ctx = cpu_ctx
+            effective_trainer_kwargs = cpu_trainer_kwargs
+        elapsed = time.monotonic() - t0
+
+        self._is_fitted = True
+        self._last_module = module
+
+        artifact_uri = _persist_native_artifact(
+            self._estimator, prefix="catboost", format="pickle"
+        )
+
+        device_report = DeviceReport(
+            family=self.family_name,
+            backend=effective_ctx.backend,
+            device_string=effective_ctx.device_string,
+            precision=effective_ctx.precision,
+            fallback_reason=fallback_reason,
+            array_api=False,
+        )
+        self._last_device_report = device_report
+
+        return TrainingResult(
+            model_uri=f"models://{self.family_name}/{uuid.uuid4().hex[:8]}",
+            metrics={metric_name: module.metric},
+            device_used=effective_ctx.device_string,
+            accelerator=effective_ctx.accelerator,
+            precision=effective_ctx.precision,
+            elapsed_seconds=elapsed,
+            tracker_run_id=effective_ctx.tracker_run_id,
+            tenant_id=effective_ctx.tenant_id,
+            artifact_uris={"native": artifact_uri},
+            lightning_trainer_config=effective_trainer_kwargs,
+            family=self.family_name,
+            hyperparameters=dict(hyperparameters or {}),
+            device=device_report,
+            trainable=self,
+        )
+
+    def predict(self, X: pl.DataFrame) -> Predictions:
+        if not self._is_fitted:
+            raise RuntimeError("CatBoostTrainable.predict() called before fit().")
         frame = (
             X.select([c for c in self._feature_names if c in X.columns])
             if self._feature_names

--- a/packages/kailash-ml/tests/integration/test_catboost_trainable_real.py
+++ b/packages/kailash-ml/tests/integration/test_catboost_trainable_real.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""W6-013 Tier-2 integration test — CatBoostTrainable end-to-end.
+
+Per ``rules/testing.md`` § Tier 2: NO mocking. The test gates on
+the ``[catboost]`` extra (``pytest.importorskip("catboost")``) and
+exercises the full ``Trainable`` contract — construction → fit →
+predict → TrainingResult — against a real CatBoost estimator
+through the Lightning-routed single-epoch wrapper.
+
+Per ``rules/orphan-detection.md`` §2 every wired manager / family
+adapter MUST have at least one Tier 2 test that imports through
+the framework facade and asserts the externally-observable effect
+(fitted model, populated TrainingResult fields). This test fills
+that role for ``CatBoostTrainable``.
+
+Skipped on darwin-arm + py3.13 mirroring the existing onnx
+roundtrip matrix (``test_engine_register_onnx_matrix.py``) where
+catboost + onnx deps are unstable on that host.
+"""
+from __future__ import annotations
+
+import platform
+import sys
+
+import pytest
+
+# Tier-2 gating — extras + heavy deps + polars are required.
+pytest.importorskip("catboost")
+pytest.importorskip("lightning.pytorch")
+pytest.importorskip("polars")
+
+# Mirror the host-skip gate from test_engine_register_onnx_matrix.py.
+_SEGFAULT_HOST = (
+    sys.platform == "darwin"
+    and platform.machine() == "arm64"
+    and sys.version_info[:2] >= (3, 13)
+)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    _SEGFAULT_HOST,
+    reason=(
+        "catboost + lightning unstable on darwin-arm + py3.13; "
+        "Tier 2 coverage runs on Linux CI."
+    ),
+)
+def test_catboost_trainable_fit_predict_classification_round_trip() -> None:
+    """End-to-end: construct → fit → predict on a small classifier task.
+
+    Asserts:
+
+    1. ``TrainingResult.family == 'catboost'``
+    2. ``TrainingResult.device`` is populated (W8 invariant 7).
+    3. ``TrainingResult.trainable`` back-reference is the adapter
+       (W33b ``km.train → km.register`` handoff).
+    4. ``TrainingResult.metrics`` contains an accuracy value > 0.5
+       (sanity — separable synthetic data).
+    5. ``predict()`` returns Predictions with the same length as inputs.
+    """
+    import numpy as np
+    import polars as pl
+    from sklearn.datasets import make_classification
+
+    from kailash_ml import CatBoostTrainable
+
+    X, y = make_classification(
+        n_samples=120,
+        n_features=6,
+        n_informative=4,
+        n_redundant=1,
+        random_state=42,
+    )
+    df = pl.DataFrame({f"x{i}": X[:, i].astype(np.float32) for i in range(X.shape[1])})
+    df = df.with_columns(pl.Series("y", y.astype(np.int64)))
+
+    trainable = CatBoostTrainable(
+        target="y",
+        task="classification",
+        iterations=10,
+        depth=3,
+        random_seed=42,
+        verbose=False,
+    )
+
+    result = trainable.fit(df, hyperparameters=None, context=None)
+
+    assert result.family == "catboost"
+    assert result.device is not None, (
+        "TrainingResult.device MUST be populated per W8 invariant 7 "
+        "(every TrainingResult return site passes device=)."
+    )
+    assert result.device.family == "catboost"
+    assert result.trainable is trainable, (
+        "TrainingResult.trainable back-reference MUST point at the adapter "
+        "for the km.train → km.register handoff (W33b regression)."
+    )
+
+    # Accuracy on the training data should be well above chance for a
+    # 10-iteration CatBoost on separable synthetic data.
+    metrics = result.metrics
+    assert metrics, f"expected non-empty metrics, got {metrics!r}"
+    metric_value = next(iter(metrics.values()))
+    assert metric_value > 0.5, f"expected accuracy > 0.5, got {metric_value}"
+
+    # Predict round-trip — same row count.
+    preds = trainable.predict(df)
+    assert preds is not None
+    raw = preds.raw
+    assert len(raw) == len(df)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    _SEGFAULT_HOST,
+    reason=(
+        "catboost + lightning unstable on darwin-arm + py3.13; "
+        "Tier 2 coverage runs on Linux CI."
+    ),
+)
+def test_catboost_trainable_fit_regression_round_trip() -> None:
+    """Regression task — task='regression' constructs CatBoostRegressor."""
+    import numpy as np
+    import polars as pl
+    from sklearn.datasets import make_regression
+
+    from kailash_ml import CatBoostTrainable
+
+    X, y = make_regression(
+        n_samples=120,
+        n_features=6,
+        n_informative=4,
+        noise=0.5,
+        random_state=42,
+    )
+    df = pl.DataFrame({f"x{i}": X[:, i].astype(np.float32) for i in range(X.shape[1])})
+    df = df.with_columns(pl.Series("y", y.astype(np.float32)))
+
+    trainable = CatBoostTrainable(
+        target="y",
+        task="regression",
+        iterations=10,
+        depth=3,
+        random_seed=42,
+        verbose=False,
+    )
+
+    result = trainable.fit(df, hyperparameters=None, context=None)
+
+    assert result.family == "catboost"
+    assert result.trainable is trainable
+    assert result.metrics, "expected at least one regression metric (r2)"
+
+    # The default classifier is a CatBoostClassifier; for task='regression'
+    # the constructor should have built a CatBoostRegressor.
+    estimator_cls = type(trainable.model).__name__
+    assert (
+        estimator_cls == "CatBoostRegressor"
+    ), f"task='regression' should yield CatBoostRegressor, got {estimator_cls}"
+
+
+@pytest.mark.integration
+def test_catboost_trainable_resolves_through_engine_family_alias() -> None:
+    """family='catboost' on MLEngine resolves to a CatBoostTrainable instance.
+
+    Walks the same dispatch path the public ``km.train(family='catboost')``
+    surface uses, ensuring the W6-013 wire reaches end-users (not just an
+    isolated import). Construction-only — does NOT call fit() — so the
+    darwin-arm + py3.13 segfault host gate does not apply.
+    """
+    from kailash_ml import CatBoostTrainable
+    from kailash_ml.engine import _build_trainable_from_family
+
+    trainable = _build_trainable_from_family("catboost", target="label")
+    assert isinstance(trainable, CatBoostTrainable)
+    assert trainable.family_name == "catboost"

--- a/packages/kailash-ml/tests/unit/test_catboost_trainable.py
+++ b/packages/kailash-ml/tests/unit/test_catboost_trainable.py
@@ -1,0 +1,192 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""W6-013 Tier-1 unit tests — CatBoostTrainable adapter.
+
+Per ``specs/ml-engines-v2-addendum.md`` § Classical-ML surface +
+``specs/ml-engines.md`` §3 (Trainable protocol). These tests cover
+the structural contract — protocol conformance, family identifier,
+device mapping behaviour for unsupported backends, and the import-
+gated extra contract — without requiring the catboost extra.
+
+Tier-2 coverage that exercises a real fit / predict round-trip
+against the [catboost] extra lives at
+``tests/integration/test_catboost_trainable_real.py`` (skipped when
+the extra is absent).
+"""
+from __future__ import annotations
+
+import pytest
+
+from kailash_ml import CatBoostTrainable, Trainable
+
+# CatBoostTrainable raises kailash_ml._device.UnsupportedFamily — the
+# canonical UnsupportedFamily lives in `_device.py` (and is re-exported
+# via `kailash_ml.errors` as part of the MLError hierarchy, but the
+# concrete class identity differs from the public namespace re-export).
+# Match the actual raise site.
+from kailash_ml._device import UnsupportedFamily
+from kailash_ml.trainable import TrainingContext
+
+
+# ---------------------------------------------------------------------------
+# Importability + protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_catboost_trainable_is_importable_from_top_level() -> None:
+    """``from kailash_ml import CatBoostTrainable`` MUST resolve."""
+    assert CatBoostTrainable is not None
+
+
+def test_catboost_trainable_in_canonical_all() -> None:
+    """``CatBoostTrainable`` MUST appear in ``kailash_ml.__all__`` Group 2."""
+    import kailash_ml
+
+    assert "CatBoostTrainable" in kailash_ml.__all__
+
+
+def test_catboost_trainable_family_name() -> None:
+    """The class MUST advertise ``family_name = 'catboost'``."""
+    assert CatBoostTrainable.family_name == "catboost"
+
+
+def test_catboost_trainable_satisfies_trainable_protocol() -> None:
+    """An instance MUST satisfy the runtime-checkable Trainable Protocol.
+
+    Construction without the extra raises ImportError, so we use a
+    Protocol-Satisfying stub (Tier-1 acceptable per
+    ``rules/testing.md`` § "Protocol Adapters") to verify the class
+    declares the required surface.
+    """
+    # The class MUST declare every Protocol method.
+    for method in (
+        "fit",
+        "predict",
+        "to_lightning_module",
+        "get_param_distribution",
+    ):
+        assert hasattr(
+            CatBoostTrainable, method
+        ), f"CatBoostTrainable missing required method: {method}"
+
+
+# ---------------------------------------------------------------------------
+# Device mapping — UnsupportedFamily on non-catboost backends
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["mps", "rocm", "xpu", "tpu"])
+def test_catboost_trainable_rejects_unsupported_backend(backend: str) -> None:
+    """fit() on MPS / ROCm / XPU / TPU MUST raise UnsupportedFamily.
+
+    The error MUST name the family + requested backend + supported
+    fallback list per ``ml-backends.md`` §5.
+    """
+    pytest.importorskip("catboost")  # need an estimator to construct
+    pytest.importorskip("polars")
+
+    import polars as pl
+
+    trainable = CatBoostTrainable(target="y", iterations=2)
+    df = pl.DataFrame(
+        {
+            "x0": [0.1, 0.2, 0.3, 0.4],
+            "x1": [1.0, 0.5, 0.0, -0.5],
+            "y": [0, 1, 0, 1],
+        }
+    )
+    ctx = TrainingContext(
+        accelerator="cpu",
+        precision="32-true",
+        devices=1,
+        device_string="cpu",
+        backend=backend,
+    )
+
+    with pytest.raises(UnsupportedFamily) as excinfo:
+        trainable.fit(df, hyperparameters=None, context=ctx)
+
+    err = excinfo.value
+    msg = str(err)
+    assert "catboost" in msg.lower()
+    assert backend in msg
+    # Pointer to fallback families per the contract.
+    assert "torch" in msg.lower() or "cuda" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# Hyperparameter search space surface
+# ---------------------------------------------------------------------------
+
+
+def test_catboost_trainable_hyperparameter_space_is_non_empty() -> None:
+    """``get_param_distribution()`` MUST return a non-empty HyperparameterSpace.
+
+    Per ``specs/ml-engines.md`` §3.2 MUST 3 — empty OK, ``None`` not.
+    The CatBoost adapter exposes iterations / depth / learning_rate.
+    """
+    pytest.importorskip("catboost")
+    trainable = CatBoostTrainable(target="y", iterations=2)
+    space = trainable.get_param_distribution()
+    assert space is not None
+    assert not space.is_empty()
+    names = set(space.names())
+    assert {"iterations", "depth", "learning_rate"} <= names
+
+
+# ---------------------------------------------------------------------------
+# to_lightning_module() refuses before fit
+# ---------------------------------------------------------------------------
+
+
+def test_to_lightning_module_before_fit_raises() -> None:
+    """Calling to_lightning_module() before fit() MUST raise RuntimeError."""
+    pytest.importorskip("catboost")
+    trainable = CatBoostTrainable(target="y", iterations=2)
+    with pytest.raises(RuntimeError, match="before fit"):
+        trainable.to_lightning_module()
+
+
+def test_predict_before_fit_raises() -> None:
+    """Calling predict() before fit() MUST raise RuntimeError."""
+    pytest.importorskip("catboost")
+    pytest.importorskip("polars")
+    import polars as pl
+
+    trainable = CatBoostTrainable(target="y", iterations=2)
+    with pytest.raises(RuntimeError, match="before fit"):
+        trainable.predict(pl.DataFrame({"x0": [0.1]}))
+
+
+# ---------------------------------------------------------------------------
+# Engine family-alias dispatch wiring (W6-013 invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_engine_family_alias_resolves_catboost() -> None:
+    """family='catboost' MUST resolve through MLEngine._build_trainable_from_family()."""
+    pytest.importorskip("catboost")
+    from kailash_ml.engine import _build_trainable_from_family
+
+    trainable = _build_trainable_from_family("catboost", target="label")
+    assert isinstance(trainable, CatBoostTrainable)
+    assert trainable.family_name == "catboost"
+
+
+def test_engine_family_alias_cb_short_form() -> None:
+    """The short alias 'cb' MUST resolve to CatBoostTrainable."""
+    pytest.importorskip("catboost")
+    from kailash_ml.engine import _build_trainable_from_family
+
+    trainable = _build_trainable_from_family("cb", target="label")
+    assert isinstance(trainable, CatBoostTrainable)
+
+
+def test_catboost_trainable_in_runtime_checkable_protocol() -> None:
+    """An instantiated CatBoostTrainable MUST satisfy isinstance(t, Trainable).
+
+    Per ``specs/ml-engines.md`` §3.1 + W8 invariant 1 — runtime-checkable.
+    """
+    pytest.importorskip("catboost")
+    trainable = CatBoostTrainable(target="y", iterations=2)
+    assert isinstance(trainable, Trainable)

--- a/packages/kailash-ml/tests/unit/test_km_all_ordering.py
+++ b/packages/kailash-ml/tests/unit/test_km_all_ordering.py
@@ -7,7 +7,8 @@ MUST be organised into 6 groups in the exact order documented there.
 Group 1 is ``track, autolog, train, diagnose, register, serve, watch,
 dashboard, seed, reproduce, resume, lineage, rl_train`` (13 entries
 per §15.9) plus ``erase_subject`` per W15 FP-MED-2 → 14. Groups 2-6
-sum to 27 (15 + 5 + 2 + 3 + 2). Total: 41.
+sum to 27 (15 + 5 + 2 + 3 + 2). Total: 41 + 7 Phase-1 Trainable
+adapters + ``CatBoostTrainable`` (W6-013) = 49.
 
 This test locks the ordering so a future refactor that silently
 reorders the list — or drops one of the canonical verbs — fails
@@ -43,6 +44,7 @@ EXPECTED_GROUP_2 = (
     "SklearnTrainable",
     "XGBoostTrainable",
     "LightGBMTrainable",
+    "CatBoostTrainable",
     "TorchTrainable",
     "LightningTrainable",
     "UMAPTrainable",
@@ -83,10 +85,14 @@ EXPECTED_ALL = (
 
 
 def test_all_has_expected_total_symbol_count() -> None:
-    """``__all__`` MUST have exactly 48 symbols (40 §15.9 + erase_subject + 7 Phase-1 adapters)."""
-    assert len(kailash_ml.__all__) == 48, (
-        f"expected 48 symbols (§15.9 40 + W15 erase_subject + 7 ml-engines.md §3.0 adapters), "
-        f"got {len(kailash_ml.__all__)}: {kailash_ml.__all__}"
+    """``__all__`` MUST have exactly 49 symbols.
+
+    40 §15.9 + W15 ``erase_subject`` + 7 Phase-1 Trainable adapters +
+    ``CatBoostTrainable`` (W6-013 / F-E1-01).
+    """
+    assert len(kailash_ml.__all__) == 49, (
+        f"expected 49 symbols (§15.9 40 + W15 erase_subject + 7 ml-engines.md §3.0 adapters "
+        f"+ CatBoostTrainable W6-013), got {len(kailash_ml.__all__)}: {kailash_ml.__all__}"
     )
 
 


### PR DESCRIPTION
## Summary

Closes W5-E1 finding F-E1-01. \`CatBoostTrainable\` implemented per \`specs/ml-engines-v2-addendum.md\` Classical-ML surface. Mirrors LightGBM/XGBoost adapter pattern.

## Trainable methods

\`fit\`, \`predict\`, \`get_param_distribution\`, \`to_lightning_module\`, \`family_name = "catboost"\`, \`model\` property. Engine \`_FAMILY_ALIASES\` extended with \`catboost\`/\`cb\`. Eager-imported into \`__all__\` (count 48 → 49) per orphan-detection §6.

## Test plan

- [x] 14/14 unit tests pass
- [x] 1 integration test pass; 2 skip on darwin-arm + py3.13 (gated)
- [x] 9/9 ordering invariants pass with new count
- [x] 4/4 W8 device-kwarg parity invariant holds
- [x] 2,437 tests collect cleanly

## Coordination

W5 ml batch — W6-015 owns version files. This PR did NOT touch \`pyproject.toml\` / \`__version__\` / \`CHANGELOG.md\`.

## Related

- Closes F-E1-01; Wave 6 todo W6-013

🤖 Generated with [Claude Code](https://claude.com/claude-code)