### PR TITLE
feat(infrastructure): WorkflowScheduler dispatch_via= for distributed workers

### DIFF
--- a/specs/scheduling.md
+++ b/specs/scheduling.md
@@ -550,7 +550,7 @@ A subclass missing any of the four methods raises `TypeError` on instantiation p
 ### 9.2 Task dataclass
 
 ```python
-@dataclass
+@dataclass(frozen=True)
 class Task:
     task_id: str
     schedule_id: str
@@ -560,14 +560,16 @@ class Task:
     kwargs: Dict[str, Any] = field(default_factory=dict)
 ```
 
-| Field               | Description                                                                                                                                                                                                 |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `task_id`           | Stable hash of `(schedule_id, planned_fire_time_iso)` produced by `compute_task_id`. 32-character lowercase hex (128 bits of collision resistance). Used as the queue's PRIMARY KEY for idempotent enqueue. |
-| `schedule_id`       | The scheduler-assigned schedule identifier (e.g. `sched-abc123def456`).                                                                                                                                     |
-| `workflow_blob`     | The serialized workflow (pickled `WorkflowBuilder.build()` output). Workers deserialize and execute.                                                                                                        |
-| `planned_fire_time` | The trigger's intended fire time as an ISO 8601 string. The scheduler-computed fire instant — NOT wall-clock now() — so multi-instance double-fires produce the same `task_id`.                             |
-| `queue_name`        | Logical queue for routing (default `"default"`).                                                                                                                                                            |
-| `kwargs`            | Additional keyword arguments forwarded to `runtime.execute(...)` on the worker side.                                                                                                                        |
+`Task` is frozen per EATP P10 — instances flow across the queue boundary and MUST NOT be mutated after construction; the queue payload is the canonical state. `SQLTaskMessage` (the queue-layer message dataclass in `kailash.infrastructure.task_queue`) is also frozen on the same principle.
+
+| Field               | Description                                                                                                                                                                                                          |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task_id`           | Stable hash of `(schedule_id, planned_fire_time_iso)` produced by `compute_task_id`. 32-character lowercase hex (128 bits of collision resistance). Used as the queue's PRIMARY KEY for idempotent enqueue.          |
+| `schedule_id`       | The scheduler-assigned schedule identifier (e.g. `sched-abc123def456`).                                                                                                                                              |
+| `workflow_blob`     | JSON-encoded UTF-8 bytes produced by `Workflow.to_dict()` then `json.dumps(...).encode("utf-8")`. Workers reconstruct via `Workflow.from_dict(json.loads(blob.decode("utf-8")))` — NOT `pickle.loads()`. See §9.4.1. |
+| `planned_fire_time` | The trigger's intended fire time as an ISO 8601 string. The scheduler-computed fire instant — NOT wall-clock now() — so multi-instance double-fires produce the same `task_id`.                                      |
+| `queue_name`        | Logical queue for routing (default `"default"`).                                                                                                                                                                     |
+| `kwargs`            | Additional keyword arguments forwarded to `runtime.execute(...)` on the worker side.                                                                                                                                 |
 
 ### 9.3 compute_task_id helper
 
@@ -602,7 +604,21 @@ await dispatcher.initialize()
 scheduler = WorkflowScheduler(dispatch_via=dispatcher)
 ```
 
-Schema (managed by the underlying `SQLTaskQueue`): `task_id PK, queue_name, payload, status, created_at, updated_at, attempts, max_attempts, visibility_timeout, worker_id, error`. The Task fields are encoded into the `payload` JSON (`schedule_id`, `workflow_blob_b64`, `planned_fire_time`, `kwargs`).
+Schema (managed by the underlying `SQLTaskQueue`): `task_id PK, queue_name, payload, status, created_at, updated_at, attempts, max_attempts, visibility_timeout, worker_id, error`. The Task fields are encoded into the `payload` JSON (`schedule_id`, `workflow_blob_json`, `planned_fire_time`, `kwargs`). `workflow_blob_json` carries the JSON-encoded workflow representation (UTF-8 string in the outer JSON) — see §9.4.1.
+
+#### 9.4.1 Workflow serialization (JSON, not pickle)
+
+`Task.workflow_blob` is JSON-encoded UTF-8 bytes produced by `Workflow.to_dict()` then `json.dumps(workflow_dict).encode("utf-8")`. Workers reconstruct via `Workflow.from_dict(json.loads(blob.decode("utf-8")))`.
+
+Pickle on a queue payload is BLOCKED. Any party with `INSERT INTO <queue_table>` privilege would otherwise execute arbitrary code on the next worker poll via `pickle.loads()` of the attacker-supplied bytes — same threat class as arbitrary-code execution on user input per `rules/security.md` § "No arbitrary-code execution on user input". The JSON contract structurally prevents that class: deserializing a JSON payload produces only Python primitives (`dict`, `list`, `str`, `int`, `float`, `bool`, `None`) — no callable, no class instance, no code path the attacker can pivot to.
+
+If a workflow representation cannot be expressed as JSON (callables, opaque binary state), the dispatcher refuses to serialize and raises `TypeError` per `rules/zero-tolerance.md` Rule 3 — silent fallback to an unsafe path (pickle) is BLOCKED.
+
+#### 9.4.2 Multi-tenant queue isolation
+
+Multi-tenant deployments MUST provision a per-tenant queue table (e.g. `table_name="kailash_task_queue_<tenant>"`). Cross-tenant queue sharing is BLOCKED by deployment convention because the worker pool that polls the queue is a single trust boundary: any party with `INSERT INTO <shared_queue>` privilege can enqueue a workflow that the worker executes under its own runtime credentials. Sharing one queue across tenants therefore grants every tenant the privilege of every other tenant.
+
+The defense is structural, not application-level: the dispatcher does not perform tenant-scoping internally. The operator's responsibility is to provision one `SQLTaskQueueDispatcher(conn, table_name="kailash_task_queue_<tenant>")` per tenant. The `_validate_identifier` regex on `table_name` (per `rules/dataflow-identifier-safety.md`) ensures the per-tenant suffix cannot inject SQL.
 
 ### 9.5 Idempotent enqueue contract
 

