### PR TITLE
docs(codify): codebase-hygiene-marker skill + issue #781 codify proposal

### DIFF
--- a/.claude/.proposals/archive/2026-05-01-kailash-py-dataflow-2.7.5.yaml
+++ b/.claude/.proposals/archive/2026-05-01-kailash-py-dataflow-2.7.5.yaml
@@ -1,0 +1,106 @@
+source_repo: kailash-py
+codify_date: "2026-05-01"
+codify_session: |
+  Session 2026-05-01 (later) — kailash-dataflow 2.7.5 release closing #774
+  (`bulk_create` AttributeError on bare-type field specs) shipped end-to-end
+  through admin-merge → tag → publish-pypi → clean-venv install verification.
+
+  One narrow tooling-quirk learning surfaced during release verification:
+
+  1. **`uv pip install --refresh` can still report unresolvable when PyPI
+     metadata is current.** Hit during the dataflow 2.7.5 release verify —
+     `pypi.org/pypi/kailash-dataflow/2.7.5/json` returned `200 OK` with
+     `info.version=2.7.5`, but `uv pip install --refresh "kailash-dataflow==2.7.5"`
+     reported `No solution found ... no version of kailash-dataflow==2.7.5`.
+     `--refresh` invalidates uv's HTTP response cache, but evidently leaves
+     a deeper index-state cache that pins the previous "latest" version.
+     Resolution: `python -m ensurepip --upgrade && python -m pip install
+     --no-cache-dir <pkg>` — pip's index TTL is shorter than uv's; one-shot
+     install succeeded immediately after `uv pip install --refresh` failed.
+     `build-repo-release-discipline.md` Rule 2's existing § "uv index-cache
+     override" paragraph names `--refresh` as the unblocker but does not
+     name the second-tier fallback when `--refresh` alone is insufficient.
+
+  Not a new structural pattern — extends the existing § "uv index-cache
+  override" paragraph with a one-sentence fallback recipe.
+
+  No agent/skill changes; no rule additions beyond the one paragraph
+  extension. The #774 fix itself follows existing patterns:
+    - `rules/cross-sdk-inspection.md` Rule 3a — structurally-unreachable
+      bug class in sibling SDK (Rust `Vec<FieldDef>` enum); no upstream
+      issue filed
+    - `rules/security.md` § Multi-Site Kwarg Plumbing — every
+      `self.model_fields.get(...).get("type")` lookup site updated in
+      same PR
+    - `rules/testing.md` § "End-to-End Pipeline Regression" + § "3-Tier
+      Testing" — Tier 1 unit + structural-invariant + Tier 2 real-Postgres
+      regression in same file
+
+status: distributed
+reviewed_date: "2026-05-02"
+distributed_date: "2026-05-02T13:15:00Z"
+distributed_by: |
+  loom /sync py Gate 2 — both py USE templates synced to loom 2.14.3 (commit 02e69bf):
+    - kailash-coc-claude-py 3.6.7 → 3.6.8 (commit 3bd3b6d, push origin/main verified)
+    - kailash-coc-py 1.1.6 → 1.1.7 (commit 7989f3c, push origin/main verified)
+  The `uv-pip-refresh-fallback` entry was lifted into loom 2.14.3 (commit 02e69bf,
+  release commit on main) as a single-sentence extension to the existing
+  `uv index-cache override` paragraph in build-repo-release-discipline.md MUST
+  Rule 2. Both py USE templates received the updated rule via direct global copy
+  (no py-variant overlay applies for build-repo-release-discipline.md) plus the
+  2.14.2 catch-up — autonomous-execution.md Rule 4 Origin += rustdoc cross-class
+  evidence — and SDK pin refresh (kailash 2.13.2 → 2.13.3, kailash-kaizen 2.14.0
+  → 2.16.1, kailash-dataflow 2.7.5 already pinned). Multi-CLI baselines re-emitted
+  via emit.mjs --all --lang py: codex AGENTS.md = 56,881 B [WARN, 7.42% headroom],
+  gemini GEMINI.md = 56,890 B [WARN, 7.41% headroom] — unchanged from 1.1.6 since
+  the abridger strips Origin paragraphs (the 2.14.2 Origin += content is invisible
+  at the abridged-baseline layer; build-repo-release-discipline.md is not on the
+  per-rule budget table). Cap-headroom telemetry preserved. CLAUDE.md preserved
+  on both templates (template-owned). Proposal closed.
+
+changes:
+  - id: uv-pip-refresh-fallback
+    type: rule_clarification
+    location: rules/build-repo-release-discipline.md § MUST Rule 2 (existing § "uv index-cache override")
+    classification_suggestion: global
+    classification: global
+    placed_at: .claude/rules/build-repo-release-discipline.md (loom global tier — appended to existing § "uv index-cache override" paragraph)
+    distributed_to:
+      - kailash-coc-claude-py@3bd3b6d (template version 3.6.8)
+      - kailash-coc-py@7989f3c (template version 1.1.7)
+      # 2.14.4 catch-up (rs-origin payload, distributed to py templates 2026-05-02T22:00Z)
+      - kailash-coc-claude-py@b729715 (template version 3.6.9) — 2.14.4 catch-up
+        (cc-artifacts Hooks Rule 8 + workspace-utils underscore-skip; rules
+        originated from kailash-rs /codify second cycle, GLOBAL classification,
+        py templates inherit on next /sync py cycle per multi-axis fan-out)
+      - kailash-coc-py@fa5d114 (template version 1.1.8) — 2.14.4 catch-up
+        (same payload; SDK pin refresh kailash-kaizen 2.16.1 → 2.18.0;
+        multi-CLI baselines unchanged at codex 7.42% / gemini 7.41% headroom
+        because cc-artifacts.md is CC-only via cli_emit_exclusions)
+    rationale: |
+      Same surface as the existing `--refresh` clarification (which was
+      classified GLOBAL on the prior cycle). `uv` is mandated by
+      `python-environment.md` Rule 1; the second-tier fallback to
+      `python -m pip install` is uv-vs-pip cache discipline, not a
+      language- or CLI-specific concern.
+    diff_summary: |
+      Append one sentence to the existing § "uv index-cache override"
+      paragraph in build-repo-release-discipline.md MUST Rule 2:
+
+        If `uv pip install --refresh` STILL reports unresolvable when
+        `pypi.org/pypi/<pkg>/<ver>/json` returns the new metadata, fall
+        back to `python -m ensurepip --upgrade && python -m pip install
+        --no-cache-dir "<pkg>==<ver>"`. pip's index TTL is shorter than
+        uv's deeper index-state cache; one-shot install succeeds where
+        `uv pip install --refresh` does not. Evidence: kailash-dataflow
+        2.7.5 release verify (2026-05-01).
+
+origin_session_artifacts:
+  prs_merged: [775, 776, 777]
+  pypi_published:
+    - kailash-dataflow 2.7.5
+  rule_edits_landed_locally: []
+  session_notes: .session-notes
+  related_journal:
+    - workspaces/.../journal/0001-DECISION-issue-774-bulk-create-field-spec-normalization.md
+    - workspaces/.../journal/0002-DISCOVERY-uv-pip-refresh-still-cache-lagged.md

