### PR TITLE
fix(kaizen): cohere_preset default to api.cohere.ai/v2 cross-SDK parity (#794)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -13,6 +13,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **7 capability matrix rows for Python-only OpenAI-compatible aggregators + local-server presets (closes #790).** `together`, `fireworks`, `openrouter`, `deepseek`, `lm_studio`, `llama_cpp`, `docker_model_runner` previously fell through to `ALL_FALSE_CAPABILITIES` because they had no row in `kaizen.llm.capabilities._PRESET_CAPABILITIES`. Calls to `LlmDeployment.together(...).supports()` reported the deployment as uncapable for tools / vision even though Together AI hosts tool-calling and vision-capable models. New rows assert the deployment-surface capability following the existing convention (vision=True means "can serve vision-capable models, per-model gating is caller's responsibility" — same as `ollama` / `groq` / `mistral`). `deepseek` is the conservative outlier (vision=False) because `api.deepseek.com/v1` exposes only deepseek-chat / deepseek-coder at the deployment surface; the DeepSeek-VL family is distributed as separate weights, not served by this preset's endpoint. Per-preset shape tests added to `tests/unit/llm/test_supports_capability_matrix.py`; the `_NON_EMPTY_PRESETS` parametrized sweep extended to cover all 7. The `<provider>_default` convenience presets (#787) carry the PARENT preset literal so capability lookup routes through the parent row automatically — no separate `_default` rows needed.
 - **Cross-SDK reconciliation note (#790).** kailash-rs `CapabilityMatrix::for_preset` at `crates/kailash-kaizen/src/llm/deployment/capabilities.rs:120-250` does NOT yet have rows for these 7 presets; it currently falls through to `Self::all_false()`. Per `rules/upstream-issue-hygiene.md`, no auto-cross-file — the kailash-rs side should land equivalent rows in a coordinated cross-SDK release. Until then, Python `supports()` reports the canonical capability matrix; Rust returns all-False for the same preset name.
 
+### Changed
+
+- **`cohere_preset` default endpoint advanced from `https://api.cohere.com/v1` (legacy Generate API) to `https://api.cohere.ai/v2` (modern Chat API) for cross-SDK parity with kailash-rs (closes #794).** kailash-rs `LlmDeployment::cohere()` at `crates/kailash-kaizen/src/llm/deployment/presets.rs:386-396` constructs `Endpoint::new("https://api.cohere.ai/v2")`; Python `cohere_preset` previously diverged at `api.cohere.com/v1`, breaking byte-equivalent cross-SDK code-portability per `rules/cross-sdk-inspection.md` § 3 (EATP D6). The on-wire request envelope at `/v2` is OpenAI-Chat-compatible — Rust delegates v2 through `OpenAiAdapter` (see `presets.rs:378-380`) and Python preserves the same `WireProtocol.CohereGenerate` tag for adapter routing continuity. The new `LlmDeployment.cohere_from_env()` constructor from #791 inherits the new default automatically. Both Cohere endpoints currently coexist (v1 has no announced sunset date), but Cohere's published API reference now directs new integrations at v2.
+
+#### Migration
+
+Callers who explicitly relied on the legacy v1 Generate API request envelope (different shape from the v2 Chat envelope) MUST opt in via explicit overrides:
+
+```python
+from kaizen.llm.presets import cohere_preset
+
+# Default behavior in 2.18.0+: v2 Chat API on api.cohere.ai
+dep = cohere_preset(api_key="...", model="command-r-plus")
+# → endpoint: https://api.cohere.ai/v2
+
+# Pre-2.18.0 legacy v1 Generate API on api.cohere.com (callers who built
+# request bodies in v1 Generate format MUST migrate via this opt-in):
+dep = cohere_preset(
+    api_key="...",
+    model="command-r-plus",
+    base_url="https://api.cohere.com",
+    path_prefix="/v1",
+)
+```
+
+Callers who did not pass explicit `base_url` / `path_prefix` overrides AND whose request handling treats Cohere as OpenAI-compatible (the canonical kaizen pattern) require no migration — the v2 Chat API is OpenAI-compatible by design.
+
 ## [2.17.1] — 2026-05-02 — CodeQL hygiene cleanup (#789 FIX track)
 
 Patch bump. Closes 4 of 13 open CodeQL findings on the kaizen surface

--- a/packages/kailash-kaizen/src/kaizen/llm/presets.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/presets.py
@@ -343,14 +343,32 @@ def cohere_preset(
     api_key: str,
     model: str,
     *,
-    base_url: str = "https://api.cohere.com",
-    path_prefix: str = "/v1",
+    base_url: str = "https://api.cohere.ai",
+    path_prefix: str = "/v2",
 ) -> LlmDeployment:
-    """Cohere Generate API.
+    """Cohere v2 Chat API.
 
     Wire:     `CohereGenerate`
-    Endpoint: `https://api.cohere.com/v1`
+    Endpoint: `https://api.cohere.ai/v2` (cross-SDK parity with kailash-rs
+              ``LlmDeployment::cohere()`` at
+              ``crates/kailash-kaizen/src/llm/deployment/presets.rs:386-396``).
     Auth:     `Authorization: Bearer <key>`
+
+    Default endpoint advanced from the legacy ``https://api.cohere.com/v1``
+    Generate API to the modern ``https://api.cohere.ai/v2`` Chat API in
+    kaizen 2.18.0 (#794) for byte-equivalent cross-SDK parity per
+    ``rules/cross-sdk-inspection.md`` § 3 (EATP D6: matching semantics).
+    The on-wire request envelope at ``/v2`` is OpenAI-Chat-compatible;
+    Rust delegates v2 through ``OpenAiAdapter`` (see ``presets.rs:378-380``)
+    and Python preserves the same ``WireProtocol.CohereGenerate`` tag for
+    adapter routing continuity.
+
+    Migration: callers who require the legacy v1 Generate API (different
+    on-wire request shape) MUST opt in explicitly via
+    ``cohere_preset(api_key, model, base_url="https://api.cohere.com",
+    path_prefix="/v1")``. Both Cohere endpoints currently coexist (v1 has
+    no announced sunset date), but Cohere's published API reference now
+    directs new integrations at v2.
     """
     _validate_required_str(api_key, name="cohere_preset.api_key")
     _validate_required_str(

--- a/packages/kailash-kaizen/tests/regression/test_issue_794_cohere_v2_endpoint.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_794_cohere_v2_endpoint.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for #794 — Cohere endpoint cross-SDK parity with kailash-rs.
+
+Per ``rules/cross-sdk-inspection.md`` § 3 (EATP D6: matching semantics) and
+§ 4 (cross-SDK parity helpers MUST pin byte-vector test cases), this test
+locks the Python ``cohere_preset`` endpoint byte-for-byte against the
+kailash-rs ``LlmDeployment::cohere()`` literal at
+``crates/kailash-kaizen/src/llm/deployment/presets.rs:386-396``.
+
+Failure-mode this prevents: a future refactor reverts the default to
+``api.cohere.com/v1`` (legacy v1 Generate API), silently breaking
+cross-SDK code-portability — a Rust user porting
+``LlmDeployment::cohere()`` to Python lands on a different host AND
+different on-wire request shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.llm.deployment import LlmDeployment, WireProtocol
+from kaizen.llm.presets import cohere_preset
+
+# ---------------------------------------------------------------------------
+# Cross-SDK byte-pinning — endpoint literal MUST match kailash-rs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_cohere_preset_endpoint_pins_kailash_rs_v2_literal() -> None:
+    """Pin the Cohere endpoint byte-for-byte to kailash-rs presets.rs:387.
+
+    The Rust SDK constructs::
+
+        Endpoint::new("https://api.cohere.ai/v2")
+
+    Python MUST emit a structurally-equivalent endpoint. ``HttpUrl``
+    normalises to a trailing slash; the test asserts the canonical
+    base-url-prefix + path-prefix decomposition Rust passes to
+    ``Endpoint::new``.
+    """
+    d = cohere_preset(api_key="co-test", model="command-r-plus")
+    # Host parity — Rust uses api.cohere.ai (NOT api.cohere.com legacy host)
+    assert str(d.endpoint.base_url).startswith(
+        "https://api.cohere.ai"
+    ), f"endpoint host drifted from kailash-rs api.cohere.ai: {d.endpoint.base_url}"
+    # Path parity — Rust uses /v2 (NOT /v1 legacy Generate API)
+    assert d.endpoint.path_prefix == "/v2", (
+        f"endpoint path drifted from kailash-rs /v2 (Chat API) to "
+        f"{d.endpoint.path_prefix!r}"
+    )
+
+
+@pytest.mark.regression
+def test_cohere_preset_classmethod_endpoint_matches_module_function() -> None:
+    """Both surfaces (``LlmDeployment.cohere()`` classmethod and
+    ``cohere_preset()`` module function) MUST produce byte-identical
+    endpoints. A drift between them means one path hit a refactor and
+    the other did not.
+    """
+    a = cohere_preset(api_key="co-test", model="command-r-plus")
+    b = LlmDeployment.cohere(api_key="co-test", model="command-r-plus")
+    assert str(a.endpoint.base_url) == str(b.endpoint.base_url)
+    assert a.endpoint.path_prefix == b.endpoint.path_prefix
+
+
+@pytest.mark.regression
+def test_cohere_preset_wire_tag_unchanged_after_v2_default() -> None:
+    """Wire tag MUST stay ``CohereGenerate`` even though the default
+    endpoint advanced to v2. Rust comment at ``presets.rs:378-380``
+    confirms v2 delegates through ``OpenAiAdapter`` under the same
+    ``WireProtocol::CohereGenerate`` tag — the wire tag is the
+    adapter-routing key, NOT the API generation indicator. Renaming
+    the wire tag in either SDK is a coordinated cross-SDK enum change
+    (issue #794 AC option (a)) and breaks this assertion loudly.
+    """
+    d = cohere_preset(api_key="co-test", model="command-r-plus")
+    assert d.wire is WireProtocol.CohereGenerate
+
+
+@pytest.mark.regression
+def test_cohere_preset_legacy_v1_callable_via_explicit_overrides() -> None:
+    """Migration safety net: callers who require the legacy v1 Generate
+    API MUST be able to opt in via explicit ``base_url``/``path_prefix``
+    overrides. If a future refactor removes those parameters or hard-codes
+    the v2 endpoint, this test fails loudly and forces a CHANGELOG
+    migration entry.
+    """
+    d = cohere_preset(
+        api_key="co-test",
+        model="command-r-plus",
+        base_url="https://api.cohere.com",
+        path_prefix="/v1",
+    )
+    assert str(d.endpoint.base_url).startswith("https://api.cohere.com")
+    assert d.endpoint.path_prefix == "/v1"
+    # Wire tag unchanged on legacy path — same WireProtocol routes both
+    # endpoints; the ``base_url``/``path_prefix`` is the only divergence
+    # the user controls.
+    assert d.wire is WireProtocol.CohereGenerate

--- a/packages/kailash-kaizen/tests/unit/llm/test_bedrock_cohere_preset.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_bedrock_cohere_preset.py
@@ -57,7 +57,9 @@ def test_bedrock_cohere_preset_distinct_from_cohere_direct() -> None:
     assert bedrock.wire == WireProtocol.BedrockInvoke
     assert direct.wire == WireProtocol.CohereGenerate
     assert "bedrock-runtime" in str(bedrock.endpoint.base_url)
-    assert "api.cohere.com" in str(direct.endpoint.base_url)
+    # Cross-SDK parity (#794): cohere_preset advanced from api.cohere.com/v1
+    # to api.cohere.ai/v2 to match kailash-rs LlmDeployment::cohere().
+    assert "api.cohere.ai" in str(direct.endpoint.base_url)
 
 
 def test_bedrock_cohere_preset_rejects_empty_api_key() -> None:

--- a/packages/kailash-kaizen/tests/unit/llm/test_from_env_presets.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_from_env_presets.py
@@ -246,13 +246,13 @@ def test_cohere_from_env_preset_shape(
     assert dep.wire == WireProtocol.CohereGenerate
     assert dep.preset_name == "cohere"
     assert dep.default_model == "command-r-plus"
-    # NOTE: the Python parent factory (`cohere_preset`) currently uses
-    # `https://api.cohere.com/v1` while Rust `presets.rs:387` uses
-    # `https://api.cohere.ai/v2`. This divergence pre-dates #791 and
-    # is a SEPARATE cross-SDK parity issue (#791 inherits whichever URL
-    # the parent factory exposes). Once the parent URL is reconciled the
-    # `_from_env` wrapper picks up the change automatically.
-    assert dep.endpoint.path_prefix == "/v1"
+    # Cross-SDK parity reconciled in #794 — parent `cohere_preset` advanced
+    # default endpoint from legacy `https://api.cohere.com/v1` to modern
+    # `https://api.cohere.ai/v2` to match kailash-rs `presets.rs:386-396`.
+    # The `_from_env` wrapper inherits whichever URL the parent factory
+    # exposes, so the path prefix is now `/v2`.
+    assert dep.endpoint.path_prefix == "/v2"
+    assert str(dep.endpoint.base_url).startswith("https://api.cohere.ai")
 
 
 def test_mistral_from_env_preset_shape(

--- a/packages/kailash-kaizen/tests/unit/llm/test_session2_direct_provider_presets.py
+++ b/packages/kailash-kaizen/tests/unit/llm/test_session2_direct_provider_presets.py
@@ -164,11 +164,30 @@ def test_google_preset_free_function_matches_classmethod() -> None:
 def test_cohere_preset_shape() -> None:
     d = LlmDeployment.cohere("k", model="command-r-plus")
     assert d.wire == WireProtocol.CohereGenerate
-    assert str(d.endpoint.base_url).startswith("https://api.cohere.com")
-    assert d.endpoint.path_prefix == "/v1"
+    # Cross-SDK parity (#794): default endpoint moved from legacy v1 to v2
+    # to match kailash-rs `LlmDeployment::cohere()` byte-for-byte.
+    assert str(d.endpoint.base_url).startswith("https://api.cohere.ai")
+    assert d.endpoint.path_prefix == "/v2"
     assert d.default_model == "command-r-plus"
     assert isinstance(d.auth, ApiKeyBearer)
     assert d.auth.kind == ApiKeyHeaderKind.Authorization_Bearer
+
+
+def test_cohere_preset_legacy_v1_opt_in_still_works() -> None:
+    """Migration path (#794): callers requiring legacy v1 Generate API
+    pass explicit base_url + path_prefix overrides. Same `CohereGenerate`
+    wire tag; the endpoint is the only knob that changes the on-wire
+    request envelope (v1 Generate vs v2 Chat).
+    """
+    d = LlmDeployment.cohere(
+        "k",
+        model="command-r-plus",
+        base_url="https://api.cohere.com",
+        path_prefix="/v1",
+    )
+    assert d.wire == WireProtocol.CohereGenerate
+    assert str(d.endpoint.base_url).startswith("https://api.cohere.com")
+    assert d.endpoint.path_prefix == "/v1"
 
 
 def test_cohere_preset_rejects_empty_key() -> None:


### PR DESCRIPTION
## Summary

- Default endpoint advanced from legacy `https://api.cohere.com/v1` (Generate API) to modern `https://api.cohere.ai/v2` (Chat API) for byte-equivalent cross-SDK parity with kailash-rs `LlmDeployment::cohere()` at `crates/kailash-kaizen/src/llm/deployment/presets.rs:386-396`.
- Wire tag stays `WireProtocol.CohereGenerate` — Rust comment confirms v2 delegates through `OpenAiAdapter` under the same wire tag.
- Migration: callers depending on legacy v1 Generate request envelope MUST opt in via explicit `base_url=` / `path_prefix=` overrides (CHANGELOG documents).

## Test plan

- [x] New `tests/regression/test_issue_794_cohere_v2_endpoint.py` — 4 byte-pinning tests pass
- [x] Existing cohere shape tests updated for new defaults; from_env divergence note resolved
- [x] Full cohere/bedrock_cohere/from_env sweep — 85/85 pass
- [x] CHANGELOG `Changed` + `Migration` sections under `[Unreleased]`
- [x] kaizen 2.17.1 → 2.18.0 (default-behavior change minor)

## Behavior change

Users who explicitly built request bodies in v1 Generate format will need to migrate. v2 Chat is OpenAI-compatible (matches the canonical kaizen pattern), so callers who treat Cohere as OpenAI-compatible need no migration. Both Cohere endpoints currently coexist (v1 has no announced sunset), but the published API reference now directs new integrations at v2.

## Related issues

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)