### PR TITLE
fix(api): patch 3 sibling FastAPI lifespan sites (S2 of #712)

### DIFF
--- a/src/kailash/api/gateway.py
+++ b/src/kailash/api/gateway.py
@@ -56,13 +56,17 @@ from typing import Any
 
 import httpx
 from fastapi import FastAPI
+from pydantic import BaseModel, Field
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
 from starlette.websockets import WebSocket
-from pydantic import BaseModel, Field
 
 from ..runtime.local import LocalRuntime
+from ..utils.lifespan import (
+    drive_router_lifespan_shutdown,
+    drive_router_lifespan_startup,
+)
 from ..workflow import Workflow
 from .workflow_api import WorkflowAPI
 
@@ -137,9 +141,15 @@ class WorkflowAPIGateway:
         async def lifespan(app: FastAPI):
             # Startup
             logger.info(f"Starting {title} v{version}")
+            # MED-S2 (#712): drive router.on_startup hooks (e.g. consumer
+            # @app.on_event("startup")). Custom lifespan replaces Starlette's
+            # _DefaultLifespan; without this iteration consumer hooks
+            # silently drop (the #500 bug class).
+            await drive_router_lifespan_startup(app)
             yield
             # Shutdown
             logger.info("Shutting down gateway")
+            await drive_router_lifespan_shutdown(app)
             if self._proxy_client:
                 await self._proxy_client.aclose()
             self.executor.shutdown(wait=True)

--- a/src/kailash/api/workflow_api.py
+++ b/src/kailash/api/workflow_api.py
@@ -15,12 +15,16 @@ import uvicorn
 
 logger = logging.getLogger(__name__)
 from fastapi import BackgroundTasks, FastAPI
+from pydantic import BaseModel, Field
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, Field
 
 from kailash.runtime.local import LocalRuntime
+from kailash.utils.lifespan import (
+    drive_router_lifespan_shutdown,
+    drive_router_lifespan_startup,
+)
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
 
@@ -168,8 +172,14 @@ class WorkflowAPI:
     async def _lifespan(self, app: FastAPI):
         """Manage app lifecycle."""
         # Startup
+        # MED-S2 (#712): drive router.on_startup hooks (e.g. consumer
+        # @app.on_event("startup")). Without this iteration, the custom
+        # _lifespan above replaces Starlette's _DefaultLifespan and
+        # silently drops every router-registered hook (the #500 bug class).
+        await drive_router_lifespan_startup(app)
         yield
         # Shutdown - cleanup cache
+        await drive_router_lifespan_shutdown(app)
         self._execution_cache.clear()
 
     def _setup_routes(self):

--- a/src/kailash/middleware/communication/api_gateway.py
+++ b/src/kailash/middleware/communication/api_gateway.py
@@ -23,6 +23,10 @@ from pydantic import BaseModel, Field
 from ...nodes.base import NodeRegistry
 from ...nodes.security import CredentialManagerNode
 from ...nodes.transform import DataTransformer
+from ...utils.lifespan import (
+    drive_router_lifespan_shutdown,
+    drive_router_lifespan_startup,
+)
 from ...workflow import Workflow
 from ...workflow.builder import WorkflowBuilder
 from ..core.agent_ui import AgentUIMiddleware
@@ -192,10 +196,16 @@ class APIGateway:
         async def lifespan(app: FastAPI):
             # Startup
             logger.info(f"Starting {title} v{version}")
+            # MED-S2 (#712): drive router.on_startup hooks (e.g. consumer
+            # @app.on_event("startup")). Without this iteration, the custom
+            # lifespan above replaces Starlette's _DefaultLifespan and
+            # silently drops every router-registered hook (the #500 bug class).
+            await drive_router_lifespan_startup(app)
             await self._log_startup()
             yield
             # Shutdown
             logger.info("Shutting down gateway")
+            await drive_router_lifespan_shutdown(app)
             await self._cleanup()
 
         self.app = FastAPI(

--- a/tests/regression/test_issue_712_sibling_fastapi_sites.py
+++ b/tests/regression/test_issue_712_sibling_fastapi_sites.py
@@ -1,0 +1,158 @@
+"""Regression: #712 (MED-S2) — sibling FastAPI sites drive router.on_startup.
+
+Three public classes were confirmed (in `workspaces/issues-712-714/01-analysis/`)
+to construct FastAPI with `lifespan=` set BUT NOT iterate `app.router.on_startup` /
+`app.router.on_shutdown` — silent #500-class bugs:
+
+  - APIGateway   — `src/kailash/middleware/communication/api_gateway.py`
+  - WorkflowAPIGateway  — `src/kailash/api/gateway.py`
+  - WorkflowAPI         — `src/kailash/api/workflow_api.py`
+
+The fix routes their custom `lifespan` through the shared helpers
+`drive_router_lifespan_startup` / `drive_router_lifespan_shutdown` (added in
+MED-S1). This test exercises the lifespan via Starlette's public
+`router.lifespan_context` — the same context manager uvicorn invokes in
+production — registering `@app.on_event("startup")` and asserting it fires.
+
+This regression MUST NOT be deleted per `rules/orphan-detection.md` Rule 4.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_workflow_api_drives_router_on_startup():
+    """WorkflowAPI lifespan iterates router.on_startup post-MED-S2."""
+    from fastapi import FastAPI
+
+    from kailash.api.workflow_api import WorkflowAPI
+    from kailash.workflow.builder import WorkflowBuilder
+
+    builder = WorkflowBuilder()
+    builder.add_node("PythonCodeNode", "noop", {"code": "result = {'ok': True}"})
+    api = WorkflowAPI(builder.build())
+    app: FastAPI = api.app
+
+    fired: list[int] = []
+
+    async def my_startup() -> None:
+        fired.append(1)
+
+    async def my_shutdown() -> None:
+        fired.append(-1)
+
+    app.router.add_event_handler("startup", my_startup)
+    app.router.add_event_handler("shutdown", my_shutdown)
+
+    # Drive lifespan via Starlette's public lifespan_context (same as uvicorn)
+    async with app.router.lifespan_context(app):
+        pass
+
+    assert fired == [1, -1], (
+        f"WorkflowAPI router-iteration broken: hooks did not fire (got {fired}). "
+        f"Pre-MED-S2 the custom _lifespan replaced Starlette's _DefaultLifespan "
+        f"and silently dropped every router.on_startup/on_shutdown handler."
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_workflow_api_gateway_drives_router_on_startup():
+    """WorkflowAPIGateway (api/gateway.py) lifespan iterates router.on_startup."""
+    from fastapi import FastAPI
+
+    from kailash.api.gateway import WorkflowAPIGateway
+
+    gateway = WorkflowAPIGateway()
+    app: FastAPI = gateway.app
+
+    fired: list[int] = []
+
+    async def my_startup() -> None:
+        fired.append(1)
+
+    async def my_shutdown() -> None:
+        fired.append(-1)
+
+    app.router.add_event_handler("startup", my_startup)
+    app.router.add_event_handler("shutdown", my_shutdown)
+
+    async with app.router.lifespan_context(app):
+        pass
+
+    assert fired == [1, -1], (
+        f"WorkflowAPIGateway router-iteration broken: hooks did not fire "
+        f"(got {fired}). Pre-MED-S2 this was an unmitigated #500-class bug."
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_kailash_api_gateway_drives_router_on_startup():
+    """APIGateway (middleware) lifespan iterates router.on_startup."""
+    pytest.importorskip("kailash.middleware.communication.api_gateway")
+
+    from fastapi import FastAPI
+
+    from kailash.middleware.communication.api_gateway import APIGateway
+
+    try:
+        gateway = APIGateway()
+    except Exception as e:
+        pytest.skip(f"APIGateway construction requires deps: {e}")
+    app: FastAPI = gateway.app
+
+    fired: list[int] = []
+
+    async def my_startup() -> None:
+        fired.append(1)
+
+    async def my_shutdown() -> None:
+        fired.append(-1)
+
+    app.router.add_event_handler("startup", my_startup)
+    app.router.add_event_handler("shutdown", my_shutdown)
+
+    async with app.router.lifespan_context(app):
+        pass
+
+    assert fired == [1, -1], (
+        f"APIGateway router-iteration broken: hooks did not fire "
+        f"(got {fired}). Pre-MED-S2 this was an unmitigated #500-class bug."
+    )
+
+
+@pytest.mark.regression
+def test_sibling_lifespans_call_shared_helper():
+    """Mechanical sweep: every sibling FastAPI site MUST call the helper.
+
+    Per `rules/security.md` § Multi-Site Kwarg Plumbing, all three sibling
+    sites and the canonical workflow_server.py MUST route through the shared
+    helper. This grep audit fails loudly if a future refactor inlines
+    `router.on_startup` iteration at any one site without the helper, or
+    drops the helper call from a site.
+    """
+    from pathlib import Path
+
+    repo_root = Path(__file__).parent.parent.parent
+    sites = [
+        repo_root / "src/kailash/middleware/communication/api_gateway.py",
+        repo_root / "src/kailash/api/gateway.py",
+        repo_root / "src/kailash/api/workflow_api.py",
+        repo_root / "src/kailash/servers/workflow_server.py",
+    ]
+    for site in sites:
+        text = site.read_text()
+        assert "drive_router_lifespan_startup" in text, (
+            f"{site.name} no longer calls drive_router_lifespan_startup — "
+            f"if the lifespan was removed entirely, drop this site from the "
+            f"audit; if a sibling helper was used instead, re-route through "
+            f"the shared helper. See rules/security.md § Multi-Site Kwarg "
+            f"Plumbing."
+        )
+        assert (
+            "drive_router_lifespan_shutdown" in text
+        ), f"{site.name} no longer calls drive_router_lifespan_shutdown."


### PR DESCRIPTION
## Summary

Three confirmed unmitigated #500-class bugs in public classes — the canonical Nexus path was patched in #722/#724 but its siblings were not. Per `rules/security.md` § Multi-Site Kwarg Plumbing, all are patched in this PR.

## Sites patched

- `APIGateway` (`src/kailash/middleware/communication/api_gateway.py`)
- `WorkflowAPIGateway` (`src/kailash/api/gateway.py`)
- `WorkflowAPI` (`src/kailash/api/workflow_api.py`)

Each class's custom `lifespan` now calls the shared helper from S1 (`drive_router_lifespan_startup` / `drive_router_lifespan_shutdown`) before/after its class-specific work.

## Test plan

- [x] 3 passing + 1 skipped (`APIGateway` requires middleware deps)
- [x] Mechanical grep audit fails if any of the 4 sites (3 siblings + workflow_server) drops the helper call

## Related

Closes the sibling sweep for #712. Workspace `workspaces/issues-712-714/`. See todo `S2-patch-sibling-fastapi-sites.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
