### PR TITLE
feat(dataflow): db.transactions_sync.begin() — sync surface for transaction context manager (#711)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -70,7 +70,7 @@ from kailash.workflow.builder import WorkflowBuilder
 from ..features.bulk import BulkOperations
 from ..features.express import ExpressDataFlow, SyncExpress
 from ..features.multi_tenant import MultiTenantManager
-from ..features.transactions import TransactionManager
+from ..features.transactions import SyncTransactionManager, TransactionManager
 from ..migrations.auto_migration_system import AutoMigrationSystem
 from ..migrations.schema_state_manager import SchemaStateManager
 from ..utils.connection import ConnectionManager
@@ -3504,6 +3504,43 @@ class DataFlow(DataFlowEventMixin):
     def transactions(self) -> TransactionManager:
         """Access transaction manager."""
         return self._transaction_manager
+
+    @property
+    def transactions_sync(self) -> SyncTransactionManager:
+        """Access SyncTransactionManager — sync surface for transactions (#711).
+
+        Mirror of :attr:`transactions` for sync callers (CLI scripts, sync
+        FastAPI handlers, pytest non-async tests, Jupyter sync cells).
+        Owns a persistent daemon-thread event loop and submits coroutines
+        via ``asyncio.run_coroutine_threadsafe`` so the pinned transaction
+        connection survives across multiple ``tx.execute_raw`` calls.
+
+        Cross-context safe — works inside pytest-asyncio / Nexus / Jupyter
+        without raising ``RuntimeError: This event loop is already running``
+        because the BG loop thread is independent of any host event loop.
+
+        Example::
+
+            with db.transactions_sync.begin() as tx:
+                existing = tx.execute_raw(
+                    "SELECT id FROM oauth_tokens "
+                    "WHERE user_id = %s FOR UPDATE",
+                    [user_id],
+                )
+                if existing:
+                    tx.execute_raw(
+                        "UPDATE oauth_tokens SET refresh_token = %s "
+                        "WHERE user_id = %s",
+                        [new_refresh, user_id],
+                    )
+
+        Returns:
+            :class:`SyncTransactionManager` — sync transaction surface.
+        """
+        self._ensure_connected()
+        if not hasattr(self, "_transactions_sync") or self._transactions_sync is None:
+            self._transactions_sync = SyncTransactionManager(self._transaction_manager)
+        return self._transactions_sync
 
     @property
     def connection(self) -> ConnectionManager:
@@ -9808,6 +9845,21 @@ class DataFlow(DataFlowEventMixin):
                     "engine.error_closing_migration_system", extra={"error": str(e)}
                 )
 
+        # Issue #711 — stop the SyncTransactionManager BG event loop thread
+        # BEFORE the pool/adapter teardown so any in-flight sync transactions
+        # do not strand on closed connections. Lazy attribute — only present
+        # if a caller actually accessed `db.transactions_sync`.
+        if hasattr(self, "_transactions_sync") and self._transactions_sync is not None:
+            try:
+                self._transactions_sync.close_sync()
+            except Exception as e:
+                logger.debug(
+                    "engine.error_closing_transactions_sync",
+                    extra={"error": str(e)},
+                )
+            finally:
+                self._transactions_sync = None
+
         # Stop pool monitor
         if self._pool_monitor is not None:
             try:
@@ -9891,6 +9943,21 @@ class DataFlow(DataFlowEventMixin):
                     "engine.error_releasing_model_registry_runtime",
                     extra={"error": str(e)},
                 )
+
+        # Issue #711 — stop the SyncTransactionManager BG event loop thread
+        # BEFORE the pool/adapter teardown so any in-flight sync transactions
+        # do not strand on closed connections. Lazy attribute — only present
+        # if a caller actually accessed `db.transactions_sync`.
+        if hasattr(self, "_transactions_sync") and self._transactions_sync is not None:
+            try:
+                self._transactions_sync.close_sync()
+            except Exception as e:
+                logger.debug(
+                    "engine.error_closing_transactions_sync",
+                    extra={"error": str(e)},
+                )
+            finally:
+                self._transactions_sync = None
 
         # Stop pool monitor (same cleanup as sync close())
         if self._pool_monitor is not None:

--- a/packages/kailash-dataflow/src/dataflow/features/transactions.py
+++ b/packages/kailash-dataflow/src/dataflow/features/transactions.py
@@ -7,12 +7,34 @@ automatic rollback on exception.
 
 All transactions run on a single connection from the pool to ensure
 atomicity. The connection is returned to the pool on commit/rollback.
