### PR TITLE
fix(kailash-ml): re-export MultiModelAdapter from kailash_ml.serving (#741)

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,38 @@
 # kailash-ml Changelog
 
+## [1.7.1] — 2026-05-01 — Re-export `MultiModelAdapter` from `kailash_ml.serving`: closes #741
+
+`MultiModelAdapter` (the 1.5.0 → 1.6.0 hard-break recovery shim, GH
+#700) is now re-exported through `kailash_ml.serving.__init__` and
+listed in `kailash_ml.serving.__all__`. The class previously existed
+at `kailash_ml.serving.multi_model_adapter.MultiModelAdapter` and was
+also exported from top-level `kailash_ml.MultiModelAdapter`, but the
+spec-documented import path
+
+```python
+from kailash_ml.serving import MultiModelAdapter
+```
+
+raised `ImportError` on a fresh install, contradicting
+`specs/ml-serving.md` § 2.6.1.
+
+Per `rules/orphan-detection.md` § 6 every public module-scope import
+in a package's `__init__.py` MUST appear in that module's `__all__`;
+this release closes the orphan with no behavioural change beyond the
+re-export.
+
+### Fixed
+
+- `kailash_ml/serving/__init__.py`: re-export `MultiModelAdapter`;
+  add `"MultiModelAdapter"` to `__all__`.
+
+### Tests
+
+- `tests/regression/test_issue_741_multi_model_adapter_serving_export.py`
+  (Tier 1) — pins the re-export, structural `ast.parse` verification of
+  `__all__`, and identity check `kailash_ml.serving.MultiModelAdapter
+is kailash_ml.MultiModelAdapter`.
+
 ## [1.7.0] — 2026-05-01 — Lightning quarantine migration: closes #752
 
 Migrates kailash-ml's PyTorch Lightning dependency from the umbrella

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "1.7.0"
+version = "1.7.1"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "1.7.0"
+__version__ = "1.7.1"

--- a/packages/kailash-ml/src/kailash_ml/serving/__init__.py
+++ b/packages/kailash-ml/src/kailash_ml/serving/__init__.py
@@ -27,6 +27,7 @@ shard (W33). Callers do:
 from __future__ import annotations
 
 from kailash_ml.serving._types import InferenceServerProtocol, ServeHandle, ServeStatus
+from kailash_ml.serving.multi_model_adapter import MultiModelAdapter
 from kailash_ml.serving.server import (
     ALLOWED_CHANNELS,
     ALLOWED_RUNTIMES,
@@ -43,6 +44,8 @@ __all__ = [
     "InferenceServerProtocol",
     "ServeHandle",
     "ServeStatus",
+    # 1.1.x back-compat shim (GH #700; subpackage export GH #741)
+    "MultiModelAdapter",
     # Constants
     "ALLOWED_CHANNELS",
     "ALLOWED_RUNTIMES",

--- a/packages/kailash-ml/tests/regression/test_issue_741_multi_model_adapter_serving_export.py
+++ b/packages/kailash-ml/tests/regression/test_issue_741_multi_model_adapter_serving_export.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression for GH issue #741 — ``MultiModelAdapter`` missing from
+``kailash_ml.serving.__all__``.
+
+Per ``rules/orphan-detection.md`` §6 every public symbol imported at
+module scope into a package's ``__init__.py`` MUST appear in that
+module's ``__all__``.
+
+Background
+----------
+
+* ``specs/ml-serving.md`` §2.6.1 advertises ``MultiModelAdapter`` as
+  the documented 1.5.0 → 1.6.0 hard-break recovery shim, importable
+  from ``kailash_ml.serving``.
+* The class exists at
+  ``kailash_ml.serving.multi_model_adapter.MultiModelAdapter`` and is
+  exported from top-level ``kailash_ml.MultiModelAdapter`` (per #700).
+* Until 1.7.1 the symbol was NOT re-exported through
+  ``kailash_ml.serving.__init__``, so the spec-documented import path
+  (``from kailash_ml.serving import MultiModelAdapter``) raised
+  ``ImportError`` on a fresh install.
+
+Asserts
+-------
+
+1. ``from kailash_ml.serving import MultiModelAdapter`` resolves.
+2. ``"MultiModelAdapter"`` appears in ``kailash_ml.serving.__all__``
+   (verified via ``ast.parse`` per ``rules/testing.md`` §
+   "``__all__`` / Re-export Symbol Counts Use Structural Enumeration,
+   Not Grep").
+3. ``kailash_ml.serving.MultiModelAdapter is
+   kailash_ml.MultiModelAdapter`` — both surfaces resolve to the
+   identical class object (no parallel definition).
+
+Behavioral, not source-grep — the AST walk is over the parsed
+``__all__`` literal, NOT a substring search.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.regression
+def test_issue_741_multi_model_adapter_importable_from_serving() -> None:
+    """Spec-documented import path must resolve on a fresh install."""
+    from kailash_ml.serving import MultiModelAdapter  # noqa: F401
+
+    # Identity: same class object as the canonical module path.
+    from kailash_ml.serving.multi_model_adapter import (
+        MultiModelAdapter as CanonicalMultiModelAdapter,
+    )
+
+    assert MultiModelAdapter is CanonicalMultiModelAdapter
+
+
+@pytest.mark.regression
+def test_issue_741_multi_model_adapter_in_serving_all_via_ast() -> None:
+    """``__all__`` enumeration must include ``MultiModelAdapter``.
+
+    Uses ``ast.parse`` per ``rules/testing.md`` § "``__all__`` /
+    Re-export Symbol Counts Use Structural Enumeration, Not Grep" —
+    avoids `grep` false positives from comments / line continuations.
+    """
+    init_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "kailash_ml"
+        / "serving"
+        / "__init__.py"
+    )
+    tree = ast.parse(init_path.read_text())
+    all_entries: list[str] | None = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "__all__"
+            and isinstance(node.value, ast.List)
+        ):
+            all_entries = [
+                elt.value
+                for elt in node.value.elts
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+            ]
+            break
+    assert (
+        all_entries is not None
+    ), "kailash_ml/serving/__init__.py must define `__all__` as a list literal"
+    assert "MultiModelAdapter" in all_entries, (
+        f"`MultiModelAdapter` missing from kailash_ml.serving.__all__; "
+        f"found: {all_entries}"
+    )
+
+
+@pytest.mark.regression
+def test_issue_741_serving_and_top_level_resolve_to_same_class() -> None:
+    """Defensive identity: both public surfaces are the same object."""
+    import kailash_ml
+    from kailash_ml.serving import MultiModelAdapter as FromServing
+
+    assert FromServing is kailash_ml.MultiModelAdapter


### PR DESCRIPTION
## Summary

Closes #741. Re-exports `MultiModelAdapter` from `kailash_ml.serving` (also adds `\"MultiModelAdapter\"` to `kailash_ml.serving.__all__`) so the spec-documented import path resolves on a fresh install.

## Context

`specs/ml-serving.md` § 2.6.1 advertises `MultiModelAdapter` as the documented 1.5.0 → 1.6.0 hard-break recovery shim, importable via:

```python
from kailash_ml.serving import MultiModelAdapter
```

The class existed at `kailash_ml.serving.multi_model_adapter.MultiModelAdapter` and was re-exported from top-level `kailash_ml` (per #700), but `kailash_ml/serving/__init__.py` never re-exported it, so the documented path raised `ImportError`. Per `rules/orphan-detection.md` § 6, every public module-scope import in a package's `__init__.py` MUST appear in that module's `__all__`.

Same fix-class as PR #720 (Nexus `MountInfo`).

## Diff

- **`packages/kailash-ml/src/kailash_ml/serving/__init__.py`** (+3) — eager import + `__all__` entry.
- **`packages/kailash-ml/tests/regression/test_issue_741_multi_model_adapter_serving_export.py`** (new, 106 lines, 3 Tier-1 tests):
  1. `from kailash_ml.serving import MultiModelAdapter` resolves; identity check vs canonical module path.
  2. `__all__` enumeration via `ast.parse` (per `rules/testing.md` § "`__all__` Counts Use Structural Enumeration").
  3. `kailash_ml.serving.MultiModelAdapter is kailash_ml.MultiModelAdapter` (no parallel definition).
- **`packages/kailash-ml/pyproject.toml`** + **`packages/kailash-ml/src/kailash_ml/_version.py`**: 1.7.0 → 1.7.1 (atomic bump per `rules/zero-tolerance.md` Rule 5).
- **`packages/kailash-ml/CHANGELOG.md`**: 1.7.1 entry prepended.

## Test plan

- [x] `pre-commit run` on changed files — green
- [x] `pytest packages/kailash-ml/tests/regression/test_issue_741_*.py` — 3/3 PASS
- [x] `pytest --collect-only packages/kailash-ml/tests/` — 2489 tests collected, exit 0
- [x] Smoke import: `from kailash_ml.serving import MultiModelAdapter` succeeds AND identical to `kailash_ml.MultiModelAdapter`
- [ ] CI green (matrix)

## Related issues

Fixes #741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)