### PR TITLE
chore(kaizen): close 4 CodeQL hygiene findings + 2.17.1 (#789 FIX)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.17.1] — 2026-05-02 — CodeQL hygiene cleanup (#789 FIX track)
+
+Patch bump. Closes 4 of 13 open CodeQL findings on the kaizen surface
+per the #789 Rule 1b deferral track. The remaining 9 findings are tracked
+as DEFER with per-finding runtime-safety proofs in #789's triage comment;
+all 9 fall into 4 categorical CodeQL false-positive classes (fingerprint
+redaction not recognised, runtime-deferred local imports, `Protocol` stub
+bodies, `__del__` interpreter-shutdown defense).
+
+### Fixed
+
+- **`packages/kailash-kaizen/src/kaizen/orchestration/runtime.py`** — removed unused `Union` import (closes CodeQL alert #10874, `py/unused-import`).
+- **`packages/kailash-kaizen/src/kaizen/signatures/core.py`** — removed unused `TYPE_CHECKING` import; the file's line-41 comment explicitly opts out of TYPE_CHECKING back-edges, so the import was deliberate non-use (closes CodeQL alert #10865, `py/unused-import`).
+- **`packages/kailash-kaizen/src/kaizen/strategies/async_single_shot.py`** — refactored two `runtime = AsyncLocalRuntime() / try / finally: runtime.close()` blocks to `async with AsyncLocalRuntime() as runtime:` form (closes CodeQL alerts #10923 + #10924, `py/should-use-with`). `AsyncLocalRuntime` exposes `__aenter__` / `__aexit__` (`src/kailash/runtime/async_local.py:1580,1590`) so the refactor is drop-in. The new form propagates exceptions cleanly through `__aexit__` on every code path including the inner-loop `break` and outer-`except` propagation; the prior form relied on an explicit synchronous `close()` in `finally` that did not await async cleanup.
+- **`packages/kailash-kaizen/tests/unit/strategies/test_async_single_shot_tool_calls.py`** — extended 7 `mock_runtime_instance` setups with `__aenter__` / `__aexit__` `AsyncMock` hooks per `orphan-detection.md` Rule 4 (refactor sweeps tests in same commit). 14/14 tool-call tests pass; 456/456 broader strategies + orchestration + signatures sweep clean.
+
+### Known follow-ups (filed separately, not blocking this release)
+
+- **9 remaining CodeQL findings** tracked as DEFER per `zero-tolerance.md` Rule 1b on issue #789 with per-finding runtime-safety proofs. Each finding falls into a categorical CodeQL static-analyzer limitation (not project-specific debt). Rule 1b conditions met: runtime-safety proof ✓, tracking issue (#789) ✓, release-PR link (this CHANGELOG entry) ✓, release-specialist signoff to be confirmed at the release PR review.
+
 ## [2.17.0] — 2026-05-02 — `<provider>_from_env` cross-SDK convenience constructors (#791)
 
 Minor bump. Closes the deferred cross-SDK API-shape parity gap surfaced

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.17.0"
+version = "2.17.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.17.0"
+__version__ = "2.17.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/orchestration/runtime.py
+++ b/packages/kailash-kaizen/src/kaizen/orchestration/runtime.py
@@ -93,7 +93,6 @@ from typing import (
     Optional,
     Protocol,
     Tuple,
-    Union,
     runtime_checkable,
 )
 

--- a/packages/kailash-kaizen/src/kaizen/signatures/core.py
+++ b/packages/kailash-kaizen/src/kaizen/signatures/core.py
@@ -23,17 +23,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass, field
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 from kailash.utils.annotations import get_namespace_annotations
 

--- a/packages/kailash-kaizen/src/kaizen/strategies/async_single_shot.py
+++ b/packages/kailash-kaizen/src/kaizen/strategies/async_single_shot.py
@@ -140,10 +140,11 @@ class AsyncSingleShotStrategy:
 
         # Execute asynchronously
         try:
-            # Use AsyncLocalRuntime for true async execution (no thread pool)
-            runtime = AsyncLocalRuntime()
-
-            try:
+            # Use AsyncLocalRuntime for true async execution (no thread pool).
+            # `async with` invokes __aenter__/__aexit__ so the runtime is closed
+            # cleanly on every exit path, including the inner break out of the
+            # tool-call loop and exception propagation up to the outer `except`.
+            async with AsyncLocalRuntime() as runtime:
                 # Transform inputs to messages
                 messages = self._create_messages_from_inputs(agent, preprocessed_inputs)
                 workflow_params = {"agent_exec": {"messages": messages}}
@@ -262,19 +263,13 @@ class AsyncSingleShotStrategy:
                     if workflow is None:
                         break
                     workflow_params = {"agent_exec": {"messages": updated_messages}}
-                    runtime_next = AsyncLocalRuntime()
-                    try:
+                    async with AsyncLocalRuntime() as runtime_next:
                         results, run_id = await runtime_next.execute_workflow_async(
                             workflow.build(), inputs=workflow_params
                         )
-                    finally:
-                        runtime_next.close()
 
                     # Update messages for potential next round
                     messages = updated_messages
-
-            finally:
-                runtime.close()
 
             # Parse result
             parsed_result = self.parse_result(results)

--- a/packages/kailash-kaizen/tests/unit/strategies/test_async_single_shot_tool_calls.py
+++ b/packages/kailash-kaizen/tests/unit/strategies/test_async_single_shot_tool_calls.py
@@ -177,6 +177,14 @@ class TestToolCallExecutionLoop:
                 ]
             )
             mock_runtime_instance.close = MagicMock()
+            # `async with AsyncLocalRuntime() as runtime:` (per #789 / 2.17.0
+            # CodeQL py/should-use-with cleanup) requires the mock to expose
+            # async context-manager hooks. __aenter__ returns the same mock so
+            # `runtime` binds to it; __aexit__ returns None for clean exit.
+            mock_runtime_instance.__aenter__ = AsyncMock(
+                return_value=mock_runtime_instance
+            )
+            mock_runtime_instance.__aexit__ = AsyncMock(return_value=None)
             MockRuntime.return_value = mock_runtime_instance
 
             result = await strategy.execute(agent, {"question": "What is the answer?"})
@@ -212,6 +220,14 @@ class TestToolCallExecutionLoop:
                 ]
             )
             mock_runtime_instance.close = MagicMock()
