### PR TITLE
release(v2.13.1): kailash 2.13.1 + dataflow 2.7.0 + nexus 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.1] — 2026-04-30 — TraceEvent timestamp microsecond padding (#731)
+
+Patch — pins the `TraceEvent` timestamp string to a fixed-width microsecond field so cross-tool log correlation no longer drifts when sub-millisecond events are emitted.
+
+### Fixed
+
+- **#731 — TraceEvent timestamp microsecond padding** — `TraceEvent` formatted timestamps with variable-width microseconds (e.g. `2026-04-30T12:34:56.7Z` for tenths-of-millisecond events), breaking lexical ordering and downstream parsers that assumed fixed-width ISO-8601. Timestamps now pad microseconds to six digits (`2026-04-30T12:34:56.700000Z`).
+
 ## [2.13.0] — 2026-04-30 — `kailash.utils.lifespan` shared FastAPI helpers (the v2.13.0 cluster: closes #712)
 
 Minor bump — ships the cross-FastAPI-site lifespan helper module that drives `app.router.on_startup` / `on_shutdown` from any custom `FastAPI(lifespan=...)` and patches three sibling sites that historically dropped router hooks silently.

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,24 @@
 # DataFlow Changelog
 
+## [2.7.0] — 2026-04-30 — Sync transaction surface (#711) + #707 test fix
+
+Minor release adding `db.transactions_sync` — a sync-style transaction manager that owns its connection lifecycle on a dedicated background event loop, so synchronous callers can compose multi-statement atomic units of work without juggling `asyncio.run()` boundaries.
+
+### Added
+
+- **`db.transactions_sync` property + `SyncTransactionManager` + `SyncTransactionScope` (#711)** — the sync surface owns its own background loop and connection acquisition. Multi-statement atomic blocks survive process restarts, fail with typed `TransactionRolledBack` on any inner exception, and return per-statement diagnostics. Spec: `packages/kailash-dataflow/specs/dataflow-cache.md` § 12.7.
+- Tier 1 unit suite for `SyncTransactionManager` lifecycle + rollback paths.
+- Tier 2 integration suite for `db.transactions_sync` against real Postgres.
+
+### Fixed
+
+- **#707 — idempotency regression test rewritten to canonical `INSERT ... ON CONFLICT DO NOTHING` pattern (#748)** — the original repro relied on `tx.execute_raw` routing `INSERT … RETURNING` through `fetch`, which is not how the sync surface dispatches statements (only `SELECT` / `WITH` are SELECT-shape). The test now follows the canonical pattern and parses the asyncpg command-tag rowcount instead.
+- **#707 — fixture missing `db.initialize()` call** — added explicit `await db.initialize()` to the sync-transaction fixture so the connection is reachable before the regression test runs.
+
+### Dependencies
+
+- `kailash>=2.13.1` (was `>=2.12.0`).
+
 ## [2.6.0] — 2026-04-30 — Lazy runtime resolution + DDL connection-reuse (the v2.13.0 cluster: closes #713, #714)
 
 Minor release closing the two remaining DataFlow surfaces in the the v2.13.0 cluster. Backward-compatible: every existing `db.runtime`-reading consumer keeps working unchanged because the new `@property` resolves to the same runtime instance per event loop, and the existing `db.runtime = X` mutation pattern is preserved through the new setter.

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.6.0"
+version = "2.7.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "kailash>=2.12.0",
+    "kailash>=2.13.1",
     "sqlalchemy>=2.0.0",
     "alembic>=1.12.0",
     "asyncpg>=0.28.0",

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -108,7 +108,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.6.0"
+__version__ = "2.7.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Nexus Changelog
 
+## [2.6.0] — 2026-04-30 — WebSocket Origin allowlist + `Connection.headers` (#673)
+
+Minor release closing the WebSocket Origin-header bypass: every `register_websocket(...)` registration now hoists Origin-allowlist enforcement to the framework so consumer handlers no longer have to re-implement the check (and silently drop it on copy-paste).
+
+### Added
+
+- **`Nexus.websocket(allowed_origins=...)` + `register_websocket(allowed_origins=...)` (#673)** — opt-in per-route Origin allowlist. The Origin validator runs before the handler is invoked; mismatched / missing Origin closes the socket with WebSocket close code `1008 (policy violation)` and emits a structured WARN log keyed on the request id.
+- **`Connection.headers` (#673)** — the request `Headers` mapping is now exposed on the `Connection` object so handlers needing per-request header inspection (auth tokens, correlation IDs) no longer parse the raw scope dict.
+- Tier 1 unit suite for the Origin validator and `Connection.headers` plumbing.
+- Tier 2 regression suite for end-to-end allowlist enforcement on a live `register_websocket` registration.
+
+### Dependencies
+
+- `kailash>=2.13.1` (was `>=2.11.0`).
+
 ## [2.5.0] — 2026-04-30 — `Nexus.add_startup_handler` / `add_shutdown_handler` (the v2.13.0 cluster: closes #712)
 
 Minor release adding the canonical "run-once at server start" hook surface so consumers no longer need to reach for `nexus.fastapi_app.on_event(...)` (which has the lazy-init timing trap — `fastapi_app` returns `None` until the enterprise gateway is initialized) or author a full `NexusPluginProtocol` implementation for a single callback.

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.5.0"
+version = "2.6.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "kailash>=2.11.0",
+    "kailash>=2.13.1",
     "starlette>=0.36.0",
     "fastapi>=0.104.0",
     # Directly imported by nexus/transports/websocket.py — per

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -102,7 +102,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 __all__ = [
     # Core
     "Nexus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.13.0"
+version = "2.13.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.13.0"
+__version__ = "2.13.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep cluster for the post-v2.13.0 merge wave (#731 #673 #711 #748).

| Package | Bump | Changes |
|---|---|---|
| `kailash` | 2.13.0 → **2.13.1** (patch) | #731 TraceEvent timestamp microsecond padding fix (fixed-width six-digit microsecond field for cross-tool log correlation) |
| `kailash-dataflow` | 2.6.0 → **2.7.0** (minor) | #711 new `db.transactions_sync` surface (sync transaction manager owning its connection lifecycle on a dedicated background event loop). Includes #707/#748 test-correctness fix. Bumps `kailash>=2.13.1`. |
| `kailash-nexus` | 2.5.0 → **2.6.0** (minor) | #673 WebSocket Origin allowlist enforcement hoisted to `register_websocket`; `Connection.headers` now exposed. Bumps `kailash>=2.13.1`. |

Sibling drift enumeration (per `build-repo-release-discipline.md` Rule 3): zero — kaizen / mcp / ml / align / pact are all in sync with PyPI.

## Test plan

- [x] All 6 version anchors atomic (`pyproject.toml` + `__init__.py`)
- [x] Both framework packages bump `kailash>=2.13.1` SDK pin
- [x] CHANGELOGs reflect every shipped PR (#731 #673 #711 #707/#748)
- [x] Pre-commit passes (Black, isort, Ruff, type annotations, Tier 1 unit tests)
- [ ] PR-gate CI green (workflows auto-skip per `release/v*` convention; verify)
- [ ] Admin merge + 3 individual tag pushes (v2.13.1, dataflow-v2.7.0, nexus-v2.6.0) per `deployment.md` MUST-individual-tag-push rule
- [ ] Clean-venv installability check post-publish per `build-repo-release-discipline.md` Rule 2

## Related issues

Releases the closures of #731, #673, #711, #707, #748.

## Notes

- TestPyPI: skipping per deployment.md exception clause (kailash 2.13.1 is patch; dataflow/nexus minors carry no breaking-change diff — both add new surfaces only). Human approval requested in this PR description.
- Cross-SDK companions (kailash-rs#712 WebhookSigner, kailash-rs#713 orphan-detection audit) await Rust-side implementation per session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)