### PR TITLE
fix(nexus): add MountInfo to __all__ per orphan-detection.md Rule 6

### DIFF
--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -131,6 +131,7 @@ __all__ = [
     "EnterpriseMiddlewareConfig",
     # Middleware API
     "MiddlewareInfo",
+    "MountInfo",
     "RouterInfo",
     "NexusPluginProtocol",
     # Preset System


### PR DESCRIPTION
## Summary

\`MountInfo\` (defined at \`nexus/core.py:86\`) is imported at module-scope into \`nexus/__init__.py:36\` but absent from \`__all__\` — pyright surfaces "MountInfo is not accessed", and \`orphan-detection.md\` Rule 6 mandates module-scope public imports MUST appear in \`__all__\`.

Adding \`MountInfo\` to the Middleware API section of \`__all__\`. Sibling entries (\`MiddlewareInfo\`, \`RouterInfo\`, \`NexusPluginProtocol\`) are already in \`__all__\` — \`MountInfo\` was the only one missing, consistent with oversight rather than intent to keep private.

Pre-existing surface — surfaced during the nexus-v2.4.0 release-prep but deferred to a separate PR per \`git.md\` § release-branch convention (metadata-only).

## Test plan

- [x] \`pre-commit run\` clean on this PR
- [ ] CI Test (Python 3.11–3.14) green
- [ ] CI \`MountInfo\` no longer flagged by pyright

## Related

\`rules/orphan-detection.md\` Rule 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)