+            # `async with AsyncLocalRuntime() as runtime:` (per #789 / 2.17.0
+            # CodeQL py/should-use-with cleanup) requires the mock to expose
+            # async context-manager hooks. __aenter__ returns the same mock so
+            # `runtime` binds to it; __aexit__ returns None for clean exit.
+            mock_runtime_instance.__aenter__ = AsyncMock(
+                return_value=mock_runtime_instance
+            )
+            mock_runtime_instance.__aexit__ = AsyncMock(return_value=None)
             MockRuntime.return_value = mock_runtime_instance
 
             result = await strategy.execute(agent, {"question": "test"})
@@ -239,6 +255,14 @@ class TestToolCallExecutionLoop:
                 return_value=(result_with_tools, "run-1")
             )
             mock_runtime_instance.close = MagicMock()
+            # `async with AsyncLocalRuntime() as runtime:` (per #789 / 2.17.0
+            # CodeQL py/should-use-with cleanup) requires the mock to expose
+            # async context-manager hooks. __aenter__ returns the same mock so
+            # `runtime` binds to it; __aexit__ returns None for clean exit.
+            mock_runtime_instance.__aenter__ = AsyncMock(
+                return_value=mock_runtime_instance
+            )
+            mock_runtime_instance.__aexit__ = AsyncMock(return_value=None)
             MockRuntime.return_value = mock_runtime_instance
 
             result = await strategy.execute(agent, {"question": "test"})
@@ -267,6 +291,14 @@ class TestToolCallExecutionLoop:
                 return_value=(never_ending_result, "run-n")
             )
             mock_runtime_instance.close = MagicMock()
+            # `async with AsyncLocalRuntime() as runtime:` (per #789 / 2.17.0
+            # CodeQL py/should-use-with cleanup) requires the mock to expose
+            # async context-manager hooks. __aenter__ returns the same mock so
+            # `runtime` binds to it; __aexit__ returns None for clean exit.
+            mock_runtime_instance.__aenter__ = AsyncMock(
+                return_value=mock_runtime_instance
+            )
+            mock_runtime_instance.__aexit__ = AsyncMock(return_value=None)
             MockRuntime.return_value = mock_runtime_instance
 
             result = await strategy.execute(agent, {"question": "test"})
@@ -302,6 +334,14 @@ class TestToolCallExecutionLoop:
                 ]
             )
             mock_runtime_instance.close = MagicMock()
+            # `async with AsyncLocalRuntime() as runtime:` (per #789 / 2.17.0
+            # CodeQL py/should-use-with cleanup) requires the mock to expose
+            # async context-manager hooks. __aenter__ returns the same mock so
+            # `runtime` binds to it; __aexit__ returns None for clean exit.
+            mock_runtime_instance.__aenter__ = AsyncMock(
+                return_value=mock_runtime_instance
+            )
+            mock_runtime_instance.__aexit__ = AsyncMock(return_value=None)
             MockRuntime.return_value = mock_runtime_instance
 
             result = await strategy.execute(agent, {"question": "test"})
