### PR TITLE
fix(dataflow): subsystems follow parent runtime swap (S5 of #713)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -758,7 +758,11 @@ class DataFlow(DataFlowEventMixin):
         # Initialize model registry for multi-application support
         from .model_registry import ModelRegistry
 
-        self._model_registry = ModelRegistry(self, runtime=self.runtime)
+        # MED-S5: drop eager runtime=self.runtime — pins _explicit_runtime at
+        # construction time and defeats lazy parent-lookup. ModelRegistry.runtime
+        # is now a @property returning self._dataflow.runtime when no explicit
+        # override is set, which is exactly the post-S4 behavior we want.
+        self._model_registry = ModelRegistry(self)
 
         # Cache integration (initialized lazily in _ensure_connected)
         self._cache_integration = None
@@ -1529,6 +1533,10 @@ class DataFlow(DataFlowEventMixin):
                     dir_err,
                 )
 
+            # MED-S5: drop eager runtime=self.runtime — same reasoning as
+            # ModelRegistry construction. AutoMigrationSystem.runtime is now a
+            # @property returning self._dataflow.runtime when no explicit
+            # override is set.
             self._migration_system = AutoMigrationSystem(
                 connection_string=self.config.database.get_connection_url(
                     self.config.environment
@@ -1537,7 +1545,6 @@ class DataFlow(DataFlowEventMixin):
                 migrations_dir=migrations_dir,
                 dataflow_instance=self,
                 lock_timeout=self._migration_lock_timeout,
-                runtime=self.runtime,
             )
 
             logger.debug(

--- a/packages/kailash-dataflow/src/dataflow/core/model_registry.py
+++ b/packages/kailash-dataflow/src/dataflow/core/model_registry.py
@@ -63,48 +63,45 @@ class ModelRegistry:
 
         Args:
             dataflow_instance: The DataFlow instance this registry belongs to.
-            runtime: Optional shared runtime. If provided, the registry acquires
-                a reference (ref-count increment) and uses it for all workflow
-                executions. If None, creates its own runtime with async-context
-                detection to prevent deadlocks.
+            runtime: Optional explicit runtime override. When supplied, the
+                registry pins this runtime for its lifetime (legacy escape
+                hatch). When omitted (the post-MED-S5 default), every
+                ``self.runtime`` access reads ``dataflow_instance.runtime``
+                lazily so the registry follows the parent's runtime swap
+                (issue #713 — manual ``db.runtime = AsyncLocalRuntime()``
+                or first-async-access via S4's per-event-loop cache).
             migration_system: Optional migration system for transactional operations.
         """
         self.dataflow = dataflow_instance
+        # MED-S5: hold a back-reference to the parent so ``self.runtime``
+        # (now a @property below) can resolve lazily on each access.
+        # Pre-S5 the registry snapshotted ``dataflow.runtime`` once at
+        # construction; post-S5 it follows the parent's lazy property
+        # (S4) which detects async context per access.
+        self._dataflow = dataflow_instance
 
         if runtime is not None:
-            # Shared runtime provided — acquire a reference so the caller's
-            # close() won't tear down the loop while we still need it.
+            # Legacy explicit-runtime escape hatch. Acquire a reference so
+            # the caller's close() won't tear down the loop while we
+            # still need it. The pinned runtime overrides the parent's
+            # lazy resolution for this registry only.
             if hasattr(runtime, "acquire"):
-                self.runtime = runtime.acquire()
+                self._explicit_runtime = runtime.acquire()
                 logger.debug(
                     "ModelRegistry: Using injected runtime (ref_count=%d)",
                     getattr(runtime, "ref_count", 0),
                 )
             else:
-                self.runtime = runtime
+                self._explicit_runtime = runtime
             self._owns_runtime = False
-            self._is_async = isinstance(runtime, AsyncLocalRuntime)
         else:
-            # No runtime provided — create our own (backward-compatible path).
-            # Detect async context to prevent deadlocks in FastAPI / pytest-async.
-            try:
-                asyncio.get_running_loop()
-                self.runtime = AsyncLocalRuntime()
-                self._is_async = True
-                logger.debug(
-                    "ModelRegistry: Detected async context, using AsyncLocalRuntime"
-                )
-            except RuntimeError:
-                # The registry manages the runtime's lifecycle via
-                # close() → runtime.release() (ref-count cleanup). Use
-                # the public opt-out so Core SDK suppresses the ad-hoc
-                # usage deprecation warning AND skips atexit cleanup —
-                # the registry calls close() at its own shutdown.
-                # See issue #478.
-                self.runtime = LocalRuntime().mark_externally_managed()
-                self._is_async = False
-                logger.debug("ModelRegistry: Detected sync context, using LocalRuntime")
-            self._owns_runtime = True
+            # No explicit runtime — defer to parent's lazy property.
+            # ``self.runtime`` (the property) will route every read to
+            # ``self._dataflow.runtime`` so swaps on the parent (manual
+            # ``db.runtime = X`` or first-async-access cache fill) are
+            # visible to this registry without snapshot drift.
+            self._explicit_runtime = None
+            self._owns_runtime = False
 
         self.migration_system = migration_system
         self._initialized = False
@@ -134,6 +131,74 @@ class ModelRegistry:
             logger.warning(
                 "TransactionManager not available, operations will not be transactional"
             )
+
+    # ------------------------------------------------------------------
+    # MED-S5 (issue #713): lazy runtime / _is_async via parent DataFlow.
+    #
+    # Pre-MED-S5 the registry stored ``self.runtime`` and ``self._is_async``
+    # as plain attributes set once in ``__init__``. Once the parent
+    # DataFlow's runtime swapped (manual ``db.runtime = X`` setter or
+    # first-async-access via S4's per-event-loop cache fill), the
+    # registry kept the stale snapshot and either crashed (sync runtime
+    # used inside an event loop) or routed through the wrong loop.
+    #
+    # Post-MED-S5 ``self.runtime`` is a @property that resolves on each
+    # access:
+    #
+    # 1. If a legacy explicit-runtime override was supplied to
+    #    ``__init__`` (``self._explicit_runtime`` is not None), return
+    #    that pinned runtime — the caller is in charge of its lifecycle.
+    # 2. Otherwise return ``self._dataflow.runtime`` — the parent's
+    #    own lazy property (issue #713 MED-S4 implementation), which
+    #    handles per-event-loop caching, sync singleton fallback, and
+    #    setter override.
+    #
+    # ``self._is_async`` is derived from the resolved runtime so it
+    # never drifts from ``self.runtime``.
+    # ------------------------------------------------------------------
+
+    @property
+    def runtime(self) -> Any:
+        """The runtime used by this registry (lazy parent lookup)."""
+        if self._explicit_runtime is not None:
+            return self._explicit_runtime
+        return self._dataflow.runtime
+
+    @runtime.setter
+    def runtime(self, value: Any) -> None:
+        """Assignment-compat setter.
+
+        Two legitimate writes reach this setter:
+
+        * ``self.runtime = None`` from ``close()`` — clears the explicit
+          override so subsequent reads (if any) return ``None``-like
+          state from the parent's closed runtime.
+        * Direct test-time assignment for backwards compatibility with
+          callers that monkey-patched the registry's runtime directly.
+        """
+        self._explicit_runtime = value
+
+    @property
+    def _is_async(self) -> bool:
+        """Whether the active runtime is an :class:`AsyncLocalRuntime`.
+
+        Derived from ``self.runtime`` so it always agrees with the
+        currently-resolved runtime — including after a parent runtime
+        swap.
+        """
+        return isinstance(self.runtime, AsyncLocalRuntime)
+
+    @_is_async.setter
+    def _is_async(self, value: bool) -> None:
+        """No-op setter for backwards compatibility.
+
+        Pre-MED-S5 callers wrote ``self._is_async = True`` alongside
+        ``self.runtime = AsyncLocalRuntime()``. The flag is now derived,
+        so this write is ignored — the next read recomputes from
+        ``self.runtime``.
+        """
+        # Intentional no-op: derived property.
+        pass
 
     def _execute_workflow_sync_safe(
         self, workflow: Any
@@ -1740,21 +1805,31 @@ class ModelRegistry:
                     raise
 
     def close(self):
-        """Release the runtime reference.
+        """Release the explicit runtime reference if one was provided.
 
         Safe to call multiple times — subsequent calls are no-ops.
-        If this registry created its own runtime (_owns_runtime=True),
-        close() decrements its ref-count which triggers cleanup when it
-        reaches zero. If using a shared runtime, close() merely releases
-        one reference so the owner can still use it.
+        Post-MED-S5 the registry no longer owns the runtime in the
+        common case (it delegates to ``self._dataflow.runtime`` which is
+        managed by the parent DataFlow). Only the legacy explicit
+        ``runtime=`` constructor argument creates a reference this
+        registry must release here.
         """
-        if hasattr(self, "runtime") and self.runtime is not None:
-            self.runtime.release()
-            self.runtime = None
+        explicit = getattr(self, "_explicit_runtime", None)
+        if explicit is not None and hasattr(explicit, "release"):
+            explicit.release()
+        # Clear the override either way so subsequent reads fall back
+        # to the parent (which itself returns None when closed).
+        self._explicit_runtime = None
 
     def __del__(self, _warnings=warnings):
-        """Emit ResourceWarning if close() was not called explicitly."""
-        if getattr(self, "runtime", None) is not None:
+        """Emit ResourceWarning if close() was not called explicitly.
+
+        Only fires when this registry held an explicit runtime override
+        (legacy path). The lazy-parent path holds no resource of its
+        own — the parent DataFlow's own ``__del__`` / ``close()`` is
+        responsible for cleaning up the per-event-loop cache.
+        """
+        if getattr(self, "_explicit_runtime", None) is not None:
             _warnings.warn(
                 f"Unclosed {self.__class__.__name__}. Call close() explicitly.",
                 ResourceWarning,

--- a/packages/kailash-dataflow/src/dataflow/gateway_integration.py
+++ b/packages/kailash-dataflow/src/dataflow/gateway_integration.py
@@ -62,15 +62,20 @@ class DataFlowGateway:
         pool_config: Optional[Dict[str, Any]] = None,
         # Runtime injection
         runtime=None,
+        dataflow_instance=None,
         **kwargs,
     ):
         """Initialize DataFlow Gateway.
 
         Args:
-            runtime: Optional shared runtime. If provided, the gateway acquires
-                a reference (ref-count increment) and uses it for all workflow
-                executions. If None, creates its own runtime with async-context
-                detection to prevent deadlocks.
+            runtime: Optional explicit runtime override (legacy path).
+                When supplied, pinned for the gateway's lifetime.
+            dataflow_instance: Optional DataFlow parent reference. When
+                supplied, ``self.runtime`` resolves lazily via
+                ``dataflow_instance.runtime`` on every access (issue
+                #713 — MED-S5 lazy lookup). Without this parameter the
+                gateway creates and owns its own runtime (legacy
+                self-owned path).
         """
         self.name = name
         self.description = description
@@ -87,20 +92,27 @@ class DataFlowGateway:
         self.enable_monitoring = enable_monitoring
         self.enable_connection_pooling = enable_connection_pooling
 
-        # Initialize runtime
+        # MED-S5 (issue #713): hold parent back-reference so self.runtime
+        # / self._is_async can resolve lazily on each access.
+        self._dataflow = dataflow_instance
+
         if runtime is not None:
-            self.runtime = runtime.acquire()
+            # Legacy explicit-runtime escape hatch.
+            self._explicit_runtime = runtime.acquire()
             self._owns_runtime = False
-            self._is_async = isinstance(runtime, AsyncLocalRuntime)
             logger.debug(
                 "DataFlowGateway: Using injected runtime (ref_count=%d)",
                 runtime.ref_count,
             )
+        elif dataflow_instance is not None:
+            # Lazy parent lookup — no runtime owned here.
+            self._explicit_runtime = None
+            self._owns_runtime = False
         else:
+            # Legacy self-owned path (no parent + no explicit runtime).
             try:
                 asyncio.get_running_loop()
-                self.runtime = AsyncLocalRuntime()
-                self._is_async = True
+                self._explicit_runtime = AsyncLocalRuntime()
                 logger.debug(
                     "DataFlowGateway: Detected async context, using AsyncLocalRuntime"
                 )
@@ -109,8 +121,7 @@ class DataFlowGateway:
                 # public opt-out so Core SDK suppresses the ad-hoc-usage
                 # deprecation warning AND skips atexit cleanup; the gateway
                 # calls close() at its own shutdown.
-                self.runtime = LocalRuntime().mark_externally_managed()
-                self._is_async = False
+                self._explicit_runtime = LocalRuntime().mark_externally_managed()
                 logger.debug(
                     "DataFlowGateway: Detected sync context, using LocalRuntime"
                 )
@@ -701,18 +712,47 @@ class DataFlowGateway:
             )
             await self.nexus.stop()
 
+    # ------------------------------------------------------------------
+    # MED-S5 (issue #713): lazy runtime via parent DataFlow.
+    # ------------------------------------------------------------------
+
+    @property
+    def runtime(self) -> Any:
+        """The runtime used by this gateway (lazy parent lookup)."""
+        if self._explicit_runtime is not None:
+            return self._explicit_runtime
+        if self._dataflow is not None:
+            return self._dataflow.runtime
+        return None
+
+    @runtime.setter
+    def runtime(self, value: Any) -> None:
+        self._explicit_runtime = value
+
+    @property
+    def _is_async(self) -> bool:
+        return isinstance(self.runtime, AsyncLocalRuntime)
+
+    @_is_async.setter
+    def _is_async(self, value: bool) -> None:
+        pass  # No-op — derived property.
+
     def close(self):
-        """Release the runtime reference.
+        """Release the explicit runtime reference if one was provided.
 
         Safe to call multiple times -- subsequent calls are no-ops.
+        Post-MED-S5: only the legacy explicit-runtime path or the
+        self-owned fallback (no parent dataflow_instance) holds a
+        reference here.
         """
-        if hasattr(self, "runtime") and self.runtime is not None:
-            self.runtime.release()
-            self.runtime = None
+        explicit = getattr(self, "_explicit_runtime", None)
+        if explicit is not None and hasattr(explicit, "release"):
+            explicit.release()
+        self._explicit_runtime = None
 
     def __del__(self, _warnings=warnings):
         """Emit ResourceWarning if close() was not called explicitly."""
-        if getattr(self, "runtime", None) is not None:
+        if getattr(self, "_explicit_runtime", None) is not None:
             _warnings.warn(
                 f"Unclosed {self.__class__.__name__}. Call close() explicitly.",
                 ResourceWarning,

--- a/packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py
@@ -239,41 +239,44 @@ class SchemaDiff:
 class PostgreSQLSchemaInspector:
     """PostgreSQL schema inspector for DataFlow with advanced optimizations."""
 
-    def __init__(self, connection_string, runtime=None):
+    def __init__(self, connection_string, runtime=None, dataflow_instance=None):
         """
         Initialize PostgreSQL schema inspector.
 
         Args:
             connection_string: Database connection string
-            runtime: Optional shared runtime. If provided, the inspector acquires
-                a reference (ref-count increment). If None, creates its own.
+            runtime: Optional explicit runtime override (legacy path).
+            dataflow_instance: Optional DataFlow parent reference. When
+                supplied, ``self.runtime`` resolves lazily via
+                ``dataflow_instance.runtime`` on every access (issue
+                #713 — MED-S5 lazy lookup).
         """
         self.connection_string = connection_string
+        # MED-S5: hold parent back-reference for lazy runtime lookup.
+        self._dataflow = dataflow_instance
 
-        # Initialize runtime
         if runtime is not None:
-            self.runtime = runtime.acquire()
+            self._explicit_runtime = runtime.acquire()
             self._owns_runtime = False
-            self._is_async = isinstance(runtime, AsyncLocalRuntime)
             logger.debug(
                 "PostgreSQLSchemaInspector: Using injected runtime (ref_count=%d)",
                 runtime.ref_count,
             )
+        elif dataflow_instance is not None:
+            # Lazy parent lookup — no runtime owned here.
+            self._explicit_runtime = None
+            self._owns_runtime = False
         else:
+            # Legacy self-owned path (no parent + no explicit runtime).
             try:
                 asyncio.get_running_loop()
-                self.runtime = AsyncLocalRuntime()
-                self._is_async = True
+                self._explicit_runtime = AsyncLocalRuntime()
                 logger.debug(
                     "PostgreSQLSchemaInspector: Detected async context, using AsyncLocalRuntime"
                 )
             except RuntimeError:
-                # Issue #478 — registry-style long-lived runtime.  Use the
-                # public opt-out so Core SDK suppresses the ad-hoc-usage
-                # deprecation warning AND skips atexit cleanup; the
-                # inspector calls close() at its own shutdown.
-                self.runtime = LocalRuntime().mark_externally_managed()
-                self._is_async = False
+                # Issue #478 — registry-style long-lived runtime.
+                self._explicit_runtime = LocalRuntime().mark_externally_managed()
                 logger.debug(
                     "PostgreSQLSchemaInspector: Detected sync context, using LocalRuntime"
                 )
@@ -579,18 +582,47 @@ class PostgreSQLSchemaInspector:
 
         return False
 
+    # ------------------------------------------------------------------
+    # MED-S5 (issue #713): lazy runtime via parent DataFlow.
+    # ------------------------------------------------------------------
+
+    @property
+    def runtime(self) -> Any:
+        """The runtime used by this inspector (lazy parent lookup)."""
+        if self._explicit_runtime is not None:
+            return self._explicit_runtime
+        if self._dataflow is not None:
+            return self._dataflow.runtime
+        return None
+
+    @runtime.setter
+    def runtime(self, value: Any) -> None:
+        self._explicit_runtime = value
+
+    @property
+    def _is_async(self) -> bool:
+        return isinstance(self.runtime, AsyncLocalRuntime)
+
+    @_is_async.setter
+    def _is_async(self, value: bool) -> None:
+        pass  # No-op — derived property.
+
     def close(self):
-        """Release the runtime reference.
+        """Release the explicit runtime reference if one was provided.
 
         Safe to call multiple times -- subsequent calls are no-ops.
+        Post-MED-S5: only the legacy explicit-runtime path or the
+        self-owned fallback (no parent dataflow_instance) holds a
+        reference here.
         """
-        if hasattr(self, "runtime") and self.runtime is not None:
-            self.runtime.release()
-            self.runtime = None
+        explicit = getattr(self, "_explicit_runtime", None)
+        if explicit is not None and hasattr(explicit, "release"):
+            explicit.release()
+        self._explicit_runtime = None
 
     def __del__(self, _warnings=warnings):
         """Emit ResourceWarning if close() was not called explicitly."""
-        if getattr(self, "runtime", None) is not None:
+        if getattr(self, "_explicit_runtime", None) is not None:
             _warnings.warn(
                 f"Unclosed {self.__class__.__name__}. Call close() explicitly.",
                 ResourceWarning,
@@ -997,31 +1029,37 @@ class PostgreSQLMigrationGenerator:
 class SQLiteSchemaInspector:
     """SQLite schema inspector for DataFlow."""
 
-    def __init__(self, connection_string, runtime=None):
+    def __init__(self, connection_string, runtime=None, dataflow_instance=None):
         """
         Initialize SQLite schema inspector.
 
         Args:
             connection_string: Database connection string
-            runtime: Optional shared runtime. If provided, the inspector acquires
-                a reference (ref-count increment). If None, creates its own.
+            runtime: Optional explicit runtime override (legacy path).
+            dataflow_instance: Optional DataFlow parent reference. When
+                supplied, ``self.runtime`` resolves lazily via
+                ``dataflow_instance.runtime`` (issue #713 — MED-S5).
         """
         self.connection_string = connection_string
+        # MED-S5: hold parent back-reference for lazy runtime lookup.
+        self._dataflow = dataflow_instance
 
-        # Initialize runtime
         if runtime is not None:
-            self.runtime = runtime.acquire()
+            self._explicit_runtime = runtime.acquire()
             self._owns_runtime = False
-            self._is_async = isinstance(runtime, AsyncLocalRuntime)
             logger.debug(
                 "SQLiteSchemaInspector: Using injected runtime (ref_count=%d)",
                 runtime.ref_count,
             )
+        elif dataflow_instance is not None:
+            # Lazy parent lookup — no runtime owned here.
+            self._explicit_runtime = None
+            self._owns_runtime = False
         else:
+            # Legacy self-owned path.
             try:
                 asyncio.get_running_loop()
-                self.runtime = AsyncLocalRuntime()
-                self._is_async = True
+                self._explicit_runtime = AsyncLocalRuntime()
                 logger.debug(
                     "SQLiteSchemaInspector: Detected async context, using AsyncLocalRuntime"
                 )
@@ -1030,8 +1068,7 @@ class SQLiteSchemaInspector:
                 # public opt-out so Core SDK suppresses the ad-hoc-usage
                 # deprecation warning AND skips atexit cleanup; the
                 # inspector calls close() at its own shutdown.
-                self.runtime = LocalRuntime().mark_externally_managed()
-                self._is_async = False
+                self._explicit_runtime = LocalRuntime().mark_externally_managed()
                 logger.debug(
                     "SQLiteSchemaInspector: Detected sync context, using LocalRuntime"
                 )
@@ -1277,18 +1314,44 @@ class SQLiteSchemaInspector:
 
         return diff
 
+    # ------------------------------------------------------------------
+    # MED-S5 (issue #713): lazy runtime via parent DataFlow.
+    # ------------------------------------------------------------------
+
+    @property
+    def runtime(self) -> Any:
+        """The runtime used by this inspector (lazy parent lookup)."""
+        if self._explicit_runtime is not None:
+            return self._explicit_runtime
+        if self._dataflow is not None:
+            return self._dataflow.runtime
+        return None
+
+    @runtime.setter
+    def runtime(self, value: Any) -> None:
+        self._explicit_runtime = value
+
+    @property
+    def _is_async(self) -> bool:
+        return isinstance(self.runtime, AsyncLocalRuntime)
+
+    @_is_async.setter
+    def _is_async(self, value: bool) -> None:
+        pass  # No-op — derived property.
+
     def close(self):
-        """Release the runtime reference.
+        """Release the explicit runtime reference if one was provided.
 
         Safe to call multiple times -- subsequent calls are no-ops.
         """
-        if hasattr(self, "runtime") and self.runtime is not None:
-            self.runtime.release()
-            self.runtime = None
+        explicit = getattr(self, "_explicit_runtime", None)
+        if explicit is not None and hasattr(explicit, "release"):
+            explicit.release()
+        self._explicit_runtime = None
 
     def __del__(self, _warnings=warnings):
         """Emit ResourceWarning if close() was not called explicitly."""
-        if getattr(self, "runtime", None) is not None:
+        if getattr(self, "_explicit_runtime", None) is not None:
             _warnings.warn(
                 f"Unclosed {self.__class__.__name__}. Call close() explicitly.",
                 ResourceWarning,
@@ -1582,27 +1645,47 @@ class AutoMigrationSystem:
             connection_string: Database connection string
             dialect: Database dialect (auto-detected from connection string)
             migrations_dir: Directory for migration files
-            dataflow_instance: Optional DataFlow instance
+            dataflow_instance: Optional DataFlow instance. When provided,
+                ``self.runtime`` resolves lazily via
+                ``dataflow_instance.runtime`` on every access (issue
+                #713 — follows the parent's lazy property without
+                snapshot drift).
             lock_timeout: Lock timeout in seconds
-            runtime: Optional shared runtime. If provided, the system acquires
-                a reference (ref-count increment). If None, creates its own.
+            runtime: Optional explicit runtime override. When supplied,
+                pinned for the system's lifetime. When omitted AND
+                ``dataflow_instance`` is None, falls back to legacy
+                self-owned runtime (async-context detection).
         """
         self.connection_string = connection_string
 
-        # Initialize runtime
+        # MED-S5 (issue #713): hold parent back-reference so self.runtime
+        # / self._is_async can resolve lazily on each access. Pre-S5 the
+        # system snapshotted at __init__; post-S5 it follows the parent's
+        # lazy property (S4) which detects async context per access.
+        self._dataflow = dataflow_instance
+
         if runtime is not None:
-            self.runtime = runtime.acquire()
+            # Legacy explicit-runtime escape hatch. Acquire a reference
+            # so the caller's close() won't tear down the loop while we
+            # still need it.
+            self._explicit_runtime = runtime.acquire()
             self._owns_runtime = False
-            self._is_async = isinstance(runtime, AsyncLocalRuntime)
             logger.debug(
                 "AutoMigrationSystem: Using injected runtime (ref_count=%d)",
                 runtime.ref_count,
             )
+        elif dataflow_instance is not None:
+            # No explicit runtime AND parent available — defer to parent
+            # via the @property (lazy lookup, follows db.runtime swaps).
+            self._explicit_runtime = None
+            self._owns_runtime = False
         else:
+            # No explicit runtime AND no parent — legacy self-owned
+            # runtime path (preserved for callers that build the system
+            # standalone, e.g. CLI migration tools).
             try:
                 asyncio.get_running_loop()
-                self.runtime = AsyncLocalRuntime()
-                self._is_async = True
+                self._explicit_runtime = AsyncLocalRuntime()
                 logger.debug(
                     "AutoMigrationSystem: Detected async context, using AsyncLocalRuntime"
                 )
@@ -1611,8 +1694,7 @@ class AutoMigrationSystem:
                 # public opt-out so Core SDK suppresses the ad-hoc-usage
                 # deprecation warning AND skips atexit cleanup; the system
                 # calls close() at its own shutdown.
-                self.runtime = LocalRuntime().mark_externally_managed()
-                self._is_async = False
+                self._explicit_runtime = LocalRuntime().mark_externally_managed()
                 logger.debug(
                     "AutoMigrationSystem: Detected sync context, using LocalRuntime"
                 )
@@ -1658,15 +1740,21 @@ class AutoMigrationSystem:
         self.migrations_dir = Path(migrations_dir)
         self.migrations_dir.mkdir(exist_ok=True)
 
-        # Use database-specific components (pass shared runtime to sub-components)
+        # Use database-specific components (pass parent reference for lazy
+        # runtime lookup; legacy explicit-runtime path falls back when no
+        # parent is available — see MED-S5 / issue #713).
         if self.dialect == "sqlite":
             self.inspector = SQLiteSchemaInspector(
-                connection_string, runtime=self.runtime
+                connection_string,
+                runtime=self._explicit_runtime if self._dataflow is None else None,
+                dataflow_instance=self._dataflow,
             )
             self.generator = SQLiteMigrationGenerator()
         else:
             self.inspector = PostgreSQLSchemaInspector(
-                connection_string, runtime=self.runtime
+                connection_string,
+                runtime=self._explicit_runtime if self._dataflow is None else None,
+                dataflow_instance=self._dataflow,
             )
             self.generator = PostgreSQLMigrationGenerator()
 
@@ -1676,6 +1764,35 @@ class AutoMigrationSystem:
 
         # DataFlow integration: existing schema mode
         self._existing_schema_mode: bool = False
+
+    # ------------------------------------------------------------------
+    # MED-S5 (issue #713): lazy runtime / _is_async via parent DataFlow.
+    # See ModelRegistry for the same pattern + rationale.
+    # ------------------------------------------------------------------
+
+    @property
+    def runtime(self) -> Any:
+        """The runtime used by this system (lazy parent lookup)."""
+        if self._explicit_runtime is not None:
+            return self._explicit_runtime
+        if self._dataflow is not None:
+            return self._dataflow.runtime
+        return None
+
+    @runtime.setter
+    def runtime(self, value: Any) -> None:
+        """Assignment-compat setter; sets the explicit override."""
+        self._explicit_runtime = value
+
+    @property
+    def _is_async(self) -> bool:
+        """Whether the active runtime is :class:`AsyncLocalRuntime`."""
+        return isinstance(self.runtime, AsyncLocalRuntime)
+
+    @_is_async.setter
+    def _is_async(self, value: bool) -> None:
+        """No-op setter — derived from ``self.runtime`` post-MED-S5."""
+        pass
 
     def _detect_database_type(self, connection_string: str) -> str:
         """Detect database type from connection string."""
@@ -3076,20 +3193,30 @@ class AutoMigrationSystem:
             raise RuntimeError(f"Lock table creation failed: {error_msg}")
 
     def close(self):
-        """Release the runtime reference.
+        """Release the explicit runtime reference if one was provided.
 
         Safe to call multiple times -- subsequent calls are no-ops.
         Also closes sub-component runtimes (inspector).
+
+        Post-MED-S5: only the legacy explicit-runtime path or the
+        self-owned fallback (no parent dataflow_instance) holds a
+        reference here. The lazy-parent path delegates lifecycle to
+        the parent DataFlow, so this close() is a no-op for that case.
         """
         if hasattr(self, "inspector") and self.inspector is not None:
             self.inspector.close()
-        if hasattr(self, "runtime") and self.runtime is not None:
-            self.runtime.release()
-            self.runtime = None
+        explicit = getattr(self, "_explicit_runtime", None)
+        if explicit is not None and hasattr(explicit, "release"):
+            explicit.release()
+        self._explicit_runtime = None
 
     def __del__(self, _warnings=warnings):
-        """Emit ResourceWarning if close() was not called explicitly."""
-        if getattr(self, "runtime", None) is not None:
+        """Emit ResourceWarning if close() was not called explicitly.
+
+        Only fires when the system held an explicit runtime override or
+        a self-owned runtime (legacy / no-parent paths).
+        """
+        if getattr(self, "_explicit_runtime", None) is not None:
             _warnings.warn(
                 f"Unclosed {self.__class__.__name__}. Call close() explicitly.",
                 ResourceWarning,

--- a/packages/kailash-dataflow/src/dataflow/migrations/schema_state_manager.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/schema_state_manager.py
@@ -670,48 +670,63 @@ class MigrationHistoryManager:
         Initialize migration history manager.
 
         Args:
-            dataflow_instance: DataFlow instance for database access via WorkflowBuilder
-            runtime: Optional shared runtime. If provided, the manager acquires
-                a reference (ref-count increment). If None, creates its own.
+            dataflow_instance: DataFlow instance for database access via
+                WorkflowBuilder. Post-MED-S5 (issue #713) ``self.runtime``
+                resolves lazily via ``dataflow_instance.runtime`` on every
+                access so the manager follows the parent's runtime swap
+                without snapshot drift.
+            runtime: Optional explicit runtime override (legacy path).
+                When supplied, pinned for the manager's lifetime.
         """
         self.dataflow = dataflow_instance
+        # MED-S5: hold parent back-reference for lazy runtime lookup.
+        self._dataflow = dataflow_instance
 
-        # Initialize runtime
         if runtime is not None:
-            self.runtime = runtime.acquire()
+            # Legacy explicit-runtime escape hatch.
+            self._explicit_runtime = runtime.acquire()
             self._owns_runtime = False
-            from kailash.runtime import AsyncLocalRuntime
-
-            self._is_async = isinstance(runtime, AsyncLocalRuntime)
             logger.debug(
                 "MigrationHistoryManager: Using injected runtime (ref_count=%d)",
                 runtime.ref_count,
             )
         else:
-            try:
-                asyncio.get_running_loop()
-                from kailash.runtime import AsyncLocalRuntime
-
-                self.runtime = AsyncLocalRuntime()
-                self._is_async = True
-                logger.debug(
-                    "MigrationHistoryManager: Detected async context, using AsyncLocalRuntime"
-                )
-            except RuntimeError:
-                from kailash.runtime.local import LocalRuntime
-
-                # Issue #478 — registry-style long-lived runtime.  Use the
-                # public opt-out so Core SDK suppresses the ad-hoc-usage
-                # deprecation warning AND skips atexit cleanup; the manager
-                # calls close() at its own shutdown.
-                self.runtime = LocalRuntime().mark_externally_managed()
-                self._is_async = False
-                logger.debug(
-                    "MigrationHistoryManager: Detected sync context, using LocalRuntime"
-                )
-            self._owns_runtime = True
+            # Lazy parent lookup — no runtime owned here. The @property
+            # below will resolve via self._dataflow.runtime on each
+            # access.
+            self._explicit_runtime = None
+            self._owns_runtime = False
 
         self._ensure_history_table()
+
+    # ------------------------------------------------------------------
+    # MED-S5 (issue #713): lazy runtime via parent DataFlow.
+    # ------------------------------------------------------------------
+
+    @property
+    def runtime(self) -> Any:
+        """The runtime used by this manager (lazy parent lookup)."""
+        if self._explicit_runtime is not None:
+            return self._explicit_runtime
+        if self._dataflow is not None:
+            return self._dataflow.runtime
+        return None
+
+    @runtime.setter
+    def runtime(self, value: Any) -> None:
+        """Assignment-compat setter; sets the explicit override."""
+        self._explicit_runtime = value
+
+    @property
+    def _is_async(self) -> bool:
+        """Whether the active runtime is :class:`AsyncLocalRuntime`."""
+        from kailash.runtime import AsyncLocalRuntime
+
+        return isinstance(self.runtime, AsyncLocalRuntime)
+
+    @_is_async.setter
+    def _is_async(self, value: bool) -> None:
+        pass  # No-op — derived property.
 
     def _extract_query_data(
         self, results: Dict[str, Any], node_id: str
@@ -1420,17 +1435,24 @@ class MigrationHistoryManager:
         return risk_levels.get(operation_type, "MEDIUM")
 
     def close(self):
-        """Release the runtime reference.
+        """Release the explicit runtime reference if one was provided.
 
         Safe to call multiple times -- subsequent calls are no-ops.
+        Post-MED-S5: only the legacy explicit-runtime path holds a
+        reference here. The lazy-parent path delegates lifecycle to
+        the parent DataFlow.
         """
-        if hasattr(self, "runtime") and self.runtime is not None:
-            self.runtime.release()
-            self.runtime = None
+        explicit = getattr(self, "_explicit_runtime", None)
+        if explicit is not None and hasattr(explicit, "release"):
+            explicit.release()
+        self._explicit_runtime = None
 
     def __del__(self, _warnings=warnings):
-        """Emit ResourceWarning if close() was not called explicitly."""
-        if getattr(self, "runtime", None) is not None:
+        """Emit ResourceWarning if close() was not called explicitly.
+
+        Only fires when the manager held an explicit runtime override.
+        """
+        if getattr(self, "_explicit_runtime", None) is not None:
             _warnings.warn(
                 f"Unclosed {self.__class__.__name__}. Call close() explicitly.",
                 ResourceWarning,

--- a/tests/regression/test_issue_713_subsystems_follow_runtime_swap.py
+++ b/tests/regression/test_issue_713_subsystems_follow_runtime_swap.py
@@ -1,0 +1,266 @@
+"""Regression: #713 (MED-S5) — DataFlow subsystems follow parent runtime swap.
+
+After MED-S4 made `DataFlow.runtime` a lazy `@property`, four subsystems
+(ModelRegistry, AutoMigrationSystem, MigrationHistoryManager via
+SchemaStateManager, GatewayIntegration) previously snapshotted `self.runtime`
+at __init__ and held a stale reference after the parent's runtime swapped.
+
+MED-S5 converts each subsystem's `runtime` to a lazy `@property` that returns
+`self._dataflow.runtime` (or the legacy explicit-runtime override). This test
+verifies the swap-following behavior end-to-end against real PostgreSQL.
+
+Pre-fix failure mode: module-import-time `db = DataFlow(...)` binds
+LocalRuntime; subsystems snapshot it; later `await db.create_tables_async()`
+inside an event loop crashes with
+`AttributeError: 'LocalRuntime' object has no attribute 'execute_workflow_async'`
+because subsystems still hold the LocalRuntime even after the parent's
+property switched to AsyncLocalRuntime.
+
+This regression MUST NOT be deleted per `rules/orphan-detection.md` Rule 4.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from kailash.runtime.async_local import AsyncLocalRuntime
+from kailash.runtime.local import LocalRuntime
+
+POSTGRES_URL = os.environ.get(
+    "DATAFLOW_TEST_POSTGRES_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+def test_model_registry_follows_runtime_swap():
+    """ModelRegistry.runtime tracks parent DataFlow.runtime swaps."""
+    from dataflow import DataFlow
+
+    db = DataFlow(POSTGRES_URL)
+    try:
+        # In sync context, parent resolves to LocalRuntime
+        assert isinstance(db.runtime, LocalRuntime)
+        # Subsystem follows parent
+        assert isinstance(db._model_registry.runtime, LocalRuntime)
+
+        # Setter override on parent → subsystem follows
+        async_rt = AsyncLocalRuntime()
+        db.runtime = async_rt
+        assert db._model_registry.runtime is async_rt
+
+        # Clear override → resumes lazy detection (LocalRuntime in sync ctx)
+        db.runtime = None
+        assert isinstance(db._model_registry.runtime, LocalRuntime)
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+def test_auto_migration_system_follows_runtime_swap():
+    """AutoMigrationSystem.runtime tracks parent DataFlow.runtime swaps."""
+    from dataflow import DataFlow
+
+    db = DataFlow(POSTGRES_URL, auto_migrate=True)
+    try:
+        # In sync context, parent resolves to LocalRuntime
+        if db._migration_system is None:
+            pytest.skip("migration system not initialized for this config")
+        assert isinstance(db._migration_system.runtime, LocalRuntime)
+
+        # Swap parent → subsystem follows
+        async_rt = AsyncLocalRuntime()
+        db.runtime = async_rt
+        assert db._migration_system.runtime is async_rt
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+def test_schema_state_manager_follows_runtime_swap():
+    """SchemaStateManager (MigrationHistoryManager) follows parent swaps."""
+    from dataflow import DataFlow
+
+    db = DataFlow(POSTGRES_URL)
+    try:
+        # The schema state manager initializes lazily on the postgres path.
+        # If the lazy path didn't construct it for this config, skip.
+        if db._schema_state_manager is None:
+            pytest.skip("schema state manager not initialized for this config")
+
+        assert isinstance(db._schema_state_manager.runtime, LocalRuntime)
+
+        async_rt = AsyncLocalRuntime()
+        db.runtime = async_rt
+        assert db._schema_state_manager.runtime is async_rt
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+def test_module_level_dataflow_then_async_ddl_succeeds_via_subsystems():
+    """Mediscribe-shape: module-level DataFlow + async DDL no longer crashes.
+
+    Pre-fix the framework crashed at create_tables_async because subsystems
+    captured LocalRuntime. Post-MED-S4 + MED-S5: parent property is lazy AND
+    subsystems read it lazily, so the same call works.
+    """
+    from dataflow import DataFlow
+
+    db = DataFlow(POSTGRES_URL)
+
+    @db.model
+    class _S5RegressionItem:  # noqa: N801 — test fixture
+        id: int
+        name: str
+
+    async def _run() -> None:
+        # Inside the event loop, parent.runtime resolves AsyncLocalRuntime
+        assert isinstance(db.runtime, AsyncLocalRuntime)
+        # And the subsystems agree
+        assert isinstance(db._model_registry.runtime, AsyncLocalRuntime)
+        # The actual call that crashed pre-fix
+        await db.create_tables_async()
+
+    try:
+        asyncio.run(_run())
+    finally:
+        # Cleanup the test table
+        async def _cleanup() -> None:
+            try:
+                from kailash.workflow.builder import WorkflowBuilder
+
+                wf = WorkflowBuilder()
+                wf.add_node(
+                    "AsyncSQLDatabaseNode",
+                    "drop",
+                    {
+                        "connection_string": POSTGRES_URL,
+                        "query": 'DROP TABLE IF EXISTS "_s5regressionitem"',
+                        "fetch_mode": "none",
+                    },
+                )
+                runtime = AsyncLocalRuntime()
+                await runtime.execute_workflow_async(wf.build(), inputs={})
+            except Exception:
+                pass
+
+        asyncio.run(_cleanup())
+        db.close()
+
+
+@pytest.mark.regression
+def test_subsystem_explicit_runtime_override_pins():
+    """Explicit runtime= argument to ModelRegistry pins its runtime.
+
+    The subsystem's @property returns self._explicit_runtime when set, falling
+    through to self._dataflow.runtime only when the override is None. This
+    test verifies the explicit-override path still works for callers that
+    intentionally pin a runtime.
+    """
+    from dataflow import DataFlow
+    from dataflow.core.model_registry import ModelRegistry
+
+    db = DataFlow(POSTGRES_URL)
+    try:
+        # Construct an explicitly-pinned ModelRegistry (legacy escape hatch)
+        pinned_runtime = AsyncLocalRuntime()
+        registry = ModelRegistry(db, runtime=pinned_runtime)
+
+        # Even after parent swaps, this registry is pinned
+        db.runtime = LocalRuntime()
+        assert registry.runtime is pinned_runtime
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+def test_subsystem_runtime_assignment_setter_compat():
+    """Legacy callers that wrote subsystem.runtime = X still work.
+
+    MED-S5 preserves backwards compat for code that mutates
+    ``model_registry.runtime`` directly — the @property has a setter that
+    stores the value as the explicit override.
+    """
+    from dataflow import DataFlow
+
+    db = DataFlow(POSTGRES_URL)
+    try:
+        original = db._model_registry.runtime
+        # Direct assignment on the subsystem
+        new_runtime = AsyncLocalRuntime()
+        db._model_registry.runtime = new_runtime
+        assert db._model_registry.runtime is new_runtime
+        # Clearing the override resumes parent-follow
+        db._model_registry.runtime = None
+        assert isinstance(db._model_registry.runtime, type(original))
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+def test_subsystem_audit_grep_no_orphan_runtime_captures():
+    """Mechanical sweep: subsystem files MUST NOT capture self.runtime in __init__.
+
+    Per MED-S5 + rules/orphan-detection.md, every subsystem with a runtime
+    surface MUST read via lazy @property (returning self._dataflow.runtime).
+    Plain attribute capture in __init__ is BLOCKED — that is the failure mode
+    this shard fixed.
+    """
+    import re
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent.parent
+    subsystems = [
+        repo_root / "packages/kailash-dataflow/src/dataflow/core/model_registry.py",
+        repo_root
+        / "packages/kailash-dataflow/src/dataflow/migrations/auto_migration_system.py",
+        repo_root
+        / "packages/kailash-dataflow/src/dataflow/migrations/schema_state_manager.py",
+        repo_root / "packages/kailash-dataflow/src/dataflow/gateway_integration.py",
+    ]
+
+    # Pattern: `self.runtime = <expr>` or `self._runtime = <expr>` inside __init__.
+    # Acceptable: setter assignments (under @runtime.setter) and explicit-override
+    # initialization (`self._explicit_runtime = runtime`).
+    bad_pattern = re.compile(
+        r"^\s*self\.(runtime|_runtime)\s*=\s*[^#\n]+", re.MULTILINE
+    )
+
+    for subsystem in subsystems:
+        if not subsystem.exists():
+            continue
+        text = subsystem.read_text()
+
+        # Find all matches and exclude legitimate ones:
+        # - inside @<...>.setter blocks
+        # - assignments to self._explicit_runtime (the new pattern)
+        for match in bad_pattern.finditer(text):
+            line_start = text.rfind("\n", 0, match.start()) + 1
+            line_end = text.find("\n", match.end())
+            line = text[line_start:line_end]
+
+            if "_explicit_runtime" in line:
+                continue  # the new pattern
+            # Look back ~10 lines for an @<...>.setter decorator
+            preceding = text[max(0, match.start() - 500) : match.start()]
+            if ".setter" in preceding.split("\n")[-15:][-1:][0] or any(
+                ".setter" in pl for pl in preceding.split("\n")[-15:]
+            ):
+                continue
+
+            pytest.fail(
+                f"Orphan runtime capture detected in {subsystem.name}:\n"
+                f"  {line.strip()}\n"
+                f"This violates MED-S5 — subsystems MUST read runtime via "
+                f"lazy @property delegating to self._dataflow.runtime. "
+                f"See rules/orphan-detection.md and "
+                f"workspaces/issues-712-714/01-analysis/01-architecture.md."
+            )


### PR DESCRIPTION
## Summary

Companion to #723 (S4 lazy `DataFlow.runtime` property). Four DataFlow subsystems were snapshotting `self.runtime` at `__init__` time, defeating the post-S4 lazy parent property — once the parent's runtime swapped (via setter or first-async-access), subsystems still held the stale reference.

This shard converts each subsystem's `runtime` to a lazy `@property` returning `self._dataflow.runtime` (with a legacy `_explicit_runtime` override slot for the rare caller that needs to pin).

## Changes

- `core/model_registry.py` — `ModelRegistry.runtime` is a `@property` (was plain attr capture)
- `migrations/auto_migration_system.py` — same pattern
- `migrations/schema_state_manager.py` (MigrationHistoryManager) — same pattern
- `gateway_integration.py` — same pattern
- `core/engine.py` — drop eager `runtime=self.runtime` arg at the two call sites that pinned subsystem runtime at construction
- `tests/regression/test_issue_713_subsystems_follow_runtime_swap.py` — 5 active + 2 skipped tests covering swap-following, module-level DataFlow + async DDL (canonical v2.13.0 pattern), explicit-override preservation, setter compat, and a mechanical grep audit that fails if any subsystem regrows orphan `self.runtime = X` capture

## Test plan

- [x] `tests/regression/test_issue_713_subsystems_follow_runtime_swap.py` — 5 passed, 2 skipped (postgres-conditional)
- [x] All 8 tests from #723 (`test_issue_713_module_import_then_async_ddl.py`) still pass
- [x] Mechanical audit grep returns no unguarded `self.runtime = X` in subsystems

## Brief framing correction

The original todo enumerated "BulkOperations and TransactionManager" as needing conversion; verification showed both already use the parent-reference pattern (`self.dataflow = dataflow_instance`, no runtime capture). They were never broken — converting them would have been a no-op refactor.

## Related

Continues #723. Together they close #713. Workspace `workspaces/issues-712-714/`. See todo `S5-subsystem-lazy-runtime-lookups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
