### PR TITLE
feat(nexus): hoist Origin allowlist enforcement + surface headers on on_connect (#673)

### DIFF
--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -644,7 +644,12 @@ class Nexus:
     # Class-based WebSocket message handlers (issue #448)
     # ------------------------------------------------------------------
 
-    def websocket(self, path: str):
+    def websocket(
+        self,
+        path: str,
+        *,
+        allowed_origins: Optional[List[str]] = None,
+    ):
         """Register a class-based WebSocket message handler on ``path``.
 
         Use as a class decorator. The decorated class MUST subclass
@@ -659,7 +664,11 @@ class Nexus:
 
             app = Nexus()
 
-            @app.websocket("/events")
+            @app.websocket(
+                "/events",
+                allowed_origins=["https://app.example.com",
+                                 "https://*.example.com"],
+            )
             class EventStream(MessageHandler):
                 async def on_connect(self, conn):
                     conn.state.subscriptions = set()
@@ -677,6 +686,10 @@ class Nexus:
             path: URL path for the WebSocket endpoint (e.g. ``"/events"``).
                 Must start with ``/``. Cannot collide with an existing
                 class-based handler path.
+            allowed_origins: optional list of HTTP ``Origin`` header
+                values allowed to upgrade. See
+                :meth:`register_websocket` for the full ``allowed_origins``
+                contract (issue #673 — DNS-rebinding defense).
 
         Returns:
             A decorator that registers the class and returns it
@@ -684,19 +697,82 @@ class Nexus:
         """
 
         def _decorator(cls):
-            self.register_websocket(path, cls)
+            self.register_websocket(path, cls, allowed_origins=allowed_origins)
             return cls
 
         return _decorator
 
-    def register_websocket(self, path: str, handler_cls) -> Any:
+    def register_websocket(
+        self,
+        path: str,
+        handler_cls,
+        *,
+        allowed_origins: Optional[List[str]] = None,
+    ) -> Any:
         """Imperative form of :meth:`websocket`.
 
         Useful when the handler class is defined elsewhere and you
         want to register it conditionally. Returns the instantiated
         handler so the caller can wire external publishers.
+
+        Args:
+            path: URL path (must start with ``/``).
+            handler_cls: subclass of
+                :class:`~nexus.websocket_handlers.MessageHandler`.
+            allowed_origins: optional list of HTTP ``Origin`` header
+                values allowed to open this WebSocket. When set, the
+                SDK rejects every handshake whose ``Origin`` header
+                does NOT match an entry BEFORE invoking
+                ``on_connect`` — closing the WebSocket with code
+                1008 (RFC 6455 policy violation) and a fingerprinted
+                reason that does NOT echo the rejected Origin back
+                to the client.
+
+                Entries:
+
+                - **Exact origin** (``"https://app.example.com"``) —
+                  case-sensitive byte-equal match against the request's
+                  ``Origin`` header.
+                - **Wildcard subdomain** (``"https://*.example.com"``) —
+                  matches strict subdomains of ``example.com`` whose
+                  scheme matches the entry's scheme. Does NOT match
+                  the bare ``example.com`` (the entry says ``*.``,
+                  requiring at least one subdomain label) and does
+                  NOT match ``example.com.evil.com`` (suffix-with-dot
+                  defense).
+                - **Literal ``"*"``** — accepts any non-empty origin.
+                  BLOCKED at registration unless the env var
+                  ``KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN=true`` is
+                  set. Fail-closed default: production deployments
+                  MUST list explicit origins; the ``"*"`` opt-in is
+                  for development / private internal services where
+                  the operator has explicitly accepted that any
+                  browser-reachable origin can open the socket.
+
+                When ``None`` (the default), the SDK does NOT
+                enforce — the registry emits a one-time WARN log at
+                registration naming the path so operators see the
+                gap. Consumers needing custom enforcement (signed-
+                token auth, per-tenant header validation) MUST use
+                :attr:`~nexus.websocket_handlers.Connection.headers`
+                from inside ``on_connect``.
+
+        Returns:
+            The instantiated handler so the caller can wire external
+            publishers.
+
+        Raises:
+            ValueError: if ``allowed_origins`` fails validation
+                (empty list, non-string entry, malformed wildcard,
+                literal ``"*"`` without env opt-in).
+
+        Cross-SDK parity: kailash-rs is expected to ship the same
+        surface semantically (per EATP D6) at the equivalent
+        register_websocket surface. Issue #673.
         """
-        return self._ws_message_handlers.register(path, handler_cls)
+        return self._ws_message_handlers.register(
+            path, handler_cls, allowed_origins=allowed_origins
+        )
 
     async def websocket_broadcast(self, path: str, event: Any) -> None:
         """Fire ``on_event`` on the handler registered at ``path``.
@@ -900,9 +976,10 @@ class Nexus:
 
         try:
             # Import Core SDK's comprehensive MCP implementation for HTTP+WebSocket mode
-            from kailash.channels import ChannelConfig, ChannelType, MCPChannel
             from kailash_mcp import MCPServer
             from kailash_mcp.auth.providers import APIKeyAuth
+
+            from kailash.channels import ChannelConfig, ChannelType, MCPChannel
 
             # Create production-ready MCP server using Core SDK
             self._mcp_server = self._create_sdk_mcp_server()
@@ -2937,6 +3014,7 @@ Check the documentation or explore available resources.
             HTTPException: If workflow not found, input invalid, or execution fails
         """
         from fastapi import HTTPException
+
         from nexus.validation import validate_workflow_inputs, validate_workflow_name
 
         # P0-5: Validate workflow name (prevent path traversal)

--- a/packages/kailash-nexus/src/nexus/websocket_handlers.py
+++ b/packages/kailash-nexus/src/nexus/websocket_handlers.py
@@ -59,8 +59,14 @@ import json
 import logging
 import time
 import uuid
-from types import SimpleNamespace
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Type
+from types import MappingProxyType, SimpleNamespace
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Set, Type
+
+from nexus.websocket_origin import (
+    fingerprint_origin,
+    origin_matches_allowlist,
+    validate_origin_allowlist,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +75,102 @@ __all__ = [
     "MessageHandler",
     "MessageHandlerRegistry",
 ]
+
+
+# Empty case-insensitive headers fallback: an immutable Mapping returned
+# when a connection arrives without parsable handshake headers (e.g. a
+# test using a bare mock socket). Letting handlers see ``conn.headers``
+# as ``None`` would force every site to ``if conn.headers is not None``;
+# returning an empty Mapping keeps the read-only API surface stable.
+_EMPTY_HEADERS: Mapping[str, str] = MappingProxyType({})
+
+
+class _CaseInsensitiveHeaders(Mapping[str, str]):
+    """Read-only case-insensitive mapping over a snapshot of HTTP headers.
+
+    Used when the underlying handshake headers come back as a plain
+    ``dict`` (test fixtures, future transports). When the websockets
+    library passes its own ``Headers`` object (which is already
+    case-insensitive), :func:`_freeze_headers` returns it wrapped in
+    ``MappingProxyType`` directly so case-insensitive lookups still
+    work at zero copy cost.
+    """
+
+    __slots__ = ("_lower",)
+
+    def __init__(self, source: Mapping[str, str]) -> None:
+        # Snapshot at construction so later mutation of the source
+        # does NOT mutate the headers handlers see.
+        self._lower: Dict[str, str] = {}
+        for k, v in source.items():
+            self._lower[k.lower()] = v
+
+    def __getitem__(self, key: str) -> str:
+        return self._lower[key.lower()]
+
+    def __iter__(self):
+        return iter(self._lower)
+
+    def __len__(self) -> int:
+        return len(self._lower)
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
+        return key.lower() in self._lower
+
+
+def _freeze_headers(source: Any) -> Mapping[str, str]:
+    """Return an immutable case-insensitive view of ``source``.
+
+    - ``None`` → empty mapping.
+    - ``dict`` (or any mutable Mapping) → fresh
+      :class:`_CaseInsensitiveHeaders` snapshot wrapped in
+      :class:`types.MappingProxyType` semantics (mutation refused).
+    - ``websockets.datastructures.Headers`` (or any other Mapping
+      subclass that already implements case-insensitive lookup) →
+      wrapped in a thin proxy that forbids mutation.
+
+    The returned object MUST raise on any mutation attempt so
+    handlers cannot mutate the source headers via ``conn.headers``
+    (operators MUST not be able to falsify the captured handshake
+    headers from inside ``on_connect``).
+    """
+    if source is None:
+        return _EMPTY_HEADERS
+    if isinstance(source, Mapping):
+        # Even though ``websockets.Headers`` is already case-insensitive,
+        # snapshotting via _CaseInsensitiveHeaders normalizes the
+        # underlying type so handlers see one consistent surface.
+        return _CaseInsensitiveHeaders(source)
+    # Best effort: try to coerce iterable-of-pairs to a Mapping.
+    try:
+        coerced = dict(source)
+    except (TypeError, ValueError):
+        return _EMPTY_HEADERS
+    return _CaseInsensitiveHeaders(coerced)
+
+
+def _extract_handshake_headers(ws: Any) -> Mapping[str, str]:
+    """Return the handshake headers from the underlying ``websockets`` socket.
+
+    websockets 16+ exposes the parsed handshake at
+    ``ws.request.headers`` (a
+    :class:`websockets.datastructures.Headers` instance). Other
+    transports may set ``ws.request_headers`` directly. Test fixtures
+    can pass a bare object; in all of those cases we fall through to
+    the empty mapping rather than raising.
+    """
+    request = getattr(ws, "request", None)
+    if request is not None:
+        headers = getattr(request, "headers", None)
+        if headers is not None:
+            return _freeze_headers(headers)
+    # Older / alternate code paths may attach headers directly.
+    direct = getattr(ws, "request_headers", None)
+    if direct is not None:
+        return _freeze_headers(direct)
+    return _EMPTY_HEADERS
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +192,15 @@ class Connection:
       the handler.
     - ``connected_at``: monotonic timestamp of connection open.
     - ``path``: the URL path the client connected on (e.g. ``/events``).
+    - ``headers``: read-only :class:`~typing.Mapping` of HTTP
+      handshake headers (Origin, Host, User-Agent, Sec-WebSocket-*,
+      cookies, custom auth headers). Captured AT HANDSHAKE; NOT
+      refreshed during the connection lifetime. Lookups are
+      case-insensitive (``conn.headers["origin"]`` and
+      ``conn.headers["Origin"]`` return the same value). The mapping
+      is structurally immutable — attempts to assign or delete keys
+      raise ``TypeError``. Operators MUST NOT be able to falsify
+      captured headers from inside ``on_connect`` (issue #673).
 
     Handlers send messages back to the client with :meth:`send_json`
     (JSON-serialized) or :meth:`send_text` (raw text frame). Both
@@ -110,9 +221,16 @@ class Connection:
         "state",
         "connected_at",
         "_alive",
+        "_headers",
     )
 
-    def __init__(self, ws: Any, connection_id: str, path: str) -> None:
+    def __init__(
+        self,
+        ws: Any,
+        connection_id: str,
+        path: str,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> None:
         self.ws = ws
         self.connection_id = connection_id
         self.path = path
@@ -120,6 +238,30 @@ class Connection:
         self.state: SimpleNamespace = SimpleNamespace()
         self.connected_at: float = time.monotonic()
         self._alive: bool = True
+        # Headers captured at handshake. Frozen via _freeze_headers so
+        # any mutation attempt raises TypeError. Defaults to the empty
+        # mapping when the caller (test fixture, alternate transport)
+        # does not supply headers.
+        self._headers: Mapping[str, str] = _freeze_headers(headers)
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        """HTTP handshake headers (Origin, Host, User-Agent, Sec-WebSocket-*).
+
+        Read-only case-insensitive Mapping. Captured AT HANDSHAKE;
+        NOT refreshed during the connection lifetime. Mutation
+        attempts (``conn.headers["X"] = "Y"`` /
+        ``del conn.headers["X"]``) raise ``TypeError``.
+
+        Issue #673: surfaces the request headers to ``on_connect`` so
+        consumers needing custom enforcement (signed-token check,
+        per-tenant auth header validation) beyond the SDK's built-in
+        ``allowed_origins`` allowlist have a structural way in. The
+        SDK-level allowlist (see :meth:`Nexus.register_websocket`'s
+        ``allowed_origins`` parameter) is the recommended default;
+        ``conn.headers`` is the escape hatch.
+        """
+        return self._headers
 
     @property
     def alive(self) -> bool:
@@ -427,21 +569,46 @@ class MessageHandlerRegistry:
         self._handlers: Dict[str, MessageHandler] = {}
         # path -> set of connection_id -> Connection
         self._connections_by_path: Dict[str, Dict[str, Connection]] = {}
+        # path -> validated allowed_origins list (None == SDK does
+        # not enforce; handler must use conn.headers itself).
+        self._allowed_origins_by_path: Dict[str, Optional[List[str]]] = {}
 
     # ------------------------------------------------------------------
     # Registration
     # ------------------------------------------------------------------
 
-    def register(self, path: str, handler_cls: Type[MessageHandler]) -> MessageHandler:
+    def register(
+        self,
+        path: str,
+        handler_cls: Type[MessageHandler],
+        *,
+        allowed_origins: Optional[List[str]] = None,
+    ) -> MessageHandler:
         """Register a handler class against a URL path.
 
         The class is instantiated immediately (with no arguments). A
         handler's ``__init__`` is therefore not a place for per-request
         work; it runs once at registration time.
 
+        Args:
+            path: URL path (must start with ``/``).
+            handler_cls: subclass of :class:`MessageHandler`.
+            allowed_origins: optional list of HTTP ``Origin`` header
+                values allowed to upgrade to this WebSocket path.
+                When set, the registry rejects every handshake whose
+                ``Origin`` does NOT match an entry BEFORE invoking
+                ``on_connect``. See :func:`validate_origin_allowlist`
+                for the entry shape (exact origins, ``https://*.x.com``
+                wildcards, fail-closed ``"*"``). When ``None``, the
+                SDK does NOT enforce — operators MUST either use
+                ``conn.headers`` from inside ``on_connect`` for custom
+                enforcement OR explicitly accept that the endpoint is
+                Origin-unfiltered. Issue #673.
+
         Raises:
-            ValueError: if ``path`` is already registered or is not a
-                valid WebSocket path (must start with ``/``).
+            ValueError: if ``path`` is already registered, is not a
+                valid WebSocket path (must start with ``/``), or
+                ``allowed_origins`` fails validation.
             TypeError: if ``handler_cls`` is not a subclass of
                 :class:`MessageHandler`.
         """
@@ -463,15 +630,44 @@ class MessageHandlerRegistry:
                 f"(got {handler_cls!r})"
             )
 
+        # Validate allowed_origins at registration time (typed
+        # ValueError on failure; raises BEFORE the handler is
+        # instantiated so a bad allowlist never silently registers).
+        validated_origins = validate_origin_allowlist(allowed_origins)
+
         handler = handler_cls()
         handler._registry = self
         handler._path = path
         self._handlers[path] = handler
         self._connections_by_path[path] = {}
+        self._allowed_origins_by_path[path] = validated_origins
         logger.info(
             "ws.handler.registered",
-            extra={"path": path, "handler": handler_cls.__name__},
+            extra={
+                "path": path,
+                "handler": handler_cls.__name__,
+                "origin_enforcement": (
+                    "sdk" if validated_origins is not None else "none"
+                ),
+            },
         )
+        if validated_origins is None:
+            # One-time WARN at registration so operators see the gap
+            # without per-request log spam. Per rules/observability.md
+            # Rule 3: WARN means "succeeded but used a degraded
+            # path" — accepting the registration without SDK Origin
+            # enforcement IS the degraded path.
+            logger.warning(
+                "ws.handler.origin_enforcement_disabled",
+                extra={
+                    "path": path,
+                    "handler": handler_cls.__name__,
+                    "remediation": (
+                        "pass allowed_origins=[...] to register_websocket "
+                        "OR enforce manually via conn.headers in on_connect"
+                    ),
+                },
+            )
         return handler
 
     def get(self, path: str) -> Optional[MessageHandler]:
@@ -493,6 +689,16 @@ class MessageHandlerRegistry:
                 conn._alive = False
         self._handlers.clear()
         self._connections_by_path.clear()
+        self._allowed_origins_by_path.clear()
+
+    def get_allowed_origins(self, path: str) -> Optional[List[str]]:
+        """Return the validated allowed_origins list for ``path``.
+
+        Returns ``None`` if no SDK enforcement is active (or no
+        handler is registered). Test-only inspection helper —
+        production code should NOT need to read this.
+        """
+        return self._allowed_origins_by_path.get(path)
 
     # ------------------------------------------------------------------
     # Connection dispatch (called from WebSocketTransport)
@@ -508,20 +714,78 @@ class MessageHandlerRegistry:
         registered handler (even if it errored), ``False`` if no
         handler was registered for the path.
 
+        Issue #673 — Origin enforcement: BEFORE invoking
+        ``on_connect``, if the path's ``allowed_origins`` list is
+        non-``None``, the request's ``Origin`` header is checked
+        against the allowlist. Mismatches close the WebSocket with
+        code 1008 (per RFC 6455 — policy violation) and a
+        fingerprinted reason; ``on_connect`` and ``on_disconnect``
+        do NOT fire (the connection never reached the handler's
+        lifecycle).
+
         State isolation invariant: each call creates a fresh
         :class:`Connection`, so ``conn.state`` is always a new
         :class:`types.SimpleNamespace`.
 
         Lifecycle invariant: ``on_disconnect`` is called for every
         ``on_connect`` that returned normally, even if the receive
-        loop raises or the socket closes abnormally.
+        loop raises or the socket closes abnormally. Origin-rejected
+        connections are NOT subject to this invariant — they never
+        invoke ``on_connect``.
         """
         handler = self._handlers.get(path)
         if handler is None:
             return False
 
+        # Extract handshake headers BEFORE constructing Connection so
+        # the headers are available to on_connect from the first
+        # millisecond of the handler's lifecycle.
+        headers = _extract_handshake_headers(ws)
+
+        # Issue #673 — Origin allowlist enforcement (pre-on_connect).
+        allowed_origins = self._allowed_origins_by_path.get(path)
+        if allowed_origins is not None:
+            origin = headers.get("origin")
+            if not origin_matches_allowlist(origin, allowed_origins):
+                # Fingerprint per rules/observability.md Rule 6 + 8:
+                # never echo the raw Origin to log aggregators.
+                fingerprint = fingerprint_origin(origin)
+                logger.warning(
+                    "ws.handler.origin_rejected",
+                    extra={
+                        "path": path,
+                        "handler": type(handler).__name__,
+                        "origin_fingerprint": fingerprint,
+                        "reason": (
+                            "missing_origin_header"
+                            if origin is None
+                            else "origin_not_in_allowlist"
+                        ),
+                    },
+                )
+                # Generic close reason — never echo the rejected
+                # Origin back to the client (would let an attacker
+                # confirm a probe). Code 1008 = "policy violation"
+                # per RFC 6455 §7.4.1.
+                try:
+                    await ws.close(1008, f"origin rejected ({fingerprint})")
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    logger.debug(
+                        "ws.handler.origin_close_failed",
+                        extra={
+                            "path": path,
+                            "origin_fingerprint": fingerprint,
+                            "error": str(exc),
+                        },
+                    )
+                # Returning True signals the transport that the
+                # connection was handled (rejected by policy is a
+                # form of handling); without it the transport falls
+                # through to the legacy single-path guard.
+                return True
+
         connection_id = uuid.uuid4().hex
-        conn = Connection(ws, connection_id, path)
+        conn = Connection(ws, connection_id, path, headers=headers)
         self._connections_by_path[path][connection_id] = conn
 
         connect_ok = False

--- a/packages/kailash-nexus/src/nexus/websocket_origin.py
+++ b/packages/kailash-nexus/src/nexus/websocket_origin.py
@@ -1,0 +1,277 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""WebSocket Origin allowlist validation (issue #673).
+
+Pre-upgrade ``Origin`` and ``Host`` allowlist enforcement is the
+structural defense against DNS-rebinding attacks on WebSocket
+endpoints (per ``rules/security.md`` § "Network Transport
+Hardening" + ``rules/ui-backend-defense.md`` Rule 3 layered defense).
+
+This module exposes:
+
+- :func:`validate_origin_allowlist` — validates an allowlist entry
+  list at registration time, refusing the literal ``"*"`` wildcard
+  unless the env flag ``KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN=true``
+  is set.
+
+- :func:`origin_matches_allowlist` — runtime predicate used by the
+  :class:`MessageHandlerRegistry` BEFORE invoking ``on_connect``.
+  Returns ``True`` only when the supplied origin matches at least
+  one allowlist entry exactly OR matches a ``https://*.example.com``
+  wildcard pattern.
+
+- :func:`fingerprint_origin` — produces an 8-char SHA-256 prefix
+  used in WARN-level audit logs per ``rules/observability.md``
+  Rule 6 + Rule 8 (schema-revealing identifiers MUST be hashed at
+  WARN; raw values MUST NOT be echoed).
+
+Cross-SDK parity: kailash-rs is expected to ship the same surface
+semantically (per EATP D6) at the equivalent register_websocket
+surface. Filed cross-SDK followup issue tracks the Rust side.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Iterable, List, Optional
+
+__all__ = [
+    "WILDCARD_ORIGIN_ENV_FLAG",
+    "WildcardOriginRefusedError",
+    "fingerprint_origin",
+    "origin_matches_allowlist",
+    "validate_origin_allowlist",
+]
+
+
+WILDCARD_ORIGIN_ENV_FLAG = "KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN"
+"""Env flag that opts in to the literal ``"*"`` wildcard allowlist entry.
+
+When this env var is set to the case-insensitive string ``"true"``,
+:func:`validate_origin_allowlist` will accept the literal ``"*"``
+entry. In every other case (unset, ``"false"``, ``"0"``, etc.), the
+literal ``"*"`` is rejected with :class:`WildcardOriginRefusedError`.
+
+This is intentionally fail-closed: production deployments MUST list
+explicit origins; the ``"*"`` opt-in is for development / private
+internal services where the operator has explicitly accepted that
+any browser-reachable origin can open the socket.
+"""
+
+
+class WildcardOriginRefusedError(ValueError):
+    """Raised when ``"*"`` appears in ``allowed_origins`` without env opt-in.
+
+    Subclass of ``ValueError`` so callers using broad ``except
+    ValueError`` still catch it; the typed subclass lets careful
+    callers distinguish wildcard refusal from other validation
+    failures.
+    """
+
+
+def _wildcard_env_set() -> bool:
+    """Return True iff ``KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN`` opts in.
+
+    Read at validation time (not at module import) so test fixtures
+    using ``monkeypatch.setenv`` can flip the flag per test.
+    """
+    return os.environ.get(WILDCARD_ORIGIN_ENV_FLAG, "").strip().lower() == "true"
+
+
+def validate_origin_allowlist(
+    allowed_origins: Optional[Iterable[str]],
+) -> Optional[List[str]]:
+    """Validate the ``allowed_origins`` parameter at registration time.
+
+    Returns the validated list (a fresh ``list[str]``) or ``None`` if
+    the input was ``None``. Raises ``ValueError`` (or its subclass
+    :class:`WildcardOriginRefusedError`) on any invalid entry.
+
+    Validation rules:
+
+    - ``None`` → returned as-is. Caller MUST emit a one-time WARN log
+      naming the path so operators see the gap (handled at the
+      registration site, not here).
+    - Must be a non-string iterable (a bare ``str`` is BLOCKED — a
+      common bug where someone writes ``allowed_origins="https://x"``
+      instead of ``allowed_origins=["https://x"]``).
+    - Must be non-empty when non-``None``.
+    - Each entry MUST be a non-empty string.
+    - The literal ``"*"`` is BLOCKED unless
+      ``KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN=true`` is set in env.
+    - Each non-wildcard entry MUST start with ``https://`` or
+      ``http://`` (case-insensitive scheme check).
+    - Wildcard subdomain entries MUST take the form
+      ``https://*.example.com`` (a single ``*`` immediately after
+      the scheme separator and before the rest of the host). Other
+      ``*`` placements are BLOCKED.
+    """
+    if allowed_origins is None:
+        return None
+    if isinstance(allowed_origins, str):
+        # Bare-string trap: someone wrote allowed_origins="https://x"
+        # expecting it to allowlist that origin. Reject loudly.
+        raise ValueError(
+            "allowed_origins must be a list of strings, not a single string "
+            '(did you mean allowed_origins=["https://..."]?)'
+        )
+    entries: List[str] = list(allowed_origins)
+    if not entries:
+        raise ValueError(
+            "allowed_origins must be a non-empty list when not None; "
+            "pass None to disable SDK enforcement"
+        )
+    validated: List[str] = []
+    for raw in entries:
+        if not isinstance(raw, str):
+            raise ValueError(
+                f"allowed_origins entries must be str; " f"got {type(raw).__name__}"
+            )
+        entry = raw.strip()
+        if not entry:
+            raise ValueError("allowed_origins entries must be non-empty strings")
+        if entry == "*":
+            if not _wildcard_env_set():
+                raise WildcardOriginRefusedError(
+                    "allowed_origins=['*'] is fail-closed by default; set "
+                    f"{WILDCARD_ORIGIN_ENV_FLAG}=true in env to opt in. "
+                    "This is intentionally noisy: '*' allows ANY browser-"
+                    "reachable origin to open the socket and disables the "
+                    "DNS-rebinding defense the allowlist exists to provide."
+                )
+            validated.append("*")
+            continue
+        # Scheme check (https:// or http://, case-insensitive).
+        lower = entry.lower()
+        if not (lower.startswith("https://") or lower.startswith("http://")):
+            raise ValueError(
+                f"allowed_origins entries must start with 'https://' or "
+                f"'http://' (got {entry!r})"
+            )
+        # Wildcard subdomain shape check: only allowed pattern is
+        # "<scheme>://*.<host>"; any other "*" is rejected.
+        if "*" in entry:
+            scheme_sep = "://"
+            sep_idx = entry.index(scheme_sep)
+            after_scheme = entry[sep_idx + len(scheme_sep) :]
+            if not after_scheme.startswith("*."):
+                raise ValueError(
+                    f"wildcard subdomain entries must take the form "
+                    f"'<scheme>://*.<host>' (got {entry!r})"
+                )
+            if "*" in after_scheme[2:]:
+                raise ValueError(
+                    f"wildcard subdomain entries may contain only one '*' "
+                    f"immediately after the scheme separator (got {entry!r})"
+                )
+        validated.append(entry)
+    return validated
+
+
+def origin_matches_allowlist(origin: object, allowed_origins: List[str]) -> bool:
+    """Return True iff ``origin`` matches at least one allowlist entry.
+
+    Shape-rejects non-string origins explicitly per
+    ``rules/ui-backend-defense.md`` Rule 2: a non-string ``origin``
+    (e.g., a header that arrived as ``None`` because the client did
+    not send it, or somehow as a list) raises ``ValueError``. The
+    caller is the registry which catches the raise and rejects the
+    upgrade — converting a runtime crash into a clean reject.
+
+    An empty-string origin returns ``False`` (no match) — empty is
+    not a valid origin and never matches a non-empty allowlist
+    entry.
+
+    Matching rules:
+
+    - Exact-string match (case-sensitive comparison of the full
+      origin including scheme + host + optional port).
+    - ``"*"`` wildcard entry matches every non-empty origin (only
+      reachable when env opt-in already validated at
+      :func:`validate_origin_allowlist`).
+    - ``"https://*.example.com"`` style wildcard matches origins
+      whose host is a strict subdomain of ``example.com`` AND
+      whose scheme matches the entry's scheme. Does NOT match the
+      bare ``example.com`` (the entry says ``*.``, requiring at
+      least one subdomain label) and does NOT match
+      ``example.com.evil.com`` (suffix-with-dot defense — the
+      candidate host MUST end with ``.example.com`` AND the dot is
+      mandatory).
+    """
+    if origin is None:
+        return False
+    if not isinstance(origin, str):
+        # Shape rejection — not a typed-error path because the
+        # registry's role is to close the connection, not to crash.
+        # Returning False is the safe disposition here; the registry
+        # logs a fingerprint of the type for triage.
+        return False
+    if not origin:
+        return False
+    for entry in allowed_origins:
+        if entry == "*":
+            return True
+        if entry == origin:
+            return True
+        if "*" in entry:
+            # Already validated as "<scheme>://*.<host>" at registration.
+            scheme_sep = "://"
+            sep_idx = entry.index(scheme_sep)
+            entry_scheme = entry[:sep_idx]
+            entry_suffix = entry[sep_idx + len(scheme_sep) + 1 :]  # ".host"
+            # Origin MUST share scheme and end with .<host> and have
+            # at least one character before the dot (no bare host
+            # match).
+            origin_lower_scheme = origin.split("://", 1)
+            if len(origin_lower_scheme) != 2:
+                continue
+            o_scheme, o_rest = origin_lower_scheme
+            if o_scheme.lower() != entry_scheme.lower():
+                continue
+            # Strip optional port and path: origin host is the part
+            # before the first "/" or ":" after the scheme.
+            o_host = o_rest.split("/", 1)[0].split(":", 1)[0]
+            if not o_host:
+                continue
+            if o_host == entry_suffix.lstrip("."):
+                # Bare host match disallowed: entry "https://*.x.com"
+                # MUST NOT match "https://x.com".
+                continue
+            if o_host.endswith(entry_suffix):
+                # Defense against suffix-injection like
+                # "x.com.evil.com": ensure the character before the
+                # entry suffix exists (the lstrip("."), since
+                # entry_suffix already starts with ".") AND that the
+                # subdomain label has at least one char.
+                prefix_len = len(o_host) - len(entry_suffix)
+                if prefix_len >= 1:
+                    return True
+    return False
+
+
+def fingerprint_origin(origin: object) -> str:
+    """Return an 8-char SHA-256 prefix of ``origin`` for audit logs.
+
+    Per ``rules/observability.md`` Rule 6 (mask helpers) + Rule 8
+    (schema-revealing identifiers at WARN MUST be hashed): WARN logs
+    on origin rejection MUST NOT echo the raw origin string back to
+    log aggregators (Datadog/Splunk/CloudWatch) where attackers can
+    correlate log entries with the URLs they attempted.
+
+    Returns ``"00000000"`` sentinel for ``None`` / empty / non-string
+    so the caller can still emit a fingerprint field even when the
+    upstream is malformed.
+    """
+    if origin is None:
+        return "00000000"
+    if not isinstance(origin, str):
+        # Hash the type name + repr for some signal without leaking
+        # the underlying object.
+        material = f"<non-string:{type(origin).__name__}>".encode("utf-8")
+    else:
+        material = origin.encode("utf-8")
+    if not material:
+        return "00000000"
+    return hashlib.sha256(material).hexdigest()[:8]

--- a/packages/kailash-nexus/tests/regression/test_issue_673_websocket_origin_allowlist.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_673_websocket_origin_allowlist.py
@@ -1,0 +1,343 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-2 regression test for issue #673.
+
+Origin/Host allowlist enforcement on register_websocket. End-to-end
+exercise against a real ``websockets`` server so the behavioral
+contract surfaces every layer (transport → registry → on_connect):
+
+- ``allowed_origins=["https://app.example.com"]`` accepts a matching
+  Origin and rejects a mismatching one with WebSocket close code
+  1008 + a fingerprinted reason that does NOT echo the Origin.
+- ``allowed_origins=None`` accepts the connection AND emits a
+  one-time WARN log naming the path so operators see the gap.
+- Wildcard subdomain ``https://*.example.com`` matches
+  ``https://api.example.com`` and rejects an unrelated origin.
+- Literal ``"*"`` is rejected at registration when the env flag is
+  absent (typed ``ValueError``); accepted when the env flag is set.
+- The fingerprint emitted in the WARN log is sha256(origin)[:8] —
+  not the raw Origin string.
+- ``Connection.headers`` exposed to ``on_connect`` carries the
+  Origin / Host / Sec-WebSocket-* headers from the handshake.
+
+Per ``rules/testing.md`` § Tier 2: real infrastructure (a real
+``websockets`` server in a background thread, a real ``websockets``
+client). NO mocking on this layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+import threading
+from typing import Any, List
+
+import pytest
+import websockets
+
+from nexus import Nexus
+from nexus.registry import HandlerRegistry
+from nexus.transports.websocket import WebSocketTransport
+from nexus.websocket_handlers import Connection, MessageHandler
+from nexus.websocket_origin import WILDCARD_ORIGIN_ENV_FLAG, WildcardOriginRefusedError
+
+# Module-scope env lock per rules/testing.md § Serialize Env-Var-Mutating Tests.
+_ENV_LOCK = threading.Lock()
+
+
+@pytest.fixture
+def _env_serialized():
+    with _ENV_LOCK:
+        yield
+
+
+def _free_port() -> int:
+    """Bind to port 0 to let the kernel pick a free port, then release."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+async def ws_server():
+    """Start a WebSocketTransport wired to a fresh Nexus's registry.
+
+    Yields ``(app, port)``. Per facade-manager-detection.md MUST
+    Rule 1, the registry is exercised through ``app.websocket`` /
+    ``app.register_websocket`` — the public facade — not by
+    importing :class:`MessageHandlerRegistry` directly.
+    """
+    app = Nexus(enable_auth=False, enable_monitoring=False)
+    port = _free_port()
+    transport = WebSocketTransport(
+        host="127.0.0.1",
+        port=port,
+        path="/legacy-ws",  # legacy JSON-RPC path, unused here
+        ping_interval=5.0,
+        ping_timeout=5.0,
+    )
+    app.add_transport(transport)
+
+    registry = HandlerRegistry()
+    await transport.start(registry)
+
+    for _ in range(50):
+        if transport.is_running:
+            break
+        await asyncio.sleep(0.02)
+    assert transport.is_running, "WebSocketTransport did not start in time"
+
+    yield app, port
+
+    await transport.stop()
+
+
+# ---------------------------------------------------------------------------
+# Allowlist-MATCH path: explicit allowlist accepts matching Origin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_issue_673_explicit_allowlist_accepts_matching_origin(
+    ws_server,
+):
+    """allowed_origins=['https://app.example.com'] accepts that Origin."""
+    app, port = ws_server
+    on_connect_fired = asyncio.Event()
+    captured_origins: List[str] = []
+
+    @app.websocket("/events", allowed_origins=["https://app.example.com"])
+    class EventStream(MessageHandler):
+        async def on_connect(self, conn: Connection) -> None:
+            captured_origins.append(conn.headers.get("origin", ""))
+            on_connect_fired.set()
+
+        async def on_message(self, conn: Connection, msg: Any) -> None:
+            await conn.send_json({"echo": msg.get("hello")})
+
+    uri = f"ws://127.0.0.1:{port}/events"
+    async with websockets.connect(uri, origin="https://app.example.com") as ws:
+        await asyncio.wait_for(on_connect_fired.wait(), timeout=2.0)
+        await ws.send('{"hello": "world"}')
+        reply = await asyncio.wait_for(ws.recv(), timeout=2.0)
+        import json
+
+        assert json.loads(reply) == {"echo": "world"}
+
+    # External-effect assertion: handler observed the Origin header.
+    assert captured_origins == ["https://app.example.com"]
+
+
+# ---------------------------------------------------------------------------
+# Allowlist-MISMATCH path: explicit allowlist rejects mismatching Origin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_issue_673_explicit_allowlist_rejects_mismatching_origin(
+    ws_server, caplog
+):
+    """Mismatching Origin → WebSocket close 1008, on_connect never fires."""
+    app, port = ws_server
+    on_connect_fired = asyncio.Event()
+
+    @app.websocket("/admin", allowed_origins=["https://app.example.com"])
+    class Admin(MessageHandler):
+        async def on_connect(self, conn: Connection) -> None:
+            # MUST NOT fire — origin enforcement happens BEFORE
+            # on_connect.
+            on_connect_fired.set()
+
+    uri = f"ws://127.0.0.1:{port}/admin"
+    with caplog.at_level(logging.WARNING, logger="nexus.websocket_handlers"):
+        with pytest.raises(
+            (
+                websockets.exceptions.InvalidStatus,
+                websockets.exceptions.ConnectionClosed,
+                websockets.exceptions.ConnectionClosedError,
+            )
+        ):
+            async with websockets.connect(uri, origin="https://evil.example.com") as ws:
+                # If the server ever returns a frame, the test
+                # MUST surface that as failure — receiving a frame
+                # would mean on_connect ran or the close was
+                # delivered with payload.
+                msg = await asyncio.wait_for(ws.recv(), timeout=2.0)
+                pytest.fail(f"unexpected frame after origin reject: {msg!r}")
+
+    # on_connect MUST NOT have fired.
+    assert not on_connect_fired.is_set(), (
+        "on_connect ran despite Origin mismatch — pre-on_connect " "enforcement broken"
+    )
+
+    # WARN log MUST contain the fingerprint, NOT the raw Origin.
+    matching = [r for r in caplog.records if r.message == "ws.handler.origin_rejected"]
+    assert matching, "missing ws.handler.origin_rejected WARN log"
+    rec = matching[-1]
+    assert rec.path == "/admin"
+    fingerprint = rec.origin_fingerprint
+    assert isinstance(fingerprint, str)
+    assert len(fingerprint) == 8
+    # Defense: the raw Origin MUST NOT appear anywhere on the record.
+    rendered = rec.getMessage() + " " + str(rec.__dict__)
+    assert "evil.example.com" not in rendered
+    assert "evil" not in fingerprint  # fingerprint is a hash
+
+
+# ---------------------------------------------------------------------------
+# allowed_origins=None — SDK does NOT enforce, WARN at registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_issue_673_none_allowlist_accepts_with_warn_log(ws_server, caplog):
+    """allowed_origins=None accepts AND emits one-time registration WARN."""
+    app, port = ws_server
+    on_connect_fired = asyncio.Event()
+
+    with caplog.at_level(logging.WARNING, logger="nexus.websocket_handlers"):
+
+        @app.websocket("/open", allowed_origins=None)
+        class Open(MessageHandler):
+            async def on_connect(self, conn: Connection) -> None:
+                on_connect_fired.set()
+
+    # Registration emitted the WARN naming the path.
+    matching = [
+        r
+        for r in caplog.records
+        if r.message == "ws.handler.origin_enforcement_disabled"
+    ]
+    assert matching, "missing one-time WARN at None-allowlist registration"
+    assert matching[-1].path == "/open"
+
+    # And the connection itself succeeds (no enforcement).
+    uri = f"ws://127.0.0.1:{port}/open"
+    async with websockets.connect(uri, origin="https://anything.example") as _:
+        await asyncio.wait_for(on_connect_fired.wait(), timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Wildcard subdomain matching — end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_issue_673_wildcard_subdomain_matches_and_rejects(ws_server, caplog):
+    """https://*.example.com matches subdomain, rejects unrelated host."""
+    app, port = ws_server
+    accepted: List[str] = []
+
+    @app.websocket("/wild", allowed_origins=["https://*.example.com"])
+    class Wild(MessageHandler):
+        async def on_connect(self, conn: Connection) -> None:
+            accepted.append(conn.headers.get("origin", ""))
+
+    uri = f"ws://127.0.0.1:{port}/wild"
+
+    # Subdomain matches.
+    async with websockets.connect(uri, origin="https://api.example.com") as _:
+        await asyncio.sleep(0.05)
+    # Unrelated host rejected.
+    with pytest.raises(
+        (
+            websockets.exceptions.InvalidStatus,
+            websockets.exceptions.ConnectionClosed,
+            websockets.exceptions.ConnectionClosedError,
+        )
+    ):
+        async with websockets.connect(uri, origin="https://evil.com") as ws:
+            await asyncio.wait_for(ws.recv(), timeout=2.0)
+
+    # Wait for the server-side on_connect for the accepted side.
+    for _ in range(50):
+        if accepted:
+            break
+        await asyncio.sleep(0.02)
+    assert accepted == ["https://api.example.com"]
+
+
+# ---------------------------------------------------------------------------
+# Literal '*' wildcard — fail-closed default + env opt-in
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_issue_673_literal_wildcard_rejected_at_registration_without_env(
+    _env_serialized, monkeypatch
+):
+    """Literal '*' rejected at register time when env flag absent."""
+    monkeypatch.delenv(WILDCARD_ORIGIN_ENV_FLAG, raising=False)
+    app = Nexus(enable_auth=False, enable_monitoring=False)
+
+    class H(MessageHandler):
+        pass
+
+    with pytest.raises(WildcardOriginRefusedError):
+        app.register_websocket("/wide", H, allowed_origins=["*"])
+
+
+@pytest.mark.regression
+def test_issue_673_literal_wildcard_accepted_with_env_opt_in(
+    _env_serialized, monkeypatch
+):
+    """Literal '*' accepted when KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN=true."""
+    monkeypatch.setenv(WILDCARD_ORIGIN_ENV_FLAG, "true")
+    app = Nexus(enable_auth=False, enable_monitoring=False)
+
+    class H(MessageHandler):
+        pass
+
+    handler = app.register_websocket("/wide", H, allowed_origins=["*"])
+    assert handler is not None
+    assert app.websocket_handlers.get_allowed_origins("/wide") == ["*"]
+
+
+# ---------------------------------------------------------------------------
+# Connection.headers exposure end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+async def test_issue_673_connection_headers_exposed_to_on_connect(
+    ws_server,
+):
+    """on_connect receives the handshake headers (Origin, Host, etc)."""
+    app, port = ws_server
+    captured: List[dict] = []
+    on_connect_fired = asyncio.Event()
+
+    @app.websocket("/headers", allowed_origins=["https://app.example.com"])
+    class HeaderProbe(MessageHandler):
+        async def on_connect(self, conn: Connection) -> None:
+            # Capture a snapshot of the headers dict so the
+            # assertion can run after the connection closes.
+            captured.append(
+                {
+                    "origin": conn.headers.get("origin"),
+                    "host": conn.headers.get("host"),
+                    "has_sec_ws_key": "sec-websocket-key" in conn.headers,
+                    "headers_type": type(conn.headers).__name__,
+                }
+            )
+            on_connect_fired.set()
+
+    uri = f"ws://127.0.0.1:{port}/headers"
+    async with websockets.connect(uri, origin="https://app.example.com") as _:
+        await asyncio.wait_for(on_connect_fired.wait(), timeout=2.0)
+
+    assert len(captured) == 1
+    snap = captured[0]
+    assert snap["origin"] == "https://app.example.com"
+    assert snap["host"] is not None  # 127.0.0.1:<port>
+    # Sec-WebSocket-Key is required by RFC 6455 §1.3 for every
+    # client-initiated handshake — its presence proves the headers
+    # are coming from the real handshake, not a fixture stub.
+    assert snap["has_sec_ws_key"] is True

