### PR TITLE
test: cross-SDK Unicode byte pins (#756, #757) + 2 sibling fixes

### DIFF
--- a/test-vectors/audit-chain-canonical.json
+++ b/test-vectors/audit-chain-canonical.json
@@ -1,0 +1,41 @@
+{
+  "spec_version": "1.0",
+  "description": "Cross-SDK canonical fixtures for AuditAnchor.compute_hash() byte-equality + SHA-256 hex digest stability between kailash-py and kailash-rs (per `kailash-rs#449` audit-chain canonical-input contract). Source: kailash-py issue #757 (U1 BMP non-ASCII, U2 above-BMP/emoji surrogate pairs). Vector inputs are reproducible from the embedded `input_repr` field. The canonical content is `{anchor_id}:{sequence}:{previous_hash_or_GENESIS_HASH}:{agent_id}:{action}:{verification_level}:{envelope_id_or_empty}:{result}:{iso8601_+00:00}[:{metadata_json_sorted_compact_ensure_ascii}]`. The `ensure_ascii=True` contract in metadata serialization requires non-ASCII codepoints render as \\uXXXX escapes (U+FFFF and below) and surrogate pairs (above U+FFFF) per RFC 8259 §7.",
+  "genesis_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "vectors": [
+    {
+      "name": "U1_bmp_metadata_key_and_value",
+      "input_repr": {
+        "anchor_id": "anc-u1-001",
+        "sequence": 0,
+        "previous_hash": null,
+        "agent_id": "agent-u1",
+        "action": "envelope_created",
+        "verification_level": "AUTO_APPROVED",
+        "envelope_id": "env-u1",
+        "result": "success",
+        "timestamp": "2026-01-15T11:00:00+00:00",
+        "metadata": { "role": "café", "中文": "value" }
+      },
+      "expected_canonical_input": "anc-u1-001:0:0000000000000000000000000000000000000000000000000000000000000000:agent-u1:envelope_created:AUTO_APPROVED:env-u1:success:2026-01-15T11:00:00+00:00:{\"role\":\"caf\\u00e9\",\"\\u4e2d\\u6587\":\"value\"}",
+      "expected_sha256": "6946e734daa8279d4dc173918109995e0d10b647a7d3cd0b36aeb4114e8e12c3"
+    },
+    {
+      "name": "U2_above_bmp_emoji_metadata_value",
+      "input_repr": {
+        "anchor_id": "anc-u2-001",
+        "sequence": 0,
+        "previous_hash": null,
+        "agent_id": "agent-u2",
+        "action": "envelope_created",
+        "verification_level": "AUTO_APPROVED",
+        "envelope_id": "env-u2",
+        "result": "success",
+        "timestamp": "2026-01-15T12:00:00+00:00",
+        "metadata": { "celebration": "🎉🚀" }
+      },
+      "expected_canonical_input": "anc-u2-001:0:0000000000000000000000000000000000000000000000000000000000000000:agent-u2:envelope_created:AUTO_APPROVED:env-u2:success:2026-01-15T12:00:00+00:00:{\"celebration\":\"\\ud83c\\udf89\\ud83d\\ude80\"}",
+      "expected_sha256": "4bba3681171049d96f6ba5863ae33dafdfa6bc0d82e26dca5267f21021872427"
+    }
+  ]
+}