@@ -357,6 +397,14 @@ class TestToolCallExecutionLoop:
                 ]
             )
             mock_runtime_instance.close = MagicMock()
+            # `async with AsyncLocalRuntime() as runtime:` (per #789 / 2.17.0
+            # CodeQL py/should-use-with cleanup) requires the mock to expose
+            # async context-manager hooks. __aenter__ returns the same mock so
+            # `runtime` binds to it; __aexit__ returns None for clean exit.
+            mock_runtime_instance.__aenter__ = AsyncMock(
+                return_value=mock_runtime_instance
+            )
+            mock_runtime_instance.__aexit__ = AsyncMock(return_value=None)
             MockRuntime.return_value = mock_runtime_instance
 
             result = await strategy.execute(agent, {"question": "test"})
@@ -381,6 +429,14 @@ class TestToolCallExecutionLoop:
                 return_value=(clean_result, "run-1")
             )
             mock_runtime_instance.close = MagicMock()
+            # `async with AsyncLocalRuntime() as runtime:` (per #789 / 2.17.0
+            # CodeQL py/should-use-with cleanup) requires the mock to expose
+            # async context-manager hooks. __aenter__ returns the same mock so
+            # `runtime` binds to it; __aexit__ returns None for clean exit.
+            mock_runtime_instance.__aenter__ = AsyncMock(
+                return_value=mock_runtime_instance
+            )
+            mock_runtime_instance.__aexit__ = AsyncMock(return_value=None)
             MockRuntime.return_value = mock_runtime_instance
 
             result = await strategy.execute(agent, {"question": "test"})


### PR DESCRIPTION
## Summary

- Closes 4 of 13 open CodeQL findings on the kaizen surface per the #789 Rule 1b deferral track. Triage table with per-finding disposition is on [#789](https://github.com/terrene-foundation/kailash-py/issues/789#issuecomment-4363591733).
- The remaining 9 findings are tracked as DEFER with per-finding runtime-safety proofs in #789's triage comment; all 9 fall into 4 categorical CodeQL false-positive classes (fingerprint redaction not recognised, runtime-deferred local imports, `Protocol` stub bodies, `__del__` interpreter-shutdown defense).

## Fixes (4)

| Alert | Path | Change |
|---|---|---|
| #10874 | `src/kaizen/orchestration/runtime.py` | drop unused `Union` import (`py/unused-import`) |
| #10865 | `src/kaizen/signatures/core.py` | drop unused `TYPE_CHECKING` import (`py/unused-import`) |
| #10923 | `src/kaizen/strategies/async_single_shot.py` | refactor inner `try/finally → async with` (`py/should-use-with`) |
| #10924 | `src/kaizen/strategies/async_single_shot.py` | refactor outer `try/finally → async with` (`py/should-use-with`) |

`AsyncLocalRuntime` exposes `__aenter__` / `__aexit__` (`src/kailash/runtime/async_local.py:1580,1590`); refactor is drop-in. Cleaner exit-path handling on every code path including the inner-loop `break` and outer-`except` propagation; the prior synchronous `close()` in `finally` did not await async cleanup.

## Test sweep

- 7 `mock_runtime_instance` setups in `test_async_single_shot_tool_calls.py` extended with `__aenter__` / `__aexit__` `AsyncMock` hooks per `orphan-detection.md` Rule 4 (refactor sweeps tests in same commit).
- 14/14 tool-call tests pass.
- 456/456 broader strategies + orchestration + signatures unit sweep clean.

## Release-specialist signoff for the 9 DEFER findings (Rule 1b condition #4)

This PR's CHANGELOG entry links to the #789 triage comment which documents per-finding runtime-safety proofs for all 9 DEFERs. Conditions met:

1. ✅ Runtime-safety proof — written in the triage comment per finding.
2. ✅ Tracking issue — #789.
3. ✅ Release-PR link — this PR + the [Unreleased] CHANGELOG entry.
4. ⏸ Release-specialist agreement — please confirm at PR review.

## Test plan

- [x] Pre-commit hooks pass (Black, isort, Ruff, type checks, Tier 1 unit tests).
- [x] Targeted preset / strategies / orchestration / signatures suite green.
- [x] Version bumped atomically: pyproject.toml 2.17.0 → 2.17.1 + `__init__.py::__version__` 2.17.0 → 2.17.1 (patch — CodeQL hygiene, no public-API change).
- [x] CHANGELOG entry under [2.17.1].

References: #789 triage comment, `zero-tolerance.md` Rule 1b, `orphan-detection.md` Rule 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)