### PR TITLE
feat(ci): block reintroduction of untracked TODO-NNN markers (T5 of #781)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,22 @@ repos:
         pass_filenames: true
         stages: [pre-commit, manual]
 
+  # No untracked TODO-NNN markers in production source (issue #781).
+  # See .claude/rules/zero-tolerance.md Rule 2 + Rule 6 — every TODO-NNN
+  # marker MUST either carry a tracker link (tracked: gh#NNN) or be
+  # deleted. The hook is read-only (no working-tree mutation) and runs
+  # in pre-commit-ci so PRs cannot reintroduce untracked markers.
+  - repo: local
+    hooks:
+      - id: no-untracked-todo-nnn
+        name: No untracked TODO-NNN markers in production source
+        description: "Block reintroduction of TODO-NNN tags without same-line tracker links."
+        entry: scripts/check_no_untracked_todo_nnn.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-commit]
+
   # Pytest - Run Tier 1 unit tests only
   - repo: local
     hooks:

--- a/scripts/check_no_untracked_todo_nnn.sh
+++ b/scripts/check_no_untracked_todo_nnn.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Block reintroduction of TODO-NNN markers in production source without
+# a same-line (tracked: ...) link or other tracker. Mirrors the regression
+# test at tests/regression/test_no_untracked_todo_nnn.py and the issue
+# #781 cleanup workstream. See .claude/rules/zero-tolerance.md Rule 2 + Rule 6.
+
+set -euo pipefail
+
+# `grep -I` skips binary files (e.g. transient *.pyc under __pycache__).
+# Exclusions (alternated, anchored by `:` to stay inside grep-output column 3+):
+#   :\s*///       Rust doc-comments  (out-of-language for src/ + packages/*/src)
+#   :\s*//!       Rust inner doc-comments
+#   /build/       transient build artifacts
+#   tracked:      explicit tracker link — Class 2 exception per Rule 6
+#   /egg-info/    setuptools-generated SOURCES.txt — references filenames, not code comments
+hits=$(grep -rInE 'TODO-[0-9]+' src/ packages/*/src/ 2>/dev/null \
+       | grep -vE ':\s*///|:\s*//!|/build/|tracked:|\.egg-info/' \
+       || true)
+
+if [ -n "$hits" ]; then
+    {
+        echo "Untracked TODO-NNN markers in production source:"
+        echo "$hits"
+        echo ""
+        echo "Each must either (1) carry a same-line (tracked: gh#NNN) link"
+        echo "or (2) be deleted. See .claude/rules/zero-tolerance.md"
+        echo "Rule 2 + Rule 6, and the issue #781 cleanup workstream."
+    } >&2
+    exit 1
+fi