--- a/test-vectors/trace-event-canonical.json
+++ b/test-vectors/trace-event-canonical.json
@@ -1,6 +1,6 @@
 {
   "spec_version": "1.0",
-  "description": "Cross-SDK canonical fixtures for TraceEvent.to_dict() byte-equality + fingerprint stability between kailash-py and kailash-rs. Generated 2026-04-30 from the corrected isoformat(timespec=microseconds) path. Source: kailash-py issue #731 fix; vector inputs are reproducible from the embedded `input_repr` field.",
+  "description": "Cross-SDK canonical fixtures for TraceEvent.to_dict() byte-equality + fingerprint stability between kailash-py and kailash-rs. Generated 2026-04-30 from the corrected isoformat(timespec=microseconds) path. Source: kailash-py issue #731 fix (V1/V2/V3) + #756 Unicode pin (V4 BMP non-ASCII, V5 above-BMP/emoji surrogate pairs). Vector inputs are reproducible from the embedded `input_repr` field. The `ensure_ascii=True` contract requires non-ASCII codepoints render as \\uXXXX escapes (U+FFFF and below) and surrogate pairs (above U+FFFF) per RFC 8259 §7.",
   "vectors": [
     {
       "name": "V1_zero_microsecond",
@@ -53,6 +53,35 @@
       },
       "expected_canonical_json": "{\"agent_id\":\"agent-V3\",\"completion_tokens\":50,\"cost_microdollars\":2500,\"duration_ms\":1234.5,\"envelope_id\":\"env-V3\",\"event_id\":\"evt-V3\",\"event_type\":\"agent.run.end\",\"llm_model\":\"gpt-4o\",\"parent_event_id\":null,\"payload\":null,\"payload_hash\":\"sha256:deadbeef\",\"prompt_tokens\":100,\"run_id\":\"run-V3\",\"span_id\":\"span-V3\",\"status\":\"ok\",\"tenant_id\":\"tenant-V3\",\"timestamp\":\"2026-12-31T23:59:59.999999+00:00\",\"tool_name\":null,\"trace_id\":\"trace-V3\"}",
       "expected_fingerprint": "ff114cf1a11dd6b9296644fde32e95a6a560839f5d0dbcc47a8846c226b7f5a1"
+    },
+    {
+      "name": "V4_bmp_non_ascii_agent_id",
+      "input_repr": {
+        "event_id": "evt-v4-bmp",
+        "run_id": "run-v4",
+        "agent_id": "agent-café-中文",
+        "cost_microdollars": 0,
+        "event_type": "agent.run.start",
+        "timestamp": "2026-04-20T12:00:00.000000+00:00"
+      },
+      "expected_canonical_json": "{\"agent_id\":\"agent-caf\\u00e9-\\u4e2d\\u6587\",\"completion_tokens\":null,\"cost_microdollars\":0,\"duration_ms\":null,\"envelope_id\":null,\"event_id\":\"evt-v4-bmp\",\"event_type\":\"agent.run.start\",\"llm_model\":null,\"parent_event_id\":null,\"payload\":null,\"payload_hash\":null,\"prompt_tokens\":null,\"run_id\":\"run-v4\",\"span_id\":null,\"status\":null,\"tenant_id\":null,\"timestamp\":\"2026-04-20T12:00:00.000000+00:00\",\"tool_name\":null,\"trace_id\":null}",
+      "expected_fingerprint": "67bade44e4044933396f8035e725929a4aa54ae274d4e2058871367a93abe95b"
+    },
+    {
+      "name": "V5_above_bmp_emoji_tool_name",
+      "input_repr": {
+        "event_id": "evt-v5-above-bmp",
+        "run_id": "run-v5",
+        "agent_id": "agent-v5",
+        "cost_microdollars": 0,
+        "tool_name": "🎉🚀",
+        "duration_ms": 10.0,
+        "event_type": "tool.call.end",
+        "timestamp": "2026-04-20T12:00:00.000000+00:00",
+        "status": "ok"
+      },
+      "expected_canonical_json": "{\"agent_id\":\"agent-v5\",\"completion_tokens\":null,\"cost_microdollars\":0,\"duration_ms\":10.0,\"envelope_id\":null,\"event_id\":\"evt-v5-above-bmp\",\"event_type\":\"tool.call.end\",\"llm_model\":null,\"parent_event_id\":null,\"payload\":null,\"payload_hash\":null,\"prompt_tokens\":null,\"run_id\":\"run-v5\",\"span_id\":null,\"status\":\"ok\",\"tenant_id\":null,\"timestamp\":\"2026-04-20T12:00:00.000000+00:00\",\"tool_name\":\"\\ud83c\\udf89\\ud83d\\ude80\",\"trace_id\":null}",
+      "expected_fingerprint": "2d372a1a42a2221ba3fb014062d735b076d11371b0f1390919b53fe908a23d1f"
     }
   ]
 }

--- a/tests/regression/test_dataflow_pool_bridge.py
+++ b/tests/regression/test_dataflow_pool_bridge.py
@@ -91,7 +91,9 @@ async def test_failed_ddl_does_not_leak_pools_under_saturation(pg_dsn):
             # also acceptable here; what matters is pool count stays bounded.
             pass
         finally:
-            await db.close()
+            # close() is sync (returns None); close_async() is the awaitable
+            # cleanup (rules/patterns.md § Async Resource Cleanup).
+            await db.close_async()
 
     # 10 concurrent accesses — all should fail with DDLFailedError, not hang.
     await asyncio.gather(*[_attempt_access(i) for i in range(10)])
