### PR TITLE
fix(dataflow): declare psycopg2-binary baseline dependency (#753)

### DIFF
--- a/SWEEP-2026-05-01.md
+++ b/SWEEP-2026-05-01.md
@@ -1,0 +1,142 @@
+# Sweep — 2026-05-01
+
+Repo: `terrene-foundation/kailash-py` @ `e65fa75d` (main, 0/0 ahead/behind origin).
+Scope: 7 sweeps per `commands/sweep.md`; project-scoped (kailash-py only — sibling SDK comparison out of scope).
+
+## Findings
+
+### [LOW][Sweep 1] No active todos in any workspace
+
+Location: `workspaces/*/todos/active/` enumerated; only `portfolio-spec-audit` has 1 active item (3d age).
+Disposition: **OK** — no work-in-progress backlog at the todo layer.
+Why: Confirms the prior session's "paired-patch cycle shipped end-to-end" closure.
+
+### [LOW][Sweep 2] 4 stale `.pending` journal entries in `_archive/`
+
+Location: `workspaces/_archive/journal/.pending/` (now removed).
+Disposition: **FIXED** — discarded inline. Two were duplicate DISCOVERY entries for commit `7bd74273` (close_async pool-bridge fix) whose discovered gap is already filed as #759. Two were duplicate RISK entries for commit `279f37cf` (release/v\* PR-gate skip clause) whose work is already merged. Per `rules/journal.md` § Entry Types disposition matrix: already-codified → discard.
+Evidence: All four had identical commit body content already captured in `git log` and on issue threads.
+
+### [HIGH][Sweep 3] `#753` (psycopg2 missing dep declaration) — 1d old, unfixed
+
+Location: `terrene-foundation/kailash-py#753`.
+Disposition: **FILE-ISSUE (already filed) — RECOMMEND NEXT-SESSION**.
+Evidence: `kailash-dataflow ≥2.4.0` imports `psycopg2` via `SQLDatabaseNode._get_shared_engine` → SQLAlchemy DDL path; declares `asyncpg` only. Every fresh install pointed at a Postgres `DATABASE_URL` fails at first auto-migrate. Reporter: 2026-04-30.
+Why: Same failure-mode class as the `kailash-kaizen 2.13.1` clean-venv hotfix codified in `rules/dependencies.md` § "`__init__.py` Module-Scope Imports Honor The Manifest". User-facing breakage on `pip install` is the highest-severity defect class for a published SDK.
+
+### [MED][Sweep 3] `#761` / `#762` / `#763` / `#764` — Kaizen LlmDeployment escape hatches
+
+Location: `kailash-py` issues filed today (2026-05-01).
+Disposition: **DEFER (planned feature work)** — cross-sdk + enhancement labels; no shard scoping yet.
+Why: Cohesive feature set (openai_compatible, anthropic_compatible, supports() matrix, register_bedrock_region runtime override). Scope is one `/analyze` cycle, not in-flight.
+
+### [MED][Sweep 3] `#760` — scheduled follow-up 2026-05-08
+
+Location: `kailash-py#760`.
+Disposition: **DEFER until 2026-05-08** — reminder to verify `kailash-rs#723` fingerprint pin + `#759` DPI-A repro.
+Why: Calendar-bound by design; no action until target date (T+7).
+
+### [MED][Sweep 3] `#693` — spec promotion gated on M2 release
+
+Location: `kailash-py#693`.
+Disposition: **DEFER (release-gated)** — spec `dataflow-ml-integration.md` stays draft until ML M2 ships.
+Why: Spec authority; no action until M2 cuts.
+
+### [MED][Sweep 3] `#643` — FeatureStore canonical surface migration (deprecation cycle)
+
+Location: `kailash-py#643`.
+Disposition: **DEFER (multi-session)** — breaking-change deprecation cycle; needs `/analyze` to scope wave plan.
+Why: `rules/zero-tolerance.md` Rule 6a deprecation-cycle protocol applies; cannot be a one-shot patch.
+
+### [LOW][Sweep 3] `#630` — Trust Vault SLIP-0039 Shamir wrapper (mint ISS-37)
+
+Location: `kailash-py#630`.
+Disposition: **BLOCKED on mint spec ISS-06** — explicitly stated in #596's triage comment which applies here too.
+Why: Spec-ratification gate; calendar-bound, not session-bound.
+
+### [LOW][Sweep 3] `#596` — TieredAuditDispatcher (blocked on mint ISS-06)
+
+Location: `kailash-py#596`.
+Disposition: **BLOCKED on spec ratification** — owner-acknowledged in 2026-04-25 comment.
+Why: Same gate as #630.
+
+### [OK][Sweep 4] Zero open PRs, zero unmerged remote branches
+
+Location: `gh pr list` and `git branch -r --no-merged origin/main` both empty.
+Disposition: **OK** — clean PR/branch state. No stale drafts, no orphan feature branches.
+
+### [LOW][Sweep 5] Spec-vs-code redteam re-derivation: skipped (no `specs/` in any workspace)
+
+Location: All 32 workspaces enumerated; none contain a `specs/` directory.
+Disposition: **N/A for this repo** — kailash-py uses workspace `briefs/` + journal model, not `specs/_index.md`. The repo-root `specs/` directory exists for SDK-level domain truth (`specs/dataflow-ml-integration.md` etc.) and is governed by `/analyze` per `rules/specs-authority.md`. Workspace-level redteam re-derivation does not apply here.
+Why: `rules/specs-authority.md` Rule 1 mandates `specs/_index.md` per project — this repo's specs live at root, not per-workspace.
+
+### [MED][Sweep 6] 15 stale workspace `.session-notes` (10–30 days old, no active work)
+
+Location: workspace ages by session-notes mtime:
+
+- 30d: `kailash`
+- 26d: `kaizen-explicit-config`
+- 24d: `kailash-ml`
+- 19d (×6): `arbor-upstream-fixes`, `bug-sweep-april`, `dataflow-perfection`, `issues-294-303`, `issues-313-318`, `pact-309-308`
+- 18d: `platform-architecture-convergence`
+- 13d: `issues-492-497`
+- 10d (×2): `issue-567-mlfp-diagnostics`, `kailash-ml-gpu-stack`
+- 5d: `kailash-ml-audit`
+- 3d: `portfolio-spec-audit` (1 active todo)
+
+Disposition: **DEFER (archive candidates)** — no active todos in any except `portfolio-spec-audit`. Archive policy isn't codified for this repo; flagging without action.
+Why: Archiving stale workspaces reduces cognitive load on future sessions reading the session-start banner. Non-blocking.
+
+### [OK][Sweep 6] No orphan worktrees, no `.pending` >14d
+
+Location: `git worktree list` shows only main; `find -path "*/.pending/*" -mtime +14` empty (the 4 `_archive` entries discarded above were ≤2d).
+Disposition: **OK**.
+
+### [MED][Sweep 7] 20+ files in `src/kailash/` contain `TODO`/`NotImplementedError` markers
+
+Location: `grep -rEn 'TODO|FIXME|HACK|XXX|NotImplementedError' src/kailash/`.
+Disposition: **DEFER (sample-checked, mostly legitimate)**.
+Sample audit:
+
+- `nodes/base.py:1920`, `nodes/base_async.py:190`, `nodes/base_with_acl.py:147`/`:258` — abstract `_execute()` method idiom (LEGITIMATE).
+- `nodes/data/bulk_operations.py:269` — `# TODO: Implement COPY FROM for maximum performance` (perf-optimization TODO, not a functional stub — permitted per `rules/zero-tolerance.md` Rule 6 "Iterative TODOs Permitted when actively tracked").
+- `nodes/auth/sso.py:44`, `nodes/auth/mfa.py:1837`, `middleware/auth/auth_manager.py:422` — provider-abstract / unsupported-provider raise sites (need targeted audit).
+
+Why: Full audit of every site exceeds sweep budget (~20 files, mixed legitimate/needs-checking). Recommend a focused `/redteam` round on `src/kailash/nodes/auth/` + `middleware/auth/` to confirm no functional-stub Rule 2 violations.
+
+### [LOW][Sweep 7] Working tree dirty (4 paths, all session-state, none code)
+
+Location: `git status --short`:
+
+- `M .claude/.proposals/latest.yaml` — Gate 1 review at loom in progress
+- `M .claude/skills/project/SKILL.md` — pre-existing modification
+- `M .session-notes` — updated this session (Rust ticket filings + #772)
+- `?? workspaces/_archive/journal/` — empty dir after discard
+
+Disposition: **DEFER** — `latest.yaml` is intentionally dirty (loom `/sync` Gate 1 in progress per session-notes). `.session-notes` is an end-of-session artifact. SKILL.md predates this session.
+Why: Not a process-hygiene gap; the dirty state is expected.
+
+## Cross-cutting observations
+
+1. **Backlog health is good.** No active todos, no open PRs, no orphan branches, working tree clean of code changes. The 11 open issues fall into three buckets: actionable-and-fresh (1 — #753), planned-but-unscoped (4 — kaizen LlmDeployment), gated-by-external-signal (6 — calendar / spec / release).
+
+2. **No structural defects surfaced.** Sweep 5 (specs-vs-code) was N/A; Sweep 7's stub-marker grep was mostly false-positives (abstract-method idiom + iterative TODOs). The `src/kailash/nodes/auth/` stubs are the only thing requiring closer audit.
+
+3. **Process hygiene is healthy.** The 4 `.pending` journal entries were duplicates of already-codified work — automatic SessionEnd-hook output, low-value, correctly discarded.
+
+4. **Stale workspace count is high (15 of 32) but not a defect.** None have active todos; they represent shipped work whose session-notes the SessionStart hook continues to surface. Archive policy would clean this up but is out of scope here.
+
+## Recommended next-session items (ranked)
+
+1. **Fix `#753`** — kailash-dataflow psycopg2 dep declaration (HIGH, user-facing breakage on every fresh Postgres install). One-shard patch: declare `psycopg2-binary` in `packages/kailash-dataflow/pyproject.toml` either as baseline or `[postgres]` extra; add Tier 2 clean-venv install regression test mirroring the kaizen 2.13.1 protocol. Estimated: 1 session.
+
+2. **Targeted audit `src/kailash/nodes/auth/` + `middleware/auth/`** for functional-stub Rule 2 violations (MED). Focused `/redteam` round on the 4 NotImplementedError sites identified in Sweep 7. Estimated: 0.5 session.
+
+3. **Scope kaizen LlmDeployment escape hatches** (`#761`–`#764`, MED). Run `/analyze` to derive a wave plan covering `openai_compatible`, `anthropic_compatible`, `supports()`, `register_bedrock_region`. Estimated: 0.5 session for `/analyze` + 1–2 sessions implementation.
+
+4. **Plan `#643` FeatureStore canonical-surface deprecation cycle** (MED). Multi-session work; `/analyze` first to scope the deprecation wave per `rules/zero-tolerance.md` Rule 6a. Estimated: 0.5 session for `/analyze`.
+
+5. **Workspace archive sweep** (LOW). Optional: codify a "session-notes >30d + no active todos → archive" rule and apply it. Estimated: 0.5 session.
+
+The recommended next item is **#1 (psycopg2 dep declaration)** — single shard, structural fix, highest user-visible severity.

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,21 @@
 # DataFlow Changelog
 
+## [2.7.4] — 2026-05-01 — Declare `psycopg2-binary` as baseline dependency (#753)
+
+Patch release closing issue #753. The synchronous DDL / migration path (`SyncDDLExecutor._get_postgresql_connection`, `MigrationConnectionManager._connect_with_retry`, `dataflow.core.pool_utils._is_postgresql_url`) imports `psycopg2` to bootstrap registry tables and run `auto_migrate=True` against PostgreSQL. The package declared `asyncpg` (covering runtime DML) but did NOT declare `psycopg2` / `psycopg2-binary` as a baseline dep nor as an optional extra. Every fresh install pointed at a PostgreSQL `DATABASE_URL` failed at the first `auto_migrate` trigger with `ModuleNotFoundError: No module named 'psycopg2'`, then crashed downstream DML with `relation "<table>" does not exist` because the registry/schema bootstrap silently failed earlier in the stack trace.
+
+### Fixed
+
+- **#753 — `psycopg2-binary>=2.9` added to baseline `dependencies`.** Treatment matches the existing baseline-driver pattern (`asyncpg`, `aiosqlite`, `aiomysql`, `motor`, `pymongo` are all baseline) — DataFlow bundles all DB drivers so users pick which they use; the asymmetric "asyncpg baseline + psycopg2 missing" was a packaging bug, not a design choice.
+
+### Tests
+
+- `tests/regression/test_issue_753_psycopg2_dep_declared.py` — structural regression covering: (a) `pyproject.toml::dependencies` declares `psycopg2-binary` (catches a future "dep cleanup" that removes it without test signal); (b) `import psycopg2` resolves at module-scope from the dataflow package; (c) `SyncDDLExecutor._get_postgresql_connection` no longer raises `ImportError` when invoked against a postgres URL.
+
+### Cross-SDK
+
+- N/A — kailash-rs uses `tokio_postgres` / `sqlx` natively and has no equivalent Python-driver-declaration failure mode.
+
 ## [2.7.3] — 2026-05-01 — `@db.model` accepts parameterized generics on Python 3.11+ (#768)
 
 Patch release closing issue #768. `FieldTypeProcessor._resolve_type` returned parameterized builtin generics (`list[str]`, `dict[str, Any]`, `typing.List[str]`, PEP 604 `list[str] | None`) verbatim. The next `isinstance(value, expected_type)` call raised `TypeError: isinstance() argument 2 cannot be a parameterized generic` on Python 3.11+, crashing every CRUD operation against models that used the standard, idiomatic form of list / dict / tuple annotations.

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.7.3"
+version = "2.7.4"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -28,6 +28,7 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "alembic>=1.12.0",
     "asyncpg>=0.28.0",
+    "psycopg2-binary>=2.9",
     "aiosqlite>=0.19.0",
     "aiomysql>=0.2.0",
     "motor>=3.3.0",

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -108,7 +108,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.7.3"
+__version__ = "2.7.4"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/tests/regression/test_cache_invalidation_exact_match.py
+++ b/packages/kailash-dataflow/tests/regression/test_cache_invalidation_exact_match.py
@@ -129,7 +129,13 @@ async def test_redis_invalidation_matches_real_key_format():
     """Regression: Redis SCAN pattern must match the actual key format.
 
     Before fix, AsyncRedisCacheAdapter used ``dataflow:{model}:*`` which
-    does NOT match Express keys ``dataflow:v1:{model}:...``.
+    does NOT match Express keys ``dataflow:v*:{model}:...``.
+
+    Per ``rules/tenant-isolation.md`` § 3a "Keyspace Version Bumps Require
+    Invalidation-Path Sweep", the canonical invalidation pattern uses a
+    ``v*`` wildcard so legacy v1 keys AND current v2 keys are swept in
+    one call. This test locks BOTH the produced key format (currently
+    v2-versioned) AND the wildcard SCAN patterns the adapter emits.
     """
     from dataflow.cache.async_redis_adapter import AsyncRedisCacheAdapter
 
@@ -138,9 +144,13 @@ async def test_redis_invalidation_matches_real_key_format():
     # Generate a real Express key to understand the format
     real_key = key_gen.generate_express_key("User", "list", {"active": True})
 
-    # The key must start with "dataflow:v1:User:"
-    assert real_key.startswith(
-        "dataflow:v1:User:"
+    # The key must start with "dataflow:v<N>:User:" — version-prefix
+    # locked, but the specific N (currently v2) intentionally NOT pinned
+    # so a legitimate keyspace bump (Rule 3a) does not require this test
+    # update. The invalidation-path assertion below uses the v* wildcard
+    # which is the canonical form per Rule 3a.
+    assert (
+        real_key.startswith("dataflow:v") and ":User:" in real_key
     ), f"Express key format changed unexpectedly: {real_key}"
 
     # Create a mock RedisCacheManager that records SCAN patterns
@@ -158,19 +168,23 @@ async def test_redis_invalidation_matches_real_key_format():
     adapter = AsyncRedisCacheAdapter(mock_redis)
     await adapter.invalidate_model("User")
 
-    # Must include the Express key pattern
+    # Must include the Express key pattern with v* wildcard so legacy
+    # v1 entries (if any survive in Redis) AND current v2+ entries are
+    # both swept. Rule 3a: producer-side keyspace bump MUST NOT silently
+    # break consumer-side invalidation pinned to one version.
     assert (
-        "dataflow:v1:User:*" in scanned_patterns
+        "dataflow:v*:User:*" in scanned_patterns
     ), f"Express key pattern not scanned. Patterns used: {scanned_patterns}"
-    # Must also include the SQL query key pattern
+    # Must also include the SQL query key pattern (different shape:
+    # version segment AFTER model name).
     assert (
-        "dataflow:User:v1:*" in scanned_patterns
+        "dataflow:User:v*:*" in scanned_patterns
     ), f"SQL query key pattern not scanned. Patterns used: {scanned_patterns}"
 
     # Verify the Express pattern would actually match a real key
     import fnmatch
 
-    express_pattern = "dataflow:v1:User:*"
+    express_pattern = "dataflow:v*:User:*"
     assert fnmatch.fnmatch(
         real_key, express_pattern
     ), f"Pattern '{express_pattern}' does not match real key '{real_key}'"
@@ -181,9 +195,10 @@ async def test_redis_invalidation_matches_real_key_format():
 async def test_redis_invalidation_does_not_match_similar_models():
     """Regression: Redis SCAN for 'User' must not match 'UserAudit'.
 
-    The SCAN pattern ``dataflow:v1:User:*`` must NOT match
-    ``dataflow:v1:UserAudit:*`` because the glob ``User:*`` requires a
-    colon immediately after 'User'.
+    The SCAN pattern ``dataflow:v*:User:*`` must NOT match
+    ``dataflow:v*:UserAudit:*`` because the glob ``User:*`` requires a
+    colon immediately after 'User'. Pattern uses v* wildcard per
+    ``rules/tenant-isolation.md`` § 3a.
     """
     import fnmatch
 
@@ -192,7 +207,7 @@ async def test_redis_invalidation_does_not_match_similar_models():
     user_key = key_gen.generate_express_key("User", "list")
     audit_key = key_gen.generate_express_key("UserAudit", "list")
 
-    express_pattern = "dataflow:v1:User:*"
+    express_pattern = "dataflow:v*:User:*"
 
     assert fnmatch.fnmatch(user_key, express_pattern)
     assert not fnmatch.fnmatch(

--- a/packages/kailash-dataflow/tests/regression/test_express_cache_tenant_isolation.py
+++ b/packages/kailash-dataflow/tests/regression/test_express_cache_tenant_isolation.py
@@ -84,22 +84,40 @@ def _reset_tenant_context() -> Any:
 
 
 def test_generate_express_key_without_tenant_matches_legacy_shape() -> None:
-    """Back-compat: no tenant → legacy shape unchanged."""
+    """Back-compat: no tenant → legacy shape unchanged.
+
+    Version segment locked as a prefix-shape (`v<digit>`) but specific
+    digit NOT pinned — Rule 3a (`rules/tenant-isolation.md`) makes
+    keyspace bumps a normal operation provided the invalidation-path
+    sweep moves with the producer. The shape's structural property
+    (5 colon-separated segments, version prefix, model name in slot 2,
+    op in slot 3) is what this test locks.
+    """
     gen = CacheKeyGenerator()
     key = gen.generate_express_key("User", "list", {"active": True})
-    # dataflow:v1:User:list:<8-hex-hash>
-    assert key.startswith("dataflow:v1:User:list:")
+    # dataflow:v<N>:User:list:<8-hex-hash>
     segments = key.split(":")
     assert len(segments) == 5
+    assert segments[0] == "dataflow"
+    assert segments[1].startswith("v") and segments[1][1:].isdigit()
+    assert segments[2] == "User"
+    assert segments[3] == "list"
 
 
 def test_generate_express_key_with_tenant_inserts_tenant_segment() -> None:
-    """With tenant → dataflow:v1:{tenant}:{model}:{op}:{hash}."""
+    """With tenant → dataflow:v<N>:{tenant}:{model}:{op}:{hash}.
+
+    See note above on version-segment shape pinning.
+    """
     gen = CacheKeyGenerator()
     key = gen.generate_express_key("User", "list", {"active": True}, tenant_id="acme")
-    assert key.startswith("dataflow:v1:acme:User:list:")
     segments = key.split(":")
     assert len(segments) == 6
+    assert segments[0] == "dataflow"
+    assert segments[1].startswith("v") and segments[1][1:].isdigit()
+    assert segments[2] == "acme"
+    assert segments[3] == "User"
+    assert segments[4] == "list"
 
 
 def test_generate_express_key_two_tenants_produce_distinct_keys() -> None:

--- a/packages/kailash-dataflow/tests/regression/test_issue_352_fastapi_startup.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_352_fastapi_startup.py
@@ -39,6 +39,7 @@ from typing import Any, Dict, Optional, Tuple
 from unittest.mock import MagicMock
 
 import pytest
+from kailash.runtime.async_local import AsyncLocalRuntime
 
 from dataflow.core.model_registry import ModelRegistry, _normalize_runtime_result
 
@@ -109,8 +110,20 @@ class _FakeSyncRuntime:
         return self.return_value
 
 
-class _FakeAsyncRuntime:
+class _FakeAsyncRuntime(AsyncLocalRuntime):
     """Stand-in for AsyncLocalRuntime.
+
+    Subclasses ``AsyncLocalRuntime`` so ``ModelRegistry._is_async``
+    (post-S5 refactor — derived from ``isinstance(runtime,
+    AsyncLocalRuntime)`` per ``model_registry.py:182-189``) resolves
+    True for instances of this fake. Pre-S5 the test set
+    ``registry._is_async = True`` directly; the S5 setter is now a
+    no-op so the parent-class isinstance check IS the dispatch.
+
+    Bypasses the parent ``__init__`` (thread pool, profiler) — the
+    fake never executes a real workflow, so the parent setup is dead
+    weight. Methods below override every entry point the helper might
+    reach so the inherited parent paths cannot run.
 
     * ``execute()`` mimics the real refusal: raises RuntimeError if a
       loop is running. The helper must NEVER hit this path because the
@@ -120,6 +133,8 @@ class _FakeAsyncRuntime:
     """
 
     def __init__(self) -> None:
+        # Intentionally skip AsyncLocalRuntime.__init__ — no thread pool
+        # or profiler needed; the fake's methods override every entry.
         self.sync_execute_calls = 0
         self.async_calls: list[Any] = []
         self.return_value: Tuple[Dict[str, Any], str] = (

--- a/packages/kailash-dataflow/tests/regression/test_issue_753_psycopg2_dep_declared.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_753_psycopg2_dep_declared.py
@@ -1,0 +1,122 @@
+"""Regression test for issue #753 — psycopg2 must be a declared dependency.
+
+`kailash-dataflow ≥2.4.0` imports `psycopg2` via the synchronous DDL /
+migration path (`SyncDDLExecutor._get_postgresql_connection`,
+`MigrationConnectionManager._connect_with_retry`,
+`dataflow.core.pool_utils._is_postgresql_url`) when bootstrapping
+registry tables and running ``auto_migrate=True`` against PostgreSQL.
+
+Pre-fix: package declared `asyncpg` (covering runtime DML) but not
+`psycopg2-binary`. Every fresh install pointed at a PostgreSQL
+``DATABASE_URL`` failed at the first ``auto_migrate`` trigger with
+``ModuleNotFoundError: No module named 'psycopg2'``, then crashed
+downstream DML with ``relation "<table>" does not exist`` because the
+registry/schema bootstrap silently failed.
+
+Post-fix: `psycopg2-binary>=2.9` is declared as a baseline dependency
+(matching the existing `asyncpg`, `aiosqlite`, `aiomysql` baseline
+treatment). This regression locks the declaration AND verifies the
+import chain so a future "dep cleanup" cannot silently re-open the
+failure mode.
+
+Per ``rules/cross-sdk-inspection.md`` MUST Rule 3a, this is a structural
+declaration / import-chain test — there is no Tier 2 connection-binding
+sibling because the bug is upstream of the connect call (the import
+itself failed).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_pyproject_declares_psycopg2_binary() -> None:
+    """`pyproject.toml::dependencies` MUST list `psycopg2-binary`.
+
+    Catches future "dep cleanup" PRs that remove the declaration without
+    test signal — without this guard, the failure surfaces only on a
+    fresh-venv install against PostgreSQL.
+    """
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    text = pyproject.read_text()
+
+    # Find the [project] dependencies block (not [project.optional-dependencies])
+    in_deps_block = False
+    declared = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "dependencies = [":
+            in_deps_block = True
+            continue
+        if in_deps_block:
+            if stripped == "]":
+                break
+            if "psycopg2-binary" in stripped or "psycopg2_binary" in stripped:
+                declared = True
+                break
+
+    assert declared, (
+        "psycopg2-binary missing from kailash-dataflow baseline dependencies. "
+        "The synchronous DDL / migration path imports psycopg2; without the "
+        "declaration, fresh-venv installs fail at auto_migrate=True against "
+        "PostgreSQL with ModuleNotFoundError. See issue #753."
+    )
+
+
+def test_psycopg2_resolves_at_module_scope() -> None:
+    """`import psycopg2` MUST succeed from the dataflow package context.
+
+    Tightens the structural defense beyond the pyproject.toml declaration —
+    proves the package the manifest resolves to is actually importable
+    (catches a manifest entry that points at a non-existent / yanked
+    distribution).
+    """
+    import psycopg2  # noqa: F401  — resolution is the test
+
+    # Defense-in-depth: the version attribute exists, confirming we have a
+    # real psycopg2 install (not a stub / shim).
+    assert hasattr(psycopg2, "__version__")
+
+
+def test_sync_ddl_executor_postgres_path_does_not_raise_importerror() -> None:
+    """``SyncDDLExecutor._get_postgresql_connection`` MUST resolve psycopg2.
+
+    The pre-fix failure mode was:
+        ImportError: psycopg2 is required for PostgreSQL migrations.
+                     Install with: pip install psycopg2-binary
+
+    Raised at the ``import psycopg2`` line (sync_ddl_executor.py:102).
+    This test invokes the method against an unreachable host so the
+    psycopg2 *import* runs but the subsequent ``psycopg2.connect`` call
+    fails with a connection-level exception (NOT ImportError).
+
+    Asserts the FAILURE TYPE — ImportError means the dep declaration
+    regressed; any other exception (OperationalError, ConnectionError,
+    socket.gaierror, etc.) means the import succeeded and the test passed.
+    """
+    from dataflow.migrations.sync_ddl_executor import SyncDDLExecutor
+
+    # Use an obviously-unreachable port so the connect attempt fails fast
+    # and we never need a real Postgres instance to run this test.
+    executor = SyncDDLExecutor(database_url="postgresql://x:x@127.0.0.1:1/x")
+
+    try:
+        executor._get_postgresql_connection()
+    except ImportError as e:
+        raise AssertionError(
+            f"psycopg2 import regressed in sync DDL path: {e!r}. "
+            f"Issue #753: psycopg2-binary MUST stay declared in "
+            f"kailash-dataflow/pyproject.toml::dependencies."
+        ) from e
+    except Exception:
+        # Connection-level exception is the success signal — the import
+        # succeeded and we hit the network layer (or psycopg2's own error
+        # taxonomy), which is exactly what we want to prove.
+        pass
+    else:
+        # Unreachable port should never produce a real connection. If it
+        # did, the test setup is wrong.
+        raise AssertionError(
+            "Unreachable Postgres URL produced a live connection — "
+            "test environment is misconfigured."
+        )


### PR DESCRIPTION
## Summary

- **Adds `psycopg2-binary>=2.9` to `kailash-dataflow` baseline `dependencies`** — closes #753. Every fresh install pointed at a PostgreSQL `DATABASE_URL` failed at the first `auto_migrate` trigger with `ModuleNotFoundError: No module named 'psycopg2'`, then crashed downstream DML with `relation does not exist` because the registry/schema bootstrap silently failed earlier in the stack trace.
- **Bumps `kailash-dataflow` 2.7.3 → 2.7.4** atomically across `pyproject.toml::version` and `__init__.py::__version__`, with CHANGELOG entry.
- **Realigns 3 stale regression tests** with current production (separate commit, no production code touched). All discovered as pre-flight gate failures for the #753 fix; per zero-tolerance Rule 1, fixed in same shard.

## Why baseline (not extras)

Treatment matches the existing baseline-driver pattern: `asyncpg`, `aiosqlite`, `aiomysql`, `motor`, `pymongo` are all baseline. DataFlow bundles all DB drivers so users pick which they use; the asymmetric "asyncpg baseline + psycopg2 missing" was a packaging bug, not a design choice.

The issue's proposed `[postgres]` extra would break existing `pip install kailash-dataflow` users with a Postgres URL — they'd need to update install commands, while `asyncpg` (also Postgres-only) stays baseline. Baseline keeps the install-time UX consistent.

## Commits

1. **`fix(dataflow): declare psycopg2-binary baseline dependency (#753)`** — pyproject.toml + __init__.py + CHANGELOG + new regression test at `tests/regression/test_issue_753_psycopg2_dep_declared.py` (3 assertions: manifest declares dep, import resolves at module scope, `SyncDDLExecutor._get_postgresql_connection` no longer raises ImportError).
2. **`chore(dataflow-tests): realign 3 stale regression tests with current production`** — `test_cache_invalidation_exact_match.py` and `test_express_cache_tenant_isolation.py` updated for the v1→v2 keyspace bump (rules/tenant-isolation.md § 3a wildcard form). `test_issue_352_fastapi_startup.py` updated for the S5 `_is_async`-as-derived-property refactor (commit `5a1a7d58`) — `_FakeAsyncRuntime` now subclasses `AsyncLocalRuntime` so the `isinstance` check resolves True.

## Test plan

- [x] New regression test at `tests/regression/test_issue_753_psycopg2_dep_declared.py` — 3/3 pass
- [x] Dataflow regression suite: 5 failed/253 passed → 0 failed/258 passed
- [x] Pre-commit hooks (Black, isort, Ruff, type-annotation check, Tier 1 unit tests) all green on both commits
- [x] No production code modified; only test files realigned with current behavior
- [ ] Full CI matrix on PR

## Out-of-scope (not addressed here)

- `test_auto_generated_bulk_parameter_mapping` (unit) — surfaced during pre-flight as a real production bug at `dataflow/core/nodes.py:837` (`AttributeError: type object 'str' has no attribute 'get'`). Different bug class, exceeds shard budget for #753, needs dataflow-specialist consultation.

## Related issues

Fixes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)