--- a/tests/regression/test_no_untracked_todo_nnn.py
+++ b/tests/regression/test_no_untracked_todo_nnn.py
@@ -1,0 +1,75 @@
+"""Regression — no untracked TODO-NNN markers in production source (issue #781).
+
+Belt-and-suspenders gate against pre-commit/CI drift. Asserts the same
+canonical condition the .pre-commit-config.yaml::no-untracked-todo-nnn
+hook enforces, so a regression slips through only if BOTH the hook AND
+this test fall over together. Per .claude/rules/zero-tolerance.md
+Rule 2 + Rule 6.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_REGEX = r"TODO-[0-9]+"
+EXCLUDE_PATTERNS = [
+    r":\s*///",  # Rust doc-comments (out of Python source)
+    r":\s*//!",  # Rust inner doc-comments
+    r"/build/",  # transient build artifacts
+    r"tracked:",  # explicit tracker link — Class 2 exception per zero-tolerance Rule 6
+    r"\.egg-info/",  # setuptools-generated SOURCES.txt — references filenames, not code comments
+]
+
+
+def _list_production_source_dirs() -> list[Path]:
+    """Return src/ + every packages/<pkg>/src/ that exists at REPO_ROOT."""
+    roots: list[Path] = []
+    if (REPO_ROOT / "src").is_dir():
+        roots.append(REPO_ROOT / "src")
+    for pkg_src in (REPO_ROOT / "packages").glob("*/src"):
+        if pkg_src.is_dir():
+            roots.append(pkg_src)
+    return roots
+
+
+@pytest.mark.regression
+def test_no_untracked_todo_nnn_in_production_source() -> None:
+    """No TODO-NNN markers in production source without (tracked: ...) links.
+
+    Mirrors .pre-commit-config.yaml::no-untracked-todo-nnn so a regression
+    requires breaking both layers. Closing #781.
+    """
+    roots = _list_production_source_dirs()
+    assert roots, "No production source roots found — check REPO_ROOT resolution"
+
+    # `-I` skips binary files (transient *.pyc under __pycache__).
+    result = subprocess.run(
+        ["grep", "-rInE", CANONICAL_REGEX, *(str(r) for r in roots)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    survivors = [
+        line
+        for line in result.stdout.splitlines()
+        if line and not any(re.search(p, line) for p in EXCLUDE_PATTERNS)
+    ]
+
+    if survivors:
+        sample = "\n".join(survivors[:20])
+        suffix = f"\n... ({len(survivors) - 20} more)" if len(survivors) > 20 else ""
+        pytest.fail(
+            f"Found {len(survivors)} untracked TODO-NNN marker(s) in production source:\n"
+            f"{sample}{suffix}\n\n"
+            "Each must either (1) carry a same-line (tracked: gh#NNN) or "
+            "(tracked: workspaces/<project>/todos/active/<file>.md) link, "
+            "or (2) be deleted.\n"
+            "See .claude/rules/zero-tolerance.md Rule 2 + Rule 6, and the "
+            "issue #781 cleanup workstream."
+        )


### PR DESCRIPTION
## Summary

Closes the #781 cleanup ratchet. Three-layer gate prevents future PRs from reintroducing untracked `TODO-NNN` markers in production source after T1-T4 brought the tree to zero.

## Layers (single source of truth: `scripts/check_no_untracked_todo_nnn.sh`)

1. **Pre-commit hook** (`.pre-commit-config.yaml::no-untracked-todo-nnn`) — runs locally on every commit AND in pre-commit-ci on every PR (the `ci.skip` list intentionally excludes this hook).
2. **Regression test** (`tests/regression/test_no_untracked_todo_nnn.py`) — belt-and-suspenders against pre-commit/CI drift; asserts the same condition.
3. **Shared script** — single source of truth for the canonical regex + exclusion list. Avoids inline-bash YAML-parser fragility.

No new GitHub Actions workflow added — pre-commit-ci already runs hooks on every PR (per `feedback_no_auto_cicd.md`).

## Canonical regex + exclusions

- Regex: `TODO-[0-9]+`
- Search roots: `src/` + `packages/*/src/`
- Exclude:
  - `:\s*///` / `:\s*//!` — Rust doc-comments (defense-in-depth; out-of-language for Python source)
  - `/build/` — transient build artifacts
  - `tracked:` — explicit `(tracked: gh#NNN)` link (Class 2 exception per zero-tolerance Rule 6)
  - `\.egg-info/` — setuptools-generated `SOURCES.txt` references filenames not code comments

## Synthetic-PR validation (passed locally before push)

| Step | Hook | Regression test |
|---|---|---|
| Clean tree | ✅ Passed | ✅ Passed (1/1) |
| Inject `# TODO-999: synthetic gate test` into `src/kailash/__init__.py` | ❌ Failed (exit 1) | ❌ Failed |
| Append ` (tracked: gh#999)` | ✅ Passed | ✅ Passed |
| Revert | ✅ Passed | ✅ Passed |

The inverse — append-then-revert — confirms the gate cannot be silently bypassed by adding-and-removing the tracker on the same line.

## Acceptance

- [x] Pre-commit hook lands in `.pre-commit-config.yaml`
- [x] Pre-commit-ci picks up the hook automatically (no new workflow needed)
- [x] Regression test exists and passes
- [x] Synthetic-PR validation: untracked fails both gates, tracked passes both
- [x] No new GH Actions workflow (per `feedback_no_auto_cicd.md`)

## Related issues

Final cleanup shard for #781 — T6 will close the issue after this merges.