@@ -143,7 +145,9 @@ async def test_failed_ddl_with_warn_mode_still_bounded(pg_dsn):
             # Warn mode may still raise other errors (missing table, etc.)
             pass
         finally:
-            await db.close()
+            # close() is sync (returns None); close_async() is the awaitable
+            # cleanup (rules/patterns.md § Async Resource Cleanup).
+            await db.close_async()
 
     await asyncio.gather(*[_attempt_access_warn(i) for i in range(10)])
 

--- a/tests/regression/test_issue_731_trace_event_timestamp_padding.py
+++ b/tests/regression/test_issue_731_trace_event_timestamp_padding.py
@@ -141,7 +141,9 @@ class TestCrossSDKFixtureParity:
 
     def test_fixture_loads(self, fixture: dict) -> None:
         assert fixture["spec_version"] == "1.0"
-        assert len(fixture["vectors"]) >= 3
+        # V1/V2/V3 (#731 microsecond padding) + V4/V5 (#756 Unicode pin).
+        # Floor stays >= so future cross-SDK additions land cleanly.
+        assert len(fixture["vectors"]) >= 5
 
     def test_every_vector_canonical_json_byte_equal(self, fixture: dict) -> None:
         for v in fixture["vectors"]:

--- a/tests/regression/test_issue_756_trace_event_unicode_pins.py
+++ b/tests/regression/test_issue_756_trace_event_unicode_pins.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #756 — TraceEvent canonical-JSON fingerprint Unicode pins.
+
+Pinned cross-SDK byte vectors that lock the ``ensure_ascii=True`` contract in
+``compute_trace_event_fingerprint``. Two algorithmic-drift failure modes this
+guards against:
+
+1. ``ensure_ascii=False`` regression — non-ASCII codepoints would emit raw UTF-8
+   instead of ``\\uXXXX`` escapes, breaking byte-equivalence with kailash-rs's
+   ``serde_json::to_string(&BTreeMap)`` (which emits ASCII-escaped output).
+
+2. Above-BMP surrogate-pair drift — a JSON writer that emits codepoints above
+   U+FFFF as 4-byte UTF-8 (``\\ud83c\\udf89`` ↔ ``🎉``) instead of surrogate
+   pairs would silently break cross-SDK fingerprint correlation for any
+   payload carrying emoji or other above-BMP content.
+
+The vectors live in ``test-vectors/trace-event-canonical.json`` (cross-SDK
+contract — kailash-rs reads the same file). This module asserts named V4/V5
+cases per the issue's acceptance criteria; ``test_issue_731_*`` already
+auto-iterates the full fixture for byte-and-fingerprint parity.
+
+Cross-SDK alignment per ``rules/cross-sdk-inspection.md`` MUST Rule 4 (byte
+vectors pinned, ≥3 vectors with sentinel coverage — V1/V2/V3 cover the
+ASCII-only / micros-padding sentinels; V4/V5 cover BMP / above-BMP).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.diagnostics.protocols import (
+    TraceEvent,
+    TraceEventStatus,
+    TraceEventType,
+    compute_trace_event_fingerprint,
+)
+
+
+@pytest.mark.regression
+class TestV4BMPNonASCIIAgentID:
+    """V4 pinned vector — BMP non-ASCII codepoints in ``agent_id``.
+
+    Codepoints exercised:
+      - U+00E9 (é, Latin-1 supplement)
+      - U+4E2D (中, CJK)
+      - U+6587 (文, CJK)
+
+    All MUST emit as ``\\uXXXX`` escapes per RFC 8259 §7 + the
+    ``ensure_ascii=True`` contract.
+    """
+
+    EXPECTED_CANONICAL_JSON = (
+        '{"agent_id":"agent-caf\\u00e9-\\u4e2d\\u6587",'
+        '"completion_tokens":null,"cost_microdollars":0,"duration_ms":null,'
+        '"envelope_id":null,"event_id":"evt-v4-bmp",'
+        '"event_type":"agent.run.start","llm_model":null,'
+        '"parent_event_id":null,"payload":null,"payload_hash":null,'
+        '"prompt_tokens":null,"run_id":"run-v4","span_id":null,'
+        '"status":null,"tenant_id":null,'
+        '"timestamp":"2026-04-20T12:00:00.000000+00:00",'
+        '"tool_name":null,"trace_id":null}'
+    )
+    EXPECTED_FINGERPRINT = (
+        "67bade44e4044933396f8035e725929a4aa54ae274d4e2058871367a93abe95b"
+    )
+
+    def _make_event(self) -> TraceEvent:
+        return TraceEvent(
+            event_id="evt-v4-bmp",
+            event_type=TraceEventType.AGENT_RUN_START,
+            timestamp=datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc),
+            run_id="run-v4",
+            agent_id="agent-café-中文",
+            cost_microdollars=0,
+        )
+
+    def test_canonical_json_byte_equal(self) -> None:
+        evt = self._make_event()
+        canonical = json.dumps(
+            evt.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        )
+        assert canonical == self.EXPECTED_CANONICAL_JSON
+
+    def test_fingerprint_matches_pinned_sha256(self) -> None:
+        assert (
+            compute_trace_event_fingerprint(self._make_event())
+            == self.EXPECTED_FINGERPRINT
+        )
+
+    def test_canonical_json_emits_ascii_only_bytes(self) -> None:
+        """Structural invariant: ASCII-only output proves ``ensure_ascii=True``
+        is not silently regressed to ``False``. A regression would surface
+        as raw multi-byte UTF-8 in the canonical-JSON output."""
+        canonical = json.dumps(
+            self._make_event().to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        )
+        assert canonical.isascii(), (
+            "canonical-JSON output must be pure ASCII; non-ASCII byte means "
+            "ensure_ascii=True regressed to False — cross-SDK byte-parity broken."
+        )
+
+    def test_fingerprint_is_sha256_of_canonical_bytes(self) -> None:
+        """The fingerprint MUST equal SHA-256 of the canonical-JSON UTF-8 bytes
+        — no transformation other than the pinned canonicalization step."""
+        evt = self._make_event()
+        canonical = json.dumps(
+            evt.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        )
+        expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        assert compute_trace_event_fingerprint(evt) == expected
+
+
+@pytest.mark.regression
+class TestV5AboveBMPEmojiToolName:
+    """V5 pinned vector — above-BMP emoji codepoints in ``tool_name``.
+
+    Codepoints exercised (each requires a UTF-16 surrogate pair):
+      - U+1F389 🎉 → ``\\ud83c\\udf89``
+      - U+1F680 🚀 → ``\\ud83d\\ude80``
+
+    Both MUST emit as surrogate-pair ``\\uXXXX\\uXXXX`` sequences per
+    RFC 8259 §7 + the ``ensure_ascii=True`` contract.
+    """
+
+    EXPECTED_CANONICAL_JSON = (
+        '{"agent_id":"agent-v5","completion_tokens":null,'
+        '"cost_microdollars":0,"duration_ms":10.0,"envelope_id":null,'
+        '"event_id":"evt-v5-above-bmp","event_type":"tool.call.end",'
+        '"llm_model":null,"parent_event_id":null,"payload":null,'
+        '"payload_hash":null,"prompt_tokens":null,"run_id":"run-v5",'
+        '"span_id":null,"status":"ok","tenant_id":null,'
+        '"timestamp":"2026-04-20T12:00:00.000000+00:00",'
+        '"tool_name":"\\ud83c\\udf89\\ud83d\\ude80","trace_id":null}'
+    )
+    EXPECTED_FINGERPRINT = (
+        "2d372a1a42a2221ba3fb014062d735b076d11371b0f1390919b53fe908a23d1f"
+    )
+
+    def _make_event(self) -> TraceEvent:
+        return TraceEvent(
+            event_id="evt-v5-above-bmp",
+            event_type=TraceEventType.TOOL_CALL_END,
+            timestamp=datetime(2026, 4, 20, 12, 0, 0, tzinfo=timezone.utc),
+            run_id="run-v5",
+            agent_id="agent-v5",
+            cost_microdollars=0,
+            tool_name="🎉🚀",
+            duration_ms=10.0,
+            status=TraceEventStatus.OK,
+        )
+
+    def test_canonical_json_byte_equal(self) -> None:
+        evt = self._make_event()
+        canonical = json.dumps(
+            evt.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        )
+        assert canonical == self.EXPECTED_CANONICAL_JSON
+
+    def test_fingerprint_matches_pinned_sha256(self) -> None:
+        assert (
+            compute_trace_event_fingerprint(self._make_event())
+            == self.EXPECTED_FINGERPRINT
+        )
+
+    def test_above_bmp_emits_surrogate_pairs(self) -> None:
+        """Structural invariant: each above-BMP codepoint MUST emit as
+        ``\\uXXXX\\uXXXX``. A regression that emits a single ``\\uXXXXX`` or
+        raw 4-byte UTF-8 would diverge from kailash-rs's surrogate-pair
+        output and silently break cross-SDK forensic correlation."""
+        canonical = json.dumps(
+            self._make_event().to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        )
+        # U+1F389 🎉 → high surrogate D83C + low surrogate DF89
+        assert "\\ud83c\\udf89" in canonical
+        # U+1F680 🚀 → high surrogate D83D + low surrogate DE80
+        assert "\\ud83d\\ude80" in canonical
+        # And no raw above-BMP characters survive in the canonical output.
+        assert "🎉" not in canonical
+        assert "🚀" not in canonical

