### PR TITLE
chore(deploy): record dataflow 2.7.5 release

### DIFF
--- a/deploy/deployments/2026-05-01-dataflow-v2.7.5.md
+++ b/deploy/deployments/2026-05-01-dataflow-v2.7.5.md
@@ -1,0 +1,51 @@
+# 2026-05-01 — kailash-dataflow 2.7.5
+
+Patch release. Closes #774.
+
+## Scope
+
+| Package          | from  | to        |
+| ---------------- | ----- | --------- |
+| kailash-dataflow | 2.7.4 | **2.7.5** |
+
+All sibling packages at PyPI parity; no sibling drift to sweep this cycle.
+
+## What shipped
+
+`bulk_create` AttributeError on bare-type field specs (#774). `NodeGenerator.generate_*_nodes` accepted both dict-form (`{"name": {"type": str}}`) and bare-type form (`{"name": str}`) by signature, but only dict-form by behavior — direct callers passing bare-type crashed at `dataflow/core/nodes.py:837` with `AttributeError: type object 'str' has no attribute 'get'`. Fix: `_normalize_field_specs()` at the constructor boundary normalizes any caller-supplied shape into canonical dict-form. Defense-in-depth `isinstance` guards added to `_coerce_record_id` and `convert_datetime_fields`.
+
+Tier 2 round-trip regression at `tests/regression/test_issue_774_bulk_create_field_spec_normalization.py` exercises real PostgreSQL via `@db.model`.
+
+## Cross-SDK
+
+kailash-rs uses strongly-typed `Vec<FieldDef>` with `FieldType` enum (`crates/kailash-dataflow/src/model.rs:587`, `:842`); the bug class is structurally unreachable. No upstream issue filed.
+
+## Pull requests
+
+- PR #775 — code fix (merged at `b895d7ee`)
+- PR #776 — release prep (metadata-only, merged on `release/v2.7.5` branch)
+
+## Tag
+
+`dataflow-v2.7.5` — pushed individually per `git.md` § "Multi-Package Release Tags Pushed Individually".
+
+## Verification
+
+| Gate                                              | Result                                                                 |
+| ------------------------------------------------- | ---------------------------------------------------------------------- |
+| Originally-failing unit test passes               | ✓ `test_bulk_create_with_data_parameter` (12/12)                       |
+| New regression suite                              | ✓ 4/4 (incl. Tier 2 real Postgres)                                     |
+| Targeted dataflow unit suite                      | ✓ 37/37 (`-k 'bulk or model_fields or field_spec or validate_inputs'`) |
+| pre-commit (ruff, black, isort, type-annotations) | ✓ clean                                                                |
+| `python -m build --wheel`                         | ✓ `kailash_dataflow-2.7.5-py3-none-any.whl`                            |
+| PyPI publish workflow                             | ✓ run 25215840937 success                                              |
+| Clean-venv install + import                       | ✓ `_normalize_field_specs`, `NodeGenerator` import OK                  |
+
+## Post-release
+
+- COC template `kailash-coc-claude-py/pyproject.toml` pin bumped: `kailash-dataflow>=2.7.3` → `>=2.7.5` (working-tree edit pending user commit).
+- Documentation deploy not triggered: dataflow CHANGELOG is at sub-package path, not root; matches prior `dataflow-v2.7.4` pattern (no regression).
+
+## Pre-existing failures surfaced (out of scope, no regression)
+
+`packages/kailash-dataflow/tests/unit/core/test_model_registry_runtime_injection.py` — 4 tests fail on `_owns_runtime` invariant. Tied to in-flight commit `87287952 wip(MED-S5): drop eager runtime=self.runtime in subsystem instantiation`. Stash test confirms predates this session. Different bug class from #774. Recorded for next session's disposition.


### PR DESCRIPTION
Post-release record for kailash-dataflow 2.7.5 (closes #774). Documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)