### PR TITLE
sync(coc): absorb loom 2.17.0 — graduated trust-posture L5 rollout

### DIFF
--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,15 +1,15 @@
 {
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "coc-build",
   "variant": "py",
-  "updated": "2026-05-01",
+  "updated": "2026-05-05",
   "description": "Kailash Python SDK BUILD repo",
   "upstream": {
     "source": "loom",
-    "version": "2.14.4",
-    "build_version": "2.14.4",
-    "synced_at": "2026-05-02T00:00:00Z",
-    "loom_sha": "e8083e8",
+    "version": "2.17.0",
+    "build_version": "2.17.0",
+    "synced_at": "2026-05-05T14:41:00Z",
+    "loom_sha": "76a3bfc",
     "sdk_packages": {
       "kailash": "2.13.3",
       "kailash-dataflow": "2.7.5",
@@ -20,9 +20,29 @@
       "kailash-ml": "1.7.1",
       "kailash-align": "0.7.0",
       "kaizen-agents": "0.9.4"
-    }
+    },
+    "template_version": "2.17.0",
+    "source_commit": "76a3bfc"
   },
   "changelog": [
+    {
+      "version": "1.0.6",
+      "date": "2026-05-05",
+      "summary": "Sync loom 2.17.0 \u2014 graduated trust-posture system. Per-repo posture ladder (L1_PSEUDO_AGENT through L5_DELEGATED) with automatic downgrade on rule violations and human-gated upgrade via /posture upgrade challenge-nonce paste-back. NEW path-scoped rule rules/trust-posture.md. NEW skill skills/32-trust-posture/ (7 files). NEW hooks detect-violations.js + posture-gate.js + 4 shared libs (instruct-and-wait, state-io, state-resolver, violation-patterns). NEW agent agents/management/posture-auditor.md (read-only weekly audit). NEW command commands/posture.md (show / history / violations / init / upgrade / override). State files (posture.json, violations.jsonl, .initialized) protected by settings.json permissions.deny + three-layer Bash mutation detection per Layer 1 redirects/heredoc/tee/sed -i, Layer 2 cp/mv/dd/rsync/install/truncate/ln, Layer 3 interpreter -c/-e/-m bodies. State files NEVER synced (per-repo, runtime-generated). MODIFIED hooks: validate-bash-command.js +3 patterns + segment-anchored regex + three-layer state-file mutation detection adopted from issue #25; enforce-framework-first.js + validate-workflow.js + validate-deployment.js refactored through instruct-and-wait; session-start.js trust-posture additionalContext; session-end.js + pre-compact.js stderr summary lines. MODIFIED commands/codify.md Step 6b ENFORCED Trust Posture Wiring requirement. MODIFIED commands/redteam.md Step 0 posture-aware audit depth (L4 = Round 1, L3 = Round 1+2, L2 = full red-team). MODIFIED agents/cc-architect.md Audit Dimension 5 mechanical wiring grep sweep. settings.json: NEW permissions.deny block on .claude/learning/* state files; detect-violations.js wired to PreToolUse(Read), PostToolUse(Bash, Edit|Write), Stop, UserPromptSubmit; posture-gate.js wired to SessionStart + PreToolUse(Bash, Edit|Write). Origin: 2026-05-05 design session grounded in CARE Principle 7 (Evolutionary Trust) + EATP graduated postures + Mirror Thesis. Red-team validated: 2 adversarial review agents + 37/37 subprocess tests at loom .claude/test-harness/trust-posture-poc/. Two-phase rollout: Phase 1 (this release) hooks + state + observer-mode detection + emergency triggers live; Phase 2 (after \u22651 month real-session bake) full PreToolUse posture-gate teeth at L2/L3.",
+      "changes": [
+        "RULE: .claude/rules/trust-posture.md NEW. priority:10/scope:path-scoped on .claude/{rules,skills,agents,hooks,commands,learning}/** + settings.json + sync-manifest.yaml. 7 MUST clauses defining posture ladder L1-L5, transition triggers (cumulative 3\u00d7 same-rule = 1 downgrade; 1\u00d7 critical = emergency to L1; regression-within-grace = emergency 1 posture), upgrade requirements (\u22657d, 0 same-class violations, demonstrated correction, human approval).",
+        "SKILL: .claude/skills/32-trust-posture/ NEW (7 files: SKILL.md, codify-integration.md, implement-integration.md, redteam-integration.md, rule-authoring-checklist.md, posture-spec.md, grace-period-mechanics.md).",
+        "COMMAND: .claude/commands/posture.md NEW. show / history / violations / init / upgrade / override.",
+        "AGENT: .claude/agents/management/posture-auditor.md NEW. Read-only weekly audit; cannot self-modify state.",
+        "HOOKS NEW: detect-violations.js (PreToolUse Read stale-record banner + PostToolUse Bash/Edit/Write 5 patterns + Stop self-confession + receipt-token validation + UserPromptSubmit regression signal); posture-gate.js (SessionStart echo + PreToolUse L2/L3 enforcement).",
+        "HOOK LIBS NEW: instruct-and-wait.js + state-io.js + state-resolver.js + violation-patterns.js.",
+        "HOOKS MODIFIED: validate-bash-command.js, enforce-framework-first.js, validate-workflow.js, validate-deployment.js, session-start.js, session-end.js, pre-compact.js.",
+        "COMMANDS MODIFIED: codify.md Step 6b ENFORCED Trust Posture Wiring; redteam.md Step 0 posture-aware audit depth.",
+        "AGENT MODIFIED: cc-architect.md Audit Dimension 5 mechanical wiring grep sweep.",
+        "SETTINGS: NEW permissions.deny on .claude/learning/{posture.json,posture.json.bak,violations.jsonl,violations.jsonl.*,.initialized}; detect-violations.js + posture-gate.js wired across PreToolUse / PostToolUse / SessionStart / Stop / UserPromptSubmit.",
+        "EXCLUDED FROM SYNC: .claude/learning/posture.json, .claude/learning/.initialized, .claude/learning/violations.jsonl \u2014 per-repo runtime state, NEVER synced. Initialize at L5_DELEGATED on first /posture init or first session-start hook run."
+      ]
+    },
     {
       "version": "1.0.5",
       "date": "2026-04-28",

--- a/.claude/agents/cc-architect.md
+++ b/.claude/agents/cc-architect.md
@@ -64,6 +64,24 @@ Expert in Claude Code's architecture, configuration system, and the CO/COC five-
 2. **Completeness** — Are edge cases handled? Cross-references for handoff?
 3. **Effectiveness** — Output format specified? Does it actually get used?
 4. **Token Efficiency** — Redundancies? Path-scoping used? Waste is waste.
+5. **Trust Posture Wiring (rules only, ENFORCED)** — Per `rules/trust-posture.md` MUST 7 + `commands/codify.md` Step 6b: every NEW rule file (post-trust-posture grandfather cutoff) MUST end with `## Trust Posture Wiring` containing all 7 fields. Audit step:
+
+   ```bash
+   # Mechanical sweep — emit FAIL on any new rule lacking the section
+   for f in $(git diff --name-only origin/main -- '.claude/rules/*.md'); do
+     if ! grep -q '^## Trust Posture Wiring' "$f"; then
+       echo "FAIL: $f missing Trust Posture Wiring"
+     fi
+     # Verify all 7 fields present (severity, grace, cumulative, regression-within-grace, receipt, detection, origin)
+     for field in '\*\*Severity:' '\*\*Grace period:' '\*\*Cumulative threshold:' \
+                   '\*\*Regression-within-grace policy:' '\*\*Receipt requirement:' \
+                   '\*\*Detection mechanism:' '\*\*Origin evidence date:'; do
+       grep -q "$field" "$f" || echo "FAIL: $f wiring missing field $field"
+     done
+   done
+   ```
+
+   Missing or incomplete → audit FAIL → /codify halts. Grandfathered rules (those pre-dating `rules/trust-posture.md`) are exempt — recognized by `git log --diff-filter=A` showing creation date before trust-posture commit SHA.
 
 ## Related Agents
 

--- a/.claude/agents/management/posture-auditor.md
+++ b/.claude/agents/management/posture-auditor.md
@@ -1,0 +1,97 @@
+---
+name: posture-auditor
+description: Read-only trust posture auditor. Use weekly or after a violation cluster to scan violations.jsonl + posture.json and recommend posture changes. Cannot self-modify state — recommendations route through /posture upgrade or /posture override (human-gated nonce).
+tools: Read, Grep, Glob, Bash
+---
+
+# posture-auditor
+
+Read-only audit of the per-repo graduated trust posture. Reads `.claude/learning/posture.json` + `.claude/learning/violations.jsonl`; produces a structured recommendation report. **Cannot mutate posture state** — recommendations are advisory, executed only via `/posture upgrade` or `/posture override` (both require user-paste-back nonce per `commands/posture.md`).
+
+Aligned with `rules/trust-posture.md` and `skills/32-trust-posture/posture-spec.md`.
+
+## When to invoke
+
+- Weekly (every 7 days) to surface upgrade-eligible postures
+- After any session containing ≥3 violations of any rule
+- After an `EMERGENCY_DOWNGRADE` transition (sanity-check the trigger)
+- Before `/sync` Gate 1 — surface posture deltas across BUILD repos
+
+## What it produces
+
+A 4-section report:
+
+### 1. Current state
+
+- Posture, since timestamp, time-at-posture (days+hours)
+- Pending verifications (rule_id, day N of grace, regression-within-grace policy)
+- Recent transitions (last 5)
+
+### 2. Violation analysis
+
+- Last 30 days, grouped by rule_id
+- Per group: count, first/last timestamp, severity distribution, % addressed
+- Flag rules with ≥3 same-rule violations (downgrade trigger imminent)
+- Flag any `regression_within_grace` events (already-fired emergency downgrade)
+
+### 3. Upgrade eligibility (per `rules/trust-posture.md` MUST 5)
+
+- Time at posture: ≥7 days? Y/N + actual days
+- Zero violations of triggering class: Y/N + count if non-zero
+- Demonstrated correction (positive observation): Y/N + obs_id if found
+- Recommend `/posture upgrade --to <next>` if all four met; otherwise list missing requirements
+
+### 4. Recommendations
+
+For each finding:
+
+- **Action**: `/posture upgrade --to LX`, `/posture override --to LX --reason "..."`, `wait N days`, `monitor`, or `escalate to human review`
+- **Why**: cite specific violations.jsonl rows + transition_history rows
+- **Risk if not addressed**: e.g., "regression_within_grace will fire at next violation; emergency downgrade likely"
+
+## What it does NOT do
+
+- Edit `posture.json`, `violations.jsonl`, or any state file (denied by settings.json)
+- Recommend posture upgrades that violate the four-requirement gate
+- Suggest bypassing the nonce gate
+- Propose changes to `rules/trust-posture.md` itself (that's `/codify` work)
+
+## Tool inventory
+
+- `Read` — for `posture.json`, `violations.jsonl`, recent commit history
+- `Grep` — for cross-referencing violation patterns against rule prose
+- `Glob` — to enumerate workspaces/journal entries
+- `Bash` — read-only commands: `git log`, `gh issue view`, `wc -l`, `node -e "require('./.claude/hooks/lib/state-io.js')...readPosture/readRecentViolations"` for parsing
+- NO `Edit`, NO `Write` — read-only enforcement
+
+## Output format example
+
+```
+=== posture-auditor report — 2026-05-12 ===
+Repo: /Users/esperie/repos/loom
+
+1. Current State
+   Posture: L4_CONTINUOUS_INSIGHT (since 2026-05-06, 6 days 23h)
+   Pending: test-completeness/MUST-1 (day 7 of 7 — grace expires today)
+   Recent transitions: L5→L4 EMERGENCY_DOWNGRADE on 2026-05-06
+
+2. Violation Analysis (last 30d)
+   - test-completeness/MUST-1: 1 occurrence (the regression that downgraded). 100% addressed.
+   - sweep-completeness/MUST-2: 0 occurrences.
+   No new clusters.
+
+3. Upgrade Eligibility (target L5_DELEGATED)
+   - Time at posture: 6d 23h (need ≥7d) — ELIGIBLE in 1h
+   - Zero violations of test-completeness class since downgrade: PASS
+   - Demonstrated correction: PASS (obs_2026-05-08T...: agent caught + fixed similar gap proactively)
+   - All four requirements met after grace expires.
+
+4. Recommendations
+   - PRIMARY: After grace expires (in 1h), run `/posture upgrade --to L5_DELEGATED` (will require user paste-back nonce).
+   - WHY: All four requirements met; downgrade trigger has not recurred.
+   - RISK: Continuing at L4 indefinitely after eligibility imposes unnecessary friction (mandatory journal+/redteam Round 1).
+```
+
+## Posture-bound restrictions
+
+posture-auditor is callable at any posture (read-only audits never need elevated trust). Its recommendations route through human-gated commands only — the agent itself cannot upgrade.

--- a/.claude/commands/codify.md
+++ b/.claude/commands/codify.md
@@ -100,6 +100,22 @@ Ensure user-facing documentation reflects new capabilities. Verify README.md, do
 
 Validate that generated agents and skills are correct, complete, and secure. **cc-architect** verifies cc-artifacts compliance (descriptions under 120 chars, agents under 400 lines, commands under 150 lines, rules path-scoped, SKILL.md progressive disclosure).
 
+### 6b. Trust Posture Wiring (MANDATORY for new rules — ENFORCED)
+
+Per `rules/trust-posture.md` MUST 7 + `skills/32-trust-posture/codify-integration.md`:
+
+For each NEW rule authored in this codify cycle (grandfathered rules pre-dating the trust-posture system are exempt):
+
+1. **Read** `.claude/learning/violations.jsonl` (last 30 days). Find self-reported / detected violations whose `addressed_by` is null AND whose root cause matches the candidate rule.
+2. **Link** the rule to those violations: update `addressed_by: "rules/<file>.md@<sha>"` for each.
+3. **Author** a "Trust Posture Wiring" section per `skills/32-trust-posture/rule-authoring-checklist.md` (severity, grace days, cumulative threshold, regression-within-grace policy, receipt requirement, detection mechanism, first-violation id, origin date).
+4. **Append** to `.claude/learning/posture.json::pending_verification` (via `state-io.js::writePosture`) — never via direct Edit/Write (denied by `permissions.deny`).
+5. **Verify** via cc-architect: every new rule file ends with `## Trust Posture Wiring`. Missing → audit FAIL → /codify halts and reports.
+
+**ENFORCEMENT**: this step is FAIL-on-missing for any rule authored after `rules/trust-posture.md` was committed. cc-architect MUST grep each new rule file for the literal `## Trust Posture Wiring` header AND verify all 7 fields present in the section body (severity / grace / cumulative / regression-within-grace / receipt / detection / first-violation / origin). Missing or incomplete → audit FAIL → /codify halts.
+
+The trust-posture rule itself is the only grandfather exception. Every other rule authored from this point forward MUST include the wiring section.
+
 ### 7. Create upstream proposal (BUILD repos) / 8. Upstream to atelier (loom only)
 
 Follow the proposal protocol in `guides/co-setup/09-proposal-protocol.md`. Key rules:

--- a/.claude/commands/posture.md
+++ b/.claude/commands/posture.md
@@ -1,0 +1,108 @@
+---
+description: Inspect or change the per-repo trust posture (L1–L5). Read-only show/history/init by default; upgrade and override require user-paste-back challenge nonce.
+---
+
+# /posture — Trust Posture Management
+
+The graduated-trust-posture system (`rules/trust-posture.md` + `skills/32-trust-posture/`) defines five autonomy levels per repo. This command surfaces and changes posture state.
+
+State lives at `<main_checkout>/.claude/learning/posture.json` (per `skills/32-trust-posture/posture-spec.md`). Direct edits are blocked by `settings.json::permissions.deny`.
+
+## Subcommands
+
+### `/posture` (no args) — show current
+
+Read posture.json and report:
+
+- Current posture (L1_PSEUDO_AGENT … L5_DELEGATED)
+- Time at current posture (e.g., "3 days 14h")
+- Pending verification entries (rule_id, day N of grace, regression-within-grace policy)
+- Last 5 transitions with type + reason
+- Last 10 violations (rule_id, severity, evidence head, addressed_by)
+- Fresh-repo flag, fail-closed flag (if applicable)
+
+Output is plain markdown — no state mutation.
+
+### `/posture init` — initialize fresh repo
+
+Used once on a repo that has never run the trust system. Writes `posture.json` with `posture: L5_DELEGATED` + creates `.initialized` marker. Refuses to run if `.initialized` already exists (use `/posture override` to change posture on an initialized repo).
+
+### `/posture history [--all | --recent N]` — transition log
+
+Reads `transition_history` from posture.json. Defaults to last 10 transitions. Each row: from → to, type, reason, ts, approved_by. `--all` dumps every transition since INIT.
+
+### `/posture violations [--rule X | --since DATE | --limit N]` — violation log
+
+Tail of `violations.jsonl`. Filters: by rule_id, by ISO date, by count. Read-only.
+
+### `/posture upgrade [--to LEVEL] [--ack NONCE]` — request posture upgrade
+
+Two-step challenge-nonce flow (mitigates red-team H3 forged ACK + M4 upgrade audit-trail):
+
+**Step 1**: User runs `/posture upgrade --to L5_DELEGATED`. Command:
+
+1. Reads posture.json — verifies all four upgrade requirements (≥7d at posture, 0 violations of triggering class, ≥1 demonstrated correction, target = current_posture + 1).
+2. Writes a random nonce to `<main_checkout>/.claude/learning/.posture-upgrade-nonce` (file readable only by hooks).
+3. Prints to user: `"To confirm upgrade to L5_DELEGATED, paste this nonce in your next message: <NONCE>"`.
+
+**Step 2**: User pastes the nonce as the next user message AND runs `/posture upgrade --to L5_DELEGATED --ack <NONCE>`. Command:
+
+1. Reads `.posture-upgrade-nonce`. If absent or mismatched → reject.
+2. Validates the user's PRIOR turn contained the nonce literal.
+3. Updates posture.json: appends transition `EARNED` with `approved_by: human`, sets `posture` to target, clears nonce file.
+4. Prints confirmation.
+
+If validation fails: nonce stays valid for ONE more attempt then is cleared. Repeated failures log `acknowledgement_failure` violation.
+
+### `/posture override --to LEVEL --reason "<text>" [--ack NONCE]` — manual override
+
+Same two-step nonce flow as `upgrade`. Used for:
+
+- False-positive recovery (downgrade was wrongful)
+- Initial bootstrap on a repo that's already mid-cycle (set L4 directly without earning L5)
+- Emergency restoration after fail-closed event
+
+Records transition with `type: OVERRIDE` and `approved_by: human`.
+
+## Implementation notes (for /posture command author)
+
+The command MUST be implemented as a thin shell over `state-io.js`:
+
+```js
+const {
+  readPosture,
+  writePosture,
+  readRecentViolations,
+} = require(".claude/hooks/lib/state-io.js");
+```
+
+For Steps 1/2 nonce flow, write nonce to file with mode 0600. Hooks read the file via state-io extension; user reads via the command echoing it. The transcript capture (user's PRIOR turn containing the nonce) is verified by reading the conversation transcript path the harness exposes; if unavailable, fall back to in-message confirmation as fail-loud.
+
+## Posture-bound restrictions on this command
+
+- `/posture init`, `show`, `history`, `violations` work at any posture (read or single-write fresh init).
+- `/posture upgrade`, `/posture override` are NEVER usable below L1 (always available regardless of posture — humans must always have escape hatch).
+- Agent invoking `/posture upgrade` autonomously without user instruction = `acknowledgement_failure` violation logged.
+
+## Output canonical format
+
+```
+=== /posture: L4_CONTINUOUS_INSIGHT ===
+Repo:    /Users/esperie/repos/loom
+Since:   2026-05-06T09:14:00Z (1 day 23h)
+
+Pending Verification:
+  - test-completeness/MUST-1 (day 2 of 7) — emergency downgrade on regression
+  - <none if list empty>
+
+Recent Transitions (last 5):
+  2026-05-06 09:14   L5 → L4   EMERGENCY_DOWNGRADE   "regression_within_grace: test-completeness/MUST-1 day 1"
+  2026-05-05 14:30   ─  → L5   INIT                  "fresh repo init via /posture init"
+
+Recent Violations (last 10):
+  2026-05-06 09:14   sweep-completeness/MUST-2   halt-and-report   "Sweep 5: 0/0/0 (clean)…"   [unaddressed]
+  ...
+
+To upgrade: /posture upgrade --to L5_DELEGATED   (requires 7+ days, 0 violations, ack nonce)
+To override (false positive recovery): /posture override --to L5_DELEGATED --reason "false positive on test-completeness"
+```

--- a/.claude/commands/redteam.md
+++ b/.claude/commands/redteam.md
@@ -23,6 +23,18 @@ Autonomous execution model (see `rules/autonomous-execution.md`). Red team conve
 
 ## Workflow
 
+### 0. Posture-aware audit depth (MUST consult first)
+
+Read `.claude/learning/posture.json` via `state-io.js::readPosture`. Audit rigor scales with posture per `skills/32-trust-posture/redteam-integration.md`:
+
+- **L5_DELEGATED**: Round 1 OPTIONAL
+- **L4_CONTINUOUS_INSIGHT**: Round 1 MANDATORY (mechanical sweeps)
+- **L3_SHARED_PLANNING**: Round 1 + Round 2 MANDATORY (closure-parity)
+- **L2_SUPERVISED**: full red-team Round 1+2+3 (incl. spec compliance vs every pending_verification rule)
+- **L1_PSEUDO_AGENT**: advisory simulation only (no autonomous /implement to red-team)
+
+Surface the posture in the first report line. Under-auditing (e.g., Round 1 only at L3) is itself a violation logged via `appendViolation` against `redteam/posture-aware-depth`.
+
 ### 1. Spec compliance audit (MUST run first)
 
 **File existence is NOT compliance.** Use the protocol in `skills/spec-compliance/SKILL.md` to verify each spec promise via AST parsing and targeted greps, NOT file existence or self-reports.

--- a/.claude/hooks/detect-violations.js
+++ b/.claude/hooks/detect-violations.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * detect-violations — POC hook for the trust-posture system.
+ *
+ * Wired to multiple events; reads tool_event from stdin payload's hookEventName field.
+ *   PostToolUse(Bash)         → repo-scope-bash, commit-claim
+ *   PostToolUse(Edit|Write)   → worktree-drift
+ *   Stop                      → pre-existing-no-SHA, sweep-substitution, self-confession
+ *   UserPromptSubmit          → regression signal from user prompt
+ *
+ * Mitigates cc-artifacts.md Rule 7 (timeout fallback).
+ */
+
+const TIMEOUT_MS = 5000;
+const fallback = setTimeout(() => {
+  process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  process.exit(1);
+}, TIMEOUT_MS);
+
+const path = require("path");
+const { emit } = require(path.join(__dirname, "lib", "instruct-and-wait.js"));
+const { appendViolation, readPosture, readRecentViolations } = require(
+  path.join(__dirname, "lib", "state-io.js"),
+);
+const P = require(path.join(__dirname, "lib", "violation-patterns.js"));
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = "";
+    if (process.stdin.isTTY) return resolve({});
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (c) => (data += c));
+    process.stdin.on("end", () => {
+      try {
+        resolve(JSON.parse(data));
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+function passthrough() {
+  clearTimeout(fallback);
+  process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  process.exit(0);
+}
+
+function logAndEmit(payload, event, finding, what_happened) {
+  appendViolation(payload.cwd, {
+    rule_id: finding.rule_id,
+    severity: finding.severity,
+    evidence: finding.evidence,
+    posture_at_time: process.env.CLAUDE_CURRENT_POSTURE || "unknown",
+    addressed_by: null,
+  });
+
+  clearTimeout(fallback);
+  emit({
+    hookEvent: event,
+    severity: finding.severity,
+    what_happened,
+    why: finding.rule_id,
+    agent_must_report: [
+      "Quote the exact text/command that triggered the detection",
+      "State which rule was violated and its origin evidence date",
+      "Propose remediation in this turn (do not file a follow-up issue)",
+    ],
+    agent_must_wait:
+      "Do not retry or proceed with related work until the user instructs.",
+    user_summary: `${finding.rule_id} — ${what_happened.slice(0, 60)}`,
+  });
+}
+
+(async () => {
+  const payload = await readStdin();
+  const event = payload.hook_event_name || payload.hookEventName || "Unknown";
+
+  // PreToolUse(Read): stale-record banner if reading session-notes /
+  // observations.jsonl / journal/* file dated before most-recent
+  // pending_verification rule was authored. Mitigates the compound failure
+  // where agent inherits its own pre-rule "all-clear" record.
+  if (event === "PreToolUse") {
+    const tool = payload.tool_name;
+    const input = payload.tool_input || {};
+    if (tool === "Read") {
+      const fp = input.file_path || "";
+      const isStaleCandidate =
+        /\.session-notes(?:$|\/)/.test(fp) ||
+        /observations\.jsonl/.test(fp) ||
+        /\/journal\//.test(fp);
+      if (isStaleCandidate) {
+        try {
+          const fs = require("fs");
+          const stat = fs.statSync(fp);
+          const posture = readPosture(payload.cwd);
+          const pending = (posture.pending_verification || []).filter(
+            (e) => e && e.rule_id && e.since,
+          );
+          if (pending.length) {
+            const newest = pending
+              .map((e) => new Date(e.since).getTime())
+              .sort((a, b) => b - a)[0];
+            if (stat.mtime.getTime() < newest) {
+              const ruleList = pending.map((e) => e.rule_id).join(", ");
+              clearTimeout(fallback);
+              process.stdout.write(
+                JSON.stringify({
+                  continue: true,
+                  hookSpecificOutput: {
+                    hookEventName: "PreToolUse",
+                    additionalContext: `⚠️ STALE RECORD — ${fp} pre-dates rule(s) ${ruleList}. Any "tests pass" / "complete" / "verified" claim within is UNVERIFIED under the new rule(s). Do not inherit conclusions; re-verify per rule before declaring readiness.`,
+                  },
+                }) + "\n",
+              );
+              process.exit(0);
+            }
+          }
+        } catch {
+          // file stat failed or no posture — fall through to passthrough
+        }
+      }
+    }
+    return passthrough();
+  }
+
+  if (event === "PostToolUse") {
+    const tool = payload.tool_name;
+    const input = payload.tool_input || {};
+
+    if (tool === "Bash") {
+      const cmd = input.command || "";
+      let f =
+        P.detectRepoScopeDriftBash(cmd, payload.cwd) ||
+        P.detectCommitClaim(cmd);
+      if (f)
+        return logAndEmit(
+          payload,
+          event,
+          f,
+          `Bash command flagged: ${cmd.slice(0, 80)}`,
+        );
+    } else if (tool === "Edit" || tool === "Write") {
+      const fp = input.file_path || "";
+      const f = P.detectWorktreeDrift(fp);
+      if (f)
+        return logAndEmit(
+          payload,
+          event,
+          f,
+          `Edit/Write to ${fp.slice(0, 80)}`,
+        );
+    }
+    return passthrough();
+  }
+
+  if (event === "Stop") {
+    const finalText = payload.transcript_path
+      ? "" // POC: would read transcript; for now expect inlined text
+      : payload.last_assistant_text || "";
+
+    // Receipt token validation (Phase 2): if pending_verification non-empty
+    // AND finalText lacks [ack: <rule_id>] for each pending rule
+    // AND no prior acknowledgement_failure logged for this (session_id, rule_id),
+    // log ack_failure (one per session per rule).
+    const ackFindings = [];
+    try {
+      const sid =
+        payload.session_id || process.env.CLAUDE_SESSION_ID || "unknown";
+      const posture = readPosture(payload.cwd);
+      const pending = (posture.pending_verification || []).filter(
+        (e) => e && e.rule_id,
+      );
+      if (pending.length) {
+        const recent = readRecentViolations(payload.cwd, { limit: 200 });
+        for (const e of pending) {
+          const ackPattern = new RegExp(
+            "\\[ack:\\s*" +
+              e.rule_id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+              "\\s*\\]",
+            "i",
+          );
+          if (ackPattern.test(finalText)) continue; // acknowledged
+          const already = recent.some(
+            (v) =>
+              v.session_id === sid &&
+              v.rule_id === `acknowledgement_failure/${e.rule_id}`,
+          );
+          if (already) continue;
+          ackFindings.push({
+            rule_id: `acknowledgement_failure/${e.rule_id}`,
+            severity: "halt-and-report",
+            evidence: `pending rule ${e.rule_id} not acknowledged via [ack: ${e.rule_id}] in agent response`,
+          });
+        }
+      }
+    } catch {
+      // posture/violations read failed → skip ack check rather than blocking session
+    }
+
+    const findings = [
+      P.detectPreExistingNoSha(finalText),
+      P.detectSweepSubstitution(finalText),
+      P.detectSelfConfession(finalText),
+      P.detectRepoScopeDriftText(finalText),
+      ...ackFindings,
+    ].filter(Boolean);
+
+    if (findings.length === 0) return passthrough();
+
+    // Stop hooks emit systemMessage (CRIT-1). Multiple findings → concatenate.
+    for (const f of findings) {
+      appendViolation(payload.cwd, {
+        rule_id: f.rule_id,
+        severity: f.severity === "block" ? "halt-and-report" : f.severity, // Stop can't truly block
+        evidence: f.evidence,
+        posture_at_time: process.env.CLAUDE_CURRENT_POSTURE || "unknown",
+        type: "post-mortem",
+      });
+    }
+
+    clearTimeout(fallback);
+    emit({
+      hookEvent: "Stop",
+      severity: "post-mortem",
+      what_happened: `${findings.length} violation pattern(s) detected in final report`,
+      why: findings.map((f) => f.rule_id).join(", "),
+      agent_must_report: findings.map(
+        (f) => `${f.rule_id}: ${f.evidence.slice(0, 100)}`,
+      ),
+      agent_must_wait: "Forensic record only — surfaced at next SessionStart.",
+      user_summary: `${findings.length} post-mortem violation(s) recorded`,
+    });
+    return;
+  }
+
+  if (event === "UserPromptSubmit") {
+    const prompt = payload.prompt || "";
+    if (/\bwhy.*(broken|regress|still failing)/i.test(prompt)) {
+      // Inject regression-signal context — does NOT log a violation, just primes the agent
+      clearTimeout(fallback);
+      process.stdout.write(
+        JSON.stringify({
+          continue: true,
+          hookSpecificOutput: {
+            hookEventName: "UserPromptSubmit",
+            additionalContext:
+              "USER REGRESSION SIGNAL DETECTED — before re-running, audit which test tiers actually ran in the last invocation and enumerate them explicitly in your response.",
+          },
+        }) + "\n",
+      );
+      process.exit(0);
+    }
+    return passthrough();
+  }
+
+  return passthrough();
+})();

--- a/.claude/hooks/enforce-framework-first.js
+++ b/.claude/hooks/enforce-framework-first.js
@@ -17,6 +17,8 @@ const timeout = setTimeout(() => {
   process.exit(1);
 }, TIMEOUT_MS);
 
+const { instructAndWait } = require("./lib/instruct-and-wait");
+
 let input = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => (input += chunk));
@@ -175,16 +177,23 @@ function checkForRawFrameworks(data) {
     for (const pattern of group.patterns) {
       if (pattern.test(content)) {
         const lib = content.match(pattern)?.[0] || "raw import";
-        return {
-          output: {
-            continue: false,
-            reason:
-              `BLOCKED: ${lib} in ${filePath}. ` +
-              `${group.reason} ` +
-              `Guide: ${group.guide}`,
-          },
-          exitCode: 2,
-        };
+        // PostToolUse: file already written. Use halt-and-report — agent must
+        // surface and rewrite using the framework. Per red-team CRIT-1, block
+        // semantics are post-hoc here; we cannot un-do the write.
+        const out = instructAndWait({
+          hookEvent: "PostToolUse",
+          severity: "halt-and-report",
+          what_happened: `Raw library import \`${lib}\` written to ${filePath}`,
+          why: `framework-first.md — Use ${group.framework} (${group.specialist}). Guide: ${group.guide}`,
+          agent_must_report: [
+            `Quote the exact import line that was just written`,
+            `State the equivalent ${group.framework} pattern (consult ${group.specialist} or read the guide)`,
+            `Propose the rewrite as a unified diff in your next response`,
+          ],
+          agent_must_wait: `Do not commit or proceed with related work until the file is rewritten using ${group.framework}.`,
+          user_summary: `Raw ${group.framework} import in ${filePath.split("/").pop()} — agent must rewrite`,
+        });
+        return { output: out.json, exitCode: out.exitCode };
       }
     }
   }

--- a/.claude/hooks/gitignored-claude-warn.js
+++ b/.claude/hooks/gitignored-claude-warn.js
@@ -18,21 +18,27 @@
  *   hook stays silent. Zero false-positive surface in artifact-managed
  *   environments.
  *
- *   Returns WARN only — never blocks. Intent is to surface the violation
- *   so the agent self-corrects (upstream to loom via GH issue) before
- *   citing the transient file in tracked content.
+ * Severity: advisory (per `hooks/lib/instruct-and-wait.js`).
+ * Non-blocking by design — the agent acknowledges and self-corrects in
+ * the same session by upstreaming via GH issue rather than writing transient
+ * .claude/ files.
+ *
+ * Output shape: routes through instructAndWait so the agent receives the
+ * canonical WHAT HAPPENED / WHY / REPORT TO USER / THEN structure rather
+ * than a flat array of validation strings (loom 2026-05-05 hook redesign).
  *
  * Origin: loom issue #19 Proposal 1 (2026-04-21 tpc/tpc_cash_treasury-scenario
  *   /redteam — agent wrote rules/spec-accuracy.md to gitignored .claude/rules/,
  *   edited tracked CLAUDE.md to cite it, almost shipped phantom-reference state).
  *
  * Exit Codes:
- *   0 = success / warn
+ *   0 = success / advisory warn
  *   1 = hook error (e.g. timeout, malformed input)
  */
 
 const path = require("path");
 const { execFileSync } = require("child_process");
+const { instructAndWait } = require("./lib/instruct-and-wait");
 
 const TIMEOUT_MS = 5000;
 const timeout = setTimeout(() => {
@@ -49,16 +55,31 @@ process.stdin.on("end", () => {
   try {
     const data = JSON.parse(input);
     const result = checkPath(data);
-    console.log(
-      JSON.stringify({
-        continue: true,
-        hookSpecificOutput: {
-          hookEventName: "PreToolUse",
-          validation: result.messages,
-        },
-      }),
-    );
-    process.exit(0);
+
+    // Not gitignored or out-of-scope → bare passthrough (no validation noise)
+    if (!result.flagged) {
+      console.log(JSON.stringify({ continue: true }));
+      process.exit(0);
+      return;
+    }
+
+    // Gitignored .claude/ write → canonical advisory shape
+    const out = instructAndWait({
+      hookEvent: "PreToolUse",
+      severity: "advisory",
+      what_happened: `Edit/Write to gitignored .claude/ subtree: ${result.rel}`,
+      why: "artifact-flow.md (loom #19 P1) — gitignored .claude/ writes are transient; the file will not be tracked, and any citation from tracked content (CLAUDE.md, rules/) becomes a phantom reference on the next sync",
+      agent_must_report: [
+        "If you intend to codify this artifact: file a GH issue against the loom source-of-truth, do NOT write the transient file",
+        "If this is a session-only note (scratch / debug): proceed, but do NOT cite the path from tracked content (CLAUDE.md / rules / specs)",
+        "Run `git check-ignore -v <path>` to confirm the .gitignore rule that matched",
+      ],
+      agent_must_wait:
+        "Acknowledge in your next message and pick the correct disposition (upstream-via-issue OR session-only).",
+      user_summary: `gitignored .claude/ write: ${result.rel}`,
+    });
+    console.log(JSON.stringify(out.json));
+    process.exit(out.exitCode);
   } catch (error) {
     console.error(`[HOOK ERROR] gitignored-claude-warn: ${error.message}`);
     console.log(JSON.stringify({ continue: true }));
@@ -68,14 +89,13 @@ process.stdin.on("end", () => {
 
 function checkPath(data) {
   const filePath = data.tool_input?.file_path || "";
-  if (!filePath) return { messages: [] };
+  if (!filePath) return { flagged: false };
 
   // Normalize and only inspect paths under .claude/.
   const norm = path.normalize(filePath);
-  if (!/(?:^|\/)\.claude\//.test(norm)) return { messages: [] };
+  if (!/(?:^|\/)\.claude\//.test(norm)) return { flagged: false };
 
   // Run git check-ignore. Exit 0 means the path IS gitignored.
-  // We pass -v for verbose; we only care about the exit code.
   const cwd = data.cwd || process.cwd();
   let ignored = false;
   try {
@@ -90,22 +110,8 @@ function checkPath(data) {
     ignored = false;
   }
 
-  if (!ignored) return { messages: [] };
+  if (!ignored) return { flagged: false };
 
   const rel = path.relative(cwd, norm);
-  return {
-    messages: [
-      {
-        severity: "warn",
-        rule: "artifact-flow.md (loom #19 P1)",
-        message:
-          `${rel}: writing to a gitignored .claude/ subtree. ` +
-          `This write is transient — the file will not be tracked, and any ` +
-          `citation from tracked content (CLAUDE.md, rules, etc.) will become ` +
-          `a phantom reference on the next sync. ` +
-          `If you intend to codify this artifact, file a GH issue against the ` +
-          `loom source-of-truth instead. If this is a session-only note, proceed.`,
-      },
-    ],
-  };
+  return { flagged: true, rel };
 }

--- a/.claude/hooks/integration-hygiene.js
+++ b/.claude/hooks/integration-hygiene.js
@@ -5,24 +5,31 @@
  * Matcher: Edit|Write
  * Purpose: Catch integration-hygiene anti-patterns the moment they land in code.
  *
- *   Detects (WARN, non-blocking):
+ *   Detects (advisory, non-blocking):
  *   - Raw SQL strings in non-migration source files (DataFlow bypass)
  *   - MOCK_/FAKE_/DUMMY_/SAMPLE_ frontend constants (hidden stub data)
  *   - Silent-swallow exception handlers (`except: pass`, `catch(e){}`, bare rescue)
  *   - New endpoint handlers with no logger call in the function body
  *   - Raw HTTP client calls (requests./httpx./fetch()) without surrounding log
  *
- * Returns WARN only -- never blocks. Intent is to surface the violation so the
- * agent self-corrects in the same session. Blocking here would break too many
- * legitimate edge cases that the agent rightly ignores.
+ * Severity: advisory (per `hooks/lib/instruct-and-wait.js`).
+ * Non-blocking by design — the agent acknowledges and self-corrects in
+ * the same session. Blocking here would break too many legitimate edge
+ * cases that the agent rightly ignores (test fixtures, SQL migration
+ * tools, deliberately bare rescue blocks at framework cleanup boundaries).
+ *
+ * Output shape: routes through instructAndWait so the agent receives the
+ * canonical WHAT HAPPENED / WHY / REPORT TO USER / THEN structure rather
+ * than a flat array of validation strings (loom 2026-05-05 hook redesign).
  *
  * Exit Codes:
- *   0 = success / warn
+ *   0 = success / advisory warn
  *   1 = hook error (e.g. timeout, malformed input)
  */
 
 const fs = require("fs");
 const path = require("path");
+const { instructAndWait } = require("./lib/instruct-and-wait");
 
 const TIMEOUT_MS = 3000;
 const timeout = setTimeout(() => {
@@ -39,16 +46,35 @@ process.stdin.on("end", () => {
   try {
     const data = JSON.parse(input);
     const result = checkFile(data);
-    console.log(
-      JSON.stringify({
-        continue: true,
-        hookSpecificOutput: {
-          hookEventName: "PostToolUse",
-          validation: result.messages,
-        },
-      }),
+
+    // No findings → bare passthrough (no validation noise)
+    if (!result.findings || result.findings.length === 0) {
+      console.log(JSON.stringify({ continue: true }));
+      process.exit(0);
+      return;
+    }
+
+    // Findings → canonical advisory shape with each pattern enumerated
+    const fileLabel = result.rel || "(edit)";
+    const findingLines = result.findings.map(
+      (f) => `${f.rule}: ${f.message}`,
     );
-    process.exit(0);
+
+    const out = instructAndWait({
+      hookEvent: "PostToolUse",
+      severity: "advisory",
+      what_happened: `${result.findings.length} integration-hygiene finding(s) on ${fileLabel}`,
+      why: "Multiple rules — see each REPORT line for the specific clause violated (zero-tolerance.md Rule 2 / Rule 3, framework-first.md, observability.md)",
+      agent_must_report: [
+        ...findingLines,
+        "Self-correct in this session: rewrite via the framework specialist OR add the missing log lines OR remove the mock-data constant",
+      ],
+      agent_must_wait:
+        "Acknowledge in your next message; do NOT defer to /redteam (these are write-time hygiene checks, not audit-time).",
+      user_summary: `integration-hygiene: ${result.findings.length} finding(s) on ${fileLabel.split("/").pop()}`,
+    });
+    console.log(JSON.stringify(out.json));
+    process.exit(out.exitCode);
   } catch (error) {
     console.error(`[HOOK ERROR] integration-hygiene: ${error.message}`);
     console.log(JSON.stringify({ continue: true }));
@@ -65,7 +91,7 @@ function checkFile(data) {
   const ext = path.extname(filePath).toLowerCase();
 
   const sourceExts = [".py", ".rs", ".ts", ".tsx", ".js", ".jsx", ".rb"];
-  if (!sourceExts.includes(ext)) return { messages: [] };
+  if (!sourceExts.includes(ext)) return { findings: [] };
 
   // Skip migration, test, and generated files -- they have legitimate
   // reasons to contain patterns this hook would otherwise flag.
@@ -74,17 +100,17 @@ function checkFile(data) {
       filePath,
     )
   ) {
-    return { messages: [] };
+    return { findings: [] };
   }
 
   let content = "";
   try {
     content = fs.readFileSync(filePath, "utf8");
   } catch {
-    return { messages: [] }; // file deleted or unreadable; nothing to check
+    return { findings: [] }; // file deleted or unreadable; nothing to check
   }
 
-  const messages = [];
+  const findings = [];
   const rel = path.relative(data.cwd || process.cwd(), filePath);
 
   // 1. Raw SQL strings outside migration files (DataFlow bypass)
@@ -94,8 +120,7 @@ function checkFile(data) {
     sqlPattern.test(content) &&
     !/\/(?:db|infrastructure|dialect)\//.test(filePath)
   ) {
-    messages.push({
-      severity: "warn",
+    findings.push({
       rule: "framework-first.md § Work-Domain Binding",
       message: `${rel}: raw SQL string detected. DataFlow (@db.model, db.express) is MANDATORY for all DB work. Consult dataflow-specialist.`,
     });
@@ -104,8 +129,7 @@ function checkFile(data) {
   // 2. Frontend mock-data constants
   const mockPattern = /\b(MOCK|FAKE|DUMMY|SAMPLE)_[A-Z][A-Z0-9_]*\s*[:=]/;
   if (mockPattern.test(content)) {
-    messages.push({
-      severity: "warn",
+    findings.push({
       rule: "zero-tolerance.md Rule 2",
       message: `${rel}: mock/fake/dummy constant detected. Frontend mock data is a stub -- remove before ship.`,
     });
@@ -123,8 +147,7 @@ function checkFile(data) {
   ];
   for (const { pat, lang } of silentSwallowPatterns) {
     if (pat.test(content)) {
-      messages.push({
-        severity: "warn",
+      findings.push({
         rule: "zero-tolerance.md Rule 3",
         message: `${rel}: silent ${lang} exception swallow. BLOCKED per Rule 3 -- log AND act (retry, fall back, re-raise) or re-raise.`,
       });
@@ -138,8 +161,7 @@ function checkFile(data) {
   const loggerPattern =
     /(?:logger\.(?:info|warn|warning|error|debug|exception)|structlog\.|Rails\.logger|semantic_logger|tracing::)/;
   if (endpointPattern.test(content) && !loggerPattern.test(content)) {
-    messages.push({
-      severity: "warn",
+    findings.push({
       rule: "observability.md § Mandatory Log Points",
       message: `${rel}: endpoint handler detected with no logger call. Every endpoint MUST log entry, exit, and error paths.`,
     });
@@ -149,12 +171,11 @@ function checkFile(data) {
   const rawHttpPattern =
     /(?:requests\.(?:get|post|put|patch|delete)|httpx\.(?:get|post|put|patch|delete)|\bfetch\s*\(|urllib\.request)/;
   if (rawHttpPattern.test(content) && !loggerPattern.test(content)) {
-    messages.push({
-      severity: "warn",
+    findings.push({
       rule: "framework-first.md § Work-Domain Binding + observability.md",
       message: `${rel}: raw HTTP client call detected with no surrounding log. Outbound integrations MUST log intent + result. Consult nexus-specialist.`,
     });
   }
 
-  return { messages };
+  return { rel, findings };
 }

--- a/.claude/hooks/posture-gate.js
+++ b/.claude/hooks/posture-gate.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Hook: posture-gate
+ * Events:
+ *   - SessionStart — emit stderr summary so user sees current posture
+ *   - PreToolUse  — enforce posture-bound tool restrictions at L2/L3
+ *
+ * Posture allowances (per `rules/trust-posture.md` § Posture Ladder):
+ *   L5_DELEGATED            full autonomy → passthrough always
+ *   L4_CONTINUOUS_INSIGHT   full autonomy → passthrough (stricter at /redteam,
+ *                           journal mandate; gate-level enforcement only)
+ *   L3_SHARED_PLANNING      block Edit|Write|Bash beyond read-only;
+ *                           block git commit / gh pr create / git push
+ *   L2_SUPERVISED           block all Edit|Write; block any non-read-only Bash
+ *   L1_PSEUDO_AGENT         block all working-tree mutations
+ *
+ * Severity: halt-and-report (NOT block exit-2). Posture is policy, not safety;
+ * the agent receives structured instruction to surface and wait. Genuine
+ * safety blocks (rm -rf, force-push to main, secret leak) live in
+ * validate-bash-command.js / validate-deployment.js as `block` severity.
+ *
+ * Mitigates cc-artifacts.md Rule 7 (timeout fallback).
+ */
+
+const TIMEOUT_MS = 5000;
+const fallback = setTimeout(() => {
+  process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  process.exit(1);
+}, TIMEOUT_MS);
+
+const path = require("path");
+const { readPosture } = require(path.join(__dirname, "lib", "state-io.js"));
+const { instructAndWait } = require(
+  path.join(__dirname, "lib", "instruct-and-wait.js"),
+);
+
+function passthrough() {
+  clearTimeout(fallback);
+  process.stdout.write(JSON.stringify({ continue: true }) + "\n");
+  process.exit(0);
+}
+
+// Read-only Bash commands permitted at L2 (the most restrictive working-tree posture)
+const READ_ONLY_BASH = [
+  /^\s*ls\b/,
+  /^\s*cat\b/,
+  /^\s*head\b/,
+  /^\s*tail\b/,
+  /^\s*grep\b/,
+  /^\s*find\b/,
+  /^\s*git\s+(status|diff|log|show|branch|blame|reflog|rev-parse|merge-base|ls-files)\b/,
+  /^\s*gh\s+(pr|issue|release|run)\s+(view|list|status)/,
+  /^\s*node\s+--version\b/,
+  /^\s*python3?\s+--version\b/,
+  /^\s*which\s+/,
+  /^\s*echo\s+/,
+  /^\s*pwd\b/,
+  /^\s*wc\b/,
+  /^\s*jq\b/,
+];
+
+function isReadOnlyBash(cmd) {
+  return READ_ONLY_BASH.some((p) => p.test(cmd));
+}
+
+// Mutating-git commands restricted at L3
+const L3_BLOCKED_BASH = [
+  /\bgit\s+commit\b/,
+  /\bgit\s+push\b/,
+  /\bgh\s+pr\s+create\b/,
+  /\bgh\s+pr\s+merge\b/,
+  /\bgh\s+release\s+create\b/,
+];
+
+function gateAtPosture(posture, tool, input) {
+  const cmd = (input.command || "").trim();
+  const filePath = input.file_path || "";
+
+  // L5/L4: full passthrough (gate-level enforcement only at /redteam etc.)
+  if (posture === "L5_DELEGATED" || posture === "L4_CONTINUOUS_INSIGHT") {
+    return null;
+  }
+
+  // L3: block commit/push/PR; block Edit|Write to non-config files
+  if (posture === "L3_SHARED_PLANNING") {
+    if (tool === "Bash" && L3_BLOCKED_BASH.some((p) => p.test(cmd))) {
+      return {
+        what_happened: `Bash invoked at L3_SHARED_PLANNING: ${cmd.slice(0, 80)}`,
+        why: "trust-posture/L3 — commits and PR creation require explicit user instruction at L3",
+        agent_must_report: [
+          "State which mutation was attempted",
+          "Confirm whether the user instructed this commit/push IN THIS CONVERSATION",
+          "If yes, quote the user's instruction; if no, do not retry",
+        ],
+        agent_must_wait:
+          "Wait for explicit user instruction before any commit/push/PR mutation at L3.",
+        user_summary: `L3 blocked: ${cmd.slice(0, 60)}`,
+      };
+    }
+    // L3 allows Edit/Write — the gate is per-shard plan approval
+    return null;
+  }
+
+  // L2: block all Edit|Write; block all non-read-only Bash
+  if (posture === "L2_SUPERVISED") {
+    if (tool === "Edit" || tool === "Write") {
+      return {
+        what_happened: `${tool} attempted at L2_SUPERVISED: ${filePath.slice(0, 80)}`,
+        why: "trust-posture/L2 — every Edit/Write requires user instruction in the immediate prior turn",
+        agent_must_report: [
+          "State the file being modified and the change intent",
+          "Quote the user's prior-turn instruction authorizing this edit",
+          "If no instruction exists, propose the diff as a chat message instead",
+        ],
+        agent_must_wait:
+          "Do not retry the Edit/Write. Surface the proposed change to the user and wait.",
+        user_summary: `L2 blocked: ${tool} ${filePath.split("/").pop()}`,
+      };
+    }
+    if (tool === "Bash" && !isReadOnlyBash(cmd)) {
+      return {
+        what_happened: `Mutating Bash attempted at L2_SUPERVISED: ${cmd.slice(0, 80)}`,
+        why: "trust-posture/L2 — only read-only Bash is permitted; mutations require user instruction",
+        agent_must_report: [
+          "State the command and intended effect",
+          "Quote the user's prior-turn instruction authorizing this command",
+        ],
+        agent_must_wait: "Wait for explicit user instruction.",
+        user_summary: `L2 blocked: ${cmd.slice(0, 60)}`,
+      };
+    }
+    return null;
+  }
+
+  // L1: block everything except read-only Bash
+  if (posture === "L1_PSEUDO_AGENT") {
+    if (tool === "Edit" || tool === "Write") {
+      return {
+        what_happened: `${tool} attempted at L1_PSEUDO_AGENT: ${filePath.slice(0, 80)}`,
+        why: "trust-posture/L1 — zero working-tree mutations; agent proposes only",
+        agent_must_report: [
+          "Surface the proposed diff to the user as chat content",
+          "Do NOT attempt the Edit/Write again",
+        ],
+        agent_must_wait:
+          "L1 = propose only. The user runs commands; the agent advises.",
+        user_summary: `L1 blocked: ${tool}`,
+      };
+    }
+    if (tool === "Bash" && !isReadOnlyBash(cmd)) {
+      return {
+        what_happened: `Bash attempted at L1_PSEUDO_AGENT: ${cmd.slice(0, 80)}`,
+        why: "trust-posture/L1 — only read-only Bash permitted",
+        agent_must_report: [
+          "Surface the command for the user to run themselves",
+        ],
+        agent_must_wait: "L1 = advise only.",
+        user_summary: `L1 blocked: ${cmd.slice(0, 60)}`,
+      };
+    }
+    return null;
+  }
+
+  return null;
+}
+
+let input = "";
+if (process.stdin.isTTY) {
+  passthrough();
+} else {
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (c) => (input += c));
+  process.stdin.on("end", () => {
+    let data = {};
+    try {
+      data = JSON.parse(input);
+    } catch {
+      return passthrough();
+    }
+    const event = data.hook_event_name || data.hookEventName || "";
+
+    if (event === "SessionStart") {
+      try {
+        const posture = readPosture(data.cwd);
+        const pvCount = (posture.pending_verification || []).filter(
+          (e) => e && e.rule_id,
+        ).length;
+        const tag = posture._fail_closed
+          ? "FAIL-CLOSED"
+          : posture._fresh
+            ? "FRESH"
+            : "OK";
+        process.stderr.write(
+          `[posture-gate] ${posture.posture} (${tag})` +
+            (pvCount ? ` — ${pvCount} pending verification(s)` : "") +
+            "\n",
+        );
+      } catch (e) {
+        process.stderr.write(`[posture-gate] read failed: ${e.message}\n`);
+      }
+      return passthrough();
+    }
+
+    if (event === "PreToolUse") {
+      const tool = data.tool_name;
+      const toolInput = data.tool_input || {};
+      try {
+        const posture = readPosture(data.cwd);
+        const gate = gateAtPosture(posture.posture, tool, toolInput);
+        if (gate) {
+          clearTimeout(fallback);
+          const out = instructAndWait({
+            hookEvent: "PreToolUse",
+            severity: "halt-and-report",
+            ...gate,
+          });
+          process.stdout.write(JSON.stringify(out.json) + "\n");
+          process.exit(out.exitCode);
+          return;
+        }
+      } catch {
+        // posture read failed → passthrough; corrupt-state already handled
+        // by readPosture's fail-closed-to-L1 default which would block
+        // here — we explicitly choose passthrough to avoid double-failure.
+      }
+      return passthrough();
+    }
+
+    return passthrough();
+  });
+}

--- a/.claude/hooks/pre-compact.js
+++ b/.claude/hooks/pre-compact.js
@@ -32,12 +32,24 @@ process.stdin.on("data", (chunk) => (input += chunk));
 process.stdin.on("end", () => {
   try {
     const data = JSON.parse(input);
-    savePreCompactState(data);
-    // PreCompact hooks don't support hookSpecificOutput in schema
+    const result = savePreCompactState(data);
+    // PreCompact schema: no hookSpecificOutput. Surface stderr summary so
+    // user sees what was checkpointed (was DARK pre-fix).
+    if (result && result.checkpointed) {
+      const wfCount = result.workflows || 0;
+      const recCount = result.recentCount || 0;
+      process.stderr.write(
+        `[pre-compact] checkpoint saved (framework=${result.framework}, workflows=${wfCount}, recent=${recCount})\n`,
+      );
+    } else if (result) {
+      process.stderr.write(
+        `[pre-compact] checkpoint FAILED: ${result.error || "unknown"}\n`,
+      );
+    }
     console.log(JSON.stringify({ continue: true }));
     process.exit(0);
   } catch (error) {
-    console.error(`[HOOK ERROR] ${error.message}`);
+    process.stderr.write(`[pre-compact] HOOK ERROR: ${error.message}\n`);
     console.log(JSON.stringify({ continue: true }));
     process.exit(1);
   }
@@ -111,7 +123,13 @@ function savePreCompactState(data) {
     // Clean up old checkpoints (keep last 10 per session)
     cleanupOldCheckpoints(checkpointDir, session_id, 10);
 
-    return { checkpointed: true, path: checkpointFile };
+    return {
+      checkpointed: true,
+      path: checkpointFile,
+      framework: checkpoint.preservedContext.frameworkInUse,
+      workflows: checkpoint.preservedContext.activeWorkflows.length,
+      recentCount: checkpoint.preservedContext.recentlyModified.length,
+    };
   } catch (error) {
     return { checkpointed: false, error: error.message };
   }

--- a/.claude/hooks/session-end.js
+++ b/.claude/hooks/session-end.js
@@ -32,12 +32,16 @@ process.stdin.on("data", (chunk) => (input += chunk));
 process.stdin.on("end", () => {
   try {
     const data = JSON.parse(input);
-    saveSession(data);
-    // SessionEnd hooks don't support hookSpecificOutput in schema
+    const summary = saveSession(data);
+    // SessionEnd schema: no hookSpecificOutput. Surface a stderr summary so
+    // the user sees what was checkpointed (was DARK pre-fix).
+    if (summary) {
+      process.stderr.write(`[session-end] ${summary}\n`);
+    }
     console.log(JSON.stringify({ continue: true }));
     process.exit(0);
   } catch (error) {
-    console.error(`[HOOK ERROR] ${error.message}`);
+    process.stderr.write(`[session-end] HOOK ERROR: ${error.message}\n`);
     console.log(JSON.stringify({ continue: true }));
     process.exit(1);
   }
@@ -113,9 +117,15 @@ function saveSession(data) {
     // Clean up old sessions (keep last 20)
     cleanupOldSessions(sessionDir, 20);
 
-    return { saved: true, path: sessionFile };
+    // User-visible summary (was DARK before; mitigates red-team session-end-DARK)
+    const stats = sessionData.stats || {};
+    const fileCount = Object.values(stats).reduce(
+      (a, b) => a + (typeof b === "number" ? b : 0),
+      0,
+    );
+    return `checkpoint saved (session=${session_id.slice(0, 8)}, ~${fileCount} touched, learning digest built)`;
   } catch (error) {
-    return { saved: false, error: error.message };
+    return `checkpoint FAILED: ${error.message}`;
   }
 }
 

--- a/.claude/hooks/session-start.js
+++ b/.claude/hooks/session-start.js
@@ -46,15 +46,57 @@ const _timeout = setTimeout(() => {
 let input = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => (input += chunk));
+const { readPosture } = require("./lib/state-io");
+
 process.stdin.on("end", () => {
   try {
     const data = JSON.parse(input);
     const result = initializeSession(data);
+
+    // Trust-posture gate (mitigates red-team H4 / Phase 1 of trust-posture rollout)
+    let trustGate = "";
+    try {
+      const posture = readPosture(data.cwd);
+      const lines = [];
+      lines.push(
+        `\n## Trust Posture: ${posture.posture}` +
+          (posture._fail_closed
+            ? " (FAIL-CLOSED — state was missing/corrupt)"
+            : "") +
+          (posture._fresh ? " (fresh repo)" : ""),
+      );
+      lines.push(`since: ${posture.since}`);
+      const pv = (posture.pending_verification || []).filter(
+        (e) => e && e.rule_id,
+      );
+      if (pv.length) {
+        lines.push("\n⚠️ TRUST GATE — Verification Pending:");
+        for (const e of pv) {
+          const days = Math.floor(
+            (Date.now() - new Date(e.since).getTime()) / 86400000,
+          );
+          lines.push(
+            `  - ${e.rule_id} (day ${days + 1} of ${e.grace_period_days}). ` +
+              `Violation within grace = EMERGENCY DOWNGRADE. ` +
+              `Include \`[ack: ${e.rule_id}]\` in your first response.`,
+          );
+        }
+      }
+      trustGate = lines.join("\n");
+    } catch {
+      // If readPosture itself fails, surface a quiet warning — don't block session
+      trustGate =
+        "\n## Trust Posture: UNREADABLE — manual /posture init required";
+    }
+
     const output = { continue: true };
-    if (result.sessionNotesContext) {
+    const ctxParts = [];
+    if (result.sessionNotesContext) ctxParts.push(result.sessionNotesContext);
+    if (trustGate) ctxParts.push(trustGate);
+    if (ctxParts.length) {
       output.hookSpecificOutput = {
         hookEventName: "SessionStart",
-        additionalContext: result.sessionNotesContext,
+        additionalContext: ctxParts.join("\n\n"),
       };
     }
     console.log(JSON.stringify(output));

--- a/.claude/hooks/validate-bash-command.js
+++ b/.claude/hooks/validate-bash-command.js
@@ -19,6 +19,7 @@ const path = require("path");
 const {
   logObservation: logLearningObservation,
 } = require("./lib/learning-utils");
+const { instructAndWait } = require("./lib/instruct-and-wait");
 
 // Timeout handling for PreToolUse hooks (5 second limit)
 const TIMEOUT_MS = 5000;
@@ -36,6 +37,21 @@ process.stdin.on("end", () => {
   try {
     const data = JSON.parse(input);
     const result = validateBashCommand(data);
+    // If result is structured for instruct-and-wait, use canonical shape
+    if (result.severity) {
+      const out = instructAndWait({
+        hookEvent: "PreToolUse",
+        severity: result.severity,
+        what_happened: result.what_happened,
+        why: result.why,
+        agent_must_report: result.agent_must_report,
+        agent_must_wait: result.agent_must_wait,
+        user_summary: result.user_summary,
+      });
+      console.log(JSON.stringify(out.json));
+      process.exit(out.exitCode);
+    }
+    // Legacy advisory path
     console.log(
       JSON.stringify({
         continue: result.continue,
@@ -76,6 +92,48 @@ function validateBashCommand(data) {
     } catch {
       // Advisory failure must never block the commit.
     }
+  }
+
+  // BLOCK: Three-layer Bash mutation detection against trust-posture state files.
+  // Mitigates the gap where `permissions.deny` on Edit/Write is bypassable via
+  // bash redirects, file utils, or interpreter -c/-e/-m bodies. Pattern adopted
+  // from tpc_cash_treasury state-file-write-guard (issue #25, c0aeff73).
+  //
+  // Protected paths: .claude/learning/posture.json, posture.json.bak,
+  // violations.jsonl, violations.jsonl.*, .initialized
+  //
+  // Commit-message exception: `git commit -m "..."` or `git commit -F path`
+  // bodies are documentation prose, not executable commands. Skip detection
+  // entirely for those (segment-anchor isn't sufficient — the body can span
+  // many lines containing arbitrary shell-like syntax as documentation).
+  const STATE_PATH_RX =
+    /\.claude\/learning\/(?:posture\.json(?:\.bak|\.tmp\.\d+)?|violations\.jsonl(?:\.[A-Za-z0-9_-]+)?|\.initialized)\b/;
+  const isGitCommitWithBody = /^\s*git\s+commit\b[^|;]*(?:\s-m\s|\s-F\s)/.test(
+    command,
+  );
+  const stateFileMutation = isGitCommitWithBody
+    ? null
+    : detectStateFileMutation(command, STATE_PATH_RX);
+  if (stateFileMutation) {
+    try {
+      logLearningObservation(cwd, "rule_violation", {
+        rule: "trust-posture/state-file-mutation",
+        layer: stateFileMutation.layer,
+      });
+    } catch {}
+    return {
+      severity: "block",
+      what_happened: `Bash command attempts to mutate trust-posture state file (Layer ${stateFileMutation.layer}: ${stateFileMutation.kind}): ${command.slice(0, 120)}`,
+      why: "trust-posture/state-file-mutation — state files (posture.json, violations.jsonl, .initialized) are owned by hooks; agent edits are BLOCKED",
+      agent_must_report: [
+        "Quote the exact bash command that was attempted",
+        "State whether you intended to read, debug, or modify the state",
+        "If reading: use `cat` (allowed); if modifying: use /posture command instead",
+      ],
+      agent_must_wait:
+        "Do not retry. State-file mutations route through the /posture command (challenge-nonce gated), never directly.",
+      user_summary: `state-file mutation blocked (Layer ${stateFileMutation.layer})`,
+    };
   }
 
   // BLOCK: Dangerous commands (with evasion-resistant patterns)
@@ -119,10 +177,82 @@ function validateBashCommand(data) {
       } catch {}
 
       if (message.startsWith("Blocked")) {
-        return { continue: false, exitCode: 2, message };
+        return {
+          severity: "block",
+          what_happened: `Bash command matched dangerous pattern: ${command.slice(0, 120)}`,
+          why: `validate-bash-command/${message}`,
+          agent_must_report: [
+            "Quote the exact command that was attempted",
+            "State why the dangerous pattern matched (which clause)",
+            "If the user truly intended this, ask them to confirm in plain language; do NOT retry without confirmation",
+          ],
+          agent_must_wait:
+            "Do not retry the command. Wait for explicit user instruction.",
+          user_summary: message,
+        };
       }
       return { continue: true, exitCode: 0, message };
     }
+  }
+
+  // Split on shell-segment separators so dangerous patterns inside quoted
+  // commit-message bodies (e.g. `git commit -m "...git reset --hard..."`) do NOT
+  // false-positive. Each segment's LEADING token determines the actual command.
+  const segments = command.split(/(?:\|\||&&|;|\|(?!\|))/);
+  const isLeadingCmd = (seg, re) => re.test(seg.trim());
+
+  // BLOCK: git reset --hard without preceding porcelain check (rules/git.md MUST 7)
+  if (segments.some((s) => isLeadingCmd(s, /^git\s+reset\s+--hard\b/))) {
+    return {
+      severity: "block",
+      what_happened: `Bash invoked \`git reset --hard\`: ${command.slice(0, 120)}`,
+      why: "git.md MUST 'git reset --hard MUST verify clean working tree' — prefer git reset --keep which aborts on local changes",
+      agent_must_report: [
+        "Show `git status --porcelain` output proving the working tree is clean",
+        "OR rewrite the command to use `git reset --keep <ref>` which aborts on dirty tree",
+        "Explain why --hard was chosen if the user explicitly authorized it",
+      ],
+      agent_must_wait:
+        "Do not retry --hard until porcelain check is shown OR user authorizes after seeing the risk.",
+      user_summary:
+        "git reset --hard blocked — needs porcelain check or --keep",
+    };
+  }
+
+  // BLOCK: force-push to main/master (segment-anchored to avoid commit-msg false-positives)
+  const forcePushPattern =
+    /^git\s+push\b[^|;]*--force(?:-with-lease)?\b[^|;]*\b(main|master)\b|^git\s+push\b[^|;]*\b(main|master)\b[^|;]*--force(?:-with-lease)?\b/;
+  if (segments.some((s) => isLeadingCmd(s, forcePushPattern))) {
+    return {
+      severity: "block",
+      what_happened: `Bash attempted force-push to protected branch: ${command.slice(0, 120)}`,
+      why: "git.md branch protection — main/master direct push is rejected; force-push is destructive",
+      agent_must_report: [
+        "State which branch was being force-pushed",
+        "Explain the user-facing reason (commit history rewrite? recovery? bug?)",
+        "Confirm whether the user explicitly authorized force-push to main/master IN THIS CONVERSATION",
+      ],
+      agent_must_wait:
+        "Do not retry. Force-push to main requires explicit per-action user authorization.",
+      user_summary: "force-push to main/master blocked",
+    };
+  }
+
+  // HALT-AND-REPORT: --no-verify (segment-anchored)
+  if (segments.some((s) => /(?:^|\s)--no-verify\b/.test(s.trim()))) {
+    return {
+      severity: "halt-and-report",
+      what_happened: `Bash command uses --no-verify: ${command.slice(0, 120)}`,
+      why: "git.md — pre-commit hooks exist for a reason; --no-verify requires explicit user instruction",
+      agent_must_report: [
+        "State which hook is being bypassed and why",
+        "Explain the underlying issue you would otherwise have to fix",
+        "Confirm whether the user authorized --no-verify IN THIS CONVERSATION",
+      ],
+      agent_must_wait:
+        "Do not retry without explicit user instruction. Investigate hook failure root cause first.",
+      user_summary: "--no-verify usage requires user authorization",
+    };
   }
 
   // ====================================================================
@@ -256,6 +386,81 @@ function validateBashCommand(data) {
 /**
  * Extract test-relevant flags from command for learning.
  */
+/**
+ * Three-layer mutation detection for trust-posture state files.
+ *
+ * Per issue #25 (esperie-enterprise/loom) — adopted from tpc_cash_treasury's
+ * state-file-write-guard (commit c0aeff73). Closes the bypass gap where
+ * settings.json `permissions.deny` on Edit/Write does NOT cover bash-mediated
+ * mutations (redirects, file utilities, interpreter -c/-e/-m bodies).
+ *
+ * Returns { layer, kind } if a mutation is detected against any path matching
+ * `pathRx`, else null.
+ *
+ * Per-line scanning: matchers operate on `[^|\\n]*` so multi-line commands
+ * cannot cross-match a verb on one line with a protected path on a later line.
+ */
+function detectStateFileMutation(command, pathRx) {
+  if (!command || !pathRx) return null;
+  const lines = command.split("\n");
+  for (const line of lines) {
+    // Layer 1: redirect / heredoc / tee / sed -i / jq -i — but NOT 2>&1 fd-redirect or /dev/null sink
+    // Output redirect to protected path
+    if (/(?:^|[^&\d2])>\s*[^|\n]*?/.test(line)) {
+      const redirectMatch = line.match(/(?:^|[^&\d2])>>?\s*([^\s|;&]+)/);
+      if (redirectMatch && pathRx.test(redirectMatch[1])) {
+        return { layer: 1, kind: "redirect" };
+      }
+    }
+    // Heredoc to protected path: `cat > path << EOF` or `>>path<<EOF`
+    if (/<<[-~]?\s*['"]?[A-Za-z_]/.test(line)) {
+      // Heredoc body itself is delivered later; the line that opens it
+      // typically has the redirect target. Match `> <protected>` on this line.
+      const m = line.match(/>\s*([^\s|;&<]+)/);
+      if (m && pathRx.test(m[1])) {
+        return { layer: 1, kind: "heredoc" };
+      }
+    }
+    // tee
+    if (/\btee\b\s+/.test(line)) {
+      const m = line.match(/\btee\b\s+(?:-[a-zA-Z]+\s+)*([^\s|;&]+)/);
+      if (m && pathRx.test(m[1])) {
+        return { layer: 1, kind: "tee" };
+      }
+    }
+    // sed -i / jq -i in-place editing
+    if (/\b(?:sed|jq)\b\s+[^|\n]*-i\b/.test(line)) {
+      if (pathRx.test(line)) return { layer: 1, kind: "in-place-edit" };
+    }
+
+    // Layer 2: file-mutating utilities
+    const layer2Verbs =
+      /\b(?:cp|mv|dd|rsync|install|truncate|ln|chmod|chown|touch)\b\s+/;
+    if (layer2Verbs.test(line) && pathRx.test(line)) {
+      const verbMatch = line.match(layer2Verbs);
+      return {
+        layer: 2,
+        kind: verbMatch ? verbMatch[0].trim() : "file-mutation-util",
+      };
+    }
+
+    // Layer 3: interpreter -c / -e / -m bodies (e.g. python -c "...", node -e "...")
+    // Includes combined short-flag forms like `-uc`, `-uec`
+    const interpreterBody =
+      /\b(?:python3?|node|nodejs|ruby|perl|bash|sh|zsh)\b\s+[^|\n]*-[a-zA-Z]*[cem][a-zA-Z]*\b\s+["'][^"']*["']/;
+    if (interpreterBody.test(line) && pathRx.test(line)) {
+      const interpMatch = line.match(
+        /\b(python3?|node|nodejs|ruby|perl|bash|sh|zsh)\b/,
+      );
+      return {
+        layer: 3,
+        kind: interpMatch ? `${interpMatch[1]} -c/-e/-m` : "interpreter-body",
+      };
+    }
+  }
+  return null;
+}
+
 function extractTestFlags(command) {
   const flags = [];
   if (/-x\b/.test(command)) flags.push("fail-fast");

--- a/.claude/hooks/validate-deployment.js
+++ b/.claude/hooks/validate-deployment.js
@@ -13,20 +13,28 @@
  */
 
 const TIMEOUT_MS = 10000;
+const { instructAndWait } = require("./lib/instruct-and-wait");
 const timeout = setTimeout(() => {
-  console.error(
-    "[HOOK TIMEOUT] validate-deployment exceeded 10s — CREDENTIAL CHECK SKIPPED",
-  );
-  console.log(
-    JSON.stringify({
-      continue: true,
-      hookSpecificOutput: {
-        hookEventName: "PostToolUse",
-        validation:
-          "WARNING: Deployment credential check timed out. Manual review required.",
-      },
-    }),
-  );
+  // Mitigates red-team validate-deployment-silent-skip:
+  // On timeout, surface halt-and-report so agent knows the credential check
+  // DID NOT complete. Old behavior silently allowed continue.
+  const out = instructAndWait({
+    hookEvent: "PostToolUse",
+    severity: "halt-and-report",
+    what_happened:
+      "validate-deployment hook timed out before completing the credential scan",
+    why: "validate-deployment.js — timeout means scan was interrupted; bypassing credential checks is BLOCKED",
+    agent_must_report: [
+      "State which file was being written when the hook timed out",
+      "Manually scan the file for: AWS keys, Azure secrets, GCP SA JSON, private keys, GitHub/PyPI/Docker PATs, sk-* API keys",
+      "Confirm in the report whether ANY credential pattern is present in the just-written file",
+    ],
+    agent_must_wait:
+      "Do not commit or proceed with deploy work until manual credential scan is reported.",
+    user_summary:
+      "validate-deployment timeout — manual credential scan required",
+  });
+  console.log(JSON.stringify(out.json));
   process.exit(1);
 }, TIMEOUT_MS);
 
@@ -38,6 +46,13 @@ process.stdin.on("end", () => {
   try {
     const data = JSON.parse(input);
     const result = validateDeployment(data);
+    // Structured output from credential block (already shaped via instruct-and-wait)
+    if (result.output) {
+      console.log(JSON.stringify(result.output));
+      process.exit(result.exitCode);
+      return;
+    }
+    // Legacy advisory path
     console.log(
       JSON.stringify({
         continue: result.continue,
@@ -50,16 +65,19 @@ process.stdin.on("end", () => {
     process.exit(result.exitCode);
   } catch (error) {
     console.error(`[HOOK ERROR] ${error.message}`);
-    console.log(
-      JSON.stringify({
-        continue: true,
-        hookSpecificOutput: {
-          hookEventName: "PostToolUse",
-          validation:
-            "WARNING: Deployment validation hook errored. Manual credential review required.",
-        },
-      }),
-    );
+    const out = instructAndWait({
+      hookEvent: "PostToolUse",
+      severity: "halt-and-report",
+      what_happened: `validate-deployment hook errored: ${error.message}`,
+      why: "validate-deployment.js — hook error means scan did not complete",
+      agent_must_report: [
+        "State the file being processed when the hook errored",
+        "Manually scan that file for credential patterns; report findings",
+      ],
+      agent_must_wait: "Do not commit or proceed until manual scan reported.",
+      user_summary: "validate-deployment hook error — manual scan required",
+    });
+    console.log(JSON.stringify(out.json));
     process.exit(1);
   }
 });
@@ -147,7 +165,24 @@ function validateDeployment(data) {
   for (const { pattern, context, message } of credentialPatterns) {
     if (pattern.test(content)) {
       if (context && !context.test(content)) continue;
-      return { continue: false, exitCode: 2, message };
+      // PostToolUse: file already written. Surface halt-and-report so agent
+      // immediately scrubs the secret before any downstream commit/push.
+      const out = instructAndWait({
+        hookEvent: "PostToolUse",
+        severity: "halt-and-report",
+        what_happened: `Credential pattern detected in ${filePath}: ${message}`,
+        why: "security.md No-Hardcoded-Secrets — credentials in deploy files leak into git history",
+        agent_must_report: [
+          `State the exact line number(s) where the pattern matched`,
+          `Quote the pattern (redact the value if it's a real secret) for the user`,
+          `Propose: remove the literal value, replace with env-var reference, scrub from git index if already staged`,
+          `Confirm whether this credential was authentic or a false-positive (e.g., test fixture)`,
+        ],
+        agent_must_wait:
+          "Do not commit or push. Do not proceed with the next file. Wait for user instruction.",
+        user_summary: message,
+      });
+      return { output: out.json, exitCode: out.exitCode };
     }
   }
 

--- a/.claude/hooks/validate-prod-deploy.js
+++ b/.claude/hooks/validate-prod-deploy.js
@@ -11,6 +11,17 @@
  * To use this hook, register it in .claude/settings.json under PreToolUse:Bash.
  * See deploy/scripts/ for the stage.sh and deploy.sh that write/read the marker.
  *
+ * Severity: block (per `hooks/lib/instruct-and-wait.js`).
+ * Genuine safety block — direct production deploys without staging verification
+ * are unrecoverable in the worst case (broken prod, no rollback marker). The
+ * --skip-staging escape hatch + deploy/scripts/promote.sh are the documented
+ * paths around the block.
+ *
+ * Output shape: routes through instructAndWait so the agent receives the
+ * canonical WHAT HAPPENED / WHY / REPORT TO USER / THEN structure (loom
+ * 2026-05-05 hook redesign) instead of just stderr boxes the user sees but
+ * the agent has to interpret without context.
+ *
  * Exit Codes:
  *   0 = allow (command is safe or staging verified)
  *   2 = block (direct production deploy without staging)
@@ -18,13 +29,28 @@
 
 const fs = require("fs");
 const path = require("path");
-const { execSync } = require("child_process");
+const { execFileSync } = require("child_process");
+const { instructAndWait } = require("./lib/instruct-and-wait");
 
 const TIMEOUT_MS = 5000;
 const timeout = setTimeout(() => {
   // Timeout = allow (fail-open to avoid blocking all Bash commands)
   process.exit(0);
 }, TIMEOUT_MS);
+
+function emitBlock({ what, why, report, wait, summary }) {
+  const out = instructAndWait({
+    hookEvent: "PreToolUse",
+    severity: "block",
+    what_happened: what,
+    why,
+    agent_must_report: report,
+    agent_must_wait: wait,
+    user_summary: summary,
+  });
+  console.log(JSON.stringify(out.json));
+  process.exit(out.exitCode);
+}
 
 async function main() {
   try {
@@ -95,13 +121,12 @@ async function main() {
       return;
     }
 
-    // Skip-staging escape hatch — allow but warn loudly
+    // Skip-staging escape hatch — allow but warn loudly to stderr (user-visible)
     if (command.includes("--skip-staging")) {
-      console.error(
-        "\n" +
-          "[DEPLOY HOOK] WARNING: --skip-staging detected.\n" +
-          "[DEPLOY HOOK] Allowing direct production deploy WITHOUT staging verification.\n" +
-          "[DEPLOY HOOK] You MUST document the reason in deploy/deployment-config.md.\n",
+      process.stderr.write(
+        "[DEPLOY HOOK] WARNING: --skip-staging detected. " +
+          "Allowing direct production deploy WITHOUT staging verification. " +
+          "Document the reason in deploy/deployment-config.md.\n",
       );
       clearTimeout(timeout);
       process.exit(0);
@@ -111,7 +136,7 @@ async function main() {
     // Locate repo root by walking up from cwd or script location
     let repoRoot;
     try {
-      repoRoot = execSync("git rev-parse --show-toplevel", {
+      repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
         encoding: "utf8",
         timeout: 3000,
       }).trim();
@@ -124,26 +149,21 @@ async function main() {
 
     const markerPath = path.join(repoRoot, ".staging-passed");
 
-    // Check that .staging-passed exists
+    // Block 1: .staging-passed marker missing
     if (!fs.existsSync(markerPath)) {
-      console.error(
-        "\n" +
-          "╔══════════════════════════════════════════════════════════╗\n" +
-          "║  BLOCKED: Production deploy without staging             ║\n" +
-          "║                                                          ║\n" +
-          "║  Run staging first:                                      ║\n" +
-          "║    bash deploy/scripts/promote.sh                        ║\n" +
-          "║                                                          ║\n" +
-          "║  Or step-by-step on the server:                          ║\n" +
-          "║    bash deploy/scripts/stage.sh                          ║\n" +
-          "║    bash deploy/scripts/deploy.sh                         ║\n" +
-          "║                                                          ║\n" +
-          "║  Emergency bypass (document the reason afterward):       ║\n" +
-          "║    Add --skip-staging to your command                    ║\n" +
-          "╚══════════════════════════════════════════════════════════╝\n",
-      );
       clearTimeout(timeout);
-      process.exit(2); // Block
+      emitBlock({
+        what: `Production deploy attempted without staging verification: ${command.slice(0, 120)}`,
+        why: "deploy/deployment-config.md — .staging-passed marker is the deploy gate; no marker = no proof staging passed for the current commit",
+        report: [
+          "Quote the exact deploy command that was attempted",
+          "Run staging first: `bash deploy/scripts/promote.sh` (which runs stage + deploy together) — OR step-by-step: `bash deploy/scripts/stage.sh` then `bash deploy/scripts/deploy.sh`",
+          "Emergency bypass (document the reason afterward in deploy/deployment-config.md): add `--skip-staging` to the command",
+          "Confirm whether the user explicitly authorized direct prod deploy IN THIS CONVERSATION",
+        ],
+        wait: "Do not retry the deploy command. Run staging first OR get explicit user authorization for --skip-staging.",
+        summary: "production deploy blocked — staging not passed",
+      });
       return;
     }
 
@@ -151,7 +171,7 @@ async function main() {
     const marker = fs.readFileSync(markerPath, "utf8").trim();
     let currentCommit;
     try {
-      currentCommit = execSync("git rev-parse HEAD", {
+      currentCommit = execFileSync("git", ["rev-parse", "HEAD"], {
         cwd: repoRoot,
         encoding: "utf8",
         timeout: 3000,
@@ -165,27 +185,27 @@ async function main() {
 
     const shortHash = currentCommit.substring(0, 7);
     if (!marker.includes(shortHash)) {
-      console.error(
-        "\n" +
-          "╔══════════════════════════════════════════════════════════╗\n" +
-          "║  BLOCKED: Staging marker is stale                        ║\n" +
-          "║                                                          ║\n" +
-          "║  Code has changed since staging last passed.             ║\n" +
-          `║  Current commit: ${shortHash.padEnd(42)}║\n` +
-          `║  Staging marker: ${marker.substring(0, 7).padEnd(42)}║\n` +
-          "║                                                          ║\n" +
-          "║  Re-run staging:                                         ║\n" +
-          "║    bash deploy/scripts/promote.sh                        ║\n" +
-          "╚══════════════════════════════════════════════════════════╝\n",
-      );
+      const markerHash = marker.substring(0, 7);
       clearTimeout(timeout);
-      process.exit(2); // Block
+      emitBlock({
+        what: `Production deploy attempted with stale staging marker: ${command.slice(0, 80)}`,
+        why: `deploy/deployment-config.md — current commit ${shortHash} does not match staging marker ${markerHash}; code has changed since staging last passed`,
+        report: [
+          `Current commit: ${shortHash}`,
+          `Staging marker:  ${markerHash}`,
+          "Re-run staging against the current commit: `bash deploy/scripts/promote.sh`",
+          "OR step-by-step on the server: `bash deploy/scripts/stage.sh` then `bash deploy/scripts/deploy.sh`",
+          "Confirm the marker mismatch is not a sync/branch issue (e.g., wrong git branch checked out at deploy time)",
+        ],
+        wait: "Do not retry the deploy. Re-run staging or investigate the marker mismatch.",
+        summary: `production deploy blocked — stale staging marker (${markerHash} vs ${shortHash})`,
+      });
       return;
     }
 
     // Staging verified and current — allow production deploy
-    console.error(
-      `[DEPLOY HOOK] Staging verified (${shortHash}). Allowing production deploy.`,
+    process.stderr.write(
+      `[DEPLOY HOOK] Staging verified (${shortHash}). Allowing production deploy.\n`,
     );
     clearTimeout(timeout);
     process.exit(0);

--- a/.claude/hooks/validate-workflow.js
+++ b/.claude/hooks/validate-workflow.js
@@ -34,11 +34,39 @@ const timeout = setTimeout(() => {
 let input = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (chunk) => (input += chunk));
+const { instructAndWait: _iaw } = require("./lib/instruct-and-wait");
+
 process.stdin.on("end", () => {
   clearTimeout(timeout);
   try {
     const data = JSON.parse(input);
     const result = validateFile(data);
+    // If the validator decided to block (exitCode 2), route through
+    // instruct-and-wait for canonical halt-and-report shape (PostToolUse can't
+    // truly block; surface clear REPORT/THEN to agent + stderr summary to user).
+    if (result.exitCode === 2 || result.continue === false) {
+      const filePath = data.tool_input?.file_path || "(unknown file)";
+      const msgs = Array.isArray(result.messages)
+        ? result.messages
+        : [result.messages];
+      const blocked = msgs.filter((m) => /^BLOCKED:/.test(String(m)));
+      const out = _iaw({
+        hookEvent: "PostToolUse",
+        severity: "halt-and-report",
+        what_happened: `validate-workflow detected ${blocked.length} blocked pattern(s) in ${filePath}`,
+        why: "validate-workflow.js — stub / hardcoded-model / mock-data / fake-impl detection",
+        agent_must_report: blocked
+          .slice(0, 8)
+          .map((m) => String(m).slice(0, 240)),
+        agent_must_wait:
+          "Do not commit or proceed with related work until each blocked pattern is removed or replaced.",
+        user_summary: `validate-workflow: ${blocked.length} blocked pattern(s) in ${filePath.split("/").pop()}`,
+      });
+      console.log(JSON.stringify(out.json));
+      process.exit(out.exitCode);
+      return;
+    }
+    // Advisory / clean path
     console.log(
       JSON.stringify({
         continue: result.continue,

--- a/.claude/rules/trust-posture.md
+++ b/.claude/rules/trust-posture.md
@@ -1,0 +1,128 @@
+---
+priority: 10
+scope: path-scoped
+paths:
+  - "**/.claude/rules/**"
+  - "**/.claude/skills/**"
+  - "**/.claude/agents/**"
+  - "**/.claude/hooks/**"
+  - "**/.claude/commands/**"
+  - "**/.claude/learning/**"
+  - "**/.claude/settings.json"
+  - "**/.claude/sync-manifest.yaml"
+---
+
+# Trust Posture — Graduated Autonomy Discipline
+
+See `.claude/skills/32-trust-posture/` for codify/implement/redteam integration procedures and grace-period mechanics.
+
+## Principle
+
+Per CARE Principle 7 (Evolutionary Trust): _"Boundaries evolve based on demonstrated performance"_ (`skills/co-reference/care-spec.md:65`). Per EATP: _"Postures upgrade through demonstrated performance. They downgrade instantly if conditions change"_ (`skills/co-reference/eatp-spec.md:48`). Per Mirror Thesis: trust is validated against observable execution, not promised behavior — humans are the structural gate for upgrade; the system is the structural gate for downgrade.
+
+The agent's autonomy is bounded by a **per-repo posture**. The posture starts at L5 DELEGATED on a fresh repo (with `.initialized` marker). It is automatically tightened by violation detection. It can only be loosened by human approval (challenge-nonce gated).
+
+## Posture Ladder (L1 ← L5)
+
+| Posture                   | Agent CAN do unilaterally                                                   | Requires human gate                                                     |
+| ------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **L5_DELEGATED**          | Plan + implement + commit + open PR; parallel worktree agents; full /codify | Cross-repo writes; release tags; destructive ops                        |
+| **L4_CONTINUOUS_INSIGHT** | Same as L5 + mandatory journal per shard + /redteam Round 1 before merge    | Posture upgrade; multi-shard releases                                   |
+| **L3_SHARED_PLANNING**    | Edit + run tests; one shard at a time                                       | /todos plan approval before /implement; PR creation; commits to feat/\* |
+| **L2_SUPERVISED**         | Read; propose diffs; run linters                                            | Every Edit/Write; every commit; every Bash beyond read-only             |
+| **L1_PSEUDO_AGENT**       | Propose plans + diffs in chat                                               | Everything that touches the working tree                                |
+
+## MUST Rules
+
+### 1. Posture Is Per-Repo, Read From Main Checkout
+
+The current posture is defined by `<main_checkout>/.claude/learning/posture.json`. Worktree-isolated agents MUST read from the main checkout (resolved via `git worktree list --porcelain` filtering out `.claude/worktrees/`), never their own worktree path.
+
+```js
+// DO — resolveMainCheckout() in hooks/lib/state-resolver.js
+const main = resolveMainCheckout(process.cwd());
+const posture = readPosture(main);
+// DO NOT — use cwd directly inside a worktree
+const posture = readPosture(process.cwd()); // reads stale or absent worktree state
+```
+
+**Why:** Worktrees are auto-deleted on cleanup; posture state written there is silently lost. The main checkout is the single source of truth (mitigates red-team CRIT-2).
+
+### 2. Fresh Repo vs. Corrupt State Are Different
+
+Missing `posture.json` AND missing `.initialized` marker → fresh repo, posture = L5 (default trust). Missing or corrupt `posture.json` WITH `.initialized` marker present → fail-closed to L1 (state was deleted/damaged; cannot trust).
+
+**Why:** Without this distinction, an agent that nukes its own state file gets rewarded with full trust on next session. The init marker pinpoints "this repo has run before"; absent state after that is evidence of corruption, not freshness (mitigates red-team CRIT-4).
+
+### 3. Downgrades Are Automatic; Upgrades Are Human-Gated
+
+Downgrades fire on detection — no human in the loop, per EATP "downgrade instantly if conditions change." Upgrades require `/posture upgrade` with a challenge-nonce response from the user (the agent CANNOT self-promote).
+
+**Why:** EATP Mirror Thesis — humans validate against observable execution. An agent that can self-promote has no upper bound on rationalization (mitigates red-team H2/M3).
+
+### 4. Downgrade Triggers (Cumulative + Emergency)
+
+**Cumulative (graceful):**
+
+- 3× same-rule violations in 30-day window → drop one posture
+- 5× total violations in 30-day window → drop one posture
+
+**Emergency (instant downgrade by 1 posture, or to L1 for critical):**
+
+- 1× `regression_within_grace` (violating a rule authored within its 7-day grace period) → drop 1 posture
+- 1× **critical**: destructive op without confirm (rm -rf, git reset --hard without porcelain check, force-push to main); secret leak; cross-repo write outside scope → drop to L1
+- 1× corrupt-state event (with init marker) → drop to L1
+
+**Why:** Cumulative thresholds tolerate noise; emergency triggers reflect rules whose violation IS the worst-case failure mode. `regression_within_grace` is special — violating a rule the agent itself authored within days is the worst kind of self-deception.
+
+### 5. Upgrade Requirements (All Four)
+
+- ≥7 days at current posture (`time_at_current_posture_hours ≥ 168`)
+- 0 violations of the rule class that triggered the most recent downgrade
+- Demonstrated correction: ≥1 session where the agent caught + fixed a same-class issue proactively (logged as positive observation)
+- Human approval via `/posture upgrade` — challenge-nonce paste-back
+
+**Why:** Time alone is gameable (wait it out); zero-violations alone is gameable (avoid the surface); human gate alone is forgeable (agent invokes the slash command itself). All four together close the rationalization loop.
+
+### 6. Grace Period Semantics
+
+When `/codify` authors a rule that addresses a self-reported or detected violation, the rule enters `pending_verification` for 7 days. During grace:
+
+- SessionStart hook injects a high-visibility trust-gate banner naming the rule
+- `detect-violations.js` runs the rule's pattern in `halt-and-report` severity (not observer-only)
+- A violation matching the rule = `regression_within_grace` → emergency downgrade
+
+**Why:** A rule the agent just authored to fix itself, then violates within days, is the loudest possible signal that the rule needs teeth. Grace period turns the new rule from passive prose into active enforcement.
+
+### 7. Trust Posture Wiring Required In Codified Rules
+
+`/codify` MUST attach a "Trust Posture Wiring" section to every new rule proposal: severity tag (`block`/`halt-and-report`/`advisory`), grace-period days, regression-within-grace policy, receipt requirement (whether SessionStart should require `[ack: <rule_id>]`). Proposals without the wiring section are rejected at sync-reviewer Gate 1.
+
+**Why:** A rule without wiring is institutional prose — no automatic enforcement, no detection, no consequences for violation. Wiring is what makes a rule a structural defense rather than a hopeful suggestion.
+
+## MUST NOT
+
+- Edit `.claude/learning/posture.json`, `.claude/learning/posture.json.bak`, or `.claude/learning/violations.jsonl` directly via Edit/Write/Bash. Settings.json `permissions.deny` enforces this.
+
+**Why:** State self-modification is the rationalization loophole that defeats the entire system. The hooks are the only legitimate writers (mitigates red-team CRIT-3).
+
+- Sync `posture.json` or `violations.jsonl` between repos via `/sync` or `/sync-to-build`. State is per-repo.
+
+**Why:** A USE template inheriting BUILD repo's degraded posture would corrupt downstream. Insight (rule patterns) syncs through `/codify`; state stays local (mitigates red-team M1).
+
+- Treat `regression_within_grace` as a routine cumulative violation — it MUST emergency-downgrade.
+
+**Why:** Routing it through the cumulative path lets the agent rationalize "1 of 3, still fine" while violating its own freshly-authored rule. The emergency path closes that gap.
+
+- Self-confess + log + downgrade in one shot from a lexical regex match alone.
+
+**Why:** Lexical patterns ("I missed", "incomplete") are evadable AND false-positive-prone. Self-confession is `advisory`/`post-mortem` only. Real downgrades come from behavioral signals (test-collection exit codes, AST checks, command-history audit) — never from prose alone (mitigates red-team H2).
+
+## Two-Phase Rollout
+
+Phase 1 (current): hooks + state files + observer-mode detection + `/posture` show + emergency triggers live. No `/codify` integration enforcement yet.
+Phase 2 (after ≥10 real sessions exercise the system): `/codify` Trust Posture Wiring requirement enforced; full PreToolUse posture-gate teeth at L2/L3.
+
+**Why:** A meta-rule and its enforcement should never bootstrap in the same release — the rule is then drafted by an agent operating without it (mitigates red-team H4 bootstrapping circularity).
+
+Origin: 2026-05-05 design session, red-team-validated by 21/21 subprocess tests on POC at `.claude/test-harness/trust-posture-poc/`. Grounded in CARE Principle 7 + EATP graduated postures + Mirror Thesis (`skills/co-reference/care-spec.md:65`, `skills/co-reference/eatp-spec.md:42-48`). Tabletop scenario: incomplete-test → user-catch → /codify rule → next-day regression → emergency downgrade L5→L4. See `skills/32-trust-posture/` for procedures.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,24 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"
   },
+  "permissions": {
+    "deny": [
+      "Edit(.claude/learning/posture.json)",
+      "Edit(.claude/learning/posture.json.bak)",
+      "Edit(.claude/learning/violations.jsonl)",
+      "Edit(.claude/learning/violations.jsonl.*)",
+      "Edit(.claude/learning/.initialized)",
+      "Write(.claude/learning/posture.json)",
+      "Write(.claude/learning/posture.json.bak)",
+      "Write(.claude/learning/violations.jsonl)",
+      "Write(.claude/learning/violations.jsonl.*)",
+      "Write(.claude/learning/.initialized)",
+      "Bash(rm:.claude/learning/posture*)",
+      "Bash(rm:.claude/learning/violations*)",
+      "Bash(mv:.claude/learning/posture*)",
+      "Bash(mv:.claude/learning/violations*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -15,11 +33,51 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/validate-bash-command.js\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/posture-gate.js\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/gitignored-claude-warn.js\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/posture-gate.js\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/detect-violations.js\"",
+            "timeout": 5
           }
         ]
       }
     ],
     "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/detect-violations.js\"",
+            "timeout": 5
+          }
+        ]
+      },
       {
         "matcher": "Edit|Write",
         "hooks": [
@@ -47,6 +105,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-framework-first.js\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/detect-violations.js\"",
+            "timeout": 5
           }
         ]
       }
@@ -57,6 +120,11 @@
           {
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.js\""
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/posture-gate.js\"",
+            "timeout": 5
           }
         ]
       }
@@ -88,6 +156,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/user-prompt-rules-reminder.js\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/detect-violations.js\"",
+            "timeout": 5
           }
         ]
       }
@@ -104,6 +177,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/log-triage-gate.js\"",
             "timeout": 7
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/detect-violations.js\"",
+            "timeout": 5
           }
         ]
       }

--- a/.claude/skills/32-trust-posture/SKILL.md
+++ b/.claude/skills/32-trust-posture/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: 32-trust-posture
+description: Graduated trust posture system — five autonomy levels (L1 PSEUDO_AGENT → L5 DELEGATED), violation tracking, automatic downgrade, earned upgrade. MANDATORY consult when authoring rules in /codify, designing /redteam audits, interpreting /implement gates, or asking "should this rule trigger a downgrade?". Auto-loads on /codify, /redteam, /implement, /sweep. Without this skill, rules ship without severity tags / grace periods / downgrade triggers, and the trust system silently degrades to un-instrumented enforcement.
+---
+
+# Trust Posture — Implementation Skill
+
+The contract is `rules/trust-posture.md`. This skill is the **how** — what /codify, /redteam, /implement, and rule authors do to wire a rule into the graduated-trust loop.
+
+## When to load this skill
+
+- Authoring a new rule (anywhere in `/codify`)
+- Designing audit depth (`/redteam`)
+- Interpreting gate behavior (`/implement` halts, `/sweep` reports)
+- Reading or recommending a posture change (`/posture`, `posture-auditor` agent)
+- Reviewing whether a violation pattern should trigger automatic downgrade
+
+If your task is none of the above, this skill is not for you.
+
+## The five-question rule-authoring checklist
+
+Every rule authored by `/codify` MUST answer these in a "Trust Posture Wiring" section. See `rule-authoring-checklist.md` for the canonical format.
+
+1. **Severity** — `block` / `halt-and-report` / `advisory` / `post-mortem`. Use `block` only when the action MUST be physically prevented (PreToolUse + destructive). Use `halt-and-report` when the action already happened but the agent must surface and wait. Use `advisory` for soft warnings. Use `post-mortem` for Stop-class detections (forensic only, surfaces next session).
+2. **Grace period** — 0 days (rule is teeth-from-day-one), 7 days (standard for newly codified rules), 30 days (large surface change requiring migration time). During grace, the rule is in `pending_verification`; SessionStart announces it; violations trigger `regression_within_grace`.
+3. **Receipt requirement** — does the rule warrant `[ack: <rule_id>]` from the agent in the first response of every new session? Reserve for high-stakes rules where evidence shows the agent ignores SessionStart context.
+4. **Cumulative threshold** — default 3× same-rule in 30 days = 1 posture downgrade. Override only if the rule's failure mode is so severe that 1× should emergency-downgrade (e.g., destructive bash without confirm, secret leak).
+5. **Detection mechanism** — regex (lexical), AST (structural), behavioral (cross-reference), or human-only. Lexical alone is `advisory`/`post-mortem`. Auto-downgrade requires structural or behavioral signal.
+
+## Severity decision matrix
+
+| If the action is…                                            | And it's at this hook event… | Severity                                         |
+| ------------------------------------------------------------ | ---------------------------- | ------------------------------------------------ |
+| Destructive + reversible (rm -rf in tmp dir)                 | PreToolUse                   | `block`                                          |
+| Destructive + irreversible (force-push to main, secret leak) | PreToolUse                   | `block`                                          |
+| Already executed (Edit wrote a fastapi import)               | PostToolUse                  | `halt-and-report`                                |
+| Policy violation, file already on disk                       | PostToolUse                  | `halt-and-report`                                |
+| Soft warning, work continues                                 | Pre/PostToolUse              | `advisory`                                       |
+| Detected in agent's final message                            | Stop                         | `post-mortem`                                    |
+| User regression signal in prompt                             | UserPromptSubmit             | `additionalContext` injection (no violation log) |
+
+## What this skill DOES NOT do
+
+- It does NOT define the posture ladder or transition rules — that's `rules/trust-posture.md`.
+- It does NOT define the EATP / CARE / PACT canonical specs — that's `skills/co-reference/`.
+- It does NOT implement the hooks — that's `.claude/hooks/detect-violations.js` + `lib/instruct-and-wait.js`.
+
+## Sub-files
+
+- `codify-integration.md` — what `/codify` reads, writes, and emits per cycle
+- `implement-integration.md` — how `/implement` behaves at L4/L3/L2
+- `redteam-integration.md` — how `/redteam` audit depth scales with posture
+- `rule-authoring-checklist.md` — the canonical "Trust Posture Wiring" section format
+- `posture-spec.md` — data shapes for posture.json, violations.jsonl
+- `grace-period-mechanics.md` — pending_verification lifecycle, regression-within-grace
+
+Origin: 2026-05-05 design session validated by 21/21 subprocess tests; promoted from `.claude/test-harness/trust-posture-poc/`.

--- a/.claude/skills/32-trust-posture/codify-integration.md
+++ b/.claude/skills/32-trust-posture/codify-integration.md
@@ -1,0 +1,52 @@
+# /codify Integration — Trust Posture Wiring
+
+`/codify` MUST consult this file when authoring or amending rules. Without the integration, rules ship without enforcement, and the trust system degrades to un-instrumented prose.
+
+## Mandatory Step at /codify
+
+After pattern extraction and before writing the proposal manifest:
+
+### Step N: Trust Posture Wiring (MUST)
+
+For each candidate rule in this codify cycle:
+
+1. **Read** `.claude/learning/violations.jsonl` (last 30 days). Find self-reported / detected violations whose `addressed_by` is null AND whose root cause matches the candidate rule.
+
+2. **Link** addressed violations to the new rule: update `addressed_by: "rules/<file>.md@<sha>"` for each.
+
+3. **Author** the rule's "Trust Posture Wiring" section using `rule-authoring-checklist.md` format. The section MUST include severity, grace days, cumulative threshold, regression-within-grace policy, detection mechanism.
+
+4. **Append** to `posture.json` `pending_verification` array:
+
+   ```json
+   {
+     "rule_id": "<rule_id>",
+     "since": "<ISO ts>",
+     "grace_period_days": 7,
+     "first_violation": "<vio_id or null>"
+   }
+   ```
+
+5. **Emit** the proposal to `.claude/.proposals/latest.yaml` per `rules/artifact-flow.md`. The proposal entry MUST include the wiring section verbatim. Proposals lacking wiring are rejected at sync-reviewer Gate 1.
+
+## What's grandfathered
+
+Rules that pre-date the trust-posture system do NOT require retroactive wiring. Mark them with `_grandfathered: true` in violations.jsonl entries. New /codify cycles wire only NEW rules.
+
+## How /codify discovers existing pending_verifications
+
+```bash
+node -e "
+const {readPosture} = require('.claude/hooks/lib/state-io.js');
+const p = readPosture(process.cwd());
+console.log(JSON.stringify(p.pending_verification, null, 2));
+"
+```
+
+## Bootstrapping note
+
+The first /codify cycle that ships a rule under this system did NOT itself follow the wiring step (the skill didn't exist yet). That's the only legitimate exception, recorded as the Phase 1 / Phase 2 split in `rules/trust-posture.md`. Every subsequent /codify cycle MUST wire.
+
+## Integration with cc-architect agent
+
+`cc-architect` is the validation pass at /codify. It MUST grep the proposal for the literal string `## Trust Posture Wiring` and verify the section has all 5 fields. Missing → audit failure → /codify halts.

--- a/.claude/skills/32-trust-posture/grace-period-mechanics.md
+++ b/.claude/skills/32-trust-posture/grace-period-mechanics.md
@@ -1,0 +1,78 @@
+# Grace Period Mechanics
+
+When `/codify` authors a rule that addresses a violation, the rule enters `pending_verification` for a grace period (default 7 days). During grace, the rule has heightened detection and emergency-downgrade triggers.
+
+## Lifecycle
+
+```
+/codify authors rule        7 days elapse        rule "graduates"
+       │                          │                    │
+   pending_verification ────────────────────────→  permanent
+       │                          │                    │
+   first_violation logged      grace_clock              standard cumulative threshold applies
+       │                          │
+   ↓ violation matches rule       ↓ no violation
+   │
+   regression_within_grace
+       │
+       ↓
+   EMERGENCY DOWNGRADE (1 posture)
+```
+
+## Detection escalation during grace
+
+| Phase                              | Detector mode                            | Severity at hit                                |
+| ---------------------------------- | ---------------------------------------- | ---------------------------------------------- |
+| Pre-grace (before /codify authors) | Observer-only (logs but doesn't surface) | post-mortem                                    |
+| In-grace (days 1-7)                | Active surface                           | halt-and-report + emergency downgrade          |
+| Post-grace (days 8+)               | Active surface                           | halt-and-report (cumulative threshold applies) |
+
+## SessionStart behavior during grace
+
+`session-start.js` injects via `additionalContext`:
+
+```
+⚠️ TRUST GATE — Verification Pending (Day N of 7)
+
+Rule: <rule_id>
+Authored: <ISO ts> to address <vio_id>
+Cause: <evidence text from violations.jsonl>
+
+This session MUST follow the rule. Hooks will scan for: <detection pattern>
+
+RECEIPT REQUIRED: include `[ack: <rule_id>]` in your first response.
+
+Violation within grace = EMERGENCY DOWNGRADE to <next lower posture>.
+```
+
+## Stale-record skepticism
+
+PreToolUse(Read) on `.session-notes`, `observations.jsonl`, `journal/*` files dated BEFORE the most recent pending_verification rule injects:
+
+```
+⚠️ This file pre-dates rule <rule_id> (authored <date>).
+Any "tests pass" / "complete" / "verified" claim within is UNVERIFIED under the new rule.
+Do not inherit conclusions; re-verify per rule.
+```
+
+This defends against the compound failure: agent inherits its own pre-rule "all-clear" record and assumes the new rule is satisfied.
+
+## Promotion (graduation) logic
+
+After 7 days with zero violations of the rule, the entry is REMOVED from `pending_verification`. The rule is now "permanent" — standard cumulative threshold (3× in 30d) applies. No special SessionStart banner. Detector mode stays active.
+
+Promotion is automatic; no human gate. The rule has earned its place.
+
+## Demotion (rule rollback)
+
+If the rule generates 3+ false positives in grace, `/codify` MAY author a follow-up rule that scopes or repeals the original. The `pending_verification` entry stays until the follow-up replaces it. Repealed rules do NOT graduate — they're flagged as `repealed_at: <ts>` in the rule's frontmatter.
+
+## Multi-rule coordination
+
+Multiple rules in pending_verification simultaneously is normal. SessionStart concatenates banners; receipt token requires `[ack: <rule_id_1>]` + `[ack: <rule_id_2>]`. UserPromptSubmit hook validates each.
+
+`violation_window_30d` tracks each rule independently. A regression on one rule emergency-downgrades by 1; a regression on two simultaneously stacks (drop 2 postures).
+
+## Bootstrapping the very first rule
+
+The first rule authored under this system is `rules/trust-posture.md` itself. It enters `pending_verification` at /codify time with grace period 0 (teeth-from-day-one). Per `rules/trust-posture.md` Phase 1 / Phase 2 rollout, the /codify wiring step doesn't enforce on bootstrap — by design.

--- a/.claude/skills/32-trust-posture/implement-integration.md
+++ b/.claude/skills/32-trust-posture/implement-integration.md
@@ -1,0 +1,47 @@
+# /implement Integration — Posture-Aware Execution
+
+`/implement` MUST consult `posture.json` at session start (the `posture-gate.js` SessionStart hook injects this automatically; this file documents the contract).
+
+## Posture-bound implementation behavior
+
+### L5 DELEGATED — full autonomy
+
+Plan, edit, commit, open PR, run worktree-isolated parallel agents, full /codify. Confirmation required only for: cross-repo writes, release tags, destructive ops (per `rules/git.md`).
+
+### L4 CONTINUOUS_INSIGHT
+
+Same as L5 PLUS:
+
+- Mandatory journal entry per shard (`workspaces/<X>/journal/`)
+- /redteam Round 1 (mechanical sweeps) MUST run before merge
+- Surface posture status in the closing summary of each session
+
+### L3 SHARED_PLANNING
+
+- One shard at a time (no parallel worktree agents)
+- /todos plan approval gate before /implement (re-approve every shard)
+- PR creation requires explicit user instruction
+- Commits to feat/\* branches require explicit user instruction (working-tree edits OK)
+
+### L2 SUPERVISED
+
+- Read-only by default
+- Every Edit/Write requires user instruction in the immediate prior turn
+- Every Bash beyond read-only commands (ls, cat, git status, git diff, gh view) requires instruction
+- Linters/formatters OK without instruction
+
+### L1 PSEUDO_AGENT
+
+- Propose plans + diffs in chat only
+- Zero working-tree mutations
+- The user runs commands; the agent advises
+
+## Reading current posture in /implement
+
+The hooks inject the posture into `additionalContext` at SessionStart. /implement MUST surface it in its first reply:
+
+> "Current posture: L4 CONTINUOUS_INSIGHT (since 2026-05-06, 1 day at this posture). Constraints: mandatory journal per shard, /redteam Round 1 before merge."
+
+## Acknowledgement when pending_verification non-empty
+
+Posture-gate SessionStart injects `[ack: <rule_id>]` requirement when any pending verification is active. /implement MUST emit the literal token in its first response of the session. Failure to emit twice = `acknowledgement_failure` violation logged.

--- a/.claude/skills/32-trust-posture/posture-spec.md
+++ b/.claude/skills/32-trust-posture/posture-spec.md
@@ -1,0 +1,105 @@
+# Posture State Specifications
+
+Data shapes for `posture.json` and `violations.jsonl`. State files live in `<main_checkout>/.claude/learning/`.
+
+## posture.json
+
+```json
+{
+  "posture": "L5_DELEGATED",
+  "since": "2026-05-05T00:00:00.000Z",
+  "transition_history": [
+    {
+      "from": null,
+      "to": "L5_DELEGATED",
+      "type": "INIT",
+      "reason": "fresh repo init via /posture init",
+      "ts": "2026-05-05T00:00:00.000Z",
+      "approved_by": "system"
+    },
+    {
+      "from": "L5_DELEGATED",
+      "to": "L4_CONTINUOUS_INSIGHT",
+      "type": "EMERGENCY_DOWNGRADE",
+      "reason": "regression_within_grace: test-completeness/MUST-1 day 1",
+      "ts": "2026-05-06T09:14:00.000Z",
+      "approved_by": "system"
+    }
+  ],
+  "pending_verification": [
+    {
+      "rule_id": "test-completeness/MUST-1",
+      "since": "2026-05-05T14:30:00.000Z",
+      "grace_period_days": 7,
+      "first_violation": "vio_2026-05-05T14:22_a3f"
+    }
+  ],
+  "violation_window_30d": {
+    "test-completeness/MUST-1": 2,
+    "sweep-completeness/MUST-2": 0
+  },
+  "_initialized": true
+}
+```
+
+### Field semantics
+
+- `posture` — current level; one of L1_PSEUDO_AGENT / L2_SUPERVISED / L3_SHARED_PLANNING / L4_CONTINUOUS_INSIGHT / L5_DELEGATED
+- `since` — ISO timestamp of last transition into current posture
+- `transition_history` — append-only; oldest first; types: INIT / EARNED / EMERGENCY_DOWNGRADE / CUMULATIVE_DOWNGRADE / FAIL_CLOSED / OVERRIDE
+- `pending_verification` — rules in grace period; cleared when grace expires OR when rule promoted to permanent
+- `violation_window_30d` — rolling counter per rule_id; updated on append; pruned at SessionStart for entries older than 30d
+- `_initialized` — distinguishes fresh-repo from corrupted-state (per `rules/trust-posture.md` MUST 2)
+
+### Validation invariants (state-io.js enforces)
+
+- `posture` MUST be in `VALID_POSTURES` set
+- `transition_history[i].from === transition_history[i-1].to` (chain consistency)
+- `pending_verification[].grace_period_days` between 0 and 30
+- `violation_window_30d` keys all present in either history or pending list
+
+## violations.jsonl (append-only JSONL)
+
+One JSON object per line. Each line ≤2KB (POSIX atomic-append safety).
+
+```json
+{
+  "id": "vio_1715000000_a3f",
+  "timestamp": "2026-05-05T14:22:00.000Z",
+  "session_id": "abc-123",
+  "repo": "/Users/esperie/repos/loom",
+  "rule_id": "test-completeness/MUST-1",
+  "severity": "halt-and-report",
+  "evidence": "agent ran `pytest tests/unit/` only; spec required tier 2",
+  "posture_at_time": "L5_DELEGATED",
+  "addressed_by": null,
+  "type": "detected"
+}
+```
+
+### Field semantics
+
+- `id` — globally unique; format `vio_<unix_ms>_<random_hex>`
+- `severity` — block / halt-and-report / advisory / post-mortem
+- `evidence` — truncated to keep line ≤2KB; `_truncated: true` set if so
+- `posture_at_time` — repo's posture when violation fired (forensic; downgrade decisions use current posture)
+- `addressed_by` — null until /codify links to a rule; format `rules/<file>.md@<commit_sha>`
+- `type` — one of `detected` (regex/AST hit), `self_reported` (Stop-hook self-confession scan), `acknowledgement_failure` (missing receipt token), `regression_within_grace` (grace-period violation)
+
+### Rotation
+
+violations.jsonl rotates at 10MB or 90 days, whichever first. Old file → `violations.jsonl.YYYY-MM`. Posture decisions consider only last 30d window regardless.
+
+## File-system layout
+
+```
+<main_checkout>/.claude/learning/
+├── posture.json              # current state (denied to agent edits)
+├── posture.json.bak          # write-ahead backup
+├── violations.jsonl          # append-only log (denied to agent edits)
+├── violations.jsonl.YYYY-MM  # rotated archives
+├── observations.jsonl        # existing accomplishments log
+└── .initialized              # marker; absence + missing posture.json = fresh repo
+```
+
+`permissions.deny` in `.claude/settings.json` blocks Edit/Write/Bash(rm|mv|cat>) against the first three.

--- a/.claude/skills/32-trust-posture/redteam-integration.md
+++ b/.claude/skills/32-trust-posture/redteam-integration.md
@@ -1,0 +1,48 @@
+# /redteam Integration — Posture-Scaled Audit Depth
+
+/redteam audit rigor scales with posture. Higher trust = lighter touch; lower trust = full red-team.
+
+## Audit Depth By Posture
+
+| Posture               | /redteam mandatory rounds                                                                                          | Optional rounds                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------- |
+| L5 DELEGATED          | Round 1 OPTIONAL (agent's discretion)                                                                              | Round 2+ on agent's discretion      |
+| L4 CONTINUOUS_INSIGHT | **Round 1 MANDATORY** before merge — mechanical sweeps (grep, AST, pytest --collect-only, file-existence)          | Round 2 closure-parity recommended  |
+| L3 SHARED_PLANNING    | **Round 1 + Round 2 MANDATORY** — closure-parity verification of every prior-round finding                         | Round 3 spec-compliance recommended |
+| L2 SUPERVISED         | **Full red-team (Round 1+2+3) MANDATORY** — including spec compliance grep against every pending_verification rule | Round 4 if surface > 1000 LOC       |
+| L1 PSEUDO_AGENT       | **N/A** — no autonomous /implement to red-team. /redteam invocations at L1 are advisory simulation only            |
+
+## Mechanical Sweeps (Round 1)
+
+Per `rules/agents.md` "Reviewer Mechanical Sweeps":
+
+- `grep -c` parity on critical call-site patterns
+- `pytest --collect-only -q` exit 0 across all test dirs
+- Every public symbol in `__all__` added by this PR has an eager import
+- AST-walk every `Literal[...]` / `Enum`-valued dispatch parameter; confirm exhaustive branches
+- Grep `.claude/learning/violations.jsonl` for unaddressed entries from current session
+
+## Closure-Parity (Round 2)
+
+Per `rules/agents.md` "Audit/Closure-Parity Verification Specialist":
+
+- For every prior-round finding, run gh pr view / gh pr diff / pytest --collect-only
+- Convert FORWARDED rows to VERIFIED with command output evidence
+- Specialist MUST be Bash+Read equipped (pact-specialist or general-purpose, NOT analyst)
+
+## Spec Compliance (Round 3)
+
+Per `rules/specs-authority.md`:
+
+- For every promise in `specs/`, extract literal assertions (class signatures, field names, test names)
+- AST-parse / grep the actual code; compute compliance percentage
+- < 100% = block; feed gaps back to /implement
+
+## Posture-aware /redteam invocation
+
+```bash
+# /redteam reads posture.json automatically; explicit posture override:
+/redteam --posture L4   # forces L4 audit depth even if posture.json says L5
+```
+
+The invocation logs a violation if the agent attempts to UNDER-audit (e.g., running Round 1 only at L3 posture).

--- a/.claude/skills/32-trust-posture/rule-authoring-checklist.md
+++ b/.claude/skills/32-trust-posture/rule-authoring-checklist.md
@@ -1,0 +1,75 @@
+# Rule Authoring Checklist — "Trust Posture Wiring" Section Format
+
+Every rule authored by `/codify` after Phase 2 cutover MUST end with the section below. cc-architect rejects proposals lacking it.
+
+## Canonical Format
+
+```markdown
+## Trust Posture Wiring
+
+- **Severity:** halt-and-report
+- **Grace period:** 7 days
+- **Cumulative threshold:** 3× same-rule violations in 30d → 1 posture downgrade
+- **Regression-within-grace policy:** emergency downgrade (1 posture)
+- **Receipt requirement:** No (rule is purely behavioral, not procedural)
+- **Detection mechanism:** regex on agent's final message (Stop hook); pattern: `<regex or AST predicate>`
+- **First violation triggering this rule:** vio_2026-05-05T14:22_a3f
+- **Origin evidence date:** 2026-05-05
+```
+
+## Field Reference
+
+### Severity (one of)
+
+- `block` — PreToolUse only; tool call physically prevented; reserved for destructive + irreversible
+- `halt-and-report` — tool already executed; agent must surface and wait; default for policy violations
+- `advisory` — soft warning; agent acknowledges, may proceed
+- `post-mortem` — Stop-class detection; forensic only, surfaces at next SessionStart
+
+### Grace period (integer days)
+
+- `0` — teeth-from-day-one (use only for high-stakes rules with broad consensus, e.g., security)
+- `7` — standard for newly codified rules
+- `30` — large surface change requiring migration
+
+### Cumulative threshold
+
+Default `3× same-rule in 30d → 1 posture downgrade`. Override only if 1× should emergency-downgrade.
+
+### Regression-within-grace policy
+
+- `emergency downgrade (1 posture)` — default; loud signal that agent violated its own freshly-authored rule
+- `emergency downgrade to L1` — if the rule prevents a critical failure mode (secret leak, destructive op)
+- `cumulative only` — explicitly disable the within-grace fast-path (rare; requires justification)
+
+### Receipt requirement
+
+- `Yes` — SessionStart will require `[ack: <rule_id>]` from agent's first response
+- `No` — rule is detected at runtime; receipt would add friction without benefit
+
+### Detection mechanism
+
+Concrete predicate. Regex string, AST node-type, behavioral signal, or "human-only" if no automated detection exists. Lexical alone → advisory/post-mortem only.
+
+### First violation triggering this rule
+
+`vio_<id>` from violations.jsonl, or `null` if rule is preventive (no violation yet).
+
+### Origin evidence date
+
+ISO date of the session/incident that motivated the rule. Required for `git log --grep` traceability.
+
+## Worked Example (the trust-posture rule itself)
+
+```markdown
+## Trust Posture Wiring
+
+- **Severity:** halt-and-report (Phase 2: posture-gate adds PreToolUse block teeth)
+- **Grace period:** 0 (foundational rule; teeth-from-day-one)
+- **Cumulative threshold:** 1× violation = 1 posture downgrade (state-file edit attempt)
+- **Regression-within-grace policy:** N/A (no grace)
+- **Receipt requirement:** Yes — `[ack: trust-posture/MUST-1]`
+- **Detection mechanism:** PreToolUse(Edit|Write|Bash) regex against `.claude/learning/(posture|violations)`
+- **First violation triggering this rule:** null (preventive)
+- **Origin evidence date:** 2026-05-05
+```


### PR DESCRIPTION
## Summary

Loom 2.17.0 sync down to BUILD repo. Per `.claude/VERSION` 1.0.6 changelog (loom sha `76a3bfc`, synced 2026-05-05): graduated per-repo trust-posture system with automatic downgrade + human-gated upgrade.

**NEW artifacts:**

- `rules/trust-posture.md` (priority:10, path-scoped) — 7 MUST clauses defining the L1_PSEUDO_AGENT → L5_DELEGATED ladder, transition triggers (cumulative 3× same-rule = 1 downgrade; 1× critical = emergency to L1; regression-within-grace = emergency 1 posture), upgrade requirements (≥7d at posture, 0 same-class violations, demonstrated correction, human approval via `/posture upgrade` challenge-nonce paste-back).
- `skills/32-trust-posture/` — 7 files: SKILL.md, codify-integration, implement-integration, redteam-integration, rule-authoring-checklist, posture-spec, grace-period-mechanics.
- `commands/posture.md` — show / history / violations / init / upgrade / override.
- `agents/management/posture-auditor.md` — read-only weekly audit; cannot self-modify state.
- `hooks/detect-violations.js` + `hooks/posture-gate.js` — wired across PreToolUse (Read/Bash/Edit/Write) + PostToolUse + SessionStart + Stop + UserPromptSubmit.

**MODIFIED:**

- Hooks: `validate-bash-command.js` (+3 patterns + segment-anchored regex + three-layer state-file mutation detection per Layer 1 redirects/heredoc/tee/sed -i, Layer 2 cp/mv/dd/rsync/install/truncate/ln, Layer 3 interpreter -c/-e/-m bodies), `enforce-framework-first.js` + `validate-workflow.js` + `validate-deployment.js` refactored through `instruct-and-wait`, `session-start.js` trust-posture additionalContext, `session-end.js` + `pre-compact.js` stderr summary lines.
- Commands: `codify.md` Step 6b ENFORCED Trust Posture Wiring requirement, `redteam.md` Step 0 posture-aware audit depth (L4 = Round 1, L3 = Round 1+2, L2 = full red-team).
- Agent: `cc-architect.md` Audit Dimension 5 mechanical wiring grep sweep.
- `settings.json` — NEW `permissions.deny` block on `.claude/learning/{posture.json, posture.json.bak, violations.jsonl, .initialized}`; both new hooks wired.

**Excluded from sync (per-repo runtime state, NEVER synced):** `.claude/learning/posture.json`, `.claude/learning/.initialized`, `.claude/learning/violations.jsonl`. Initialized at L5_DELEGATED on first `/posture init` or first session-start hook run.

**Two-phase rollout** per `rules/trust-posture.md`:

- Phase 1 (this release): hooks + state files + observer-mode detection + emergency triggers live. No `/codify` integration enforcement yet.
- Phase 2 (after ≥1 month real-session bake): full PreToolUse posture-gate teeth at L2/L3.

Self-applies the new Rule 1a carve-out from PR #830 — `.claude/`-only diff, no source-tree changes, no `/release` cycle.

## Test plan

- [x] Pre-commit gates passed (YAML / JSON syntax, trailing whitespace, EOF, merge-conflicts, large-files, TODO-NNN markers, Tier 1 unit tests, doc-style)
- [x] `.claude/VERSION` 1.0.6 records the sync (loom 2.14.4 → 2.17.0)
- [ ] Reviewer confirms `permissions.deny` paths match the state-file exclusion list in `rules/trust-posture.md` MUST 7 (`posture.json`, `posture.json.bak`, `violations.jsonl`, `violations.jsonl.*`, `.initialized`)
- [ ] Reviewer confirms hook wiring in `settings.json` matches the integration map in `skills/32-trust-posture/posture-spec.md`
- [ ] Post-merge: `node .claude/hooks/posture-gate.js --self-test` (if a CLI mode exists) OR session-start hook run verifies posture initialization at L5_DELEGATED (per `rules/trust-posture.md` MUST 2)

## Related issues

- Origin: 2026-05-05 loom design session grounded in CARE Principle 7 (Evolutionary Trust) + EATP graduated postures + Mirror Thesis (`skills/co-reference/care-spec.md:65`, `skills/co-reference/eatp-spec.md:42-48`).
- Red-team validated upstream: 2 adversarial review agents + 37/37 subprocess tests at loom `.claude/test-harness/trust-posture-poc/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)