### PR TITLE
chore(release): kailash 2.13.3 — catch up PyPI for #779

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.3] — 2026-05-02 — auth Rule 2 cleanup release (#779)
+
+Patch release cutting PyPI for the auth-stub Rule 2 cleanup that landed in
+PR #779 (commit `9364027b`, merged 2026-05-01) without a same-PR version bump.
+No new code in this release; the bump catches PyPI up to main per
+`rules/build-repo-release-discipline.md` Rule 5 (sub-package src changes
+require same-PR version bump — when the bump is missed, a follow-up
+release-prep PR closes the gap).
+
+### Fixed (recap from #779)
+
+- **7 `raise NotImplementedError` stubs eliminated across `src/kailash/{nodes,middleware}/auth/`** per `rules/zero-tolerance.md` Rule 2 § "Fake dispatch" and `rules/orphan-detection.md` Rule 3. Default-config users previously hit `NotImplementedError` from documented public APIs (`SSOAuthenticationNode(provider="saml")`, `EnterpriseAuthProviderNode(method="passwordless")`, the unconditional `_assess_behavior_risk` call). Each surface now either raises a typed `ValueError` naming the override path, returns a documented no-op default, or — for orphan helpers with zero production callers — was deleted outright.
+- Locked by `tests/regression/test_auth_stub_rule2_cleanup.py` (11 tests, all passing), including a structural sweep that fails if `raise NotImplementedError` re-appears anywhere in `src/kailash/{nodes,middleware}/auth/`.
+
 ## [2.13.2] — 2026-05-01 — `durability_middleware` passes through SSE / `StreamingResponse` (#767)
 
 Patch release closing issue #767. `DurableWorkflowServer._add_durability_middleware` (the durability middleware that `EnterpriseWorkflowServer` and `Nexus()` mount on every 2xx response) drained `response.body_iterator` before forwarding any bytes. For `StreamingResponse` (SSE, chunked transfer, file streams, gRPC streaming) this destroyed streaming semantics on the first request and replayed the captured stream as a JSON envelope on every cache hit, breaking every SSE / `EventSource` client.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.13.2"
+version = "2.13.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.13.2"
+__version__ = "2.13.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Patch release cutting PyPI for the auth-stub Rule 2 cleanup that landed in PR #779 (commit `9364027b`, merged 2026-05-01) without a same-PR version bump per `rules/build-repo-release-discipline.md` Rule 5.

## Summary

- Bumps `kailash` 2.13.2 → 2.13.3 (`pyproject.toml` + `src/kailash/__init__.py`)
- Adds CHANGELOG entry recapping the #779 fix scope (7 `raise NotImplementedError` stubs eliminated across `src/kailash/{nodes,middleware}/auth/`).
- No new code in this PR — the bump catches PyPI up to main. The fix landed in #779; downstream consumers hitting `SSOAuthenticationNode(provider="saml")` / `EnterpriseAuthProviderNode(method="passwordless")` / the unconditional `_assess_behavior_risk` path are still seeing `NotImplementedError` from the published wheel until this release cuts.

## Branch convention

Opened from `release/v2.13.3` per `rules/git.md` § "Release-Prep PRs MUST Use `release/v*` Branch Convention" — auto-skips the PR-gate matrix on this metadata-only diff (saves ~45 min × matrix-size of CI minutes).

## Test plan

- [x] `kailash.__version__` smoke test confirms 2.13.3 imports cleanly
- [x] pre-commit (black, isort, ruff, type-annotations gate) passed
- [x] No source code changes — risk surface is the version anchors + CHANGELOG only

## Related issues

- Catches up: PR #779 (auth Rule 2 cleanup, merged 2026-05-01 without same-PR bump)
- Rule reference: `rules/build-repo-release-discipline.md` Rule 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)