### PR TITLE
test(kaizen-agents): add coverage for research_patterns/* (#821)

### DIFF
--- a/packages/kaizen-agents/tests/unit/research_patterns/test_advanced_patterns.py
+++ b/packages/kaizen-agents/tests/unit/research_patterns/test_advanced_patterns.py
@@ -1,0 +1,352 @@
+"""Unit tests for kaizen_agents.research_patterns.advanced_patterns.
+
+Tier 1 — pure logic, no infrastructure.
+Re-establishes coverage for the modules moved by PR #75 (closes #821).
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from kaizen_agents.research_patterns.advanced_patterns import (
+    AdaptationStrategy,
+    AdaptivePattern,
+    AdvancedPatternBuilder,
+    CompositionalPattern,
+    HierarchicalPattern,
+    LearningStrategy,
+    MetaLearningPattern,
+    PatternStrategy,
+)
+
+# ---------------------------------------------------------------------------
+# Enum smoke
+# ---------------------------------------------------------------------------
+
+
+class TestEnums:
+    def test_pattern_strategy_members(self) -> None:
+        assert PatternStrategy.SEQUENTIAL.value == "sequential"
+        assert PatternStrategy.PARALLEL.value == "parallel"
+        assert PatternStrategy.ENSEMBLE.value == "ensemble"
+
+    def test_adaptation_strategy_members(self) -> None:
+        assert AdaptationStrategy.PERFORMANCE_BASED.value == "performance_based"
+        assert AdaptationStrategy.ACCURACY_BASED.value == "accuracy_based"
+        assert AdaptationStrategy.FAULT_TOLERANT.value == "fault_tolerant"
+
+    def test_learning_strategy_members(self) -> None:
+        assert LearningStrategy.BANDIT.value == "bandit"
+        assert LearningStrategy.GRADIENT.value == "gradient"
+
+
+# ---------------------------------------------------------------------------
+# CompositionalPattern
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionalPattern:
+    def test_post_init_sets_num_components(self) -> None:
+        pattern = CompositionalPattern(features=["a", "b", "c"], strategy="sequential")
+        assert pattern.num_components == 3
+
+    def test_post_init_empty_features(self) -> None:
+        pattern = CompositionalPattern(features=[], strategy="sequential")
+        assert pattern.num_components == 0
+
+    def test_execute_sequential(self) -> None:
+        pattern = CompositionalPattern(
+            features=["alpha", "beta", "gamma"], strategy="sequential"
+        )
+        result = pattern.execute({"start": "input"})
+        assert result["execution_order"] == ["alpha", "beta", "gamma"]
+        assert result["output"]["processed_by"] == "gamma"  # last feature wins
+        assert result["output"]["start"] == "input"  # original key preserved
+
+    def test_execute_parallel(self) -> None:
+        pattern = CompositionalPattern(features=["x", "y"], strategy="parallel")
+        result = pattern.execute({"data": 1})
+        assert result["num_parallel"] == 2
+        assert {entry["feature"] for entry in result["outputs"]} == {"x", "y"}
+        for entry in result["outputs"]:
+            assert entry["result"] == f"output_from_{entry['feature']}"
+
+    def test_execute_ensemble(self) -> None:
+        pattern = CompositionalPattern(
+            features=["one", "two", "three"], strategy="ensemble"
+        )
+        result = pattern.execute({})
+        assert result["confidence"] == 0.85
+        assert len(result["votes"]) == 3
+        assert result["consensus_output"] == result["votes"][0]
+
+
+# ---------------------------------------------------------------------------
+# HierarchicalPattern
+# ---------------------------------------------------------------------------
+
+
+class TestHierarchicalPattern:
+    def test_post_init_sets_num_levels(self) -> None:
+        pattern = HierarchicalPattern(levels=[["a"], ["b", "c"], ["d"]])
+        assert pattern.num_levels == 3
+
+    def test_get_level_features_in_range(self) -> None:
+        pattern = HierarchicalPattern(levels=[["root"], ["mid1", "mid2"]])
+        assert pattern.get_level_features(0) == ["root"]
+        assert pattern.get_level_features(1) == ["mid1", "mid2"]
+
+    def test_get_level_features_out_of_range(self) -> None:
+        pattern = HierarchicalPattern(levels=[["only"]])
+        assert pattern.get_level_features(-1) == []
+        assert pattern.get_level_features(5) == []
+
+    def test_execute_records_levels(self) -> None:
+        pattern = HierarchicalPattern(levels=[["lvl0"], ["lvl1a", "lvl1b"]])
+        result = pattern.execute({"seed": 1})
+        assert result["execution_levels"] == [0, 1]
+        # final_output is the last feature of the last level reached
+        assert result["final_output"] == "lvl1b"
+        assert result["level_0_output"] is not None
+        assert result["level_0_output"]["level"] == 0
+        assert result["level_1_input"] == result["level_0_output"]
+
+
+# ---------------------------------------------------------------------------
+# AdaptivePattern
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptivePattern:
+    def test_post_init_initializes_performance_stats(self) -> None:
+        pattern = AdaptivePattern(
+            base_features=["a", "b", "c"], adaptation_strategy="performance_based"
+        )
+        assert pattern.performance_stats == {"a": 0.5, "b": 0.5, "c": 0.5}
+        assert pattern.can_adapt is True
+        assert pattern.adaptation_history == []
+
+    def test_execute_performance_based_prefers_fast_feature(self) -> None:
+        pattern = AdaptivePattern(
+            base_features=["slow-feature", "fast-feature", "other"],
+            adaptation_strategy="performance_based",
+        )
+        result = pattern.execute({"x": 1})
+        assert result["selected_feature"] == "fast-feature"
+        assert result["adaptation_applied"] is True
+        assert result["feature_used"] == "fast-feature"
+
+    def test_execute_performance_based_falls_back_to_first(self) -> None:
+        pattern = AdaptivePattern(
+            base_features=["alpha", "beta"], adaptation_strategy="performance_based"
+        )
+        result = pattern.execute({})
+        assert result["selected_feature"] == "alpha"
+
+    def test_execute_accuracy_based_prefers_accurate_feature(self) -> None:
+        pattern = AdaptivePattern(
+            base_features=["other", "accurate-feature"],
+            adaptation_strategy="accuracy_based",
+        )
+        result = pattern.execute({})
+        assert result["selected_feature"] == "accurate-feature"
+
+    def test_execute_fault_tolerant_returns_primary(self) -> None:
+        pattern = AdaptivePattern(
+            base_features=["primary", "backup"], adaptation_strategy="fault_tolerant"
+        )
+        result = pattern.execute({})
+        assert result["selected_feature"] == "primary"
+
+    def test_execute_unknown_strategy_returns_first(self) -> None:
+        pattern = AdaptivePattern(
+            base_features=["a", "b"], adaptation_strategy="unknown_mode"
+        )
+        result = pattern.execute({})
+        assert result["selected_feature"] == "a"
+
+    def test_get_adaptation_history_grows_with_executions(self) -> None:
+        pattern = AdaptivePattern(
+            base_features=["only"], adaptation_strategy="fault_tolerant"
+        )
+        pattern.execute({})
+        pattern.execute({})
+        history = pattern.get_adaptation_history()
+        assert len(history) == 2
+        assert all(entry["feature"] == "only" for entry in history)
+        assert all("timestamp" in entry for entry in history)
+
+
+# ---------------------------------------------------------------------------
+# MetaLearningPattern
+# ---------------------------------------------------------------------------
+
+
+class TestMetaLearningPattern:
+    def test_post_init_initializes_uniform_weights(self) -> None:
+        pattern = MetaLearningPattern(
+            candidate_features=["a", "b", "c", "d"], learning_strategy="bandit"
+        )
+        assert set(pattern.feature_weights.keys()) == {"a", "b", "c", "d"}
+        # Uniform distribution sums to 1.0
+        assert pytest.approx(sum(pattern.feature_weights.values())) == 1.0
+        for weight in pattern.feature_weights.values():
+            assert pytest.approx(weight) == 0.25
+
+    def test_execute_bandit_returns_valid_feature(self) -> None:
+        random.seed(0)
+        pattern = MetaLearningPattern(
+            candidate_features=["x", "y", "z"],
+            learning_strategy="bandit",
+            exploration_rate=0.5,
+        )
+        result = pattern.execute({"data": 1})
+        assert result["selected_feature"] in {"x", "y", "z"}
+        assert result["execution_id"] == "exec_0"
+        assert len(pattern.execution_history) == 1
+
+    def test_execute_gradient_picks_highest_weight(self) -> None:
+        pattern = MetaLearningPattern(
+            candidate_features=["lo", "hi"], learning_strategy="gradient"
+        )
+        # Bias the weights so "hi" dominates
+        pattern.feature_weights["hi"] = 0.9
+        pattern.feature_weights["lo"] = 0.1
+        result = pattern.execute({})
+        assert result["selected_feature"] == "hi"
+
+    def test_execute_unknown_strategy_returns_first(self) -> None:
+        pattern = MetaLearningPattern(
+            candidate_features=["first", "second"], learning_strategy="unknown"
+        )
+        result = pattern.execute({})
+        assert result["selected_feature"] == "first"
+
+    def test_provide_feedback_bandit_updates_weight_to_average_reward(self) -> None:
+        pattern = MetaLearningPattern(
+            candidate_features=["a", "b"], learning_strategy="bandit"
+        )
+        # Force selection of "a" by making it highest-weight + zero exploration
+        pattern.feature_weights["a"] = 0.99
+        pattern.feature_weights["b"] = 0.01
+        pattern.exploration_rate = 0.0
+        result1 = pattern.execute({})
+        pattern.provide_feedback(result1["execution_id"], 0.8)
+        assert pytest.approx(pattern.feature_weights["a"]) == 0.8
+        # Second feedback averages
+        pattern.feature_weights["a"] = 0.99  # re-bias for second selection
+        result2 = pattern.execute({})
+        pattern.provide_feedback(result2["execution_id"], 0.4)
+        assert pytest.approx(pattern.feature_weights["a"]) == 0.6  # avg(0.8, 0.4)
+
+    def test_provide_feedback_gradient_adds_learning_rate_times_reward(self) -> None:
+        pattern = MetaLearningPattern(
+            candidate_features=["a"], learning_strategy="gradient"
+        )
+        baseline = pattern.feature_weights["a"]
+        result = pattern.execute({})
+        pattern.provide_feedback(result["execution_id"], 1.0)
+        # Gradient: weight += 0.1 * reward
+        assert pytest.approx(pattern.feature_weights["a"]) == baseline + 0.1
+
+    def test_provide_feedback_unknown_id_is_noop(self) -> None:
+        pattern = MetaLearningPattern(
+            candidate_features=["a"], learning_strategy="bandit"
+        )
+        baseline_weight = pattern.feature_weights["a"]
+        baseline_rewards = dict(pattern.feature_rewards)
+        pattern.provide_feedback("does_not_exist", 5.0)
+        assert pattern.feature_weights["a"] == baseline_weight
+        assert dict(pattern.feature_rewards) == baseline_rewards
+
+    def test_get_learning_stats_shape(self) -> None:
+        pattern = MetaLearningPattern(
+            candidate_features=["a", "b"], learning_strategy="bandit"
+        )
+        random.seed(1)
+        result = pattern.execute({})
+        pattern.provide_feedback(result["execution_id"], 0.5)
+        stats = pattern.get_learning_stats()
+        assert stats["total_executions"] == 1
+        assert set(stats["feature_preferences"].keys()) == {"a", "b"}
+        assert "average_rewards" in stats
+
+    def test_get_feature_weights_returns_live_dict(self) -> None:
+        pattern = MetaLearningPattern(
+            candidate_features=["a"], learning_strategy="gradient"
+        )
+        weights = pattern.get_feature_weights()
+        assert weights is pattern.feature_weights
+
+
+# ---------------------------------------------------------------------------
+# AdvancedPatternBuilder
+# ---------------------------------------------------------------------------
+
+
+class TestAdvancedPatternBuilder:
+    def test_init_defaults_to_none(self) -> None:
+        builder = AdvancedPatternBuilder()
+        assert builder.registry is None
+        assert builder.feature_manager is None
+
+    def test_init_accepts_registry_and_manager(self) -> None:
+        sentinel_registry = object()
+        sentinel_manager = object()
+        builder = AdvancedPatternBuilder(
+            registry=sentinel_registry, feature_manager=sentinel_manager
+        )
+        assert builder.registry is sentinel_registry
+        assert builder.feature_manager is sentinel_manager
+
+    def test_compose_returns_compositional_pattern(self) -> None:
+        builder = AdvancedPatternBuilder()
+        pattern = builder.compose(features=["a", "b"], strategy="ensemble")
+        assert isinstance(pattern, CompositionalPattern)
+        assert pattern.features == ["a", "b"]
+        assert pattern.strategy == "ensemble"
+
+    def test_hierarchical_returns_hierarchical_pattern(self) -> None:
+        builder = AdvancedPatternBuilder()
+        pattern = builder.hierarchical(levels=[["root"], ["leaf1", "leaf2"]])
+        assert isinstance(pattern, HierarchicalPattern)
+        assert pattern.levels == [["root"], ["leaf1", "leaf2"]]
+        assert pattern.num_levels == 2
+
+    def test_adaptive_returns_adaptive_pattern(self) -> None:
+        builder = AdvancedPatternBuilder()
+        pattern = builder.adaptive(
+            base_features=["a", "b"], adaptation_strategy="performance_based"
+        )
+        assert isinstance(pattern, AdaptivePattern)
+        assert pattern.base_features == ["a", "b"]
+        assert pattern.adaptation_strategy == "performance_based"
+
+    def test_meta_learning_default_exploration_rate(self) -> None:
+        builder = AdvancedPatternBuilder()
+        pattern = builder.meta_learning(
+            candidate_features=["a", "b"], learning_strategy="bandit"
+        )
+        assert isinstance(pattern, MetaLearningPattern)
+        assert pattern.exploration_rate == 0.1
+
+    def test_meta_learning_explicit_exploration_rate(self) -> None:
+        builder = AdvancedPatternBuilder()
+        pattern = builder.meta_learning(
+            candidate_features=["a"],
+            learning_strategy="gradient",
+            exploration_rate=0.42,
+        )
+        assert pattern.exploration_rate == 0.42
+
+    def test_get_available_features_with_no_registry(self) -> None:
+        builder = AdvancedPatternBuilder()
+        assert builder.get_available_features() == []
+
+    def test_get_available_features_with_registry(self) -> None:
+        builder = AdvancedPatternBuilder(registry=object())
+        # Current implementation returns [] regardless — pin the contract so a
+        # future enhancement that wires the registry update this test in lockstep.
+        assert builder.get_available_features() == []

--- a/packages/kaizen-agents/tests/unit/research_patterns/test_experimental.py
+++ b/packages/kaizen-agents/tests/unit/research_patterns/test_experimental.py
@@ -1,0 +1,250 @@
+"""Unit tests for kaizen_agents.research_patterns.experimental.
+
+Tier 1 — pure logic, no infrastructure.
+Re-establishes coverage for the modules moved by PR #75 (closes #821).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.research.parser import ResearchPaper
+from kaizen.research.validator import ValidationResult
+from kaizen.signatures import Signature
+from kaizen_agents.research_patterns.experimental import ExperimentalFeature
+
+
+class _MockExecuteSignatureStub(Signature):
+    """Minimal Signature subclass that records execute() invocations.
+
+    Suffix `Stub` per `rules/testing.md` — pytest will not collect this
+    helper as a test class.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(inputs=["query"], outputs=["result"])
+
+    def execute(self, **kwargs: object) -> dict:  # type: ignore[override]
+        return {"called_with": kwargs}
+
+
+def _make_paper(arxiv_id: str = "2106.00001") -> ResearchPaper:
+    return ResearchPaper(
+        arxiv_id=arxiv_id,
+        title="Flash Attention",
+        authors=["Tri Dao", "Daniel Y. Fu"],
+        abstract="abstract text",
+        methodology="methodology text",
+    )
+
+
+def _make_validation() -> ValidationResult:
+    return ValidationResult(
+        validation_passed=True,
+        reproducibility_score=0.96,
+    )
+
+
+@pytest.fixture
+def feature() -> ExperimentalFeature:
+    return ExperimentalFeature(
+        feature_id="flash-attention-v1",
+        paper=_make_paper(),
+        validation=_make_validation(),
+        signature_class=_MockExecuteSignatureStub,
+        version="1.0.0",
+        status="experimental",
+        compatibility={"kaizen": ">=0.1.0"},
+        performance={"speedup": 2.7},
+        metadata={"tags": ["attention", "optimization"], "description": "Fast attn"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction + enable / disable
+# ---------------------------------------------------------------------------
+
+
+class TestEnableDisable:
+    def test_is_enabled_defaults_to_false(self, feature: ExperimentalFeature) -> None:
+        assert feature.is_enabled() is False
+
+    def test_enable_sets_state(self, feature: ExperimentalFeature) -> None:
+        feature.enable()
+        assert feature.is_enabled() is True
+
+    def test_disable_clears_state(self, feature: ExperimentalFeature) -> None:
+        feature.enable()
+        feature.disable()
+        assert feature.is_enabled() is False
+
+    def test_enable_is_idempotent(self, feature: ExperimentalFeature) -> None:
+        feature.enable()
+        feature.enable()
+        assert feature.is_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# execute()
+# ---------------------------------------------------------------------------
+
+
+class TestExecute:
+    def test_execute_when_disabled_raises(self, feature: ExperimentalFeature) -> None:
+        with pytest.raises(RuntimeError, match="flash-attention-v1"):
+            feature.execute(query="test")
+
+    def test_execute_when_enabled_calls_signature(
+        self, feature: ExperimentalFeature
+    ) -> None:
+        feature.enable()
+        result = feature.execute(query="hello", key="k")
+        assert result == {"called_with": {"query": "hello", "key": "k"}}
+
+    def test_execute_after_disable_raises(self, feature: ExperimentalFeature) -> None:
+        feature.enable()
+        feature.disable()
+        with pytest.raises(RuntimeError, match="not enabled"):
+            feature.execute(query="x")
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: update_status()
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStatusValidTransitions:
+    @pytest.mark.parametrize(
+        "start_status, end_status",
+        [
+            ("experimental", "beta"),
+            ("experimental", "deprecated"),
+            ("beta", "stable"),
+            ("beta", "deprecated"),
+            ("stable", "deprecated"),
+        ],
+    )
+    def test_valid_transitions(self, start_status: str, end_status: str) -> None:
+        feature = ExperimentalFeature(
+            feature_id="f",
+            paper=_make_paper(),
+            validation=_make_validation(),
+            signature_class=_MockExecuteSignatureStub,
+            version="1.0.0",
+            status=start_status,
+            compatibility={},
+            performance={},
+            metadata={},
+        )
+        feature.update_status(end_status)
+        assert feature.status == end_status
+
+
+class TestUpdateStatusInvalidTransitions:
+    @pytest.mark.parametrize(
+        "start_status, end_status",
+        [
+            ("experimental", "stable"),  # must go through beta
+            ("stable", "experimental"),  # cannot downgrade
+            ("stable", "beta"),  # cannot downgrade
+            ("beta", "experimental"),  # cannot downgrade
+            ("deprecated", "experimental"),  # terminal
+            ("deprecated", "beta"),  # terminal
+            ("deprecated", "stable"),  # terminal
+        ],
+    )
+    def test_invalid_transitions_raise(
+        self, start_status: str, end_status: str
+    ) -> None:
+        feature = ExperimentalFeature(
+            feature_id="f",
+            paper=_make_paper(),
+            validation=_make_validation(),
+            signature_class=_MockExecuteSignatureStub,
+            version="1.0.0",
+            status=start_status,
+            compatibility={},
+            performance={},
+            metadata={},
+        )
+        with pytest.raises(ValueError, match="Invalid status transition"):
+            feature.update_status(end_status)
+        # Status MUST be unchanged after a refused transition.
+        assert feature.status == start_status
+
+
+# ---------------------------------------------------------------------------
+# get_documentation()
+# ---------------------------------------------------------------------------
+
+
+class TestGetDocumentation:
+    def test_documentation_contains_metadata_description_as_title(
+        self, feature: ExperimentalFeature
+    ) -> None:
+        docs = feature.get_documentation()
+        # When metadata.description is set, it wins over paper.title for the H1.
+        assert docs.startswith("# Fast attn")
+
+    def test_documentation_contains_feature_metadata(
+        self, feature: ExperimentalFeature
+    ) -> None:
+        docs = feature.get_documentation()
+        assert "**Feature ID**: flash-attention-v1" in docs
+        assert "**Version**: 1.0.0" in docs
+        assert "**Status**: experimental" in docs
+
+    def test_documentation_contains_paper_section(
+        self, feature: ExperimentalFeature
+    ) -> None:
+        docs = feature.get_documentation()
+        assert "## Source Research" in docs
+        assert "**Paper**: Flash Attention" in docs
+        assert "Tri Dao" in docs and "Daniel Y. Fu" in docs
+        assert "**arXiv**: 2106.00001" in docs
+
+    def test_documentation_contains_validation_section(
+        self, feature: ExperimentalFeature
+    ) -> None:
+        docs = feature.get_documentation()
+        assert "## Validation" in docs
+        assert "**Reproducibility Score**: 96.00%" in docs
+        assert "**Validation Passed**: True" in docs
+
+    def test_documentation_contains_performance_section(
+        self, feature: ExperimentalFeature
+    ) -> None:
+        docs = feature.get_documentation()
+        assert "## Performance" in docs
+        assert "**speedup**: 2.7" in docs
+
+    def test_documentation_contains_compatibility_section(
+        self, feature: ExperimentalFeature
+    ) -> None:
+        docs = feature.get_documentation()
+        assert "## Compatibility" in docs
+        assert "**kaizen**: >=0.1.0" in docs
+
+    def test_documentation_contains_tags(self, feature: ExperimentalFeature) -> None:
+        docs = feature.get_documentation()
+        assert "## Tags" in docs
+        assert "attention, optimization" in docs
+
+    def test_documentation_falls_back_to_paper_title(self) -> None:
+        feature = ExperimentalFeature(
+            feature_id="bare",
+            paper=_make_paper(),
+            validation=_make_validation(),
+            signature_class=_MockExecuteSignatureStub,
+            version="0.1.0",
+            status="experimental",
+            compatibility={},
+            performance={},
+            metadata={},  # no description, no tags
+        )
+        docs = feature.get_documentation()
+        # When metadata.description is absent, paper.title is the H1.
+        assert docs.startswith("# Flash Attention")
+        assert "## Tags" not in docs
+        assert "## Performance" not in docs
+        assert "## Compatibility" not in docs

--- a/packages/kaizen-agents/tests/unit/research_patterns/test_intelligent_optimizer.py
+++ b/packages/kaizen-agents/tests/unit/research_patterns/test_intelligent_optimizer.py
@@ -1,0 +1,223 @@
+"""Unit tests for kaizen_agents.research_patterns.intelligent_optimizer.
+
+Tier 1 — pure logic, no infrastructure.
+Re-establishes coverage for the modules moved by PR #75 (closes #821).
+"""
+
+from __future__ import annotations
+
+import random
+import re
+
+from kaizen_agents.research_patterns.intelligent_optimizer import (
+    IntelligentOptimizer,
+    OptimizationResult,
+)
+
+# ---------------------------------------------------------------------------
+# OptimizationResult
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizationResult:
+    def test_construction(self) -> None:
+        result = OptimizationResult(
+            best_params={"lr": 0.01, "depth": 4}, improvement=0.85, iterations=10
+        )
+        assert result.best_params == {"lr": 0.01, "depth": 4}
+        assert result.improvement == 0.85
+        assert result.iterations == 10
+
+
+# ---------------------------------------------------------------------------
+# IntelligentOptimizer __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_defaults(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="bayesian")
+        assert optimizer.strategy == "bayesian"
+        assert optimizer.acquisition_function == "ei"
+        assert optimizer.population_size == 20
+        assert optimizer.crossover_rate == 0.8
+        assert optimizer.mutation_rate == 0.1
+        assert optimizer.epsilon == 0.1
+        assert optimizer.objectives == []
+        assert optimizer.weights == []
+        assert optimizer.policy == {}
+        assert optimizer.q_values == {}
+
+    def test_overrides(self) -> None:
+        optimizer = IntelligentOptimizer(
+            strategy="genetic",
+            acquisition="ucb",
+            population_size=50,
+            crossover_rate=0.6,
+            mutation_rate=0.2,
+            epsilon=0.3,
+            objectives=["accuracy", "latency"],
+            weights=[0.7, 0.3],
+        )
+        assert optimizer.strategy == "genetic"
+        assert optimizer.acquisition_function == "ucb"
+        assert optimizer.population_size == 50
+        assert optimizer.crossover_rate == 0.6
+        assert optimizer.mutation_rate == 0.2
+        assert optimizer.epsilon == 0.3
+        assert optimizer.objectives == ["accuracy", "latency"]
+        assert optimizer.weights == [0.7, 0.3]
+
+
+# ---------------------------------------------------------------------------
+# optimize() dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestOptimizeBayesian:
+    def test_returns_expected_shape(self) -> None:
+        random.seed(0)
+        optimizer = IntelligentOptimizer(strategy="bayesian", acquisition="ei")
+        result = optimizer.optimize(
+            feature_id="x",
+            parameter_space={"lr": (0.001, 0.1), "depth": (2, 8)},
+            n_iterations=5,
+        )
+        assert set(result.keys()) == {"best_params", "improvement", "acquisition"}
+        assert result["acquisition"] == "ei"
+        assert "lr" in result["best_params"]
+        assert "depth" in result["best_params"]
+
+    def test_int_bounds_yield_int_samples(self) -> None:
+        random.seed(0)
+        optimizer = IntelligentOptimizer(strategy="bayesian")
+        result = optimizer.optimize(
+            feature_id="x", parameter_space={"depth": (1, 5)}, n_iterations=3
+        )
+        assert isinstance(result["best_params"]["depth"], int)
+        assert 1 <= result["best_params"]["depth"] <= 5
+
+    def test_float_bounds_yield_float_samples(self) -> None:
+        random.seed(0)
+        optimizer = IntelligentOptimizer(strategy="bayesian")
+        result = optimizer.optimize(
+            feature_id="x", parameter_space={"lr": (0.0, 1.0)}, n_iterations=3
+        )
+        assert isinstance(result["best_params"]["lr"], float)
+        assert 0.0 <= result["best_params"]["lr"] <= 1.0
+
+
+class TestOptimizeGenetic:
+    def test_returns_expected_shape(self) -> None:
+        random.seed(1)
+        optimizer = IntelligentOptimizer(strategy="genetic", population_size=5)
+        result = optimizer.optimize(
+            feature_id="x",
+            parameter_space={"lr": (0.001, 0.1), "depth": (2, 8)},
+            n_generations=3,
+        )
+        assert set(result.keys()) == {"best_genome", "fitness"}
+        assert "lr" in result["best_genome"]
+        assert "depth" in result["best_genome"]
+        assert 0.0 <= result["fitness"] <= 1.0
+
+
+class TestOptimizeMultiObjective:
+    def test_returns_expected_shape(self) -> None:
+        random.seed(2)
+        optimizer = IntelligentOptimizer(
+            strategy="multi_objective", objectives=["accuracy", "latency"]
+        )
+        result = optimizer.optimize(
+            feature_id="x", parameter_space={"lr": (0.0, 1.0)}, n_iterations=4
+        )
+        assert set(result.keys()) == {"pareto_frontier", "n_solutions"}
+        assert result["n_solutions"] == 4
+        assert isinstance(result["pareto_frontier"], list)
+        for solution in result["pareto_frontier"]:
+            assert "params" in solution
+            assert "objectives" in solution
+            assert set(solution["objectives"].keys()) == {"accuracy", "latency"}
+
+
+class TestOptimizeUnknownStrategy:
+    def test_returns_empty_dict(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="not_a_real_strategy")
+        result = optimizer.optimize(
+            feature_id="x", parameter_space={"lr": (0.0, 1.0)}, n_iterations=2
+        )
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# RL methods
+# ---------------------------------------------------------------------------
+
+
+_ACTION_RE = re.compile(r"^action_[0-5]$")
+
+
+class TestSelectAction:
+    def test_explore_branch_returns_random_action(self) -> None:
+        random.seed(0)
+        optimizer = IntelligentOptimizer(strategy="rl", epsilon=1.0)  # always explore
+        action = optimizer.select_action({"step": 1})
+        assert _ACTION_RE.match(action)
+
+    def test_exploit_branch_returns_max_q_action(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="rl", epsilon=0.0)  # never explore
+        state = {"step": 1}
+        state_key = str(sorted(state.items()))
+        # Pre-seed a Q-table so exploit has a deterministic max
+        optimizer.q_values[state_key] = {
+            "action_0": 0.1,
+            "action_3": 0.9,
+            "action_5": 0.2,
+        }
+        assert optimizer.select_action(state) == "action_3"
+
+    def test_exploit_with_no_qvalue_falls_back_to_random(self) -> None:
+        random.seed(0)
+        optimizer = IntelligentOptimizer(strategy="rl", epsilon=0.0)
+        action = optimizer.select_action({"step": 99})
+        assert _ACTION_RE.match(action)
+
+
+class TestUpdatePolicy:
+    def test_creates_entry_for_new_action(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="rl")
+        optimizer.update_policy("action_2", 0.7)
+        assert optimizer.policy == {"action_2": [0.7]}
+
+    def test_appends_to_existing_action(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="rl")
+        optimizer.update_policy("action_2", 0.7)
+        optimizer.update_policy("action_2", 0.4)
+        assert optimizer.policy == {"action_2": [0.7, 0.4]}
+
+    def test_get_policy_returns_live_dict(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="rl")
+        optimizer.update_policy("action_1", 0.5)
+        assert optimizer.get_policy() is optimizer.policy
+
+
+# ---------------------------------------------------------------------------
+# _dominates predicate
+# ---------------------------------------------------------------------------
+
+
+class TestDominates:
+    def test_strict_domination(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="multi_objective")
+        # obj1 is better-or-equal in both AND strictly better in one
+        assert optimizer._dominates({"a": 0.9, "b": 0.7}, {"a": 0.5, "b": 0.7}) is True
+
+    def test_no_domination_when_tied(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="multi_objective")
+        # Equal across all keys — no strict-better axis
+        assert optimizer._dominates({"a": 0.5, "b": 0.5}, {"a": 0.5, "b": 0.5}) is False
+
+    def test_no_domination_when_mixed(self) -> None:
+        optimizer = IntelligentOptimizer(strategy="multi_objective")
+        # obj1 better on a, worse on b — neither dominates
+        assert optimizer._dominates({"a": 0.9, "b": 0.3}, {"a": 0.5, "b": 0.7}) is False


### PR DESCRIPTION
## Summary

Re-establishes Tier 1 unit-test parity for the three modules under
`packages/kaizen-agents/src/kaizen_agents/research_patterns/`. PR #75
(commit `801de2bb`, 2026-03-25) moved `advanced_patterns.py`,
`experimental.py`, and `intelligent_optimizer.py` from
`packages/kailash-kaizen/src/kaizen/research/` but did NOT move the
sibling test files. Issue #814 Shard 2 (PR #820) deleted those orphan
test files; this PR creates fresh coverage at the new home.

82 tests across 3 files (+ `__init__.py`) exercise every class named in
the issue's acceptance criteria:

- `AdvancedPatternBuilder` + factory methods
- `CompositionalPattern` (sequential / parallel / ensemble strategies)
- `HierarchicalPattern` (level access + execute)
- `AdaptivePattern` (3 adaptation strategies + history)
- `MetaLearningPattern` (bandit + gradient learning, feedback, stats)
- `ExperimentalFeature` (lifecycle table, enable/disable, execute, docs)
- `IntelligentOptimizer` (bayesian / genetic / multi-objective dispatch + RL)

## Verification

```
$ uv run pytest --collect-only -q packages/kaizen-agents/tests/
3,359 tests collected in 3.22s

$ uv run pytest packages/kaizen-agents/tests/unit/research_patterns/ -q
82 passed in 0.15s

$ uv run pre-commit run --files <new files>
all hooks passed
```

## Test plan

- [x] `pytest --collect-only` exits 0 on the package's full test tree
- [x] All 82 new tests pass
- [x] No production-code changes; new tests live in their own directory
      with no touch points to existing test files
- [x] Helper class uses `*Stub` suffix per `rules/testing.md`
- [x] `random` calls are seeded for determinism
- [x] Pre-commit (black + isort + ruff + Tier-1 hook) green

## Related issues

Fixes #821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)