### PR TITLE
fix(dataflow): validate workflow.name before filename interpolation (2.7.7 → 2.7.8)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,27 @@
 # DataFlow Changelog
 
+## [2.7.8] — 2026-05-06 — CLI generate command: filename validation hardening
+
+Patch release closing a Tier-1 test isolation bug AND the production code path that allowed it. Bug fix; no API surface change; no migration required.
+
+### Fixed
+
+- **CLI `dataflow generate docs` no longer accepts unsafe `workflow.name` values for filename interpolation.** `dataflow.cli.generate.docs` previously interpolated `workflow.name` directly into the output filename via `f"{workflow.name}.md"`. Any non-string, path-traversal substring (`..`), or filesystem-unsafe character (`/`, `\`, control chars, shell metacharacters) was written to disk verbatim. Now routes through `dataflow.utils.filenames.safe_workflow_filename(name, ext)` which validates against `^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`, rejects path-traversal substrings, and raises `WorkflowNameError` (a `ValueError` subclass) on any invalid input.
+
+### Added
+
+- **NEW: `dataflow.utils.filenames`** — public helper module exporting `safe_workflow_filename()` and `WorkflowNameError`. Same trust-boundary discipline as `dialect.quote_identifier()` for SQL identifiers, applied to filesystem identifiers. Logs at WARN with a hashed `sha256[:8]` fingerprint on rejection (per `observability.md` Rule 8 — the raw input is never echoed to logs).
+- **NEW: 52 Tier-1 regression tests** at `tests/unit/utils/test_filenames.py` pinning the helper's accept/reject contract: 9 accepted forms, 23 rejected forms (path-traversal, control chars, shell metacharacters, length cap, Unicode bidi-override, non-string, Mock-repr leak vector), 9 extension validation cases, plus error-message and logging hygiene assertions.
+- **NEW regression test** `test_generate_documentation_rejects_unsafe_workflow_name` at `tests/unit/cli/test_generate_command.py` — exercises the historical Mock-leak vector end-to-end through the Click runner; asserts `exit_code == 2` and zero `<Mock` files written.
+
+### Changed
+
+- **`tests/unit/cli/test_generate_command.py`** — replaced `Mock(name="test_workflow")` (which sets the Mock's repr-name, NOT `.name`) with a `_make_workflow_mock()` helper that constructs the Mock then assigns `.name = "test_workflow"` post-construction. The `docs` test now uses `tmp_path` for `--output-dir` (per `tests/unit/CLAUDE.md` Tier-1 filesystem-isolation contract); previously pointed at the real `./docs/` directory and `Path.write_text` (used by `generate.py`) is NOT intercepted by `patch("builtins.open", mock_open())`.
+
+### Origin
+
+108 orphan `<Mock name='test_workflow.name' id='*'>.md` files accumulated under `docs/` (107) and `packages/kailash-dataflow/docs/` (1) since 2026-04-15 because the `unittest.mock.Mock(name=...)` API surface diverges from caller expectation: the `name=` kwarg sets the Mock's repr-name, NOT the `.name` attribute. Production code that f-strings `workflow.name` into a filename interpolated the child-Mock's `__str__` ("`<Mock name='test_workflow.name' id='...'>`") into a real path. Fix is two-layered: (a) the production code now validates at the trust boundary regardless of test-side correctness, (b) the test correctly constructs the Mock and uses `tmp_path`. Workspace `issue-829-kaizen-llm-first-traits/journal/0005-DECISION-codify-loopback-close-after-loom-sync-2.20.0.md` § F4 captures the discovery and the orphan-file cleanup.
+
 ## [2.7.7] — 2026-05-04 — engine.py pyright cleanup (dataflow-engine-pyright-cleanup workspace)
 
 Patch release cutting PyPI for the dataflow-engine-pyright-cleanup workspace (T1–T8). Static-analysis-only diff: brings `engine.py` from `5 errors, 56 warnings` to `0 errors, 8 warnings` against pinned `pyright==1.1.371`.

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.7.7"
+version = "2.7.8"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -108,7 +108,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.7.7"
+__version__ = "2.7.8"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/cli/generate.py
+++ b/packages/kailash-dataflow/src/dataflow/cli/generate.py
@@ -7,11 +7,12 @@ Generates workflow reports, diagrams, and documentation.
 import json
 import sys
 from pathlib import Path
-from typing import Any
 
 import click
+
 from dataflow.cli.output import get_formatter
 from dataflow.cli.validate import load_workflow
+from dataflow.utils.filenames import safe_workflow_filename
 
 
 @click.group()
@@ -152,8 +153,11 @@ def docs(workflow_path: str, output_dir: str):
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
 
-        # Write documentation
-        doc_file = output_path / f"{workflow.name}.md"
+        # Write documentation. Route workflow.name through the validation
+        # helper so a malformed name (path-traversal, filesystem-unsafe chars,
+        # Mock-object repr leaked from a fixture) raises WorkflowNameError
+        # BEFORE the filesystem touch — see dataflow.utils.filenames.
+        doc_file = output_path / safe_workflow_filename(workflow.name, "md")
         doc_file.write_text(docs_content)
 
         formatter.print_success(f"Documentation generated in {output_dir}/")

--- a/packages/kailash-dataflow/src/dataflow/utils/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/utils/__init__.py
@@ -1,6 +1,7 @@
 """DataFlow Utilities."""
 
 from .connection import ConnectionManager
+from .filenames import WorkflowNameError, safe_workflow_filename
 from .suppress_warnings import (
     configure_dataflow_logging,
     dataflow_logging_context,
@@ -14,6 +15,9 @@ from .suppress_warnings import (
 __all__ = [
     # Connection management
     "ConnectionManager",
+    # Filesystem-safe filename construction
+    "WorkflowNameError",
+    "safe_workflow_filename",
     # Logging utilities
     "configure_dataflow_logging",
     "restore_dataflow_logging",

--- a/packages/kailash-dataflow/src/dataflow/utils/filenames.py
+++ b/packages/kailash-dataflow/src/dataflow/utils/filenames.py
@@ -1,0 +1,155 @@
+"""Filesystem-safe filename construction for workflow-derived outputs.
+
+DataFlow CLI commands that derive a filesystem path from
+``workflow.name`` (or any other dynamic, user-influenced string)
+MUST use :func:`safe_workflow_filename` to validate the input
+against a strict allowlist before interpolating it into a
+:class:`pathlib.Path`. Direct interpolation
+(``f"{workflow.name}.md"``) is BLOCKED — unvalidated names can be
+path-traversal vectors, can contain filesystem-unsafe characters,
+or can be a Mock-object repr leaked from a test fixture.
+
+This is the filename-surface sibling of
+``rules/dataflow-identifier-safety.md`` MUST Rule 1
+(``dialect.quote_identifier()`` for SQL) and
+``rules/security.md`` § "Input Validation" — same "validate at the
+trust boundary" principle, applied to filesystem identifiers.
+
+Origin: 2026-05-06 — ``Mock(name="X")`` does NOT set ``Mock.name``;
+accessing ``.name`` returns a child Mock whose ``__str__`` is
+``<Mock name='X.name' id='...'>``. ``generate.py:156`` interpolated
+this into a real filename, leaking 108 orphan files into ``docs/``
+across the repo before this helper landed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+# Filesystem-safe allowlist for workflow names:
+#   - First char: alphanumeric or underscore (no leading dot, no leading hyphen)
+#   - Remaining chars: alphanumeric, underscore, hyphen, dot
+#   - Length 1..128 (conservative across POSIX/NTFS/HFS+; FS limit is 255 but
+#     workflow names that long are almost certainly bugs)
+_WORKFLOW_NAME_RE: Final = re.compile(r"^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$")
+
+# Path-traversal substring that the regex above CAN technically allow
+# (e.g. "x..y" matches the regex but contains "..", which on some
+# filesystems produces ambiguous traversal behavior).
+_PATH_TRAVERSAL_SUBSTR: Final = ".."
+
+# Extension allowlist: short alphanumeric only (md, json, txt, html, csv, ...)
+_EXT_RE: Final = re.compile(r"^[A-Za-z0-9]{1,16}$")
+
+
+class WorkflowNameError(ValueError):
+    """Raised when a workflow name is unsafe to interpolate into a filename.
+
+    The exception message NEVER echoes the raw offending name (that
+    would be a log-poisoning / stored-XSS vector for user-influenced
+    inputs); instead it carries a short ``sha256[:8]`` fingerprint
+    of the input for forensic correlation across logs.
+
+    Subclass of :class:`ValueError` so callers that catch
+    ``ValueError`` continue to work.
+    """
+
+
+def _fingerprint(raw: object) -> str:
+    """Return ``sha256[:8]`` of ``str(raw)`` (best-effort, never raises)."""
+    try:
+        encoded = str(raw).encode("utf-8", errors="replace")
+    except Exception:  # pragma: no cover — defensive; str() can rarely fail
+        return "________"
+    return hashlib.sha256(encoded).hexdigest()[:8]
+
+
+def safe_workflow_filename(name: object, ext: str) -> str:
+    """Return a filesystem-safe ``"<name>.<ext>"`` filename or raise.
+
+    Parameters
+    ----------
+    name
+        The workflow name. MUST be a string matching
+        ``^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`` AND MUST NOT contain
+        the substring ``..``.
+    ext
+        File extension WITHOUT the leading dot (``"md"``, not
+        ``".md"``). MUST match ``^[A-Za-z0-9]{1,16}$``.
+
+    Returns
+    -------
+    str
+        A filename of the form ``"<name>.<ext>"`` safe to interpolate
+        into ``Path()`` joins.
+
+    Raises
+    ------
+    WorkflowNameError
+        When ``name`` is not a string, is empty, exceeds 128 chars,
+        contains characters outside the allowlist, contains the
+        path-traversal substring ``..``, or when ``ext`` fails its
+        own allowlist. Logs at WARN with a hashed fingerprint
+        (per ``rules/observability.md`` Rule 8 — never log the raw
+        name, which may be a schema identifier).
+    """
+    # Validate ext first (fixed-form internal parameter, fast reject).
+    if not isinstance(ext, str) or not _EXT_RE.match(ext):
+        raise WorkflowNameError(
+            "invalid extension: must be 1-16 alphanumeric chars "
+            f"(fingerprint={_fingerprint(ext)})"
+        )
+
+    fp = _fingerprint(name)
+
+    if not isinstance(name, str):
+        logger.warning(
+            "filename.invalid_workflow_name",
+            extra={
+                "reason": "not_a_string",
+                "fingerprint": fp,
+                "type": type(name).__name__,
+            },
+        )
+        raise WorkflowNameError(
+            f"workflow name must be a string (got {type(name).__name__}, "
+            f"fingerprint={fp}). This often indicates a Mock object whose "
+            "`.name` attribute returned a child Mock — use "
+            "`mock.name = 'X'` (post-construction) instead of "
+            "`Mock(name='X')`, which sets the Mock's repr-name, NOT `.name`."
+        )
+
+    if _PATH_TRAVERSAL_SUBSTR in name:
+        logger.warning(
+            "filename.invalid_workflow_name",
+            extra={"reason": "path_traversal", "fingerprint": fp},
+        )
+        raise WorkflowNameError(
+            "workflow name contains path-traversal substring '..' "
+            f"(fingerprint={fp})"
+        )
+
+    if not _WORKFLOW_NAME_RE.match(name):
+        logger.warning(
+            "filename.invalid_workflow_name",
+            extra={
+                "reason": "regex_mismatch",
+                "fingerprint": fp,
+                "length": len(name),
+            },
+        )
+        raise WorkflowNameError(
+            "workflow name failed allowlist validation: must match "
+            r"`^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$` "
+            f"(fingerprint={fp}, length={len(name)})"
+        )
+
+    return f"{name}.{ext}"
+
+
+__all__ = ["WorkflowNameError", "safe_workflow_filename"]

--- a/packages/kailash-dataflow/tests/unit/cli/test_generate_command.py
+++ b/packages/kailash-dataflow/tests/unit/cli/test_generate_command.py
@@ -3,12 +3,36 @@ Unit tests for CLI generate command.
 
 Tests the dataflow-generate command for report generation,
 diagram creation, and documentation generation.
+
+Mock-construction discipline (origin: 2026-05-06 docs/Mock leak):
+``Mock(name="X")`` does NOT set ``Mock.name`` — the ``name=`` kwarg
+configures the Mock's repr-name (used in str/repr), and ``.name``
+remains a child Mock. Code that f-strings the workflow's ``.name``
+into a filename leaks ``"<Mock name='test_workflow.name' id='...'>.md"``
+to disk. ALWAYS construct via ``mock = Mock(...); mock.name = "X"``
+post-construction.
+
+Filesystem-isolation discipline (per ``tests/unit/CLAUDE.md`` Tier 1):
+the ``docs`` subcommand calls ``Path.write_text`` which is NOT
+intercepted by ``patch("builtins.open", ...)``. Any test exercising
+that path MUST point ``--output-dir`` at ``tmp_path`` so writes are
+bounded and auto-cleaned by pytest.
 """
 
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
+
+
+def _make_workflow_mock(*, nodes, connections, name="test_workflow"):
+    """Build a Mock workflow with `.name` set CORRECTLY.
+
+    See module docstring on why ``Mock(name=...)`` is wrong here.
+    """
+    mock_workflow = Mock(nodes=nodes, connections=connections)
+    mock_workflow.name = name  # post-construction assignment, NOT Mock(name=)
+    return mock_workflow
 
 
 class TestGenerateCommand:
@@ -50,10 +74,9 @@ class TestGenerateCommand:
         from dataflow.cli.commands import generate
 
         with patch("dataflow.cli.generate.load_workflow") as mock_load:
-            mock_load.return_value = Mock(
+            mock_load.return_value = _make_workflow_mock(
                 nodes=workflow_data["nodes"],
                 connections=workflow_data["connections"],
-                name="test_workflow",
             )
 
             with patch("dataflow.platform.inspector.Inspector") as mock_inspector:
@@ -87,10 +110,9 @@ class TestGenerateCommand:
         from dataflow.cli.commands import generate
 
         with patch("dataflow.cli.generate.load_workflow") as mock_load:
-            mock_load.return_value = Mock(
+            mock_load.return_value = _make_workflow_mock(
                 nodes=workflow_data["nodes"],
                 connections=workflow_data["connections"],
-                name="test_workflow",
             )
 
             with patch("dataflow.platform.inspector.Inspector") as mock_inspector:
@@ -112,7 +134,7 @@ class TestGenerateCommand:
                 assert "node1" in result.output
                 assert "node2" in result.output
 
-    def test_generate_documentation_command(self, runner, workflow_data):
+    def test_generate_documentation_command(self, runner, workflow_data, tmp_path):
         """
         Test generate command creates workflow documentation.
 
@@ -120,14 +142,16 @@ class TestGenerateCommand:
         - Generates markdown documentation
         - Includes node descriptions, parameters
         - Saves to output directory
+        - Filename derives from validated `workflow.name` via
+          `safe_workflow_filename` (rejects path-traversal,
+          filesystem-unsafe chars, Mock-repr leaks).
         """
         from dataflow.cli.commands import generate
 
         with patch("dataflow.cli.generate.load_workflow") as mock_load:
-            mock_load.return_value = Mock(
+            mock_load.return_value = _make_workflow_mock(
                 nodes=workflow_data["nodes"],
                 connections=workflow_data["connections"],
-                name="test_workflow",
             )
 
             with patch("dataflow.platform.inspector.Inspector") as mock_inspector:
@@ -151,13 +175,73 @@ class TestGenerateCommand:
                     docs_content
                 )
 
-                with patch("builtins.open", mock_open()) as mock_file:
-                    result = runner.invoke(
-                        generate, ["docs", "workflow.py", "--output-dir", "./docs"]
-                    )
+                # tmp_path bounds the filesystem write so it auto-cleans.
+                # `Path.write_text` (used by generate.py:159) is NOT caught
+                # by `patch("builtins.open", mock_open())`, so we point the
+                # real write at pytest's tmp dir.
+                output_dir = tmp_path / "docs"
+                result = runner.invoke(
+                    generate,
+                    ["docs", "workflow.py", "--output-dir", str(output_dir)],
+                )
 
-                    assert result.exit_code == 0
-                    assert (
-                        "documentation" in result.output.lower()
-                        or "generated" in result.output.lower()
+                assert result.exit_code == 0
+                assert (
+                    "documentation" in result.output.lower()
+                    or "generated" in result.output.lower()
+                )
+                # Verify the file landed under tmp_path with the validated name.
+                doc_file = output_dir / "test_workflow.md"
+                assert doc_file.exists(), (
+                    f"expected {doc_file} to exist, got "
+                    f"{list(output_dir.glob('*.md')) if output_dir.exists() else 'no dir'}"
+                )
+                assert "test_workflow" in doc_file.read_text()
+
+    def test_generate_documentation_rejects_unsafe_workflow_name(
+        self, runner, workflow_data, tmp_path
+    ):
+        """
+        Regression for 2026-05-06 docs/Mock leak.
+
+        When `workflow.name` is not a string (e.g. a Mock object whose
+        `.name` returned a child Mock), the docs command MUST raise
+        rather than write `<Mock name='...' id='...'>.md` to disk.
+        """
+        from dataflow.cli.commands import generate
+
+        # Reproduce the historical bug: Mock(name="X") sets repr-name,
+        # NOT .name — so .name returns a child Mock that f-strings to
+        # `<Mock name='X.name' id='...'>` if the helper doesn't validate.
+        bad_mock = Mock(
+            nodes=workflow_data["nodes"],
+            connections=workflow_data["connections"],
+            name="test_workflow",  # WRONG — does not set .name to "test_workflow"
+        )
+
+        with patch("dataflow.cli.generate.load_workflow") as mock_load:
+            mock_load.return_value = bad_mock
+
+            with patch("dataflow.platform.inspector.Inspector") as mock_inspector:
+                mock_inspector.return_value.generate_documentation.return_value = "x"
+
+                output_dir = tmp_path / "docs"
+                result = runner.invoke(
+                    generate,
+                    ["docs", "workflow.py", "--output-dir", str(output_dir)],
+                )
+
+                # Click runner returns exit_code 2 when the command's
+                # except-Exception branch fires after WorkflowNameError.
+                assert result.exit_code == 2, result.output
+                # And — the critical assertion — NO Mock-repr file was written.
+                if output_dir.exists():
+                    leaked = [
+                        p.name
+                        for p in output_dir.iterdir()
+                        if p.name.startswith("<Mock")
+                    ]
+                    assert leaked == [], (
+                        f"safe_workflow_filename failed to reject Mock-repr "
+                        f"input — leaked files: {leaked}"
                     )

--- a/packages/kailash-dataflow/tests/unit/utils/test_filenames.py
+++ b/packages/kailash-dataflow/tests/unit/utils/test_filenames.py
@@ -1,0 +1,187 @@
+"""Tier-1 regression tests for ``dataflow.utils.filenames``.
+
+Origin: 2026-05-06 — ``Mock(name="X")`` does NOT set ``Mock.name``;
+accessing ``.name`` returns a child Mock whose ``__str__`` is
+``<Mock name='X.name' id='...'>``. ``generate.py:156`` interpolated
+this into a real filename, leaking 108 orphan files into ``docs/``
+across the repo. ``safe_workflow_filename`` is the structural
+defense; this suite pins its allowlist + reject behavior so a
+future loosening of the regex re-opens the leak loudly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from dataflow.utils.filenames import WorkflowNameError, safe_workflow_filename
+
+
+class TestSafeWorkflowFilenameAccepts:
+    """Names that MUST be accepted (sample of the production allowlist)."""
+
+    @pytest.mark.parametrize(
+        "name,ext,expected",
+        [
+            ("test_workflow", "md", "test_workflow.md"),
+            ("a", "md", "a.md"),
+            ("My_Workflow_2026", "md", "My_Workflow_2026.md"),
+            ("workflow-v1.2.3", "md", "workflow-v1.2.3.md"),
+            ("_underscore_first", "md", "_underscore_first.md"),
+            ("digits_123", "md", "digits_123.md"),
+            ("X" * 128, "md", "X" * 128 + ".md"),  # exactly 128 chars
+            ("workflow", "json", "workflow.json"),
+            ("workflow", "html", "workflow.html"),
+        ],
+    )
+    def test_accepts_valid(self, name, ext, expected):
+        assert safe_workflow_filename(name, ext) == expected
+
+
+class TestSafeWorkflowFilenameRejects:
+    """Names that MUST be rejected (the historical leak vectors + injection vectors)."""
+
+    @pytest.mark.parametrize(
+        "bad_name,why",
+        [
+            ("", "empty string"),
+            (" ", "whitespace only"),
+            (".", "single dot (current dir)"),
+            ("..", "double dot (parent dir / path traversal)"),
+            (".hidden", "leading dot (hidden file)"),
+            ("-leading-hyphen", "leading hyphen (looks like CLI flag)"),
+            ("name with space", "embedded space"),
+            ("name/slash", "POSIX path separator"),
+            ("name\\backslash", "Windows path separator"),
+            ("../etc/passwd", "explicit path traversal"),
+            ("foo..bar", "embedded path-traversal substring"),
+            ("name\x00null", "null byte injection"),
+            ("name\nnewline", "control char (newline)"),
+            ("name\ttab", "control char (tab)"),
+            ("name@symbol", "shell-metachar @"),
+            ("name;semicolon", "shell-metachar ;"),
+            ("name|pipe", "shell-metachar |"),
+            ("name`backtick`", "shell-metachar backtick"),
+            ("name$variable", "shell-metachar $"),
+            ("X" * 129, "exceeds 128-char length cap"),
+            ("X" * 1000, "extreme length"),
+            ("‮" + "rtl_override", "Unicode bidi-override"),
+            ("résumé", "Unicode letters (allowlist is ASCII-only)"),
+        ],
+    )
+    def test_rejects_unsafe_strings(self, bad_name, why):
+        with pytest.raises(WorkflowNameError, match=r"workflow name"):
+            safe_workflow_filename(bad_name, "md")
+        # `why` is consumed in the failure message via parametrize id;
+        # binding it here keeps it accessible to debuggers + linters.
+        assert isinstance(why, str)
+
+    @pytest.mark.parametrize(
+        "bad_input",
+        [
+            None,
+            123,
+            12.5,
+            ["test_workflow"],
+            {"name": "test_workflow"},
+            object(),
+        ],
+    )
+    def test_rejects_non_string(self, bad_input):
+        with pytest.raises(WorkflowNameError):
+            safe_workflow_filename(bad_input, "md")
+
+    def test_rejects_mock_object_directly(self):
+        """Regression for the originating leak (2026-05-06).
+
+        ``Mock(name="test_workflow")`` does NOT set ``Mock.name``; accessing
+        ``.name`` returns a child Mock that f-strings to
+        ``<Mock name='test_workflow.name' id='...'>``. The helper MUST
+        reject the child Mock, NOT silently produce a Mock-repr filename.
+        """
+        mock = Mock(name="test_workflow")
+        with pytest.raises(WorkflowNameError):
+            safe_workflow_filename(mock.name, "md")
+
+    def test_accepts_mock_with_name_set_correctly(self):
+        """Sanity: the CORRECT Mock-construction pattern (post-assignment) works."""
+        mock = Mock()
+        mock.name = "test_workflow"
+        assert safe_workflow_filename(mock.name, "md") == "test_workflow.md"
+
+
+class TestSafeWorkflowFilenameExtension:
+    """Extension MUST also be validated (defense-in-depth)."""
+
+    @pytest.mark.parametrize(
+        "bad_ext",
+        [
+            "",
+            ".md",  # leading dot is the API contract violation
+            "md.",
+            "md/sub",
+            "md\\sub",
+            "md with space",
+            "x" * 17,  # exceeds 16-char cap
+            None,
+            123,
+        ],
+    )
+    def test_rejects_bad_extension(self, bad_ext):
+        with pytest.raises(WorkflowNameError):
+            safe_workflow_filename("workflow", bad_ext)
+
+
+class TestSafeWorkflowFilenameErrorMessage:
+    """Error messages MUST NOT echo raw input (log-poisoning defense)."""
+
+    def test_error_message_does_not_echo_raw_input(self):
+        """Per ``observability.md`` Rule 8 + ``security.md`` § Output Encoding,
+        the message carries a hashed fingerprint, NOT the raw input."""
+        sentinel = "INJECTION_PAYLOAD_d8f7e6a5b4c3"
+        try:
+            safe_workflow_filename(sentinel + "/etc/passwd", "md")
+        except WorkflowNameError as exc:
+            assert sentinel not in str(
+                exc
+            ), f"WorkflowNameError leaked raw input into message: {exc!r}"
+        else:
+            pytest.fail("expected WorkflowNameError")
+
+    def test_error_message_includes_actionable_mock_hint_for_non_string(self):
+        """When called with a non-string, the message MUST hint at the
+        Mock(name=) anti-pattern (the originating cause of this rule)."""
+        mock = Mock(name="test_workflow")
+        try:
+            safe_workflow_filename(mock.name, "md")
+        except WorkflowNameError as exc:
+            msg = str(exc)
+            assert (
+                "Mock" in msg and "post-construction" in msg
+            ), f"expected Mock-anti-pattern hint, got: {msg!r}"
+        else:
+            pytest.fail("expected WorkflowNameError")
+
+
+class TestSafeWorkflowFilenameLogging:
+    """Logging contract: WARN with hashed fingerprint, never raw input."""
+
+    def test_logs_warn_with_fingerprint_on_invalid(self, caplog):
+        """Per observability.md Rule 8 — WARN logs schema-revealing data
+        as hashed fingerprints, never the raw input."""
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="dataflow.utils.filenames")
+        sentinel = "RAW_INPUT_SENTINEL_5e8a3f"
+        with pytest.raises(WorkflowNameError):
+            safe_workflow_filename(sentinel + "/x", "md")
+
+        assert any(
+            "filename.invalid_workflow_name" in r.message for r in caplog.records
+        ), "expected structured warn log"
+        # Critical: no log line carries the raw sentinel.
+        for record in caplog.records:
+            assert (
+                sentinel not in record.getMessage()
+            ), f"raw input leaked into log: {record.getMessage()!r}"

--- a/workspaces/issue-829-kaizen-llm-first-traits/.session-notes
+++ b/workspaces/issue-829-kaizen-llm-first-traits/.session-notes
@@ -1,87 +1,26 @@
-# Session Notes — 2026-05-06 (issue #829 SHIPPED)
+# Session Notes — 2026-05-06
 
 ## Where we are
 
-Issue #829 closed end-to-end. Workstream complete from `/analyze` through
-`/release`.
+Issue #829 SHIPPED end-to-end. Full COC cycle ran: `/analyze` → `/todos` →
+`/implement` → `/release` → `/redteam` → `/codify`. kailash-kaizen 2.20.0
+live on PyPI; codify proposal pending loom Gate 1.
 
-- **PR #836** (`fe6ed609`) — kailash-kaizen 2.19.0 → 2.20.0 — admin-merged
-  after CI green (Python 3.11/3.12/3.13/3.14 × 2 workflows + CodeQL +
-  Spec Drift + PACT + infrastructure all pass).
-- **Tag** `kaizen-v2.20.0` pushed; publish-pypi.yml run `25393777596`
-  succeeded. PyPI now serves kailash-kaizen 2.20.0.
-- **Clean-venv install verified live**: `kaizen.__version__ == "2.20.0"`
-  + `RoleToTraitsSignature` importable + `Kaizen._TRAIT_CACHE_MAX == 256`
-  + keyword classifier residue absent from `inspect.getsource`.
-- **PR #837** (`9a028691`) — deploy record + config update — admin-merged.
-- **Issue #829** auto-closed at PR #836 merge; code-reference comment
-  posted citing PR #836 + commit `fe6ed609` + tag + publish workflow.
+## Read first
 
-## What shipped
+1. `journal/0004-DECISION-codified-rule-4-amend-and-conftest-stub-pattern.md` — what was proposed upstream and why; entry point if the next session is loom-side reviewing the proposal.
+2. `.claude/.proposals/latest.yaml` — the codify proposal itself (`status: pending_review`); the canonical surface loom Gate 1 reads.
+3. `04-validate/01-spec-compliance.md` — Round 1 audit assertion table (14 spec rows + 4 brief AC); evidence that nothing more needs auditing in this workspace.
+4. `journal/0001..0003` — the implementation-time DISCOVERY/DECISION trail for any deep-dive on the LLM-first derivation design.
+5. `CLAUDE.md` — entry point if the next session pivots to a different workstream.
 
-- New `kailash_kaizen.core._role_traits_signature.RoleToTraitsSignature`
-  (private, not in `__all__`).
-- `Kaizen._generate_role_based_traits` rewritten as LLM-first via
-  `BaseAgent.run()` against the configured provider.
-- Bounded LRU cache (`OrderedDict`, max 256, `popitem(last=False)`
-  eviction) keyed by `role.strip().lower()`.
-- Output sanitization regex `^[a-z0-9_ ]{1,32}$` (prompt-injection
-  defense — protects downstream `_generate_role_based_prompt`).
-- Hashed `role_hash=<sha256[:8]>` + `raw_len=<int>` in WARN logs and
-  `RuntimeError` messages (PII-leakage defense).
-- Failure mode: `KAIZEN_DEFAULT_MODEL` unset OR LLM call failure →
-  `RuntimeError` naming both escape hatches; previously: silent default
-  list (Rule-1 violation).
-- `tests/unit/conftest.py` autouse fixture stubs derivation for Tier-1
-  (one fixture replaces 36 individual call-site edits).
-- 6 new Tier-2 tests across two new files; 2 in-place rewrites of
-  pre-existing keyword-pinning tests.
-- `specs/kaizen-core.md` §7.5 (Trait Derivation) added.
+## In-flight state
 
-## Cross-SDK disposition
-
-Cross-SDK kailash-rs orphan-pattern audit DEFERRED to a future kailash-rs
-session per `rules/repo-scope-discipline.md`. Carry-forward signal lives
-in `todos/completed/1.8-cross-sdk-deferred-followup.md` (gitignored —
-reachable only from a local checkout) with grep commands + filing
-disposition decision tree.
-
-## Read first (only relevant if revisiting trait derivation)
-
-1. `journal/0001-DISCOVERY-trait-derivation-call-graph-bounded.md` —
-   why the fix has only one production call site.
-2. `journal/0002-DECISION-sync-surface-locks-implementation-shape.md` —
-   why `BaseAgent.run()` (sync) was the only feasible primitive.
-3. `journal/0003-DISCOVERY-tier1-conftest-stub-replaces-36-call-site-edits.md` —
-   why one autouse fixture beat 36 hand edits.
-4. `02-plans/01-architecture.md` — full plan.
-5. `01-analysis/02-risks-and-edges.md` — 7 risks identified at /analyze;
-   all 7 dispositions visible in shipped code.
+- User flagged 2026-05-06 mid-session: "loom has updated your coc artifacts too." No `sync/coc-*` PR was open against this repo at session-end; expect a `sync(coc)` PR to land in a future session and reconcile against `.claude/.proposals/latest.yaml`.
+- Workspace `todos/active/` is empty. All 9 todos in `todos/completed/`. Workspace can be closed in a future session if no follow-ups attach.
 
 ## Traps
 
-- The reviewer's "Sweep 3 collection blocker" was an environmental
-  false alarm (kailash editable install not present in the reviewer's
-  shell); local + CI envs had the editable install. Future sessions
-  running collection-gate sweeps should `uv pip install -e .` first.
-- Security-reviewer's initial REJECT (3 findings: prompt-injection,
-  PII logging, DoS via cache pollution) all fixed in same shard per
-  `autonomous-execution.md` Rule 4. The HIGH/MEDIUM dispositions are
-  now part of the spec at §7.5.
-- `BaseAgent.run()` returns `Dict[str, Any]` keyed on Signature output
-  field names; my impl reads `result.get("traits_csv", "")`. If the
-  Signature is renamed in a future refactor, update the parser.
-- The Tier-1 `tests/unit/conftest.py` stub returns
-  `["professional", "reliable", "adaptive"]` — same default list the
-  keyword classifier returned for unmatched roles. If a future Tier-1
-  test asserts trait CONTENTS (not just shape), it will break against
-  this stub; rewrite to shape-only OR move to Tier-2.
-
-## Closing pointers
-
-- `/codify` could lift two patterns from this workstream: (a)
-  conftest-stub-replaces-N-callsite-edits as a sweep optimization
-  pattern; (b) same-shard security-reviewer findings (HIGH+MEDIUM) =
-  fix-immediately per Rule 4 — extend to security-reviewer outputs
-  beyond just code-review surfacing. Both candidate `/codify`
-  upstreams to loom.
+- `tests/unit/conftest.py` autouse fixture stubs `Kaizen._generate_role_based_traits` to a fixed 3-element list. Any future Tier-1 test that asserts trait CONTENTS (not just shape) will fail against this stub — rewrite to shape-only OR move to Tier-2.
+- Cross-SDK kailash-rs orphan-pattern audit lives at `todos/completed/1.8-cross-sdk-deferred-followup.md` (gitignored — local checkout only). When a kailash-rs session opens, run the grep commands in that file before any orphan audit.
+- The `_generate_role_based_traits` BaseAgent.run signature reads `result.get("traits_csv", "")`. If `RoleToTraitsSignature` output field is renamed, update the parser at `framework.py:606`.

--- a/workspaces/issue-829-kaizen-llm-first-traits/journal/0005-DECISION-codify-loopback-close-after-loom-sync-2.20.0.md
+++ b/workspaces/issue-829-kaizen-llm-first-traits/journal/0005-DECISION-codify-loopback-close-after-loom-sync-2.20.0.md
@@ -1,0 +1,111 @@
+---
+type: DECISION
+date: 2026-05-06
+session: codify-loopback-after-loom-sync
+---
+
+# Codify loop-back close after loom 2.17.0 → 2.20.0 sync
+
+## Context
+
+Loom completed `/sync-to-build py` mid-session. Working tree now carries the
+2.20.0 distribution, including:
+
+- **3 NEW rules**: `coc-sync-landing.md`, `hook-output-discipline.md`, `sync-completeness.md`
+- **1 NEW hook**: `coc-drift-warn.js` (wired into `settings.json` SessionStart)
+- **1 NEW guide-extract**: `guides/rule-extracts/coc-sync-landing.md`
+- **1 NEW audit-fixtures dir**: `.claude/audit-fixtures/violation-patterns/detectRepoScopeDriftBash/`
+- **AMENDED rules**: `autonomous-execution.md` (Rule 4 trigger broadened — our proposal),
+  `testing.md` (Tier-1 Conftest Stub subsection — our proposal),
+  `worktree-isolation.md` (priority demoted 0→10, scope path-scoped per loom 2.19.0 cap-headroom)
+- **MODIFIED hook lib**: `.claude/hooks/lib/violation-patterns.js` — `detectRepoScopeDriftBash`
+  shell-variable false-positive fix
+- **VERSION bump**: 1.0.6 → 1.0.7 (loom 2.17.0 → 2.20.0; canonical sync-completeness MUST-3
+  schema migration with `upstream.build_version` retained one cycle for back-compat)
+- **Proposal status**: `pending_review` → `reviewed` → `distributed` (loom Gate 1+2 complete)
+
+## Decision
+
+This /codify cycle is a **loop-back close**, not a fresh extraction.
+
+**Rationale:**
+
+- Learning digest hash unchanged (`sha256:e0f13`) since prior cycle (last_codified 2026-05-06T18:30Z).
+- Journals 0001-0004 already capture the substantive work of issue #829.
+- The proposal lifecycle reached terminal state `distributed`. No new patterns from THIS
+  loop-back warrant new rules / agents / skills:
+  - The "sync arrives as working-tree drift" pattern is exactly what `coc-sync-landing.md`
+    was authored to handle (loom-side codification of this same surface, Origin 2026-05-02).
+  - The polling-cadence-while-waiting (5 polls × ~30 min over ~105 min) is generic /loop
+    usage, not novel enough for codification.
+  - The artifact-flow lifecycle (`pending_review` → `reviewed` → `distributed`) worked as
+    designed.
+
+**Step 6b (Trust Posture Wiring) is N/A** — no new rules authored in this cycle. The 3 new
+synced rules came in via loom Gate 2 distribution, not via local /codify authorship.
+
+## Findings (surface-only, no autonomous filing)
+
+### F1: `coc-sync-landing.md` shipped without Trust Posture Wiring section
+
+```bash
+grep -n "Trust Posture Wiring" .claude/rules/coc-sync-landing.md   # → empty
+grep -n "Trust Posture Wiring" .claude/rules/hook-output-discipline.md  # → 198
+grep -n "Trust Posture Wiring" .claude/rules/sync-completeness.md       # → 192
+```
+
+Per `commands/codify.md` Step 6b ENFORCEMENT: "cc-architect MUST grep each new rule file
+for the literal `## Trust Posture Wiring` header AND verify all 7 fields present in the
+section body (severity / grace / cumulative / regression-within-grace / receipt /
+detection / first-violation / origin). Missing or incomplete → audit FAIL → /codify halts."
+
+This is a **loom-side enforcement gap** — the rule was authored at loom and synced down.
+The two sibling new rules (`hook-output-discipline.md`, `sync-completeness.md`) DO carry
+the wiring. Per `repo-scope-discipline.md`, this finding is surfaced for user review only
+— no autonomous file/edit upstream.
+
+**Disposition:** user decides whether to surface to loom for next codify cycle there.
+
+### F2: 3 `.pending/` stub journals discarded
+
+`SessionEnd` hook auto-generated commit-message reflection stubs after 2026-05-05 commits
+(`8f0950af`, `ba476b88`, `86334ec4`). Content was already covered by promoted journals
+0001-0004. Per the stubs' own instructions ("Discard: rm this file"), removed.
+
+### F3: Sync drift requires PR-landing per `coc-sync-landing.md` Rule 1
+
+Working tree currently carries the loom 2.20.0 distribution as uncommitted drift on `main`.
+Per the just-synced `coc-sync-landing.md` Rule 1: "COC Drift Lands as PR #1. Land it FIRST.
+Non-COC-PR workarounds BLOCKED. Cross-session carry BLOCKED."
+
+Per BUILD-repo standing feedback, agent does NOT autonomously commit/push in kailash-py —
+this is the user's gate. Surfaced to user for staging + admin-merge per Rule 2 (stage
+explicit paths) + Rule 3 (admin-merge per owner workflow).
+
+### F4: Pre-existing 107 `<Mock name=...>.md` files in `docs/`
+
+Created 2026-04-15 (well pre-dating session start, gitignored, not tracked). Symptom of
+a doc-build test that didn't mock `test_workflow.name` properly. Pre-existing per
+zero-tolerance Rule 1c (SHA-grounded: file mtimes 21 days before session start, not
+tracked). **Out of scope for this codify cycle** — surface only. Separate workspace can
+address if user prioritizes.
+
+## What unlocks for the next session
+
+- Loop-back proposal status is recorded (`distributed`, learning-codified.json updated).
+- Issue #829 workspace is closeable: todos all in `completed/`, journal complete (0001-0005),
+  redteam Round 1 clean, codify loop-back closed. Workspace can be archived or referenced
+  by future kaizen sessions.
+- Synced 2.20.0 rules + hook are in working tree, awaiting user-gated PR #1 landing per
+  `coc-sync-landing.md`.
+
+## Alternatives considered
+
+- **Author a new rule for the polling-cadence pattern** — rejected. Pattern is generic
+  /loop usage; not specific enough to deserve a rule. The /loop skill already documents
+  this.
+- **File upstream issue against loom for F1 (coc-sync-landing.md missing wiring)** —
+  deferred per `upstream-issue-hygiene.md` MUST Rule 1 (human gate before filing).
+  User decides whether to surface.
+- **Promote one of the .pending stubs to a real journal** — rejected. Content was
+  already in 0001-0004; promoting would be duplication.


