### PR TITLE
fix(kaizen): resolve pre-existing pyright type-safety diagnostics in tools/native + research [Shard 1 of #814]

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/research/adapter.py
+++ b/packages/kailash-kaizen/src/kaizen/research/adapter.py
@@ -12,7 +12,7 @@ Performance Target: <1 second per adaptation
 import importlib
 import inspect
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from kaizen.signatures import Signature
 
@@ -109,13 +109,13 @@ class ResearchAdapter:
 
             def __init__(self):
                 """Initialize with paper metadata."""
-                # Initialize with inputs/outputs to satisfy Signature requirements
-                inputs = (
-                    {name: f"Input {name}" for name in param_names}
-                    if param_names
-                    else {"input": "Input data"}
-                )
-                outputs = {"result": "Research result"}
+                # Signature.__init__ requires List[str] for `inputs` and
+                # List[str | List[str]] for `outputs` — the parameter names,
+                # not a name->description dict. Passing dicts here silently
+                # corrupts Signature._inputs_list (typed List[str]). See
+                # issue #814.
+                inputs: List[str] = list(param_names) if param_names else ["input"]
+                outputs: List[Union[str, List[str]]] = ["result"]
                 super().__init__(inputs=inputs, outputs=outputs)
 
                 self.paper_id = paper.arxiv_id

--- a/packages/kailash-kaizen/src/kaizen/research/parser.py
+++ b/packages/kailash-kaizen/src/kaizen/research/parser.py
@@ -73,7 +73,7 @@ class ResearchParser:
             ValueError: If paper not found or invalid ID
             ImportError: If arxiv library is not installed
         """
-        if not ARXIV_AVAILABLE:
+        if not ARXIV_AVAILABLE or arxiv is None:
             raise ImportError(
                 "arxiv library is required for parsing arXiv papers. "
                 "Install with: pip install arxiv"
@@ -123,7 +123,7 @@ class ResearchParser:
             FileNotFoundError: If PDF file not found
             ImportError: If pypdf library is not installed
         """
-        if not PYPDF_AVAILABLE:
+        if not PYPDF_AVAILABLE or PdfReader is None:
             raise ImportError(
                 "pypdf library is required for parsing PDF files. "
                 "Install with: pip install pypdf"

--- a/packages/kailash-kaizen/src/kaizen/tools/native/bash_tools.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/bash_tools.py
@@ -13,7 +13,6 @@ Security Features:
 
 import asyncio
 import re
-import subprocess
 from typing import Any, Dict, List, Optional
 
 from kaizen.tools.native.base import BaseTool, NativeToolResult
@@ -124,9 +123,11 @@ class BashTool(BaseTool):
 
     async def execute(
         self,
+        *,
         command: str,
         timeout: int = 120,
         cwd: Optional[str] = None,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """
         Execute bash command.

--- a/packages/kailash-kaizen/src/kaizen/tools/native/file_tools.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/file_tools.py
@@ -17,9 +17,7 @@ import asyncio
 import glob as glob_module
 import os
 import re
-import subprocess
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import aiofiles
 
@@ -59,9 +57,11 @@ class ReadFileTool(BaseTool):
 
     async def execute(
         self,
+        *,
         path: str,
         offset: int = 0,
         limit: int = 2000,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Read file contents with pagination."""
         # Validate path
@@ -152,7 +152,13 @@ class WriteFileTool(BaseTool):
         super().__init__()
         self.allowed_base = allowed_base
 
-    async def execute(self, path: str, content: str) -> NativeToolResult:
+    async def execute(
+        self,
+        *,
+        path: str,
+        content: str,
+        **_kwargs: Any,
+    ) -> NativeToolResult:
         """Write content to file."""
         # Validate path
         if self.allowed_base:
@@ -224,10 +230,12 @@ class EditFileTool(BaseTool):
 
     async def execute(
         self,
+        *,
         path: str,
         old_string: str,
         new_string: str,
         replace_all: bool = False,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Edit file with string replacement."""
         # Validate path
@@ -325,8 +333,10 @@ class GlobTool(BaseTool):
 
     async def execute(
         self,
+        *,
         pattern: str,
         path: str = ".",
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Find files matching glob pattern."""
         try:
@@ -398,10 +408,12 @@ class GrepTool(BaseTool):
 
     async def execute(
         self,
+        *,
         pattern: str,
         path: str = ".",
         file_glob: str = "*",
         case_insensitive: bool = False,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Search for pattern in files."""
         try:
@@ -436,7 +448,7 @@ class GrepTool(BaseTool):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, stderr = await asyncio.wait_for(
+            stdout, _stderr = await asyncio.wait_for(
                 process.communicate(),
                 timeout=30.0,
             )
@@ -566,7 +578,12 @@ class ListDirectoryTool(BaseTool):
     danger_level = DangerLevel.SAFE
     category = ToolCategory.SYSTEM
 
-    async def execute(self, path: str) -> NativeToolResult:
+    async def execute(
+        self,
+        *,
+        path: str,
+        **_kwargs: Any,
+    ) -> NativeToolResult:
         """List directory contents."""
         if not os.path.isabs(path):
             return NativeToolResult.from_error(f"Path must be absolute: {path}")
@@ -640,7 +657,12 @@ class FileExistsTool(BaseTool):
     danger_level = DangerLevel.SAFE
     category = ToolCategory.SYSTEM
 
-    async def execute(self, path: str) -> NativeToolResult:
+    async def execute(
+        self,
+        *,
+        path: str,
+        **_kwargs: Any,
+    ) -> NativeToolResult:
         """Check if file/directory exists."""
         try:
             exists = os.path.exists(path)

--- a/packages/kailash-kaizen/src/kaizen/tools/native/interaction_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/interaction_tool.py
@@ -30,9 +30,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from enum import Enum
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Union, cast
 
 from kaizen.tools.native.base import BaseTool, NativeToolResult
@@ -248,7 +247,7 @@ class AskUserQuestionTool(BaseTool):
         *,
         questions: List[Dict[str, Any]],
         metadata: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Ask user questions and collect answers.
 

--- a/packages/kailash-kaizen/src/kaizen/tools/native/interaction_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/interaction_tool.py
@@ -33,7 +33,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union, cast
 
 from kaizen.tools.native.base import BaseTool, NativeToolResult
 from kaizen.tools.types import DangerLevel, ToolCategory
@@ -245,9 +245,10 @@ class AskUserQuestionTool(BaseTool):
 
     async def execute(
         self,
+        *,
         questions: List[Dict[str, Any]],
         metadata: Optional[Dict[str, Any]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> NativeToolResult:
         """Ask user questions and collect answers.
 
@@ -343,17 +344,20 @@ class AskUserQuestionTool(BaseTool):
                     metadata=metadata or {},
                 )
 
-            # Call user callback
+            # Call user callback. Bind to local so pyright can narrow on the
+            # Union[sync, async] callable across the iscoroutinefunction branch
+            # (attribute narrowing across await is not supported).
+            cb = self._user_callback
             try:
                 # Handle both sync and async callbacks
-                if asyncio.iscoroutinefunction(self._user_callback):
-                    answers = await asyncio.wait_for(
-                        self._user_callback(parsed_questions),
+                if asyncio.iscoroutinefunction(cb):
+                    answers_raw = await asyncio.wait_for(
+                        cb(parsed_questions),
                         timeout=self._timeout_seconds,
                     )
                 else:
-                    answers = await asyncio.wait_for(
-                        asyncio.to_thread(self._user_callback, parsed_questions),
+                    answers_raw = await asyncio.wait_for(
+                        asyncio.to_thread(cb, parsed_questions),
                         timeout=self._timeout_seconds,
                     )
             except asyncio.TimeoutError:
@@ -365,8 +369,14 @@ class AskUserQuestionTool(BaseTool):
                 logger.error(f"User callback failed: {e}")
                 return NativeToolResult.from_error(f"User callback failed: {e}")
 
-            # Store answers
-            self._answers = answers if answers else []
+            # Store answers. Cast resolves the Union[List, Awaitable] inferred
+            # signature — both branches above ultimately resolve to a concrete
+            # List[QuestionAnswer] at runtime (asyncio.wait_for awaits both
+            # the coroutine and the to_thread future).
+            answers: List[QuestionAnswer] = (
+                cast("List[QuestionAnswer]", answers_raw) if answers_raw else []
+            )
+            self._answers = answers
             self._pending_questions = []  # Clear pending
 
             # Format answers for output

--- a/packages/kailash-kaizen/src/kaizen/tools/native/notebook_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/notebook_tool.py
@@ -104,12 +104,13 @@ class NotebookEditTool(BaseTool):
 
     async def execute(
         self,
+        *,
         notebook_path: str,
         new_source: str,
         cell_id: Optional[str] = None,
         cell_type: str = "code",
         edit_mode: str = "replace",
-        **kwargs,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Edit a Jupyter notebook cell.
 
@@ -220,11 +221,19 @@ class NotebookEditTool(BaseTool):
 
             # Perform edit
             if mode == EditMode.REPLACE:
+                # cell_id is guaranteed non-None by validator at L188
+                assert cell_id is not None
                 result = self._replace_cell(notebook, cell_id, new_source, ctype)
             elif mode == EditMode.INSERT:
                 result = self._insert_cell(notebook, cell_id, new_source, ctype)
             elif mode == EditMode.DELETE:
+                # cell_id is guaranteed non-None by validator at L188
+                assert cell_id is not None
                 result = self._delete_cell(notebook, cell_id)
+            else:
+                raise RuntimeError(
+                    f"unreachable: EditMode {mode!r} not handled — validator drift"
+                )
 
             if not result["success"]:
                 return NativeToolResult.from_error(result["error"])

--- a/packages/kailash-kaizen/src/kaizen/tools/native/process_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/process_tool.py
@@ -31,7 +31,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, Optional
 
 from kaizen.tools.native.base import BaseTool, NativeToolResult
 from kaizen.tools.types import DangerLevel, ToolCategory
@@ -364,8 +364,9 @@ class KillShellTool(BaseTool):
 
     async def execute(
         self,
+        *,
         shell_id: str,
-        **kwargs,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Kill a background shell.
 
@@ -477,10 +478,11 @@ class TaskOutputTool(BaseTool):
 
     async def execute(
         self,
+        *,
         task_id: str,
         block: bool = True,
         timeout: float = 30000,
-        **kwargs,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Get task output.
 

--- a/packages/kailash-kaizen/src/kaizen/tools/native/search_tools.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/search_tools.py
@@ -10,7 +10,7 @@ Tools:
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 from kaizen.tools.native.base import BaseTool, NativeToolResult
@@ -63,8 +63,10 @@ class WebSearchTool(BaseTool):
 
     async def execute(
         self,
+        *,
         query: str,
         num_results: int = 5,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """
         Search the web.
@@ -226,8 +228,10 @@ class WebFetchTool(BaseTool):
 
     async def execute(
         self,
+        *,
         url: str,
         extract_text: bool = True,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """
         Fetch content from URL.

--- a/packages/kailash-kaizen/src/kaizen/tools/native/skill_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/skill_tool.py
@@ -95,8 +95,10 @@ class SkillTool(BaseTool):
 
     async def execute(
         self,
+        *,
         skill_name: str,
         load_additional_files: bool = True,
+        **kwargs: Any,
     ) -> NativeToolResult:
         """Invoke a registered skill.
 

--- a/packages/kailash-kaizen/src/kaizen/tools/native/skill_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/skill_tool.py
@@ -98,7 +98,7 @@ class SkillTool(BaseTool):
         *,
         skill_name: str,
         load_additional_files: bool = True,
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Invoke a registered skill.
 

--- a/packages/kailash-kaizen/src/kaizen/tools/native/task_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/task_tool.py
@@ -124,7 +124,7 @@ class TaskTool(BaseTool):
         max_turns: Optional[int] = None,
         run_in_background: bool = False,
         resume: Optional[str] = None,
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Spawn and execute a subagent.
 

--- a/packages/kailash-kaizen/src/kaizen/tools/native/task_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/task_tool.py
@@ -116,6 +116,7 @@ class TaskTool(BaseTool):
 
     async def execute(
         self,
+        *,
         subagent_type: str,
         prompt: str,
         description: str = "",
@@ -123,6 +124,7 @@ class TaskTool(BaseTool):
         max_turns: Optional[int] = None,
         run_in_background: bool = False,
         resume: Optional[str] = None,
+        **kwargs: Any,
     ) -> NativeToolResult:
         """Spawn and execute a subagent.
 
@@ -280,6 +282,14 @@ class TaskTool(BaseTool):
             SubagentResult with execution output and metrics
         """
         # Get specialist-configured adapter
+        if self._adapter is None:
+            return SubagentResult.from_error(
+                subagent_id=subagent_id,
+                error_message=(
+                    "TaskTool._adapter is None — construct via "
+                    "TaskTool(adapter=...) with a non-None adapter"
+                ),
+            )
         specialist_adapter = self._adapter.for_specialist(subagent_type)
         if specialist_adapter is None:
             return SubagentResult.from_error(

--- a/packages/kailash-kaizen/src/kaizen/tools/native/todo_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/todo_tool.py
@@ -279,7 +279,7 @@ class TodoWriteTool(BaseTool):
         self,
         *,
         todos: List[Dict[str, Any]],
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> NativeToolResult:
         """Update the todo list with new items.
 

--- a/packages/kailash-kaizen/src/kaizen/tools/native/todo_tool.py
+++ b/packages/kailash-kaizen/src/kaizen/tools/native/todo_tool.py
@@ -277,8 +277,9 @@ class TodoWriteTool(BaseTool):
 
     async def execute(
         self,
+        *,
         todos: List[Dict[str, Any]],
-        **kwargs,
+        **kwargs: Any,
     ) -> NativeToolResult:
         """Update the todo list with new items.
 

--- a/packages/kailash-kaizen/tests/regression/test_issue_814_research_adapter_inputs_list.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_814_research_adapter_inputs_list.py
@@ -1,0 +1,164 @@
+"""Regression test for issue #814 — research/adapter.py:119 dict→List corruption.
+
+Pre-fix bug:
+    `ResearchAdapter.create_signature_adapter()` constructed an inner
+    `ResearchSignature` whose `__init__` invoked
+    `super().__init__(inputs={name: f"Input {name}"...}, outputs={"result": "..."})`.
+    `Signature.__init__` declares `inputs: Optional[List[str]]` and
+    `outputs: Optional[List[Union[str, List[str]]]]`. Passing dicts silently
+    broke the `Signature._inputs_list: List[str]` invariant because
+    `_inputs_list = inputs` ran without type-checking, leaving the list
+    populated with whatever iter-order the dict produced (just keys, not
+    name-description pairs).
+
+Post-fix:
+    The adapter now passes `inputs = list(param_names)` (a List[str] of
+    the actual implementation function's parameter names) and
+    `outputs = ["result"]`. `_inputs_list` is now a proper List[str] of
+    parameter names.
+
+This test calls the public entrypoint, then asserts the resulting
+`Signature._inputs_list` is a list of str, in the canonical order of
+the implementation function's parameters.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Load `adapter.py` and `parser.py` directly from disk via spec-from-file
+# rather than `from kaizen.research.adapter import ...`. The parent package
+# `kaizen.research.__init__` carries vestigial imports of moved modules
+# (`advanced_patterns`, `experimental`, `intelligent_optimizer`) that were
+# relocated to `kaizen-agents` by PR #75 and not yet deleted from the
+# `__init__` re-export list — pre-existing condition handled by Shard 2 of
+# issue #814. Loading the adapter module directly bypasses that broken
+# init and exercises the unit under test.
+_research_dir = Path(__file__).resolve().parents[2] / "src" / "kaizen" / "research"
+
+
+def _load_module(name: str, path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# parser.py first so adapter.py's `from .parser import ResearchPaper`
+# resolves against this loaded copy.
+_parser_mod = _load_module("kaizen.research.parser", _research_dir / "parser.py")
+# adapter.py imports `from .parser import ResearchPaper` — that relative
+# import will look up `kaizen.research.parser` in sys.modules, which we
+# just populated, and skip re-executing the parent `kaizen.research`
+# init. We register a stub package module to satisfy the relative import
+# machinery.
+if "kaizen.research" not in sys.modules:
+    _stub = types.ModuleType("kaizen.research")
+    _stub.__path__ = [str(_research_dir)]  # type: ignore[attr-defined]
+    sys.modules["kaizen.research"] = _stub
+    sys.modules["kaizen.research"].parser = _parser_mod  # type: ignore[attr-defined]
+
+_adapter_mod = _load_module("kaizen.research.adapter", _research_dir / "adapter.py")
+ResearchAdapter = _adapter_mod.ResearchAdapter
+ResearchPaper = _parser_mod.ResearchPaper
+
+
+@pytest.fixture
+def fake_implementation_module(monkeypatch):
+    """Install a synthetic implementation module that exposes a function with
+    two known parameters (`query`, `limit`) so the adapter can introspect them.
+    """
+    module_name = "kaizen_test_research_impl_issue_814"
+    mod = types.ModuleType(module_name)
+
+    def search(query: str, limit: int = 10) -> dict:
+        """Synthetic research implementation."""
+        return {"query": query, "limit": limit, "results": []}
+
+    mod.search = search  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, mod)
+    return module_name
+
+
+@pytest.mark.regression
+def test_issue_814_adapter_inputs_list_is_list_of_param_names(
+    fake_implementation_module,
+):
+    """adapter.py:119 must hand Signature a List[str] of param names, not a dict."""
+    paper = ResearchPaper(
+        arxiv_id="2026.00814",
+        title="Test Paper",
+        authors=["Author"],
+        abstract="abstract",
+        methodology="methodology",
+    )
+
+    adapter = ResearchAdapter()
+    SignatureCls = adapter.create_signature_adapter(
+        paper=paper,
+        implementation_module=fake_implementation_module,
+        main_function="search",
+    )
+
+    sig = SignatureCls()
+
+    # Behavior assertion: _inputs_list is a List[str] of param names.
+    assert isinstance(
+        sig._inputs_list, list
+    ), f"_inputs_list must be list, got {type(sig._inputs_list).__name__}"
+    assert all(isinstance(item, str) for item in sig._inputs_list), (
+        f"_inputs_list entries must all be str, got "
+        f"{[type(x).__name__ for x in sig._inputs_list]}"
+    )
+    assert sig._inputs_list == ["query", "limit"], (
+        f"_inputs_list must contain function param names in order; "
+        f"got {sig._inputs_list!r}"
+    )
+
+    # Pre-fix this would have been a dict-keys-derived list of f"Input {name}"
+    # strings; post-fix it is the actual parameter names.
+    assert "Input query" not in sig._inputs_list
+    assert "Input limit" not in sig._inputs_list
+
+
+@pytest.mark.regression
+def test_issue_814_adapter_inputs_list_falls_back_to_input_when_no_params(
+    monkeypatch,
+):
+    """When the implementation function has zero params, _inputs_list defaults
+    to ['input'] — not an empty list and not a dict."""
+    module_name = "kaizen_test_research_impl_issue_814_noparams"
+    mod = types.ModuleType(module_name)
+
+    def noop() -> dict:
+        return {}
+
+    mod.noop = noop  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, module_name, mod)
+
+    paper = ResearchPaper(
+        arxiv_id="2026.00814b",
+        title="Test Paper No Params",
+        authors=["Author"],
+        abstract="abstract",
+        methodology="methodology",
+    )
+
+    adapter = ResearchAdapter()
+    SignatureCls = adapter.create_signature_adapter(
+        paper=paper,
+        implementation_module=module_name,
+        main_function="noop",
+    )
+
+    sig = SignatureCls()
+
+    assert isinstance(sig._inputs_list, list)
+    assert sig._inputs_list == ["input"]


### PR DESCRIPTION
## Summary

Resolves Issue #814 Cluster A, B, D — type-safety pyright diagnostics in `kailash-kaizen`. Pyright count: **29 errors, 8 warnings → 7 errors, 1 warning** (all 7/1 are Cluster C / Shard 2 territory: orphan re-exports + undeclared optional deps).

This is **PR A** (Shard 1) of a 2-PR sequence per the architecture plan in `workspaces/issue-814-kaizen-pyright/02-plans/01-architecture.md`. **PR B (Shard 2)** will follow with orphan-import deletion + optional-extras + spec extension + version bump per `rules/spec-accuracy.md` Rule 5 (specs follow code).

### What changed

**Cluster A — BaseTool override conformance (17 sites, 9 files + 2 additional sites surfaced during impl):**
- Every `BaseTool.execute` override now uses `*, <named params>, **_kwargs: Any` matching the canonical `planning_tool.py` exemplar
- The base contract (`tools/native/base.py:149-165`) is already kwargs-permissive — overrides needed the keyword-only marker + `**_kwargs: Any` LSP-conformance sink
- Caller pattern unchanged: `registry.py:325` calls `tool.execute_with_timing(**params)` with kwargs-spread; the LLM consumes `BaseTool.get_schema()` (signature is invisible to tool-calling)
- 19 BaseTool subclass overrides now uniform across all 9 tool files

**Brief inaccuracy correction:** Issue #814 enumerated 7 sites for Category A; pyright shows 17. Files entirely missed by the brief: `bash_tools.py`, `file_tools.py` (8 sites), `interaction_tool.py`, `notebook_tool.py`. Documented in `workspaces/issue-814-kaizen-pyright/journal/0001-DISCOVERY-brief-undercounts-baseTool-override-sites.md`.

**Cluster B — Optional/None safety (6 root-cause clusters, 12 pyright diagnostics):**
- `notebook_tool.py`: exhaustive `else: raise` for EditMode dispatch + `cell_id` asserts
- `parser.py`: lazy-import sentinels (`arxiv`, `pypdf`) guarded with `is None` checks
- `task_tool.py`: typed `Optional[Adapter]` guard per `rules/zero-tolerance.md` Rule 3a
- `interaction_tool.py`: local-bind `cb = self._user_callback` for narrowing across attribute boundary

**Cluster D — Real runtime bug at `research/adapter.py:119` + Tier 2 regression test:**
- `dict[str, str]` was being passed where `List[str]` was expected; `Signature._inputs_list` was silently corrupted (every consumer operating on dict-keys-as-list rather than param-name list)
- Fix: `inputs: List[str] = list(param_names) if param_names else ["input"]`
- New behavioral regression at `tests/regression/test_issue_814_research_adapter_inputs_list.py` per `rules/testing.md` "Behavioral Regression Tests Over Source-Grep"

**Pre-existing unused-import cleanup** in files I was already touching: `subprocess`, `Path`, `List`, `Awaitable`, `Callable`, `Union`, `field`, `Enum` per `rules/zero-tolerance.md` Rule 1 ("if you found it, you own it").

### Test plan

- [x] `cd packages/kailash-kaizen && uv run pyright src/kaizen/tools/native/ src/kaizen/research/` reports 7 errors / 1 warning (all Cluster C / Shard 2 — duckduckgo_search, arxiv, pypdf, bs4, orphan re-exports). Down from 29/8 baseline.
- [x] `tests/regression/test_issue_814_research_adapter_inputs_list.py`: 2 passed (and FAILS on pre-fix code per behavioral assertion shape)
- [x] `tests/unit/tools/native/`: 452 passed, 1 pre-existing failure (`test_extract_text_basic` — bs4 not installed; Shard 2 `[web-search]` extra)
- [x] All 19 BaseTool subclasses have direct `execute()` unit tests (per `rules/testing.md` § "One Direct Test Per Variant In Every Delegating Pair")
- [x] Pre-FIRST-push CI parity: `pre-commit run --all-files` exits 0
- [ ] CI matrix green (awaiting)

### Commits

- `96193c0e` fix(kaizen): resolve pyright type-safety diagnostics — overrides + Optional/None (#814)
- `a4a840aa` fix(kaizen): finish interaction_tool.py override + cleanup unused imports (#814)
- `eb2c42f0` fix(kaizen): correct research/adapter.py Signature.inputs/outputs to List[str] + Tier 2 regression (#814)

### Related issues

Partial: #814 (Clusters A, B, D — Cluster C ships in PR B Shard 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)