### PR TITLE
release: kailash-nexus 2.6.2

### DIFF
--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nexus Changelog
 
-## [Unreleased] — fix MCP WebSocket transport binding (#816)
+## [2.6.2] — 2026-05-06 — fix MCP WebSocket transport binding (#816)
 
 Wires the MCP WebSocket transport so AI agents can actually connect to a Nexus instance over `ws://host:mcp_port`. Prior to this fix the MCP server was constructed in stdio mode and never bound a TCP listener — every WebSocket connect attempt failed with a connection-refused error.
 

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.6.1"
+version = "2.6.2"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -102,7 +102,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.6.1"
+__version__ = "2.6.2"
 __all__ = [
     # Core
     "Nexus",


### PR DESCRIPTION
## Summary

- Bumps kailash-nexus from 2.6.1 → 2.6.2 (PATCH)
- Converts `[Unreleased]` CHANGELOG section to `[2.6.2] — 2026-05-06`
- Metadata-only diff: `pyproject.toml`, `__init__.py::__version__`, `CHANGELOG.md`

## Source change being released

PR #849 merged two commits that fix the MCP WebSocket transport in the `production_nexus` pytest fixture:

- `9504d5f9` — `wip(#816): bind WebSocket transport on _mcp_port`
- `215aea62` — `wip(#816): fix workflow tool registration + JSON response format`

## Why this matters

Before this fix the `production_nexus` fixture constructed an `MCPServer` in stdio mode. Any AI agent attempting to connect via `ws://localhost:<mcp_port>` received a connection-refused error. Workflows registered with `Nexus.register()` never appeared in `tools/list` over WebSocket because the decorator path that populates `_tool_registry` was bypassed. JSON responses carried Python `repr()` (single-quoted keys) rather than valid JSON.

## Related issues

Fixes #816 via PR #849.

## Release wave

Release 2 of 5 in the standing-authorized release wave.

## CI note

Branch name `release/v2.6.2-nexus` triggers the `if: !startsWith(github.head_ref, 'release/')` auto-skip on the PR-gate matrix — metadata-only diff, no test run needed.