### PR TITLE
feat(kaizen): test-only mock_preset module for cross-SDK parity (#788)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`kaizen.llm.testing.mock_preset()` test-only deployment factory (closes #788; cross-SDK parity with kailash-rs `LlmDeployment::mock()` at `crates/kailash-kaizen/src/llm/deployment/presets.rs:1183`).** New module `kaizen.llm.testing` exposes `mock_preset(model: str = "mock-model") -> LlmDeployment` for test code that needs a structurally-valid `LlmDeployment` without binding to a real provider. The deployment carries `preset_name="mock"`, `WireProtocol.OpenAiChat`, `StaticNone` auth, and an endpoint at `https://example.com/v1` (RFC-2606 reserved test host that resolves under the SSRF guard). Cross-SDK parity: Rust gates `mock()` behind `#[cfg(any(test, feature = "test-utils"))]` so the symbol does not exist in production builds; Python lacks cargo features, so the structural defense is **physical module separation** — `LlmDeployment.mock` does NOT exist on the production class, `kaizen.llm.presets.mock_preset` does NOT exist, and `"mock"` is NOT a registered preset. Test code MUST `from kaizen.llm.testing import mock_preset` explicitly. The module path is the deliberate red flag — production code that imports from a module named `testing` is structurally identifiable by `grep -rn 'kaizen.llm.testing' src/`. `mock_preset(...).supports()` returns the fail-closed all-False matrix, matching Rust's `CapabilityMatrix::for_preset("mock")` fall-through behavior (no explicit `"mock"` row in either SDK).
+
 ## [2.17.1] — 2026-05-02 — CodeQL hygiene cleanup (#789 FIX track)
 
 Patch bump. Closes 4 of 13 open CodeQL findings on the kaizen surface

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.17.1"
+version = "2.18.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.17.1"
+__version__ = "2.18.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/llm/testing/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/testing/__init__.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test-only deployment factories — physically separated from the
+production import surface (#788).
+
+Cross-SDK parity with kailash-rs ``LlmDeployment::mock()`` at
+``crates/kailash-kaizen/src/llm/deployment/presets.rs:1183``, which is
+gated behind ``#[cfg(any(test, feature = "test-utils"))]`` so production
+builds without the ``test-utils`` feature CANNOT construct a mock
+deployment at compile time.
+
+Python lacks cargo features, so an equivalent compile-time gate does not
+exist. The structural defense here is **physical module separation**:
+
+- Production code imports ``kaizen.llm.presets`` (or
+  ``kaizen.llm.deployment.LlmDeployment``); neither exposes a ``mock``
+  classmethod or factory.
+- Test code that wants a mock deployment imports
+  ``kaizen.llm.testing.mock_preset`` explicitly.
+
+The split is structurally enforced — the symbol simply does not exist on
+the production import surface. ``LlmDeployment.mock()`` raises
+``AttributeError`` and ``from kaizen.llm.presets import mock_preset``
+raises ``ImportError``. The Tier-1 test suite at
+``tests/unit/llm/test_mock_preset_isolation.py`` asserts both invariants.
+
+Use this module ONLY in test code (``tests/`` directories,
+``conftest.py``, ``test_*.py`` files). Importing
+``kaizen.llm.testing.mock_preset`` from production code is a
+``rules/zero-tolerance.md`` Rule 2 violation (no mock data in
+production); the import path is the deliberate red flag — production
+code that imports from a module named ``testing`` is structurally
+identifiable by ``grep -rn 'kaizen.llm.testing' src/``.
+
+Capability matrix: Rust's ``CapabilityMatrix::for_preset("mock")`` falls
+through to ``Self::all_false()`` (no explicit row at
+``crates/kailash-kaizen/src/llm/deployment/capabilities.rs:120-250``).
+Python preserves the same behavior — ``"mock"`` is intentionally absent
+from ``_PRESET_CAPABILITIES`` so ``mock.supports()`` returns the
+fail-closed all-False default. Cross-SDK parity per
+``rules/cross-sdk-inspection.md`` § 3a.
+"""
+
+from __future__ import annotations
+
+from kaizen.llm.auth.bearer import StaticNone
+from kaizen.llm.deployment import Endpoint, LlmDeployment, WireProtocol
+
+
+def mock_preset(model: str = "mock-model") -> LlmDeployment:
+    """Mock LLM deployment for testing.
+
+    Constructs an :class:`LlmDeployment` with ``preset_name="mock"``,
+    ``WireProtocol.OpenAiChat``, ``StaticNone`` auth, and an endpoint
+    pointing at the RFC-2606 reserved test host ``https://example.com``.
+    Cross-SDK parity with kailash-rs ``LlmDeployment::mock()`` at
+    ``crates/kailash-kaizen/src/llm/deployment/presets.rs:1183``.
+
+    The deployment is NOT intended to make real HTTP calls — test code
+    routes requests through the existing ``MockLlmProvider`` registered
+    under the ``"mock"`` provider name. The preset exists so the
+    abstraction surfaces a ``"mock"`` preset literal consistently
+    across SDKs.
+
+    The default ``model="mock-model"`` matches Rust's hardcoded test
+    model literal, keeping cross-SDK ported test code byte-identical.
+    Callers may override for tests that need a specific model name in
+    assertions.
+
+    Capability matrix: ``mock_preset(...).supports()`` returns the
+    fail-closed all-False matrix because ``"mock"`` is intentionally
+    absent from :data:`kaizen.llm.capabilities._PRESET_CAPABILITIES` —
+    matches Rust's ``CapabilityMatrix::for_preset("mock")`` fall-through
+    behavior. Tests that need to assert non-trivial capabilities must
+    use a real preset (``LlmDeployment.openai("sk-test", ...)``).
+
+    Example::
+
+        from kaizen.llm.testing import mock_preset
+
+        def test_my_feature():
+            dep = mock_preset()
+            assert dep.preset_name == "mock"
+            assert dep.default_model == "mock-model"
+    """
+    endpoint = Endpoint(base_url="https://example.com", path_prefix="/v1")
+    return LlmDeployment(
+        wire=WireProtocol.OpenAiChat,
+        endpoint=endpoint,
+        auth=StaticNone(),
+        default_model=model,
+        preset_name="mock",
+    )
+
+
+__all__ = ["mock_preset"]

--- a/packages/kailash-kaizen/tests/unit/llm/test_mock_preset_isolation.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_mock_preset_isolation.py
@@ -1,0 +1,211 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the test-only mock_preset module isolation (#788).
+
+Cross-SDK parity with kailash-rs ``LlmDeployment::mock()`` at
+``crates/kailash-kaizen/src/llm/deployment/presets.rs:1183``, which is
+gated behind ``#[cfg(any(test, feature = "test-utils"))]``. Python's
+structural defense is physical module separation —
+``kaizen.llm.testing.mock_preset`` exists; ``LlmDeployment.mock`` does
+not exist; ``kaizen.llm.presets.mock_preset`` does not exist.
+
+This file is the structural-defense Tier-1 test suite. The tests
+deliberately exercise the absence of symbols on the production import
+surface so that any future regression (e.g. someone copies
+``mock_preset`` to ``presets.py`` and forgets the gating intent)
+fails loudly here.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from kaizen.llm.deployment import Endpoint, LlmDeployment, WireProtocol
+
+# ---------------------------------------------------------------------------
+# Structural defense — mock symbol is absent from production import surface
+# ---------------------------------------------------------------------------
+
+
+def test_llm_deployment_has_no_mock_classmethod() -> None:
+    """The production ``LlmDeployment`` class MUST NOT expose a
+    ``mock`` classmethod. Cross-SDK parity with Rust's
+    ``#[cfg(any(test, feature = "test-utils"))]`` gating.
+
+    If this assertion fails, someone has wired ``mock_preset`` into the
+    production ``LlmDeployment`` surface — undoing the structural
+    defense per ``rules/zero-tolerance.md`` Rule 2 (no fake/simulated
+    data on the production surface).
+    """
+    assert not hasattr(
+        LlmDeployment, "mock"
+    ), "LlmDeployment.mock() MUST NOT exist on the production surface"
+
+
+def test_kaizen_llm_presets_does_not_export_mock_preset() -> None:
+    """The production ``kaizen.llm.presets`` module MUST NOT export
+    a ``mock_preset`` factory. Test code wanting a mock deployment
+    MUST import from ``kaizen.llm.testing`` explicitly.
+    """
+    presets = importlib.import_module("kaizen.llm.presets")
+    assert not hasattr(
+        presets, "mock_preset"
+    ), "kaizen.llm.presets.mock_preset MUST NOT exist (use kaizen.llm.testing)"
+
+
+def test_mock_is_not_in_preset_registry() -> None:
+    """The preset registry MUST NOT have a ``"mock"`` entry. Adding
+    one would expose the mock factory through ``get_preset("mock")``
+    and ``LlmDeployment.<name>`` classmethod attachment, defeating
+    the testing-module isolation.
+    """
+    from kaizen.llm.presets import list_presets
+
+    registered = list_presets()
+    assert (
+        "mock" not in registered
+    ), "preset registry MUST NOT contain 'mock' (it lives in kaizen.llm.testing)"
+
+
+# ---------------------------------------------------------------------------
+# Functional — mock_preset constructs a working LlmDeployment
+# ---------------------------------------------------------------------------
+
+
+def test_mock_preset_constructs_llm_deployment() -> None:
+    from kaizen.llm.testing import mock_preset
+
+    dep = mock_preset()
+    assert isinstance(dep, LlmDeployment)
+    assert dep.preset_name == "mock"
+    assert dep.default_model == "mock-model"
+    assert dep.wire is WireProtocol.OpenAiChat
+
+
+def test_mock_preset_default_model_matches_cross_sdk_literal() -> None:
+    """Default model literal pinned for cross-SDK parity. Rust's
+    ``LlmDeployment::mock()`` constructs deployments named ``"mock"``;
+    the model string is the next consumer assertion surface in test
+    code that ports between SDKs.
+    """
+    from kaizen.llm.testing import mock_preset
+
+    dep = mock_preset()
+    assert dep.default_model == "mock-model"
+
+
+def test_mock_preset_endpoint_uses_rfc2606_test_host() -> None:
+    """Mock endpoint MUST resolve under SSRF guard — uses the
+    RFC-2606 reserved test host ``example.com``. Same literal as
+    Rust's ``Endpoint::new("https://example.com")`` at
+    ``presets.rs:1183``.
+    """
+    from kaizen.llm.testing import mock_preset
+
+    dep = mock_preset()
+    assert isinstance(dep.endpoint, Endpoint)
+    # `HttpUrl` normalises to a trailing slash; pin the prefix.
+    assert str(dep.endpoint.base_url).startswith("https://example.com")
+    assert dep.endpoint.path_prefix == "/v1"
+
+
+def test_mock_preset_accepts_caller_model_override() -> None:
+    """Callers may override the default model for tests that need a
+    specific literal in assertions (e.g. registry lookups keyed on
+    model name).
+    """
+    from kaizen.llm.testing import mock_preset
+
+    dep = mock_preset(model="custom-test-model")
+    assert dep.default_model == "custom-test-model"
+    assert dep.preset_name == "mock"  # preset literal unchanged
+
+
+# ---------------------------------------------------------------------------
+# Capability matrix — mock falls through to all-False (matches Rust)
+# ---------------------------------------------------------------------------
+
+
+def test_mock_preset_supports_returns_all_false() -> None:
+    """Cross-SDK parity: Rust's ``CapabilityMatrix::for_preset("mock")``
+    falls through to ``Self::all_false()`` because no explicit row
+    exists at
+    ``crates/kailash-kaizen/src/llm/deployment/capabilities.rs:120-250``.
+    Python preserves the same behavior via fail-closed default.
+    """
+    from kaizen.llm.testing import mock_preset
+
+    caps = mock_preset().supports()
+    assert caps == {
+        "tools": False,
+        "vision": False,
+        "batch": False,
+        "caching": False,
+        "audio": False,
+    }
+
+
+def test_mock_is_not_in_preset_capabilities_table() -> None:
+    """The capability table MUST NOT have a ``"mock"`` entry — the
+    fail-closed default is the deliberate cross-SDK-parity behavior.
+    Adding a row would diverge from Rust.
+    """
+    from kaizen.llm.capabilities import _PRESET_CAPABILITIES
+
+    assert "mock" not in _PRESET_CAPABILITIES, (
+        "kaizen.llm.capabilities._PRESET_CAPABILITIES MUST NOT have a 'mock' "
+        "row — Rust's CapabilityMatrix::for_preset('mock') falls through to "
+        "all-False (no row); Python parity requires the same"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Importability — module discoverability + no test-side imports leak
+# ---------------------------------------------------------------------------
+
+
+def test_kaizen_llm_testing_module_is_importable() -> None:
+    """Sanity: the test-only module MUST be importable. If this
+    fails, the package layout is broken.
+    """
+    mod = importlib.import_module("kaizen.llm.testing")
+    assert hasattr(mod, "mock_preset")
+    assert "mock_preset" in mod.__all__
+
+
+def test_mock_preset_module_path_signals_test_only_intent() -> None:
+    """The module path ``kaizen.llm.testing`` is the deliberate red
+    flag: production code that imports from a module named
+    ``testing`` is structurally identifiable by
+    ``grep -rn 'kaizen.llm.testing' src/``. This test asserts the
+    intended path so a future refactor doesn't quietly rename the
+    module to something less obvious.
+    """
+    from kaizen.llm import testing as testing_module
+
+    assert testing_module.__name__ == "kaizen.llm.testing"
+
+
+# ---------------------------------------------------------------------------
+# Future-proofing — explicit guard against re-introducing the gap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name", ["mock", "Mock", "MOCK", "mock_preset", "test", "fake"]
+)
+def test_no_mock_aliased_classmethod_under_alternate_names(name: str) -> None:
+    """Belt-and-suspenders: assert no alternate-cased mock attribute
+    leaks onto the production surface either. If a future refactor
+    needs to add a ``MockLlmDeployment`` class for some other reason,
+    this test exists to force the author to revisit the gating
+    intent rather than pattern-match an existing classmethod.
+    """
+    assert (
+        not hasattr(LlmDeployment, name)
+        or not callable(getattr(LlmDeployment, name, None))
+        or name not in {"mock", "Mock", "MOCK", "mock_preset"}
+    ), f"LlmDeployment.{name} MUST NOT be a callable mock surface"


### PR DESCRIPTION
## Summary

- New `kaizen.llm.testing.mock_preset()` test-only deployment factory; cross-SDK parity with kailash-rs `LlmDeployment::mock()` (gated behind `#[cfg(any(test, feature = "test-utils"))]`).
- Python lacks cargo features → structural defense is **physical module separation**: `LlmDeployment.mock` does NOT exist on production class, `kaizen.llm.presets.mock_preset` does NOT exist, `"mock"` is NOT a registered preset.
- 17 Tier-1 tests assert the structural-defense + functional-correctness contract.

## Test plan

- [x] `pytest tests/unit/llm/test_mock_preset_isolation.py` — 17/17 pass
- [x] Broader llm + regression sweep — 1094 pass (excluding pre-existing AWS botocore env failures + #254 azure_json_prompt failure on main HEAD `027692a3`)
- [x] CHANGELOG entry under `[Unreleased]`
- [x] kaizen 2.17.1 → 2.18.0 (additive minor: new public test-only module surface)

## Related issues

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)