### PR TITLE
feat(kaizen): 12 <provider>_from_env constructors on LlmDeployment (#791)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.17.0] — 2026-05-02 — `<provider>_from_env` cross-SDK convenience constructors (#791)
+
+Minor bump. Closes the deferred cross-SDK API-shape parity gap surfaced
+by the post-2.16.2 audit: kailash-rs exposes 12 zero-arg
+`pub fn <provider>() -> Self` classmethods on `LlmDeployment` (constructing
+auth-less deployments with the canonical hosted URL; callers chain
+`.with_api_key(...)` to populate credentials before use). Python's parent
+`<provider>_preset(api_key, model)` factories require both inputs at
+construction per `rules/env-models.md`, so a Rust user porting
+`LlmDeployment::openai()` directly hit `TypeError`. This release adds an
+explicit `_from_env` constructor variant per provider — eager-validates
+against the environment, raises typed `MissingCredential` on missing keys
+or models, and routes capability lookups through the parent preset row.
+
+### Added
+
+- **12 `<provider>_from_env` convenience constructors on `LlmDeployment` (closes #791; cross-SDK parity with the 12 zero-arg `pub fn <provider>() -> Self` classmethods on kailash-rs `LlmDeployment` at `crates/kailash-kaizen/src/llm/deployment/presets.rs:153,249,346,386,408,430,458,928,964,1000,1036,1072`).** Each `LlmDeployment.<provider>_from_env()` (and module-level `<provider>_from_env_preset()`) reads `<PROVIDER>_API_KEY` plus `<PROVIDER>_PROD_MODEL` (with legacy fallback to `<PROVIDER>_MODEL`) from the environment and delegates to the existing parent factory. Eager-validates per `rules/env-models.md` — missing env vars raise typed `MissingCredential` with the env var name as `source_hint`. Providers covered: `openai`, `anthropic`, `google`, `cohere`, `mistral`, `perplexity`, `huggingface`, `groq`, `together`, `fireworks`, `openrouter`, `deepseek`. Each returned deployment carries the PARENT `preset_name` literal (e.g. `"openai"`, not `"openai_from_env"`) so `LlmDeployment.supports()` and `for_preset(...)` capability lookups route through the parent row automatically — consistent with the `<provider>_default` precedent (#787).
+- **Registry round-trip via `get_preset("<provider>_from_env")()`.** Each `<provider>_from_env` name is registered alongside its classmethod attachment so both surfaces produce structurally identical deployments. Cross-SDK parity sweep enumerates all 12 names against a frozen set in `tests/unit/llm/test_from_env_presets.py::test_from_env_preset_names_complete`; adding a new Rust zero-arg classmethod without wiring its Python `_from_env` peer fails the sweep loudly.
+
+### Implementation notes — design rationale (#791)
+
+Three candidate designs were on the issue body; **Option 3 (`_from_env` variant)** was selected because it is the only design that satisfies `rules/env-models.md` ("ALL API keys MUST come from `.env`") while preserving the eager-validation convention every existing `_preset` factory already enforces. Option 1 (auth-less constructor + `.with_api_key(...)` builder) introduces an `LlmDeployment` whose state is structurally unauthenticated until a builder call — a divergent shape from every other Python preset factory. Option 2 (`<provider>(api_key=os.environ.get(...))`) silently couples the default to an env var; the call site cannot tell whether env was consulted, which is the implicit-magic failure pattern the Python idiom rejects. Option 3 is a separate explicit method per provider; the suffix announces env-driven construction at every call site. Per EATP D6 (`rules/cross-sdk-inspection.md` § 3): semantics match Rust (same endpoint, wire protocol, eventual auth strategy); the idiom-difference is the explicit `_from_env` naming + eager validation at construction time.
+
+A user porting Rust `LlmDeployment::openai()` (zero-arg, auth-less, configured later via `.with_api_key(env::var("OPENAI_API_KEY")?)`) transcribes the contract to Python as a single `LlmDeployment.openai_from_env()` call; the resulting deployment is byte-equivalent to the long-form `openai_preset(api_key, model)` shape with credentials sourced from `OPENAI_API_KEY` + `OPENAI_PROD_MODEL`.
+
+### Tested
+
+- `tests/unit/llm/test_from_env_presets.py` — 36 tests covering: cross-SDK registry parity sweep across all 12 names; per-provider deployment shape (wire / auth / preset_name / endpoint URL byte-pinned to the Rust source-of-truth literal); typed `MissingCredential` raise on missing api_key (parametrized × 12) and on missing model (parametrized × 4 representative providers); `<PROVIDER>_PROD_MODEL` precedence over `<PROVIDER>_MODEL`; legacy `<PROVIDER>_MODEL` fallback when PROD is unset; `GEMINI_PROD_MODEL` legacy fallback for `google_from_env`; classmethod ↔ module-function agreement; registry round-trip via `get_preset`; capability-matrix routing through the parent row. All env-mutating tests serialize through a module-scope `threading.Lock` per `rules/testing.md` § "Serialize Env-Var-Mutating Tests Via Module Lock".
+
+### Known follow-ups (filed separately, not blocking this release)
+
+- **Cohere endpoint URL divergence between Python (`api.cohere.com/v1` + `CohereGenerate` wire) and Rust (`api.cohere.ai/v2`).** Surfaced during the #791 cross-SDK source-of-truth audit; pre-dates #791. The `_from_env` wrapper inherits whichever URL the parent `cohere_preset` exposes, so reconciling the parent URL automatically lifts both surfaces. Tracked separately so the URL+wire decision (v1 Generate vs v2 Chat — different on-wire contracts) gets its own design pass.
+- **#788 (`LlmDeployment.mock()` test-utils gating), #789 (CodeQL Rule 1b deferral track), #790 (capability rows for 7 Python-only presets).** Sibling cross-SDK parity / hygiene workstreams from the post-2.16.2 audit.
+
 ## [2.16.2] — 2026-05-02 — Default-URL convenience presets (cross-SDK parity)
 
 Patch bump. Closes the cross-SDK API-shape parity gap surfaced by the

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.16.2"
+version = "2.17.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.16.2"
+__version__ = "2.17.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/llm/presets.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/presets.py
@@ -31,6 +31,7 @@ Security invariants enforced here:
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import Any, Callable, Dict, Optional
 
@@ -40,7 +41,7 @@ from kaizen.llm.auth.aws import AwsBearerToken
 from kaizen.llm.auth.bearer import ApiKey, ApiKeyBearer, ApiKeyHeaderKind, StaticNone
 from kaizen.llm.auth.gcp import GcpOauth
 from kaizen.llm.deployment import Endpoint, LlmDeployment, WireProtocol
-from kaizen.llm.errors import ModelRequired
+from kaizen.llm.errors import MissingCredential, ModelRequired
 from kaizen.llm.grammar.bedrock import (
     BedrockClaudeGrammar,
     BedrockCohereGrammar,
@@ -1853,6 +1854,210 @@ def _attach_bedrock_region_classmethod() -> None:
 _attach_bedrock_region_classmethod()
 
 
+# ---------------------------------------------------------------------------
+# `<provider>_from_env` convenience presets (#791 — cross-SDK parity with the
+# 12 zero-arg `pub fn <provider>() -> Self` classmethods on kailash-rs
+# `LlmDeployment` at `crates/kailash-kaizen/src/llm/deployment/presets.rs`
+# lines 153, 249, 346, 386, 408, 430, 458, 928, 964, 1000, 1036, 1072.
+# ---------------------------------------------------------------------------
+#
+# Cross-SDK contract per `rules/cross-sdk-inspection.md` § 3 (EATP D6):
+# semantics MUST match; idioms MAY differ.
+#
+# Rust exposes a *zero-arg* `pub fn openai() -> Self` that constructs an
+# auth-less deployment with the canonical hosted URL; callers chain
+# `.with_api_key(...)` to populate credentials before use. The Python idiom
+# (`rules/env-models.md`) mandates eager validation: an `LlmDeployment`
+# without a real api_key + model raises at construction. Reconciling the two
+# without compromising either:
+#
+# Each `<provider>_from_env_preset()` factory:
+#   1. Reads `<PROVIDER>_API_KEY` from the environment (raises
+#      `MissingCredential("<PROVIDER>_API_KEY")` if absent / empty).
+#   2. Reads `<PROVIDER>_PROD_MODEL` (canonical), falling back to
+#      `<PROVIDER>_MODEL` (legacy compatibility with `from_env.py`'s
+#      precedence chain), raising `MissingCredential` if neither is set.
+#   3. Delegates to the existing parent `<provider>_preset(api_key, model)`
+#      factory — same wire / endpoint / auth shape as the long-form, with
+#      eager validation preserved through the parent's own checks.
+#
+# A user porting Rust code that calls `LlmDeployment::openai()` zero-arg
+# transcribes it to Python as `LlmDeployment.openai_from_env()`, with a
+# clear contract: API key + model come from environment variables exactly
+# as `rules/env-models.md` mandates, and missing env vars raise a typed
+# `MissingCredential` error rather than failing later at the provider 401.
+#
+# Registry name pattern: `<provider>_from_env` (parent + suffix), parallel
+# to the `<provider>_default` pattern from #787. Capability-matrix lookup
+# routes through the parent row automatically because the deployment's
+# `preset_name` is the PARENT literal (`"openai"`, not `"openai_from_env"`).
+
+# Canonical model-env precedence: PROD first (per parent factory docstrings),
+# legacy short-form fallback (per `from_env.py::_call_preset_from_env`).
+_FROM_ENV_PROVIDERS: list[tuple[str, str, tuple[str, ...]]] = [
+    # (preset_name, api_key_env, (model_env_candidates_in_precedence_order))
+    ("openai", "OPENAI_API_KEY", ("OPENAI_PROD_MODEL", "OPENAI_MODEL")),
+    ("anthropic", "ANTHROPIC_API_KEY", ("ANTHROPIC_PROD_MODEL", "ANTHROPIC_MODEL")),
+    # GOOGLE / GEMINI key-and-model env vars are interchangeable per
+    # `rules/env-models.md`; precedence prefers the canonical GOOGLE_* name.
+    (
+        "google",
+        "GOOGLE_API_KEY",
+        ("GOOGLE_PROD_MODEL", "GOOGLE_MODEL", "GEMINI_PROD_MODEL", "GEMINI_MODEL"),
+    ),
+    ("cohere", "COHERE_API_KEY", ("COHERE_PROD_MODEL", "COHERE_MODEL")),
+    ("mistral", "MISTRAL_API_KEY", ("MISTRAL_PROD_MODEL", "MISTRAL_MODEL")),
+    ("perplexity", "PERPLEXITY_API_KEY", ("PERPLEXITY_PROD_MODEL", "PERPLEXITY_MODEL")),
+    (
+        "huggingface",
+        "HUGGINGFACE_API_KEY",
+        ("HUGGINGFACE_PROD_MODEL", "HUGGINGFACE_MODEL"),
+    ),
+    ("groq", "GROQ_API_KEY", ("GROQ_PROD_MODEL", "GROQ_MODEL")),
+    ("together", "TOGETHER_API_KEY", ("TOGETHER_PROD_MODEL", "TOGETHER_MODEL")),
+    ("fireworks", "FIREWORKS_API_KEY", ("FIREWORKS_PROD_MODEL", "FIREWORKS_MODEL")),
+    ("openrouter", "OPENROUTER_API_KEY", ("OPENROUTER_PROD_MODEL", "OPENROUTER_MODEL")),
+    ("deepseek", "DEEPSEEK_API_KEY", ("DEEPSEEK_PROD_MODEL", "DEEPSEEK_MODEL")),
+]
+
+
+def _read_first_env(*candidates: str) -> Optional[str]:
+    """Return the first non-empty env var in precedence order, or None."""
+    for var in candidates:
+        val = os.environ.get(var, "").strip()
+        if val:
+            return val
+    return None
+
+
+def _resolve_from_env_credentials(
+    *,
+    preset: str,
+    api_key_var: str,
+    model_vars: tuple[str, ...],
+) -> tuple[str, str]:
+    """Read api_key + model from env or raise typed `MissingCredential`.
+
+    `MissingCredential.source_hint` is a constant chosen by the loader (not
+    user input), so the env var name is safe to embed verbatim and gives
+    operators an actionable error message. Order of checks is api_key first
+    so the operator fixes the most common omission (no key set) before
+    diagnosing model selection.
+    """
+    api_key = _read_first_env(api_key_var)
+    if api_key is None:
+        raise MissingCredential(api_key_var)
+    model = _read_first_env(*model_vars)
+    if model is None:
+        # Compose source_hint from the candidate list so the message is
+        # actionable: "checked envelope: OPENAI_PROD_MODEL or OPENAI_MODEL".
+        joined = " or ".join(model_vars)
+        raise MissingCredential(joined)
+    return api_key, model
+
+
+def _from_env_factory_for(preset: str) -> Callable[[], LlmDeployment]:
+    """Build the parameter-less factory for one provider's `_from_env` form.
+
+    Closure captures `preset` so the factory ID is stable in stack traces
+    and matches the registry name byte-for-byte.
+    """
+    # Resolve the entry once (linear scan acceptable: 12 entries).
+    spec = next((s for s in _FROM_ENV_PROVIDERS if s[0] == preset), None)
+    if spec is None:
+        raise ValueError(f"_from_env_factory_for: unknown preset {preset!r}")
+    _name, api_key_var, model_vars = spec
+    parent_factory = get_preset(preset)
+
+    def _factory() -> LlmDeployment:
+        api_key, model = _resolve_from_env_credentials(
+            preset=preset, api_key_var=api_key_var, model_vars=model_vars
+        )
+        return parent_factory(api_key, model=model)
+
+    _factory.__name__ = f"{preset}_from_env_preset"
+    _factory.__qualname__ = f"{preset}_from_env_preset"
+    _factory.__doc__ = (
+        f"Construct `{preset}_preset` from environment variables.\n\n"
+        f"Reads {api_key_var} and the first non-empty value of "
+        f"{', '.join(model_vars)} from `os.environ`. Raises typed "
+        f"`MissingCredential` if either is unset / empty.\n\n"
+        f"Cross-SDK parity with kailash-rs `LlmDeployment::{preset}()` "
+        f"(zero-arg auth-less constructor at "
+        f"`crates/kailash-kaizen/src/llm/deployment/presets.rs`). Per EATP "
+        f"D6, the Python idiom-difference is the explicit `_from_env` "
+        f"naming + eager validation; semantics match (same endpoint, wire "
+        f"protocol, and auth strategy as the long-form `{preset}_preset`)."
+    )
+    return _factory
+
+
+# Module-level binding for each `<provider>_from_env_preset` so callers can
+# import the symbol directly:
+#
+#     from kaizen.llm.presets import openai_from_env_preset
+#     dep = openai_from_env_preset()
+#
+# (Mirrors `<provider>_preset` and `<provider>_default_preset` precedent.)
+openai_from_env_preset = _from_env_factory_for("openai")
+anthropic_from_env_preset = _from_env_factory_for("anthropic")
+google_from_env_preset = _from_env_factory_for("google")
+cohere_from_env_preset = _from_env_factory_for("cohere")
+mistral_from_env_preset = _from_env_factory_for("mistral")
+perplexity_from_env_preset = _from_env_factory_for("perplexity")
+huggingface_from_env_preset = _from_env_factory_for("huggingface")
+groq_from_env_preset = _from_env_factory_for("groq")
+together_from_env_preset = _from_env_factory_for("together")
+fireworks_from_env_preset = _from_env_factory_for("fireworks")
+openrouter_from_env_preset = _from_env_factory_for("openrouter")
+deepseek_from_env_preset = _from_env_factory_for("deepseek")
+
+
+def _register_and_attach_from_env_presets() -> None:
+    """Register all 12 `_from_env` factories AND attach as `LlmDeployment.<name>_from_env`.
+
+    Registry name is `<parent>_from_env` (parallel to `<parent>_default`).
+    The deployment's `preset_name` is the PARENT literal (`"openai"`, not
+    `"openai_from_env"`) because the parent factory sets it; capability-
+    matrix lookup therefore routes through the parent row.
+
+    Both surfaces (registry round-trip + classmethod) MUST be installed
+    atomically per the precedent in `_register_and_attach_session_2_presets`
+    so a preset that is registered but not attached (or vice versa) is
+    structurally impossible.
+    """
+    factory_table = [
+        ("openai_from_env", openai_from_env_preset),
+        ("anthropic_from_env", anthropic_from_env_preset),
+        ("google_from_env", google_from_env_preset),
+        ("cohere_from_env", cohere_from_env_preset),
+        ("mistral_from_env", mistral_from_env_preset),
+        ("perplexity_from_env", perplexity_from_env_preset),
+        ("huggingface_from_env", huggingface_from_env_preset),
+        ("groq_from_env", groq_from_env_preset),
+        ("together_from_env", together_from_env_preset),
+        ("fireworks_from_env", fireworks_from_env_preset),
+        ("openrouter_from_env", openrouter_from_env_preset),
+        ("deepseek_from_env", deepseek_from_env_preset),
+    ]
+
+    for name, factory in factory_table:
+        register_preset(name, factory)
+
+        # Bind factory via a default-arg closure so each classmethod
+        # captures its own factory reference (standard Python closure
+        # pitfall workaround — same shape as `_register_and_attach_session_2_presets`).
+        def _from_env_cm(cls, _factory=factory) -> LlmDeployment:
+            return _factory()
+
+        _from_env_cm.__name__ = name
+        _from_env_cm.__qualname__ = f"LlmDeployment.{name}"
+        setattr(LlmDeployment, name, classmethod(_from_env_cm))
+
+
+_register_and_attach_from_env_presets()
+
+
 __all__ = [
     # S1
     "openai_preset",
@@ -1895,4 +2100,19 @@ __all__ = [
     "lm_studio_default_preset",
     "llama_cpp_default_preset",
     "docker_model_runner_default_preset",
+    # S7c -- _from_env convenience presets (#791, cross-SDK parity with the
+    # 12 zero-arg `pub fn <provider>() -> Self` constructors on kailash-rs
+    # `LlmDeployment`).
+    "openai_from_env_preset",
+    "anthropic_from_env_preset",
+    "google_from_env_preset",
+    "cohere_from_env_preset",
+    "mistral_from_env_preset",
+    "perplexity_from_env_preset",
+    "huggingface_from_env_preset",
+    "groq_from_env_preset",
+    "together_from_env_preset",
+    "fireworks_from_env_preset",
+    "openrouter_from_env_preset",
+    "deepseek_from_env_preset",
 ]

--- a/packages/kailash-kaizen/tests/unit/llm/test_from_env_presets.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_from_env_presets.py
@@ -1,0 +1,545 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""`<provider>_from_env` convenience preset tests (#791).
+
+Cross-SDK parity with the 12 zero-arg `pub fn <provider>() -> Self`
+classmethods on kailash-rs `LlmDeployment` at
+`crates/kailash-kaizen/src/llm/deployment/presets.rs` lines 153, 249, 346,
+386, 408, 430, 458, 928, 964, 1000, 1036, 1072.
+
+Each Python `<provider>_from_env_preset()` factory:
+
+1. Reads `<PROVIDER>_API_KEY` from the environment, raising
+   `MissingCredential` if absent / empty.
+2. Reads `<PROVIDER>_PROD_MODEL` (canonical) with fallback to
+   `<PROVIDER>_MODEL` (legacy precedence chain), raising
+   `MissingCredential` if neither is set.
+3. Delegates to the existing parent `<provider>_preset(api_key, model)` —
+   same wire / endpoint / auth shape as the long-form factory.
+
+Per `rules/cross-sdk-inspection.md` § 3 EATP D6: implementation-idiom
+difference (Python `_from_env` reads env explicitly + eager-validates;
+Rust `<provider>()` is auth-less + caller chains `.with_api_key(...)`)
+is acceptable when semantics match.
+
+Per `rules/testing.md` § "Serialize Env-Var-Mutating Tests Via Module
+Lock": every test mutating shared `os.environ` keys takes the
+`_env_serialized` fixture, so cross-test scheduling on xdist cannot
+observe each other's monkeypatched values.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from kaizen.llm.auth.bearer import ApiKeyBearer, ApiKeyHeaderKind
+from kaizen.llm.deployment import LlmDeployment, WireProtocol
+from kaizen.llm.errors import MissingCredential
+from kaizen.llm.presets import (
+    anthropic_from_env_preset,
+    cohere_from_env_preset,
+    deepseek_from_env_preset,
+    fireworks_from_env_preset,
+    get_preset,
+    google_from_env_preset,
+    groq_from_env_preset,
+    huggingface_from_env_preset,
+    list_presets,
+    mistral_from_env_preset,
+    openai_from_env_preset,
+    openrouter_from_env_preset,
+    perplexity_from_env_preset,
+    together_from_env_preset,
+)
+
+# ---------------------------------------------------------------------------
+# Env-var serialization fixture (rules/testing.md)
+# ---------------------------------------------------------------------------
+
+_ENV_LOCK = threading.Lock()
+
+# Canonical env vars consumed by the 12 from_env factories. Tests that mutate
+# any of these MUST take `_env_serialized` so xdist scheduling cannot
+# interleave per-test monkeypatch teardowns.
+_FROM_ENV_VARS = (
+    "OPENAI_API_KEY",
+    "OPENAI_PROD_MODEL",
+    "OPENAI_MODEL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_PROD_MODEL",
+    "ANTHROPIC_MODEL",
+    "GOOGLE_API_KEY",
+    "GOOGLE_PROD_MODEL",
+    "GOOGLE_MODEL",
+    "GEMINI_API_KEY",
+    "GEMINI_PROD_MODEL",
+    "GEMINI_MODEL",
+    "COHERE_API_KEY",
+    "COHERE_PROD_MODEL",
+    "COHERE_MODEL",
+    "MISTRAL_API_KEY",
+    "MISTRAL_PROD_MODEL",
+    "MISTRAL_MODEL",
+    "PERPLEXITY_API_KEY",
+    "PERPLEXITY_PROD_MODEL",
+    "PERPLEXITY_MODEL",
+    "HUGGINGFACE_API_KEY",
+    "HUGGINGFACE_PROD_MODEL",
+    "HUGGINGFACE_MODEL",
+    "GROQ_API_KEY",
+    "GROQ_PROD_MODEL",
+    "GROQ_MODEL",
+    "TOGETHER_API_KEY",
+    "TOGETHER_PROD_MODEL",
+    "TOGETHER_MODEL",
+    "FIREWORKS_API_KEY",
+    "FIREWORKS_PROD_MODEL",
+    "FIREWORKS_MODEL",
+    "OPENROUTER_API_KEY",
+    "OPENROUTER_PROD_MODEL",
+    "OPENROUTER_MODEL",
+    "DEEPSEEK_API_KEY",
+    "DEEPSEEK_PROD_MODEL",
+    "DEEPSEEK_MODEL",
+)
+
+
+@pytest.fixture
+def _env_serialized(monkeypatch: pytest.MonkeyPatch):
+    """Hold the module-scope lock across the entire test body.
+
+    Pre-strips every from_env env var so each test starts from a clean
+    slate regardless of the host shell's `.env`. monkeypatch restores at
+    teardown, but teardown runs AFTER the test body — the lock prevents
+    a sibling test from observing this test's still-set values.
+    """
+    with _ENV_LOCK:
+        for var in _FROM_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Cross-SDK parity: registry name byte-match the Rust classmethod literals
+# ---------------------------------------------------------------------------
+
+
+_FROM_ENV_PRESETS_RUST_PARITY = frozenset(
+    {
+        "openai_from_env",
+        "anthropic_from_env",
+        "google_from_env",
+        "cohere_from_env",
+        "mistral_from_env",
+        "perplexity_from_env",
+        "huggingface_from_env",
+        "groq_from_env",
+        "together_from_env",
+        "fireworks_from_env",
+        "openrouter_from_env",
+        "deepseek_from_env",
+    }
+)
+
+
+def test_from_env_preset_names_complete() -> None:
+    """All 12 `_from_env` factories registered under their canonical names.
+
+    Cross-SDK contract: each name is `<rust_classmethod_name>_from_env`,
+    where `<rust_classmethod_name>` is the byte-identical Rust literal at
+    `crates/kailash-kaizen/src/llm/deployment/presets.rs`. The `_from_env`
+    suffix is the Python idiom-difference per EATP D6.
+    """
+    registered = set(list_presets())
+    missing = _FROM_ENV_PRESETS_RUST_PARITY - registered
+    assert not missing, (
+        f"_from_env presets missing from registry: {sorted(missing)}. "
+        f"Every Rust zero-arg `<provider>()` classmethod MUST have a Python "
+        f"registered factory under the byte-matching `<provider>_from_env` name."
+    )
+
+
+def test_from_env_classmethods_attached() -> None:
+    """Every registered `<provider>_from_env` is callable on `LlmDeployment`.
+
+    Both surfaces (registry round-trip + classmethod) MUST be installed
+    atomically per the precedent in
+    `_register_and_attach_session_2_presets` — a preset that is registered
+    but not attached (or vice versa) would be visible via only one path.
+    """
+    for name in _FROM_ENV_PRESETS_RUST_PARITY:
+        assert hasattr(LlmDeployment, name), (
+            f"LlmDeployment.{name} not attached — registry has it but the "
+            f"classmethod is missing"
+        )
+        method = getattr(LlmDeployment, name)
+        assert callable(method)
+
+
+# ---------------------------------------------------------------------------
+# Per-provider shape tests — each variant called DIRECTLY (testing.md MUST:
+# "One Direct Test Per Variant In Every Delegating Pair").
+# ---------------------------------------------------------------------------
+
+
+def test_openai_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-openai")
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o")
+    dep = openai_from_env_preset()
+    assert dep.wire == WireProtocol.OpenAiChat
+    assert dep.preset_name == "openai"
+    assert dep.default_model == "gpt-4o"
+    assert isinstance(dep.auth, ApiKeyBearer)
+    assert dep.auth.kind == ApiKeyHeaderKind.Authorization_Bearer
+    # Pin endpoint URL byte-for-byte to the Rust source-of-truth literal at
+    # `presets.rs:154` — `Endpoint::new("https://api.openai.com/v1")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.openai.com"
+    assert dep.endpoint.path_prefix == "/v1"
+
+
+def test_anthropic_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("ANTHROPIC_PROD_MODEL", "claude-3-5-sonnet-latest")
+    dep = anthropic_from_env_preset()
+    assert dep.wire == WireProtocol.AnthropicMessages
+    assert dep.preset_name == "anthropic"
+    assert dep.default_model == "claude-3-5-sonnet-latest"
+    assert isinstance(dep.auth, ApiKeyBearer)
+    assert dep.auth.kind == ApiKeyHeaderKind.X_Api_Key
+    # Rust `presets.rs:250`: `Endpoint::new("https://api.anthropic.com")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.anthropic.com"
+
+
+def test_google_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GOOGLE_API_KEY", "AIza-test")
+    monkeypatch.setenv("GOOGLE_PROD_MODEL", "gemini-1.5-pro")
+    dep = google_from_env_preset()
+    assert dep.wire == WireProtocol.GoogleGenerateContent
+    assert dep.preset_name == "google"
+    assert dep.default_model == "gemini-1.5-pro"
+    assert isinstance(dep.auth, ApiKeyBearer)
+    assert dep.auth.kind == ApiKeyHeaderKind.X_Goog_Api_Key
+    # Rust `presets.rs:347`:
+    #   `Endpoint::new("https://generativelanguage.googleapis.com/v1beta")`.
+    assert (
+        str(dep.endpoint.base_url).rstrip("/")
+        == "https://generativelanguage.googleapis.com"
+    )
+    assert dep.endpoint.path_prefix == "/v1beta"
+
+
+def test_cohere_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COHERE_API_KEY", "co-test")
+    monkeypatch.setenv("COHERE_PROD_MODEL", "command-r-plus")
+    dep = cohere_from_env_preset()
+    assert dep.wire == WireProtocol.CohereGenerate
+    assert dep.preset_name == "cohere"
+    assert dep.default_model == "command-r-plus"
+    # NOTE: the Python parent factory (`cohere_preset`) currently uses
+    # `https://api.cohere.com/v1` while Rust `presets.rs:387` uses
+    # `https://api.cohere.ai/v2`. This divergence pre-dates #791 and
+    # is a SEPARATE cross-SDK parity issue (#791 inherits whichever URL
+    # the parent factory exposes). Once the parent URL is reconciled the
+    # `_from_env` wrapper picks up the change automatically.
+    assert dep.endpoint.path_prefix == "/v1"
+
+
+def test_mistral_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MISTRAL_API_KEY", "mi-test")
+    monkeypatch.setenv("MISTRAL_PROD_MODEL", "mistral-large-latest")
+    dep = mistral_from_env_preset()
+    assert dep.wire == WireProtocol.MistralChat
+    assert dep.preset_name == "mistral"
+    assert dep.default_model == "mistral-large-latest"
+    # Rust `presets.rs:409`: `Endpoint::new("https://api.mistral.ai/v1")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.mistral.ai"
+    assert dep.endpoint.path_prefix == "/v1"
+
+
+def test_perplexity_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pplx-test")
+    monkeypatch.setenv("PERPLEXITY_PROD_MODEL", "sonar-pro")
+    dep = perplexity_from_env_preset()
+    assert dep.wire == WireProtocol.OpenAiChat
+    assert dep.preset_name == "perplexity"
+    assert dep.default_model == "sonar-pro"
+    # Rust `presets.rs:431`: `Endpoint::new("https://api.perplexity.ai")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.perplexity.ai"
+
+
+def test_huggingface_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf-test")
+    monkeypatch.setenv("HUGGINGFACE_PROD_MODEL", "meta-llama/Llama-3-70B-Instruct")
+    dep = huggingface_from_env_preset()
+    assert dep.wire == WireProtocol.HuggingFaceInference
+    assert dep.preset_name == "huggingface"
+    # Rust `presets.rs:459`:
+    #   `Endpoint::new("https://api-inference.huggingface.co")`.
+    assert (
+        str(dep.endpoint.base_url).rstrip("/") == "https://api-inference.huggingface.co"
+    )
+
+
+def test_groq_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+    monkeypatch.setenv("GROQ_PROD_MODEL", "llama-3.1-70b-versatile")
+    dep = groq_from_env_preset()
+    assert dep.wire == WireProtocol.OpenAiChat
+    assert dep.preset_name == "groq"
+    # Rust `presets.rs:929`:
+    #   `Endpoint::new("https://api.groq.com/openai/v1")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.groq.com"
+    assert dep.endpoint.path_prefix == "/openai/v1"
+
+
+def test_together_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TOGETHER_API_KEY", "tg-test")
+    monkeypatch.setenv("TOGETHER_PROD_MODEL", "meta-llama/Llama-3-70b-chat-hf")
+    dep = together_from_env_preset()
+    assert dep.wire == WireProtocol.OpenAiChat
+    assert dep.preset_name == "together"
+    # Rust `presets.rs:965`:
+    #   `Endpoint::new("https://api.together.xyz/v1")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.together.xyz"
+    assert dep.endpoint.path_prefix == "/v1"
+
+
+def test_fireworks_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw-test")
+    monkeypatch.setenv(
+        "FIREWORKS_PROD_MODEL", "accounts/fireworks/models/llama-v3p1-70b"
+    )
+    dep = fireworks_from_env_preset()
+    assert dep.wire == WireProtocol.OpenAiChat
+    assert dep.preset_name == "fireworks"
+    # Rust `presets.rs:1001`:
+    #   `Endpoint::new("https://api.fireworks.ai/inference/v1")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.fireworks.ai"
+    assert dep.endpoint.path_prefix == "/inference/v1"
+
+
+def test_openrouter_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test")
+    monkeypatch.setenv("OPENROUTER_PROD_MODEL", "anthropic/claude-3.5-sonnet")
+    dep = openrouter_from_env_preset()
+    assert dep.wire == WireProtocol.OpenAiChat
+    assert dep.preset_name == "openrouter"
+    # Rust `presets.rs:1037`: `Endpoint::new("https://openrouter.ai/api/v1")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://openrouter.ai"
+    assert dep.endpoint.path_prefix == "/api/v1"
+
+
+def test_deepseek_from_env_preset_shape(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test")
+    monkeypatch.setenv("DEEPSEEK_PROD_MODEL", "deepseek-chat")
+    dep = deepseek_from_env_preset()
+    assert dep.wire == WireProtocol.OpenAiChat
+    assert dep.preset_name == "deepseek"
+    # Rust `presets.rs:1073`: `Endpoint::new("https://api.deepseek.com/v1")`.
+    assert str(dep.endpoint.base_url).rstrip("/") == "https://api.deepseek.com"
+    assert dep.endpoint.path_prefix == "/v1"
+
+
+# ---------------------------------------------------------------------------
+# Missing-env-var handling — typed `MissingCredential` per provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("factory", "api_key_var"),
+    [
+        (openai_from_env_preset, "OPENAI_API_KEY"),
+        (anthropic_from_env_preset, "ANTHROPIC_API_KEY"),
+        (google_from_env_preset, "GOOGLE_API_KEY"),
+        (cohere_from_env_preset, "COHERE_API_KEY"),
+        (mistral_from_env_preset, "MISTRAL_API_KEY"),
+        (perplexity_from_env_preset, "PERPLEXITY_API_KEY"),
+        (huggingface_from_env_preset, "HUGGINGFACE_API_KEY"),
+        (groq_from_env_preset, "GROQ_API_KEY"),
+        (together_from_env_preset, "TOGETHER_API_KEY"),
+        (fireworks_from_env_preset, "FIREWORKS_API_KEY"),
+        (openrouter_from_env_preset, "OPENROUTER_API_KEY"),
+        (deepseek_from_env_preset, "DEEPSEEK_API_KEY"),
+    ],
+)
+def test_from_env_preset_missing_api_key_raises(
+    factory, api_key_var: str, _env_serialized
+) -> None:
+    """Each `<provider>_from_env_preset()` raises typed `MissingCredential`
+    naming the missing api_key env var when it's unset."""
+    with pytest.raises(MissingCredential) as exc_info:
+        factory()
+    assert exc_info.value.source_hint == api_key_var
+
+
+@pytest.mark.parametrize(
+    ("factory", "api_key_var", "model_var_hint"),
+    [
+        (
+            openai_from_env_preset,
+            "OPENAI_API_KEY",
+            "OPENAI_PROD_MODEL or OPENAI_MODEL",
+        ),
+        (
+            anthropic_from_env_preset,
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_PROD_MODEL or ANTHROPIC_MODEL",
+        ),
+        (
+            cohere_from_env_preset,
+            "COHERE_API_KEY",
+            "COHERE_PROD_MODEL or COHERE_MODEL",
+        ),
+        (
+            mistral_from_env_preset,
+            "MISTRAL_API_KEY",
+            "MISTRAL_PROD_MODEL or MISTRAL_MODEL",
+        ),
+    ],
+)
+def test_from_env_preset_missing_model_raises(
+    factory,
+    api_key_var: str,
+    model_var_hint: str,
+    _env_serialized,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each `<provider>_from_env_preset()` with key-but-no-model raises
+    typed `MissingCredential` listing the model env var candidates."""
+    monkeypatch.setenv(api_key_var, "test-key-value")
+    with pytest.raises(MissingCredential) as exc_info:
+        factory()
+    assert exc_info.value.source_hint == model_var_hint
+
+
+def test_google_from_env_falls_back_to_gemini_env_vars(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`google_from_env_preset` accepts `GEMINI_*` env vars when `GOOGLE_*`
+    is unset, per `rules/env-models.md` (the two are interchangeable).
+
+    Precedence: GOOGLE_API_KEY wins over GEMINI_API_KEY when both set;
+    GEMINI_* is the legacy fallback.
+    """
+    # NOTE: GOOGLE_API_KEY is the api-key env var ONLY for this provider;
+    # the function does not currently fall back to GEMINI_API_KEY because
+    # `_FROM_ENV_PROVIDERS` declares only GOOGLE_API_KEY for the api_key
+    # slot. That keeps the contract narrow: api_key has one canonical
+    # source per provider; model has multiple legacy fallbacks.
+    monkeypatch.setenv("GOOGLE_API_KEY", "AIza-test")
+    monkeypatch.setenv("GEMINI_PROD_MODEL", "gemini-2.0-flash")
+    dep = google_from_env_preset()
+    assert dep.default_model == "gemini-2.0-flash"
+
+
+def test_from_env_preset_legacy_model_env_var_accepted(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy `<PROVIDER>_MODEL` (no `_PROD_` infix) is accepted when
+    `<PROVIDER>_PROD_MODEL` is unset.
+
+    Precedence: PROD wins over legacy when both are set. This mirrors the
+    fallback chain in `kaizen.llm.from_env::_call_preset_from_env`.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4o-mini")
+    dep = openai_from_env_preset()
+    assert dep.default_model == "gpt-4o-mini"
+
+
+def test_from_env_preset_prod_model_takes_precedence(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When both `<PROVIDER>_PROD_MODEL` and `<PROVIDER>_MODEL` are set,
+    PROD wins (it's the canonical name per parent factory docstrings)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4o-mini")
+    dep = openai_from_env_preset()
+    assert dep.default_model == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Registry round-trip — get_preset(<name>)() works the same as the symbol
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_preset_registry_round_trip(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`get_preset("openai_from_env")()` produces an identical deployment
+    to `openai_from_env_preset()` — the registry path matches the
+    symbol path byte-for-byte."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o")
+    direct = openai_from_env_preset()
+    via_registry = get_preset("openai_from_env")()
+    assert direct.wire == via_registry.wire
+    assert direct.preset_name == via_registry.preset_name
+    assert direct.default_model == via_registry.default_model
+    assert str(direct.endpoint.base_url).rstrip("/") == str(
+        via_registry.endpoint.base_url
+    ).rstrip("/")
+    assert direct.endpoint.path_prefix == via_registry.endpoint.path_prefix
+
+
+def test_from_env_classmethod_matches_module_function(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`LlmDeployment.openai_from_env()` ≡ `openai_from_env_preset()` —
+    both surfaces produce structurally identical deployments."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o")
+    via_module = openai_from_env_preset()
+    via_classmethod = LlmDeployment.openai_from_env()
+    assert via_module.wire == via_classmethod.wire
+    assert via_module.preset_name == via_classmethod.preset_name
+    assert via_module.default_model == via_classmethod.default_model
+
+
+def test_from_env_preset_routes_through_parent_capability_row(
+    _env_serialized, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Capability lookups for an `_from_env` deployment route through the
+    PARENT preset row, not a separate `_from_env` row.
+
+    The `from_env` factory delegates to `<provider>_preset` which sets
+    `preset_name="<provider>"` (parent literal) on the deployment, so
+    `for_preset(dep.preset_name)` resolves to the parent's capability row
+    automatically. This mirrors the `<provider>_default` precedent (#787).
+    """
+    from kaizen.llm.capabilities import for_preset
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_PROD_MODEL", "gpt-4o")
+    dep = openai_from_env_preset()
+    via_dep = for_preset(dep.preset_name or "")
+    via_parent = for_preset("openai")
+    assert via_dep == via_parent

--- a/packages/kailash-kaizen/tests/unit/llm/test_preset_name_and_compatible.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_preset_name_and_compatible.py
@@ -231,12 +231,22 @@ def test_compatible_presets_appear_in_registry() -> None:
 def test_total_preset_count_after_retrofit() -> None:
     """Lock the registry size so future regressions surface loudly.
 
-    24 existing presets (S1 + 15 S3 + 4 S4b + 1 S4a + 2 S5 + 1 S6 + the
-    `azure_entra` factory which is registered via S6) + 2 new compatible
-    presets = 26.
+    Composition (cumulative across releases):
+
+    * S1 + 15 S3 (direct providers) + 4 S4b (bedrock non-claude) + 1 S4a
+      (bedrock claude) + 2 S5 (vertex) + 1 S6 (azure openai) +
+      `azure_entra` factory registered via S6 = 24 (pre-2.15.0 baseline).
+    * + 2 compatible presets (`openai_compatible`, `anthropic_compatible`,
+      #761 / #762) shipped in 2.15.0 → 26.
+    * + 4 default-URL convenience presets (`ollama_default`,
+      `lm_studio_default`, `llama_cpp_default`,
+      `docker_model_runner_default`, #787) shipped in 2.16.2 → 30.
+    * + 12 `<provider>_from_env` convenience presets (#791) for OpenAI,
+      Anthropic, Google, Cohere, Mistral, Perplexity, HuggingFace, Groq,
+      Together, Fireworks, OpenRouter, DeepSeek → 42.
 
     NB: `azure_entra` is registered as a preset name even though it is
     really an auth-strategy factory; this is pre-existing in the kaizen
-    LLM surface. If a future cleanup removes it, update this count to 25.
+    LLM surface. If a future cleanup removes it, decrement this count.
     """
-    assert len(list_presets()) == 26
+    assert len(list_presets()) == 42


### PR DESCRIPTION
## Summary

- Adds 12 `<provider>_from_env` convenience constructors on `LlmDeployment` (one per kailash-rs zero-arg classmethod): `openai`, `anthropic`, `google`, `cohere`, `mistral`, `perplexity`, `huggingface`, `groq`, `together`, `fireworks`, `openrouter`, `deepseek`.
- Cross-SDK parity with kailash-rs `LlmDeployment` zero-arg classmethods at `crates/kailash-kaizen/src/llm/deployment/presets.rs:153,249,346,386,408,430,458,928,964,1000,1036,1072`.
- Each `<provider>_from_env_preset()` reads `<PROVIDER>_API_KEY` plus `<PROVIDER>_PROD_MODEL` (legacy fallback to `<PROVIDER>_MODEL`) from env, eager-validates per `rules/env-models.md`, raises typed `MissingCredential` on missing keys/models.

## Design rationale

Three options on the issue body; **Option 3 (`_from_env` variant)** selected because it is the only design satisfying `rules/env-models.md` ("ALL API keys MUST come from `.env`") while preserving the project's eager-validation convention. Option 1 (auth-less + later builder) introduces a structurally unauthenticated `LlmDeployment` shape; Option 2 (api_key default to env) silently couples the call site to env state. Option 3 announces env-driven construction at every call site.

Per EATP D6: semantics match Rust (same endpoint / wire protocol / eventual auth strategy); idiom-difference is the explicit `_from_env` naming + eager validation. Each returned deployment carries the PARENT `preset_name` literal so capability lookups (`for_preset(...)`, `LlmDeployment.supports()`) route through the parent row automatically — mirrors the `<provider>_default` precedent (#787 / 2.16.2).

## Test plan

- [x] 36 new tests in `tests/unit/llm/test_from_env_presets.py` covering: cross-SDK registry parity sweep × 12 names; per-provider deployment shape (wire / auth / preset_name / endpoint URL byte-pinned to the Rust source-of-truth literal); typed `MissingCredential` raise (parametrized × 12 missing api_key, × 4 missing model); `<PROVIDER>_PROD_MODEL` precedence over `<PROVIDER>_MODEL`; legacy fallback chain; classmethod ↔ module-function agreement; registry round-trip via `get_preset`; capability-matrix routing through parent row.
- [x] Env-mutating tests serialize via module-scope `threading.Lock` per `rules/testing.md` § "Serialize Env-Var-Mutating Tests Via Module Lock".
- [x] Count-dependent test (`test_total_preset_count_after_retrofit`) updated 26 → 42 (per `orphan-detection.md` Rule 6a — also captures 2.16.2's missed +4 default-URL update).
- [x] All 5 preset test files: 182 / 182 pass in 0.27s (`test_from_env_presets.py`, `test_preset_name_and_compatible.py`, `test_default_url_presets.py`, `test_session2_direct_provider_presets.py`, `test_supports_capability_matrix.py`).
- [x] Pre-commit hooks pass (Black, isort, Ruff, type checks, Tier 1 unit tests, doc-style).
- [x] Version bumped atomically: `pyproject.toml` 2.16.2 → 2.17.0 + `__init__.py::__version__` 2.16.2 → 2.17.0 (minor, new public API per `build-repo-release-discipline.md` Rule 5).

## Known follow-ups (filed separately, not blocking)

- Cohere endpoint URL divergence between Python (`api.cohere.com/v1` + `CohereGenerate` wire) and Rust (`api.cohere.ai/v2`) — surfaced during the cross-SDK source-of-truth audit; pre-dates #791. The `_from_env` wrapper inherits whichever URL the parent `cohere_preset` exposes. Tracked separately so the v1-Generate-vs-v2-Chat decision gets its own design pass.
- Sibling cross-SDK / hygiene workstreams: #788 (mock test-utils gating), #789 (CodeQL Rule 1b deferral track), #790 (capability rows for 7 Python-only presets).

Closes #791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)