--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1,106 +1,127 @@
 source_repo: kailash-py
-codify_date: "2026-05-01"
+codify_date: "2026-05-03"
 codify_session: |
-  Session 2026-05-01 (later) — kailash-dataflow 2.7.5 release closing #774
-  (`bulk_create` AttributeError on bare-type field specs) shipped end-to-end
-  through admin-merge → tag → publish-pypi → clean-venv install verification.
+  Session 2026-05-03 — issue #781 TODO-NNN cleanup workstream completion
+  + 6-package release cycle.
 
-  One narrow tooling-quirk learning surfaced during release verification:
+  Five implementation shards (T1 dataflow / T2 kaizen / T3 kaizen-agents /
+  T4 core+nexus / T5 CI gate) merged via PRs #804/#805/#806/#807/#808.
+  272 markers triaged across 5 packages. Three-layer hygiene gate landed
+  via T5 (#808) — pre-commit hook + shared bash script + Tier-2 regression
+  test, with synthetic-PR validation proving fail-on-untracked + pass-on-tracked.
 
-  1. **`uv pip install --refresh` can still report unresolvable when PyPI
-     metadata is current.** Hit during the dataflow 2.7.5 release verify —
-     `pypi.org/pypi/kailash-dataflow/2.7.5/json` returned `200 OK` with
-     `info.version=2.7.5`, but `uv pip install --refresh "kailash-dataflow==2.7.5"`
-     reported `No solution found ... no version of kailash-dataflow==2.7.5`.
-     `--refresh` invalidates uv's HTTP response cache, but evidently leaves
-     a deeper index-state cache that pins the previous "latest" version.
-     Resolution: `python -m ensurepip --upgrade && python -m pip install
-     --no-cache-dir <pkg>` — pip's index TTL is shorter than uv's; one-shot
-     install succeeded immediately after `uv pip install --refresh` failed.
-     `build-repo-release-discipline.md` Rule 2's existing § "uv index-cache
-     override" paragraph names `--refresh` as the unblocker but does not
-     name the second-tier fallback when `--refresh` alone is insufficient.
+  Six-package release-prep PR #809 cut PyPI for kailash 2.13.4, kailash-dataflow
+  2.7.6, kailash-kaizen 2.18.1, kailash-nexus 2.6.1, kaizen-agents 0.9.5,
+  kailash-mcp 0.2.11 (sibling sweep per build-repo-release-discipline.md
+  Rule 1). All 6 publish-pypi.yml workflows succeeded; clean-venv install
+  + import verified for each at correct version. Issue #781 closed via T6
+  audit.
 
-  Not a new structural pattern — extends the existing § "uv index-cache
-  override" paragraph with a one-sentence fallback recipe.
+  One genuinely-novel + reusable methodology surfaced:
 
-  No agent/skill changes; no rule additions beyond the one paragraph
-  extension. The #774 fix itself follows existing patterns:
-    - `rules/cross-sdk-inspection.md` Rule 3a — structurally-unreachable
-      bug class in sibling SDK (Rust `Vec<FieldDef>` enum); no upstream
-      issue filed
-    - `rules/security.md` § Multi-Site Kwarg Plumbing — every
-      `self.model_fields.get(...).get("type")` lookup site updated in
-      same PR
-    - `rules/testing.md` § "End-to-End Pipeline Regression" + § "3-Tier
-      Testing" — Tier 1 unit + structural-invariant + Tier 2 real-Postgres
-      regression in same file
+  1. **TODO-NNN cleanup methodology + three-layer canonical-regex gate
+     pattern.** Previously tacit knowledge (4-class disposition catalog,
+     three-layer gate pattern with single-source-of-truth bash script,
+     synthetic-PR validation protocol). Codified into new validation-
+     patterns sub-file `validate-codebase-hygiene-markers.md` + indexed
+     in SKILL.md. Reusable for any future workstream gating a regex out
+     of production source (FIXME, HACK, internal-tracker IDs, deprecated-
+     API references).
 
-status: distributed
-reviewed_date: "2026-05-02"
-distributed_date: "2026-05-02T13:15:00Z"
-distributed_by: |
-  loom /sync py Gate 2 — both py USE templates synced to loom 2.14.3 (commit 02e69bf):
-    - kailash-coc-claude-py 3.6.7 → 3.6.8 (commit 3bd3b6d, push origin/main verified)
-    - kailash-coc-py 1.1.6 → 1.1.7 (commit 7989f3c, push origin/main verified)
-  The `uv-pip-refresh-fallback` entry was lifted into loom 2.14.3 (commit 02e69bf,
-  release commit on main) as a single-sentence extension to the existing
-  `uv index-cache override` paragraph in build-repo-release-discipline.md MUST
-  Rule 2. Both py USE templates received the updated rule via direct global copy
-  (no py-variant overlay applies for build-repo-release-discipline.md) plus the
-  2.14.2 catch-up — autonomous-execution.md Rule 4 Origin += rustdoc cross-class
-  evidence — and SDK pin refresh (kailash 2.13.2 → 2.13.3, kailash-kaizen 2.14.0
-  → 2.16.1, kailash-dataflow 2.7.5 already pinned). Multi-CLI baselines re-emitted
-  via emit.mjs --all --lang py: codex AGENTS.md = 56,881 B [WARN, 7.42% headroom],
-  gemini GEMINI.md = 56,890 B [WARN, 7.41% headroom] — unchanged from 1.1.6 since
-  the abridger strips Origin paragraphs (the 2.14.2 Origin += content is invisible
-  at the abridged-baseline layer; build-repo-release-discipline.md is not on the
-  per-rule budget table). Cap-headroom telemetry preserved. CLAUDE.md preserved
-  on both templates (template-owned). Proposal closed.
+  Most other patterns surfaced were textbook execution against existing
+  rules (sibling-package release sweep — already in build-repo-release-
+  discipline.md Rule 1; SHA-grounded pre-existing diagnostic disposition
+  — already in zero-tolerance.md Rule 1c; release-prep branch convention
+  — already in git.md; sequential tag pushes — already in deployment.md).
+
+  No agent changes; no rule additions. The skill sub-file is the single
+  new artifact.
+
+status: pending_review
 
 changes:
-  - id: uv-pip-refresh-fallback
-    type: rule_clarification
-    location: rules/build-repo-release-discipline.md § MUST Rule 2 (existing § "uv index-cache override")
-    classification_suggestion: global
-    classification: global
-    placed_at: .claude/rules/build-repo-release-discipline.md (loom global tier — appended to existing § "uv index-cache override" paragraph)
-    distributed_to:
-      - kailash-coc-claude-py@3bd3b6d (template version 3.6.8)
-      - kailash-coc-py@7989f3c (template version 1.1.7)
-      # 2.14.4 catch-up (rs-origin payload, distributed to py templates 2026-05-02T22:00Z)
-      - kailash-coc-claude-py@b729715 (template version 3.6.9) — 2.14.4 catch-up
-        (cc-artifacts Hooks Rule 8 + workspace-utils underscore-skip; rules
-        originated from kailash-rs /codify second cycle, GLOBAL classification,
-        py templates inherit on next /sync py cycle per multi-axis fan-out)
-      - kailash-coc-py@fa5d114 (template version 1.1.8) — 2.14.4 catch-up
-        (same payload; SDK pin refresh kailash-kaizen 2.16.1 → 2.18.0;
-        multi-CLI baselines unchanged at codex 7.42% / gemini 7.41% headroom
-        because cc-artifacts.md is CC-only via cli_emit_exclusions)
+  - kind: skill_addition
+    path: .claude/skills/16-validation-patterns/validate-codebase-hygiene-markers.md
+    classification: pending_human_review_at_loom
+    summary: |
+      New validation-patterns sub-file capturing the TODO-NNN cleanup
+      methodology developed for issue #781. Covers:
+
+        - 4-class disposition catalog (Class 1a header banner / 1b docstring
+          provenance / 2 active iterative / 3 cross-reference) with per-class
+          rules + ambiguous-Class-1/2 boundary heuristic
+        - Three-layer hygiene gate pattern (.pre-commit-config.yaml local hook
+          + scripts/check_<name>.sh shared bash script + tests/regression/
+          test_no_untracked_<name>.py Tier-2 regression test)
+        - Synthetic-PR validation protocol (inject + verify-fail + add-tracker
+          + verify-pass + revert)
+        - Multi-shard cleanup strategy + release-cycle integration checklist
+        - Authoring gotchas (YAML scalar fragility with embedded colons in
+          pre-commit `entry:`, `grep -I` for binary-skip, `\.egg-info/`
+          exclusion shape)
+
+      Cross-language reusability note: pattern is language-agnostic; bash
+      script + regression test translate directly to cargo test / rspec /
+      equivalent. Worth global classification at loom Gate 1 (not Python-
+      variant) so future kailash-rs / kailash-rb hygiene workstreams
+      inherit the same methodology.
+
     rationale: |
-      Same surface as the existing `--refresh` clarification (which was
-      classified GLOBAL on the prior cycle). `uv` is mandated by
-      `python-environment.md` Rule 1; the second-tier fallback to
-      `python -m pip install` is uv-vs-pip cache discipline, not a
-      language- or CLI-specific concern.
-    diff_summary: |
-      Append one sentence to the existing § "uv index-cache override"
-      paragraph in build-repo-release-discipline.md MUST Rule 2:
+      Genuinely-novel + reusable institutional knowledge. The 4-class
+      taxonomy + three-layer gate pattern survived through a 6-package
+      release cycle with the gate firing correctly on synthetic-PR
+      validation. Worth codifying as institutional knowledge so future
+      similar workstreams (FIXME scrub, deprecated-API reference scrub,
+      internal-tracker namespace migration) can reuse the methodology
+      without re-discovering it.
 
-        If `uv pip install --refresh` STILL reports unresolvable when
-        `pypi.org/pypi/<pkg>/<ver>/json` returns the new metadata, fall
-        back to `python -m ensurepip --upgrade && python -m pip install
-        --no-cache-dir "<pkg>==<ver>"`. pip's index TTL is shorter than
-        uv's deeper index-state cache; one-shot install succeeds where
-        `uv pip install --refresh` does not. Evidence: kailash-dataflow
-        2.7.5 release verify (2026-05-01).
+    cross_sdk_consideration: |
+      The methodology is language-agnostic. kailash-rs and any future
+      kailash-rb would benefit from the same skill sub-file translated
+      to their toolchain (cargo test, rspec). Loom Gate 1 should
+      classify as global with cross-SDK propagation noted for the next
+      kailash-rs /sync cycle. NOT auto-filed per upstream-issue-hygiene
+      Rule 1.
 
-origin_session_artifacts:
-  prs_merged: [775, 776, 777]
-  pypi_published:
-    - kailash-dataflow 2.7.5
-  rule_edits_landed_locally: []
-  session_notes: .session-notes
-  related_journal:
-    - workspaces/.../journal/0001-DECISION-issue-774-bulk-create-field-spec-normalization.md
-    - workspaces/.../journal/0002-DISCOVERY-uv-pip-refresh-still-cache-lagged.md
+  - kind: skill_index_update
+    path: .claude/skills/16-validation-patterns/SKILL.md
+    classification: pending_human_review_at_loom
+    summary: |
+      - Added "Codebase Hygiene Validations" section in sub-file index
+        referencing the new validate-codebase-hygiene-markers.md
+      - Added missing reference to orphan-audit-playbook.md (companion
+        validation pattern that was previously not indexed despite being
+        a sub-file)
+      - Extended description keyword list with: 'codebase hygiene',
+        'TODO marker scrub', 'marker cleanup', 'three-layer gate',
+        'regex gate' (so semantic skill-loader picks up cleanup-workstream
+        queries)
+
+    rationale: |
+      Index-only update; no behavioral change to existing validations.
+      Required for the new sub-file to be discoverable via the skill's
+      progressive-disclosure entry point.
+
+deferred_for_codify:
+  - rationale: |
+      Three follow-up workstreams flagged in PR bodies for human approval
+      (NOT auto-filed per upstream-issue-hygiene.md Rule 1):
+        1. kaizen pyright cleanup — pre-existing diagnostics in
+           tools/native/* BaseTool override mismatches + missing research/
+           modules; SHA-grounded to b511f186 (2026-03-19). Draft issue at
+           workspaces/issue-781-todo-nnn-cleanup/03-implementation/
+           T2-followup-issue-kaizen-pyright.md.
+        2. kaizen-agents Black/Ruff modernization sweep — Optional[X] →
+           X | None etc.; rejected from T3 to keep diffs comment-only.
+           Bypass documented in commit bodies per rules/git.md.
+        3. nexus E2E port-mismatch — test_ai_agent_discovery_and_exploration
+           pre-existing failure; SHA-grounded to b553104c (2026-03-11).
+
+cross_sdk_loop:
+  rationale: |
+    The codebase-hygiene-marker methodology applies symmetrically to
+    kailash-rs (Rust internal-tracker IDs, doc-comment scrubbing) and
+    any future kailash-rb. Recommended loom action: at Gate 1, flag
+    the new skill sub-file for cross-SDK propagation. No automatic
+    cross-filing per upstream-issue-hygiene Rule 1 — the user reviews
+    each cross-SDK landing as a separate decision.

--- a/.claude/skills/16-validation-patterns/SKILL.md
+++ b/.claude/skills/16-validation-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validation-patterns
-description: "Validation patterns and compliance checking for Kailash SDK including parameter validation, DataFlow pattern validation, connection validation, absolute import validation, workflow structure validation, and security validation. Use when asking about 'validation', 'validate', 'check compliance', 'verify', 'lint', 'code review', 'parameter validation', 'connection validation', 'import validation', 'security validation', or 'workflow validation'."
+description: "Validation patterns and compliance checking for Kailash SDK including parameter validation, DataFlow pattern validation, connection validation, absolute import validation, workflow structure validation, security validation, and codebase hygiene marker scrubbing. Use when asking about 'validation', 'validate', 'check compliance', 'verify', 'lint', 'code review', 'parameter validation', 'connection validation', 'import validation', 'security validation', 'workflow validation', 'codebase hygiene', 'TODO marker scrub', 'marker cleanup', 'three-layer gate', or 'regex gate'."
 ---
 
 # Kailash Validation Patterns
@@ -27,6 +27,17 @@ Validation patterns and compliance checking for Kailash SDK development.
   - Absolute vs relative, module path correctness, circular/missing import detection
 - **[validate-security](validate-security.md)** - Security checks
   - Secret exposure, SQL/code injection, file path traversal, API key handling
+
+### Codebase Hygiene Validations
+
+- **[validate-codebase-hygiene-markers](validate-codebase-hygiene-markers.md)** - Internal-tracker marker scrubbing + three-layer regex gate
+  - 4-class disposition catalog (Class 1a banner / 1b docstring provenance / 2 active iterative / 3 cross-reference)
+  - Three-layer hygiene gate (pre-commit hook + shared script + Tier-2 regression test)
+  - Synthetic-PR validation protocol + multi-shard cleanup strategy + release-cycle integration
+  - Authoring gotchas: YAML scalar fragility with embedded colons, `grep -I` for binary skip, `\.egg-info/` exclusion shape
+  - Origin: issue #781 (TODO-NNN cleanup, May 2026)
+- **[orphan-audit-playbook](orphan-audit-playbook.md)** - Orphan detection for facade/manager classes
+  - Phase 5.11 evidence (2,407 LOC trust orphan); 5-step `/redteam` audit; sub-package collection-gate patterns; same-shard sweep §4a
 
 ## Quick Reference
 

--- a/.claude/skills/16-validation-patterns/validate-codebase-hygiene-markers.md
+++ b/.claude/skills/16-validation-patterns/validate-codebase-hygiene-markers.md
@@ -1,0 +1,232 @@
+# Validate Codebase Hygiene Markers
+
+A validation pattern for scrubbing internal-tracker markers (`TODO-NNN`, `FIXME-NNN`, `HACK-NNN`, deprecated-API references, post-migration internal IDs) from production source AND preventing future reintroduction via a three-layer canonical-regex gate.
+
+This skill captures the methodology developed for issue #781 (TODO-NNN cleanup workstream, 272 markers triaged across 5 packages, May 2026). The same pattern applies to any future workstream that needs to gate a regex out of production source.
+
+## When to Use
+
+Apply this pattern when:
+
+- A class of comment markers (`TODO-NNN`, `FIXME-NNN`, internal tracker IDs from a deprecated tracker namespace, `// REVIEW`, etc.) accumulated in production source over time and now violates `rules/zero-tolerance.md` Rule 2 / Rule 6.
+- The cleanup needs to be permanent — future PRs must NOT be able to reintroduce the pattern.
+- The cleanup spans multiple packages and requires per-shard disposition (per `rules/autonomous-execution.md` Per-Session Capacity Budget).
+
+## The 4-Class Disposition Catalog
+
+Most "TODO marker" populations are NOT homogenous. The methodology splits markers into 4 classes based on their syntactic shape and semantic intent:
+
+### Class 1a — header banner / group label / inline-shipped marker
+
+**Shape:** `# === <Topic> (v<X.Y.Z>, TODO-NNN) ===` or `# === <Topic> (TODO-NNN) ===` or `# Topic (TODO-NNN)` (inline group label).
+
+**Semantics:** The marker labels SHIPPED code; the surrounding code implements the named topic. The tracker tag is provenance, not pending work.
+
+**Disposition rule:**
+
+- If a version is paired (`vX.Y.Z`): rewrite `(TODO-NNN)` → `(SHIPPED-vX.Y.Z)`. The version pairing is the only case where retaining a parenthetical adds grep-able forensic value.
+- Otherwise (most cases): drop the `(TODO-NNN)` parenthetical entirely. Keep the banner text. The git log and CHANGELOG are the right home for "which workstream produced this".
+
+### Class 1b — module/class docstring provenance
+
+**Shape:** `Module Foo - TODO-NNN Phase X` or `Created: <date> (Phase 3, Day 2, TODO-NNN)` in module docstrings, OR `See: TODO-NNN` / `Related: TODO-NNN` see-also lines.
+
+**Semantics:** Provenance metadata about which workstream produced the file.
+
+**Disposition rule:**
+
+- Strip `TODO-NNN Phase X` (or the equivalent see-also line) entirely. Module docstrings describe what the module does; provenance lives in `git log` and CHANGELOG.
+- Exception: if the marker pairs with an ADR (e.g., `ADR-013 Specialist System`), preserve the ADR reference and strip only the TODO-NNN.
+
+### Class 2 — active iterative TODO
+
+**Shape:** `# TODO-NNN: <description of unfinished work>` introducing a comment that describes work the file has NOT done.
+
+**Disposition rule:** Per `rules/zero-tolerance.md` Rule 6 (iterative TODOs permitted only when actively tracked), each MUST acquire a same-line tracker link. Format: `# TODO-NNN: <description> (tracked: gh#NNN)` or `(tracked: workspaces/<project>/todos/active/<file>.md)`.
+
+If no tracker exists, the choice is **binary**: open a tracker AND link, OR delete the comment. "Will track later" is the institutional ratchet `zero-tolerance.md` Rule 1 prevents.
+
+**Common false-positive:** Many comments shaped like Class 2 (`# TODO-NNN: <topic>`) turn out to be Class 1a in disguise — the comment is a group label inside `__all__` and the named symbol IS exported and IS implemented. Per-hit triage: read ±10 lines after the marker. If they implement the topic, it's Class 1a; if they punt or stub, it's Class 2.
+
+### Class 3 — forwarded reference to external tracker
+
+**Shape:** `# Integration with X (TODO-N1, TODO-N2, TODO-N3)` or References blocks like `- TODO-157: Phase 3 Tasks 3S.2-3S.5`. Marker appears mid-comment as a parenthetical cross-reference.
+
+**Disposition rule:** Strip the `(TODO-NNN)` references. The substantive prose (class names, concept names) stays. The internal tracker namespace is workspace-only and not grep-able for outside contributors.
+
+### Ambiguous Class-1/2 boundary
+
+**Shape:** `# TODO-NNN: <topic>` precedes either a fully-shipped block (Class 1a in disguise) or actually-unfinished work (Class 2). Pattern-matching alone cannot disambiguate.
+
+**Disposition rule:** Per-hit triage during cleanup. Heuristic: read the next ~30 lines after the marker. If they implement the topic, it's Class 1a; if they punt or stub, it's Class 2.
+
+## The Three-Layer Hygiene Gate
+
+After cleanup brings the tree to zero markers, ship a permanent gate so future PRs cannot reintroduce the pattern. Three layers, single source of truth (a shared bash script):
+
+### Layer 1 — Pre-commit hook (`.pre-commit-config.yaml`)
+
+```yaml
+- repo: local
+  hooks:
+    - id: no-untracked-todo-nnn
+      name: No untracked TODO-NNN markers in production source
+      description: "Block reintroduction of TODO-NNN tags without same-line tracker links."
+      entry: scripts/check_no_untracked_todo_nnn.sh
+      language: system
+      pass_filenames: false
+      always_run: true
+      stages: [pre-commit]
+```
+
+The hook runs locally on every commit AND in `pre-commit-ci` on every PR (provided the hook id is NOT in the `ci.skip:` list). No new GitHub Actions workflow needed — pre-commit-ci already handles the CI surface.
+
+### Layer 2 — Shared script (`scripts/check_<name>.sh`)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `grep -I` skips binary files (transient *.pyc under __pycache__).
+# Exclusions:
+#   :\s*///       Rust doc-comments
+#   :\s*//!       Rust inner doc-comments
+#   /build/       transient build artifacts
+#   tracked:      explicit tracker link — Class 2 exception per Rule 6
+#   \.egg-info/   setuptools-generated SOURCES.txt — references filenames not code
+hits=$(grep -rInE 'TODO-[0-9]+' src/ packages/*/src/ 2>/dev/null \
+       | grep -vE ':\s*///|:\s*//!|/build/|tracked:|\.egg-info/' \
+       || true)
+
+if [ -n "$hits" ]; then
+    {
+        echo "Untracked TODO-NNN markers in production source:"
+        echo "$hits"
+        echo ""
+        echo "Each must either (1) carry a same-line (tracked: gh#NNN) link"
+        echo "or (2) be deleted. See .claude/rules/zero-tolerance.md Rule 2 + Rule 6."
+    } >&2
+    exit 1
+fi
+```
+
+The script is the single source of truth for the canonical regex AND the exclusion list. Both the pre-commit hook AND the regression test invoke this script (or equivalent logic), so changes to the contract land in one file.
+
+### Layer 3 — Regression test (`tests/regression/test_no_untracked_*.py`)
+
+Belt-and-suspenders against pre-commit/CI drift. The test mirrors the same canonical condition the hook enforces, so a regression slips through only if BOTH layers fail simultaneously.
+
+```python
+@pytest.mark.regression
+def test_no_untracked_todo_nnn_in_production_source() -> None:
+    """No TODO-NNN markers in production source without (tracked: ...) links."""
+    REPO_ROOT = Path(__file__).resolve().parents[2]
+    CANONICAL_REGEX = r"TODO-[0-9]+"
+    EXCLUDE_PATTERNS = [r":\s*///", r":\s*//!", r"/build/", r"tracked:", r"\.egg-info/"]
+
+    roots = [REPO_ROOT / "src"] + list((REPO_ROOT / "packages").glob("*/src"))
+
+    # `-I` skips binary files (transient *.pyc under __pycache__).
+    result = subprocess.run(
+        ["grep", "-rInE", CANONICAL_REGEX, *(str(r) for r in roots)],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    survivors = [
+        line for line in result.stdout.splitlines()
+        if line and not any(re.search(p, line) for p in EXCLUDE_PATTERNS)
+    ]
+    if survivors:
+        pytest.fail(f"Found {len(survivors)} untracked TODO-NNN markers: ...")
+```
+
+The regression test lives in `tests/regression/` (collected by default pytest) so it runs in every CI build. Per `rules/refactor-invariants.md` Rule 2, invariant tests outside the CI default test path are decoration.
+
+## Synthetic-PR Validation Protocol
+
+Before merging the gate-shipping PR, validate the gate works by intentionally injecting a synthetic violation:
+
+```bash
+# 1. Hook + test on clean tree (expect PASS)
+pre-commit run no-untracked-todo-nnn --all-files
+uv run pytest tests/regression/test_no_untracked_todo_nnn.py -x
+
+# 2. Inject synthetic untracked TODO into a production source file
+echo "# TODO-999: synthetic gate test" >> src/<package>/__init__.py
+
+# 3. Hook + test now (expect FAIL on both)
+pre-commit run no-untracked-todo-nnn --all-files   # exit 1
+uv run pytest tests/regression/test_no_untracked_todo_nnn.py -x  # FAILED
+
+# 4. Add tracker link
+sed -i 's|# TODO-999: synthetic gate test|# TODO-999: synthetic gate test (tracked: gh#999)|' src/<package>/__init__.py
+
+# 5. Hook + test now (expect PASS on both)
+pre-commit run no-untracked-todo-nnn --all-files   # exit 0
+uv run pytest tests/regression/test_no_untracked_todo_nnn.py -x  # PASSED
+
+# 6. Revert
+git checkout src/<package>/__init__.py
+```
+
+The inverse-then-revert sequence proves the gate cannot be silently bypassed by adding-and-removing the tracker on the same line.
+
+## Authoring Gotchas
+
+### YAML scalar fragility with embedded colons in pre-commit `entry:`
+
+When the hook `entry:` field uses inline bash with regex containing colons (`grep -vE ':\s*///'`), the YAML parser raises `InvalidConfigError: mapping values are not allowed in this context`. The colons are interpreted as YAML key:value separators inside the scalar.
+
+```yaml
+# DO NOT — inline bash with embedded colons
+entry: bash -c 'grep ... | grep -vE ":\s*///" || true'
+# → InvalidConfigError on pre-commit run
+
+# DO — extract to a script file, reference by path
+entry: scripts/check_no_untracked_todo_nnn.sh
+# → YAML parses cleanly; script is also more maintainable
+```
+
+The scalar form (no quoting / quoting / block scalar) is irrelevant — the colon-as-key-separator parser ambiguity surfaces in every form. Extracting to a script file is the structural fix.
+
+### `grep -r` matches binary files by default
+
+`grep -rnE 'TODO-[0-9]+' src/` recurses into `__pycache__/*.pyc` and reports `Binary file ... matches` lines that pollute the output and break the regression test's count assertion. Use `grep -rInE` (the `-I` flag skips binary files).
+
+### Egg-info `SOURCES.txt` references filenames
+
+Setuptools-generated `packages/<pkg>/src/<pkg>.egg-info/SOURCES.txt` lists every file shipped in the wheel — including any documentation file or example whose filename contains the canonical regex (e.g., `docs/architecture/adr/TODO-158-PHASE-3-HOOKS-SYSTEM-REQUIREMENTS.md`). These are NOT code comments and MUST be excluded via `\.egg-info/` in the exclusion list. The regex `\.egg-info/` (escaped dot, trailing slash) matches `kailash_kaizen.egg-info/` correctly; the naïve `/egg-info/` does NOT (the path segment is preceded by `_kaizen.`, not `/`).
+
+## Multi-Shard Cleanup Strategy
+
+For populations larger than ~50 markers across multiple packages, shard per-package. Each shard:
+
+1. Builds a per-package disposition catalog mirroring the canonical T1 catalog format (file:line, snippet, class, disposition, notes).
+2. Applies edits per class. Comment-only edits CANNOT introduce import / signature / unbound-variable errors — pyright diagnostics that surface during shard work are pre-existing per `rules/zero-tolerance.md` Rule 1c (SHA-grounded provenance required).
+3. Verifies `grep -rInE '<canonical regex>' packages/<pkg>/src/` returns 0 hits (or only `tracked:` exceptions).
+4. Runs the package's own pytest suite. Pre-existing failures get SHA-grounded provenance per Rule 1c; do NOT defer "pre-existing" without git-log evidence.
+5. Documents the disposition table in PR body (per-class counts + any class-2 deletion rationales + pre-existing pyright diagnostics + pre-existing test failures with SHAs).
+
+The closing shard ships the gate (Layers 1+2+3 above). Order matters: gate ships LAST so the cleanup-then-gate ratchet holds — landing the gate before cleanup blocks every legitimate cleanup PR.
+
+## Release-Cycle Integration
+
+When the cleanup workstream completes across multiple packages, the next BUILD-repo session MUST proceed through `/release` per `rules/build-repo-release-discipline.md` Rule 1. Comment-only changes are still byte-changes worth surfacing through PyPI so downstream consumers pick up the cleaned tree AND the new gate.
+
+Release plan checklist for hygiene-only cleanup releases:
+
+- [ ] Patch bump for every package whose `src/` was touched (per Rule 5 — sub-package src changes require same-PR version bump)
+- [ ] SDK dep pin (`kailash>=`) bumped in ALL framework packages, even those not being released this cycle (per /release Step 2 SDK Dependency Pin Update Rule)
+- [ ] CHANGELOG entry per released package describing the per-class disposition counts + the gate (if shipping)
+- [ ] Single release-prep PR on `release/v*` branch (auto-skips PR-gate matrix on metadata-only diff per `rules/git.md`)
+- [ ] Sequential tag pushes after admin-merge (batch push silently drops triggers per `rules/deployment.md`)
+- [ ] Clean-venv install verification per package per `rules/build-repo-release-discipline.md` Rule 2
+
+## Origin
+
+Methodology developed for issue #781 (TODO-NNN cleanup, May 2026):
+
+- 5 cleanup shards (T1 dataflow / T2 kaizen / T3 kaizen-agents / T4 core+nexus / T5 CI gate) merged via PRs #804/#805/#806/#807/#808
+- 272 markers triaged across kailash-dataflow, kailash-kaizen, kaizen-agents, kailash-nexus, src/kailash
+- Gate shipped via PR #808 (pre-commit hook + regression test + shared script)
+- Released via PR #809 — kailash 2.13.4, kailash-dataflow 2.7.6, kailash-kaizen 2.18.1, kailash-nexus 2.6.1, kaizen-agents 0.9.5, kailash-mcp 0.2.11 (sibling sweep per build-repo-release-discipline.md Rule 1)
+- Workspace plan + per-shard disposition catalogs at `workspaces/issue-781-todo-nnn-cleanup/`

--- a/workspaces/issue-781-todo-nnn-cleanup/journal/0005-DECISION-codified-hygiene-marker-skill.md
+++ b/workspaces/issue-781-todo-nnn-cleanup/journal/0005-DECISION-codified-hygiene-marker-skill.md
@@ -1,0 +1,56 @@
+# DECISION: codify TODO-NNN methodology + three-layer gate as validation-patterns sub-file
+
+**Date:** 2026-05-03
+**Phase:** /codify (post-release)
+
+## What was codified
+
+Created `.claude/skills/16-validation-patterns/validate-codebase-hygiene-markers.md` — a reusable methodology for scrubbing internal-tracker markers from production source AND preventing future reintroduction via a three-layer canonical-regex gate.
+
+The skill captures, as institutional knowledge:
+
+1. **4-class disposition catalog** — Class 1a (header banner / inline-shipped), Class 1b (docstring provenance / see-also), Class 2 (active iterative TODO), Class 3 (mid-comment cross-reference). Per-class disposition rules + the ambiguous-Class-1/2 boundary heuristic (read ±10–30 lines after the marker).
+2. **Three-layer hygiene gate pattern** — `.pre-commit-config.yaml` `local` hook + `scripts/check_<name>.sh` shared bash script + `tests/regression/test_no_untracked_<name>.py` Tier-2 regression test. Single source of truth (the script) so the canonical regex + exclusion list lives in one file.
+3. **Synthetic-PR validation protocol** — inject + verify-fail + add-tracker + verify-pass + revert. The inverse-then-revert sequence proves the gate cannot be silently bypassed.
+4. **Multi-shard cleanup strategy** — per-package sharding, comment-only edits cannot introduce import / signature / unbound-variable errors per `rules/zero-tolerance.md` Rule 1c (SHA-grounded provenance required for any pyright diagnostics that surface).
+5. **Authoring gotchas** — YAML scalar fragility with embedded colons in pre-commit `entry:` (resolution: extract to script file); `grep -I` for binary-skip; `\.egg-info/` exclusion shape (NOT `/egg-info/` because the path segment is preceded by `_kaizen.`, not `/`).
+6. **Release-cycle integration checklist** — patch bump per touched package, SDK dep pin sweep across all framework packages, single release-prep PR on `release/v*` branch, sequential tag pushes, clean-venv install verification.
+
+## What was updated
+
+- `.claude/skills/16-validation-patterns/SKILL.md` — added "Codebase Hygiene Validations" section in the sub-file index and extended the description's keyword list (`'codebase hygiene'`, `'TODO marker scrub'`, `'marker cleanup'`, `'three-layer gate'`, `'regex gate'`).
+- Sub-file index also surfaces `orphan-audit-playbook.md` which was previously not indexed (companion validation pattern).
+
+## Why these and not others
+
+The session shipped a 6-package release. Most "patterns" surfaced during execution were already codified:
+
+- Sibling-package release sweep: already in `rules/build-repo-release-discipline.md` Rule 1.
+- SHA-grounded pre-existing diagnostic disposition: already in `rules/zero-tolerance.md` Rule 1c.
+- Single release-prep PR for N packages: already in `rules/git.md` § Release-Prep PRs.
+- Sequential tag pushes: already in `rules/deployment.md` § "Multi-Package Release Tags Pushed Individually".
+- TestPyPI-skip exception for patch releases: already in `rules/deployment.md` § "TestPyPI Validation".
+
+The genuinely-novel + reusable institutional knowledge is the marker-scrubbing methodology + gate pattern (above). Everything else was textbook execution against existing rules.
+
+## Where this lands in the artifact flow
+
+This is a BUILD-repo `/codify` writing to local `.claude/`. Per `rules/artifact-flow.md`:
+
+- New skill sub-file is immediately usable in this BUILD repo.
+- Proposal manifest (`.claude/.proposals/latest.yaml`) is appended for the next loom `/sync` cycle to classify (global vs Python-variant) and distribute to USE templates.
+- Per `rules/cc-artifacts.md` Rule 6 — `/codify` MUST deploy `cc-architect` for validation. The new sub-file is 250 LOC (under 400-line skill limit), description extension is non-CLAUDE.md duplication.
+
+## Cross-SDK note
+
+The 4-class disposition catalog is language-agnostic — `TODO-NNN` markers are equally pervasive in Rust / Ruby / Go codebases. The three-layer gate translates directly:
+
+- Pre-commit hook → identical (pre-commit is multi-language).
+- Shared bash script → identical (shell is portable).
+- Regression test → translate to `cargo test` / `rspec` / equivalent — same canonical-grep + assertion shape.
+
+This warrants cross-SDK propagation when kailash-rs or future kailash-rb hits a similar marker-cleanup workstream. NOT auto-filed per `rules/upstream-issue-hygiene.md` Rule 1.
+
+## Origin
+
+Closes the codify loop for issue #781 (TODO-NNN cleanup workstream, May 2026, 272 markers triaged, 6 packages released).


### PR DESCRIPTION
## Summary

/codify deliverables capturing the issue #781 TODO-NNN cleanup workstream's genuinely-novel + reusable institutional knowledge.

## Files

- **NEW** `.claude/skills/16-validation-patterns/validate-codebase-hygiene-markers.md` (~250 lines, under 400-line skill limit per `cc-artifacts.md`) — 4-class disposition catalog + three-layer hygiene gate pattern + synthetic-PR validation protocol + multi-shard cleanup strategy + release-cycle integration + authoring gotchas (YAML scalar fragility with embedded colons, `grep -I` for binary-skip, `\.egg-info/` exclusion shape).
- **MODIFIED** `.claude/skills/16-validation-patterns/SKILL.md` — added "Codebase Hygiene Validations" sub-file index section, reference to `orphan-audit-playbook.md` (previously unindexed), extended description keyword list.
- **NEW** `workspaces/issue-781-todo-nnn-cleanup/journal/0005-DECISION-codified-hygiene-marker-skill.md` — DECISION entry per /codify MUST gate.
- **NEW** `.claude/.proposals/latest.yaml` (status `pending_review`) for next loom /sync cycle.
- **NEW** `.claude/.proposals/archive/2026-05-01-kailash-py-dataflow-2.7.5.yaml` — prior `distributed` proposal archived per `artifact-flow.md` rule.

## Cross-SDK note

The codebase-hygiene-marker methodology is language-agnostic — bash script + regression test translate directly to `cargo test` / `rspec`. Loom Gate 1 should classify as **global** (not Python-variant) with cross-SDK propagation flagged for the next kailash-rs `/sync` cycle. NOT auto-filed per `rules/upstream-issue-hygiene.md` Rule 1.

## What was NOT codified

Most patterns surfaced this session were textbook execution against existing rules: sibling-package release sweep (already in `build-repo-release-discipline.md` Rule 1), SHA-grounded pre-existing diagnostic disposition (`zero-tolerance.md` Rule 1c), release-prep branch convention (`git.md`), sequential tag pushes (`deployment.md`). No new agent / rule additions warranted.

## Compliance

Per `cc-artifacts.md` Rule 6: skill sub-file is 232 lines (under 400-line limit), no CLAUDE.md duplication, sub-file uses progressive disclosure (SKILL.md is entry point).

## Related

Closes the codify loop for issue #781. PRs #804/#805/#806/#807/#808 (cleanup shards) + #809 (release-prep, 6 packages to PyPI) + #810 (deployment record) all merged. This PR is the final docs trail.