### PR TITLE
fix(kailash): extract shared FastAPI lifespan router-iteration helper (S1 of #712)

### DIFF
--- a/src/kailash/servers/workflow_server.py
+++ b/src/kailash/servers/workflow_server.py
@@ -5,7 +5,6 @@ WorkflowAPIGateway with clearer naming and better organization.
 """
 
 import asyncio
-import inspect
 import logging
 import time
 from collections import defaultdict, deque
@@ -21,6 +20,10 @@ from starlette.websockets import WebSocket
 
 from ..api.workflow_api import WorkflowAPI
 from ..runtime.shutdown import ShutdownCoordinator
+from ..utils.lifespan import (
+    drive_router_lifespan_shutdown,
+    drive_router_lifespan_startup,
+)
 from ..workflow import Workflow
 from .connection_metrics_router import (
     ConnectionMetricsProvider,
@@ -221,20 +224,21 @@ class WorkflowServer:
                 extra={"title": title, "version": version},
             )
             try:
-                # Iterate `router.on_startup` directly rather than
+                # Drive `router.on_startup` via the shared helper rather than
                 # calling a dispatch method. FastAPI has shipped both
-                # `.startup()` (older) and `._startup()` (newer) over
-                # the years and upgrades flip which one exists; the
-                # on_startup list itself is the only stable surface.
-                # Issue #531: nexus 2.1.0 shipped with `app.router.startup()`
-                # which crashed production FastAPI builds that only
-                # expose `_startup`. Driving the list directly matches
-                # what `_DefaultLifespan` does internally and survives
-                # FastAPI/Starlette version churn.
-                for handler in app.router.on_startup:
-                    result = handler()
-                    if inspect.iscoroutine(result):
-                        await result
+                # `.startup()` (older) and `._startup()` (newer) over the
+                # years and upgrades flip which one exists; the on_startup
+                # list itself is the only stable surface. Issue #531: nexus
+                # 2.1.0 shipped with `app.router.startup()` which crashed
+                # production FastAPI builds that only expose `_startup`.
+                # Driving the list directly matches what `_DefaultLifespan`
+                # does internally and survives FastAPI/Starlette version
+                # churn. The helper (kailash.utils.lifespan) is the single
+                # source of truth used by every Kailash FastAPI surface that
+                # sets `lifespan=` so the cross-version invariant lives in
+                # one place — see #712 for the discoverability + multi-site
+                # context.
+                await drive_router_lifespan_startup(app)
                 # Run injected Nexus plugin startup hooks inside uvicorn's
                 # loop so any background tasks they spawn survive (#501).
                 if startup_hook is not None:
@@ -276,10 +280,14 @@ class WorkflowServer:
                         )
                 try:
                     # Paired with the on_startup iteration above — see #531.
-                    for handler in app.router.on_shutdown:
-                        result = handler()
-                        if inspect.iscoroutine(result):
-                            await result
+                    # propagate_errors=False because shutdown is best-effort
+                    # cleanup: one failing on_shutdown handler MUST NOT block
+                    # the ShutdownCoordinator below from running. The helper
+                    # already emits a structured WARN per failing handler
+                    # (observability.md Rule 7), and the ASGI server is
+                    # already tearing down — re-raising here would only mask
+                    # the real shutdown chain.
+                    await drive_router_lifespan_shutdown(app, propagate_errors=False)
                 except Exception:
                     logger.warning(
                         "workflow_server.lifespan.router_shutdown_failed",

--- a/src/kailash/utils/__init__.py
+++ b/src/kailash/utils/__init__.py
@@ -1,8 +1,27 @@
-"""Internal utilities for the Kailash SDK.
+"""Utilities for the Kailash SDK.
 
-This package contains internal implementation utilities that are not part of the public API.
-Users should not directly import from this package.
+This package contains implementation utilities. Most are internal; a small set
+is intentionally public because third-party integrations need them to honor
+framework-version-stable patterns (see ``framework-first.md`` § "Drive The
+Data, Not The Dispatch"):
+
+- :func:`drive_router_lifespan_startup` / :func:`drive_router_lifespan_shutdown`
+  — iterate ``FastAPI.router.on_startup`` / ``on_shutdown`` from a custom
+  ``lifespan=`` context manager so user-registered ``@app.on_event("startup")``
+  handlers fire (#500). Used by every Kailash FastAPI surface that sets
+  ``lifespan=`` (``WorkflowServer``, ``KailashAPIGateway``, ``WorkflowAPIGateway``,
+  ``WorkflowAPI``) and available to user code that does the same.
+
+Other modules (annotations, data_paths, etc.) remain internal — direct imports
+from those are discouraged.
 """
 
-# Internal utilities - not part of public API
-__all__ = []
+from kailash.utils.lifespan import (
+    drive_router_lifespan_shutdown,
+    drive_router_lifespan_startup,
+)
+
+__all__ = [
+    "drive_router_lifespan_shutdown",
+    "drive_router_lifespan_startup",
+]

--- a/src/kailash/utils/lifespan.py
+++ b/src/kailash/utils/lifespan.py
@@ -1,0 +1,188 @@
+"""Shared FastAPI/Starlette router-iteration helpers for custom lifespans.
+
+A custom ``lifespan`` passed to ``FastAPI(lifespan=...)`` REPLACES Starlette's
+default ``_DefaultLifespan``, which is the only code that iterates
+``router.on_startup`` / ``router.on_shutdown``. Custom lifespans that do NOT
+re-iterate those lists silently drop every handler users register via
+``@app.on_event("startup")`` or ``app.router.on_startup.append(...)``. This is
+the #500 bug pattern.
+
+Per ``framework-first.md`` § "Drive The Data, Not The Dispatch", these helpers
+iterate the registered-handlers list — the data structure FastAPI's own
+internal dispatcher walks — instead of calling ``app.router.startup()`` /
+``app.router.shutdown()`` by name. Method names drift across FastAPI/Starlette
+versions (underscore-prefix transitions, removals); the on_startup /
+on_shutdown lists are strictly more stable because the framework's own hooks
+depend on them.
+
+Both helpers handle sync handlers (return ``None``) and async handlers (return
+a coroutine) using ``inspect.iscoroutine(result)`` on the call's return value
+— the same shape ``WorkflowServer`` previously inlined at lines 234-237. They
+ISOLATE per-handler exceptions: one handler raising does NOT prevent the next
+from running. After all handlers run, the FIRST exception is re-raised so the
+ASGI server still sees a startup failure (preserving fail-fast semantics) UNLESS
+``propagate_errors=False`` is passed (useful in shutdown, where best-effort
+cleanup is the norm).
+
+Example (custom lifespan honoring router hooks)::
+
+    from contextlib import asynccontextmanager
+    from fastapi import FastAPI
+    from kailash.utils import drive_router_lifespan_startup, drive_router_lifespan_shutdown
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        await drive_router_lifespan_startup(app)
+        try:
+            yield
+        finally:
+            await drive_router_lifespan_shutdown(app, propagate_errors=False)
+
+    app = FastAPI(lifespan=lifespan)
+    @app.on_event("startup")
+    async def warm_cache(): ...
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+
+async def _drive_handlers(
+    handlers: list,
+    *,
+    phase: str,
+    propagate_errors: bool,
+) -> None:
+    """Iterate ``handlers`` calling each, isolating per-handler failures.
+
+    ``phase`` is a short label ("startup" / "shutdown") used in WARN log lines
+    so an operator can tell which iteration produced the error.
+
+    Per ``observability.md`` Rule 7 (bulk operations log partial failures at
+    WARN), each failing handler emits a structured WARN line with the handler
+    name and traceback. After the loop, the FIRST captured exception is
+    re-raised when ``propagate_errors`` is True — preserving fail-fast for
+    startup so uvicorn aborts boot cleanly. Shutdown callers typically pass
+    ``propagate_errors=False`` because cleanup paths are best-effort and a
+    later handler may still need to run even after an earlier one raises (same
+    carve-out as ``zero-tolerance.md`` Rule 3 for cleanup paths).
+    """
+    first_error: BaseException | None = None
+
+    for handler in list(handlers):
+        handler_name = getattr(handler, "__qualname__", None) or getattr(
+            handler, "__name__", repr(handler)
+        )
+        try:
+            # Match the existing workflow_server.py pattern at lines 234-237:
+            # call the handler, then await the result if it's a coroutine.
+            # This handles both sync (`def`) and async (`async def`) handlers
+            # uniformly without needing to introspect the function itself,
+            # which is brittle when handlers are wrapped (functools.partial,
+            # decorators, etc).
+            result = handler()
+            if inspect.iscoroutine(result):
+                await result
+        except BaseException as exc:  # noqa: BLE001 — isolate per-handler failures
+            # exc_info=True attaches the full traceback to the log record so
+            # operators can see WHERE in the handler the failure happened, not
+            # just the exception class. Per observability.md Rule 7 the WARN
+            # MUST be structured (kwargs / extra), not f-string interpolated.
+            logger.warning(
+                "lifespan.%s.handler_failed",
+                phase,
+                exc_info=True,
+                extra={"handler": handler_name, "phase": phase},
+            )
+            if first_error is None:
+                first_error = exc
+
+    if first_error is not None and propagate_errors:
+        raise first_error
+
+
+async def drive_router_lifespan_startup(
+    app: "FastAPI",
+    *,
+    propagate_errors: bool = True,
+) -> None:
+    """Drive every handler in ``app.router.on_startup`` to completion.
+
+    Iterates ``app.router.on_startup`` — the SAME list Starlette's default
+    lifespan walks internally — calling each handler in registration order.
+    Sync handlers (return ``None``) are accepted; async handlers (return a
+    coroutine) are awaited.
+
+    Per-handler exceptions are isolated: if handler N raises, handlers N+1,
+    N+2, ... still run. After all handlers complete, the FIRST captured
+    exception is re-raised when ``propagate_errors`` is True (the default).
+    This preserves fail-fast semantics at startup — uvicorn aborts the boot
+    cleanly when any registered hook fails, matching what
+    ``_DefaultLifespan.startup`` would have produced.
+
+    Pass ``propagate_errors=False`` to log-only without re-raising. This is
+    rarely correct at startup but available for symmetry with shutdown.
+
+    Args:
+        app: The FastAPI application whose ``router.on_startup`` to drive.
+        propagate_errors: If True (default), re-raise the first captured
+            handler exception after all handlers complete. If False, log
+            failures and return normally.
+
+    Why a helper module: three sibling FastAPI sites (``KailashAPIGateway``,
+    ``WorkflowAPIGateway``, ``WorkflowAPI``) construct ``FastAPI`` with
+    ``lifespan=`` set but do NOT iterate ``on_startup`` — they ship the same
+    #500 silent-drop bug as the pre-fix ``WorkflowServer``. Routing every
+    site through one helper localizes the cross-version invariant per
+    ``framework-first.md`` § "Drive The Data".
+    """
+    await _drive_handlers(
+        app.router.on_startup,
+        phase="startup",
+        propagate_errors=propagate_errors,
+    )
+
+
+async def drive_router_lifespan_shutdown(
+    app: "FastAPI",
+    *,
+    propagate_errors: bool = True,
+) -> None:
+    """Drive every handler in ``app.router.on_shutdown`` to completion.
+
+    Symmetric to :func:`drive_router_lifespan_startup`. Iterates
+    ``app.router.on_shutdown`` calling each handler, awaiting coroutines, and
+    isolating per-handler exceptions.
+
+    By default the FIRST captured exception is re-raised after all handlers
+    complete (``propagate_errors=True``). Shutdown callers commonly pass
+    ``propagate_errors=False`` because cleanup paths are best-effort: one
+    failing cleanup handler MUST NOT prevent later handlers from running, and
+    the ASGI server is already tearing down — re-raising serves no purpose
+    beyond the WARN log lines this helper already emits.
+
+    Args:
+        app: The FastAPI application whose ``router.on_shutdown`` to drive.
+        propagate_errors: If True (default), re-raise the first captured
+            handler exception after all handlers complete. If False, log
+            failures and return normally — the typical shutdown choice.
+    """
+    await _drive_handlers(
+        app.router.on_shutdown,
+        phase="shutdown",
+        propagate_errors=propagate_errors,
+    )
+
+
+__all__ = [
+    "drive_router_lifespan_startup",
+    "drive_router_lifespan_shutdown",
+]

--- a/tests/integration/utils/test_lifespan_helper_with_fastapi.py
+++ b/tests/integration/utils/test_lifespan_helper_with_fastapi.py
@@ -1,0 +1,208 @@
+"""Tier 2 integration tests — drive_router_lifespan_* against real FastAPI.
+
+The Tier 1 unit suite at ``tests/unit/utils/test_lifespan_helper.py`` proves
+the helper's contract in isolation via a router stub. This Tier 2 suite
+proves the WIRING: that the helper, when called from a custom ``lifespan=``
+context manager, actually drives the handlers registered on a real
+``FastAPI.router.on_startup`` / ``on_shutdown`` list.
+
+Per ``testing.md`` § 3-Tier Testing, Tier 2 uses NO mocking — these tests
+construct a real ``FastAPI`` app and drive its lifespan via Starlette's own
+public ``app.router.lifespan_context(app)`` async context manager. This is
+the same API uvicorn calls in production at lifespan boot/teardown, and the
+same API Starlette's internal test infrastructure uses to run lifespan in
+tests. It also avoids the ``@app.on_event`` deprecation warning surface (per
+``zero-tolerance.md`` Rule 1) by registering hooks via
+``app.router.add_event_handler`` and the public ``router.on_startup`` /
+``router.on_shutdown`` lists — the SAME lists ``@app.on_event`` writes to
+internally and the SAME lists the helper iterates.
+
+End-to-end coverage of the helper through the FULL uvicorn HTTP transport
+already exists at ``tests/regression/test_issue_500_router_on_startup.py``,
+which boots an actual uvicorn server on a real socket. This file covers the
+helper layer DIRECTLY with the lifespan API, independent of any HTTP server
+or ASGI transport.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import pytest
+from fastapi import FastAPI
+
+from kailash.utils.lifespan import (
+    drive_router_lifespan_shutdown,
+    drive_router_lifespan_startup,
+)
+
+
+def _make_app_with_helper_lifespan() -> FastAPI:
+    """Build a FastAPI app whose lifespan is driven by the shared helper.
+
+    The custom ``lifespan=`` here is the EXACT pattern WorkflowServer (and
+    the three sibling FastAPI sites patched in MED-S2) use: a custom
+    asynccontextmanager that calls the helper to drive ``router.on_startup``
+    / ``router.on_shutdown``. Without those helper calls, the custom
+    lifespan replaces Starlette's default and silently drops every
+    user-registered hook (the #500 bug).
+    """
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        await drive_router_lifespan_startup(app)
+        try:
+            yield
+        finally:
+            # Best-effort shutdown — matches WorkflowServer's call site at
+            # workflow_server.py:283-292: one failing on_shutdown handler
+            # MUST NOT block siblings or the ShutdownCoordinator.
+            await drive_router_lifespan_shutdown(app, propagate_errors=False)
+
+    return FastAPI(lifespan=lifespan)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_helper_drives_router_on_startup_via_lifespan_context() -> None:
+    """Hooks registered on ``router.on_startup`` MUST fire under the helper.
+
+    This is the #500 reproducer pattern: register a hook on the router's
+    on_startup list (the public API ``@app.on_event("startup")`` writes to),
+    then drive lifespan via the SAME context manager Starlette/uvicorn
+    drive in production. Pre-helper, the hook was silently dropped because
+    the custom lifespan replaced Starlette's default. Post-helper, both
+    sync and async hooks fire in registration order.
+    """
+    app = _make_app_with_helper_lifespan()
+    events: list[str] = []
+
+    async def warm_cache() -> None:
+        events.append("startup_async")
+
+    def init_metrics() -> None:  # sync handler
+        events.append("startup_sync")
+
+    # Register via the public router.add_event_handler API. This is what
+    # @app.on_event("startup") does internally; using it directly avoids
+    # the FastAPI on_event DeprecationWarning while exercising the SAME
+    # router.on_startup list the helper iterates.
+    app.router.add_event_handler("startup", warm_cache)
+    app.router.add_event_handler("startup", init_metrics)
+
+    # Drive lifespan via Starlette's own public context manager — the SAME
+    # API uvicorn invokes at boot. No HTTP transport needed; the helper
+    # runs to completion when the context manager enters.
+    async with app.router.lifespan_context(app):
+        # Inside the lifespan: app is "running". Both handlers fired during
+        # the __aenter__ phase before yielding control here.
+        assert events == ["startup_async", "startup_sync"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_helper_drives_router_on_shutdown_via_lifespan_context() -> None:
+    """Hooks on ``router.on_shutdown`` MUST fire when the lifespan exits."""
+    app = _make_app_with_helper_lifespan()
+    events: list[str] = []
+
+    async def flush_metrics() -> None:
+        events.append("shutdown_async")
+
+    def close_pool() -> None:  # sync handler
+        events.append("shutdown_sync")
+
+    app.router.add_event_handler("shutdown", flush_metrics)
+    app.router.add_event_handler("shutdown", close_pool)
+
+    async with app.router.lifespan_context(app):
+        # Inside the lifespan — shutdown handlers haven't fired yet.
+        assert events == []
+
+    # After __aexit__: the helper's drive_router_lifespan_shutdown ran in
+    # the lifespan's `finally:` and walked router.on_shutdown.
+    assert events == ["shutdown_async", "shutdown_sync"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_helper_handles_router_on_startup_append_pattern() -> None:
+    """``app.router.on_startup.append(fn)`` MUST fire — the #500 minimal repro.
+
+    This is the EXACT pattern from the #500 issue body: bypass the
+    add_event_handler API, append directly to the list. Pre-fix, this hook
+    was silently dropped because the custom lifespan didn't iterate the
+    list. Post-fix (helper), it fires.
+    """
+    app = _make_app_with_helper_lifespan()
+    events: list[str] = []
+
+    async def my_startup() -> None:
+        events.append("router_append")
+
+    app.router.on_startup.append(my_startup)
+
+    async with app.router.lifespan_context(app):
+        assert events == ["router_append"], (
+            "router.on_startup.append handler did not fire — this is the "
+            "#500 regression class. Helper must iterate router.on_startup."
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_helper_runs_all_startup_handlers_even_when_one_raises() -> None:
+    """Handler isolation MUST hold under a real FastAPI lifespan.
+
+    Per the helper's contract: handler N raising MUST NOT prevent N+1. The
+    Tier 1 suite tests this through a router stub; this Tier 2 test
+    confirms the behavior survives the real Starlette lifespan_context API.
+
+    The first handler's exception propagates out of the `async with`
+    because drive_router_lifespan_startup uses propagate_errors=True by
+    default — preserving fail-fast for startup so uvicorn aborts cleanly.
+    """
+    app = _make_app_with_helper_lifespan()
+    events: list[str] = []
+
+    def first() -> None:
+        events.append("first")
+
+    async def second_raises() -> None:
+        events.append("second")
+        raise RuntimeError("intentional failure for isolation test")
+
+    def third() -> None:
+        events.append("third")
+
+    app.router.add_event_handler("startup", first)
+    app.router.add_event_handler("startup", second_raises)
+    app.router.add_event_handler("startup", third)
+
+    with pytest.raises(RuntimeError, match="intentional failure"):
+        async with app.router.lifespan_context(app):
+            # Should never reach here — startup raised.
+            pytest.fail("lifespan body executed despite startup failure")
+
+    # Critical assertion: ALL THREE handlers ran despite the middle raising.
+    # This is the helper's per-handler-isolation contract under real FastAPI.
+    assert events == ["first", "second", "third"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_helper_with_no_handlers_is_noop_under_real_fastapi() -> None:
+    """A FastAPI app with zero on_event hooks MUST drive lifespan cleanly.
+
+    Empty-list path is the most common case for a freshly built app; the
+    helper MUST not raise when the lists are empty AND lifespan must
+    complete its full enter/exit cycle.
+    """
+    app = _make_app_with_helper_lifespan()
+    body_ran = False
+
+    async with app.router.lifespan_context(app):
+        body_ran = True
+
+    assert body_ran, "lifespan body did not execute"

--- a/tests/unit/utils/test_lifespan_helper.py
+++ b/tests/unit/utils/test_lifespan_helper.py
@@ -1,0 +1,290 @@
+"""Tier 1 unit tests for ``kailash.utils.lifespan``.
+
+These tests cover the helper's contract in isolation using a tiny stub object
+that exposes the same ``router.on_startup`` / ``router.on_shutdown`` shape
+FastAPI exposes — sufficient for unit coverage of the iteration semantics.
+
+The shared helper lives at ``src/kailash/utils/lifespan.py`` and is consumed
+by every Kailash FastAPI surface that sets a custom ``lifespan=`` (per
+``framework-first.md`` § "Drive The Data, Not The Dispatch"). This file
+exercises:
+
+- sync handler dispatch (``def`` returning ``None``)
+- async handler dispatch (``async def`` returning a coroutine)
+- mixed sync + async dispatch in registration order
+- per-handler exception isolation (handler N raises, N+1 still runs)
+- first-exception re-raise after the loop completes
+- ``propagate_errors=False`` log-only behavior
+- empty list = no-op (no spurious raises)
+
+A real FastAPI app is exercised in the Tier 2 integration test sibling at
+``tests/integration/utils/test_lifespan_helper_with_fastapi.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kailash.utils.lifespan import (
+    drive_router_lifespan_shutdown,
+    drive_router_lifespan_startup,
+)
+
+
+class _RouterStub:
+    """Minimal stand-in for ``FastAPI.router`` exposing the two list surfaces."""
+
+    def __init__(self) -> None:
+        self.on_startup: list = []
+        self.on_shutdown: list = []
+
+
+class _AppStub:
+    """Minimal stand-in for ``FastAPI`` exposing only ``.router``."""
+
+    def __init__(self) -> None:
+        self.router = _RouterStub()
+
+
+# ---------------------------------------------------------------------------
+# Startup helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_dispatches_sync_handler() -> None:
+    """Sync handlers (return None) MUST be invoked exactly once."""
+    app = _AppStub()
+    calls: list[str] = []
+
+    def sync_handler() -> None:
+        calls.append("sync")
+
+    app.router.on_startup.append(sync_handler)
+
+    await drive_router_lifespan_startup(app)
+
+    assert calls == ["sync"]
+
+
+@pytest.mark.asyncio
+async def test_startup_dispatches_async_handler() -> None:
+    """Async handlers (return a coroutine) MUST be awaited."""
+    app = _AppStub()
+    calls: list[str] = []
+
+    async def async_handler() -> None:
+        calls.append("async")
+
+    app.router.on_startup.append(async_handler)
+
+    await drive_router_lifespan_startup(app)
+
+    assert calls == ["async"]
+
+
+@pytest.mark.asyncio
+async def test_startup_dispatches_mixed_sync_and_async_in_order() -> None:
+    """Mixed registrations MUST execute in registration order."""
+    app = _AppStub()
+    calls: list[str] = []
+
+    def sync_first() -> None:
+        calls.append("sync_first")
+
+    async def async_second() -> None:
+        calls.append("async_second")
+
+    def sync_third() -> None:
+        calls.append("sync_third")
+
+    app.router.on_startup.extend([sync_first, async_second, sync_third])
+
+    await drive_router_lifespan_startup(app)
+
+    assert calls == ["sync_first", "async_second", "sync_third"]
+
+
+@pytest.mark.asyncio
+async def test_startup_isolates_handler_exceptions() -> None:
+    """A raise in handler N MUST NOT prevent handler N+1 from running.
+
+    The helper's contract: every registered handler runs exactly once even
+    when an earlier one raises. After the loop completes, the FIRST captured
+    exception is re-raised so uvicorn aborts cleanly. This test asserts both
+    invariants on a 3-handler list where the middle handler fails.
+    """
+    app = _AppStub()
+    calls: list[str] = []
+
+    def first_runs() -> None:
+        calls.append("first")
+
+    async def second_raises() -> None:
+        calls.append("second")
+        raise RuntimeError("boom from second")
+
+    def third_still_runs() -> None:
+        calls.append("third")
+
+    app.router.on_startup.extend([first_runs, second_raises, third_still_runs])
+
+    with pytest.raises(RuntimeError, match="boom from second"):
+        await drive_router_lifespan_startup(app)
+
+    # Critically: ALL THREE handlers ran despite the middle one raising.
+    assert calls == ["first", "second", "third"]
+
+
+@pytest.mark.asyncio
+async def test_startup_reraises_first_exception_when_multiple_fail() -> None:
+    """When N>1 handlers raise, the FIRST one is the one re-raised.
+
+    Preserves the "first failure wins" semantics callers reason about when
+    debugging — the operator sees the actual root cause in the traceback,
+    not the last failure to fire.
+    """
+    app = _AppStub()
+
+    def raises_a() -> None:
+        raise ValueError("first error")
+
+    def raises_b() -> None:
+        raise RuntimeError("second error")
+
+    app.router.on_startup.extend([raises_a, raises_b])
+
+    with pytest.raises(ValueError, match="first error"):
+        await drive_router_lifespan_startup(app)
+
+
+@pytest.mark.asyncio
+async def test_startup_propagate_errors_false_swallows_after_logging(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """propagate_errors=False MUST log + suppress; all handlers still run."""
+    app = _AppStub()
+    calls: list[str] = []
+
+    def first_raises() -> None:
+        calls.append("first")
+        raise RuntimeError("ignored failure")
+
+    async def second_runs() -> None:
+        calls.append("second")
+
+    app.router.on_startup.extend([first_raises, second_runs])
+
+    caplog.set_level(logging.WARNING, logger="kailash.utils.lifespan")
+    # No raise expected.
+    await drive_router_lifespan_startup(app, propagate_errors=False)
+
+    assert calls == ["first", "second"]
+    # Verify the failure was logged at WARN with the structured event name.
+    warns = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("lifespan.startup.handler_failed" in r.message for r in warns), warns
+
+
+@pytest.mark.asyncio
+async def test_startup_empty_list_is_noop() -> None:
+    """An empty on_startup MUST NOT raise — common case for apps with no hooks."""
+    app = _AppStub()
+    # No handlers registered at all.
+    await drive_router_lifespan_startup(app)
+
+
+# ---------------------------------------------------------------------------
+# Shutdown helper — symmetric coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shutdown_dispatches_sync_handler() -> None:
+    app = _AppStub()
+    calls: list[str] = []
+
+    def sync_handler() -> None:
+        calls.append("sync")
+
+    app.router.on_shutdown.append(sync_handler)
+
+    await drive_router_lifespan_shutdown(app)
+
+    assert calls == ["sync"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_dispatches_async_handler() -> None:
+    app = _AppStub()
+    calls: list[str] = []
+
+    async def async_handler() -> None:
+        calls.append("async")
+
+    app.router.on_shutdown.append(async_handler)
+
+    await drive_router_lifespan_shutdown(app)
+
+    assert calls == ["async"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_isolates_handler_exceptions() -> None:
+    """Symmetric with startup — middle handler raise does not block siblings."""
+    app = _AppStub()
+    calls: list[str] = []
+
+    def first_runs() -> None:
+        calls.append("first")
+
+    async def second_raises() -> None:
+        calls.append("second")
+        raise RuntimeError("shutdown boom")
+
+    def third_still_runs() -> None:
+        calls.append("third")
+
+    app.router.on_shutdown.extend([first_runs, second_raises, third_still_runs])
+
+    with pytest.raises(RuntimeError, match="shutdown boom"):
+        await drive_router_lifespan_shutdown(app)
+
+    assert calls == ["first", "second", "third"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_propagate_errors_false_swallows_after_logging(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """propagate_errors=False is the typical shutdown choice — log, don't raise.
+
+    Mirrors the WorkflowServer call site which passes propagate_errors=False
+    so a failing on_shutdown handler does NOT block ShutdownCoordinator.
+    """
+    app = _AppStub()
+    calls: list[str] = []
+
+    def first_raises() -> None:
+        calls.append("first")
+        raise RuntimeError("cleanup failure")
+
+    async def second_runs() -> None:
+        calls.append("second")
+
+    app.router.on_shutdown.extend([first_raises, second_runs])
+
+    caplog.set_level(logging.WARNING, logger="kailash.utils.lifespan")
+    await drive_router_lifespan_shutdown(app, propagate_errors=False)
+
+    assert calls == ["first", "second"]
+    warns = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("lifespan.shutdown.handler_failed" in r.message for r in warns), warns
+
+
+@pytest.mark.asyncio
+async def test_shutdown_empty_list_is_noop() -> None:
+    """Empty on_shutdown MUST NOT raise — symmetric with startup."""
+    app = _AppStub()
+    await drive_router_lifespan_shutdown(app)


### PR DESCRIPTION
## Summary

First shard of #712 cluster — extracts the FastAPI/Starlette `router.on_startup` / `on_shutdown` iteration semantic into a single shared helper module. Refactors the existing inline iteration in `WorkflowServer` to call the helper. Sibling FastAPI sites (3 confirmed unmitigated) and the new public `Nexus.add_startup_handler` API land in subsequent PRs.

## Changes

- New `src/kailash/utils/lifespan.py` — `drive_router_lifespan_startup(app)` + `drive_router_lifespan_shutdown(app)` helpers with per-handler exception isolation
- `src/kailash/utils/__init__.py` — exports both via `__all__`
- `src/kailash/servers/workflow_server.py` — refactored `lifespan` to call the new helpers (was inline `for handler in app.router.on_startup`)
- 12 Tier-1 unit tests + 5 Tier-2 integration tests
- Existing `tests/regression/test_issue_500_router_on_startup.py` preserved (still green)

## Test plan

- [x] `pytest tests/unit/utils/test_lifespan_helper.py` — 12 passing
- [x] `pytest tests/integration/utils/test_lifespan_helper_with_fastapi.py` — 5 passing
- [x] `pytest tests/regression/test_issue_500_router_on_startup.py` — still passing
- [x] Pre-commit clean on shard files
- [x] `grep` verification: zero `router.on_startup` iteration outside the helper

## Why this matters

`@app.on_event("startup")` worked under `WorkflowServer` thanks to inline router-iteration added by #533/#540 fix for #500/#501/#531. But three other public FastAPI-constructing classes (`KailashAPIGateway`, `WorkflowAPIGateway`, `WorkflowAPI`) construct FastAPI with custom `lifespan=` AND do NOT iterate the router — silent #500-class bugs. Per `rules/security.md` § Multi-Site Kwarg Plumbing, the helper extraction localizes the cross-version invariant so all four sites can call the same code (siblings patched in next PR).

## Related issues

Part of #712 (v2.13.0 downstream incident cluster — #712/#713/#714). Workspace: `workspaces/issues-712-714/`. See `01-analysis/01-architecture.md` and todo `S1-extract-lifespan-helper.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
