### PR TITLE
fix(dataflow): #857 AppendOnlyForbiddenNode + bulk_upsert defense-in-depth

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -282,15 +282,30 @@ def _make_append_only_forbidden_node(model_name: str, operation: str) -> Type[No
                 f"to permit mutations. See issue #839."
             )
 
-        # Concrete stubs for the Node ABC — unreachable because __init__
-        # raises. Required so Python's abstract-method gate (CPython
-        # 3.11+ enforces the gate before __init__) does not raise
-        # TypeError and shadow the typed AppendOnlyViolationError.
-        def get_parameters(self):  # pragma: no cover — unreachable
+        # Concrete stubs for the Node ABC. ``__init__`` raises so the
+        # happy path never reaches these bodies; required so Python's
+        # abstract-method gate (CPython 3.11+ enforces the gate before
+        # __init__) does not raise TypeError and shadow the typed
+        # AppendOnlyViolationError.
+        #
+        # Issue #857: ``run()`` is reachable IF an attacker bypasses
+        # __init__ via ``NodeClass.__new__(NodeClass)``. Defense in
+        # depth: also raise from run() so __new__-bypassed instances
+        # fail closed with the same typed error class — the security
+        # promise of @db.model(append_only=True) holds regardless of
+        # how the node was constructed.
+        def get_parameters(self):  # pragma: no cover — unreachable on __init__ path
             return {}
 
-        def run(self, **kwargs):  # pragma: no cover — unreachable
-            return {}
+        def run(self, **kwargs):
+            raise AppendOnlyViolationError(
+                f"{op_human} rejected on append-only model "
+                f"'{model_name}'. Models declared with "
+                f"@db.model(append_only=True) only accept "
+                f"Create / BulkCreate / Read / List / Count. Remove "
+                f"`append_only=True` from the @db.model() decorator "
+                f"to permit mutations. See issue #839."
+            )
 
     AppendOnlyForbiddenNode.__name__ = f"{model_name}{operation.capitalize()}Forbidden"
     AppendOnlyForbiddenNode.__qualname__ = AppendOnlyForbiddenNode.__name__

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -1571,6 +1571,11 @@ class DataFlowExpress:
             pass  # get_model_fields not available — skip validation
 
         async def _bulk_upsert():
+            # Issue #857: defense-in-depth — redundant with the outer-body
+            # guard at L1557. Kept so direct invocations of the inner
+            # coroutine (callers that bypass the public `bulk_upsert`
+            # entry point) also fail closed with AppendOnlyViolationError.
+            # Removing this line would silently re-open the bypass.
             self._check_append_only(model, "bulk_upsert")
             node = self._create_node(model, "BulkUpsert")
             # BulkUpsertNode accepts conflict_columns in its config.

