### PR TITLE
release(kailash v2.11.3): ship ML error classes missed in v2.11.2 wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.3] — 2026-04-27 — Patch: ML error classes missed in v2.11.2 wheel (W6-014, W6-020)
+
+Patch bump — ships two `kailash.ml.errors` additions that were committed to main after
+the `v2.11.2` tag and therefore absent from the published wheel. Required by `kailash-ml
+1.4.2` at import time.
+
+### Added
+
+- **`LineageNotImplementedError(TrackingError)`** — raised by `km.lineage(...)` while the
+  cross-engine LineageGraph surface is deferred to Wave 6.5b. Typed error allows callers
+  to distinguish "not yet implemented" from generic failure. Added in commit `56fe3f7a`
+  (W6-014).
+- **`MigrationRequiredError(MLError)`** — raised by an engine's hot path when a required
+  schema object (table/column/index) is absent, indicating the operator has not run the
+  corresponding numbered migration. Distinct from `MigrationFailedError` and
+  `MigrationImportError`. Added in commit `f5127b15` (W6-020).
+
 ## [2.11.2] — 2026-04-26 — JWT security hardening (#635 + #636, Wave 5 audit)
 
 Patch bump — closes two security findings surfaced by Wave 5 portfolio spec audit (workspace `portfolio-spec-audit/04-validate/W5-C-findings.md`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.11.2"
+version = "2.11.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.11.2"
+__version__ = "2.11.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Patch release — ships two `kailash.ml.errors` additions that were committed after the `v2.11.2` tag and were absent from the published wheel, causing `ImportError` in `kailash-ml 1.4.2` on clean install.

## Root cause

`LineageNotImplementedError` (commit `56fe3f7a`, W6-014) and `MigrationRequiredError` (commit `f5127b15`, W6-020) were added to `src/kailash/ml/errors.py` after the `v2.11.2` tag was pushed. The published PyPI wheel for kailash 2.11.2 does not contain them. kailash-ml 1.4.2 imports both at module load; every clean `pip install kailash-ml==1.4.2` fails with `ImportError: cannot import name 'LineageNotImplementedError'`.

## Changes

- `pyproject.toml`: `2.11.2` → `2.11.3`
- `src/kailash/__init__.py`: `__version__` → `"2.11.3"`
- `CHANGELOG.md`: add `[2.11.3]` entry

## Related issues

Unblocks: kailash-ml 1.4.2 clean-venv install verification (release pipeline continuation)