### PR TITLE
release(nexus-v2.4.1): MountInfo exported in __all__

### DIFF
--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Nexus Changelog
 
+## [2.4.1] — 2026-04-29 — `MountInfo` exported in `__all__`
+
+Patch release closing the build-repo-release-discipline.md Rule 5 drift from PR #720. `MountInfo` (`nexus/core.py`) was already imported at module-scope in `nexus/__init__.py` but absent from `__all__`, triggering `pyright` "MountInfo is not accessed" and violating `orphan-detection.md` Rule 6 (Module-Scope Public Imports Appear In `__all__`). No behavioral change; pure public-API contract repair.
+
+### Fixed
+
+- `MountInfo` added to `__all__` alongside its sibling middleware-API entries (`MiddlewareInfo`, `RouterInfo`, `NexusPluginProtocol`). Pre-existing oversight surfaced during the 2.4.0 release-prep cycle; deferred to this patch per `git.md` § release-branch metadata-only convention.
+
 ## [2.4.0] — 2026-04-29 — Pluggable WebhookSigner + Twilio support + ML mount-path canonicalization
 
 Minor release adding pluggable webhook signature verification (PR #717, closes #687), canonicalizing the ML mount path documentation (W6-009, closes F-C-26), and registering the long-standing `regression` pytest marker. Backward-compatible: every existing `WebhookTransport(secret=...)` caller sees zero behavior change (default signer preserves the historical `sha256=<hex>` HMAC-SHA256 raw-body shape).

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.4.0"
+version = "2.4.1"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -102,7 +102,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 __all__ = [
     # Core
     "Nexus",


### PR DESCRIPTION
## Summary

Patch release-prep for \`kailash-nexus\` 2.4.0 → 2.4.1.

Closes the \`build-repo-release-discipline.md\` Rule 5 drift from merged PR #720 (MountInfo orphan fix landed after the \`nexus-v2.4.0\` tag). No behavioral change — \`MountInfo\` was already importable; this patch only adds it to \`__all__\` to satisfy \`orphan-detection.md\` Rule 6 + pyright.

## Diff

- \`pyproject.toml\` version 2.4.0 → 2.4.1
- \`src/nexus/__init__.py::__version__\` 2.4.0 → 2.4.1
- \`CHANGELOG.md\` new \`[2.4.1] — 2026-04-29\` section

## Test plan

- [x] \`pre-commit run\` clean
- [ ] CI Version Consistency check passes
- [ ] Tag \`nexus-v2.4.1\` triggers \`publish-pypi.yml\`
- [ ] Clean-venv install: \`uv pip install kailash-nexus==2.4.1\` + \`from nexus import MountInfo\` works

## Related

Builds on PR #720 (merged into \`nexus-v2.4.0\` post-tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)