### PR TITLE
release(kaizen): 2.19.0 — dead MCP surface deletion (#822) + research/web-search extras (#814 Shard 2)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.0] — 2026-05-05 — Dead MCP integration surface deletion (#822) + research/web-search extras (#814 Shard 2)
+
 ### Added
 
 - **`research` and `web-search` optional-dependency extras (closes #814 Shard 2).** `pyproject.toml` now declares two optional-extras groups so users opt in to the lazy-imported runtime deps in `kaizen.research.parser` (arXiv paper search + PDF parsing) and `kaizen.tools.native.search_tools` (DuckDuckGo + HTML extraction). Install via `pip install 'kailash-kaizen[research]'` or `pip install 'kailash-kaizen[web-search]'` per `rules/dependencies.md` "Declared = Imported". Replaces the pre-existing pattern where `arxiv`, `pypdf`, `duckduckgo-search`, and `beautifulsoup4` were lazy-imported in source but undeclared in the manifest.

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.18.2"
+version = "2.19.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.18.2"
+__version__ = "2.19.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

Release-prep PR for `kailash-kaizen 2.18.2 → 2.19.0`. Metadata-only diff (3 files: pyproject, __init__, CHANGELOG) — branched from `release/v*` per `rules/git.md` to skip the PR-gate matrix.

## Scope

- **#822 Shard 1** (PR #825): Optional/None pyright cascade fix + `signature_programming` silent no-op gate (cleared 26 errors, restored signature programming behavior).
- **#822 Shard 2** (PR #826): Dead MCP integration surface deletion — 12 documented public methods + 1 property predating the apps/→packages move. Methods imported `..mcp.registry::get_global_registry`, `..mcp::AutoDiscovery`, `..mcp::MCPConnection` — none of which have ever existed in the kaizen source tree at any commit. Wrapped in `try/except ImportError` blocks that ALWAYS fell through. Per `zero-tolerance.md` Rule 2 (no fake integration on documented public API) and `orphan-detection.md` Rule 3 (removed-not-deprecated), deletion is the only valid disposition. Net: ~800 LOC removed.
- **#814 Shard 2** (commit `24446c7c`): research/web-search optional-extras + `WebFetchTool` bs4 loud failure. Already shipped on PyPI as 2.18.2 without a CHANGELOG header; consolidated under the 2.19.0 entry alongside the structural deletions above.

## Test plan

- [ ] PR-gate matrix auto-skipped (release/v* branch convention)
- [ ] Admin-merge once CI checks pass (Add to Project Board, Auto-label, etc.)
- [ ] `/release` skill invoked post-merge → tag push `kaizen-v2.19.0` → publish-pypi.yml
- [ ] Clean-venv install verification (`build-repo-release-discipline.md` Rule 2):
  ```bash
  uv venv /tmp/verify-kaizen --python 3.12
  uv pip install --python /tmp/verify-kaizen/bin/python "kailash-kaizen==2.19.0"
  /tmp/verify-kaizen/bin/python -c "
  from kaizen import Agent, Kaizen
  from kaizen.core.agents import Agent as CoreAgent
  assert not hasattr(CoreAgent, 'expose_as_mcp_server')
  assert not hasattr(CoreAgent, 'connect_to_mcp_servers')
  assert not hasattr(Kaizen, 'mcp_registry')
  print('OK')
  "
  ```

## Related issues

Closes #822 — on PyPI publish + clean-venv install verification.