### PR TITLE
feat(kaizen): LlmDeployment.openai_compatible + anthropic_compatible + preset_name field (#761, #762)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0] — 2026-05-02 — LlmDeployment escape-hatch presets + `preset_name` retrofit
+
+Minor bump. Two cross-SDK parity issues close together:
+
+- **(Added)** `LlmDeployment.openai_compatible(base_url, api_key)` (#761) and `LlmDeployment.anthropic_compatible(base_url, api_key)` (#762) escape-hatch presets — wrap an arbitrary HTTPS endpoint with the canonical OpenAI Chat / Anthropic Messages wire protocol. Cross-SDK parity with kailash-rs PR #722 / PR #724.
+- **(Added)** `LlmDeployment.preset_name: Optional[str]` field, set by every preset factory (24 existing + 2 new) to the canonical literal. Cross-SDK parity with kailash-rs `LlmDeployment::preset_name()`.
+
+### Added
+
+- **`LlmDeployment.openai_compatible(base_url, api_key)` + `LlmDeployment.anthropic_compatible(base_url, api_key)` escape-hatch presets (closes #761, #762; cross-SDK parity with kailash-rs PR #722 / PR #724).** Wraps an arbitrary HTTPS endpoint with the canonical OpenAI Chat / Anthropic Messages wire protocol — useful for vLLM, llama.cpp servers, LM Studio remotes, LiteLLM proxies, OpenRouter Anthropic mode, internal gateways, and third-party OpenAI/Anthropic-compatible providers. SSRF guard runs on `Endpoint.base_url` automatically via the field validator (`deployment.py:129`, `mode="before"`); loopback (literal-IP) / RFC1918 private / link-local / cloud-metadata / non-HTTP(S) URLs raise `InvalidEndpoint` at construction. Anthropic variant defaults `anthropic-version: 2023-06-01` on `Endpoint.required_headers` (overridable). Both factories are reachable via the registry (`get_preset("openai_compatible")`, `get_preset("anthropic_compatible")`) AND the classmethod surface.
+- **`LlmDeployment.preset_name: Optional[str]` field — canonical preset literal exposed on every constructed deployment.** Set by every preset factory (all 24 existing presets retrofitted in the same PR per `rules/zero-tolerance.md` Rule 6 Implement Fully) to the literal registered in `_PRESETS`. The literal — NOT the host or any caller-supplied URL fragment — prevents log-aggregator label cardinality blow-up and credential enumeration via observability per `rules/observability.md` § 8 (schema-revealing field names). Manual constructions leave it `None`; that's structural — `preset_name` is a public-API contract for preset-built deployments only. Cross-SDK parity with kailash-rs `LlmDeployment::preset_name()`. Python idiom is field access (`dep.preset_name`) rather than the Rust method-style (`dep.preset_name()`); the field IS the contract surface, and is consumed by the upcoming `supports()` capability matrix (#763) without per-call introspection.
+- **`azure_openai_preset` added to `kaizen.llm.presets.__all__`.** Pre-existing orphan-detection §6 violation surfaced by this change (`__all__`-completeness audit) — the preset was eagerly defined and registered at module load, but absent from `__all__`, so `from kaizen.llm.presets import *` silently dropped it from the public re-export. Same-bug-class fix-immediately per `rules/autonomous-execution.md` MUST Rule 4.
+
+### Tested
+
+- `tests/unit/llm/test_preset_name_and_compatible.py` — 22 tests covering both new compatible presets (shape, classmethod parity, empty-arg rejection, parametrized SSRF guard rejection over loopback / private / link-local / cloud-metadata / non-HTTP(S)), every retrofitted preset's `preset_name` literal, registry membership, and a structural `len(list_presets()) == 26` lock so future regressions surface loudly.
+
 ## [2.14.0] — 2026-04-30 — Canonical `kaizen.core` re-exports + MLAwareAgent + env-model resolution
 
 Minor bump. Three load-bearing changes land together:

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.14.0"
+version = "2.15.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.14.0"
+__version__ = "2.15.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/llm/deployment.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/deployment.py
@@ -313,6 +313,18 @@ class LlmDeployment(BaseModel):
     default_model: Optional[str] = None
     streaming: StreamingConfig = Field(default_factory=StreamingConfig)
     retry: RetryConfig = Field(default_factory=RetryConfig)
+    preset_name: Optional[str] = None
+    """Canonical preset literal (e.g. ``"openai"``, ``"openai_compatible"``).
+
+    Set by every preset factory to the literal registered in ``_PRESETS``.
+    Manual constructions leave it ``None``. The literal — NOT the host or
+    any caller-supplied URL fragment — prevents log-aggregator label
+    cardinality blow-up and credential enumeration via observability per
+    ``rules/observability.md`` § 8 (schema-revealing field names) and
+    cross-SDK parity with kailash-rs ``LlmDeployment::preset_name()``.
+    Python idiom is field access (``dep.preset_name``) rather than the
+    Rust method-style ``dep.preset_name()``.
+    """
 
     # -------------------------------------------------------------
     # Preset classmethod STUBS — only `.openai` is implemented in S1+S2.

--- a/packages/kailash-kaizen/src/kaizen/llm/presets.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/presets.py
@@ -35,6 +35,7 @@ import re
 from typing import Any, Callable, Dict, Optional
 
 from kailash.utils.url_credentials import fingerprint_secret
+
 from kaizen.llm.auth.aws import AwsBearerToken
 from kaizen.llm.auth.bearer import ApiKey, ApiKeyBearer, ApiKeyHeaderKind, StaticNone
 from kaizen.llm.auth.gcp import GcpOauth
@@ -202,6 +203,7 @@ def openai_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="openai",
     )
 
 
@@ -300,6 +302,7 @@ def anthropic_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="anthropic",
     )
 
 
@@ -331,6 +334,7 @@ def google_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="google",
     )
 
 
