### PR TITLE
chore(deploy): record kailash-kaizen 2.17.1 CodeQL hygiene cleanup

### DIFF
--- a/deploy/deployments/2026-05-02-kaizen-v2.17.1.md
+++ b/deploy/deployments/2026-05-02-kaizen-v2.17.1.md
@@ -1,0 +1,83 @@
+# 2026-05-02 — `kailash-kaizen` 2.17.1
+
+Single-package patch release closing 4 of 13 open CodeQL findings on the
+kaizen surface per the #789 Rule 1b deferral track. Same-day patch on
+top of 2.17.0 — both releases close cross-SDK / hygiene loops surfaced
+during the post-2.16.2 audit.
+
+## Release scope (per `build-repo-release-discipline.md` § 3)
+
+| Package          | main → PyPI     | Released?      |
+| ---------------- | --------------- | -------------- |
+| kailash          | 2.13.3 → 2.13.3 | no — at parity |
+| kailash-dataflow | 2.7.5 → 2.7.5   | no — at parity |
+| kailash-kaizen   | 2.17.1 → 2.17.0 | YES — this PR  |
+| kailash-mcp      | 0.2.10 → 0.2.10 | no — at parity |
+| kailash-ml       | 1.7.1 → 1.7.1   | no — at parity |
+| kailash-nexus    | 2.6.0 → 2.6.0   | no — at parity |
+| kailash-pact     | 0.11.0 → 0.11.0 | no — at parity |
+| kailash-align    | 0.7.0 → 0.7.0   | no — at parity |
+| kaizen-agents    | 0.9.4 → 0.9.4   | no — at parity |
+
+Clean release scope — no sibling drift.
+
+## Trail
+
+- **PR**: [#796](https://github.com/terrene-foundation/kailash-py/pull/796) — `chore/789-codeql-hygiene`
+- **Closes**: 4 of 13 alerts on [#789](https://github.com/terrene-foundation/kailash-py/issues/789); remaining 9 tracked as DEFER per Rule 1b
+- **Triage comment**: [#789 disposition table](https://github.com/terrene-foundation/kailash-py/issues/789#issuecomment-4363591733)
+- **Merge commit**: `c32267eec5190c01d33c28e46669a5fcf88e6e50`
+- **Tag**: `kaizen-v2.17.1` (lightweight, on merge commit)
+- **publish-pypi.yml run**: [25250196385](https://github.com/terrene-foundation/kailash-py/actions/runs/25250196385) — completed `success`
+
+## CodeQL findings closed
+
+| Alert  | Path                                         | Rule                 | Change                           |
+| ------ | -------------------------------------------- | -------------------- | -------------------------------- |
+| #10874 | `src/kaizen/orchestration/runtime.py`        | `py/unused-import`   | drop `Union`                     |
+| #10865 | `src/kaizen/signatures/core.py`              | `py/unused-import`   | drop `TYPE_CHECKING`             |
+| #10923 | `src/kaizen/strategies/async_single_shot.py` | `py/should-use-with` | inner `try/finally → async with` |
+| #10924 | `src/kaizen/strategies/async_single_shot.py` | `py/should-use-with` | outer `try/finally → async with` |
+
+`AsyncLocalRuntime` exposes `__aenter__` / `__aexit__` (`src/kailash/runtime/async_local.py:1580,1590`); the `async with` refactor is drop-in. The new form propagates exceptions cleanly through `__aexit__` on every exit path including the inner-loop `break` and outer-`except` propagation; the prior synchronous `close()` in `finally` did not await async cleanup.
+
+## DEFER track (9 findings — Rule 1b)
+
+All 9 remaining findings have per-finding runtime-safety proofs in the #789 triage comment. They fall into 4 categorical CodeQL false-positive classes:
+
+- **Fingerprint redaction not recognised** (#10866 + #10867): `_fingerprint(...)` calls `fingerprint_secret(...)` which returns BLAKE2b digest (per #617). CodeQL taint-analyzer follows the input through the helper but does not register `fingerprint_secret` as a redaction sink.
+- **Runtime-deferred local imports** (#10876 + #10877): cyclic-import warnings on `from X import Y` statements that live inside method bodies, not at module scope. The cycle is consummated only when the method runs; both modules import successfully in isolation. Standard Python idiom for breaking cyclic imports.
+- **`Protocol` stub bodies** (#10868 + #10869 + #10870 + #10871): `...` (ellipsis) inside `typing.Protocol` method bodies. PEP 544 idiom; the body is never executed at runtime — the `Protocol` exists only for static type checking.
+- **`__del__` interpreter-shutdown defense** (#10837): structure mandated by `rules/patterns.md` § Async Resource Cleanup ("conditional fallback import; try/except for interpreter-shutdown"). The "complexity" CodeQL flags is the documented defense against `__del__` firing during interpreter shutdown when module-level `warnings` may already be GC'd.
+
+Rule 1b conditions met: runtime-safety proof ✓, tracking issue (#789) ✓, release-PR link (this record) ✓, release-specialist signoff at #796 review ✓.
+
+## Verification (Rule 2 — done gate)
+
+- Clean-venv install (`uv venv /tmp/verify-kaizen-2.17.1 --python 3.12`) — attempt 1 hit PyPI/uv index cache lag (`No solution found ... no version of kailash-kaizen==2.17.1`). Attempt 2 with `--refresh` succeeded after ~60s.
+- `kaizen.__version__ = 2.17.1` ✓.
+- Structural sweep on the wheel's installed source confirms all 4 fixes shipped: `async with AsyncLocalRuntime() as runtime[_next]` in `strategies/async_single_shot.py`, no `Union` in `orchestration/runtime.py`'s `from typing import (...)` block, no `TYPE_CHECKING` in `signatures/core.py`'s `from typing import (...)` block.
+
+## Test surface
+
+- 7 `mock_runtime_instance` setups in `test_async_single_shot_tool_calls.py` extended with `__aenter__` / `__aexit__` `AsyncMock` hooks per `orphan-detection.md` Rule 4 (refactor sweeps tests in same commit). 14/14 tool-call tests pass.
+- 456/456 broader strategies + orchestration + signatures unit sweep clean.
+
+## Cumulative cycle (2026-05-02)
+
+Three back-to-back kailash-kaizen releases shipped today, each closing a
+deferred audit-cycle workstream:
+
+| Version | Workstream                                          | PRs              |
+| ------- | --------------------------------------------------- | ---------------- |
+| 2.16.1  | `ollama_default` capability alias                   | #785 paired wave |
+| 2.16.2  | Default-URL convenience constructors (#787)         | #786, #787       |
+| 2.17.0  | `<provider>_from_env` cross-SDK constructors (#791) | #793, #795       |
+| 2.17.1  | CodeQL hygiene cleanup (#789 FIX track)             | #796 (this)      |
+
+## Known follow-ups (filed separately)
+
+- **#794** — Cohere endpoint divergence between Python (`api.cohere.com/v1`) and kailash-rs (`api.cohere.ai/v2`). LOW severity; design pass. Pre-dates #791 and #789.
+- **#788** — `LlmDeployment.mock()` test-utils gating (cross-SDK design).
+- **#790** — Capability matrix rows for 7 Python-only presets.
+- **9 DEFER CodeQL findings** on #789 — Rule 1b deferred with runtime-safety proofs; tracking remains on #789 with the FIX/DEFER table.


### PR DESCRIPTION
## Summary

- Records the `kailash-kaizen 2.17.1` release closing 4 of 13 open CodeQL findings on the kaizen surface per the #789 Rule 1b deferral track.
- Doc-only change. PyPI publication already shipped via `kaizen-v2.17.1` tag triggering `publish-pypi.yml` run [25250196385](https://github.com/terrene-foundation/kailash-py/actions/runs/25250196385).
- Clean-venv install + structural verify of the 4 fixes confirmed at attempt 2 (PyPI cache lag — Rule 2 `--refresh` documented unblocker).

## Test plan

- [x] PR #796 merged at `c32267eec5190c01d33c28e46669a5fcf88e6e50`.
- [x] `kaizen-v2.17.1` lightweight tag pushed.
- [x] `publish-pypi.yml` workflow `success`.
- [x] `uv pip install --refresh "kailash-kaizen==2.17.1"` + structural verify (async-with refactor + Union/TYPE_CHECKING removed in installed wheel).
- [x] No sibling drift — every other package at PyPI parity.
- [x] 9 DEFER findings continue to track on #789 with per-finding runtime-safety proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)