### PR TITLE
chore: release v2.14.1 — SQLite job-store TOCTOU + WAL/SHM hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.1] - 2026-05-07
+
+Patch release shipping the #871 SQLite job-store security hardening that landed on `main` (commit `597d4736`, PR #873) after v2.14.0 was cut earlier the same day. No other changes since v2.14.0.
+
+### Security
+
+- **HIGH:** SQLite job-store TOCTOU + WAL/SHM 0o600 hardening (#871, PR #873). The prior open-then-chmod sequence in `WorkflowScheduler` left a window where the job-store DB existed on disk with default 0o644 perms before chmod tightened it to 0o600 — observable to other local processes during scheduler init. The fix introduces `_secure_init_sqlite_jobstore()` (`src/kailash/runtime/scheduler.py`) which creates the file with `os.O_CREAT | os.O_WRONLY` + explicit `mode=0o600` via `os.open` BEFORE handing the path to APScheduler's `SQLAlchemyJobStore`, and applies the same 0o600 mode to the WAL/SHM sidecars on first commit. Six regression tests at `tests/regression/test_issue_871_sqlite_jobstore_security.py` cover all four #871 acceptance criteria. Closes #871.
+
 ## [2.14.0] - 2026-05-07
 
 Minor bump shipping two new public APIs on the runtime + scheduler surface — durable execution checkpoints and pluggable scheduler dispatch — plus a series of W1/W3 hardening fixes from the parallel implementation work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.14.0"
+version = "2.14.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.14.0"
+__version__ = "2.14.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Patch release cutting PyPI for the #871 SQLite job-store security hardening that landed on `main` (commit `597d4736`, PR #873) after v2.14.0 was cut earlier the same day. No other changes since v2.14.0.

The only commit between `v2.14.0` and `main` is `597d4736 fix(runtime): #871 SQLite job-store TOCTOU + WAL/SHM 0o600` — pure patch scope.

## Anchors bumped

- `pyproject.toml` → `2.14.1`
- `src/kailash/__init__.py::__version__` → `"2.14.1"`
- `CHANGELOG.md` → new `[2.14.1] - 2026-05-07` section

## Why a patch (not a minor)

Single security fix, no API additions, no behavior changes outside the runtime scheduler's job-store init path. SemVer patch is the correct increment.

## CodeQL / scanner findings

None expected — no source changes since v2.14.0.

## Branch convention

`release/v2.14.1` per `git.md` § Release-Prep PRs MUST Use `release/v*` Branch Convention. PR-gate matrix should auto-skip via `if: !startsWith(github.head_ref, 'release/')`.

## Related issues

- Closes #871 (TOCTOU + WAL/SHM HIGH security findings — fix shipped via PR #873, this PR releases it to PyPI)

## Test plan

- [x] `tests/regression/test_issue_871_sqlite_jobstore_security.py` — 6/6 passing locally on this branch
- [x] `import kailash; print(kailash.__version__)` reports `2.14.1`
- [x] Pre-commit clean on staged files (Black, isort, Ruff, doc8, type-annotations, etc.)
- [ ] CI matrix green on this PR (auto-skip on `release/v*` head_ref)
- [ ] Tag-trigger publish-pypi.yml after merge
- [ ] Clean-venv installability + import verification post-publish