### PR TITLE
feat(dataflow): DataFlowEngine surface fixes — register_model + build_sync (DPI-C, #685 #686)

### DIFF
--- a/SWEEP-2026-04-28-v2.md
+++ b/SWEEP-2026-04-28-v2.md
@@ -1,0 +1,137 @@
+# /sweep findings — 2026-04-28 (v2, supersedes 09:57 sweep)
+
+Re-run of `/sweep` after the 09:57 sweep. The intervening hours brought 6 new GH issues (#696–#701) filed during a JourneyMate production-incident response — all in the urgent area the user flagged (db / DataFlow / kailash-ml). The prior sweep's "No CRIT/HIGH bugs" headline is now stale.
+
+This file is a DELTA report. Findings carried forward unchanged from v1 are referenced, not restated. New CRIT/HIGH findings are written in full.
+
+## Summary
+
+- **CRIT: 2** (production-incident: connection-leak + DDL-retry storm)
+- **HIGH: 4** (kailash-ml 1.5.x breaking-change debt + DataFlowEngine API holes)
+- **MED: 4** (carried forward from v1)
+- **LOW: 6** (carried forward from v1)
+- **INFO: 5** (carried forward from v1)
+
+**Net assessment.** Source-tree state is unchanged from v1 (8 packages still at PyPI parity, 0 open PRs, 1 worktree). The change is **discovered defects in already-shipped versions**: a production incident on JourneyMate (Azure FastAPI + DataFlow) surfaced two CRIT connection-leak / DDL-retry pathologies in `kailash` 2.11.3 + `kailash-dataflow` 2.3.3, and an MLFP M5 notebook smoke-test sweep surfaced three HIGH 1.5.1 breaking-change bugs in `kailash-ml`. Two HIGH `DataFlowEngine.builder()` shape bugs (#685, #686) were filed earlier today and remain unaddressed. **None of these is a "release coordination" problem — every fix needs source code work.**
+
+---
+
+## NEW Findings (filed since v1 sweep at 09:57)
+
+### [CRIT] [Sweep 3: open issues] DataFlow auto_migrate fires failed CREATE TABLE on every model access — production-incident class
+
+**Location:** `src/dataflow/core/engine.py:1576-1599` (model registration eager create), `:6391-6455` (`create_tables()`), `:7426` (log line), `:7511-7600` (`_create_table_sync()` retry path) — issue #696
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (already filed; needs analyst → dataflow-specialist)
+**Evidence:** Production incident on JourneyMate 2026-04-28. BE logs showed the same 4 DDLs repeating every 30 s for the entire BE process uptime: `ERROR:dataflow.core.engine:Failed to execute DDL: CREATE TABLE IF NOT EXISTS "evaluation_dimensions" ...` × forever. Combined with the per-pool fallback bug (#697 below), each retry leaks 5–20 connections. Reproducible by defining a `@db.model` whose CREATE TABLE will fail (FK ordering, role lacks CREATE) with `auto_migrate=True`.
+**Why this matters:** Saturates Azure PG's 100–200 connection ceiling within minutes of receiving traffic. User had to set `auto_migrate=False` and manage migrations outside DataFlow to recover. The DDL-retry-on-every-access semantic is a design defect, not a one-line fix — it needs fail-fast + backoff + circuit-breaker around model-access-time DDL.
+**Action recommended:** Open workspace `workspaces/issue-696-697-dataflow-leak/` for paired investigation with #697. Fix is in `kailash-dataflow` package (so a 2.3.4 release on land) + likely also needs `kailash` core touch for the AsyncSQLDatabaseNode side (#697). Per `feedback_drive_to_completion`, this should land + release in one cycle, not be left at "issue filed."
+
+### [CRIT] [Sweep 3: open issues] AsyncSQLDatabaseNode per-pool-locking fallback leaks pools, never reclaimed mid-process
+
+**Location:** `src/kailash/nodes/data/async_sql.py:501` (pool init), `:574` (get_or_create), `:3835` (`_generate_pool_key()`), `:3944-3956` (fallback path) — issue #697
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (paired with #696)
+**Evidence:** Same JourneyMate incident. Under load, `WARNING:kailash.nodes.data.async_sql:Per-pool locking failed ... Falling back to dedicated pool mode.` — each fallback creates a new `EnterpriseConnectionPool` (5–20 connections) only held on the node instance; subsequent calls each become another dedicated pool. No mid-process eviction; only `cleanup_all_pools()` at shutdown frees them. Combined with #696 saturates Azure PG at 480–500 connections.
+**Why this matters:** Fatal under load. Took the user's production BE down for 30+ minutes during a routine deploy. The per-pool key includes `id(get_running_loop())`, so any event-loop transition forces a new pool — common under uvicorn worker pre-fork patterns. Fix needs structural rework: longer lock-hold, fail-fast typed error, OR process-wide registry with idle-eviction.
+**Action recommended:** Pair with #696 in the same workspace. Issue body proposes Option A (longer hold or fail-fast) preferred over Option B (registry + eviction). Same-bug-class as #698 (the enhancement counterpart asking for explicit `idle_timeout` + `max_pool_count_per_process` API). Per `rules/autonomous-execution.md` § Fix-Immediately when same-class within shard budget — these three (#696, #697, #698) are one shard.
+
+### [HIGH] [Sweep 3: open issues] kailash-ml 1.5.1 InferenceServer hard break — multi-model API removed without deprecation
+
+**Location:** `kailash-ml` package (1.5.1) — issue #700
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (urgent — every consumer using 1.1.x multi-model pattern is broken on import-load)
+**Evidence:** 1.5.x redesigned `InferenceServer` to one-model-per-server (`InferenceServer.from_registry(name, registry=...)` + `InferenceServerConfig`). The 1.1.x surface — `InferenceServer(registry=registry, cache_size=5)` + `await server.warm_cache(...)` + `await server.load_model(...)` — was removed in the same release with no deprecation cycle and no migration in CHANGELOG. Every consumer gets a `TypeError: InferenceServer.__init__() got an unexpected keyword argument 'cache_size'` on construction. MLFP M5 ex_2/03 + ex_7/05 affected.
+**Why this matters:** Per `rules/zero-tolerance.md` Rule 6 ("if endpoint exists, it returns real data; never half-implemented features") — this is the inverse: an endpoint advertised in 1.1.x docs that NOW raises. Per `feedback_no_shims` the user prefers no deprecation timelines; the right disposition here is either (a) restore the 1.1.x surface as a thin adapter that lazy-constructs one-server-per-model on warm_cache/load_model OR (b) document the migration explicitly in CHANGELOG + release a 1.5.2 with a `from_registry_many()` helper and a clear-error message that names the migration. Option (b) aligns with feedback_no_shims and is the simpler ship.
+**Action recommended:** dataflow/ML cycle should bundle #699 + #700 + #701 in one shard; same release; same release-prep PR.
+
+### [HIGH] [Sweep 3: open issues] kailash-ml 1.5.1 ExperimentTracker + ModelRegistry on shared store_url schema clash
+
+**Location:** `packages/kailash-ml/src/kailash_ml/engines/model_registry.py:197+` (`_create_registry_tables`), :240 / :250 / :509 / :732 / :909 (`name = ?`) vs :997 / :1004 (`model_name = ?`) — issue #699
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM
+**Evidence:** Half-finished migration. `ExperimentTracker.create()` initializes `_kml_model_versions` with tenant-aware schema (`tenant_id, model_name, version, ...`). `ModelRegistry._create_registry_tables` uses `CREATE TABLE IF NOT EXISTS` with the older `name, version, ...` schema; IF-NOT-EXISTS guard skips creation; `register_model()` then runs `INSERT INTO _kml_model_versions (name, version, ...)` against the tenant-aware schema — `OperationalError: table _kml_model_versions has no column named name`. The same source file holds BOTH schema queries — five `name = ?` sites and two `model_name = ?` sites.
+**Why this matters:** The "tracker + registry on one store" pattern is documented and is the canonical MLFP M5 setup. Every consumer using both engines hits this. Per `rules/orphan-detection.md` § 1 the failure mode resembles a partial schema-migration where one half of a paired API has migrated and the other has not — a cross-cutting consistency violation. Fix needs schema unification (preferred: tenant-aware everywhere; revert is BLOCKED because ExperimentTracker has shipped tenant-aware writes already).
+**Action recommended:** Bundle with #700 + #701 in one shard. Schema-unification PR with regression test that exercises the docs-exact pattern (per `rules/testing.md` § End-to-End Pipeline Regression — this is precisely the "fake integration via missing handoff field" sibling at the schema level).
+
+### [HIGH] [Sweep 3: open issues] kailash-ml 1.5.1 diagnose() three call paths, none cleanly handles PyTorch + DataLoader
+
+**Location:** `kailash-ml` package (1.5.1) — issue #701
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM
+**Evidence:** `diagnose(model, kind="dl", data=loader)` returns a bare `DLDiagnostics` object — `data=` arg is silently ignored (the worst class of API smell per zero-tolerance.md). `kind="classifier"` raises ValueError because §3.1 only accepts "classical_classifier". 1.1.x kwargs (`title`, `n_batches`, `train_losses`, `val_losses`, `forward_returns_tuple`) all dropped without replacement.
+**Why this matters:** This is the canonical use-case for every deep-learning lesson; the 1.5.x surface forces consumers into boilerplate or direct `DLDiagnostics` instantiation that contradicts the dispatched entry point. Per `rules/zero-tolerance.md` Rule 6 — silently-ignored `data=` parameter is a stub-shaped feature.
+**Action recommended:** Bundle with #699 + #700. Make `kind="dl"` accept `data=`; add `kind="classifier"`/`kind="regressor"` aliases; either honor 1.1.x kwargs or document migration. Add Tier-2 regression test exercising the `(model, val_loader)` path the docs teach.
+
+### [HIGH] [Sweep 3: open issues] DataFlowEngine.register_model calls non-existent method on DataFlow primitive
+
+**Location:** `packages/kailash-dataflow/src/dataflow/engine.py::DataFlowEngine.register_model` — issue #685 (filed 2026-04-28 07:51, still open)
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (no workspace yet)
+**Evidence:** `engine.register_model(None, Foo)` raises `AttributeError: 'DataFlow' object has no attribute 'register_model'`. The implementation calls `self._dataflow.register_model(model)` but `DataFlow` exposes registration via the `@db.model` decorator only. Blocks engine-first migration in downstream apps (HANA Phase 2 deferred via ADR 0003).
+**Why this matters:** Per `rules/framework-first.md` `DataFlowEngine` is the recommended surface; an API hole in the recommended surface forces downstream apps to drop back to `@db.model` against `DataFlow` directly, defeating the engine-first guidance. Cross-SDK with `kailash-rs#403`-class.
+**Action recommended:** Single-shard fix in dataflow-specialist: implement registration on `DataFlow` (the right home — `engine.register_model` should opt the model into the classification policy + register it for `get_model_classification_report()`), or delete the engine-side method if `@db.model` is the only intended path. Same shard as #686.
+
+### [HIGH] [Sweep 3: open issues] DataFlowEngineBuilder.build() is async but body is purely synchronous
+
+**Location:** `packages/kailash-dataflow/src/dataflow/engine.py::DataFlowEngineBuilder.build` — issue #686 (filed 2026-04-28 07:51, still open)
+**Disposition:** FILE-FOR-NEXT-WORKSTREAM (paired with #685)
+**Evidence:** Body never `await`s; signature `async def build(self) -> "DataFlowEngine"`. Forces every caller into `await` even though no async work happens — module-import-time `@lru_cache get_db()` patterns can't use it. HANA Phase 2 has 8 `@db.model` files that all do `db = get_db()` at import; cannot await without restructuring.
+**Why this matters:** Per `rules/patterns.md` § "Paired Public Surface — Consistent Async-ness", inconsistency between surface (async) and body (sync) is a paper-cut every caller pays. Likely originated from cross-SDK parity with kailash-rs (where async IS load-bearing for runtime init).
+**Action recommended:** Add `build_sync()` as escape hatch (preferred) OR make `build()` sync + ship `build_async()` for cross-SDK parity. Ship same shard as #685.
+
+### [INFO] Other open issues unchanged from v1
+
+- #673, #643, #630, #596, #687, #693 carried forward from v1 sweep with no state change. Each is its own scoped enhancement / new workstream. None blocking.
+- #688 closed (CSP regression carry-forward fixed in PR #690).
+- #683 closed (not-null handler test mock-method drift fixed in PR #689).
+- #684 closed via PR #684 / cf945373 (kailash-dataflow 2.3.3).
+
+---
+
+## Findings carried forward from v1 sweep (unchanged)
+
+- **[MED]** Codify proposal stalled at `pending_review` since 2026-04-27. **No change** — the cycle-10 proposal added today (PR #695, `git-reset-hard-discipline`) is also at `reviewed` waiting for loom Gate 2 distribution. **2 GLOBAL rules pending** loom-side propagation.
+- **[MED]** `diagnostics-catalog.md` orphan in `specs/_index.md`. **No change.**
+- **[MED]** 18 of 72 spec files marked `Version: 1.0.0 (draft)`. **No change.**
+- **[MED]** Deferred-codify backlog at 8 items; 5 rule files exceed 200-line guidance. **No change.**
+- **[LOW]** 11 active todos in `workspaces/spec-drift-gate/`. **No change.**
+- **[LOW]** 78 pending journal entries across 6 workspaces. **+0** (none promoted today). Now 78 across 7 workspaces (kailash-ml-audit was undercounted; it has 6).
+- **[LOW]** 9 unmerged remote branches without open PRs. **+1**: branch list above shows 10 now (`feat/outstanding-issues-consolidation` from 2026-04-05 reappears in unmerged enumeration).
+- **[LOW]** 122 stub markers in production code. **−3** (PR #682 resolved 3 markers from prior LOW-6).
+- **[LOW]** 12 workspaces with `.session-notes` >30d. **−12** (PR #681 archived all 12; sweep flag now reads as 0 stale workspaces ≥30d).
+- **[INFO]** 0 open PRs. **No change.**
+- **[INFO]** 0 issues in kailash-coc-claude-py. **No change.**
+- **[INFO]** 1 worktree (main only). **No change.**
+
+---
+
+## Cross-cutting observations
+
+1. **The CRIT class is a coupled DataFlow/Core-SDK pair (#696 ↔ #697 ↔ #698).** They surface together under load and amplify each other (DDL retry storm × per-pool leak = 480-conn saturation in minutes). Fixing only one of them leaves the production incident class open. This is precisely the same-shard same-bug-class scenario `rules/autonomous-execution.md` § 4 mandates fix-immediately when budget allows. Estimated shard size: 1 session.
+
+2. **The HIGH class on kailash-ml 1.5.x is "stub-shaped after release" (Rule 6 at semver-major-bump scale).** #699 (schema fork), #700 (removed kwargs), #701 (silently-ignored arg) all share a root cause: 1.5.x bumped a major shape without the regression tests `rules/testing.md` § End-to-End Pipeline Regression mandates. The MLFP M5 notebook sweep is functioning as the canary. Per `feedback_drive_to_completion` — these need to land + release as 1.5.2, not get filed and forgotten.
+
+3. **The DataFlowEngine API holes (#685, #686) coexist with the production-incident pair on the same package.** Bundling them into one workspace (4 issues, one DataFlow release cycle) is structurally cheaper than two separate cycles. They share specialist (dataflow-specialist), shared invariant set (engine surface + connection lifecycle), shared CI cycle. Single-PR risk is low because the surface area is well-bounded.
+
+4. **The codify pipeline is now two cycles deep (Cycle 10 reviewed today; Cycle 11 from this sweep would be premature)** — the 2 GLOBAL rules from Wave 6/7 + the `git reset --hard` rule from this morning all sit at loom's `/sync` Gate 2 backlog. Adding a third unsynced cycle would not help; the bottleneck is loom-side, not BUILD-repo-side.
+
+5. **No new release work needed for the existing source.** All 8 packages at PyPI parity. The CRIT/HIGH issues require code fixes BEFORE release, so a release is the OUTPUT of the next workstream, not a pre-requisite.
+
+---
+
+## Recommended next-session scope (re-ranked by criticality)
+
+1. **Open workspace `workspaces/dataflow-prod-incident/`** — analyst step on #696 + #697 + #698 (production-incident triage). Single shard, dataflow-specialist + analyst, paired-PR delivery. **Dispatches to a release of `kailash-dataflow` + `kailash`** once landed. Highest urgency given user said "urgent" and these are CRIT.
+
+2. **Open workspace `workspaces/kailash-ml-1.5.x-followup/`** — analyst step on #699 + #700 + #701 (canonical-pattern bugs from 1.5.1 release). Schema unification + adapter-or-document for InferenceServer + diagnose() entry-point fix. **Dispatches to release of `kailash-ml` 1.5.2.** Per `feedback_drive_to_completion` ship through `/release` after merge.
+
+3. **Open workspace `workspaces/dataflow-engine-builder-api/`** OR fold into #1 — #685 + #686 (DataFlowEngine surface holes). Single shard, dataflow-specialist. Same release as #1 (one `kailash-dataflow` cut covers both).
+
+4. **Loom `/sync` to clear cycle-10 + cycle-11** (15 min) — switch to `~/repos/loom/`, run `/sync` to process the kailash-py `pending_review` and process the new `git reset --hard` rule. Distributes 3 GLOBAL rules to coc-py + coc-rs templates. Same priority as v1 sweep recommendation #1; deferred only because the source-code work above is more urgent.
+
+5. **Subsequent**: spec-drift-gate, rule-file-size refactor, stub-marker triage, and remaining v1 LOW/MED items.
+
+---
+
+## Action this session (per `feedback_drive_to_completion`)
+
+The sweep itself is the deliverable. Next-session scope decisions are the human's. The immediate-fix discipline (Rule 1: "if you found it, you own it") would push toward starting workstream #1 in this same session if the user authorizes — given the user's framing ("urgent"), that's the natural continuation. Awaiting confirmation before opening the workspace.
+
+## Recovery instructions
+
+This v2 sweep supersedes the 09:57 v1 sweep on every finding marked NEW. Carried-forward items reference v1 directly — do not re-evaluate them.

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -1385,6 +1385,86 @@ class DataFlow(DataFlowEventMixin):
         # 4. Run migrations if needed
         # 5. Setup monitoring if enabled
 
+    def register_model(
+        self,
+        model_cls: Type,
+        *,
+        replace: bool = False,
+        force_drop: bool = False,
+    ) -> Type:
+        """Register a model with DataFlow non-decoratively.
+
+        Programmatic counterpart to ``@db.model``. Both paths share the
+        same body — ``register_model(Foo)`` produces identical state to
+        ``@db.model class Foo: ...`` (entries in ``_models``,
+        ``_registered_models``, ``_model_fields``; CRUD/bulk node
+        generation; classification-policy registration; deferred
+        relationship detection). Returns ``model_cls`` for chaining.
+
+        Idempotency: by default, calling ``register_model`` on an
+        already-registered model raises ``ValueError`` (consistent with
+        the ``@db.model`` duplicate-registration check). Pass
+        ``replace=True`` AND ``force_drop=True`` to drop the prior
+        table and re-register — see ``rules/dataflow-identifier-safety.md``
+        Rule 4 for the destructive-confirmation pattern.
+
+        Args:
+            model_cls: The model class to register.
+            replace: When ``True``, allow re-registration of an
+                already-registered model. Requires ``force_drop=True``.
+            force_drop: When ``True``, acknowledge that re-registration
+                may drop and recreate the underlying table. Required
+                when ``replace=True``.
+
+        Returns:
+            ``model_cls`` (same class, for chaining).
+
+        Raises:
+            ValueError: Model already registered and ``replace=False``.
+            ValueError: ``replace=True`` without ``force_drop=True``.
+
+        Example:
+            >>> db = DataFlow("sqlite:///app.db")
+            >>> class User:
+            ...     name: str
+            ...     email: str
+            >>> db.register_model(User)
+            <class 'User'>
+        """
+        model_name = model_cls.__name__
+
+        if model_name in self._models:
+            if not replace:
+                raise ValueError(
+                    f"Model '{model_name}' is already registered. "
+                    f"Pass replace=True (and force_drop=True) to "
+                    f"explicitly drop and re-register. "
+                    f"Currently registered models: "
+                    f"{list(self._models.keys())}"
+                )
+            if not force_drop:
+                # Per rules/dataflow-identifier-safety.md Rule 4 —
+                # destructive operations require structural confirmation.
+                raise ValueError(
+                    f"register_model('{model_name}', replace=True) refused "
+                    f"— pass force_drop=True to acknowledge that "
+                    f"re-registration may drop and recreate the "
+                    f"underlying table; data loss is irreversible."
+                )
+            # Tear down the prior registration so model() does not raise
+            # the duplicate-registration enhanced error.
+            self._models.pop(model_name, None)
+            self._registered_models.pop(model_name, None)
+            self._model_fields.pop(model_name, None)
+            self._pending_relationship_detection.discard(model_name)
+            if model_name in self._pending_table_creations:
+                self._pending_table_creations.remove(model_name)
+
+        # Delegate to the canonical decorator body so both surfaces
+        # produce identical state. ``model()`` returns the (possibly
+        # mutated) class; we propagate that back to the caller.
+        return self.model(model_cls)
+
     def model(self, cls: Type) -> Type:
         """Decorator to register a model with DataFlow.
 

--- a/packages/kailash-dataflow/src/dataflow/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/engine.py
@@ -232,8 +232,36 @@ class DataFlowEngineBuilder:
         self._dataflow_kwargs.update(kwargs)
         return self
 
-    async def build(self) -> DataFlowEngine:
-        """Build the DataFlowEngine instance (async -- connects to database)."""
+    def build_sync(self) -> DataFlowEngine:
+        """Build the DataFlowEngine instance synchronously.
+
+        Identical body to :meth:`build` (which never awaits in
+        kailash-py); this companion exists for module-import-time
+        patterns where wrapping in ``asyncio.run()`` would conflict with
+        an already-running event loop (Nexus handlers, pytest-asyncio,
+        Jupyter kernels, ``@functools.lru_cache``-decorated factories).
+
+        Use ``build_sync()`` when constructing an engine outside of an
+        async context. Use ``build()`` for cross-SDK parity with
+        kailash-rs (where the equivalent IS legitimately async due to
+        Tokio runtime initialization).
+
+        Both paths produce identical engine state — they delegate to a
+        single body so the two surfaces cannot drift.
+
+        Example::
+
+            # Module-import-time pattern:
+            from functools import lru_cache
+
+            @lru_cache(maxsize=1)
+            def get_engine() -> DataFlowEngine:
+                return (
+                    DataFlowEngine.builder("sqlite:///app.db")
+                    .slow_query_threshold(0.5)
+                    .build_sync()
+                )
+        """
         # Extract fabric-specific config before passing to DataFlow
         kwargs = dict(self._dataflow_kwargs)
         fabric_sources = kwargs.pop("_fabric_sources", [])
@@ -263,6 +291,22 @@ class DataFlowEngineBuilder:
         engine._fabric_config = fabric_config
 
         return engine
+
+    async def build(self) -> DataFlowEngine:
+        """Build the DataFlowEngine instance (async signature).
+
+        The async signature is preserved for cross-SDK parity with
+        kailash-rs, where engine construction IS legitimately async
+        (Tokio runtime initialization). In kailash-py the body has no
+        awaits, so this method delegates to :meth:`build_sync` to
+        guarantee both surfaces produce identical engine state.
+
+        Use this method when building under an existing event loop
+        (Nexus / FastAPI handlers, pytest-asyncio, Jupyter). Use
+        :meth:`build_sync` for module-import-time patterns where no
+        loop is available.
+        """
+        return self.build_sync()
 
 
 class DataFlowEngine:
@@ -328,14 +372,28 @@ class DataFlowEngine:
     def register_model(self, registry: Any, model: Any) -> None:
         """Register a model and generate its CRUD nodes.
 
-        If a ``DataClassificationPolicy`` is set and it exposes a
-        ``register_model`` method, the model is also registered with the
-        classification policy so field metadata is available for
-        ``get_model_classification_report``.
+        Delegates to ``DataFlow.register_model`` (auto-generates 11
+        workflow nodes per SQL model + records the model in
+        ``_models`` / ``_registered_models`` / ``_model_fields``). If a
+        ``DataClassificationPolicy`` is set and exposes a
+        ``register_model`` method, the model is ALSO registered with
+        the classification policy so field metadata is available for
+        :meth:`get_model_classification_report`.
 
-        Delegates to DataFlow's model registration which auto-generates
-        11 workflow nodes per SQL model.
+        Args:
+            registry: Kept for cross-SDK parity with kailash-rs, where
+                the equivalent method takes a model registry instance.
+                kailash-py threads model registration through the
+                DataFlow primitive itself, so this argument is unused
+                here — pass ``None``. Removing the parameter would
+                break the cross-SDK signature contract; see
+                ``rules/cross-sdk-inspection.md`` § 3a.
+            model: The model class to register.
         """
+        # ``DataFlow.register_model`` (DPI-C1) is the underlying
+        # mechanism; both the ``@db.model`` decorator and this engine
+        # surface route through it so registration state is identical
+        # regardless of entry path.
         self._dataflow.register_model(model)
         self._registered_models.append(model)
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_685_engine_register_model.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_685_engine_register_model.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #685 — DataFlowEngine.register_model.
+
+Pre-fix: ``DataFlowEngine.register_model`` called
+``self._dataflow.register_model(model)`` on the DataFlow primitive,
+which did not have a ``register_model`` method. Every non-decorator
+registration path raised ``AttributeError`` before any work happened.
+
+Post-fix:
+1. ``DataFlow.register_model(model_cls)`` is the canonical entry point
+   (DPI-C1) — both ``@db.model`` and ``DataFlowEngine.register_model``
+   route through it.
+2. ``DataFlowEngine.register_model(None, Model)`` works end-to-end;
+   the ``registry`` param is kept for cross-SDK parity per
+   ``rules/cross-sdk-inspection.md`` § 3a.
+
+These tests use a file-backed SQLite URL (per
+``packages/kailash-dataflow/tests/regression/conftest.py::sqlite_file_url``)
+because the fixes touched no PG-specific behaviour and Tier-2
+SQLite is the appropriate carve-out for surface-level engine tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dataflow import DataFlow, DataFlowEngine
+from dataflow.classification import (
+    ClassificationPolicy,
+    DataClassification,
+    MaskingStrategy,
+    classify,
+)
+
+
+@pytest.mark.regression
+def test_register_model_does_not_raise_attributeerror(sqlite_file_url):
+    """Repro from issue #685.
+
+    Pre-fix: ``engine.register_model(None, Foo)`` raised
+    ``AttributeError: 'DataFlow' object has no attribute 'register_model'``.
+
+    Post-fix: completes without raising and the model is registered on
+    BOTH the underlying DataFlow primitive AND the engine's
+    ``_registered_models`` list.
+    """
+    engine = DataFlowEngine.builder(sqlite_file_url).build_sync()
+
+    class Foo:
+        name: str
+        active: bool = True
+
+    # Must not raise AttributeError.
+    engine.register_model(None, Foo)
+
+    # State assertions: both the DataFlow primitive AND the engine's
+    # tracking list must show the registration.
+    assert "Foo" in engine.dataflow._models
+    assert Foo in engine._registered_models
+    assert "Foo" in engine.dataflow._model_fields
+
+
+@pytest.mark.regression
+def test_register_model_with_classification_policy(sqlite_file_url):
+    """Classification-policy passthrough still works after DPI-C1/DPI-C2.
+
+    When the engine has a ``ClassificationPolicy`` set via
+    ``.classification_policy(policy)``, ``register_model`` MUST
+    propagate the model to the policy so per-field classification
+    metadata is registered in BOTH the engine's policy AND the
+    DataFlow primitive's policy.
+    """
+    policy = ClassificationPolicy()
+
+    engine = (
+        DataFlowEngine.builder(sqlite_file_url)
+        .classification_policy(policy)
+        .build_sync()
+    )
+
+    @classify(
+        "email",
+        DataClassification.PII,
+        masking=MaskingStrategy.REDACT,
+    )
+    class User:
+        email: str
+        name: str
+
+    engine.register_model(None, User)
+
+    # Engine-level classification policy registration: the
+    # classification helper used for get_model_classification_report
+    # is the @classify decorator metadata stored on the class itself.
+    report = engine.get_model_classification_report(User)
+    assert "email" in report
+    assert report["email"]["classification"] == DataClassification.PII.value
+
+
+@pytest.mark.regression
+def test_get_model_classification_report_after_register(sqlite_file_url):
+    """Full round-trip from issue #685 acceptance criteria.
+
+    Pre-fix: the AttributeError fired before any registration could
+    happen, so the classification report could not be built.
+
+    Post-fix: a model registered via ``engine.register_model`` exposes
+    its ``@classify`` metadata via ``get_model_classification_report``.
+    """
+    engine = DataFlowEngine.builder(sqlite_file_url).build_sync()
+
+    @classify(
+        "ssn",
+        DataClassification.PII,
+        masking=MaskingStrategy.REDACT,
+    )
+    @classify(
+        "salary",
+        DataClassification.HIGHLY_CONFIDENTIAL,
+        masking=MaskingStrategy.REDACT,
+    )
+    class Employee:
+        name: str
+        ssn: str
+        salary: float
+
+    engine.register_model(None, Employee)
+
+    report = engine.get_model_classification_report(Employee)
+
+    assert "ssn" in report
+    assert "salary" in report
+    assert report["ssn"]["classification"] == DataClassification.PII.value
+    assert (
+        report["salary"]["classification"]
+        == DataClassification.HIGHLY_CONFIDENTIAL.value
+    )
+
+
+@pytest.mark.regression
+def test_dataflow_register_model_idempotency_raises(sqlite_file_url):
+    """DPI-C1 idempotency contract.
+
+    Calling ``DataFlow.register_model(Foo)`` twice without ``replace=True``
+    raises ``ValueError`` per the destructive-confirmation pattern in
+    rules/dataflow-identifier-safety.md Rule 4.
+    """
+    db = DataFlow(sqlite_file_url)
+
+    class Foo:
+        name: str
+
+    db.register_model(Foo)
+
+    with pytest.raises(ValueError, match="already registered"):
+        db.register_model(Foo)
+
+
+@pytest.mark.regression
+def test_dataflow_register_model_replace_requires_force_drop(sqlite_file_url):
+    """DPI-C1 destructive-confirmation contract.
+
+    ``register_model(Foo, replace=True)`` without ``force_drop=True``
+    is refused — re-registration may DROP the underlying table, which
+    is irreversible per rules/dataflow-identifier-safety.md Rule 4.
+    """
+    db = DataFlow(sqlite_file_url)
+
+    class Bar:
+        value: int
+
+    db.register_model(Bar)
+
+    with pytest.raises(ValueError, match="force_drop=True"):
+        db.register_model(Bar, replace=True)
+
+
+@pytest.mark.regression
+def test_dataflow_register_model_replace_with_force_drop_succeeds(
+    sqlite_file_url,
+):
+    """DPI-C1 explicit re-registration path.
+
+    Passing both ``replace=True`` AND ``force_drop=True`` allows
+    re-registration. The class is returned for chaining.
+    """
+    db = DataFlow(sqlite_file_url)
+
+    class Baz:
+        amount: int
+
+    db.register_model(Baz)
+    assert "Baz" in db._models
+
+    # Re-register the same class — the explicit double-flag path.
+    result = db.register_model(Baz, replace=True, force_drop=True)
+    assert result is Baz
+    assert "Baz" in db._models  # Re-registered, not removed.
+
+
+@pytest.mark.regression
+def test_register_model_decorator_and_method_produce_identical_state(
+    sqlite_file_url,
+):
+    """DPI-C1 contract: ``@db.model`` and ``db.register_model`` produce
+    identical state.
+
+    Both paths must populate the same DataFlow internal state
+    (``_models``, ``_registered_models``, ``_model_fields``,
+    ``_pending_relationship_detection``) so downstream consumers
+    cannot tell which path the user took.
+    """
+    db1 = DataFlow(sqlite_file_url)
+    db2 = DataFlow(sqlite_file_url)
+
+    @db1.model
+    class ModelA:
+        name: str
+        active: bool = True
+
+    class ModelB:  # Identical structure, different class identity
+        name: str
+        active: bool = True
+
+    ModelB.__name__ = "ModelA"  # Match the decorator path's keyspace
+    db2.register_model(ModelB)
+
+    # Per-keyspace structural equality — both paths registered "ModelA".
+    assert "ModelA" in db1._models
+    assert "ModelA" in db2._models
+
+    fields_a = db1._model_fields["ModelA"]
+    fields_b = db2._model_fields["ModelA"]
+    assert set(fields_a.keys()) == set(fields_b.keys())
+    for fname in fields_a:
+        assert fields_a[fname]["type"] == fields_b[fname]["type"]
+        assert fields_a[fname]["required"] == fields_b[fname]["required"]

--- a/packages/kailash-dataflow/tests/regression/test_issue_686_builder_sync.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_686_builder_sync.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #686 — DataFlowEngineBuilder.build sync.
+
+Pre-fix: ``DataFlowEngineBuilder.build()`` was ``async def`` but the
+body had no ``await``s. Module-import-time patterns (``@lru_cache``
+factories, top-level ``DataFlow`` setup, fixtures running before any
+event loop is bound) had to wrap the call in ``asyncio.run()``, which
+then crashed with ``RuntimeError: This event loop is already running``
+inside Nexus / FastAPI handlers, pytest-asyncio, and Jupyter kernels.
+
+Post-fix:
+1. ``build_sync()`` is the canonical body — synchronous, no event loop
+   required.
+2. The async ``build()`` becomes a thin wrapper that calls
+   ``build_sync()`` so both surfaces share a single body and cannot
+   drift.
+3. The async signature is preserved for cross-SDK parity with
+   kailash-rs (where the equivalent IS legitimately async).
+
+Per rules/cross-sdk-inspection.md § 3a, this file also includes a
+**structural API-divergence test** that pins the async signature so a
+future refactor that mistakenly drops the async surface (or grows
+``build()`` body to use ``asyncio.run``) fails loudly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from functools import lru_cache
+
+import pytest
+
+from dataflow import DataFlowEngine
+from dataflow.engine import DataFlowEngineBuilder
+
+
+@pytest.mark.regression
+def test_build_sync_works_at_module_import_time(sqlite_file_url):
+    """Repro from issue #686.
+
+    The ``@lru_cache get_db()`` pattern is the canonical
+    module-import-time use case. Before the fix this required either
+    ``asyncio.run(builder.build())`` (RuntimeError under any running
+    loop) OR awaiting in an async wrapper (crashes top-level imports).
+
+    Post-fix: ``build_sync()`` works synchronously with no event loop
+    required and is safe to call from any caller context.
+    """
+    factory_url = sqlite_file_url
+
+    @lru_cache(maxsize=1)
+    def get_engine() -> DataFlowEngine:
+        return (
+            DataFlowEngine.builder(factory_url).slow_query_threshold(0.5).build_sync()
+        )
+
+    engine_a = get_engine()
+    engine_b = get_engine()
+
+    assert engine_a is engine_b  # lru_cache works
+    assert engine_a.dataflow is not None
+    assert engine_a.query_engine.slow_query_threshold == 0.5
+
+
+@pytest.mark.regression
+def test_build_sync_and_build_async_produce_identical_state(sqlite_file_url):
+    """Both paths produce identical engine state.
+
+    Per the DPI-C2 contract, ``build()`` is implemented as a thin
+    wrapper that calls ``build_sync()``. Both paths MUST yield engines
+    with structurally equivalent internal state — same DataFlow
+    config, same QueryEngine threshold, same validate_on_write flag,
+    same fabric config carried through.
+    """
+    builder_factory = lambda: (  # noqa: E731 — concise factory
+        DataFlowEngine.builder(sqlite_file_url)
+        .slow_query_threshold(0.7)
+        .validate_on_write(True)
+    )
+
+    sync_engine = builder_factory().build_sync()
+    async_engine = asyncio.run(builder_factory().build())
+
+    # Top-level structural equality across both surfaces.
+    assert sync_engine.query_engine.slow_query_threshold == (
+        async_engine.query_engine.slow_query_threshold
+    )
+    assert sync_engine.validate_on_write == async_engine.validate_on_write
+    assert sync_engine.validation == async_engine.validation
+    assert sync_engine.classification == async_engine.classification
+
+    # Both engines wrap a real DataFlow instance with the same URL.
+    assert sync_engine.dataflow.config.database.url == (
+        async_engine.dataflow.config.database.url
+    )
+
+
+@pytest.mark.regression
+def test_async_build_signature_invariant():
+    """Structural invariant — async ``build()`` signature is preserved.
+
+    Per rules/cross-sdk-inspection.md § 3a: pinning the async signature
+    means that a future refactor which "simplifies" by removing the
+    ``async`` keyword (and so breaks cross-SDK parity with kailash-rs)
+    fails this test loudly with a direct pointer back to the
+    cross-SDK contract.
+
+    The async surface is intentionally kept even though the kailash-py
+    body is sync, because the Rust DataFlowEngineBuilder.build IS
+    legitimately async and downstream cross-SDK code expects to
+    ``await`` build() regardless of language.
+    """
+    # build() MUST stay async.
+    assert inspect.iscoroutinefunction(DataFlowEngineBuilder.build), (
+        "DataFlowEngineBuilder.build MUST remain async for cross-SDK "
+        "parity with kailash-rs (rules/cross-sdk-inspection.md § 3a). "
+        "If you intentionally removed async, you have broken the "
+        "cross-SDK contract and MUST file a kailash-rs issue first."
+    )
+
+    # build_sync() MUST stay sync — that's the entire point of having it.
+    assert not inspect.iscoroutinefunction(DataFlowEngineBuilder.build_sync), (
+        "DataFlowEngineBuilder.build_sync MUST remain synchronous. "
+        "If async was added, the build_sync companion has lost its "
+        "purpose (module-import-time patterns)."
+    )
+
+    # Signature pin: build() returns DataFlowEngine; build_sync() returns
+    # DataFlowEngine. Both signatures must accept only ``self``.
+    build_sig = inspect.signature(DataFlowEngineBuilder.build)
+    build_sync_sig = inspect.signature(DataFlowEngineBuilder.build_sync)
+    build_params = [n for n in build_sig.parameters if n != "self"]
+    build_sync_params = [n for n in build_sync_sig.parameters if n != "self"]
+    assert build_params == [], f"build() signature drifted: {build_sig}"
+    assert build_sync_params == [], f"build_sync() signature drifted: {build_sync_sig}"
+
+
+@pytest.mark.regression
+def test_build_sync_works_under_running_event_loop(sqlite_file_url):
+    """``build_sync()`` works even when called from inside a running loop.
+
+    The original issue #686 failure mode: callers wrapped
+    ``asyncio.run(builder.build())`` and crashed under pytest-asyncio /
+    Nexus handlers / Jupyter. ``build_sync()`` MUST work in any caller
+    context — sync, async, nested.
+    """
+
+    async def _build_inside_loop() -> DataFlowEngine:
+        # Inside a running loop. asyncio.run would raise RuntimeError.
+        # build_sync must work without any wrapping.
+        return DataFlowEngine.builder(sqlite_file_url).build_sync()
+
+    engine = asyncio.run(_build_inside_loop())
+    assert engine is not None
+    assert engine.dataflow is not None

--- a/specs/dataflow-core.md
+++ b/specs/dataflow-core.md
@@ -197,16 +197,85 @@ await engine.close()
 
 ### 14.1 Builder Methods
 
-| Method                           | Purpose                                         |
-| -------------------------------- | ----------------------------------------------- |
-| `.validation(layer)`             | Set a `ValidationLayer` protocol implementation |
-| `.classification_policy(policy)` | Set a `DataClassificationPolicy`                |
-| `.slow_query_threshold(seconds)` | Slow query detection threshold (default: 1.0s)  |
-| `.validate_on_write(enabled)`    | Enable auto-validation before writes            |
-| `.source(name, config)`          | Register an external data source                |
-| `.fabric(**kwargs)`              | Configure fabric runtime parameters             |
-| `.config(**kwargs)`              | Pass additional kwargs to `DataFlow`            |
-| `.build()`                       | Build the engine (async)                        |
+| Method                           | Purpose                                                                |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| `.validation(layer)`             | Set a `ValidationLayer` protocol implementation                        |
+| `.classification_policy(policy)` | Set a `DataClassificationPolicy`                                       |
+| `.slow_query_threshold(seconds)` | Slow query detection threshold (default: 1.0s)                         |
+| `.validate_on_write(enabled)`    | Enable auto-validation before writes                                   |
+| `.source(name, config)`          | Register an external data source                                       |
+| `.fabric(**kwargs)`              | Configure fabric runtime parameters                                    |
+| `.config(**kwargs)`              | Pass additional kwargs to `DataFlow`                                   |
+| `.build()`                       | Build the engine (async — preserved for cross-SDK parity)              |
+| `.build_sync()`                  | Build the engine synchronously (module-import-time / lru_cache safe)   |
+
+**`build()` vs `build_sync()`** — both surfaces produce identical
+engine state. `build()` is `async def` for cross-SDK parity with
+kailash-rs (where engine construction IS legitimately async due to
+Tokio runtime initialization); the kailash-py body has no `await`s and
+delegates to `build_sync()` so the two surfaces share a single body
+and cannot drift.
+
+| Caller context                                        | Use         |
+| ----------------------------------------------------- | ----------- |
+| Module-import-time (`@lru_cache` factory, top-level)  | `build_sync()` |
+| Inside a running event loop (Nexus, FastAPI, Jupyter) | `build_sync()` (or `await build()`) |
+| Cross-SDK polyglot code that awaits build everywhere  | `build()`   |
+
+Per `rules/patterns.md` § "Paired Public Surface — Consistent
+Async-ness", offering both shapes is permitted here because the
+underlying body is genuinely sync (no `asyncio.run` wrap) — neither
+surface raises `RuntimeError` under any caller context. Per
+`rules/cross-sdk-inspection.md` § 3a, a structural invariant test
+pins the `async def` signature on `build()` so a future refactor that
+drops it fails loudly.
+
+### 14.1.1 Model Registration — `DataFlowEngine.register_model`
+
+`DataFlowEngine.register_model(registry, model)` registers a model
+end-to-end through the engine surface:
+
+```python
+engine = DataFlowEngine.builder("sqlite:///app.db").build_sync()
+engine.register_model(None, UserModel)            # ← model registered
+report = engine.get_model_classification_report(UserModel)
+```
+
+The `registry` argument is kept for cross-SDK parity with kailash-rs
+(where the equivalent method takes a model registry instance);
+kailash-py threads model registration through the DataFlow primitive
+itself, so callers pass `None`. Removing the parameter would break
+the cross-SDK signature contract.
+
+`DataFlowEngine.register_model` delegates to
+`DataFlow.register_model` (§ 14.1.2 below), so the engine path and
+the `@db.model` decorator path produce identical state — entries in
+`_models` / `_registered_models` / `_model_fields`, CRUD/bulk node
+generation, classification-policy registration, deferred relationship
+detection. Additionally, when the engine has a
+`DataClassificationPolicy` set via `.classification_policy(policy)`,
+the model is also registered with the policy so per-field
+classification metadata is available for
+`get_model_classification_report`.
+
+### 14.1.2 `DataFlow.register_model` — Underlying Mechanism
+
+`DataFlow.register_model(model_cls, *, replace=False, force_drop=False)`
+is the programmatic counterpart to the `@db.model` decorator. Both
+paths share the same body — `db.register_model(Foo)` produces
+identical state to `@db.model class Foo`.
+
+| Call                                                    | Behaviour                                                          |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| `db.register_model(Foo)`                                | Registers `Foo`; returns `Foo` for chaining.                       |
+| `db.register_model(Foo)` again                          | Raises `ValueError("already registered")`.                         |
+| `db.register_model(Foo, replace=True)`                  | Refused — raises `ValueError("force_drop=True required")`.         |
+| `db.register_model(Foo, replace=True, force_drop=True)` | Tears down prior registration and re-registers. Destructive.       |
+
+The `replace` + `force_drop` two-flag pattern follows the
+destructive-confirmation discipline mandated by
+`rules/dataflow-identifier-safety.md` Rule 4 — re-registration may
+DROP and recreate the underlying table, which is irreversible.
 
 ### 14.2 QueryEngine
 

--- a/workspaces/dataflow-prod-incident/01-analysis/01-research/01-failure-points.md
+++ b/workspaces/dataflow-prod-incident/01-analysis/01-research/01-failure-points.md
@@ -1,0 +1,200 @@
+# 01 — Failure Points Analysis
+
+Five issues, three coupled shards, two coupled root causes. This file maps each issue to the production code that produced it, identifies the underlying invariant violated, and surfaces the cross-cutting failure pattern.
+
+## Shard A — DataFlow auto_migrate retry storm (#696)
+
+### Code path
+
+| File                                                    |     Lines | Behavior                                                                                                                                                                            |
+| ------------------------------------------------------- | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/kailash-dataflow/src/dataflow/core/engine.py` | 1576-1599 | `_register_model` calls `_create_table_sync()` if connected; on failure, `logger.debug("sync DDL failed, table will be created lazily on first access")` and proceeds.              |
+| `packages/kailash-dataflow/src/dataflow/core/engine.py` | 1603-1689 | `ensure_table_exists()` is the lazy-creation hot path. Checks `_schema_cache` (line 1632), runs full migration if not cached. **Cache is marked-ensured ONLY on success.**          |
+| `packages/kailash-dataflow/src/dataflow/core/engine.py` | 7400-7429 | `_execute_ddl` (sync). Bare `except Exception as e: logger.error(f"Failed to execute DDL: {statement[:100]}... Error: {e}"); continue` — no state, no retry-suppression, no metric. |
+| `packages/kailash-dataflow/src/dataflow/core/engine.py` | 7431-7509 | `_execute_ddl_async`. Same swallow pattern at line 7504-7508.                                                                                                                       |
+
+### Root cause
+
+The error path violates two MUST clauses:
+
+1. **`zero-tolerance.md` Rule 3 (silent fallbacks).** `except Exception: continue` after a DDL failure is the canonical silent-fallback. The error log is ERROR level (correct) but the **next** model access re-enters `ensure_table_exists()`, the cache says "not ensured", and the failed DDL fires again. The "fallback" is implicit: failure becomes infinite retry.
+2. **`dataflow-pool.md` Rule 2 (validate at startup).** Pool config and connectivity are validated, but DDL applicability is not. A model whose CREATE TABLE will fail (FK ordering, role lacks CREATE, column-type mismatch) is NOT detected at `DataFlow.__init__` — only at first access.
+
+### Why it amplifies in production
+
+- Every 30 s, the FastAPI app's health check (or any user request that touches a model) re-enters `ensure_table_exists()`.
+- The schema cache in `_schema_cache` only marks-ensured on success, so failed-DDL models stay un-cached forever.
+- Combined with #697 below, every retry creates a brand-new connection pool of 5–20 connections that is never reclaimed.
+
+### Invariant the fix must preserve
+
+A failed CREATE TABLE under `auto_migrate=True` MUST be a single, loud, fail-fast error AT STARTUP — not a per-access silent retry. The user MUST be able to override (e.g., `auto_migrate="warn"` for dev) but the default MUST surface the failure at the point the operator can act on it.
+
+---
+
+## Shard B — AsyncSQLDatabaseNode pool fallback leak (#697 + #698)
+
+### Code path
+
+| File                                  |     Lines | Behavior                                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------- | --------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/kailash/nodes/data/async_sql.py` |   501-575 | `EnterpriseConnectionPool.__init__`. Min/max size, health-check interval, analytics interval. **No `idle_timeout`. No process-wide cap.**                                                                                                                                                                                                                                           |
+| `src/kailash/nodes/data/async_sql.py` | 3835-3876 | `_generate_pool_key()` includes `id(get_running_loop())` for event-loop isolation. Per-event-loop separation is intentional; per-instance fallback is not.                                                                                                                                                                                                                          |
+| `src/kailash/nodes/data/async_sql.py` | 3878-3962 | `_get_adapter` — three priority paths: external pool → runtime pool → class-level shared pool. The shared-pool path acquires a per-pool lock with `timeout=5.0`.                                                                                                                                                                                                                    |
+| `src/kailash/nodes/data/async_sql.py` | 3944-3956 | **The leak.** `except (RuntimeError, asyncio.TimeoutError, Exception)` catches anything; sets `self._share_pool = False`, `self._pool_key = None`, calls `_create_adapter()` to make a fresh dedicated pool. **The dedicated pool is held only on the node instance** — every subsequent call sees `self._adapter is None` (different instance) and creates ANOTHER dedicated pool. |
+
+### Root cause
+
+Three coupled MUST violations:
+
+1. **`zero-tolerance.md` Rule 3 (silent fallback).** The `WARNING` log fires once per fallback, but the leak is invisible to alerting because the log doesn't escalate. From the issue body: "These pairs repeated 4-5 times per 30s. Each 'fallback' creates a brand-new EnterpriseConnectionPool (5-20 connections) that is never reclaimed mid-process."
+2. **`dataflow-pool.md` Rule 5 (no orphan runtimes — extends to pools).** A pool created in fallback mode has no parent registry that would call its `close()`. Only `AsyncSQLDatabaseNode.cleanup_all_pools()` at process shutdown reaps it. This is the orphan-pool sibling of the orphan-runtime pattern (Phase 5.11 prior art).
+3. **`zero-tolerance.md` Rule 6 (no half-implementation).** `EnterpriseConnectionPool` ships with no `idle_timeout`, no LRU eviction, no `max_pool_count_per_process`. The class advertises "enterprise" features (analytics, health checks, circuit breaker) but lacks the lifecycle invariant that any production-grade pool needs.
+
+### Why it amplifies in production
+
+- Per-event-loop isolation means each gunicorn worker pre-fork sees `id(get_running_loop())` change → new pool key → new pool.
+- 13 DataFlow instances × N event-loop transitions = 13 × N pools.
+- Combined with #696, every 30 s the failed-DDL retry fires under saturation. Saturation triggers the 5 s lock-timeout. Each timeout creates a new 5–20 connection pool.
+- Within minutes: 480–500 connections vs Azure PG's 100–200 ceiling.
+
+### Invariant the fix must preserve
+
+(a) Fallback is a structural option, not a silent default. (b) Every pool created in fallback mode is registered process-wide so it can be reclaimed on idle. (c) Pool-creation events are bounded — when the pool count exceeds a threshold, new lock-timeouts fail-fast instead of creating yet another pool.
+
+---
+
+## Shard C — DataFlowEngine surface holes (#685 + #686)
+
+### Code path
+
+| File                                               |   Lines | Behavior                                                                                                                                                                            |
+| -------------------------------------------------- | ------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/kailash-dataflow/src/dataflow/engine.py` | 235-265 | `DataFlowEngineBuilder.build()` is `async def`, body never `await`s. Body: instantiate DataFlow + QueryEngine, call `dataflow.source()` (sync method), instantiate DataFlowEngine.  |
+| `packages/kailash-dataflow/src/dataflow/engine.py` | 328-346 | `DataFlowEngine.register_model(self, registry, model)` calls `self._dataflow.register_model(model)` — **DataFlow has no such method.** Decorator-only registration via `@db.model`. |
+
+### Root cause
+
+Two MUST violations:
+
+1. **`zero-tolerance.md` Rule 6 (no half-implementation).** Line 339 — `self._dataflow.register_model(model)` — IS the half-implementation. The method is documented in the docstring (line 32-36 of `engine.py`: "engine.register_model(registry, UserModel)"), the signature exists, the inner body refers to a nonexistent method on the wrapped object. This is the canonical "if endpoint exists, it returns real data" failure mode.
+2. **`patterns.md` § "Paired Public Surface — Consistent Async-ness".** `build()` is async, never awaits. Module-import-time `@lru_cache get_db()` patterns can't use it. HANA Phase 2 deferred via ADR 0003 because of this.
+
+### Why these are HIGH not CRIT
+
+- They block engine-first migration but don't take production down. HANA's deferral is the audit trail.
+- The fix is small (single-shard, ≤200 LOC) and well-bounded — the engine surface is < 500 LOC total.
+
+### Invariant the fix must preserve
+
+(a) `register_model` either works end-to-end (registers with classification policy + `_registered_models` + the `DataFlow` model registry) OR is removed (zero-tolerance Rule 6 — half-implementation is BLOCKED, but the surgical option is delete-not-deprecate per `orphan-detection.md` Rule 3). User comment on the issue suggests it should work. (b) `build()` shape matches its body: either drop async OR add a synchronous companion that downstream import-time patterns can use.
+
+---
+
+## Cross-cutting failure pattern
+
+**Three of five issues (#696, #697, #698) trace to the same root: silent fallback + no lifecycle bound.**
+
+In each case, the failure mode is "the framework ran into an error, decided to keep working, and didn't surface the cost of keeping working":
+
+- #696: failed DDL → "we'll try again next time" (forever)
+- #697: per-pool lock timeout → "we'll make a dedicated pool" (forever, no eviction)
+- #698: pool created → "we'll keep it until shutdown" (forever, no idle bound)
+
+This is the production-incident class that `zero-tolerance.md` Rule 3 + `dataflow-pool.md` Rule 5 + `observability.md` Rule 7 all target separately. The fix is structural at three layers:
+
+- **Surface (DDL):** convert "failed → retry on every access" into "failed → flagged + bounded + surfaced".
+- **Lifecycle (pool):** convert "pool created → pool kept" into "pool created → pool tracked → pool reclaimed".
+- **Visibility:** every state transition emits a structured log + metric so alerting can fire BEFORE the connection ceiling.
+
+#685 + #686 are independent surface-holes on the engine builder; same package, same release, different bug class. Bundling them into the same workstream is correct (one release cycle, one specialist) but they do not share a root cause with #696/#697/#698.
+
+---
+
+## Repro setup (for Tier-2 regression tests)
+
+Per `rules/testing.md` § "End-to-End Pipeline Regression", every fix lands a regression test that exercises the docs-exact pattern:
+
+### Repro 1 — DDL retry storm (#696)
+
+```python
+# Define a model whose CREATE TABLE will fail (FK ordering)
+@db.model
+class Order:
+    user_id: int  # references user.id, but user table not yet defined
+
+# Initialize with auto_migrate=True
+db = DataFlow(test_pg_url, auto_migrate=True)
+
+# Touch the model 10 times — failed DDL must NOT fire 10 times
+for _ in range(10):
+    try: await db.express.list("Order")
+    except Exception: pass
+
+# Assertion: log captured exactly 1 ERROR + 1 metric, NOT 10
+assert error_log_count("Failed to execute DDL") == 1  # not 10
+```
+
+### Repro 2 — Pool fallback leak (#697 + #698)
+
+```python
+# Force lock contention by setting timeout very low + spawning many concurrent calls
+import os; os.environ["DATAFLOW_PER_POOL_LOCK_TIMEOUT"] = "0.1"
+db = DataFlow(test_pg_url)
+
+# 50 concurrent reads — many will hit the lock-timeout fallback
+await asyncio.gather(*(db.express.list("User") for _ in range(50)))
+
+# Assertion: total pool count stays bounded under a configured cap
+assert AsyncSQLDatabaseNode.pool_count() <= MAX_POOL_COUNT_PER_PROCESS
+```
+
+### Repro 3 — Engine.register_model (#685)
+
+```python
+db = DataFlow("sqlite:///:memory:", auto_migrate=True)
+engine = await DataFlowEngine.builder("sqlite:///:memory:").build()
+
+@db.model
+class Foo:
+    name: str
+
+engine.register_model(None, Foo)  # MUST succeed (no AttributeError)
+report = engine.get_model_classification_report(Foo)
+assert isinstance(report, dict)
+```
+
+### Repro 4 — Builder sync companion (#686)
+
+```python
+# Module-import-time pattern (HANA Phase 2's blocker)
+@lru_cache
+def get_db():
+    return DataFlowEngine.builder_sync("sqlite:///app.db").build_sync()
+
+# OR confirm async signature is honest:
+import inspect
+src = inspect.getsource(DataFlowEngineBuilder.build)
+assert "await " in src or "async with" in src  # signature MUST match body
+```
+
+---
+
+## Cross-SDK applicability (per `rules/cross-sdk-inspection.md`)
+
+| Issue | kailash-rs equivalent?                                                                                                                                                           | Disposition                                                                        |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| #696  | Likely. Rust DataFlow auto-migrate has the same model-access lazy-creation pattern.                                                                                              | File cross-SDK issue at `esperie/kailash-rs` after this fix lands; reference here. |
+| #697  | Almost certainly. Rust DataFlow has `EnterpriseConnectionPool` analog.                                                                                                           | File cross-SDK issue.                                                              |
+| #698  | Same as #697.                                                                                                                                                                    | Bundle.                                                                            |
+| #685  | Probably not — Rust uses generics for model registration; the AttributeError class doesn't exist. Verify with structural-API-divergence test per `cross-sdk-inspection.md` § 3a. | File a verification ticket only.                                                   |
+| #686  | Originated from cross-SDK parity. Rust's `build()` IS legitimately async (runtime initialization). The fix here is a sync companion, not a surface change.                       | No cross-SDK issue.                                                                |
+
+---
+
+## Open questions for the implementation phase
+
+1. **DDL fail-fast vs retry-with-backoff.** The user's recommendation in #696 is fail-fast at startup with a clear error. Is there a consumer who legitimately wants retry-with-backoff (e.g., DDL in a multi-region setup where the secondary takes time to propagate)? If yes, that becomes a configurable option (`auto_migrate=True` → fail-fast; `auto_migrate="retry"` → bounded retry with circuit breaker).
+2. **Pool eviction policy.** LRU on idle-timeout is the obvious choice. But for an event-loop-isolated pool key, "LRU" needs to mean "evict the oldest pool whose event loop is still alive" or "evict pools whose event loop is gone". The latter is automatic (the loop is dead, the pool can't be used); the former needs explicit tracking.
+3. **`MAX_POOL_COUNT_PER_PROCESS` default.** The issue body proposes 50. With 13 DataFlow instances × ~5 distinct event loops = ~65, so 50 is too low. Realistic default depends on PG `max_connections` ceiling. Probably 100 is safer; needs benchmarking.
+4. **`force_drop=True` interaction.** If we add a "registered-models" registry to `DataFlow` for #685, does removing/replacing a model need `force_drop` semantics per `dataflow-identifier-safety.md` Rule 4? Probably yes — registration replacement that drops the prior table is destructive.

--- a/workspaces/dataflow-prod-incident/01-analysis/02-spec-mapping.md
+++ b/workspaces/dataflow-prod-incident/01-analysis/02-spec-mapping.md
@@ -1,0 +1,90 @@
+# 02 — Spec Mapping
+
+Per `/analyze` Step 5, every requirement sentence in `briefs/` MUST map to a corresponding spec file section. This file is the traceability matrix.
+
+## Existing spec authority
+
+The kailash-py SDK already has spec coverage for both packages this workstream touches:
+
+| Spec file                   | Authority over                                                      |
+| --------------------------- | ------------------------------------------------------------------- |
+| `specs/dataflow-core.md`    | DataFlow class, constructor, `auto_migrate`, engine, exceptions     |
+| `specs/dataflow-cache.md`   | Cache layer, **dialect, record ID coercion, transactions, pooling** |
+| `specs/dataflow-express.md` | Express API surface                                                 |
+| `specs/dataflow-models.md`  | `@db.model` decorator semantics                                     |
+| `specs/core-nodes.md`       | AsyncSQLDatabaseNode contract (within Core SDK)                     |
+
+No NEW spec file is needed. The fix is updating sections in TWO existing specs:
+
+## Spec gap 1 — `specs/dataflow-core.md`
+
+**Current state:** likely has an `auto_migrate` section but treats it as a boolean flag.
+
+**Required addition:** semantic specification of `auto_migrate` enum with three values:
+
+- `True` (default): fail-fast on first failed DDL with `DDLFailedError`; subsequent accesses re-raise; operator must override or fix.
+- `"warn"`: log + continue (current behavior, opt-in for legacy apps).
+- `False`: no auto-migration; operator manages migrations explicitly.
+
+**Required addition:** explicit specification that `_failed_table_creations` is a public-but-frozen attribute readable for diagnostic purposes (`db._failed_table_creations` enumerable for support scripts).
+
+**Required addition:** the invariant that a failed DDL fires exactly ONE log line + ONE metric increment, NOT N per request.
+
+## Spec gap 2 — `specs/dataflow-cache.md`
+
+**Current state:** likely covers dialect + transactions + pooling but at the DataFlow layer, not the underlying `AsyncSQLDatabaseNode`.
+
+**Required addition (for #697 + #698):** AsyncSQLDatabaseNode pool lifecycle contract:
+
+- Pool lifecycle states: `created → active → idle → reaped`.
+- `_PROCESS_POOL_REGISTRY` is the single ground truth for pool count; `pool_count()` enumerates.
+- `idle_timeout` default: 300 s; configurable via `set_pool_defaults()`.
+- `max_pool_count_per_process` default: 100; configurable via `set_pool_defaults()`.
+- `PoolExhaustedError` semantics — typed error raised when cap is reached; caller chooses to wait, retry, or raise.
+- The fallback path is bounded — under cap, fallback creates pool + registers; over cap, fallback fails-fast.
+
+**Required addition:** the invariant that pools created in fallback mode are tracked + reapable, identical to pools created via the runtime-managed path.
+
+**Required addition (cross-SDK alignment):** Note that `kailash-rs`'s pool lifecycle MUST match this contract semantically (per `rules/cross-sdk-inspection.md` § 3 EATP D6).
+
+## Spec gap 3 — `specs/dataflow-core.md` (DataFlowEngine section)
+
+**Current state:** likely has a DataFlowEngine section that documents `register_model(registry, model)`.
+
+**Required addition (for #685):** explicit cross-reference that `DataFlow.register_model(model_cls)` is the underlying mechanism + that `@db.model` is sugar over the same path. Both produce identical state.
+
+**Required addition (for #686):** `DataFlowEngineBuilder.build()` is async-by-signature for cross-SDK parity but body is sync in kailash-py; `build_sync()` is the documented Python escape hatch for module-import-time patterns.
+
+## Brief traceability check
+
+Each requirement sentence in `briefs/01-incident-context.md` maps to a spec section:
+
+| Brief requirement                                                                            | Spec section                                          |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| "DDL failures fail-fast at startup with typed error + bounded retry"                         | `dataflow-core.md` § auto_migrate semantics           |
+| "AsyncSQLDatabaseNode pool fallback either holds longer / fails-fast OR registers"           | `dataflow-cache.md` § pool lifecycle contract         |
+| "idle-timeout + LRU cap configurable on EnterpriseConnectionPool"                            | `dataflow-cache.md` § pool lifecycle contract         |
+| "DataFlowEngine.register_model is either implemented end-to-end or removed"                  | `dataflow-core.md` § DataFlowEngine.register_model    |
+| "DataFlowEngineBuilder.build() either gains a sync companion or honours its async signature" | `dataflow-core.md` § DataFlowEngine.builder           |
+| "Tier-2 regression tests for every fix"                                                      | `dataflow-core.md` § conformance / `rules/testing.md` |
+| "Cross-SDK inspection on every fix"                                                          | `rules/cross-sdk-inspection.md` § 1 + EATP D6         |
+
+ALL brief requirements have a spec home. No orphan requirements.
+
+## What this means for /implement
+
+Spec updates land in the SAME PR as the source code changes — per `rules/specs-authority.md`. Each shard's PR includes:
+
+- Source code fix
+- Spec section update
+- Tier-2 regression test
+- CHANGELOG entry
+
+This avoids the "spec drift behind code" failure mode that issue #693 tracks for ML.
+
+## Out-of-scope spec gaps
+
+The following are spec-level questions worth flagging but NOT blocking this workstream:
+
+- **`specs/dataflow-cache.md` does not currently spec `EnterpriseConnectionPool` as a manager-shape class** — per `rules/facade-manager-detection.md` § 2, manager classes need named Tier-2 wiring tests. The pool registry test added in Shard B satisfies this implicitly but should be referenced from the spec for traceability.
+- **No spec exists for the `_failed_table_creations` diagnostic surface** — adding it post-implementation is fine; the spec authoritatively reflects what shipped.

--- a/workspaces/dataflow-prod-incident/02-plans/01-implementation-plan.md
+++ b/workspaces/dataflow-prod-incident/02-plans/01-implementation-plan.md
@@ -1,0 +1,220 @@
+# 02 — Implementation Plan
+
+Three shards, sized per `rules/autonomous-execution.md` § "Per-Session Capacity Budget" (≤500 LOC load-bearing logic, ≤5–10 invariants, ≤3–4 call-graph hops, describable in 3 sentences). Each shard is a single session with a single specialist + reviewer.
+
+## Sequencing
+
+```
+Shard A (#696 DDL fail-fast)            ─┐
+                                         ├──→ kailash-dataflow 2.4.0 release
+Shard B (#697 + #698 pool lifecycle)    ─┤    + kailash 2.12.0 patch
+                                         │    (one paired release; both
+Shard C (#685 + #686 engine surface)    ─┘     packages share regression
+                                              tests)
+```
+
+A and B may run in parallel under `rules/worktree-isolation.md` waves-of-3 protocol — they touch different packages (`kailash-dataflow` for A, `kailash` core for B). C is independent surface work in `kailash-dataflow` and may run in parallel with A if their files don't overlap (they don't — A is `core/engine.py`, C is `engine.py`).
+
+Recommended: launch A + C as a wave-of-2 (both in `kailash-dataflow`, separate worktrees), then B on its own (different package, different specialist load).
+
+## Shard A — DDL fail-fast circuit breaker (#696)
+
+**Specialist:** dataflow-specialist
+**Estimated LOC:** ~250 load-bearing logic
+**Invariants held:** 4 (cache-hit fast-path; failed-DDL state tracking; user override flag; no log spam)
+**Files touched:** 2
+
+### Description (3 sentences)
+
+A failed CREATE TABLE under `auto_migrate=True` MUST be a single, loud error at startup — not a per-access silent retry. Add a per-model failed-DDL state to `DataFlow._schema_cache` that records the failure + reason, prevents subsequent retries, and surfaces a clear runtime error on the next access. Operators get one ERROR log + one metric increment per failed model, not N per request.
+
+### Changes
+
+1. **`packages/kailash-dataflow/src/dataflow/core/engine.py`**
+   - Add `_failed_table_creations: dict[str, FailedDDLRecord]` to `DataFlow.__init__` where `FailedDDLRecord = (timestamp, error_message, statement_preview)`.
+   - In `_register_model` (line 1576-1599), if `_create_table_sync()` returns False AND we're connected, fail-fast with `DDLFailedError(model_name, error)` instead of falling through to lazy creation.
+   - In `ensure_table_exists()` (line 1603), check `_failed_table_creations` BEFORE the cache check. If present, raise `DDLFailedError` immediately — do NOT re-fire the DDL.
+   - In `_execute_ddl()` (line 7400-7429) and `_execute_ddl_async` (line 7431-7509), wrap each statement's `except Exception` to record the failure into `_failed_table_creations` AND emit metric `dataflow.ddl_failed_total{model=...}`. Continue iterating ONLY for index/FK statements; CREATE TABLE failures abort the whole batch.
+   - Add `auto_migrate` enum: `True` (fail-fast at startup, default), `"warn"` (log + continue, current behavior), `False` (no auto-migration, manual). Update `DataFlow.__init__` signature to accept `bool | Literal["warn"]`.
+2. **`packages/kailash-dataflow/src/dataflow/core/exceptions.py`** (new file or existing)
+   - Add `DDLFailedError(DataFlowError)` with `.model_name`, `.statement`, `.original_error` attributes.
+
+### Tests
+
+Per `rules/testing.md` § "End-to-End Pipeline Regression":
+
+- **Tier 2 regression:** `tests/regression/test_issue_696_ddl_retry_storm.py` — define a model whose CREATE TABLE will fail (FK ordering or column-type mismatch), call `db.express.list()` 10 times, assert ERROR-level log fires exactly once + assert `_failed_table_creations` contains the record.
+- **Tier 2 invariant:** assert that calling the failed-DDL path 100x in a tight loop does NOT increase connection count beyond 1 (proves no retry storm under saturation).
+- **Tier 1 unit:** `auto_migrate="warn"` reproduces current behavior (continue + log); `auto_migrate=True` (default) fails-fast.
+
+### Cross-SDK action
+
+File `esperie/kailash-rs#NNN` — "DataFlow auto-migrate retry storm — same bug class as kailash-py#696". Include byte-vector regression test per `rules/cross-sdk-inspection.md` § 4.
+
+### Edge cases / risks
+
+- **Existing apps relying on retry-on-access** — none expected (the retry was a bug, not a feature). Migration path: `auto_migrate="warn"` opt-in.
+- **Race in concurrent registration** — multiple workers may all hit the failed DDL once each before `_failed_table_creations` is populated. Acceptable: `dict.setdefault()` semantics give us at-least-once semantics; metric is correct.
+- **Migration tracking table failure** — if `_ensure_migration_tables` itself fails (line 6427), the system can't track ANYTHING; needs a separate fail-fast path. Acceptable: this fails so loud you'd never miss it.
+
+---
+
+## Shard B — Pool lifecycle: bounded fallback + idle eviction (#697 + #698)
+
+**Specialist:** dataflow-specialist (with infrastructure-specialist consult on the pool-registry pattern)
+**Estimated LOC:** ~400 load-bearing logic
+**Invariants held:** 6 (pool-key uniqueness; per-event-loop isolation; max-pool-count cap; idle-timeout reclamation; tenant-isolation preserved; no leaked pools across worker pre-fork)
+**Files touched:** 2
+
+### Description (3 sentences)
+
+`AsyncSQLDatabaseNode`'s per-pool-locking fallback creates a fresh `EnterpriseConnectionPool` per call with no process-wide registration; pools accumulate until process shutdown. Add a process-wide `PoolRegistry` that tracks every pool by key, evicts on idle-timeout (default 300 s), and bounds total count via LRU (default 100); when the cap is exceeded, lock-timeout MUST fail-fast with a typed error instead of creating yet another pool. The eviction is event-loop-aware: pools whose loop is closed are reaped immediately; live pools wait for idle.
+
+### Changes
+
+1. **`src/kailash/nodes/data/async_sql.py`**
+   - Add module-level `_PROCESS_POOL_REGISTRY: weakref.WeakValueDictionary[str, EnterpriseConnectionPool]` keyed on `pool_key`.
+   - Add module-level config `_POOL_DEFAULTS = {"idle_timeout": 300, "max_pool_count_per_process": 100}` overridable via `set_pool_defaults()`.
+   - Add `EnterpriseConnectionPool.set_idle_timeout(seconds: int)` and `EnterpriseConnectionPool.is_idle()` (last-activity timestamp tracking).
+   - Add `EnterpriseConnectionPool._reaper_task` that runs every `idle_timeout / 4` seconds, walks the registry, calls `close()` + `del registry[key]` for any idle pool whose event loop is alive (pools with dead loops are reaped immediately on registry access via the WeakValueDictionary).
+   - In `_get_adapter` fallback path (line 3944-3956): replace the silent fallback with:
+     ```python
+     except (RuntimeError, asyncio.TimeoutError) as e:
+         if len(_PROCESS_POOL_REGISTRY) >= _POOL_DEFAULTS["max_pool_count_per_process"]:
+             raise PoolExhaustedError(
+                 f"Pool count {len(_PROCESS_POOL_REGISTRY)} exceeds cap "
+                 f"{_POOL_DEFAULTS['max_pool_count_per_process']}; refusing to create dedicated fallback. "
+                 f"Increase via set_pool_defaults(max_pool_count_per_process=N) or fix the contention root cause."
+             ) from e
+         logger.warning("async_sql.fallback_pool_created",
+             extra={"pool_key": self._pool_key, "registry_size": len(_PROCESS_POOL_REGISTRY)})
+         self._adapter = await self._create_adapter()
+         _PROCESS_POOL_REGISTRY[f"fallback_{id(self)}"] = self._adapter._pool  # tracked!
+     ```
+     Note: catching bare `Exception` is removed — only `RuntimeError` (closed loop) and `asyncio.TimeoutError` (lock timeout) are legitimate fallback triggers per `rules/zero-tolerance.md` Rule 3.
+   - Add `AsyncSQLDatabaseNode.pool_count() -> int` classmethod (returns `len(_PROCESS_POOL_REGISTRY)`).
+2. **`src/kailash/nodes/data/exceptions.py`** (existing or new)
+   - Add `PoolExhaustedError(NodeExecutionError)`.
+
+### Tests
+
+Per `rules/testing.md` § "End-to-End Pipeline Regression":
+
+- **Tier 2 regression:** `tests/regression/test_issue_697_pool_leak.py` — set `max_pool_count_per_process=10`, set lock timeout to 0.1 s, spawn 50 concurrent reads against real PG. Assert pool count never exceeds 10 + assert `PoolExhaustedError` fires when cap reached.
+- **Tier 2 idle eviction:** create 20 pools with `idle_timeout=2`, sleep 5 s, assert `pool_count() == 0`.
+- **Tier 2 cross-event-loop:** create pool in event loop A, switch to event loop B, assert pool A is reaped (WeakValueDictionary semantics).
+- **Tier 1 unit:** signature/structural invariant on `set_pool_defaults` — accepts only `idle_timeout`, `max_pool_count_per_process`; rejects unknown kwargs.
+
+### Cross-SDK action
+
+File `esperie/kailash-rs#NNN` — Rust DataFlow has its own pool primitive; same lifecycle gaps likely apply.
+
+### Edge cases / risks
+
+- **Event-loop GC race** — WeakValueDictionary auto-cleanup happens on GC; under high churn the cleanup may lag. Add an explicit reaper task as belt-and-suspenders.
+- **Per-test cleanup** — pytest tests may leave registries non-empty across tests. Add `cleanup_all_pools()` extension that clears registry; fixture in `conftest.py` calls it after every test.
+- **Tenant-isolation preserved** — pool keys already include `dialect|connection_string` per `rules/tenant-isolation.md` § 1; multi-tenant deployments using separate connection strings get separate pools. NO change to the keying.
+- **Backwards compat** — apps that depend on unbounded pool creation will see `PoolExhaustedError` they didn't see before. Mitigation: default cap at 100 (generous) + clear error message naming `set_pool_defaults`.
+
+---
+
+## Shard C — DataFlowEngine surface fixes (#685 + #686)
+
+**Specialist:** dataflow-specialist
+**Estimated LOC:** ~150 load-bearing logic
+**Invariants held:** 3 (engine.register_model is end-to-end; build() body matches signature; cross-SDK parity preserved on the async build path)
+**Files touched:** 2
+
+### Description (3 sentences)
+
+`DataFlowEngine.register_model` calls a non-existent method on `DataFlow` and `DataFlowEngineBuilder.build()` is async-but-sync. Implement `DataFlow.register_model(model)` as a non-decorator entry-point that performs the same registration as `@db.model`, and add `DataFlowEngineBuilder.build_sync()` for module-import-time patterns. The async `build()` stays for cross-SDK parity with kailash-rs (where it IS legitimately async).
+
+### Changes
+
+1. **`packages/kailash-dataflow/src/dataflow/core/engine.py`**
+   - Add `DataFlow.register_model(self, model_cls)` — extracts the class-decorator logic from `@db.model` (which currently uses `__init_subclass__` or similar) into a callable. Both paths share the same body. Returns the decorated class for chaining.
+2. **`packages/kailash-dataflow/src/dataflow/engine.py`**
+   - `DataFlowEngine.register_model(self, registry, model)` — fix the implementation. The `registry` param is unused by the docstring but exists for cross-SDK parity (kailash-rs passes a registry). Kailash-py path: `self._dataflow.register_model(model)`. Same downstream — append to `_registered_models`, register with classification policy if available.
+   - Add `DataFlowEngineBuilder.build_sync(self) -> DataFlowEngine` — body identical to current async `build()` (which doesn't await). Document `build_async()` (alias for `build()`) for cross-SDK clarity.
+
+### Tests
+
+- **Tier 2 regression:** `tests/regression/test_issue_685_engine_register_model.py` — repro from issue body + assert no AttributeError + assert `engine.get_model_classification_report(Foo)` returns a dict.
+- **Tier 2 regression:** `tests/regression/test_issue_686_builder_sync.py` — `DataFlowEngine.builder("sqlite:///:memory:").build_sync()` returns engine without requiring an event loop.
+- **Tier 1 invariant:** `DataFlowEngineBuilder.build()` must be async OR call `build_sync()` directly — never reach a state where the async signature has body-side `await`s removed.
+
+### Cross-SDK action
+
+- #685: filed as cross-SDK; verify Rust `register_model` is end-to-end.
+- #686: NOT filed cross-SDK — Rust's `build()` IS legitimately async (runtime init). Python's sync companion is a Python-specific affordance.
+
+### Edge cases / risks
+
+- **Existing `@db.model` usage** — extracting the class-decorator body MUST not change `@db.model` semantics. Tier 1 test: `@db.model class X` produces same registration as `db.register_model(X)`.
+- **HANA Phase 2 unblock** — once `build_sync` ships, HANA's ADR 0003 deferral is closed. Add a note to the release CHANGELOG.
+
+---
+
+## Combined release plan
+
+### Branches (per `rules/git.md` § Release-Prep)
+
+- `feat/dataflow-696-ddl-fail-fast` (Shard A)
+- `feat/dataflow-697-698-pool-lifecycle` (Shard B)
+- `feat/dataflow-685-686-engine-surface` (Shard C)
+- `release/v2.4.0-dataflow-prod-incident` (release-prep PR, metadata-only)
+
+### Release scope
+
+- **`kailash-dataflow`** 2.3.3 → 2.4.0 (semver-major because `auto_migrate=True` default now fails-fast — behavioral change for apps that depended on the retry-storm bug)
+- **`kailash`** 2.11.3 → 2.12.0 (semver-major because `_PROCESS_POOL_REGISTRY` adds a process-wide cap that fails-fast on exhaustion)
+
+Per `feedback_optimal_outcome` — choose the optimal architecture; semver-major is the honest semver call. Per `feedback_no_shims` — no deprecation timeline; the cleanup happens in the same release.
+
+### Pre-release gates
+
+Per `rules/deployment.md` § "Before Any Release" + `rules/git.md` § "Pre-FIRST-Push CI Parity":
+
+1. Full test suite green across Python 3.11 / 3.12 / 3.13 / 3.14
+2. Tier-2 regression tests pass against real PostgreSQL (Azure-class)
+3. Cross-SDK parity issues filed at `esperie/kailash-rs`
+4. Security review by security-reviewer (mandatory per `rules/agents.md` Quality Gates)
+5. Reviewer + security-reviewer pass at `/implement` gate
+6. `pre-commit run --all-files` + `pytest --collect-only` exit 0 across every test directory
+7. CHANGELOG entries for all three shards under one 2.4.0 / 2.12.0 release block
+8. Spec updates: `specs/dataflow-core.md` section on `auto_migrate` semantics; `specs/dataflow-cache.md` section on pool lifecycle
+
+### Cross-SDK propagation
+
+After kailash-py release, file these issues at `esperie/kailash-rs`:
+
+- DataFlow auto-migrate retry storm (cross-SDK of #696)
+- DataFlow per-pool-locking fallback leak (cross-SDK of #697 + #698)
+- DataFlowEngine.register_model parity check (cross-SDK of #685 — verify Rust path)
+
+Per `rules/cross-sdk-inspection.md` § 4: each cross-SDK issue includes byte-vector test cases derived from kailash-py's regression tests.
+
+---
+
+## What stays out of this workstream
+
+- **#699 / #700 / #701** — kailash-ml 1.5.x followup; separate workspace.
+- **Loom `/sync`** — cycle 10 + cycle 11 propagation; not BUILD-repo work.
+- **Spec-drift-gate** — separate workspace, not blocked by this one.
+- **Stub-marker triage** — 122 markers from sweep v1 LOW-6; spread across multiple sessions.
+
+---
+
+## Acceptance — "done" gate
+
+The workspace is converged when ALL of the following hold:
+
+1. PRs for all three shards merged to main + reviewed by reviewer + security-reviewer.
+2. Release PR for `kailash-dataflow` 2.4.0 + `kailash` 2.12.0 merged.
+3. Tags pushed individually per `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually" (`v2.12.0`, `dataflow-v2.4.0`).
+4. PyPI publishing workflow_dispatch successful for both packages.
+5. Clean-venv install verified against PyPI for both packages.
+6. The user's repro script runs for 30 minutes without connection-count growth.
+7. Cross-SDK issues filed at kailash-rs.
+8. Issues #696, #697, #698, #685, #686 closed with delivered-code references per `rules/git.md` § Issue Closure Discipline.
+9. `/codify` extracts new institutional knowledge (e.g., "silent-fallback + no-lifecycle is one failure pattern; structural fix at three layers" deserves codification).

--- a/workspaces/dataflow-prod-incident/briefs/01-incident-context.md
+++ b/workspaces/dataflow-prod-incident/briefs/01-incident-context.md
@@ -1,0 +1,56 @@
+# Brief — DataFlow + Core SDK production-incident class
+
+Filed during a JourneyMate (Azure FastAPI + DataFlow) production-incident response on 2026-04-28. Five GH issues cluster around two coupled defects (DDL-retry storm + AsyncSQLDatabaseNode pool leak) plus three independent surface holes. User flagged as urgent; sweep classified two as CRIT, three as HIGH.
+
+## What the user reported
+
+A routine deploy of the JourneyMate backend onto Azure Container Apps started a self-amplifying connection-leak loop. Backend logs showed two patterns repeating every 30 seconds:
+
+1. **DDL retry storm.** `ERROR:dataflow.core.engine:Failed to execute DDL: CREATE TABLE IF NOT EXISTS "evaluation_dimensions" ...` and three sibling DDLs, repeating indefinitely. Root cause: when an `auto_migrate=True` DDL fails, the engine flags the model as "needs migration" and re-attempts on the **next model access**, not at startup.
+
+2. **Pool fallback leak.** `WARNING:kailash.nodes.data.async_sql:Per-pool locking failed for AsyncSQLDatabaseNode (pool_key: ...). Falling back to dedicated pool mode.` followed by `EnterpriseConnectionPool 'postgresql_...' initialized with 5-20 connections`. Each fallback creates a fresh 5–20 connection pool that is **never reclaimed mid-process** — only `cleanup_all_pools(graceful=True)` at shutdown frees them.
+
+Combined effect: every 30 seconds, the failed-DDL retry fires `AsyncSQLDatabaseNode` under saturation; lock-timeout path fires; new dedicated pool created; subsequent calls each create another. Within minutes, Azure PG saturates at 480–500 connections out of the 100–200 ceiling. Backend was down ~30 minutes; recovery required setting `auto_migrate=False`, restarting the BE revision, and migrating 342 hot-path call sites away from `AsyncSQLDatabaseNode` to a dedicated app-managed asyncpg pool.
+
+## Issues bundled into this workspace
+
+| #       | Severity | Title                                                                                         | File pointers                                                                     |
+| ------- | -------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **696** | CRIT     | DataFlow auto_migrate fires failed CREATE TABLE on every model access                         | `src/dataflow/core/engine.py:1576-1599`, `:6391-6455`, `:7426`, `:7511-7600`      |
+| **697** | CRIT     | AsyncSQLDatabaseNode 'Per-pool locking failed' silently falls back, leaks 5-20 conns per call | `src/kailash/nodes/data/async_sql.py:501`, `:574`, `:3835`, `:3944-3956`          |
+| **698** | HIGH     | AsyncSQLDatabaseNode pools have no idle-timeout / LRU reclamation                             | `src/kailash/nodes/data/async_sql.py` (`EnterpriseConnectionPool`)                |
+| **685** | HIGH     | `DataFlowEngine.register_model` calls non-existent method on `DataFlow` primitive             | `packages/kailash-dataflow/src/dataflow/engine.py::DataFlowEngine.register_model` |
+| **686** | HIGH     | `DataFlowEngineBuilder.build()` is async but body is purely synchronous                       | `packages/kailash-dataflow/src/dataflow/engine.py::DataFlowEngineBuilder.build`   |
+
+## Why one workspace
+
+- **Shared specialist** — every fix belongs to dataflow-specialist + analyst; no other framework specialists involved.
+- **Shared invariant set** — engine surface, model registration, connection lifecycle, classification policy. Splitting risks duplicate root-cause analysis and divergent remediation.
+- **Shared release cycle** — every fix lands in `kailash-dataflow` (and `kailash` core for the AsyncSQL side). One release-prep PR, not three.
+- **Shared bug class** — #696 + #697 + #698 share the connection-lifecycle root; #685 + #686 share the engine-builder surface. Same-bug-class within shard budget per `rules/autonomous-execution.md` § 4.
+
+## What "done" looks like
+
+1. **Production-incident pair (#696 + #697 + #698) closed** — DDL failures fail-fast at startup with typed error + bounded retry; AsyncSQLDatabaseNode pool fallback either holds longer / fails-fast OR registers the dedicated pool in a process-wide eviction registry; idle-timeout + LRU cap configurable on `EnterpriseConnectionPool`.
+2. **Engine builder surface (#685 + #686) closed** — `DataFlowEngine.register_model` is either implemented end-to-end (registers with classification policy + adds to engine's registered_models) or removed; `DataFlowEngineBuilder.build()` either gains a sync companion or honours its async signature.
+3. **Tier-2 regression tests** for every fix per `rules/testing.md` § "End-to-End Pipeline Regression" — each canonical pipeline the user could reasonably write must execute against real PG without leaking connections or storming on DDL failure.
+4. **Release of `kailash-dataflow` 2.3.4 (or 2.4.0 if behavioural)** + matching `kailash` patch; PyPI-published; clean-venv install verified.
+5. **Cross-SDK inspection** — every fix evaluated against kailash-rs per `rules/cross-sdk-inspection.md` MUST Rule 1.
+
+## Constraints
+
+- **No workarounds for SDK bugs** (rules/zero-tolerance.md Rule 4) — these are SDK source bugs; fix at the SDK, not in downstream callers.
+- **No silent fallbacks** (rules/zero-tolerance.md Rule 3) — the AsyncSQL fallback today is a silent fallback; the fix must surface the failure mode.
+- **No half-implementations** (rules/zero-tolerance.md Rule 6) — `DataFlowEngine.register_model` is a half-implementation right now. Either complete it or remove it.
+- **No mocking in Tier 2/3 tests** (rules/testing.md § 3-Tier Testing) — the regression tests MUST run against real PostgreSQL with a real failing DDL scenario.
+- **Tenant isolation preserved** (rules/tenant-isolation.md) — `_kml_model_versions` schema fork in #699 is sibling work; this workspace's fixes touch DataFlow but must not regress multi-tenant DataFlow patterns.
+
+## Out of scope (sibling workstreams)
+
+- **kailash-ml 1.5.x followup** — #699, #700, #701 belong in `workspaces/kailash-ml-1.5.x-followup/`. They share the same MLFP M5 trigger but touch a different package.
+- **Loom /sync** — the cycle-10 + cycle-11 codify proposals belong at `~/repos/loom/`; not BUILD-repo work.
+- **Spec-drift-gate** — separate workstream, not blocked by this one.
+
+## Success metric (the human's ratchet)
+
+A clean reproduction script — `auto_migrate=True` model whose CREATE TABLE will fail, `AsyncSQLDatabaseNode` under load — runs for 30 minutes and the connection count stays bounded under the configured `max_size`, with a single ERROR + metric on the failed DDL, no retry storm, no pool leak.

--- a/workspaces/dataflow-prod-incident/journal/0001-DISCOVERY-silent-fallback-no-lifecycle-is-one-pattern.md
+++ b/workspaces/dataflow-prod-incident/journal/0001-DISCOVERY-silent-fallback-no-lifecycle-is-one-pattern.md
@@ -1,0 +1,60 @@
+# 0001 DISCOVERY — Silent Fallback + No Lifecycle Is One Failure Pattern
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /analyze
+**Type:** DISCOVERY
+
+## Finding
+
+Three of the five issues in this workstream (#696, #697, #698) trace to the same compound failure pattern. Each looks like a separate bug at first reading; together they form a single architectural anti-pattern that the rules already prohibit at three layers but that surfaces when those layers don't reinforce each other.
+
+**The pattern is:** the framework hits an error condition, decides to keep working in a degraded mode, and creates state for that degraded mode WITHOUT a lifecycle bound. The result is monotonic resource accumulation that surfaces as a production outage hours or days later.
+
+| Issue | Error condition       | Degraded mode           | Lifecycle bound (missing)               |
+| ----- | --------------------- | ----------------------- | --------------------------------------- |
+| #696  | CREATE TABLE fails    | "Try again next time"   | Failed-DDL state with retry suppression |
+| #697  | Per-pool lock timeout | "Make a dedicated pool" | Process-wide registry with eviction     |
+| #698  | Pool created          | "Keep until shutdown"   | Idle-timeout reaper                     |
+
+Each one alone is a slow leak; combined they are mutually amplifying — the DDL retry fires the AsyncSQL node every 30 s, which under saturation triggers the lock-timeout fallback, which creates a fresh pool. Within minutes, Azure PG saturates.
+
+## Why the existing rules didn't catch it
+
+`zero-tolerance.md` Rule 3 (silent fallbacks) covers the error-handling layer.
+`dataflow-pool.md` Rule 5 (no orphan runtimes) covers the lifecycle layer.
+`observability.md` Rule 7 (bulk ops MUST WARN on partial failure) covers the visibility layer.
+
+Each rule is correctly scoped to its concern. The compound pattern needs all three to fire together — and the framework historically separated them across files (engine.py owns DDL; async_sql.py owns pools; the visibility layer is implicit in both). No single agent reading any one file would see the compound.
+
+## Codification candidate
+
+Add a meta-rule (or a clause to one of the existing rules) that names "silent fallback + no lifecycle bound" as a single failure class with a structural defense:
+
+> Whenever the framework chooses to continue past an error condition, the chosen continuation MUST be (a) bounded — there is a structural cap on how many times the continuation can fire, (b) tracked — the continuation creates state that's enumerable + reapable, and (c) surfaced — every continuation event emits a structured log + metric so alerting can fire BEFORE the cap.
+
+This is a 3-axis test that would have caught all three issues at PR review time:
+
+- #696: continuation = "lazy DDL retry"; bounded? NO. tracked? NO. surfaced? ERROR-only, no metric.
+- #697: continuation = "dedicated pool fallback"; bounded? NO. tracked? NO (instance-only). surfaced? WARN, no metric.
+- #698: continuation = "pool kept alive"; bounded? NO. tracked? class-shared dict but not bounded. surfaced? NO.
+
+## Cross-SDK applicability
+
+The pattern is architectural, not language-specific. Rust DataFlow has the same architecture:
+
+- `EnterpriseConnectionPool` analog with similar lifecycle gaps
+- `auto_migrate` in `kailash-rs` shares the lazy-creation-on-access pattern
+- The compound failure is platform-independent
+
+Cross-SDK issues to file after this fix lands.
+
+## Action
+
+This DISCOVERY feeds into the `/codify` step at the end of this workstream. The codified rule extension MUST land at loom (cross-SDK) given the architectural breadth.
+
+## Related
+
+- Sibling: `rules/zero-tolerance.md` Rule 3
+- Sibling: `rules/dataflow-pool.md` Rule 5
+- Sibling: `rules/observability.md` Rule 7
+- Compound failure mode prior art: Phase 5.11 orphan trust executor (rules/orphan-detection.md)

--- a/workspaces/dataflow-prod-incident/journal/0002-RISK-multipackage-coupled-release-blast-radius.md
+++ b/workspaces/dataflow-prod-incident/journal/0002-RISK-multipackage-coupled-release-blast-radius.md
@@ -1,0 +1,49 @@
+# 0002 RISK — Multi-Package Coupled Release Blast Radius
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /analyze
+**Type:** RISK
+
+## Finding
+
+This workstream's fix touches BOTH `kailash` core (Shard B — `src/kailash/nodes/data/async_sql.py`) AND `kailash-dataflow` (Shards A + C). Both packages need a coupled release because:
+
+1. Shard B's `_PROCESS_POOL_REGISTRY` change in `kailash` IS the underlying mechanism Shard A's regression test depends on (the test asserts `pool_count() <= cap`).
+2. `kailash-dataflow` declares `kailash>=2.X.X` in its `pyproject.toml`; bumping kailash without bumping kailash-dataflow's floor leaves a half-released SDK where the pool fix isn't reachable from the DataFlow tests.
+
+## The blast radius
+
+Per `rules/deployment.md` § "Optional Dependencies Pin to PyPI-Resolvable Versions":
+
+- `kailash-dataflow` 2.4.0 must declare `kailash>=2.12.0` after kailash 2.12.0 is on PyPI.
+- The release-prep PR for `kailash-dataflow` MUST land AFTER `kailash` 2.12.0 publishes — otherwise `pip install kailash-dataflow==2.4.0` resolves against `kailash` 2.11.3 (pre-fix) and the fix is not present in the user's install.
+- Multi-tag push order: `v2.12.0` (kailash) FIRST, sleep, then `dataflow-v2.4.0`. Per `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually" — sequential pushes only, never batched.
+
+## Why this is HIGH risk
+
+Two failure modes exist:
+
+1. **Tag order error:** if `dataflow-v2.4.0` is pushed before `v2.12.0` clears PyPI, the release CI for kailash-dataflow may fail to install kailash 2.12.0 (PyPI cache lag is 30–90 s for `info.version`, longer for simple-index per `feedback_drive_to_completion`).
+2. **Floor pin mismatch:** if Shard A's PR (kailash-dataflow) lands BEFORE the kailash floor is bumped to 2.12.0, fresh installs from PyPI resolve to kailash 2.11.3 + the new dataflow that calls `pool_count()` — which doesn't exist in 2.11.3 — `AttributeError: type object 'AsyncSQLDatabaseNode' has no attribute 'pool_count'`.
+
+## Mitigation
+
+1. **Sequence the merge** — Shard B's PR (kailash core) merges + releases FIRST as 2.12.0. Verified clean on PyPI (clean-venv install per `rules/deployment.md`). THEN Shards A + C merge with their kailash floor bump in pyproject.toml in the same PR.
+2. **Floor-pin discipline** — Per `rules/deployment.md` § "Optional Dependencies Pin to PyPI-Resolvable Versions", the `kailash-dataflow` 2.4.0 release-prep PR MUST bump `dependencies = ["kailash>=2.12.0", ...]` and verify the floor is on PyPI before tagging.
+3. **CI cross-package install** — Per `rules/deployment.md` § "Sibling-Package CI Installs Root SDK Editable", every sub-package CI workflow that imports from `kailash.nodes.data.async_sql` MUST `uv pip install -e "."` the root kailash editable BEFORE installing kailash-dataflow's `[dev]` extras.
+4. **Bridge regression test** — Add a Tier-2 cross-package test `tests/integration/test_kailash_dataflow_pool_bridge.py` that imports BOTH `kailash.nodes.data.async_sql.AsyncSQLDatabaseNode.pool_count` AND `kailash_dataflow` and exercises the integration. Per `rules/deployment.md` § "Bi-Directional At Bridge Boundaries" — install BOTH packages editable in BOTH CI workflows.
+
+## What "done" looks like
+
+- `kailash` 2.12.0 on PyPI; clean-venv install verified.
+- Wait 60 s for PyPI cache lag.
+- `kailash-dataflow` 2.4.0 on PyPI; clean-venv install verified; bridge test passes.
+- Both packages report consistent `__version__` per `rules/zero-tolerance.md` Rule 5.
+- Issues #696/#697/#698/#685/#686 closed with delivered-code references.
+
+## Related
+
+- `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually"
+- `rules/deployment.md` § "Bi-Directional At Bridge Boundaries"
+- `rules/zero-tolerance.md` Rule 5 (version consistency on release)
+- `feedback_build_repo_release` (BUILD repo sessions MUST proceed through /release after merge)

--- a/workspaces/dataflow-prod-incident/journal/0003-CONNECTION-jeourneymate-incident-as-canary-for-azure-class-deployments.md
+++ b/workspaces/dataflow-prod-incident/journal/0003-CONNECTION-jeourneymate-incident-as-canary-for-azure-class-deployments.md
@@ -1,0 +1,56 @@
+# 0003 CONNECTION — JourneyMate Incident As Canary For Azure-Class Deployments
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /analyze
+**Type:** CONNECTION
+
+## Finding
+
+The JourneyMate incident has the structural fingerprint of "Azure Container Apps + FastAPI + DataFlow with multiple instances" — a deployment shape that is increasingly common across kailash-dataflow's downstream consumers. The connection-leak + DDL-retry pair surfaces fastest in this shape because:
+
+1. **Azure PG defaults to 100–200 max_connections** (vs AWS RDS's typically larger pools), making the saturation point closer.
+2. **gunicorn worker pre-fork creates new event loops per worker** — `_generate_pool_key` includes `id(get_running_loop())` so each worker gets its own pool keyspace; 8 workers × 13 DataFlow instances = 104 distinct pool keys before any user traffic.
+3. **Azure Container Apps' default 30 s health-check interval** matches the DDL retry cadence — every health-probe touches a model, which fires the failed DDL, which creates a new pool.
+4. **FastAPI lifespan + DataFlow `auto_migrate=True`** is the documented pattern in DataFlow's quickstart. Anyone copying the docs verbatim into a multi-instance Azure deployment hits this.
+
+## Connection to other workstreams
+
+This is the THIRD time in 2026-04 that a downstream Azure deployment has surfaced a kailash bug class:
+
+- 2026-04-12: arbor-upstream-fixes (multi-tenant DataFlow + Azure)
+- 2026-04-19: issue #525 (cross-SDK execute_raw + Postgres bind layer)
+- 2026-04-28: this incident (JourneyMate)
+
+The pattern: **Azure-class deployments are running ahead of the SDK's test-tier coverage.** Tier-2 tests target real PG via Docker — which runs single-process, single-event-loop, with `max_connections=100` defaults. The compound failure modes only appear under multi-process + multi-event-loop + Azure ceiling.
+
+## What this implies
+
+The Tier-2 regression tests for Shards A + B should NOT use docker-compose-PG with default settings. They should:
+
+- Set `max_connections` low (50?) to surface saturation faster
+- Spawn multiple event loops via `asyncio.new_event_loop()` to exercise the per-loop pool keying
+- Run for 30 s+ wall clock to catch idle-timeout eviction
+
+This is more expensive than current Tier-2 tests (which assume <1 s per test). But the alternative is the next JourneyMate-class incident.
+
+Codification candidate (for future cycle):
+
+> SDK regression tests for shared-architecture concerns (DataFlow connection lifecycle, Nexus session lifecycle, Kaizen agent budget) MUST include at least one test that runs against a constrained-resource real-infrastructure setup (low max_connections, low memory, multi-event-loop) — not just docker-default. The test names this constraint explicitly so future runners know it's load-bearing.
+
+This deserves codification but only with a 2nd occurrence pattern (per `learning-codified.json` deferral discipline). This is the 3rd Azure-incident in 16 days, so 2nd occurrence is met.
+
+## Action this workstream
+
+The Tier-2 regression tests in `02-plans/01-implementation-plan.md` Shards A + B EXPLICITLY include constrained-resource setup:
+
+- Shard A: `auto_migrate=True` with FK-misordered model (forces real DDL failure)
+- Shard B: `max_pool_count_per_process=10` + `lock_timeout=0.1` (forces real saturation)
+
+These mirror JourneyMate's failure conditions, run against real PG, and would catch a regression that re-introduces either bug.
+
+## Related
+
+- arbor-upstream-fixes session 2026-04-12
+- Issue #525 / PR #528 (cross-SDK execute_raw)
+- This workstream (#696/#697/#698/#685/#686)
+- `rules/testing.md` § "End-to-End Pipeline Regression"

--- a/workspaces/dataflow-prod-incident/journal/0004-DECISION-shard-sequencing-and-paired-release.md
+++ b/workspaces/dataflow-prod-incident/journal/0004-DECISION-shard-sequencing-and-paired-release.md
@@ -1,0 +1,52 @@
+# 0004 DECISION — Shard Sequencing and Paired Release
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /todos
+**Type:** DECISION
+
+## Decision
+
+Three shards execute in this dependency order:
+
+1. **Shards A + C in parallel** (both kailash-dataflow, different files in different worktrees)
+2. **Shard B independently** (kailash core, separate package, separate specialist load)
+3. **Shard D (cross-package integration)** runs once A + B + C all merge to main
+4. **Shard E (release)** runs in two waves: kailash 2.12.0 first → wait → kailash-dataflow 2.4.0
+
+## Rationale
+
+Three forces shape the ordering:
+
+1. **Per-package release coupling** — `kailash-dataflow`'s `kailash>=2.12.0` floor (DPI-D1) makes the bump dependent on kailash 2.12.0 being on PyPI. Per `rules/deployment.md` § "Optional Dependencies Pin to PyPI-Resolvable Versions" this MUST be sequential, never parallel.
+2. **Worktree isolation discipline** — Shards A and C both edit `kailash-dataflow` but DIFFERENT files (`core/engine.py` for A; `engine.py` for C). Per `rules/worktree-isolation.md` § 4 (waves of ≤3) and § 5 (merge-base check) parallel is safe with explicit pre-flight verification.
+3. **Specialist load** — Shard B requires both dataflow-specialist + infrastructure-specialist (the pool-registry pattern); A and C only need dataflow-specialist. Running B alongside A+C would double-load the dataflow-specialist context.
+
+## Alternatives considered
+
+**Alt 1: Single sequential cycle** — A → B → C → D → E. Cleaner mental model but loses the parallelism multiplier (3-5x per `rules/autonomous-execution.md` § 10x throughput). Rejected: too slow when shards are genuinely independent.
+
+**Alt 2: All four shards parallel** — A + B + C in waves of 3. Rejected: B's pool-registry change is mechanism for D2's bridge test; if B lands AFTER A's regression test runs, the bridge gap is invisible. Sequencing B before D is structural.
+
+**Alt 3: Single mega-PR** — Land all shards in one PR + one release. Rejected: violates `rules/autonomous-execution.md` § Per-Session Capacity Budget (the combined ~800 LOC + ~14 invariants exceeds shard threshold) AND would require waves of bridge fixes if any one shard regressed.
+
+## Risks
+
+The chosen ordering has one risk surfaced in `journal/0002 RISK` — kailash-dataflow PR opens BEFORE kailash 2.12.0 is on PyPI. Mitigation: DPI-D1 is gated by DPI-E1 + the 60 s PyPI cache lag wait in DPI-E4. The release-specialist owns this gate.
+
+## Cross-SDK propagation
+
+After all five issues close at kailash-py, file three cross-SDK issues at esperie/kailash-rs (DPI-E6). The Rust SDK is expected to have the same `EnterpriseConnectionPool` analog and the same `auto_migrate` lazy-creation pattern; verifying via reading kailash-rs source is the next workstream's first step. Per `rules/cross-sdk-inspection.md` § 4 — every closure includes the cross-SDK-checklist verification.
+
+## What this decision affects
+
+- DPI-D1, DPI-E1, DPI-E2, DPI-E4 are all sequenced behind DPI-B5 + DPI-A4 + DPI-C3 (per-shard regression tests)
+- DPI-D2 (bridge test) is the structural defense against the multi-package release ordering risk
+- The `release/v*` branch convention (per `rules/git.md`) auto-skips PR-gate CI on metadata-only release-prep PRs
+
+## Related
+
+- `journal/0001 DISCOVERY` — silent-fallback + no-lifecycle is one pattern (motivates Shard B's bundling)
+- `journal/0002 RISK` — multi-package release blast radius
+- `journal/0003 CONNECTION` — JourneyMate as canary for Azure-class deployments
+- `rules/autonomous-execution.md` § Per-Session Capacity Budget
+- `rules/deployment.md` § Multi-Package Release Tags Pushed Individually

--- a/workspaces/dataflow-prod-incident/journal/0005-TRADE-OFF-semver-major-vs-minor-for-behavioural-fix.md
+++ b/workspaces/dataflow-prod-incident/journal/0005-TRADE-OFF-semver-major-vs-minor-for-behavioural-fix.md
@@ -1,0 +1,49 @@
+# 0005 TRADE-OFF — Semver Major vs Minor For Behavioural Fix
+
+**Date:** 2026-04-28
+**Session:** dataflow-prod-incident /todos
+**Type:** TRADE-OFF
+
+## The trade-off
+
+Both releases (kailash and kailash-dataflow) include behavioural breaking changes:
+
+- **kailash 2.12.0** — `_get_adapter` fallback path changes from "create unbounded dedicated pool" to "register + cap + fail-fast at cap". Apps relying on the unbounded behaviour see new `PoolExhaustedError`.
+- **kailash-dataflow 2.4.0** — `auto_migrate=True` (default) changes from "retry on every access" to "fail-fast on first error". Apps relying on the retry-storm bug as a feature (i.e., expecting eventual recovery as the failed DDL becomes valid) see `DDLFailedError`.
+
+The semver question: **major bump (3.0.0 / 3.0.0)** signaling breaking, OR **minor bump (2.12.0 / 2.4.0)** treating the prior behaviour as a bug?
+
+## Decision: minor bump (2.12.0 / 2.4.0)
+
+Both behaviours WERE bugs. The "feature" was the failure mode this workstream exists to fix. Per `feedback_no_shims` (the user's preference): no deprecation timeline; fix is the same release. Per `feedback_optimal_outcome`: choose the optimal architecture, not the politically safer one.
+
+A major bump would imply the prior behaviour was an intended feature being removed — this is the wrong narrative. The prior behaviour was a bug that produced production incidents (JourneyMate). Treating it as a "feature deprecation" would set the precedent that future bug fixes also require major bumps, which would amplify the existing changelog noise without proportionate benefit.
+
+## What downstream callers experience
+
+Apps with the JourneyMate failure mode see a NEW error class on the failure mode they were already failing on. Net change: same failure → typed error with actionable message + bounded resource cost. Strictly better.
+
+Apps without the failure mode see no change. Their CREATE TABLEs succeed; their pools stay shared.
+
+Apps that intentionally relied on lazy-retry (extremely rare; the retry-storm IS the known bug) get `auto_migrate="warn"` as the explicit opt-in. The CHANGELOG names this escape hatch.
+
+## What this affects in the todos
+
+- DPI-E1 / DPI-E2 use minor bumps (2.11.3 → 2.12.0; 2.3.3 → 2.4.0)
+- CHANGELOG entries name the behavioural change but frame it as bug-fix-with-bounded-error, not "removed feature"
+- The `auto_migrate="warn"` escape hatch IS documented; legacy apps can opt out
+
+## Alternative considered
+
+**Major bump (3.0.0 / 3.0.0)** — clearer signaling at the cost of artificial breaking-change perception. Rejected per the rationale above.
+
+## Cross-SDK relevance
+
+When the equivalent fixes ship to kailash-rs, the same trade-off applies. The Rust SDK's semver discipline matches Python's; the same minor-bump frame should hold.
+
+## Related
+
+- `feedback_no_shims` (no deprecation timelines)
+- `feedback_optimal_outcome` (choose optimal architecture)
+- `rules/zero-tolerance.md` Rule 6 (half-implementation is BLOCKED)
+- `journal/0004 DECISION` (shard sequencing assumes minor-bump ordering)


### PR DESCRIPTION
## Summary

- Implements `DataFlow.register_model(model_cls, *, replace=False, force_drop=False)` — non-decorator entry that produces identical state to `@db.model`
- Fixes `DataFlowEngine.register_model` (was calling non-existent method on DataFlow)
- Adds `DataFlowEngineBuilder.build_sync()` companion for module-import-time patterns; async `build()` delegates to `build_sync()`
- 11 Tier-2 regression tests (7 for #685, 4 for #686)

## Issues fixed

Fixes #685 — DataFlowEngine.register_model calls non-existent method on DataFlow primitive
Fixes #686 — DataFlowEngineBuilder.build() is async but body is purely synchronous

## Test plan

- [x] 11 regression tests pass against sqlite_file_url fixture (0.44s)
- [x] Idempotency: `register_model(Foo)` twice raises `ValueError`; replacement requires `replace=True` AND `force_drop=True`
- [x] `build()` and `build_sync()` produce structurally identical engine state
- [x] `pre-commit run --all-files` clean

## Rule compliance

- `rules/zero-tolerance.md` Rule 6 — `register_model` now end-to-end (was half-implementation)
- `rules/dataflow-identifier-safety.md` Rule 4 — replacement requires `force_drop=True`
- `rules/patterns.md` "Paired Public Surface" — async `build()` delegates to canonical `build_sync()` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)