### PR TITLE
feat(dataflow): TransactionScope.execute_raw for multi-statement raw SQL atomicity (#707)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,35 @@
 # DataFlow Changelog
 
+## [Unreleased]
+
+### Added
+
+- **`TransactionScope.execute_raw(sql, params=None)` for multi-statement raw-SQL atomicity (#707)**: `db.transactions.begin()` now yields a `TransactionScope` (replacing the prior bare `dict`) carrying the canonical metadata (`id`, `isolation_level`, `status`, `type`, `depth`) AND an `execute_raw` method that routes every call to the connection pinned for the lifetime of the `async with` body. Closes the OAuth credential rotation use case from #707: SELECT FOR UPDATE + UPDATE-or-INSERT now expressible in one atomic transaction without the Express API. Calling `tx.execute_raw` outside the `async with` body raises `RuntimeError` per `rules/zero-tolerance.md` Rule 3a (typed delegate guard) — the pinned connection only exists while the scope is active. The asyncpg vs aiosqlite parameter-binding shape is dispatched by connection type. SELECT-style statements return rows; INSERT/UPDATE/DELETE return the driver's command-tag string (asyncpg) or cursor (aiosqlite). Backward-compat: existing `txn["id"]` / `txn["status"]= "..."` dict-style access preserved via `__getitem__` / `__setitem__` that map through to attributes — every prior consumer keeps working unchanged. Public surface: `TransactionScope` exported from `dataflow.features` (and via `dataflow.features.transactions`).
+
+### Fixed
+
+- **Savepoint context-manager invocation (#707, bundled fix)**: `TransactionManager.begin()` previously invoked the nested-transaction (savepoint) path with `async for ctx in self._savepoint(): yield ctx`, which iterates an `@asynccontextmanager`-decorated method as if it were an async generator. Corrected to `async with self._savepoint() as ctx: yield ctx`. The bug was latent because no test exercised nested `db.transactions.begin()` calls; the new #707 regression suite covers the canonical surface and the reviewer flagged the savepoint path as adjacent.
+
+### Tests
+
+- Added Tier 2 regression suite at `packages/kailash-dataflow/tests/regression/test_issue_707_transaction_pins_connection.py`:
+  - `test_multi_statement_atomicity_via_tx_execute_raw` — BEGIN-INSERT-INSERT-COMMIT verified via fresh-connection read-back.
+  - `test_auto_rollback_on_exception` — exception inside `async with` body MUST roll back; OAuth-rotation invariant.
+  - `test_oauth_credential_rotation_pattern` — full SELECT FOR UPDATE + UPDATE-or-INSERT cycle across 4 transactions.
+  - `test_select_for_update_then_insert_idempotency` — two concurrent transactions racing on the same idempotency token serialize on `SELECT ... FOR UPDATE`; exactly-one-insert invariant.
+  - `test_partial_failure_within_transaction_rolls_back_all` — UNIQUE-constraint violation mid-txn rolls back the prior row.
+  - `test_execute_raw_outside_scope_raises_runtime_error` — Rule 3a typed delegate guard, runs without infrastructure.
+
+### Cross-SDK
+
+- kailash-rs#688 tracks the equivalent `TransactionScope::execute_raw` surface for the Rust SDK (cross-SDK alignment per `rules/cross-sdk-inspection.md` Rule 1 + EATP D6 matching semantics).
+
+### Specification
+
+- `specs/dataflow-cache.md` §12.6 documents the multi-statement atomicity surface and pins the `_active_transaction` ContextVar contract that `tx.execute_raw` and `db.execute_raw_lightweight` (called inside the `async with` body) both honor.
+
+---
+
 ## [2.4.0] — 2026-04-28 — DDL fail-fast, DDLFailedError, build_sync surface
 
 Minor release delivering three production-incident fixes from the `dataflow-prod-incident` workstream (shards DPI-A, DPI-C) plus the kailash core floor bump to 2.12.0 required by DPI-B (pool registry leak fix).

--- a/packages/kailash-dataflow/src/dataflow/features/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/features/__init__.py
@@ -4,7 +4,7 @@ from .bulk import BulkOperations
 from .derived import DerivedModelEngine, DerivedModelMeta, RefreshResult
 from .express import ExpressDataFlow
 from .multi_tenant import MultiTenantManager
-from .transactions import TransactionManager
+from .transactions import TransactionManager, TransactionScope
 
 __all__ = [
     "BulkOperations",
@@ -14,4 +14,5 @@ __all__ = [
     "MultiTenantManager",
     "RefreshResult",
     "TransactionManager",
+    "TransactionScope",
 ]

--- a/packages/kailash-dataflow/src/dataflow/features/transactions.py
+++ b/packages/kailash-dataflow/src/dataflow/features/transactions.py
@@ -12,7 +12,7 @@ atomicity. The connection is returned to the pool on commit/rollback.
 import logging
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
-from typing import Any, AsyncGenerator, Dict, Optional
+from typing import Any, AsyncGenerator, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +21,154 @@ _active_transaction: ContextVar[Optional[Any]] = ContextVar(
     "_active_transaction", default=None
 )
 _savepoint_depth: ContextVar[int] = ContextVar("_savepoint_depth", default=0)
+
+
+class TransactionScope:
+    """The yielded scope inside an ``async with db.transactions.begin()`` block.
+
+    Holds the pinned connection for the lifetime of the ``async with`` body
+    and exposes ``execute_raw(sql, params)`` for multi-statement raw SQL the
+    Express API does not express directly (DDL inside a tx, SELECT FOR UPDATE
+    + INSERT, complex UPSERT-or-UPDATE).
+
+    The pinned connection is set in ``_active_transaction`` ContextVar by the
+    enclosing ``TransactionManager`` and cleared on exit. Calling
+    ``execute_raw`` outside the ``async with`` body raises ``RuntimeError``
+    per ``rules/zero-tolerance.md`` Rule 3a (typed delegate guard) — the
+    pinned connection only exists while the scope is active.
+
+    Backward-compat: existing tests / consumer code may treat this as a dict
+    (``txn["id"]``) — ``__getitem__`` maps the canonical attributes through.
+    """
+
+    __slots__ = ("id", "isolation_level", "status", "type", "depth")
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        isolation_level: str,
+        status: str = "active",
+        type: str = "transaction",
+        depth: Optional[int] = None,
+    ) -> None:
+        self.id = id
+        self.isolation_level = isolation_level
+        self.status = status
+        self.type = type
+        self.depth = depth
+
+    def __getitem__(self, key: str) -> Any:
+        """Backward-compat dict-style access.
+
+        ``txn["id"]`` / ``txn["isolation_level"]`` / ``txn["status"]`` MUST
+        keep working for code written against the prior dict-yielding API.
+        Unknown keys raise ``KeyError`` to keep the dict semantics tight.
+        """
+        if key == "id":
+            return self.id
+        if key == "isolation_level":
+            return self.isolation_level
+        if key == "status":
+            return self.status
+        if key == "type":
+            return self.type
+        if key == "depth":
+            return self.depth
+        raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Backward-compat: allow ``txn["status"] = "committed"`` writes.
+
+        Internal manager code historically assigned ``txn_context["status"] =
+        "committed"`` after COMMIT. Preserve that affordance.
+        """
+        if key == "id":
+            self.id = value
+        elif key == "isolation_level":
+            self.isolation_level = value
+        elif key == "status":
+            self.status = value
+        elif key == "type":
+            self.type = value
+        elif key == "depth":
+            self.depth = value
+        else:
+            raise KeyError(key)
+
+    async def execute_raw(self, sql: str, params: Optional[List[Any]] = None) -> Any:
+        """Execute a raw SQL statement on the pinned transaction connection.
+
+        Routes the call through the connection bound by the enclosing
+        ``async with db.transactions.begin()`` block. Use for multi-statement
+        atomicity the Express API does not express directly:
+
+            async with db.transactions.begin() as tx:
+                rows = await tx.execute_raw(
+                    "SELECT id FROM oauth_tokens WHERE user_id = $1 FOR UPDATE",
+                    [user_id],
+                )
+                if rows:
+                    await tx.execute_raw(
+                        "UPDATE oauth_tokens SET refresh_token = $1 "
+                        "WHERE user_id = $2",
+                        [new_refresh, user_id],
+                    )
+
+        Args:
+            sql: SQL statement. PostgreSQL placeholders are ``$1``, ``$2``,
+                ``...``; SQLite placeholders are ``?``; MySQL placeholders are
+                ``%s``. Pass dialect-appropriate placeholders for the
+                underlying connection.
+            params: Optional positional parameter list. asyncpg expects
+                positional unpacking; aiosqlite expects a list/tuple. The
+                method dispatches the binding shape based on the underlying
+                connection type.
+
+        Returns:
+            For SELECT statements on asyncpg: a list of ``asyncpg.Record``
+            rows (use ``dict(row)`` to materialize). For
+            INSERT/UPDATE/DELETE on asyncpg: the command-tag string
+            (e.g. ``"INSERT 0 1"``). For aiosqlite: the cursor object after
+            ``execute()`` — use ``await cursor.fetchall()`` for SELECT.
+
+        Raises:
+            RuntimeError: When called outside the ``async with`` body —
+                the pinned connection only exists while the scope is active.
+        """
+        conn = _active_transaction.get()
+        if conn is None:
+            raise RuntimeError(
+                "TransactionScope.execute_raw called outside the transaction "
+                "body — ensure the call is inside the "
+                "`async with db.transactions.begin()` scope. "
+                "The pinned connection is only valid while the scope is active."
+            )
+
+        # asyncpg: connection.fetch / .execute take *params positional.
+        # aiosqlite: connection.execute takes a single tuple/list arg.
+        # Dispatch by connection type to bind correctly. asyncpg connections
+        # have a `fetch` method; aiosqlite connections do not.
+        is_asyncpg = hasattr(conn, "fetch") and hasattr(conn, "fetchrow")
+
+        sql_stripped = sql.lstrip()
+        is_select = (
+            sql_stripped[:6].upper() == "SELECT" or sql_stripped[:4].upper() == "WITH"
+        )
+
+        if is_asyncpg:
+            if params is None:
+                if is_select:
+                    return await conn.fetch(sql)
+                return await conn.execute(sql)
+            # asyncpg: positional unpacking
+            if is_select:
+                return await conn.fetch(sql, *params)
+            return await conn.execute(sql, *params)
+        # aiosqlite-style: single tuple param
+        if params is None:
+            return await conn.execute(sql)
+        return await conn.execute(sql, params)
 
 
 class TransactionManager:
@@ -35,12 +183,24 @@ class TransactionManager:
 
     Usage::
 
-        async with db.transactions.begin() as txn:
+        async with db.transactions.begin() as tx:
             await db.express.create("User", {"name": "Alice"})
             await db.express.create("Profile", {"user_id": 1})
             # Both committed atomically on exit
 
-        async with db.transactions.begin() as txn:
+        async with db.transactions.begin() as tx:
+            # Multi-statement raw SQL atomicity via tx.execute_raw
+            existing = await tx.execute_raw(
+                "SELECT id FROM users WHERE email = $1 FOR UPDATE",
+                ["alice@example.com"],
+            )
+            if not existing:
+                await tx.execute_raw(
+                    "INSERT INTO users (email) VALUES ($1)",
+                    ["alice@example.com"],
+                )
+
+        async with db.transactions.begin() as outer:
             await db.express.create("User", {"name": "Bob"})
             async with db.transactions.begin() as nested:
                 # This is a SAVEPOINT
@@ -60,7 +220,7 @@ class TransactionManager:
     @asynccontextmanager
     async def begin(
         self, isolation_level: str = "READ COMMITTED"
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    ) -> AsyncGenerator[TransactionScope, None]:
         """Begin a database transaction.
 
         Args:
@@ -70,7 +230,10 @@ class TransactionManager:
                 - "SERIALIZABLE" (strictest, may fail under contention)
 
         Yields:
-            Transaction context dict with metadata (id, isolation_level, status).
+            TransactionScope with metadata (id, isolation_level, status) plus
+            ``execute_raw(sql, params)`` for multi-statement raw SQL on the
+            pinned connection. Backward-compatible dict-style access
+            (``txn["id"]``) is preserved.
 
         Raises:
             Exception: Re-raises any exception from the transaction body
@@ -79,7 +242,7 @@ class TransactionManager:
         current = _active_transaction.get()
         if current is not None:
             # Nested transaction — use SAVEPOINT
-            async for ctx in self._savepoint():
+            async with self._savepoint() as ctx:
                 yield ctx
             return
 
@@ -109,17 +272,18 @@ class TransactionManager:
             # Start the transaction with the requested isolation level
             await conn.execute(f"BEGIN ISOLATION LEVEL {isolation_level}")
 
-            txn_context: Dict[str, Any] = {
-                "id": txn_id,
-                "isolation_level": isolation_level,
-                "status": "active",
-            }
+            scope = TransactionScope(
+                id=txn_id,
+                isolation_level=isolation_level,
+                status="active",
+                type="transaction",
+            )
 
-            yield txn_context
+            yield scope
 
             # Commit on clean exit
             await conn.execute("COMMIT")
-            txn_context["status"] = "committed"
+            scope.status = "committed"
             self._stats["total_committed"] += 1
             logger.info(
                 "transaction.commit",
@@ -150,7 +314,7 @@ class TransactionManager:
             await adapter.connection_pool.release(conn)
 
     @asynccontextmanager
-    async def _savepoint(self) -> AsyncGenerator[Dict[str, Any], None]:
+    async def _savepoint(self) -> AsyncGenerator[TransactionScope, None]:
         """Create a SAVEPOINT within an existing transaction."""
         conn = _active_transaction.get()
         if conn is None:
@@ -168,17 +332,18 @@ class TransactionManager:
         try:
             await conn.execute(f"SAVEPOINT {sp_name}")
 
-            ctx: Dict[str, Any] = {
-                "id": sp_name,
-                "type": "savepoint",
-                "depth": depth,
-                "status": "active",
-            }
+            scope = TransactionScope(
+                id=sp_name,
+                isolation_level="",  # savepoints inherit from outer txn
+                status="active",
+                type="savepoint",
+                depth=depth,
+            )
 
-            yield ctx
+            yield scope
 
             await conn.execute(f"RELEASE SAVEPOINT {sp_name}")
-            ctx["status"] = "released"
+            scope.status = "released"
 
         except Exception as e:
             try:

--- a/packages/kailash-dataflow/tests/regression/test_issue_707_transaction_pins_connection.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_707_transaction_pins_connection.py
@@ -1,0 +1,350 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression test for issue #707 — `db.transactions.begin()` MUST pin one
+connection across all `tx.execute_raw` calls, auto-commit on clean exit,
+auto-rollback on exception. Tier 2 (real PostgreSQL).
+
+The yielded `TransactionScope` exposes `execute_raw(sql, params=None)` so
+consumers can express multi-statement atomic patterns (DDL inside a tx,
+SELECT FOR UPDATE + INSERT, complex UPSERT-or-UPDATE) the Express API
+does not express directly. Calling `tx.execute_raw` outside the
+`async with` body raises `RuntimeError` per `rules/zero-tolerance.md`
+Rule 3a (typed delegate guard).
+
+Per `rules/testing.md` § "3-Tier Testing" Tier 2: NO mocking. Every
+test runs against the real PostgreSQL test instance via the
+`test_suite` fixture from `tests/integration/conftest.py`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.features.transactions import TransactionScope
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+pytestmark = [pytest.mark.regression, pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures — `test_suite` lives in tests/integration/conftest.py and
+# is not auto-discovered for tests/regression/. Define a regression-scope
+# copy that uses the same IntegrationTestSuite harness against real Postgres.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def pg_test_suite():
+    """Create the IntegrationTestSuite once per regression test (real Postgres).
+
+    Skips the test cleanly when PostgreSQL on port 5434 is not reachable —
+    matches the integration-tier behavior where the test suite is the
+    canonical real-infra harness.
+    """
+    suite = IntegrationTestSuite()
+    try:
+        async with suite.session():
+            yield suite
+    except Exception as exc:
+        pytest.skip(
+            f"Cannot reach PostgreSQL test infra: {type(exc).__name__}: {exc}. "
+            f"Ensure shared SDK Docker is running on port 5434."
+        )
+
+
+@pytest.fixture
+async def temp_table_name():
+    """Unique temp table name per test for isolation."""
+    return f"tx_707_{int(time.time() * 1_000_000)}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+async def temp_table(pg_test_suite, temp_table_name):
+    """Create + drop a clean test table for each test.
+
+    The CREATE / DROP DDL runs OUTSIDE any DataFlow transaction (the
+    test is exercising the transaction surface against pre-existing
+    tables). Cleanup uses a fresh connection to guarantee teardown
+    even when the test transaction was rolled back.
+    """
+    create_sql = f"""
+        CREATE TABLE {temp_table_name} (
+            id SERIAL PRIMARY KEY,
+            email TEXT UNIQUE,
+            payload TEXT,
+            created_at TIMESTAMP DEFAULT NOW()
+        )
+    """
+    async with pg_test_suite.get_connection() as conn:
+        await conn.execute(create_sql)
+
+    yield temp_table_name
+
+    async with pg_test_suite.get_connection() as conn:
+        await conn.execute(f"DROP TABLE IF EXISTS {temp_table_name} CASCADE")
+
+
+@pytest.fixture
+async def df(pg_test_suite):
+    """A DataFlow against the real Postgres infra; closed on teardown."""
+    instance = DataFlow(database_url=pg_test_suite.config.url, auto_migrate=False)
+    try:
+        yield instance
+    finally:
+        # Explicit close per rules/testing.md § "Fixtures Yield + Cleanup"
+        # — avoids the GC-finalizer deadlock the __del__ rule warns about.
+        try:
+            await instance.close_async()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 regression coverage
+# ---------------------------------------------------------------------------
+
+
+async def _count_rows(pg_test_suite, table: str) -> int:
+    """Verify-via-readback per rules/testing.md § State Persistence Verification.
+
+    Uses a FRESH connection from the integration test suite — outside any
+    DataFlow transaction. This proves the transaction's commit/rollback
+    actually persisted to the database, not just to the pinned connection.
+    """
+    async with pg_test_suite.get_connection() as conn:
+        return await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+
+
+async def test_multi_statement_atomicity_via_tx_execute_raw(
+    df, pg_test_suite, temp_table
+):
+    """Issue #707 canonical: BEGIN-INSERT-INSERT-COMMIT all via tx.execute_raw.
+
+    Asserts both rows are visible after commit when read back from a fresh
+    connection — proves the COMMIT actually persisted state to the database.
+    """
+    async with df.transactions.begin() as tx:
+        assert isinstance(tx, TransactionScope), (
+            f"transactions.begin() yielded {type(tx).__name__}, expected "
+            "TransactionScope (issue #707 contract)"
+        )
+        assert tx.status == "active"
+
+        await tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            ["alice@example.test", "row-1"],
+        )
+        await tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            ["bob@example.test", "row-2"],
+        )
+        # Read-within-transaction: the pinned connection sees its own writes.
+        in_tx_rows = await tx.execute_raw(
+            f"SELECT email FROM {temp_table} ORDER BY email"
+        )
+        assert len(in_tx_rows) == 2
+        assert {dict(r)["email"] for r in in_tx_rows} == {
+            "alice@example.test",
+            "bob@example.test",
+        }
+
+    # Read-back via a DIFFERENT connection — proves COMMIT happened.
+    assert await _count_rows(pg_test_suite, temp_table) == 2
+
+
+async def test_auto_rollback_on_exception(df, pg_test_suite, temp_table):
+    """Exceptions inside the `async with` body MUST roll back the entire txn.
+
+    Insert one row, raise, then read back from a FRESH connection — zero
+    rows MUST persist. This is the load-bearing invariant for the OAuth
+    credential rotation pattern (failure mid-rotation MUST NOT leave a
+    partially-written token row).
+    """
+    with pytest.raises(RuntimeError, match="forced rollback"):
+        async with df.transactions.begin() as tx:
+            await tx.execute_raw(
+                f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+                ["alice@example.test", "should-not-persist"],
+            )
+            raise RuntimeError("forced rollback")
+
+    # Read-back: nothing persisted because the txn was rolled back.
+    assert await _count_rows(pg_test_suite, temp_table) == 0
+
+
+async def test_oauth_credential_rotation_pattern(df, pg_test_suite, temp_table):
+    """Canonical use case from issue #707: SELECT existing token + UPDATE-or-INSERT.
+
+    1. Tx A inserts the initial token row (commit).
+    2. Tx B reads the row, decides to UPDATE, commits.
+    3. Tx C reads the row, decides to UPDATE again, commits.
+    4. Tx D for a NEW user — row missing, INSERT branch fires.
+
+    All steps run via `tx.execute_raw` only. Read-back from a fresh
+    connection verifies the final state.
+    """
+    user_a = "user-a@example.test"
+    user_b = "user-b@example.test"
+
+    # Tx A: initial INSERT for user A
+    async with df.transactions.begin() as tx:
+        await tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            [user_a, "refresh-v1"],
+        )
+
+    # Tx B: rotation 1 — SELECT then UPDATE
+    async with df.transactions.begin() as tx:
+        existing = await tx.execute_raw(
+            f"SELECT id FROM {temp_table} WHERE email = $1 FOR UPDATE",
+            [user_a],
+        )
+        assert len(existing) == 1, "user_a row MUST exist for UPDATE branch"
+        await tx.execute_raw(
+            f"UPDATE {temp_table} SET payload = $1 WHERE email = $2",
+            ["refresh-v2", user_a],
+        )
+
+    # Tx C: rotation 2 — same UPDATE branch
+    async with df.transactions.begin() as tx:
+        existing = await tx.execute_raw(
+            f"SELECT id FROM {temp_table} WHERE email = $1 FOR UPDATE",
+            [user_a],
+        )
+        assert len(existing) == 1
+        await tx.execute_raw(
+            f"UPDATE {temp_table} SET payload = $1 WHERE email = $2",
+            ["refresh-v3", user_a],
+        )
+
+    # Tx D: new user — row missing, INSERT branch fires
+    async with df.transactions.begin() as tx:
+        existing = await tx.execute_raw(
+            f"SELECT id FROM {temp_table} WHERE email = $1 FOR UPDATE",
+            [user_b],
+        )
+        assert len(existing) == 0, "user_b row MUST be absent for INSERT branch"
+        await tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            [user_b, "refresh-v1"],
+        )
+
+    # Read-back from a fresh connection: 2 rows, user_a's payload is v3.
+    async with pg_test_suite.get_connection() as conn:
+        rows = await conn.fetch(
+            f"SELECT email, payload FROM {temp_table} ORDER BY email"
+        )
+    by_email = {r["email"]: r["payload"] for r in rows}
+    assert by_email == {user_a: "refresh-v3", user_b: "refresh-v1"}
+
+
+async def test_select_for_update_then_insert_idempotency(pg_test_suite, temp_table):
+    """Two concurrent transactions racing on SELECT FOR UPDATE + INSERT.
+
+    The canonical idempotency pattern: each caller checks for an existing
+    row keyed by an idempotency token, and INSERTs only if absent. SELECT
+    FOR UPDATE serializes the two transactions on the row that the first
+    caller inserts, so the second caller observes the inserted row and
+    skips its own INSERT.
+
+    Asserts exactly one row exists post-race.
+    """
+    idempotency_token = "idem-707-abc"
+
+    async def maybe_insert(label: str) -> str:
+        # Each task uses its OWN DataFlow instance — distinct connection
+        # pools, so the two tasks genuinely race against each other on
+        # the database, not on a shared in-process lock.
+        local_df = DataFlow(database_url=pg_test_suite.config.url, auto_migrate=False)
+        try:
+            async with local_df.transactions.begin() as tx:
+                # Use the idempotency token in the email column for uniqueness.
+                # Insert a tiny delay so both tasks reliably overlap on the
+                # SELECT FOR UPDATE.
+                existing = await tx.execute_raw(
+                    f"SELECT id FROM {temp_table} WHERE email = $1 FOR UPDATE",
+                    [idempotency_token],
+                )
+                if len(existing) == 0:
+                    await asyncio.sleep(0.05)
+                    await tx.execute_raw(
+                        f"INSERT INTO {temp_table} (email, payload) "
+                        f"VALUES ($1, $2)",
+                        [idempotency_token, label],
+                    )
+                    return "inserted"
+                return "observed-existing"
+        finally:
+            try:
+                await local_df.close_async()
+            except Exception:
+                pass
+
+    results = await asyncio.gather(maybe_insert("task-1"), maybe_insert("task-2"))
+
+    # Exactly one task inserted, exactly one observed the existing row.
+    assert sorted(results) == [
+        "inserted",
+        "observed-existing",
+    ], f"Race did not serialize on FOR UPDATE: results={results!r}"
+    # And exactly one row persists.
+    assert await _count_rows(pg_test_suite, temp_table) == 1
+
+
+async def test_partial_failure_within_transaction_rolls_back_all(
+    df, pg_test_suite, temp_table
+):
+    """INSERT row 1, INSERT row 2 with constraint violation, expect rollback.
+
+    Asserts neither row persists. The constraint is the UNIQUE on `email`:
+    insert the same email twice in the same transaction.
+    """
+    duplicate_email = "duplicate@example.test"
+
+    with pytest.raises(Exception):  # asyncpg.UniqueViolationError or wrapper
+        async with df.transactions.begin() as tx:
+            await tx.execute_raw(
+                f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+                [duplicate_email, "row-1"],
+            )
+            # Same email — UNIQUE constraint violation, rolls back row-1 too.
+            await tx.execute_raw(
+                f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+                [duplicate_email, "row-2"],
+            )
+
+    # Read-back from a fresh connection: NEITHER row persists.
+    assert await _count_rows(pg_test_suite, temp_table) == 0
+
+
+# ---------------------------------------------------------------------------
+# Outside-scope guard — typed delegate per rules/zero-tolerance.md Rule 3a
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_raw_outside_scope_raises_runtime_error():
+    """Calling `tx.execute_raw` AFTER the `async with` block raises RuntimeError.
+
+    The typed delegate guard converts an opaque AttributeError ("None has
+    no attribute 'execute'") into an actionable RuntimeError that names
+    the scope contract.
+
+    This test does not need real Postgres — it exercises the guard purely.
+    """
+    # Construct a TransactionScope without entering any begin() — the
+    # ContextVar is unset, so execute_raw MUST raise the typed guard.
+    scope = TransactionScope(
+        id="manual",
+        isolation_level="READ COMMITTED",
+        status="active",
+        type="transaction",
+    )
+
+    with pytest.raises(RuntimeError, match="outside the transaction body"):
+        await scope.execute_raw("SELECT 1")

--- a/specs/dataflow-cache.md
+++ b/specs/dataflow-cache.md
@@ -231,6 +231,43 @@ stats = db.transactions.get_stats()
 # {"total_started": int, "total_committed": int, "total_rolled_back": int}
 ```
 
+### 12.6 Multi-Statement Raw-SQL Atomicity
+
+The yielded `TransactionScope` exposes `execute_raw(sql, params=None)`,
+routing every call to the pinned connection. Use this for multi-statement
+patterns the Express API does not express directly (DDL inside a tx,
+SELECT FOR UPDATE + INSERT, complex UPSERT-or-UPDATE).
+
+```python
+async with db.transactions.begin() as tx:
+    existing = await tx.execute_raw(
+        "SELECT id FROM oauth_tokens WHERE user_id = $1 FOR UPDATE",
+        [user_id],
+    )
+    if existing:
+        await tx.execute_raw(
+            "UPDATE oauth_tokens SET refresh_token = $1, "
+            "rotated_at = NOW() WHERE user_id = $2",
+            [new_refresh, user_id],
+        )
+    else:
+        await tx.execute_raw(
+            "INSERT INTO oauth_tokens (user_id, refresh_token) VALUES ($1, $2)",
+            [user_id, new_refresh],
+        )
+    # BEGIN / SELECT / UPDATE-or-INSERT / COMMIT all run on one connection.
+    # Auto-rollback on any exception; auto-commit on clean exit.
+```
+
+Calling `tx.execute_raw` outside the `async with` body raises
+`RuntimeError` per `rules/zero-tolerance.md` Rule 3a (typed delegate
+guard) — the pinned connection only exists while the scope is active.
+
+`db.execute_raw_lightweight()` called inside the `async with` body still
+routes through the pinned connection via the `_active_transaction`
+ContextVar — the two surfaces are functionally equivalent. Prefer
+`tx.execute_raw` for grep-able multi-statement transactions.
+
 ---
 
 ## 13. Connection Pooling
@@ -293,12 +330,12 @@ uniformly.
 created → active → idle → reaped
 ```
 
-| State    | Definition                                                                  | Transition trigger                            |
-| -------- | --------------------------------------------------------------------------- | --------------------------------------------- |
-| created  | Pool exists in `_PROCESS_POOL_REGISTRY` and has run zero queries            | `_get_adapter` returns the new pool           |
-| active   | Pool's `_last_activity_at` was refreshed within `idle_timeout` seconds      | Each `get_connection()` call                  |
-| idle     | `now - _last_activity_at >= idle_timeout`; `is_idle()` returns True         | Time elapses                                  |
-| reaped   | Pool removed from registry; `close()` awaited                               | Reaper task processes idle pool, OR loop dies |
+| State   | Definition                                                             | Transition trigger                            |
+| ------- | ---------------------------------------------------------------------- | --------------------------------------------- |
+| created | Pool exists in `_PROCESS_POOL_REGISTRY` and has run zero queries       | `_get_adapter` returns the new pool           |
+| active  | Pool's `_last_activity_at` was refreshed within `idle_timeout` seconds | Each `get_connection()` call                  |
+| idle    | `now - _last_activity_at >= idle_timeout`; `is_idle()` returns True    | Time elapses                                  |
+| reaped  | Pool removed from registry; `close()` awaited                          | Reaper task processes idle pool, OR loop dies |
 
 **Configurable defaults:**
 


### PR DESCRIPTION
## Summary

- \`db.transactions.begin()\` now yields a \`TransactionScope\` with \`execute_raw(sql, params)\` that routes to the pinned connection — the OAuth-credential-rotation use case from #707 (SELECT FOR UPDATE + UPDATE-or-INSERT in one atomic txn) is now expressible.
- Backward-compatible: \`txn["id"]\` / \`txn["status"]= "..."\` dict-style access preserved via \`__getitem__\` / \`__setitem__\` shim.
- Bundled fix: \`TransactionManager._savepoint\` was being iterated as an async generator (\`async for ctx in ...\`) but is decorated as \`@asynccontextmanager\` — corrected to \`async with self._savepoint() as ctx\`.

## Test plan

- [x] 1/1 outside-scope guard test passes locally (\`test_execute_raw_outside_scope_raises_runtime_error\`)
- [x] 5 Tier 2 regression tests skip cleanly without Postgres on 5434 — CI runs them
- [x] 30/30 sibling \`TransactionScopeNode\` async tests pass (no name collision)
- [x] 3/3 transactions unit tests pass (no Dict→TransactionScope regression)
- [x] \`mypy --strict\` clean on \`transactions.py\`
- [ ] CI Tier 2 regression suite (5 tests) runs against Postgres on 5434

## Related issues

Closes #707
Cross-SDK: kailash-rs#688

🤖 Generated with [Claude Code](https://claude.com/claude-code)