### PR TITLE
fix(dataflow): align list cache invalidation patterns with producer key shape (#750, 2.7.2)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,22 @@
 # DataFlow Changelog
 
+## [2.7.2] — 2026-05-01 — Express list/count cache invalidation aligned with producer key shape (#750)
+
+Patch release closing issue #750. `db.express.list(...)` returned STALE rows after `db.express.update / .delete / .create` because the `ListNodeCacheIntegration` invalidation patterns never matched the actual cache keys. Disk state was always correct; the bug was a silent no-op invalidation in the read-path cache layer.
+
+### Fixed
+
+- **#750 — `ListNodeCacheIntegration._setup_invalidation_patterns` now uses the producer-side key prefix.** `CacheKeyGenerator.generate_key` produces keys of shape `{prefix}:{model}:{version}:{hash}` where `prefix` defaults to `"dataflow:query"` (per `DataFlowConfig.cache_key_prefix`). Previous patterns `"{model}:list:*"` / `"{model}:record:{id}"` / `"{model}:count:*"` substring-matched against expanded patterns like `"Tag:list:"` — which never appears in any real key — so every create/update/delete/bulk\__ invalidation was a silent no-op. Patterns now use a version-wildcard sweep `f"{prefix}:{{model}}:_"`so every cache entry for the model is swept regardless of operation kind, and the format survives future keyspace bumps unchanged (per`rules/tenant-isolation.md`Rule 3a). Affects all DataFlow consumers with`enable_query_cache=True`(the default) — every`list()`/`count()` / filtered-list call after a mutation served stale data.
+- **`asyncio.iscoroutinefunction` deprecated since Python 3.14, scheduled for removal in 3.16.** Replaced with `inspect.iscoroutinefunction` in `packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py` and `packages/kailash-dataflow/src/dataflow/cache/invalidation.py` (3 call sites total) per `rules/zero-tolerance.md` Rule 1. The `asyncio.iscoroutine` form remains valid and is unchanged.
+
+### Tests
+
+- `tests/regression/test_issue_750_express_list_cache_invalidation.py` — Tier-2 SQLite regression test asserting list reflects update / delete / create across the full express → node → cache_integration path (the path that the broken patterns silently no-op'd). Includes a structural-invariant test that pins the actual key shape against a registered invalidation pattern, so any future refactor that introduces a producer/invalidator key-format drift fails loudly at gate time.
+
+### Cross-SDK
+
+- kailash-rs DataFlow's read-path cache layer (if it exposes a comparable invalidation pattern system) is expected to carry the same gap if its producer key shape and invalidator pattern strings were drafted independently. Cross-SDK verification ticket per `rules/cross-sdk-inspection.md` MUST Rule 1 — disposition pending explicit human approval per `rules/upstream-issue-hygiene.md` MUST Rule 1.
+
 ## [2.7.1] — 2026-05-01 — DPI-A propagation: Express raises `DDLFailedError` instead of returning failure dict (#759)
 
 Patch release closing issue #759. DataFlow Express's `create` / `update` / `delete` / `upsert` / `upsert_advanced` previously returned the underlying CRUD node's `{"success": False, "error": ...}` failure dict to the caller when an auto-migration DDL failure recorded the model as failed. This broke the DPI-A 2.4.0 fail-fast contract — `await db.express.create(...)` returned a "result" with `success=False` instead of raising the typed `DDLFailedError` the user-facing API documented.

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.7.1"
+version = "2.7.2"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -108,7 +108,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/cache/invalidation.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/invalidation.py
@@ -124,9 +124,9 @@ class CacheInvalidator:
 
         is_async = False
         if delete_method is not None:
-            is_async = asyncio.iscoroutinefunction(delete_method)
+            is_async = inspect.iscoroutinefunction(delete_method)
         if not is_async and clear_pattern_method is not None:
-            is_async = asyncio.iscoroutinefunction(clear_pattern_method)
+            is_async = inspect.iscoroutinefunction(clear_pattern_method)
 
         if is_async:
             logger.debug(

--- a/packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py
+++ b/packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py
@@ -5,6 +5,7 @@ Integrates Redis caching with DataFlow ListNode operations
 for automatic query result caching and cache invalidation.
 """
 
+import inspect
 import logging
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -73,9 +74,7 @@ class ListNodeCacheIntegration:
         # FIX: Properly await async cache.can_cache() method
         if not cache_enabled or not await self.cache_manager.can_cache():
             # Execute directly without caching
-            import asyncio
-
-            if asyncio.iscoroutinefunction(executor_func):
+            if inspect.iscoroutinefunction(executor_func):
                 result = await executor_func()
             else:
                 result = executor_func()
@@ -100,9 +99,8 @@ class ListNodeCacheIntegration:
         logger.debug(
             "list_node_integration.cache_miss_for_key", extra={"cache_key": cache_key}
         )
-        import asyncio
 
-        if asyncio.iscoroutinefunction(executor_func):
+        if inspect.iscoroutinefunction(executor_func):
             result = await executor_func()
         else:
             result = executor_func()
@@ -212,40 +210,56 @@ class ListNodeCacheIntegration:
         return result
 
     def _setup_invalidation_patterns(self):
-        """Setup default invalidation patterns for common operations."""
+        """Setup default invalidation patterns for common operations.
+
+        Issue #750 — patterns MUST match the actual cache key format produced
+        by ``self.key_generator.generate_key()``: ``{prefix}:{model}:{version}:{hash}``
+        where ``{prefix}`` defaults to ``"dataflow:query"``. The previous
+        ``{model}:list:*`` shape never matched any real key and silently
+        no-op'd every invalidation, leaving stale list/count entries served
+        forever. Per ``rules/tenant-isolation.md`` Rule 3a, patterns use a
+        version-wildcard sweep (``{prefix}:{model}:*``) so v1, v2, and any
+        future keyspace bump are all swept in one call.
+        """
+        # Anchor patterns at the producer-side prefix so InMemoryCache /
+        # AsyncRedisCacheAdapter substring-matchers find the real keys.
+        prefix = self.key_generator.prefix
+
         # Create patterns for common CRUD operations
         create_pattern = InvalidationPattern(
             model="*",  # Apply to all models
             operation="create",
-            invalidates=["{model}:list:*", "{model}:count:*"],
+            invalidates=[f"{prefix}:{{model}}:*"],
         )
 
         update_pattern = InvalidationPattern(
             model="*",
             operation="update",
-            invalidates=["{model}:record:{id}", "{model}:list:*"],
+            invalidates=[f"{prefix}:{{model}}:*"],
         )
 
         delete_pattern = InvalidationPattern(
             model="*",
             operation="delete",
-            invalidates=["{model}:record:{id}", "{model}:list:*", "{model}:count:*"],
+            invalidates=[f"{prefix}:{{model}}:*"],
         )
 
         bulk_create_pattern = InvalidationPattern(
             model="*",
             operation="bulk_create",
-            invalidates=["{model}:list:*", "{model}:count:*"],
+            invalidates=[f"{prefix}:{{model}}:*"],
         )
 
         bulk_update_pattern = InvalidationPattern(
-            model="*", operation="bulk_update", invalidates=["{model}:list:*"]
+            model="*",
+            operation="bulk_update",
+            invalidates=[f"{prefix}:{{model}}:*"],
         )
 
         bulk_delete_pattern = InvalidationPattern(
             model="*",
             operation="bulk_delete",
-            invalidates=["{model}:list:*", "{model}:count:*"],
+            invalidates=[f"{prefix}:{{model}}:*"],
         )
 
         # Register patterns

--- a/tests/regression/test_issue_750_express_list_cache_invalidation.py
+++ b/tests/regression/test_issue_750_express_list_cache_invalidation.py
@@ -1,0 +1,200 @@
+"""Issue #750 regression — db.express.list MUST reflect mutations on SQLite.
+
+Issue: db.express.list("Tag") returned STALE data after db.express.update / .delete on
+SQLite (and PostgreSQL with `enable_query_cache=True`). The disk WAS updated; the bug
+was in the cache invalidation pattern strings used by `ListNodeCacheIntegration`.
+
+Root cause:
+  ListNodeCacheIntegration._setup_invalidation_patterns registered InvalidationPattern
+  objects with `invalidates=["{model}:list:*", "{model}:count:*"]`. These pattern
+  strings were intended to match cache keys produced by `CacheKeyGenerator.generate_key`
+  but the actual key shape is `{prefix}:{model}:{version}:{hash}` where `prefix`
+  defaults to `"dataflow:query"` (from `DataFlowConfig.cache_key_prefix`). So the
+  expanded pattern `Tag:list:*` never matched the actual key
+  `dataflow:query:Tag:v2:<hash>`. Cache invalidation was a no-op; subsequent list
+  queries served stale results from the cache_integration cache.
+
+Fix: align invalidation patterns with the producer-side key format using version-
+wildcard sweep `{prefix}:{{model}}:*` per `tenant-isolation.md` Rule 3a — so legacy
+v1 keys, current v2 keys, and any future keyspace bump are all swept in one call.
+
+Disk state was always correct. The user-observable bug was list staleness:
+  1. create row → disk has row
+  2. update value → disk has new value, list cache has old row
+  3. list → returns STALE (cache hit on stale entry never invalidated)
+
+This test asserts the user-visible contract: after every mutation, list reflects
+the new state. Runs against SQLite (deterministic, sub-second feedback) and exercises
+the full express → node → cache_integration path that the fix repairs.
+
+See:
+- packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py::_setup_invalidation_patterns
+- packages/kailash-dataflow/src/dataflow/cache/key_generator.py::generate_key
+- packages/kailash-dataflow/src/dataflow/cache/memory_cache.py::InMemoryCache.clear_pattern
+- rules/tenant-isolation.md MUST Rule 3a (Keyspace Version Bumps Require Invalidation-Path Sweep)
+- rules/zero-tolerance.md Rule 2 (no fake/no-op invalidation)
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from dataflow import DataFlow
+
+pytestmark = [pytest.mark.regression, pytest.mark.asyncio]
+
+
+@pytest.fixture
+def sqlite_url():
+    """File-backed SQLite URL — exercises the same cache-integration path as Postgres."""
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="issue_750_")
+    os.close(fd)
+    yield f"sqlite:///{path}"
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+async def test_list_after_update_reflects_change(sqlite_url):
+    """list() MUST return the updated row after express.update — not a cached stale entry."""
+    db = DataFlow(sqlite_url, auto_migrate=True)
+
+    @db.model
+    class Tag:
+        name: str
+        value: str = ""
+
+    try:
+        await db.express.create("Tag", {"name": "x", "value": "old"})
+        rows = await db.express.list("Tag")
+        assert len(rows) == 1
+        rid = rows[0]["id"]
+
+        # First list populates the cache_integration cache for this query.
+        # Subsequent update MUST invalidate the cached entry.
+        upd = await db.express.update("Tag", rid, {"value": "new"})
+        assert upd["value"] == "new"
+
+        # Default cache TTL applies — invalidation is the only correct
+        # mechanism here. cache_ttl=0 would bypass the bug; this assertion
+        # exercises the actual invalidation path.
+        rows_after = await db.express.list("Tag")
+        assert rows_after[0]["value"] == "new", (
+            f"list() returned stale value after update — cache invalidation failed. "
+            f"Got: {rows_after[0]}"
+        )
+    finally:
+        await db.close_async()
+
+
+async def test_list_after_delete_reflects_removal(sqlite_url):
+    """list() MUST omit the deleted row after express.delete — not return a cached stale entry."""
+    db = DataFlow(sqlite_url, auto_migrate=True)
+
+    @db.model
+    class Tag:
+        name: str
+        value: str = ""
+
+    try:
+        await db.express.create("Tag", {"name": "x", "value": "v1"})
+        await db.express.create("Tag", {"name": "y", "value": "v2"})
+        rows = await db.express.list("Tag")
+        assert len(rows) == 2
+        deleted_id = rows[0]["id"]
+
+        deleted = await db.express.delete("Tag", deleted_id)
+        assert deleted is True
+
+        rows_after = await db.express.list("Tag")
+        assert len(rows_after) == 1, (
+            f"list() returned {len(rows_after)} rows after deleting one of two — "
+            f"cache invalidation failed. Got: {rows_after}"
+        )
+        assert rows_after[0]["id"] != deleted_id
+    finally:
+        await db.close_async()
+
+
+async def test_list_after_create_reflects_new_row(sqlite_url):
+    """list() MUST include the new row after express.create — not return a cached pre-create entry."""
+    db = DataFlow(sqlite_url, auto_migrate=True)
+
+    @db.model
+    class Tag:
+        name: str
+        value: str = ""
+
+    try:
+        await db.express.create("Tag", {"name": "first", "value": "v1"})
+        rows = await db.express.list("Tag")
+        assert len(rows) == 1
+
+        await db.express.create("Tag", {"name": "second", "value": "v2"})
+
+        rows_after = await db.express.list("Tag")
+        assert len(rows_after) == 2, (
+            f"list() returned {len(rows_after)} rows after creating second — "
+            f"cache invalidation failed. Got: {rows_after}"
+        )
+        names = {r["name"] for r in rows_after}
+        assert names == {"first", "second"}
+    finally:
+        await db.close_async()
+
+
+async def test_invalidation_patterns_match_actual_key_shape():
+    """Structural invariant: ListNodeCacheIntegration patterns MUST cover the actual key shape.
+
+    This is the structural defense against a future refactor that re-introduces
+    a producer/invalidator key-format drift (rules/tenant-isolation.md Rule 3a).
+
+    Asserts:
+      1. The default key prefix the cache integration uses
+      2. The invalidator's registered patterns include a version-wildcard sweep
+         covering the actual prefix (so v1, v2, and any future bump are swept)
+    """
+    from dataflow.cache import (
+        CacheBackend,
+        CacheInvalidator,
+        CacheKeyGenerator,
+        create_cache_integration,
+    )
+
+    cm = CacheBackend.auto_detect(
+        redis_url="redis://localhost:6379/0", ttl=300, max_size=100
+    )
+    kg = CacheKeyGenerator(prefix="dataflow:query")
+    inv = CacheInvalidator(cm)
+    ci = create_cache_integration(cm, kg, inv)
+
+    sample_key = kg.generate_key("Tag", "SELECT * FROM tags", [])
+    assert sample_key.startswith(
+        "dataflow:query:Tag:"
+    ), f"Cache key shape changed. Patterns must be re-aligned. Got: {sample_key}"
+
+    update_patterns = [p for p in ci.invalidator.patterns if p.operation == "update"]
+    assert update_patterns, "no update invalidation pattern registered"
+
+    matching = []
+    for p in update_patterns:
+        for inv_pattern in p.invalidates:
+            expanded = inv_pattern.replace("{model}", "Tag")
+            if "*" in expanded:
+                segment = expanded.replace("*", "")
+                if segment in sample_key:
+                    matching.append(expanded)
+            elif expanded == sample_key:
+                matching.append(expanded)
+
+    assert matching, (
+        f"No registered update-invalidation pattern matches the actual cache key. "
+        f"Patterns: {[p.invalidates for p in update_patterns]}; "
+        f"key sample: {sample_key!r}. "
+        f"Per rules/tenant-isolation.md Rule 3a, patterns MUST cover the producer-side "
+        f"key format with a version-wildcard sweep."
+    )


### PR DESCRIPTION
## Summary

- Fixes #750. `db.express.list()` returned STALE rows after `db.express.update / .delete / .create` because `ListNodeCacheIntegration._setup_invalidation_patterns` registered `InvalidationPattern` strings (`{model}:list:*` / `{model}:record:{id}` / `{model}:count:*`) that **never matched any real cache key**. Disk state was always correct — the bug was a silent no-op invalidation in the read-path cache layer.
- `CacheKeyGenerator.generate_key` produces keys shaped `{prefix}:{model}:{version}:{hash}` where `prefix` defaults to `"dataflow:query"` (per `DataFlowConfig.cache_key_prefix`). Patterns now anchor at `self.key_generator.prefix` and use a version-wildcard sweep `f"{prefix}:{{model}}:*"` per `rules/tenant-isolation.md` Rule 3a — every model entry is swept regardless of operation kind, and the format survives future keyspace bumps unchanged.
- Same-class `DeprecationWarning` cleanup: replaced 3 deprecated `asyncio.iscoroutinefunction` calls with `inspect.iscoroutinefunction` (Python 3.16 removal) per `rules/zero-tolerance.md` Rule 1.

## Root cause

```python
# packages/kailash-dataflow/src/dataflow/cache/list_node_integration.py (BEFORE)
update_pattern = InvalidationPattern(
    model="*", operation="update",
    invalidates=["{model}:record:{id}", "{model}:list:*"],  # never matched
)

# Actual key emitted by key_generator:
# 'dataflow:query:Tag:v2:279430c5949b46ab'
# Substring search for 'Tag:list:' finds nothing → invalidate is a no-op.
```

After the fix, `update_pattern.invalidates = [f"{prefix}:{{model}}:*"]` → `clear_pattern("dataflow:query:Tag:*")` → matches every cache slot for the model.

Affects every DataFlow consumer with `enable_query_cache=True` (the default).

## Test plan

- [x] Tier-2 SQLite regression test in `tests/regression/test_issue_750_express_list_cache_invalidation.py` covers list-after-update / list-after-delete / list-after-create — fails on unfixed main with `'old' != 'new'`, passes on this branch.
- [x] Structural-invariant test pins the actual key shape against a registered pattern, so any future producer/invalidator drift fails loudly at gate time (per `rules/refactor-invariants.md`).
- [x] Full `packages/kailash-dataflow/tests/integration/cache/` + `tests/unit/cache/` suites: 121 passed, 27 skipped (Redis-only).
- [x] `tests/regression/test_issue_759_express_propagates_ddl_failure.py`: 5 passed (no regression to last release's #759 fix).
- [x] Pre-existing E2E failures in `tests/e2e/test_cache_e2e.py` (column "age" of relation "users" does not exist) confirmed pre-existing on `main` — unrelated to this fix.

## Cross-SDK

Per `rules/cross-sdk-inspection.md` MUST Rule 1, the Rust SDK's read-path cache layer (if it exposes a comparable invalidation pattern system) likely carries the same gap if its producer key shape and invalidator pattern strings were drafted independently. Cross-SDK verification ticket pending explicit human approval per `rules/upstream-issue-hygiene.md` MUST Rule 1.

## Related issues

Fixes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)