### PR TITLE
release(dataflow-v2.5.0): TransactionScope.execute_raw for multi-statement raw-SQL atomicity

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,6 +1,8 @@
 # DataFlow Changelog
 
-## [Unreleased]
+## [2.5.0] — 2026-04-29 — `TransactionScope.execute_raw` for multi-statement raw-SQL atomicity
+
+Minor release adding the `TransactionScope.execute_raw` surface from issue #707 (closed by PR #716). Backward-compatible: every prior `db.transactions.begin()` consumer keeps working unchanged via the dict-style `__getitem__`/`__setitem__` shim. Bundles a latent savepoint async-context-manager bug fix discovered during implementation review.
 
 ### Added
 

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.4.0"
+version = "2.5.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -108,7 +108,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Minor release-prep for \`kailash-dataflow\` 2.4.0 → 2.5.0.

- Closes #707 via merged PR #716 (TransactionScope.execute_raw — multi-statement raw-SQL atomicity).
- Backward-compatible: existing \`db.transactions.begin()\` callers using dict-style \`txn["id"]\` keep working via \`__getitem__\` / \`__setitem__\` shim.
- Bundled fix: \`TransactionManager._savepoint\` async-context-manager invocation (was incorrectly iterated as async generator).

## Diff

- \`pyproject.toml\` version 2.4.0 → 2.5.0
- \`src/dataflow/__init__.py::__version__\` 2.4.0 → 2.5.0
- \`CHANGELOG.md\` \`[Unreleased]\` → \`[2.5.0] — 2026-04-29\` (with summary header)

## Test plan

- [x] 17 unit tests pass on PR #717 (nexus webhook signer); 1/1 dataflow #707 outside-scope guard passes; 5 Tier 2 regression tests skip cleanly without infra (CI runs them).
- [x] \`mypy --strict\` clean on \`transactions.py\`
- [x] \`pre-commit run\` clean on this PR
- [ ] CI Version Consistency check passes
- [ ] CI Test (Python 3.11–3.14) green
- [ ] Tag \`dataflow-v2.5.0\` triggers \`publish-pypi.yml\` workflow
- [ ] Clean-venv install: \`uv pip install --python <fresh-venv> "kailash-dataflow==2.5.0"\` + \`from dataflow.features import TransactionScope\` (per build-repo-release-discipline.md Rule 2)

## Related

Closes #707
Cross-SDK: kailash-rs#688

🤖 Generated with [Claude Code](https://claude.com/claude-code)