### PR TITLE
chore(ci): adopt release/v* PR-gate skip clause across 12 workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   notify:
-    if: github.event.label.name == 'auto-fix' || github.event.label.name == 'needs-review'
+    # Skip release-prep PRs (release/v*) — they should never carry the auto-fix
+    # / needs-review labels per ci-runners.md MUST Rule 8 (defense-in-depth).
+    if: (github.event.label.name == 'auto-fix' || github.event.label.name == 'needs-review') && !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Notify Discord

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ permissions:
 jobs:
   analyze:
     name: Analyze Python
+    # Skip release-prep PRs (release/v*) — they are metadata-only per
+    # ci-runners.md MUST Rule 8. Tag-triggered scans cover release-cut SHAs.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/cross-sdk-interop.yml
+++ b/.github/workflows/cross-sdk-interop.yml
@@ -28,6 +28,10 @@ concurrency:
 jobs:
   conformance:
     name: PACT N6 Conformance Vectors
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # they are metadata-only (paths filter rarely matches anyway, but
+    # defense-in-depth in case a release-prep PR touches trust/pact).
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/example-validation.yml
+++ b/.github/workflows/example-validation.yml
@@ -21,6 +21,10 @@ concurrency:
 jobs:
   validate-examples:
     name: Validate Autonomy Examples
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # release/v* paths rarely match the kaizen-agents examples filter, but
+    # defense-in-depth keeps the rule's enforcement uniform.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -27,7 +27,9 @@ jobs:
   label-based-on-files:
     name: Auto-label based on files changed
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # they are metadata-only and don't need path-based label assignment.
+    if: github.event_name == 'pull_request' && github.event.action == 'opened' && !startsWith(github.head_ref, 'release/')
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -26,6 +26,12 @@ env:
 jobs:
   security-tests:
     name: Adversarial Security Tests
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # release-prep diffs touch only version anchors + CHANGELOG (paths
+    # filter on trust modules rarely matches), and the source-change PRs
+    # that the release bundles already exercised this suite. Scheduled
+    # weekly + workflow_dispatch still cover release-cut SHAs.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/test-kailash-align.yml
+++ b/.github/workflows/test-kailash-align.yml
@@ -64,6 +64,11 @@ jobs:
 
   test:
     name: Test (Python ${{ matrix.python-version }})
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # the source-change PRs already exercised this matrix. version-check
+    # above stays unguarded to verify pyproject.toml ↔ _version.py
+    # consistency on the release-cut diff (release-relevant gate).
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     needs: version-check
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -131,8 +136,11 @@ jobs:
   test-gpu:
     name: GPU Tests (optional)
     needs: version-check
+    # workflow_dispatch + run-gpu opt-in only; release/v* exclusion is
+    # implicit (release branches don't carry workflow_dispatch inputs)
+    # but kept explicit per ci-runners.md MUST Rule 8.
     if: >-
-      github.event_name == 'workflow_dispatch' && inputs.run-gpu == true
+      github.event_name == 'workflow_dispatch' && inputs.run-gpu == true && !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -165,6 +173,10 @@ jobs:
 
   inter-package:
     name: Inter-Package (align + dev ML)
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # release-prep diffs are metadata-only; cross-package compat already
+    # verified on the source-change PRs that the release bundles.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     needs: version-check
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/test-kailash-ml.yml
+++ b/.github/workflows/test-kailash-ml.yml
@@ -77,6 +77,11 @@ jobs:
 
   test-base:
     name: Base (Python ${{ matrix.python-version }})
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # the source-change PRs already exercised this matrix. version-check
+    # above stays unguarded to verify pyproject.toml ↔ _version.py
+    # consistency on the release-cut diff (release-relevant gate).
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     needs: version-check
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -161,9 +166,13 @@ jobs:
   test-dl:
     name: Deep Learning
     needs: version-check
