### PR TITLE
chore(deploy): record kailash-kaizen 2.16.1 + 2.16.2 cross-SDK parity wave

### DIFF
--- a/deploy/deployments/2026-05-02-v2.16.2-kaizen-cross-sdk-parity-cleanup.md
+++ b/deploy/deployments/2026-05-02-v2.16.2-kaizen-cross-sdk-parity-cleanup.md
@@ -1,0 +1,194 @@
+# 2026-05-02 — kailash-kaizen 2.16.2: cross-SDK parity cleanup wave
+
+Two same-day patch releases following the 2.16.0 paired wave (recorded in
+`deploy/deployments/2026-05-02-v2.13.3-kaizen-v2.16.0.md`). Both close
+cross-SDK API-surface gaps that the 2.16.0 reviewer pass and the
+post-2.16.1 `/redteam` audit surfaced as same-bug-class to the four
+LlmDeployment parity issues that 2.16.0 closed (#761/#762/#763/#764).
+`rules/autonomous-execution.md` Rule 4 (fix-immediately when same-bug-class
+gap fits one shard) drove both ship-now dispositions; four findings the
+same audit surfaced were filed as follow-ups (#788–#791) because each
+exceeds shard budget OR requires cross-SDK design alignment.
+
+## Scope
+
+| Package        | from   | to         | trigger                                                 |
+| -------------- | ------ | ---------- | ------------------------------------------------------- |
+| kailash-kaizen | 2.16.0 | **2.16.1** | reviewer-deferred `ollama_default` capability-alias gap |
+| kailash-kaizen | 2.16.1 | **2.16.2** | /redteam surfaced 4 zero-arg classmethod parity gaps    |
+
+All sibling packages remained at PyPI parity throughout — release-scope
+enumeration at session start showed only kaizen ahead of PyPI, no sibling
+drift to sweep.
+
+| Package          | main / PyPI                     |
+| ---------------- | ------------------------------- |
+| kailash          | 2.13.3 ✓ (caught up by PR #785) |
+| kailash-dataflow | 2.7.5 ✓                         |
+| kailash-nexus    | 2.6.0 ✓                         |
+| kailash-mcp      | 0.2.10 ✓                        |
+| kailash-ml       | 1.7.1 ✓                         |
+| kailash-align    | 0.7.0 ✓                         |
+| kailash-pact     | 0.11.0 ✓                        |
+
+## What shipped
+
+### kailash-kaizen 2.16.1 — `ollama_default` preset alias parity
+
+Patch. Reviewer flagged during the 2.16.0 pre-release pass that kailash-rs
+`CapabilityMatrix::for_preset` accepts `"ollama_default"` as an alias for
+`"ollama"` on the same capability row
+(`crates/kailash-kaizen/src/llm/deployment/capabilities.rs:212` —
+`str_eq(preset_name, "ollama") || str_eq(preset_name, "ollama_default")`)
+while Python `_PRESET_CAPABILITIES` had only `"ollama"`. A Python caller
+porting the alias literal from Rust hit the fail-closed all-False default
+while the Rust caller saw the wired row — exactly the cross-SDK divergence
+`rules/cross-sdk-inspection.md` § 3a was written to catch.
+
+The fix added the alias row byte-identical to `"ollama"` (`tools=True,
+vision=True, batch=False, caching=False, audio=False`) and extended the
+parametrized `_NON_EMPTY_PRESETS` cross-SDK row-completeness sweep in
+`tests/unit/llm/test_supports_capability_matrix.py` to cover
+`"ollama_default"` so a future drift in either SDK fails the test loudly.
+
+### kailash-kaizen 2.16.2 — default-URL convenience presets cross-SDK parity
+
+Patch. /redteam audit pinned at `kaizen-v2.16.1` SHA `74b911ac` enumerated
+every kailash-rs `LlmDeployment` constructor and surfaced four zero-arg
+classmethods with no Python equivalent:
+
+| Rust constructor        | File:Line                                                 | Default URL                                   |
+| ----------------------- | --------------------------------------------------------- | --------------------------------------------- |
+| `ollama_default()`      | `crates/kailash-kaizen/src/llm/deployment/presets.rs:509` | `http://localhost:11434/v1`                   |
+| `lm_studio_default()`   | `presets.rs:1138`                                         | `http://localhost:1234/v1`                    |
+| `llama_cpp_default()`   | `presets.rs:1170`                                         | `http://localhost:8080/v1`                    |
+| `docker_model_runner()` | `presets.rs:527` (zero-arg form)                          | `http://localhost:12434/engines/llama.cpp/v1` |
+
+Python required callers to thread the localhost URL by hand. Same
+bug class as 2.16.1's alias fix — Rust convenience surface on
+`LlmDeployment` that Python lacked.
+
+The fix added 4 factory functions + classmethod attachments via a new
+`model_only_table` in `_register_and_attach_session_2_presets()`:
+
+- `LlmDeployment.ollama_default(model)` + `ollama_default_preset(model)`
+- `LlmDeployment.lm_studio_default(model)` + `lm_studio_default_preset(model)`
+- `LlmDeployment.llama_cpp_default(model)` + `llama_cpp_default_preset(model)`
+- `LlmDeployment.docker_model_runner_default(model)` + `docker_model_runner_default_preset(model)`
+
+Each `_default_preset` delegates to its parent factory with the canonical
+localhost URL. The deployment carries the **parent** preset literal
+(`"ollama"`, `"lm_studio"`, `"llama_cpp"`, `"docker_model_runner"`) per
+Rust semantics — `<provider>_default()` calls `Self::<provider>(...)`
+internally — so capability-matrix lookup routes through the parent row
+automatically. The `_default` variant is a constructor convenience, NOT a
+distinct preset identity. 28 new Tier-1 tests cover shape, byte-equivalence
+with the long-form factory, classmethod ↔ free-function agreement,
+empty-model rejection, registry round-trip via `get_preset`, and the
+parent-row capability-matrix routing invariant.
+
+#### Reviewer-deferred fix-immediately landed in same PR
+
+The PR-#787 reviewer surfaced one CRITICAL `__all__` gap: the four new
+factory functions were registered + classmethod-attached but absent from
+`packages/kailash-kaizen/src/kaizen/llm/presets.py::__all__`, so
+`from kaizen.llm.presets import *` silently dropped them — same trap
+class as the 2.15.0 `azure_openai_preset` orphan that the prior
+CHANGELOG entry references. `rules/orphan-detection.md` § 6 violation;
+`rules/autonomous-execution.md` Rule 4 same-shard fix-immediately. The
+fix landed in commit `2a340ca7` on the same `release/v2.16.2` branch
+before merge, adding the four `*_default_preset` symbols to `__all__`
+under a new `# S7b — Default-URL convenience presets (#787, cross-SDK parity)`
+group.
+
+#### Python idiom-difference (EATP D6)
+
+`model` is REQUIRED on every Python `_default_preset(model)` factory per
+`rules/env-models.md`; Rust accepts truly zero-arg signatures. Acceptable
+per `rules/cross-sdk-inspection.md` § 3 — semantics match (deployment
+routes requests to a local server with the canonical default URL); only
+construction arity differs.
+
+## Cross-SDK
+
+- 2.16.1 capability matrix row for `"ollama_default"` byte-matches the
+  kailash-rs `||` alias row at `capabilities.rs:212`.
+- 2.16.2 four `_default` constructors produce deployments byte-equivalent
+  to their parent factory called with the canonical localhost URL. The
+  parent preset literal carried by `preset_name` ensures
+  `for_preset(deployment.preset_name)` returns the same row whether the
+  deployment was built via the long-form or `_default` constructor.
+- Reviewer's full Rust `||` alias enumeration verified there are NO
+  remaining same-class capability-matrix alias gaps after 2.16.1
+  (`openai`/`openai_compatible`, `anthropic`/`anthropic_compatible`,
+  `bedrock_llama`/`bedrock_titan`/`bedrock_mistral`/`bedrock_cohere`,
+  `ollama`/`ollama_default` all present in both SDKs).
+
+## Pull requests
+
+- PR #786 — kailash-kaizen 2.16.1 release-prep + alias fix
+  (`release/v2.16.1` branch, 5 files +25/-2 LOC, merged 2026-05-02 at
+  `74b911ac`).
+- PR #787 — kailash-kaizen 2.16.2 default-URL convenience presets
+  (`release/v2.16.2` branch, 5 files +454/-2 LOC including the
+  `__all__` fix-immediately, merged 2026-05-02 at `4e134c92`).
+
+## Tags
+
+Pushed individually per `rules/git.md` § "Multi-Package Release Tags
+Pushed Individually":
+
+- `kaizen-v2.16.1` — kailash-kaizen 2.16.1 (`74b911ac`)
+- `kaizen-v2.16.2` — kailash-kaizen 2.16.2 (`4e134c92`)
+
+## Verification
+
+| Gate                                                      | 2.16.1                                                                                                                                     | 2.16.2                                                                                                                                                                                                                                              |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Targeted test suite                                       | ✓ 33/33 capability-matrix tests                                                                                                            | ✓ 28/28 new default-URL tests + 33/33 capability matrix + 63/63 session-2 presets (no regression)                                                                                                                                                   |
+| pre-commit (black, isort, ruff, type-annotations, Tier 1) | ✓ all clean                                                                                                                                | ✓ all clean (isort reformat known trap; re-staged + retried)                                                                                                                                                                                        |
+| `pytest --collect-only`                                   | ✓ exit 0                                                                                                                                   | ✓ 940 tests collected, exit 0                                                                                                                                                                                                                       |
+| Code review (reviewer)                                    | ✓ APPROVED — 8/8 mechanical sweeps clean                                                                                                   | ✓ APPROVED conditional on `__all__` fix (landed in same PR via commit `2a340ca7` per Rule 4)                                                                                                                                                        |
+| Security review (security-reviewer)                       | ✓ APPROVED — no fail-closed regression; cross-SDK byte-identity verified                                                                   | ✓ APPROVED — all 4 URLs loopback only; `StaticNone` auth; `model` required end-to-end; no closure leak                                                                                                                                              |
+| PR-gate matrix                                            | auto-skipped (`release/v*` convention)                                                                                                     | auto-skipped (`release/v*` convention)                                                                                                                                                                                                              |
+| PyPI publish workflow                                     | ✓ run `25241359947` success                                                                                                                | ✓ run `25244610463` success                                                                                                                                                                                                                         |
+| Clean-venv install + import                               | ✓ `kaizen.__version__ == "2.16.1"`; `for_preset("ollama_default") == for_preset("ollama")`; fail-closed default for unknown presets intact | ✓ `kaizen.__version__ == "2.16.2"`; all 4 classmethods callable; preset_name parent-routing verified; capability-matrix `dep.supports() == LlmDeployment.ollama(URL, m).supports()`; registry has all 4; `__all__` wildcard-import surface complete |
+| GitHub release                                            | ✓ `kaizen-v2.16.1` published, not draft                                                                                                    | ✓ `kaizen-v2.16.2` published, not draft                                                                                                                                                                                                             |
+
+TestPyPI gate disposition: both **skipped** (patch releases, explicit
+human approval per `rules/deployment.md` § "TestPyPI Validation" exception
+clause). The OIDC trusted-publisher path is unchanged from the 2.16.0
+ship of the same day; reviewer + security gates passed and the new code
+surfaces are unit-tested with parametrized cross-SDK byte-match coverage.
+PyPI simple-index propagation lag observed on 2.16.2 install verification
+(60s) per `rules/build-repo-release-discipline.md` § 2 — handled via the
+documented `pip install --no-cache-dir` retry loop; `pypi.org/pypi/<pkg>/<ver>/json`
+returned the new metadata immediately while `simple/` lagged.
+
+## Cross-SDK parity follow-ups (filed as issues, deferred from 2.16.2 scope)
+
+The same /redteam round that authorised 2.16.1's parametrised
+`_NON_EMPTY_PRESETS` sweep and 2.16.2's four `_default` constructors
+surfaced four additional findings, each of which exceeded one-shard budget
+OR required cross-SDK design alignment that warrants its own discussion
+gate. Filed per `rules/cross-sdk-inspection.md` § 2 with `cross-sdk` label
+
+- explicit references back to this deploy record:
+
+* **#788** — `feat(kaizen): LlmDeployment.mock() cross-SDK parity with kailash-rs (test-utils gating design)`. Rust gates `mock()` behind `#[cfg(any(test, feature = "test-utils"))]` to prevent "mock shipped to prod" at compile time (`crates/kailash-kaizen/src/llm/deployment/presets.rs:1183`). Python parity requires designing an equivalent runtime gate (test-only module / import-side opt-in / env-var). Ungated would violate `rules/zero-tolerance.md` Rule 2.
+* **#789** — `chore(kaizen): triage 17 open CodeQL findings — Rule 1b deferral track per finding`. Includes alert #10866 (`py/clear-text-logging-sensitive-data` on `presets.py:101`) — verified false positive, `_fingerprint(name)` calls `fingerprint_secret(raw)` (BLAKE2b non-reversible per #617). Tracking issue is the Rule 1b paperwork half (runtime-safety proof + tracking issue + release-PR link + release-specialist signoff).
+* **#790** — `feat(kaizen): add CapabilityMatrix rows for 7 Python-only presets (cross-SDK alignment)`. Python registers `together`, `fireworks`, `openrouter`, `deepseek`, `lm_studio`, `llama_cpp`, `docker_model_runner` factories; none have a row in either SDK's capability matrix. Per-provider research + kailash-rs row coordination required.
+* **#791** — `feat(kaizen): cross-SDK parity for 12 Rust zero-arg <provider>() constructors (auth-strategy design)`. kailash-rs exposes 12 zero-arg `pub fn <provider>() -> Self` classmethods with `StaticNone` auth (caller chains `.with_api_key(...)`). Python requires `api_key` at construction per `rules/env-models.md` — design decision needed (auth-less + builder vs `from_env()` variant vs eager-validation default).
+
+Surfaced by reviewer of PR #787 specifically: #791 is the parent-class
+gap to which 2.16.2's four `_default` constructors are the
+convenience-class subset. Closing #791 closes the auth-strategy half of
+the cross-SDK constructor surface.
+
+## Post-release
+
+- COC template `kailash-coc-claude-py/pyproject.toml` pin MAY bump
+  `kailash-kaizen>=2.16.0` → `>=2.16.2` (loom-orchestrated; out of scope
+  for this BUILD-repo record).
+- No upstream issue filed against kailash-rs — these Python patches
+  caught up to existing Rust constructors that already shipped.


### PR DESCRIPTION
## Summary

- New deploy record `deploy/deployments/2026-05-02-v2.16.2-kaizen-cross-sdk-parity-cleanup.md` documenting the same-day 2.16.0 → 2.16.1 → 2.16.2 cross-SDK parity cleanup wave
- Mirrors PR #785's "what actually shipped" record shape: scope, what shipped per version, cross-SDK proofs, PR/tag/workflow IDs, verification matrix, follow-up issue links
- Captures the 4 follow-up issues (#788–#791) the same /redteam round surfaced but that exceed one-shard budget or require cross-SDK design alignment

## What's in the record

### kailash-kaizen 2.16.1 (PR #786, merged at `74b911ac`)
Reviewer-deferred `ollama_default` capability-matrix alias added byte-identical to the kailash-rs `||` alias at `capabilities.rs:212`. `_NON_EMPTY_PRESETS` parametrized sweep extended to lock byte-parity going forward.

### kailash-kaizen 2.16.2 (PR #787, merged at `4e134c92`)
4 zero-arg-default-URL convenience constructors mirroring kailash-rs `LlmDeployment::{ollama_default, lm_studio_default, llama_cpp_default, docker_model_runner}()` at `presets.rs:509,1138,1170,527`. Each `_default_preset(model)` delegates to its parent factory with the canonical localhost URL; deployment carries the parent preset literal so capability-matrix lookup routes through the parent row. Plus same-PR `__all__` fix-immediately on the reviewer's CRITICAL finding (commit `2a340ca7`).

### Follow-ups filed
- #788 — `LlmDeployment.mock()` cross-SDK parity (test-utils gating design)
- #789 — Triage 17 open CodeQL findings (Rule 1b deferral track)
- #790 — CapabilityMatrix rows for 7 Python-only presets (cross-SDK alignment)
- #791 — Cross-SDK parity for 12 Rust zero-arg constructors (auth-strategy design)

## Diff stat

1 file added: `deploy/deployments/2026-05-02-v2.16.2-kaizen-cross-sdk-parity-cleanup.md` (+194 LOC). Metadata-only — no code surface change.

## Related

Continuation of PR #785's release-record discipline. Both 2.16.1 and 2.16.2 already shipped to PyPI; this PR is the audit-trail half of the release cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)