@@ -359,6 +363,7 @@ def cohere_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="cohere",
     )
 
 
@@ -392,6 +397,7 @@ def mistral_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="mistral",
     )
 
 
@@ -423,6 +429,7 @@ def perplexity_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="perplexity",
     )
 
 
@@ -451,6 +458,7 @@ def huggingface_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="huggingface",
     )
 
 
@@ -482,6 +490,7 @@ def ollama_preset(
         endpoint=endpoint,
         auth=StaticNone(),
         default_model=model,
+        preset_name="ollama",
     )
 
 
@@ -513,6 +522,7 @@ def docker_model_runner_preset(
         endpoint=endpoint,
         auth=StaticNone(),
         default_model=model,
+        preset_name="docker_model_runner",
     )
 
 
@@ -539,6 +549,7 @@ def groq_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="groq",
     )
 
 
@@ -567,6 +578,7 @@ def together_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="together",
     )
 
 
@@ -595,6 +607,7 @@ def fireworks_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="fireworks",
     )
 
 
@@ -623,6 +636,7 @@ def openrouter_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="openrouter",
     )
 
 
@@ -651,6 +665,7 @@ def deepseek_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=model,
+        preset_name="deepseek",
     )
 
 
@@ -677,6 +692,7 @@ def lm_studio_preset(
         endpoint=endpoint,
         auth=StaticNone(),
         default_model=model,
+        preset_name="lm_studio",
     )
 
 
@@ -703,6 +719,7 @@ def llama_cpp_preset(
         endpoint=endpoint,
         auth=StaticNone(),
         default_model=model,
+        preset_name="llama_cpp",
     )
 
 
