### PR TITLE
fix(auth): replace 7 NotImplementedError stubs with typed errors and documented overrides

### DIFF
--- a/src/kailash/middleware/auth/auth_manager.py
+++ b/src/kailash/middleware/auth/auth_manager.py
@@ -11,7 +11,7 @@ import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import jwt
 from fastapi import Depends
@@ -404,21 +404,3 @@ class MiddlewareAuthManager:
             raise HTTPException(status_code=401, detail="Not authenticated")
 
         return verify_user
-
-
-# Convenience function for creating auth dependencies
-def require_auth(permissions: List[str] = None):  # type: ignore[reportArgumentType]
-    """
-    Create authentication dependency with required permissions.
-
-    Args:
-        permissions: List of required permissions
-
-    Returns:
-        FastAPI dependency
-    """
-    # This would use a global auth manager instance
-    # In practice, this would be configured at app startup
-    raise NotImplementedError(
-        "Use auth_manager.get_current_user_dependency(permissions) instead"
-    )

--- a/src/kailash/nodes/auth/enterprise_auth_provider.py
+++ b/src/kailash/nodes/auth/enterprise_auth_provider.py
@@ -69,7 +69,6 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
             "sso",
             "mfa",
             "directory",
-            "passwordless",
             "social",
             "api_key",
             "jwt",
@@ -446,11 +445,6 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
                 method=credentials.get("mfa_method", "totp"),
             )
 
-        elif auth_method == "passwordless":
-            return await self._authenticate_passwordless(
-                credentials, user_id, risk_context
-            )
-
         elif auth_method == "social":
             return await self._authenticate_social(credentials, user_id, risk_context)
 
@@ -460,26 +454,18 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
         elif auth_method == "jwt":
             return await self._authenticate_jwt(credentials, user_id, risk_context)
 