+    # workflow_dispatch-only; release/v* exclusion is implicit (release
+    # branches don't carry workflow_dispatch inputs) but kept explicit
+    # per ci-runners.md MUST Rule 8.
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      (inputs.variant == 'dl' || inputs.variant == 'all')
+      (inputs.variant == 'dl' || inputs.variant == 'all') &&
+      !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -194,9 +203,12 @@ jobs:
   test-rl:
     name: Reinforcement Learning
     needs: version-check
+    # workflow_dispatch-only; release/v* exclusion is implicit but kept
+    # explicit per ci-runners.md MUST Rule 8.
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      (inputs.variant == 'rl' || inputs.variant == 'all')
+      (inputs.variant == 'rl' || inputs.variant == 'all') &&
+      !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -245,9 +257,12 @@ jobs:
   test-cuda:
     name: CUDA smoke (km.doctor + DeviceReport)
     needs: version-check
+    # workflow_dispatch-only; release/v* exclusion is implicit but kept
+    # explicit per ci-runners.md MUST Rule 8.
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      (inputs.variant == 'cuda' || inputs.variant == 'all')
+      (inputs.variant == 'cuda' || inputs.variant == 'all') &&
+      !startsWith(github.head_ref, 'release/')
     # IT-1: route to self-hosted GPU runner once provisioned.
     # Keep this runs-on value — as soon as the runner registers with these
     # labels, GitHub will assign jobs here automatically.
@@ -319,9 +334,12 @@ jobs:
   test-cuda-dl:
     name: CUDA deep learning (torch training on GPU)
     needs: version-check
+    # workflow_dispatch-only; release/v* exclusion is implicit but kept
+    # explicit per ci-runners.md MUST Rule 8.
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      (inputs.variant == 'cuda' || inputs.variant == 'all')
+      (inputs.variant == 'cuda' || inputs.variant == 'all') &&
+      !startsWith(github.head_ref, 'release/')
     # IT-1: route to self-hosted GPU runner once provisioned.
     runs-on: [self-hosted, cuda, gpu]
     # IT-1: non-blocking until runner live — remove this line to make blocking

--- a/.github/workflows/test-with-infrastructure.yml
+++ b/.github/workflows/test-with-infrastructure.yml
@@ -23,6 +23,12 @@ env:
 
 jobs:
   test-with-infrastructure:
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # release diffs touch only version anchors + CHANGELOG; Docker
+    # infrastructure compatibility was already verified on the source-
+    # change PRs the release bundles. Scheduled weekly + workflow_dispatch
+    # still cover release-cut SHAs.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20 # Prevent hanging workflows
     env:

--- a/.github/workflows/trust-plane.yml
+++ b/.github/workflows/trust-plane.yml
@@ -24,6 +24,11 @@ concurrency:
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # paths filter on src/kailash/trust/** rarely matches release-cut diffs,
+    # but defense-in-depth keeps the rule's enforcement uniform across all
+    # PR-gate jobs.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -62,6 +67,9 @@ jobs:
 
   smoke:
     name: Smoke Test (entry points)
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # entry-point smoke verifies imports already exercised on source-change PRs.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: test

--- a/.github/workflows/trust-tests.yml
+++ b/.github/workflows/trust-tests.yml
@@ -34,6 +34,11 @@ concurrency:
 jobs:
   trust-unit-tests:
     name: Trust Unit Tests
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # paths filter on trust modules rarely matches release-cut diffs, but
+    # defense-in-depth keeps the rule's enforcement uniform. Scheduled
+    # weekly + workflow_dispatch still cover release-cut SHAs.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -49,6 +49,11 @@ jobs:
   # Skip push CI when an open PR already covers the branch
   check-duplicate:
     name: Check for Duplicate Run
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8.
+    # On push events, head_ref is empty so this expression evaluates to true,
+    # leaving push-event behavior intact. On pull_request events from
+    # release/v*, this short-circuits before the duplicate-PR check fires.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
     runs-on: ubuntu-latest
     outputs:
       should-skip: ${{ steps.check.outputs.skip }}
