### PR TITLE
release(kailash-dataflow v2.3.3): pyright + migration test-suite follow-through

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -18,7 +18,7 @@
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
 | kailash (core)   | `v*`               | 2.11.3          |
-| kailash-dataflow | `dataflow-v*`      | 2.3.2           |
+| kailash-dataflow | `dataflow-v*`      | 2.3.3           |
 | kailash-kaizen   | `kaizen-v*`        | 2.13.1          |
 | kailash-nexus    | `nexus-v*`         | 2.3.0           |
 | kailash-pact     | `pact-v*`          | 0.11.0          |
@@ -27,7 +27,7 @@
 | kailash-mcp      | `mcp-v*`           | 0.2.10          |
 | kaizen-agents    | `kaizen-agents-v*` | 0.9.4           |
 
-Last updated: 2026-04-28 (W7 follow-up — kailash-ml 1.5.1 patch). kailash-ml 1.5.1 (PR #679) routes the `engines/model_registry.py` `ModelNotFoundError` through the canonical `kailash.ml.errors.ModelNotFoundError` (subclass of `ModelRegistryError → MLError`), removing the divergent local `class ModelNotFoundError(Exception)` that surfaced when the W7-001 LineageGraph walker raised canonical while `ModelRegistry.get_model` raised local. 6 raise sites converted to canonical kwargs; 3 regression tests pin class-identity + AST invariant. PR #679 also adds `scripts/development/find-venv-python.sh` — wrapper that resolves `.venv/bin/python` via `git rev-parse --git-common-dir` so pre-commit hooks run from inside `.claude/worktrees/<X>/` without the `core.hooksPath=/dev/null` bypass; 3 regression tests pin the worktree-safe invariants. Clean-venv install verified live: `kailash-ml==1.5.1` + `ModelNotFoundError canonical identity: OK` + `__all__ count: 50 (AST-derived)`. No sibling drift.
+Last updated: 2026-04-28 (kailash-dataflow 2.3.3 patch — closes merged-but-unreleased gap from PRs #684 / #689 / #690: `not_null_handler.py` pyright cleanup + 8 migration unit-test mock-method-drift repairs. No production behavior change beyond type-checking cleanup; 13 pre-existing pytest warnings in the migrations suite remain on separate workstreams). kailash-ml 1.5.1 (PR #679) routes the `engines/model_registry.py` `ModelNotFoundError` through the canonical `kailash.ml.errors.ModelNotFoundError` (subclass of `ModelRegistryError → MLError`), removing the divergent local `class ModelNotFoundError(Exception)` that surfaced when the W7-001 LineageGraph walker raised canonical while `ModelRegistry.get_model` raised local. 6 raise sites converted to canonical kwargs; 3 regression tests pin class-identity + AST invariant. PR #679 also adds `scripts/development/find-venv-python.sh` — wrapper that resolves `.venv/bin/python` via `git rev-parse --git-common-dir` so pre-commit hooks run from inside `.claude/worktrees/<X>/` without the `core.hooksPath=/dev/null` bypass; 3 regression tests pin the worktree-safe invariants. Clean-venv install verified live: `kailash-ml==1.5.1` + `ModelNotFoundError canonical identity: OK` + `__all__ count: 50 (AST-derived)`. No sibling drift.
 
 Prior 2026-04-27 — W7 portfolio remediation: kailash-ml 1.5.0 (PR #677 closes #657) ships the cross-engine `LineageGraph` engine module; kailash-dataflow 2.3.2 (PR #678) wires `format_error_for_event` through `emit_train_end` at the emitter.
 

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,23 @@
 # DataFlow Changelog
 
+## [2.3.3] — 2026-04-28 — Migration test-suite + pyright cleanup follow-through
+
+Patch release closing the merged-but-unreleased gap on `kailash-dataflow` main. Three commits since 2.3.2:
+
+- `95e8e2c8` (PR #684) — `not_null_handler.py` pyright cleanup: 8 errors / 2 warnings to 0 / 0. Production source change in `packages/kailash-dataflow/src/dataflow/migrations/not_null_handler.py`; per `rules/build-repo-release-discipline.md` Rule 5 this triggers the version bump.
+- `f1dfb194` (PR #689, closes #683) — repaired test mock-method drift in 4 not_null_handler unit-test files where mocks invoked methods that no longer exist on the production class.
+- `391617d1` (PR #690, closes #688) — aligned 4 migration unit-test files (column removal, dependency analyzer, impact analysis reporter, application-safe rename) to the post-refactor production surface.
+
+### Fixed
+
+- Pyright drift in `not_null_handler.py` (PR #684).
+- Test-mock drift across 8 migration unit-test files (PRs #689, #690). Local `pytest packages/kailash-dataflow/tests/unit/migrations/` is GREEN at 717 passed / 0 failed; these tests are not yet in CI per #688.
+
+### Notes
+
+- No production runtime behavior change beyond the type-checking cleanup in `not_null_handler.py`.
+- 13 pre-existing pytest warnings in the migrations suite remain (separate workstreams: `MigrationPerformanceTracker._stop_monitoring` un-awaited coroutine, `AsyncMockMixin._execute_mock_call` un-awaited coroutine in test framework).
+
 ## [2.3.2] — 2026-04-27 — emit_train_end structural error redaction (W7-002, Round-3 LOW-2 carry-forward)
 
 ### Security
@@ -24,7 +42,7 @@
 ### Documentation
 
 - Updated `specs/dataflow-ml-integration.md` § 4A.2 — replaced the "Caller is responsible for sanitizing" docstring contract with the emitter-redacted contract, referencing `format_error_for_event` and `rules/event-payload-classification.md` § 1.
-- Cross-spec re-derivation per `rules/specs-authority.md` § 5b: `kailash-core-ml-integration.md` § 3.4 (MLError discipline) lightly amended to clarify that the emitter-side helper is defense-in-depth, NOT a license to construct leaky MLError messages — the caller-construction discipline remains the primary gate. Other ml-* and dataflow-ml-* specs were re-derived but required no changes (no references to `emit_train_end` / `format_error_for_event` / caller-sanitization vocabulary).
+- Cross-spec re-derivation per `rules/specs-authority.md` § 5b: `kailash-core-ml-integration.md` § 3.4 (MLError discipline) lightly amended to clarify that the emitter-side helper is defense-in-depth, NOT a license to construct leaky MLError messages — the caller-construction discipline remains the primary gate. Other ml-_ and dataflow-ml-_ specs were re-derived but required no changes (no references to `emit_train_end` / `format_error_for_event` / caller-sanitization vocabulary).
 
 ## [Unreleased] — DataFlow × ML error-name spec compliance + TenantTrustManager orphan removal (W6-003 / W6-006 / W6-017)
 

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.3.2"
+version = "2.3.3"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -107,7 +107,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Patch release closing the merged-but-unreleased gap on `kailash-dataflow` main since 2.3.2 (release/v* branch — auto-skip PR-gate matrix per `git.md`).

Three commits since 2.3.2:

| Commit | PR | Closes | Surface |
| --- | --- | --- | --- |
| `95e8e2c8` | #684 | — | `not_null_handler.py` pyright cleanup (8 err / 2 warn → 0/0). Production-src change → triggers version bump per `build-repo-release-discipline.md` Rule 5. |
| `f1dfb194` | #689 | #683 | Test-only mock-method drift repair across 4 not_null_handler unit-test files. |
| `391617d1` | #690 | #688 | Test-only mock alignment across 4 migration unit-test files. |

No production runtime behavior change beyond the type-checking cleanup.

## Why

`build-repo-release-discipline.md` Rule 1 mandates a release cycle in the same session as merges. PR #684 modified production source without bumping; per Rule 5 that's a release-needed gap. This release closes it and rides PRs #689 / #690 along.

## Test plan

- [x] Local `.venv/bin/python -m pytest packages/kailash-dataflow/tests/unit/migrations/ -m 'not integration and not e2e'` — 717 passed / 0 failed.
- [x] Atomic version bump: `pyproject.toml` 2.3.2 → 2.3.3 + `__init__.py::__version__` 2.3.2 → 2.3.3.
- [x] CHANGELOG entry added (lists all 3 commit references).
- [x] `deploy/deployment-config.md` current-version table row updated.
- [ ] Post-merge: tag `dataflow-v2.3.3` on main → triggers `publish-pypi.yml`.
- [ ] Post-publish: clean-venv `pip install kailash-dataflow==2.3.3 && python -c "import dataflow; print(dataflow.__version__)"` per Rule 2.

## Related issues

Closes the version-bump gap from PR #684 (production-src in not_null_handler without same-PR bump). Prior siblings already closed: #683 (PR #689), #688 (PR #690).

🤖 Generated with [Claude Code](https://claude.com/claude-code)