### PR TITLE
docs(specs): update for #712/#713/#714 cluster (S7)

### DIFF
--- a/specs/dataflow-core.md
+++ b/specs/dataflow-core.md
@@ -66,43 +66,43 @@ DataFlow(
 
 **Parameter reference:**
 
-| Parameter                      | Type                       | Default | Purpose                                                                                                                       |
-| ------------------------------ | -------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `database_url`                 | `Optional[str]`            | `None`  | Database connection URL. Falls back to `DATABASE_URL` env var. `None` with no config triggers `DataFlowConfig.from_env()`.    |
-| `config`                       | `Optional[DataFlowConfig]` | `None`  | Full configuration object. Individual parameters override matching config fields.                                             |
-| `pool_size`                    | `Optional[int]`            | `None`  | Connection pool size. `None` defers to `DatabaseConfig.get_pool_size()`.                                                      |
-| `pool_max_overflow`            | `Optional[int]`            | `None`  | Maximum overflow connections beyond `pool_size`.                                                                              |
-| `pool_recycle`                 | `int`                      | `3600`  | Seconds before recycling idle connections.                                                                                    |
-| `echo`                         | `bool`                     | `False` | Echo SQL statements to log.                                                                                                   |
-| `multi_tenant`                 | `bool`                     | `False` | Enable multi-tenant data isolation. When `True`, every Express operation requires a tenant context.                           |
-| `encryption_key`               | `Optional[str]`            | `None`  | Encryption key for sensitive data.                                                                                            |
-| `audit_logging`                | `bool`                     | `False` | Enable audit trail persistence.                                                                                               |
-| `cache_enabled`                | `bool`                     | `True`  | Enable query result caching in Express.                                                                                       |
-| `cache_ttl`                    | `int`                      | `3600`  | Default cache TTL in seconds.                                                                                                 |
-| `monitoring`                   | `Optional[bool]`           | `None`  | Enable performance monitoring. `None` = disabled.                                                                             |
-| `slow_query_threshold`         | `float`                    | `1.0`   | Seconds above which a query is logged as slow.                                                                                |
-| `debug`                        | `bool`                     | `False` | Enable debug logging.                                                                                                         |
-| `migration_enabled`            | `bool`                     | `True`  | Enable automatic database migrations.                                                                                         |
+| Parameter                      | Type                       | Default | Purpose                                                                                                                                                                                                                                                                                      |
+| ------------------------------ | -------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `database_url`                 | `Optional[str]`            | `None`  | Database connection URL. Falls back to `DATABASE_URL` env var. `None` with no config triggers `DataFlowConfig.from_env()`.                                                                                                                                                                   |
+| `config`                       | `Optional[DataFlowConfig]` | `None`  | Full configuration object. Individual parameters override matching config fields.                                                                                                                                                                                                            |
+| `pool_size`                    | `Optional[int]`            | `None`  | Connection pool size. `None` defers to `DatabaseConfig.get_pool_size()`.                                                                                                                                                                                                                     |
+| `pool_max_overflow`            | `Optional[int]`            | `None`  | Maximum overflow connections beyond `pool_size`.                                                                                                                                                                                                                                             |
+| `pool_recycle`                 | `int`                      | `3600`  | Seconds before recycling idle connections.                                                                                                                                                                                                                                                   |
+| `echo`                         | `bool`                     | `False` | Echo SQL statements to log.                                                                                                                                                                                                                                                                  |
+| `multi_tenant`                 | `bool`                     | `False` | Enable multi-tenant data isolation. When `True`, every Express operation requires a tenant context.                                                                                                                                                                                          |
+| `encryption_key`               | `Optional[str]`            | `None`  | Encryption key for sensitive data.                                                                                                                                                                                                                                                           |
+| `audit_logging`                | `bool`                     | `False` | Enable audit trail persistence.                                                                                                                                                                                                                                                              |
+| `cache_enabled`                | `bool`                     | `True`  | Enable query result caching in Express.                                                                                                                                                                                                                                                      |
+| `cache_ttl`                    | `int`                      | `3600`  | Default cache TTL in seconds.                                                                                                                                                                                                                                                                |
+| `monitoring`                   | `Optional[bool]`           | `None`  | Enable performance monitoring. `None` = disabled.                                                                                                                                                                                                                                            |
+| `slow_query_threshold`         | `float`                    | `1.0`   | Seconds above which a query is logged as slow.                                                                                                                                                                                                                                               |
+| `debug`                        | `bool`                     | `False` | Enable debug logging.                                                                                                                                                                                                                                                                        |
+| `migration_enabled`            | `bool`                     | `True`  | Enable automatic database migrations.                                                                                                                                                                                                                                                        |
 | `auto_migrate`                 | `Union[bool, str]`         | `True`  | Auto-migration mode. `True` (fail-fast on DDL failure, default since v2.4.0), `False` (no DDL execution), or `"warn"` (legacy log-and-continue escape hatch). See § 1.6 Auto-Migrate Semantics. Typo strings (`"WARN"`, `"warning"`, etc.) raise `DataFlowConfigurationError` at `__init__`. |
-| `existing_schema_mode`         | `bool`                     | `False` | Safe mode for existing databases -- validates compatibility without modifying schema.                                         |
-| `enable_model_persistence`     | `bool`                     | `True`  | Enable persistent model registry for multi-application support.                                                               |
-| `tdd_mode`                     | `bool`                     | `False` | Enable TDD mode for testing. Also settable via `DATAFLOW_TDD_MODE` env var.                                                   |
-| `test_mode`                    | `Optional[bool]`           | `None`  | `None` = auto-detect (checks for pytest env), `True` = enable, `False` = disable.                                             |
-| `test_mode_aggressive_cleanup` | `bool`                     | `True`  | Enable aggressive pool cleanup in test mode.                                                                                  |
-| `migration_lock_timeout`       | `int`                      | `30`    | Migration lock timeout in seconds for concurrent safety. Minimum 1 second.                                                    |
-| `enable_connection_pooling`    | `bool`                     | `True`  | Enable connection pooling.                                                                                                    |
-| `validate_on_write`            | `bool`                     | `True`  | Run `@field_validator` rules before every Express write operation.                                                            |
-| `log_level`                    | `Optional[int]`            | `None`  | Override log level (e.g. `logging.DEBUG`).                                                                                    |
-| `log_config`                   | `Optional[LoggingConfig]`  | `None`  | Full logging configuration for category-specific control.                                                                     |
-| `read_url`                     | `Optional[str]`            | `None`  | Read replica URL for read/write splitting (TSG-105).                                                                          |
-| `read_pool_size`               | `Optional[int]`            | `None`  | Separate pool size for the read replica.                                                                                      |
-| `redis_url`                    | `Optional[str]`            | `None`  | Redis URL for Express cache backend. Falls back to `REDIS_URL` env var. When absent or unreachable, uses in-memory LRU cache. |
-| `trust_enforcement_mode`       | `Optional[str]`            | `None`  | Trust plane enforcement: `"disabled"` (default), `"permissive"`, `"enforcing"`.                                               |
-| `trust_audit_enabled`          | `Optional[bool]`           | `None`  | Enable trust audit store.                                                                                                     |
-| `trust_audit_signing_key`      | `Optional[bytes]`          | `None`  | Ed25519 signing key for audit entries.                                                                                        |
-| `trust_audit_verify_key`       | `Optional[bytes]`          | `None`  | Ed25519 verification key for audit entries.                                                                                   |
-| `enable_caching`               | `Optional[bool]`           | `None`  | Alias for `cache_enabled`.                                                                                                    |
-| `max_overflow`                 | `Optional[int]`            | `None`  | Alias for `pool_max_overflow`.                                                                                                |
+| `existing_schema_mode`         | `bool`                     | `False` | Safe mode for existing databases -- validates compatibility without modifying schema.                                                                                                                                                                                                        |
+| `enable_model_persistence`     | `bool`                     | `True`  | Enable persistent model registry for multi-application support.                                                                                                                                                                                                                              |
+| `tdd_mode`                     | `bool`                     | `False` | Enable TDD mode for testing. Also settable via `DATAFLOW_TDD_MODE` env var.                                                                                                                                                                                                                  |
+| `test_mode`                    | `Optional[bool]`           | `None`  | `None` = auto-detect (checks for pytest env), `True` = enable, `False` = disable.                                                                                                                                                                                                            |
+| `test_mode_aggressive_cleanup` | `bool`                     | `True`  | Enable aggressive pool cleanup in test mode.                                                                                                                                                                                                                                                 |
+| `migration_lock_timeout`       | `int`                      | `30`    | Migration lock timeout in seconds for concurrent safety. Minimum 1 second.                                                                                                                                                                                                                   |
+| `enable_connection_pooling`    | `bool`                     | `True`  | Enable connection pooling.                                                                                                                                                                                                                                                                   |
+| `validate_on_write`            | `bool`                     | `True`  | Run `@field_validator` rules before every Express write operation.                                                                                                                                                                                                                           |
+| `log_level`                    | `Optional[int]`            | `None`  | Override log level (e.g. `logging.DEBUG`).                                                                                                                                                                                                                                                   |
+| `log_config`                   | `Optional[LoggingConfig]`  | `None`  | Full logging configuration for category-specific control.                                                                                                                                                                                                                                    |
+| `read_url`                     | `Optional[str]`            | `None`  | Read replica URL for read/write splitting (TSG-105).                                                                                                                                                                                                                                         |
+| `read_pool_size`               | `Optional[int]`            | `None`  | Separate pool size for the read replica.                                                                                                                                                                                                                                                     |
+| `redis_url`                    | `Optional[str]`            | `None`  | Redis URL for Express cache backend. Falls back to `REDIS_URL` env var. When absent or unreachable, uses in-memory LRU cache.                                                                                                                                                                |
+| `trust_enforcement_mode`       | `Optional[str]`            | `None`  | Trust plane enforcement: `"disabled"` (default), `"permissive"`, `"enforcing"`.                                                                                                                                                                                                              |
+| `trust_audit_enabled`          | `Optional[bool]`           | `None`  | Enable trust audit store.                                                                                                                                                                                                                                                                    |
+| `trust_audit_signing_key`      | `Optional[bytes]`          | `None`  | Ed25519 signing key for audit entries.                                                                                                                                                                                                                                                       |
+| `trust_audit_verify_key`       | `Optional[bytes]`          | `None`  | Ed25519 verification key for audit entries.                                                                                                                                                                                                                                                  |
+| `enable_caching`               | `Optional[bool]`           | `None`  | Alias for `cache_enabled`.                                                                                                                                                                                                                                                                   |
+| `max_overflow`                 | `Optional[int]`            | `None`  | Alias for `pool_max_overflow`.                                                                                                                                                                                                                                                               |
 
 **Known `**kwargs`:\*\*
 
@@ -163,14 +163,40 @@ DataFlow uses lazy connection initialization. The constructor (`__init__`) store
 
 **Design rationale:** Lazy connection means `DataFlow("sqlite:///app.db")` returns instantly with zero I/O. This allows `@db.model` decorators to register models at import time without blocking module loading. Connection is deferred until the application actually needs the database, which also means misconfigured connection URLs fail at first use, not at import time.
 
+**DDL connection lifecycle (issue #714):** `db.create_tables()` / `await db.create_tables_async()` no longer construct one `AsyncSQLDatabaseNode` per CREATE TABLE / index statement. The entire DDL batch runs on a single sync connection acquired via `SyncDDLExecutor.execute_ddl_batch_per_statement` (sync path direct, async path via `asyncio.to_thread`). See §1.6.5 for the connection-reuse contract and the cross-reference to `dataflow.migrations.sync_ddl_executor`.
+
 ### 1.5 Runtime Detection
 
-DataFlow detects whether it is running in an async or sync context at construction time:
+Origin: GitHub issue #713 (2026-04-30). Pre-#713 DataFlow bound a single runtime at construction time. Module-import construction (the `db = DataFlow(...)` at module scope pattern Mediscribe and similar consumers use) permanently bound `LocalRuntime` because no event loop is running at import time, then `await db.create_tables_async()` raised "no running event loop" or quietly used the wrong runtime when later invoked from inside FastAPI/uvicorn. The fix replaces eager construction-time selection with lazy per-access resolution via a per-event-loop cache.
 
-- **Async context** (running event loop detected): uses `AsyncLocalRuntime`
-- **Sync context** (no running event loop): uses `LocalRuntime`
+**Runtime resolution is now lazy** — performed on every read of `db.runtime`, not at construction. Resolution order:
 
-All subsystems share a single runtime via `acquire()`/`release()` ref-counting to prevent orphan runtimes and pool exhaustion.
+1. **Setter override** — if `db.runtime = X` (or `runtime=X` kwarg in `__init__`) is active, return the override unconditionally. Preserves the existing `db.runtime = AsyncLocalRuntime()` workaround pattern, the `monkeypatch.setattr(db, "runtime", X)` test idiom, and explicit caller control.
+2. **Closed instance** — if the DataFlow has been `close()`d, return `None`. Subsystem callers expect `None` from a closed instance and short-circuit accordingly.
+3. **Async context (running event loop)** — return a per-event-loop cached `AsyncLocalRuntime`, keyed by `id(loop)`. Different loops get different runtimes; the same loop always sees the same runtime. Cache mirrors the per-event-loop pattern already used by `_async_sql_node_cache` (engine.py:7488).
+4. **Sync context (no running loop)** — return the cached `LocalRuntime` singleton, allocated on first access. The singleton is marked `mark_externally_managed()` (issue #478) so the SDK suppresses its ad-hoc-usage deprecation warning and skips atexit cleanup — DataFlow's own shutdown drives `close()`.
+
+#### `runtime` property — getter / setter
+
+| Surface             | Behavior                                                                                              |
+| ------------------- | ----------------------------------------------------------------------------------------------------- |
+| `db.runtime` (read) | Resolves via the 4-step order above. Returns `Any` (LocalRuntime or AsyncLocalRuntime).               |
+| `db.runtime = X`    | Stores `X` in `_runtime_override`. Every subsequent read returns `X` unconditionally.                 |
+| `db.runtime = None` | Clears the override. Subsequent reads resume lazy per-loop detection (or return `None` if `_closed`). |
+
+#### `runtime=` constructor kwarg
+
+`DataFlow(database_url, runtime=AsyncLocalRuntime())` routes the kwarg through the `@runtime.setter` (descriptor protocol), so the value lands in `_runtime_override` and behaves identically to a post-construction `db.runtime = X` assignment. Explicit escape hatch for callers that need a specific runtime instance from the start.
+
+#### Subsystem-capture pattern
+
+Subsystems (`DataFlowExpress`, `DataFlowExpressSync`, `BulkOperations`, `TransactionManager`, `_DataFlowAuditQueryProxy`, `_DataFlowAuditExportProxy`) MUST hold a back-reference to the DataFlow parent (`self._dataflow = dataflow`) and read `self._dataflow.runtime` lazily on each operation — NOT capture the runtime at subsystem `__init__` time. Captured runtimes do NOT follow setter overrides, do NOT survive a `db.runtime = X` mutation, and miss the per-event-loop cache. Per the lazy-resolution contract, `runtime` is per-access; subsystems that snapshot it ship the same #713 footgun at a different layer.
+
+#### Pickle / deepcopy round-trip
+
+`__getstate__` / `__setstate__` exclude `_loop_runtime_cache` and `_sync_runtime_singleton` from the pickled state. The cache is rebuilt lazily on first `runtime` access in the unpickled instance. This makes DataFlow safe to ship across process boundaries (multiprocessing pools, Ray actors, Dask workers) without dragging an event-loop-bound runtime that would be invalid in the destination process.
+
+All subsystems still share a single runtime instance per `DataFlow` per event loop via `acquire()`/`release()` ref-counting to prevent orphan runtimes and pool exhaustion. Per-loop caching does NOT spawn N runtimes per loop — it spawns ONE runtime per loop, shared by every subsystem invocation in that loop.
 
 ### 1.6 Auto-Migrate Semantics
 
@@ -178,21 +204,21 @@ Origin: GitHub issue #696 (per `workspaces/dataflow-prod-incident`, 2026-04-28).
 
 The `auto_migrate` parameter accepts three values, each with a distinct behavioural contract. Strings other than `"warn"` (case-sensitive) are rejected at `__init__` with `DataFlowConfigurationError` so a typo (`"WARN"`, `"warning"`, `"true"`) cannot silently degrade behavior at deploy time.
 
-| Value     | DDL execution        | On DDL failure (e.g. invalid type, FK ordering, role permission)                                                                                                                                                                                                                       | Subsequent access to failed model                                                                                                                                              |
-| --------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `True`    | Yes (default)        | Records the failure on `_failed_table_creations[model_name] = FailedDDLRecord(timestamp, error_message, statement_preview)`. Emits exactly ONE `engine.ddl_failed_recorded` ERROR log per `(model, DataFlow instance)` pair. Raises `DDLFailedError` to the caller of the first access. | Fail-fast: raises `DDLFailedError` from the head of `ensure_table_exists()` BEFORE re-entering the DDL path. NO connection acquired, NO DDL fired, NO additional log emitted. |
-| `False`   | No (skip mode)       | N/A — DDL never runs. Schema is assumed managed externally (Alembic, Liquibase, dba-issued DDL).                                                                                                                                                                                       | Standard SQL-layer access. SELECT/INSERT errors surface from the database normally; no circuit-breaker engagement.                                                             |
-| `"warn"`  | Yes (legacy)         | Records the failure on `_failed_table_creations` AND emits the `engine.ddl_failed_recorded` ERROR log (same as fail-fast). Returns `False` from `ensure_table_exists()`. **Does NOT raise.**                                                                                            | Legacy retry-on-access: `_check_failed_ddl()` is a no-op, the DDL path resumes pre-#696 semantics. Operators who explicitly opt in accept the pool-leak risk this entails.    |
+| Value    | DDL execution  | On DDL failure (e.g. invalid type, FK ordering, role permission)                                                                                                                                                                                                                        | Subsequent access to failed model                                                                                                                                             |
+| -------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `True`   | Yes (default)  | Records the failure on `_failed_table_creations[model_name] = FailedDDLRecord(timestamp, error_message, statement_preview)`. Emits exactly ONE `engine.ddl_failed_recorded` ERROR log per `(model, DataFlow instance)` pair. Raises `DDLFailedError` to the caller of the first access. | Fail-fast: raises `DDLFailedError` from the head of `ensure_table_exists()` BEFORE re-entering the DDL path. NO connection acquired, NO DDL fired, NO additional log emitted. |
+| `False`  | No (skip mode) | N/A — DDL never runs. Schema is assumed managed externally (Alembic, Liquibase, dba-issued DDL).                                                                                                                                                                                        | Standard SQL-layer access. SELECT/INSERT errors surface from the database normally; no circuit-breaker engagement.                                                            |
+| `"warn"` | Yes (legacy)   | Records the failure on `_failed_table_creations` AND emits the `engine.ddl_failed_recorded` ERROR log (same as fail-fast). Returns `False` from `ensure_table_exists()`. **Does NOT raise.**                                                                                            | Legacy retry-on-access: `_check_failed_ddl()` is a no-op, the DDL path resumes pre-#696 semantics. Operators who explicitly opt in accept the pool-leak risk this entails.    |
 
 #### 1.6.1 The `DDLFailedError` Typed Surface
 
 `DDLFailedError` (`dataflow.core.exceptions.DDLFailedError`, also exported at `dataflow.DDLFailedError`) is the structured exception raised by the fail-fast circuit breaker. It subclasses `DataFlowError` so callers using `except DataFlowError` continue to catch the new type without explicit import.
 
-| Attribute            | Type             | Description                                                                                                                                                              |
-| -------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model_name`         | `str`            | The model whose `CREATE TABLE` / `ALTER TABLE` failed.                                                                                                                   |
-| `original_error`     | `BaseException`  | The underlying exception from the DDL execution (PostgreSQL `UndefinedObject`, MySQL `OperationalError`, etc.). Operators do not need to chain `__cause__` to diagnose. |
-| `statement_preview`  | `str` (≤200 ch)  | First 200 characters of the failed DDL statement. Bounded to avoid leaking large schema bodies through error chains shipped to log aggregators.                          |
+| Attribute           | Type            | Description                                                                                                                                                             |
+| ------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model_name`        | `str`           | The model whose `CREATE TABLE` / `ALTER TABLE` failed.                                                                                                                  |
+| `original_error`    | `BaseException` | The underlying exception from the DDL execution (PostgreSQL `UndefinedObject`, MySQL `OperationalError`, etc.). Operators do not need to chain `__cause__` to diagnose. |
+| `statement_preview` | `str` (≤200 ch) | First 200 characters of the failed DDL statement. Bounded to avoid leaking large schema bodies through error chains shipped to log aggregators.                         |
 
 The `str(DDLFailedError)` rendering includes `model_name`, `original_error` type+message, optionally `statement_preview` (when non-empty), and inline operator guidance: "Subsequent access to this model will fail-fast without re-firing the DDL. Diagnose the root cause, then restart the application to retry. Use `auto_migrate='warn'` (legacy) to opt into log-and-continue behavior instead of fail-fast."
 
@@ -220,6 +246,38 @@ The log line is structured (per `rules/observability.md` Rule 1) and carries `mo
 - `rules/observability.md` Rule 7 — bulk operations MUST log partial failures at WARN. Issue #696 surfaced the analogous gap for DDL operations: a per-model failure that re-fires every 30 seconds with no aggregation-pipeline visibility. The idempotent-once ERROR log + the `auto_migrate_mode` field together close that gap for the DDL surface.
 - `rules/dataflow-pool.md` Rule 2 — fail-fast at startup. The DDL fail-fast circuit breaker is the model-access-time analogue of the pool-config validator: convert a silent degradation into a deployment-time failure that surfaces before users observe broken endpoints.
 
+#### 1.6.5 DDL Connection Reuse — Single Sync Connection Per Batch
+
+Origin: GitHub issue #714 (2026-04-30). Pre-#714 `_execute_ddl` / `_execute_ddl_async` routed every CREATE TABLE / CREATE INDEX through a fresh `AsyncSQLDatabaseNode` instance — one connection acquire/release per statement. Under `auto_migrate=True` with N models, this produced ≈ 2N+ connection acquires at startup (one per CREATE TABLE, one per index batch, one per FK addition). Against pgbouncer transaction-pooling or a constrained Azure PostgreSQL `max_connections`, the burst exhausted available slots before the application opened to traffic — the same failure-mode class as #696 (model-access-time DDL spam) but at a different surface (startup-time DDL spam).
+
+The refactor replaces the per-statement `AsyncSQLDatabaseNode` plumbing with `SyncDDLExecutor.execute_ddl_batch_per_statement` — a single sync connection from the dialect driver (`psycopg2` / `sqlite3` / `pymysql`) that iterates the entire batch in order and releases the connection in `try/finally`. Per-statement results are captured (success / error / duration_ms) so the #696 fail-fast circuit-breaker still fires on individual CREATE TABLE failures while index/FK/auxiliary failures continue past (legacy semantics).
+
+**Sync vs async pathing:**
+
+| DataFlow method                          | Path                                                                                               | Connection model                                                                        |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `db.create_tables()` (sync)              | `_execute_ddl()` → `SyncDDLExecutor.execute_ddl_batch_per_statement()` directly                    | One sync connection, in-thread                                                          |
+| `await db.create_tables_async()` (async) | `_execute_ddl_async()` → `asyncio.to_thread(SyncDDLExecutor.execute_ddl_batch_per_statement, ...)` | One sync connection, off-loop via `asyncio.to_thread` so the event loop stays unblocked |
+
+**`asyncio.to_thread` rationale:** `SyncDDLExecutor` uses blocking `psycopg2.connect()`. Calling it directly from `_execute_ddl_async` would block the running event loop for the duration of the DDL batch (potentially seconds on large schemas against high-latency PostgreSQL). `asyncio.to_thread` off-loads the blocking call to the default executor, preserving event-loop responsiveness for concurrent requests during startup.
+
+**Per-statement result shape** (from `execute_ddl_batch_per_statement`):
+
+```python
+[
+    {"sql": str, "success": bool, "error": Optional[str], "duration_ms": float},
+    ...  # one entry per input statement, ordering preserved
+]
+```
+
+Failed-statement entries also carry `"exception": e` so the `_execute_ddl` caller can re-raise as `DDLFailedError` per #696 without losing the original cause chain.
+
+**Cross-reference:**
+
+- Issue #696 (auto-migrate semantics, §1.6 above) — the model-access-time DDL spam this fix's startup-time analogue closes for.
+- `packages/kailash-dataflow/src/dataflow/migrations/sync_ddl_executor.py::SyncDDLExecutor.execute_ddl_batch_per_statement` — the new helper used by both DDL paths.
+- `packages/kailash-dataflow/tests/regression/test_issue_714_ddl_single_connection.py` — structural + behavioral regression suite pinning the single-connection contract.
+
 ---
 
 ## 14. DataFlowEngine (Builder Pattern)
@@ -245,17 +303,17 @@ await engine.close()
 
 ### 14.1 Builder Methods
 
-| Method                           | Purpose                                                                |
-| -------------------------------- | ---------------------------------------------------------------------- |
-| `.validation(layer)`             | Set a `ValidationLayer` protocol implementation                        |
-| `.classification_policy(policy)` | Set a `DataClassificationPolicy`                                       |
-| `.slow_query_threshold(seconds)` | Slow query detection threshold (default: 1.0s)                         |
-| `.validate_on_write(enabled)`    | Enable auto-validation before writes                                   |
-| `.source(name, config)`          | Register an external data source                                       |
-| `.fabric(**kwargs)`              | Configure fabric runtime parameters                                    |
-| `.config(**kwargs)`              | Pass additional kwargs to `DataFlow`                                   |
-| `.build()`                       | Build the engine (async — preserved for cross-SDK parity)              |
-| `.build_sync()`                  | Build the engine synchronously (module-import-time / lru_cache safe)   |
+| Method                           | Purpose                                                              |
+| -------------------------------- | -------------------------------------------------------------------- |
+| `.validation(layer)`             | Set a `ValidationLayer` protocol implementation                      |
+| `.classification_policy(policy)` | Set a `DataClassificationPolicy`                                     |
+| `.slow_query_threshold(seconds)` | Slow query detection threshold (default: 1.0s)                       |
+| `.validate_on_write(enabled)`    | Enable auto-validation before writes                                 |
+| `.source(name, config)`          | Register an external data source                                     |
+| `.fabric(**kwargs)`              | Configure fabric runtime parameters                                  |
+| `.config(**kwargs)`              | Pass additional kwargs to `DataFlow`                                 |
+| `.build()`                       | Build the engine (async — preserved for cross-SDK parity)            |
+| `.build_sync()`                  | Build the engine synchronously (module-import-time / lru_cache safe) |
 
 **`build()` vs `build_sync()`** — both surfaces produce identical
 engine state. `build()` is `async def` for cross-SDK parity with
@@ -264,11 +322,11 @@ Tokio runtime initialization); the kailash-py body has no `await`s and
 delegates to `build_sync()` so the two surfaces share a single body
 and cannot drift.
 
-| Caller context                                        | Use         |
-| ----------------------------------------------------- | ----------- |
-| Module-import-time (`@lru_cache` factory, top-level)  | `build_sync()` |
+| Caller context                                        | Use                                 |
+| ----------------------------------------------------- | ----------------------------------- |
+| Module-import-time (`@lru_cache` factory, top-level)  | `build_sync()`                      |
 | Inside a running event loop (Nexus, FastAPI, Jupyter) | `build_sync()` (or `await build()`) |
-| Cross-SDK polyglot code that awaits build everywhere  | `build()`   |
+| Cross-SDK polyglot code that awaits build everywhere  | `build()`                           |
 
 Per `rules/patterns.md` § "Paired Public Surface — Consistent
 Async-ness", offering both shapes is permitted here because the
@@ -313,12 +371,12 @@ is the programmatic counterpart to the `@db.model` decorator. Both
 paths share the same body — `db.register_model(Foo)` produces
 identical state to `@db.model class Foo`.
 
-| Call                                                    | Behaviour                                                          |
-| ------------------------------------------------------- | ------------------------------------------------------------------ |
-| `db.register_model(Foo)`                                | Registers `Foo`; returns `Foo` for chaining.                       |
-| `db.register_model(Foo)` again                          | Raises `ValueError("already registered")`.                         |
-| `db.register_model(Foo, replace=True)`                  | Refused — raises `ValueError("force_drop=True required")`.         |
-| `db.register_model(Foo, replace=True, force_drop=True)` | Tears down prior registration and re-registers. Destructive.       |
+| Call                                                    | Behaviour                                                    |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| `db.register_model(Foo)`                                | Registers `Foo`; returns `Foo` for chaining.                 |
+| `db.register_model(Foo)` again                          | Raises `ValueError("already registered")`.                   |
+| `db.register_model(Foo, replace=True)`                  | Refused — raises `ValueError("force_drop=True required")`.   |
+| `db.register_model(Foo, replace=True, force_drop=True)` | Tears down prior registration and re-registers. Destructive. |
 
 The `replace` + `force_drop` two-flag pattern follows the
 destructive-confirmation discipline mandated by

--- a/specs/nexus-core.md
+++ b/specs/nexus-core.md
@@ -82,18 +82,18 @@ The `enforce-framework-first` hook (see `scripts/hooks/enforce-framework-first.j
 
 **Tier 1 — Engine/Foundation layer** (raw `starlette`/`fastapi` imports required):
 
-| Exempted directory            | Reason                                                                                                                                  |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/kailash/servers/`        | Server hierarchy creates FastAPI apps directly via `create_gateway()`. Importing from `nexus` would create `kailash -> nexus -> kailash` circular import. |
-| `src/kailash/api/`            | API route definitions consumed during `kailash` init; same circular import chain as `servers/`.                                         |
-| `src/kailash/gateway/`        | Gateway layer creates FastAPI apps and uses `APIRouter`, `Depends`, `BackgroundTasks`, `CORSMiddleware` directly. Circular: `kailash -> nexus -> kailash`. |
-| `src/kailash/middleware/communication/` | `APIGateway` and `RealtimeMiddleware` are loaded during `kailash.middleware.__init__`. `api_gateway.py` uses full FastAPI features; `realtime.py` uses Starlette types (`Request`, `Response`, `WebSocket`, `StreamingResponse`). |
-| `src/kailash/middleware/auth/` | Auth middleware is loaded during `kailash.middleware.__init__`. Uses `fastapi.Depends`, `HTTPBearer`, `starlette.requests.Request`, `starlette.exceptions.HTTPException`. |
-| `src/kailash/middleware/gateway/` | Durable gateway layer uses Starlette types directly. Loaded as part of the middleware init chain.                                     |
-| `src/kailash/middleware/database/` | Database middleware uses FastAPI dependency injection (`get_middleware_db_session`). Part of the middleware init chain.                |
-| `src/kailash/channels/`      | Channel implementations are loaded during `kailash` init; circular chain through `kailash.middleware -> nexus -> kailash`.               |
-| `adapters/`, `backends/`, `transports/`, `providers/`, `drivers/` | Infrastructure layer: database adapters, cache backends, transport implementations. These are below the framework abstraction and use raw driver imports. |
-| `trust/*store`, `trust/constraints/`, `trust/enforce/` | Trust plane persistence and enforcement layer operates below the framework boundary.                                                |
+| Exempted directory                                                | Reason                                                                                                                                                                                                                            |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/kailash/servers/`                                            | Server hierarchy creates FastAPI apps directly via `create_gateway()`. Importing from `nexus` would create `kailash -> nexus -> kailash` circular import.                                                                         |
+| `src/kailash/api/`                                                | API route definitions consumed during `kailash` init; same circular import chain as `servers/`.                                                                                                                                   |
+| `src/kailash/gateway/`                                            | Gateway layer creates FastAPI apps and uses `APIRouter`, `Depends`, `BackgroundTasks`, `CORSMiddleware` directly. Circular: `kailash -> nexus -> kailash`.                                                                        |
+| `src/kailash/middleware/communication/`                           | `APIGateway` and `RealtimeMiddleware` are loaded during `kailash.middleware.__init__`. `api_gateway.py` uses full FastAPI features; `realtime.py` uses Starlette types (`Request`, `Response`, `WebSocket`, `StreamingResponse`). |
+| `src/kailash/middleware/auth/`                                    | Auth middleware is loaded during `kailash.middleware.__init__`. Uses `fastapi.Depends`, `HTTPBearer`, `starlette.requests.Request`, `starlette.exceptions.HTTPException`.                                                         |
+| `src/kailash/middleware/gateway/`                                 | Durable gateway layer uses Starlette types directly. Loaded as part of the middleware init chain.                                                                                                                                 |
+| `src/kailash/middleware/database/`                                | Database middleware uses FastAPI dependency injection (`get_middleware_db_session`). Part of the middleware init chain.                                                                                                           |
+| `src/kailash/channels/`                                           | Channel implementations are loaded during `kailash` init; circular chain through `kailash.middleware -> nexus -> kailash`.                                                                                                        |
+| `adapters/`, `backends/`, `transports/`, `providers/`, `drivers/` | Infrastructure layer: database adapters, cache backends, transport implementations. These are below the framework abstraction and use raw driver imports.                                                                         |
+| `trust/*store`, `trust/constraints/`, `trust/enforce/`            | Trust plane persistence and enforcement layer operates below the framework boundary.                                                                                                                                              |
 
 **Tier 2 — Framework layer** (imports from `nexus` re-exports):
 
@@ -510,6 +510,68 @@ def add_plugin(self, plugin: Any) -> Nexus
 **Startup hooks:** Called in registration order during `start()`. Errors are logged but do not prevent other hooks.
 
 **Shutdown hooks:** Called in reverse registration order during `stop()`.
+
+For one-off async hooks without authoring a Plugin class, use §10.3 `add_startup_handler` / `add_shutdown_handler`. The two surfaces share the same internal `_startup_hooks` / `_shutdown_hooks` lists and run from the same FastAPI lifespan dispatch.
+
+### 10.3 add_startup_handler / add_shutdown_handler
+
+Origin: GitHub issue #712 (2026-04-30). Mediscribe and other consumers needed a "run async DDL once at server start" hook (DataFlow `await db.create_tables_async()`, cache warming, upstream connection pre-open) but reaching for `nexus.fastapi_app.on_event("startup")` hit the §10.3 timing trap (the property returns `None` until lazy gateway init fires). Authoring a full `NexusPluginProtocol` implementation for a single callback was the only documented escape. The two new methods close that gap: register a callable directly against the same `_startup_hooks` / `_shutdown_hooks` lists the plugin protocol uses.
+
+```python
+def add_startup_handler(self, func: Callable[[], Any]) -> "Nexus"
+def add_shutdown_handler(self, func: Callable[[], Any]) -> "Nexus"
+```
+
+| Surface                      | Behavior                                                                                                                                                                                                                   |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `add_startup_handler(func)`  | Append `func` to `_startup_hooks`. Runs once during the FastAPI lifespan startup phase, in registration order, inside uvicorn's event loop. Both `def` and `async def` callables accepted.                                 |
+| `add_shutdown_handler(func)` | Append `func` to `_shutdown_hooks`. Runs during the lifespan exit path (or via `Nexus.stop()` if torn down out-of-band) in REVERSE registration order — last-registered runs first, mirroring resource (open, close) LIFO. |
+
+**Validation:**
+
+- `func` MUST be callable. Non-callables raise `TypeError`.
+- Both methods MUST be called BEFORE `Nexus.start()`. Post-start registration raises `RuntimeError` — the lifespan has already fired or is firing, and a late append cannot be guaranteed to run.
+
+**Returns:** `self`, for method chaining.
+
+**Why prefer over `fastapi_app.on_event`:** the `fastapi_app` property returns `None` until the enterprise gateway is lazily initialized (gateway init fires on the first `register()` call or, failing that, at `start()`). Code that accesses `fastapi_app` immediately after `Nexus(...)` therefore sees `None` and `nexus.fastapi_app.on_event("startup")` raises `AttributeError: 'NoneType' object has no attribute 'on_event'`. The two new methods are safe to call before any `register()` / `start()` because they queue against the Nexus's own hook lists, not the FastAPI app's.
+
+**Lifespan dispatch chain order** (see `specs/nexus-services.md` § FastAPI lifespan for full detail):
+
+1. `app.router.on_startup` — driven via `kailash.utils.drive_router_lifespan_startup` (the shared helper from MED-S1 / issue #712). Iterates the same list Starlette's `_DefaultLifespan` walks; preserves `@app.on_event("startup")` and `app.router.on_startup.append(...)` registrations.
+2. Plugin / handler `_startup_hooks` — populated by `add_plugin` (§10.2), `add_startup_handler` (this section), and any internal Nexus initialization. Run in registration order.
+3. User code inside the lifespan body (between Nexus's startup and shutdown halves).
+4. Plugin / handler `_shutdown_hooks` — REVERSE registration order.
+5. `app.router.on_shutdown` — driven via `drive_router_lifespan_shutdown(app, propagate_errors=False)`.
+
+**Example:**
+
+```python
+from nexus import Nexus
+from dataflow import DataFlow
+
+app = Nexus()
+db = DataFlow("postgresql://...")
+
+@db.model
+class User:
+    id: int
+    name: str
+
+async def create_schema() -> None:
+    await db.create_tables_async()
+
+app.add_startup_handler(create_schema)
+app.register("greet", greet_workflow)
+app.start()  # create_schema runs inside uvicorn's event loop
+```
+
+**Cross-reference:**
+
+- §10.2 `add_plugin` — registers a full `NexusPluginProtocol` whose optional `on_startup` / `on_shutdown` methods land in the same internal lists.
+- `specs/nexus-services.md` § Lifespan + `fastapi_app` timing trap — full lifespan-handler chain order and the `fastapi_app` lazy-init timing contract.
+- `kailash.utils.drive_router_lifespan_startup` / `drive_router_lifespan_shutdown` — the shared helpers that drive `app.router.on_startup` / `on_shutdown` from inside any custom FastAPI lifespan.
+- `rules/framework-first.md` § "Drive The Data, Not The Dispatch" — the version-stable rationale for iterating the registered-handlers list instead of calling `app.router.startup()` by name.
 
 ---
 

--- a/specs/nexus-services.md
+++ b/specs/nexus-services.md
@@ -494,3 +494,82 @@ task = app.run_in_background(send_email(user))
 ```
 
 Runs a coroutine as a background task via `asyncio.create_task()`. Truly concurrent and decoupled from any HTTP request lifecycle. Task errors are logged, not propagated. Returns the `asyncio.Task` (can be cancelled).
+
+## 29. FastAPI Lifespan + `fastapi_app` Property
+
+Origin: GitHub issue #712 (2026-04-30). Mediscribe and similar consumers needed an async startup hook (DataFlow `await db.create_tables_async()`, cache warming, upstream connection pre-open) and reached for `nexus.fastapi_app.on_event("startup")`. The property returned `None` immediately after `Nexus(...)` because the enterprise gateway is built lazily, and the downstream `.on_event(...)` raised `AttributeError`. The fix is documented here so consumers can pick the right surface.
+
+### 29.1 `fastapi_app` Lazy-Init Timing Trap
+
+`Nexus.fastapi_app` returns the underlying `FastAPI` app once the enterprise gateway is initialized — and `None` until then. Gateway init is **lazy**: it fires on the first `Nexus.register(...)` call or, failing that, at `Nexus.start()`. The state machine:
+
+| Lifecycle event                          | `nexus.fastapi_app` returns          |
+| ---------------------------------------- | ------------------------------------ |
+| `Nexus(...)` (constructor only)          | `None`                               |
+| `nexus.register("workflow", w)`          | `FastAPI` instance (lazy init fires) |
+| `nexus.start()` (without prior register) | `FastAPI` instance (lazy init fires) |
+| After `start()`                          | `FastAPI` instance                   |
+
+Code that accesses `fastapi_app` immediately after `Nexus(...)` therefore sees `None`; any downstream attribute access (e.g. `nexus.fastapi_app.on_event("startup")`) raises `AttributeError: 'NoneType' object has no attribute 'on_event'`.
+
+**Recommended pattern** for one-off async startup/shutdown hooks: `Nexus.add_startup_handler(func)` / `Nexus.add_shutdown_handler(func)` (see `specs/nexus-core.md` §10.3). Both methods queue the handler in `_startup_hooks` / `_shutdown_hooks` BEFORE the gateway is initialized, so they're safe to call immediately after `Nexus(...)`.
+
+**Direct `on_event` is supported** — but only after a `register()` or `start()` has triggered gateway construction. Authors who hold a reference to `fastapi_app` early MUST either gate on `nexus.fastapi_app is not None` or migrate to `add_startup_handler`.
+
+### 29.2 Lifespan-Handler Chain Order
+
+When a Nexus consumer wraps the FastAPI app in a custom lifespan (the documented "I want to add my own startup logic" pattern), the chain MUST drive every registered handler list in the canonical order. The shared helper module `kailash.utils.lifespan` (issue #712 / MED-S1) exposes the two drivers Nexus and every sibling FastAPI gateway uses:
+
+```python
+from kailash.utils import (
+    drive_router_lifespan_startup,
+    drive_router_lifespan_shutdown,
+)
+```
+
+**Canonical lifespan chain** (Nexus's own lifespan implements this; custom lifespans MUST mirror it):
+
+1. **`app.router.on_startup`** — driven via `drive_router_lifespan_startup(app)`. Iterates the SAME list Starlette's default `_DefaultLifespan` walks. Without this step, every handler registered via `@app.on_event("startup")` or `app.router.on_startup.append(...)` is silently dropped (the #500 bug pattern).
+2. **Plugin / handler `_startup_hooks`** — populated by `add_plugin` (`specs/nexus-core.md` §10.2), `add_startup_handler` (§10.3), and Nexus's own internal init. Run in registration order. Per-hook exceptions are isolated; the FIRST captured exception is re-raised after all hooks complete.
+3. **User code inside the lifespan body** (between Nexus's startup and shutdown halves).
+4. **Plugin / handler `_shutdown_hooks`** — REVERSE registration order (last-registered runs first), mirroring resource (open, close) LIFO.
+5. **`app.router.on_shutdown`** — driven via `drive_router_lifespan_shutdown(app, propagate_errors=False)`. The `propagate_errors=False` flag is correct for shutdown: cleanup paths are best-effort and a later handler MUST run even if an earlier one raises.
+
+**`drive_router_lifespan_startup` / `_shutdown` contract:**
+
+- Iterate `app.router.on_startup` / `app.router.on_shutdown` in registration order.
+- Sync handlers (return `None`) are accepted; async handlers (return a coroutine) are awaited.
+- Per-handler exceptions are isolated: if handler N raises, handlers N+1, N+2, ... still run.
+- After all handlers complete, the FIRST captured exception is re-raised when `propagate_errors=True` (startup default — preserves uvicorn fail-fast). `propagate_errors=False` logs failures and returns normally (shutdown convention).
+
+**Why a shared helper:** four sibling FastAPI sites (`WorkflowServer`, `KailashAPIGateway`, `WorkflowAPIGateway`, `WorkflowAPI`) each construct `FastAPI(lifespan=...)` and historically hand-rolled the iteration. Three of them shipped with the iteration missing entirely (the #500 silent-drop bug). Routing every site through one helper localizes the cross-version invariant per `rules/framework-first.md` § "Drive The Data, Not The Dispatch" — `app.router.on_startup` is the data structure FastAPI's own internal dispatcher walks, and is strictly more stable than any dispatch method name.
+
+**Example — custom lifespan honoring router hooks:**
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
+from kailash.utils import (
+    drive_router_lifespan_startup,
+    drive_router_lifespan_shutdown,
+)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await drive_router_lifespan_startup(app)
+    try:
+        yield
+    finally:
+        await drive_router_lifespan_shutdown(app, propagate_errors=False)
+
+app = FastAPI(lifespan=lifespan)
+
+@app.on_event("startup")
+async def warm_cache(): ...
+```
+
+**Cross-reference:**
+
+- `specs/nexus-core.md` §10.3 `add_startup_handler` / `add_shutdown_handler` — the recommended Nexus-level surface for one-off hooks.
+- `kailash.utils.lifespan` (`src/kailash/utils/lifespan.py`) — the shared driver module.
+- `rules/framework-first.md` § "Drive The Data, Not The Dispatch" — the version-stable rationale.


### PR DESCRIPTION
## Summary

Updates spec authority for the the v2.13.0 cluster (#712/#713/#714) per `rules/specs-authority.md` Rule 5 (first-instance updates) and Rule 5b (sibling re-derivation). Lands after PRs #722, #723, #724, #725, #726, #727 merged the underlying code.

## Spec changes

**specs/dataflow-core.md**
- §1.4 Lazy Connection — note the new DDL connection lifecycle (single sync connection per batch) with cross-ref to §1.6.5.
- §1.5 Runtime Detection — replace "selects at construction time" with the lazy per-event-loop resolution contract. Document the `runtime` `@property` (4-step resolution order: setter override > closed > per-loop async cache > sync singleton), the setter, the `runtime=` `__init__` kwarg, the subsystem-capture pattern (subsystems hold `_dataflow` ref and read `_dataflow.runtime` lazily), and pickle/deepcopy round-trip support.
- §1.6.5 (new) — DDL connection-reuse contract: single sync connection per `_execute_ddl` batch via `SyncDDLExecutor.execute_ddl_batch_per_statement`; async path off-loops via `asyncio.to_thread` so the event loop stays unblocked. Per-statement result shape; cross-ref to #696 (auto-migrate).

**specs/nexus-core.md**
- §10.2 — cross-reference §10.3 ("for one-off async hooks without authoring a Plugin class").
- §10.3 (new) — `Nexus.add_startup_handler` / `add_shutdown_handler` public API. Validation contract (`TypeError` on non-callable, `RuntimeError` on post-`start()` registration), LIFO shutdown order, full lifespan dispatch chain, DataFlow async DDL example.

**specs/nexus-services.md**
- §29 (new) — FastAPI Lifespan + `fastapi_app` Property. Documents the `fastapi_app` lazy-init timing trap (returns `None` until first `register()` / `start()`), the canonical 5-step lifespan-handler chain order (router on_startup → plugin/handler hooks → user code → reverse for shutdown → router on_shutdown), and the `kailash.utils.lifespan` shared driver helpers.

## Sibling sweep (Rule 5b)

| Spec file | Drift found? |
| --------- | ------------ |
| `specs/dataflow-cache.md` | No — `AsyncSQLDatabaseNode` references are CRUD pool tracking (separate concern from DDL refactor). |
| `specs/dataflow-express.md` | No — no relevant references. |
| `specs/dataflow-models.md` | No — no relevant references. |
| `specs/nexus-channels.md` | No — `runtime=` references are channel-level (unrelated to DataFlow runtime); `on_event` references are WebSocket events (not lifespan). |
| `specs/nexus-auth.md` | No — no relevant references. |

## Test plan

- [x] Pre-commit clean (`pre-commit run --files specs/dataflow-core.md specs/nexus-core.md specs/nexus-services.md`)
- [x] Spec drift gate passes
- [x] Tier 1 unit tests pass
- [x] Sibling sweep (Rule 5b) — every dataflow-* and nexus-* spec checked for stale references; results table above

## Related issues

Resolves S7. Closes the the v2.13.0 cluster (#712/#713/#714) acceptance criterion #5 (PR-D specs landed).

Related: #712, #713, #714