@@ -78,7 +83,11 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     needs: check-duplicate
-    if: needs.check-duplicate.outputs.should-skip != 'true'
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8 —
+    # release diffs are metadata-only (pyproject.toml version anchors +
+    # CHANGELOG); the source-change PRs the release bundles already
+    # exercised this matrix. Saves ~45 min × matrix-size per release cycle.
+    if: needs.check-duplicate.outputs.should-skip != 'true' && !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     continue-on-error: false
@@ -143,7 +152,8 @@ jobs:
   test-pact:
     name: Test PACT (Python 3.11)
     needs: check-duplicate
-    if: needs.check-duplicate.outputs.should-skip != 'true'
+    # Skip release-prep PRs (release/v*) per ci-runners.md MUST Rule 8.
+    if: needs.check-duplicate.outputs.should-skip != 'true' && !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

- Adopts `if: !startsWith(github.head_ref, 'release/')` on every PR-gate job in 12 of 14 PR-triggered workflows (the other 2 already complied: `docs-build.yml`, `spec-drift-gate.yml`).
- Per `rules/ci-runners.md` MUST Rule 8: release-prep PRs are by contract metadata-only (version anchors + CHANGELOG); re-running the full PR-gate matrix on them re-exercises code already verified on the source-change PRs the release bundles. Saves ~45 min × matrix-size of avoidable runner wall-clock per release cycle.
- Exception: `version-check` jobs in `test-kailash-{ml,align}.yml` stay unguarded — they are the only PR-time gate verifying `pyproject.toml::version` ↔ `_version.py::__version__` consistency, uniquely relevant to release-prep diffs. (Tag-triggered `publish-pypi.yml` doesn't fire until after merge, so without this gate there is no PR-time anchor-consistency check.)

## Files changed

`.github/workflows/`: `auto-merge.yml`, `codeql.yml`, `cross-sdk-interop.yml`, `example-validation.yml`, `project-automation.yml`, `security-tests.yml`, `test-kailash-align.yml`, `test-kailash-ml.yml`, `test-with-infrastructure.yml`, `trust-plane.yml`, `trust-tests.yml`, `unified-ci.yml`

## Edge cases

- `unified-ci.yml::check-duplicate` (consumes `head_ref`) — on push events `head_ref` is empty so `!startsWith('', 'release/')` evaluates true; push behavior preserved. On `pull_request` from `release/v*`, `check-duplicate` skips, which auto-skips dependent `test` and `test-pact` jobs (also independently gated for safety).
- `test-kailash-{ml,align}.yml::test-cuda*` and `test-{dl,rl,gpu}` — these jobs are already `workflow_dispatch`-only; the release-skip is belt-and-suspenders per the rule's "every PR-gate job" enforcement clause.

## Test plan

- [x] All 21 `.github/workflows/*.yml` parse cleanly under `yaml.safe_load` (validated locally)
- [x] Pre-commit hooks (Tier 1 unit tests, YAML check, formatting) pass
- [ ] PR-gate matrix runs against this PR (this is NOT a `release/v*` branch, so the matrix WILL fire — that's correct, the change is to CI config and warrants full validation)
- [ ] Future `release/v*` PRs verify their PR-gate matrix is fully skipped (acceptance: a release-prep PR opens with the PR-gate suite showing ~all skipped, only `version-check` runs in test-kailash-{ml,align}.yml)

## Cross-SDK

`kailash-rs` has the same `release/v*` convention per `rules/git.md` and would benefit from the same audit. Companion issue filing requires explicit authorization per `rules/upstream-issue-hygiene.md` MUST Rule 1.

## Related

- Rule: `.claude/rules/ci-runners.md` § "Release PRs MUST Skip The PR-Gate Suite" (MUST Rule 8)
- Sibling rule: `.claude/rules/git.md` § "Release-Prep PRs MUST Use `release/v*` Branch Convention"
- Origin: 2026-04-22 codification — release PR observed running full PR-gate suite for the third time on the same code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)