### PR TITLE
fix(dataflow): @db.model accepts parameterized generics on Python 3.11+ (#768, 2.7.3)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,26 @@
 # DataFlow Changelog
 
+## [2.7.3] — 2026-05-01 — `@db.model` accepts parameterized generics on Python 3.11+ (#768)
+
+Patch release closing issue #768. `FieldTypeProcessor._resolve_type` returned parameterized builtin generics (`list[str]`, `dict[str, Any]`, `typing.List[str]`, PEP 604 `list[str] | None`) verbatim. The next `isinstance(value, expected_type)` call raised `TypeError: isinstance() argument 2 cannot be a parameterized generic` on Python 3.11+, crashing every CRUD operation against models that used the standard, idiomatic form of list / dict / tuple annotations.
+
+### Fixed
+
+- **#768 — `_resolve_type` strips parameterized generics down to their origin.** `list[str]` / `typing.List[str]` resolves to `list`; `dict[str, Any]` resolves to `dict`; `tuple[int, ...]` resolves to `tuple`. The Optional / Union path now recurses on the inner non-None type so `Optional[list[str]]` resolves through `list[str]` to `list`.
+- **#768 — PEP 604 union form (`list[str] | None`) handled.** `get_origin` returns `types.UnionType` for PEP 604 syntax (vs `typing.Union` for the legacy form). The resolver now matches both and recurses identically through the parameterized inner type.
+
+### Tests
+
+- `tests/regression/test_issue_768_parameterized_generics.py` — 15 tests covering: structural invariants on `_resolve_type` for every generic shape called out in the issue acceptance (`list[str]`, `dict[str, Any]`, `tuple[int, ...]`, `typing.List[str]`, `typing.Dict[str, Any]`, `typing.Optional[list[str]]`, PEP 604 `list[str] | None`, `dict[str, Any] | None`, plain types unchanged); end-to-end CRUD against SQLite for `@db.model` with `list[str]`, `dict[str, Any]`, `typing.List[str]`, and PEP 604 `list[str] | None` field annotations. Pre-fix behavior: `TypeError("isinstance() argument 2 cannot be a parameterized generic")` on every CRUD operation. Post-fix: 15/15 pass.
+
+### Cross-SDK
+
+- kailash-rs uses `syn`-time parsing for model derivation and is structurally immune to this Python-runtime `isinstance` failure mode (Rust types are erased at compile time; runtime isinstance equivalent does not exist). Cross-SDK loop closure pending explicit human approval per `rules/upstream-issue-hygiene.md` MUST Rule 1.
+
+### Follow-up
+
+- `_resolve_type` and `dataflow.core.nodes._normalize_type_annotation` remain as parallel implementations of essentially the same logic. Consolidation into a single shared helper is recommended (issue acceptance criterion 6). Deferred to follow-up issue — exceeds the one-shard budget for this fix and would expand blast radius beyond the surface the bug class touched.
+
 ## [2.7.2] — 2026-05-01 — Express list/count cache invalidation aligned with producer key shape (#750)
 
 Patch release closing issue #750. `db.express.list(...)` returned STALE rows after `db.express.update / .delete / .create` because the `ListNodeCacheIntegration` invalidation patterns never matched the actual cache keys. Disk state was always correct; the bug was a silent no-op invalidation in the read-path cache layer.

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.7.2"
+version = "2.7.3"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -108,7 +108,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.7.2"
+__version__ = "2.7.3"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/type_processor.py
+++ b/packages/kailash-dataflow/src/dataflow/core/type_processor.py
@@ -7,6 +7,7 @@ Related: TODO-153 - Type-Aware Model Processing
 """
 
 import logging
+import types
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Any, Dict, Optional, Union, get_args, get_origin
@@ -48,9 +49,18 @@ class TypeAwareFieldProcessor:
             )
 
     def _resolve_type(self, field_type: Any) -> Any:
-        """Resolve a field type, unwrapping Optional and Union types.
+        """Resolve a field type, unwrapping Optional/Union and parameterized generics.
 
-        Returns the base type, unwrapping Optional[T] to T.
+        Returns a type usable as the second argument to ``isinstance``:
+        - ``Optional[T]`` / ``T | None`` -> resolved ``T``
+        - parameterized generic (``list[str]``, ``dict[str, Any]``) -> origin
+          (``list``, ``dict``)
+        - parameterized + Optional (``Optional[list[str]]``,
+          ``list[str] | None``) -> origin of inner non-None type
+
+        Python 3.11+ raises ``TypeError`` when a parameterized generic is
+        passed to ``isinstance``; stripping to the origin keeps the runtime
+        validation path working without changing the model annotation.
 
         Args:
             field_type: The type annotation to resolve
@@ -62,13 +72,26 @@ class TypeAwareFieldProcessor:
             return None
 
         origin = get_origin(field_type)
-        if origin is Union:
+
+        # ``Optional[T]`` / ``Union[T, None]`` (legacy typing form) and PEP 604
+        # ``T | None`` (the ``X | Y`` syntax) both reach this branch. The
+        # legacy form returns ``Union`` from ``get_origin``; PEP 604 returns
+        # ``types.UnionType``. Match either.
+        if origin is Union or origin is types.UnionType:
             args = get_args(field_type)
             non_none_types = [t for t in args if t is not type(None)]
             if len(non_none_types) == 1:
-                return non_none_types[0]
+                # Recurse so Optional[list[str]] resolves through list[str] to list.
+                return self._resolve_type(non_none_types[0])
             # Multi-type union, return as-is
             return field_type
+
+        if origin is not None:
+            # Parameterized builtin generic — strip parameters so isinstance() can
+            # use it. list[str] -> list, dict[str, Any] -> dict, tuple[int, ...] -> tuple.
+            # Python 3.11+ raises TypeError if the parameterized form reaches isinstance.
+            return origin
+
         return field_type
 
     def validate_field(self, field_name: str, value: Any, strict: bool = False) -> Any:

--- a/tests/regression/test_issue_768_parameterized_generics.py
+++ b/tests/regression/test_issue_768_parameterized_generics.py
@@ -1,0 +1,228 @@
+"""Regression test: @db.model MUST handle parameterized generics on Python 3.11+.
+
+Issue #768 — DataFlow's ``FieldTypeProcessor._resolve_type`` returned
+parameterized builtin generics (``list[str]``, ``dict[str, Any]``,
+``typing.List[str]``, PEP 604 ``list[str] | None``) verbatim. The next
+``isinstance(value, expected_type)`` call raised
+``TypeError: isinstance() argument 2 cannot be a parameterized generic``
+on Python 3.11+, crashing every CRUD operation against the model.
+
+The fix in ``packages/kailash-dataflow/src/dataflow/core/type_processor.py``
+strips parameterized generics down to their origin (``list[str] -> list``,
+``dict[str, Any] -> dict``) and recurses through ``Optional`` / PEP 604
+unions so ``Optional[list[str]]`` resolves to ``list``.
+
+This test exercises:
+
+1. The structural invariant — ``_resolve_type`` strips parameterized
+   generics for every shape called out in the issue acceptance.
+2. The end-to-end CRUD path against SQLite — create/list/update on a
+   ``@db.model`` with ``list[str]`` and ``dict[str, Any]`` fields no
+   longer crashes.
+
+See:
+- packages/kailash-dataflow/src/dataflow/core/type_processor.py
+- packages/kailash-dataflow/src/dataflow/core/nodes.py::_normalize_type_annotation
+  (parallel implementation; consolidation tracked separately).
+- rules/zero-tolerance.md Rule 4 (no workarounds for SDK bugs)
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import typing
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.core.type_processor import TypeAwareFieldProcessor
+
+pytestmark = [pytest.mark.regression]
+
+
+@pytest.fixture
+def sqlite_url():
+    """Per-test SQLite URL on disk."""
+    fd, path = tempfile.mkstemp(suffix=".db", prefix="dpi_768_")
+    os.close(fd)
+    yield f"sqlite:///{path}"
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+# -- Structural invariants --------------------------------------------------
+
+
+def _processor_for(field_type) -> TypeAwareFieldProcessor:
+    return TypeAwareFieldProcessor(
+        {"f": {"type": field_type, "required": False}}, model_name="Issue768"
+    )
+
+
+def test_resolve_type_strips_pep585_list():
+    proc = _processor_for(list[str])
+    assert proc._resolved_types["f"] is list
+
+
+def test_resolve_type_strips_pep585_dict():
+    proc = _processor_for(dict[str, typing.Any])
+    assert proc._resolved_types["f"] is dict
+
+
+def test_resolve_type_strips_pep585_tuple():
+    proc = _processor_for(tuple[int, ...])
+    assert proc._resolved_types["f"] is tuple
+
+
+def test_resolve_type_strips_typing_list():
+    proc = _processor_for(typing.List[str])
+    assert proc._resolved_types["f"] is list
+
+
+def test_resolve_type_strips_typing_dict():
+    proc = _processor_for(typing.Dict[str, typing.Any])
+    assert proc._resolved_types["f"] is dict
+
+
+def test_resolve_type_optional_parameterized_typing_union():
+    proc = _processor_for(typing.Optional[list[str]])
+    assert proc._resolved_types["f"] is list
+
+
+def test_resolve_type_optional_parameterized_pep604():
+    """PEP 604 ``list[str] | None`` — get_origin returns types.UnionType, not Union."""
+    proc = _processor_for(list[str] | None)
+    assert proc._resolved_types["f"] is list
+
+
+def test_resolve_type_pep604_dict_optional():
+    proc = _processor_for(dict[str, typing.Any] | None)
+    assert proc._resolved_types["f"] is dict
+
+
+def test_resolve_type_plain_types_unchanged():
+    """Regression guard: non-generic types still resolve to themselves."""
+    assert _processor_for(str)._resolved_types["f"] is str
+    assert _processor_for(int)._resolved_types["f"] is int
+    assert _processor_for(typing.Optional[int])._resolved_types["f"] is int
+
+
+def test_validate_field_isinstance_works_after_strip():
+    """The bug surface: isinstance(value, resolved_type) MUST not raise."""
+    proc = _processor_for(list[str])
+    out = proc.validate_field("f", ["a", "b"])
+    assert out == ["a", "b"]
+
+
+def test_validate_field_isinstance_works_for_pep604_union():
+    proc = _processor_for(list[str] | None)
+    assert proc.validate_field("f", ["a", "b"]) == ["a", "b"]
+    assert proc.validate_field("f", None) is None
+
+
+# -- End-to-end CRUD against SQLite ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_model_with_pep585_list_str(sqlite_url):
+    """@db.model with tags: list[str] = [] — CRUD MUST not crash."""
+    db = DataFlow(sqlite_url)
+    try:
+
+        @db.model
+        class Issue768Doc1:
+            id: int
+            title: str
+            tags: list[str] = []
+
+        # Pre-fix: this raised TypeError("isinstance() argument 2 cannot be a
+        # parameterized generic"). The CRUD round-trip succeeding (with whatever
+        # SQLite-side serialization the storage layer applies) is the
+        # observable proof of the fix.
+        created = await db.express.create(
+            "Issue768Doc1", {"id": 1, "title": "doc one", "tags": ["a", "b"]}
+        )
+        assert created["id"] == 1
+        rows = await db.express.list("Issue768Doc1")
+        assert len(rows) == 1
+        await db.express.update("Issue768Doc1", 1, {"tags": ["c"]})
+    finally:
+        await db.close_async()
+
+
+@pytest.mark.asyncio
+async def test_db_model_with_pep585_dict_str_any(sqlite_url):
+    """@db.model with metadata: dict[str, Any] = {} — CRUD MUST not crash."""
+    db = DataFlow(sqlite_url)
+    try:
+
+        @db.model
+        class Issue768Doc2:
+            id: int
+            title: str
+            meta: dict[str, typing.Any] = {}
+
+        # Pre-fix: TypeError on isinstance(value, dict[str, Any]).
+        created = await db.express.create(
+            "Issue768Doc2",
+            {"id": 1, "title": "doc two", "meta": {"k": "v", "n": 1}},
+        )
+        assert created["id"] == 1
+        rows = await db.express.list("Issue768Doc2")
+        assert len(rows) == 1
+    finally:
+        await db.close_async()
+
+
+@pytest.mark.asyncio
+async def test_db_model_with_typing_list_legacy_form(sqlite_url):
+    """@db.model with tags: typing.List[str] = [] (legacy form) — CRUD MUST not crash."""
+    db = DataFlow(sqlite_url)
+    try:
+
+        @db.model
+        class Issue768Doc3:
+            id: int
+            title: str
+            tags: typing.List[str] = []
+
+        # Pre-fix: TypeError on isinstance(value, typing.List[str]).
+        created = await db.express.create(
+            "Issue768Doc3", {"id": 1, "title": "doc three", "tags": ["x"]}
+        )
+        assert created["id"] == 1
+        rows = await db.express.list("Issue768Doc3")
+        assert len(rows) == 1
+    finally:
+        await db.close_async()
+
+
+@pytest.mark.asyncio
+async def test_db_model_with_pep604_optional_parameterized(sqlite_url):
+    """@db.model with tags: list[str] | None = None (PEP 604) — CRUD MUST not crash."""
+    db = DataFlow(sqlite_url)
+    try:
+
+        @db.model
+        class Issue768Doc4:
+            id: int
+            title: str
+            tags: list[str] | None = None
+
+        # Pre-fix: TypeError on isinstance(value, list[str] | None) — the union
+        # form passes through get_origin as types.UnionType (PEP 604), which
+        # the resolver MUST recurse-then-strip to land at ``list``.
+        # Both None and concrete list MUST validate against the same field.
+        await db.express.create(
+            "Issue768Doc4", {"id": 1, "title": "doc four-a", "tags": None}
+        )
+        await db.express.create(
+            "Issue768Doc4", {"id": 2, "title": "doc four-b", "tags": ["t"]}
+        )
+        rows = sorted(await db.express.list("Issue768Doc4"), key=lambda r: r["id"])
+        assert len(rows) == 2
+    finally:
+        await db.close_async()


### PR DESCRIPTION
## Summary

- Fixes #768. `@db.model` crashed every CRUD operation against models that used the idiomatic form of list / dict / tuple annotations (PEP 585 `list[str]`, `dict[str, Any]`, legacy `typing.List[str]`, PEP 604 `list[str] | None`) on Python 3.11+. `FieldTypeProcessor._resolve_type` returned the parameterized form as-is and the next `isinstance(value, expected_type)` raised `TypeError: isinstance() argument 2 cannot be a parameterized generic`.
- ~5 LoC fix as suggested in the issue body. Strips parameterized generics down to their origin (`list[str]` -> `list`); recurses through Optional / Union so `Optional[list[str]]` resolves through `list[str]` to `list`; matches PEP 604 `types.UnionType` alongside legacy `typing.Union`.

## Root cause

```python
# packages/kailash-dataflow/src/dataflow/core/type_processor.py (BEFORE)
def _resolve_type(self, field_type):
    if field_type is None:
        return None
    origin = get_origin(field_type)
    if origin is Union:                       # PEP 604 returns types.UnionType, NOT Union — missed
        args = get_args(field_type)
        non_none_types = [t for t in args if t is not type(None)]
        if len(non_none_types) == 1:
            return non_none_types[0]          # Optional[list[str]] returns list[str], NOT list
        return field_type
    return field_type                          # list[str] / typing.List[str] returned verbatim

# Next call:
isinstance(value, expected_type)
# TypeError: isinstance() argument 2 cannot be a parameterized generic
```

After the fix, `_resolve_type` (1) handles both `Union` and `types.UnionType`, (2) recurses on the inner non-None type so `Optional[list[str]]` resolves correctly, and (3) strips any parameterized generic down to its origin so `isinstance` accepts it.

Affects every Python 3.11+ user of `@db.model`. Worked around in HMI/HANA by dropping the parameter (`tags: list = []` instead of `tags: list[str] = []`); fixed at the SDK layer here.

## Test plan

- [x] Tier 2 regression test in `tests/regression/test_issue_768_parameterized_generics.py` — 15 tests covering structural invariants on `_resolve_type` for every shape called out in the issue acceptance (`list[str]`, `dict[str, Any]`, `tuple[int, ...]`, `typing.List[str]`, `typing.Dict[str, Any]`, `typing.Optional[list[str]]`, PEP 604 `list[str] | None`, `dict[str, Any] | None`, plain types unchanged) plus end-to-end CRUD against SQLite for `@db.model` with each generic shape.
- [x] Pre-fix verification: stashed the fix, ran the structural tests against unfixed `_resolve_type` — `assert list[str] is list` failed (expected). Re-applied fix → all 15 pass.
- [x] No regression: `tests/regression/test_issue_759_express_propagates_ddl_failure.py` — 5 passed (last release's #759 fix unaffected).
- [x] Pre-commit: black / isort / ruff / type-annotations / debug-statements / TOML / Tier 1 unit suite — all pass.

## Cross-SDK

kailash-rs uses `syn`-time parsing for model derivation. Rust types are erased at compile time and the runtime equivalent of `isinstance(value, parameterized_generic)` does not exist there — the Rust SDK is structurally immune to this Python-runtime failure mode. Cross-SDK loop closure pending explicit human approval per `rules/upstream-issue-hygiene.md` MUST Rule 1.

## Follow-up

Issue acceptance criterion 6 (`_resolve_type` and `_normalize_type_annotation` consolidated into a single shared helper) deferred to a follow-up issue. Both implementations remain in place; only the broken side is patched here. Consolidation exceeds the one-shard budget for this fix and would expand blast radius beyond the crash class — `_normalize_type_annotation` already correctly handles parameterized generics, so consolidating is a refactor, not a fix. Filing a follow-up after merge.

## Version stacking

This PR bumps kailash-dataflow `2.7.1 -> 2.7.3` because PR #769 (issue #750, list-cache invalidation) is in flight ahead of this one bumping `2.7.1 -> 2.7.2`. If #769 merges first, this branch rebases cleanly onto `main` at 2.7.2; the CHANGELOG entry for 2.7.3 sits above the 2.7.2 entry. If this PR merges first, #769 rebases to 2.7.3 -> 2.7.4 (its choice).

## Related issues

Fixes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)