### PR TITLE
fix(dataflow): repair not_null_handler test mock-method drift

### DIFF
--- a/packages/kailash-dataflow/tests/unit/migrations/test_not_null_column_addition.py
+++ b/packages/kailash-dataflow/tests/unit/migrations/test_not_null_column_addition.py
@@ -15,6 +15,7 @@ from decimal import Decimal
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
 from dataflow.migrations.constraint_validator import (
     CheckConstraint,
     ConstraintValidationResult,
@@ -824,11 +825,14 @@ class TestNotNullColumnHandler:
         assert result.result == AdditionResult.SUCCESS
         assert result.affected_rows == 1000
 
-        # Verify SQL was executed
+        # Verify SQL was executed.
+        # NOTE: per rules/dataflow-identifier-safety.md MUST Rule 1, table and
+        # column identifiers route through dialect.quote_identifier() before
+        # interpolation, producing the quoted forms in the emitted DDL.
         self.mock_connection.execute.assert_called_once()
         call_args = self.mock_connection.execute.call_args[0][0]
-        assert "ALTER TABLE test_table" in call_args
-        assert "ADD COLUMN status VARCHAR(50)" in call_args
+        assert 'ALTER TABLE "test_table"' in call_args
+        assert 'ADD COLUMN "status" VARCHAR(50)' in call_args
         assert "NOT NULL DEFAULT 'active'" in call_args
 
 
@@ -909,9 +913,9 @@ class TestIntegrationScenarios:
             strategy_type, reason = self.strategy_manager.recommend_strategy(
                 case["column"], case["table_info"]
             )
-            assert strategy_type == case["expected"], (
-                f"Failed for {case['column'].name}: got {strategy_type}, expected {case['expected']}"
-            )
+            assert (
+                strategy_type == case["expected"]
+            ), f"Failed for {case['column'].name}: got {strategy_type}, expected {case['expected']}"
 
     def test_validation_result_aggregation(self):
         """Test aggregation of validation results from multiple components."""

--- a/packages/kailash-dataflow/tests/unit/migrations/test_not_null_concurrency.py
+++ b/packages/kailash-dataflow/tests/unit/migrations/test_not_null_concurrency.py
@@ -241,17 +241,22 @@ class TestRaceConditions:
         batch_updates = []
         update_lock = asyncio.Lock()
 
-        async def mock_fetchval_update(query, *args):
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop (returns RETURNING rows for accurate counting). Mock the
+        # `WITH batch AS` predicate on fetch(), and keep fetchval() for
+        # non-batched scalar queries like SELECT COUNT(*).
+        async def mock_fetch_update(query, *args):
             if "WITH batch AS" in query:
                 async with update_lock:
                     batch_updates.append(time.time())
                     # Simulate some batches having no rows left
                     if len(batch_updates) > 3:
-                        return None
-                    return 1000  # Rows updated
-            return 10000
+                        return []  # Empty list breaks the loop
+                    return [(1,)] * 1000  # 1000 RETURNING rows
+            return []
 
-        mock_connection.fetchval = mock_fetchval_update
+        mock_connection.fetch = mock_fetch_update
+        mock_connection.fetchval.return_value = 10000  # Row count for COUNT(*)
         mock_connection.execute = AsyncMock()
 
         with patch.object(

--- a/packages/kailash-dataflow/tests/unit/migrations/test_not_null_error_recovery.py
+++ b/packages/kailash-dataflow/tests/unit/migrations/test_not_null_error_recovery.py
@@ -166,18 +166,21 @@ class TestResourceExhaustion:
         mock_connection.fetchval.return_value = 10000000  # Very large table
         mock_connection.fetch.return_value = []
 
-        # Simulate memory error during batch processing
+        # Simulate memory error during batch processing.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         batch_count = {"count": 0}
 
-        async def mock_fetchval_batch(query, *args):
+        async def mock_fetch_batch(query, *args):
             if "WITH batch AS" in query:
                 batch_count["count"] += 1
                 if batch_count["count"] > 5:
                     raise MemoryError("Out of memory processing large batch")
-                return 10000  # Rows updated
-            return 10000000
+                return [(1,)] * 10000  # 10000 RETURNING rows
+            return []
 
-        mock_connection.fetchval = mock_fetchval_batch
+        mock_connection.fetch = mock_fetch_batch
+        mock_connection.fetchval.return_value = 10000000  # Row count for COUNT(*)
         mock_connection.execute = AsyncMock()
 
         # Transaction context is already properly configured by create_mock_connection()
@@ -402,20 +405,22 @@ class TestPartialFailures:
         mock_connection.fetch.return_value = []
         mock_connection.execute = AsyncMock()
 
-        # Simulate partial batch failure
+        # Simulate partial batch failure.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         batch_count = {"count": 0}
 
-        async def mock_fetchval_batch(query, *args):
+        async def mock_fetch_batch(query, *args):
             if "WITH batch AS" in query:
                 batch_count["count"] += 1
                 if batch_count["count"] == 3:
                     raise Exception("Batch 3 failed: unique constraint violation")
                 elif batch_count["count"] > 5:
-                    return None  # No more rows
-                return 1000  # Rows updated
-            return 10000
+                    return []  # No more rows
+                return [(1,)] * 1000  # 1000 RETURNING rows
+            return []
 
-        mock_connection.fetchval = mock_fetchval_batch
+        mock_connection.fetch = mock_fetch_batch
 
         # Transaction context is already properly configured by create_mock_connection()
 

--- a/packages/kailash-dataflow/tests/unit/migrations/test_not_null_performance_boundaries.py
+++ b/packages/kailash-dataflow/tests/unit/migrations/test_not_null_performance_boundaries.py
@@ -115,21 +115,27 @@ class TestProductionScalePerformance:
         mock_connection = create_mock_connection()
         mock_connection.fetch.return_value = []
 
-        # Track batch execution
+        # Track batch execution.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         batch_count = {"count": 0}
 
-        async def mock_fetchval_batch(query, *args):
+        async def mock_fetchval_misc(query, *args):
             # Handle constraint validation query (check for NULL values)
             if "IS NULL" in query and "COUNT" in query.upper():
                 return 0  # No NULL violations
+            return 100000  # Default row count for COUNT(*)
+
+        async def mock_fetch_batch(query, *args):
             if "WITH batch AS" in query:
                 batch_count["count"] += 1
                 if batch_count["count"] * 10000 >= 100000:
-                    return None  # No more rows
-                return 10000  # Rows updated per batch
-            return 100000
+                    return []  # No more rows
+                return [(1,)] * 10000  # 10000 RETURNING rows
+            return []
 
-        mock_connection.fetchval = mock_fetchval_batch
+        mock_connection.fetchval = mock_fetchval_misc
+        mock_connection.fetch = mock_fetch_batch
         mock_connection.execute = AsyncMock()
 
         with patch.object(
@@ -161,23 +167,28 @@ class TestProductionScalePerformance:
         mock_connection = create_mock_connection()
         mock_connection.fetch.return_value = []
 
-        # Simulate realistic batch processing delays
+        # Simulate realistic batch processing delays.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         batch_times = []
 
-        async def mock_fetchval_batch(query, *args):
-            # Handle constraint validation query (check for NULL values)
+        async def mock_fetchval_misc(query, *args):
             if "IS NULL" in query and "COUNT" in query.upper():
-                return 0  # No NULL violations
+                return 0
+            return 1000000
+
+        async def mock_fetch_batch(query, *args):
             if "WITH batch AS" in query:
                 start = time.time()
                 await asyncio.sleep(0.001)  # Simulate batch processing time
                 batch_times.append(time.time() - start)
                 if len(batch_times) * 10000 >= 1000000:
-                    return None
-                return 10000
-            return 1000000
+                    return []
+                return [(1,)] * 10000
+            return []
 
-        mock_connection.fetchval = mock_fetchval_batch
+        mock_connection.fetchval = mock_fetchval_misc
+        mock_connection.fetch = mock_fetch_batch
         mock_connection.execute = AsyncMock()
 
         with patch.object(
@@ -214,19 +225,22 @@ class TestProductionScalePerformance:
         mock_connection.fetchval.return_value = 10000000  # 10M rows
         mock_connection.fetch.return_value = []
 
-        # Simulate timeout scenario
+        # Simulate timeout scenario.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         batch_count = {"count": 0}
 
-        async def mock_fetchval_batch(query, *args):
+        async def mock_fetch_batch(query, *args):
             if "WITH batch AS" in query:
                 batch_count["count"] += 1
                 if batch_count["count"] > 50:
                     # Simulate timeout after 500K rows
                     raise asyncio.TimeoutError("Operation timed out")
-                return 10000
-            return 10000000
+                return [(1,)] * 10000
+            return []
 
-        mock_connection.fetchval = mock_fetchval_batch
+        mock_connection.fetch = mock_fetch_batch
+        mock_connection.fetchval.return_value = 10000000  # Row count for COUNT(*)
         mock_connection.execute = AsyncMock()
 
         # Mock transaction for rollback
@@ -308,9 +322,9 @@ class TestProductionScalePerformance:
                 plan = await self.handler.plan_not_null_addition("test_table", column)
 
                 # Verify estimation is within reasonable bounds
-                assert min_time <= plan.estimated_duration <= max_time, (
-                    f"Estimation {plan.estimated_duration}s out of range [{min_time}, {max_time}] for {row_count} rows with {default_type}"
-                )
+                assert (
+                    min_time <= plan.estimated_duration <= max_time
+                ), f"Estimation {plan.estimated_duration}s out of range [{min_time}, {max_time}] for {row_count} rows with {default_type}"
 
 
 class TestMemoryUsagePatterns:
@@ -379,9 +393,9 @@ class TestMemoryUsagePatterns:
                 memory_growth_ratio = (
                     avg_last_10 / avg_first_10 if avg_first_10 > 0 else 1
                 )
-                assert memory_growth_ratio < 2.0, (
-                    f"Memory grew too much: {memory_growth_ratio}x"
-                )
+                assert (
+                    memory_growth_ratio < 2.0
+                ), f"Memory grew too much: {memory_growth_ratio}x"
 
     @pytest.mark.asyncio
     async def test_batch_size_optimization(self):
@@ -420,9 +434,9 @@ class TestMemoryUsagePatterns:
                 plan = await self.handler.plan_not_null_addition("test_table", column)
 
                 # Verify batch size is optimized for table size
-                assert plan.batch_size == expected_batch_size, (
-                    f"Expected batch size {expected_batch_size} for {row_count} rows, got {plan.batch_size}"
-                )
+                assert (
+                    plan.batch_size == expected_batch_size
+                ), f"Expected batch size {expected_batch_size} for {row_count} rows, got {plan.batch_size}"
 
 
 class TestTimeoutAndCancellation:
@@ -439,10 +453,12 @@ class TestTimeoutAndCancellation:
         mock_connection.fetchval.return_value = 1000000  # 1M rows
         mock_connection.fetch.return_value = []
 
-        # Track progress
+        # Track progress.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         progress = {"batches_completed": 0, "rows_updated": 0}
 
-        async def mock_fetchval_batch(query, *args):
+        async def mock_fetch_batch(query, *args):
             if "WITH batch AS" in query:
                 progress["batches_completed"] += 1
                 progress["rows_updated"] += 10000
@@ -452,10 +468,11 @@ class TestTimeoutAndCancellation:
                     raise asyncio.TimeoutError("Operation timed out")
 
                 await asyncio.sleep(0.01)  # Simulate work
-                return 10000
-            return 1000000
+                return [(1,)] * 10000
+            return []
 
-        mock_connection.fetchval = mock_fetchval_batch
+        mock_connection.fetch = mock_fetch_batch
+        mock_connection.fetchval.return_value = 1000000  # Row count for COUNT(*)
         mock_connection.execute = AsyncMock()
 
         # Mock transaction
@@ -507,11 +524,13 @@ class TestTimeoutAndCancellation:
         mock_connection.fetchval.return_value = 500000
         mock_connection.fetch.return_value = []
 
-        # Track cancellation
+        # Track cancellation.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         cancelled = {"flag": False}
         batch_count = {"count": 0}
 
-        async def mock_fetchval_batch(query, *args):
+        async def mock_fetch_batch(query, *args):
             if "WITH batch AS" in query:
                 batch_count["count"] += 1
 
@@ -523,10 +542,11 @@ class TestTimeoutAndCancellation:
                 if batch_count["count"] == 20:
                     cancelled["flag"] = True
 
-                return 10000
-            return 500000
+                return [(1,)] * 10000
+            return []
 
-        mock_connection.fetchval = mock_fetchval_batch
+        mock_connection.fetch = mock_fetch_batch
+        mock_connection.fetchval.return_value = 500000  # Row count for COUNT(*)
         mock_connection.execute = AsyncMock()
 
         # Mock transaction
@@ -784,13 +804,17 @@ class TestProgressTracking:
         mock_connection = create_mock_connection()
         mock_connection.fetch.return_value = []
 
-        # Track progress reports
+        # Track progress reports.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         progress_reports = []
 
-        async def mock_fetchval_with_progress(query, *args):
-            # Handle constraint validation query (check for NULL values)
+        async def mock_fetchval_misc(query, *args):
             if "IS NULL" in query and "COUNT" in query.upper():
-                return 0  # No NULL violations
+                return 0
+            return 1000000
+
+        async def mock_fetch_with_progress(query, *args):
             if "WITH batch AS" in query:
                 # Simulate progress callback
                 progress = len(progress_reports) * 10000 / 1000000 * 100
@@ -803,11 +827,12 @@ class TestProgressTracking:
                 )
 
                 if len(progress_reports) * 10000 >= 1000000:
-                    return None
-                return 10000
-            return 1000000
+                    return []
+                return [(1,)] * 10000
+            return []
 
-        mock_connection.fetchval = mock_fetchval_with_progress
+        mock_connection.fetchval = mock_fetchval_misc
+        mock_connection.fetch = mock_fetch_with_progress
         mock_connection.execute = AsyncMock()
 
         with patch.object(
@@ -851,14 +876,18 @@ class TestProgressTracking:
         mock_connection = create_mock_connection()
         mock_connection.fetch.return_value = []
 
-        # Track timing for ETA calculation
+        # Track timing for ETA calculation.
+        # NOTE: production refactored fetchval()→fetch() in the batched-update
+        # loop; mock the `WITH batch AS` predicate on fetch().
         batch_times = []
         start_time = time.time()
 
-        async def mock_fetchval_with_timing(query, *args):
-            # Handle constraint validation query (check for NULL values)
+        async def mock_fetchval_misc(query, *args):
             if "IS NULL" in query and "COUNT" in query.upper():
-                return 0  # No NULL violations
+                return 0
+            return 500000
+
+        async def mock_fetch_with_timing(query, *args):
             if "WITH batch AS" in query:
                 batch_times.append(time.time() - start_time)
 
@@ -875,13 +904,14 @@ class TestProgressTracking:
                     assert eta < 3600  # Less than 1 hour
 
                 if len(batch_times) >= 50:
-                    return None
+                    return []
 
                 await asyncio.sleep(0.001)  # Simulate work
-                return 10000
-            return 500000
+                return [(1,)] * 10000
+            return []
 
-        mock_connection.fetchval = mock_fetchval_with_timing
+        mock_connection.fetchval = mock_fetchval_misc
+        mock_connection.fetch = mock_fetch_with_timing
         mock_connection.execute = AsyncMock()
 
         with patch.object(


### PR DESCRIPTION
## Summary

Production `NotNullHandler` refactored `fetchval()` → `fetch()` at
`not_null_handler.py:1071-1074` to return RETURNING rows for accurate
batch counting. Test mocks were not updated; predicates on `fetchval`
with `WITH batch AS` never fired and `len(batch_updates)` resolved to
0 across 11 tests. This PR aligns 4 test files to the new mock surface
plus an identifier-quoting assertion fix.

## Test plan

- [x] Run `.venv/bin/python -m pytest packages/kailash-dataflow/tests/unit/migrations/ -m 'not integration and not e2e' --no-header -q` — 717/717 pass
- [x] All 11 originally-failing tests now pass: 135/135 not_null tests green
- [ ] CI matrix (note: these tests are NOT in CI per #683 — only `tests/unit/trust/` is)

## Related issues

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)