--- a/packages/kailash-nexus/tests/unit/test_connection_headers.py
+++ b/packages/kailash-nexus/tests/unit/test_connection_headers.py
@@ -1,0 +1,158 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-1 unit tests for Connection.headers exposure (issue #673).
+
+The ``Connection.headers`` Mapping is the consumer-side escape
+hatch for custom enforcement beyond the SDK's static
+``allowed_origins`` allowlist (e.g., per-tenant signed-token check,
+custom auth header validation). The contract:
+
+- Captured at handshake; NOT refreshed during the connection.
+- Read-only Mapping — mutation attempts raise ``TypeError``.
+- Case-insensitive lookup (``conn.headers["origin"]`` and
+  ``conn.headers["Origin"]`` return the same value).
+- Defaults to an empty Mapping when no headers are supplied (test
+  fixtures, alternate transports) so handlers do NOT need to guard
+  ``if conn.headers is not None``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.websocket_handlers import Connection
+
+
+def test_headers_default_is_empty_mapping() -> None:
+    """Connection constructed without headers exposes empty Mapping."""
+    conn = Connection(ws=None, connection_id="c1", path="/x")
+    assert len(conn.headers) == 0
+    assert "origin" not in conn.headers
+
+
+def test_headers_origin_round_trip() -> None:
+    conn = Connection(
+        ws=None,
+        connection_id="c1",
+        path="/x",
+        headers={"Origin": "https://app.example.com"},
+    )
+    assert conn.headers["origin"] == "https://app.example.com"
+
+
+def test_headers_lookup_is_case_insensitive() -> None:
+    conn = Connection(
+        ws=None,
+        connection_id="c1",
+        path="/x",
+        headers={"Origin": "https://app.example.com"},
+    )
+    # All three should return the same value
+    assert conn.headers["Origin"] == "https://app.example.com"
+    assert conn.headers["origin"] == "https://app.example.com"
+    assert conn.headers["ORIGIN"] == "https://app.example.com"
+
+
+def test_headers_contains_is_case_insensitive() -> None:
+    conn = Connection(
+        ws=None,
+        connection_id="c1",
+        path="/x",
+        headers={"Sec-WebSocket-Key": "abc"},
+    )
+    assert "sec-websocket-key" in conn.headers
+    assert "Sec-WebSocket-Key" in conn.headers
+    assert "SEC-WEBSOCKET-KEY" in conn.headers
+
+
+def test_headers_get_returns_default() -> None:
+    conn = Connection(
+        ws=None,
+        connection_id="c1",
+        path="/x",
+        headers={"Origin": "https://x.com"},
+    )
+    assert conn.headers.get("origin") == "https://x.com"
+    assert conn.headers.get("missing") is None
+    assert conn.headers.get("missing", "fallback") == "fallback"
+
+
+def test_headers_iteration_yields_lower_keys() -> None:
+    """Iteration MUST be deterministic and case-normalized so
+    handlers iterating over headers see one canonical form."""
+    conn = Connection(
+        ws=None,
+        connection_id="c1",
+        path="/x",
+        headers={
+            "Origin": "https://x.com",
+            "Host": "x.com",
+            "User-Agent": "test/1.0",
+        },
+    )
+    keys = sorted(conn.headers)
+    assert keys == ["host", "origin", "user-agent"]
+
+
+def test_headers_mutation_raises_type_error() -> None:
+    """Operators MUST NOT be able to falsify captured headers from
+    inside on_connect — issue #673 immutability invariant."""
+    conn = Connection(
+        ws=None,
+        connection_id="c1",
+        path="/x",
+        headers={"Origin": "https://app.example.com"},
+    )
+    with pytest.raises(TypeError):
+        conn.headers["x"] = "y"  # type: ignore[index]
+
+
+def test_headers_deletion_raises_type_error() -> None:
+    conn = Connection(
+        ws=None,
+        connection_id="c1",
+        path="/x",
+        headers={"Origin": "https://app.example.com"},
+    )
+    with pytest.raises(TypeError):
+        del conn.headers["origin"]  # type: ignore[attr-defined]
+
+
+def test_headers_snapshot_isolated_from_source_mutation() -> None:
+    """Mutating the dict passed at construction MUST NOT affect
+    Connection.headers — defense against on_connect-time mutation
+    by the surrounding code."""
+    source = {"Origin": "https://app.example.com"}
+    conn = Connection(ws=None, connection_id="c1", path="/x", headers=source)
+    source["Origin"] = "https://evil.com"
+    source["X-Injected"] = "yes"
+    assert conn.headers["origin"] == "https://app.example.com"
+    assert "x-injected" not in conn.headers
+
+
+def test_headers_with_websockets_headers_object() -> None:
+    """When the websockets library passes its own Headers object
+    (which is already case-insensitive), Connection.headers wraps
+    it in the case-insensitive snapshot."""
+    from websockets.datastructures import Headers
+
+    h = Headers([("Origin", "https://app.example.com"), ("Host", "x")])
+    conn = Connection(ws=None, connection_id="c1", path="/x", headers=h)
+    assert conn.headers["origin"] == "https://app.example.com"
+    assert conn.headers["host"] == "x"
+
+
+def test_connection_id_and_path_preserved() -> None:
+    """Smoke check the new headers param did not regress the existing
+    Connection contract."""
+    conn = Connection(
+        ws="ws-stub",
+        connection_id="abc123",
+        path="/events",
+        headers={"Origin": "https://x.com"},
+    )
+    assert conn.connection_id == "abc123"
+    assert conn.path == "/events"
+    assert conn.ws == "ws-stub"
+    assert conn.alive is True

--- a/packages/kailash-nexus/tests/unit/test_websocket_origin_validation.py
+++ b/packages/kailash-nexus/tests/unit/test_websocket_origin_validation.py
@@ -1,0 +1,322 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-1 unit tests for WebSocket Origin allowlist validation (issue #673).
+
+Covers ``nexus.websocket_origin``:
+
+- :func:`validate_origin_allowlist` — registration-time validation
+- :func:`origin_matches_allowlist` — runtime predicate
+- :func:`fingerprint_origin` — log fingerprint shape
+
+Per ``rules/testing.md`` §3-Tier Testing, Tier 1 is allowed to
+exercise pure-function helpers in isolation. Tier-2 wiring against
+real WebSocket clients lives in
+``tests/regression/test_issue_673_websocket_origin_allowlist.py``.
+
+Per ``rules/testing.md`` § Serialize Env-Var-Mutating Tests Via
+Module Lock, every test that mutates ``KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN``
+takes the ``_env_serialized`` fixture so concurrent xdist workers
+do not race over the env var.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from nexus.websocket_origin import (
+    WILDCARD_ORIGIN_ENV_FLAG,
+    WildcardOriginRefusedError,
+    fingerprint_origin,
+    origin_matches_allowlist,
+    validate_origin_allowlist,
+)
+
+# Module-scope lock — see rules/testing.md § Env-Var Test Isolation.
+_ENV_LOCK = threading.Lock()
+
+
+@pytest.fixture
+def _env_serialized():
+    with _ENV_LOCK:
+        yield
+
+
+# ---------------------------------------------------------------------------
+# validate_origin_allowlist — typed-error / shape contract
+# ---------------------------------------------------------------------------
+
+
+def test_validate_none_passes_through() -> None:
+    assert validate_origin_allowlist(None) is None
+
+
+def test_validate_empty_list_rejected() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        validate_origin_allowlist([])
+
+
+def test_validate_bare_string_rejected() -> None:
+    """Common bug: allowed_origins='https://x' instead of [...]."""
+    with pytest.raises(ValueError, match="list of strings"):
+        validate_origin_allowlist("https://app.example.com")  # type: ignore[arg-type]
+
+
+def test_validate_non_string_entry_rejected() -> None:
+    with pytest.raises(ValueError, match="entries must be str"):
+        validate_origin_allowlist(["https://x.com", 42])  # type: ignore[list-item]
+
+
+def test_validate_empty_string_entry_rejected() -> None:
+    with pytest.raises(ValueError, match="non-empty strings"):
+        validate_origin_allowlist(["https://x.com", "   "])
+
+
+def test_validate_missing_scheme_rejected() -> None:
+    with pytest.raises(ValueError, match="must start with"):
+        validate_origin_allowlist(["app.example.com"])
+
+
+def test_validate_exact_origin_accepted() -> None:
+    assert validate_origin_allowlist(["https://app.example.com"]) == [
+        "https://app.example.com"
+    ]
+
+
+def test_validate_http_scheme_accepted() -> None:
+    # Some downstream consumers run mixed-mode (http://) for dev.
+    assert validate_origin_allowlist(["http://localhost:3000"]) == [
+        "http://localhost:3000"
+    ]
+
+
+def test_validate_wildcard_subdomain_accepted() -> None:
+    assert validate_origin_allowlist(["https://*.example.com"]) == [
+        "https://*.example.com"
+    ]
+
+
+def test_validate_wildcard_must_be_at_subdomain_position() -> None:
+    with pytest.raises(ValueError, match="<scheme>://\\*\\.<host>"):
+        validate_origin_allowlist(["https://example.*.com"])
+
+
+def test_validate_multiple_wildcards_rejected() -> None:
+    with pytest.raises(ValueError, match="only one '\\*'"):
+        validate_origin_allowlist(["https://*.*.example.com"])
+
+
+def test_validate_literal_wildcard_rejected_without_env(_env_serialized) -> None:
+    with pytest.raises(WildcardOriginRefusedError):
+        validate_origin_allowlist(["*"])
+
+
+def test_validate_literal_wildcard_accepted_with_env(
+    _env_serialized, monkeypatch
+) -> None:
+    monkeypatch.setenv(WILDCARD_ORIGIN_ENV_FLAG, "true")
+    assert validate_origin_allowlist(["*"]) == ["*"]
+
+
+def test_validate_literal_wildcard_env_case_insensitive(
+    _env_serialized, monkeypatch
+) -> None:
+    monkeypatch.setenv(WILDCARD_ORIGIN_ENV_FLAG, "TRUE")
+    assert validate_origin_allowlist(["*"]) == ["*"]
+
+
+def test_validate_literal_wildcard_rejected_when_env_is_false(
+    _env_serialized, monkeypatch
+) -> None:
+    monkeypatch.setenv(WILDCARD_ORIGIN_ENV_FLAG, "false")
+    with pytest.raises(WildcardOriginRefusedError):
+        validate_origin_allowlist(["*"])
+
+
+def test_validate_literal_wildcard_rejected_when_env_unset(
+    _env_serialized, monkeypatch
+) -> None:
+    monkeypatch.delenv(WILDCARD_ORIGIN_ENV_FLAG, raising=False)
+    with pytest.raises(WildcardOriginRefusedError):
+        validate_origin_allowlist(["*"])
+
+
+def test_validate_returns_fresh_list() -> None:
+    """The validated list MUST NOT alias the input — caller mutation
+    of the input MUST NOT affect the registered allowlist."""
+    src = ["https://app.example.com"]
+    out = validate_origin_allowlist(src)
+    assert out is not src
+    src.append("https://evil.com")
+    assert out == ["https://app.example.com"]
+
+
+# ---------------------------------------------------------------------------
+# origin_matches_allowlist — runtime predicate
+# ---------------------------------------------------------------------------
+
+
+def test_match_none_origin_returns_false() -> None:
+    assert origin_matches_allowlist(None, ["https://app.example.com"]) is False
+
+
+def test_match_non_string_origin_returns_false() -> None:
+    """Shape rejection per rules/ui-backend-defense.md Rule 2."""
+    assert origin_matches_allowlist(123, ["https://x.com"]) is False
+    assert origin_matches_allowlist([], ["https://x.com"]) is False
+    assert origin_matches_allowlist({}, ["https://x.com"]) is False
+
+
+def test_match_empty_origin_returns_false() -> None:
+    assert origin_matches_allowlist("", ["https://x.com"]) is False
+
+
+def test_match_exact_origin() -> None:
+    assert (
+        origin_matches_allowlist("https://app.example.com", ["https://app.example.com"])
+        is True
+    )
+
+
+def test_match_exact_origin_case_sensitive() -> None:
+    """Origins are case-sensitive per RFC 6454; 'HTTPS://' MUST NOT
+    match 'https://' — every real client emits the lowercase form."""
+    assert (
+        origin_matches_allowlist("HTTPS://APP.EXAMPLE.COM", ["https://app.example.com"])
+        is False
+    )
+
+
+def test_match_wildcard_subdomain_matches_subdomain() -> None:
+    assert (
+        origin_matches_allowlist("https://api.example.com", ["https://*.example.com"])
+        is True
+    )
+
+
+def test_match_wildcard_subdomain_matches_deep_subdomain() -> None:
+    """Deep subdomain (a.b.example.com) matches *.example.com."""
+    assert (
+        origin_matches_allowlist("https://a.b.example.com", ["https://*.example.com"])
+        is True
+    )
+
+
+def test_match_wildcard_subdomain_rejects_bare_host() -> None:
+    """https://*.example.com MUST NOT match https://example.com."""
+    assert (
+        origin_matches_allowlist("https://example.com", ["https://*.example.com"])
+        is False
+    )
+
+
+def test_match_wildcard_subdomain_rejects_suffix_attack() -> None:
+    """Defense against https://example.com.evil.com."""
+    assert (
+        origin_matches_allowlist(
+            "https://example.com.evil.com", ["https://*.example.com"]
+        )
+        is False
+    )
+
+
+def test_match_wildcard_subdomain_rejects_scheme_mismatch() -> None:
+    """https://*.example.com MUST NOT match http://api.example.com."""
+    assert (
+        origin_matches_allowlist("http://api.example.com", ["https://*.example.com"])
+        is False
+    )
+
+
+def test_match_wildcard_with_port_match() -> None:
+    """Port is stripped from the candidate host before matching."""
+    assert (
+        origin_matches_allowlist(
+            "https://api.example.com:8443", ["https://*.example.com"]
+        )
+        is True
+    )
+
+
+def test_match_literal_wildcard_matches_anything(_env_serialized, monkeypatch) -> None:
+    monkeypatch.setenv(WILDCARD_ORIGIN_ENV_FLAG, "true")
+    allow = validate_origin_allowlist(["*"])
+    assert allow is not None
+    assert origin_matches_allowlist("https://anything.example", allow) is True
+    assert origin_matches_allowlist("http://x.io", allow) is True
+
+
+def test_match_literal_wildcard_rejects_empty(_env_serialized, monkeypatch) -> None:
+    monkeypatch.setenv(WILDCARD_ORIGIN_ENV_FLAG, "true")
+    allow = validate_origin_allowlist(["*"])
+    assert allow is not None
+    assert origin_matches_allowlist("", allow) is False
+    assert origin_matches_allowlist(None, allow) is False
+
+
+def test_match_multiple_entries_first_match_wins() -> None:
+    allow = ["https://app.example.com", "https://*.staging.example.com"]
+    assert origin_matches_allowlist("https://app.example.com", allow) is True
+    assert origin_matches_allowlist("https://x.staging.example.com", allow) is True
+    assert origin_matches_allowlist("https://other.com", allow) is False
+
+
+def test_match_origin_with_path_in_allowlist_does_not_match_path() -> None:
+    """Origin headers from real browsers do not include paths.
+    A defensive test: an attacker-controlled origin with a path
+    suffix MUST NOT match the bare-host entry."""
+    allow = ["https://app.example.com"]
+    assert origin_matches_allowlist("https://app.example.com/evil", allow) is False
+
+
+# ---------------------------------------------------------------------------
+# fingerprint_origin — log shape
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_is_8_hex_chars_for_string() -> None:
+    fp = fingerprint_origin("https://app.example.com")
+    assert len(fp) == 8
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+def test_fingerprint_is_deterministic() -> None:
+    """Two calls with the same input MUST produce the same fingerprint."""
+    a = fingerprint_origin("https://app.example.com")
+    b = fingerprint_origin("https://app.example.com")
+    assert a == b
+
+
+def test_fingerprint_differs_per_input() -> None:
+    a = fingerprint_origin("https://app.example.com")
+    b = fingerprint_origin("https://evil.com")
+    assert a != b
+
+
+def test_fingerprint_none_is_sentinel() -> None:
+    assert fingerprint_origin(None) == "00000000"
+
+
+def test_fingerprint_empty_is_sentinel() -> None:
+    assert fingerprint_origin("") == "00000000"
+
+
+def test_fingerprint_does_not_echo_origin() -> None:
+    """The fingerprint MUST NOT contain any substring of the origin —
+    rules/observability.md Rule 6 + 8 (no schema-revealing identifiers
+    at WARN level)."""
+    origin = "https://app.example.com"
+    fp = fingerprint_origin(origin)
+    assert "example" not in fp
+    assert "app" not in fp
+    assert "https" not in fp
+
+
+def test_fingerprint_non_string_returns_hash_of_type() -> None:
+    """Non-string inputs hash the type name — provides some signal
+    without leaking the underlying object."""
+    fp = fingerprint_origin(123)
+    assert len(fp) == 8
+    assert fp != fingerprint_origin([])  # different types → different fp

--- a/specs/nexus-channels.md
+++ b/specs/nexus-channels.md
@@ -156,11 +156,37 @@ Server push:
 
 #### 4.4.1 Class-based MessageHandler API
 
-For per-connection state, subscription fanout, or any pattern that exceeds stateless request/response, register a `MessageHandler` subclass at a path via `Nexus.websocket(path)` decorator or `Nexus.register_websocket(path, handler_cls)`. The `MessageHandlerRegistry` (`app.websocket_handlers`) routes incoming frames to the handler's lifecycle hooks and tracks `Connection` objects with isolated `state: SimpleNamespace`.
+For per-connection state, subscription fanout, or any pattern that exceeds stateless request/response, register a `MessageHandler` subclass at a path via `Nexus.websocket(path, *, allowed_origins=None)` decorator or `Nexus.register_websocket(path, handler_cls, *, allowed_origins=None)`. The `MessageHandlerRegistry` (`app.websocket_handlers`) routes incoming frames to the handler's lifecycle hooks and tracks `Connection` objects with isolated `state: SimpleNamespace`.
+
+**Connection object (`nexus.websocket_handlers.Connection`):**
+
+- `connection_id: str` — stable UUID hex for the lifetime of the connection.
+- `path: str` — URL path the client connected on (e.g. `/events`).
+- `state: SimpleNamespace` — handler-owned bookkeeping; the framework never writes to it.
+- `connected_at: float` — monotonic timestamp of connection open.
+- `headers: Mapping[str, str]` — read-only case-insensitive Mapping of HTTP handshake headers (Origin, Host, User-Agent, Sec-WebSocket-*, cookies, custom auth headers). **Captured AT HANDSHAKE; NOT refreshed during the connection lifetime.** Lookups are case-insensitive (`conn.headers["origin"]` and `conn.headers["Origin"]` return the same value). The mapping is structurally immutable — assignment / deletion raise `TypeError`. Consumers needing custom enforcement (signed-token check, per-tenant header validation) beyond the static `allowed_origins` allowlist read from this surface inside `on_connect` (issue #673).
+- `alive: bool` — whether the registry still considers the connection open.
+- `await conn.send_json(payload)`, `await conn.send_text(message)`, `await conn.close(code, reason)` — outbound helpers.
+
+**Origin allowlist enforcement (issue #673 — DNS-rebinding defense):**
+
+`register_websocket(path, handler_cls, *, allowed_origins=None)` and the `@app.websocket(path, *, allowed_origins=None)` decorator accept an optional `allowed_origins: list[str] | None`. When set, the SDK enforces the HTTP `Origin` header against the allowlist BEFORE invoking `on_connect` — a mismatch closes the WebSocket with code 1008 (RFC 6455 policy violation) and a fingerprinted reason that does NOT echo the rejected Origin back to the client. This is the structural defense against DNS-rebinding attacks per `rules/security.md` § Network Transport Hardening.
+
+Allowlist entry shapes:
+
+- **Exact origin** (`"https://app.example.com"`) — case-sensitive byte-equal match.
+- **Wildcard subdomain** (`"https://*.example.com"`) — matches strict subdomains of `example.com` whose scheme matches the entry's scheme. Does NOT match the bare `example.com` and does NOT match `example.com.evil.com` (suffix-with-dot defense).
+- **Literal `"*"`** — accepts any non-empty origin. **BLOCKED at registration** with `WildcardOriginRefusedError` (subclass of `ValueError`) unless `KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN=true` is set in env. Fail-closed default: production deployments MUST list explicit origins; the `"*"` opt-in is for development / private internal services where the operator has explicitly accepted that any browser-reachable origin can open the socket.
+
+When `allowed_origins` is `None` (the default), the SDK does NOT enforce — the registry emits a one-time `ws.handler.origin_enforcement_disabled` WARN log at registration naming the path so operators see the gap. Consumers needing custom enforcement MUST use `Connection.headers` from inside `on_connect` to implement their own rejection (e.g. raising from `on_connect`, which closes the WebSocket with code 4500).
+
+Rejection emits a `ws.handler.origin_rejected` WARN log carrying `path`, `handler`, `origin_fingerprint` (sha256(origin)[:8] per `rules/observability.md` Rule 6 + Rule 8), and `reason` (`missing_origin_header` | `origin_not_in_allowlist`). The raw Origin is NEVER echoed to log aggregators.
+
+**Cross-SDK parity:** kailash-rs is expected to ship the same surface semantically (per EATP D6) at the equivalent `register_websocket` surface — the `allowed_origins` parameter, the wildcard-subdomain shape, the fail-closed `"*"` env flag, the close code 1008 + fingerprinted reason, and the `Connection::headers` exposure.
 
 **Lifecycle hooks (override in subclass, all async):**
 
-- `async on_connect(self, conn)` — fired after handshake; initialize `conn.state.*`.
+- `async on_connect(self, conn)` — fired after handshake AND after Origin allowlist check (if any). Initialize `conn.state.*`. Read `conn.headers` for custom enforcement beyond the static allowlist.
 - `async on_message(self, conn, msg) -> Any` — fired per JSON-decoded frame; **return value contract** (issue #618):
   - `None` → no auto-reply (handler-owned `await conn.send_*`).
   - `dict` / `list` → auto-sent as JSON text frame via `conn.send_json`.
@@ -168,7 +194,7 @@ For per-connection state, subscription fanout, or any pattern that exceeds state
   - `bytes` → UTF-8 decoded then `conn.send_text`; invalid UTF-8 logged at WARN and dropped.
   - any other → best-effort `conn.send_json` with `default=str`; `TypeError`/`ValueError` logged at WARN.
 - `async on_text(self, conn, text) -> Any` — same return-value contract as `on_message`.
-- `async on_disconnect(self, conn)` — fired after socket close; `conn` already removed from `self.connections`.
+- `async on_disconnect(self, conn)` — fired after socket close; `conn` already removed from `self.connections`. Origin-rejected connections do NOT invoke `on_disconnect` (they never reached `on_connect`).
 - `async on_event(self, event)` — fanout hook called by `broadcast_event` (NOT by the framework directly).
 
 **Tenant safety:** `on_message` auto-replies are scoped to the originating socket — no broadcast leakage. Per-connection unicast push from external publishers uses `Nexus.websocket_send_to(path, connection_id, payload)` (issue #618), which scopes dispatch to one tracked connection.


### PR DESCRIPTION
## Summary

Closes #673. Two complementary changes (defense-in-depth per `rules/ui-backend-defense.md` Rule 3):

**(A) Hoist Origin allowlist enforcement into the SDK** — `Nexus.register_websocket(path, handler_cls, *, allowed_origins=None)` and the `Nexus.websocket(path, *, allowed_origins=None)` decorator both accept the new parameter. When set, `MessageHandlerRegistry.handle_connection` rejects every handshake whose `Origin` does NOT match the allowlist BEFORE invoking `on_connect`. Reject path: WebSocket close 1008 + fingerprinted reason (sha256(origin)[:8]) per `rules/observability.md` Rule 6 + Rule 8.

**(B) Surface request headers on `Connection`** — new `Connection.headers` immutable Mapping carries the HTTP handshake headers (Origin, Host, User-Agent, Sec-WebSocket-*). Case-insensitive, snapshot-isolated, mutation raises `TypeError`. Operators can implement custom enforcement logic from inside `on_connect` even when `allowed_origins` is None.

Wildcard subdomain matching (`https://*.example.com`) supported. Literal `"*"` rejected at `register_websocket` time unless `KAILASH_NEXUS_ALLOW_WILDCARD_ORIGIN=true` is set in env (typed `WildcardOriginRefusedError`). When `allowed_origins is None`, the SDK accepts but emits a one-time WARN at registration so operators see the gap.

## Test plan

- [x] 28 + 22 + 7 = 57 new tests pass; 95 pre-existing WebSocket tests still pass — no regression
- [x] Total local: 152 passed in 5.65s
- [x] `pre-commit run` clean on staged files
- [x] `pyright` on the 3 modified files: only pre-existing operator-on-Optional errors (unrelated MCP code at core.py:1546+); no new errors from #673

## Cross-SDK

The kailash-rs companion (`Connection::headers` exposure + `allowed_origins` parameter + close code 1008 + fingerprinted reason) belongs at the Rust repo per `rules/cross-sdk-inspection.md` Rule 1. To be filed separately at `esperie/kailash-rs`.

## Related issues

Closes #673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)