@@ -877,6 +894,7 @@ def bedrock_claude_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=resolved_model,
+        preset_name="bedrock_claude",
     )
     logger.info(
         "llm.deployment.bedrock_claude.constructed",
@@ -973,6 +991,7 @@ def _build_bedrock_deployment(
         endpoint=endpoint,
         auth=auth,
         default_model=resolved_model,
+        preset_name=preset_name,
     )
     logger.info(
         f"llm.deployment.{preset_name}.constructed",
@@ -1258,6 +1277,7 @@ def _build_vertex_deployment(
         endpoint=endpoint,
         auth=auth,
         default_model=resolved_model,
+        preset_name=preset_name,
     )
     logger.info(
         f"llm.deployment.{preset_name}.constructed",
@@ -1500,6 +1520,7 @@ def azure_openai_preset(
         endpoint=endpoint,
         auth=auth,
         default_model=resolved_deployment,
+        preset_name="azure_openai",
     )
     logger.info(
         "llm.deployment.azure_openai.constructed",
@@ -1565,6 +1586,140 @@ def _register_and_attach_session_6_presets() -> None:
 _register_and_attach_session_6_presets()
 
 
+# ---------------------------------------------------------------------------
+# Compatible-endpoint presets — wrap an arbitrary HTTPS endpoint with a
+# canonical wire protocol. Cross-SDK parity with kailash-rs PR #722
+# (openai_compatible) and PR #724 (anthropic_compatible).
+#
+# Use cases: vLLM, llama.cpp servers, LM Studio remotes, LiteLLM proxies,
+# OpenRouter Anthropic mode, internal gateways, third-party OpenAI/Anthropic-
+# compatible providers. SSRF guard runs on `Endpoint.base_url` via the
+# field validator in `deployment.py:129` (mode="before"), so loopback /
+# private / link-local / cloud-metadata URLs are rejected at construction.
+#
+# `preset_name()` returns the literal `"openai_compatible"` /
+# `"anthropic_compatible"` (NOT the host) per spec § 6.M2 — this prevents
+# log-aggregator label cardinality blow-up and credential enumeration via
+# observability (`rules/observability.md` § 8).
+# ---------------------------------------------------------------------------
+
+
+def openai_compatible_preset(
+    base_url: str,
+    api_key: str,
+    *,
+    path_prefix: str = "/v1",
+) -> LlmDeployment:
+    """OpenAI-compatible endpoint at a caller-provided base URL.
+
+    Wire:     `OpenAiChat`
+    Endpoint: caller-provided (e.g. `https://vllm.example.com`)
+    Auth:     `Authorization: Bearer <api_key>` via
+              `ApiKeyBearer(Authorization_Bearer)`
+
+    Both `base_url` and `api_key` are REQUIRED non-empty strings. SSRF
+    guard runs on `base_url` automatically via the `Endpoint` field
+    validator — loopback / private / link-local / cloud-metadata /
+    non-HTTP(S) URLs raise the appropriate typed error.
+
+    Cross-SDK parity with kailash-rs `LlmDeployment::openai_compatible`
+    (PR #722). The preset name on the constructed deployment is the
+    literal `"openai_compatible"` — never the caller-provided host.
+    """
+    _validate_required_str(base_url, name="openai_compatible_preset.base_url")
+    _validate_required_str(
+        api_key,
+        name="openai_compatible_preset.api_key",
+        env_hint="OPENAI_COMPATIBLE_API_KEY",
+    )
+
+    endpoint = Endpoint(base_url=base_url, path_prefix=path_prefix)
+    auth = ApiKeyBearer(
+        kind=ApiKeyHeaderKind.Authorization_Bearer,
+        key=ApiKey(api_key),
+    )
+    return LlmDeployment(
+        wire=WireProtocol.OpenAiChat,
+        endpoint=endpoint,
+        auth=auth,
+        default_model=None,
+        preset_name="openai_compatible",
+    )
+
+
+def anthropic_compatible_preset(
+    base_url: str,
+    api_key: str,
+    *,
+    path_prefix: str = "/v1",
+    anthropic_version: str = "2023-06-01",
+) -> LlmDeployment:
+    """Anthropic-compatible endpoint at a caller-provided base URL.
+
+    Wire:     `AnthropicMessages`
+    Endpoint: caller-provided (e.g. `https://anthropic-proxy.example.com`)
+    Auth:     `X-Api-Key: <api_key>` via `ApiKeyBearer(X_Api_Key)`
+    Headers:  `anthropic-version` on `Endpoint.required_headers` (default
+              `"2023-06-01"`, override for proxies pinned to a different
+              wire version)
+
+    Both `base_url` and `api_key` are REQUIRED non-empty strings. SSRF
+    guard runs on `base_url` automatically via the `Endpoint` field
+    validator.
+
+    Cross-SDK parity with kailash-rs `LlmDeployment::anthropic_compatible`
+    (PR #724). The preset name on the constructed deployment is the
+    literal `"anthropic_compatible"` — never the caller-provided host.
+    """
+    _validate_required_str(base_url, name="anthropic_compatible_preset.base_url")
+    _validate_required_str(
+        api_key,
+        name="anthropic_compatible_preset.api_key",
+        env_hint="ANTHROPIC_COMPATIBLE_API_KEY",
+    )
+
+    endpoint = Endpoint(
+        base_url=base_url,
+        path_prefix=path_prefix,
+        required_headers={"anthropic-version": anthropic_version},
+    )
+    auth = ApiKeyBearer(kind=ApiKeyHeaderKind.X_Api_Key, key=ApiKey(api_key))
+    return LlmDeployment(
+        wire=WireProtocol.AnthropicMessages,
+        endpoint=endpoint,
+        auth=auth,
+        default_model=None,
+        preset_name="anthropic_compatible",
+    )
+
+
+def _attach_compatible_classmethods() -> None:
+    """Register `openai_compatible` / `anthropic_compatible` AND attach as
+    `LlmDeployment.<name>` classmethods. Mirrors the
+    `_register_and_attach_session_*` pattern.
+    """
+    register_preset("openai_compatible", openai_compatible_preset)
+    register_preset("anthropic_compatible", anthropic_compatible_preset)
+
+    @classmethod  # type: ignore[misc]
+    def openai_compatible(
+        cls, base_url: str, api_key: str, **kwargs: Any
+    ) -> LlmDeployment:
+        return openai_compatible_preset(base_url, api_key, **kwargs)
+
+    @classmethod  # type: ignore[misc]
+    def anthropic_compatible(
+        cls, base_url: str, api_key: str, **kwargs: Any
+    ) -> LlmDeployment:
+        return anthropic_compatible_preset(base_url, api_key, **kwargs)
+
+    LlmDeployment.openai_compatible = openai_compatible  # type: ignore[attr-defined]
+    LlmDeployment.anthropic_compatible = anthropic_compatible  # type: ignore[attr-defined]
+
+
+_attach_compatible_classmethods()
+
+
 __all__ = [
     # S1
     "openai_preset",
@@ -1597,4 +1752,9 @@ __all__ = [
     # S5 -- Vertex AI presets
     "vertex_claude_preset",
     "vertex_gemini_preset",
+    # S6 -- Azure OpenAI
+    "azure_openai_preset",
+    # S7 -- Compatible-endpoint presets (#761, #762)
+    "openai_compatible_preset",
+    "anthropic_compatible_preset",
 ]

--- a/packages/kailash-kaizen/tests/unit/llm/test_preset_name_and_compatible.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_preset_name_and_compatible.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `preset_name` retrofit + new compatible-endpoint presets.
+
+Covers terrene-foundation/kailash-py#761 (`openai_compatible`) and
+terrene-foundation/kailash-py#762 (`anthropic_compatible`), and the
+`preset_name` field added to `LlmDeployment` in the same PR. Cross-SDK
+parity with kailash-rs PR #722 / PR #724.
+
+Per `rules/zero-tolerance.md` Rule 6 (Implement Fully): the new
+`preset_name` field is wired into ALL existing presets in the same PR,
+not only the new compatible variants — leaving the field as ``None``
+for established presets would ship a half-implemented public contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm.auth.bearer import ApiKeyBearer, ApiKeyHeaderKind
+from kaizen.llm.deployment import LlmDeployment, WireProtocol
+from kaizen.llm.errors import InvalidEndpoint
+from kaizen.llm.presets import (
+    anthropic_compatible_preset,
+    list_presets,
+    openai_compatible_preset,
+)
+
+# A non-loopback, DNS-resolvable, RFC-2606 reserved hostname. Used for
+# happy-path construction; we never make a real HTTP request to it.
+_RESOLVABLE_HOST = "https://example.com"
+
+
+# ---------------------------------------------------------------------------
+# `openai_compatible` preset (#761)
+# ---------------------------------------------------------------------------
+
+
+def test_openai_compatible_preset_shape() -> None:
+    d = LlmDeployment.openai_compatible(_RESOLVABLE_HOST + "/v1", "sk-test")
+    assert d.wire == WireProtocol.OpenAiChat
+    assert d.preset_name == "openai_compatible"
+    assert str(d.endpoint.base_url).startswith("https://example.com")
+    assert isinstance(d.auth, ApiKeyBearer)
+    assert d.auth.kind == ApiKeyHeaderKind.Authorization_Bearer
+    # default_model is intentionally unset for compatible presets — the
+    # caller pins per-request via ResolvedModel.
+    assert d.default_model is None
+
+
+def test_openai_compatible_classmethod_matches_free_function() -> None:
+    cm = LlmDeployment.openai_compatible(_RESOLVABLE_HOST, "sk-test")
+    fn = openai_compatible_preset(_RESOLVABLE_HOST, "sk-test")
+    assert cm.wire == fn.wire
+    assert cm.preset_name == fn.preset_name == "openai_compatible"
+
+
+def test_openai_compatible_rejects_empty_base_url() -> None:
+    with pytest.raises(ValueError, match=r"base_url"):
+        LlmDeployment.openai_compatible("", "sk-test")
+
+
+def test_openai_compatible_rejects_empty_api_key() -> None:
+    with pytest.raises(ValueError, match=r"OPENAI_COMPATIBLE_API_KEY|api_key"):
+        LlmDeployment.openai_compatible(_RESOLVABLE_HOST, "")
+
+
+@pytest.mark.parametrize(
+    "blocked_url",
+    [
+        "http://127.0.0.1",  # loopback (literal IP)
+        # NB: `http://localhost` (named) is intentionally allowed by the
+        # SSRF guard for local-server presets (ollama, lm_studio) — only
+        # literal-IP loopback is rejected.
+        "http://10.0.0.5",  # RFC1918 private
+        "http://192.168.1.1",  # RFC1918 private
+        "http://169.254.169.254",  # AWS / GCP / Azure cloud metadata
+        "http://fd00::1",  # IPv6 ULA
+        "ftp://example.com",  # non-HTTP(S) scheme
+    ],
+)
+def test_openai_compatible_ssrf_guard_rejects(blocked_url: str) -> None:
+    """SSRF guard runs on Endpoint.base_url for the new compatible presets.
+
+    Spec § 5.1 + spec § 6.M2: compatible presets MUST inherit the same
+    SSRF guard as the rest of the deployment surface — loopback,
+    private, link-local, cloud metadata, and non-HTTP(S) URLs are
+    rejected at construction.
+    """
+    with pytest.raises(InvalidEndpoint):
+        LlmDeployment.openai_compatible(blocked_url, "sk-test")
+
+
+# ---------------------------------------------------------------------------
+# `anthropic_compatible` preset (#762)
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_compatible_preset_shape() -> None:
+    d = LlmDeployment.anthropic_compatible(_RESOLVABLE_HOST, "sk-test")
+    assert d.wire == WireProtocol.AnthropicMessages
+    assert d.preset_name == "anthropic_compatible"
+    assert isinstance(d.auth, ApiKeyBearer)
+    assert d.auth.kind == ApiKeyHeaderKind.X_Api_Key
+    assert d.default_model is None
+    # `anthropic-version` MUST be set on required_headers (default 2023-06-01).
+    assert d.endpoint.required_headers.get("anthropic-version") == "2023-06-01"
+
+
+def test_anthropic_compatible_accepts_custom_anthropic_version() -> None:
+    d = anthropic_compatible_preset(
+        _RESOLVABLE_HOST, "sk-test", anthropic_version="2024-09-01"
+    )
+    assert d.endpoint.required_headers["anthropic-version"] == "2024-09-01"
+
+
+def test_anthropic_compatible_rejects_empty_base_url() -> None:
+    with pytest.raises(ValueError, match=r"base_url"):
+        LlmDeployment.anthropic_compatible("", "sk-test")
+
+
+def test_anthropic_compatible_rejects_empty_api_key() -> None:
+    with pytest.raises(ValueError, match=r"ANTHROPIC_COMPATIBLE_API_KEY|api_key"):
+        LlmDeployment.anthropic_compatible(_RESOLVABLE_HOST, "")
+
+
+@pytest.mark.parametrize(
+    "blocked_url",
+    [
+        "http://127.0.0.1",
+        "http://10.0.0.5",
+        "http://169.254.169.254",
+        "ftp://example.com",
+    ],
+)
+def test_anthropic_compatible_ssrf_guard_rejects(blocked_url: str) -> None:
+    with pytest.raises(InvalidEndpoint):
+        LlmDeployment.anthropic_compatible(blocked_url, "sk-test")
+
+
+# ---------------------------------------------------------------------------
+# Preset name retrofit (cross-cutting — verifies every existing preset
+# returns its canonical literal). Same-bug-class fix-immediately per
+# `rules/autonomous-execution.md` MUST Rule 4 — without retrofit, the
+# capability matrix in PR-B (#763) cannot reliably look up presets.
+# ---------------------------------------------------------------------------
+
+
+def test_preset_name_field_present_on_all_constructions() -> None:
+    """`LlmDeployment.preset_name` is set to the canonical literal for
+    every preset that admits a no-side-effect smoke construction.
+
+    Bedrock / Vertex / Azure presets need region / auth-instance kwargs
+    that aren't smoke-testable here; their retrofit is verified by the
+    helper-internal `preset_name=` keyword to `_build_*_deployment`,
+    which threads to `LlmDeployment(preset_name=...)`. Coverage at the
+    helper level is structural (the helpers have no other code path).
+    """
+    cases = [
+        # (preset_name, callable form, kwargs for happy-path construction)
+        ("openai", LlmDeployment.openai, {"api_key": "sk-test", "model": "m"}),
+        ("anthropic", LlmDeployment.anthropic, {"api_key": "sk-test", "model": "m"}),
+        ("google", LlmDeployment.google, {"api_key": "sk-test", "model": "m"}),
+        ("cohere", LlmDeployment.cohere, {"api_key": "sk-test", "model": "m"}),
+        ("mistral", LlmDeployment.mistral, {"api_key": "sk-test", "model": "m"}),
+        ("perplexity", LlmDeployment.perplexity, {"api_key": "sk-test", "model": "m"}),
+        (
+            "huggingface",
+            LlmDeployment.huggingface,
+            {"api_key": "sk-test", "model": "m"},
+        ),
+        ("groq", LlmDeployment.groq, {"api_key": "sk-test", "model": "m"}),
+        ("together", LlmDeployment.together, {"api_key": "sk-test", "model": "m"}),
+        ("fireworks", LlmDeployment.fireworks, {"api_key": "sk-test", "model": "m"}),
+        ("openrouter", LlmDeployment.openrouter, {"api_key": "sk-test", "model": "m"}),
+        ("deepseek", LlmDeployment.deepseek, {"api_key": "sk-test", "model": "m"}),
+        (
+            "ollama",
+            LlmDeployment.ollama,
+            {"base_url": "http://localhost:11434", "model": "m"},
+        ),
+        (
+            "docker_model_runner",
+            LlmDeployment.docker_model_runner,
+            {"base_url": "http://localhost:12434", "model": "m"},
+        ),
+        (
+            "lm_studio",
+            LlmDeployment.lm_studio,
+            {"base_url": "http://localhost:1234", "model": "m"},
+        ),
+        (
+            "llama_cpp",
+            LlmDeployment.llama_cpp,
+            {"base_url": "http://localhost:8080", "model": "m"},
+        ),
+    ]
+    for canonical_name, factory, kwargs in cases:
+        d = factory(**kwargs)
+        assert d.preset_name == canonical_name, (
+            f"preset {canonical_name!r} retrofit incomplete: "
+            f"got preset_name={d.preset_name!r}"
+        )
+
+
+def test_bedrock_claude_preset_name_threads_through_standalone_path() -> None:
+    """`bedrock_claude` is the only Bedrock preset on a non-helper code
+    path — verify directly. Other Bedrock families (`bedrock_llama`,
+    `bedrock_titan`, `bedrock_mistral`, `bedrock_cohere`) all share the
+    `_build_bedrock_deployment` helper which threads `preset_name`
+    through structurally; the helper IS a single code path so verifying
+    one variant proves the whole family.
+    """
+    d = LlmDeployment.bedrock_claude(
+        api_key="test-tok", region="us-east-1", model="claude-sonnet-4-6"
+    )
+    assert d.preset_name == "bedrock_claude"
+
+
+def test_compatible_presets_appear_in_registry() -> None:
+    """Both new presets MUST be reachable via the registry, not only via
+    the classmethod surface — this is the contract `rules/orphan-detection.md`
+    Rule 1 protects (every facade has a registered call site).
+    """
+    presets = list_presets()
+    assert "openai_compatible" in presets
+    assert "anthropic_compatible" in presets
+
+
+def test_total_preset_count_after_retrofit() -> None:
+    """Lock the registry size so future regressions surface loudly.
+
+    24 existing presets (S1 + 15 S3 + 4 S4b + 1 S4a + 2 S5 + 1 S6 + the
+    `azure_entra` factory which is registered via S6) + 2 new compatible
+    presets = 26.
+
+    NB: `azure_entra` is registered as a preset name even though it is
+    really an auth-strategy factory; this is pre-existing in the kaizen
+    LLM surface. If a future cleanup removes it, update this count to 25.
+    """
+    assert len(list_presets()) == 26


### PR DESCRIPTION
## Summary
- Two cross-SDK escape-hatch presets land for Python kaizen, parity with shipped kailash-rs PRs #722 (`openai_compatible`) and #724 (`anthropic_compatible`).
- `LlmDeployment.preset_name` field added and wired into ALL 24 existing presets in the same PR, per `rules/zero-tolerance.md` Rule 6 Implement Fully — leaving the field as `None` for established presets would ship a half-implemented public contract that the upcoming `supports()` matrix (#763) cannot rely on.
- SSRF guard (loopback literal-IP / RFC1918 / link-local / cloud-metadata / non-HTTP(S)) inherited automatically via the existing `Endpoint` field validator (`deployment.py:129`, `mode="before"`) — no new guard code; the validator runs on the new presets' caller-provided `base_url`.
- `kailash-kaizen` 2.14.0 → 2.15.0 (minor — new feature) per `rules/zero-tolerance.md` Rule 5 atomic version bump.

## Test plan
- [x] 22 new tests pass locally (`tests/unit/llm/test_preset_name_and_compatible.py`)
- [x] 125 broader preset-related tests pass (existing + new)
- [x] Full kaizen LLM unit test sweep passes (846 tests, excluding pre-existing botocore-not-installed environment failures unrelated to this PR)
- [x] Smoke verified: SSRF rejects loopback literal-IP / RFC1918 / link-local / cloud metadata; `preset_name` returns canonical literal per preset; 26 presets registered
- [ ] CI green

## Notes
- `http://localhost` (named) is intentionally allowed by the existing SSRF guard for local-server presets (ollama, lm_studio); only literal-IP loopback (`127.0.0.1`) is rejected. The new `test_openai_compatible_ssrf_guard_rejects` parametrize set excludes named-localhost to match this contract.
- `azure_openai_preset` was missing from `kaizen.llm.presets.__all__` before this PR (eagerly imported but absent from the public re-export). Fixed in same PR per `rules/autonomous-execution.md` MUST Rule 4 (same-bug-class fix-immediately).
- Python idiom for `preset_name` is field access (`dep.preset_name`), not method-style (`dep.preset_name()`) — matches Pydantic conventions; field IS the contract surface.

## Related issues
Closes #761, #762. Sibling PR-B (closes #763 + #764: `supports()` capability matrix + `register_bedrock_region` runtime override) follows after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)