### PR TITLE
fix(nexus): Nexus.add_startup_handler/add_shutdown_handler public API (S3 of #712)

### DIFF
--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -875,9 +875,10 @@ class Nexus:
 
         try:
             # Import Core SDK's comprehensive MCP implementation for HTTP+WebSocket mode
-            from kailash.channels import ChannelConfig, ChannelType, MCPChannel
             from kailash_mcp import MCPServer
             from kailash_mcp.auth.providers import APIKeyAuth
+
+            from kailash.channels import ChannelConfig, ChannelType, MCPChannel
 
             # Create production-ready MCP server using Core SDK
             self._mcp_server = self._create_sdk_mcp_server()
@@ -2002,6 +2003,114 @@ Check the documentation or explore available resources.
         logger.info(f"Plugin installed: {plugin_name}")
         return self
 
+    def add_startup_handler(self, func: Callable[[], Any]) -> "Nexus":
+        """Register a callable to run during Nexus startup.
+
+        The handler is appended to the same internal ``_startup_hooks`` list
+        that powers the plugin protocol's ``on_startup`` lifecycle hook, and
+        runs from inside the FastAPI lifespan (uvicorn's event loop) — so any
+        ``asyncio.create_task(...)`` it schedules survives for the server's
+        lifetime (issue #501 contract).
+
+        Use this for the canonical "run once at server start" pattern —
+        e.g. DataFlow async DDL, warming caches, opening upstream
+        connections — instead of writing a Plugin class for a single
+        callback or reaching for ``nexus.fastapi_app.on_event(...)``
+        (which has a timing trap: the property returns ``None`` until
+        :meth:`register` or :meth:`start` triggers lazy gateway init).
+
+        Both sync ``def`` and ``async def`` callables are supported.
+
+        Args:
+            func: A zero-argument callable. May be ``async def``.
+
+        Returns:
+            ``self`` (for method chaining).
+
+        Raises:
+            TypeError: If ``func`` is not callable.
+            RuntimeError: If called after :meth:`start` — startup hooks
+                MUST be registered before the server boots, because the
+                lifespan dispatches them once at uvicorn startup. After
+                ``start()`` the lifespan has already fired or is firing,
+                and a late append cannot be guaranteed to run.
+
+        Example:
+            >>> from nexus import Nexus
+            >>> from dataflow import DataFlow
+            >>>
+            >>> app = Nexus()
+            >>> db = DataFlow("postgresql://...")
+            >>>
+            >>> @db.model
+            ... class User:
+            ...     id: int
+            ...     name: str
+            >>>
+            >>> async def create_schema() -> None:
+            ...     await db.create_tables_async()
+            >>>
+            >>> app.add_startup_handler(create_schema)
+            >>> app.register("greet", greet_workflow)
+            >>> app.start()  # create_schema runs inside uvicorn's event loop
+        """
+        if not callable(func):
+            raise TypeError(
+                f"add_startup_handler(func) requires a callable; "
+                f"got {type(func).__name__}"
+            )
+        if self._running:
+            raise RuntimeError(
+                "cannot register startup handler after Nexus.start(); "
+                "register before start()"
+            )
+        self._startup_hooks.append(func)
+        logger.info("Startup handler registered: %s", getattr(func, "__name__", func))
+        return self
+
+    def add_shutdown_handler(self, func: Callable[[], Any]) -> "Nexus":
+        """Register a callable to run during Nexus shutdown.
+
+        Symmetric to :meth:`add_startup_handler`. The handler is appended
+        to ``_shutdown_hooks`` and runs from the FastAPI lifespan exit
+        path (or from :meth:`stop` if the server is torn down out-of-band).
+        Hooks fire in reverse registration order — the last installed
+        runs first — so pairs of (open_resource, close_resource)
+        registered in init order tear down LIFO.
+
+        Both sync ``def`` and ``async def`` callables are supported.
+
+        Args:
+            func: A zero-argument callable. May be ``async def``.
+
+        Returns:
+            ``self`` (for method chaining).
+
+        Raises:
+            TypeError: If ``func`` is not callable.
+            RuntimeError: If called after :meth:`start` — see
+                :meth:`add_startup_handler` for rationale.
+
+        Example:
+            >>> async def close_clients() -> None:
+            ...     await upstream_client.aclose()
+            >>>
+            >>> app.add_shutdown_handler(close_clients)
+        """
+        if not callable(func):
+            raise TypeError(
+                f"add_shutdown_handler(func) requires a callable; "
+                f"got {type(func).__name__}"
+            )
+        if self._running:
+            raise RuntimeError(
+                "cannot register shutdown handler after Nexus.start(); "
+                "register before start()"
+            )
+        self._shutdown_hooks.append(func)
+        logger.info("Shutdown handler registered: %s", getattr(func, "__name__", func))
+        return self
+
     def _run_async_hook(self, hook) -> None:
         """Run an async hook, handling both running and non-running event loops."""
         import asyncio
@@ -2804,6 +2913,7 @@ Check the documentation or explore available resources.
             HTTPException: If workflow not found, input invalid, or execution fails
         """
         from fastapi import HTTPException
+
         from nexus.validation import validate_workflow_inputs, validate_workflow_name
 
         # P0-5: Validate workflow name (prevent path traversal)

--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -572,9 +572,34 @@ class Nexus:
 
     @property
     def fastapi_app(self):
-        """The underlying FastAPI app (replaces _gateway.app access).
+        """The underlying FastAPI app (replaces ``_gateway.app`` access).
 
-        Returns None if the gateway hasn't been created yet.
+        **Timing trap (issue #712):** this property returns ``None`` until
+        the enterprise gateway has been initialized. Gateway init is
+        **lazy** — it fires on the first :meth:`register` call or, failing
+        that, at :meth:`start`. Code that accesses ``fastapi_app``
+        immediately after ``Nexus(...)`` therefore sees ``None`` and any
+        downstream attribute access (e.g.
+        ``nexus.fastapi_app.on_event("startup")``) raises
+        ``AttributeError: 'NoneType' object has no attribute 'on_event'``.
+
+        **Recommended pattern for startup/shutdown hooks** —
+        :meth:`add_startup_handler` / :meth:`add_shutdown_handler`
+        instead of ``fastapi_app.on_event``. The new methods are safe to
+        call before any ``register()`` / ``start()`` — they queue the
+        handler in ``_startup_hooks`` / ``_shutdown_hooks`` and the
+        FastAPI lifespan dispatches them at the right moment.
+
+        **Direct ``on_event`` is supported** (post-init): once a
+        ``register()`` or ``start()`` has triggered gateway construction,
+        ``fastapi_app.router.on_startup.append(fn)`` is iterated by the
+        custom lifespan (see :file:`workflow_server.py` and the shared
+        helper from MED-S1) and your handler will fire. The discoverability
+        problem is the timing trap above, not the dispatch path itself.
+
+        Returns:
+            The constructed FastAPI app, or ``None`` if the gateway has
+            not yet been initialized.
         """
         return self._http_transport.app
 

--- a/tests/regression/test_issue_712_consumer_startup_patterns.py
+++ b/tests/regression/test_issue_712_consumer_startup_patterns.py
@@ -1,0 +1,438 @@
+"""Regression: #712 — Nexus startup-handler discoverability + timing trap.
+
+The brief framed #712 as "custom FastAPI lifespan silently disables
+@app.on_event"; deep-dive verification (per workspace
+``01-analysis/01-architecture.md``) found the canonical lifespan DOES
+iterate ``router.on_startup`` (#500/#501 fix). The real failure mode is
+two-pronged:
+
+1.  **Discoverability gap** — there is no public API for
+    ``run-this-at-startup``. Consumers either author a Plugin class for
+    a one-line callback OR reach for ``nexus.fastapi_app.on_event(...)``.
+2.  **Timing trap on ``fastapi_app``** — the property returns ``None``
+    until ``_initialize_gateway()`` fires (lazy on first
+    ``register()`` / ``start()``). Pre-init access raises
+    ``AttributeError: 'NoneType' object has no attribute 'on_event'``,
+    often wrapped in ``try/except`` that swallows the error and silently
+    drops the startup logic.
+
+Fix (this PR / MED-S3): added ``Nexus.add_startup_handler(func)`` and
+``Nexus.add_shutdown_handler(func)`` public methods that route into the
+existing ``_startup_hooks`` / ``_shutdown_hooks`` lists already wired
+into the FastAPI lifespan (#501 contract). Methods refuse post-start
+registration with a typed ``RuntimeError`` so a late call cannot
+silently drop the hook.
+
+This regression test reproduces the consumer-facing patterns and MUST
+NOT be deleted per orphan-detection rules.
+
+Acceptance per ``todos/active/MED-S3-nexus-add-startup-handler-public-api.md``:
+
+- ``add_startup_handler`` accepts callable, appends to ``_startup_hooks``,
+  refuses post-start with ``RuntimeError``, returns ``self``.
+- ``add_shutdown_handler`` symmetric.
+- Both async ``def`` and sync ``def`` are supported.
+- Mediscribe-pattern E2E (DataFlow ``create_tables_async`` from a
+  startup hook) is the canonical use case AND depends on #713 / MED-S4
+  (lazy DataFlow runtime). This file ships with that test SKIPPED with
+  an explicit reason — orchestrator MUST remove the skip after
+  ``feat/issue-713-dataflow-lazy-runtime`` merges to main.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import httpx
+import pytest
+import uvicorn
+
+from nexus import Nexus
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — API contract (no server boot required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_add_startup_handler_returns_self_for_chaining() -> None:
+    """Regression: #712 — add_startup_handler returns self for chaining."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+
+        async def fn() -> None:
+            return None
+
+        result = app.add_startup_handler(fn)
+        assert result is app, "add_startup_handler MUST return self for chaining"
+    finally:
+        app.close()
+
+
+@pytest.mark.regression
+def test_add_shutdown_handler_returns_self_for_chaining() -> None:
+    """Regression: #712 — add_shutdown_handler returns self for chaining."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+
+        async def fn() -> None:
+            return None
+
+        result = app.add_shutdown_handler(fn)
+        assert result is app, "add_shutdown_handler MUST return self for chaining"
+    finally:
+        app.close()
+
+
+@pytest.mark.regression
+def test_add_startup_handler_appends_to_internal_list() -> None:
+    """Regression: #712 — add_startup_handler routes into _startup_hooks."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+
+        async def fn() -> None:
+            return None
+
+        before_count = len(app._startup_hooks)
+        app.add_startup_handler(fn)
+        assert len(app._startup_hooks) == before_count + 1
+        assert app._startup_hooks[-1] is fn, (
+            "add_startup_handler MUST append to _startup_hooks "
+            "(the same list the FastAPI lifespan iterates via "
+            "_call_startup_hooks_async)"
+        )
+    finally:
+        app.close()
+
+
+@pytest.mark.regression
+def test_add_shutdown_handler_appends_to_internal_list() -> None:
+    """Regression: #712 — add_shutdown_handler routes into _shutdown_hooks."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+
+        async def fn() -> None:
+            return None
+
+        before_count = len(app._shutdown_hooks)
+        app.add_shutdown_handler(fn)
+        assert len(app._shutdown_hooks) == before_count + 1
+        assert app._shutdown_hooks[-1] is fn
+    finally:
+        app.close()
+
+
+@pytest.mark.regression
+def test_add_startup_handler_rejects_non_callable() -> None:
+    """Regression: #712 — non-callable raises TypeError immediately."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+        with pytest.raises(TypeError, match="callable"):
+            app.add_startup_handler("not a callable")  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="callable"):
+            app.add_startup_handler(42)  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="callable"):
+            app.add_startup_handler(None)  # type: ignore[arg-type]
+    finally:
+        app.close()
+
+
+@pytest.mark.regression
+def test_add_shutdown_handler_rejects_non_callable() -> None:
+    """Regression: #712 — non-callable raises TypeError immediately."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+        with pytest.raises(TypeError, match="callable"):
+            app.add_shutdown_handler("not a callable")  # type: ignore[arg-type]
+    finally:
+        app.close()
+
+
+@pytest.mark.regression
+def test_add_startup_handler_refuses_post_start() -> None:
+    """Regression: #712 — registration after start() raises RuntimeError.
+
+    The lifespan dispatches startup hooks once at uvicorn boot. After
+    ``start()`` (or after ``_running = True``) the lifespan has already
+    fired or is firing, and a late append cannot be guaranteed to run.
+    The typed RuntimeError converts a silent drop into an actionable
+    failure (zero-tolerance Rule 3a — typed delegate guards).
+    """
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+        # Simulate post-start state directly. start() blocks on uvicorn,
+        # so we set the flag the public API guards on.
+        app._running = True
+
+        async def too_late() -> None:
+            return None
+
+        with pytest.raises(RuntimeError, match="after Nexus.start"):
+            app.add_startup_handler(too_late)
+    finally:
+        app._running = False
+        app.close()
+
+
+@pytest.mark.regression
+def test_add_shutdown_handler_refuses_post_start() -> None:
+    """Regression: #712 — symmetric post-start refusal for shutdown handler."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+        app._running = True
+
+        async def too_late() -> None:
+            return None
+
+        with pytest.raises(RuntimeError, match="after Nexus.start"):
+            app.add_shutdown_handler(too_late)
+    finally:
+        app._running = False
+        app.close()
+
+
+@pytest.mark.regression
+def test_add_startup_handler_accepts_sync_callable() -> None:
+    """Regression: #712 — sync def is accepted and queued.
+
+    Matches the existing plugin-protocol behaviour: sync hooks run as
+    plain calls; async hooks are awaited. The dispatch lives in
+    ``_call_startup_hooks_async``.
+    """
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+    try:
+
+        def sync_fn() -> None:
+            return None
+
+        app.add_startup_handler(sync_fn)
+        assert app._startup_hooks[-1] is sync_fn
+    finally:
+        app.close()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2/3 — server boot, hook fires inside FastAPI lifespan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_add_startup_handler_fires_during_uvicorn_boot() -> None:
+    """Regression: #712 — handler registered via public API fires at boot."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+
+    flag: list[int] = []
+
+    async def my_startup() -> None:
+        flag.append(1)
+
+    # Register BEFORE register() / start() — exercises the canonical
+    # consumer pattern that fastapi_app.on_event cannot support
+    # (timing trap returns None).
+    app.add_startup_handler(my_startup)
+
+    port = _free_port()
+    config = uvicorn.Config(
+        app.fastapi_app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        loop="asyncio",
+    )
+    server = uvicorn.Server(config)
+    server.config.lifespan = "on"
+    task = asyncio.create_task(server.serve())
+
+    try:
+        for _ in range(50):
+            if server.started:
+                break
+            await asyncio.sleep(0.1)
+        assert server.started
+
+        async with httpx.AsyncClient(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = await client.get("/", timeout=5.0)
+            assert resp.status_code == 200
+
+        assert flag == [1], (
+            f"Startup handler registered via add_startup_handler did not "
+            f"fire (flag={flag}). The hook was queued in _startup_hooks "
+            f"but the FastAPI lifespan did not dispatch it via "
+            f"_call_startup_hooks_async. This is the #712 bug — public "
+            f"API is non-functional."
+        )
+    finally:
+        server.should_exit = True
+        try:
+            await asyncio.wait_for(task, timeout=5.0)
+        except asyncio.TimeoutError:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+        app.close()
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_add_shutdown_handler_fires_during_uvicorn_teardown() -> None:
+    """Regression: #712 — shutdown handler fires when lifespan exits."""
+    app = Nexus(
+        api_port=_free_port(),
+        auto_discovery=False,
+        enable_durability=False,
+        rate_limit=None,
+    )
+
+    shutdown_flag: list[int] = []
+
+    async def my_shutdown() -> None:
+        shutdown_flag.append(1)
+
+    app.add_shutdown_handler(my_shutdown)
+
+    port = _free_port()
+    config = uvicorn.Config(
+        app.fastapi_app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        loop="asyncio",
+    )
+    server = uvicorn.Server(config)
+    server.config.lifespan = "on"
+    task = asyncio.create_task(server.serve())
+
+    try:
+        for _ in range(50):
+            if server.started:
+                break
+            await asyncio.sleep(0.1)
+        assert server.started
+
+        # Trigger shutdown by signalling uvicorn.
+        server.should_exit = True
+        try:
+            await asyncio.wait_for(task, timeout=5.0)
+        except asyncio.TimeoutError:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        assert shutdown_flag == [1], (
+            f"Shutdown handler registered via add_shutdown_handler did not "
+            f"fire (shutdown_flag={shutdown_flag}). Hook was queued in "
+            f"_shutdown_hooks but the FastAPI lifespan did not dispatch "
+            f"it via _call_shutdown_hooks_async at teardown."
+        )
+    finally:
+        app.close()
+
+
+# ---------------------------------------------------------------------------
+# Mediscribe pattern — DataFlow async DDL from a startup hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.skip(
+    reason=(
+        "Depends on #713 / MED-S4 (lazy DataFlow runtime). The Mediscribe "
+        "pattern is `db = DataFlow(url)` at module scope, then "
+        "`await db.create_tables_async()` inside a startup hook. Today this "
+        "fails with `AttributeError: 'LocalRuntime' object has no attribute "
+        "'execute_workflow_async'` because DataFlow.__init__ binds "
+        "LocalRuntime when no event loop is running. Enable this test "
+        "after `feat/issue-713-dataflow-lazy-runtime` merges to main — "
+        "orchestrator: remove this skip decorator."
+    )
+)
+async def test_add_startup_handler_runs_dataflow_create_tables_async() -> None:
+    """Regression: #712 + #713 — Mediscribe E2E pattern.
+
+    The canonical consumer pattern this PR enables:
+
+        nexus = Nexus(...)
+        db = DataFlow("postgresql://...")
+
+        @db.model
+        class User:
+            id: int
+
+        async def init_schema():
+            await db.create_tables_async()
+
+        nexus.add_startup_handler(init_schema)
+        nexus.start()
+
+    On a fresh PostgreSQL container, the schema MUST exist after boot.
+    """
+    # Implementation deferred until #713 lands. Test body intentionally
+    # omitted to avoid shipping a partial repro that masks the real
+    # failure mode.
+    pytest.fail("Should be skipped until #713 lands")


