### PR TITLE
fix(diagnostics): pin TraceEvent timestamp microsecond padding (#731)

### DIFF
--- a/schemas/trace-event.v1.json
+++ b/schemas/trace-event.v1.json
@@ -7,7 +7,7 @@
   "version": "1.0.0",
   "canonicalization": {
     "json_serialization": "sort_keys=true, separators=(',', ':'), ensure_ascii=true, default=str (Python) / serde_json::to_string(&BTreeMap) (Rust)",
-    "timestamp_format": "RFC 3339 with explicit +00:00 UTC offset; never Z",
+    "timestamp_format": "RFC 3339 with explicit +00:00 UTC offset AND fixed six-digit microsecond precision (`YYYY-MM-DDThh:mm:ss.uuuuuu+00:00`); never Z; never elide microseconds when zero. Eliding the decimal portion when microsecond == 0 is the failure mode kailash-py issue #731 fixed — both SDKs MUST emit six microsecond digits unconditionally.",
     "fingerprint_algorithm": "SHA-256 of the UTF-8 bytes of the canonical JSON, hex-encoded lowercase",
     "comparison": "hmac.compare_digest (Python) / subtle::ConstantTimeEq (Rust). Never == on hex digests (timing side-channel).",
     "cross_sdk_note": "Python and Rust MUST produce byte-identical canonical JSON and byte-identical SHA-256 fingerprints for the same logical input. Paired with `schemas/audit-anchor.v1.json` (kailash-rs#449) — same canonicalization contract."
@@ -47,8 +47,8 @@
     "timestamp": {
       "type": "string",
       "format": "date-time",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?\\+00:00$",
-      "description": "RFC 3339 timestamp with explicit +00:00 UTC offset. Z-form is BLOCKED to keep the byte-level form stable across SDKs."
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}\\+00:00$",
+      "description": "RFC 3339 timestamp with explicit +00:00 UTC offset AND fixed six-digit microsecond precision. Z-form is BLOCKED; eliding the decimal portion when microsecond == 0 is BLOCKED — both make the byte form non-canonical across SDKs. See kailash-py issue #731 for the originating defect (Python `datetime.isoformat()` elided the decimal when microsecond was zero, breaking cross-SDK fingerprint parity for any TraceEvent landing on a whole second)."
     },
     "run_id": {
       "type": "string",

--- a/src/kailash/diagnostics/protocols.py
+++ b/src/kailash/diagnostics/protocols.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from enum import Enum
 from typing import (
@@ -218,8 +218,13 @@ class TraceEvent:
         # Enum values → strings.
         d["event_type"] = self.event_type.value
         d["status"] = self.status.value if self.status is not None else None
-        # Timestamp → ISO-8601 with explicit +00:00 offset.
-        d["timestamp"] = self.timestamp.isoformat()
+        # Timestamp → ISO-8601 with explicit +00:00 offset AND fixed
+        # six-digit microsecond precision. ``isoformat()`` alone elides
+        # the decimal portion when ``microsecond == 0``, breaking
+        # cross-SDK byte-equality with kailash-rs (which always emits
+        # six microsecond digits via its own canonical path). See #731
+        # and ``rules/cross-sdk-inspection.md`` MUST Rule 4.
+        d["timestamp"] = self.timestamp.isoformat(timespec="microseconds")
         return d
 
     @classmethod

--- a/test-vectors/trace-event-canonical.json
+++ b/test-vectors/trace-event-canonical.json
@@ -1,0 +1,58 @@
+{
+  "spec_version": "1.0",
+  "description": "Cross-SDK canonical fixtures for TraceEvent.to_dict() byte-equality + fingerprint stability between kailash-py and kailash-rs. Generated 2026-04-30 from the corrected isoformat(timespec=microseconds) path. Source: kailash-py issue #731 fix; vector inputs are reproducible from the embedded `input_repr` field.",
+  "vectors": [
+    {
+      "name": "V1_zero_microsecond",
+      "input_repr": {
+        "event_id": "evt-V1",
+        "run_id": "run-V1",
+        "agent_id": "agent-V1",
+        "cost_microdollars": 0,
+        "event_type": "agent.run.start",
+        "timestamp": "2026-04-20T12:00:00.000000+00:00"
+      },
+      "expected_canonical_json": "{\"agent_id\":\"agent-V1\",\"completion_tokens\":null,\"cost_microdollars\":0,\"duration_ms\":null,\"envelope_id\":null,\"event_id\":\"evt-V1\",\"event_type\":\"agent.run.start\",\"llm_model\":null,\"parent_event_id\":null,\"payload\":null,\"payload_hash\":null,\"prompt_tokens\":null,\"run_id\":\"run-V1\",\"span_id\":null,\"status\":null,\"tenant_id\":null,\"timestamp\":\"2026-04-20T12:00:00.000000+00:00\",\"tool_name\":null,\"trace_id\":null}",
+      "expected_fingerprint": "792c13984825844cac0f9446730a0e63183632369827311009ae52ee1ce3023c"
+    },
+    {
+      "name": "V2_nonzero_microsecond",
+      "input_repr": {
+        "event_id": "evt-V2",
+        "run_id": "run-V2",
+        "agent_id": "agent-V2",
+        "cost_microdollars": 150,
+        "tool_name": "search",
+        "duration_ms": 42.5,
+        "event_type": "tool.call.start",
+        "timestamp": "2026-04-20T12:00:00.123456+00:00"
+      },
+      "expected_canonical_json": "{\"agent_id\":\"agent-V2\",\"completion_tokens\":null,\"cost_microdollars\":150,\"duration_ms\":42.5,\"envelope_id\":null,\"event_id\":\"evt-V2\",\"event_type\":\"tool.call.start\",\"llm_model\":null,\"parent_event_id\":null,\"payload\":null,\"payload_hash\":null,\"prompt_tokens\":null,\"run_id\":\"run-V2\",\"span_id\":null,\"status\":null,\"tenant_id\":null,\"timestamp\":\"2026-04-20T12:00:00.123456+00:00\",\"tool_name\":\"search\",\"trace_id\":null}",
+      "expected_fingerprint": "049db1a3d005c455df3f457a11603d9de5dee446601af0034fb1a82dc6ef3577"
+    },
+    {
+      "name": "V3_full_event",
+      "input_repr": {
+        "event_id": "evt-V3",
+        "run_id": "run-V3",
+        "agent_id": "agent-V3",
+        "cost_microdollars": 2500,
+        "trace_id": "trace-V3",
+        "span_id": "span-V3",
+        "tenant_id": "tenant-V3",
+        "envelope_id": "env-V3",
+        "llm_model": "gpt-4o",
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "duration_ms": 1234.5,
+        "payload_hash": "sha256:deadbeef",
+        "payload": null,
+        "event_type": "agent.run.end",
+        "timestamp": "2026-12-31T23:59:59.999999+00:00",
+        "status": "ok"
+      },
+      "expected_canonical_json": "{\"agent_id\":\"agent-V3\",\"completion_tokens\":50,\"cost_microdollars\":2500,\"duration_ms\":1234.5,\"envelope_id\":\"env-V3\",\"event_id\":\"evt-V3\",\"event_type\":\"agent.run.end\",\"llm_model\":\"gpt-4o\",\"parent_event_id\":null,\"payload\":null,\"payload_hash\":\"sha256:deadbeef\",\"prompt_tokens\":100,\"run_id\":\"run-V3\",\"span_id\":\"span-V3\",\"status\":\"ok\",\"tenant_id\":\"tenant-V3\",\"timestamp\":\"2026-12-31T23:59:59.999999+00:00\",\"tool_name\":null,\"trace_id\":\"trace-V3\"}",
+      "expected_fingerprint": "ff114cf1a11dd6b9296644fde32e95a6a560839f5d0dbcc47a8846c226b7f5a1"
+    }
+  ]
+}

--- a/tests/regression/test_issue_731_trace_event_timestamp_padding.py
+++ b/tests/regression/test_issue_731_trace_event_timestamp_padding.py
@@ -1,0 +1,190 @@
+"""Regression tests for #731 — TraceEvent.to_dict() timestamp microsecond padding.
+
+The defect: ``datetime.isoformat()`` in CPython elides the decimal portion
+when ``microsecond == 0``, breaking cross-SDK byte-equivalence with kailash-rs
+(which always emits six microsecond digits via its own canonical path).
+
+The fix: ``datetime.isoformat(timespec="microseconds")`` always emits six
+microsecond digits.
+
+These tests are paired:
+
+1. :class:`TestMicrosecondPaddingBehavior` — direct behavioral assertion
+   that the corrected ``to_dict()`` output ALWAYS contains six microsecond
+   digits, regardless of the underlying ``datetime`` value.
+
+2. :class:`TestCrossSDKFixtureParity` — Tier-2 conformance test that loads
+   the canonical fixture file at ``test-vectors/trace-event-canonical.json``
+   and asserts that the corrected ``to_dict()`` produces byte-equal canonical
+   JSON AND a matching SHA-256 fingerprint for every pinned vector. The
+   fixture is the cross-SDK contract — kailash-rs is expected to emit
+   identical bytes for identical inputs (per ``rules/cross-sdk-inspection.md``
+   MUST Rule 4 — byte-vector pin contract).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kailash.diagnostics.protocols import (
+    TraceEvent,
+    TraceEventStatus,
+    TraceEventType,
+    compute_trace_event_fingerprint,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2] / "test-vectors" / "trace-event-canonical.json"
+)
+
+
+@pytest.mark.regression
+class TestMicrosecondPaddingBehavior:
+    """Direct behavioral guards on ``TraceEvent.to_dict()`` timestamp shape."""
+
+    def _make_event(self, ts: datetime) -> TraceEvent:
+        return TraceEvent(
+            event_id="evt-731",
+            event_type=TraceEventType.AGENT_RUN_START,
+            timestamp=ts,
+            run_id="run-731",
+            agent_id="agent-731",
+            cost_microdollars=0,
+        )
+
+    def test_zero_microsecond_is_padded_to_six_digits(self) -> None:
+        ts = datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc)
+        out = self._make_event(ts).to_dict()["timestamp"]
+        assert out == "2026-04-20T12:00:00.000000+00:00", out
+
+    def test_nonzero_microsecond_round_trips_byte_for_byte(self) -> None:
+        ts = datetime(2026, 4, 20, 12, 0, 0, 123456, tzinfo=timezone.utc)
+        out = self._make_event(ts).to_dict()["timestamp"]
+        assert out == "2026-04-20T12:00:00.123456+00:00", out
+
+    def test_microsecond_999999_is_emitted_in_full(self) -> None:
+        ts = datetime(2026, 12, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+        out = self._make_event(ts).to_dict()["timestamp"]
+        assert out == "2026-12-31T23:59:59.999999+00:00", out
+
+    def test_to_dict_timestamp_always_has_six_microsecond_digits(self) -> None:
+        """Structural invariant: regardless of input, the ``timestamp`` field
+        in ``to_dict()`` output always carries six microsecond digits between
+        ``.`` and the ``+00:00`` offset.
+        """
+        for microsecond in (0, 1, 999, 100_000, 999_999):
+            ts = datetime(2026, 4, 20, 12, 0, 0, microsecond, tzinfo=timezone.utc)
+            out = self._make_event(ts).to_dict()["timestamp"]
+            decimal = out.split(".")[1].split("+")[0]
+            assert len(decimal) == 6, (
+                f"microsecond={microsecond} produced decimal={decimal!r} "
+                f"(len={len(decimal)}); expected exactly 6 digits."
+            )
+
+
+@pytest.mark.regression
+class TestCrossSDKFixtureParity:
+    """Cross-SDK canonical-fixture conformance tests.
+
+    The fixture at ``test-vectors/trace-event-canonical.json`` pins three
+    vectors (V1: zero microsecond, V2: nonzero microsecond, V3: full event)
+    that BOTH kailash-py and kailash-rs MUST produce byte-for-byte. These
+    tests exercise the kailash-py side; the kailash-rs side has the
+    symmetric tests at ``crates/kailash-kaizen/tests/cross_sdk_trace_event.rs``.
+    """
+
+    @pytest.fixture(scope="class")
+    def fixture(self) -> dict:
+        assert _FIXTURE_PATH.exists(), (
+            f"cross-SDK fixture missing at {_FIXTURE_PATH}; "
+            f"regenerate via the snippet in tests/regression/"
+            f"test_issue_731_trace_event_timestamp_padding.py docstring."
+        )
+        return json.loads(_FIXTURE_PATH.read_text())
+
+    def _construct_event(self, input_repr: dict) -> TraceEvent:
+        ts = datetime.fromisoformat(input_repr["timestamp"])
+        kwargs: dict = {
+            "event_id": input_repr["event_id"],
+            "event_type": TraceEventType(input_repr["event_type"]),
+            "timestamp": ts,
+            "run_id": input_repr["run_id"],
+            "agent_id": input_repr["agent_id"],
+            "cost_microdollars": input_repr["cost_microdollars"],
+        }
+        # Forward any optional fields present in the fixture.
+        optional_fields = (
+            "parent_event_id",
+            "trace_id",
+            "span_id",
+            "tenant_id",
+            "envelope_id",
+            "tool_name",
+            "llm_model",
+            "prompt_tokens",
+            "completion_tokens",
+            "duration_ms",
+            "payload_hash",
+            "payload",
+        )
+        for field_name in optional_fields:
+            if field_name in input_repr:
+                kwargs[field_name] = input_repr[field_name]
+        if "status" in input_repr:
+            kwargs["status"] = TraceEventStatus(input_repr["status"])
+        return TraceEvent(**kwargs)
+
+    def test_fixture_loads(self, fixture: dict) -> None:
+        assert fixture["spec_version"] == "1.0"
+        assert len(fixture["vectors"]) >= 3
+
+    def test_every_vector_canonical_json_byte_equal(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            evt = self._construct_event(v["input_repr"])
+            d = evt.to_dict()
+            canonical = json.dumps(
+                d,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                default=str,
+            )
+            assert canonical == v["expected_canonical_json"], (
+                f"vector {v['name']}: byte-divergence — "
+                f"got {canonical!r}, expected {v['expected_canonical_json']!r}"
+            )
+
+    def test_every_vector_fingerprint_matches(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            evt = self._construct_event(v["input_repr"])
+            d = evt.to_dict()
+            canonical = json.dumps(
+                d,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                default=str,
+            )
+            fp = hashlib.sha256(canonical.encode()).hexdigest()
+            assert fp == v["expected_fingerprint"], (
+                f"vector {v['name']}: fingerprint divergence — "
+                f"got {fp}, expected {v['expected_fingerprint']}"
+            )
+
+    def test_compute_trace_event_fingerprint_matches_fixture(
+        self, fixture: dict
+    ) -> None:
+        """The public ``compute_trace_event_fingerprint`` helper MUST agree
+        with the fixture's expected_fingerprint for every vector. This is
+        the consumer-facing API kailash-rs callers will see."""
+        for v in fixture["vectors"]:
+            evt = self._construct_event(v["input_repr"])
+            assert compute_trace_event_fingerprint(evt) == v["expected_fingerprint"], (
+                f"vector {v['name']}: compute_trace_event_fingerprint() "
+                f"disagrees with fixture expected_fingerprint."
+            )


### PR DESCRIPTION
## Summary

- **Fix**: `src/kailash/diagnostics/protocols.py:222` — `isoformat()` → `isoformat(timespec="microseconds")`. Closes the cross-SDK byte-equality break with kailash-rs for any TraceEvent landing on a whole second (the pre-fix \`isoformat()\` elided the decimal portion when \`microsecond == 0\`).
- **Schema**: `schemas/trace-event.v1.json` pattern tightened to \`\\.\\d{6}\\+00:00\` so a future refactor cannot silently re-introduce the elision; canonicalization description updated.
- **Cross-SDK fixture**: new `test-vectors/trace-event-canonical.json` with three pinned vectors (zero microsecond, nonzero microsecond, full event) per `rules/cross-sdk-inspection.md` MUST Rule 4. kailash-rs is expected to consume the same vectors via its symmetric harness.
- **Regression tests**: 8 tests in `tests/regression/test_issue_731_trace_event_timestamp_padding.py` — behavioral padding assertions + Tier-2 fixture conformance (byte-equal canonical JSON + matching SHA-256 fingerprints).
- **Drive-by**: removed unused \`field\` import surfaced by pyright (zero-tolerance Rule 1 same-shard cleanup).

## Test plan

- [x] `pytest tests/regression/test_issue_731_trace_event_timestamp_padding.py` — 8 / 8 pass
- [x] `pytest tests/unit/diagnostics/` — 35 / 35 pass (no regression on the existing diagnostics suite)
- [x] `pre-commit run` — clean
- [x] Schema pattern verified to accept the new form, reject pre-fix form, reject Z-form

## Related issues

Closes #731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)