### PR TITLE
release: kailash-ml 1.7.2 — FeatureStore deprecation-warning bridge (#643)

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,6 +1,6 @@
 # kailash-ml Changelog
 
-## [Unreleased] — FeatureStore canonical surface bridge release
+## [1.7.2] — 2026-05-06 — FeatureStore deprecation-warning bridge (#643)
 
 Per `rules/zero-tolerance.md` Rule 6a (Public-API Removal Requires Deprecation
 Cycle), this bridge release emits a `DeprecationWarning` on first access of

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "1.7.1"
+version = "1.7.2"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "1.7.1"
+__version__ = "1.7.2"


### PR DESCRIPTION
## Summary

PATCH bump 1.7.1 → 1.7.2. Metadata-only diff.

**Source change being released:** commit `9e186e74` — `feat(ml): emit DeprecationWarning for legacy FeatureStore resolution (#643)` (PR #851).

### What ships

- Legacy top-level `from kailash_ml import FeatureStore` now emits a `DeprecationWarning` on first access, naming the canonical replacement `kailash_ml.features.FeatureStore`.
- **No behavior change in 1.7.x** — the legacy resolution path is intact. The warning is the only new output.
- Legacy path removal targeted at kailash-ml 2.0.0 per `rules/zero-tolerance.md` Rule 6a (deprecation cycle before removal).

### Files changed

- `packages/kailash-ml/pyproject.toml` — version 1.7.1 → 1.7.2
- `packages/kailash-ml/src/kailash_ml/_version.py` — `__version__` 1.7.1 → 1.7.2
- `packages/kailash-ml/CHANGELOG.md` — `[Unreleased]` → `[1.7.2] — 2026-05-06`

### Branch convention

`release/v*` branch — CI PR-gate auto-skips per `.github/workflows` path filter.

## Related issues

Closes step 1 of #643. References PR #851.