--- a/specs/scheduling.md
+++ b/specs/scheduling.md
@@ -89,12 +89,12 @@ WorkflowScheduler(
 
 **Parameters**:
 
-| Parameter         | Type                  | Default                  | Description                                                                                                                                                                                                                                                                  |
-| ----------------- | --------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `job_store_path`  | `Optional[str]`       | `"kailash_schedules.db"` | Path to the SQLite database for APScheduler job persistence. `None` uses in-memory store.                                                                                                                                                                                    |
-| `runtime_factory` | `Optional[Callable]`  | `None`                   | Callable returning a runtime instance. Default creates a new `LocalRuntime()` per execution.                                                                                                                                                                                  |
-| `timezone`        | `str`                 | `"UTC"`                  | Timezone string for cron expression evaluation.                                                                                                                                                                                                                              |
-| `dispatch_via`    | `Optional[Dispatcher]` | `None`                  | Optional `kailash.runtime.dispatcher.Dispatcher`. When provided, every fired trigger enqueues a `Task` to the dispatcher instead of executing in-process. Default `None` preserves the existing in-process behavior. Keyword-only. See §10 "Queue Dispatch" for the contract. |
+| Parameter         | Type                   | Default                  | Description                                                                                                                                                                                                                                                                   |
+| ----------------- | ---------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `job_store_path`  | `Optional[str]`        | `"kailash_schedules.db"` | Path to the SQLite database for APScheduler job persistence. `None` uses in-memory store.                                                                                                                                                                                     |
+| `runtime_factory` | `Optional[Callable]`   | `None`                   | Callable returning a runtime instance. Default creates a new `LocalRuntime()` per execution.                                                                                                                                                                                  |
+| `timezone`        | `str`                  | `"UTC"`                  | Timezone string for cron expression evaluation.                                                                                                                                                                                                                               |
+| `dispatch_via`    | `Optional[Dispatcher]` | `None`                   | Optional `kailash.runtime.dispatcher.Dispatcher`. When provided, every fired trigger enqueues a `Task` to the dispatcher instead of executing in-process. Default `None` preserves the existing in-process behavior. Keyword-only. See §10 "Queue Dispatch" for the contract. |
 
 **Raises**:
 
@@ -538,12 +538,12 @@ class Dispatcher(ABC):
 
 The contract is intentionally minimal:
 
-| Method      | Contract                                                                                                                                                                                                                                                  |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enqueue`   | Idempotent on `task.task_id`. A duplicate enqueue with the same `task_id` MUST be a silent no-op (no exception). Non-duplicate failures (connectivity, serialization) propagate after a structured ERROR log.                                              |
-| `poll`      | Returns an `AsyncIterator[Task]` that yields claimed tasks one at a time. Implementations atomically transition each task to `processing` status. When the queue is empty the iterator stops; long-polling callers re-invoke `poll()` in a loop.        |
-| `ack`       | Marks a task as completed. Idempotent (acking a completed task is a no-op).                                                                                                                                                                                |
-| `nack`      | Marks a task as failed with a short reason. The dispatcher decides whether to requeue (transient failure) or dead-letter (max attempts exceeded) based on its own attempt counter. The reason MUST NOT contain secrets or PII.                            |
+| Method    | Contract                                                                                                                                                                                                                                         |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enqueue` | Idempotent on `task.task_id`. A duplicate enqueue with the same `task_id` MUST be a silent no-op (no exception). Non-duplicate failures (connectivity, serialization) propagate after a structured ERROR log.                                    |
+| `poll`    | Returns an `AsyncIterator[Task]` that yields claimed tasks one at a time. Implementations atomically transition each task to `processing` status. When the queue is empty the iterator stops; long-polling callers re-invoke `poll()` in a loop. |
+| `ack`     | Marks a task as completed. Idempotent (acking a completed task is a no-op).                                                                                                                                                                      |
+| `nack`    | Marks a task as failed with a short reason. The dispatcher decides whether to requeue (transient failure) or dead-letter (max attempts exceeded) based on its own attempt counter. The reason MUST NOT contain secrets or PII.                   |
 
 A subclass missing any of the four methods raises `TypeError` on instantiation per Python's `ABC` contract.
 
@@ -560,14 +560,14 @@ class Task:
     kwargs: Dict[str, Any] = field(default_factory=dict)
 ```
 
-| Field               | Description                                                                                                                                                                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `task_id`           | Stable hash of `(schedule_id, planned_fire_time_iso)` produced by `compute_task_id`. 32-character lowercase hex (128 bits of collision resistance). Used as the queue's PRIMARY KEY for idempotent enqueue.                                  |
-| `schedule_id`       | The scheduler-assigned schedule identifier (e.g. `sched-abc123def456`).                                                                                                                                                                      |
-| `workflow_blob`     | The serialized workflow (pickled `WorkflowBuilder.build()` output). Workers deserialize and execute.                                                                                                                                          |
-| `planned_fire_time` | The trigger's intended fire time as an ISO 8601 string. The scheduler-computed fire instant — NOT wall-clock now() — so multi-instance double-fires produce the same `task_id`.                                                              |
-| `queue_name`        | Logical queue for routing (default `"default"`).                                                                                                                                                                                              |
-| `kwargs`            | Additional keyword arguments forwarded to `runtime.execute(...)` on the worker side.                                                                                                                                                          |
+| Field               | Description                                                                                                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task_id`           | Stable hash of `(schedule_id, planned_fire_time_iso)` produced by `compute_task_id`. 32-character lowercase hex (128 bits of collision resistance). Used as the queue's PRIMARY KEY for idempotent enqueue. |
+| `schedule_id`       | The scheduler-assigned schedule identifier (e.g. `sched-abc123def456`).                                                                                                                                     |
+| `workflow_blob`     | The serialized workflow (pickled `WorkflowBuilder.build()` output). Workers deserialize and execute.                                                                                                        |
+| `planned_fire_time` | The trigger's intended fire time as an ISO 8601 string. The scheduler-computed fire instant — NOT wall-clock now() — so multi-instance double-fires produce the same `task_id`.                             |
+| `queue_name`        | Logical queue for routing (default `"default"`).                                                                                                                                                            |
+| `kwargs`            | Additional keyword arguments forwarded to `runtime.execute(...)` on the worker side.                                                                                                                        |
 
 ### 9.3 compute_task_id helper
 
@@ -622,15 +622,25 @@ When `dispatch_via=None` (the default), `WorkflowScheduler._execute_workflow` ru
 
 Every enqueue failure (whether silently-skipped duplicate or genuinely-failed) generates exactly one structured log line:
 
-| Outcome                      | Level | Fields                                                              |
-| ---------------------------- | ----- | ------------------------------------------------------------------- |
-| Duplicate (silent skip)      | DEBUG | `task.enqueue.duplicate task_id_hash=… schedule_id=…`                |
-| Non-duplicate failure        | ERROR | `task.enqueue.failed task_id_hash=… schedule_id=… reason=<ExcName>`  |
-| Successful enqueue           | INFO  | `scheduler.dispatch.enqueued schedule_id=… task_id_hash=…`           |
-| Serialization failure        | ERROR | `scheduler.dispatch.serialize_failed schedule_id=… task_id_hash=…`   |
-| Dispatch invocation start    | INFO  | `scheduler.dispatch.start schedule_id=… task_id_hash=… run_id=…`     |
+| Outcome                   | Level | Fields                                                              |
+| ------------------------- | ----- | ------------------------------------------------------------------- |
+| Duplicate (silent skip)   | DEBUG | `task.enqueue.duplicate task_id_hash=… schedule_id=…`               |
+| Non-duplicate failure     | ERROR | `task.enqueue.failed task_id_hash=… schedule_id=… reason=<ExcName>` |
+| Successful enqueue        | INFO  | `scheduler.dispatch.enqueued schedule_id=… task_id_hash=…`          |
+| Serialization failure     | ERROR | `scheduler.dispatch.serialize_failed schedule_id=… task_id_hash=…`  |
+| Dispatch invocation start | INFO  | `scheduler.dispatch.start schedule_id=… task_id_hash=… run_id=…`    |
 
 `task_id_hash` is the first 8 hex chars of `sha256(task_id)` per `rules/observability.md` Rule 8 (raw `task_id` reveals the schedule identifier and fire-time, which is schema-revealing for log aggregators).
+
+### 9.9 planned_fire_time capture mechanism
+
+`planned_fire_time` is captured at job-submission time via APScheduler's `EVENT_JOB_SUBMITTED` listener — NOT read from `job.next_run_time` at callback entry. The submission event fires BEFORE the job callback runs and exposes `event.scheduled_run_times: list[datetime]`, the actual trigger fire instants for the currently-firing job. The scheduler records the LAST element (the most recent fire — typically the only one; coalesce/misfire policies may produce several) keyed by `event.job_id`.
+
+This mechanism is required because by the time the dispatch callback runs, APScheduler has already advanced `job.next_run_time` to the NEXT scheduled fire. Reading `job.next_run_time` from inside the callback would record a fire instant one interval ahead of truth on every cron/interval trigger.
+
+The capture is symmetric: `EVENT_JOB_EXECUTED | EVENT_JOB_ERROR` listener clears the recorded entry once the job finishes. If `_planned_fire_time(schedule_id)` is invoked without a prior submit-event recording, it raises `RuntimeError` rather than falling back to `datetime.now(UTC)` — silent fallback would silently break multi-instance dedup (each scheduler instance would compute a different `task_id` for the same fire).
+
+Stability across multi-instance schedulers: every instance receives the same `scheduled_run_times` from APScheduler for the same trigger fire, so `compute_task_id(schedule_id, fire_time)` produces the SAME `task_id` and the queue layer dedups via PRIMARY KEY.
 
 ---
 

--- a/specs/scheduling.md
+++ b/specs/scheduling.md
@@ -658,6 +658,32 @@ The capture is symmetric: `EVENT_JOB_EXECUTED | EVENT_JOB_ERROR` listener clears
 
 Stability across multi-instance schedulers: every instance receives the same `scheduled_run_times` from APScheduler for the same trigger fire, so `compute_task_id(schedule_id, fire_time)` produces the SAME `task_id` and the queue layer dedups via PRIMARY KEY.
 
+### 9.10 Payload bounds
+
+`WorkflowScheduler` enforces an 8 MiB cap on the JSON-serialized workflow_blob at the producer boundary. `MAX_WORKFLOW_BLOB_BYTES = 8 * 1024 * 1024` is defined at `src/kailash/runtime/scheduler.py`; if `len(json.dumps(workflow.to_dict()).encode("utf-8")) > MAX_WORKFLOW_BLOB_BYTES`, the dispatch callback raises `ValueError` BEFORE constructing a `Task` and BEFORE invoking the dispatcher's `enqueue`. The error message names the actual blob size, the cap, and the remediation paths (split sub-workflows, externalize large inputs, fall back to in-process dispatch via `dispatch_via=None`).
+
+`SQLTaskQueue.enqueue` enforces the same 8 MiB cap on the outer payload as defense-in-depth at the consumer boundary. `MAX_PAYLOAD_BYTES` is defined at `src/kailash/infrastructure/task_queue.py`; callers bypassing the scheduler and writing directly to the queue still encounter the cap. The duplicate enforcement is intentional — neither layer trusts the other to have validated.
+
+`SQLTaskQueue.enqueue` also validates caller-supplied `task_id`: length must be in `[1, 128]` characters and the value must match `[a-zA-Z0-9_-]+`. UUIDs (auto-generated default) and `compute_task_id()` outputs both pass. Validation is applied via `_validate_task_id()` in the same module. The validation closes the dedup-namespace-poisoning vector where a caller could choose a `task_id` that shadows a legitimate stable-hash output.
+
+### 9.11 Operator runbook — purge cadence
+
+The queue table grows monotonically with every successful enqueue. Operators MUST schedule periodic `SQLTaskQueue.purge_completed(queue_name, older_than=...)` calls to drop rows in terminal status (`completed`, `dead_lettered`); without periodic purge, the table fills disk over the deployment's lifetime.
+
+`SQLTaskQueueDispatcher` exposes an optional `soft_row_cap` constructor kwarg (keyword-only) that emits a structured WARN log when the queue table holds more than `soft_row_cap` rows for the target queue at enqueue time. The WARN is rate-limited to once per minute per `queue_name` to prevent log flooding under sustained over-cap conditions. When `soft_row_cap` is `None` (default), no row-count check fires and no warning emits.
+
+The cap is operational signal — it does NOT refuse the enqueue. Refusing would silently drop scheduled work; a noisy log is the correct trade-off because operator action (call `purge_completed` or raise the cap) restores headroom without losing fires. Recommended `soft_row_cap` range is 100,000 - 1,000,000 depending on purge cadence and average task lifetime.
+
+```python
+from kailash.db.connection import ConnectionManager
+from kailash.infrastructure.task_queue import SQLTaskQueueDispatcher
+
+conn = ConnectionManager("postgresql://...")
+dispatcher = SQLTaskQueueDispatcher(conn, soft_row_cap=500_000)
+# every enqueue past 500k rows in the queue emits a WARN log
+# `task.queue.over_cap queue_name=… rows=… soft_row_cap=500000 remediation=call_purge_completed_or_raise_cap`
+```
+
 ---
 
 ## 10. Constraints and Limitations

--- a/specs/scheduling.md
+++ b/specs/scheduling.md
@@ -1,9 +1,9 @@
 # Scheduling Specification
 
-Version: 2.8.5
+Version: 2.9.0
 Package: `kailash`
 Status: Authoritative domain truth document
-Scope: WorkflowScheduler, cron/interval/one-shot scheduling, APScheduler integration, SQLite job persistence, runtime integration
+Scope: WorkflowScheduler, cron/interval/one-shot scheduling, APScheduler integration, SQLite job persistence, runtime integration, queue dispatch
 
 This specification covers every public contract, parameter, return type, edge case, and constraint for the Kailash scheduling subsystem. It is the single source of truth for how workflows are scheduled for recurring and deferred execution.
 
@@ -82,16 +82,19 @@ WorkflowScheduler(
     job_store_path: Optional[str] = "kailash_schedules.db",
     runtime_factory: Optional[Callable] = None,
     timezone: str = "UTC",
+    *,
+    dispatch_via: Optional[Dispatcher] = None,
 )
 ```
 
 **Parameters**:
 
-| Parameter         | Type                 | Default                  | Description                                                                                  |
-| ----------------- | -------------------- | ------------------------ | -------------------------------------------------------------------------------------------- |
-| `job_store_path`  | `Optional[str]`      | `"kailash_schedules.db"` | Path to the SQLite database for APScheduler job persistence. `None` uses in-memory store.    |
-| `runtime_factory` | `Optional[Callable]` | `None`                   | Callable returning a runtime instance. Default creates a new `LocalRuntime()` per execution. |
-| `timezone`        | `str`                | `"UTC"`                  | Timezone string for cron expression evaluation.                                              |
+| Parameter         | Type                  | Default                  | Description                                                                                                                                                                                                                                                                  |
+| ----------------- | --------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `job_store_path`  | `Optional[str]`       | `"kailash_schedules.db"` | Path to the SQLite database for APScheduler job persistence. `None` uses in-memory store.                                                                                                                                                                                    |
+| `runtime_factory` | `Optional[Callable]`  | `None`                   | Callable returning a runtime instance. Default creates a new `LocalRuntime()` per execution.                                                                                                                                                                                  |
+| `timezone`        | `str`                 | `"UTC"`                  | Timezone string for cron expression evaluation.                                                                                                                                                                                                                              |
+| `dispatch_via`    | `Optional[Dispatcher]` | `None`                  | Optional `kailash.runtime.dispatcher.Dispatcher`. When provided, every fired trigger enqueues a `Task` to the dispatcher instead of executing in-process. Default `None` preserves the existing in-process behavior. Keyword-only. See §10 "Queue Dispatch" for the contract. |
 
 **Raises**:
 
@@ -105,8 +108,8 @@ WorkflowScheduler(
    - Creates a `SQLAlchemyJobStore` backed by `sqlite:///{job_store_path}`.
    - On POSIX systems, sets the SQLite file permissions to `0o600` (owner read/write only). Logs a warning if `chmod` fails (does not raise).
 4. Creates an `AsyncIOScheduler` with the configured job stores and timezone.
-5. Sets `self._runtime_factory`, `self._schedules` (empty dict), and `self._timezone`.
-6. Logs initialization at INFO level.
+5. Sets `self._runtime_factory`, `self._schedules` (empty dict), `self._timezone`, and `self._dispatcher` (the `dispatch_via` arg or `None`).
+6. Logs initialization at INFO level. Log line includes `dispatch=queue` when `dispatch_via` is provided, `dispatch=in_process` otherwise.
 
 **Security contract**: The SQLite job store file is created with `0o600` permissions on POSIX systems, preventing other users from reading scheduled workflow configurations. On non-POSIX systems (Windows), the file is created with default permissions.
 
@@ -512,12 +515,131 @@ scheduler = WorkflowScheduler(job_store_path=None)
 
 ---
 
-## 9. Constraints and Limitations
+## 9. Queue Dispatch
+
+**Module**: `kailash.runtime.dispatcher` (ABC + helpers) + `kailash.infrastructure.task_queue` (SQL adapter)
+**Added in**: v2.9.0
+
+When `WorkflowScheduler` is constructed with `dispatch_via=<Dispatcher>`, every fired trigger enqueues a `Task` to the dispatcher in lieu of executing the workflow in-process. A separate worker pool polls the dispatcher and runs the workflow against its own runtime. This enables (a) multi-instance scheduler deployments where two scheduler processes can fire the same trigger and the second is silently deduped at the queue layer, and (b) worker-side resume from checkpoint when paired with a checkpoint store.
+
+### 9.1 Dispatcher ABC
+
+**Module**: `kailash.runtime.dispatcher`
+
+```python
+class Dispatcher(ABC):
+    async def enqueue(self, task: Task) -> None: ...
+    def poll(self, queue_name: str = "default") -> AsyncIterator[Task]: ...
+    async def ack(self, task_id: str) -> None: ...
+    async def nack(self, task_id: str, *, reason: str) -> None: ...
+```
+
+**Public exports** of `kailash.runtime.dispatcher` (`__all__`): `Dispatcher`, `Task`, `compute_task_id`.
+
+The contract is intentionally minimal:
+
+| Method      | Contract                                                                                                                                                                                                                                                  |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enqueue`   | Idempotent on `task.task_id`. A duplicate enqueue with the same `task_id` MUST be a silent no-op (no exception). Non-duplicate failures (connectivity, serialization) propagate after a structured ERROR log.                                              |
+| `poll`      | Returns an `AsyncIterator[Task]` that yields claimed tasks one at a time. Implementations atomically transition each task to `processing` status. When the queue is empty the iterator stops; long-polling callers re-invoke `poll()` in a loop.        |
+| `ack`       | Marks a task as completed. Idempotent (acking a completed task is a no-op).                                                                                                                                                                                |
+| `nack`      | Marks a task as failed with a short reason. The dispatcher decides whether to requeue (transient failure) or dead-letter (max attempts exceeded) based on its own attempt counter. The reason MUST NOT contain secrets or PII.                            |
+
+A subclass missing any of the four methods raises `TypeError` on instantiation per Python's `ABC` contract.
+
+### 9.2 Task dataclass
+
+```python
+@dataclass
+class Task:
+    task_id: str
+    schedule_id: str
+    workflow_blob: bytes
+    planned_fire_time: str            # ISO 8601 UTC
+    queue_name: str = "default"
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+```
+
+| Field               | Description                                                                                                                                                                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `task_id`           | Stable hash of `(schedule_id, planned_fire_time_iso)` produced by `compute_task_id`. 32-character lowercase hex (128 bits of collision resistance). Used as the queue's PRIMARY KEY for idempotent enqueue.                                  |
+| `schedule_id`       | The scheduler-assigned schedule identifier (e.g. `sched-abc123def456`).                                                                                                                                                                      |
+| `workflow_blob`     | The serialized workflow (pickled `WorkflowBuilder.build()` output). Workers deserialize and execute.                                                                                                                                          |
+| `planned_fire_time` | The trigger's intended fire time as an ISO 8601 string. The scheduler-computed fire instant — NOT wall-clock now() — so multi-instance double-fires produce the same `task_id`.                                                              |
+| `queue_name`        | Logical queue for routing (default `"default"`).                                                                                                                                                                                              |
+| `kwargs`            | Additional keyword arguments forwarded to `runtime.execute(...)` on the worker side.                                                                                                                                                          |
+
+### 9.3 compute_task_id helper
+
+```python
+def compute_task_id(schedule_id: str, planned_fire_time: datetime) -> str:
+    """Return SHA-256(schedule_id || planned_fire_time.isoformat())[:32]."""
+```
+
+Stability contract:
+
+- Same `(schedule_id, planned_fire_time)` ALWAYS produces the same hex string.
+- Changing either input flips the hash.
+- The ISO 8601 representation preserves microsecond precision when present. Naive datetimes (no tzinfo) and aware datetimes in different timezones produce different `task_id`s — callers MUST be consistent about timezone awareness within a single schedule.
+
+### 9.4 SQLTaskQueueDispatcher
+
+**Module**: `kailash.infrastructure.task_queue`
+
+Reference `Dispatcher` implementation backed by a SQL table managed by `kailash.db.connection.ConnectionManager`. PostgreSQL, MySQL 8.0+, and SQLite portable per `rules/infrastructure-sql.md` (uses `dialect.text_column`, `dialect.quote_identifier`, `for_update_skip_locked`, canonical `?` placeholders translated by `ConnectionManager.execute`).
+
+```python
+from kailash.db.connection import ConnectionManager
+from kailash.infrastructure.task_queue import SQLTaskQueueDispatcher
+from kailash.runtime.scheduler import WorkflowScheduler
+
+conn = ConnectionManager("postgresql://...")
+await conn.initialize()
+
+dispatcher = SQLTaskQueueDispatcher(conn)
+await dispatcher.initialize()
+
+scheduler = WorkflowScheduler(dispatch_via=dispatcher)
+```
+
+Schema (managed by the underlying `SQLTaskQueue`): `task_id PK, queue_name, payload, status, created_at, updated_at, attempts, max_attempts, visibility_timeout, worker_id, error`. The Task fields are encoded into the `payload` JSON (`schedule_id`, `workflow_blob_b64`, `planned_fire_time`, `kwargs`).
+
+### 9.5 Idempotent enqueue contract
+
+`SQLTaskQueueDispatcher.enqueue(task)` catches PRIMARY KEY / unique-constraint violations across asyncpg (`UniqueViolationError` / `TransactionIntegrityConstraintViolationError`), sqlite (`IntegrityError` whose message contains `UNIQUE` or `PRIMARY KEY`), and aiomysql (errno 1062) and treats them as silent no-ops with a DEBUG log line carrying the `task_id_hash` (8-char SHA-256 prefix). Multi-instance scheduler double-fire reduces to one row at the queue layer.
+
+Non-PK failures log at ERROR with grep-able `schedule_id` + `task_id_hash` + reason, then propagate to the caller (which surfaces to APScheduler's misfire / retry policy).
+
+### 9.6 Worker resume hint
+
+Workers polling a `Dispatcher` SHOULD pass the received `task.task_id` as the `idempotency_key` argument to `runtime.execute(...)` when paired with a checkpoint store. This gives resume-from-checkpoint semantics on crash recovery — the worker that picks up a previously-running task sees the existing checkpoint and resumes from the last completed node. This contract is informational; nothing in the dispatcher enforces it (the binding is between the worker and the checkpoint-aware runtime).
+
+### 9.7 In-process fallback semantics
+
+When `dispatch_via=None` (the default), `WorkflowScheduler._execute_workflow` runs the workflow inline via the configured runtime — the existing v0.13.0 behavior. The dispatcher branch is a strict superset: setting `dispatch_via=` does not change anything else about the scheduler's API or storage.
+
+### 9.8 Error log surface
+
+Every enqueue failure (whether silently-skipped duplicate or genuinely-failed) generates exactly one structured log line:
+
+| Outcome                      | Level | Fields                                                              |
+| ---------------------------- | ----- | ------------------------------------------------------------------- |
+| Duplicate (silent skip)      | DEBUG | `task.enqueue.duplicate task_id_hash=… schedule_id=…`                |
+| Non-duplicate failure        | ERROR | `task.enqueue.failed task_id_hash=… schedule_id=… reason=<ExcName>`  |
+| Successful enqueue           | INFO  | `scheduler.dispatch.enqueued schedule_id=… task_id_hash=…`           |
+| Serialization failure        | ERROR | `scheduler.dispatch.serialize_failed schedule_id=… task_id_hash=…`   |
+| Dispatch invocation start    | INFO  | `scheduler.dispatch.start schedule_id=… task_id_hash=… run_id=…`     |
+
+`task_id_hash` is the first 8 hex chars of `sha256(task_id)` per `rules/observability.md` Rule 8 (raw `task_id` reveals the schedule identifier and fire-time, which is schema-revealing for log aggregators).
+
+---
+
+## 10. Constraints and Limitations
 
 1. **No async-native execution**: The default `_execute_workflow` calls `runtime.execute()` synchronously inside an async callback. For fully async execution, provide a custom `runtime_factory` with `AsyncLocalRuntime`.
-2. **No distributed scheduling**: The scheduler is single-process. For distributed scheduling across multiple instances, use an external scheduler (Celery, Temporal) with Kailash workflows as tasks.
+2. **No built-in worker pool**: The scheduler enqueues to the dispatcher; the application is responsible for running worker processes that call `dispatcher.poll()` in a loop. The Kailash SDK supplies the dispatcher contract and the SQL-backed adapter; worker orchestration is left to the deploying application.
 3. **No schedule modification**: There is no `update_schedule()` method. To change a schedule's trigger, cancel it and create a new one.
 4. **No pause/resume**: Individual schedules cannot be paused. The entire scheduler can be shut down and restarted.
 5. **Schedule ID format**: IDs are `sched-{12_hex_chars}`. Not configurable.
-6. **No retry on failure**: If a scheduled execution fails, it is logged but not retried. The next trigger fires normally.
+6. **No retry on failure**: If a scheduled execution fails (in-process or enqueue-side), it is logged but the scheduler does not retry. The next trigger fires normally. Worker-side retry on `nack` is the dispatcher implementation's responsibility (`SQLTaskQueueDispatcher` requeues until `max_attempts`, then dead-letters).
 7. **APScheduler version**: Requires `apscheduler>=3.10`. APScheduler 4.x has a different API and is not supported.

--- a/src/kailash/infrastructure/task_queue.py
+++ b/src/kailash/infrastructure/task_queue.py
@@ -17,12 +17,15 @@ the target dialect automatically.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+from kailash.runtime.dispatcher import Dispatcher, Task
 
 logger = logging.getLogger(__name__)
 

--- a/src/kailash/infrastructure/task_queue.py
+++ b/src/kailash/infrastructure/task_queue.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -34,6 +35,49 @@ __all__ = [
     "SQLTaskMessage",
     "SQLTaskQueueDispatcher",
 ]
+
+# Bounds on the queue's caller-controlled inputs. Defense-in-depth against
+# poisoning by parties with INSERT privilege on the queue table (the
+# multi-tenant queue isolation contract documented in
+# `specs/scheduling.md` § "Multi-tenant queue isolation" assumes the
+# operator gates writers; these bounds ensure even a permitted writer
+# cannot DoS the worker pool by enqueueing unbounded payloads).
+MAX_TASK_ID_LEN = 128  # uuid4 is 36 chars; W3 stable_hash is 32 chars
+_TASK_ID_RE = re.compile(r"^[a-zA-Z0-9_\-]+$")
+MAX_PAYLOAD_BYTES = 8 * 1024 * 1024  # 8 MiB — matches MAX_WORKFLOW_BLOB_BYTES
+
+
+def _validate_task_id(tid: Any) -> None:
+    """Validate a caller-supplied task_id.
+
+    Per ``rules/security.md`` § "Input Validation", any caller-controlled
+    string flowing into a primary-key column MUST be length- and charset-
+    validated. Although the column is bound as a parameter (no SQLi),
+    accepting unbounded keys lets a caller poison the dedup namespace
+    (the W3 dispatcher computes ``task_id = stable_hash(schedule_id,
+    fire_time)`` precisely so duplicate fires collapse — a caller who
+    bypasses that and submits a chosen ``task_id`` could shadow a
+    legitimate one).
+
+    Accepts ``Any`` rather than ``str`` so the runtime type-confusion
+    branch is reachable from external callers; static-typed callers see
+    no widening because internal call sites still pass a ``str``.
+
+    Raises
+    ------
+    ValueError
+        If ``tid`` is not a non-empty string ≤ ``MAX_TASK_ID_LEN`` chars
+        matching ``[a-zA-Z0-9_-]+``.
+    """
+    if not isinstance(tid, str):
+        raise ValueError(f"task_id must be str, got {type(tid).__name__}")
+    if len(tid) == 0 or len(tid) > MAX_TASK_ID_LEN:
+        raise ValueError(f"task_id length {len(tid)} outside [1, {MAX_TASK_ID_LEN}]")
+    if not _TASK_ID_RE.match(tid):
+        raise ValueError(
+            f"task_id must match {_TASK_ID_RE.pattern} "
+            "(alphanumeric, underscore, hyphen)"
+        )
 
 
 @dataclass(frozen=True)
@@ -207,6 +251,27 @@ class SQLTaskQueue:
             The task ID.
         """
         tid = task_id or str(uuid.uuid4())
+        # Always validate, including the auto-generated UUID (defense-in-
+        # depth: if uuid.uuid4 ever drifts to a different shape, the cap
+        # still holds). Caller-supplied IDs are the actual attack surface
+        # — see _validate_task_id docstring.
+        _validate_task_id(tid)
+
+        # Cap payload size before writing to the queue. A worker that
+        # dequeues a multi-megabyte JSON blob will `json.loads` it into
+        # memory; an unbounded payload OOMs the dequeueing worker. The
+        # MAX_WORKFLOW_BLOB_BYTES cap on the producer (scheduler.py) is
+        # the primary gate; this cap is the consumer-boundary defense
+        # for callers that bypass the scheduler and enqueue directly.
+        payload_json = json.dumps(payload)
+        if len(payload_json.encode("utf-8")) > MAX_PAYLOAD_BYTES:
+            raise ValueError(
+                f"payload size {len(payload_json)} bytes exceeds "
+                f"MAX_PAYLOAD_BYTES ({MAX_PAYLOAD_BYTES} bytes / "
+                f"{MAX_PAYLOAD_BYTES // (1024 * 1024)} MiB). Reduce the "
+                f"task payload (split work, externalize large inputs)."
+            )
+
         now = time.time()
         vt = (
             visibility_timeout
@@ -221,7 +286,7 @@ class SQLTaskQueue:
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             tid,
             queue_name,
-            json.dumps(payload),
+            payload_json,
             "pending",
             now,
             now,
@@ -505,6 +570,19 @@ class SQLTaskQueueDispatcher(Dispatcher):
     own table; no application-level multi-tenancy is performed inside
     the dispatcher.
 
+    Operator runbook — purge cadence
+    --------------------------------
+    The queue table grows monotonically with every fire. Operators MUST
+    schedule periodic :meth:`SQLTaskQueue.purge_completed` calls to
+    drop rows in terminal status; otherwise the table fills disk over
+    time. A soft cap is available via the ``soft_row_cap`` constructor
+    arg: when set, the dispatcher emits a structured WARN log every
+    time :meth:`enqueue` lands while the table holds more than
+    ``soft_row_cap`` rows for the target queue. The WARN is operational
+    signal — it does NOT refuse the enqueue (refusal would silently
+    drop scheduled work; a noisy log is the correct trade-off). See
+    ``specs/scheduling.md`` § "Queue dispatch — operator runbook".
+
     Parameters
     ----------
     conn:
@@ -514,17 +592,38 @@ class SQLTaskQueueDispatcher(Dispatcher):
         Validated against ``[a-zA-Z_][a-zA-Z0-9_]*`` in the underlying
         :class:`SQLTaskQueue`. For multi-tenant deployments use one
         table per tenant (see "Multi-tenant deployment contract").
+    soft_row_cap:
+        Optional row-count threshold. When ``None`` (default), no cap
+        warning fires. When set to an integer, every :meth:`enqueue`
+        that lands while the queue table holds more than this many
+        rows for the target queue emits a WARN log. Recommended range:
+        100_000 - 1_000_000 depending on purge cadence.
 
     See Also
     --------
     :class:`~kailash.runtime.dispatcher.Dispatcher` -- the abstract contract.
     :func:`~kailash.runtime.dispatcher.compute_task_id` -- stable task_id helper.
     :class:`~kailash.runtime.scheduler.WorkflowScheduler` -- the producer.
+    :meth:`SQLTaskQueue.purge_completed` -- the operator runbook step.
     """
 
-    def __init__(self, conn: Any, table_name: str = "kailash_task_queue") -> None:
+    def __init__(
+        self,
+        conn: Any,
+        table_name: str = "kailash_task_queue",
+        *,
+        soft_row_cap: Optional[int] = None,
+    ) -> None:
+        if soft_row_cap is not None and soft_row_cap <= 0:
+            raise ValueError(
+                f"soft_row_cap must be positive or None, got {soft_row_cap}"
+            )
         self._queue = SQLTaskQueue(conn, table_name=table_name)
         self._initialized = False
+        self._soft_row_cap = soft_row_cap
+        # Suppress the WARN flood — fire at most once per minute per
+        # queue_name. The cap is operational signal, not per-row alert.
+        self._cap_warn_last: Dict[str, float] = {}
 
     async def initialize(self) -> None:
         """Create the underlying queue table if it does not exist.
@@ -586,6 +685,56 @@ class SQLTaskQueueDispatcher(Dispatcher):
                 type(exc).__name__,
             )
             raise
+
+        # Operator runbook signal: warn (rate-limited) when the queue
+        # has grown past the soft cap. Refusing the enqueue would
+        # silently drop scheduled work; the WARN is the operational
+        # cue to call purge_completed or raise the cap. See class
+        # docstring "Operator runbook — purge cadence".
+        if self._soft_row_cap is not None:
+            await self._maybe_warn_row_count(task.queue_name)
+
+    async def _maybe_warn_row_count(self, queue_name: str) -> None:
+        """Emit a rate-limited WARN if queue depth exceeds soft_row_cap.
+
+        Cheap COUNT query; only runs when ``soft_row_cap`` is set. Fires
+        at most once per minute per queue_name to bound log volume on
+        a sustained over-cap deployment (the operator sees the same
+        signal once per minute; not on every enqueue).
+        """
+        # soft_row_cap is None-checked at the call site; this method
+        # is only invoked when it is set. Rebind to a local int so
+        # static analyzers can narrow Optional[int] to int.
+        cap = self._soft_row_cap
+        if cap is None:
+            return  # pragma: no cover (defensive — caller already checked)
+        now = time.time()
+        last = self._cap_warn_last.get(queue_name, 0.0)
+        if now - last < 60.0:
+            return
+        try:
+            row = await self._queue._conn.fetchone(
+                f"SELECT COUNT(*) AS c FROM {self._queue._table} WHERE queue_name = ?",
+                queue_name,
+            )
+        except Exception:
+            # COUNT is operational signal; never let its failure
+            # propagate to the caller's enqueue success path.
+            logger.debug(
+                "task.queue.row_count_check_failed queue_name=%s",
+                queue_name,
+            )
+            return
+        count = (row or {}).get("c", 0) if isinstance(row, dict) else 0
+        if count > cap:
+            logger.warning(
+                "task.queue.over_cap queue_name=%s rows=%s soft_row_cap=%s "
+                "remediation=call_purge_completed_or_raise_cap",
+                queue_name,
+                count,
+                cap,
+            )
+            self._cap_warn_last[queue_name] = now
 
     def poll(self, queue_name: str = "default") -> AsyncIterator[Task]:
         """Yield tasks claimed from the queue, one at a time.

--- a/src/kailash/infrastructure/task_queue.py
+++ b/src/kailash/infrastructure/task_queue.py
@@ -36,9 +36,13 @@ __all__ = [
 ]
 
 
-@dataclass
+@dataclass(frozen=True)
 class SQLTaskMessage:
     """A task message stored in the SQL task queue.
+
+    Frozen per EATP P10 — message instances flow across the queue boundary
+    and MUST NOT be mutated after construction; the database row is the
+    canonical state.
 
     Attributes:
         task_id: Unique identifier for the task.
@@ -488,6 +492,19 @@ class SQLTaskQueueDispatcher(Dispatcher):
     semantics on crash recovery -- see ``specs/scheduling.md``
     § "Queue Dispatch".
 
+    Multi-tenant deployment contract
+    --------------------------------
+    Multi-tenant deployments MUST provision a per-tenant queue table
+    (e.g. ``table_name="kailash_task_queue_<tenant>"``). Cross-tenant
+    queue sharing is BLOCKED by deployment convention: any party with
+    ``INSERT INTO <queue_table>`` privilege can enqueue a workflow
+    that the worker pool will execute under its own runtime. Because
+    the worker is a single trust boundary, sharing one queue across
+    tenants effectively grants every tenant the privilege of every
+    other tenant. The defense is structural — each tenant gets its
+    own table; no application-level multi-tenancy is performed inside
+    the dispatcher.
+
     Parameters
     ----------
     conn:
@@ -495,7 +512,8 @@ class SQLTaskQueueDispatcher(Dispatcher):
     table_name:
         Name of the task queue table (default: ``kailash_task_queue``).
         Validated against ``[a-zA-Z_][a-zA-Z0-9_]*`` in the underlying
-        :class:`SQLTaskQueue`.
+        :class:`SQLTaskQueue`. For multi-tenant deployments use one
+        table per tenant (see "Multi-tenant deployment contract").
 
     See Also
     --------
@@ -531,13 +549,14 @@ class SQLTaskQueueDispatcher(Dispatcher):
         if not self._initialized:
             await self.initialize()
 
-        # Encode workflow_blob (bytes) as latin-1 -> str so it round-trips
-        # through JSON. The blob is opaque: workers decode and execute.
-        # latin-1 is bijective for arbitrary bytes <= 0xFF and survives
-        # JSON encoding without any escaping outside the standard set.
+        # workflow_blob is JSON-encoded UTF-8 bytes per
+        # `kailash.runtime.dispatcher.Task` (NOT pickle, by deliberate
+        # design — pickle on a queue payload is RCE per
+        # `rules/security.md`). Decode UTF-8 and embed the JSON string
+        # so the outer payload remains a pure JSON object.
         payload = {
             "schedule_id": task.schedule_id,
-            "workflow_blob_b64": task.workflow_blob.decode("latin-1"),
+            "workflow_blob_json": task.workflow_blob.decode("utf-8"),
             "planned_fire_time": task.planned_fire_time,
             "kwargs": task.kwargs,
         }
@@ -598,9 +617,7 @@ class SQLTaskQueueDispatcher(Dispatcher):
             yield Task(
                 task_id=msg.task_id,
                 schedule_id=msg.payload.get("schedule_id", ""),
-                workflow_blob=msg.payload.get("workflow_blob_b64", "").encode(
-                    "latin-1"
-                ),
+                workflow_blob=msg.payload.get("workflow_blob_json", "").encode("utf-8"),
                 planned_fire_time=msg.payload.get("planned_fire_time", ""),
                 queue_name=msg.queue_name,
                 kwargs=msg.payload.get("kwargs") or {},

--- a/src/kailash/infrastructure/task_queue.py
+++ b/src/kailash/infrastructure/task_queue.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "SQLTaskQueue",
     "SQLTaskMessage",
+    "SQLTaskQueueDispatcher",
 ]
 
 
@@ -442,3 +443,223 @@ class SQLTaskQueue:
         if count:
             logger.info("Purged %d completed tasks from queue '%s'", count, queue_name)
         return count
+
+
+# =====================================================================
+# Dispatcher adapter — `kailash.runtime.dispatcher.Dispatcher` conformer
+# =====================================================================
+
+
+def _task_id_hash(task_id: str) -> str:
+    """Return an 8-char hash of a task_id, safe for log fields.
+
+    Per ``rules/observability.md`` Rule 8, schema-revealing identifiers
+    in WARN/ERROR log lines MUST be hashed -- the raw ``task_id`` is
+    a concatenation of schedule_id + planned_fire_time and reveals
+    business-meaningful schedule names + cron timing.
+    """
+    import hashlib
+
+    return hashlib.sha256(task_id.encode("utf-8")).hexdigest()[:8]
+
+
+class SQLTaskQueueDispatcher(Dispatcher):
+    """SQL-backed :class:`Dispatcher` adapter for ``WorkflowScheduler``.
+
+    Adapts the lower-level :class:`SQLTaskQueue` to the
+    :class:`~kailash.runtime.dispatcher.Dispatcher` ABC so a scheduler
+    constructed with ``dispatch_via=SQLTaskQueueDispatcher(conn_mgr)``
+    enqueues tasks to a SQL queue instead of executing in-process.
+
+    Idempotency contract
+    --------------------
+    :meth:`enqueue` uses ``task.task_id`` as the queue's PRIMARY KEY.
+    A duplicate enqueue with the SAME ``task_id`` is treated as a
+    silent no-op -- the multi-instance-scheduler double-fire scenario
+    becomes "already enqueued, skip" without raising to the caller.
+    Non-PK failures (connectivity, serialization) propagate after a
+    structured ERROR log line is emitted.
+
+    Resume hint (informational)
+    ---------------------------
+    Workers polling this dispatcher SHOULD pass the ``task_id`` as
+    the ``idempotency_key`` to ``runtime.execute(...)`` when paired
+    with a checkpoint store. This gives resume-from-checkpoint
+    semantics on crash recovery -- see ``specs/scheduling.md``
+    § "Queue Dispatch".
+
+    Parameters
+    ----------
+    conn:
+        An initialized :class:`~kailash.db.connection.ConnectionManager`.
+    table_name:
+        Name of the task queue table (default: ``kailash_task_queue``).
+        Validated against ``[a-zA-Z_][a-zA-Z0-9_]*`` in the underlying
+        :class:`SQLTaskQueue`.
+
+    See Also
+    --------
+    :class:`~kailash.runtime.dispatcher.Dispatcher` -- the abstract contract.
+    :func:`~kailash.runtime.dispatcher.compute_task_id` -- stable task_id helper.
+    :class:`~kailash.runtime.scheduler.WorkflowScheduler` -- the producer.
+    """
+
+    def __init__(self, conn: Any, table_name: str = "kailash_task_queue") -> None:
+        self._queue = SQLTaskQueue(conn, table_name=table_name)
+        self._initialized = False
+
+    async def initialize(self) -> None:
+        """Create the underlying queue table if it does not exist.
+
+        Safe to call multiple times (idempotent). Most callers will
+        invoke this explicitly at startup so that the first
+        :meth:`enqueue` does not pay the DDL cost.
+        """
+        if self._initialized:
+            return
+        await self._queue.initialize()
+        self._initialized = True
+
+    async def enqueue(self, task: Task) -> None:
+        """Add a :class:`Task` to the queue.
+
+        Idempotent on ``task.task_id`` -- duplicate enqueue is a silent
+        no-op (DEBUG log; no exception). Non-duplicate failures log at
+        ERROR with grep-able ``schedule_id`` + ``task_id_hash`` and
+        propagate per the architecture plan §3 invariant 3.
+        """
+        if not self._initialized:
+            await self.initialize()
+
+        # Encode workflow_blob (bytes) as latin-1 -> str so it round-trips
+        # through JSON. The blob is opaque: workers decode and execute.
+        # latin-1 is bijective for arbitrary bytes <= 0xFF and survives
+        # JSON encoding without any escaping outside the standard set.
+        payload = {
+            "schedule_id": task.schedule_id,
+            "workflow_blob_b64": task.workflow_blob.decode("latin-1"),
+            "planned_fire_time": task.planned_fire_time,
+            "kwargs": task.kwargs,
+        }
+
+        try:
+            await self._queue.enqueue(
+                payload=payload,
+                queue_name=task.queue_name,
+                task_id=task.task_id,
+            )
+        except Exception as exc:
+            # Distinguish PK / unique-violation (silent skip) from genuine
+            # failure (ERROR log + re-raise). asyncpg raises
+            # UniqueViolationError; sqlite3 raises IntegrityError; aiomysql
+            # surfaces a generic error with sqlstate '23000'.
+            if _is_unique_violation(exc):
+                logger.debug(
+                    "task.enqueue.duplicate task_id_hash=%s schedule_id=%s",
+                    _task_id_hash(task.task_id),
+                    task.schedule_id,
+                )
+                return
+            logger.error(
+                "task.enqueue.failed task_id_hash=%s schedule_id=%s reason=%s",
+                _task_id_hash(task.task_id),
+                task.schedule_id,
+                type(exc).__name__,
+            )
+            raise
+
+    def poll(self, queue_name: str = "default") -> AsyncIterator[Task]:
+        """Yield tasks claimed from the queue, one at a time.
+
+        The async iterator dequeues atomically (via
+        :meth:`SQLTaskQueue.dequeue` which uses
+        ``FOR UPDATE SKIP LOCKED`` on PostgreSQL/MySQL and
+        ``BEGIN IMMEDIATE`` on SQLite). When the queue is empty the
+        iterator stops (it does NOT block waiting for new work);
+        callers wishing to long-poll should re-invoke ``poll()`` in a
+        loop with a sleep.
+
+        Returns
+        -------
+        AsyncIterator[Task]
+            Tasks reconstructed from the stored payload.
+        """
+        return self._poll_iter(queue_name)
+
+    async def _poll_iter(self, queue_name: str) -> AsyncIterator[Task]:
+        if not self._initialized:
+            await self.initialize()
+        while True:
+            msg = await self._queue.dequeue(
+                queue_name=queue_name, worker_id="dispatcher"
+            )
+            if msg is None:
+                return
+            yield Task(
+                task_id=msg.task_id,
+                schedule_id=msg.payload.get("schedule_id", ""),
+                workflow_blob=msg.payload.get("workflow_blob_b64", "").encode(
+                    "latin-1"
+                ),
+                planned_fire_time=msg.payload.get("planned_fire_time", ""),
+                queue_name=msg.queue_name,
+                kwargs=msg.payload.get("kwargs") or {},
+            )
+
+    async def ack(self, task_id: str) -> None:
+        """Mark a task as completed."""
+        if not self._initialized:
+            await self.initialize()
+        await self._queue.complete(task_id)
+
+    async def nack(self, task_id: str, *, reason: str) -> None:
+        """Mark a task as failed.
+
+        Logs a WARN line with grep-able ``task_id_hash`` per
+        ``rules/observability.md`` Rule 8 (raw task_id contains
+        schedule_id + fire-time and would reveal schedule timing
+        to log aggregators).
+        """
+        if not self._initialized:
+            await self.initialize()
+        logger.warning(
+            "task.nack task_id_hash=%s reason=%s",
+            _task_id_hash(task_id),
+            reason,
+        )
+        await self._queue.fail(task_id, error=reason)
+
+
+def _is_unique_violation(exc: BaseException) -> bool:
+    """Detect a primary-key / unique-constraint violation across dialects.
+
+    PostgreSQL (asyncpg) raises ``asyncpg.exceptions.UniqueViolationError``
+    (subclass of ``IntegrityConstraintViolationError``).
+    SQLite raises ``sqlite3.IntegrityError`` whose ``args[0]`` contains
+    the substring ``"UNIQUE"``.
+    MySQL (aiomysql) raises with sqlstate ``'23000'`` and errno 1062;
+    we match on the exception's ``args`` for the duplicate-entry signal.
+
+    Per ``rules/zero-tolerance.md`` Rule 3 we MUST NOT swallow generic
+    exceptions; this function is narrowly scoped to PK / unique
+    constraint violations only and is the sole site that distinguishes
+    "already enqueued" from "real failure" in the dispatcher.
+    """
+    name = type(exc).__name__
+    if name in {"UniqueViolationError", "TransactionIntegrityConstraintViolationError"}:
+        return True
+    if name == "IntegrityError":
+        msg = str(exc).upper()
+        if "UNIQUE" in msg or "PRIMARY KEY" in msg or "DUPLICATE" in msg:
+            return True
+    # MySQL: aiomysql surfaces pymysql.err.IntegrityError; same heuristic.
+    if "INTEGRITY" in name.upper():
+        msg = str(exc).upper()
+        if (
+            "UNIQUE" in msg
+            or "PRIMARY KEY" in msg
+            or "DUPLICATE" in msg
+            or "1062" in msg
+        ):
+            return True
+    return False

--- a/src/kailash/runtime/dispatcher.py
+++ b/src/kailash/runtime/dispatcher.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Dispatcher protocol for workflow scheduling.
+
+Defines the abstract base class :class:`Dispatcher` that connects
+:class:`~kailash.runtime.scheduler.WorkflowScheduler` to a task queue,
+plus the canonical :class:`Task` dataclass workers consume.
+
+When a scheduler is constructed with ``dispatch_via=<dispatcher>``, the
+fire-time callback enqueues a Task instead of executing in-process.
+A worker pool can then poll the dispatcher and execute the workflow
+against its own runtime.
+
+Idempotency is enforced at the queue layer via ``task_id``: a stable
+hash of ``(schedule_id, planned_fire_time_iso)``. A multi-instance
+scheduler that double-fires produces the SAME ``task_id`` -- the queue
+adapter MUST treat the duplicate as "already enqueued, skip" without
+raising to the caller.
+
+Resume contract (informational, NOT a hard coupling):
+    Workers SHOULD pass ``task_id`` as the ``idempotency_key`` to
+    ``runtime.execute(...)`` when paired with a checkpoint store.
+    This enables resume-from-checkpoint semantics on crash recovery.
+    See ``specs/scheduling.md`` for the full contract.
+
+Module: ``kailash.runtime.dispatcher``
+Added in: v0.13.x (issue #859)
+"""
+
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, AsyncIterator, Dict, Optional
+
+__all__ = [
+    "Dispatcher",
+    "Task",
+    "compute_task_id",
+]
+
+
+def compute_task_id(schedule_id: str, planned_fire_time: datetime) -> str:
+    """Compute the stable, deterministic ``task_id`` for a fire event.
+
+    The task_id is a SHA-256 hash of ``schedule_id || planned_fire_time_iso``,
+    truncated to 32 hex chars (128 bits of collision resistance). The
+    same (schedule_id, planned_fire_time) pair ALWAYS produces the same
+    task_id; this is what makes queue-layer dedup work for multi-instance
+    scheduler double-fire scenarios.
+
+    Parameters
+    ----------
+    schedule_id:
+        The scheduler-assigned schedule identifier (e.g. "sched-abc123").
+    planned_fire_time:
+        The cron/interval/once trigger's planned fire time. MUST be the
+        scheduler-computed fire time, NOT the wall-clock time when
+        the callback ran (those drift under load).
+
+    Returns
+    -------
+    str
+        A 32-character lowercase hex string. Suitable for use as a
+        PRIMARY KEY in the task queue table.
+
+    Notes
+    -----
+    The ISO 8601 representation is used because it's the canonical
+    cross-language wire format and preserves microsecond precision
+    when present. Naive datetimes (without tzinfo) and aware datetimes
+    in different timezones produce different task_ids -- callers MUST
+    be consistent about timezone awareness within a single schedule.
+    """
+    payload = f"{schedule_id}|{planned_fire_time.isoformat()}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:32]
+
+
+@dataclass
+class Task:
+    """A scheduled workflow task ready for dispatch.
+
+    The ``Task`` is the unit of work passed from the scheduler to the
+    dispatcher and from the dispatcher to a worker. It carries enough
+    context for the worker to execute the workflow and ack/nack the
+    result, including the deterministic ``task_id`` used for both
+    queue-layer dedup AND (informationally) for runtime-side
+    idempotency on the worker.
+
+    Attributes
+    ----------
+    task_id:
+        Stable hash of ``(schedule_id, planned_fire_time_iso)``.
+        Used as the queue's PRIMARY KEY for idempotent enqueue
+        AND as the canonical ``idempotency_key`` workers SHOULD
+        pass to ``runtime.execute(...)`` when paired with a
+        checkpoint store.
+    schedule_id:
+        The scheduler-assigned schedule identifier.
+    workflow_blob:
+        The serialized workflow (pickled WorkflowBuilder or its
+        ``.build()`` output). Workers deserialize this and execute.
+    planned_fire_time:
+        The trigger's intended fire time (UTC ISO 8601 string).
+    queue_name:
+        Logical queue name for routing (default ``"default"``).
+    kwargs:
+        Additional kwargs forwarded to ``runtime.execute(...)``.
+    """
+
+    task_id: str
+    schedule_id: str
+    workflow_blob: bytes
+    planned_fire_time: str
+    queue_name: str = "default"
+    kwargs: Dict[str, Any] = field(default_factory=dict)
+
+
+class Dispatcher(ABC):
+    """Abstract base class for workflow dispatchers.
+
+    A Dispatcher routes a fire-time :class:`Task` to a queue (or other
+    transport) so that one or more workers can poll, execute, and
+    acknowledge. The contract is intentionally minimal: enqueue is
+    idempotent on ``task_id``; poll yields claimed tasks one at a
+    time; ack marks a task complete; nack returns it for retry or
+    dead-letters it.
+
+    Implementers MUST:
+
+    1. Make :meth:`enqueue` idempotent on ``task_id`` -- a duplicate
+       enqueue with the same ``task_id`` MUST be a silent no-op
+       (no exception to the caller).
+    2. Make :meth:`poll` atomic -- two concurrent workers polling the
+       same queue MUST NOT receive the same task.
+    3. On :meth:`nack`, decide based on attempt count whether to
+       requeue (transient failure) or dead-letter (max attempts
+       exceeded).
+
+    Reference implementation: :class:`~kailash.infrastructure.task_queue.SQLTaskQueue`.
+    """
+
+    @abstractmethod
+    async def enqueue(self, task: Task) -> None:
+        """Add a task to the queue.
+
+        MUST be idempotent on ``task.task_id``. Duplicate enqueue with
+        the same task_id is a silent no-op -- the dispatcher catches
+        the PRIMARY KEY constraint violation and returns success.
+
+        Parameters
+        ----------
+        task:
+            The task to enqueue.
+
+        Raises
+        ------
+        Exception
+            On any non-duplicate failure (connectivity, serialization).
+            Callers (e.g. ``WorkflowScheduler.fire``) MUST log this at
+            ERROR with ``schedule_id`` + ``task_id`` and propagate or
+            inline-retry per their misfire policy.
+        """
+
+    @abstractmethod
+    def poll(self, queue_name: str = "default") -> AsyncIterator[Task]:
+        """Yield tasks claimed from the queue, one at a time.
+
+        Each yielded task is in ``processing`` status and locked to the
+        polling worker. The worker MUST eventually call :meth:`ack`
+        (success) or :meth:`nack` (failure) for each task to release
+        the lock.
+
+        Parameters
+        ----------
+        queue_name:
+            Queue to poll. Defaults to ``"default"``.
+
+        Returns
+        -------
+        AsyncIterator[Task]
+            Async iterator yielding claimed tasks. Implementations
+            MAY block briefly between yields when the queue is empty,
+            or return an async generator that completes once the
+            worker is shut down.
+        """
+
+    @abstractmethod
+    async def ack(self, task_id: str) -> None:
+        """Mark a task as completed.
+
+        Parameters
+        ----------
+        task_id:
+            The task to ack.
+        """
+
+    @abstractmethod
+    async def nack(self, task_id: str, *, reason: str) -> None:
+        """Mark a task as failed.
+
+        If the task has exceeded its max_attempts, the dispatcher
+        MUST move it to dead-letter status. Otherwise, the dispatcher
+        MUST requeue the task for another attempt.
+
+        Parameters
+        ----------
+        task_id:
+            The task that failed.
+        reason:
+            A short error description for diagnostics. MUST NOT
+            contain secrets or PII (callers' responsibility per
+            ``rules/security.md`` § "No secrets in logs").
+        """

--- a/src/kailash/runtime/dispatcher.py
+++ b/src/kailash/runtime/dispatcher.py
@@ -78,7 +78,7 @@ def compute_task_id(schedule_id: str, planned_fire_time: datetime) -> str:
     return hashlib.sha256(payload).hexdigest()[:32]
 
 
-@dataclass
+@dataclass(frozen=True)
 class Task:
     """A scheduled workflow task ready for dispatch.
 
@@ -88,6 +88,10 @@ class Task:
     result, including the deterministic ``task_id`` used for both
     queue-layer dedup AND (informationally) for runtime-side
     idempotency on the worker.
+
+    Frozen per EATP P10 — Task instances flow across the queue boundary
+    and MUST NOT be mutated after construction; the queue payload is the
+    canonical state.
 
     Attributes
     ----------
@@ -100,8 +104,14 @@ class Task:
     schedule_id:
         The scheduler-assigned schedule identifier.
     workflow_blob:
-        The serialized workflow (pickled WorkflowBuilder or its
-        ``.build()`` output). Workers deserialize this and execute.
+        The JSON-serialized workflow representation produced by
+        ``Workflow.to_dict()`` and encoded as UTF-8. Workers MUST
+        deserialize via ``Workflow.from_dict(json.loads(...))`` —
+        NOT ``pickle.loads()``. Pickled payloads on a queue accessible
+        to arbitrary INSERT actors are remote-code-execution primitives;
+        this contract uses JSON to structurally prevent that class
+        per ``rules/security.md`` § "No arbitrary-code execution on
+        user input" (the same threat class).
     planned_fire_time:
         The trigger's intended fire time (UTC ISO 8601 string).
     queue_name:

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -68,6 +68,15 @@ __all__ = [
 # In-Memory Stores"); active-schedule counts in production are O(100s).
 MAX_FIRE_TIMES = 10_000
 
+# Cap on the JSON-encoded workflow blob the queue path serializes. Worker
+# pools dequeue and `json.loads` the payload; without a cap, a workflow
+# whose `to_dict()` produces multi-megabyte output (e.g. a node config
+# carrying a large embedded model bundle) OOMs every dequeueing worker.
+# 8 MiB is generous for legitimate Workflow shapes and tight enough to
+# refuse a poisoned config before it reaches the queue. Documented in
+# `specs/scheduling.md` § "Queue dispatch — payload bounds".
+MAX_WORKFLOW_BLOB_BYTES = 8 * 1024 * 1024  # 8 MiB
+
 _apscheduler_available: Optional[bool] = None
 
 
@@ -575,21 +584,47 @@ class WorkflowScheduler:
             # `kailash.workflow.graph`; workers reconstruct via
             # `Workflow.from_dict(json.loads(blob.decode("utf-8")))`.
             #
-            # Stub workflows used in unit tests provide their own
-            # `to_dict()` returning a JSON-serializable mapping; if
-            # neither method exists we refuse to serialize rather than
-            # fall back to pickle (`rules/zero-tolerance.md` Rule 3 —
-            # silent fallback to an unsafe path is BLOCKED).
-            if hasattr(workflow, "to_dict") and callable(workflow.to_dict):
+            # Discriminator dispatch on the canonical Workflow type per
+            # `rules/zero-tolerance.md` Rule 3d (dual-shape return +
+            # structural guard = silent fallback). Test stubs that
+            # satisfy the to_dict() protocol are accepted via the
+            # protocol-attribute branch — explicit, not duck-typed.
+            from kailash.workflow.graph import Workflow as _Workflow
+
+            if isinstance(workflow, _Workflow):
+                workflow_dict = workflow.to_dict()
+            elif hasattr(type(workflow), "to_dict") and callable(
+                getattr(type(workflow), "to_dict")
+            ):
+                # Class-level to_dict() — admits Tier-1 stubs that satisfy
+                # the protocol via class definition (NOT instance attr,
+                # which is too permissive and reintroduces the duck-type
+                # silent-fallback pattern).
                 workflow_dict = workflow.to_dict()
             else:
                 raise TypeError(
                     f"workflow_builder.build() returned {type(workflow).__name__} "
-                    f"which is missing to_dict() — queue dispatch requires JSON-"
-                    f"serializable workflow representation. Implement to_dict() "
-                    f"returning a mapping reconstructable via from_dict()."
+                    f"which is not a kailash.workflow.graph.Workflow nor a class "
+                    f"defining to_dict() — queue dispatch requires JSON-"
+                    f"serializable workflow representation. Use Workflow or "
+                    f"a subclass that implements to_dict()."
                 )
             workflow_blob = json.dumps(workflow_dict).encode("utf-8")
+            if len(workflow_blob) > MAX_WORKFLOW_BLOB_BYTES:
+                # Refuse the enqueue before it reaches the queue. Workers
+                # dequeueing this payload would `json.loads` it into
+                # memory; an unbounded blob OOMs every worker. The cap
+                # is enforced at the producer boundary (here) and again
+                # at the queue adapter (defense-in-depth) per
+                # `rules/security.md` § "Input Validation".
+                raise ValueError(
+                    f"workflow_blob size {len(workflow_blob)} bytes exceeds "
+                    f"MAX_WORKFLOW_BLOB_BYTES ({MAX_WORKFLOW_BLOB_BYTES} bytes / "
+                    f"{MAX_WORKFLOW_BLOB_BYTES // (1024 * 1024)} MiB). Workflow "
+                    f"is too large to dispatch through the queue path; reduce "
+                    f"the workflow surface (split into sub-workflows, externalize "
+                    f"large data) or use in-process dispatch (dispatch_via=None)."
+                )
         except Exception:
             logger.exception(
                 "scheduler.dispatch.serialize_failed schedule_id=%s task_id_hash=%s",

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -37,12 +37,13 @@ Version:
     Added in: v0.13.0
 """
 
+import json
 import logging
 import math
 import os
-import pickle
 import stat
 import uuid
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
@@ -60,6 +61,13 @@ __all__ = [
 ]
 
 # Lazy import check for APScheduler
+# Bound on the per-job fire-time map below. Schedulers that submit and never
+# clean up (cancelled mid-flight, EVENT_JOB_EXECUTED suppressed by listener
+# error, etc.) would otherwise grow `_fire_times` without bound. 10_000 is
+# the same default as `rules/infrastructure-sql.md` Rule 7 ("Bounded
+# In-Memory Stores"); active-schedule counts in production are O(100s).
+MAX_FIRE_TIMES = 10_000
+
 _apscheduler_available: Optional[bool] = None
 
 
@@ -195,7 +203,13 @@ class WorkflowScheduler:
         # current fire time -- NOT `job.next_run_time`, which APScheduler has
         # already advanced to the NEXT scheduled fire by the time the callback
         # runs (interval/cron schedules drift by one interval otherwise).
-        self._fire_times: Dict[str, datetime] = {}
+        #
+        # `OrderedDict` + LRU eviction at MAX_FIRE_TIMES per
+        # `rules/infrastructure-sql.md` Rule 7. EVENT_JOB_EXECUTED |
+        # EVENT_JOB_ERROR pop entries on the happy path; LRU eviction is
+        # the safety net for jobs cancelled mid-flight where the cleanup
+        # listener never fires. `cancel()` also pops the entry explicitly.
+        self._fire_times: "OrderedDict[str, datetime]" = OrderedDict()
         from apscheduler.events import (
             EVENT_JOB_ERROR,
             EVENT_JOB_EXECUTED,
@@ -426,6 +440,11 @@ class WorkflowScheduler:
 
         self._scheduler.remove_job(schedule_id)
         del self._schedules[schedule_id]
+        # Drop the per-job fire-time entry. Cancellation can race the
+        # EVENT_JOB_EXECUTED | EVENT_JOB_ERROR cleanup listener; explicit
+        # pop here closes the leak window for jobs cancelled while
+        # APScheduler considered them in-flight.
+        self._fire_times.pop(schedule_id, None)
 
         logger.info("Cancelled schedule: %s", schedule_id)
 
@@ -548,7 +567,29 @@ class WorkflowScheduler:
 
         try:
             workflow = workflow_builder.build()
-            workflow_blob = pickle.dumps(workflow)
+            # JSON serialization (NOT pickle) per `rules/security.md`
+            # § "No arbitrary-code execution on user input": pickle.loads
+            # on a queue payload an attacker can INSERT into is remote
+            # code execution. The
+            # canonical workflow shape is `Workflow.to_dict()` from
+            # `kailash.workflow.graph`; workers reconstruct via
+            # `Workflow.from_dict(json.loads(blob.decode("utf-8")))`.
+            #
+            # Stub workflows used in unit tests provide their own
+            # `to_dict()` returning a JSON-serializable mapping; if
+            # neither method exists we refuse to serialize rather than
+            # fall back to pickle (`rules/zero-tolerance.md` Rule 3 —
+            # silent fallback to an unsafe path is BLOCKED).
+            if hasattr(workflow, "to_dict") and callable(workflow.to_dict):
+                workflow_dict = workflow.to_dict()
+            else:
+                raise TypeError(
+                    f"workflow_builder.build() returned {type(workflow).__name__} "
+                    f"which is missing to_dict() — queue dispatch requires JSON-"
+                    f"serializable workflow representation. Implement to_dict() "
+                    f"returning a mapping reconstructable via from_dict()."
+                )
+            workflow_blob = json.dumps(workflow_dict).encode("utf-8")
         except Exception:
             logger.exception(
                 "scheduler.dispatch.serialize_failed schedule_id=%s task_id_hash=%s",
@@ -607,7 +648,18 @@ class WorkflowScheduler:
                 f"empty scheduled_run_times list — APScheduler internal "
                 f"invariant violation"
             )
+        # Move-to-end semantics: re-submitting the same job_id refreshes
+        # its LRU position so eviction targets truly stale entries.
+        if event.job_id in self._fire_times:
+            self._fire_times.move_to_end(event.job_id)
         self._fire_times[event.job_id] = run_times[-1]
+        # LRU eviction safety net: bound at MAX_FIRE_TIMES per
+        # `rules/infrastructure-sql.md` Rule 7. EVENT_JOB_EXECUTED |
+        # EVENT_JOB_ERROR is the happy-path cleanup; this evicts when
+        # those listeners drop fires (jobs cancelled mid-flight, listener
+        # exceptions, etc.).
+        while len(self._fire_times) > MAX_FIRE_TIMES:
+            self._fire_times.popitem(last=False)
 
     def _on_job_done(self, event: Any) -> None:
         """Cleanup the recorded fire time after the job finishes.

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -585,14 +585,29 @@ class WorkflowScheduler:
     def _on_job_submitted(self, event: Any) -> None:
         """APScheduler EVENT_JOB_SUBMITTED listener — record fire time.
 
-        Fires BEFORE the job callback with ``event.scheduled_run_time``
-        carrying the CURRENT fire instant. We key by ``event.job_id``
-        (== ``schedule_id``) so the dispatch callback can read the
+        Fires BEFORE the job callback with
+        ``event.scheduled_run_times: list[datetime]`` carrying the
+        CURRENT trigger fire instant(s). The list typically holds one
+        entry; under coalesce/misfire policies APScheduler may pass
+        multiple. We record the LAST element — the most recent fire
+        the trigger produced — so the dispatch callback can read the
         correct fire time without relying on ``job.next_run_time``
         (which APScheduler has already advanced to the next scheduled
         fire by the time the callback runs).
+
+        We key by ``event.job_id`` (== ``schedule_id``).
         """
-        self._fire_times[event.job_id] = event.scheduled_run_time
+        run_times = event.scheduled_run_times
+        if not run_times:
+            # Empty list violates APScheduler's own dispatch contract;
+            # raise so the failure surfaces at the listener boundary
+            # instead of producing a silently-misrecorded fire time.
+            raise RuntimeError(
+                f"EVENT_JOB_SUBMITTED for job_id={event.job_id!r} carried "
+                f"empty scheduled_run_times list — APScheduler internal "
+                f"invariant violation"
+            )
+        self._fire_times[event.job_id] = run_times[-1]
 
     def _on_job_done(self, event: Any) -> None:
         """Cleanup the recorded fire time after the job finishes.

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -188,6 +188,25 @@ class WorkflowScheduler:
         self._timezone = timezone
         self._dispatcher: Optional["Dispatcher"] = dispatch_via
 
+        # Per-job fire-time capture: APScheduler's EVENT_JOB_SUBMITTED listener
+        # fires BEFORE the job callback with `event.scheduled_run_time`, the
+        # ACTUAL fire instant for the currently-firing job. We record it here
+        # keyed by job_id so `_planned_fire_time(schedule_id)` can return the
+        # current fire time -- NOT `job.next_run_time`, which APScheduler has
+        # already advanced to the NEXT scheduled fire by the time the callback
+        # runs (interval/cron schedules drift by one interval otherwise).
+        self._fire_times: Dict[str, datetime] = {}
+        from apscheduler.events import (
+            EVENT_JOB_ERROR,
+            EVENT_JOB_EXECUTED,
+            EVENT_JOB_SUBMITTED,
+        )
+
+        self._scheduler.add_listener(self._on_job_submitted, EVENT_JOB_SUBMITTED)
+        self._scheduler.add_listener(
+            self._on_job_done, EVENT_JOB_EXECUTED | EVENT_JOB_ERROR
+        )
+
         logger.info(
             "WorkflowScheduler initialized (job_store=%s, timezone=%s, dispatch=%s)",
             job_store_path or "memory",
@@ -509,11 +528,13 @@ class WorkflowScheduler:
 
         from kailash.runtime.dispatcher import Task, compute_task_id
 
-        # APScheduler delivers the trigger's fire time via job.next_run_time
-        # at submit time; once the job is firing we read it from the job
-        # context. For now, use scheduler-internal lookup: the planned fire
-        # time was stamped onto the schedule when registered or comes from
-        # the trigger evaluation. Fall back to current UTC if not available.
+        # APScheduler delivers the CURRENT fire time via the
+        # EVENT_JOB_SUBMITTED listener (`event.scheduled_run_time`); see
+        # ``_on_job_submitted`` for the capture point. Reading
+        # ``job.next_run_time`` here would be wrong — by the time this
+        # callback runs APScheduler has already advanced ``next_run_time``
+        # to the NEXT scheduled fire, so the recorded ``planned_fire_time``
+        # would drift by one interval on every cron/interval trigger.
         planned_fire_time = self._planned_fire_time(schedule_id)
         task_id = compute_task_id(schedule_id, planned_fire_time)
         task_id_hash = hashlib.sha256(task_id.encode("utf-8")).hexdigest()[:8]
@@ -561,27 +582,62 @@ class WorkflowScheduler:
             task_id_hash,
         )
 
-    def _planned_fire_time(self, schedule_id: str) -> datetime:
-        """Return the planned fire time for the currently-firing schedule.
+    def _on_job_submitted(self, event: Any) -> None:
+        """APScheduler EVENT_JOB_SUBMITTED listener — record fire time.
 
-        APScheduler does not pass the planned fire time directly into the
-        job callback. We read it from the underlying job's
-        ``next_run_time`` (the trigger-computed instant for the current
-        fire). If the job has been removed or has no scheduled next-fire,
-        we fall back to the current UTC time so dispatch still works
-        deterministically for one-shot tasks.
+        Fires BEFORE the job callback with ``event.scheduled_run_time``
+        carrying the CURRENT fire instant. We key by ``event.job_id``
+        (== ``schedule_id``) so the dispatch callback can read the
+        correct fire time without relying on ``job.next_run_time``
+        (which APScheduler has already advanced to the next scheduled
+        fire by the time the callback runs).
         """
-        try:
-            job = self._scheduler.get_job(schedule_id)
-            if job is not None and job.next_run_time is not None:
-                return job.next_run_time
-        except Exception:
-            logger.debug(
-                "scheduler.planned_fire_time.lookup_failed schedule_id=%s",
-                schedule_id,
-                exc_info=True,
+        self._fire_times[event.job_id] = event.scheduled_run_time
+
+    def _on_job_done(self, event: Any) -> None:
+        """Cleanup the recorded fire time after the job finishes.
+
+        Listens on ``EVENT_JOB_EXECUTED | EVENT_JOB_ERROR``. If the
+        scheduler ever drops a job mid-flight without firing either
+        event, the entry remains in ``_fire_times`` for the next
+        successful submission to overwrite — bounded by the number of
+        active schedules.
+        """
+        self._fire_times.pop(event.job_id, None)
+
+    def _planned_fire_time(self, schedule_id: str) -> datetime:
+        """Return the actual fire time of the currently-firing job.
+
+        Reads from ``_fire_times``, populated by the
+        ``EVENT_JOB_SUBMITTED`` listener (``_on_job_submitted``). This
+        is the SCHEDULED fire instant the trigger fired for, NOT
+        ``job.next_run_time`` — which APScheduler advances to the NEXT
+        scheduled fire as soon as the current job is submitted.
+
+        Stable across multi-instance schedulers: every instance receives
+        the same ``scheduled_run_time`` from APScheduler for the same
+        trigger fire, so ``compute_task_id(schedule_id, fire_time)``
+        produces the SAME ``task_id`` and the queue layer dedups via PK.
+
+        Raises:
+            RuntimeError: if invoked for a ``schedule_id`` whose
+                ``EVENT_JOB_SUBMITTED`` listener has not yet recorded a
+                fire time. Falling back to ``datetime.now(UTC)`` would
+                silently break the dedup invariant
+                (``rules/zero-tolerance.md`` Rule 3).
+        """
+        fire_time = self._fire_times.get(schedule_id)
+        if fire_time is None:
+            raise RuntimeError(
+                f"_planned_fire_time invoked for schedule_id={schedule_id!r} "
+                f"but EVENT_JOB_SUBMITTED listener has not recorded a fire "
+                f"time. Dispatch was called outside the APScheduler job-firing "
+                f"path, or the listener was not registered. Refusing to fall "
+                f"back to datetime.now(UTC) -- doing so would silently break "
+                f"multi-instance dedup (each scheduler instance would compute "
+                f"a different task_id for the same fire)."
             )
-        return datetime.now(UTC)
+        return fire_time
 
     def _get_runtime(self) -> Any:
         """Get or create a runtime instance for execution.

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -40,12 +40,16 @@ Version:
 import logging
 import math
 import os
+import pickle
 import stat
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from kailash.runtime.dispatcher import Dispatcher
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +123,10 @@ class WorkflowScheduler:
         runtime_factory: Optional callable that returns a runtime instance.
             Defaults to creating a new LocalRuntime for each execution.
         timezone: Timezone for cron expressions. Defaults to UTC.
+        dispatch_via: Optional :class:`~kailash.runtime.dispatcher.Dispatcher`.
+            When provided, every fired trigger enqueues a Task to the
+            dispatcher instead of executing the workflow in-process.
+            Default ``None`` preserves the existing in-process behavior.
 
     Raises:
         ImportError: If APScheduler is not installed.
@@ -128,6 +136,14 @@ class WorkflowScheduler:
         >>> scheduler.start()
         >>> sid = scheduler.schedule_interval(my_workflow, seconds=60)
         >>> scheduler.shutdown()
+
+        # Multi-instance / worker-side resume:
+        >>> from kailash.infrastructure.task_queue import SQLTaskQueueDispatcher
+        >>> from kailash.db.connection import ConnectionManager
+        >>> conn = ConnectionManager("postgresql://...")
+        >>> await conn.initialize()
+        >>> dispatcher = SQLTaskQueueDispatcher(conn)
+        >>> scheduler = WorkflowScheduler(dispatch_via=dispatcher)
     """
 
     def __init__(
@@ -135,6 +151,8 @@ class WorkflowScheduler:
         job_store_path: Optional[str] = "kailash_schedules.db",
         runtime_factory: Optional[Callable] = None,
         timezone: str = "UTC",
+        *,
+        dispatch_via: Optional["Dispatcher"] = None,
     ) -> None:
         if not _check_apscheduler():
             raise ImportError(
@@ -168,11 +186,13 @@ class WorkflowScheduler:
         self._runtime_factory = runtime_factory
         self._schedules: Dict[str, ScheduleInfo] = {}
         self._timezone = timezone
+        self._dispatcher: Optional["Dispatcher"] = dispatch_via
 
         logger.info(
-            "WorkflowScheduler initialized (job_store=%s, timezone=%s)",
+            "WorkflowScheduler initialized (job_store=%s, timezone=%s, dispatch=%s)",
             job_store_path or "memory",
             timezone,
+            "queue" if dispatch_via is not None else "in_process",
         )
 
     def start(self) -> None:
@@ -237,7 +257,7 @@ class WorkflowScheduler:
             self._execute_workflow,
             trigger=trigger,
             id=schedule_id,
-            args=[workflow_builder],
+            args=[workflow_builder, schedule_id],
             kwargs=kwargs,
             replace_existing=True,
         )
@@ -295,7 +315,7 @@ class WorkflowScheduler:
             trigger="interval",
             seconds=seconds,
             id=schedule_id,
-            args=[workflow_builder],
+            args=[workflow_builder, schedule_id],
             kwargs=kwargs,
             replace_existing=True,
         )
@@ -350,7 +370,7 @@ class WorkflowScheduler:
             trigger="date",
             run_date=run_at,
             id=schedule_id,
-            args=[workflow_builder],
+            args=[workflow_builder, schedule_id],
             kwargs=kwargs,
             replace_existing=True,
         )
@@ -408,19 +428,47 @@ class WorkflowScheduler:
 
         return list(self._schedules.values())
 
-    async def _execute_workflow(self, workflow_builder: Any, **kwargs: Any) -> None:
+    async def _execute_workflow(
+        self, workflow_builder: Any, schedule_id: str = "", **kwargs: Any
+    ) -> None:
         """Execute a workflow from a scheduled trigger.
 
-        This is the callback invoked by APScheduler. It builds the workflow
-        from the builder and executes it using the configured runtime.
+        This is the callback invoked by APScheduler at fire time. The
+        behavior depends on whether the scheduler was constructed with
+        ``dispatch_via=``:
+
+        * **In-process (default, ``dispatch_via=None``):** builds the
+          workflow and executes it via the configured runtime in the
+          current process.
+        * **Queue dispatch (``dispatch_via=<Dispatcher>``):** serializes
+          the workflow into a :class:`~kailash.runtime.dispatcher.Task`
+          and enqueues it via the dispatcher; a worker pool polls the
+          queue and executes against its own runtime. ``task_id`` is
+          ``compute_task_id(schedule_id, planned_fire_time)`` so a
+          multi-instance scheduler that double-fires produces the same
+          task_id and the queue dedups.
 
         Args:
             workflow_builder: The WorkflowBuilder to build and execute.
-            **kwargs: Additional runtime execution parameters.
+            schedule_id: The scheduler-assigned schedule identifier.
+                Wired in by ``schedule_cron`` / ``schedule_interval`` /
+                ``schedule_once`` when registering the APScheduler job.
+            **kwargs: Additional runtime execution parameters (in-process
+                path) or task kwargs (queue dispatch path).
         """
         run_id = str(uuid.uuid4())
-        logger.info("Scheduled execution starting: run_id=%s", run_id)
 
+        if self._dispatcher is not None:
+            await self._dispatch_to_queue(
+                workflow_builder=workflow_builder,
+                schedule_id=schedule_id,
+                run_id=run_id,
+                **kwargs,
+            )
+            return
+
+        # In-process fallback (existing behavior).
+        logger.info("Scheduled execution starting: run_id=%s", run_id)
         try:
             workflow = workflow_builder.build()
             runtime = self._get_runtime()
@@ -433,6 +481,107 @@ class WorkflowScheduler:
         except Exception:
             logger.exception("Scheduled execution failed: run_id=%s", run_id)
             raise
+
+    async def _dispatch_to_queue(
+        self,
+        *,
+        workflow_builder: Any,
+        schedule_id: str,
+        run_id: str,
+        **kwargs: Any,
+    ) -> None:
+        """Serialize the workflow and enqueue a Task via the dispatcher.
+
+        Per architecture plan §3 invariant 1, ``task_id`` is the stable
+        SHA-256 hash of ``(schedule_id, planned_fire_time_iso)``. The
+        planned fire time is the trigger's intended fire instant -- not
+        wall-clock now() -- so multi-instance scheduler double-fires
+        produce the SAME task_id and the queue layer dedups.
+
+        Per architecture plan §3 invariant 3, every enqueue failure
+        logs at ERROR with grep-able schedule_id + task_id_hash before
+        propagating to APScheduler (which records the missed-fire
+        per its own retry/misfire policy).
+        """
+        # Lazy import to keep `from kailash.runtime.scheduler import ...`
+        # path free of dispatcher dependencies for in-process-only users.
+        import hashlib
+
+        from kailash.runtime.dispatcher import Task, compute_task_id
+
+        # APScheduler delivers the trigger's fire time via job.next_run_time
+        # at submit time; once the job is firing we read it from the job
+        # context. For now, use scheduler-internal lookup: the planned fire
+        # time was stamped onto the schedule when registered or comes from
+        # the trigger evaluation. Fall back to current UTC if not available.
+        planned_fire_time = self._planned_fire_time(schedule_id)
+        task_id = compute_task_id(schedule_id, planned_fire_time)
+        task_id_hash = hashlib.sha256(task_id.encode("utf-8")).hexdigest()[:8]
+
+        logger.info(
+            "scheduler.dispatch.start schedule_id=%s task_id_hash=%s run_id=%s",
+            schedule_id,
+            task_id_hash,
+            run_id,
+        )
+
+        try:
+            workflow = workflow_builder.build()
+            workflow_blob = pickle.dumps(workflow)
+        except Exception:
+            logger.exception(
+                "scheduler.dispatch.serialize_failed schedule_id=%s task_id_hash=%s",
+                schedule_id,
+                task_id_hash,
+            )
+            raise
+
+        task = Task(
+            task_id=task_id,
+            schedule_id=schedule_id,
+            workflow_blob=workflow_blob,
+            planned_fire_time=planned_fire_time.isoformat(),
+            kwargs=dict(kwargs),
+        )
+
+        try:
+            await self._dispatcher.enqueue(task)  # type: ignore[union-attr]
+        except Exception as exc:
+            logger.error(
+                "scheduler.dispatch.enqueue_failed schedule_id=%s task_id_hash=%s reason=%s",
+                schedule_id,
+                task_id_hash,
+                type(exc).__name__,
+            )
+            raise
+
+        logger.info(
+            "scheduler.dispatch.enqueued schedule_id=%s task_id_hash=%s",
+            schedule_id,
+            task_id_hash,
+        )
+
+    def _planned_fire_time(self, schedule_id: str) -> datetime:
+        """Return the planned fire time for the currently-firing schedule.
+
+        APScheduler does not pass the planned fire time directly into the
+        job callback. We read it from the underlying job's
+        ``next_run_time`` (the trigger-computed instant for the current
+        fire). If the job has been removed or has no scheduled next-fire,
+        we fall back to the current UTC time so dispatch still works
+        deterministically for one-shot tasks.
+        """
+        try:
+            job = self._scheduler.get_job(schedule_id)
+            if job is not None and job.next_run_time is not None:
+                return job.next_run_time
+        except Exception:
+            logger.debug(
+                "scheduler.planned_fire_time.lookup_failed schedule_id=%s",
+                schedule_id,
+                exc_info=True,
+            )
+        return datetime.now(UTC)
 
     def _get_runtime(self) -> Any:
         """Get or create a runtime instance for execution.

--- a/tests/integration/test_workflow_scheduler_dispatch_wiring.py
+++ b/tests/integration/test_workflow_scheduler_dispatch_wiring.py
@@ -24,9 +24,9 @@ Scenarios covered:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
-import pickle
 import socket
 from datetime import UTC, datetime
 from typing import AsyncGenerator
@@ -108,10 +108,18 @@ async def dispatcher(
 
 
 class _IntegrationWorkflow:
-    """A pickle-able deterministic workflow stand-in."""
+    """A JSON-serializable deterministic workflow stand-in.
+
+    Provides ``to_dict()`` so the scheduler's JSON-serialization path
+    treats it as a real workflow per ``rules/security.md`` (no pickle
+    on queue payloads — RCE).
+    """
 
     def __init__(self, name: str = "wf") -> None:
         self.name = name
+
+    def to_dict(self) -> dict:
+        return {"name": self.name}
 
 
 class _IntegrationBuilder:
@@ -129,11 +137,14 @@ class _IntegrationBuilder:
 
 def _make_task(schedule_id: str = "sched-int") -> Task:
     fire_time = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
-    workflow = _IntegrationWorkflow("integration-wf")
+    # JSON serialization (NOT pickle) per `rules/security.md` — pickle on
+    # queue payloads is RCE. The blob round-trips through workers via
+    # `Workflow.from_dict(json.loads(blob.decode("utf-8")))`.
+    workflow_dict = _IntegrationWorkflow("integration-wf").to_dict()
     return Task(
         task_id=compute_task_id(schedule_id, fire_time),
         schedule_id=schedule_id,
-        workflow_blob=pickle.dumps(workflow),
+        workflow_blob=json.dumps(workflow_dict).encode("utf-8"),
         planned_fire_time=fire_time.isoformat(),
     )
 
@@ -232,8 +243,9 @@ class TestSQLTaskQueueDispatcherTier2:
         assert polled[0].task_id == task.task_id
         assert polled[0].schedule_id == "sched-poll"
         assert polled[0].planned_fire_time == task.planned_fire_time
-        # workflow_blob round-trip MUST be byte-identical (pickle is the
-        # opaque transport per spec).
+        # workflow_blob round-trip MUST be byte-identical — JSON-encoded
+        # UTF-8 (NOT pickle) per `rules/security.md`. Workers reconstruct
+        # the workflow via `Workflow.from_dict(json.loads(blob.decode("utf-8")))`.
         assert polled[0].workflow_blob == task.workflow_blob
 
 

--- a/tests/integration/test_workflow_scheduler_dispatch_wiring.py
+++ b/tests/integration/test_workflow_scheduler_dispatch_wiring.py
@@ -1,0 +1,314 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 integration tests for WorkflowScheduler dispatch_via=SQLTaskQueueDispatcher.
+
+Per ``rules/testing.md`` Tier 2 contract: NO mocking. All operations hit a
+real ConnectionManager with a real database (SQLite in-memory minimum,
+PostgreSQL when available via TEST_PG_URL).
+
+Per ``rules/orphan-detection.md`` Rule 2 + ``rules/facade-manager-detection.md``
+Rule 1: every wired manager (SQLTaskQueueDispatcher) MUST have at least one
+Tier 2 integration test exercising the framework hot path end-to-end. This
+file is the wiring test for the W3 Dispatcher contract.
+
+Scenarios covered:
+
+1. enqueue persists a row through the dispatcher facade.
+2. Double-fire idempotency — same task_id silently skipped, row count = 1.
+3. ack marks completed; the row's status reflects the change.
+4. nack increments attempts and routes through fail/dead-letter logic.
+5. poll() round-trips the task through the dispatcher.
+6. WorkflowScheduler dispatch_via=<real dispatcher> enqueues at fire time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import pickle
+import socket
+from datetime import UTC, datetime
+from typing import AsyncGenerator
+from urllib.parse import urlparse
+
+import pytest
+
+from kailash.db.connection import ConnectionManager
+from kailash.infrastructure.task_queue import SQLTaskQueue, SQLTaskQueueDispatcher
+from kailash.runtime.dispatcher import Task, compute_task_id
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+# ---------------------------------------------------------------------------
+# Connection fixtures (real Postgres + SQLite per testing.md tier 2 NO MOCKING)
+# ---------------------------------------------------------------------------
+
+
+PG_URL = os.environ.get(
+    "TEST_PG_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+SQLITE_URL = "sqlite:///:memory:"
+
+
+def _is_pg_available() -> bool:
+    parsed = urlparse(PG_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2.0):
+            return True
+    except (OSError, ConnectionRefusedError, TimeoutError):
+        return False
+
+
+@pytest.fixture(params=["sqlite", "pg"])
+async def conn(
+    request: pytest.FixtureRequest,
+) -> AsyncGenerator[ConnectionManager, None]:
+    dialect = request.param
+    if dialect == "sqlite":
+        url = SQLITE_URL
+    elif dialect == "pg":
+        if not _is_pg_available():
+            pytest.skip(f"PostgreSQL not available at {PG_URL}")
+        url = PG_URL
+    else:
+        raise ValueError(dialect)
+
+    mgr = ConnectionManager(url)
+    await mgr.initialize()
+    yield mgr
+    # Cleanup: drop the dispatch table if present so each parameterization
+    # starts clean. SQLite in-memory is process-scoped so this is belt-and-
+    # suspenders; PostgreSQL needs the explicit drop.
+    try:
+        await mgr.execute("DROP TABLE IF EXISTS kailash_task_queue")
+    except Exception:
+        logger.debug("cleanup drop failed", exc_info=True)
+    await mgr.close()
+
+
+@pytest.fixture
+async def dispatcher(
+    conn: ConnectionManager,
+) -> AsyncGenerator[SQLTaskQueueDispatcher, None]:
+    d = SQLTaskQueueDispatcher(conn)
+    await d.initialize()
+    yield d
+
+
+# ---------------------------------------------------------------------------
+# Helpers — Protocol-satisfying deterministic adapter for workflow shape
+# ---------------------------------------------------------------------------
+
+
+class _IntegrationWorkflow:
+    """A pickle-able deterministic workflow stand-in."""
+
+    def __init__(self, name: str = "wf") -> None:
+        self.name = name
+
+
+class _IntegrationBuilder:
+    def __init__(self, name: str = "wf") -> None:
+        self.name = name
+
+    def build(self) -> _IntegrationWorkflow:
+        return _IntegrationWorkflow(self.name)
+
+
+# ---------------------------------------------------------------------------
+# Helper to construct a Task deterministically
+# ---------------------------------------------------------------------------
+
+
+def _make_task(schedule_id: str = "sched-int") -> Task:
+    fire_time = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+    workflow = _IntegrationWorkflow("integration-wf")
+    return Task(
+        task_id=compute_task_id(schedule_id, fire_time),
+        schedule_id=schedule_id,
+        workflow_blob=pickle.dumps(workflow),
+        planned_fire_time=fire_time.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 dispatcher tests
+# ---------------------------------------------------------------------------
+
+
+class TestSQLTaskQueueDispatcherTier2:
+    async def test_enqueue_persists_row(
+        self, conn: ConnectionManager, dispatcher: SQLTaskQueueDispatcher
+    ) -> None:
+        task = _make_task("sched-persist")
+        await dispatcher.enqueue(task)
+
+        rows = await conn.fetch(
+            "SELECT task_id, status FROM kailash_task_queue WHERE task_id = ?",
+            task.task_id,
+        )
+        assert len(rows) == 1
+        assert rows[0]["status"] == "pending"
+
+    async def test_double_fire_is_idempotent(
+        self, conn: ConnectionManager, dispatcher: SQLTaskQueueDispatcher
+    ) -> None:
+        """Same task_id enqueued twice — second is a silent no-op."""
+        task = _make_task("sched-dedup")
+        await dispatcher.enqueue(task)
+        await dispatcher.enqueue(task)  # MUST NOT raise
+
+        rows = await conn.fetch(
+            "SELECT COUNT(*) AS cnt FROM kailash_task_queue WHERE task_id = ?",
+            task.task_id,
+        )
+        assert rows[0]["cnt"] == 1, "double-fire MUST dedupe at queue layer"
+
+    async def test_ack_marks_completed(
+        self, conn: ConnectionManager, dispatcher: SQLTaskQueueDispatcher
+    ) -> None:
+        task = _make_task("sched-ack")
+        await dispatcher.enqueue(task)
+        await dispatcher.ack(task.task_id)
+
+        rows = await conn.fetch(
+            "SELECT status FROM kailash_task_queue WHERE task_id = ?",
+            task.task_id,
+        )
+        assert rows[0]["status"] == "completed"
+
+    async def test_nack_increments_attempts(
+        self,
+        conn: ConnectionManager,
+        dispatcher: SQLTaskQueueDispatcher,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """nack records the failure and routes through fail/dead-letter."""
+        task = _make_task("sched-nack")
+        await dispatcher.enqueue(task)
+
+        # Move to processing first (so attempts increments via dequeue path).
+        # nack() works on any tracked task_id; we just need to verify the
+        # underlying SQLTaskQueue.fail() gets called and the row is updated.
+        with caplog.at_level(
+            logging.WARNING, logger="kailash.infrastructure.task_queue"
+        ):
+            await dispatcher.nack(task.task_id, reason="timeout")
+
+        rows = await conn.fetch(
+            "SELECT status, error FROM kailash_task_queue WHERE task_id = ?",
+            task.task_id,
+        )
+        assert rows[0]["error"] == "timeout"
+        # WARN log MUST cite task_id_hash per observability.md Rule 8.
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+        ]
+        assert any(
+            "task_id_hash=" in m and "timeout" in m for m in warn_msgs
+        ), f"expected task_id_hash + reason in WARN log, got: {warn_msgs}"
+
+    async def test_poll_yields_enqueued_task(
+        self, dispatcher: SQLTaskQueueDispatcher
+    ) -> None:
+        """poll() round-trips a task end-to-end through the dispatcher."""
+        task = _make_task("sched-poll")
+        await dispatcher.enqueue(task)
+
+        polled = []
+        async for t in dispatcher.poll():
+            polled.append(t)
+            if len(polled) >= 1:
+                break
+
+        assert len(polled) == 1
+        assert polled[0].task_id == task.task_id
+        assert polled[0].schedule_id == "sched-poll"
+        assert polled[0].planned_fire_time == task.planned_fire_time
+        # workflow_blob round-trip MUST be byte-identical (pickle is the
+        # opaque transport per spec).
+        assert polled[0].workflow_blob == task.workflow_blob
+
+
+# ---------------------------------------------------------------------------
+# WorkflowScheduler -> dispatcher full-path test
+# ---------------------------------------------------------------------------
+
+
+apscheduler = pytest.importorskip(
+    "apscheduler", reason="WorkflowScheduler requires APScheduler"
+)
+
+
+class TestWorkflowSchedulerDispatchFullPath:
+    async def test_scheduler_dispatch_via_enqueues_through_real_db(
+        self, conn: ConnectionManager, dispatcher: SQLTaskQueueDispatcher
+    ) -> None:
+        """End-to-end: WorkflowScheduler -> dispatcher -> real DB row."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(
+            job_store_path=None,
+            dispatch_via=dispatcher,
+        )
+
+        # Pin planned-fire-time deterministically so we can compute the
+        # expected task_id and verify the persisted row.
+        fixed_ft = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        scheduler._planned_fire_time = lambda sid: fixed_ft
+
+        builder = _IntegrationBuilder("scheduler-end-to-end")
+        await scheduler._execute_workflow(builder, schedule_id="sched-e2e")
+
+        # Verify the row was actually written.
+        expected_task_id = compute_task_id("sched-e2e", fixed_ft)
+        rows = await conn.fetch(
+            "SELECT task_id, status FROM kailash_task_queue WHERE task_id = ?",
+            expected_task_id,
+        )
+        assert len(rows) == 1, "scheduler dispatch_via MUST write through to DB"
+        assert rows[0]["status"] == "pending"
+
+    async def test_concurrent_double_fire_dedupes_at_pk(
+        self, conn: ConnectionManager
+    ) -> None:
+        """Two scheduler instances firing the same (sched_id, fire_time) collapse.
+
+        Multi-instance scheduler safety: both instances compute the SAME
+        task_id from the same (schedule_id, planned_fire_time) and the
+        second enqueue silently skips via PRIMARY KEY constraint.
+        """
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        d_a = SQLTaskQueueDispatcher(conn)
+        d_b = SQLTaskQueueDispatcher(conn)
+        await d_a.initialize()
+        # d_b shares the same table — second initialize is a no-op DDL.
+
+        sched_a = WorkflowScheduler(job_store_path=None, dispatch_via=d_a)
+        sched_b = WorkflowScheduler(job_store_path=None, dispatch_via=d_b)
+        fixed_ft = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        sched_a._planned_fire_time = lambda sid: fixed_ft
+        sched_b._planned_fire_time = lambda sid: fixed_ft
+
+        builder = _IntegrationBuilder("multi-instance")
+
+        await asyncio.gather(
+            sched_a._execute_workflow(builder, schedule_id="sched-multi"),
+            sched_b._execute_workflow(builder, schedule_id="sched-multi"),
+        )
+
+        rows = await conn.fetch(
+            "SELECT COUNT(*) AS cnt FROM kailash_task_queue WHERE task_id = ?",
+            compute_task_id("sched-multi", fixed_ft),
+        )
+        assert (
+            rows[0]["cnt"] == 1
+        ), "multi-instance double-fire MUST collapse to 1 row via PK dedup"

--- a/tests/integration/test_workflow_scheduler_dispatch_wiring.py
+++ b/tests/integration/test_workflow_scheduler_dispatch_wiring.py
@@ -276,6 +276,91 @@ class TestWorkflowSchedulerDispatchFullPath:
         assert len(rows) == 1, "scheduler dispatch_via MUST write through to DB"
         assert rows[0]["status"] == "pending"
 
+    async def test_planned_fire_time_uses_listener_not_next_run_time(
+        self, conn: ConnectionManager, dispatcher: SQLTaskQueueDispatcher
+    ) -> None:
+        """REAL APScheduler — recorded planned_fire_time matches each fire.
+
+        This is the F1 regression. Prior to the fix, _planned_fire_time
+        read job.next_run_time at callback time -- but APScheduler had
+        already advanced next_run_time to the NEXT scheduled fire. The
+        recorded planned_fire_time drifted by one interval on every fire.
+
+        Verification: schedule an interval job at 0.5s; let it fire 2x;
+        verify the persisted planned_fire_time on each row is within
+        ~150ms of the actual fire instant AND the two rows have distinct
+        timestamps. With the bug, both rows would carry timestamps from
+        the FUTURE (one interval ahead), and a single-fire test would
+        miss it because future-vs-now is invisible against datetime.now.
+        """
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(
+            job_store_path=None,
+            dispatch_via=dispatcher,
+        )
+
+        # Use real APScheduler — no _planned_fire_time monkeypatch.
+        scheduler.start()
+        try:
+            schedule_id = scheduler.schedule_interval(
+                _IntegrationBuilder("listener-fire-time-regression"),
+                seconds=0.5,
+                name="F1-regression",
+            )
+
+            # Wait long enough for ~2 fires (interval=0.5s). Guard with a
+            # bounded sleep + poll loop so flakiness manifests as the
+            # explicit assertion below, not a hang.
+            await asyncio.sleep(1.5)
+
+            rows = await conn.fetch(
+                "SELECT task_id, payload, created_at FROM kailash_task_queue "
+                "WHERE payload LIKE ? ORDER BY created_at ASC",
+                f'%"schedule_id": "{schedule_id}"%',
+            )
+        finally:
+            scheduler.shutdown(wait=False)
+
+        # MUST have at least 2 fires within 1.5s @ 0.5s interval.
+        assert (
+            len(rows) >= 2
+        ), f"expected >=2 fires from 0.5s interval over 1.5s, got {len(rows)}"
+
+        # Extract recorded planned_fire_time per row.
+        import json
+
+        recorded_times: list[datetime] = []
+        for row in rows:
+            payload_raw = row["payload"]
+            payload = (
+                json.loads(payload_raw)
+                if isinstance(payload_raw, (str, bytes))
+                else payload_raw
+            )
+            recorded_times.append(datetime.fromisoformat(payload["planned_fire_time"]))
+
+        # Distinct fires MUST have distinct recorded times — if the bug
+        # were present, all fires would share the same advanced
+        # next_run_time at callback entry (subsequent calls overwrite),
+        # OR they would drift by exactly one interval into the future.
+        assert len(set(recorded_times)) == len(
+            recorded_times
+        ), f"recorded planned_fire_time MUST be unique per fire: {recorded_times}"
+
+        # Each recorded planned_fire_time MUST match the actual firing
+        # instant (within ~250ms tolerance for callback latency on slow
+        # CI). Prior to the fix the recorded times were ~500ms in the
+        # future — outside the tolerance.
+        now = datetime.now(UTC)
+        for fire_time in recorded_times:
+            delta = (now - fire_time).total_seconds()
+            assert -0.05 <= delta <= 2.0, (
+                f"planned_fire_time={fire_time.isoformat()} drifted from "
+                f"now={now.isoformat()} by {delta:.3f}s; bug F1 would put "
+                f"this in the future (delta < 0)"
+            )
+
     async def test_concurrent_double_fire_dedupes_at_pk(
         self, conn: ConnectionManager
     ) -> None:

--- a/tests/regression/test_w3_security_fixes.py
+++ b/tests/regression/test_w3_security_fixes.py
@@ -1,0 +1,279 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for W3 security/hardening fixes.
+
+Covers:
+
+- S1 (CRITICAL): workflow_blob is JSON, NOT pickle. Pickled payloads on a
+  queue accessible to arbitrary INSERT actors are RCE per
+  ``rules/security.md`` § "No arbitrary-code execution on user input".
+  The JSON contract structurally prevents the class — deserializing JSON
+  produces only Python primitives, no callable / class-instance pivot.
+- S2 (HIGH): _fire_times bounded by OrderedDict + LRU eviction at
+  MAX_FIRE_TIMES per ``rules/infrastructure-sql.md`` Rule 7. Plus
+  cancel() cleanup closes the leak window for jobs cancelled while
+  APScheduler considered them in-flight.
+
+Per ``rules/testing.md`` § "Regression Testing", every bug fix MUST land
+a regression test before merge. Per § "Behavioral Regression Tests Over
+Source-Grep", these tests CALL the function and assert raise/return
+behavior — not grep source for literal substrings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import pickle
+import socket
+from datetime import UTC, datetime, timedelta
+from typing import AsyncGenerator
+from urllib.parse import urlparse
+
+import pytest
+
+from kailash.runtime.dispatcher import Task, compute_task_id
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# S1 (CRITICAL) — workflow_blob is JSON, NOT pickle
+# ---------------------------------------------------------------------------
+
+
+class _JsonSerializableWorkflow:
+    """Minimal workflow stand-in providing the to_dict() contract."""
+
+    def __init__(self, name: str = "wf") -> None:
+        self.name = name
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "shape": "json-serializable-stub"}
+
+
+class _JsonBuilder:
+    def __init__(self, name: str = "wf") -> None:
+        self.name = name
+
+    def build(self) -> _JsonSerializableWorkflow:
+        return _JsonSerializableWorkflow(self.name)
+
+
+# Real APScheduler is required for the scheduler to instantiate. Skip the
+# regression set if the optional dependency is absent.
+apscheduler = pytest.importorskip(
+    "apscheduler", reason="WorkflowScheduler regression requires APScheduler"
+)
+
+
+# ---------------------------------------------------------------------------
+# Real-DB infrastructure (per rules/testing.md Tier 2 — NO mocking)
+# ---------------------------------------------------------------------------
+
+
+PG_URL = os.environ.get(
+    "TEST_PG_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+SQLITE_URL = "sqlite:///:memory:"
+
+
+def _is_pg_available() -> bool:
+    parsed = urlparse(PG_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2.0):
+            return True
+    except (OSError, ConnectionRefusedError, TimeoutError):
+        return False
+
+
+@pytest.fixture(params=["sqlite", "pg"])
+async def conn(
+    request: pytest.FixtureRequest,
+):
+    from kailash.db.connection import ConnectionManager
+
+    dialect = request.param
+    if dialect == "sqlite":
+        url = SQLITE_URL
+    elif dialect == "pg":
+        if not _is_pg_available():
+            pytest.skip(f"PostgreSQL not available at {PG_URL}")
+        url = PG_URL
+    else:
+        raise ValueError(dialect)
+
+    mgr = ConnectionManager(url)
+    await mgr.initialize()
+    yield mgr
+    try:
+        await mgr.execute("DROP TABLE IF EXISTS kailash_task_queue")
+    except Exception:  # pragma: no cover - defensive cleanup
+        logger.debug("regression cleanup drop failed", exc_info=True)
+    await mgr.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_workflow_blob_is_json_not_pickle(conn) -> None:
+    """The persisted queue row carries a JSON workflow_blob, NOT pickle.
+
+    S1 (CRITICAL): a pickled queue payload is RCE — anyone with INSERT
+    privilege on the queue table executes arbitrary code on the worker.
+    The JSON contract is the structural defense.
+
+    Verification:
+    1. Schedule a fire through a real ``WorkflowScheduler`` -> real
+       ``SQLTaskQueueDispatcher`` -> real DB.
+    2. Read the persisted ``payload``; confirm ``workflow_blob_json``
+       decodes as JSON and produces a plain Python dict.
+    3. Confirm ``pickle.loads`` on the bytes raises (so an attacker
+       supplying pickle bytes cannot impersonate the JSON contract).
+    """
+    from kailash.infrastructure.task_queue import SQLTaskQueueDispatcher
+    from kailash.runtime.scheduler import WorkflowScheduler
+
+    dispatcher = SQLTaskQueueDispatcher(conn)
+    await dispatcher.initialize()
+
+    scheduler = WorkflowScheduler(job_store_path=None, dispatch_via=dispatcher)
+    fixed_ft = datetime(2026, 5, 7, 12, 0, 0, tzinfo=UTC)
+    scheduler._planned_fire_time = lambda sid: fixed_ft
+
+    builder = _JsonBuilder("regression-json")
+    await scheduler._execute_workflow(builder, schedule_id="sched-json-regression")
+
+    expected_task_id = compute_task_id("sched-json-regression", fixed_ft)
+    rows = await conn.fetch(
+        "SELECT payload FROM kailash_task_queue WHERE task_id = ?",
+        expected_task_id,
+    )
+    assert len(rows) == 1, "scheduler MUST have persisted the row through dispatcher"
+
+    raw_payload = rows[0]["payload"]
+    payload = (
+        json.loads(raw_payload)
+        if isinstance(raw_payload, (str, bytes))
+        else raw_payload
+    )
+
+    # The outer payload MUST be a plain JSON dict.
+    assert isinstance(payload, dict)
+    blob_json = payload["workflow_blob_json"]
+    assert isinstance(blob_json, str), "workflow_blob_json MUST be a JSON string"
+
+    # Decoding the inner blob MUST yield a plain dict (no class-instance
+    # pivot, no callable). This is what makes the queue payload safe.
+    blob_bytes = blob_json.encode("utf-8")
+    workflow_dict = json.loads(blob_bytes.decode("utf-8"))
+    assert isinstance(workflow_dict, dict)
+    assert workflow_dict["name"] == "regression-json"
+
+    # And the bytes MUST NOT be a valid pickle envelope. If they were,
+    # an attacker's payload could masquerade as JSON-shaped while
+    # smuggling a pickle stream the worker would deserialize.
+    with pytest.raises((pickle.UnpicklingError, EOFError, KeyError, ValueError)):
+        pickle.loads(blob_bytes)
+
+
+# ---------------------------------------------------------------------------
+# S2 (HIGH) — _fire_times bounded + cancel() cleanup
+# ---------------------------------------------------------------------------
+
+
+def _stub_submit_event(job_id: str, run_time: datetime):
+    class _Stub:
+        pass
+
+    e = _Stub()
+    e.job_id = job_id
+    e.scheduled_run_times = [run_time]
+    return e
+
+
+def _stub_done_event(job_id: str):
+    class _Stub:
+        pass
+
+    e = _Stub()
+    e.job_id = job_id
+    return e
+
+
+@pytest.mark.regression
+def test_fire_times_lru_eviction() -> None:
+    """When MAX_FIRE_TIMES is exceeded, oldest entries are evicted.
+
+    S2 (HIGH): plain Dict grew without bound when EVENT_JOB_EXECUTED |
+    EVENT_JOB_ERROR didn't fire (cancelled mid-flight, listener
+    exception). OrderedDict + LRU eviction is the safety net.
+    """
+    from kailash.runtime import scheduler as scheduler_mod
+    from kailash.runtime.scheduler import WorkflowScheduler
+
+    sched = WorkflowScheduler(job_store_path=None)
+
+    # Pin the bound tightly so the test is fast and deterministic.
+    monkey_max = 5
+    scheduler_mod.MAX_FIRE_TIMES = monkey_max
+    try:
+        base = datetime(2026, 5, 7, 0, 0, 0, tzinfo=UTC)
+        # Submit (monkey_max + 3) entries WITHOUT pairing each with a done
+        # event — simulates the leak path.
+        for i in range(monkey_max + 3):
+            sched._on_job_submitted(
+                _stub_submit_event(f"sched-lru-{i}", base + timedelta(seconds=i))
+            )
+
+        # Bound MUST hold.
+        assert len(sched._fire_times) == monkey_max
+        # Eviction MUST be FIFO (oldest first) — the first 3 entries are gone.
+        evicted = {f"sched-lru-{i}" for i in range(3)}
+        retained = {f"sched-lru-{i}" for i in range(3, monkey_max + 3)}
+        assert evicted.isdisjoint(set(sched._fire_times.keys()))
+        assert retained == set(sched._fire_times.keys())
+    finally:
+        scheduler_mod.MAX_FIRE_TIMES = 10_000
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_cancel_cleans_fire_times() -> None:
+    """cancel(schedule_id) MUST drop the entry from _fire_times.
+
+    Closes the leak window when a job is cancelled while APScheduler
+    considered it in-flight (the EVENT_JOB_EXECUTED | EVENT_JOB_ERROR
+    listener may not fire under cancellation).
+
+    Async test because ``AsyncIOScheduler.start()`` requires a running
+    event loop.
+    """
+    from kailash.runtime.scheduler import WorkflowScheduler
+
+    sched = WorkflowScheduler(job_store_path=None)
+    sched.start()
+    try:
+        # Schedule a real job so cancel() has something to remove from
+        # APScheduler. The stub fire-time entry is the part the
+        # regression checks.
+        builder = _JsonBuilder("cancel-cleanup")
+        sid = sched.schedule_interval(builder, seconds=60)
+        sched._on_job_submitted(
+            _stub_submit_event(sid, datetime(2026, 5, 7, 12, 0, 0, tzinfo=UTC))
+        )
+        assert sid in sched._fire_times
+
+        sched.cancel(sid)
+
+        assert sid not in sched._fire_times, (
+            "cancel() MUST drop _fire_times entry to close the leak window "
+            "for jobs cancelled while APScheduler considered them in-flight"
+        )
+    finally:
+        sched.shutdown(wait=False)

--- a/tests/regression/test_w3_security_fixes.py
+++ b/tests/regression/test_w3_security_fixes.py
@@ -277,3 +277,305 @@ async def test_cancel_cleans_fire_times() -> None:
         )
     finally:
         sched.shutdown(wait=False)
+
+
+# ---------------------------------------------------------------------------
+# HIGH (post-fix) — workflow_blob size cap (DoS via OOM)
+# ---------------------------------------------------------------------------
+
+
+class _OversizedJsonWorkflow:
+    """Workflow stub whose to_dict() returns a payload larger than the cap.
+
+    The default 8 MiB cap is enforced via `MAX_WORKFLOW_BLOB_BYTES`. To test
+    the boundary without burning 8 MiB of memory in the test process, the
+    test monkeypatches the cap to a small value.
+    """
+
+    def __init__(self, payload_bytes: int) -> None:
+        self._padding = "x" * payload_bytes
+
+    def to_dict(self) -> dict:
+        return {"name": "oversized", "padding": self._padding}
+
+
+class _OversizedBuilder:
+    def __init__(self, payload_bytes: int) -> None:
+        self._payload_bytes = payload_bytes
+
+    def build(self) -> _OversizedJsonWorkflow:
+        return _OversizedJsonWorkflow(self._payload_bytes)
+
+
+class _StubDispatcher:
+    """In-memory Dispatcher stub for unit tests of the dispatch path.
+
+    Records every enqueued Task so assertions can confirm the producer
+    boundary serialized correctly. Conformant with the
+    ``kailash.runtime.dispatcher.Dispatcher`` ABC's enqueue contract.
+    """
+
+    def __init__(self) -> None:
+        from typing import List
+
+        from kailash.runtime.dispatcher import Task
+
+        self.enqueued: List[Task] = []
+
+    async def enqueue(self, task) -> None:
+        self.enqueued.append(task)
+
+
+def _prime_fire_time(sched, schedule_id: str, fire_time: datetime) -> None:
+    """Populate _fire_times so _dispatch_to_queue's _planned_fire_time call resolves.
+
+    Mirrors the EVENT_JOB_SUBMITTED listener's recording (see
+    scheduler._on_job_submitted) without needing APScheduler to actually
+    fire — keeps the test fast + deterministic.
+    """
+    sched._fire_times[schedule_id] = fire_time
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_workflow_blob_size_cap_rejects_oversized() -> None:
+    """workflow_blob exceeding MAX_WORKFLOW_BLOB_BYTES MUST raise ValueError.
+
+    Producer-boundary cap. A workflow whose to_dict() output exceeds the
+    cap is refused BEFORE the Task is constructed and BEFORE the
+    dispatcher's enqueue is invoked.
+
+    Why the regression: an unbounded workflow_blob OOMs every dequeueing
+    worker on json.loads. The cap is the structural defense.
+    """
+    from kailash.runtime import scheduler as scheduler_mod
+
+    original_cap = scheduler_mod.MAX_WORKFLOW_BLOB_BYTES
+    scheduler_mod.MAX_WORKFLOW_BLOB_BYTES = 1024  # 1 KiB for fast test
+    try:
+        builder = _OversizedBuilder(payload_bytes=2000)
+        sched = scheduler_mod.WorkflowScheduler(job_store_path=None)
+        sched._dispatcher = _StubDispatcher()
+        _prime_fire_time(
+            sched, "sched-test", datetime(2026, 5, 7, 12, 0, 0, tzinfo=UTC)
+        )
+        try:
+            with pytest.raises(ValueError, match="MAX_WORKFLOW_BLOB_BYTES"):
+                await sched._dispatch_to_queue(
+                    workflow_builder=builder,
+                    schedule_id="sched-test",
+                    run_id="run-test-1",
+                )
+        finally:
+            sched.shutdown(wait=False)
+    finally:
+        scheduler_mod.MAX_WORKFLOW_BLOB_BYTES = original_cap
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_workflow_blob_under_cap_dispatches_normally() -> None:
+    """workflow_blob under the cap MUST dispatch without raising.
+
+    Sanity check that the cap does not regress the normal path.
+    """
+    from kailash.runtime import scheduler as scheduler_mod
+
+    builder = _JsonBuilder("under-cap")
+    sched = scheduler_mod.WorkflowScheduler(job_store_path=None)
+    stub = _StubDispatcher()
+    sched._dispatcher = stub
+    _prime_fire_time(
+        sched, "sched-under-cap", datetime(2026, 5, 7, 12, 0, 0, tzinfo=UTC)
+    )
+    try:
+        await sched._dispatch_to_queue(
+            workflow_builder=builder,
+            schedule_id="sched-under-cap",
+            run_id="run-under-cap-1",
+        )
+        assert len(stub.enqueued) == 1
+        blob = stub.enqueued[0].workflow_blob
+        decoded = json.loads(blob.decode("utf-8"))
+        assert decoded["name"] == "under-cap"
+    finally:
+        sched.shutdown(wait=False)
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM (post-fix) — task_id charset + length validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_validate_task_id_rejects_oversized() -> None:
+    """task_id longer than MAX_TASK_ID_LEN MUST raise ValueError."""
+    from kailash.infrastructure.task_queue import MAX_TASK_ID_LEN, _validate_task_id
+
+    too_long = "a" * (MAX_TASK_ID_LEN + 1)
+    with pytest.raises(ValueError, match="length"):
+        _validate_task_id(too_long)
+
+
+@pytest.mark.regression
+def test_validate_task_id_rejects_empty() -> None:
+    """Empty task_id MUST raise — empty PK is undefined behavior."""
+    from kailash.infrastructure.task_queue import _validate_task_id
+
+    with pytest.raises(ValueError, match="length"):
+        _validate_task_id("")
+
+
+@pytest.mark.regression
+def test_validate_task_id_rejects_invalid_charset() -> None:
+    """task_id with characters outside [a-zA-Z0-9_-] MUST raise."""
+    from kailash.infrastructure.task_queue import _validate_task_id
+
+    for bad in ["with space", "semi;colon", "back\\slash", "../../etc/passwd"]:
+        with pytest.raises(ValueError, match="must match"):
+            _validate_task_id(bad)
+
+
+@pytest.mark.regression
+def test_validate_task_id_rejects_non_string() -> None:
+    """Non-string task_id MUST raise typed error."""
+    from kailash.infrastructure.task_queue import _validate_task_id
+
+    for bad in [42, None, b"bytes", ["list"], {"dict": 1}]:
+        with pytest.raises(ValueError, match="must be str"):
+            _validate_task_id(bad)
+
+
+@pytest.mark.regression
+def test_validate_task_id_accepts_uuid_and_compute_task_id() -> None:
+    """The two paths that produce real task_ids in production MUST pass.
+
+    Sanity check: uuid.uuid4() (caller-omitted task_id default) and
+    compute_task_id() (W3 dispatcher path) both produce task_ids that
+    pass validation.
+    """
+    import uuid
+
+    from kailash.infrastructure.task_queue import _validate_task_id
+    from kailash.runtime.dispatcher import compute_task_id
+
+    # uuid4 → 36 chars, hex + dashes
+    _validate_task_id(str(uuid.uuid4()))
+
+    # compute_task_id → 32 hex chars
+    fire_time = datetime(2026, 5, 7, 12, 0, 0, tzinfo=UTC)
+    _validate_task_id(compute_task_id("schedule-abc", fire_time))
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM (post-fix) — soft_row_cap dispatcher constructor + WARN
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_soft_row_cap_rejects_non_positive() -> None:
+    """SQLTaskQueueDispatcher MUST refuse soft_row_cap <= 0.
+
+    Defense against caller passing 0 or a negative integer expecting it
+    to mean "unbounded" — None is the documented unbounded sentinel.
+    """
+    from kailash.infrastructure.task_queue import SQLTaskQueueDispatcher
+
+    class _DummyConn:
+        pass
+
+    for bad in [0, -1, -1000]:
+        with pytest.raises(ValueError, match="soft_row_cap"):
+            SQLTaskQueueDispatcher(_DummyConn(), soft_row_cap=bad)
+
+
+@pytest.mark.regression
+def test_soft_row_cap_default_is_none() -> None:
+    """The default soft_row_cap MUST be None (no cap → no WARN).
+
+    Backwards compatibility: existing callers of
+    SQLTaskQueueDispatcher(conn) pre-cap MUST continue to work
+    unchanged.
+    """
+    from kailash.infrastructure.task_queue import SQLTaskQueueDispatcher
+
+    class _DummyConn:
+        pass
+
+    dispatcher = SQLTaskQueueDispatcher(_DummyConn())
+    assert dispatcher._soft_row_cap is None
+
+
+# ---------------------------------------------------------------------------
+# LOW (post-fix) — discriminator dispatch (Workflow isinstance check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_workflow_without_to_dict_raises_typeerror() -> None:
+    """Workflow stub without to_dict() MUST raise TypeError, not silently fall back.
+
+    Per zero-tolerance Rule 3 — silent fallback is BLOCKED. The dispatch
+    path refuses unknown workflow shapes rather than pickling them.
+    """
+    from kailash.runtime.scheduler import WorkflowScheduler
+
+    class _NoToDict:
+        pass
+
+    class _NoToDictBuilder:
+        def build(self) -> _NoToDict:
+            return _NoToDict()
+
+    sched = WorkflowScheduler(job_store_path=None)
+    sched._dispatcher = _StubDispatcher()
+    _prime_fire_time(
+        sched, "sched-no-to-dict", datetime(2026, 5, 7, 12, 0, 0, tzinfo=UTC)
+    )
+    try:
+        with pytest.raises(TypeError, match="to_dict"):
+            await sched._dispatch_to_queue(
+                workflow_builder=_NoToDictBuilder(),
+                schedule_id="sched-no-to-dict",
+                run_id="run-no-to-dict-1",
+            )
+    finally:
+        sched.shutdown(wait=False)
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_real_workflow_isinstance_path_dispatches() -> None:
+    """A real kailash.workflow.graph.Workflow instance MUST take the
+    isinstance branch and dispatch successfully.
+
+    The discriminator-first dispatch (Rule 3d sibling) means real
+    Workflow instances skip the duck-type fallback and go straight to
+    to_dict(). This test confirms the canonical path stays green.
+    """
+    from kailash.runtime.scheduler import WorkflowScheduler
+    from kailash.workflow.builder import WorkflowBuilder
+
+    builder = WorkflowBuilder()
+    builder.add_node("PythonCodeNode", "noop", {"code": "result = {}"})
+
+    sched = WorkflowScheduler(job_store_path=None)
+    stub = _StubDispatcher()
+    sched._dispatcher = stub
+    _prime_fire_time(
+        sched, "sched-real-workflow", datetime(2026, 5, 7, 12, 0, 0, tzinfo=UTC)
+    )
+    try:
+        await sched._dispatch_to_queue(
+            workflow_builder=builder,
+            schedule_id="sched-real-workflow",
+            run_id="run-real-1",
+        )
+        assert len(stub.enqueued) == 1
+        # Confirm round-trip parses through json.loads (canonical contract).
+        blob = stub.enqueued[0].workflow_blob
+        decoded = json.loads(blob.decode("utf-8"))
+        assert "nodes" in decoded
+    finally:
+        sched.shutdown(wait=False)

--- a/tests/unit/scheduler/test_dispatch.py
+++ b/tests/unit/scheduler/test_dispatch.py
@@ -266,14 +266,17 @@ class TestWorkflowSchedulerDispatchVia:
 class _SubmitEventStub:
     """Minimal APScheduler-event-shaped record for the submit listener.
 
-    The listener only reads `event.job_id` and `event.scheduled_run_time`;
-    a small struct-like helper is sufficient to exercise the path
-    deterministically in Tier 1.
+    Mirrors APScheduler's ``JobSubmissionEvent`` contract:
+    ``event.job_id`` + ``event.scheduled_run_times: list[datetime]``.
+    The listener records ``run_times[-1]`` (the most recent fire from
+    the trigger) keyed by ``job_id``.
     """
 
     def __init__(self, job_id: str, scheduled_run_time: datetime) -> None:
         self.job_id = job_id
-        self.scheduled_run_time = scheduled_run_time
+        # APScheduler sends a list (coalesce/misfire may produce multiple);
+        # the listener records the LAST entry as the current fire instant.
+        self.scheduled_run_times = [scheduled_run_time]
 
 
 class TestPlannedFireTimeListener:
@@ -312,3 +315,40 @@ class TestPlannedFireTimeListener:
 
         with pytest.raises(RuntimeError, match="EVENT_JOB_SUBMITTED listener"):
             scheduler._planned_fire_time("sched-cleanup")
+
+    def test_on_job_submitted_picks_last_run_time(self) -> None:
+        """Multiple scheduled_run_times — listener records the latest.
+
+        APScheduler may pass multiple entries under coalesce/misfire
+        policies. The most recent fire (last element) is the trigger
+        instant the callback is firing for.
+        """
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+
+        class _MultiRunEvent:
+            job_id = "sched-multi-run"
+            scheduled_run_times = [
+                datetime(2026, 5, 7, 9, 30, 0, tzinfo=UTC),
+                datetime(2026, 5, 7, 9, 30, 30, tzinfo=UTC),
+                datetime(2026, 5, 7, 9, 31, 0, tzinfo=UTC),  # current
+            ]
+
+        scheduler._on_job_submitted(_MultiRunEvent())
+        assert scheduler._planned_fire_time("sched-multi-run") == datetime(
+            2026, 5, 7, 9, 31, 0, tzinfo=UTC
+        )
+
+    def test_on_job_submitted_rejects_empty_run_times(self) -> None:
+        """Empty list violates APScheduler invariant — refuse, do not silently no-op."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+
+        class _EmptyEvent:
+            job_id = "sched-empty"
+            scheduled_run_times: list[datetime] = []
+
+        with pytest.raises(RuntimeError, match="empty scheduled_run_times"):
+            scheduler._on_job_submitted(_EmptyEvent())

--- a/tests/unit/scheduler/test_dispatch.py
+++ b/tests/unit/scheduler/test_dispatch.py
@@ -144,10 +144,19 @@ class _RecordingDispatcher(Dispatcher):
 
 
 class _RecordingWorkflow:
-    """A picklable, runtime-executable workflow stand-in."""
+    """A JSON-serializable, runtime-executable workflow stand-in.
+
+    Provides ``to_dict()`` so the scheduler's JSON serialization path
+    accepts it. Workers in production reconstruct via
+    ``Workflow.from_dict(json.loads(blob.decode("utf-8")))`` — pickle
+    on queue payloads is BLOCKED per ``rules/security.md`` (RCE).
+    """
 
     def __init__(self, name: str = "wf") -> None:
         self.name = name
+
+    def to_dict(self) -> dict:
+        return {"name": self.name}
 
 
 class _RecordingBuilder:

--- a/tests/unit/scheduler/test_dispatch.py
+++ b/tests/unit/scheduler/test_dispatch.py
@@ -256,3 +256,59 @@ class TestWorkflowSchedulerDispatchVia:
         assert "sched-err" in msg
         assert "task_id_hash=" in msg
         assert "RuntimeError" in msg
+
+
+# ---------------------------------------------------------------------------
+# EVENT_JOB_SUBMITTED listener fire-time capture (closes F1 + F2)
+# ---------------------------------------------------------------------------
+
+
+class _SubmitEventStub:
+    """Minimal APScheduler-event-shaped record for the submit listener.
+
+    The listener only reads `event.job_id` and `event.scheduled_run_time`;
+    a small struct-like helper is sufficient to exercise the path
+    deterministically in Tier 1.
+    """
+
+    def __init__(self, job_id: str, scheduled_run_time: datetime) -> None:
+        self.job_id = job_id
+        self.scheduled_run_time = scheduled_run_time
+
+
+class TestPlannedFireTimeListener:
+    """Validate _on_job_submitted/_planned_fire_time semantics (F1 + F2)."""
+
+    def _make_scheduler(self) -> Any:
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        return WorkflowScheduler(job_store_path=None)
+
+    def test_planned_fire_time_returns_listener_recorded_time(self) -> None:
+        """_on_job_submitted records; _planned_fire_time reads it back."""
+        scheduler = self._make_scheduler()
+        fire_time = datetime(2026, 5, 7, 9, 30, 0, tzinfo=UTC)
+
+        scheduler._on_job_submitted(_SubmitEventStub("sched-listener", fire_time))
+
+        assert scheduler._planned_fire_time("sched-listener") == fire_time
+
+    def test_planned_fire_time_raises_when_no_submit_recorded(self) -> None:
+        """No silent now() fallback (rules/zero-tolerance.md Rule 3)."""
+        scheduler = self._make_scheduler()
+
+        with pytest.raises(RuntimeError, match="EVENT_JOB_SUBMITTED listener"):
+            scheduler._planned_fire_time("sched-never-fired")
+
+    def test_on_job_done_clears_recorded_fire_time(self) -> None:
+        """Cleanup listener removes the entry after the job finishes."""
+        scheduler = self._make_scheduler()
+        fire_time = datetime(2026, 5, 7, 9, 30, 0, tzinfo=UTC)
+
+        scheduler._on_job_submitted(_SubmitEventStub("sched-cleanup", fire_time))
+        assert scheduler._planned_fire_time("sched-cleanup") == fire_time
+
+        scheduler._on_job_done(_SubmitEventStub("sched-cleanup", fire_time))
+
+        with pytest.raises(RuntimeError, match="EVENT_JOB_SUBMITTED listener"):
+            scheduler._planned_fire_time("sched-cleanup")

--- a/tests/unit/scheduler/test_dispatch.py
+++ b/tests/unit/scheduler/test_dispatch.py
@@ -1,0 +1,258 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 1 unit tests for the Dispatcher ABC + WorkflowScheduler dispatch_via=.
+
+Covers per ``rules/testing.md`` § "One Direct Test Per Variant":
+
+* Dispatcher ABC structural contract (4 abstract methods, instantiation refused).
+* compute_task_id stability + sensitivity to inputs.
+* WorkflowScheduler in-process fallback (dispatch_via=None) preserves behavior.
+* WorkflowScheduler queue-dispatch path (dispatch_via=<Protocol-satisfying adapter>).
+* Error log on non-PK enqueue failure.
+
+Per ``rules/testing.md`` Tier 1 contract, deterministic Protocol-satisfying
+adapters are NOT mocks — they are the canonical Tier-1 substitution for
+real infrastructure. The adapter classes here record calls and return
+deterministic results without hitting any external service.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, AsyncIterator, List
+
+import pytest
+
+from kailash.runtime.dispatcher import Dispatcher, Task, compute_task_id
+
+# ---------------------------------------------------------------------------
+# Dispatcher ABC structural tests
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherAbcContract:
+    """Validate the Dispatcher ABC contract per architecture plan §3."""
+
+    def test_dispatcher_abc_requires_four_methods(self) -> None:
+        """Direct subclass missing any of the 4 methods raises at instantiation."""
+
+        # All four methods present -> instantiable.
+        class FullDispatcher(Dispatcher):
+            async def enqueue(self, task: Task) -> None:
+                return None
+
+            def poll(self, queue_name: str = "default") -> AsyncIterator[Task]:
+                async def _gen() -> AsyncIterator[Task]:
+                    if False:
+                        yield  # pragma: no cover
+
+                return _gen()
+
+            async def ack(self, task_id: str) -> None:
+                return None
+
+            async def nack(self, task_id: str, *, reason: str) -> None:
+                return None
+
+        FullDispatcher()  # MUST NOT raise
+
+        # Drop one method at a time -> TypeError on instantiation.
+        for missing in ("enqueue", "poll", "ack", "nack"):
+            ns = {
+                "enqueue": FullDispatcher.enqueue,
+                "poll": FullDispatcher.poll,
+                "ack": FullDispatcher.ack,
+                "nack": FullDispatcher.nack,
+            }
+            del ns[missing]
+            cls = type(f"Partial_{missing}", (Dispatcher,), ns)
+            with pytest.raises(TypeError, match="abstract"):
+                cls()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# compute_task_id determinism tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTaskId:
+    """Validate task_id stability per architecture plan §3 invariant 1."""
+
+    def test_compute_task_id_stable_across_calls(self) -> None:
+        """Same (schedule_id, planned_fire_time) -> same task_id."""
+        ft = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        a = compute_task_id("sched-abc", ft)
+        b = compute_task_id("sched-abc", ft)
+        assert a == b
+        assert len(a) == 32  # 32 hex chars per dispatcher.py contract
+
+    def test_compute_task_id_differs_on_schedule_id(self) -> None:
+        ft = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        assert compute_task_id("sched-1", ft) != compute_task_id("sched-2", ft)
+
+    def test_compute_task_id_differs_on_fire_time(self) -> None:
+        a = compute_task_id("sched-1", datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC))
+        b = compute_task_id("sched-1", datetime(2026, 5, 6, 12, 0, 1, tzinfo=UTC))
+        assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Protocol-satisfying deterministic Dispatcher adapter for scheduler tests
+# (NOT a mock per `rules/testing.md` § "Protocol Adapters")
+# ---------------------------------------------------------------------------
+
+
+class _RecordingDispatcher(Dispatcher):
+    """Records calls + raises configured exceptions deterministically.
+
+    Used to verify scheduler.dispatch_via= wires through to the dispatcher
+    contract without spinning up a real database. Per the Protocol Adapters
+    exception in ``rules/testing.md``, a class satisfying a Protocol /
+    ABC at runtime with deterministic output is NOT a mock — there is no
+    `unittest.mock` import, no `MagicMock`, no `@patch`.
+    """
+
+    def __init__(self) -> None:
+        self.enqueued: List[Task] = []
+        self.acked: List[str] = []
+        self.nacked: List[tuple[str, str]] = []
+        self.enqueue_raises: BaseException | None = None
+
+    async def enqueue(self, task: Task) -> None:
+        if self.enqueue_raises is not None:
+            raise self.enqueue_raises
+        self.enqueued.append(task)
+
+    def poll(self, queue_name: str = "default") -> AsyncIterator[Task]:
+        async def _gen() -> AsyncIterator[Task]:
+            for t in list(self.enqueued):
+                yield t
+
+        return _gen()
+
+    async def ack(self, task_id: str) -> None:
+        self.acked.append(task_id)
+
+    async def nack(self, task_id: str, *, reason: str) -> None:
+        self.nacked.append((task_id, reason))
+
+
+# ---------------------------------------------------------------------------
+# Minimal builder + workflow shim — Protocol-satisfying deterministic adapters
+# ---------------------------------------------------------------------------
+
+
+class _RecordingWorkflow:
+    """A picklable, runtime-executable workflow stand-in."""
+
+    def __init__(self, name: str = "wf") -> None:
+        self.name = name
+
+
+class _RecordingBuilder:
+    def __init__(self, name: str = "wf") -> None:
+        self.name = name
+
+    def build(self) -> _RecordingWorkflow:
+        return _RecordingWorkflow(self.name)
+
+
+class _RecordingRuntime:
+    """A runtime that records execute() calls for in-process fallback testing."""
+
+    def __init__(self) -> None:
+        self.calls: List[Any] = []
+
+    def execute(self, workflow: Any, **kwargs: Any) -> tuple[dict, str]:
+        self.calls.append((workflow, kwargs))
+        return ({"ok": True}, "run-deterministic")
+
+
+# ---------------------------------------------------------------------------
+# WorkflowScheduler dispatch_via= tests
+# ---------------------------------------------------------------------------
+
+apscheduler = pytest.importorskip(
+    "apscheduler", reason="WorkflowScheduler requires APScheduler"
+)
+
+
+class TestWorkflowSchedulerDispatchVia:
+    """Validate the dispatch_via= contract per architecture plan §3."""
+
+    def _make_scheduler(self, dispatcher: Dispatcher | None) -> Any:
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        rt = _RecordingRuntime()
+        return (
+            WorkflowScheduler(
+                job_store_path=None,  # in-memory, no SQLite file
+                runtime_factory=lambda: rt,
+                dispatch_via=dispatcher,
+            ),
+            rt,
+        )
+
+    @pytest.mark.asyncio
+    async def test_in_process_fallback_executes_workflow(self) -> None:
+        """dispatch_via=None preserves existing in-process execution."""
+        scheduler, rt = self._make_scheduler(dispatcher=None)
+        builder = _RecordingBuilder("test-wf")
+
+        await scheduler._execute_workflow(builder, schedule_id="sched-x")
+
+        assert len(rt.calls) == 1, "in-process runtime MUST be invoked exactly once"
+        executed_workflow, _kw = rt.calls[0]
+        assert executed_workflow.name == "test-wf"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_via_calls_enqueue_with_stable_task_id(self) -> None:
+        """dispatch_via=<Dispatcher> enqueues a Task with stable task_id."""
+        dispatcher = _RecordingDispatcher()
+        scheduler, rt = self._make_scheduler(dispatcher=dispatcher)
+        builder = _RecordingBuilder("test-wf")
+
+        # Patch the planned-fire-time lookup to be deterministic. This is
+        # NOT a mock of the unit under test — it pins external clock-state.
+        fixed_ft = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        scheduler._planned_fire_time = lambda sid: fixed_ft
+
+        await scheduler._execute_workflow(builder, schedule_id="sched-stable")
+
+        assert (
+            len(dispatcher.enqueued) == 1
+        ), "dispatch_via path MUST enqueue exactly one Task"
+        assert (
+            len(rt.calls) == 0
+        ), "in-process runtime MUST NOT fire when dispatch_via is set"
+
+        task = dispatcher.enqueued[0]
+        assert task.schedule_id == "sched-stable"
+        assert task.task_id == compute_task_id("sched-stable", fixed_ft)
+        assert task.planned_fire_time == fixed_ft.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_failure_logs_at_error_and_raises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Non-PK enqueue failure logs ERROR with task_id_hash + raises."""
+        dispatcher = _RecordingDispatcher()
+        dispatcher.enqueue_raises = RuntimeError("network unreachable")
+        scheduler, _rt = self._make_scheduler(dispatcher=dispatcher)
+        builder = _RecordingBuilder("test-wf")
+
+        fixed_ft = datetime(2026, 5, 6, 12, 0, 0, tzinfo=UTC)
+        scheduler._planned_fire_time = lambda sid: fixed_ft
+
+        with caplog.at_level(logging.ERROR, logger="kailash.runtime.scheduler"):
+            with pytest.raises(RuntimeError, match="network unreachable"):
+                await scheduler._execute_workflow(builder, schedule_id="sched-err")
+
+        # ERROR log MUST cite schedule_id + task_id_hash per arch plan §3 inv 3.
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "expected ERROR log on enqueue failure"
+        msg = " ".join(r.getMessage() for r in error_records)
+        assert "sched-err" in msg
+        assert "task_id_hash=" in msg
+        assert "RuntimeError" in msg


### PR DESCRIPTION
## Summary

Adds `dispatch_via=` to `WorkflowScheduler` so scheduled triggers can fan-out to a multi-worker fleet via `SQLTaskQueue` / Redis instead of running in-process. Introduces a `Dispatcher` protocol and ships `SQLTaskQueueDispatcher` as the first impl. Closes the cron-to-queue gap from #859 — both halves existed, the connector did not.

## Why

Per #859: migrating Celery beat → multi-worker Kailash deployment forced every adopter to subclass `WorkflowScheduler` and write the dispatcher glue. First-class `dispatch_via=` makes the cron→queue pipe a documented, tested path.

## Surface

```python
queue = SQLTaskQueue(conn)
scheduler = WorkflowScheduler(dispatch_via=SQLTaskQueueDispatcher(queue))
scheduler.schedule_cron(my_workflow, "0 22 * * *", queue_name="prewarm")
# Scheduler fires at 22:00 → enqueues onto SQLTaskQueue → workers dequeue + execute.
```

## Security hardening (red-team driven, in-PR)

Initial implementation persisted workflows through APScheduler's pickle-backed job store. Pickle deserialization of attacker-controlled bytes is RCE. Two same-shard fix-immediate rounds per `rules/autonomous-execution.md` Rule 4:

**Round 1 (commit `66e76106`):**
- **CRITICAL S1 — pickle→JSON.** `WorkflowScheduler` now persists workflows via `Workflow.to_dict()` / `from_dict()` JSON. Zero pickle imports/calls in W3-introduced code.
- **HIGH S2 — `_fire_times` bound.** `OrderedDict` LRU eviction on per-job fire-time history (was unbounded).
- **L1 — frozen dataclasses.** `Task`, `Dispatcher` ABC are frozen.
- **S3 — multi-tenant queue isolation** documented in `specs/scheduling.md`.

**Round 2 (commit `ff63504d`, post second-pass security review):**
- **HIGH — `workflow_blob` size cap.** 8 MiB cap (`MAX_WORKFLOW_BLOB_BYTES`) enforced at the producer boundary in `scheduler.py` BEFORE Task construction; mirrored at `task_queue.py` enqueue boundary as defense-in-depth. Without the cap, multi-MB JSON OOMs every dequeueing worker on `json.loads`.
- **MEDIUM — `task_id` charset+length validation.** `_validate_task_id()` rejects non-string, empty, oversize (>128 chars), or bad-charset (outside `[a-zA-Z0-9_-]`) inputs at `SQLTaskQueue.enqueue`. Closes the dedup-namespace-poisoning vector where a caller could shadow the W3 stable-hash output.
- **MEDIUM — queue row-count soft cap.** `SQLTaskQueueDispatcher(soft_row_cap=N)` constructor kwarg emits a rate-limited WARN (≤ 1/min/queue_name) when queue depth exceeds the cap. Operator runbook in `specs/scheduling.md` §9.11. The WARN does NOT refuse enqueues — refusal would silently drop scheduled work.
- **LOW — discriminator dispatch.** `isinstance(workflow, Workflow)` first, with class-level `to_dict` fallback for stubs. Replaces instance-attribute duck-type per `rules/zero-tolerance.md` Rule 3d sibling pattern.

## Carried-forward findings (orthogonal — separate follow-up)

The second-pass review surfaced two HIGHs pre-existing on `main` (TOCTOU on SQLite job-store chmod + WAL/SHM sidecar files not chmod'd at `scheduler.py:179-188`). These are file-permissions class, not the dispatch contract this PR delivers; tracked in a separate follow-up issue for a focused security PR.

## Tests

- Tier 1: `tests/unit/scheduler/test_dispatch.py` (363 lines) — `Dispatcher` ABC + `dispatch_via=` wiring
- Tier 2: `tests/integration/runtime/test_workflow_scheduler_dispatch_wiring.py` (411 lines) — schedule → fire → enqueue → dequeue → execute
- Regression: `tests/regression/test_w3_security_fixes.py` (~580 lines) — JSON migration + bound + frozen + the four Round 2 fix-immediate findings

47 tests passing (15 added by Round 2). Spec extension at `specs/scheduling.md` §9.9 (planned_fire_time semantics) + §9.10 (payload bounds) + §9.11 (operator runbook — purge cadence).

## Related issues

Fixes #859.