-        elif auth_method == "certificate":
-            return await self._authenticate_certificate(
-                credentials, user_id, risk_context
+        elif auth_method in {"passwordless", "certificate"}:
+            raise ValueError(
+                f"Authentication method {auth_method!r} is not implemented in the "
+                f"Core SDK class — it requires protocol-specific cryptography "
+                f"(WebAuthn/FIDO2 or X.509 client certificate validation). "
+                f"Subclass EnterpriseAuthProviderNode and override "
+                f"_perform_authentication() to add this method, or use a "
+                f"specialized auth provider package."
             )
 
         else:
             raise ValueError(f"Unsupported authentication method: {auth_method}")
-
-    async def _authenticate_passwordless(
-        self, credentials: Dict[str, Any], user_id: str, risk_context: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Authenticate using passwordless methods (WebAuthn, FIDO2).
-
-        Requires a WebAuthn library (e.g., py_webauthn) for proper
-        assertion validation against registered credentials.
-        """
-        raise NotImplementedError(
-            "WebAuthn/FIDO2 authentication requires a WebAuthn library "
-            "(e.g., py_webauthn). Provide a concrete implementation."
-        )
 
     async def _authenticate_social(
         self, credentials: Dict[str, Any], user_id: str, risk_context: Dict[str, Any]
@@ -584,19 +570,6 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
                 return {"authenticated": False, "error": "Invalid JWT format"}
         except Exception as e:
             return {"authenticated": False, "error": f"JWT validation failed: {e}"}
-
-    async def _authenticate_certificate(
-        self, credentials: Dict[str, Any], user_id: str, risk_context: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Authenticate using client certificate.
-
-        Requires a cryptography library (e.g., ``cryptography``) for proper
-        certificate parsing, CA chain validation, and revocation checking.
-        """
-        raise NotImplementedError(
-            "Client certificate authentication requires a cryptography library "
-            "for CA validation and revocation checking. Provide a concrete implementation."
-        )
 
     async def _validate_social_token(
         self, provider: str, access_token: str
@@ -758,18 +731,6 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
                 "success": mfa_result.get("verified", False),
                 "factor": factor,
                 "mfa_result": mfa_result,
-            }
-
-        elif factor == "passwordless":
-            # Handle passwordless factor
-            passwordless_result = await self._authenticate_passwordless(
-                credentials, user_id, risk_context
-            )
-
-            return {
-                "success": passwordless_result.get("authenticated", False),
-                "factor": factor,
-                "passwordless_result": passwordless_result,
             }
 
         else:
@@ -944,12 +905,12 @@ class EnterpriseAuthProviderNode(SecurityMixin, PerformanceMixin, LoggingMixin, 
     ) -> Dict[str, Any]:
         """Assess risk based on user behavior patterns.
 
-        Requires historical login data and a behavioral analysis engine.
+        Default implementation returns zero risk. Subclasses backed by a
+        user activity store or behavioral analysis engine should override
+        this method to inspect ``risk_context`` against historical patterns
+        (recent IPs, devices, login times) and return a non-zero score.
         """
-        raise NotImplementedError(
-            "Behavioral risk assessment requires historical pattern analysis. "
-            "Provide a concrete implementation backed by a user activity store."
-        )
+        return {"score": 0.0, "factors": []}
 
     async def _ai_risk_assessment(
         self, user_id: str, risk_context: Dict[str, Any], existing_factors: List[str]

--- a/src/kailash/nodes/auth/mfa.py
+++ b/src/kailash/nodes/auth/mfa.py
@@ -1824,21 +1824,6 @@ class MultiFactorAuthNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node):
             "expires_at": datetime.now(UTC) + timedelta(minutes=5),
         }
 
-    def _send_sms(self, phone: str, message: str) -> bool:
-        """Send SMS message (for test compatibility).
-
-        Args:
-            phone: Phone number
-            message: SMS message
-
-        Returns:
-            True if successful
-        """
-        raise NotImplementedError(
-            "SMS sending requires an SMS gateway integration (e.g., Twilio, AWS SNS). "
-            "Provide a concrete _send_sms() implementation or configure an SMS provider."
-        )
-
     def _send_email_code(self, email: str, code: str, user_id: str) -> None:
         """Send email verification code.
 

--- a/src/kailash/nodes/auth/sso.py
+++ b/src/kailash/nodes/auth/sso.py
@@ -19,7 +19,6 @@ import json
 import secrets
 import time
 import uuid
-import xml.etree.ElementTree as ET
 from datetime import UTC, datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -29,22 +28,6 @@ from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import JSONReaderNode
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security import AuditLogNode, SecurityEventNode
-
-
-def _validate_saml_response(saml_response_data: str) -> Dict[str, Any]:
-    """Module-level SAML response validation function for test compatibility.
-
-    Args:
-        saml_response_data: Base64 encoded SAML response
-
-    Returns:
-        Dict containing validation results
-    """
-    # In production, this would use proper SAML libraries like python3-saml
-    raise NotImplementedError(
-        "SAML response validation requires a SAML library (e.g., python3-saml). "
-        "Install the library and provide a concrete implementation."
-    )
 
 
 @register_node()
@@ -71,7 +54,7 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
     ):
         # Set attributes before calling super().__init__()
         self.name = name
-        self.providers = providers or ["saml", "oauth2", "oidc", "ldap"]
+        self.providers = providers or ["oauth2", "oidc"]
         self.saml_settings = saml_settings or {}
         self.oauth_settings = oauth_settings or {}
         self.ldap_settings = ldap_settings or {}
@@ -597,60 +580,26 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
     async def _handle_callback(
         self, provider: str, request_data: Dict[str, Any], **kwargs
     ) -> Dict[str, Any]:
-        """Handle SSO callback from provider."""
-        if provider == "saml":
-            return await self._handle_saml_callback(request_data, **kwargs)
-        elif provider in ["oauth2", "oidc", "azure", "google", "okta"]:
+        """Handle SSO callback from provider.
+
+        SAML and LDAP require protocol-specific cryptography (XML-DSig
+        canonicalization for SAML, LDAP bind/search for directory) that is
+        not implemented in the Core SDK. Subclass and override
+        ``_handle_callback`` to add ``provider="saml"`` or ``provider="ldap"``
+        support backed by ``python3-saml`` / ``ldap3``.
+        """
+        if provider in ["oauth2", "oidc", "azure", "google", "okta"]:
             return await self._handle_oauth_callback(provider, request_data, **kwargs)
-        elif provider == "ldap":
-            return await self._handle_ldap_callback(request_data, **kwargs)
+        elif provider in {"saml", "ldap"}:
+            raise ValueError(
+                f"SSO provider {provider!r} is not implemented in the Core SDK class — "
+                f"it requires protocol-specific cryptography "
+                f"({'XML-DSig validation' if provider == 'saml' else 'LDAP bind/search'}). "
+                f"Subclass SSOAuthenticationNode and override _handle_callback() to add "
+                f"this provider, or use a specialized auth provider package."
+            )
         else:
             raise ValueError(f"Unsupported callback provider: {provider}")
-
-    async def _handle_saml_callback(
-        self, request_data: Dict[str, Any], **kwargs
-    ) -> Dict[str, Any]:
-        """Handle SAML assertion callback."""
-        saml_response = request_data.get("SAMLResponse")
-        if not saml_response:
-            raise ValueError("Missing SAML response")
-
-        # For test compatibility, use the module-level validation function
-        try:
-            validation_result = _validate_saml_response(saml_response)
-
-            if not validation_result.get("authenticated"):
-                raise ValueError(
-                    f"SAML validation failed: {validation_result.get('error', 'Unknown validation error')}"
-                )
-        except Exception as e:
-            # Re-raise with validation context
-            raise ValueError(f"SAML validation failed: {str(e)}")
-
-        # Extract user attributes from validation result
-        user_attributes = validation_result.get("attributes", {})
-
-        # Map attributes to internal format
-        mapped_attributes = self._map_attributes(user_attributes, "saml")
-
-        # Provision user if enabled
-        if self.enable_jit_provisioning:
-            user_result = await self._provision_user(mapped_attributes, "saml")
-        else:
-            user_result = {"user_id": mapped_attributes.get("email")}
-
-        # Create session
-        session_result = await self._create_sso_session(
-            user_result["user_id"], "saml", mapped_attributes  # type: ignore[reportArgumentType]
-        )
-
-        return {
-            "provider": "saml",
-            "user_attributes": mapped_attributes,
-            "user_id": user_result["user_id"],
-            "session_id": session_result["session_id"],
-            "authenticated": True,
-        }
 
     async def _handle_oauth_callback(
         self, provider: str, request_data: Dict[str, Any], **kwargs
@@ -698,44 +647,6 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
             "session_id": session_result["session_id"],
             "tokens": token_result,
             "access_token": token_result.get("access_token"),  # For test compatibility
-            "authenticated": True,
-        }
-
-    async def _handle_ldap_callback(
-        self, request_data: Dict[str, Any], **kwargs
-    ) -> Dict[str, Any]:
-        """Handle LDAP authentication."""
-        username = request_data.get("username")
-        password = request_data.get("password")
-
-        if not username or not password:
-            raise ValueError("Username and password required for LDAP authentication")
-
-        # Authenticate with LDAP (simulation - in production use actual LDAP library)
-        ldap_result = await self._authenticate_ldap(username, password)
-
-        if not ldap_result["authenticated"]:
-            raise ValueError("LDAP authentication failed")
-
-        # Map LDAP attributes
-        mapped_attributes = self._map_attributes(ldap_result["attributes"], "ldap")
-
-        # Provision user if enabled
-        if self.enable_jit_provisioning:
-            user_result = await self._provision_user(mapped_attributes, "ldap")
-        else:
-            user_result = {"user_id": username}
-
-        # Create session
-        session_result = await self._create_sso_session(
-            user_result["user_id"], "ldap", mapped_attributes
-        )
-
-        return {
-            "provider": "ldap",
-            "user_attributes": mapped_attributes,
-            "user_id": user_result["user_id"],
-            "session_id": session_result["session_id"],
             "authenticated": True,
         }
 
@@ -835,40 +746,6 @@ class SSOAuthenticationNode(SecurityMixin, PerformanceMixin, LoggingMixin, Node)
                 }
             else:
                 raise ValueError(f"User info request failed: {str(e)}")
-
-    async def _authenticate_ldap(self, username: str, password: str) -> Dict[str, Any]:
-        """Authenticate user against LDAP/Active Directory.
-
-        Requires an LDAP library (e.g., python-ldap or ldap3).
-        """
-        raise NotImplementedError(
-            "LDAP authentication requires an LDAP library (e.g., python-ldap, ldap3). "
-            "Install the library and provide a concrete implementation."
-        )
-
-    def _extract_saml_attributes(self, saml_root: ET.Element) -> Dict[str, Any]:
-        """Extract user attributes from SAML assertion."""
-        attributes = {}
-
-        # Find attribute statements
-        for attr_stmt in saml_root.findall(
-            ".//{urn:oasis:names:tc:SAML:2.0:assertion}AttributeStatement"
-        ):
-            for attr in attr_stmt.findall(
-                ".//{urn:oasis:names:tc:SAML:2.0:assertion}Attribute"
-            ):
-                name = attr.get("Name", "")
-                values = []
-                for value in attr.findall(
-                    ".//{urn:oasis:names:tc:SAML:2.0:assertion}AttributeValue"
-                ):
-                    if value.text:
-                        values.append(value.text)
-
-                if values:
-                    attributes[name] = values[0] if len(values) == 1 else values
-
-        return attributes
 
     def _map_attributes(
         self, raw_attributes: Dict[str, Any], provider: str

--- a/tests/integration/nodes/test_mfa_functional.py
+++ b/tests/integration/nodes/test_mfa_functional.py
@@ -173,8 +173,8 @@ class TestMultiFactorAuthNodeConfiguration:
 
             # Verify custom configuration
             assert (
-                mfa_  # node.methods == - Node attribute not accessible ["totp", "sms"]
-            )
+                mfa_node is not None
+            )  # Node attribute access not available; smoke check only
             # # assert mfa_  # node.default_method == - Node attribute not accessible "sms"  # Node attributes not accessible directly  # Node attributes not accessible directly
             # # assert mfa_  # node.issuer == - Node attribute not accessible "MyApp"  # Node attributes not accessible directly  # Node attributes not accessible directly
             # # assert mfa_node.backup_codes is False  # Node attributes not accessible directly  # Node attributes not accessible directly

--- a/tests/regression/test_auth_stub_rule2_cleanup.py
+++ b/tests/regression/test_auth_stub_rule2_cleanup.py
@@ -1,0 +1,220 @@
+"""Regression tests for the auth-module Rule 2 stub cleanup.
+
+The Core SDK's ``SSOAuthenticationNode``, ``EnterpriseAuthProviderNode``,
+``MultiFactorAuthNode``, and ``MiddlewareAuthManager`` shipped with seven
+``raise NotImplementedError`` stubs reachable from documented public-API
+surfaces. Per ``rules/zero-tolerance.md`` Rule 2 § "Fake dispatch" and
+``rules/orphan-detection.md`` Rule 3, these were either deleted (orphans)
+or replaced with documented no-op defaults / typed dispatcher errors.
+
+These tests lock in the cleanup so a future refactor can't silently
+re-introduce the stubs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.regression
+def test_sso_default_providers_excludes_unimplemented_protocols():
+    """SAML and LDAP are NOT in the Core SDK's advertised default providers.
+
+    Pre-fix the default ``providers`` list was
+    ``["saml", "oauth2", "oidc", "ldap"]`` — every default-config user
+    configured SAML or LDAP only to crash at runtime with
+    ``NotImplementedError``. The default now advertises only the protocols
+    the Core SDK actually implements.
+    """
+    from kailash.nodes.auth.sso import SSOAuthenticationNode
+
+    node = SSOAuthenticationNode()
+    assert node.providers == ["oauth2", "oidc"]
+    assert "saml" not in node.providers
+    assert "ldap" not in node.providers
+
+
+@pytest.mark.regression
+def test_sso_callback_rejects_saml_and_ldap_with_value_error():
+    """``_handle_callback`` rejects unimplemented providers with a typed error.
+
+    Pre-fix calling ``_handle_callback("saml", ...)`` raised
+    ``NotImplementedError`` from a private helper. The dispatcher now raises
+    ``ValueError`` with a message that names the override path.
+    """
+    from kailash.nodes.auth.sso import SSOAuthenticationNode
+
+    node = SSOAuthenticationNode()
+    for provider in ("saml", "ldap"):
+        with pytest.raises(ValueError, match=f"SSO provider {provider!r}"):
+            asyncio.run(node._handle_callback(provider, {}))
+
+
+@pytest.mark.regression
+def test_sso_no_orphan_saml_or_ldap_helpers():
+    """The deleted SAML/LDAP helper methods MUST stay deleted.
+
+    ``_validate_saml_response``, ``_authenticate_ldap``,
+    ``_handle_saml_callback``, ``_handle_ldap_callback``, and
+    ``_extract_saml_attributes`` were orphans after the dispatcher was
+    tightened. They were deleted; this test guards against revival.
+    """
+    import kailash.nodes.auth.sso as sso_module
+    from kailash.nodes.auth.sso import SSOAuthenticationNode
+
+    assert not hasattr(sso_module, "_validate_saml_response")
+    node = SSOAuthenticationNode()
+    for orphan in (
+        "_authenticate_ldap",
+        "_handle_saml_callback",
+        "_handle_ldap_callback",
+        "_extract_saml_attributes",
+    ):
+        assert not hasattr(node, orphan), (
+            f"{orphan} should be deleted (Rule 2 stub cleanup); "
+            "if you re-added it, also implement the protocol-specific path."
+        )
+
+
+@pytest.mark.regression
+def test_enterprise_auth_default_methods_excludes_passwordless_and_certificate():
+    """Default ``enabled_methods`` does NOT advertise unimplemented methods.
+
+    Pre-fix the default included ``passwordless`` (every default-config
+    user got a broken auth method advertised). The default now lists only
+    methods the Core SDK actually implements.
+    """
+    from kailash.nodes.auth.enterprise_auth_provider import EnterpriseAuthProviderNode
+
+    node = EnterpriseAuthProviderNode()
+    assert "passwordless" not in node.enabled_methods
+    assert "certificate" not in node.enabled_methods
+    assert node.enabled_methods == [
+        "sso",
+        "mfa",
+        "directory",
+        "social",
+        "api_key",
+        "jwt",
+    ]
+
+
+@pytest.mark.regression
+def test_enterprise_auth_dispatcher_rejects_passwordless_and_certificate():
+    """``_perform_authentication`` rejects unimplemented methods with ValueError."""
+    from kailash.nodes.auth.enterprise_auth_provider import EnterpriseAuthProviderNode
+
+    node = EnterpriseAuthProviderNode()
+    for method in ("passwordless", "certificate"):
+        with pytest.raises(ValueError, match=f"Authentication method {method!r}"):
+            asyncio.run(node._perform_authentication(method, {}, "user-1", {}))
+
+
+@pytest.mark.regression
+def test_enterprise_auth_no_orphan_passwordless_or_certificate_methods():
+    """Deleted dispatch-target stubs MUST stay deleted."""
+    from kailash.nodes.auth.enterprise_auth_provider import EnterpriseAuthProviderNode
+
+    node = EnterpriseAuthProviderNode()
+    for orphan in ("_authenticate_passwordless", "_authenticate_certificate"):
+        assert not hasattr(node, orphan), (
+            f"{orphan} should be deleted (Rule 2 stub cleanup); "
+            "subclasses requiring this method should override "
+            "_perform_authentication directly."
+        )
+
+
+@pytest.mark.regression
+def test_enterprise_auth_assess_behavior_risk_returns_documented_default():
+    """``_assess_behavior_risk`` is a documented override point with a no-op default.
+
+    Pre-fix this method raised ``NotImplementedError`` on EVERY auth call
+    that included a user_id (because ``_calculate_risk_score`` invoked it
+    unconditionally). The top-level try/except converted the crash into a
+    permanent auth failure with a misleading "behavioral analysis" error
+    text. The fix replaces the stub with a zero-risk default that
+    subclasses can override.
+    """
+    from kailash.nodes.auth.enterprise_auth_provider import EnterpriseAuthProviderNode
+
+    node = EnterpriseAuthProviderNode()
+    result = asyncio.run(node._assess_behavior_risk("user-1", {}))
+    assert result == {"score": 0.0, "factors": []}
+
+
+@pytest.mark.regression
+def test_mfa_orphan_send_sms_method_is_deleted():
+    """``MultiFactorAuthNode._send_sms`` orphan method is gone.
+
+    Two ``_send_sms`` symbols existed: a working module-level helper
+    (``mfa._send_sms`` — kept) and an orphan instance method that no
+    production code called (deleted). This test guards against revival of
+    the orphan method.
+    """
+    from kailash.nodes.auth.mfa import MultiFactorAuthNode
+
+    node = MultiFactorAuthNode()
+    bound = getattr(node, "_send_sms", None)
+    # Module-level _send_sms is NOT a method on the instance.
+    # If the instance method comes back, ``bound`` becomes a bound method.
+    assert bound is None or not callable(bound) or not hasattr(bound, "__self__"), (
+        "MultiFactorAuthNode._send_sms instance method should remain deleted "
+        "(only the module-level kailash.nodes.auth.mfa._send_sms is kept)."
+    )
+
+
+@pytest.mark.regression
+def test_mfa_module_level_send_sms_helper_still_exists():
+    """The module-level ``_send_sms`` helper stays — it IS used (line 648)."""
+    from kailash.nodes.auth import mfa
+
+    assert callable(mfa._send_sms)
+    assert mfa._send_sms("+15555550123", "test message") is True
+
+
+@pytest.mark.regression
+def test_middleware_require_auth_orphan_function_is_deleted():
+    """``require_auth`` is gone — it was an orphan stub redirect.
+
+    The function raised ``NotImplementedError`` pointing callers at
+    ``MiddlewareAuthManager.get_current_user_dependency``; no code in the
+    repo or downstream packages imported it. Per
+    ``rules/orphan-detection.md`` Rule 3 (Removed = Deleted).
+    """
+    with pytest.raises(ImportError):
+        from kailash.middleware.auth.auth_manager import require_auth  # noqa: F401
+
+
+@pytest.mark.regression
+def test_no_notimplementederror_in_auth_module_tree():
+    """Repository-wide guard: no ``raise NotImplementedError`` in auth code.
+
+    This is the structural defense against the stub-revival pattern. If a
+    future refactor re-introduces a stub, this test fails loudly and forces
+    the author to either implement it or delete the dispatch branch.
+    """
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    auth_dirs = [
+        repo_root / "src" / "kailash" / "nodes" / "auth",
+        repo_root / "src" / "kailash" / "middleware" / "auth",
+    ]
+
+    offenders: list[str] = []
+    for d in auth_dirs:
+        if not d.is_dir():
+            continue
+        for py in d.rglob("*.py"):
+            text = py.read_text()
+            if "raise NotImplementedError" in text:
+                offenders.append(str(py.relative_to(repo_root)))
+
+    assert not offenders, (
+        "Auth code MUST NOT raise NotImplementedError on documented public "
+        "surfaces (rules/zero-tolerance.md Rule 2 § Fake dispatch). "
+        f"Offenders: {offenders}. Either implement the method or delete "
+        "the dispatch branch and remove the symbol from the default config."
+    )


### PR DESCRIPTION
## Summary
- Eliminates 7 `raise NotImplementedError` sites across `src/kailash/{nodes,middleware}/auth/` per `rules/zero-tolerance.md` Rule 2 § "Fake dispatch" and `rules/orphan-detection.md` Rule 3.
- Default-config users previously hit `NotImplementedError` from documented public APIs (`SSOAuthenticationNode(provider="saml")`, `EnterpriseAuthProviderNode(method="passwordless")`, the unconditional `_assess_behavior_risk` call). Each surface now either raises a typed `ValueError` naming the override path, returns a documented no-op default, or — for orphan helpers with zero production callers — is deleted outright.
- Locked by `tests/regression/test_auth_stub_rule2_cleanup.py` (11 tests, all passing), including a structural sweep that fails if `raise NotImplementedError` re-appears anywhere in `src/kailash/{nodes,middleware}/auth/`.

## Test plan
- [x] 11 new regression tests pass locally (`.venv/bin/python -m pytest tests/regression/test_auth_stub_rule2_cleanup.py` — 0.71s)
- [x] Structural sweep asserts no `NotImplementedError` in auth tree
- [ ] CI green

## Out of scope
16 pre-existing failures in `tests/integration/nodes/test_mfa_functional.py` from `operation=` vs `action=` parameter drift (different bug class, predates this branch). Filed separately as #778. The `test_mfa_node_custom_configuration` Python syntax error (`mfa_  # node.methods`) is minimally fixed in this PR to unblock pytest collection.

## Related issues
Resolves SWEEP-2026-05-01 priority #2 (auth Rule 2 stub audit).
Related: #778 (MFA test parameter drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)