### PR TITLE
release(v2.13.0): kailash 2.13.0 + nexus 2.5.0 + dataflow 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.0] — 2026-04-30 — `kailash.utils.lifespan` shared FastAPI helpers (Mediscribe cluster: closes #712)
+
+Minor bump — ships the cross-FastAPI-site lifespan helper module that drives `app.router.on_startup` / `on_shutdown` from any custom `FastAPI(lifespan=...)` and patches three sibling sites that historically dropped router hooks silently.
+
+### Added
+
+- **`kailash.utils.drive_router_lifespan_startup` / `drive_router_lifespan_shutdown` (#712 / MED-S1)** — shared async helpers that iterate `app.router.on_startup` / `app.router.on_shutdown` (the same lists Starlette's default `_DefaultLifespan` walks) from inside any custom FastAPI lifespan. Both sync (`def`) and async (`async def`) handlers are accepted; per-handler exceptions are isolated and logged at WARN per `rules/observability.md` Rule 7. The first captured exception is re-raised when `propagate_errors=True` (the default for startup, preserves uvicorn fail-fast); shutdown callers typically pass `propagate_errors=False` for best-effort cleanup. Drives the data structure FastAPI's own internal dispatcher walks rather than calling `app.router.startup()` / `.shutdown()` by name — version-stable per `rules/framework-first.md` § "Drive The Data, Not The Dispatch" (the dispatch method names drift across FastAPI / Starlette versions; the registration lists do not).
+
+### Fixed
+
+- **#712 — three sibling FastAPI lifespan sites silently drop router-registered handlers (MED-S2)** — `KailashAPIGateway`, `WorkflowAPIGateway`, and `WorkflowAPI` each constructed `FastAPI(lifespan=...)` without iterating `app.router.on_startup` / `app.router.on_shutdown`, so every handler registered via `@app.on_event("startup")` or `app.router.on_startup.append(...)` was silently dropped (the #500 silent-drop bug pattern at three additional sites). All three now route through `drive_router_lifespan_startup` / `drive_router_lifespan_shutdown` so router-registered hooks fire correctly.
+
+### Tests
+
+- `tests/regression/test_issue_712_sibling_fastapi_sites.py` — Tier 2 regression suite verifying every sibling site drives its router hooks through the shared helper.
+- `tests/regression/test_issue_712_consumer_startup_patterns.py` — Tier 2 regression for the canonical consumer patterns (`Nexus.add_startup_handler` + DataFlow async DDL); cross-references kailash-nexus 2.5.0.
+
+### Cross-SDK
+
+- kailash-rs uses axum + tokio; no equivalent custom-lifespan footgun. No companion issue.
+
 ## [2.12.0] — 2026-04-28 — Pool lifecycle hardening (DPI-B: closes #697, #698)
 
 Minor bump — ships the process-pool lifecycle management surface that was missing from the

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,31 @@
 # DataFlow Changelog
 
+## [2.6.0] — 2026-04-30 — Lazy runtime resolution + DDL connection-reuse (Mediscribe cluster: closes #713, #714)
+
+Minor release closing the two remaining DataFlow surfaces in the Mediscribe cluster. Backward-compatible: every existing `db.runtime`-reading consumer keeps working unchanged because the new `@property` resolves to the same runtime instance per event loop, and the existing `db.runtime = X` mutation pattern is preserved through the new setter.
+
+### Added
+
+- **`DataFlow.runtime` lazy `@property` + setter + `runtime=` `__init__` kwarg (#713 / MED-S4)** — `DataFlow.runtime` is now resolved per access via a per-event-loop cache rather than bound at construction time. Resolution order: (1) setter override (`db.runtime = X`, `runtime=` kwarg, `monkeypatch.setattr`), (2) `None` if `_closed`, (3) per-event-loop `AsyncLocalRuntime` cache (mirrors the per-loop `_async_sql_node_cache` pattern at engine.py:7488), (4) cached sync `LocalRuntime` singleton. The `runtime=` `__init__` kwarg is the explicit escape hatch for callers that need a specific runtime from construction. Pickle / deepcopy round-trip support: the per-loop cache is excluded from `__getstate__` and rebuilt lazily on first access in the unpickled instance, making DataFlow safe to ship across multiprocessing / Ray / Dask workers.
+- **DDL connection reuse via `SyncDDLExecutor.execute_ddl_batch_per_statement` (#714 / MED-S6)** — `_execute_ddl` (sync) and `_execute_ddl_async` (async, via `asyncio.to_thread`) now run the entire DDL batch on a single sync connection acquired from the dialect driver (`psycopg2` / `sqlite3` / `pymysql`). Per-statement results are captured (success/error/duration_ms) so the #696 fail-fast circuit-breaker continues to fire on individual CREATE TABLE failures while index/FK/auxiliary failures continue past (legacy semantics).
+
+### Fixed
+
+- **#713 — module-import construction permanently bound `LocalRuntime` (MED-S4)** — pre-fix, `db = DataFlow(...)` at module scope ran with no event loop and bound `LocalRuntime` for the instance's lifetime, so `await db.create_tables_async()` from inside FastAPI/uvicorn either raised "no running event loop" or quietly used the wrong runtime. Lazy per-loop resolution fixes this without breaking the synchronous CLI path.
+- **#713 — subsystem captures snapshot the runtime at `__init__` time (MED-S5)** — `DataFlowExpress`, `DataFlowExpressSync`, `BulkOperations`, `TransactionManager`, `_DataFlowAuditQueryProxy`, `_DataFlowAuditExportProxy` previously captured `self.runtime = dataflow.runtime` at construction. Captured runtimes did not follow setter overrides and missed the per-event-loop cache. All six subsystems now hold `self._dataflow = dataflow` and read `self._dataflow.runtime` lazily on each operation, picking up `db.runtime = X` mutations and the per-loop cache transparently.
+- **#714 — DDL connection thrash (MED-S6)** — pre-fix, `_execute_ddl` / `_execute_ddl_async` routed every CREATE TABLE / CREATE INDEX through a fresh `AsyncSQLDatabaseNode` instance (one connection acquire/release per statement). Under `auto_migrate=True` with N models, this produced ≈ 2N+ connection acquires at startup, exhausting pgbouncer transaction-pool slots or constrained Azure PostgreSQL `max_connections` before the application opened to traffic. The single-sync-connection path closes that failure mode.
+
+### Tests
+
+- `packages/kailash-dataflow/tests/regression/test_issue_713_module_import_then_async_ddl.py` — Tier 3 regression for the module-import construction → async DDL path.
+- `packages/kailash-dataflow/tests/regression/test_issue_713_subsystems_follow_runtime_swap.py` — Tier 2 regression for subsystem lazy lookups (every subsystem follows `db.runtime = X` mutations).
+- `packages/kailash-dataflow/tests/regression/test_issue_714_ddl_single_connection.py` — structural + behavioral regression suite pinning the single-connection contract; verifies the #696 fail-fast circuit-breaker is preserved through the refactor.
+
+### Cross-SDK
+
+- kailash-rs Tokio runtime is always present at construction time; no equivalent module-import footgun for #713. No companion issue.
+- kailash-rs may have analogous DDL connection thrash for #714 — companion issue to be filed.
+
 ## [2.5.0] — 2026-04-29 — `TransactionScope.execute_raw` for multi-statement raw-SQL atomicity
 
 Minor release adding the `TransactionScope.execute_raw` surface from issue #707 (closed by PR #716). Backward-compatible: every prior `db.transactions.begin()` consumer keeps working unchanged via the dict-style `__getitem__`/`__setitem__` shim. Bundles a latent savepoint async-context-manager bug fix discovered during implementation review.

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.5.0"
+version = "2.6.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -108,7 +108,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Nexus Changelog
 
+## [2.5.0] — 2026-04-30 — `Nexus.add_startup_handler` / `add_shutdown_handler` (Mediscribe cluster: closes #712)
+
+Minor release adding the canonical "run-once at server start" hook surface so consumers no longer need to reach for `nexus.fastapi_app.on_event(...)` (which has the lazy-init timing trap — `fastapi_app` returns `None` until the enterprise gateway is initialized) or author a full `NexusPluginProtocol` implementation for a single callback.
+
+### Added
+
+- **`Nexus.add_startup_handler(func)` (#712 / MED-S3)** — registers a zero-argument callable (sync `def` or `async def`) that fires during the FastAPI lifespan startup phase, in registration order, inside uvicorn's event loop. Appends to the same internal `_startup_hooks` list that powers the plugin protocol's `on_startup` lifecycle hook (§10.2). Returns `self` for chaining. Raises `TypeError` on non-callables and `RuntimeError` if called after `Nexus.start()` (the lifespan has already fired or is firing; a late append cannot be guaranteed to run). The canonical pattern for "run DataFlow async DDL at server start" — `app.add_startup_handler(create_schema)` where `create_schema` is `async def create_schema(): await db.create_tables_async()`.
+- **`Nexus.add_shutdown_handler(func)` (#712 / MED-S3)** — symmetric to `add_startup_handler`. Appends to `_shutdown_hooks`. Hooks fire in REVERSE registration order — the last installed runs first — so pairs of (open_resource, close_resource) registered in init order tear down LIFO. Same validation contract.
+
+### Documented
+
+- **`fastapi_app` lazy-init timing trap (issue #712)** — the `fastapi_app` property returns `None` until the enterprise gateway has been initialized; gateway init is lazy (fires on the first `register()` call, or at `start()` if no `register()` was called first). Code that accesses `fastapi_app` immediately after `Nexus(...)` therefore sees `None` and any downstream attribute access (e.g. `nexus.fastapi_app.on_event("startup")`) raises `AttributeError: 'NoneType' object has no attribute 'on_event'`. Docstring on `fastapi_app` now warns explicitly and points to `add_startup_handler` as the safe pre-init surface. See `specs/nexus-services.md` §29 for the full timing contract.
+
+### Tests
+
+- `tests/regression/test_issue_712_consumer_startup_patterns.py` — Tier 2 regression (in the kailash root repo) verifying the new API against real DataFlow async DDL + sibling FastAPI lifespan sites.
+
+### Cross-SDK
+
+- kailash-rs uses axum + tokio; no equivalent custom-lifespan footgun. No companion issue.
+
 ## [2.4.1] — 2026-04-29 — `MountInfo` exported in `__all__`
 
 Patch release closing the build-repo-release-discipline.md Rule 5 drift from PR #720. `MountInfo` (`nexus/core.py`) was already imported at module-scope in `nexus/__init__.py` but absent from `__all__`, triggering `pyright` "MountInfo is not accessed" and violating `orphan-detection.md` Rule 6 (Module-Scope Public Imports Appear In `__all__`). No behavioral change; pure public-API contract repair.

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.4.1"
+version = "2.5.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -102,7 +102,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.4.1"
+__version__ = "2.5.0"
 __all__ = [
     # Core
     "Nexus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.12.0"
+version = "2.13.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.12.0"
+__version__ = "2.13.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep PR for the the v2.13.0 cluster (#712 / #713 / #714). Three packages bumped atomically per `rules/zero-tolerance.md` Rule 5 (`pyproject.toml` + `__init__.py::__version__`). Branch on `release/v*` per `rules/git.md` to auto-skip the PR-gate matrix on metadata-only diff.

## Version bumps

| Package | Old | New | Reason |
| ------- | --- | --- | ------ |
| `kailash` | 2.12.0 | **2.13.0** | Adds `kailash.utils.lifespan` shared helpers (S1) + patches 3 sibling FastAPI lifespan sites (S2). New public API surface. |
| `kailash-nexus` | 2.4.1 | **2.5.0** | Adds `Nexus.add_startup_handler` / `add_shutdown_handler` public API (S3). |
| `kailash-dataflow` | 2.5.0 | **2.6.0** | Lazy `runtime` `@property` + setter + `runtime=` kwarg (S4) + 6 subsystem captures → lazy lookups (S5) + DDL connection-reuse refactor (S6). |

## Specs landed in #728 (already merged)

- `specs/dataflow-core.md` §1.4 (DDL note), §1.5 (lazy runtime contract), §1.6.5 (DDL connection-reuse)
- `specs/nexus-core.md` §10.2 (cross-ref), §10.3 (add_startup_handler / add_shutdown_handler)
- `specs/nexus-services.md` §29 (FastAPI lifespan + fastapi_app timing trap)

## Underlying merged PRs

- #722 (S1): `kailash.utils.lifespan` shared helper
- #723 (S4): DataFlow lazy `runtime` `@property` + setter + `runtime=` kwarg
- #724 (S3): `Nexus.add_startup_handler` / `add_shutdown_handler` public API
- #725 (S5): 6 subsystem captures → lazy lookups
- #726 (S2): patch 3 sibling FastAPI lifespan sites
- #727 (S6): DDL connection-reuse via `SyncDDLExecutor.execute_ddl_batch_per_statement`
- #728 (S7): spec updates

## Test plan

- [x] `pyproject.toml::version` matches `src/kailash/__init__.py::__version__` for kailash (2.13.0)
- [x] `pyproject.toml::version` matches `src/nexus/__init__.py::__version__` for kailash-nexus (2.5.0)
- [x] `pyproject.toml::version` matches `src/dataflow/__init__.py::__version__` for kailash-dataflow (2.6.0)
- [x] CHANGELOGs updated for all three packages
- [x] Pre-commit clean (Tier 1 tests pass, all hooks green)
- [ ] After merge: `/release` cycle for all three packages
- [ ] After merge: clean-venv installability verification per `rules/build-repo-release-discipline.md` Rule 2

## Related issues

Closes the v2.13.0 cluster acceptance gate criterion #6 (PyPI release shipped). Related: #712, #713, #714.
