### PR TITLE
release: kaizen-agents 0.9.6 — black + ruff modernization sweep (#815)

### DIFF
--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.6] — 2026-05-06 — black + ruff modernization sweep (#815, PR #850)
+
+1222 unit tests pass (PR #850 CI). No public API change: `__init__.py` exports + `__all__`
+lists are byte-for-byte identical between main and HEAD on every package init module.
+Wheel content unchanged for any consumer-visible surface.
+Pre-existing pyright drift (not introduced by this release) tracked in issue #855.
 
 ### Changed (issue #815 — chore-only modernization sweep, packages/kaizen-agents/src/)
 

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.9.5"
+version = "0.9.6"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate


### PR DESCRIPTION
## Summary

PATCH release cutting PyPI for the Black + Ruff modernization sweep of `packages/kaizen-agents/src/` (issue #815, PR #850).

**Bump**: 0.9.5 → 0.9.6

**Source changes** (all merged via PR #850 — 3 commits):
- `ad7a650c` chore(kaizen-agents): finalize black + ruff modernization sweep (#815)
- `a6993377` chore(kaizen-agents): apply ruff auto-fixes — PEP 604/585 modernization (#815)
- `89ac9ca6` chore(kaizen-agents): apply black formatting at line-length=88 (#815)

**No public API change**: `__init__.py` exports + `__all__` lists are byte-for-byte identical between main and HEAD. Wheel content unchanged for any consumer-visible surface.

**Test result**: 1222 unit tests pass (PR #850 CI). Root suite 3598 passed / 3 skipped on this branch's pre-commit run.

**Pre-existing pyright drift** (NOT introduced by this release) tracked in issue #855 — noted in CHANGELOG.

## Version anchors changed

- `packages/kaizen-agents/pyproject.toml` → `version = "0.9.6"`
- `packages/kaizen-agents/src/kaizen_agents/__init__.py` → `__version__ = "0.9.6"`
- `packages/kaizen-agents/CHANGELOG.md` → `[0.9.6]` entry

## CI

Release-prep branch (`release/v*`) auto-skips the PR-gate matrix per workflow `if: !startsWith(github.head_ref, 'release/')`.

## Related issues

Ref: #815 (kaizen-agents black + ruff sweep — source work)
Ref: #850 (source PR already merged)
Ref: #855 (pyright drift — pre-existing, not in scope)