### PR TITLE
release(kailash-ml v1.4.2): atomic version bump for __version__ in __all__ addition

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,20 @@
 # kailash-ml Changelog
 
+## [1.4.2] — 2026-04-27 — W6 round-3 MED-1 catch-up: `__version__` in canonical `__all__`
+
+Atomic version bump to pair with the public-API addition landed in PR #674
+(commit `6e106d13`). Per `rules/zero-tolerance.md` Rule 5, version must be
+bumped atomically with the public-API surface change — that bump was missed
+at merge time and is caught up here.
+
+### Added
+
+- **`__version__` in canonical `__all__`** (Group 0 — Package metadata) —
+  `from kailash_ml import *` now exports the package version string per
+  `rules/orphan-detection.md` §6 (every eagerly-imported module-scope symbol
+  MUST appear in `__all__`). Closes W6 round-3 finding MED-1. Landed in PR #674
+  (commit `6e106d13`); version bump caught up in this release.
+
 ## [1.4.1] — 2026-04-27 — W8 wave: FeatureStore wiring test + spec hygiene
 
 Bundles two Wave 6 follow-ups (W6-022 + W6-023) into one W8-wave

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "1.4.1"
+version = "1.4.2"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "1.4.1"
+__version__ = "1.4.2"


### PR DESCRIPTION
## Summary

- Atomically bumps `kailash-ml` from `1.4.1` → `1.4.2` in all three required locations (`pyproject.toml`, `_version.py`, `CHANGELOG.md`) per `rules/zero-tolerance.md` Rule 5.
- The public-API change (`__version__` added to canonical `__all__` Group 0) landed in PR #674 (commit `6e106d13`) but the version bump was not included at that time; this release-prep PR catches it up.

## Version locations updated

- `packages/kailash-ml/pyproject.toml` → `version = "1.4.2"`
- `packages/kailash-ml/src/kailash_ml/_version.py` → `__version__ = "1.4.2"`
- `packages/kailash-ml/CHANGELOG.md` → new `[1.4.2]` entry

## Related issues

Closes W6 round-3 MED-1 catch-up. Paired version bump for PR #674.