--- a/tests/regression/test_issue_757_audit_chain_unicode_pins.py
+++ b/tests/regression/test_issue_757_audit_chain_unicode_pins.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #757 — audit-chain canonical-input Unicode byte pins.
+
+The PACT audit-chain canonical-input contract (per ``kailash-rs#449`` §2 and
+``schemas/audit-anchor.v1.json``) builds the SHA-256 input as a colon-delimited
+string ending in JSON-serialized metadata. The metadata uses
+``sort_keys=True, separators=(",", ":"), ensure_ascii=True``  so that Python's
+``json.dumps`` output matches Rust's ``serde_json::to_string(&BTreeMap)``
+byte-for-byte.
+
+These tests pin two cross-SDK byte vectors (U1 BMP non-ASCII metadata, U2
+above-BMP/emoji metadata) and assert both:
+
+1. The exact canonical-input string ``AuditAnchor.compute_hash`` would feed to
+   SHA-256 (reconstructed via the documented format).
+2. The SHA-256 hex digest matches the pinned cross-SDK contract.
+
+Two algorithmic-drift failure modes this guards against:
+
+A. ``ensure_ascii=False`` regression — non-ASCII metadata keys/values would
+   emit raw UTF-8 instead of ``\\uXXXX`` escapes, breaking PACT N4 audit-chain
+   correlation between Python and Rust SDKs.
+
+B. Above-BMP surrogate-pair drift — emoji and other above-BMP codepoints
+   in metadata values would emit as 4-byte UTF-8 rather than UTF-16 surrogate
+   pairs, silently breaking cross-SDK SHA-256 parity.
+
+Vectors live in ``test-vectors/audit-chain-canonical.json`` (cross-SDK
+contract — kailash-rs reads the same file). This module asserts named U1/U2
+cases per the issue's acceptance criteria and includes an auto-iterating
+fixture-parity test.
+
+Cross-SDK alignment per ``rules/cross-sdk-inspection.md`` MUST Rule 4 (byte
+vectors pinned). Sibling of #756 (TraceEvent fingerprint Unicode pins) and
+#731 (TraceEvent timestamp microsecond padding).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kailash.trust.pact.audit import GENESIS_HASH, AuditAnchor
+from kailash.trust.pact.config import VerificationLevel
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2] / "test-vectors" / "audit-chain-canonical.json"
+)
+
+
+def _build_canonical_input(anchor: AuditAnchor) -> str:
+    """Reproduce the canonical-input string that ``AuditAnchor.compute_hash``
+    feeds to SHA-256. Mirrors ``src/kailash/trust/pact/audit.py::compute_hash``
+    so the test asserts the inputs to the hash, not just the digest."""
+    content = (
+        f"{anchor.anchor_id}:{anchor.sequence}:"
+        f"{anchor.previous_hash or GENESIS_HASH}:"
+        f"{anchor.agent_id}:{anchor.action}:{anchor.verification_level.value}:"
+        f"{anchor.envelope_id or ''}:{anchor.result}:"
+        f"{anchor.timestamp.isoformat()}"
+    )
+    if anchor.metadata:
+        content += ":" + json.dumps(
+            anchor.metadata,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        )
+    return content
+
+
+@pytest.mark.regression
+class TestU1BMPMetadata:
+    """U1 pinned vector — BMP non-ASCII codepoints in metadata KEY and VALUE.
+
+    Codepoints exercised:
+      - Latin-1 supplement U+00E9 (é) in value
+      - CJK U+4E2D (中) + U+6587 (文) in key
+
+    Sort order: ``role`` (starts U+0072) sorts before ``中文`` (starts U+4E2D)
+    by codepoint comparison — this is the order ``sort_keys=True`` produces
+    and what kailash-rs's ``BTreeMap`` produces.
+
+    All MUST emit as ``\\uXXXX`` escapes per RFC 8259 §7.
+    """
+
+    EXPECTED_CANONICAL_INPUT = (
+        "anc-u1-001:0:" + "0" * 64 + ":agent-u1:envelope_created:AUTO_APPROVED:"
+        "env-u1:success:2026-01-15T11:00:00+00:00:"
+        '{"role":"caf\\u00e9","\\u4e2d\\u6587":"value"}'
+    )
+    EXPECTED_SHA256 = "6946e734daa8279d4dc173918109995e0d10b647a7d3cd0b36aeb4114e8e12c3"
+
+    def _make_anchor(self) -> AuditAnchor:
+        return AuditAnchor(
+            anchor_id="anc-u1-001",
+            sequence=0,
+            previous_hash=None,
+            agent_id="agent-u1",
+            action="envelope_created",
+            verification_level=VerificationLevel.AUTO_APPROVED,
+            envelope_id="env-u1",
+            result="success",
+            metadata={"role": "café", "中文": "value"},
+            timestamp=datetime(2026, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
+        )
+
+    def test_canonical_input_byte_equal(self) -> None:
+        assert (
+            _build_canonical_input(self._make_anchor()) == self.EXPECTED_CANONICAL_INPUT
+        )
+
+    def test_compute_hash_matches_pinned_sha256(self) -> None:
+        assert self._make_anchor().compute_hash() == self.EXPECTED_SHA256
+
+    def test_canonical_input_emits_ascii_only_bytes(self) -> None:
+        """Structural invariant: ASCII-only output proves
+        ``ensure_ascii=True`` on metadata serialization is not silently
+        regressed to ``False``."""
+        canonical = _build_canonical_input(self._make_anchor())
+        assert canonical.isascii(), (
+            "canonical-input must be pure ASCII; non-ASCII byte means "
+            "ensure_ascii=True regressed in metadata json.dumps — "
+            "cross-SDK SHA-256 parity broken."
+        )
+
+    def test_compute_hash_equals_sha256_of_canonical_input(self) -> None:
+        """The on-disk hash MUST equal SHA-256 of the documented canonical
+        input string — no transformation other than the pinned step."""
+        anchor = self._make_anchor()
+        expected = hashlib.sha256(
+            _build_canonical_input(anchor).encode("utf-8")
+        ).hexdigest()
+        assert anchor.compute_hash() == expected
+
+
+@pytest.mark.regression
+class TestU2AboveBMPEmojiMetadata:
+    """U2 pinned vector — above-BMP emoji codepoints in metadata VALUE.
+
+    Codepoints exercised (each requires a UTF-16 surrogate pair):
+      - U+1F389 🎉 → ``\\ud83c\\udf89``
+      - U+1F680 🚀 → ``\\ud83d\\ude80``
+
+    Both MUST emit as surrogate-pair ``\\uXXXX\\uXXXX`` sequences per
+    RFC 8259 §7.
+    """
+
+    EXPECTED_CANONICAL_INPUT = (
+        "anc-u2-001:0:" + "0" * 64 + ":agent-u2:envelope_created:AUTO_APPROVED:"
+        "env-u2:success:2026-01-15T12:00:00+00:00:"
+        '{"celebration":"\\ud83c\\udf89\\ud83d\\ude80"}'
+    )
+    EXPECTED_SHA256 = "4bba3681171049d96f6ba5863ae33dafdfa6bc0d82e26dca5267f21021872427"
+
+    def _make_anchor(self) -> AuditAnchor:
+        return AuditAnchor(
+            anchor_id="anc-u2-001",
+            sequence=0,
+            previous_hash=None,
+            agent_id="agent-u2",
+            action="envelope_created",
+            verification_level=VerificationLevel.AUTO_APPROVED,
+            envelope_id="env-u2",
+            result="success",
+            metadata={"celebration": "🎉🚀"},
+            timestamp=datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
+    def test_canonical_input_byte_equal(self) -> None:
+        assert (
+            _build_canonical_input(self._make_anchor()) == self.EXPECTED_CANONICAL_INPUT
+        )
+
+    def test_compute_hash_matches_pinned_sha256(self) -> None:
+        assert self._make_anchor().compute_hash() == self.EXPECTED_SHA256
+
+    def test_above_bmp_emits_surrogate_pairs(self) -> None:
+        """Structural invariant: each above-BMP codepoint MUST emit as
+        ``\\uXXXX\\uXXXX``. A regression that emits a single ``\\uXXXXX`` or
+        raw 4-byte UTF-8 would diverge from kailash-rs's surrogate-pair
+        output and break cross-SDK SHA-256 parity."""
+        canonical = _build_canonical_input(self._make_anchor())
+        # U+1F389 🎉 → high surrogate D83C + low surrogate DF89
+        assert "\\ud83c\\udf89" in canonical
+        # U+1F680 🚀 → high surrogate D83D + low surrogate DE80
+        assert "\\ud83d\\ude80" in canonical
+        # And no raw above-BMP characters survive in the canonical output.
+        assert "🎉" not in canonical
+        assert "🚀" not in canonical
+
+
+@pytest.mark.regression
+class TestCrossSDKFixtureParity:
+    """Cross-SDK canonical-fixture conformance tests for the audit chain.
+
+    The fixture at ``test-vectors/audit-chain-canonical.json`` pins vectors
+    that BOTH kailash-py and kailash-rs MUST produce byte-for-byte. These
+    tests exercise the kailash-py side; the kailash-rs side has the symmetric
+    tests at ``crates/kailash-audit-vectors/`` (per #757 issue body).
+    """
+
+    @pytest.fixture(scope="class")
+    def fixture(self) -> dict:
+        assert _FIXTURE_PATH.exists(), (
+            f"cross-SDK audit-chain fixture missing at {_FIXTURE_PATH}; "
+            f"this fixture is the cross-SDK byte contract — its absence "
+            f"means the U1/U2 contract from #757 is not enforced."
+        )
+        return json.loads(_FIXTURE_PATH.read_text())
+
+    def _construct_anchor(self, input_repr: dict) -> AuditAnchor:
+        return AuditAnchor(
+            anchor_id=input_repr["anchor_id"],
+            sequence=input_repr["sequence"],
+            previous_hash=input_repr.get("previous_hash"),
+            agent_id=input_repr["agent_id"],
+            action=input_repr["action"],
+            verification_level=VerificationLevel(input_repr["verification_level"]),
+            envelope_id=input_repr.get("envelope_id"),
+            result=input_repr["result"],
+            metadata=input_repr.get("metadata") or {},
+            timestamp=datetime.fromisoformat(input_repr["timestamp"]),
+        )
+
+    def test_fixture_loads(self, fixture: dict) -> None:
+        assert fixture["spec_version"] == "1.0"
+        # U1 + U2 (#757). Floor stays >= so future cross-SDK additions land cleanly.
+        assert len(fixture["vectors"]) >= 2
+
+    def test_fixture_pins_canonical_genesis_hash(self, fixture: dict) -> None:
+        """The cross-SDK genesis-hash sentinel is part of the contract. Drift
+        here would re-open the legacy ``"genesis"`` literal silently."""
+        assert fixture["genesis_hash"] == GENESIS_HASH
+
+    def test_every_vector_canonical_input_byte_equal(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            anchor = self._construct_anchor(v["input_repr"])
+            actual = _build_canonical_input(anchor)
+            assert actual == v["expected_canonical_input"], (
+                f"vector {v['name']}: canonical-input byte-divergence — "
+                f"got {actual!r}, expected {v['expected_canonical_input']!r}"
+            )
+
+    def test_every_vector_sha256_matches(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            anchor = self._construct_anchor(v["input_repr"])
+            assert anchor.compute_hash() == v["expected_sha256"], (
+                f"vector {v['name']}: SHA-256 divergence — "
+                f"got {anchor.compute_hash()}, expected {v['expected_sha256']}"
+            )

--- a/tests/regression/test_loc_invariants.py
+++ b/tests/regression/test_loc_invariants.py
@@ -38,10 +38,18 @@ def test_delegate_loc():
 
 @pytest.mark.regression
 def test_pact_engine_loc():
-    """Guard: pact/engine.py must stay under 1148 LOC after convergence extraction."""
+    """Guard: pact/engine.py must stay under threshold.
+
+    Baseline re-anchored 2026-05-01 from 998 (pre-#567) → 1414 (post-#567,
+    commit 9ffc23d0 absorbed three MLFP-rejected GovernanceDiagnostics
+    capabilities — verify_audit_chain, envelope_snapshot,
+    iter_audit_anchors — as first-class PactEngine methods, +387 LOC of
+    legitimate feature code, NOT a re-inlining merge regression).
+    Threshold = 1414 × 1.15 ≈ 1626 per rules/refactor-invariants.md Rule 1.
+    """
     path = Path("packages/kailash-pact/src/pact/engine.py")
     lines = len(path.read_text().splitlines())
-    limit = 1148  # 998 post-refactor + 15% margin
+    limit = 1626  # 1414 post-#567 baseline + 15% margin
     assert lines <= limit, (
         f"engine.py: {lines} lines (limit {limit}). "
         f"Code may have been re-inlined by a merge. "


### PR DESCRIPTION
## Summary

- **#756 / #757** — pin V4/V5 (TraceEvent canonical-JSON fingerprint) and U1/U2 (audit-chain canonical-input + SHA-256) Unicode byte vectors as cross-SDK contract artifacts. Both `ensure_ascii=True` regression and above-BMP surrogate-pair drift would silently break cross-SDK forensic correlation; pinning bytes locks the contract.
- **Sibling fix 1** — re-anchor `pact/engine.py` LOC invariant from 1148 (pre-#567 baseline + margin) to 1626 (post-#567 baseline + 15% margin per `rules/refactor-invariants.md` Rule 1). Growth at commit `9ffc23d0` (#567 absorbed `verify_audit_chain` + `envelope_snapshot` + `iter_audit_anchors`) was legitimate feature work, not re-inlining; threshold was never re-anchored.
- **Sibling fix 2** — replace `await db.close()` with `await db.close_async()` in `test_dataflow_pool_bridge.py` (close was sync; awaiting `None` raised `TypeError` and masked a real DPI-A semantic gap surfaced as #759).

## Changes

```
M  test-vectors/trace-event-canonical.json                              # V4/V5 added
A  test-vectors/audit-chain-canonical.json                              # cross-SDK contract artifact
M  tests/regression/test_issue_731_trace_event_timestamp_padding.py     # count floor 3 → 5
A  tests/regression/test_issue_756_trace_event_unicode_pins.py          # named V4/V5 + invariants
A  tests/regression/test_issue_757_audit_chain_unicode_pins.py          # named U1/U2 + fixture parity
M  tests/regression/test_loc_invariants.py                              # pact/engine.py threshold re-anchor
M  tests/regression/test_dataflow_pool_bridge.py                        # close_async fix
```

## Test plan

- [x] 18 dedicated regression tests (V4/V5/U1/U2 + cross-SDK fixture parity) pass locally
- [x] Sibling #731 cross-SDK fixture-parity tests still green (auto-iterates V1–V5)
- [x] `pact/engine.py` LOC invariant green at 1414 (under 1626 threshold)
- [x] `test_failed_ddl_with_warn_mode_still_bounded` passes after close_async fix
- [x] Local pre-flight CI parity: pre-commit on all touched files PASS; full regression suite ex-#759 = 471/10/0 in 4.91s
- [ ] CI matrix green (cross-SDK fixture-parity tests, regression suite)

## Cross-SDK alignment

Per `rules/cross-sdk-inspection.md` MUST Rule 4 (byte vectors pinned for cross-SDK helpers): kailash-rs is the originating side — the V4/V5 and U1/U2 vectors live at `crates/kailash-audit-vectors/` + `crates/kailash-kaizen/tests/cross_sdk_trace_event.rs`. Both fixture JSON files in this PR are the byte-identical contract; the SDK that drifts will fail its own fixture-parity test loudly. `esperie-enterprise/kailash-rs#723` (SHA-256 fingerprint pin in `cross_sdk_trace_event.rs`) is the rs-side companion to #731.

## Expected CI failure

`tests/regression/test_dataflow_pool_bridge.py::test_failed_ddl_does_not_leak_pools_under_saturation` will fail in CI — this is an **expected, pre-existing DPI-A regression tracked at #759**. The close_async fix in this PR is what surfaced it (the prior `TypeError: object NoneType can't be used in 'await' expression` was masking the real semantic gap). Out of shard budget for this PR; root cause is in `dataflow.core.model_registry` swallow path between `register` and `DataFlow.express.create` return.

The sibling test `test_failed_ddl_with_warn_mode_still_bounded` passes — DPI-D2 pool-bound invariant is intact.

## Related issues

- Closes #756
- Closes #757
- Surfaces (does not fix) #759
- Tracking follow-up: #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)