### PR TITLE
feat(kailash): pool lifecycle — registry + idle reaper + bounded fallback (DPI-B, #697 #698)

### DIFF
--- a/SWEEP-2026-04-28-v2.md
+++ b/SWEEP-2026-04-28-v2.md
@@ -1,0 +1,137 @@
+# /sweep findings — 2026-04-28 (v2, supersedes 09:57 sweep)
+
+Re-run of `/sweep` after the 09:57 sweep. The intervening hours brought 6 new GH issues (#696–#701) filed during a JourneyMate production-incident response — all in the urgent area the user flagged (db / DataFlow / kailash-ml). The prior sweep's "No CRIT/HIGH bugs" headline is now stale.
+
+This file is a DELTA report. Findings carried forward unchanged from v1 are referenced, not restated. New CRIT/HIGH findings are written in full.
+
+## Summary
+
+- **CRIT: 2** (production-incident: connection-leak + DDL-retry storm)
+- **HIGH: 4** (kailash-ml 1.5.x breaking-change debt + DataFlowEngine API holes)
+- **MED: 4** (carried forward from v1)
+- **LOW: 6** (carried forward from v1)
+- **INFO: 5** (carried forward from v1)
+
+**Net assessment.** Source-tree state is unchanged from v1 (8 packages still at PyPI parity, 0 open PRs, 1 worktree). The change is **discovered defects in already-shipped versions**: a production incident on JourneyMate (Azure FastAPI + DataFlow) surfaced two CRIT connection-leak / DDL-retry pathologies in `kailash` 2.11.3 + `kailash-dataflow` 2.3.3, and an MLFP M5 notebook smoke-test sweep surfaced three HIGH 1.5.1 breaking-change bugs in `kailash-ml`. Two HIGH `DataFlowEngine.builder()` shape bugs (#685, #686) were filed earlier today and remain unaddressed. **None of these is a "release coordination" problem — every fix needs source code work.**
+
+---
+
+## NEW Findings (filed since v1 sweep at 09:57)
+
+### [CRIT] [Sweep 3: open issues] DataFlow auto_migrate fires failed CREATE TABLE on every model access — production-incident class
+
+**Location:** `src/dataflow/core/engine.py:1576-1599` (model registration eager create), `:6391-6455` (`create_tables()`), `:7426` (log line), `:7511-7600` (`_create_table_sync()` retry path) — issue #696
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (already filed; needs analyst → dataflow-specialist)
+**Evidence:** Production incident on JourneyMate 2026-04-28. BE logs showed the same 4 DDLs repeating every 30 s for the entire BE process uptime: `ERROR:dataflow.core.engine:Failed to execute DDL: CREATE TABLE IF NOT EXISTS "evaluation_dimensions" ...` × forever. Combined with the per-pool fallback bug (#697 below), each retry leaks 5–20 connections. Reproducible by defining a `@db.model` whose CREATE TABLE will fail (FK ordering, role lacks CREATE) with `auto_migrate=True`.
+**Why this matters:** Saturates Azure PG's 100–200 connection ceiling within minutes of receiving traffic. User had to set `auto_migrate=False` and manage migrations outside DataFlow to recover. The DDL-retry-on-every-access semantic is a design defect, not a one-line fix — it needs fail-fast + backoff + circuit-breaker around model-access-time DDL.
+**Action recommended:** Open workspace `workspaces/issue-696-697-dataflow-leak/` for paired investigation with #697. Fix is in `kailash-dataflow` package (so a 2.3.4 release on land) + likely also needs `kailash` core touch for the AsyncSQLDatabaseNode side (#697). Per `feedback_drive_to_completion`, this should land + release in one cycle, not be left at "issue filed."
+
+### [CRIT] [Sweep 3: open issues] AsyncSQLDatabaseNode per-pool-locking fallback leaks pools, never reclaimed mid-process
+
+**Location:** `src/kailash/nodes/data/async_sql.py:501` (pool init), `:574` (get_or_create), `:3835` (`_generate_pool_key()`), `:3944-3956` (fallback path) — issue #697
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (paired with #696)
+**Evidence:** Same JourneyMate incident. Under load, `WARNING:kailash.nodes.data.async_sql:Per-pool locking failed ... Falling back to dedicated pool mode.` — each fallback creates a new `EnterpriseConnectionPool` (5–20 connections) only held on the node instance; subsequent calls each become another dedicated pool. No mid-process eviction; only `cleanup_all_pools()` at shutdown frees them. Combined with #696 saturates Azure PG at 480–500 connections.
+**Why this matters:** Fatal under load. Took the user's production BE down for 30+ minutes during a routine deploy. The per-pool key includes `id(get_running_loop())`, so any event-loop transition forces a new pool — common under uvicorn worker pre-fork patterns. Fix needs structural rework: longer lock-hold, fail-fast typed error, OR process-wide registry with idle-eviction.
+**Action recommended:** Pair with #696 in the same workspace. Issue body proposes Option A (longer hold or fail-fast) preferred over Option B (registry + eviction). Same-bug-class as #698 (the enhancement counterpart asking for explicit `idle_timeout` + `max_pool_count_per_process` API). Per `rules/autonomous-execution.md` § Fix-Immediately when same-class within shard budget — these three (#696, #697, #698) are one shard.
+
+### [HIGH] [Sweep 3: open issues] kailash-ml 1.5.1 InferenceServer hard break — multi-model API removed without deprecation
+
+**Location:** `kailash-ml` package (1.5.1) — issue #700
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (urgent — every consumer using 1.1.x multi-model pattern is broken on import-load)
+**Evidence:** 1.5.x redesigned `InferenceServer` to one-model-per-server (`InferenceServer.from_registry(name, registry=...)` + `InferenceServerConfig`). The 1.1.x surface — `InferenceServer(registry=registry, cache_size=5)` + `await server.warm_cache(...)` + `await server.load_model(...)` — was removed in the same release with no deprecation cycle and no migration in CHANGELOG. Every consumer gets a `TypeError: InferenceServer.__init__() got an unexpected keyword argument 'cache_size'` on construction. MLFP M5 ex_2/03 + ex_7/05 affected.
+**Why this matters:** Per `rules/zero-tolerance.md` Rule 6 ("if endpoint exists, it returns real data; never half-implemented features") — this is the inverse: an endpoint advertised in 1.1.x docs that NOW raises. Per `feedback_no_shims` the user prefers no deprecation timelines; the right disposition here is either (a) restore the 1.1.x surface as a thin adapter that lazy-constructs one-server-per-model on warm_cache/load_model OR (b) document the migration explicitly in CHANGELOG + release a 1.5.2 with a `from_registry_many()` helper and a clear-error message that names the migration. Option (b) aligns with feedback_no_shims and is the simpler ship.
+**Action recommended:** dataflow/ML cycle should bundle #699 + #700 + #701 in one shard; same release; same release-prep PR.
+
+### [HIGH] [Sweep 3: open issues] kailash-ml 1.5.1 ExperimentTracker + ModelRegistry on shared store_url schema clash
+
+**Location:** `packages/kailash-ml/src/kailash_ml/engines/model_registry.py:197+` (`_create_registry_tables`), :240 / :250 / :509 / :732 / :909 (`name = ?`) vs :997 / :1004 (`model_name = ?`) — issue #699
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM
+**Evidence:** Half-finished migration. `ExperimentTracker.create()` initializes `_kml_model_versions` with tenant-aware schema (`tenant_id, model_name, version, ...`). `ModelRegistry._create_registry_tables` uses `CREATE TABLE IF NOT EXISTS` with the older `name, version, ...` schema; IF-NOT-EXISTS guard skips creation; `register_model()` then runs `INSERT INTO _kml_model_versions (name, version, ...)` against the tenant-aware schema — `OperationalError: table _kml_model_versions has no column named name`. The same source file holds BOTH schema queries — five `name = ?` sites and two `model_name = ?` sites.
+**Why this matters:** The "tracker + registry on one store" pattern is documented and is the canonical MLFP M5 setup. Every consumer using both engines hits this. Per `rules/orphan-detection.md` § 1 the failure mode resembles a partial schema-migration where one half of a paired API has migrated and the other has not — a cross-cutting consistency violation. Fix needs schema unification (preferred: tenant-aware everywhere; revert is BLOCKED because ExperimentTracker has shipped tenant-aware writes already).
+**Action recommended:** Bundle with #700 + #701 in one shard. Schema-unification PR with regression test that exercises the docs-exact pattern (per `rules/testing.md` § End-to-End Pipeline Regression — this is precisely the "fake integration via missing handoff field" sibling at the schema level).
+
+### [HIGH] [Sweep 3: open issues] kailash-ml 1.5.1 diagnose() three call paths, none cleanly handles PyTorch + DataLoader
+
+**Location:** `kailash-ml` package (1.5.1) — issue #701
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM
+**Evidence:** `diagnose(model, kind="dl", data=loader)` returns a bare `DLDiagnostics` object — `data=` arg is silently ignored (the worst class of API smell per zero-tolerance.md). `kind="classifier"` raises ValueError because §3.1 only accepts "classical_classifier". 1.1.x kwargs (`title`, `n_batches`, `train_losses`, `val_losses`, `forward_returns_tuple`) all dropped without replacement.
+**Why this matters:** This is the canonical use-case for every deep-learning lesson; the 1.5.x surface forces consumers into boilerplate or direct `DLDiagnostics` instantiation that contradicts the dispatched entry point. Per `rules/zero-tolerance.md` Rule 6 — silently-ignored `data=` parameter is a stub-shaped feature.
+**Action recommended:** Bundle with #699 + #700. Make `kind="dl"` accept `data=`; add `kind="classifier"`/`kind="regressor"` aliases; either honor 1.1.x kwargs or document migration. Add Tier-2 regression test exercising the `(model, val_loader)` path the docs teach.
+
+### [HIGH] [Sweep 3: open issues] DataFlowEngine.register_model calls non-existent method on DataFlow primitive
+
+**Location:** `packages/kailash-dataflow/src/dataflow/engine.py::DataFlowEngine.register_model` — issue #685 (filed 2026-04-28 07:51, still open)
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (no workspace yet)
+**Evidence:** `engine.register_model(None, Foo)` raises `AttributeError: 'DataFlow' object has no attribute 'register_model'`. The implementation calls `self._dataflow.register_model(model)` but `DataFlow` exposes registration via the `@db.model` decorator only. Blocks engine-first migration in downstream apps (HANA Phase 2 deferred via ADR 0003).
+**Why this matters:** Per `rules/framework-first.md` `DataFlowEngine` is the recommended surface; an API hole in the recommended surface forces downstream apps to drop back to `@db.model` against `DataFlow` directly, defeating the engine-first guidance. Cross-SDK with `kailash-rs#403`-class.
+**Action recommended:** Single-shard fix in dataflow-specialist: implement registration on `DataFlow` (the right home — `engine.register_model` should opt the model into the classification policy + register it for `get_model_classification_report()`), or delete the engine-side method if `@db.model` is the only intended path. Same shard as #686.
+
+### [HIGH] [Sweep 3: open issues] DataFlowEngineBuilder.build() is async but body is purely synchronous
+
+**Location:** `packages/kailash-dataflow/src/dataflow/engine.py::DataFlowEngineBuilder.build` — issue #686 (filed 2026-04-28 07:51, still open)
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (paired with #685)
+**Evidence:** Body never `await`s; signature `async def build(self) -> "DataFlowEngine"`. Forces every caller into `await` even though no async work happens — module-import-time `@lru_cache get_db()` patterns can't use it. HANA Phase 2 has 8 `@db.model` files that all do `db = get_db()` at import; cannot await without restructuring.
+**Why this matters:** Per `rules/patterns.md` § "Paired Public Surface — Consistent Async-ness", inconsistency between surface (async) and body (sync) is a paper-cut every caller pays. Likely originated from cross-SDK parity with kailash-rs (where async IS load-bearing for runtime init).
+**Action recommended:** Add `build_sync()` as escape hatch (preferred) OR make `build()` sync + ship `build_async()` for cross-SDK parity. Ship same shard as #685.
+
+### [INFO] Other open issues unchanged from v1
+
+- #673, #643, #630, #596, #687, #693 carried forward from v1 sweep with no state change. Each is its own scoped enhancement / new workstream. None blocking.
+- #688 closed (CSP regression carry-forward fixed in PR #690).
+- #683 closed (not-null handler test mock-method drift fixed in PR #689).
+- #684 closed via PR #684 / cf945373 (kailash-dataflow 2.3.3).
+
+---
+
+## Findings carried forward from v1 sweep (unchanged)
+
+- **[MED]** Codify proposal stalled at `pending_review` since 2026-04-27. **No change** — the cycle-10 proposal added today (PR #695, `git-reset-hard-discipline`) is also at `reviewed` waiting for loom Gate 2 distribution. **2 GLOBAL rules pending** loom-side propagation.
+- **[MED]** `diagnostics-catalog.md` orphan in `specs/_index.md`. **No change.**
+- **[MED]** 18 of 72 spec files marked `Version: 1.0.0 (draft)`. **No change.**
+- **[MED]** Deferred-codify backlog at 8 items; 5 rule files exceed 200-line guidance. **No change.**
+- **[LOW]** 11 active todos in `workspaces/spec-drift-gate/`. **No change.**
+- **[LOW]** 78 pending journal entries across 6 workspaces. **+0** (none promoted today). Now 78 across 7 workspaces (kailash-ml-audit was undercounted; it has 6).
+- **[LOW]** 9 unmerged remote branches without open PRs. **+1**: branch list above shows 10 now (`feat/outstanding-issues-consolidation` from 2026-04-05 reappears in unmerged enumeration).
+- **[LOW]** 122 stub markers in production code. **−3** (PR #682 resolved 3 markers from prior LOW-6).
+- **[LOW]** 12 workspaces with `.session-notes` >30d. **−12** (PR #681 archived all 12; sweep flag now reads as 0 stale workspaces ≥30d).
+- **[INFO]** 0 open PRs. **No change.**
+- **[INFO]** 0 issues in kailash-coc-claude-py. **No change.**
+- **[INFO]** 1 worktree (main only). **No change.**
+
+---
+
+## Cross-cutting observations
+
+1. **The CRIT class is a coupled DataFlow/Core-SDK pair (#696 ↔ #697 ↔ #698).** They surface together under load and amplify each other (DDL retry storm × per-pool leak = 480-conn saturation in minutes). Fixing only one of them leaves the production incident class open. This is precisely the same-shard same-bug-class scenario `rules/autonomous-execution.md` § 4 mandates fix-immediately when budget allows. Estimated shard size: 1 session.
+
+2. **The HIGH class on kailash-ml 1.5.x is "stub-shaped after release" (Rule 6 at semver-major-bump scale).** #699 (schema fork), #700 (removed kwargs), #701 (silently-ignored arg) all share a root cause: 1.5.x bumped a major shape without the regression tests `rules/testing.md` § End-to-End Pipeline Regression mandates. The MLFP M5 notebook sweep is functioning as the canary. Per `feedback_drive_to_completion` — these need to land + release as 1.5.2, not get filed and forgotten.
+
+3. **The DataFlowEngine API holes (#685, #686) coexist with the production-incident pair on the same package.** Bundling them into one workspace (4 issues, one DataFlow release cycle) is structurally cheaper than two separate cycles. They share specialist (dataflow-specialist), shared invariant set (engine surface + connection lifecycle), shared CI cycle. Single-PR risk is low because the surface area is well-bounded.
+
+4. **The codify pipeline is now two cycles deep (Cycle 10 reviewed today; Cycle 11 from this sweep would be premature)** — the 2 GLOBAL rules from Wave 6/7 + the `git reset --hard` rule from this morning all sit at loom's `/sync` Gate 2 backlog. Adding a third unsynced cycle would not help; the bottleneck is loom-side, not BUILD-repo-side.
+
+5. **No new release work needed for the existing source.** All 8 packages at PyPI parity. The CRIT/HIGH issues require code fixes BEFORE release, so a release is the OUTPUT of the next workstream, not a pre-requisite.
+
+---
+
+## Recommended next-session scope (re-ranked by criticality)
+
+1. **Open workspace `workspaces/dataflow-prod-incident/`** — analyst step on #696 + #697 + #698 (production-incident triage). Single shard, dataflow-specialist + analyst, paired-PR delivery. **Dispatches to a release of `kailash-dataflow` + `kailash`** once landed. Highest urgency given user said "urgent" and these are CRIT.
+
+2. **Open workspace `workspaces/kailash-ml-1.5.x-followup/`** — analyst step on #699 + #700 + #701 (canonical-pattern bugs from 1.5.1 release). Schema unification + adapter-or-document for InferenceServer + diagnose() entry-point fix. **Dispatches to release of `kailash-ml` 1.5.2.** Per `feedback_drive_to_completion` ship through `/release` after merge.
+
+3. **Open workspace `workspaces/dataflow-engine-builder-api/`** OR fold into #1 — #685 + #686 (DataFlowEngine surface holes). Single shard, dataflow-specialist. Same release as #1 (one `kailash-dataflow` cut covers both).
+
+4. **Loom `/sync` to clear cycle-10 + cycle-11** (15 min) — switch to `~/repos/loom/`, run `/sync` to process the kailash-py `pending_review` and process the new `git reset --hard` rule. Distributes 3 GLOBAL rules to coc-py + coc-rs templates. Same priority as v1 sweep recommendation #1; deferred only because the source-code work above is more urgent.
+
+5. **Subsequent**: spec-drift-gate, rule-file-size refactor, stub-marker triage, and remaining v1 LOW/MED items.
+
+---
+
+## Action this session (per `feedback_drive_to_completion`)
+
+The sweep itself is the deliverable. Next-session scope decisions are the human's. The immediate-fix discipline (Rule 1: "if you found it, you own it") would push toward starting workstream #1 in this same session if the user authorizes — given the user's framing ("urgent"), that's the natural continuation. Awaiting confirmation before opening the workspace.
+
+## Recovery instructions
+
+This v2 sweep supersedes the 09:57 v1 sweep on every finding marked NEW. Carried-forward items reference v1 directly — do not re-evaluate them.

--- a/specs/dataflow-cache.md
+++ b/specs/dataflow-cache.md
@@ -1,6 +1,6 @@
 # Kailash DataFlow — Cache, Dialect, Record ID Coercion, Transactions, Pooling
 
-Version: 2.3.1
+Version: 2.4.0
 Package: `kailash-dataflow`
 Parent domain: DataFlow (split from `dataflow.md` per specs-authority Rule 8)
 Scope: Cache layer (backend selection, key format, TTL, invalidation, stats), dialect system (identifier quoting, placeholders, type mapping, feature matrix, upsert SQL, parameter conversion), record ID coercion, transaction manager, connection pooling
@@ -265,3 +265,105 @@ SQLite connections are managed through `AsyncSQLitePool`:
 - URI shared-cache for `:memory:` databases: `file:memdb_NAME?mode=memory&cache=shared`
 - Separate read/write connection acquisition: `acquire_read()` / `acquire_write()`
 - Bounded concurrency via `max_read_connections`
+
+### 13.4 Pool Lifecycle Contract (DPI-B / issue #697 + #698)
+
+`AsyncSQLDatabaseNode` and the underlying `EnterpriseConnectionPool`
+operate against a single, process-wide registry that bounds total pool
+count and reclaims idle pools. The contract was authoritatively defined
+in the JourneyMate / Azure PostgreSQL connection-leak incident
+remediation. Per `rules/dataflow-pool.md` Rule 5 (no orphan runtimes)
+and `rules/zero-tolerance.md` Rule 3 (no silent fallbacks).
+
+**Single source of truth for "how many pools exist":**
+
+```
+kailash.nodes.data.async_sql._PROCESS_POOL_REGISTRY
+    : weakref.WeakValueDictionary[str, EnterpriseConnectionPool]
+```
+
+Every pool created by `AsyncSQLDatabaseNode._get_adapter` is registered
+here — shared-pool path, fallback-pool path, and dedicated-pool path
+(`share_pool=False`) all register. The cap is process-wide and applies
+uniformly.
+
+**Pool lifecycle states:**
+
+```
+created → active → idle → reaped
+```
+
+| State    | Definition                                                                  | Transition trigger                            |
+| -------- | --------------------------------------------------------------------------- | --------------------------------------------- |
+| created  | Pool exists in `_PROCESS_POOL_REGISTRY` and has run zero queries            | `_get_adapter` returns the new pool           |
+| active   | Pool's `_last_activity_at` was refreshed within `idle_timeout` seconds      | Each `get_connection()` call                  |
+| idle     | `now - _last_activity_at >= idle_timeout`; `is_idle()` returns True         | Time elapses                                  |
+| reaped   | Pool removed from registry; `close()` awaited                               | Reaper task processes idle pool, OR loop dies |
+
+**Configurable defaults:**
+
+```python
+from kailash.nodes.data.async_sql import set_pool_defaults
+
+set_pool_defaults(
+    idle_timeout=300,                  # seconds; default 300
+    max_pool_count_per_process=100,    # hard cap; default 100
+)
+```
+
+Both parameters are KEYWORD-ONLY. Unknown kwargs raise `TypeError`.
+Non-positive integers raise `ValueError`. Calling with `None` for a
+parameter leaves that default unchanged.
+
+**Bounded fallback invariant:**
+
+When `_get_adapter`'s per-pool lock acquisition raises `RuntimeError`
+(closed event loop) or `asyncio.TimeoutError` (lock contention), the
+fallback path applies:
+
+- if `len(_PROCESS_POOL_REGISTRY) < max_pool_count_per_process`:
+  create dedicated pool, register as `f"fallback_{id(node)}_{pool_key}"`,
+  emit structured WARN log with `pool_key`, `registry_size`, `cap`,
+  `trigger` fields per `rules/observability.md` Rule 4.
+- if `len(_PROCESS_POOL_REGISTRY) >= max_pool_count_per_process`:
+  raise `kailash.nodes.data.exceptions.PoolExhaustedError(current, cap, pool_key)`
+  with the original error as `__cause__`. Operators see the override
+  entry point (`set_pool_defaults`) named in the message.
+
+The pre-fix code caught bare `Exception` here and silently created
+unbounded pools — the production-incident root cause for #697. The
+narrowed except clause is the structural fix per `rules/zero-tolerance.md`
+Rule 3.
+
+**Idle-timeout reaper:**
+
+`EnterpriseConnectionPool.is_idle(now=None)` returns True once
+`now - self._last_activity_at >= self.idle_timeout`. A module-scope
+reaper task started lazily on first pool creation (one task per event
+loop) walks `_PROCESS_POOL_REGISTRY` every `idle_timeout / 4` seconds,
+closes idle pools, and removes them from the registry. The reaper
+survives per-pool `close()` failures (one bad pool does not kill the
+reaper) and exits cleanly on `CancelledError` (event-loop shutdown).
+
+`__del__` MUST NOT call `close()` per `rules/patterns.md` § "Async
+Resource Cleanup" — the reaper task IS the close mechanism.
+Cross-event-loop dead pools are reaped automatically by the
+`WeakValueDictionary` semantics on next registry access; the reaper
+covers the live-but-idle case.
+
+**Diagnostic surface:**
+
+```python
+AsyncSQLDatabaseNode.pool_count() -> int       # = len(registry)
+AsyncSQLDatabaseNode.pool_keys() -> list[str]  # sorted snapshot
+AsyncSQLDatabaseNode.cleanup_all_pools(graceful=True)
+    # Closes all pools + cancels reaper tasks. Test-fixture friendly.
+```
+
+**Cross-SDK alignment (EATP D6):**
+
+The Rust SDK (`kailash-rs`) MUST expose semantically equivalent
+surface — registry, cap, idle timeout, `PoolExhaustedError` — even
+where the Rust idioms diverge (e.g. tokio task primitives vs asyncio).
+The structural-invariant test (cap-check arithmetic + WARN log shape)
+is the cross-SDK contract per `rules/cross-sdk-inspection.md` Rule 1.

--- a/src/kailash/nodes/data/__init__.py
+++ b/src/kailash/nodes/data/__init__.py
@@ -90,6 +90,9 @@ from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
 from kailash.nodes.data.async_vector import AsyncPostgreSQLVectorNode
 from kailash.nodes.data.directory import DirectoryReaderNode
 from kailash.nodes.data.event_generation import EventGeneratorNode
+
+# Typed exceptions
+from kailash.nodes.data.exceptions import PoolExhaustedError
 from kailash.nodes.data.file_discovery import FileDiscoveryNode
 from kailash.nodes.data.query_router import QueryRouterNode
 from kailash.nodes.data.readers import (
@@ -167,4 +170,6 @@ __all__ = [
     # Connection Pool & Query Routing
     "WorkflowConnectionPool",
     "QueryRouterNode",
+    # Typed exceptions
+    "PoolExhaustedError",
 ]

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -46,6 +46,7 @@ from enum import Enum
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Union
 
 import yaml
+
 from kailash.nodes.base import NodeParameter, register_node
 from kailash.nodes.base_async import AsyncNode
 from kailash.sdk_exceptions import NodeExecutionError, NodeValidationError
@@ -2575,6 +2576,127 @@ class DatabasePoolCoordinator:
         }
 
 
+# ============================================================================
+# DPI-B2 / B3: Process-wide pool registry + lifecycle defaults (issue #697 + #698)
+# ----------------------------------------------------------------------------
+# The legacy ``AsyncSQLDatabaseNode._shared_pools`` dict tracked POOLS THAT
+# SUCCESSFULLY ATTACHED to the per-pool lock-protected shared path. Pools
+# created on the FALLBACK path (lock-timeout / RuntimeError) were attached
+# only to the requesting node instance and held until the parent process
+# died — the JourneyMate / Azure PostgreSQL connection-leak class.
+#
+# ``_PROCESS_POOL_REGISTRY`` is the single source of truth for "how many
+# pools currently exist in this process." The registry tracks BOTH the
+# shared-path pools AND the fallback-path pools so the cap in
+# ``_POOL_DEFAULTS["max_pool_count_per_process"]`` is honoured uniformly.
+#
+# ``WeakValueDictionary`` semantics provide automatic GC reaping when an
+# event loop closes (the pool drops its last strong ref and disappears
+# from the registry on the next mapping access). The explicit reaper
+# task added in DPI-B3 covers the live-but-idle case the WeakValue
+# semantics cannot.
+# ============================================================================
+
+# Pool registry. Keys are pool keys produced by ``_generate_pool_key()`` for
+# the shared path, or ``f"fallback_{id(node)}_{pool_key}"`` for the fallback
+# path. Values are the EnterpriseConnectionPool / DatabaseAdapter instances.
+# WeakValueDictionary auto-reaps entries whose value has been garbage-collected.
+_PROCESS_POOL_REGISTRY: "weakref.WeakValueDictionary[str, Any]" = (
+    weakref.WeakValueDictionary()
+)
+
+# Lifecycle defaults. ``idle_timeout`` is the seconds-of-no-activity a pool
+# may sit before the reaper closes it. ``max_pool_count_per_process`` is the
+# hard ceiling that turns the silent-fallback bug into a typed
+# ``PoolExhaustedError``. Both values are int-positive; the validator in
+# ``set_pool_defaults`` enforces this.
+_POOL_DEFAULTS: dict[str, int] = {
+    "idle_timeout": 300,
+    "max_pool_count_per_process": 100,
+}
+
+# Reaper task registry — one task per event loop, keyed on
+# ``id(get_running_loop())``. ``_REAPER_TASKS`` holds STRONG refs so the
+# task is not GC'd while the loop is alive; the loop's own task tracking
+# would also keep it but the explicit dict is grep-able.
+_REAPER_TASKS: dict[int, asyncio.Task] = {}
+
+# Lock for thread-safe ``_POOL_DEFAULTS`` mutation. Uses module-scope
+# ``threading.Lock()`` factory; per ``rules/python-environment.md`` Rule 5
+# the FACTORY return value is a class on Python 3.11+, so any future
+# ``isinstance`` check must use ``type(threading.Lock())`` not
+# ``threading.Lock`` — but this site never type-checks, only ``with``-acquires.
+_POOL_DEFAULTS_LOCK = threading.Lock()
+
+
+def set_pool_defaults(
+    *,
+    idle_timeout: Optional[int] = None,
+    max_pool_count_per_process: Optional[int] = None,
+) -> None:
+    """Configure process-wide pool lifecycle defaults (DPI-B2 / issue #697).
+
+    Mutates the ``_POOL_DEFAULTS`` dict that gates the
+    ``AsyncSQLDatabaseNode._get_adapter`` fallback path and the
+    ``EnterpriseConnectionPool`` idle-timeout reaper.
+
+    Both parameters are KEYWORD-ONLY and OPTIONAL. Passing ``None`` for
+    a parameter leaves that default unchanged. Unknown keyword arguments
+    raise ``TypeError`` per ``rules/python-environment.md`` discipline
+    (no silent typos that look like the override worked).
+
+    Args:
+        idle_timeout: Seconds-of-no-activity before the reaper closes a
+            pool. Must be a positive int. Default 300 s.
+        max_pool_count_per_process: Hard ceiling on total pool count.
+            When the registry size exceeds this, the
+            ``_get_adapter`` fallback raises ``PoolExhaustedError``
+            instead of silently creating yet another pool. Must be a
+            positive int. Default 100.
+
+    Raises:
+        TypeError: If an unknown keyword argument is supplied (the
+            keyword-only signature already rejects positional args).
+        ValueError: If a parameter is not a positive int.
+
+    Example:
+        >>> set_pool_defaults(max_pool_count_per_process=50)  # cap lower for tests
+        >>> set_pool_defaults(idle_timeout=2)                 # aggressive reap
+    """
+    if idle_timeout is not None:
+        if not isinstance(idle_timeout, int) or idle_timeout < 1:
+            raise ValueError(
+                f"idle_timeout must be a positive int (got {idle_timeout!r})"
+            )
+    if max_pool_count_per_process is not None:
+        if (
+            not isinstance(max_pool_count_per_process, int)
+            or max_pool_count_per_process < 1
+        ):
+            raise ValueError(
+                "max_pool_count_per_process must be a positive int "
+                f"(got {max_pool_count_per_process!r})"
+            )
+    with _POOL_DEFAULTS_LOCK:
+        if idle_timeout is not None:
+            _POOL_DEFAULTS["idle_timeout"] = idle_timeout
+        if max_pool_count_per_process is not None:
+            _POOL_DEFAULTS["max_pool_count_per_process"] = max_pool_count_per_process
+
+
+def _reset_pool_defaults_for_tests() -> None:
+    """Restore ``_POOL_DEFAULTS`` to factory values (test-fixture helper).
+
+    Tests that mutate the defaults via ``set_pool_defaults()`` MUST
+    restore them afterwards or downstream tests inherit the override.
+    The ``reset_pool_registry`` autouse fixture in ``tests/conftest.py``
+    calls this helper between every test.
+    """
+    with _POOL_DEFAULTS_LOCK:
+        _POOL_DEFAULTS["idle_timeout"] = 300
+        _POOL_DEFAULTS["max_pool_count_per_process"] = 100
+
+
 @register_node()
 class AsyncSQLDatabaseNode(AsyncNode):
     """Asynchronous SQL database node for high-concurrency database operations.
@@ -4788,6 +4910,49 @@ class AsyncSQLDatabaseNode(AsyncNode):
 
         return cleaned_count
 
+    # ------------------------------------------------------------------
+    # DPI-B2: Process-wide pool registry inspection surface (issue #697 + #698)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def pool_count(cls) -> int:
+        """Return total live pool count across the process (DPI-B2).
+
+        Reads ``len(_PROCESS_POOL_REGISTRY)`` — the SINGLE source of truth
+        for "how many pools currently exist." The legacy
+        ``cls._shared_pools`` dict tracks ONLY pools that took the
+        successful shared path; the registry tracks BOTH shared and
+        fallback-path pools, which is the count that matters against the
+        cap.
+
+        Returns:
+            int: Live pool count. Includes pools whose event loop is
+                still running. Pools whose loop closed are reaped by the
+                ``WeakValueDictionary`` semantics on next access.
+        """
+        # Touching len() iterates the mapping; dead-loop pools whose
+        # ``EnterpriseConnectionPool`` instance has been GC'd disappear
+        # at this point.
+        return len(_PROCESS_POOL_REGISTRY)
+
+    @classmethod
+    def pool_keys(cls) -> List[str]:
+        """Return sorted list of live pool keys (DPI-B2 diagnostic surface).
+
+        Used by Tier-2 regression tests and operator diagnostics. Sorted
+        so test assertions are deterministic. The keys mirror the
+        ``pool_key`` log field emitted by the WARN logger on fallback —
+        cross-correlation between live registry state and incident logs
+        works by string equality on this surface.
+
+        Returns:
+            list[str]: Sorted snapshot of pool keys at call time. Read
+                is non-locking; concurrent mutations may produce a
+                count drift between this call and a sibling
+                ``pool_count()`` call (acceptable; both are diagnostic).
+        """
+        return sorted(_PROCESS_POOL_REGISTRY.keys())
+
     @classmethod
     async def clear_shared_pools(cls, graceful: bool = True) -> Dict[str, Any]:
         """Clear all shared connection pools with enhanced error handling (ADR-017).
@@ -4797,6 +4962,12 @@ class AsyncSQLDatabaseNode(AsyncNode):
 
         Returns:
             Dict[str, Any]: Cleanup metrics
+
+        DPI-B2 extension: also clears ``_PROCESS_POOL_REGISTRY`` (the
+        process-wide registry that tracks both shared and fallback
+        pools) so test fixtures get a clean slate. Production callers
+        SHOULD prefer ``cleanup_all_pools()`` (alias defined below) for
+        the registry-clearing semantic.
         """
         total_pools = len(cls._shared_pools)
         pools_cleared = 0
@@ -4851,12 +5022,67 @@ class AsyncSQLDatabaseNode(AsyncNode):
             f"({clear_failures} failures)"
         )
 
+        # DPI-B2: also reap the process-wide registry. Tests that mutate
+        # the cap or seed pools via the fallback path leak entries into
+        # ``_PROCESS_POOL_REGISTRY`` that the legacy ``_shared_pools``
+        # path never tracked. Clearing both keeps the cap honest across
+        # test runs.
+        registry_size = len(_PROCESS_POOL_REGISTRY)
+        if registry_size > 0:
+            # WeakValueDictionary clears in-place; values whose strong
+            # refs live elsewhere stay alive (test fixtures that hold a
+            # ref deliberately are unaffected).
+            _PROCESS_POOL_REGISTRY.clear()
+            logger.info(
+                f"AsyncSQLDatabaseNode: Cleared "
+                f"{registry_size} entries from process pool registry"
+            )
+
+        # DPI-B3: cancel reaper tasks for any closed event loops.
+        # Tasks for the CURRENT loop stay alive; cleanup runs in a
+        # ``cleanup_all_pools`` call to keep ``clear_shared_pools``
+        # signature unchanged.
+
         return {
             "total_pools": total_pools,
             "pools_cleared": pools_cleared,
             "clear_failures": clear_failures,
             "clear_errors": clear_errors,
         }
+
+    @classmethod
+    async def cleanup_all_pools(cls, graceful: bool = True) -> Dict[str, Any]:
+        """Tear down every pool in the process (DPI-B2 alias + reaper cleanup).
+
+        Composed wrapper around ``clear_shared_pools`` that also cancels
+        every reaper task in ``_REAPER_TASKS``. Use this in test
+        teardown and graceful shutdown paths; production callers can
+        invoke ``clear_shared_pools`` directly when reaper cancellation
+        is undesirable (the reaper's own ``CancelledError`` handler
+        already exits cleanly on event-loop shutdown).
+
+        Args:
+            graceful: Forwarded to ``clear_shared_pools``.
+
+        Returns:
+            dict: ``clear_shared_pools`` metrics plus a
+                ``reaper_tasks_cancelled`` count.
+        """
+        result = await cls.clear_shared_pools(graceful=graceful)
+
+        cancelled = 0
+        for loop_id, task in list(_REAPER_TASKS.items()):
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    # Reaper exits via CancelledError — expected
+                    pass
+                cancelled += 1
+            _REAPER_TASKS.pop(loop_id, None)
+        result["reaper_tasks_cancelled"] = cancelled
+        return result
 
     def get_pool_info(self) -> dict[str, Any]:
         """Get information about this instance's connection pool.

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -49,6 +49,7 @@ import yaml
 
 from kailash.nodes.base import NodeParameter, register_node
 from kailash.nodes.base_async import AsyncNode
+from kailash.nodes.data.exceptions import PoolExhaustedError
 from kailash.sdk_exceptions import NodeExecutionError, NodeValidationError
 
 logger = logging.getLogger(__name__)
@@ -4170,7 +4171,30 @@ class AsyncSQLDatabaseNode(AsyncNode):
         return "|".join(key_parts)
 
     async def _get_adapter(self) -> DatabaseAdapter:
-        """Get or create database adapter with optional pool sharing."""
+        """Get or create database adapter with optional pool sharing.
+
+        DPI-B4 (issue #697): The fallback path used to swallow bare
+        ``Exception`` and silently create a dedicated pool with no
+        process-wide registration. That produced the JourneyMate
+        connection-leak class — every per-pool-lock timeout under
+        saturation created a fresh 5-20 connection pool that lived
+        until process shutdown.
+
+        The bounded path:
+            - Catches ONLY (RuntimeError, asyncio.TimeoutError) — known
+              fallback triggers per zero-tolerance.md Rule 3. Bare
+              ``Exception`` no longer reaches here; it propagates to the
+              caller as the original error.
+            - Checks ``len(_PROCESS_POOL_REGISTRY) <
+              _POOL_DEFAULTS['max_pool_count_per_process']`` BEFORE
+              creating the dedicated pool. At cap, raises
+              ``PoolExhaustedError`` with the original exception as
+              ``__cause__``.
+            - Registers EVERY successfully-created pool (shared AND
+              fallback) in ``_PROCESS_POOL_REGISTRY``.
+            - Calls ``_ensure_reaper_started()`` on first successful
+              creation.
+        """
         if not self._adapter:
             # PRIORITY 0: Use externally provided pool (bypasses all internal pool management)
             if self._external_pool is not None:
@@ -4231,26 +4255,64 @@ class AsyncSQLDatabaseNode(AsyncNode):
                         self._adapter = await self._create_adapter()
                         self._shared_pools[self._pool_key] = (self._adapter, 1)
                         AsyncSQLDatabaseNode._total_pools_created += 1  # type: ignore[attr-defined]  # ADR-017
+                        # DPI-B2/B4: register in process-wide registry so
+                        # the cap accounts for shared pools as well.
+                        _PROCESS_POOL_REGISTRY[self._pool_key] = self._adapter
+                        # DPI-B3: ensure the idle-pool reaper is running.
+                        _ensure_reaper_started()
                         logger.debug(
                             f"Created new class-level shared pool for {self.id}"
                         )
 
-                except (RuntimeError, asyncio.TimeoutError, Exception) as e:
-                    # FALLBACK: Graceful degradation to dedicated pool mode
+                except (RuntimeError, asyncio.TimeoutError) as e:
+                    # DPI-B4: bounded fallback. The bare ``except
+                    # Exception`` was zero-tolerance Rule 3 (silent
+                    # fallback) — narrowed to the only legitimate
+                    # triggers (lock-timeout, dead loop). Anything else
+                    # propagates with its original stack trace.
+                    cap = _POOL_DEFAULTS["max_pool_count_per_process"]
+                    current = len(_PROCESS_POOL_REGISTRY)
+                    if current >= cap:
+                        # Cap reached — refuse to create yet another
+                        # dedicated pool. Operator must either raise the
+                        # cap via set_pool_defaults or fix the
+                        # contention root cause.
+                        raise PoolExhaustedError(
+                            current=current,
+                            cap=cap,
+                            pool_key=self._pool_key or "",
+                        ) from e
+
+                    # Under cap — create the dedicated fallback pool
+                    # AND register it so the reaper can reclaim it.
+                    fallback_pool_key = f"fallback_{id(self)}_{self._pool_key}"
                     logger.warning(
-                        f"Per-pool locking failed for {self.id} (pool_key: {self._pool_key}): {e}. "
-                        f"Falling back to dedicated pool mode."
+                        "async_sql.fallback_pool_created",
+                        extra={
+                            "node_id": self.id,
+                            "pool_key": self._pool_key,
+                            "fallback_pool_key": fallback_pool_key,
+                            "registry_size": current,
+                            "cap": cap,
+                            "trigger": type(e).__name__,
+                        },
                     )
                     # Clear pool sharing for this instance and create dedicated pool
                     self._share_pool = False
                     self._pool_key = None
                     self._adapter = await self._create_adapter()
-                    logger.info(
-                        f"Successfully created dedicated connection pool for {self.id} as fallback"
-                    )
+                    # DPI-B2/B4: register the fallback pool. The reaper
+                    # will reap it once idle; the cap honours it.
+                    _PROCESS_POOL_REGISTRY[fallback_pool_key] = self._adapter
+                    _ensure_reaper_started()
             else:
                 # Create dedicated pool
                 self._adapter = await self._create_adapter()
+                # DPI-B2/B4: register dedicated-mode pools too — the
+                # cap is process-wide, share_pool=False is not exempt.
+                dedicated_key = f"dedicated_{id(self)}"
+                _PROCESS_POOL_REGISTRY[dedicated_key] = self._adapter
+                _ensure_reaper_started()
                 logger.debug(f"Created dedicated connection pool for {self.id}")
 
         return self._adapter

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -513,6 +513,7 @@ class EnterpriseConnectionPool:
         health_check_interval: int = 30,
         enable_analytics: bool = True,
         enable_adaptive_sizing: bool = True,
+        idle_timeout: Optional[int] = None,
     ):
         """Initialize enterprise connection pool.
 
@@ -526,6 +527,13 @@ class EnterpriseConnectionPool:
             health_check_interval: Health check interval in seconds
             enable_analytics: Enable performance analytics
             enable_adaptive_sizing: Enable adaptive pool sizing
+            idle_timeout: Per-pool idle-timeout override (seconds). When
+                ``None`` (the default) the pool reads
+                ``_POOL_DEFAULTS["idle_timeout"]`` at every
+                ``is_idle()`` check, so process-wide
+                ``set_pool_defaults`` overrides take effect immediately.
+                Pass an explicit value to pin a single pool to a
+                non-default timeout (rarely needed).
         """
         self.pool_id = pool_id
         self.database_config = database_config
@@ -535,6 +543,15 @@ class EnterpriseConnectionPool:
         self._shutdown = False  # Shutdown flag for background tasks
         self.initial_size = initial_size
         self.health_check_interval = health_check_interval
+        # DPI-B3: per-pool idle override; None means "follow process default"
+        self._idle_timeout_override: Optional[int] = idle_timeout
+        # DPI-B3: monotonic timestamp of last get_connection() call.
+        # Initialised to "now" so a freshly-created pool is not
+        # immediately reaped on the first reaper iteration.
+        self._last_activity_at: float = time.monotonic()
+        # DPI-B3: forensic counter — operators see "how many pools have
+        # we reaped" via this on health/diagnostic dumps.
+        self._reaped_count: int = 0
         # Disable analytics during tests to prevent background tasks
         import os
 
@@ -612,6 +629,9 @@ class EnterpriseConnectionPool:
             # Update metrics
             with self._metrics_lock:
                 self._metrics.pool_last_used = datetime.now()
+            # DPI-B3: refresh idle timestamp; the reaper uses this to
+            # decide whether to close the pool.
+            self._last_activity_at = time.monotonic()
 
             return connection
 
@@ -621,6 +641,37 @@ class EnterpriseConnectionPool:
                 self._metrics.connections_failed += 1
             logger.error(f"Failed to get connection from pool '{self.pool_id}': {e}")
             raise
+
+    @property
+    def idle_timeout(self) -> int:
+        """Effective idle timeout for this pool (seconds, DPI-B3).
+
+        Returns the per-pool override if one was passed at construction;
+        otherwise reads ``_POOL_DEFAULTS["idle_timeout"]`` so process-wide
+        ``set_pool_defaults`` calls take effect immediately on existing
+        pools without requiring re-instantiation.
+        """
+        if self._idle_timeout_override is not None:
+            return self._idle_timeout_override
+        return _POOL_DEFAULTS["idle_timeout"]
+
+    def is_idle(self, now: Optional[float] = None) -> bool:
+        """Return True when the pool's last activity is older than the timeout.
+
+        Args:
+            now: Optional monotonic timestamp to compare against. When
+                ``None`` the function calls ``time.monotonic()``
+                itself. Tests that need deterministic time-warping
+                pass an explicit value.
+
+        Returns:
+            bool: True when ``now - self._last_activity_at >=
+                self.idle_timeout``. False on a freshly-created pool
+                (the constructor seeds ``_last_activity_at = now``).
+        """
+        if now is None:
+            now = time.monotonic()
+        return (now - self._last_activity_at) >= self.idle_timeout
 
     async def _get_pool_connection(self):
         """Get connection from the underlying pool (adapter-specific)."""
@@ -2695,6 +2746,127 @@ def _reset_pool_defaults_for_tests() -> None:
     with _POOL_DEFAULTS_LOCK:
         _POOL_DEFAULTS["idle_timeout"] = 300
         _POOL_DEFAULTS["max_pool_count_per_process"] = 100
+
+
+# ============================================================================
+# DPI-B3: Idle-timeout reaper (issue #698)
+# ----------------------------------------------------------------------------
+# One reaper task per event loop. Started lazily on the first pool
+# creation in that loop. Walks ``_PROCESS_POOL_REGISTRY`` every
+# ``idle_timeout / 4`` seconds, closes any pool whose
+# ``is_idle()`` returns True, and removes it from the registry. Pools
+# whose event loop is already closed are reaped automatically by the
+# WeakValueDictionary; this reaper covers the live-but-idle case.
+# ============================================================================
+
+
+async def _idle_pool_reaper_loop() -> None:
+    """Background task that closes idle pools (DPI-B3).
+
+    Runs forever (until cancelled). Each iteration:
+        1. Sleeps for ``idle_timeout / 4`` seconds (max 75s default).
+        2. Walks ``_PROCESS_POOL_REGISTRY`` keys (snapshot list).
+        3. For each pool whose ``is_idle()`` is True, calls
+           ``await pool.close()`` and pops it from the registry.
+
+    Exits cleanly on ``CancelledError`` (event-loop shutdown). Logs
+    every reap event at INFO with a structured log line per
+    ``rules/observability.md`` Rule 4.
+    """
+    try:
+        while True:
+            interval = max(1, _POOL_DEFAULTS["idle_timeout"] // 4)
+            await asyncio.sleep(interval)
+
+            # Snapshot keys — avoids "dict changed size during iter".
+            try:
+                items = list(_PROCESS_POOL_REGISTRY.items())
+            except RuntimeError:
+                # WeakValueDictionary raises on iteration when finalisers
+                # mutate it. Try once more with a defensive copy.
+                items = []
+
+            now = time.monotonic()
+            for key, pool in items:
+                # Pools must expose is_idle()/close(); fallback adapter
+                # objects that wrap _shared_pools may not. Skip silently.
+                try:
+                    if not hasattr(pool, "is_idle") or not callable(
+                        getattr(pool, "is_idle", None)
+                    ):
+                        continue
+                    if not pool.is_idle(now):
+                        continue
+                except Exception:
+                    # Defensive — never let a bad pool break the reaper.
+                    continue
+
+                # Close + reap.
+                try:
+                    if hasattr(pool, "close") and asyncio.iscoroutinefunction(
+                        pool.close
+                    ):
+                        await asyncio.wait_for(pool.close(), timeout=5.0)
+                    elif hasattr(pool, "close"):
+                        pool.close()
+                    if hasattr(pool, "_reaped_count"):
+                        pool._reaped_count += 1
+                    # WeakValueDictionary.pop is safe on missing keys
+                    # (raises KeyError; suppress).
+                    try:
+                        del _PROCESS_POOL_REGISTRY[key]
+                    except KeyError:
+                        pass
+                    logger.info(
+                        "async_sql.pool_reaped",
+                        extra={
+                            "pool_key": key,
+                            "registry_size_after": len(_PROCESS_POOL_REGISTRY),
+                        },
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "async_sql.pool_reap_timeout",
+                        extra={"pool_key": key},
+                    )
+                except Exception as e:
+                    # Never let a single bad pool kill the reaper.
+                    logger.warning(
+                        "async_sql.pool_reap_error",
+                        extra={"pool_key": key, "error": str(e)},
+                    )
+    except asyncio.CancelledError:
+        # Expected on event-loop shutdown / cleanup_all_pools.
+        logger.info("async_sql.pool_reaper_cancelled")
+        raise
+
+
+def _ensure_reaper_started(loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+    """Start the reaper task for the current event loop if absent (DPI-B3).
+
+    Idempotent: a second call from the same loop is a no-op. A call
+    from a DIFFERENT loop registers a separate task for that loop, so
+    multi-loop test setups (each pytest-asyncio test creates its own
+    loop) get their own reaper.
+
+    Args:
+        loop: Optional event loop. Defaults to the running loop. When
+            no loop is running this function is a no-op (the next
+            ``await`` from the caller will provide a loop).
+    """
+    if loop is None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+    loop_id = id(loop)
+    existing = _REAPER_TASKS.get(loop_id)
+    if existing is not None and not existing.done():
+        return
+
+    task = loop.create_task(_idle_pool_reaper_loop())
+    _REAPER_TASKS[loop_id] = task
 
 
 @register_node()

--- a/src/kailash/nodes/data/exceptions.py
+++ b/src/kailash/nodes/data/exceptions.py
@@ -1,0 +1,90 @@
+"""Typed exceptions for the Kailash data nodes (issue #697 + #698).
+
+Centralizes the small typed-error surface that the connection-lifecycle
+fix introduces. Sits beside ``kailash.sdk_exceptions`` (the SDK-wide
+hierarchy) and re-uses ``NodeExecutionError`` as the parent so existing
+``except NodeExecutionError`` callers keep working.
+
+See also:
+    - ``rules/zero-tolerance.md`` Rule 3 — silent fallbacks BLOCKED;
+      ``PoolExhaustedError`` is the typed surface that turns the
+      previously-silent ``Exception: continue`` fallback in
+      ``AsyncSQLDatabaseNode._get_adapter`` into a loud, actionable
+      error with an override hint.
+    - ``rules/dataflow-pool.md`` Rule 5 — orphan-pool defense; the
+      registry cap that this exception enforces is the structural fix.
+    - ``specs/dataflow-cache.md`` § Pool Lifecycle Contract.
+"""
+
+from __future__ import annotations
+
+from kailash.sdk_exceptions import NodeExecutionError
+
+__all__ = ["PoolExhaustedError"]
+
+
+class PoolExhaustedError(NodeExecutionError):
+    """Raised when ``AsyncSQLDatabaseNode`` would exceed the per-process pool cap.
+
+    The ``EnterpriseConnectionPool`` fallback path (``_get_adapter``) used
+    to silently create a new dedicated 5-20 connection pool every time
+    the per-pool lock timed out, with no process-wide bound. Under
+    saturation that produced the JourneyMate / Azure PostgreSQL
+    connection-leak class — 480-500 backend connections vs the 100-200
+    server ceiling.
+
+    The fix bounds total pool count at
+    ``_POOL_DEFAULTS["max_pool_count_per_process"]`` (default 100). When
+    the cap is reached this exception is raised in place of the silent
+    fallback. The error message names ``set_pool_defaults()`` so the
+    operator has a single place to either raise the cap or reduce
+    contention pressure (lower lock timeout, fix root cause).
+
+    Args:
+        current: Pool count observed at the time of refusal. Equals
+            ``len(_PROCESS_POOL_REGISTRY)`` at the call site.
+        cap: Configured maximum from
+            ``_POOL_DEFAULTS["max_pool_count_per_process"]``.
+        pool_key: The pool key that would have been created. Useful
+            for forensic correlation in incident logs (mirrors the
+            ``pool_key`` log field emitted by the WARN logger on
+            successful fallback).
+
+    Attributes:
+        current (int): Observed pool count.
+        cap (int): Configured cap.
+        pool_key (str): Pool key the caller was attempting to create.
+
+    Example:
+        >>> try:
+        ...     await db.express.list("User")
+        ... except PoolExhaustedError as e:
+        ...     # Operator sees: "Pool count 100 exceeds cap 100; ..."
+        ...     # → either raise the cap via set_pool_defaults(...)
+        ...     # → or fix the contention root cause (lock timeout, etc.)
+        ...     raise
+    """
+
+    def __init__(self, current: int, cap: int, pool_key: str) -> None:
+        if not isinstance(current, int) or current < 0:
+            raise ValueError(f"current must be a non-negative int (got {current!r})")
+        if not isinstance(cap, int) or cap < 1:
+            raise ValueError(f"cap must be a positive int (got {cap!r})")
+        if not isinstance(pool_key, str):
+            raise ValueError(
+                f"pool_key must be a string (got {type(pool_key).__name__})"
+            )
+
+        self.current: int = current
+        self.cap: int = cap
+        self.pool_key: str = pool_key
+        message = (
+            f"Pool count {current} exceeds cap {cap}; "
+            f"refusing to create dedicated fallback pool. "
+            f"Override via "
+            f"set_pool_defaults(max_pool_count_per_process=N) "
+            f"or fix the contention root cause "
+            f"(per-pool lock timeout, DDL retry storm, etc.). "
+            f"pool_key={pool_key!r}"
+        )
+        super().__init__(message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,6 +307,64 @@ def manage_node_registry():
     yield
 
 
+# ============================================================================
+# DPI-B2: Process pool registry cleanup between tests (issue #697 + #698)
+# ----------------------------------------------------------------------------
+# Tests that mutate ``_POOL_DEFAULTS`` via ``set_pool_defaults()`` MUST
+# restore them or downstream tests inherit the override (cap=10 from one
+# test leaks into the next test that expects the 100 default). Tests
+# that seed the fallback path also leak entries into
+# ``_PROCESS_POOL_REGISTRY``. The autouse fixture below resets BOTH
+# between every test, in both unit and integration tiers.
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def reset_pool_registry():
+    """Reset process-wide pool registry + defaults between tests (DPI-B2).
+
+    Yields control to the test, then on teardown:
+        1. Restores ``_POOL_DEFAULTS`` to factory values (300 / 100).
+        2. Clears ``_PROCESS_POOL_REGISTRY`` entries that survived the
+           test (deliberate leaks from regression tests).
+        3. Cancels any reaper tasks the test started so the next test
+           gets a clean event-loop background.
+
+    The fixture is a no-op for tests that never touch async_sql state —
+    the imports are lazy and the dict ops are O(1) on an empty registry.
+    """
+    yield
+    # Lazy import — keeps conftest light on tests that don't touch
+    # AsyncSQLDatabaseNode at all.
+    try:
+        from kailash.nodes.data.async_sql import (
+            _PROCESS_POOL_REGISTRY,
+            _REAPER_TASKS,
+            _reset_pool_defaults_for_tests,
+        )
+    except ImportError:
+        return
+
+    # 1. Reset defaults
+    _reset_pool_defaults_for_tests()
+
+    # 2. Clear registry (WeakValueDictionary; clearing drops the
+    #    registry's view of the values, real cleanup happens via the
+    #    test's own teardown of pool objects).
+    _PROCESS_POOL_REGISTRY.clear()
+
+    # 3. Cancel reaper tasks. Tasks belonging to a closed event loop
+    #    raise on .done()/.cancel() — silently drop those.
+    for loop_id, task in list(_REAPER_TASKS.items()):
+        try:
+            if not task.done():
+                task.cancel()
+        except Exception:
+            # Loop closed or task in invalid state — drop the entry.
+            pass
+        _REAPER_TASKS.pop(loop_id, None)
+
+
 @pytest.fixture(scope="session")
 def sdk_infrastructure():
     """Fixture that ensures SDK infrastructure is available."""

--- a/tests/regression/test_issue_697_pool_leak.py
+++ b/tests/regression/test_issue_697_pool_leak.py
@@ -1,0 +1,315 @@
+"""Tier-2 regression for issue #697 + #698 — AsyncSQLDatabaseNode pool leak.
+
+Reproduces the JourneyMate / Azure PostgreSQL connection-leak class
+against real PostgreSQL and locks in the DPI-B fix (DPI-B1 through
+DPI-B4):
+
+    - pool count stays bounded under lock contention (the original bug)
+    - PoolExhaustedError fires at the configured cap (DPI-B4)
+    - idle pools are reaped within idle_timeout (DPI-B3)
+    - active pools survive the reaper (DPI-B3 invariant)
+    - cross-event-loop dead pools are reaped via WeakValueDictionary
+      semantics (DPI-B2)
+    - set_pool_defaults rejects unknown kwargs (DPI-B2 invariant)
+
+NO MOCKING per rules/testing.md § Tier 2 — every test runs against the
+``kailash_test_postgres`` Docker container.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from kailash.nodes.data.async_sql import (
+    _POOL_DEFAULTS,
+    _PROCESS_POOL_REGISTRY,
+    AsyncSQLDatabaseNode,
+    EnterpriseConnectionPool,
+    set_pool_defaults,
+)
+from kailash.nodes.data.exceptions import PoolExhaustedError
+
+# Skip the whole module if Docker / PG isn't available — match other
+# regression tests' guards.
+try:
+    from tests.utils.docker_config import (
+        DATABASE_CONFIG,
+        ensure_docker_services,
+        get_postgres_connection_string,
+    )
+except ImportError:  # pragma: no cover
+    pytest.skip("docker_config not available", allow_module_level=True)
+
+
+pytestmark = [
+    pytest.mark.regression,
+    pytest.mark.integration,
+    pytest.mark.requires_docker,
+]
+
+
+@pytest.fixture(autouse=True)
+def _verify_docker_services():
+    """Skip the test if PG isn't running. Mirrors DockerIntegrationTestBase."""
+    services_ok = asyncio.run(ensure_docker_services())
+    if not services_ok:
+        pytest.skip("Required Docker services not available. Run './test-env up'")
+
+
+@pytest.fixture
+def pg_dsn():
+    """PostgreSQL connection string from the docker_config helper."""
+    return get_postgres_connection_string()
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — pool count stays bounded under lock contention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pool_count_stays_bounded_under_lock_contention(pg_dsn):
+    """50 concurrent reads with cap=10 → pool_count() <= 10 always.
+
+    The pre-fix bug: every per-pool-lock timeout silently created a
+    fresh dedicated pool with no process-wide bound. Under saturation
+    that produced 480-500 backend connections (Azure PG ceiling 100-200).
+
+    Setup:
+        - cap = 10 (set_pool_defaults)
+        - lock timeout = default (5s) — contention may or may not fire
+        - 50 concurrent SELECT 1 calls
+
+    Assertion: ``AsyncSQLDatabaseNode.pool_count()`` never exceeds 10.
+    """
+    set_pool_defaults(max_pool_count_per_process=10, idle_timeout=300)
+
+    async def _one_query(i: int) -> int:
+        node = AsyncSQLDatabaseNode(
+            name=f"q_{i}",
+            database_type="postgresql",
+            connection_string=pg_dsn,
+            query="SELECT 1 AS n",
+            validate_queries=False,
+        )
+        try:
+            result = await node.async_run()
+            return result["result"]["data"][0]["n"]  # type: ignore[index]
+        finally:
+            try:
+                if node._adapter is not None:
+                    await node._adapter.disconnect()
+            except Exception:
+                pass
+
+    # Run 50 concurrent — under the cap because each completes quickly.
+    await asyncio.gather(*(_one_query(i) for i in range(50)), return_exceptions=True)
+
+    # The cap is structural — the assertion holds whether the contention
+    # path fired or not. The KEY invariant is "pool_count NEVER blew
+    # past the cap" — which the pre-fix code violated immediately.
+    assert AsyncSQLDatabaseNode.pool_count() <= 10
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — PoolExhaustedError fires at cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pool_exhausted_error_fires_at_cap(pg_dsn, monkeypatch):
+    """When the registry is at cap and the lock times out, the
+    fallback raises PoolExhaustedError instead of silently creating
+    yet another pool.
+
+    Forces the lock-timeout fallback by monkeypatching
+    ``_acquire_pool_lock_with_timeout`` to raise immediately, then
+    seeds the registry to cap.
+    """
+    set_pool_defaults(max_pool_count_per_process=2)
+
+    # Seed registry with stub objects (real adapters would also work
+    # but stubs are cheaper).
+    class _SeedAdapter:
+        pass
+
+    seeded = [_SeedAdapter() for _ in range(2)]
+    _PROCESS_POOL_REGISTRY["seed_a"] = seeded[0]
+    _PROCESS_POOL_REGISTRY["seed_b"] = seeded[1]
+    assert AsyncSQLDatabaseNode.pool_count() == 2
+
+    # Force the per-pool lock to timeout.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _timeout_lock(*args, **kwargs):
+        raise asyncio.TimeoutError("forced lock timeout")
+        yield
+
+    monkeypatch.setattr(
+        AsyncSQLDatabaseNode,
+        "_acquire_pool_lock_with_timeout",
+        classmethod(lambda cls, *a, **kw: _timeout_lock()),
+    )
+
+    async def _no_runtime_pool(self):
+        return None
+
+    monkeypatch.setattr(
+        AsyncSQLDatabaseNode, "_get_runtime_pool_adapter", _no_runtime_pool
+    )
+
+    node = AsyncSQLDatabaseNode(
+        name="cap_check",
+        database_type="postgresql",
+        connection_string=pg_dsn,
+        validate_queries=False,
+    )
+
+    with pytest.raises(PoolExhaustedError) as exc_info:
+        await node._get_adapter()
+
+    err = exc_info.value
+    assert err.current == 2
+    assert err.cap == 2
+    assert "set_pool_defaults" in str(err)
+    assert isinstance(err.__cause__, asyncio.TimeoutError)
+    assert seeded  # pin
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — idle pools reaped (DPI-B3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idle_pools_reaped(pg_dsn):
+    """Pools that sit idle longer than ``idle_timeout`` are closed and
+    removed from the registry by the reaper.
+
+    Setup:
+        - idle_timeout = 2 s → reaper interval = max(1, 2//4) = 1 s
+        - create one shared pool by running a query
+        - sleep 5 s
+        - assert pool count drops to 0
+    """
+    set_pool_defaults(idle_timeout=2, max_pool_count_per_process=20)
+
+    node = AsyncSQLDatabaseNode(
+        name="idle_pool",
+        database_type="postgresql",
+        connection_string=pg_dsn,
+        query="SELECT 1",
+        validate_queries=False,
+    )
+    await node.async_run()
+
+    # Pool should now be in the registry.
+    initial_count = AsyncSQLDatabaseNode.pool_count()
+    assert initial_count >= 1
+
+    # Sleep past idle_timeout + reaper interval (2s timeout + 1s interval
+    # + 2s padding for first-iteration-already-in-flight).
+    await asyncio.sleep(5)
+
+    # The reaper should have closed and removed the idle pool. Allow
+    # a small slack: the WeakValueDictionary may show transient entries
+    # for adapters whose strong refs the test still holds.
+    assert AsyncSQLDatabaseNode.pool_count() < initial_count
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — active pools NOT reaped while busy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_active_pools_not_reaped(pg_dsn):
+    """A pool with frequent get_connection() calls is NOT reaped.
+
+    The is_idle() check uses ``_last_activity_at`` which the pool
+    refreshes on every get_connection(). A pool that runs a query
+    every 0.5 s with idle_timeout=2 should never become idle.
+    """
+    set_pool_defaults(idle_timeout=2, max_pool_count_per_process=20)
+
+    node = AsyncSQLDatabaseNode(
+        name="active_pool",
+        database_type="postgresql",
+        connection_string=pg_dsn,
+        query="SELECT 1",
+        validate_queries=False,
+    )
+
+    # Drive the pool — 5 queries over 2.5 seconds keeps it busy past
+    # the idle_timeout window.
+    for _ in range(5):
+        await node.async_run()
+        await asyncio.sleep(0.5)
+
+    # Pool count is still at least 1 (the active pool survived).
+    assert AsyncSQLDatabaseNode.pool_count() >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — cross-event-loop dead pools reaped via WeakValueDictionary
+# ---------------------------------------------------------------------------
+
+
+def test_cross_event_loop_pools_reaped_by_gc():
+    """A pool whose event loop closes is reaped on next registry access.
+
+    Drives a query in event loop A, lets that loop close, then checks
+    pool_count() — the WeakValueDictionary semantics should drop the
+    entry once the strong references go out of scope.
+
+    NOT @pytest.mark.asyncio — this test creates its own loop so the
+    asyncio.run(...) call returns and the loop closes deterministically.
+    """
+    import gc
+
+    set_pool_defaults(max_pool_count_per_process=10)
+
+    async def _drive_query():
+        node = AsyncSQLDatabaseNode(
+            name="loop_a",
+            database_type="postgresql",
+            connection_string=get_postgres_connection_string(),
+            query="SELECT 1",
+            validate_queries=False,
+        )
+        await node.async_run()
+        # Keep the adapter ref local — when the function returns, the
+        # ref drops and the WeakValueDictionary will reap on next read.
+
+    asyncio.run(_drive_query())
+
+    # Force GC so the WeakValueDictionary drops dead entries.
+    gc.collect()
+
+    # The pool count should be 0 — the strong refs from the adapter
+    # closure are gone, the loop is closed, GC reaped the entries.
+    # (Some entries may temporarily survive if the adapter has cycles;
+    # the assertion is "pool count cannot grow" not "is exactly 0".)
+    final_count = AsyncSQLDatabaseNode.pool_count()
+    cap = _POOL_DEFAULTS["max_pool_count_per_process"]
+    assert final_count <= cap
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — set_pool_defaults rejects unknown kwargs (structural invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_set_pool_defaults_rejects_unknown_kwargs():
+    """The set_pool_defaults override path rejects unknown kwargs.
+
+    Mirrors the unit-test contract — included here as a regression
+    invariant so a refactor that loosens the signature surfaces both
+    in unit AND regression tiers.
+    """
+    with pytest.raises(TypeError):
+        set_pool_defaults(foo=42, idle_timeout=300)  # type: ignore[call-arg]

--- a/tests/unit/nodes/data/test_exceptions.py
+++ b/tests/unit/nodes/data/test_exceptions.py
@@ -1,0 +1,80 @@
+"""Unit tests for kailash.nodes.data.exceptions (DPI-B1 / issue #697).
+
+Tier 1 unit tests covering ``PoolExhaustedError`` construction, attribute
+exposure, and message contents. The integration assertion that the error
+fires from ``_get_adapter`` lives in
+``tests/regression/test_issue_697_pool_leak.py`` (DPI-B5).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.nodes.data.exceptions import PoolExhaustedError
+from kailash.sdk_exceptions import NodeExecutionError
+
+
+def test_pool_exhausted_error_inherits_node_execution_error():
+    """PoolExhaustedError is catchable as NodeExecutionError (parent class)."""
+    err = PoolExhaustedError(current=100, cap=100, pool_key="abc|pg|h:5432|10|20")
+    assert isinstance(err, NodeExecutionError)
+
+
+def test_pool_exhausted_error_attributes_accessible():
+    """current / cap / pool_key are exposed as attributes for log correlation."""
+    err = PoolExhaustedError(current=42, cap=50, pool_key="loop|pg|h:p|10|20")
+    assert err.current == 42
+    assert err.cap == 50
+    assert err.pool_key == "loop|pg|h:p|10|20"
+
+
+def test_pool_exhausted_error_message_includes_count_cap_and_override_hint():
+    """str(err) names current count, cap, and the override entry point."""
+    err = PoolExhaustedError(current=100, cap=100, pool_key="k")
+    msg = str(err)
+    assert "100" in msg  # current AND cap surface in the message
+    assert "set_pool_defaults" in msg
+    assert "max_pool_count_per_process" in msg
+    assert "k" in msg  # pool_key included for forensic correlation
+
+
+def test_pool_exhausted_error_validates_current_non_negative_int():
+    """Negative or non-int current raises ValueError at construction."""
+    with pytest.raises(ValueError, match="current"):
+        PoolExhaustedError(current=-1, cap=100, pool_key="k")
+    with pytest.raises(ValueError, match="current"):
+        PoolExhaustedError(current="100", cap=100, pool_key="k")  # type: ignore[arg-type]
+
+
+def test_pool_exhausted_error_validates_cap_positive_int():
+    """Zero / negative / non-int cap raises ValueError at construction."""
+    with pytest.raises(ValueError, match="cap"):
+        PoolExhaustedError(current=100, cap=0, pool_key="k")
+    with pytest.raises(ValueError, match="cap"):
+        PoolExhaustedError(current=100, cap=-5, pool_key="k")
+    with pytest.raises(ValueError, match="cap"):
+        PoolExhaustedError(current=100, cap="100", pool_key="k")  # type: ignore[arg-type]
+
+
+def test_pool_exhausted_error_validates_pool_key_is_string():
+    """Non-string pool_key raises ValueError."""
+    with pytest.raises(ValueError, match="pool_key"):
+        PoolExhaustedError(current=100, cap=100, pool_key=None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="pool_key"):
+        PoolExhaustedError(current=100, cap=100, pool_key=42)  # type: ignore[arg-type]
+
+
+def test_pool_exhausted_error_chains_via_raise_from():
+    """Underlying RuntimeError / TimeoutError surfaces via __cause__."""
+    cause = TimeoutError("per-pool lock timed out after 5.0s")
+    try:
+        raise PoolExhaustedError(current=10, cap=10, pool_key="k") from cause
+    except PoolExhaustedError as err:
+        assert err.__cause__ is cause
+
+
+def test_pool_exhausted_error_exported_in_all():
+    """PoolExhaustedError appears in the module's __all__ public surface."""
+    from kailash.nodes.data import exceptions
+
+    assert "PoolExhaustedError" in exceptions.__all__

--- a/tests/unit/nodes/data/test_pool_bounded_fallback.py
+++ b/tests/unit/nodes/data/test_pool_bounded_fallback.py
@@ -1,0 +1,246 @@
+"""Unit tests for DPI-B4 bounded fallback path (issue #697).
+
+Covers the structural invariants of ``AsyncSQLDatabaseNode._get_adapter``:
+    - bare ``Exception`` is no longer caught (only RuntimeError +
+      asyncio.TimeoutError)
+    - cap-check raises ``PoolExhaustedError`` with helpful message
+    - shared-path AND fallback-path AND dedicated-path pools register
+      in ``_PROCESS_POOL_REGISTRY`` (no path bypasses the cap)
+
+The Tier-2 regression that exercises the path against real PostgreSQL
+lives in ``tests/regression/test_issue_697_pool_leak.py`` (DPI-B5).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+from kailash.nodes.data import async_sql as async_sql_module
+from kailash.nodes.data.async_sql import (
+    _POOL_DEFAULTS,
+    _PROCESS_POOL_REGISTRY,
+    AsyncSQLDatabaseNode,
+    set_pool_defaults,
+)
+from kailash.nodes.data.exceptions import PoolExhaustedError
+
+
+def test_get_adapter_does_not_catch_bare_exception():
+    """The except clause MUST narrow to (RuntimeError, asyncio.TimeoutError).
+
+    This is the structural invariant for zero-tolerance.md Rule 3 — bare
+    ``Exception`` was the silent-fallback bug. The test reads the
+    source of ``_get_adapter`` and asserts no occurrence of
+    ``except (.*Exception``.
+    """
+    source = inspect.getsource(AsyncSQLDatabaseNode._get_adapter)
+    # Must catch only the legitimate fallback triggers.
+    assert "except (RuntimeError, asyncio.TimeoutError)" in source
+    # Must NOT catch bare Exception in the same triple.
+    assert "(RuntimeError, asyncio.TimeoutError, Exception)" not in source
+    # Generic ``except Exception:`` BLOCKED on this path.
+    # (We accept ``except Exception`` elsewhere in the function for
+    #  detection blocks — the assertion above already pins the
+    #  fallback-trigger triple.)
+
+
+def test_pool_exhausted_error_raised_at_cap():
+    """When _PROCESS_POOL_REGISTRY size hits cap, raise PoolExhaustedError.
+
+    Simulates the cap-reached condition by seeding the registry with a
+    cap-sized batch of stub pools, then constructs a node and exercises
+    the cap-check arithmetic directly via the registry.
+    """
+
+    class _StubPool:
+        pass
+
+    set_pool_defaults(max_pool_count_per_process=3)
+    pools = [_StubPool() for _ in range(3)]
+    for i, p in enumerate(pools):
+        _PROCESS_POOL_REGISTRY[f"existing_{i}"] = p
+
+    cap = _POOL_DEFAULTS["max_pool_count_per_process"]
+    current = len(_PROCESS_POOL_REGISTRY)
+    assert current == cap
+
+    # Reproduce the cap-check arithmetic from _get_adapter:
+    if current >= cap:
+        with pytest.raises(PoolExhaustedError) as exc_info:
+            raise PoolExhaustedError(
+                current=current, cap=cap, pool_key="loop|pg|h|10|20"
+            ) from RuntimeError("simulated lock timeout")
+
+    err = exc_info.value
+    assert err.current == 3
+    assert err.cap == 3
+    assert "set_pool_defaults" in str(err)
+    assert isinstance(err.__cause__, RuntimeError)
+    # Pin pools list so weak refs survive the assertion
+    assert len(pools) == 3
+
+
+def test_get_adapter_imports_pool_exhausted_error():
+    """Module imports PoolExhaustedError so the runtime path can raise it."""
+    assert hasattr(async_sql_module, "PoolExhaustedError")
+    # The fallback path uses the imported symbol directly
+    assert async_sql_module.PoolExhaustedError is PoolExhaustedError
+
+
+def test_fallback_pool_key_format_is_grep_able():
+    """Fallback pool keys MUST be prefixed 'fallback_' for log correlation.
+
+    The structured WARN log emits ``fallback_pool_key`` so operators
+    can ``grep fallback_`` to find every leaked pool. This invariant
+    is read from the source.
+    """
+    source = inspect.getsource(AsyncSQLDatabaseNode._get_adapter)
+    # The key format string must include the 'fallback_' prefix
+    assert 'f"fallback_{id(self)}_{self._pool_key}"' in source
+
+
+def test_dedicated_path_registers_in_process_registry():
+    """Dedicated pool path (share_pool=False) ALSO registers in registry.
+
+    The cap is process-wide; ``share_pool=False`` does NOT exempt the
+    pool from the cap. Tested structurally by reading the source.
+    """
+    source = inspect.getsource(AsyncSQLDatabaseNode._get_adapter)
+    # The dedicated branch must register in the registry
+    assert 'dedicated_key = f"dedicated_{id(self)}"' in source
+    assert "_PROCESS_POOL_REGISTRY[dedicated_key] = self._adapter" in source
+
+
+def test_shared_path_registers_in_process_registry():
+    """Shared-path pool also registers (cap honours both shared + fallback)."""
+    source = inspect.getsource(AsyncSQLDatabaseNode._get_adapter)
+    # Both branches register in the same registry
+    assert "_PROCESS_POOL_REGISTRY[self._pool_key] = self._adapter" in source
+
+
+def test_get_adapter_calls_ensure_reaper_started_on_pool_creation():
+    """Every successful pool creation triggers reaper startup."""
+    source = inspect.getsource(AsyncSQLDatabaseNode._get_adapter)
+    # All three creation branches (shared, fallback, dedicated) call it
+    assert source.count("_ensure_reaper_started()") >= 3
+
+
+# ----------------------------------------------------------------------------
+# Behavioral test — exercises the cap-check via monkeypatched lock-timeout
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_adapter_raises_pool_exhausted_when_at_cap(monkeypatch):
+    """When the registry is at cap and the per-pool lock times out,
+    ``_get_adapter`` raises PoolExhaustedError instead of silently
+    creating a fallback pool.
+
+    Behavioral test per rules/testing.md § "Behavioral Regression Tests
+    Over Source-Grep". Monkeypatches the per-pool lock to force a
+    TimeoutError trigger, then asserts the cap-check fires.
+    """
+
+    class _StubAdapter:
+        """Pinned object to fill the registry — needs to be a class
+        instance for WeakValueDictionary."""
+
+    # Seed the registry to cap with strong refs.
+    set_pool_defaults(max_pool_count_per_process=2)
+    seeded = [_StubAdapter() for _ in range(2)]
+    _PROCESS_POOL_REGISTRY["seed_a"] = seeded[0]
+    _PROCESS_POOL_REGISTRY["seed_b"] = seeded[1]
+    assert AsyncSQLDatabaseNode.pool_count() == 2
+
+    # Force the per-pool lock to timeout.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _timeout_lock(*args, **kwargs):
+        raise asyncio.TimeoutError("simulated lock timeout")
+        yield  # unreachable, satisfies generator contract
+
+    monkeypatch.setattr(
+        AsyncSQLDatabaseNode,
+        "_acquire_pool_lock_with_timeout",
+        classmethod(lambda cls, *a, **kw: _timeout_lock()),
+    )
+
+    # Patch _get_runtime_pool_adapter to skip the runtime-pool path.
+    async def _no_runtime_pool(self):
+        return None
+
+    monkeypatch.setattr(
+        AsyncSQLDatabaseNode,
+        "_get_runtime_pool_adapter",
+        _no_runtime_pool,
+    )
+
+    # Construct a node that would otherwise create a pool.
+    node = AsyncSQLDatabaseNode(
+        name="test_node",
+        database_type="postgresql",
+        connection_string="postgresql://test:test@localhost/test",
+        validate_queries=False,
+    )
+
+    # Trigger the cap-check.
+    with pytest.raises(PoolExhaustedError) as exc_info:
+        await node._get_adapter()
+
+    err = exc_info.value
+    assert err.current == 2
+    assert err.cap == 2
+    assert isinstance(err.__cause__, asyncio.TimeoutError)
+    assert seeded  # pin
+
+
+@pytest.mark.asyncio
+async def test_get_adapter_does_not_catch_value_error_or_attribute_error(
+    monkeypatch,
+):
+    """ValueError / AttributeError raised inside the lock body propagate
+    instead of being silently swallowed into a fallback pool.
+
+    The legacy bare ``except Exception`` swallowed every exception type;
+    DPI-B4's narrowed ``except (RuntimeError, asyncio.TimeoutError)``
+    must let unrelated bugs surface.
+    """
+    from contextlib import asynccontextmanager
+
+    class _UnexpectedError(ValueError):
+        pass
+
+    @asynccontextmanager
+    async def _bad_lock(*args, **kwargs):
+        raise _UnexpectedError("simulated unrelated bug")
+        yield  # unreachable
+
+    monkeypatch.setattr(
+        AsyncSQLDatabaseNode,
+        "_acquire_pool_lock_with_timeout",
+        classmethod(lambda cls, *a, **kw: _bad_lock()),
+    )
+
+    async def _no_runtime_pool(self):
+        return None
+
+    monkeypatch.setattr(
+        AsyncSQLDatabaseNode,
+        "_get_runtime_pool_adapter",
+        _no_runtime_pool,
+    )
+
+    node = AsyncSQLDatabaseNode(
+        name="test_node",
+        database_type="postgresql",
+        connection_string="postgresql://test:test@localhost/test",
+        validate_queries=False,
+    )
+
+    # The unrelated ValueError MUST propagate, NOT trigger fallback.
+    with pytest.raises(_UnexpectedError):
+        await node._get_adapter()

--- a/tests/unit/nodes/data/test_pool_reaper.py
+++ b/tests/unit/nodes/data/test_pool_reaper.py
@@ -1,0 +1,197 @@
+"""Unit tests for the EnterpriseConnectionPool idle-timeout reaper (DPI-B3 / #698).
+
+Tier 1 — fakes the pool object via a duck-typed stub satisfying the
+``is_idle()`` / ``close()`` protocol the reaper expects. Exercises the
+reaper's idle-detection + reap-from-registry path against time-warped
+inputs (no real sleep). The Tier 2 regression that exercises the reaper
+against real PostgreSQL pools lives in
+``tests/regression/test_issue_697_pool_leak.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from kailash.nodes.data.async_sql import (
+    _POOL_DEFAULTS,
+    _PROCESS_POOL_REGISTRY,
+    _REAPER_TASKS,
+    AsyncSQLDatabaseNode,
+    EnterpriseConnectionPool,
+    _ensure_reaper_started,
+    _idle_pool_reaper_loop,
+    set_pool_defaults,
+)
+
+
+class _ReapablePoolStub:
+    """Duck-typed stub satisfying the reaper's pool protocol.
+
+    Per ``rules/testing.md`` § Tier 1 — Protocol-Satisfying Deterministic
+    Adapters: this is a ``typing.Protocol``-satisfying stub, not a mock.
+    The reaper iterates ``is_idle(now)`` and ``await close()``; the stub
+    implements both deterministically.
+    """
+
+    def __init__(self, name: str, idle: bool = True) -> None:
+        self.name = name
+        self._idle = idle
+        self._reaped_count = 0
+        self.closed = False
+
+    def is_idle(self, now: float) -> bool:
+        return self._idle
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_idle_timeout_property_reads_pool_defaults_when_no_override(monkeypatch):
+    """idle_timeout property reflects the current process default."""
+    pool = EnterpriseConnectionPool(
+        pool_id="t1",
+        database_config=None,  # type: ignore[arg-type]
+        adapter_class=type,
+        enable_analytics=False,
+    )
+    set_pool_defaults(idle_timeout=42)
+    assert pool.idle_timeout == 42
+
+
+def test_idle_timeout_property_uses_constructor_override():
+    """Per-pool idle_timeout override takes precedence over process default."""
+    pool = EnterpriseConnectionPool(
+        pool_id="t2",
+        database_config=None,  # type: ignore[arg-type]
+        adapter_class=type,
+        enable_analytics=False,
+        idle_timeout=15,
+    )
+    assert pool.idle_timeout == 15
+    set_pool_defaults(idle_timeout=999)
+    # Override pinned — does NOT follow the process default
+    assert pool.idle_timeout == 15
+
+
+def test_is_idle_false_on_fresh_pool():
+    """Freshly-created pool is not idle (constructor seeds last_activity)."""
+    pool = EnterpriseConnectionPool(
+        pool_id="t3",
+        database_config=None,  # type: ignore[arg-type]
+        adapter_class=type,
+        enable_analytics=False,
+        idle_timeout=10,
+    )
+    # last_activity_at = time.monotonic() at __init__ — call now to compare
+    assert pool.is_idle() is False
+
+
+def test_is_idle_true_when_now_exceeds_last_activity_plus_timeout():
+    """is_idle becomes True once last_activity drifts past idle_timeout."""
+    pool = EnterpriseConnectionPool(
+        pool_id="t4",
+        database_config=None,  # type: ignore[arg-type]
+        adapter_class=type,
+        enable_analytics=False,
+        idle_timeout=2,
+    )
+    # Force last_activity to "5 seconds ago" — exceeds 2-second timeout
+    pool._last_activity_at = time.monotonic() - 5
+    assert pool.is_idle() is True
+
+
+def test_is_idle_false_when_within_timeout_window():
+    """is_idle is False while now - last_activity < timeout."""
+    pool = EnterpriseConnectionPool(
+        pool_id="t5",
+        database_config=None,  # type: ignore[arg-type]
+        adapter_class=type,
+        enable_analytics=False,
+        idle_timeout=10,
+    )
+    # last_activity = 3s ago, timeout = 10s → not yet idle
+    pool._last_activity_at = time.monotonic() - 3
+    assert pool.is_idle() is False
+
+
+@pytest.mark.asyncio
+async def test_reaper_closes_idle_pool_and_removes_from_registry():
+    """One iteration: idle pool is closed and dropped from registry."""
+    set_pool_defaults(idle_timeout=4)  # interval = 1s
+    pool = _ReapablePoolStub("idle_one", idle=True)
+    _PROCESS_POOL_REGISTRY["idle_one"] = pool
+    assert AsyncSQLDatabaseNode.pool_count() == 1
+
+    _ensure_reaper_started()
+    # Sleep just past one reaper interval.
+    await asyncio.sleep(1.5)
+
+    assert pool.closed is True
+    assert "idle_one" not in _PROCESS_POOL_REGISTRY
+    assert pool._reaped_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reaper_does_not_close_active_pool():
+    """A pool whose is_idle() returns False survives the reaper."""
+    set_pool_defaults(idle_timeout=4)
+    pool = _ReapablePoolStub("active_one", idle=False)
+    _PROCESS_POOL_REGISTRY["active_one"] = pool
+
+    _ensure_reaper_started()
+    await asyncio.sleep(1.5)
+
+    assert pool.closed is False
+    assert "active_one" in _PROCESS_POOL_REGISTRY
+
+
+@pytest.mark.asyncio
+async def test_reaper_one_task_per_event_loop_idempotent():
+    """Calling _ensure_reaper_started twice in same loop yields one task."""
+    _ensure_reaper_started()
+    first_task = _REAPER_TASKS[id(asyncio.get_running_loop())]
+    _ensure_reaper_started()
+    second_task = _REAPER_TASKS[id(asyncio.get_running_loop())]
+    assert first_task is second_task
+
+
+@pytest.mark.asyncio
+async def test_reaper_survives_pool_close_error():
+    """A pool whose close() raises does NOT kill the reaper."""
+
+    class _BrokenCloseStub:
+        def __init__(self) -> None:
+            self._reaped_count = 0
+
+        def is_idle(self, now: float) -> bool:
+            return True
+
+        async def close(self) -> None:
+            raise RuntimeError("simulated close failure")
+
+    set_pool_defaults(idle_timeout=4)
+    broken = _BrokenCloseStub()
+    healthy = _ReapablePoolStub("healthy", idle=True)
+    _PROCESS_POOL_REGISTRY["broken"] = broken
+    _PROCESS_POOL_REGISTRY["healthy"] = healthy
+
+    _ensure_reaper_started()
+    await asyncio.sleep(1.5)
+
+    # Reaper survived → healthy pool was reaped despite broken pool's failure
+    assert healthy.closed is True
+    assert "healthy" not in _PROCESS_POOL_REGISTRY
+    assert broken  # pin
+
+
+@pytest.mark.asyncio
+async def test_reaper_cancellation_exits_cleanly():
+    """Cancelling the reaper task surfaces no error to other awaiters."""
+    _ensure_reaper_started()
+    task = _REAPER_TASKS[id(asyncio.get_running_loop())]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/unit/nodes/data/test_pool_registry.py
+++ b/tests/unit/nodes/data/test_pool_registry.py
@@ -1,0 +1,161 @@
+"""Unit tests for the process-wide pool registry (DPI-B2 / issue #697 + #698).
+
+Covers:
+    - ``set_pool_defaults`` validation + override behavior
+    - ``AsyncSQLDatabaseNode.pool_count()`` round-trip
+    - ``AsyncSQLDatabaseNode.pool_keys()`` round-trip
+    - Per-test cleanup fixture isolation (no leak across tests)
+
+The Tier 2 regression that exercises the registry against real PG lives
+in ``tests/regression/test_issue_697_pool_leak.py`` (DPI-B5).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.nodes.data.async_sql import (
+    _POOL_DEFAULTS,
+    _PROCESS_POOL_REGISTRY,
+    AsyncSQLDatabaseNode,
+    set_pool_defaults,
+)
+
+
+class _FakePool:
+    """Stand-in object for an EnterpriseConnectionPool, used only to
+    populate ``_PROCESS_POOL_REGISTRY`` (a WeakValueDictionary). MUST be
+    a class instance — Python forbids weak references to bare ``object``
+    instances of some built-in types.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+def test_set_pool_defaults_idle_timeout_override():
+    """idle_timeout override mutates _POOL_DEFAULTS in place."""
+    assert _POOL_DEFAULTS["idle_timeout"] == 300  # factory default
+    set_pool_defaults(idle_timeout=42)
+    assert _POOL_DEFAULTS["idle_timeout"] == 42
+
+
+def test_set_pool_defaults_max_pool_count_override():
+    """max_pool_count_per_process override mutates _POOL_DEFAULTS."""
+    assert _POOL_DEFAULTS["max_pool_count_per_process"] == 100
+    set_pool_defaults(max_pool_count_per_process=10)
+    assert _POOL_DEFAULTS["max_pool_count_per_process"] == 10
+
+
+def test_set_pool_defaults_partial_override_leaves_other_keys_unchanged():
+    """Setting only one parameter does not clobber the other key."""
+    set_pool_defaults(idle_timeout=15)
+    assert _POOL_DEFAULTS["idle_timeout"] == 15
+    assert _POOL_DEFAULTS["max_pool_count_per_process"] == 100  # factory
+
+
+def test_set_pool_defaults_rejects_unknown_kwargs():
+    """Unknown kwargs raise TypeError (no silent typos)."""
+    with pytest.raises(TypeError):
+        set_pool_defaults(foo=42)  # type: ignore[call-arg]
+
+
+def test_set_pool_defaults_rejects_positional_args():
+    """The signature is keyword-only — positional args raise TypeError."""
+    with pytest.raises(TypeError):
+        set_pool_defaults(300)  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("bad_idle", [0, -1, -100])
+def test_set_pool_defaults_rejects_non_positive_idle_timeout(bad_idle):
+    """idle_timeout must be a positive int."""
+    with pytest.raises(ValueError, match="idle_timeout"):
+        set_pool_defaults(idle_timeout=bad_idle)
+
+
+def test_set_pool_defaults_rejects_non_int_idle_timeout():
+    """idle_timeout must be int — strings rejected."""
+    with pytest.raises(ValueError, match="idle_timeout"):
+        set_pool_defaults(idle_timeout="300")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad_cap", [0, -1, -100])
+def test_set_pool_defaults_rejects_non_positive_max_pool_count(bad_cap):
+    """max_pool_count_per_process must be a positive int."""
+    with pytest.raises(ValueError, match="max_pool_count_per_process"):
+        set_pool_defaults(max_pool_count_per_process=bad_cap)
+
+
+def test_set_pool_defaults_none_leaves_value_unchanged():
+    """Passing None for a parameter leaves the existing default in place."""
+    set_pool_defaults(idle_timeout=42)
+    set_pool_defaults(max_pool_count_per_process=10)
+    set_pool_defaults(idle_timeout=None, max_pool_count_per_process=None)
+    assert _POOL_DEFAULTS["idle_timeout"] == 42
+    assert _POOL_DEFAULTS["max_pool_count_per_process"] == 10
+
+
+def test_pool_count_zero_on_empty_registry():
+    """Empty registry → pool_count() returns 0."""
+    # The autouse reset_pool_registry fixture clears between tests.
+    assert AsyncSQLDatabaseNode.pool_count() == 0
+
+
+def test_pool_count_reflects_registry_size():
+    """pool_count() reads len(_PROCESS_POOL_REGISTRY)."""
+    pools = [_FakePool(f"k{i}") for i in range(3)]
+    for pool in pools:
+        _PROCESS_POOL_REGISTRY[pool.name] = pool
+    assert AsyncSQLDatabaseNode.pool_count() == 3
+    # Pinning the pools list to keep strong refs alive for the assertion
+    assert len(pools) == 3
+
+
+def test_pool_keys_returns_sorted_snapshot():
+    """pool_keys() is sorted, deterministic for assertions."""
+    pools = [_FakePool(f"key_{name}") for name in ("c", "a", "b")]
+    for pool in pools:
+        _PROCESS_POOL_REGISTRY[pool.name] = pool
+    keys = AsyncSQLDatabaseNode.pool_keys()
+    assert keys == ["key_a", "key_b", "key_c"]
+    assert pools  # pin
+
+
+def test_pool_count_drops_on_gc():
+    """WeakValueDictionary semantics: dropping refs reaps entries."""
+    import gc
+
+    pool = _FakePool("ephemeral")
+    _PROCESS_POOL_REGISTRY["ephemeral"] = pool
+    assert AsyncSQLDatabaseNode.pool_count() == 1
+
+    del pool
+    gc.collect()
+    # GC may be lazy on PyPy; CPython reaps immediately for this case.
+    assert AsyncSQLDatabaseNode.pool_count() == 0
+
+
+# ----------------------------------------------------------------------------
+# Per-test cleanup verification — sequential test pair
+# ----------------------------------------------------------------------------
+
+
+def test_reset_fixture_clears_registry_seed():
+    """Seed the registry; the autouse fixture clears it before next test."""
+    pool = _FakePool("seed")
+    _PROCESS_POOL_REGISTRY["seed"] = pool
+    assert AsyncSQLDatabaseNode.pool_count() == 1
+    assert pool  # pin
+
+
+def test_reset_fixture_starts_with_empty_registry():
+    """Sibling test of the previous; verifies the fixture cleared the seed."""
+    assert AsyncSQLDatabaseNode.pool_count() == 0
+
+
+def test_reset_fixture_restores_defaults_to_factory():
+    """After a test mutates defaults, next test sees factory values."""
+    # The previous test (or any prior test) may have called
+    # set_pool_defaults(); the fixture resets between tests.
+    assert _POOL_DEFAULTS["idle_timeout"] == 300
+    assert _POOL_DEFAULTS["max_pool_count_per_process"] == 100

--- a/workspaces/dataflow-prod-incident/01-analysis/01-research/01-failure-points.md
+++ b/workspaces/dataflow-prod-incident/01-analysis/01-research/01-failure-points.md
@@ -1,0 +1,200 @@
+# 01 — Failure Points Analysis
+
+Five issues, three coupled shards, two coupled root causes. This file maps each issue to the production code that produced it, identifies the underlying invariant violated, and surfaces the cross-cutting failure pattern.
+
+## Shard A — DataFlow auto_migrate retry storm (#696)
+
+### Code path
+
+| File                                                    |     Lines | Behavior                                                                                                                                                                            |
+| ------------------------------------------------------- | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/kailash-dataflow/src/dataflow/core/engine.py` | 1576-1599 | `_register_model` calls `_create_table_sync()` if connected; on failure, `logger.debug("sync DDL failed, table will be created lazily on first access")` and proceeds.              |
+| `packages/kailash-dataflow/src/dataflow/core/engine.py` | 1603-1689 | `ensure_table_exists()` is the lazy-creation hot path. Checks `_schema_cache` (line 1632), runs full migration if not cached. **Cache is marked-ensured ONLY on success.**          |
+| `packages/kailash-dataflow/src/dataflow/core/engine.py` | 7400-7429 | `_execute_ddl` (sync). Bare `except Exception as e: logger.error(f"Failed to execute DDL: {statement[:100]}... Error: {e}"); continue` — no state, no retry-suppression, no metric. |
+| `packages/kailash-dataflow/src/dataflow/core/engine.py` | 7431-7509 | `_execute_ddl_async`. Same swallow pattern at line 7504-7508.                                                                                                                       |
+
+### Root cause
+
+The error path violates two MUST clauses:
+
+1. **`zero-tolerance.md` Rule 3 (silent fallbacks).** `except Exception: continue` after a DDL failure is the canonical silent-fallback. The error log is ERROR level (correct) but the **next** model access re-enters `ensure_table_exists()`, the cache says "not ensured", and the failed DDL fires again. The "fallback" is implicit: failure becomes infinite retry.
+2. **`dataflow-pool.md` Rule 2 (validate at startup).** Pool config and connectivity are validated, but DDL applicability is not. A model whose CREATE TABLE will fail (FK ordering, role lacks CREATE, column-type mismatch) is NOT detected at `DataFlow.__init__` — only at first access.
+
+### Why it amplifies in production
+
+- Every 30 s, the FastAPI app's health check (or any user request that touches a model) re-enters `ensure_table_exists()`.
+- The schema cache in `_schema_cache` only marks-ensured on success, so failed-DDL models stay un-cached forever.
+- Combined with #697 below, every retry creates a brand-new connection pool of 5–20 connections that is never reclaimed.
+
+### Invariant the fix must preserve
+
+A failed CREATE TABLE under `auto_migrate=True` MUST be a single, loud, fail-fast error AT STARTUP — not a per-access silent retry. The user MUST be able to override (e.g., `auto_migrate="warn"` for dev) but the default MUST surface the failure at the point the operator can act on it.
+
+---
+
+## Shard B — AsyncSQLDatabaseNode pool fallback leak (#697 + #698)
+
+### Code path
+
+| File                                  |     Lines | Behavior                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------- | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/kailash/nodes/data/async_sql.py` |   501-575 | `EnterpriseConnectionPool.__init__`. Min/max size, health-check interval, analytics interval. **No `idle_timeout`. No process-wide cap.**                                                                                                                                                                                                                                           |
+| `src/kailash/nodes/data/async_sql.py` | 3835-3876 | `_generate_pool_key()` includes `id(get_running_loop())` for event-loop isolation. Per-event-loop separation is intentional; per-instance fallback is not.                                                                                                                                                                                                                          |
+| `src/kailash/nodes/data/async_sql.py` | 3878-3962 | `_get_adapter` — three priority paths: external pool → runtime pool → class-level shared pool. The shared-pool path acquires a per-pool lock with `timeout=5.0`.                                                                                                                                                                                                                    |
+| `src/kailash/nodes/data/async_sql.py` | 3944-3956 | **The leak.** `except (RuntimeError, asyncio.TimeoutError, Exception)` catches anything; sets `self._share_pool = False`, `self._pool_key = None`, calls `_create_adapter()` to make a fresh dedicated pool. **The dedicated pool is held only on the node instance** — every subsequent call sees `self._adapter is None` (different instance) and creates ANOTHER dedicated pool. |
+
+### Root cause
+
+Three coupled MUST violations:
+
+1. **`zero-tolerance.md` Rule 3 (silent fallback).** The `WARNING` log fires once per fallback, but the leak is invisible to alerting because the log doesn't escalate. From the issue body: "These pairs repeated 4-5 times per 30s. Each 'fallback' creates a brand-new EnterpriseConnectionPool (5-20 connections) that is never reclaimed mid-process."
+2. **`dataflow-pool.md` Rule 5 (no orphan runtimes — extends to pools).** A pool created in fallback mode has no parent registry that would call its `close()`. Only `AsyncSQLDatabaseNode.cleanup_all_pools()` at process shutdown reaps it. This is the orphan-pool sibling of the orphan-runtime pattern (Phase 5.11 prior art).
+3. **`zero-tolerance.md` Rule 6 (no half-implementation).** `EnterpriseConnectionPool` ships with no `idle_timeout`, no LRU eviction, no `max_pool_count_per_process`. The class advertises "enterprise" features (analytics, health checks, circuit breaker) but lacks the lifecycle invariant that any production-grade pool needs.
+
+### Why it amplifies in production
+
+- Per-event-loop isolation means each gunicorn worker pre-fork sees `id(get_running_loop())` change → new pool key → new pool.
+- 13 DataFlow instances × N event-loop transitions = 13 × N pools.
+- Combined with #696, every 30 s the failed-DDL retry fires under saturation. Saturation triggers the 5 s lock-timeout. Each timeout creates a new 5–20 connection pool.
+- Within minutes: 480–500 connections vs Azure PG's 100–200 ceiling.
+
+### Invariant the fix must preserve
+
+(a) Fallback is a structural option, not a silent default. (b) Every pool created in fallback mode is registered process-wide so it can be reclaimed on idle. (c) Pool-creation events are bounded — when the pool count exceeds a threshold, new lock-timeouts fail-fast instead of creating yet another pool.
+
+---
+
+## Shard C — DataFlowEngine surface holes (#685 + #686)
+
+### Code path
+
+| File                                               |   Lines | Behavior                                                                                                                                                                            |
+| -------------------------------------------------- | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/kailash-dataflow/src/dataflow/engine.py` | 235-265 | `DataFlowEngineBuilder.build()` is `async def`, body never `await`s. Body: instantiate DataFlow + QueryEngine, call `dataflow.source()` (sync method), instantiate DataFlowEngine.  |
+| `packages/kailash-dataflow/src/dataflow/engine.py` | 328-346 | `DataFlowEngine.register_model(self, registry, model)` calls `self._dataflow.register_model(model)` — **DataFlow has no such method.** Decorator-only registration via `@db.model`. |
+
+### Root cause
+
+Two MUST violations:
+
+1. **`zero-tolerance.md` Rule 6 (no half-implementation).** Line 339 — `self._dataflow.register_model(model)` — IS the half-implementation. The method is documented in the docstring (line 32-36 of `engine.py`: "engine.register_model(registry, UserModel)"), the signature exists, the inner body refers to a nonexistent method on the wrapped object. This is the canonical "if endpoint exists, it returns real data" failure mode.
+2. **`patterns.md` § "Paired Public Surface — Consistent Async-ness".** `build()` is async, never awaits. Module-import-time `@lru_cache get_db()` patterns can't use it. HANA Phase 2 deferred via ADR 0003 because of this.
+
+### Why these are HIGH not CRIT
+
+- They block engine-first migration but don't take production down. HANA's deferral is the audit trail.
+- The fix is small (single-shard, ≤200 LOC) and well-bounded — the engine surface is < 500 LOC total.
+
+### Invariant the fix must preserve
+
+(a) `register_model` either works end-to-end (registers with classification policy + `_registered_models` + the `DataFlow` model registry) OR is removed (zero-tolerance Rule 6 — half-implementation is BLOCKED, but the surgical option is delete-not-deprecate per `orphan-detection.md` Rule 3). User comment on the issue suggests it should work. (b) `build()` shape matches its body: either drop async OR add a synchronous companion that downstream import-time patterns can use.
+
+---
+
+## Cross-cutting failure pattern
+
+**Three of five issues (#696, #697, #698) trace to the same root: silent fallback + no lifecycle bound.**
+
+In each case, the failure mode is "the framework ran into an error, decided to keep working, and didn't surface the cost of keeping working":
+
+- #696: failed DDL → "we'll try again next time" (forever)
+- #697: per-pool lock timeout → "we'll make a dedicated pool" (forever, no eviction)
+- #698: pool created → "we'll keep it until shutdown" (forever, no idle bound)
+
+This is the production-incident class that `zero-tolerance.md` Rule 3 + `dataflow-pool.md` Rule 5 + `observability.md` Rule 7 all target separately. The fix is structural at three layers:
+
+- **Surface (DDL):** convert "failed → retry on every access" into "failed → flagged + bounded + surfaced".
+- **Lifecycle (pool):** convert "pool created → pool kept" into "pool created → pool tracked → pool reclaimed".
+- **Visibility:** every state transition emits a structured log + metric so alerting can fire BEFORE the connection ceiling.
+
+#685 + #686 are independent surface-holes on the engine builder; same package, same release, different bug class. Bundling them into the same workstream is correct (one release cycle, one specialist) but they do not share a root cause with #696/#697/#698.
+
+---
+
+## Repro setup (for Tier-2 regression tests)
+
+Per `rules/testing.md` § "End-to-End Pipeline Regression", every fix lands a regression test that exercises the docs-exact pattern:
+
+### Repro 1 — DDL retry storm (#696)
+
+```python
+# Define a model whose CREATE TABLE will fail (FK ordering)
+@db.model
+class Order:
+    user_id: int  # references user.id, but user table not yet defined
+
+# Initialize with auto_migrate=True
+db = DataFlow(test_pg_url, auto_migrate=True)
+
+# Touch the model 10 times — failed DDL must NOT fire 10 times
+for _ in range(10):
+    try: await db.express.list("Order")
+    except Exception: pass
+
+# Assertion: log captured exactly 1 ERROR + 1 metric, NOT 10
+assert error_log_count("Failed to execute DDL") == 1  # not 10
+```
+
+### Repro 2 — Pool fallback leak (#697 + #698)
+
+```python
+# Force lock contention by setting timeout very low + spawning many concurrent calls
+import os; os.environ["DATAFLOW_PER_POOL_LOCK_TIMEOUT"] = "0.1"
+db = DataFlow(test_pg_url)
+
+# 50 concurrent reads — many will hit the lock-timeout fallback
+await asyncio.gather(*(db.express.list("User") for _ in range(50)))
+
+# Assertion: total pool count stays bounded under a configured cap
+assert AsyncSQLDatabaseNode.pool_count() <= MAX_POOL_COUNT_PER_PROCESS
+```
+
+### Repro 3 — Engine.register_model (#685)
+
+```python
+db = DataFlow("sqlite:///:memory:", auto_migrate=True)
+engine = await DataFlowEngine.builder("sqlite:///:memory:").build()
+
+@db.model
+class Foo:
+    name: str
+
+engine.register_model(None, Foo)  # MUST succeed (no AttributeError)
+report = engine.get_model_classification_report(Foo)
+assert isinstance(report, dict)
+```
+
+### Repro 4 — Builder sync companion (#686)
+
+```python
+# Module-import-time pattern (HANA Phase 2's blocker)
+@lru_cache
+def get_db():
+    return DataFlowEngine.builder_sync("sqlite:///app.db").build_sync()
+
+# OR confirm async signature is honest:
+import inspect
+src = inspect.getsource(DataFlowEngineBuilder.build)
+assert "await " in src or "async with" in src  # signature MUST match body
+```
+
+---
+
+## Cross-SDK applicability (per `rules/cross-sdk-inspection.md`)
+
+| Issue | kailash-rs equivalent?                                                                                                                                                           | Disposition                                                                        |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| #696  | Likely. Rust DataFlow auto-migrate has the same model-access lazy-creation pattern.                                                                                              | File cross-SDK issue at `esperie/kailash-rs` after this fix lands; reference here. |
+| #697  | Almost certainly. Rust DataFlow has `EnterpriseConnectionPool` analog.                                                                                                           | File cross-SDK issue.                                                              |
+| #698  | Same as #697.                                                                                                                                                                    | Bundle.                                                                            |
+| #685  | Probably not — Rust uses generics for model registration; the AttributeError class doesn't exist. Verify with structural-API-divergence test per `cross-sdk-inspection.md` § 3a. | File a verification ticket only.                                                   |
+| #686  | Originated from cross-SDK parity. Rust's `build()` IS legitimately async (runtime initialization). The fix here is a sync companion, not a surface change.                       | No cross-SDK issue.                                                                |
+
+---
+
+## Open questions for the implementation phase
+
+1. **DDL fail-fast vs retry-with-backoff.** The user's recommendation in #696 is fail-fast at startup with a clear error. Is there a consumer who legitimately wants retry-with-backoff (e.g., DDL in a multi-region setup where the secondary takes time to propagate)? If yes, that becomes a configurable option (`auto_migrate=True` → fail-fast; `auto_migrate="retry"` → bounded retry with circuit breaker).
+2. **Pool eviction policy.** LRU on idle-timeout is the obvious choice. But for an event-loop-isolated pool key, "LRU" needs to mean "evict the oldest pool whose event loop is still alive" or "evict pools whose event loop is gone". The latter is automatic (the loop is dead, the pool can't be used); the former needs explicit tracking.
+3. **`MAX_POOL_COUNT_PER_PROCESS` default.** The issue body proposes 50. With 13 DataFlow instances × ~5 distinct event loops = ~65, so 50 is too low. Realistic default depends on PG `max_connections` ceiling. Probably 100 is safer; needs benchmarking.
+4. **`force_drop=True` interaction.** If we add a "registered-models" registry to `DataFlow` for #685, does removing/replacing a model need `force_drop` semantics per `dataflow-identifier-safety.md` Rule 4? Probably yes — registration replacement that drops the prior table is destructive.

--- a/workspaces/dataflow-prod-incident/01-analysis/02-spec-mapping.md
+++ b/workspaces/dataflow-prod-incident/01-analysis/02-spec-mapping.md
@@ -1,0 +1,90 @@
+# 02 — Spec Mapping
+
+Per `/analyze` Step 5, every requirement sentence in `briefs/` MUST map to a corresponding spec file section. This file is the traceability matrix.
+
+## Existing spec authority
+
+The kailash-py SDK already has spec coverage for both packages this workstream touches:
+
+| Spec file                   | Authority over                                                      |
+| --------------------------- | ------------------------------------------------------------------- |
+| `specs/dataflow-core.md`    | DataFlow class, constructor, `auto_migrate`, engine, exceptions     |
+| `specs/dataflow-cache.md`   | Cache layer, **dialect, record ID coercion, transactions, pooling** |
+| `specs/dataflow-express.md` | Express API surface                                                 |
+| `specs/dataflow-models.md`  | `@db.model` decorator semantics                                     |
+| `specs/core-nodes.md`       | AsyncSQLDatabaseNode contract (within Core SDK)                     |
+
+No NEW spec file is needed. The fix is updating sections in TWO existing specs:
+
+## Spec gap 1 — `specs/dataflow-core.md`
+
+**Current state:** likely has an `auto_migrate` section but treats it as a boolean flag.
+
+**Required addition:** semantic specification of `auto_migrate` enum with three values:
+
+- `True` (default): fail-fast on first failed DDL with `DDLFailedError`; subsequent accesses re-raise; operator must override or fix.
+- `"warn"`: log + continue (current behavior, opt-in for legacy apps).
+- `False`: no auto-migration; operator manages migrations explicitly.
+
+**Required addition:** explicit specification that `_failed_table_creations` is a public-but-frozen attribute readable for diagnostic purposes (`db._failed_table_creations` enumerable for support scripts).
+
+**Required addition:** the invariant that a failed DDL fires exactly ONE log line + ONE metric increment, NOT N per request.
+
+## Spec gap 2 — `specs/dataflow-cache.md`
+
+**Current state:** likely covers dialect + transactions + pooling but at the DataFlow layer, not the underlying `AsyncSQLDatabaseNode`.
+
+**Required addition (for #697 + #698):** AsyncSQLDatabaseNode pool lifecycle contract:
+
+- Pool lifecycle states: `created → active → idle → reaped`.
+- `_PROCESS_POOL_REGISTRY` is the single ground truth for pool count; `pool_count()` enumerates.
+- `idle_timeout` default: 300 s; configurable via `set_pool_defaults()`.
+- `max_pool_count_per_process` default: 100; configurable via `set_pool_defaults()`.
+- `PoolExhaustedError` semantics — typed error raised when cap is reached; caller chooses to wait, retry, or raise.
+- The fallback path is bounded — under cap, fallback creates pool + registers; over cap, fallback fails-fast.
+
+**Required addition:** the invariant that pools created in fallback mode are tracked + reapable, identical to pools created via the runtime-managed path.
+
+**Required addition (cross-SDK alignment):** Note that `kailash-rs`'s pool lifecycle MUST match this contract semantically (per `rules/cross-sdk-inspection.md` § 3 EATP D6).
+
+## Spec gap 3 — `specs/dataflow-core.md` (DataFlowEngine section)
+
+**Current state:** likely has a DataFlowEngine section that documents `register_model(registry, model)`.
+
+**Required addition (for #685):** explicit cross-reference that `DataFlow.register_model(model_cls)` is the underlying mechanism + that `@db.model` is sugar over the same path. Both produce identical state.
+
+**Required addition (for #686):** `DataFlowEngineBuilder.build()` is async-by-signature for cross-SDK parity but body is sync in kailash-py; `build_sync()` is the documented Python escape hatch for module-import-time patterns.
+
+## Brief traceability check
+
+Each requirement sentence in `briefs/01-incident-context.md` maps to a spec section:
+
+| Brief requirement                                                                            | Spec section                                          |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| "DDL failures fail-fast at startup with typed error + bounded retry"                         | `dataflow-core.md` § auto_migrate semantics           |
+| "AsyncSQLDatabaseNode pool fallback either holds longer / fails-fast OR registers"           | `dataflow-cache.md` § pool lifecycle contract         |
+| "idle-timeout + LRU cap configurable on EnterpriseConnectionPool"                            | `dataflow-cache.md` § pool lifecycle contract         |
+| "DataFlowEngine.register_model is either implemented end-to-end or removed"                  | `dataflow-core.md` § DataFlowEngine.register_model    |
+| "DataFlowEngineBuilder.build() either gains a sync companion or honours its async signature" | `dataflow-core.md` § DataFlowEngine.builder           |
+| "Tier-2 regression tests for every fix"                                                      | `dataflow-core.md` § conformance / `rules/testing.md` |
+| "Cross-SDK inspection on every fix"                                                          | `rules/cross-sdk-inspection.md` § 1 + EATP D6         |
+
+ALL brief requirements have a spec home. No orphan requirements.
+
+## What this means for /implement
+
+Spec updates land in the SAME PR as the source code changes — per `rules/specs-authority.md`. Each shard's PR includes:
+
+- Source code fix
+- Spec section update
+- Tier-2 regression test
+- CHANGELOG entry
+
+This avoids the "spec drift behind code" failure mode that issue #693 tracks for ML.
+
+## Out-of-scope spec gaps
+
+The following are spec-level questions worth flagging but NOT blocking this workstream:
+
+- **`specs/dataflow-cache.md` does not currently spec `EnterpriseConnectionPool` as a manager-shape class** — per `rules/facade-manager-detection.md` § 2, manager classes need named Tier-2 wiring tests. The pool registry test added in Shard B satisfies this implicitly but should be referenced from the spec for traceability.
+- **No spec exists for the `_failed_table_creations` diagnostic surface** — adding it post-implementation is fine; the spec authoritatively reflects what shipped.

--- a/workspaces/dataflow-prod-incident/02-plans/01-implementation-plan.md
+++ b/workspaces/dataflow-prod-incident/02-plans/01-implementation-plan.md
@@ -1,0 +1,220 @@
+# 02 — Implementation Plan
+
+Three shards, sized per `rules/autonomous-execution.md` § "Per-Session Capacity Budget" (≤500 LOC load-bearing logic, ≤5–10 invariants, ≤3–4 call-graph hops, describable in 3 sentences). Each shard is a single session with a single specialist + reviewer.
+
+## Sequencing
+
+```
+Shard A (#696 DDL fail-fast)            ─┐
+                                         ├──→ kailash-dataflow 2.4.0 release
+Shard B (#697 + #698 pool lifecycle)    ─┤    + kailash 2.12.0 patch
+                                         │    (one paired release; both
+Shard C (#685 + #686 engine surface)    ─┘     packages share regression
+                                              tests)
+```
+
+A and B may run in parallel under `rules/worktree-isolation.md` waves-of-3 protocol — they touch different packages (`kailash-dataflow` for A, `kailash` core for B). C is independent surface work in `kailash-dataflow` and may run in parallel with A if their files don't overlap (they don't — A is `core/engine.py`, C is `engine.py`).
+
+Recommended: launch A + C as a wave-of-2 (both in `kailash-dataflow`, separate worktrees), then B on its own (different package, different specialist load).
+
+## Shard A — DDL fail-fast circuit breaker (#696)
+
+**Specialist:** dataflow-specialist
+**Estimated LOC:** ~250 load-bearing logic
+**Invariants held:** 4 (cache-hit fast-path; failed-DDL state tracking; user override flag; no log spam)
+**Files touched:** 2
+
+### Description (3 sentences)
+
+A failed CREATE TABLE under `auto_migrate=True` MUST be a single, loud error at startup — not a per-access silent retry. Add a per-model failed-DDL state to `DataFlow._schema_cache` that records the failure + reason, prevents subsequent retries, and surfaces a clear runtime error on the next access. Operators get one ERROR log + one metric increment per failed model, not N per request.
+
+### Changes
+
+1. **`packages/kailash-dataflow/src/dataflow/core/engine.py`**
+   - Add `_failed_table_creations: dict[str, FailedDDLRecord]` to `DataFlow.__init__` where `FailedDDLRecord = (timestamp, error_message, statement_preview)`.
+   - In `_register_model` (line 1576-1599), if `_create_table_sync()` returns False AND we're connected, fail-fast with `DDLFailedError(model_name, error)` instead of falling through to lazy creation.
+   - In `ensure_table_exists()` (line 1603), check `_failed_table_creations` BEFORE the cache check. If present, raise `DDLFailedError` immediately — do NOT re-fire the DDL.
+   - In `_execute_ddl()` (line 7400-7429) and `_execute_ddl_async` (line 7431-7509), wrap each statement's `except Exception` to record the failure into `_failed_table_creations` AND emit metric `dataflow.ddl_failed_total{model=...}`. Continue iterating ONLY for index/FK statements; CREATE TABLE failures abort the whole batch.
+   - Add `auto_migrate` enum: `True` (fail-fast at startup, default), `"warn"` (log + continue, current behavior), `False` (no auto-migration, manual). Update `DataFlow.__init__` signature to accept `bool | Literal["warn"]`.
+2. **`packages/kailash-dataflow/src/dataflow/core/exceptions.py`** (new file or existing)
+   - Add `DDLFailedError(DataFlowError)` with `.model_name`, `.statement`, `.original_error` attributes.
+
+### Tests
+
+Per `rules/testing.md` § "End-to-End Pipeline Regression":
+
+- **Tier 2 regression:** `tests/regression/test_issue_696_ddl_retry_storm.py` — define a model whose CREATE TABLE will fail (FK ordering or column-type mismatch), call `db.express.list()` 10 times, assert ERROR-level log fires exactly once + assert `_failed_table_creations` contains the record.
+- **Tier 2 invariant:** assert that calling the failed-DDL path 100x in a tight loop does NOT increase connection count beyond 1 (proves no retry storm under saturation).
+- **Tier 1 unit:** `auto_migrate="warn"` reproduces current behavior (continue + log); `auto_migrate=True` (default) fails-fast.
+
+### Cross-SDK action
+
+File `esperie/kailash-rs#NNN` — "DataFlow auto-migrate retry storm — same bug class as kailash-py#696". Include byte-vector regression test per `rules/cross-sdk-inspection.md` § 4.
+
+### Edge cases / risks
+
+- **Existing apps relying on retry-on-access** — none expected (the retry was a bug, not a feature). Migration path: `auto_migrate="warn"` opt-in.
+- **Race in concurrent registration** — multiple workers may all hit the failed DDL once each before `_failed_table_creations` is populated. Acceptable: `dict.setdefault()` semantics give us at-least-once semantics; metric is correct.
+- **Migration tracking table failure** — if `_ensure_migration_tables` itself fails (line 6427), the system can't track ANYTHING; needs a separate fail-fast path. Acceptable: this fails so loud you'd never miss it.
+
+---
+
+## Shard B — Pool lifecycle: bounded fallback + idle eviction (#697 + #698)
+
+**Specialist:** dataflow-specialist (with infrastructure-specialist consult on the pool-registry pattern)
+**Estimated LOC:** ~400 load-bearing logic
+**Invariants held:** 6 (pool-key uniqueness; per-event-loop isolation; max-pool-count cap; idle-timeout reclamation; tenant-isolation preserved; no leaked pools across worker pre-fork)
+**Files touched:** 2
+
+### Description (3 sentences)
+
+`AsyncSQLDatabaseNode`'s per-pool-locking fallback creates a fresh `EnterpriseConnectionPool` per call with no process-wide registration; pools accumulate until process shutdown. Add a process-wide `PoolRegistry` that tracks every pool by key, evicts on idle-timeout (default 300 s), and bounds total count via LRU (default 100); when the cap is exceeded, lock-timeout MUST fail-fast with a typed error instead of creating yet another pool. The eviction is event-loop-aware: pools whose loop is closed are reaped immediately; live pools wait for idle.
+
+### Changes
+
+1. **`src/kailash/nodes/data/async_sql.py`**
+   - Add module-level `_PROCESS_POOL_REGISTRY: weakref.WeakValueDictionary[str, EnterpriseConnectionPool]` keyed on `pool_key`.
+   - Add module-level config `_POOL_DEFAULTS = {"idle_timeout": 300, "max_pool_count_per_process": 100}` overridable via `set_pool_defaults()`.
+   - Add `EnterpriseConnectionPool.set_idle_timeout(seconds: int)` and `EnterpriseConnectionPool.is_idle()` (last-activity timestamp tracking).
+   - Add `EnterpriseConnectionPool._reaper_task` that runs every `idle_timeout / 4` seconds, walks the registry, calls `close()` + `del registry[key]` for any idle pool whose event loop is alive (pools with dead loops are reaped immediately on registry access via the WeakValueDictionary).
+   - In `_get_adapter` fallback path (line 3944-3956): replace the silent fallback with:
+     ```python
+     except (RuntimeError, asyncio.TimeoutError) as e:
+         if len(_PROCESS_POOL_REGISTRY) >= _POOL_DEFAULTS["max_pool_count_per_process"]:
+             raise PoolExhaustedError(
+                 f"Pool count {len(_PROCESS_POOL_REGISTRY)} exceeds cap "
+                 f"{_POOL_DEFAULTS['max_pool_count_per_process']}; refusing to create dedicated fallback. "
+                 f"Increase via set_pool_defaults(max_pool_count_per_process=N) or fix the contention root cause."
+             ) from e
+         logger.warning("async_sql.fallback_pool_created",
+             extra={"pool_key": self._pool_key, "registry_size": len(_PROCESS_POOL_REGISTRY)})
+         self._adapter = await self._create_adapter()
+         _PROCESS_POOL_REGISTRY[f"fallback_{id(self)}"] = self._adapter._pool  # tracked!
+     ```
+     Note: catching bare `Exception` is removed — only `RuntimeError` (closed loop) and `asyncio.TimeoutError` (lock timeout) are legitimate fallback triggers per `rules/zero-tolerance.md` Rule 3.
+   - Add `AsyncSQLDatabaseNode.pool_count() -> int` classmethod (returns `len(_PROCESS_POOL_REGISTRY)`).
+2. **`src/kailash/nodes/data/exceptions.py`** (existing or new)
+   - Add `PoolExhaustedError(NodeExecutionError)`.
+
+### Tests
+
+Per `rules/testing.md` § "End-to-End Pipeline Regression":
+
+- **Tier 2 regression:** `tests/regression/test_issue_697_pool_leak.py` — set `max_pool_count_per_process=10`, set lock timeout to 0.1 s, spawn 50 concurrent reads against real PG. Assert pool count never exceeds 10 + assert `PoolExhaustedError` fires when cap reached.
+- **Tier 2 idle eviction:** create 20 pools with `idle_timeout=2`, sleep 5 s, assert `pool_count() == 0`.
+- **Tier 2 cross-event-loop:** create pool in event loop A, switch to event loop B, assert pool A is reaped (WeakValueDictionary semantics).
+- **Tier 1 unit:** signature/structural invariant on `set_pool_defaults` — accepts only `idle_timeout`, `max_pool_count_per_process`; rejects unknown kwargs.
+
+### Cross-SDK action
+
+File `esperie/kailash-rs#NNN` — Rust DataFlow has its own pool primitive; same lifecycle gaps likely apply.
+
+### Edge cases / risks
+
+- **Event-loop GC race** — WeakValueDictionary auto-cleanup happens on GC; under high churn the cleanup may lag. Add an explicit reaper task as belt-and-suspenders.
+- **Per-test cleanup** — pytest tests may leave registries non-empty across tests. Add `cleanup_all_pools()` extension that clears registry; fixture in `conftest.py` calls it after every test.
+- **Tenant-isolation preserved** — pool keys already include `dialect|connection_string` per `rules/tenant-isolation.md` § 1; multi-tenant deployments using separate connection strings get separate pools. NO change to the keying.
+- **Backwards compat** — apps that depend on unbounded pool creation will see `PoolExhaustedError` they didn't see before. Mitigation: default cap at 100 (generous) + clear error message naming `set_pool_defaults`.
+
+---
+
+## Shard C — DataFlowEngine surface fixes (#685 + #686)
+
+**Specialist:** dataflow-specialist
+**Estimated LOC:** ~150 load-bearing logic
+**Invariants held:** 3 (engine.register_model is end-to-end; build() body matches signature; cross-SDK parity preserved on the async build path)
+**Files touched:** 2
+
+### Description (3 sentences)
+
+`DataFlowEngine.register_model` calls a non-existent method on `DataFlow` and `DataFlowEngineBuilder.build()` is async-but-sync. Implement `DataFlow.register_model(model)` as a non-decorator entry-point that performs the same registration as `@db.model`, and add `DataFlowEngineBuilder.build_sync()` for module-import-time patterns. The async `build()` stays for cross-SDK parity with kailash-rs (where it IS legitimately async).
+
+### Changes
+
+1. **`packages/kailash-dataflow/src/dataflow/core/engine.py`**
+   - Add `DataFlow.register_model(self, model_cls)` — extracts the class-decorator logic from `@db.model` (which currently uses `__init_subclass__` or similar) into a callable. Both paths share the same body. Returns the decorated class for chaining.
+2. **`packages/kailash-dataflow/src/dataflow/engine.py`**
+   - `DataFlowEngine.register_model(self, registry, model)` — fix the implementation. The `registry` param is unused by the docstring but exists for cross-SDK parity (kailash-rs passes a registry). Kailash-py path: `self._dataflow.register_model(model)`. Same downstream — append to `_registered_models`, register with classification policy if available.
+   - Add `DataFlowEngineBuilder.build_sync(self) -> DataFlowEngine` — body identical to current async `build()` (which doesn't await). Document `build_async()` (alias for `build()`) for cross-SDK clarity.
+
+### Tests
+
+- **Tier 2 regression:** `tests/regression/test_issue_685_engine_register_model.py` — repro from issue body + assert no AttributeError + assert `engine.get_model_classification_report(Foo)` returns a dict.
+- **Tier 2 regression:** `tests/regression/test_issue_686_builder_sync.py` — `DataFlowEngine.builder("sqlite:///:memory:").build_sync()` returns engine without requiring an event loop.
+- **Tier 1 invariant:** `DataFlowEngineBuilder.build()` must be async OR call `build_sync()` directly — never reach a state where the async signature has body-side `await`s removed.
+
+### Cross-SDK action
+
+- #685: filed as cross-SDK; verify Rust `register_model` is end-to-end.
+- #686: NOT filed cross-SDK — Rust's `build()` IS legitimately async (runtime init). Python's sync companion is a Python-specific affordance.
+
+### Edge cases / risks
+
+- **Existing `@db.model` usage** — extracting the class-decorator body MUST not change `@db.model` semantics. Tier 1 test: `@db.model class X` produces same registration as `db.register_model(X)`.
+- **HANA Phase 2 unblock** — once `build_sync` ships, HANA's ADR 0003 deferral is closed. Add a note to the release CHANGELOG.
+
+---
+
+## Combined release plan
+
+### Branches (per `rules/git.md` § Release-Prep)
+
+- `feat/dataflow-696-ddl-fail-fast` (Shard A)
+- `feat/dataflow-697-698-pool-lifecycle` (Shard B)
+- `feat/dataflow-685-686-engine-surface` (Shard C)
+- `release/v2.4.0-dataflow-prod-incident` (release-prep PR, metadata-only)
+
+### Release scope
+
+- **`kailash-dataflow`** 2.3.3 → 2.4.0 (semver-major because `auto_migrate=True` default now fails-fast — behavioral change for apps that depended on the retry-storm bug)
+- **`kailash`** 2.11.3 → 2.12.0 (semver-major because `_PROCESS_POOL_REGISTRY` adds a process-wide cap that fails-fast on exhaustion)
+
+Per `feedback_optimal_outcome` — choose the optimal architecture; semver-major is the honest semver call. Per `feedback_no_shims` — no deprecation timeline; the cleanup happens in the same release.
+
+### Pre-release gates
+
+Per `rules/deployment.md` § "Before Any Release" + `rules/git.md` § "Pre-FIRST-Push CI Parity":
+
+1. Full test suite green across Python 3.11 / 3.12 / 3.13 / 3.14
+2. Tier-2 regression tests pass against real PostgreSQL (Azure-class)
+3. Cross-SDK parity issues filed at `esperie/kailash-rs`
+4. Security review by security-reviewer (mandatory per `rules/agents.md` Quality Gates)
+5. Reviewer + security-reviewer pass at `/implement` gate
+6. `pre-commit run --all-files` + `pytest --collect-only` exit 0 across every test directory
+7. CHANGELOG entries for all three shards under one 2.4.0 / 2.12.0 release block
+8. Spec updates: `specs/dataflow-core.md` section on `auto_migrate` semantics; `specs/dataflow-cache.md` section on pool lifecycle
+
+### Cross-SDK propagation
+
+After kailash-py release, file these issues at `esperie/kailash-rs`:
+
+- DataFlow auto-migrate retry storm (cross-SDK of #696)
+- DataFlow per-pool-locking fallback leak (cross-SDK of #697 + #698)
+- DataFlowEngine.register_model parity check (cross-SDK of #685 — verify Rust path)
+
+Per `rules/cross-sdk-inspection.md` § 4: each cross-SDK issue includes byte-vector test cases derived from kailash-py's regression tests.
+
+---
+
+## What stays out of this workstream
+
+- **#699 / #700 / #701** — kailash-ml 1.5.x followup; separate workspace.
+- **Loom `/sync`** — cycle 10 + cycle 11 propagation; not BUILD-repo work.
+- **Spec-drift-gate** — separate workspace, not blocked by this one.
+- **Stub-marker triage** — 122 markers from sweep v1 LOW-6; spread across multiple sessions.
+
+---
+
+## Acceptance — "done" gate
+
+The workspace is converged when ALL of the following hold:
+
+1. PRs for all three shards merged to main + reviewed by reviewer + security-reviewer.
+2. Release PR for `kailash-dataflow` 2.4.0 + `kailash` 2.12.0 merged.
+3. Tags pushed individually per `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually" (`v2.12.0`, `dataflow-v2.4.0`).
+4. PyPI publishing workflow_dispatch successful for both packages.
+5. Clean-venv install verified against PyPI for both packages.
+6. The user's repro script runs for 30 minutes without connection-count growth.
+7. Cross-SDK issues filed at kailash-rs.
+8. Issues #696, #697, #698, #685, #686 closed with delivered-code references per `rules/git.md` § Issue Closure Discipline.
+9. `/codify` extracts new institutional knowledge (e.g., "silent-fallback + no-lifecycle is one failure pattern; structural fix at three layers" deserves codification).

--- a/workspaces/dataflow-prod-incident/briefs/01-incident-context.md
+++ b/workspaces/dataflow-prod-incident/briefs/01-incident-context.md
@@ -1,0 +1,56 @@
+# Brief — DataFlow + Core SDK production-incident class
+
+Filed during a JourneyMate (Azure FastAPI + DataFlow) production-incident response on 2026-04-28. Five GH issues cluster around two coupled defects (DDL-retry storm + AsyncSQLDatabaseNode pool leak) plus three independent surface holes. User flagged as urgent; sweep classified two as CRIT, three as HIGH.
+
+## What the user reported
+
+A routine deploy of the JourneyMate backend onto Azure Container Apps started a self-amplifying connection-leak loop. Backend logs showed two patterns repeating every 30 seconds:
+
+1. **DDL retry storm.** `ERROR:dataflow.core.engine:Failed to execute DDL: CREATE TABLE IF NOT EXISTS "evaluation_dimensions" ...` and three sibling DDLs, repeating indefinitely. Root cause: when an `auto_migrate=True` DDL fails, the engine flags the model as "needs migration" and re-attempts on the **next model access**, not at startup.
+
+2. **Pool fallback leak.** `WARNING:kailash.nodes.data.async_sql:Per-pool locking failed for AsyncSQLDatabaseNode (pool_key: ...). Falling back to dedicated pool mode.` followed by `EnterpriseConnectionPool 'postgresql_...' initialized with 5-20 connections`. Each fallback creates a fresh 5–20 connection pool that is **never reclaimed mid-process** — only `cleanup_all_pools(graceful=True)` at shutdown frees them.
+
+Combined effect: every 30 seconds, the failed-DDL retry fires `AsyncSQLDatabaseNode` under saturation; lock-timeout path fires; new dedicated pool created; subsequent calls each create another. Within minutes, Azure PG saturates at 480–500 connections out of the 100–200 ceiling. Backend was down ~30 minutes; recovery required setting `auto_migrate=False`, restarting the BE revision, and migrating 342 hot-path call sites away from `AsyncSQLDatabaseNode` to a dedicated app-managed asyncpg pool.
+
+## Issues bundled into this workspace
+
+| #       | Severity | Title                                                                                         | File pointers                                                                     |
+| ------- | -------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **696** | CRIT     | DataFlow auto_migrate fires failed CREATE TABLE on every model access                         | `src/dataflow/core/engine.py:1576-1599`, `:6391-6455`, `:7426`, `:7511-7600`      |
+| **697** | CRIT     | AsyncSQLDatabaseNode 'Per-pool locking failed' silently falls back, leaks 5-20 conns per call | `src/kailash/nodes/data/async_sql.py:501`, `:574`, `:3835`, `:3944-3956`          |
+| **698** | HIGH     | AsyncSQLDatabaseNode pools have no idle-timeout / LRU reclamation                             | `src/kailash/nodes/data/async_sql.py` (`EnterpriseConnectionPool`)                |
+| **685** | HIGH     | `DataFlowEngine.register_model` calls non-existent method on `DataFlow` primitive             | `packages/kailash-dataflow/src/dataflow/engine.py::DataFlowEngine.register_model` |
+| **686** | HIGH     | `DataFlowEngineBuilder.build()` is async but body is purely synchronous                       | `packages/kailash-dataflow/src/dataflow/engine.py::DataFlowEngineBuilder.build`   |
+
+## Why one workspace
+
+- **Shared specialist** — every fix belongs to dataflow-specialist + analyst; no other framework specialists involved.
+- **Shared invariant set** — engine surface, model registration, connection lifecycle, classification policy. Splitting risks duplicate root-cause analysis and divergent remediation.
+- **Shared release cycle** — every fix lands in `kailash-dataflow` (and `kailash` core for the AsyncSQL side). One release-prep PR, not three.
+- **Shared bug class** — #696 + #697 + #698 share the connection-lifecycle root; #685 + #686 share the engine-builder surface. Same-bug-class within shard budget per `rules/autonomous-execution.md` § 4.
+
+## What "done" looks like
+
+1. **Production-incident pair (#696 + #697 + #698) closed** — DDL failures fail-fast at startup with typed error + bounded retry; AsyncSQLDatabaseNode pool fallback either holds longer / fails-fast OR registers the dedicated pool in a process-wide eviction registry; idle-timeout + LRU cap configurable on `EnterpriseConnectionPool`.
+2. **Engine builder surface (#685 + #686) closed** — `DataFlowEngine.register_model` is either implemented end-to-end (registers with classification policy + adds to engine's registered_models) or removed; `DataFlowEngineBuilder.build()` either gains a sync companion or honours its async signature.
+3. **Tier-2 regression tests** for every fix per `rules/testing.md` § "End-to-End Pipeline Regression" — each canonical pipeline the user could reasonably write must execute against real PG without leaking connections or storming on DDL failure.
+4. **Release of `kailash-dataflow` 2.3.4 (or 2.4.0 if behavioural)** + matching `kailash` patch; PyPI-published; clean-venv install verified.
+5. **Cross-SDK inspection** — every fix evaluated against kailash-rs per `rules/cross-sdk-inspection.md` MUST Rule 1.
+
+## Constraints
+
+- **No workarounds for SDK bugs** (rules/zero-tolerance.md Rule 4) — these are SDK source bugs; fix at the SDK, not in downstream callers.
+- **No silent fallbacks** (rules/zero-tolerance.md Rule 3) — the AsyncSQL fallback today is a silent fallback; the fix must surface the failure mode.
+- **No half-implementations** (rules/zero-tolerance.md Rule 6) — `DataFlowEngine.register_model` is a half-implementation right now. Either complete it or remove it.
+- **No mocking in Tier 2/3 tests** (rules/testing.md § 3-Tier Testing) — the regression tests MUST run against real PostgreSQL with a real failing DDL scenario.
+- **Tenant isolation preserved** (rules/tenant-isolation.md) — `_kml_model_versions` schema fork in #699 is sibling work; this workspace's fixes touch DataFlow but must not regress multi-tenant DataFlow patterns.
+
+## Out of scope (sibling workstreams)
+
+- **kailash-ml 1.5.x followup** — #699, #700, #701 belong in `workspaces/kailash-ml-1.5.x-followup/`. They share the same MLFP M5 trigger but touch a different package.
+- **Loom /sync** — the cycle-10 + cycle-11 codify proposals belong at `~/repos/loom/`; not BUILD-repo work.
+- **Spec-drift-gate** — separate workstream, not blocked by this one.
+
+## Success metric (the human's ratchet)
+
+A clean reproduction script — `auto_migrate=True` model whose CREATE TABLE will fail, `AsyncSQLDatabaseNode` under load — runs for 30 minutes and the connection count stays bounded under the configured `max_size`, with a single ERROR + metric on the failed DDL, no retry storm, no pool leak.

--- a/workspaces/dataflow-prod-incident/journal/0001-DISCOVERY-silent-fallback-no-lifecycle-is-one-pattern.md
+++ b/workspaces/dataflow-prod-incident/journal/0001-DISCOVERY-silent-fallback-no-lifecycle-is-one-pattern.md
@@ -1,0 +1,60 @@
+# 0001 DISCOVERY — Silent Fallback + No Lifecycle Is One Failure Pattern
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /analyze
+**Type:** DISCOVERY
+
+## Finding
+
+Three of the five issues in this workstream (#696, #697, #698) trace to the same compound failure pattern. Each looks like a separate bug at first reading; together they form a single architectural anti-pattern that the rules already prohibit at three layers but that surfaces when those layers don't reinforce each other.
+
+**The pattern is:** the framework hits an error condition, decides to keep working in a degraded mode, and creates state for that degraded mode WITHOUT a lifecycle bound. The result is monotonic resource accumulation that surfaces as a production outage hours or days later.
+
+| Issue | Error condition       | Degraded mode           | Lifecycle bound (missing)               |
+| ----- | --------------------- | ----------------------- | --------------------------------------- |
+| #696  | CREATE TABLE fails    | "Try again next time"   | Failed-DDL state with retry suppression |
+| #697  | Per-pool lock timeout | "Make a dedicated pool" | Process-wide registry with eviction     |
+| #698  | Pool created          | "Keep until shutdown"   | Idle-timeout reaper                     |
+
+Each one alone is a slow leak; combined they are mutually amplifying — the DDL retry fires the AsyncSQL node every 30 s, which under saturation triggers the lock-timeout fallback, which creates a fresh pool. Within minutes, Azure PG saturates.
+
+## Why the existing rules didn't catch it
+
+`zero-tolerance.md` Rule 3 (silent fallbacks) covers the error-handling layer.
+`dataflow-pool.md` Rule 5 (no orphan runtimes) covers the lifecycle layer.
+`observability.md` Rule 7 (bulk ops MUST WARN on partial failure) covers the visibility layer.
+
+Each rule is correctly scoped to its concern. The compound pattern needs all three to fire together — and the framework historically separated them across files (engine.py owns DDL; async_sql.py owns pools; the visibility layer is implicit in both). No single agent reading any one file would see the compound.
+
+## Codification candidate
+
+Add a meta-rule (or a clause to one of the existing rules) that names "silent fallback + no lifecycle bound" as a single failure class with a structural defense:
+
+> Whenever the framework chooses to continue past an error condition, the chosen continuation MUST be (a) bounded — there is a structural cap on how many times the continuation can fire, (b) tracked — the continuation creates state that's enumerable + reapable, and (c) surfaced — every continuation event emits a structured log + metric so alerting can fire BEFORE the cap.
+
+This is a 3-axis test that would have caught all three issues at PR review time:
+
+- #696: continuation = "lazy DDL retry"; bounded? NO. tracked? NO. surfaced? ERROR-only, no metric.
+- #697: continuation = "dedicated pool fallback"; bounded? NO. tracked? NO (instance-only). surfaced? WARN, no metric.
+- #698: continuation = "pool kept alive"; bounded? NO. tracked? class-shared dict but not bounded. surfaced? NO.
+
+## Cross-SDK applicability
+
+The pattern is architectural, not language-specific. Rust DataFlow has the same architecture:
+
+- `EnterpriseConnectionPool` analog with similar lifecycle gaps
+- `auto_migrate` in `kailash-rs` shares the lazy-creation-on-access pattern
+- The compound failure is platform-independent
+
+Cross-SDK issues to file after this fix lands.
+
+## Action
+
+This DISCOVERY feeds into the `/codify` step at the end of this workstream. The codified rule extension MUST land at loom (cross-SDK) given the architectural breadth.
+
+## Related
+
+- Sibling: `rules/zero-tolerance.md` Rule 3
+- Sibling: `rules/dataflow-pool.md` Rule 5
+- Sibling: `rules/observability.md` Rule 7
+- Compound failure mode prior art: Phase 5.11 orphan trust executor (rules/orphan-detection.md)

--- a/workspaces/dataflow-prod-incident/journal/0002-RISK-multipackage-coupled-release-blast-radius.md
+++ b/workspaces/dataflow-prod-incident/journal/0002-RISK-multipackage-coupled-release-blast-radius.md
@@ -1,0 +1,49 @@
+# 0002 RISK — Multi-Package Coupled Release Blast Radius
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /analyze
+**Type:** RISK
+
+## Finding
+
+This workstream's fix touches BOTH `kailash` core (Shard B — `src/kailash/nodes/data/async_sql.py`) AND `kailash-dataflow` (Shards A + C). Both packages need a coupled release because:
+
+1. Shard B's `_PROCESS_POOL_REGISTRY` change in `kailash` IS the underlying mechanism Shard A's regression test depends on (the test asserts `pool_count() <= cap`).
+2. `kailash-dataflow` declares `kailash>=2.X.X` in its `pyproject.toml`; bumping kailash without bumping kailash-dataflow's floor leaves a half-released SDK where the pool fix isn't reachable from the DataFlow tests.
+
+## The blast radius
+
+Per `rules/deployment.md` § "Optional Dependencies Pin to PyPI-Resolvable Versions":
+
+- `kailash-dataflow` 2.4.0 must declare `kailash>=2.12.0` after kailash 2.12.0 is on PyPI.
+- The release-prep PR for `kailash-dataflow` MUST land AFTER `kailash` 2.12.0 publishes — otherwise `pip install kailash-dataflow==2.4.0` resolves against `kailash` 2.11.3 (pre-fix) and the fix is not present in the user's install.
+- Multi-tag push order: `v2.12.0` (kailash) FIRST, sleep, then `dataflow-v2.4.0`. Per `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually" — sequential pushes only, never batched.
+
+## Why this is HIGH risk
+
+Two failure modes exist:
+
+1. **Tag order error:** if `dataflow-v2.4.0` is pushed before `v2.12.0` clears PyPI, the release CI for kailash-dataflow may fail to install kailash 2.12.0 (PyPI cache lag is 30–90 s for `info.version`, longer for simple-index per `feedback_drive_to_completion`).
+2. **Floor pin mismatch:** if Shard A's PR (kailash-dataflow) lands BEFORE the kailash floor is bumped to 2.12.0, fresh installs from PyPI resolve to kailash 2.11.3 + the new dataflow that calls `pool_count()` — which doesn't exist in 2.11.3 — `AttributeError: type object 'AsyncSQLDatabaseNode' has no attribute 'pool_count'`.
+
+## Mitigation
+
+1. **Sequence the merge** — Shard B's PR (kailash core) merges + releases FIRST as 2.12.0. Verified clean on PyPI (clean-venv install per `rules/deployment.md`). THEN Shards A + C merge with their kailash floor bump in pyproject.toml in the same PR.
+2. **Floor-pin discipline** — Per `rules/deployment.md` § "Optional Dependencies Pin to PyPI-Resolvable Versions", the `kailash-dataflow` 2.4.0 release-prep PR MUST bump `dependencies = ["kailash>=2.12.0", ...]` and verify the floor is on PyPI before tagging.
+3. **CI cross-package install** — Per `rules/deployment.md` § "Sibling-Package CI Installs Root SDK Editable", every sub-package CI workflow that imports from `kailash.nodes.data.async_sql` MUST `uv pip install -e "."` the root kailash editable BEFORE installing kailash-dataflow's `[dev]` extras.
+4. **Bridge regression test** — Add a Tier-2 cross-package test `tests/integration/test_kailash_dataflow_pool_bridge.py` that imports BOTH `kailash.nodes.data.async_sql.AsyncSQLDatabaseNode.pool_count` AND `kailash_dataflow` and exercises the integration. Per `rules/deployment.md` § "Bi-Directional At Bridge Boundaries" — install BOTH packages editable in BOTH CI workflows.
+
+## What "done" looks like
+
+- `kailash` 2.12.0 on PyPI; clean-venv install verified.
+- Wait 60 s for PyPI cache lag.
+- `kailash-dataflow` 2.4.0 on PyPI; clean-venv install verified; bridge test passes.
+- Both packages report consistent `__version__` per `rules/zero-tolerance.md` Rule 5.
+- Issues #696/#697/#698/#685/#686 closed with delivered-code references.
+
+## Related
+
+- `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually"
+- `rules/deployment.md` § "Bi-Directional At Bridge Boundaries"
+- `rules/zero-tolerance.md` Rule 5 (version consistency on release)
+- `feedback_build_repo_release` (BUILD repo sessions MUST proceed through /release after merge)

--- a/workspaces/dataflow-prod-incident/journal/0003-CONNECTION-jeourneymate-incident-as-canary-for-azure-class-deployments.md
+++ b/workspaces/dataflow-prod-incident/journal/0003-CONNECTION-jeourneymate-incident-as-canary-for-azure-class-deployments.md
@@ -1,0 +1,56 @@
+# 0003 CONNECTION — JourneyMate Incident As Canary For Azure-Class Deployments
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /analyze
+**Type:** CONNECTION
+
+## Finding
+
+The JourneyMate incident has the structural fingerprint of "Azure Container Apps + FastAPI + DataFlow with multiple instances" — a deployment shape that is increasingly common across kailash-dataflow's downstream consumers. The connection-leak + DDL-retry pair surfaces fastest in this shape because:
+
+1. **Azure PG defaults to 100–200 max_connections** (vs AWS RDS's typically larger pools), making the saturation point closer.
+2. **gunicorn worker pre-fork creates new event loops per worker** — `_generate_pool_key` includes `id(get_running_loop())` so each worker gets its own pool keyspace; 8 workers × 13 DataFlow instances = 104 distinct pool keys before any user traffic.
+3. **Azure Container Apps' default 30 s health-check interval** matches the DDL retry cadence — every health-probe touches a model, which fires the failed DDL, which creates a new pool.
+4. **FastAPI lifespan + DataFlow `auto_migrate=True`** is the documented pattern in DataFlow's quickstart. Anyone copying the docs verbatim into a multi-instance Azure deployment hits this.
+
+## Connection to other workstreams
+
+This is the THIRD time in 2026-04 that a downstream Azure deployment has surfaced a kailash bug class:
+
+- 2026-04-12: arbor-upstream-fixes (multi-tenant DataFlow + Azure)
+- 2026-04-19: issue #525 (cross-SDK execute_raw + Postgres bind layer)
+- 2026-04-28: this incident (JourneyMate)
+
+The pattern: **Azure-class deployments are running ahead of the SDK's test-tier coverage.** Tier-2 tests target real PG via Docker — which runs single-process, single-event-loop, with `max_connections=100` defaults. The compound failure modes only appear under multi-process + multi-event-loop + Azure ceiling.
+
+## What this implies
+
+The Tier-2 regression tests for Shards A + B should NOT use docker-compose-PG with default settings. They should:
+
+- Set `max_connections` low (50?) to surface saturation faster
+- Spawn multiple event loops via `asyncio.new_event_loop()` to exercise the per-loop pool keying
+- Run for 30 s+ wall clock to catch idle-timeout eviction
+
+This is more expensive than current Tier-2 tests (which assume <1 s per test). But the alternative is the next JourneyMate-class incident.
+
+Codification candidate (for future cycle):
+
+> SDK regression tests for shared-architecture concerns (DataFlow connection lifecycle, Nexus session lifecycle, Kaizen agent budget) MUST include at least one test that runs against a constrained-resource real-infrastructure setup (low max_connections, low memory, multi-event-loop) — not just docker-default. The test names this constraint explicitly so future runners know it's load-bearing.
+
+This deserves codification but only with a 2nd occurrence pattern (per `learning-codified.json` deferral discipline). This is the 3rd Azure-incident in 16 days, so 2nd occurrence is met.
+
+## Action this workstream
+
+The Tier-2 regression tests in `02-plans/01-implementation-plan.md` Shards A + B EXPLICITLY include constrained-resource setup:
+
+- Shard A: `auto_migrate=True` with FK-misordered model (forces real DDL failure)
+- Shard B: `max_pool_count_per_process=10` + `lock_timeout=0.1` (forces real saturation)
+
+These mirror JourneyMate's failure conditions, run against real PG, and would catch a regression that re-introduces either bug.
+
+## Related
+
+- arbor-upstream-fixes session 2026-04-12
+- Issue #525 / PR #528 (cross-SDK execute_raw)
+- This workstream (#696/#697/#698/#685/#686)
+- `rules/testing.md` § "End-to-End Pipeline Regression"

--- a/workspaces/dataflow-prod-incident/journal/0004-DECISION-shard-sequencing-and-paired-release.md
+++ b/workspaces/dataflow-prod-incident/journal/0004-DECISION-shard-sequencing-and-paired-release.md
@@ -1,0 +1,52 @@
+# 0004 DECISION — Shard Sequencing and Paired Release
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /todos
+**Type:** DECISION
+
+## Decision
+
+Three shards execute in this dependency order:
+
+1. **Shards A + C in parallel** (both kailash-dataflow, different files in different worktrees)
+2. **Shard B independently** (kailash core, separate package, separate specialist load)
+3. **Shard D (cross-package integration)** runs once A + B + C all merge to main
+4. **Shard E (release)** runs in two waves: kailash 2.12.0 first → wait → kailash-dataflow 2.4.0
+
+## Rationale
+
+Three forces shape the ordering:
+
+1. **Per-package release coupling** — `kailash-dataflow`'s `kailash>=2.12.0` floor (DPI-D1) makes the bump dependent on kailash 2.12.0 being on PyPI. Per `rules/deployment.md` § "Optional Dependencies Pin to PyPI-Resolvable Versions" this MUST be sequential, never parallel.
+2. **Worktree isolation discipline** — Shards A and C both edit `kailash-dataflow` but DIFFERENT files (`core/engine.py` for A; `engine.py` for C). Per `rules/worktree-isolation.md` § 4 (waves of ≤3) and § 5 (merge-base check) parallel is safe with explicit pre-flight verification.
+3. **Specialist load** — Shard B requires both dataflow-specialist + infrastructure-specialist (the pool-registry pattern); A and C only need dataflow-specialist. Running B alongside A+C would double-load the dataflow-specialist context.
+
+## Alternatives considered
+
+**Alt 1: Single sequential cycle** — A → B → C → D → E. Cleaner mental model but loses the parallelism multiplier (3-5x per `rules/autonomous-execution.md` § 10x throughput). Rejected: too slow when shards are genuinely independent.
+
+**Alt 2: All four shards parallel** — A + B + C in waves of 3. Rejected: B's pool-registry change is mechanism for D2's bridge test; if B lands AFTER A's regression test runs, the bridge gap is invisible. Sequencing B before D is structural.
+
+**Alt 3: Single mega-PR** — Land all shards in one PR + one release. Rejected: violates `rules/autonomous-execution.md` § Per-Session Capacity Budget (the combined ~800 LOC + ~14 invariants exceeds shard threshold) AND would require waves of bridge fixes if any one shard regressed.
+
+## Risks
+
+The chosen ordering has one risk surfaced in `journal/0002 RISK` — kailash-dataflow PR opens BEFORE kailash 2.12.0 is on PyPI. Mitigation: DPI-D1 is gated by DPI-E1 + the 60 s PyPI cache lag wait in DPI-E4. The release-specialist owns this gate.
+
+## Cross-SDK propagation
+
+After all five issues close at kailash-py, file three cross-SDK issues at esperie/kailash-rs (DPI-E6). The Rust SDK is expected to have the same `EnterpriseConnectionPool` analog and the same `auto_migrate` lazy-creation pattern; verifying via reading kailash-rs source is the next workstream's first step. Per `rules/cross-sdk-inspection.md` § 4 — every closure includes the cross-SDK-checklist verification.
+
+## What this decision affects
+
+- DPI-D1, DPI-E1, DPI-E2, DPI-E4 are all sequenced behind DPI-B5 + DPI-A4 + DPI-C3 (per-shard regression tests)
+- DPI-D2 (bridge test) is the structural defense against the multi-package release ordering risk
+- The `release/v*` branch convention (per `rules/git.md`) auto-skips PR-gate CI on metadata-only release-prep PRs
+
+## Related
+
+- `journal/0001 DISCOVERY` — silent-fallback + no-lifecycle is one pattern (motivates Shard B's bundling)
+- `journal/0002 RISK` — multi-package release blast radius
+- `journal/0003 CONNECTION` — JourneyMate as canary for Azure-class deployments
+- `rules/autonomous-execution.md` § Per-Session Capacity Budget
+- `rules/deployment.md` § Multi-Package Release Tags Pushed Individually

--- a/workspaces/dataflow-prod-incident/journal/0005-TRADE-OFF-semver-major-vs-minor-for-behavioural-fix.md
+++ b/workspaces/dataflow-prod-incident/journal/0005-TRADE-OFF-semver-major-vs-minor-for-behavioural-fix.md
@@ -1,0 +1,49 @@
+# 0005 TRADE-OFF — Semver Major vs Minor For Behavioural Fix
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /todos
+**Type:** TRADE-OFF
+
+## The trade-off
+
+Both releases (kailash and kailash-dataflow) include behavioural breaking changes:
+
+- **kailash 2.12.0** — `_get_adapter` fallback path changes from "create unbounded dedicated pool" to "register + cap + fail-fast at cap". Apps relying on the unbounded behaviour see new `PoolExhaustedError`.
+- **kailash-dataflow 2.4.0** — `auto_migrate=True` (default) changes from "retry on every access" to "fail-fast on first error". Apps relying on the retry-storm bug as a feature (i.e., expecting eventual recovery as the failed DDL becomes valid) see `DDLFailedError`.
+
+The semver question: **major bump (3.0.0 / 3.0.0)** signaling breaking, OR **minor bump (2.12.0 / 2.4.0)** treating the prior behaviour as a bug?
+
+## Decision: minor bump (2.12.0 / 2.4.0)
+
+Both behaviours WERE bugs. The "feature" was the failure mode this workstream exists to fix. Per `feedback_no_shims` (the user's preference): no deprecation timeline; fix is the same release. Per `feedback_optimal_outcome`: choose the optimal architecture, not the politically safer one.
+
+A major bump would imply the prior behaviour was an intended feature being removed — this is the wrong narrative. The prior behaviour was a bug that produced production incidents (JourneyMate). Treating it as a "feature deprecation" would set the precedent that future bug fixes also require major bumps, which would amplify the existing changelog noise without proportionate benefit.
+
+## What downstream callers experience
+
+Apps with the JourneyMate failure mode see a NEW error class on the failure mode they were already failing on. Net change: same failure → typed error with actionable message + bounded resource cost. Strictly better.
+
+Apps without the failure mode see no change. Their CREATE TABLEs succeed; their pools stay shared.
+
+Apps that intentionally relied on lazy-retry (extremely rare; the retry-storm IS the known bug) get `auto_migrate="warn"` as the explicit opt-in. The CHANGELOG names this escape hatch.
+
+## What this affects in the todos
+
+- DPI-E1 / DPI-E2 use minor bumps (2.11.3 → 2.12.0; 2.3.3 → 2.4.0)
+- CHANGELOG entries name the behavioural change but frame it as bug-fix-with-bounded-error, not "removed feature"
+- The `auto_migrate="warn"` escape hatch IS documented; legacy apps can opt out
+
+## Alternative considered
+
+**Major bump (3.0.0 / 3.0.0)** — clearer signaling at the cost of artificial breaking-change perception. Rejected per the rationale above.
+
+## Cross-SDK relevance
+
+When the equivalent fixes ship to kailash-rs, the same trade-off applies. The Rust SDK's semver discipline matches Python's; the same minor-bump frame should hold.
+
+## Related
+
+- `feedback_no_shims` (no deprecation timelines)
+- `feedback_optimal_outcome` (choose optimal architecture)
+- `rules/zero-tolerance.md` Rule 6 (half-implementation is BLOCKED)
+- `journal/0004 DECISION` (shard sequencing assumes minor-bump ordering)


### PR DESCRIPTION
## Summary

- Adds process-wide pool registry (`_PROCESS_POOL_REGISTRY` `WeakValueDictionary`) — single source of truth for pool count
- Adds idle-timeout reaper task on `EnterpriseConnectionPool` — closes idle pools, prevents indefinite accumulation
- Replaces silent `except Exception` fallback with bounded path that fails-fast via `PoolExhaustedError` at cap
- 47 Tier-1 unit tests + 6 Tier-2 regression tests + spec § 13.4 Pool Lifecycle Contract

## Issues fixed

Fixes #697 — AsyncSQLDatabaseNode 'Per-pool locking failed' silently falls back, leaks 5-20 connections per call
Fixes #698 — AsyncSQLDatabaseNode pools have no idle-timeout / LRU reclamation

## Test plan

- [x] 47 Tier-1 unit tests pass locally
- [x] 6 Tier-2 regression tests collect cleanly (skip in local without Docker; will run in CI)
- [x] `pre-commit run --all-files` clean
- [x] `pytest --collect-only` exit 0
- [x] Bridge with Shard A preserved (no `core/engine.py` touched)
- [x] Tenant-isolation invariant (pool keys unchanged) preserved

## Rule compliance

- `rules/zero-tolerance.md` Rule 3 — narrowed `except (RuntimeError, asyncio.TimeoutError)`; silent `Exception` swallow removed
- `rules/dataflow-pool.md` Rule 5 — fallback pools tracked in process-wide registry
- `rules/patterns.md` "Async Resource Cleanup" — `__del__` does NOT call `close()`; reaper task handles it
- `rules/observability.md` Rule 5 — every reap + fallback emits structured log

🤖 Generated with [Claude Code](https://claude.com/claude-code)