+
+Sync surface — ``db.transactions_sync.begin()`` — mirrors the async API
+for callers that cannot ``await`` (CLI scripts, sync FastAPI handlers,
+pytest non-async tests, Jupyter sync cells). The sync wrapper owns a
+persistent daemon-thread event loop and routes every coroutine via
+``asyncio.run_coroutine_threadsafe`` so the pinned connection survives
+across multiple ``tx.execute_raw`` calls — the same pattern
+``SyncExpress`` uses (see ``packages/kailash-dataflow/src/dataflow/
+features/express.py::SyncExpress``). Cross-context safe: the BG loop
+thread is independent of the host event loop, so the surface works
+inside pytest-asyncio, Nexus handlers, and Jupyter without raising
+``RuntimeError: This event loop is already running``.
 """
 
+import asyncio
 import logging
-from contextlib import asynccontextmanager
+import threading
+import warnings
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
-from typing import Any, AsyncGenerator, Dict, List, Optional
+from typing import (
+    Any,
+    AsyncGenerator,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -421,3 +443,329 @@ class _PoolWrapper:
 
     def __init__(self, pool: Any) -> None:
         self.connection_pool = pool
+
+
+# ============================================================================
+# Sync surface — ``db.transactions_sync.begin()`` (issue #711)
+# ============================================================================
+
+# Sentinel placed in the sync scope when the ``with`` block has exited. Any
+# subsequent ``tx.execute_raw`` call MUST raise ``RuntimeError`` per
+# ``rules/zero-tolerance.md`` Rule 3a (typed delegate guard) — the pinned
+# connection only exists while the scope is active.
+_SCOPE_INACTIVE = object()
+
+
+class SyncTransactionScope:
+    """Sync analogue of :class:`TransactionScope`.
+
+    Yielded by :func:`SyncTransactionManager.begin`. Holds a reference to the
+    underlying async :class:`TransactionScope` and the BG-loop submitter so
+    ``tx.execute_raw(sql, params)`` can invoke the async ``execute_raw`` from
+    sync code without the caller awaiting anything.
+
+    The scope is single-use — exiting the ``with`` block sets ``_async_scope``
+    to ``_SCOPE_INACTIVE`` so any further ``execute_raw`` calls raise the
+    typed-guard ``RuntimeError`` instead of silently re-using a connection
+    that has been returned to the pool.
+
+    Mirrors the async ``TransactionScope`` metadata surface (id,
+    isolation_level, status, type) for parity with the async API; the
+    backward-compat dict ``__getitem__`` / ``__setitem__`` from the async
+    scope is intentionally NOT mirrored — sync callers landed in 0.x with
+    the canonical attribute access only.
+    """
+
+    __slots__ = ("_async_scope", "_run_sync")
+
+    def __init__(self, async_scope: TransactionScope, run_sync: Any) -> None:
+        # ``run_sync`` is a callable: ``run_sync(coro) -> result``. It submits
+        # the coroutine to the manager's BG event loop and blocks for the
+        # result. Stored on the scope so it survives the ``with`` body even
+        # when the manager is closed mid-call (rare).
+        self._async_scope: Any = async_scope
+        self._run_sync = run_sync
+
+    # --- Metadata mirror of the async scope (read-only attribute proxies) ---
+
+    @property
+    def id(self) -> str:
+        return self._guarded_async_scope().id
+
+    @property
+    def isolation_level(self) -> str:
+        return self._guarded_async_scope().isolation_level
+
+    @property
+    def status(self) -> str:
+        return self._guarded_async_scope().status
+
+    @property
+    def type(self) -> str:
+        return self._guarded_async_scope().type
+
+    @property
+    def depth(self) -> Optional[int]:
+        return self._guarded_async_scope().depth
+
+    # --- Sync execute_raw — the load-bearing surface ---
+
+    def execute_raw(self, sql: str, params: Optional[List[Any]] = None) -> Any:
+        """Execute a raw SQL statement on the pinned transaction connection.
+
+        Sync analogue of :meth:`TransactionScope.execute_raw`. Submits the
+        underlying async call to the manager's BG event loop and blocks for
+        the result, so the pinned connection is the same across every call
+        inside the ``with`` body — the load-bearing invariant for the OAuth
+        credential-rotation pattern this surface was added for.
+
+        Calling ``execute_raw`` outside the ``with`` body raises
+        ``RuntimeError`` (typed delegate guard per
+        ``rules/zero-tolerance.md`` Rule 3a) — the pinned connection only
+        exists while the scope is active.
+
+        Args:
+            sql: SQL statement using dialect-appropriate placeholders
+                (``$1`` / ``$2`` for asyncpg, ``?`` for aiosqlite, ``%s``
+                for MySQL).
+            params: Optional positional parameter list.
+
+        Returns:
+            Same return shape as :meth:`TransactionScope.execute_raw` — the
+            sync wrapper does not transform the result.
+        """
+        async_scope = self._guarded_async_scope()
+        return self._run_sync(async_scope.execute_raw(sql, params))
+
+    # --- Internal: typed guard for out-of-scope access ---
+
+    def _guarded_async_scope(self) -> TransactionScope:
+        if self._async_scope is _SCOPE_INACTIVE:
+            raise RuntimeError(
+                "SyncTransactionScope.execute_raw called outside the "
+                "transaction body — ensure the call is inside the "
+                "`with db.transactions_sync.begin()` scope. "
+                "The pinned connection is only valid while the scope is "
+                "active."
+            )
+        return self._async_scope  # type: ignore[return-value]
+
+    def _mark_inactive(self) -> None:
+        """Called by the manager when the ``with`` block exits.
+
+        Replaces the async-scope reference with the inactive sentinel so the
+        guarded accessor raises a typed error rather than silently re-using
+        a connection that has been returned to the pool.
+        """
+        self._async_scope = _SCOPE_INACTIVE
+
+
+class SyncTransactionManager:
+    """Sync surface for :class:`TransactionManager` (issue #711).
+
+    Mirror of :func:`TransactionManager.begin` for sync callers. Owns a
+    persistent daemon-thread event loop and submits every coroutine to it
+    via ``asyncio.run_coroutine_threadsafe`` — the same pattern
+    :class:`SyncExpress` uses. One BG loop is shared across all
+    ``begin()`` calls so the pinned connection survives across multiple
+    ``tx.execute_raw`` invocations inside one ``with`` block.
+
+    Cross-context safe — the BG loop thread is independent of any host
+    event loop. The surface works inside pytest-asyncio, Nexus handlers,
+    and Jupyter cells without raising
+    ``RuntimeError: This event loop is already running``.
+
+    Lifecycle::
+
+        # Construction (lazy at db.transactions_sync first access):
+        sync_mgr = SyncTransactionManager(async_mgr)
+
+        # Use:
+        with sync_mgr.begin() as tx:
+            existing = tx.execute_raw(
+                "SELECT id FROM oauth_tokens WHERE user_id = %s FOR UPDATE",
+                [user_id],
+            )
+            if existing:
+                tx.execute_raw(
+                    "UPDATE oauth_tokens SET refresh_token = %s "
+                    "WHERE user_id = %s",
+                    [new_refresh, user_id],
+                )
+
+        # Teardown (wired into DataFlow.close() / close_async()):
+        sync_mgr.close_sync()
+    """
+
+    def __init__(self, transactions: TransactionManager) -> None:
+        # Reference to the async manager — every ``begin()`` call delegates
+        # to the async ``begin()`` context manager so the sync surface
+        # cannot drift from the async semantics (single source of truth).
+        self._transactions = transactions
+
+        # Persistent BG event loop in a daemon thread. Mirrors
+        # ``SyncExpress.__init__`` (express.py:1772-1779). Daemon=True so
+        # the thread dies with the interpreter even if ``close_sync`` was
+        # not called — defensive, matches SyncExpress.
+        self._loop: Optional[asyncio.AbstractEventLoop] = asyncio.new_event_loop()
+        self._thread: Optional[threading.Thread] = threading.Thread(
+            target=self._loop.run_forever,
+            daemon=True,
+            name="SyncTransactionManager-loop",
+        )
+        self._thread.start()
+
+        # Per `rules/zero-tolerance.md` Rule 6 — explicit close path.
+        # `_closed` lets ``__del__`` distinguish "user forgot to close"
+        # (ResourceWarning) from "user closed correctly" (silent).
+        self._closed = False
+
+    # --- BG-loop dispatch ---
+
+    def _run_sync(self, coro: Any) -> Any:
+        """Run an async coroutine synchronously on the persistent BG loop.
+
+        Mirrors ``SyncExpress._run_sync`` (express.py:1775-1784). All async
+        operations submit to the same BG loop so the pinned transaction
+        connection (which is bound to that loop) survives across calls.
+        """
+        if self._closed or self._loop is None:
+            raise RuntimeError(
+                "SyncTransactionManager is closed — construct a fresh "
+                "DataFlow instance or avoid calling close_sync() before "
+                "the transaction surface is fully drained."
+            )
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    # --- Public: begin() ---
+
+    @contextmanager
+    def begin(
+        self, isolation_level: str = "READ COMMITTED"
+    ) -> Iterator[SyncTransactionScope]:
+        """Begin a database transaction (sync).
+
+        Mirror of :func:`TransactionManager.begin`. Yields a
+        :class:`SyncTransactionScope` whose ``execute_raw(sql, params)``
+        runs on the pinned connection.
+
+        Args:
+            isolation_level: SQL isolation level (default ``"READ COMMITTED"``).
+                See :func:`TransactionManager.begin` for supported values.
+
+        Yields:
+            :class:`SyncTransactionScope` — exposes ``execute_raw`` and the
+            metadata fields (``id``, ``isolation_level``, ``status``,
+            ``type``, ``depth``) mirrored from the async scope.
+
+        Raises:
+            Re-raises any exception from the body after rollback.
+        """
+        # The async ``begin()`` is itself an ``@asynccontextmanager`` — we
+        # cannot directly enter it from sync code, so we drive it manually
+        # via ``__aenter__`` / ``__aexit__`` on the BG loop. This preserves
+        # the async manager's commit-on-clean-exit / rollback-on-exception
+        # semantics WITHOUT duplicating the SQL or the ContextVar wiring.
+        async_cm = self._transactions.begin(isolation_level)
+
+        # Enter the async context manager on the BG loop. The pinned
+        # connection (set in `_active_transaction` ContextVar) becomes
+        # visible to every subsequent ``execute_raw`` submitted to the
+        # same loop.
+        async_scope = self._run_sync(async_cm.__aenter__())
+        sync_scope = SyncTransactionScope(async_scope, self._run_sync)
+
+        try:
+            yield sync_scope
+        except BaseException:
+            # Propagate the exception type/value/tb to the async CM so it
+            # rolls back. Use ``sys.exc_info()`` shape via a wrapper coro
+            # — the async CM expects ``(exc_type, exc_val, exc_tb)``.
+            import sys
+
+            exc_type, exc_val, exc_tb = sys.exc_info()
+            try:
+                # Returns True iff the async CM swallowed the exception.
+                # ``TransactionManager.begin`` re-raises after rollback so
+                # we expect this to return False; we re-raise either way to
+                # preserve the original traceback chain.
+                self._run_sync(async_cm.__aexit__(exc_type, exc_val, exc_tb))
+            except BaseException:
+                # The async CM may itself raise during rollback — surface
+                # that to the caller. Either way, mark the scope inactive
+                # so any post-with ``execute_raw`` raises the typed guard.
+                sync_scope._mark_inactive()
+                raise
+            sync_scope._mark_inactive()
+            raise
+        else:
+            # Clean-exit: drive the async CM exit, then mark the scope
+            # inactive so post-with ``execute_raw`` calls raise the typed
+            # guard (rules/zero-tolerance.md Rule 3a).
+            self._run_sync(async_cm.__aexit__(None, None, None))
+            sync_scope._mark_inactive()
+
+    # --- Lifecycle ---
+
+    def close_sync(self) -> None:
+        """Stop the BG event loop thread cleanly.
+
+        Wired into :func:`DataFlow.close` and :func:`DataFlow.close_async`
+        so ``with DataFlow(...)`` / ``async with`` callers do not need to
+        invoke this manually. Safe to call multiple times.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        loop = self._loop
+        thread = self._thread
+        # Drop references first so concurrent ``_run_sync`` callers see
+        # ``self._closed = True`` and raise the closed-error.
+        self._loop = None
+        self._thread = None
+
+        if loop is not None and loop.is_running():
+            try:
+                loop.call_soon_threadsafe(loop.stop)
+            except RuntimeError:
+                # Loop already stopped or destroyed — safe to ignore in
+                # cleanup; the closed flag prevents reuse.
+                pass
+
+        if thread is not None and thread.is_alive():
+            # Bounded join — the loop should stop near-instantly. A 5s
+            # ceiling prevents test hangs if something pathological keeps
+            # the loop alive (we can't deadlock the suite for cleanup).
+            thread.join(timeout=5.0)
+
+        if loop is not None:
+            try:
+                loop.close()
+            except RuntimeError:
+                # Loop may already be closed by run_forever() shutdown —
+                # the closed flag is the source of truth.
+                pass
+
+    def __del__(self, _warnings: Any = warnings) -> None:
+        """Emit ``ResourceWarning`` if the BG thread was not stopped cleanly.
+
+        Per ``rules/patterns.md`` § Async Resource Cleanup: emit warning,
+        do nothing else. We do NOT call ``close_sync`` here — touching the
+        BG loop / thread from a finalizer is the deadlock pattern that
+        rule documents.
+        """
+        if not getattr(self, "_closed", True):
+            try:
+                _warnings.warn(
+                    f"{type(self).__name__} not closed; call "
+                    f"db.close()/await db.close_async() to stop the BG "
+                    f"event loop thread cleanly.",
+                    ResourceWarning,
+                    stacklevel=2,
+                )
+            except Exception:
+                # Finalizer must not raise. Hooks/cleanup carve-out per
+                # rules/zero-tolerance.md Rule 3.
+                pass

--- a/packages/kailash-dataflow/src/dataflow/features/transactions.py
+++ b/packages/kailash-dataflow/src/dataflow/features/transactions.py
@@ -456,18 +456,84 @@ class _PoolWrapper:
 _SCOPE_INACTIVE = object()
 
 
+# --- Async helpers used by SyncTransactionManager ------------------------
+#
+# These are module-level coroutines (NOT methods on the class) so the BG
+# loop can await them without holding a reference to the manager — keeps
+# the coroutine objects pickle-light and avoids retaining the manager
+# across the BG loop's lifetime.
+
+
+async def _open_connection_for_url(url: str) -> Any:
+    """Open a fresh asyncpg/aiosqlite connection on the current loop.
+
+    Dispatches by URL scheme. The returned connection is bound to the
+    event loop currently executing this coroutine — for the sync surface,
+    that is the SyncTransactionManager's BG loop.
+    """
+    scheme = url.split(":", 1)[0].lower()
+    if scheme in ("postgresql", "postgres"):
+        import asyncpg
+
+        return await asyncpg.connect(url)
+    if scheme == "sqlite":
+        import aiosqlite
+
+        # Strip the sqlite:// prefix; aiosqlite expects the path.
+        path = url.split("://", 1)[1] if "://" in url else url
+        # aiosqlite.connect returns a connection-context object; calling
+        # ``__aenter__`` opens the connection and returns the conn.
+        conn = aiosqlite.connect(path)
+        return await conn.__aenter__()
+    raise RuntimeError(
+        f"SyncTransactionManager: unsupported database scheme '{scheme}' "
+        f"in URL — only postgresql and sqlite are wired."
+    )
+
+
+async def _begin_isolation(conn: Any, isolation_level: str) -> None:
+    """Issue ``BEGIN ISOLATION LEVEL <level>`` on the connection."""
+    is_asyncpg = hasattr(conn, "fetch") and hasattr(conn, "fetchrow")
+    if is_asyncpg:
+        await conn.execute(f"BEGIN ISOLATION LEVEL {isolation_level}")
+    else:
+        # SQLite ignores ISOLATION LEVEL; use plain BEGIN.
+        await conn.execute("BEGIN")
+
+
+async def _commit(conn: Any) -> None:
+    """Issue COMMIT on the pinned transaction connection."""
+    await conn.execute("COMMIT")
+
+
+async def _rollback(conn: Any) -> None:
+    """Issue ROLLBACK on the pinned transaction connection."""
+    await conn.execute("ROLLBACK")
+
+
+async def _close_connection(conn: Any) -> None:
+    """Close the connection. Dispatches by connection type."""
+    is_asyncpg = hasattr(conn, "fetch") and hasattr(conn, "fetchrow")
+    if is_asyncpg:
+        await conn.close()
+    else:
+        # aiosqlite Connection has ``close`` returning a coroutine.
+        await conn.close()
+
+
 class SyncTransactionScope:
     """Sync analogue of :class:`TransactionScope`.
 
-    Yielded by :func:`SyncTransactionManager.begin`. Holds a reference to the
-    underlying async :class:`TransactionScope` and the BG-loop submitter so
-    ``tx.execute_raw(sql, params)`` can invoke the async ``execute_raw`` from
-    sync code without the caller awaiting anything.
+    Yielded by :func:`SyncTransactionManager.begin`. Holds the BG-loop
+    submitter and a reference to the pinned asyncpg/aiosqlite connection
+    so ``tx.execute_raw(sql, params)`` can issue async DB calls from sync
+    code without the caller awaiting anything.
 
-    The scope is single-use — exiting the ``with`` block sets ``_async_scope``
-    to ``_SCOPE_INACTIVE`` so any further ``execute_raw`` calls raise the
-    typed-guard ``RuntimeError`` instead of silently re-using a connection
-    that has been returned to the pool.
+    The scope is single-use — exiting the ``with`` block clears the
+    pinned connection reference so any further ``execute_raw`` calls
+    raise the typed-guard ``RuntimeError`` (per
+    ``rules/zero-tolerance.md`` Rule 3a) instead of silently re-using a
+    connection that has been returned to the pool / closed.
 
     Mirrors the async ``TransactionScope`` metadata surface (id,
     isolation_level, status, type) for parity with the async API; the
@@ -476,37 +542,62 @@ class SyncTransactionScope:
     the canonical attribute access only.
     """
 
-    __slots__ = ("_async_scope", "_run_sync")
+    __slots__ = (
+        "_conn",
+        "_run_sync",
+        "_id",
+        "_isolation_level",
+        "_status",
+        "_type",
+        "_depth",
+    )
 
-    def __init__(self, async_scope: TransactionScope, run_sync: Any) -> None:
-        # ``run_sync`` is a callable: ``run_sync(coro) -> result``. It submits
-        # the coroutine to the manager's BG event loop and blocks for the
-        # result. Stored on the scope so it survives the ``with`` body even
-        # when the manager is closed mid-call (rare).
-        self._async_scope: Any = async_scope
+    def __init__(
+        self,
+        *,
+        conn: Any,
+        run_sync: Any,
+        id: str,
+        isolation_level: str,
+        status: str = "active",
+        type: str = "transaction",
+        depth: Optional[int] = None,
+    ) -> None:
+        # ``conn`` is the pinned asyncpg/aiosqlite connection (NOT a pool)
+        # bound to the manager's BG event loop. Set to ``_SCOPE_INACTIVE``
+        # when the with-block exits so post-block ``execute_raw`` raises.
+        self._conn: Any = conn
+        # ``run_sync`` is a callable: ``run_sync(coro) -> result``. It
+        # submits the coroutine to the manager's BG event loop and blocks
+        # for the result. Stored on the scope so it survives the with body.
         self._run_sync = run_sync
+        self._id = id
+        self._isolation_level = isolation_level
+        self._status = status
+        self._type = type
+        self._depth = depth
 
     # --- Metadata mirror of the async scope (read-only attribute proxies) ---
 
     @property
     def id(self) -> str:
-        return self._guarded_async_scope().id
+        return self._id
 
     @property
     def isolation_level(self) -> str:
-        return self._guarded_async_scope().isolation_level
+        return self._isolation_level
 
     @property
     def status(self) -> str:
-        return self._guarded_async_scope().status
+        return self._status
 
     @property
     def type(self) -> str:
-        return self._guarded_async_scope().type
+        return self._type
 
     @property
     def depth(self) -> Optional[int]:
-        return self._guarded_async_scope().depth
+        return self._depth
 
     # --- Sync execute_raw — the load-bearing surface ---
 
@@ -531,16 +622,18 @@ class SyncTransactionScope:
             params: Optional positional parameter list.
 
         Returns:
-            Same return shape as :meth:`TransactionScope.execute_raw` — the
-            sync wrapper does not transform the result.
+            For SELECT statements on asyncpg: a list of ``asyncpg.Record``
+            rows (use ``dict(row)`` to materialize). For
+            INSERT/UPDATE/DELETE on asyncpg: the command-tag string. For
+            aiosqlite: the cursor object after ``execute()``.
         """
-        async_scope = self._guarded_async_scope()
-        return self._run_sync(async_scope.execute_raw(sql, params))
+        conn = self._guarded_conn()
+        return self._run_sync(_execute_raw_on_conn(conn, sql, params))
 
     # --- Internal: typed guard for out-of-scope access ---
 
-    def _guarded_async_scope(self) -> TransactionScope:
-        if self._async_scope is _SCOPE_INACTIVE:
+    def _guarded_conn(self) -> Any:
+        if self._conn is _SCOPE_INACTIVE:
             raise RuntimeError(
                 "SyncTransactionScope.execute_raw called outside the "
                 "transaction body — ensure the call is inside the "
@@ -548,32 +641,68 @@ class SyncTransactionScope:
                 "The pinned connection is only valid while the scope is "
                 "active."
             )
-        return self._async_scope  # type: ignore[return-value]
+        return self._conn
 
     def _mark_inactive(self) -> None:
         """Called by the manager when the ``with`` block exits.
 
-        Replaces the async-scope reference with the inactive sentinel so the
-        guarded accessor raises a typed error rather than silently re-using
-        a connection that has been returned to the pool.
+        Replaces the connection reference with the inactive sentinel so
+        the guarded accessor raises a typed error rather than silently
+        re-using a connection that has been returned to the pool.
         """
-        self._async_scope = _SCOPE_INACTIVE
+        self._conn = _SCOPE_INACTIVE
+
+
+async def _execute_raw_on_conn(
+    conn: Any, sql: str, params: Optional[List[Any]] = None
+) -> Any:
+    """Execute a raw SQL statement on an asyncpg/aiosqlite connection.
+
+    Mirrors :meth:`TransactionScope.execute_raw`'s connection-type
+    dispatch — asyncpg takes positional ``*params``, aiosqlite takes a
+    single tuple/list. SELECT vs INSERT/UPDATE/DELETE chooses
+    ``fetch`` vs ``execute`` for asyncpg.
+    """
+    is_asyncpg = hasattr(conn, "fetch") and hasattr(conn, "fetchrow")
+    sql_stripped = sql.lstrip()
+    is_select = (
+        sql_stripped[:6].upper() == "SELECT" or sql_stripped[:4].upper() == "WITH"
+    )
+    if is_asyncpg:
+        if params is None:
+            if is_select:
+                return await conn.fetch(sql)
+            return await conn.execute(sql)
+        if is_select:
+            return await conn.fetch(sql, *params)
+        return await conn.execute(sql, *params)
+    # aiosqlite-style: single tuple param.
+    if params is None:
+        return await conn.execute(sql)
+    return await conn.execute(sql, params)
 
 
 class SyncTransactionManager:
     """Sync surface for :class:`TransactionManager` (issue #711).
 
     Mirror of :func:`TransactionManager.begin` for sync callers. Owns a
-    persistent daemon-thread event loop and submits every coroutine to it
-    via ``asyncio.run_coroutine_threadsafe`` — the same pattern
-    :class:`SyncExpress` uses. One BG loop is shared across all
-    ``begin()`` calls so the pinned connection survives across multiple
-    ``tx.execute_raw`` invocations inside one ``with`` block.
+    persistent daemon-thread event loop AND a private asyncpg/aiosqlite
+    connection lifecycle on that loop — every ``begin()`` opens a fresh
+    connection on the BG loop, runs the transaction body, and closes the
+    connection. The same BG loop is shared across all ``begin()`` calls
+    so the pinned connection survives across multiple ``tx.execute_raw``
+    invocations inside one ``with`` block.
 
     Cross-context safe — the BG loop thread is independent of any host
     event loop. The surface works inside pytest-asyncio, Nexus handlers,
     and Jupyter cells without raising
-    ``RuntimeError: This event loop is already running``.
+    ``RuntimeError: This event loop is already running`` AND without
+    sharing the DataFlow asyncpg pool (which is bound to whatever loop
+    initialized it). asyncpg connections are loop-bound; sharing a pool
+    across the host loop and the BG loop produces
+    ``RuntimeError: Future ... attached to a different loop``. Owning
+    a private connection lifecycle on the BG loop is the structural
+    fix for cross-loop usage.
 
     Lifecycle::
 
@@ -583,13 +712,13 @@ class SyncTransactionManager:
         # Use:
         with sync_mgr.begin() as tx:
             existing = tx.execute_raw(
-                "SELECT id FROM oauth_tokens WHERE user_id = %s FOR UPDATE",
+                "SELECT id FROM oauth_tokens WHERE user_id = $1 FOR UPDATE",
                 [user_id],
             )
             if existing:
                 tx.execute_raw(
-                    "UPDATE oauth_tokens SET refresh_token = %s "
-                    "WHERE user_id = %s",
+                    "UPDATE oauth_tokens SET refresh_token = $1 "
+                    "WHERE user_id = $2",
                     [new_refresh, user_id],
                 )
 
@@ -598,9 +727,11 @@ class SyncTransactionManager:
     """
 
     def __init__(self, transactions: TransactionManager) -> None:
-        # Reference to the async manager — every ``begin()`` call delegates
-        # to the async ``begin()`` context manager so the sync surface
-        # cannot drift from the async semantics (single source of truth).
+        # Reference to the async manager — used to read the database URL
+        # via ``transactions.dataflow`` AND to participate in the shared
+        # transaction-statistics counter. The sync surface does NOT drive
+        # the async ``begin()`` directly because asyncpg connections are
+        # loop-bound (see class docstring).
         self._transactions = transactions
 
         # Persistent BG event loop in a daemon thread. Mirrors
@@ -620,6 +751,16 @@ class SyncTransactionManager:
         # (ResourceWarning) from "user closed correctly" (silent).
         self._closed = False
 
+        # Counter shared with the async manager so `db.transactions.get_stats`
+        # reflects sync transactions too. Falls back to a private counter
+        # when the async manager has no `_stats` attribute (defensive).
+        if not hasattr(self._transactions, "_stats"):
+            self._transactions._stats = {  # type: ignore[attr-defined]
+                "total_started": 0,
+                "total_committed": 0,
+                "total_rolled_back": 0,
+            }
+
     # --- BG-loop dispatch ---
 
     def _run_sync(self, coro: Any) -> Any:
@@ -637,6 +778,43 @@ class SyncTransactionManager:
             )
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
         return future.result()
+
+    def _resolve_database_url(self) -> str:
+        """Resolve the database URL from the wrapped DataFlow instance.
+
+        The URL is the only state the sync manager needs from the
+        DataFlow — the asyncpg connection is opened fresh on the BG loop
+        for each transaction. Raises a typed error if the URL cannot be
+        resolved (per rules/zero-tolerance.md Rule 3a).
+        """
+        dataflow = getattr(self._transactions, "dataflow", None)
+        if dataflow is None:
+            raise RuntimeError(
+                "SyncTransactionManager: TransactionManager has no "
+                "`dataflow` back-reference; cannot resolve database URL."
+            )
+        # DataFlow's canonical URL accessor — falls back to config.database.url.
+        url = None
+        for attr_path in (
+            ("config", "database", "url"),
+            ("_database_url",),
+            ("database_url",),
+        ):
+            obj = dataflow
+            try:
+                for attr in attr_path:
+                    obj = getattr(obj, attr)
+            except AttributeError:
+                continue
+            if obj:
+                url = obj
+                break
+        if not url:
+            raise RuntimeError(
+                "SyncTransactionManager: could not resolve database URL "
+                "from DataFlow instance."
+            )
+        return url
 
     # --- Public: begin() ---
 
@@ -662,49 +840,79 @@ class SyncTransactionManager:
         Raises:
             Re-raises any exception from the body after rollback.
         """
-        # The async ``begin()`` is itself an ``@asynccontextmanager`` — we
-        # cannot directly enter it from sync code, so we drive it manually
-        # via ``__aenter__`` / ``__aexit__`` on the BG loop. This preserves
-        # the async manager's commit-on-clean-exit / rollback-on-exception
-        # semantics WITHOUT duplicating the SQL or the ContextVar wiring.
-        async_cm = self._transactions.begin(isolation_level)
+        url = self._resolve_database_url()
+        # Acquire a fresh connection on the BG loop, BEGIN the transaction.
+        # The connection is loop-bound to the BG loop, NOT the host loop,
+        # so subsequent ``execute_raw`` calls (also routed via the BG loop)
+        # use the same connection without cross-loop drift.
+        conn = self._run_sync(_open_connection_for_url(url))
+        try:
+            self._run_sync(_begin_isolation(conn, isolation_level))
+        except BaseException:
+            # If BEGIN fails, close the conn before propagating so we
+            # don't leak the asyncpg socket on the BG loop.
+            try:
+                self._run_sync(_close_connection(conn))
+            except Exception:
+                pass
+            raise
 
-        # Enter the async context manager on the BG loop. The pinned
-        # connection (set in `_active_transaction` ContextVar) becomes
-        # visible to every subsequent ``execute_raw`` submitted to the
-        # same loop.
-        async_scope = self._run_sync(async_cm.__aenter__())
-        sync_scope = SyncTransactionScope(async_scope, self._run_sync)
+        self._transactions._stats["total_started"] += 1
+        txn_id = f"sync_txn_{self._transactions._stats['total_started']}"
+
+        logger.info(
+            "transaction.sync.begin",
+            extra={
+                "transaction_id": txn_id,
+                "isolation_level": isolation_level,
+            },
+        )
+
+        sync_scope = SyncTransactionScope(
+            conn=conn,
+            run_sync=self._run_sync,
+            id=txn_id,
+            isolation_level=isolation_level,
+            status="active",
+            type="transaction",
+        )
 
         try:
             yield sync_scope
         except BaseException:
-            # Propagate the exception type/value/tb to the async CM so it
-            # rolls back. Use ``sys.exc_info()`` shape via a wrapper coro
-            # — the async CM expects ``(exc_type, exc_val, exc_tb)``.
-            import sys
-
-            exc_type, exc_val, exc_tb = sys.exc_info()
+            # Rollback on exception — mirror TransactionManager.begin's
+            # rollback path.
             try:
-                # Returns True iff the async CM swallowed the exception.
-                # ``TransactionManager.begin`` re-raises after rollback so
-                # we expect this to return False; we re-raise either way to
-                # preserve the original traceback chain.
-                self._run_sync(async_cm.__aexit__(exc_type, exc_val, exc_tb))
-            except BaseException:
-                # The async CM may itself raise during rollback — surface
-                # that to the caller. Either way, mark the scope inactive
-                # so any post-with ``execute_raw`` raises the typed guard.
-                sync_scope._mark_inactive()
-                raise
-            sync_scope._mark_inactive()
+                self._run_sync(_rollback(conn))
+            except Exception:
+                logger.warning(
+                    "transaction.sync.rollback_failed",
+                    extra={"transaction_id": txn_id},
+                )
+            self._transactions._stats["total_rolled_back"] += 1
+            logger.error(
+                "transaction.sync.rollback",
+                extra={"transaction_id": txn_id},
+            )
             raise
         else:
-            # Clean-exit: drive the async CM exit, then mark the scope
-            # inactive so post-with ``execute_raw`` calls raise the typed
-            # guard (rules/zero-tolerance.md Rule 3a).
-            self._run_sync(async_cm.__aexit__(None, None, None))
+            # Commit on clean exit.
+            self._run_sync(_commit(conn))
+            sync_scope._status = "committed"
+            self._transactions._stats["total_committed"] += 1
+            logger.info(
+                "transaction.sync.commit",
+                extra={"transaction_id": txn_id},
+            )
+        finally:
             sync_scope._mark_inactive()
+            try:
+                self._run_sync(_close_connection(conn))
+            except Exception:
+                logger.debug(
+                    "transaction.sync.close_failed",
+                    extra={"transaction_id": txn_id},
+                )
 
     # --- Lifecycle ---
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_707_transaction_pins_connection.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_707_transaction_pins_connection.py
@@ -92,8 +92,19 @@ async def temp_table(pg_test_suite, temp_table_name):
 
 @pytest.fixture
 async def df(pg_test_suite):
-    """A DataFlow against the real Postgres infra; closed on teardown."""
+    """A DataFlow against the real Postgres infra; closed on teardown.
+
+    NOTE: ``await instance.initialize()`` is required for the DataFlow
+    connection adapter to be created on the host event loop. Without
+    it, ``TransactionManager._get_adapter()`` returns None and
+    ``db.transactions.begin()`` raises "no database connection
+    available" before reaching the BEGIN statement. This is the
+    pre-existing bug Issue #711 surfaced when the sync fixture was
+    derived from this one — applied here too for symmetry per
+    rules/zero-tolerance.md Rule 1 (fix-immediately, same bug class).
+    """
     instance = DataFlow(database_url=pg_test_suite.config.url, auto_migrate=False)
+    await instance.initialize()
     try:
         yield instance
     finally:
@@ -262,6 +273,7 @@ async def test_select_for_update_then_insert_idempotency(pg_test_suite, temp_tab
         # pools, so the two tasks genuinely race against each other on
         # the database, not on a shared in-process lock.
         local_df = DataFlow(database_url=pg_test_suite.config.url, auto_migrate=False)
+        await local_df.initialize()
         try:
             async with local_df.transactions.begin() as tx:
                 # Use the idempotency token in the email column for uniqueness.

--- a/packages/kailash-dataflow/tests/regression/test_issue_711_transactions_sync.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_711_transactions_sync.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #711 — sync surface for transactions.
+
+`db.transactions_sync.begin()` MUST pin one connection across all
+`tx.execute_raw` calls (sync), auto-commit on clean exit, auto-rollback
+on exception. Tier 2 (real PostgreSQL).
+
+This is the sync analogue of issue #707 (which covered the async
+surface ``db.transactions.begin()``). Per
+``rules/cross-sdk-inspection.md`` § 3a "Structural API-Divergence
+Disposition" and ``rules/testing.md`` § "One Direct Test Per Variant",
+the sync paired variant gets its own direct-call regression coverage —
+delegation through the async path does not satisfy the contract.
+
+Per ``rules/testing.md`` § "3-Tier Testing" Tier 2: NO mocking. Every
+test runs against the real PostgreSQL test instance via the
+``IntegrationTestSuite`` fixture from ``tests/infrastructure/test_harness``.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.features.transactions import (
+    SyncTransactionManager,
+    SyncTransactionScope,
+)
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+pytestmark = [pytest.mark.regression, pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Local fixtures — `test_suite` lives in tests/integration/conftest.py and
+# is not auto-discovered for tests/regression/. Define a regression-scope
+# copy that uses the same IntegrationTestSuite harness against real Postgres.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def pg_test_suite():
+    """Create the IntegrationTestSuite once per regression test (real Postgres).
+
+    Skips the test cleanly when PostgreSQL on port 5434 is not reachable —
+    matches the integration-tier behavior where the test suite is the
+    canonical real-infra harness.
+    """
+    suite = IntegrationTestSuite()
+    try:
+        async with suite.session():
+            yield suite
+    except Exception as exc:
+        pytest.skip(
+            f"Cannot reach PostgreSQL test infra: {type(exc).__name__}: {exc}. "
+            f"Ensure shared SDK Docker is running on port 5434."
+        )
+
+
+@pytest.fixture
+async def temp_table_name():
+    """Unique temp table name per test for isolation."""
+    return f"tx_711_{int(time.time() * 1_000_000)}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+async def temp_table(pg_test_suite, temp_table_name):
+    """Create + drop a clean test table for each test.
+
+    The CREATE / DROP DDL runs OUTSIDE any DataFlow transaction (the
+    test is exercising the transaction surface against pre-existing
+    tables). Cleanup uses a fresh connection to guarantee teardown
+    even when the test transaction was rolled back.
+    """
+    create_sql = f"""
+        CREATE TABLE {temp_table_name} (
+            id SERIAL PRIMARY KEY,
+            email TEXT UNIQUE,
+            payload TEXT,
+            created_at TIMESTAMP DEFAULT NOW()
+        )
+    """
+    async with pg_test_suite.get_connection() as conn:
+        await conn.execute(create_sql)
+
+    yield temp_table_name
+
+    async with pg_test_suite.get_connection() as conn:
+        await conn.execute(f"DROP TABLE IF EXISTS {temp_table_name} CASCADE")
+
+
+@pytest.fixture
+async def df(pg_test_suite):
+    """A DataFlow against the real Postgres infra; closed on teardown.
+
+    The fixture is async because IntegrationTestSuite is async; the
+    DataFlow returned is used SYNCHRONOUSLY by the body (no await on
+    db.transactions_sync.begin()). Sync surface is exercised inside a
+    pytest-asyncio context — proves no `RuntimeError: event loop already
+    running` per the issue's cross-context safety acceptance criterion.
+
+    NOTE: ``await instance.initialize()`` is required for the DataFlow
+    connection adapter to be created on the host event loop. Without
+    it, ``TransactionManager._get_adapter()`` returns None and the
+    sync surface raises "no database connection available" before it
+    can even reach the BG-loop dispatch.
+    """
+    instance = DataFlow(database_url=pg_test_suite.config.url, auto_migrate=False)
+    await instance.initialize()
+    try:
+        yield instance
+    finally:
+        # Explicit close per rules/testing.md § "Fixtures Yield + Cleanup".
+        # close_async() also stops the SyncTransactionManager BG thread
+        # if `db.transactions_sync` was accessed during the test.
+        try:
+            await instance.close_async()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _count_rows(pg_test_suite, table: str) -> int:
+    """Verify-via-readback per rules/testing.md § State Persistence Verification.
+
+    Uses a FRESH connection from the integration test suite — outside any
+    DataFlow transaction. This proves the transaction's commit/rollback
+    actually persisted to the database, not just to the pinned connection.
+    """
+    async with pg_test_suite.get_connection() as conn:
+        return await conn.fetchval(f"SELECT COUNT(*) FROM {table}")
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 regression coverage — mirrors test_issue_707 for the SYNC surface
+# ---------------------------------------------------------------------------
+
+
+async def test_multi_statement_atomicity_via_sync_tx_execute_raw(
+    df, pg_test_suite, temp_table
+):
+    """Issue #711 canonical: BEGIN-INSERT-INSERT-COMMIT all via sync tx.execute_raw.
+
+    Asserts both rows are visible after commit when read back from a fresh
+    connection — proves the COMMIT actually persisted state to the database
+    AND that the sync wrapper preserved the connection pinning across calls.
+    """
+    # NOTE: The fixture body is async (pytest-asyncio), but the with block
+    # below uses the SYNC surface — this is exactly the cross-context
+    # scenario the issue calls out. If the sync surface tried to call
+    # ``asyncio.run()`` per statement, this test would raise
+    # ``RuntimeError: This event loop is already running``.
+    assert isinstance(df.transactions_sync, SyncTransactionManager)
+
+    with df.transactions_sync.begin() as tx:
+        assert isinstance(tx, SyncTransactionScope), (
+            f"transactions_sync.begin() yielded {type(tx).__name__}, "
+            "expected SyncTransactionScope (issue #711 contract)"
+        )
+        assert tx.status == "active"
+        assert tx.type == "transaction"
+
+        tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            ["alice@example.test", "row-1"],
+        )
+        tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            ["bob@example.test", "row-2"],
+        )
+        # Read-within-transaction: the pinned connection sees its own writes.
+        in_tx_rows = tx.execute_raw(f"SELECT email FROM {temp_table} ORDER BY email")
+        assert len(in_tx_rows) == 2
+        assert {dict(r)["email"] for r in in_tx_rows} == {
+            "alice@example.test",
+            "bob@example.test",
+        }
+
+    # Read-back via a DIFFERENT connection — proves COMMIT happened.
+    assert await _count_rows(pg_test_suite, temp_table) == 2
+
+
+async def test_sync_auto_rollback_on_exception(df, pg_test_suite, temp_table):
+    """Exceptions inside the `with` body MUST roll back the entire txn.
+
+    Insert one row, raise, then read back from a FRESH connection — zero
+    rows MUST persist. Sync analogue of the load-bearing rollback
+    invariant for the OAuth credential rotation pattern.
+    """
+    with pytest.raises(RuntimeError, match="forced rollback"):
+        with df.transactions_sync.begin() as tx:
+            tx.execute_raw(
+                f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+                ["alice@example.test", "should-not-persist"],
+            )
+            raise RuntimeError("forced rollback")
+
+    # Read-back: nothing persisted because the txn was rolled back.
+    assert await _count_rows(pg_test_suite, temp_table) == 0
+
+
+async def test_sync_oauth_credential_rotation_pattern(df, pg_test_suite, temp_table):
+    """Canonical use case from issue #711: SELECT existing token + UPDATE-or-INSERT.
+
+    1. Tx A inserts the initial token row (commit).
+    2. Tx B reads the row, decides to UPDATE, commits.
+    3. Tx C reads the row, decides to UPDATE again, commits.
+    4. Tx D for a NEW user — row missing, INSERT branch fires.
+
+    All steps run via sync `tx.execute_raw` only. Read-back from a fresh
+    connection verifies the final state.
+    """
+    user_a = "user-a@example.test"
+    user_b = "user-b@example.test"
+
+    # Tx A: initial INSERT for user A
+    with df.transactions_sync.begin() as tx:
+        tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            [user_a, "refresh-v1"],
+        )
+
+    # Tx B: rotation 1 — SELECT then UPDATE
+    with df.transactions_sync.begin() as tx:
+        existing = tx.execute_raw(
+            f"SELECT id FROM {temp_table} WHERE email = $1 FOR UPDATE",
+            [user_a],
+        )
+        assert len(existing) == 1, "user_a row MUST exist for UPDATE branch"
+        tx.execute_raw(
+            f"UPDATE {temp_table} SET payload = $1 WHERE email = $2",
+            ["refresh-v2", user_a],
+        )
+
+    # Tx C: rotation 2 — same UPDATE branch
+    with df.transactions_sync.begin() as tx:
+        existing = tx.execute_raw(
+            f"SELECT id FROM {temp_table} WHERE email = $1 FOR UPDATE",
+            [user_a],
+        )
+        assert len(existing) == 1
+        tx.execute_raw(
+            f"UPDATE {temp_table} SET payload = $1 WHERE email = $2",
+            ["refresh-v3", user_a],
+        )
+
+    # Tx D: new user — row missing, INSERT branch fires
+    with df.transactions_sync.begin() as tx:
+        existing = tx.execute_raw(
+            f"SELECT id FROM {temp_table} WHERE email = $1 FOR UPDATE",
+            [user_b],
+        )
+        assert len(existing) == 0, "user_b row MUST be absent for INSERT branch"
+        tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            [user_b, "refresh-v1"],
+        )
+
+    # Read-back from a fresh connection: 2 rows, user_a's payload is v3.
+    async with pg_test_suite.get_connection() as conn:
+        rows = await conn.fetch(
+            f"SELECT email, payload FROM {temp_table} ORDER BY email"
+        )
+    by_email = {r["email"]: r["payload"] for r in rows}
+    assert by_email == {user_a: "refresh-v3", user_b: "refresh-v1"}
+
+
+async def test_sync_partial_failure_within_transaction_rolls_back_all(
+    df, pg_test_suite, temp_table
+):
+    """INSERT row 1, INSERT row 2 with constraint violation, expect rollback.
+
+    Asserts neither row persists. The constraint is the UNIQUE on `email`:
+    insert the same email twice in the same transaction.
+    """
+    duplicate_email = "duplicate@example.test"
+
+    with pytest.raises(Exception):  # asyncpg.UniqueViolationError or wrapper
+        with df.transactions_sync.begin() as tx:
+            tx.execute_raw(
+                f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+                [duplicate_email, "row-1"],
+            )
+            # Same email — UNIQUE constraint violation, rolls back row-1 too.
+            tx.execute_raw(
+                f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+                [duplicate_email, "row-2"],
+            )
+
+    # Read-back from a fresh connection: NEITHER row persists.
+    assert await _count_rows(pg_test_suite, temp_table) == 0
+
+
+async def test_sync_execute_raw_outside_scope_raises_runtime_error(df):
+    """Calling `tx.execute_raw` AFTER the `with` block raises RuntimeError.
+
+    The typed delegate guard converts an opaque AttributeError into an
+    actionable RuntimeError that names the scope contract. Sync analogue
+    of the test_execute_raw_outside_scope_raises_runtime_error from the
+    async regression file.
+
+    This test does need a real DataFlow because the sync `begin()` runs
+    on the BG event loop and calls into the async `begin()` which needs
+    a live adapter — but only the RuntimeError-on-out-of-scope branch is
+    asserted here, NOT the database side-effect.
+    """
+    captured_scope: SyncTransactionScope | None = None
+
+    with df.transactions_sync.begin() as tx:
+        captured_scope = tx
+        # Inside the with block: execute_raw works.
+        result = tx.execute_raw("SELECT 1 AS one")
+        assert len(result) == 1
+        assert dict(result[0])["one"] == 1
+
+    # Outside the with block: the typed guard fires.
+    assert captured_scope is not None
+    with pytest.raises(RuntimeError, match="outside the transaction body"):
+        captured_scope.execute_raw("SELECT 1")
+
+
+async def test_sync_surface_inside_pytest_asyncio_does_not_raise_event_loop_error(
+    df, pg_test_suite, temp_table
+):
+    """Cross-context safety: sync surface MUST work inside pytest-asyncio.
+
+    This is the load-bearing acceptance criterion from issue #711 — the
+    sync surface MUST work without raising
+    ``RuntimeError: This event loop is already running`` when the caller
+    is inside an active event loop (pytest-asyncio, Nexus handler,
+    Jupyter cell). The other tests in this module already exercise the
+    sync surface from inside an async test body (every test in this file
+    is async because the fixture is async), but this test asserts the
+    invariant explicitly with a comment that pins the contract.
+
+    If a future refactor moves the sync surface to per-call
+    ``asyncio.run()``, every other test in this file will start raising
+    ``RuntimeError`` — and this test makes the failure mode legible by
+    naming it.
+    """
+    # We are inside a pytest-asyncio test → there IS an active event loop
+    # in this thread. The sync surface uses a SEPARATE BG-thread event
+    # loop, so calling ``begin()`` here MUST NOT raise.
+    import asyncio
+
+    assert (
+        asyncio.get_running_loop() is not None
+    ), "test precondition: must run inside pytest-asyncio event loop"
+
+    with df.transactions_sync.begin() as tx:
+        tx.execute_raw(
+            f"INSERT INTO {temp_table} (email, payload) VALUES ($1, $2)",
+            ["nested@example.test", "from-async-context"],
+        )
+
+    assert await _count_rows(pg_test_suite, temp_table) == 1

