### PR TITLE
release(kaizen): 2.16.1 — close ollama_default cross-SDK alias gap

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.1] — 2026-05-02 — `ollama_default` preset alias parity
+
+Patch bump. Closes the deferred cross-SDK parity gap reviewer flagged during
+the 2.16.0 pre-release pass: the `"ollama_default"` preset literal kailash-rs
+`CapabilityMatrix::for_preset` accepts as an alias for `"ollama"` was missing
+from `kaizen.llm.capabilities._PRESET_CAPABILITIES`, so a Python caller
+porting the alias from Rust hit the fail-closed all-False default while the
+Rust caller saw the wired row.
+
+### Fixed
+
+- **`for_preset("ollama_default")` now returns the canonical Ollama capability row (cross-SDK parity with kailash-rs `CapabilityMatrix::for_preset` line 212 — `str_eq(preset_name, "ollama") || str_eq(preset_name, "ollama_default")`).** Row is byte-identical to `"ollama"` (`tools=True, vision=True, batch=False, caching=False, audio=False`) per `rules/cross-sdk-inspection.md` § 3a. Test surface: `_NON_EMPTY_PRESETS` parametrized sweep in `tests/unit/llm/test_supports_capability_matrix.py` extended to `"ollama_default"` so a future row drift in either SDK fails loudly.
+
 ## [2.16.0] — 2026-05-02 — LlmDeployment.supports() + register_bedrock_region
 
 Cross-SDK parity with kailash-rs PR #725 (`CapabilityMatrix::for_preset`)

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.16.0"
+version = "2.16.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.16.0"
+__version__ = "2.16.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/llm/capabilities.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/capabilities.py
@@ -140,6 +140,15 @@ _PRESET_CAPABILITIES: Final[Mapping[str, Mapping[str, bool]]] = {
     # --- Local / open-weight servers -------------------------------------
     "groq": _caps(tools=True, vision=True, batch=False, caching=False, audio=False),
     "ollama": _caps(tools=True, vision=True, batch=False, caching=False, audio=False),
+    # ``ollama_default`` is the alias kailash-rs ``CapabilityMatrix::for_preset``
+    # accepts alongside ``"ollama"`` (see kailash-rs
+    # ``crates/kailash-kaizen/src/llm/deployment/capabilities.rs:212`` —
+    # ``str_eq(preset_name, "ollama") || str_eq(preset_name, "ollama_default")``).
+    # Cross-SDK parity row per ``rules/cross-sdk-inspection.md`` § 3a; row is
+    # byte-identical to ``"ollama"`` above.
+    "ollama_default": _caps(
+        tools=True, vision=True, batch=False, caching=False, audio=False
+    ),
     # --- Direct providers ------------------------------------------------
     "cohere": _caps(tools=True, vision=False, batch=False, caching=False, audio=False),
     "mistral": _caps(tools=True, vision=True, batch=False, caching=False, audio=False),

--- a/packages/kailash-kaizen/tests/unit/llm/test_supports_capability_matrix.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_supports_capability_matrix.py
@@ -242,6 +242,7 @@ _NON_EMPTY_PRESETS = (
     "bedrock_cohere",
     "groq",
     "ollama",
+    "ollama_default",
     "cohere",
     "mistral",
 )


### PR DESCRIPTION
## Summary

- Adds `"ollama_default"` row to `kaizen.llm.capabilities._PRESET_CAPABILITIES` mirroring `"ollama"` byte-for-byte (`tools=True, vision=True, batch=False, caching=False, audio=False`)
- Closes the deferred cross-SDK parity gap that reviewer flagged during the 2.16.0 pre-release pass — kailash-rs `CapabilityMatrix::for_preset` accepts both `"ollama"` AND `"ollama_default"` (`crates/kailash-kaizen/src/llm/deployment/capabilities.rs:212`); Python silently fell through to the all-False fail-closed default for `"ollama_default"` until now
- Extends the parametrized cross-SDK row-completeness sweep (`_NON_EMPTY_PRESETS`) so a future row-drift in either SDK fails the test loudly

## Cross-SDK parity contract

Per `rules/cross-sdk-inspection.md` § 3a, every preset literal accepted by kailash-rs `CapabilityMatrix::for_preset` MUST have a Python row. The Rust source-of-truth on the `ollama` arm:

```rust
// crates/kailash-kaizen/src/llm/deployment/capabilities.rs:212
if str_eq(preset_name, "ollama") || str_eq(preset_name, "ollama_default") {
    // tools=true, vision=true, batch=false, caching=false, audio=false
}
```

Python row is now byte-identical to the `"ollama"` row directly above it in `_PRESET_CAPABILITIES`.

## Test plan

- [x] `pytest packages/kailash-kaizen/tests/unit/llm/test_supports_capability_matrix.py` — 33/33 passing including new `test_every_non_empty_preset_has_capability_row[ollama_default]` parametrized assertion
- [ ] reviewer + security-reviewer gate (MUST per `rules/agents.md`)
- [ ] Admin-merge → tag `kaizen-v2.16.1` → push tag individually
- [ ] `/release` to PyPI; clean-venv install + import verification

## Related issues

Continuation of the cross-SDK parity track from #763 (kailash-rs PR #725). Deferral was recorded in `deploy/deployments/2026-05-02-v2.13.3-kaizen-v2.16.0.md` § "Cross-SDK parity follow-ups (deferred)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)