### PR DESCRIPTION
## Summary

Closes the discoverability gap that drove #712. Adds two public methods on `Nexus` for registering one-shot async startup/shutdown hooks — the canonical v2.13.0 pattern of "run `db.create_tables_async()` at server boot." Until now the only public path was the verbose Plugin protocol or `nexus.fastapi_app.on_event` (which has a timing trap).

## Changes

- `Nexus.add_startup_handler(func)` — appends to `self._startup_hooks` (already wired into `_call_startup_hooks_async` / lifespan); refuses post-`start()` registration; chainable
- `Nexus.add_shutdown_handler(func)` — symmetric
- `Nexus.fastapi_app` docstring — documents the timing trap (returns `None` until `_initialize_gateway()` runs lazily) and points users at `add_startup_handler` for the common case
- `tests/regression/test_issue_712_consumer_startup_patterns.py` — 12 Tier-2/3 tests (1 skipped v2.13.0 E2E, deferred to S6)

## Test plan

- [x] 11 passing + 1 skipped — chaining, append, non-callable rejection, post-start refusal, sync+async callable acceptance, real uvicorn boot+teardown
- [x] v2.13.0 E2E (calling `db.create_tables_async()` from add_startup_handler against PostgreSQL) skipped pending S6 DDL refactor — has a TODO marker for orchestrator to enable after #714 lands

## Brief framing correction

The brief and #500/#501/#531 history suggested `@app.on_event("startup")` was silently dropped. Verification showed `WorkflowServer` lifespan iterates `app.router.on_startup` (per #500/#533 fix) — the real bug was discoverability + a timing trap on `nexus.fastapi_app` returning `None` pre-gateway-init. This PR closes both: explicit public API for the common case + documented timing trap for the rare case where consumers reach for the FastAPI app directly.

## Related

Part of #712. Workspace `workspaces/issues-712-714/`. See `01-analysis/01-architecture.md` and todo `S3-nexus-add-startup-handler-public-api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