--- a/packages/kailash-dataflow/tests/unit/test_sync_transaction_manager.py
+++ b/packages/kailash-dataflow/tests/unit/test_sync_transaction_manager.py
@@ -1,0 +1,213 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 1 unit tests for ``SyncTransactionManager`` (issue #711).
+
+These tests exercise the lifecycle of the BG-event-loop thread and the
+typed-guard contract WITHOUT touching a real database. The Tier 2
+regression tests in ``tests/regression/test_issue_711_transactions_sync.py``
+cover the end-to-end behavior against real PostgreSQL.
+
+Per ``rules/testing.md`` § 3-Tier Testing:
+- Tier 1: mocking allowed, < 1s per test, no real infra.
+"""
+
+from __future__ import annotations
+
+import threading
+import warnings
+from typing import Any
+
+import pytest
+
+from dataflow.features.transactions import (
+    SyncTransactionManager,
+    SyncTransactionScope,
+    TransactionManager,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles — Protocol-Satisfying Deterministic Adapter per
+# rules/testing.md § "Protocol Adapters". These are NOT mocks: they are
+# real classes with deterministic behavior used to satisfy the constructor
+# contract without spawning a real database connection.
+# ---------------------------------------------------------------------------
+
+
+class _DataFlowStub:
+    """Minimal stand-in for the DataFlow instance.
+
+    SyncTransactionManager only reaches the DataFlow via its inner async
+    TransactionManager when ``begin()`` is invoked — these unit tests cover
+    construction + close + scope guard, none of which call begin(), so
+    the stub never needs adapter resolution.
+    """
+
+
+@pytest.fixture
+def async_manager() -> TransactionManager:
+    """Real TransactionManager backed by the stub DataFlow."""
+    return TransactionManager(_DataFlowStub())
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: BG thread starts on construction, stops on close
+# ---------------------------------------------------------------------------
+
+
+def test_construction_starts_bg_thread(async_manager):
+    """SyncTransactionManager() spawns a daemon thread running the BG loop."""
+    sync_mgr = SyncTransactionManager(async_manager)
+    try:
+        assert sync_mgr._thread is not None
+        assert sync_mgr._thread.is_alive()
+        assert sync_mgr._thread.daemon is True
+        # Loop is running on the BG thread.
+        assert sync_mgr._loop is not None
+        assert sync_mgr._loop.is_running()
+        assert sync_mgr._closed is False
+    finally:
+        sync_mgr.close_sync()
+
+
+def test_close_sync_stops_bg_thread(async_manager):
+    """close_sync() stops the loop and joins the thread."""
+    sync_mgr = SyncTransactionManager(async_manager)
+    thread_ref = sync_mgr._thread
+
+    sync_mgr.close_sync()
+
+    assert sync_mgr._closed is True
+    # Refs cleared so post-close _run_sync raises the closed-error.
+    assert sync_mgr._loop is None
+    assert sync_mgr._thread is None
+    # The captured thread reference has finished.
+    assert thread_ref is not None
+    assert not thread_ref.is_alive()
+
+
+def test_close_sync_is_idempotent(async_manager):
+    """Calling close_sync() twice MUST NOT raise."""
+    sync_mgr = SyncTransactionManager(async_manager)
+    sync_mgr.close_sync()
+    # Second call is a no-op.
+    sync_mgr.close_sync()
+    assert sync_mgr._closed is True
+
+
+def test_run_sync_after_close_raises(async_manager):
+    """Once closed, ``_run_sync`` raises a typed ``RuntimeError``.
+
+    This is the structural defense per ``rules/zero-tolerance.md`` Rule 3a:
+    routing through a None backing object MUST raise an actionable typed
+    error rather than a downstream ``AttributeError``.
+    """
+
+    sync_mgr = SyncTransactionManager(async_manager)
+    sync_mgr.close_sync()
+
+    async def _noop():
+        return 1
+
+    coro = _noop()
+    try:
+        with pytest.raises(RuntimeError, match="SyncTransactionManager is closed"):
+            sync_mgr._run_sync(coro)
+    finally:
+        # Close the un-awaited coroutine so pytest does not surface a
+        # RuntimeWarning at GC. The closed-manager path refuses the call
+        # before the coroutine is scheduled, so it stays un-awaited.
+        coro.close()
+
+
+# ---------------------------------------------------------------------------
+# ResourceWarning: __del__ on un-closed instance MUST emit ResourceWarning
+# per rules/patterns.md § Async Resource Cleanup.
+# ---------------------------------------------------------------------------
+
+
+def test_del_emits_resource_warning_on_unclosed(async_manager):
+    """Garbage-collecting an un-closed manager emits ResourceWarning.
+
+    Per ``rules/patterns.md`` § Async Resource Cleanup: __del__ MUST emit
+    ``ResourceWarning`` and do nothing else (no close call from the
+    finalizer — that's the deadlock pattern the rule documents).
+    """
+    sync_mgr = SyncTransactionManager(async_manager)
+    # Capture the BG thread so we can join it post-test (we did NOT call
+    # close_sync — the warning fires precisely because of that).
+    thread_ref = sync_mgr._thread
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", ResourceWarning)
+        # Trigger __del__ by removing the only ref.
+        del sync_mgr
+
+        # Force a GC pass to ensure __del__ ran in this thread (CPython
+        # refcount-based finalization fires synchronously when the last
+        # ref drops, but PyPy / cyclic patterns rely on GC).
+        import gc
+
+        gc.collect()
+
+    resource_warnings = [w for w in captured if issubclass(w.category, ResourceWarning)]
+    assert len(resource_warnings) >= 1, (
+        f"expected ResourceWarning on un-closed SyncTransactionManager; "
+        f"got categories: {[w.category.__name__ for w in captured]}"
+    )
+    assert "not closed" in str(resource_warnings[0].message)
+
+    # Manually clean up the BG thread we leaked on purpose. The daemon
+    # flag means it dies with the interpreter regardless, but joining
+    # keeps the test runner from leaking threads across the suite.
+    if thread_ref is not None and thread_ref.is_alive():
+        # The loop is still running — there's no manager left to call
+        # close_sync, so we drive the loop stop directly via the thread's
+        # loop attribute (we captured nothing else). Best-effort — the
+        # daemon flag is the safety net.
+        thread_ref.join(timeout=0.01)
+
+
+def test_del_silent_on_closed(async_manager):
+    """A cleanly-closed manager does NOT emit ResourceWarning on GC."""
+    sync_mgr = SyncTransactionManager(async_manager)
+    sync_mgr.close_sync()
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always", ResourceWarning)
+        del sync_mgr
+        import gc
+
+        gc.collect()
+
+    resource_warnings = [w for w in captured if issubclass(w.category, ResourceWarning)]
+    assert resource_warnings == [], (
+        f"closed manager MUST NOT emit ResourceWarning; got: "
+        f"{[(w.category.__name__, str(w.message)) for w in captured]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Out-of-scope guard on SyncTransactionScope (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+def test_sync_scope_execute_raw_after_inactive_raises():
+    """``execute_raw`` outside the with body raises typed ``RuntimeError``.
+
+    Mirrors the async-side test
+    ``test_execute_raw_outside_scope_raises_runtime_error`` but for the
+    sync surface — exercises the typed delegate guard per
+    ``rules/zero-tolerance.md`` Rule 3a.
+    """
+    # Construct a sync scope without entering any begin(); the inactive
+    # marker is set explicitly so ``execute_raw`` MUST raise the typed
+    # guard.
+    sync_scope = SyncTransactionScope(
+        async_scope=None,  # type: ignore[arg-type] — sentinel path
+        run_sync=lambda coro: None,
+    )
+    sync_scope._mark_inactive()
+
+    with pytest.raises(RuntimeError, match="outside the transaction body"):
+        sync_scope.execute_raw("SELECT 1")

--- a/packages/kailash-dataflow/tests/unit/test_sync_transaction_manager.py
+++ b/packages/kailash-dataflow/tests/unit/test_sync_transaction_manager.py
@@ -202,10 +202,15 @@ def test_sync_scope_execute_raw_after_inactive_raises():
     """
     # Construct a sync scope without entering any begin(); the inactive
     # marker is set explicitly so ``execute_raw`` MUST raise the typed
-    # guard.
+    # guard. ``conn`` is a placeholder — the test exercises the guard
+    # path before any DB call could fire.
     sync_scope = SyncTransactionScope(
-        async_scope=None,  # type: ignore[arg-type] — sentinel path
+        conn=object(),
         run_sync=lambda coro: None,
+        id="test_scope",
+        isolation_level="READ COMMITTED",
+        status="active",
+        type="transaction",
     )
     sync_scope._mark_inactive()
 

--- a/specs/dataflow-cache.md
+++ b/specs/dataflow-cache.md
@@ -268,6 +268,68 @@ routes through the pinned connection via the `_active_transaction`
 ContextVar — the two surfaces are functionally equivalent. Prefer
 `tx.execute_raw` for grep-able multi-statement transactions.
 
+### 12.7 Sync Surface — `db.transactions_sync.begin()`
+
+Sync analogue of §12.6 for callers that cannot `await` (CLI scripts, sync
+FastAPI handlers, pytest non-async tests, Jupyter sync cells). Yields a
+`SyncTransactionScope` whose `tx.execute_raw(sql, params)` runs on a
+pinned connection; auto-commit on clean exit, auto-rollback on exception.
+
+```python
+with db.transactions_sync.begin() as tx:
+    existing = tx.execute_raw(
+        "SELECT id FROM oauth_tokens WHERE user_id = $1 FOR UPDATE",
+        [user_id],
+    )
+    if existing:
+        tx.execute_raw(
+            "UPDATE oauth_tokens SET refresh_token = $1, "
+            "rotated_at = NOW() WHERE user_id = $2",
+            [new_refresh, user_id],
+        )
+    else:
+        tx.execute_raw(
+            "INSERT INTO oauth_tokens (user_id, refresh_token) VALUES ($1, $2)",
+            [user_id, new_refresh],
+        )
+    # BEGIN / SELECT / UPDATE-or-INSERT / COMMIT all run on one
+    # asyncpg connection bound to a private background event loop.
+```
+
+Calling `tx.execute_raw` outside the `with` body raises `RuntimeError`
+per `rules/zero-tolerance.md` Rule 3a (typed delegate guard) — the
+pinned connection only exists while the scope is active.
+
+**BG event loop semantics.** `db.transactions_sync` owns a persistent
+daemon-thread event loop (mirror of `db.express_sync`) and submits every
+coroutine via `asyncio.run_coroutine_threadsafe(coro, loop).result()`.
+The same loop is shared across all `begin()` calls so the pinned
+connection (loop-bound for asyncpg) survives across multiple
+`tx.execute_raw` invocations inside one `with` block.
+
+**Connection lifecycle.** Unlike the async surface (which acquires from
+the shared DataFlow pool), the sync surface opens a fresh
+`asyncpg.connect()` / `aiosqlite.connect()` on its BG loop for each
+`begin()` and closes it on exit. asyncpg connections are loop-bound;
+sharing the DataFlow pool across the host loop and the BG loop produces
+`RuntimeError: Future ... attached to a different loop`. The private
+connection lifecycle is the structural fix for cross-loop usage and is
+why the sync surface is safe inside pytest-asyncio / Nexus handlers /
+Jupyter cells without raising
+`RuntimeError: This event loop is already running`.
+
+**Statistics counter.** The async and sync surfaces share
+`db.transactions._stats` — `db.transactions.get_stats()` reflects both
+async (`begin()`) and sync (`transactions_sync.begin()`) transaction
+totals. Sync transaction IDs are prefixed `sync_txn_` to distinguish
+them in logs.
+
+**Lifecycle integration.** The BG loop thread is stopped cleanly during
+`db.close()` / `await db.close_async()` so callers do not need to invoke
+`transactions_sync.close_sync()` manually. An un-closed manager emits
+`ResourceWarning` on garbage collection per `rules/patterns.md` § Async
+Resource Cleanup.
+
 ---
 
 ## 13. Connection Pooling


### PR DESCRIPTION
## Summary

Closes #711. Sync analogue of `db.transactions.begin()` mirroring the `db.express` ↔ `db.express_sync` split. Enables sync callers (CLI scripts, pytest-asyncio test bodies, Jupyter, Nexus handlers) to use multi-statement atomic transactions without `asyncio.run()` per-call event-loop traps.

## Design — own connection lifecycle on background event loop

The implementation owns a daemon-thread event loop (mirror of `SyncExpress` at `express.py:1758+`), but **does not delegate to the async `TransactionManager`'s context manager**. Instead, `SyncTransactionManager` opens a fresh `asyncpg.connect()` (or `aiosqlite.connect()`) on the BG loop for each `begin()` call, runs `BEGIN` + work + `COMMIT`/`ROLLBACK` on the same connection on the same loop, then closes it.

**Why the redesign:** asyncpg connections are loop-bound; DataFlow's pool is created on the host loop. Driving the async TransactionManager's `__aenter__`/`__aexit__` on the BG loop produces `RuntimeError: Future ... attached to a different loop` / `RuntimeError: Event loop is closed`. The own-connection-on-BG-loop pattern is the structural cross-loop fix the issue's "Cross-context safety" acceptance criterion required. Test `test_sync_surface_inside_pytest_asyncio_does_not_raise_event_loop_error` proves this works inside an active pytest-asyncio loop.

## Files

**Modified (production):**
- `packages/kailash-dataflow/src/dataflow/features/transactions.py` — added `SyncTransactionScope`, `SyncTransactionManager`, async helpers (`_open_connection_for_url`, `_begin_isolation`, `_commit`, `_rollback`, `_close_connection`)
- `packages/kailash-dataflow/src/dataflow/core/engine.py` — added `db.transactions_sync` property + close hooks in both `close()` and `close_async()`

**New (tests):**
- `packages/kailash-dataflow/tests/unit/test_sync_transaction_manager.py` — 7 Tier 1 unit tests (BG-thread lifecycle, ResourceWarning, typed guards)
- `packages/kailash-dataflow/tests/regression/test_issue_711_transactions_sync.py` — 6 Tier 2 regression tests against real Postgres (mirrors 707 + cross-context safety test)

**Modified (test fixture, same-shard fix per zero-tolerance Rule 1):**
- `packages/kailash-dataflow/tests/regression/test_issue_707_transaction_pins_connection.py` — added `await db.initialize()` to fixture (pre-existing bug — fixture didn't initialize, so `TransactionManager._get_adapter()` returned None and 707 tests silently no-op'd; surfaced incidentally)

**Spec:**
- `specs/dataflow-cache.md` §12.7 — sync transaction surface documented (paired with §12.6 async)

## Test plan

- [x] 7 Tier-1 unit tests pass — BG-thread lifecycle, idempotent close, typed guards, `ResourceWarning` on un-closed
- [x] 6 Tier-2 regression tests pass against real Postgres — multi-statement atomicity, auto-commit, auto-rollback, OAuth credential rotation pattern, partial-failure rollback, scope-out-of-`with` raises, cross-context safety inside pytest-asyncio
- [x] All 13 tests pass in 1.40s
- [x] `pyright` on modified `transactions.py`: 0 errors, 0 warnings

## Known follow-up (out of #711 scope)

Pre-existing #707 race-condition test (`test_select_for_update_then_insert_idempotency`) surfaced after my fixture-init fix made it actually run. The race is in DataFlow's async pool path under concurrent `FOR UPDATE`, NOT in #711's sync surface. New shard — different bug class, different surface. Will surface for follow-up issue filing.

## Cross-SDK

Filed at `esperie/kailash-rs#688` per the issue body. Sync vs async distinction maps differently in Rust (Tokio vs non-Tokio callers); the Rust issue handles that.

## Related issues

Closes #711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)