### PR TITLE
fix(nexus): bind MCP WebSocket transport + workflow tool registration in production_nexus fixture (#816)

### DIFF
--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Nexus Changelog
 
+## [Unreleased] — fix MCP WebSocket transport binding (#816)
+
+Wires the MCP WebSocket transport so AI agents can actually connect to a Nexus instance over `ws://host:mcp_port`. Prior to this fix the MCP server was constructed in stdio mode and never bound a TCP listener — every WebSocket connect attempt failed with a connection-refused error.
+
+### Fixed
+
+- **MCP WebSocket transport bound on `_mcp_port` (#816)** — `Nexus._initialize_mcp_server` now constructs `kailash_mcp.MCPServer` with `transport="websocket"`, `websocket_host="0.0.0.0"`, and `websocket_port=self._mcp_port`. Previously the server defaulted to `transport="stdio"` and dispatched through `MCPServerBase.start()` (hardcoded to stdio); the `_mcp_port` attribute was never actually bound. AI agents connecting via `ws://localhost:<mcp_port>` now reach a real WebSocket listener that handles MCP 2025-06-18 JSON-RPC dispatch (`tools/list`, `resources/list`, `tools/call`, `resources/read`, etc.).
+- **WebSocket-only mode supported** — `enable_http_transport=False AND enable_sse_transport=False` is now a first-class deployment shape (the canonical AI-agent-only configuration). Previously `_initialize_mcp_server` early-exited and set `_mcp_server = None` whenever HTTP was disabled, leaving the WebSocket transport orphaned. The HTTP/SSE flags now correctly gate only the **additional** sub-transports inside the MCP server, not the always-on WebSocket listener.
+- **Workflow-as-MCP-tool registration via the proper decorator path** — `_register_workflow_as_mcp_tool` now registers via `mcp_server.tool()(workflow_tool)` instead of writing to `mcp_server._tools[name]` directly. The previous direct write populated only the FastMCP-shim dict (which the MCPServer's JSON-RPC handlers do NOT read); the decorator path populates `_tool_registry` which `tools/list` actually iterates. Workflows registered before this fix never appeared in `tools/list` over WebSocket.
+- **Workflow inputs forwarded under `parameters` key** — `workflow_tool` now passes `inputs={"parameters": params}` to `execute_workflow_async`, matching the on-wire convention shared with the HTTP `/execute` endpoint. PythonCodeNode workflows reading `parameters.get(...)` now receive their args correctly. Previously args arrived as direct top-level keys, raising `NameError: name 'parameters' is not defined`.
+- **JSON response payloads** — `workflow_tool` and resource handlers now return JSON strings rather than Python dicts. `MCPServer._handle_call_tool` and `_handle_read_resource` wrap return values via `str(...)`; returning a dict produced Python repr() (single-quoted keys), invalid JSON for downstream MCP clients. Single-node workflow results are unwrapped from `{"<node_id>": {"result": {...}}}` to the inner dict so agents see `{"echo": "hello"}` not `{"echo": {"result": {...}}}`.
+- **`workflow://<name>` resources registered per-workflow** — `Nexus.register()` now installs a `workflow://<name>` MCP resource alongside the tool registration. `resources/list` returns the workflow descriptor URIs and `resources/read workflow://<name>` returns a JSON-encoded summary of the workflow's nodes and schema.
+- **Default MCP resources wired** — `_register_default_mcp_resources()` (previously orphan code, never called) now registers `docs://quickstart`, `config://platform`, and `help://getting-started` via the proper `@server.resource()` decorator path so they appear in `resources/list`. `system://nexus/info` returns a JSON string instead of a dict-with-content-field.
+- **Circuit-breaker disabled in MCP server** — Removed `circuit_breaker_config={"failure_threshold": 5}` from `MCPServer` construction. The kailash_mcp circuit-breaker pre-check synthesizes `MCPError("Circuit breaker check")` with the default `retryable=False`, which causes `should_retry()` to return False on the very first tool call in the closed state. The `circuit_breaker_config=None` default disables the pre-check until the upstream behavior is corrected.
+
+### Tests
+
+- `packages/kailash-nexus/tests/integration/test_mcp_websocket_discovery.py` — new Tier-2 sibling test covering the MCP WebSocket discovery contract (5 tests: tools/list, resources/list, system info JSON, tools/call JSON payload, workflow resource read). Independent of `tests/e2e/test_ai_agent_workflows.py` so an E2E flake does not lose discovery-contract coverage.
+- All 7 tests under `tests/e2e/test_ai_agent_workflows.py::TestAIAgentScenarios` (using the `production_nexus` fixture) now pass.
+
+### Internal
+
+- `_run_mcp_server` calls `MCPServer.run()` (which dispatches on the `transport` attribute) instead of `MCPServer.start()` (which hardcodes stdio).
+- MCPChannel is bypassed in WebSocket-only mode — its `_server_loop` only sleeps and binds nothing, so it adds no value when HTTP/SSE sub-transports are off.
+
 ## [2.6.1] — 2026-05-03 — issue #781 hygiene release (T4)
 
 Patch release cutting PyPI for T4 (nexus TODO-NNN comment-strip) of the issue #781 cleanup workstream.

--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -960,35 +960,62 @@ class Nexus:
     def _initialize_mcp_server(self):
         """Initialize MCP server for AI agent integration.
 
-        Uses the Core SDK's MCPServer + MCPChannel for full protocol support.
-        The old Nexus-specific MCP server has been removed in favour of the
-        unified ``kailash-platform`` MCP server (``kailash_mcp.platform_server``).
+        Uses the Core SDK's MCPServer for full protocol support over a
+        WebSocket transport bound to ``self._mcp_port``. The MCP server
+        binds the port unconditionally — the ``enable_http_transport`` and
+        ``enable_sse_transport`` flags only gate the *additional* HTTP/SSE
+        sub-transports inside the MCP server, not the always-on WebSocket
+        listener that AI agents connect to (per spec ``ws://host:mcp_port``).
+
+        WebSocket-only mode (``enable_http_transport=False AND
+        enable_sse_transport=False``) is supported and is the default for
+        production AI-agent deployments — the WebSocket transport is the
+        single bound listener.
+
+        MCPChannel is only used when HTTP/SSE sub-transports are enabled,
+        because the channel layer adds workflow-management semantics on top
+        of HTTP routing. In WebSocket-only mode the MCPServer's own
+        ``_run_websocket()`` path handles JSON-RPC dispatch directly.
         """
-        if not self._enable_http_transport:
-            # Without HTTP transport, MCP is not available
-            self._mcp_server = None
-            self._mcp_channel = None
-            logger.info(
-                "HTTP transport disabled; MCP server not started. "
-                "Use kailash-mcp for MCP access."
-            )
-            return
-
         try:
-            # Import Core SDK's comprehensive MCP implementation for HTTP+WebSocket mode
-            from kailash_mcp import MCPServer
-            from kailash_mcp.auth.providers import APIKeyAuth
+            # Import Core SDK's comprehensive MCP implementation
+            from kailash_mcp import MCPServer  # noqa: F401  (import-time guard)
+            from kailash_mcp.auth.providers import APIKeyAuth  # noqa: F401
 
-            from kailash.channels import ChannelConfig, ChannelType, MCPChannel
-
-            # Create production-ready MCP server using Core SDK
+            # Create production-ready MCP server using Core SDK.
+            # The server binds a WebSocket transport on ``self._mcp_port``
+            # via its built-in ``WebSocketServerTransport`` (uses
+            # ``websockets.serve``; no fastmcp dependency).
             self._mcp_server = self._create_sdk_mcp_server()
 
-            # Create MCP channel for workflow management
-            self._mcp_channel = self._setup_mcp_channel()
-            logger.info("Full MCP protocol support enabled (tools, resources, prompts)")
+            # MCPChannel is only useful when HTTP/SSE sub-transports are
+            # enabled (it bolts workflow-management hooks onto the HTTP
+            # path). In WebSocket-only mode the MCPServer's own JSON-RPC
+            # handler dispatches tools/list, resources/list, tools/call
+            # directly — MCPChannel adds nothing.
+            if self._enable_http_transport or self._enable_sse_transport:
+                self._mcp_channel = self._setup_mcp_channel()
+                logger.info(
+                    "Full MCP protocol support enabled (tools, resources, "
+                    "prompts) via WebSocket + HTTP/SSE transports"
+                )
+            else:
+                # WebSocket-only mode: bypass MCPChannel
+                self._mcp_channel = None
+                logger.info(
+                    "MCP WebSocket-only mode enabled (tools, resources, "
+                    "prompts via JSON-RPC over WebSocket)"
+                )
 
-            logger.info(f"Production MCP server initialized on port {self._mcp_port}")
+            # Wire default resources (system info, workflow descriptors,
+            # docs, config, help) into the MCP server's resource registry
+            # so resources/list returns them. Without this call,
+            # _register_default_mcp_resources stays orphan code.
+            self._register_default_mcp_resources()
+
+            logger.info(
+                f"Production MCP server initialized on ws://0.0.0.0:{self._mcp_port}"
+            )
 
         except ImportError as e:
             # Core SDK MCP not available -- direct users to kailash-mcp
@@ -1000,65 +1027,30 @@ class Nexus:
             self._mcp_channel = None
 
     def _register_default_mcp_resources(self):
-        """Register default MCP resources (system, docs, config, help)."""
+        """Register default MCP resources (docs, config, help) on the
+        Core SDK MCPServer's resource registry.
+
+        Resource handlers MUST return a JSON string (or other serializable
+        text) — the MCPServer's ``_handle_read_resource`` calls
+        ``str(handler())`` to populate the ``text`` field of the response.
+        Returning a dict produces Python repr() which is not valid JSON
+        and breaks JSON-RPC consumers.
+
+        Per-workflow ``workflow://<name>`` resources are registered at
+        ``register()`` time (see :meth:`register`), not here, because the
+        set of workflows is dynamic.
+        """
         import json
 
-        # System info resource
-        async def system_info_handler(uri: str):
-            info = {
-                "platform": "Kailash Nexus",
-                "version": getattr(self, "_version", "1.0.0"),
-                "workflows": list(self._workflows.keys()),
-                "api_port": self._api_port,
-                "mcp_port": self._mcp_port,
-            }
-            return {
-                "content": json.dumps(info, indent=2),
-                "mimeType": "application/json",
-            }
-
-        self._mcp_server._resources["system://nexus/info"] = system_info_handler
-
-        # Workflow resource handler (detailed)
-        async def workflow_detail_handler(uri: str):
-            # Extract workflow name from URI (workflow://name)
-            workflow_name = uri.split("://")[1] if "://" in uri else uri
-            if workflow_name not in self._workflows:
-                return {
-                    "content": json.dumps(
-                        {"error": f"Workflow not found: {workflow_name}"}
-                    ),
-                    "mimeType": "application/json",
-                }
-
-            workflow = self._workflows[workflow_name]
-            workflow_info = {
-                "name": workflow_name,
-                "type": "workflow",
-                "nodes": [
-                    {"id": node_id, "type": str(type(node).__name__)}
-                    for node_id, node in workflow.nodes.items()
-                ],
-                "schema": {
-                    "inputs": (
-                        getattr(workflow.metadata, "parameters", {})
-                        if hasattr(workflow, "metadata") and workflow.metadata
-                        else {}
-                    ),
-                    "outputs": {},
-                },
-            }
-            return {
-                "content": json.dumps(workflow_info, indent=2),
-                "mimeType": "application/json",
-            }
-
-        # Register workflow:// pattern (wildcard)
-        self._mcp_server._resources["workflow://*"] = workflow_detail_handler
+        if self._mcp_server is None or not callable(
+            getattr(self._mcp_server, "resource", None)
+        ):
+            return
 
         # Documentation resource
-        async def docs_handler(uri: str):
-            docs_content = """# Nexus Quick Start Guide
+        @self._mcp_server.resource("docs://quickstart")
+        async def _docs_handler() -> str:
+            return """# Nexus Quick Start Guide
 
 Welcome to Kailash Nexus! This guide will help you get started.
 
@@ -1076,12 +1068,10 @@ Nexus is a multi-channel platform that exposes workflows via:
 
 For more information, visit the documentation.
 """
-            return {"content": docs_content, "mimeType": "text/markdown"}
 
-        self._mcp_server._resources["docs://quickstart"] = docs_handler
-
-        # Configuration resource
-        async def config_handler(uri: str):
+        # Configuration resource (snapshot of current platform state)
+        @self._mcp_server.resource("config://platform")
+        async def _config_handler() -> str:
             config = {
                 "name": "Kailash Nexus",
                 "api_port": self._api_port,
@@ -1094,19 +1084,12 @@ For more information, visit the documentation.
                     "auth": self._enable_auth,
                 },
             }
-            return {
-                "content": json.dumps(config, indent=2),
-                "mimeType": "application/json",
-            }
+            return json.dumps(config, indent=2)
 
-        self._mcp_server._resources["config://platform"] = config_handler
-
-        # Help resource
-        async def help_handler(uri: str):
-            help_content = """# Getting Started with Nexus
-
-## Available Workflows
-"""
+        # Help resource — describes available URIs
+        @self._mcp_server.resource("help://getting-started")
+        async def _help_handler() -> str:
+            help_content = "# Getting Started with Nexus\n\n## Available Workflows\n"
             for workflow_name in self._workflows.keys():
                 help_content += f"- **{workflow_name}**: Workflow tool\n"
 
@@ -1121,9 +1104,53 @@ For more information, visit the documentation.
 ## Need Help?
 Check the documentation or explore available resources.
 """
-            return {"content": help_content, "mimeType": "text/markdown"}
+            return help_content
 
-        self._mcp_server._resources["help://getting-started"] = help_handler
+    def _register_workflow_as_mcp_resource(self, name: str, workflow):
+        """Register a single workflow as an MCP resource at ``workflow://<name>``.
+
+        The resource handler returns a JSON string describing the workflow's
+        nodes and schema. This satisfies the MCP ``resources/list`` and
+        ``resources/read`` contracts for AI-agent discovery.
+
+        Resource handlers MUST return a JSON string — see
+        :meth:`_register_default_mcp_resources` for the str(handler())
+        contract MCPServer enforces.
+        """
+        import json
+
+        if self._mcp_server is None or not callable(
+            getattr(self._mcp_server, "resource", None)
+        ):
+            return
+
+        uri = f"workflow://{name}"
+
+        @self._mcp_server.resource(uri)
+        async def _workflow_resource_handler() -> str:
+            # Bind workflow + name into closure so each registered handler
+            # describes its own workflow (closure capture, not loop-shared).
+            wf = workflow
+            wf_name = name
+            workflow_info = {
+                "name": wf_name,
+                "type": "workflow",
+                "nodes": [
+                    {"id": node_id, "type": str(type(node).__name__)}
+                    for node_id, node in wf.nodes.items()
+                ],
+                "schema": {
+                    "inputs": (
+                        getattr(wf.metadata, "parameters", {})
+                        if hasattr(wf, "metadata") and wf.metadata
+                        else {}
+                    ),
+                    "outputs": {},
+                },
+            }
+            return json.dumps(workflow_info, indent=2)
+
+        logger.debug(f"Workflow '{name}' registered as MCP resource at {uri}")
 
     def _create_mock_mcp_server(self):
         """Create a simple mock MCP server for testing."""
@@ -1171,9 +1198,23 @@ Check the documentation or explore available resources.
                 # APIKeyAuth expects a list of keys when using simple format
                 auth_provider = APIKeyAuth(list(api_keys.values()))
 
-        # Create enhanced MCP server with all enterprise features
+        # Create enhanced MCP server with all enterprise features.
+        #
+        # transport="websocket" routes the server through MCPServer's
+        # _run_websocket() path, which binds a WebSocketServerTransport
+        # on (websocket_host, websocket_port) using ``websockets.serve``.
+        # AI agents connect via ``ws://host:mcp_port`` and the server
+        # dispatches JSON-RPC (tools/list, resources/list, tools/call,
+        # initialize, etc.) per the MCP 2025-06-18 spec.
+        #
+        # The enable_http_transport / enable_sse_transport flags below
+        # gate ADDITIONAL sub-transports the server can expose, NOT the
+        # base WebSocket listener — that one is always bound.
         server = MCPServer(
             name=f"{self.name}-mcp",
+            transport="websocket",
+            websocket_host="0.0.0.0",
+            websocket_port=self._mcp_port,
             enable_cache=True,
             enable_metrics=True,
             auth_provider=auth_provider,
@@ -1242,7 +1283,14 @@ Check the documentation or explore available resources.
         """Register a workflow as an MCP tool dynamically.
 
         This is used when MCPChannel is not available (WebSocket-only mode).
-        We manually register the workflow as a tool with the Core SDK's MCPServer.
+        Registers the workflow with the Core SDK's MCPServer via its
+        ``tool()`` decorator path, which populates ``_tool_registry`` —
+        the dict ``_handle_list_tools`` reads to answer ``tools/list``.
+
+        Direct writes to ``_mcp_server._tools`` are BLOCKED: that dict only
+        exists on the FastMCP fallback shim (kailash_mcp/server.py:236) and
+        is invisible to the MCPServer's JSON-RPC handlers, so tools added
+        that way never appear in ``tools/list`` over WebSocket.
 
         Uses self.runtime (server-level shared runtime) instead of creating
         a new AsyncLocalRuntime per invocation (M3-001 fix).
@@ -1265,14 +1313,40 @@ Check the documentation or explore available resources.
                 "run_id": run_id,
             }
 
-        # Register as tool with the MCPServer
-        # The @tool decorator syntax won't work dynamically, so we use internal registration
+        # Set the function name so MCPServer's tool decorator picks it up
+        # (the decorator uses func.__name__ when no explicit name kwarg is
+        # provided to register the tool).
+        workflow_tool.__name__ = name
+        workflow_tool.__doc__ = f"Execute workflow '{name}'"
+
+        # Register via the proper @tool() decorator path — this writes to
+        # ``_tool_registry`` which JSON-RPC ``tools/list`` reads from.
+        if hasattr(self._mcp_server, "tool") and callable(
+            getattr(self._mcp_server, "tool")
+        ):
+            try:
+                self._mcp_server.tool()(workflow_tool)
+                logger.info(
+                    f"Workflow '{name}' registered as MCP tool (WebSocket mode)"
+                )
+                return
+            except Exception as e:
+                logger.warning(
+                    f"MCPServer.tool() registration for '{name}' failed: {e}; "
+                    f"falling back to direct registry write"
+                )
+
+        # Fallback: write to the FastMCP-shim _tools dict for compatibility
+        # with simple/mock MCP servers used in tests.
         if hasattr(self._mcp_server, "_tools"):
             self._mcp_server._tools[name] = workflow_tool
-            logger.info(f"Workflow '{name}' registered as MCP tool (WebSocket mode)")
+            logger.info(
+                f"Workflow '{name}' registered as MCP tool via fallback _tools dict"
+            )
         else:
             logger.warning(
-                f"Could not register workflow '{name}' as MCP tool - _tools attribute missing"
+                f"Could not register workflow '{name}' as MCP tool - "
+                f"neither tool() decorator nor _tools attribute available"
             )
 
     def _get_api_keys(self) -> Dict[str, str]:
@@ -1369,6 +1443,9 @@ Check the documentation or explore available resources.
             # MCPChannel automatically exposes workflow as tool
             self._mcp_channel.register_workflow(name, workflow)
             logger.info(f"Workflow '{name}' registered with enhanced MCP channel")
+            # Also register as a workflow:// resource so resources/list
+            # surfaces the workflow descriptor for AI-agent discovery.
+            self._register_workflow_as_mcp_resource(name, workflow)
         elif hasattr(self, "_mcp_server") and self._mcp_server:
             # Register workflow as MCP tool when using WebSocket wrapper
             # Core SDK MCPServer uses decorators, so we register dynamically
@@ -1378,6 +1455,8 @@ Check the documentation or explore available resources.
             else:
                 # Core SDK MCPServer - register as tool manually
                 self._register_workflow_as_mcp_tool(name, workflow)
+            # Register as workflow:// resource for resources/list discovery.
+            self._register_workflow_as_mcp_resource(name, workflow)
 
         # Track performance metric
         registration_time = time.time() - registration_start
@@ -3071,27 +3150,52 @@ Check the documentation or explore available resources.
             )
 
     def _run_mcp_server(self):
-        """Run MCP server in thread."""
+        """Run MCP server in thread.
+
+        Dispatches by what the platform configured at init time:
+
+        * ``self._mcp_channel`` set (HTTP/SSE sub-transports enabled) →
+          run the channel's lifecycle, which orchestrates HTTP routes plus
+          a background-task wrapping ``mcp_server.run()``.
+        * ``self._mcp_server`` set without a channel (WebSocket-only mode)
+          → call the synchronous ``run()`` method directly. ``MCPServer.run()``
+          dispatches on its ``transport`` attribute: when ``transport``
+          is ``"websocket"`` (set by :meth:`_create_sdk_mcp_server`), it
+          internally calls ``asyncio.run(self._run_websocket())`` which
+          binds the WebSocket port via ``websockets.serve`` and runs the
+          JSON-RPC dispatcher.
+
+        ``MCPServerBase.start()`` is BLOCKED here: that method is hard-coded
+        to stdio (kailash_mcp/server.py:286) and ignores the ``transport``
+        attribute, so it would silently route the WebSocket-only mode into
+        stdio and bind no port.
+        """
         try:
             import asyncio
 
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-
-            # Use MCP channel if available (full protocol support)
+            # Use MCP channel if available (HTTP/SSE sub-transports active)
             if hasattr(self, "_mcp_channel") and self._mcp_channel:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
                 loop.run_until_complete(self._mcp_channel.start())
-            elif hasattr(self, "_mcp_server") and self._mcp_server:
-                # Core SDK MCPServer -- start if it has start()
-                if hasattr(self._mcp_server, "start"):
-                    loop.run_until_complete(self._mcp_server.start())
-                else:
-                    logger.warning("MCP server has no start() method, skipping")
-            else:
-                logger.info("No MCP server configured. Use kailash-mcp for MCP access.")
+                loop.run_forever()
                 return
 
-            loop.run_forever()
+            # WebSocket-only mode: call MCPServer.run() directly.
+            # run() is synchronous and blocks until shutdown — it manages
+            # its own asyncio loop internally for the websocket transport.
+            if hasattr(self, "_mcp_server") and self._mcp_server:
+                if hasattr(self._mcp_server, "run") and callable(self._mcp_server.run):
+                    # Blocks the thread until shutdown. The MCP server's
+                    # transport=='websocket' branch calls asyncio.run()
+                    # internally which is safe in a worker thread that
+                    # has no preexisting event loop.
+                    self._mcp_server.run()
+                else:
+                    logger.warning("MCP server has no run() method, skipping")
+                return
+
+            logger.info("No MCP server configured. Use kailash-mcp for MCP access.")
         except Exception as e:
             logger.warning(f"MCP server error: {e}. Continuing with other channels.")
 

--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -1210,6 +1210,19 @@ Check the documentation or explore available resources.
         # The enable_http_transport / enable_sse_transport flags below
         # gate ADDITIONAL sub-transports the server can expose, NOT the
         # base WebSocket listener — that one is always bound.
+        # NOTE — circuit_breaker_config intentionally omitted.
+        # kailash_mcp.MCPServer ships a circuit-breaker pre-check that
+        # constructs ``MCPError("Circuit breaker check")`` with the default
+        # ``retryable=False`` and feeds it into ``should_retry()`` (server.py
+        # line 929-940). In the closed state, ``should_retry()`` returns
+        # ``error.is_retryable()`` — which is False for that synthetic error
+        # — so EVERY tool call fails on the first attempt with
+        # "Circuit breaker open for <tool>". Passing ``circuit_breaker_config=None``
+        # (the default) sets ``self.circuit_breaker = None`` (server.py line 538)
+        # so the gate at line 929 short-circuits past the broken check.
+        # This is a workaround for the upstream behavior; until kailash_mcp
+        # adjusts its synthetic-error retryability the breaker cannot be
+        # enabled here.
         server = MCPServer(
             name=f"{self.name}-mcp",
             transport="websocket",
@@ -1221,29 +1234,29 @@ Check the documentation or explore available resources.
             enable_http_transport=self._enable_http_transport,
             enable_sse_transport=self._enable_sse_transport,
             rate_limit_config=self.rate_limit_config,
-            circuit_breaker_config={"failure_threshold": 5},
             enable_discovery=self._enable_discovery,
             enable_streaming=True,
         )
 
-        # Register default system information as a resource
+        # Register default system information as a resource.
+        # Resource handlers MUST return a JSON string (or other plain text)
+        # — MCPServer's _handle_read_resource calls str(handler()) into the
+        # response's text field. Returning a dict produces Python repr()
+        # which is not valid JSON. See _register_default_mcp_resources for
+        # the same str(handler()) contract on docs/config/help resources.
         @server.resource("system://nexus/info")
-        async def get_system_info() -> Dict[str, Any]:
-            """Provide Nexus system information."""
-            return {
-                "uri": "system://nexus/info",
-                "mimeType": "application/json",
-                "content": json.dumps(
-                    {
-                        "platform": "Kailash Nexus",
-                        "version": "1.0.0",
-                        "workflows": list(self._workflows.keys()),
-                        "capabilities": ["tools", "resources", "prompts"],
-                        "transports": self._get_enabled_transports(),
-                    },
-                    indent=2,
-                ),
-            }
+        async def get_system_info() -> str:
+            """Provide Nexus system information as a JSON string."""
+            return json.dumps(
+                {
+                    "platform": "Kailash Nexus",
+                    "version": "1.0.0",
+                    "workflows": list(self._workflows.keys()),
+                    "capabilities": ["tools", "resources", "prompts"],
+                    "transports": self._get_enabled_transports(),
+                },
+                indent=2,
+            )
 
         return server
 
@@ -1299,19 +1312,56 @@ Check the documentation or explore available resources.
         shared_runtime = self.runtime
 
         async def workflow_tool(**params):
-            """Execute workflow with given parameters."""
+            """Execute workflow with given parameters.
+
+            Args from MCP ``tools/call`` arrive as kwargs in ``params``.
+            They are wrapped under the ``parameters`` key when forwarded to
+            the runtime — Kailash workflow nodes (esp. PythonCodeNode) read
+            their inputs as ``parameters.get(...)`` from the executing
+            namespace, so the workflow's ``parameters`` variable is the
+            on-wire convention shared with the HTTP /execute endpoint.
+
+            Returns a JSON string. ``MCPServer._handle_call_tool`` wraps
+            the return value with ``str(result)`` into a text content
+            item; downstream MCP clients expect that text to be parseable
+            JSON (per MCP 2025-06-18 ``tools/call`` response shape).
+            Returning a Python dict here would produce Python repr() in
+            the response (single-quoted keys) which is NOT valid JSON.
+            """
+            import json
+
             execution_result = await shared_runtime.execute_workflow_async(
-                workflow, inputs=params
+                workflow, inputs={"parameters": params}
             )
             if isinstance(execution_result, tuple):
                 results, run_id = execution_result
             else:
                 results = execution_result.get("results", execution_result)
                 run_id = execution_result.get("run_id", None)
-            return {
-                "results": results,
-                "run_id": run_id,
-            }
+
+            # Workflows commonly produce one node's ``result`` dict (the
+            # PythonCodeNode convention is ``result = {...}`` at end of
+            # script). Surface that shape directly when there's a single
+            # node-result so MCP clients see ``{"analysis": {...}}`` not
+            # ``{"node_id": {"result": {"analysis": {...}}}}``.
+            #
+            # Fallback: surface the full ``results`` map alongside run_id
+            # when the workflow has multiple nodes / non-trivial output.
+            payload: Dict[str, Any]
+            if (
+                isinstance(results, dict)
+                and len(results) == 1
+                and isinstance(next(iter(results.values())), dict)
+                and "result" in next(iter(results.values()))
+            ):
+                inner = next(iter(results.values()))["result"]
+                if isinstance(inner, dict):
+                    payload = inner
+                else:
+                    payload = {"result": inner, "run_id": run_id}
+            else:
+                payload = {"results": results, "run_id": run_id}
+            return json.dumps(payload)
 
         # Set the function name so MCPServer's tool decorator picks it up
         # (the decorator uses func.__name__ when no explicit name kwarg is

--- a/packages/kailash-nexus/tests/e2e/test_ai_agent_workflows.py
+++ b/packages/kailash-nexus/tests/e2e/test_ai_agent_workflows.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List
 import pytest
 import pytest_asyncio
 import websockets
+
 from kailash.workflow.builder import WorkflowBuilder
 from nexus import Nexus
 
@@ -38,7 +39,20 @@ class TestAIAgentScenarios:
 
     @pytest_asyncio.fixture
     async def production_nexus(self):
-        """Create a production-like Nexus instance."""
+        """Create a production-like Nexus instance.
+
+        Configures Nexus in MCP WebSocket-only mode: ``enable_http_transport``
+        and ``enable_sse_transport`` are both False, which means the only
+        MCP transport bound on ``mcp_port`` is the always-on WebSocket
+        listener (provided by ``kailash_mcp.MCPServer`` with
+        ``transport="websocket"``). AI agents connect via
+        ``ws://localhost:<mcp_port>`` and dispatch JSON-RPC per the
+        MCP 2025-06-18 spec.
+
+        See ``packages/kailash-nexus/src/nexus/core.py::_initialize_mcp_server``
+        for the wiring — the WebSocket binding is unconditional regardless
+        of the HTTP/SSE flags, which only gate additional sub-transports.
+        """
         # Find free ports dynamically to avoid conflicts
         api_port = find_free_port(8890)
         mcp_port = find_free_port(api_port + 100)
@@ -48,7 +62,9 @@ class TestAIAgentScenarios:
             mcp_port=mcp_port,
             enable_auth=False,  # TODO: Test with auth in separate scenario
             enable_monitoring=True,
-            enable_http_transport=False,  # Use simple MCP server for WebSocket-only mode
+            # WebSocket-only mode: HTTP and SSE sub-transports off, but
+            # the base MCP WebSocket listener on mcp_port is always bound.
+            enable_http_transport=False,
             enable_sse_transport=False,
             enable_discovery=False,
             rate_limit_config={"default": 100, "burst": 200},
@@ -63,7 +79,7 @@ class TestAIAgentScenarios:
         server_thread = threading.Thread(target=app.start, daemon=True)
         server_thread.start()
 
-        # Wait for full initialization
+        # Wait for full initialization (HTTP gateway + MCP WebSocket bind)
         await asyncio.sleep(3)
 
         yield app

--- a/packages/kailash-nexus/tests/integration/test_mcp_websocket_discovery.py
+++ b/packages/kailash-nexus/tests/integration/test_mcp_websocket_discovery.py
@@ -1,0 +1,231 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier-2 integration test for the MCP WebSocket discovery contract.
+
+This test guards the production_nexus MCP wiring independently of the
+Tier-3 e2e suite (test_ai_agent_workflows.py) so an E2E flake does not
+lose coverage of the underlying discovery contract.
+
+Issue #816 — production_nexus fixture's WebSocket-only mode pointed at an
+unbound _mcp_port. Root cause: kailash_mcp.MCPServer was constructed with
+the default ``transport="stdio"`` and never set ``websocket_host`` /
+``websocket_port``, so no WebSocket listener was bound. Fix: pass
+``transport="websocket"`` + websocket port params at MCPServer creation,
+and use ``MCPServer.run()`` (which dispatches on the transport attribute)
+rather than ``MCPServer.start()`` (hardcoded stdio).
+
+What this test asserts (the contract a Nexus user discovers via MCP):
+
+  * tools/list returns every registered workflow with a non-empty name.
+  * resources/list returns one ``workflow://<name>`` resource per workflow,
+    plus the default ``system://nexus/info`` and ``docs://quickstart`` /
+    ``config://platform`` / ``help://getting-started`` resources.
+  * resources/read on ``system://nexus/info`` returns a JSON string
+    parseable by ``json.loads`` (NOT Python repr — see the
+    str(handler()) contract enforced by MCPServer._handle_read_resource).
+  * tools/call on a registered workflow returns a content list whose
+    text field is also a JSON string (not Python repr).
+"""
+
+import asyncio
+import json
+import socket
+import threading
+import time
+from contextlib import closing
+
+import pytest
+import pytest_asyncio
+import websockets
+
+from kailash.workflow.builder import WorkflowBuilder
+from nexus import Nexus
+
+
+def _find_free_port(start: int) -> int:
+    for port in range(start, start + 200):
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            try:
+                s.bind(("", port))
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(f"Could not find free port from {start}")
+
+
+@pytest_asyncio.fixture
+async def websocket_only_nexus():
+    """Nexus instance in MCP WebSocket-only mode.
+
+    HTTP and SSE sub-transports are off; the MCP server's only bound
+    listener is the WebSocket transport on ``mcp_port``. This is the
+    canonical AI-agent-only deployment shape — same configuration as
+    ``test_ai_agent_workflows.py::production_nexus`` but pinned at the
+    Tier-2 level so a failure here is independent evidence of the
+    transport-binding contract.
+    """
+    api_port = _find_free_port(8700)
+    mcp_port = _find_free_port(api_port + 100)
+
+    app = Nexus(
+        api_port=api_port,
+        mcp_port=mcp_port,
+        enable_auth=False,
+        enable_monitoring=False,
+        enable_http_transport=False,
+        enable_sse_transport=False,
+        enable_discovery=False,
+    )
+
+    # Register two simple workflows to populate tool / resource lists.
+    echo = WorkflowBuilder()
+    echo.add_node(
+        "PythonCodeNode",
+        "echo",
+        {"code": "result = {'echo': parameters.get('message', 'hi')}"},
+    )
+    app.register("echo", echo.build())
+
+    add = WorkflowBuilder()
+    add.add_node(
+        "PythonCodeNode",
+        "adder",
+        {"code": ("result = {'sum': parameters.get('a', 0) + parameters.get('b', 0)}")},
+    )
+    app.register("add", add.build())
+
+    server_thread = threading.Thread(target=app.start, daemon=True)
+    server_thread.start()
+
+    # Wait for both API + MCP transports to bind.
+    await asyncio.sleep(3)
+    yield app
+
+    app.stop()
+
+
+async def _send_recv(uri: str, request: dict) -> dict:
+    """Open a fresh WebSocket connection, send one JSON-RPC, await the reply."""
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps(request))
+        raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
+        return json.loads(raw)
+
+
+@pytest.mark.asyncio
+async def test_tools_list_returns_registered_workflows(websocket_only_nexus):
+    """tools/list MUST surface every registered workflow as a tool name."""
+    uri = f"ws://localhost:{websocket_only_nexus._mcp_port}"
+    data = await _send_recv(uri, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+    assert "result" in data, f"unexpected response: {data}"
+    tools = data["result"]["tools"]
+    names = {t["name"] for t in tools}
+    # Read fixture state — do NOT hardcode workflow names per
+    # rules/e2e-god-mode.md Rule 2.
+    expected = set(websocket_only_nexus._workflows.keys())
+    assert expected.issubset(
+        names
+    ), f"tools/list missing workflows: expected {expected} ⊆ {names}"
+
+
+@pytest.mark.asyncio
+async def test_resources_list_returns_workflow_resources(websocket_only_nexus):
+    """resources/list MUST emit one ``workflow://<name>`` per workflow."""
+    uri = f"ws://localhost:{websocket_only_nexus._mcp_port}"
+    data = await _send_recv(
+        uri, {"jsonrpc": "2.0", "id": 2, "method": "resources/list"}
+    )
+
+    assert "result" in data, f"unexpected response: {data}"
+    resources = data["result"]["resources"]
+    workflow_uris = {r["uri"] for r in resources if r["uri"].startswith("workflow://")}
+    expected_uris = {
+        f"workflow://{name}" for name in websocket_only_nexus._workflows.keys()
+    }
+    assert expected_uris.issubset(
+        workflow_uris
+    ), f"missing workflow:// resources: {expected_uris - workflow_uris}"
+
+
+@pytest.mark.asyncio
+async def test_resources_read_system_info_returns_valid_json(websocket_only_nexus):
+    """resources/read on system://nexus/info MUST return parseable JSON.
+
+    This test pins the Rule-2-Stub-Defense for the resource-handler
+    contract: handlers return JSON STRINGS, not dicts. A handler that
+    returns ``{"content": json.dumps(...)}`` produces Python repr in
+    the response text field — invalid JSON, breaks every MCP client.
+    """
+    uri = f"ws://localhost:{websocket_only_nexus._mcp_port}"
+    data = await _send_recv(
+        uri,
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "resources/read",
+            "params": {"uri": "system://nexus/info"},
+        },
+    )
+
+    assert "result" in data, f"unexpected response: {data}"
+    text = data["result"]["contents"][0]["text"]
+    # MUST be parseable as JSON (NOT Python repr of a dict).
+    info = json.loads(text)
+    assert info["platform"] == "Kailash Nexus"
+    assert "workflows" in info
+    assert set(info["workflows"]) == set(websocket_only_nexus._workflows.keys())
+
+
+@pytest.mark.asyncio
+async def test_tools_call_returns_json_text_payload(websocket_only_nexus):
+    """tools/call MUST return a content list with a JSON-string text field."""
+    uri = f"ws://localhost:{websocket_only_nexus._mcp_port}"
+    data = await _send_recv(
+        uri,
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"message": "hello-tier2"}},
+        },
+    )
+
+    assert "result" in data, f"unexpected response: {data}"
+    content = data["result"]["content"]
+    assert isinstance(content, list) and len(content) > 0
+    text = content[0]["text"]
+    # text MUST be valid JSON (NOT Python repr of a dict).
+    payload = json.loads(text)
+    # The echo workflow's PythonCodeNode emits result={'echo': <message>}.
+    # workflow_tool unwraps single-node {'<id>': {'result': {...}}} into
+    # the inner dict per core.py::_register_workflow_as_mcp_tool.
+    assert payload.get("echo") == "hello-tier2", f"unexpected payload: {payload}"
+
+
+@pytest.mark.asyncio
+async def test_workflow_resource_read_returns_workflow_descriptor(
+    websocket_only_nexus,
+):
+    """resources/read on workflow://<name> MUST return a JSON descriptor."""
+    workflow_name = next(iter(websocket_only_nexus._workflows.keys()))
+    uri = f"ws://localhost:{websocket_only_nexus._mcp_port}"
+    data = await _send_recv(
+        uri,
+        {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "resources/read",
+            "params": {"uri": f"workflow://{workflow_name}"},
+        },
+    )
+
+    assert "result" in data, f"unexpected response: {data}"
+    text = data["result"]["contents"][0]["text"]
+    descriptor = json.loads(text)
+    assert descriptor["name"] == workflow_name
+    assert descriptor["type"] == "workflow"
+    assert "nodes" in descriptor
+    assert "schema" in descriptor


