### PR TITLE
chore(deploy): record v2.13.0 cluster cut in deployment-config.md

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -17,17 +17,19 @@
 
 | Package          | Tag Pattern        | Current Version |
 | ---------------- | ------------------ | --------------- |
-| kailash (core)   | `v*`               | 2.11.3          |
-| kailash-dataflow | `dataflow-v*`      | 2.3.3           |
+| kailash (core)   | `v*`               | 2.13.0          |
+| kailash-dataflow | `dataflow-v*`      | 2.6.0           |
 | kailash-kaizen   | `kaizen-v*`        | 2.13.1          |
-| kailash-nexus    | `nexus-v*`         | 2.3.0           |
+| kailash-nexus    | `nexus-v*`         | 2.5.0           |
 | kailash-pact     | `pact-v*`          | 0.11.0          |
-| kailash-ml       | `ml-v*`            | 1.5.1           |
+| kailash-ml       | `ml-v*`            | 1.6.0           |
 | kailash-align    | `align-v*`         | 0.7.0           |
 | kailash-mcp      | `mcp-v*`           | 0.2.10          |
 | kaizen-agents    | `kaizen-agents-v*` | 0.9.4           |
 
-Last updated: 2026-04-28 (kailash-dataflow 2.3.3 patch — closes merged-but-unreleased gap from PRs #684 / #689 / #690: `not_null_handler.py` pyright cleanup + 8 migration unit-test mock-method-drift repairs. No production behavior change beyond type-checking cleanup; 13 pre-existing pytest warnings in the migrations suite remain on separate workstreams). kailash-ml 1.5.1 (PR #679) routes the `engines/model_registry.py` `ModelNotFoundError` through the canonical `kailash.ml.errors.ModelNotFoundError` (subclass of `ModelRegistryError → MLError`), removing the divergent local `class ModelNotFoundError(Exception)` that surfaced when the W7-001 LineageGraph walker raised canonical while `ModelRegistry.get_model` raised local. 6 raise sites converted to canonical kwargs; 3 regression tests pin class-identity + AST invariant. PR #679 also adds `scripts/development/find-venv-python.sh` — wrapper that resolves `.venv/bin/python` via `git rev-parse --git-common-dir` so pre-commit hooks run from inside `.claude/worktrees/<X>/` without the `core.hooksPath=/dev/null` bypass; 3 regression tests pin the worktree-safe invariants. Clean-venv install verified live: `kailash-ml==1.5.1` + `ModelNotFoundError canonical identity: OK` + `__all__ count: 50 (AST-derived)`. No sibling drift.
+Last updated: 2026-04-30 — Mediscribe cluster cut: `kailash 2.12.0 → 2.13.0` (adds `kailash.utils.lifespan` shared FastAPI helpers + patches 3 sibling FastAPI lifespan sites for #712), `kailash-nexus 2.4.1 → 2.5.0` (adds `Nexus.add_startup_handler` / `add_shutdown_handler` public API for #712), `kailash-dataflow 2.5.0 → 2.6.0` (lazy `runtime` `@property` + setter + `runtime=` kwarg for #713 + 6 subsystem captures → lazy lookups + DDL connection-reuse via `SyncDDLExecutor.execute_ddl_batch_per_statement` for #714). Three tags pushed individually (per multi-tag discipline), three `publish-pypi.yml` runs triggered. Specs landed in PR #728 (`specs/dataflow-core.md` §1.4/1.5/1.6.5 + `specs/nexus-core.md` §10.2/10.3 + `specs/nexus-services.md` §29). Cross-SDK: kailash-rs uses axum + Tokio (no equivalent custom-lifespan footgun for #712, no module-import event-loop binding for #713); analogous DDL connection thrash for #714 may exist — companion issue to be filed.
+
+Prior 2026-04-28 (kailash-dataflow 2.3.3 patch — closes merged-but-unreleased gap from PRs #684 / #689 / #690: `not_null_handler.py` pyright cleanup + 8 migration unit-test mock-method-drift repairs. No production behavior change beyond type-checking cleanup; 13 pre-existing pytest warnings in the migrations suite remain on separate workstreams). kailash-ml 1.5.1 (PR #679) routes the `engines/model_registry.py` `ModelNotFoundError` through the canonical `kailash.ml.errors.ModelNotFoundError` (subclass of `ModelRegistryError → MLError`), removing the divergent local `class ModelNotFoundError(Exception)` that surfaced when the W7-001 LineageGraph walker raised canonical while `ModelRegistry.get_model` raised local. 6 raise sites converted to canonical kwargs; 3 regression tests pin class-identity + AST invariant. PR #679 also adds `scripts/development/find-venv-python.sh` — wrapper that resolves `.venv/bin/python` via `git rev-parse --git-common-dir` so pre-commit hooks run from inside `.claude/worktrees/<X>/` without the `core.hooksPath=/dev/null` bypass; 3 regression tests pin the worktree-safe invariants. Clean-venv install verified live: `kailash-ml==1.5.1` + `ModelNotFoundError canonical identity: OK` + `__all__ count: 50 (AST-derived)`. No sibling drift.
 
 Prior 2026-04-27 — W7 portfolio remediation: kailash-ml 1.5.0 (PR #677 closes #657) ships the cross-engine `LineageGraph` engine module; kailash-dataflow 2.3.2 (PR #678) wires `format_error_for_event` through `emit_train_end` at the emitter.
 


### PR DESCRIPTION
## Summary

Updates `deploy/deployment-config.md` Current Version table for the the v2.13.0 cluster cut (PR #729 / tags `v2.13.0`, `dataflow-v2.6.0`, `nexus-v2.5.0`):

- `kailash`: 2.11.3 → **2.13.0**
- `kailash-dataflow`: 2.3.3 → **2.6.0**
- `kailash-nexus`: 2.3.0 → **2.5.0**
- `kailash-ml`: 1.5.1 → **1.6.0** (drift catch-up; was already on PyPI)

Plus a dated narrative entry summarizing the cluster.

## Verification

Clean-venv installability verified — all 3 versions resolved + new public APIs importable (`kailash.utils.drive_router_lifespan_startup` + `Nexus.add_startup_handler` / `add_shutdown_handler` + `DataFlow.runtime` lazy property + `SyncDDLExecutor.execute_ddl_batch_per_statement`).

## Related issues

#712, #713, #714 — the v2.13.0 cluster.
