### PR TITLE
fix(ml): update Phase 1 family-count invariants 7 → 8 (CatBoost)

### DIFF
--- a/packages/kailash-ml/tests/regression/test_predictions_device_invariant.py
+++ b/packages/kailash-ml/tests/regression/test_predictions_device_invariant.py
@@ -47,10 +47,11 @@ def test_every_return_predictions_has_device_kwarg() -> None:
     ``pred.device.fallback_reason``. This test catches the drop at
     test-collection time.
 
-    Scope: Predictions() calls appear in 7 predict() methods (one per
-    family). This test walks the AST, filters to Predictions calls that
-    are inside a function whose name is 'predict', and asserts each one
-    passes device= as a kwarg.
+    Scope: Predictions() calls appear in 8 predict() methods (one per
+    family: sklearn / xgboost / lightgbm / catboost / torch / lightning /
+    UMAP / HDBSCAN). This test walks the AST, filters to Predictions calls
+    that are inside a function whose name is 'predict', and asserts each
+    one passes device= as a kwarg.
     """
     src = _trainable_module_path().read_text()
     tree = ast.parse(src)
@@ -105,8 +106,10 @@ def test_every_fit_caches_last_device_report() -> None:
         if isinstance(node, ast.FunctionDef) and node.name == "fit"
     ]
 
-    # Phase 1 ships 7 families; each class has one fit(). Protocol definition
-    # Trainable.fit (a `...` body) brings the total to 8 — filter it out.
+    # Phase 1 ships 8 families (sklearn / xgboost / lightgbm / catboost /
+    # torch / lightning / UMAP / HDBSCAN); each class has one fit().
+    # Protocol definition Trainable.fit (a `...` body) brings the total to
+    # 9 — filter it out.
     real_fits = [
         f
         for f in fit_functions
@@ -116,8 +119,8 @@ def test_every_fit_caches_last_device_report() -> None:
             and isinstance(f.body[0].value, ast.Constant)
         )
     ]
-    assert len(real_fits) == 7, (
-        f"Expected 7 concrete fit() methods (one per Phase 1 family); "
+    assert len(real_fits) == 8, (
+        f"Expected 8 concrete fit() methods (one per Phase 1 family); "
         f"found {len(real_fits)}. If a family was added/removed, update "
         f"this invariant."
     )

--- a/packages/kailash-ml/tests/regression/test_trainable_device_report_invariant.py
+++ b/packages/kailash-ml/tests/regression/test_trainable_device_report_invariant.py
@@ -73,15 +73,18 @@ def test_every_return_trainingresult_has_device_kwarg() -> None:
 
 
 @pytest.mark.regression
-def test_all_seven_phase_one_trainables_in_kailash_ml_all() -> None:
-    """specs/ml-engines.md §3.0 — all 7 family adapters MUST be in kailash_ml.__all__.
+def test_all_phase_one_trainables_in_kailash_ml_all() -> None:
+    """specs/ml-engines-v2.md §3 — all 8 family adapters MUST be in kailash_ml.__all__.
 
     Origin: round-3 redteam spec-to-code sweep (2026-04-19) found only 2 of
     7 Trainables (UMAP + HDBSCAN — the new ones from Shard C) were in
     kailash_ml.__all__. The 5 pre-existing (Sklearn/XGBoost/LightGBM/
     Torch/Lightning) were accessible via kailash_ml.trainable but absent
     from the top-level export — silent spec violation that had been
-    accumulating since 0.10.x. Fixed in 0.12.0.
+    accumulating since 0.10.x. Fixed in 0.12.0. CatBoostTrainable added
+    to the asserted set in the 1.6.x follow-up (W6-013) — previously
+    silent in the expected set despite being a Phase 1 family per
+    ml-engines-v2.md §2.1 (line 249).
     """
     import kailash_ml
 
@@ -89,6 +92,7 @@ def test_all_seven_phase_one_trainables_in_kailash_ml_all() -> None:
         "SklearnTrainable",
         "XGBoostTrainable",
         "LightGBMTrainable",
+        "CatBoostTrainable",
         "TorchTrainable",
         "LightningTrainable",
         "UMAPTrainable",
@@ -97,7 +101,7 @@ def test_all_seven_phase_one_trainables_in_kailash_ml_all() -> None:
     actual = {n for n in kailash_ml.__all__ if n.endswith("Trainable")}
     missing = expected - actual
     assert not missing, (
-        f"Per specs/ml-engines.md §3.0, all 7 Phase 1 family adapters MUST "
+        f"Per specs/ml-engines-v2.md §3, all 8 Phase 1 family adapters MUST "
         f"be in kailash_ml.__all__. Missing: {sorted(missing)}. "
         f"Add eager imports to packages/kailash-ml/src/kailash_ml/__init__.py "
         f"AND list them in __all__ (per orphan-detection §6)."


### PR DESCRIPTION
## Summary

Closes the F-3 zero-tolerance Rule 1 debt carried through PR #708 (kailash-ml-1.5.x-followup) and the 1.6.0 release. Two regression tests in `packages/kailash-ml/tests/regression/` had stale Phase 1 family counts of 7 — the spec ground truth (`specs/ml-engines-v2.md` §2.1 line 249 + §3) is 8 (sklearn / xgboost / lightgbm / catboost / torch / lightning / UMAP / HDBSCAN).

- `test_predictions_device_invariant.py::test_every_fit_caches_last_device_report` was **actively failing** on main with `assert 8 == 7`.
- `test_trainable_device_report_invariant.py::test_all_seven_phase_one_trainables_in_kailash_ml_all` was **passing by coincidence** — its `expected` set was missing `CatBoostTrainable`, so the `expected - actual` check came up empty even though the spec assertion was incomplete. Renamed to `test_all_phase_one_trainables_in_kailash_ml_all` to drop the now-misleading "seven" in the symbol.

Also re-points stale `specs/ml-engines.md §3.0` references to the renamed `specs/ml-engines-v2.md §3`.

Test-only diff. No production code changes.

## Test plan

- [x] `pytest packages/kailash-ml/tests/regression/test_predictions_device_invariant.py packages/kailash-ml/tests/regression/test_trainable_device_report_invariant.py -v` → 6/6 pass
- [x] `pytest packages/kailash-ml/tests/regression/ -q` → green (full ml regression suite)
- [x] `pytest packages/kailash-ml/tests/ --collect-only` → 2483 tests collect cleanly
- [x] Pre-commit hooks (Black, isort, Ruff, type-annotations, no-eval, no-deprecated-log-warn, Tier 1 unit) → all pass

## Related issues

Resolves the F-3 followup-debt from `workspaces/kailash-ml-1.5.x-followup/.session-notes` (per zero-tolerance Rule 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)