### PR DESCRIPTION
## Summary

Closes a Tier-1 test isolation bug AND the production code path that allowed it. The CLI `dataflow generate docs` subcommand interpolated `workflow.name` directly into a filesystem path; any non-string, path-traversal substring, or filesystem-unsafe character was written verbatim. 108 orphan `<Mock name='test_workflow.name' id='*'>.md` files accumulated under `docs/` (107) and `packages/kailash-dataflow/docs/` (1) since 2026-04-15.

Two-layered fix per autonomize directive ("root cause over symptom, long-term over short-term"):

1. **Production code validates at the trust boundary** regardless of test-side correctness. Same principle as `dialect.quote_identifier()` for SQL identifiers, applied to filesystem identifiers.
2. **Test correctly constructs the Mock** + uses `tmp_path` for filesystem isolation per `tests/unit/CLAUDE.md`.

## Root cause

`unittest.mock.Mock(name="X")` sets the Mock's repr-name (used by `__str__`/`__repr__`), NOT the `.name` attribute. Accessing `.name` returns a child Mock whose `__str__` is `<Mock name='X.name' id='...'>`. `generate.py:156` interpolated this into a real `Path()` and `Path.write_text` (which is NOT caught by `patch("builtins.open", mock_open())` in modern Python) wrote the file.

