### PR TITLE
release: kailash-dataflow 2.8.0

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,28 +1,33 @@
 # DataFlow Changelog
-## [Unreleased]
+
+## [2.8.0] — 2026-05-06 — append-only models + asyncpg DSN normalization
+
+Minor bump shipping a new public API (`@db.model(append_only=True)` + `AppendOnlyViolationError`) plus an asyncpg DSN normalization fix and the orphan-fix that wires the append-only enforcement into every express mutation method.
 
 ### Added
 
-- `@db.model(append_only=True)` for immutable event-log models. DataFlow registers `AppendOnlyForbiddenNode` stubs at Update/Delete/Upsert/BulkUpdate/BulkDelete/BulkUpsert node names; express mutation methods raise `AppendOnlyViolationError` before issuing SQL. Create/BulkCreate/Read/List/Count continue to be generated normally. See issue #839.
-- `AppendOnlyViolationError` typed exception in `dataflow.exceptions` (re-exported at top level).
-
-
-## [Unreleased] — `+asyncpg` driver-suffix DSN normalization (#819)
-
-Patch fixing a runtime regression where `async with db.get_connection()` raised `ValueError: invalid dsn: invalid connection option "asyncpg"` whenever the configured database URL carried the SQLAlchemy `+asyncpg` driver suffix — the form many docker-compose stacks and `DATABASE_URL` env-vars use (`postgresql+asyncpg://user:pass@host:5432/db`). Bug fix; no public API surface change; no migration required.
+- **`@db.model(append_only=True)` decorator (#839)** — declare an immutable event-log model. Mutation node names register as `AppendOnlyForbiddenNode` stubs that raise `AppendOnlyViolationError` on construction; `db.express.update / delete / upsert / upsert_advanced / bulk_update / bulk_delete / bulk_upsert` route through `_check_append_only` and raise the same typed exception BEFORE any SQL fires. Create/BulkCreate/Read/List/Count continue to be generated normally. (PR #852, PR #856)
+- **`AppendOnlyViolationError`** — public exception class re-exported from `dataflow` top level. Inherits from `DataFlowError` so callers can catch the broad framework-error class. (#839, PR #852)
+- **Tier-3 E2E coverage** — `tests/e2e/test_issue_839_append_only_e2e.py` exercises Create/Read/List/Count success + 6 mutation rejection paths against real Postgres + workflow-builder construction surface + non-append-only-model invariant. (PR #856)
 
 ### Fixed
 
-- **`DatabaseConfig.get_connection_url()` now strips the SQLAlchemy `+asyncpg` / `+psycopg2` driver suffix.** Previously the method returned `self.url` verbatim and the engine's `connection_context()` handed that string straight to `asyncpg.connect()`, which rejects any scheme other than `postgresql://` or `postgres://`. The bare scheme is consumable by both SQLAlchemy (which infers the driver) AND asyncpg (which requires the bare scheme), so stripping at the canonical accessor means every caller — `engine.connection_context()`, `pool_utils.probe_max_connections`, migration sites, model registry — benefits from one fix. Issue #819.
-- **`DataFlow.__init__()` URL validator now accepts the four driver-suffix variants:** `postgresql+asyncpg`, `postgres+asyncpg`, `postgresql+psycopg2`, `postgres+psycopg2`. Previously only `postgresql+asyncpg` passed the validator, so users whose `DATABASE_URL` carried `postgres+asyncpg://` (the alternative bare scheme some Heroku-style stacks emit) hit `DF-401` at construction time before the new normalization could run.
+- **#819 asyncpg DSN normalization (PR #847)** — `DatabaseConfig.get_connection_url()` now strips the SQLAlchemy `+asyncpg` / `+psycopg2` driver suffix. Previously the method returned `self.url` verbatim and the engine's `connection_context()` handed that string straight to `asyncpg.connect()`, which rejects any scheme other than `postgresql://` or `postgres://`. The bare scheme is consumable by both SQLAlchemy (which infers the driver) AND asyncpg (which requires the bare scheme), so stripping at the canonical accessor means every caller benefits from one fix.
+- **#819 URL validator extended (PR #847)** — `DataFlow.__init__()` URL validator now accepts the four driver-suffix variants: `postgresql+asyncpg`, `postgres+asyncpg`, `postgresql+psycopg2`, `postgres+psycopg2`. Previously only `postgresql+asyncpg` passed the validator, so users whose `DATABASE_URL` carried `postgres+asyncpg://` hit `DF-401` at construction time before the new normalization could run.
+- **Orphan: 14 express mutation methods now invoke `_check_append_only` (PR #856)** — `_check_append_only` was defined in PR #852 but only one of 14 mutation method bodies called it; the other 13 silently permitted writes on `append_only=True` models, defeating the documented contract. Same-shard fix-immediately per `rules/autonomous-execution.md` Rule 4. Defense-in-depth: `bulk_upsert` checks at both outer-body and inner-coroutine. ABC-gate fix on `AppendOnlyForbiddenNode` so typed exception surfaces instead of `TypeError: Can't instantiate abstract class`.
 
 ### Changed
 
-- **`pool_utils._probe_postgresql` now routes its inline `+asyncpg` strip through the canonical helper** (`dataflow.core.config._strip_asyncpg_driver_suffix`). Defense-in-depth — callers passing raw URLs that have not been routed through `DatabaseConfig.get_connection_url()` (e.g., a fallback `os.environ["DATABASE_URL"]` read) still get the suffix stripped here.
+- **`pool_utils._probe_postgresql` (PR #847)** now routes its inline `+asyncpg` strip through the canonical helper `dataflow.core.config._strip_asyncpg_driver_suffix`. Defense-in-depth — callers passing raw URLs that have not been routed through `DatabaseConfig.get_connection_url()` still get the suffix stripped here.
 
 ### Tests
 
-- 10 new Tier-2 regression tests at `tests/integration/test_issue_819_asyncpg_dsn_normalization.py` covering: helper passthrough on plain / non-Postgres URLs; helper strip on `postgresql+asyncpg`, `postgres+asyncpg`, `postgresql+psycopg2`; `DatabaseConfig.get_connection_url` returns stripped form for all three Postgres inputs; real-Postgres `DataFlow.get_connection()` round-trip succeeds on `postgresql+asyncpg://`, plain `postgresql://`, and `postgres+asyncpg://` DSNs; raw asyncpg connect succeeds on the stripped output for all three forms.
+- **#819:** 10 new Tier-2 regression tests at `tests/integration/test_issue_819_asyncpg_dsn_normalization.py` covering helper passthrough / strip behavior across plain/non-Postgres URLs and all three Postgres driver-suffix variants; real-Postgres round-trip via `DataFlow.get_connection()`; raw asyncpg connect on stripped output.
+- **#839 + orphan:** 7 Tier-2 + 4 Tier-3 regression tests covering structural invariants and end-to-end rejection across all mutation surfaces against real Postgres.
+
+### Migration
+
+No breaking changes. Existing models without `append_only=True` operate identically. `@db.model(append_only=True)` is opt-in.
 
 ## [2.7.9] — 2026-05-06 — Async transaction event-loop mismatch (#835)
 

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.7.9"
+version = "2.8.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -47,7 +47,6 @@ from .configuration import (
 from .core.config import DataFlowConfig, LoggingConfig, mask_sensitive
 from .core.engine import DataFlow
 from .core.exceptions import DDLFailedError
-from .exceptions import AppendOnlyViolationError, DataFlowError
 from .core.logging_config import DEFAULT_SENSITIVE_PATTERNS
 from .core.logging_config import LoggingConfig as AdvancedLoggingConfig
 from .core.logging_config import (
@@ -68,6 +67,7 @@ from .engine import (
     QueryEngine,
     ValidationLayer,
 )
+from .exceptions import AppendOnlyViolationError, DataFlowError
 from .features.express import SyncExpress
 from .utils.suppress_warnings import (
     configure_dataflow_logging,
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.7.9"
+__version__ = "2.8.0"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

MINOR bump shipping new public API (`@db.model(append_only=True)` + `AppendOnlyViolationError`) plus the orphan-fix from PR #856 (wired `_check_append_only` into all 14 express mutation methods) and the #819 asyncpg DSN normalization from PR #847.

## What landed

### Added
- **`@db.model(append_only=True)` decorator (#839, PR #852)** — declare immutable event-log models. Mutation node names register as `AppendOnlyForbiddenNode` stubs; express mutation methods raise `AppendOnlyViolationError` BEFORE any SQL fires.
- **`AppendOnlyViolationError`** — public exception re-exported from `dataflow` top level. Inherits from `DataFlowError`.
- **Tier-3 E2E coverage (PR #856)** — 4 tests against real Postgres.

### Fixed
- **#819 asyncpg DSN normalization (PR #847)** — `DatabaseConfig.get_connection_url()` strips `+asyncpg` / `+psycopg2` suffix at the canonical accessor.
- **Orphan: 14 express mutation methods now invoke `_check_append_only` (PR #856)** — only 1 of 14 was wired in PR #852; rest silently permitted writes. Defense-in-depth: `bulk_upsert` checks at both outer-body and inner-coroutine. ABC-gate fix on `AppendOnlyForbiddenNode`.

### Migration
No breaking changes. New API is opt-in.

## Test plan

- [x] Tier 2: 7 tests (`test_issue_839_append_only_flag.py`) — pass
- [x] Tier 3: 4 tests (`test_issue_839_append_only_e2e.py`) — pass against real Postgres
- [x] Tier 2: 10 tests (`test_issue_819_asyncpg_dsn_normalization.py`) — pass
- [ ] Path-filter PR-gate auto-skip (`release/v*` branch)
- [ ] Verification gate post-publish: clean-venv install + 3 invariants (version, AppendOnlyViolationError import + decorator, db.express.update raises on append-only model)

## Related

- Refs PR #852 (#839 append-only), PR #847 (#819 asyncpg DSN), PR #856 (orphan fix + Tier-3 E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)