### PR TITLE
fix(dataflow): normalize +asyncpg/+psycopg2 driver suffix in DatabaseConfig.get_connection_url() (#819)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,22 @@
 # DataFlow Changelog
 
+## [Unreleased] — `+asyncpg` driver-suffix DSN normalization (#819)
+
+Patch fixing a runtime regression where `async with db.get_connection()` raised `ValueError: invalid dsn: invalid connection option "asyncpg"` whenever the configured database URL carried the SQLAlchemy `+asyncpg` driver suffix — the form many docker-compose stacks and `DATABASE_URL` env-vars use (`postgresql+asyncpg://user:pass@host:5432/db`). Bug fix; no public API surface change; no migration required.
+
+### Fixed
+
+- **`DatabaseConfig.get_connection_url()` now strips the SQLAlchemy `+asyncpg` / `+psycopg2` driver suffix.** Previously the method returned `self.url` verbatim and the engine's `connection_context()` handed that string straight to `asyncpg.connect()`, which rejects any scheme other than `postgresql://` or `postgres://`. The bare scheme is consumable by both SQLAlchemy (which infers the driver) AND asyncpg (which requires the bare scheme), so stripping at the canonical accessor means every caller — `engine.connection_context()`, `pool_utils.probe_max_connections`, migration sites, model registry — benefits from one fix. Issue #819.
+- **`DataFlow.__init__()` URL validator now accepts the four driver-suffix variants:** `postgresql+asyncpg`, `postgres+asyncpg`, `postgresql+psycopg2`, `postgres+psycopg2`. Previously only `postgresql+asyncpg` passed the validator, so users whose `DATABASE_URL` carried `postgres+asyncpg://` (the alternative bare scheme some Heroku-style stacks emit) hit `DF-401` at construction time before the new normalization could run.
+
+### Changed
+
+- **`pool_utils._probe_postgresql` now routes its inline `+asyncpg` strip through the canonical helper** (`dataflow.core.config._strip_asyncpg_driver_suffix`). Defense-in-depth — callers passing raw URLs that have not been routed through `DatabaseConfig.get_connection_url()` (e.g., a fallback `os.environ["DATABASE_URL"]` read) still get the suffix stripped here.
+
+### Tests
+
+- 10 new Tier-2 regression tests at `tests/integration/test_issue_819_asyncpg_dsn_normalization.py` covering: helper passthrough on plain / non-Postgres URLs; helper strip on `postgresql+asyncpg`, `postgres+asyncpg`, `postgresql+psycopg2`; `DatabaseConfig.get_connection_url` returns stripped form for all three Postgres inputs; real-Postgres `DataFlow.get_connection()` round-trip succeeds on `postgresql+asyncpg://`, plain `postgresql://`, and `postgres+asyncpg://` DSNs; raw asyncpg connect succeeds on the stripped output for all three forms.
+
 ## [2.7.9] — 2026-05-06 — Async transaction event-loop mismatch (#835)
 
 Patch release fixing a runtime regression where `db.transactions.transaction()` raised `RuntimeError: Event loop is closed` when invoked from an event loop different from the one that constructed the DataFlow instance. Bug fix; no public API surface change; no migration required.

--- a/packages/kailash-dataflow/src/dataflow/core/config.py
+++ b/packages/kailash-dataflow/src/dataflow/core/config.py
@@ -48,8 +48,6 @@ def _strip_asyncpg_driver_suffix(url: str) -> str:
     context manager, ``pool_utils.probe_max_connections``, migration sites,
     model registry) sees the normalized URL.
     """
-    if not isinstance(url, str):
-        return url
     for prefix, replacement in _ASYNCPG_DRIVER_SUFFIXES:
         if url.startswith(prefix):
             return replacement + url[len(prefix) :]

--- a/packages/kailash-dataflow/src/dataflow/core/config.py
+++ b/packages/kailash-dataflow/src/dataflow/core/config.py
@@ -17,6 +17,45 @@ from .models import Environment
 
 logger = logging.getLogger(__name__)
 
+
+# ============================================================================
+# Connection URL Normalization (issue #819)
+# ============================================================================
+
+# SQLAlchemy-style driver suffixes carried by many DATABASE_URL env-vars and
+# docker-compose stacks. The bare scheme is consumable by BOTH SQLAlchemy
+# (which infers a driver from `postgresql://`) AND asyncpg (which rejects
+# any scheme other than `postgresql://` or `postgres://`). Stripping the
+# suffix at the canonical accessor (`DatabaseConfig.get_connection_url`)
+# means every caller — `engine.connection_context()`, `pool_utils`,
+# migrations, model registry — benefits from one fix.
+_ASYNCPG_DRIVER_SUFFIXES = (
+    ("postgresql+asyncpg://", "postgresql://"),
+    ("postgres+asyncpg://", "postgres://"),
+    ("postgresql+psycopg2://", "postgresql://"),
+    ("postgres+psycopg2://", "postgres://"),
+)
+
+
+def _strip_asyncpg_driver_suffix(url: str) -> str:
+    """Strip SQLAlchemy ``+asyncpg`` / ``+psycopg2`` driver suffix from URL.
+
+    Returns ``url`` unchanged if it does not begin with a known suffix.
+
+    See issue #819 — asyncpg rejects ``postgresql+asyncpg://`` even though
+    SQLAlchemy emits and consumes that form. The canonical fix lives at the
+    config-level accessor so every caller (the engine's ``get_connection()``
+    context manager, ``pool_utils.probe_max_connections``, migration sites,
+    model registry) sees the normalized URL.
+    """
+    if not isinstance(url, str):
+        return url
+    for prefix, replacement in _ASYNCPG_DRIVER_SUFFIXES:
+        if url.startswith(prefix):
+            return replacement + url[len(prefix) :]
+    return url
+
+
 # ============================================================================
 # ErrorEnhancer Performance Configuration
 # ============================================================================
@@ -307,18 +346,30 @@ class DatabaseConfig:
             self.pool_max_overflow = self.max_overflow
 
     def get_connection_url(self, environment: Environment) -> str:
-        """Generate connection URL based on configuration and environment"""
+        """Generate connection URL based on configuration and environment.
+
+        The SQLAlchemy ``+asyncpg`` / ``+psycopg2`` driver suffix is stripped
+        before the URL is returned so the result is consumable by both
+        SQLAlchemy (which accepts the bare ``postgresql://`` scheme and
+        infers a driver) and asyncpg (which rejects any scheme other than
+        ``postgresql://`` or ``postgres://``). Many docker-compose stacks
+        and ``DATABASE_URL`` env-vars carry the SQLAlchemy form; without
+        normalization, ``async with db.get_connection()`` raises
+        ``ValueError: invalid dsn: invalid connection option "asyncpg"``.
+
+        See issue #819.
+        """
         # Check for explicit URL first
         if self.url:
             # Handle :memory: shorthand for SQLite in-memory
             if self.url == ":memory:":
                 return "sqlite:///:memory:"
-            return self.url
+            return _strip_asyncpg_driver_suffix(self.url)
 
         # Check environment variables
         env_url = os.getenv("DATABASE_URL")
         if env_url:
-            return env_url
+            return _strip_asyncpg_driver_suffix(env_url)
 
         # Build URL from components
         if all([self.driver, self.host, self.database]):
@@ -330,7 +381,8 @@ class DatabaseConfig:
                 auth += "@"
 
             port = f":{self.port}" if self.port else ""
-            return f"{self.driver}://{auth}{self.host}{port}/{self.database}"
+            built = f"{self.driver}://{auth}{self.host}{port}/{self.database}"
+            return _strip_asyncpg_driver_suffix(built)
 
         # Default based on environment
         if environment == Environment.DEVELOPMENT:

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -10133,12 +10133,20 @@ class DataFlow(DataFlowEventMixin):
             warn_sqlite_async_limitation(url)
             return True
 
-        # Supported database schemes (11 variants for 4 database types)
+        # Supported database schemes. The SQLAlchemy `+asyncpg` / `+psycopg2`
+        # driver-suffix forms are accepted at the validator gate so users
+        # whose DATABASE_URL carries the SQLAlchemy form (common in
+        # docker-compose stacks) are not rejected at __init__; the suffix
+        # is then stripped by `DatabaseConfig.get_connection_url()` so
+        # asyncpg sees only the bare scheme. See issue #819.
         supported_schemes = [
-            # PostgreSQL (3 variants)
+            # PostgreSQL (5 variants — bare + SQLAlchemy driver suffixes)
             "postgresql",
             "postgres",
             "postgresql+asyncpg",
+            "postgres+asyncpg",
+            "postgresql+psycopg2",
+            "postgres+psycopg2",
             # MySQL (4 variants)
             "mysql",
             "mysql+pymysql",

--- a/packages/kailash-dataflow/src/dataflow/core/pool_utils.py
+++ b/packages/kailash-dataflow/src/dataflow/core/pool_utils.py
@@ -164,11 +164,14 @@ def _probe_postgresql(database_url: str) -> Optional[int]:
         )
         return None
 
-    # Normalize SQLAlchemy-style URLs for psycopg2
-    # psycopg2 expects postgresql:// not postgresql+asyncpg://
-    conn_url = database_url
-    if "+asyncpg" in conn_url or "+psycopg2" in conn_url:
-        conn_url = conn_url.split("+")[0] + "://" + conn_url.split("://", 1)[1]
+    # Normalize SQLAlchemy-style URLs for psycopg2 via the canonical helper
+    # (issue #819). psycopg2 expects postgresql:// not postgresql+asyncpg://.
+    # Defense-in-depth: callers that pass URLs not routed through
+    # DatabaseConfig.get_connection_url (e.g., a raw os.environ["DATABASE_URL"]
+    # fallback) still get the suffix stripped here.
+    from dataflow.core.config import _strip_asyncpg_driver_suffix
+
+    conn_url = _strip_asyncpg_driver_suffix(database_url)
 
     try:
         with psycopg2.connect(conn_url, connect_timeout=_PROBE_TIMEOUT_SECS) as conn:

--- a/packages/kailash-dataflow/tests/integration/test_issue_819_asyncpg_dsn_normalization.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_819_asyncpg_dsn_normalization.py
@@ -1,0 +1,221 @@
+"""Regression tests for issue #819.
+
+`DataFlow.get_connection()` raised ``ValueError: invalid dsn: invalid
+connection option "asyncpg"`` when the configured database URL carried
+the SQLAlchemy ``+asyncpg`` driver suffix — the form many docker-compose
+stacks and ``DATABASE_URL`` env-vars use:
+
+    DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/db
+
+The root cause was that ``DatabaseConfig.get_connection_url()`` returned
+the URL verbatim. The engine's ``connection_context()`` handed that
+string straight to ``asyncpg.connect()``, which rejects any scheme other
+than ``postgresql://`` or ``postgres://``.
+
+Fix: ``DatabaseConfig.get_connection_url()`` now normalizes the URL via
+``dataflow.core.config._strip_asyncpg_driver_suffix`` so every caller
+(the engine's ``get_connection()`` context manager, ``pool_utils``,
+migrations, model registry) receives the bare scheme.
+
+These tests run against real PostgreSQL (Tier 2 / NO MOCKING) so they
+exercise the same asyncpg code path a user hits in production.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse, urlunparse
+
+import asyncpg
+import pytest
+
+from dataflow import DataFlow
+from dataflow.core.config import (
+    DatabaseConfig,
+    Environment,
+    _strip_asyncpg_driver_suffix,
+)
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+
+@pytest.fixture
+async def test_suite():
+    """Standard real-Postgres test suite (Tier 2)."""
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+def _swap_scheme(plain_url: str, new_scheme: str) -> str:
+    """Replace the URL scheme while preserving userinfo / host / port / path.
+
+    Used to derive ``postgresql+asyncpg://...`` and ``postgres+asyncpg://...``
+    forms from the harness's plain ``postgresql://`` URL without re-deriving
+    credentials from environment variables.
+    """
+    parsed = urlparse(plain_url)
+    return urlunparse(parsed._replace(scheme=new_scheme))
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper coverage (no DB required) — run in any environment, fast.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_strip_asyncpg_driver_suffix_postgresql_asyncpg() -> None:
+    """``postgresql+asyncpg://`` becomes ``postgresql://`` byte-for-byte."""
+    src = "postgresql+asyncpg://user:p%40ss@host:5432/db?sslmode=require"
+    expected = "postgresql://user:p%40ss@host:5432/db?sslmode=require"
+    assert _strip_asyncpg_driver_suffix(src) == expected
+
+
+@pytest.mark.regression
+def test_strip_asyncpg_driver_suffix_postgres_asyncpg() -> None:
+    """``postgres+asyncpg://`` becomes ``postgres://`` byte-for-byte."""
+    src = "postgres+asyncpg://u:p@h:5432/d"
+    assert _strip_asyncpg_driver_suffix(src) == "postgres://u:p@h:5432/d"
+
+
+@pytest.mark.regression
+def test_strip_asyncpg_driver_suffix_psycopg2() -> None:
+    """``postgresql+psycopg2://`` becomes ``postgresql://`` byte-for-byte."""
+    src = "postgresql+psycopg2://u:p@h:5432/d"
+    assert _strip_asyncpg_driver_suffix(src) == "postgresql://u:p@h:5432/d"
+
+
+@pytest.mark.regression
+def test_strip_asyncpg_driver_suffix_passthrough_plain_postgresql() -> None:
+    """Plain ``postgresql://`` passes through unchanged (no false positives)."""
+    src = "postgresql://u:p@h:5432/d"
+    assert _strip_asyncpg_driver_suffix(src) is not None
+    assert _strip_asyncpg_driver_suffix(src) == src
+
+
+@pytest.mark.regression
+def test_strip_asyncpg_driver_suffix_passthrough_sqlite() -> None:
+    """Non-Postgres URLs pass through unchanged."""
+    assert _strip_asyncpg_driver_suffix("sqlite:///dev.db") == "sqlite:///dev.db"
+    assert _strip_asyncpg_driver_suffix("mysql://u:p@h/d") == "mysql://u:p@h/d"
+
+
+@pytest.mark.regression
+def test_database_config_get_connection_url_strips_asyncpg_suffix() -> None:
+    """``DatabaseConfig.get_connection_url`` returns the stripped form.
+
+    Behavioral assertion on the canonical accessor — every caller in
+    DataFlow / pool_utils / migrations / model_registry routes through
+    this method. Pinning its output is the structural defense.
+    """
+    cfg = DatabaseConfig(url="postgresql+asyncpg://user:pass@host:5432/db")
+    assert (
+        cfg.get_connection_url(Environment.PRODUCTION)
+        == "postgresql://user:pass@host:5432/db"
+    )
+
+    cfg2 = DatabaseConfig(url="postgres+asyncpg://user:pass@host:5432/db")
+    assert (
+        cfg2.get_connection_url(Environment.PRODUCTION)
+        == "postgres://user:pass@host:5432/db"
+    )
+
+    cfg3 = DatabaseConfig(url="postgresql://user:pass@host:5432/db")
+    assert (
+        cfg3.get_connection_url(Environment.PRODUCTION)
+        == "postgresql://user:pass@host:5432/db"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — real Postgres via IntegrationTestSuite (NO MOCKING).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_get_connection_succeeds_with_postgresql_asyncpg_dsn(
+    test_suite: IntegrationTestSuite,
+) -> None:
+    """``DataFlow.get_connection()`` succeeds against a ``+asyncpg`` DSN.
+
+    This is the user-reported failure mode: docker-compose stacks set
+    ``DATABASE_URL=postgresql+asyncpg://...`` and the SDK's ``async with
+    db.get_connection()`` raised at ``asyncpg.connect()``.
+    """
+    asyncpg_url = _swap_scheme(test_suite.config.url, "postgresql+asyncpg")
+    db = DataFlow(asyncpg_url, auto_migrate=False)
+
+    # Critical contract: get_connection() must round-trip a real query.
+    async with db.get_connection() as conn:
+        row = await conn.fetchrow("SELECT 1 AS ok")
+        assert row is not None
+        assert row["ok"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_get_connection_succeeds_with_plain_postgresql_dsn(
+    test_suite: IntegrationTestSuite,
+) -> None:
+    """Plain ``postgresql://`` continues to work (regression guard)."""
+    db = DataFlow(test_suite.config.url, auto_migrate=False)
+
+    async with db.get_connection() as conn:
+        row = await conn.fetchrow("SELECT 1 AS ok")
+        assert row is not None
+        assert row["ok"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_get_connection_succeeds_with_postgres_asyncpg_dsn(
+    test_suite: IntegrationTestSuite,
+) -> None:
+    """``postgres+asyncpg://`` (alternative bare scheme) also succeeds."""
+    asyncpg_url = _swap_scheme(test_suite.config.url, "postgres+asyncpg")
+    db = DataFlow(asyncpg_url, auto_migrate=False)
+
+    async with db.get_connection() as conn:
+        row = await conn.fetchrow("SELECT 1 AS ok")
+        assert row is not None
+        assert row["ok"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_dataflow_config_returns_stripped_form_for_all_three_inputs(
+    test_suite: IntegrationTestSuite,
+) -> None:
+    """Round-trip through ``DataFlow.config.database.get_connection_url()``.
+
+    Asserts the canonical accessor returns the bare scheme for both
+    ``+asyncpg`` forms AND passes the plain form through unchanged.
+    """
+    plain = test_suite.config.url
+
+    # +asyncpg → bare postgresql
+    db1 = DataFlow(_swap_scheme(plain, "postgresql+asyncpg"), auto_migrate=False)
+    url1 = db1.config.database.get_connection_url(db1.config.environment)
+    assert url1.startswith("postgresql://"), url1
+    assert "+asyncpg" not in url1
+
+    # postgres+asyncpg → bare postgres
+    db2 = DataFlow(_swap_scheme(plain, "postgres+asyncpg"), auto_migrate=False)
+    url2 = db2.config.database.get_connection_url(db2.config.environment)
+    assert url2.startswith("postgres://"), url2
+    assert "+asyncpg" not in url2
+
+    # plain postgresql → unchanged
+    db3 = DataFlow(plain, auto_migrate=False)
+    url3 = db3.config.database.get_connection_url(db3.config.environment)
+    assert url3.startswith("postgresql://"), url3
+    assert "+asyncpg" not in url3
+
+    # All three forms must connect successfully via raw asyncpg too —
+    # belt-and-suspenders that the stripped URL is consumable by asyncpg.
+    for url in (url1, url2, url3):
+        conn = await asyncpg.connect(url)
+        try:
+            row = await conn.fetchrow("SELECT 1 AS ok")
+            assert row["ok"] == 1
+        finally:
+            await conn.close()


### PR DESCRIPTION
## Summary

`DataFlow.get_connection()` was failing on `postgresql+asyncpg://...` DSNs that many docker-compose stacks produce, because asyncpg rejects any scheme other than `postgresql://` or `postgres://`. The strip helper already existed at `pool_utils.py:167` but only on the psycopg2 probe path.

Lifted the strip into the canonical `DatabaseConfig.get_connection_url()` so every caller (`engine.connection_context()`, `pool_utils.probe_max_connections`, migration sites, model registry) gets the normalized URL once. Engine validator widened to accept all four driver-suffix variants (`postgresql+asyncpg`, `postgres+asyncpg`, `postgresql+psycopg2`, `postgres+psycopg2`) at construction time so DF-401 doesn't fire before normalization runs.

## Changes

- `packages/kailash-dataflow/src/dataflow/core/config.py` — module-level `_strip_asyncpg_driver_suffix()`; `DatabaseConfig.get_connection_url()` routes all three URL-source branches through it.
- `packages/kailash-dataflow/src/dataflow/core/pool_utils.py` — `_probe_postgresql` calls the canonical helper (defense-in-depth for callers bypassing `get_connection_url`).
- `packages/kailash-dataflow/src/dataflow/core/engine.py` — `_is_valid_database_url` allowlist widened from 1 to 4 driver-suffix variants.
- `packages/kailash-dataflow/tests/integration/test_issue_819_asyncpg_dsn_normalization.py` — 10 regression tests (6 helper + 4 real-Postgres Tier 2).
- `packages/kailash-dataflow/CHANGELOG.md` — `[Unreleased]` entry.

## Test plan

- [x] `cd packages/kailash-dataflow && uv run pytest tests/integration/test_issue_819_asyncpg_dsn_normalization.py -v` — 10 passed (real Postgres on localhost:5434)
- [x] Pre-existing-test sanity sweep — 282 passed, no regressions
- [ ] CI matrix green

## Related issues

Fixes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)