## Changes

**NEW: `packages/kailash-dataflow/src/dataflow/utils/filenames.py`** — public helper module
- `safe_workflow_filename(name, ext) -> str` — strict allowlist `^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$`, rejects path-traversal substring `..`, validates extension `^[A-Za-z0-9]{1,16}$`.
- `WorkflowNameError(ValueError)` — exception with hashed `sha256[:8]` fingerprint of input (per `observability.md` Rule 8 + `security.md` § Output Encoding — raw input never echoed). Error messages carry actionable Mock-anti-pattern hints.
- Logs at WARN with hashed fingerprint on rejection. Re-exported from `dataflow.utils`.

**Modified `packages/kailash-dataflow/src/dataflow/cli/generate.py:159`** — routes `workflow.name` through `safe_workflow_filename(workflow.name, "md")` before `Path.write_text`.

**Modified `packages/kailash-dataflow/tests/unit/cli/test_generate_command.py`**
- Replaced `Mock(name="test_workflow")` (the wrong API) with `_make_workflow_mock()` helper that does `mock = Mock(...); mock.name = "test_workflow"`.
- `test_generate_documentation_command` now uses `tmp_path` for `--output-dir` (was real `./docs/`).
- New regression test `test_generate_documentation_rejects_unsafe_workflow_name` exercises the historical Mock-leak vector end-to-end.

