### PR TITLE
chore(deploy): record kailash-kaizen 2.17.0 from_env cross-SDK parity

### DIFF
--- a/deploy/deployments/2026-05-02-kaizen-v2.17.0.md
+++ b/deploy/deployments/2026-05-02-kaizen-v2.17.0.md
@@ -1,0 +1,106 @@
+# 2026-05-02 — `kailash-kaizen` 2.17.0
+
+Single-package minor release closing #791 — adds 12
+`<provider>_from_env` cross-SDK convenience constructors on
+`LlmDeployment`. Cross-SDK parity with the 12 zero-arg
+`pub fn <provider>() -> Self` classmethods on kailash-rs
+`LlmDeployment` at `crates/kailash-kaizen/src/llm/deployment/presets.rs:153,249,346,386,408,430,458,928,964,1000,1036,1072`.
+
+## Release scope (per `build-repo-release-discipline.md` § 3)
+
+| Package          | main → PyPI     | Released?      |
+| ---------------- | --------------- | -------------- |
+| kailash          | 2.13.3 → 2.13.3 | no — at parity |
+| kailash-dataflow | 2.7.5 → 2.7.5   | no — at parity |
+| kailash-kaizen   | 2.17.0 → 2.16.2 | YES — this PR  |
+| kailash-mcp      | 0.2.10 → 0.2.10 | no — at parity |
+| kailash-ml       | 1.7.1 → 1.7.1   | no — at parity |
+| kailash-nexus    | 2.6.0 → 2.6.0   | no — at parity |
+| kailash-pact     | 0.11.0 → 0.11.0 | no — at parity |
+| kailash-align    | 0.7.0 → 0.7.0   | no — at parity |
+| kaizen-agents    | 0.9.4 → 0.9.4   | no — at parity |
+
+Clean release scope — no sibling drift.
+
+## Trail
+
+- **PR**: [#793](https://github.com/terrene-foundation/kailash-py/pull/793) — `feat/791-from-env-constructors`
+- **Closes**: [#791](https://github.com/terrene-foundation/kailash-py/issues/791)
+- **Merge commit**: `7e15f75987557c54c5dd3383ef6109ae589d2183`
+- **Tag**: `kaizen-v2.17.0` (lightweight, on merge commit)
+- **publish-pypi.yml run**: [25249471594](https://github.com/terrene-foundation/kailash-py/actions/runs/25249471594) — completed `success`
+
+## Decision rationale (#791)
+
+Three options on the issue body; **Option 3 (`_from_env` variant)**
+selected because it is the only design that satisfies
+`rules/env-models.md` ("ALL API keys MUST come from `.env`") while
+preserving the eager-validation convention. Option 1 (auth-less +
+later builder) introduces an `LlmDeployment` whose state is structurally
+unauthenticated until a builder call. Option 2 (api_key default to env
+inside the parent constructor) silently couples the call site to env
+state. Option 3 announces env-driven construction at every call site.
+
+Per EATP D6 (`rules/cross-sdk-inspection.md` § 3): semantics match Rust
+(same endpoint / wire protocol / eventual auth strategy);
+idiom-difference is the explicit `_from_env` naming + eager validation
+at construction.
+
+## API surface added
+
+12 `<provider>_from_env` constructors covering:
+`openai`, `anthropic`, `google`, `cohere`, `mistral`, `perplexity`,
+`huggingface`, `groq`, `together`, `fireworks`, `openrouter`, `deepseek`.
+
+Each `LlmDeployment.<provider>_from_env()` (and module-level
+`<provider>_from_env_preset()`) reads `<PROVIDER>_API_KEY` plus
+`<PROVIDER>_PROD_MODEL` (with legacy fallback to `<PROVIDER>_MODEL`)
+from the environment, raises typed `kaizen.llm.errors.MissingCredential`
+on missing keys/models, and delegates to the existing parent factory.
+Each returned deployment carries the PARENT `preset_name` literal so
+capability lookups (`for_preset(...)`, `LlmDeployment.supports()`)
+route through the parent row automatically — mirrors the
+`<provider>_default` precedent (#787 / 2.16.2).
+
+## Test surface
+
+- 36 new tests in `tests/unit/llm/test_from_env_presets.py` covering:
+  cross-SDK registry parity sweep × 12 names; per-provider deployment
+  shape with endpoint URL byte-pinned to the Rust source-of-truth
+  literal; typed `MissingCredential` raise (parametrized × 12 missing
+  api_key, × 4 missing model); `<PROVIDER>_PROD_MODEL` precedence;
+  legacy `<PROVIDER>_MODEL` fallback; classmethod ↔ module-function
+  agreement; registry round-trip; capability-matrix routing through
+  parent row.
+- Env-mutating tests serialize via module-scope `threading.Lock` per
+  `rules/testing.md` § "Serialize Env-Var-Mutating Tests Via Module Lock".
+- Count-dependent test (`test_total_preset_count_after_retrofit`)
+  updated 26 → 42 (per `orphan-detection.md` Rule 6a — also captures
+  2.16.2's missed +4 default-URL update).
+- Targeted preset suite: 182 / 182 pass in 0.27s.
+
+## Verification (Rule 2 — done gate)
+
+Clean-venv install + import (`uv venv /tmp/verify-kaizen-2.17 --python 3.12`)
+attempt 1 hit PyPI/uv index cache lag (`No solution found ... no version
+of kailash-kaizen==2.17.0`). Attempt 2 with `--refresh` succeeded after
+~60s — `kaizen.__version__ = 2.17.0`, all 12 `<provider>_from_env`
+classmethods importable. Documented PyPI cache lag pattern per
+`build-repo-release-discipline.md` § 2.
+
+## Known follow-ups (filed separately, not blocking this release)
+
+- **#794** — `cohere_preset` endpoint divergence between Python
+  (`api.cohere.com/v1` + `CohereGenerate` wire) and kailash-rs
+  (`api.cohere.ai/v2`). Surfaced during the #791 cross-SDK
+  source-of-truth audit; pre-dates #791. The `_from_env` wrapper
+  inherits whichever URL the parent `cohere_preset` exposes, so
+  reconciling the parent automatically lifts both surfaces. Severity
+  LOW (both Cohere hosts return live API responses today; cross-SDK
+  divergence is the real cost). Tracked separately so the
+  v1-Generate-vs-v2-Chat decision gets its own design pass.
+- **#788** — `LlmDeployment.mock()` test-utils gating design.
+- **#789** — CodeQL Rule 1b deferral track on the kaizen surface.
+- **#790** — Capability rows for 7 Python-only presets
+  (together / fireworks / openrouter / deepseek / lm_studio /
+  llama_cpp / docker_model_runner).


### PR DESCRIPTION
## Summary

- Records the `kailash-kaizen 2.17.0` release closing #791 (12 `<provider>_from_env` cross-SDK convenience constructors).
- Doc-only change. PyPI publication already shipped via `kaizen-v2.17.0` tag triggering `publish-pypi.yml` run [25249471594](https://github.com/terrene-foundation/kailash-py/actions/runs/25249471594).
- Clean-venv install + import verified at attempt 2 (PyPI cache lag — Rule 2 `--refresh` documented unblocker).

## Test plan

- [x] PR #793 merged at `7e15f75987557c54c5dd3383ef6109ae589d2183`.
- [x] `kaizen-v2.17.0` lightweight tag pushed.
- [x] `publish-pypi.yml` workflow `success`.
- [x] `uv pip install --refresh "kailash-kaizen==2.17.0"` + import of all 12 `<provider>_from_env` classmethods verified in clean venv.
- [x] No sibling drift — every other package at PyPI parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)