--- a/packages/kailash-dataflow/tests/regression/test_issue_857_append_only_new_bypass.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_857_append_only_new_bypass.py
@@ -1,0 +1,101 @@
+"""Tier 2 regression tests for issue #857 — AppendOnlyForbiddenNode.__new__ bypass.
+
+PR #856 (issue #839 follow-up) wired ``_check_append_only`` into 14 mutation
+methods. The forbidden-mutation node stub raises ``AppendOnlyViolationError``
+from ``__init__`` so ``WorkflowBuilder.add_node("<Model>UpdateNode", ...)``
+fails loudly at construction time.
+
+#856 reviewer surfaced a residual bypass class: a caller who skips ``__init__``
+via ``NodeClass.__new__(NodeClass)`` would land on the concrete ``run()`` stub
+which previously returned ``{}`` — the security promise of
+``@db.model(append_only=True)`` would be silently violated for that one
+construction path.
+
+This module verifies the defense-in-depth fix at ``run()``: even when the
+node is constructed via ``__new__`` (skipping ``__init__``), invoking
+``run({})`` MUST raise the same typed ``AppendOnlyViolationError``.
+
+Per `rules/testing.md` Tier 2: NO mocking, behavioral assertions, real
+dispatch through the SDK's node-generation path.
+"""
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.exceptions import AppendOnlyViolationError
+
+
+@pytest.mark.regression
+def test_append_only_forbidden_node_new_bypass_run_raises_typed_error():
+    """``run({})`` invoked on a ``__new__``-bypassed instance MUST raise
+    ``AppendOnlyViolationError`` with the same actionable message users
+    see at construction time.
+
+    Issue #857: prior to this fix, ``run()`` returned ``{}`` and the
+    documented append-only refusal silently never fired for any code
+    path that constructed the node via ``Cls.__new__(Cls)`` (skipping
+    ``__init__``).
+    """
+    db = DataFlow("sqlite:///:memory:")
+
+    @db.model(append_only=True)
+    class EventLog:
+        event_type: str
+        payload: str
+
+    # Resolve the forbidden node class through the SDK's registry.
+    # ``DataFlow._nodes`` is where ``NodeGenerator.generate_crud_nodes``
+    # registers the per-model stubs (see core/nodes.py:447).
+    update_node_cls = db._nodes.get("EventLogUpdateNode")
+    assert update_node_cls is not None, (
+        "EventLogUpdateNode must be registered as the forbidden stub "
+        "for an append_only=True model"
+    )
+
+    # Bypass __init__ via __new__ — this is the exact attack surface
+    # #857 hardens. CPython's ABC gate is satisfied because the class
+    # provides concrete get_parameters / run bodies.
+    bypassed_instance = update_node_cls.__new__(update_node_cls)
+
+    # Defense in depth: run() MUST raise the same typed error that
+    # __init__ raises on the construction path.
+    with pytest.raises(AppendOnlyViolationError) as exc_info:
+        bypassed_instance.run()
+
+    # The error message MUST cite the model and operation so audit
+    # trails and incident response can grep for it. Same message
+    # contract as the __init__ path.
+    msg = str(exc_info.value)
+    assert "EventLog" in msg, f"error message must name the model; got: {msg!r}"
+    assert (
+        "append-only" in msg.lower()
+    ), f"error message must explain the refusal class; got: {msg!r}"
+    assert (
+        "#839" in msg
+    ), f"error message must reference the originating issue; got: {msg!r}"
+
+
+@pytest.mark.regression
+def test_append_only_forbidden_node_new_bypass_run_with_kwargs_raises():
+    """``run(**kwargs)`` with arbitrary inputs on a ``__new__``-bypassed
+    instance MUST also raise — the refusal contract holds regardless of
+    what payload the bypass attempt supplies.
+    """
+    db = DataFlow("sqlite:///:memory:")
+
+    @db.model(append_only=True)
+    class AuditEntry:
+        actor: str
+        action: str
+
+    delete_node_cls = db._nodes.get("AuditEntryDeleteNode")
+    assert (
+        delete_node_cls is not None
+    ), "AuditEntryDeleteNode must be registered as the forbidden stub"
+
+    bypassed_instance = delete_node_cls.__new__(delete_node_cls)
+
+    with pytest.raises(AppendOnlyViolationError):
+        # Arbitrary kwargs — the refusal MUST fire before any payload
+        # processing.
+        bypassed_instance.run(filter={"id": 1}, force=True)


### PR DESCRIPTION
## Summary

Two LOW-severity post-merge polish items from PR #856 red-team round 1, dispositioned as follow-up because they're hardening / cosmetic, not bug-class same-PR fixes.

## Why

Per #857 — both items close interpretation loops for future readers and tighten the theoretical attack surface. No user-visible behavior change.

## Items

1. **`AppendOnlyForbiddenNode.run()` fails closed** (commit 2ac6e3d6). The forbidden-mutation stub correctly raised from `__init__` on the documented construction surface, but `run()` returned `{}` if an instance was created via `NodeClass.__new__(NodeClass)` (undocumented bypass). Now raises `AppendOnlyViolationError` from `run()` so even `__new__`-bypassed instances fail closed.

2. **`bulk_upsert` inner-coroutine guard documented as defense-in-depth** (commit 87ed100a). The double `_check_append_only` call (outer body L1557 + inner async coroutine L1574) is intentional but lacked a comment explaining why both are kept. Inline comment added so a future reader doesn't see one as redundant and remove it.

## Tests

`tests/integration/test_issue_857_append_only_new_bypass.py` (101 lines) — covers the `__new__` bypass path previously unguarded.

## Related issues

Fixes #857.