**NEW: `packages/kailash-dataflow/tests/unit/utils/test_filenames.py`** — 52 Tier-1 regression tests
- 9 accepted forms (alphanumeric, underscore-leading, version-suffix dots, length 128, JSON/HTML extensions).
- 23 rejected forms (path-traversal `..`, control chars, shell metacharacters `@;|\`$`, length 129/1000, Unicode bidi-override, ASCII-only allowlist, non-string types, Mock-repr leak vector).
- 9 extension validation cases.
- Error message hygiene: never echo raw input.
- Logging hygiene: WARN logs carry hashed fingerprint, never raw input.

**Version bump (per build-repo-release-discipline.md Rule 5):** kailash-dataflow 2.7.7 → 2.7.8 (patch; pyproject + `__version__` + CHANGELOG atomically).

**Workspace records:** `journal/0005-DECISION-codify-loopback-close-after-loom-sync-2.20.0.md` § F4 captures the discovery; cleanup of 108 orphan files done locally pre-PR.

## Test plan

- [x] 52 helper tests pass (`pytest packages/kailash-dataflow/tests/unit/utils/test_filenames.py`)
- [x] 4 CLI tests pass (`pytest packages/kailash-dataflow/tests/unit/cli/test_generate_command.py`)
- [x] Zero new files leak to `docs/` during test run (verified before + after)
- [x] Pre-commit hooks pass (Black + isort + Ruff + Tier-1 tests)
- [x] Version atomically bumped in pyproject + `__version__` + CHANGELOG
- [ ] Admin-merge → `/release kailash-dataflow` per `build-repo-release-discipline.md` Rule 1 (sub-package src changed → /release REQUIRED, not carved out)
- [ ] PyPI installability verification per Rule 2: `uv pip install --refresh kailash-dataflow==2.7.8` from clean venv

## Related

- Discovered as F4 in PR #840 (`sync(coc): loom 2.17.0 → 2.20.0`) codify journal.
- Closes the docs/Mock leak class structurally (allowlist validation prevents recurrence).
- Cross-SDK inspection per `cross-sdk-inspection.md`: kailash-rs may have a similar doc-generator with the same pattern; out of repo-scope to inspect from here. Recommend cross-SDK check next kailash-rs session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)