### PR DESCRIPTION
## Summary

`test_ai_agent_discovery_and_exploration` and 6 sibling E2E tests sharing the `production_nexus` fixture were failing because:

1. **`Nexus._initialize_mcp_server` had an early-exit on `not self._enable_http_transport`** that returned BEFORE binding any transport. With both http+sse disabled, no MCP transport bound to `_mcp_port`. Every WebSocket connect attempt to `ws://localhost:{_mcp_port}` hit a closed port.
2. **Workflow tools registered via `_tools[name]`** (a FastMCP-shim dict the JSON-RPC dispatcher never reads) instead of `mcp_server.tool()` (which writes the canonical `_tool_registry`). `tools/list` returned empty.
3. **Tool/resource handlers returned Python dicts** which `MCPServer._handle_*` `str()`-coerced into invalid-JSON Python repr (single quotes, `True`/`False` instead of `true`/`false`).
4. **`circuit_breaker_config={"failure_threshold": 5}`** rejected every first tool/call with a synthetic non-retryable error.

These are surfacing in the same shard because they all only reproduce once the transport actually binds — same-bug-class fix-immediately per `autonomous-execution.md` Rule 4.

## Changes

- `packages/kailash-nexus/src/nexus/core.py` — remove early-exit; construct `MCPServer(transport="websocket", websocket_host=..., websocket_port=_mcp_port)`; replace `start()` (hardcoded stdio) with `run()` (transport-aware); register `_register_default_mcp_resources` via `@server.resource`; add `_register_workflow_as_mcp_resource` so `workflow://<name>` URIs appear in `resources/list`; `_register_workflow_as_mcp_tool` uses `mcp_server.tool()(...)`; tool/resource handlers return JSON strings; drop the broken circuit_breaker_config.
- `packages/kailash-nexus/tests/e2e/test_ai_agent_workflows.py` — fixture docstring documents the WebSocket-only mode.
- `packages/kailash-nexus/tests/integration/test_mcp_websocket_discovery.py` — new Tier-2 sibling (5 tests: tools/list, resources/list, system info JSON, tools/call payload JSON, workflow:// resource descriptor).
- `packages/kailash-nexus/CHANGELOG.md` — `[Unreleased]` entry (release-prep deferred).

## Test plan

- [x] `cd packages/kailash-nexus && uv run pytest tests/e2e/test_ai_agent_workflows.py -v` — 7/7 pass (22.09s)
- [x] `cd packages/kailash-nexus && uv run pytest tests/integration/test_mcp_websocket_discovery.py -v` — 5/5 pass (22.11s)
- [x] No mocking introduced (Tier 2/3 NO MOCKING)
- [ ] CI matrix green

## Note

Two upstream `DeprecationWarning`s emit from `websockets.legacy` and `uvicorn.protocols.websockets.websockets_impl` (third-party packages); zero warnings from our code.

## Related issues

Fixes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)