### PR TITLE
release(kaizen-v2.14.0): canonical kaizen.core re-exports + MLAwareAgent

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.0] — 2026-04-30 — Canonical `kaizen.core` re-exports + MLAwareAgent + env-model resolution
+
+Minor bump. Three load-bearing changes land together:
+
+- **(Fixed, HIGH-2)** Restores the canonical Quick Start from `specs/kaizen-core.md` §3 + `rules/patterns.md` § Kaizen — `from kaizen.core import BaseAgent, Signature, InputField, OutputField` now resolves on every fresh install.
+- **(Added)** `kaizen.ml.MLAwareAgent` — first production consumer of the §2.4 ML tool-discovery surface, closing F-D-55 (orphan-detection §1).
+- **(Changed)** `CoreAgent` + `GovernedSupervisor` no longer hardcode model strings; both resolve from `KAIZEN_DEFAULT_MODEL` per `rules/env-models.md` (closes F-D-02 + F-D-50).
+
 ### Fixed
 
 - **`from kaizen.core import BaseAgent, Signature, InputField, OutputField` raised `ImportError` on every fresh install** — the canonical Quick Start documented in `specs/kaizen-core.md` §3 BaseAgent AND the project rule `rules/patterns.md` § Kaizen Quick Start crashed before any agent code ran. `BaseAgent` lives at `kaizen.core.base_agent`; `Signature` / `InputField` / `OutputField` live in `kaizen.signatures`. Neither was re-exported through `kaizen/core/__init__.py`. Surfaced by /sweep Sweep 6 spec-vs-code drift audit (2026-04-30, HIGH-2). Fix: re-export all four symbols from `kaizen.core` and add them to `__all__`. Also adds `StructuredOutput` to `__all__` (pre-existing orphan-detection §6 violation — eagerly imported but absent). Three Tier-1 regression tests in `packages/kailash-kaizen/tests/regression/test_kaizen_core_quickstart_imports.py` pin the contract structurally (import-resolution, `__all__` membership, canonical-module identity).


### PR DESCRIPTION
## Summary

Release-prep PR for `kailash-kaizen 2.14.0`. CHANGELOG-only diff — version anchors already bumped in PR #742.

Promotes `[Unreleased]` → `[2.14.0] — 2026-04-30 — Canonical kaizen.core re-exports + MLAwareAgent + env-model resolution`.

## Release contents (cumulative `[Unreleased]` from main)

### Fixed (HIGH-2 from /sweep Sweep 6)
- `from kaizen.core import BaseAgent, Signature, InputField, OutputField` Quick Start ImportError fixed (PR #742). Restores spec/rule contract from `specs/kaizen-core.md` §3 and `rules/patterns.md` § Kaizen.

### Added
- `kaizen.ml.MLAwareAgent` — first production consumer of §2.4 ML tool-discovery surface (F-D-55, closes orphan-detection §1).
- `kaizen.errors.EnvModelMissing` — typed RuntimeError subclass for env-resolved model failures.
- W6-011: 28 Tier-1 unit tests for `kaizen.judges` (F-D-25).
- `.env.example` at repo root.

### Changed
- `CoreAgent` + `GovernedSupervisor` resolve model from `KAIZEN_DEFAULT_MODEL` env var per `rules/env-models.md` (closes F-D-02 + F-D-50).

## Test plan

- [x] CHANGELOG diff is metadata-only (no source/code changes)
- [x] Version anchors already at 2.14.0 (verified: pyproject.toml + __init__.py)
- [ ] CI passes (release/* branch — PR-gate matrix may auto-skip if `ci-runners.md` skip clause is adopted)

## Post-merge actions

1. Push `kaizen-v2.14.0` tag → triggers `publish-pypi.yml`
2. Verify clean-venv install: `pip install kailash-kaizen==2.14.0` + import canonical Quick Start
3. Close #740 / #741 references if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)