### PR TITLE
release(nexus-v2.4.0): pluggable WebhookSigner + ML mount-path canonicalization

### DIFF
--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Nexus Changelog
 
-## [Unreleased]
+## [2.4.0] — 2026-04-29 — Pluggable WebhookSigner + Twilio support + ML mount-path canonicalization
+
+Minor release adding pluggable webhook signature verification (PR #717, closes #687), canonicalizing the ML mount path documentation (W6-009, closes F-C-26), and registering the long-standing `regression` pytest marker. Backward-compatible: every existing `WebhookTransport(secret=...)` caller sees zero behavior change (default signer preserves the historical `sha256=<hex>` HMAC-SHA256 raw-body shape).
 
 ### Added
 

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.3.0"
+version = "2.4.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -102,7 +102,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 __all__ = [
     # Core
     "Nexus",


### PR DESCRIPTION
## Summary

Minor release-prep for \`kailash-nexus\` 2.3.0 → 2.4.0.

Covers two unreleased workstreams that landed on main since 2.3.0:

- **#687 / PR #717** — pluggable \`WebhookSigner\` Protocol with built-in \`HmacSha256Signer\` (default) + \`TwilioSigner\`. Cross-SDK alignment filed at [esperie-enterprise/kailash-rs#698](https://github.com/esperie-enterprise/kailash-rs/issues/698) with 8 byte-pinned vectors.
- **W6-009** — \`mount_ml_endpoints()\` ML mount-path canonicalization (closes F-C-26): legacy \`Nexus.register_service\` / \`InferenceServer.as_nexus_service\` retracted from spec; Tier-2 invariant test pinning \`mount_ml_endpoints(nexus, serve_handle, *, prefix="/ml")\` as canonical entry.
- **Test infrastructure** — \`regression\` pytest marker registered (clears pre-existing \`PytestUnknownMarkWarning\`).

Backward-compatible: every existing \`WebhookTransport(secret=...)\` caller sees zero behavior change (default signer preserves the historical \`sha256=<hex>\` shape).

## Diff

- \`pyproject.toml\` version 2.3.0 → 2.4.0
- \`src/nexus/__init__.py::__version__\` 2.3.0 → 2.4.0
- \`CHANGELOG.md\` \`[Unreleased]\` → \`[2.4.0] — 2026-04-29\` (with summary header)

## Test plan

- [x] 17/17 Tier-1 webhook signer unit tests pass on PR #717
- [x] 119/119 full \`packages/kailash-nexus/tests/unit/transports/\` suite green
- [x] \`mypy --strict\` clean on \`webhook.py\` (3 pre-existing errors fixed in #717)
- [x] \`pre-commit run\` clean on this PR
- [ ] CI Version Consistency check passes
- [ ] Tag \`nexus-v2.4.0\` triggers \`publish-pypi.yml\` workflow
- [ ] Clean-venv install: \`uv pip install --python <fresh-venv> "kailash-nexus==2.4.0"\` + \`from nexus.transports import WebhookSigner, HmacSha256Signer, TwilioSigner\` (per build-repo-release-discipline.md Rule 2)

## Related

Closes #687
Cross-SDK: esperie-enterprise/kailash-rs#698

🤖 Generated with [Claude Code](https://claude.com/claude-code)