### PR TITLE
feat(infrastructure): W2 WorkflowHistoryStore — first-party persistent workflow history

### DIFF
--- a/src/kailash/infrastructure/__init__.py
+++ b/src/kailash/infrastructure/__init__.py
@@ -64,6 +64,12 @@ from kailash.infrastructure.execution_store import (
     InMemoryExecutionStore,
 )
 from kailash.infrastructure.factory import SCHEMA_VERSION, StoreFactory
+from kailash.infrastructure.history_store import (
+    DowngradeRefusedError,
+    PostgresHistoryStore,
+    SQLiteHistoryStore,
+    WorkflowHistoryStore,
+)
 from kailash.infrastructure.idempotency import IdempotentExecutor
 from kailash.infrastructure.idempotency_store import DBIdempotencyStore
 from kailash.infrastructure.queue_factory import create_task_queue
@@ -76,12 +82,16 @@ __all__ = [
     "DBEventStoreBackend",
     "DBExecutionStore",
     "DBIdempotencyStore",
+    "DowngradeRefusedError",
     "IdempotentExecutor",
     "InMemoryExecutionStore",
+    "PostgresHistoryStore",
     "SCHEMA_VERSION",
     "SQLTaskMessage",
     "SQLTaskQueue",
     "SQLWorkerRegistry",
+    "SQLiteHistoryStore",
     "StoreFactory",
+    "WorkflowHistoryStore",
     "create_task_queue",
 ]

--- a/src/kailash/infrastructure/history_store.py
+++ b/src/kailash/infrastructure/history_store.py
@@ -73,14 +73,10 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from kailash.db.connection import ConnectionManager
-from kailash.db.dialect import _validate_identifier
-from kailash.runtime.durable import (
-    NodeCompletionEvent,
-    redact_event_for_persistence,
-)
+from kailash.runtime.durable import NodeCompletionEvent, redact_event_for_persistence
 
 logger = logging.getLogger(__name__)
 
@@ -555,8 +551,9 @@ class WorkflowHistoryStore(ABC):
         elif isinstance(since, str):
             since_iso = since
         else:
-            raise TypeError(
-                "list_failed: since must be a datetime, ISO-8601 string, " "or None"
+            raise TypeError(  # pyright: ignore[reportUnreachable]
+                f"list_failed: since must be a datetime, ISO-8601 string, or None "
+                f"— got {type(since).__name__!r}"
             )
         if since_iso is not None:
             rows = await self._conn.fetch(
@@ -618,9 +615,9 @@ class WorkflowHistoryStore(ABC):
         elif isinstance(timestamp, str):
             ts_iso = timestamp
         else:
-            raise TypeError(
-                "delete_runs_older_than: timestamp must be a datetime or "
-                "ISO-8601 string."
+            raise TypeError(  # pyright: ignore[reportUnreachable]
+                f"delete_runs_older_than: timestamp must be a datetime or "
+                f"ISO-8601 string — got {type(timestamp).__name__!r}"
             )
 
         async with self._conn.transaction() as tx:

--- a/src/kailash/infrastructure/history_store.py
+++ b/src/kailash/infrastructure/history_store.py
@@ -67,11 +67,13 @@ Per-tenant cap:
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import json
 import logging
 import re
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Mapping, Optional, Union
 
@@ -102,6 +104,13 @@ _DEFAULT_RETENTION_DAYS = 30
 
 #: Default per-tenant cap; oldest run evicted with WARN log on overflow.
 _DEFAULT_PER_TENANT_CAP = 10_000
+
+#: Bound on the per-run ``asyncio.Lock`` LRU cache.  Long-running stores
+#: shared across many runs would otherwise leak one Lock per unique
+#: ``run_id`` forever.  Mirrors ``MAX_CHECKPOINT_LOCKS`` in
+#: :mod:`kailash.runtime.local`.  Per ``rules/infrastructure-sql.md``
+#: Rule 7 (bound in-memory stores).
+_MAX_RUN_LOCKS = 10_000
 
 #: ContextVar guarding ``delete_runs_older_than`` during an internal lazy
 #: eviction sweep so the recursion through write-time eviction does not
@@ -225,6 +234,17 @@ class WorkflowHistoryStore(ABC):
         self._per_tenant_cap = per_tenant_cap
         self._policy = classification_policy
         self._initialized = False
+        # Per-run asyncio.Lock for serialising concurrent ``record_event``
+        # calls for the SAME run_id.  Mirrors the ``_checkpoint_locks``
+        # pattern in :mod:`kailash.runtime.local` (W1).  Today the W1
+        # ``NodeCompletionHookRegistry.dispatch_async`` awaits subscribers
+        # sequentially per event, so concurrent record_event calls only
+        # arise across multiple runtime instances or future parallel-
+        # branch dispatch surfaces — the lock is defense-in-depth that
+        # closes the ``MAX(event_seq) + 1`` race under READ COMMITTED
+        # isolation.  Bounded LRU per ``rules/infrastructure-sql.md``
+        # Rule 7.
+        self._run_locks: "OrderedDict[str, asyncio.Lock]" = OrderedDict()
 
     @abstractmethod
     async def initialize(self) -> None:
@@ -235,6 +255,24 @@ class WorkflowHistoryStore(ABC):
         ``/redteam`` mechanical sweep (Rule 1a) MUST grep for inline DDL
         outside ``initialize`` and BLOCK on hits.
         """
+
+    def _get_or_create_run_lock(self, run_id: str) -> asyncio.Lock:
+        """Get or create the per-run :class:`asyncio.Lock`, with LRU eviction.
+
+        Bounded by :data:`_MAX_RUN_LOCKS`.  On access an existing entry
+        is promoted to most-recently-used so an active long-lived run is
+        never aged out under the bound.  Mirrors
+        :meth:`kailash.runtime.local.LocalRuntime._get_or_create_checkpoint_lock`.
+        """
+        lock = self._run_locks.get(run_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._run_locks[run_id] = lock
+            while len(self._run_locks) > _MAX_RUN_LOCKS:
+                self._run_locks.popitem(last=False)
+        else:
+            self._run_locks.move_to_end(run_id)
+        return lock
 
     async def close(self) -> None:
         """Release any resources held by the backend.
@@ -313,6 +351,57 @@ class WorkflowHistoryStore(ABC):
         node_id_hash = _hash_short(redacted.node_id)
         is_terminal_failure = redacted.error is not None
 
+        # ``redacted.run_id`` is non-None here — the early-return at the
+        # top of this method covered ``event.run_id is None``, and the
+        # redaction helper preserves run_id verbatim.  Local rebind so
+        # the type narrows for the lock-key argument.
+        run_id_str: str = redacted.run_id  # type: ignore[assignment]
+
+        # Per-run lock serialises concurrent record_event calls for the
+        # same run_id.  Without this lock, two writers under READ COMMITTED
+        # isolation can both observe the same MAX(event_seq) and one INSERT
+        # collides with UNIQUE(run_id, event_seq).  The W1 hook registry
+        # serialises dispatch within ONE runtime instance, so this lock is
+        # primarily defense-in-depth against future parallel-branch dispatch
+        # surfaces (W3+) or shared-store deployments where multiple runtime
+        # instances target the same history_store with overlapping run_ids.
+        async with self._get_or_create_run_lock(run_id_str):
+            await self._record_event_locked(
+                redacted=redacted,
+                payload_json=payload_json,
+                classified_field_count=classified_field_count,
+                started_at_iso=started_at_iso,
+                ts_iso=ts_iso,
+                node_id_hash=node_id_hash,
+                is_terminal_failure=is_terminal_failure,
+            )
+
+        # 3) Lazy retention sweep + per-tenant cap.  These run OUTSIDE
+        #    the transaction so they cannot rollback the write that
+        #    triggered them.  Every site that performs a destructive
+        #    sweep enters via the internal-eviction context to bypass
+        #    the public ``force_downgrade=True`` gate per Rule 7.
+        await self._lazy_retention_sweep()
+        await self._enforce_per_tenant_cap(_tenant_partition(redacted.tenant_id))
+
+    async def _record_event_locked(
+        self,
+        *,
+        redacted: NodeCompletionEvent,
+        payload_json: str,
+        classified_field_count: int,
+        started_at_iso: str,
+        ts_iso: str,
+        node_id_hash: str,
+        is_terminal_failure: bool,
+    ) -> None:
+        """Inner persistence path for :meth:`record_event`.
+
+        Caller MUST hold ``self._get_or_create_run_lock(redacted.run_id)``
+        for the duration of this call so the ``MAX(event_seq) + 1``
+        computation inside the transaction cannot race against another
+        writer for the same ``run_id``.
+        """
         async with self._conn.transaction() as tx:
             # 1) Upsert the run row.  Status becomes "failed" on the
             #    first error event; otherwise runs as "running" until
@@ -356,8 +445,10 @@ class WorkflowHistoryStore(ABC):
                 )
 
             # 2) Append the per-node event.  ``event_seq`` is monotonic
-            #    per run — derived inside the same transaction so two
-            #    concurrent writers cannot collide.
+            #    per run — caller-held :meth:`_get_or_create_run_lock`
+            #    serialises concurrent writers for the same run_id so the
+            #    ``MAX(event_seq) + 1`` computation cannot race against
+            #    another writer's INSERT under READ COMMITTED isolation.
             seq_row = await tx.fetchone(
                 f"SELECT COALESCE(MAX(event_seq), 0) AS max_seq "
                 f"FROM {self._events_table} WHERE run_id = ?",
@@ -379,14 +470,6 @@ class WorkflowHistoryStore(ABC):
                 classified_field_count,
                 ts_iso,
             )
-
-        # 3) Lazy retention sweep + per-tenant cap.  These run OUTSIDE
-        #    the transaction so they cannot rollback the write that
-        #    triggered them.  Every site that performs a destructive
-        #    sweep enters via the internal-eviction context to bypass
-        #    the public ``force_downgrade=True`` gate per Rule 7.
-        await self._lazy_retention_sweep()
-        await self._enforce_per_tenant_cap(_tenant_partition(redacted.tenant_id))
 
     # ------------------------------------------------------------------
     # Read API (every method tenant-isolated)
@@ -494,21 +577,20 @@ class WorkflowHistoryStore(ABC):
                 "get_run_events: tenant_id MUST be a non-empty string.  "
                 "Cross-tenant reads are blocked at the store layer."
             )
-        # Tenant-scope check: confirm the run row exists for this tenant
-        # before returning any events.
-        run = await self._conn.fetchone(
-            f"SELECT 1 FROM {self._runs_table} " f"WHERE run_id = ? AND tenant_id = ?",
+        # Tenant scope is enforced by JOINing to the runs table — an event
+        # whose run is owned by a different tenant returns no rows.  This
+        # is defense-in-depth: the data fetch itself partitions by tenant,
+        # not just the existence check.  Closes a defense-in-depth gap
+        # surfaced by /redteam (cross-SDK security audit, 2026-05-07).
+        rows = await self._conn.fetch(
+            f"SELECT e.id, e.run_id, e.event_seq, e.node_id_hash, "
+            f"e.event_type, e.payload_json, e.classified_field_count, e.ts "
+            f"FROM {self._events_table} e "
+            f"JOIN {self._runs_table} r ON e.run_id = r.run_id "
+            f"WHERE r.run_id = ? AND r.tenant_id = ? "
+            f"ORDER BY e.event_seq ASC",
             run_id,
             _tenant_partition(tenant_id),
-        )
-        if run is None:
-            return []
-        rows = await self._conn.fetch(
-            f"SELECT id, run_id, event_seq, node_id_hash, event_type, "
-            f"payload_json, classified_field_count, ts "
-            f"FROM {self._events_table} "
-            f"WHERE run_id = ? ORDER BY event_seq ASC",
-            run_id,
         )
         result: List[Dict[str, Any]] = []
         for row in rows:

--- a/src/kailash/infrastructure/history_store.py
+++ b/src/kailash/infrastructure/history_store.py
@@ -1,0 +1,901 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""First-party persistent workflow history for the Kailash Python SDK.
+
+This module is the W2 wave of the runtime-integration-trio: a queryable
+audit log of per-node :class:`~kailash.runtime.durable.NodeCompletionEvent`
+records emitted by :class:`~kailash.runtime.local.LocalRuntime` /
+:class:`~kailash.runtime.async_local.AsyncLocalRuntime` via the W1
+``on_node_complete`` hook registry.
+
+Public surface:
+
+* :class:`WorkflowHistoryStore` — abstract base.  Defines ``record_event``
+  (the hook callback) plus the read-side query API (``list_runs``,
+  ``get_run``, ``get_run_events``, ``list_failed``).
+* :class:`PostgresHistoryStore` / :class:`SQLiteHistoryStore` — concrete
+  implementations.  Both share the same dialect-portable schema and
+  query plumbing; the subclasses exist so callers can be explicit about
+  which dialect they target.  Per ``rules/infrastructure-sql.md``
+  Rules 3-5 every query uses canonical ``?`` placeholders +
+  :meth:`~kailash.db.dialect.QueryDialect.upsert` / ``dialect.blob_type()``
+  / ``dialect.text_column()`` and per ``rules/schema-migration.md``
+  Rule 1 ALL DDL lives in :meth:`initialize`.
+
+Auto-subscribe pattern::
+
+    from kailash.db.connection import ConnectionManager
+    from kailash.infrastructure.history_store import PostgresHistoryStore
+    from kailash.runtime.local import LocalRuntime
+
+    conn = ConnectionManager(os.environ["KAILASH_DATABASE_URL"])
+    await conn.initialize()
+    history = PostgresHistoryStore(conn, retention_days=30)
+    await history.initialize()
+
+    runtime = LocalRuntime(history_store=history)
+    # The runtime auto-registers history.record_event via the W1 hook
+    # registry — every node completion lands a row in workflow_run_events
+    # (and a workflow_runs row on first sight of the run_id).
+
+Tenant isolation:
+    Every read filters by ``tenant_id`` resolved from the runtime context
+    (see :func:`~kailash.runtime.durable.resolve_tenant_id`).  Cross-tenant
+    reads are BLOCKED at the store layer per
+    ``rules/tenant-isolation.md`` MUST Rule 5.
+
+Redaction at write-time:
+    :meth:`record_event` routes every event through
+    :func:`~kailash.runtime.durable.redact_event_for_persistence` BEFORE
+    persisting.  Per the cross-cutting invariant: read-redaction at
+    write-time, never re-redacted at read-time.
+
+Retention:
+    30-day TTL on ``terminal_at`` (NOT ``started_at``) by default.
+    In-flight runs (``terminal_at IS NULL``) are NOT eligible for
+    truncation.  ``retention_days=N`` overrides; ``retention_days=False``
+    disables.  Lazy eviction at write-time + explicit
+    :meth:`delete_runs_older_than` (which requires ``force_downgrade=True``
+    per ``rules/schema-migration.md`` Rule 7).
+
+Per-tenant cap:
+    Default cap of 10,000 runs per tenant.  When a write would exceed
+    the cap, the oldest run (by ``started_at``) is evicted with a WARN
+    log line carrying op name + attempted/failed/sample fields per
+    ``rules/observability.md`` Rule 7.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import re
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union
+
+from kailash.db.connection import ConnectionManager
+from kailash.db.dialect import _validate_identifier
+from kailash.runtime.durable import (
+    NodeCompletionEvent,
+    redact_event_for_persistence,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DowngradeRefusedError",
+    "PostgresHistoryStore",
+    "SQLiteHistoryStore",
+    "WorkflowHistoryStore",
+]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Per ``rules/infrastructure-sql.md`` MUST Rule 6 — table names cannot
+#: be parameterized in SQL, so constructor-time validation is the only
+#: defense against SQL injection through dynamic table names.
+_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+#: Default 30-day TTL on ``terminal_at`` for retention sweeps.
+_DEFAULT_RETENTION_DAYS = 30
+
+#: Default per-tenant cap; oldest run evicted with WARN log on overflow.
+_DEFAULT_PER_TENANT_CAP = 10_000
+
+#: ContextVar guarding ``delete_runs_older_than`` during an internal lazy
+#: eviction sweep so the recursion through write-time eviction does not
+#: trip the ``force_downgrade=True`` requirement on the public surface.
+#: The flag is True ONLY when set explicitly inside the store's own write
+#: path; user-supplied calls to ``delete_runs_older_than`` MUST still go
+#: through the keyword-only ``force_downgrade`` gate.
+_INTERNAL_EVICTION_CONTEXT: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "kailash.history_store.internal_eviction", default=False
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class DowngradeRefusedError(RuntimeError):
+    """Raised when :meth:`WorkflowHistoryStore.delete_runs_older_than` is
+    called without the ``force_downgrade=True`` confirmation flag.
+
+    The orchestrator-layer destructive-confirmation guard mandated by
+    ``rules/schema-migration.md`` MUST Rule 7.  Distinct from
+    ``DropRefusedError`` (per ``rules/dataflow-identifier-safety.md``
+    MUST Rule 6) — the primitive layer guards individual DROP statements;
+    this layer guards the multi-row retention sweep.
+    """
+
+
+# ---------------------------------------------------------------------------
+# WorkflowHistoryStore (abstract base)
+# ---------------------------------------------------------------------------
+
+
+class WorkflowHistoryStore(ABC):
+    """Abstract base for persistent workflow history backends.
+
+    Subscribes to :meth:`runtime.on_node_complete` via :meth:`record_event`
+    and persists per-node events into a queryable audit log partitioned by
+    ``tenant_id``.
+
+    Parameters
+    ----------
+    conn_manager:
+        An initialized :class:`~kailash.db.connection.ConnectionManager`.
+        The history store does NOT close the manager on :meth:`close` —
+        per ``rules/infrastructure-sql.md`` MUST NOT clauses, all stores
+        share one pool owned by the caller (typically
+        :class:`~kailash.infrastructure.factory.StoreFactory`).
+    runs_table:
+        Name of the workflow-runs table.  Validated against
+        ``^[a-zA-Z_][a-zA-Z0-9_]*$`` per Rule 6.
+    events_table:
+        Name of the per-node-events table.  Validated similarly.
+    retention_days:
+        Number of days to retain a run after its ``terminal_at`` timestamp.
+        ``False`` disables retention.  Default 30.
+    per_tenant_cap:
+        Maximum number of runs to retain per tenant.  When exceeded, the
+        oldest run (by ``started_at``) is evicted with a WARN log line.
+        Default 10,000.
+    classification_policy:
+        Optional policy forwarded to
+        :func:`~kailash.runtime.durable.redact_event_for_persistence`.
+        ``None`` is the single-classification default.
+    """
+
+    # ------------------------------------------------------------------
+    # Construction + lifecycle
+    # ------------------------------------------------------------------
+    def __init__(
+        self,
+        conn_manager: ConnectionManager,
+        *,
+        runs_table: str = "workflow_runs",
+        events_table: str = "workflow_run_events",
+        retention_days: Union[int, bool] = _DEFAULT_RETENTION_DAYS,
+        per_tenant_cap: int = _DEFAULT_PER_TENANT_CAP,
+        classification_policy: Optional[Any] = None,
+    ) -> None:
+        # Per ``rules/infrastructure-sql.md`` MUST Rule 6 — validate the
+        # table names BEFORE storing them; constructor-time validation is
+        # the only defense against SQL injection through dynamic table
+        # names.  A future caller passing a user-supplied table name must
+        # see the failure here, not when the first query interpolates.
+        if not isinstance(runs_table, str) or not _TABLE_NAME_RE.match(runs_table):
+            raise ValueError(
+                "WorkflowHistoryStore: runs_table must match " "[a-zA-Z_][a-zA-Z0-9_]*"
+            )
+        if not isinstance(events_table, str) or not _TABLE_NAME_RE.match(events_table):
+            raise ValueError(
+                "WorkflowHistoryStore: events_table must match "
+                "[a-zA-Z_][a-zA-Z0-9_]*"
+            )
+        # retention_days: accept False (disabled) OR a positive int.
+        if retention_days is False:
+            self._retention_days: Optional[int] = None
+        elif isinstance(retention_days, bool):
+            # bool is a subclass of int — handle True explicitly so it
+            # doesn't silently coerce to 1.
+            raise ValueError(
+                "WorkflowHistoryStore: retention_days=True is not a valid "
+                "override; pass False to disable, or a positive integer."
+            )
+        elif isinstance(retention_days, int) and retention_days > 0:
+            self._retention_days = retention_days
+        else:
+            raise ValueError(
+                "WorkflowHistoryStore: retention_days must be a positive "
+                "integer or False (to disable)."
+            )
+
+        if not isinstance(per_tenant_cap, int) or per_tenant_cap <= 0:
+            raise ValueError(
+                "WorkflowHistoryStore: per_tenant_cap must be a positive " "integer."
+            )
+
+        self._conn = conn_manager
+        self._runs_table = runs_table
+        self._events_table = events_table
+        self._per_tenant_cap = per_tenant_cap
+        self._policy = classification_policy
+        self._initialized = False
+
+    @abstractmethod
+    async def initialize(self) -> None:
+        """Create tables + indexes if they do not already exist.
+
+        Per ``rules/schema-migration.md`` MUST Rule 1 ALL ``CREATE TABLE``
+        and ``CREATE INDEX`` DDL lives in this method ONLY — the
+        ``/redteam`` mechanical sweep (Rule 1a) MUST grep for inline DDL
+        outside ``initialize`` and BLOCK on hits.
+        """
+
+    async def close(self) -> None:
+        """Release any resources held by the backend.
+
+        The underlying ConnectionManager is NOT closed here — it is
+        owned by the caller and may be shared with other stores per
+        ``rules/infrastructure-sql.md`` MUST NOT clause "No separate
+        ConnectionManagers per store".
+        """
+        logger.debug("WorkflowHistoryStore backend closed")
+
+    # ------------------------------------------------------------------
+    # Hook-side: record_event (subscribed via runtime.on_node_complete)
+    # ------------------------------------------------------------------
+    async def record_event(self, event: NodeCompletionEvent) -> None:
+        """Persist *event* — called by the runtime hook registry.
+
+        Read-redaction at write time.  Per the cross-cutting invariant
+        the event is routed through
+        :func:`~kailash.runtime.durable.redact_event_for_persistence`
+        BEFORE any database write.  Subscribers downstream of this store
+        observe ALREADY-redacted rows.
+
+        On first sight of ``event.run_id`` an entry is upserted into the
+        runs table (``status='running'``); on every subsequent event the
+        row is updated to reflect the latest state.  Terminal events
+        (an event whose ``error`` field is set OR whose node is the
+        workflow's final node) close out the run with ``terminal_at`` set.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "WorkflowHistoryStore.record_event(): store is not "
+                "initialized.  Call await store.initialize() before "
+                "registering the callback with runtime.on_node_complete()."
+            )
+
+        if event.run_id is None:
+            # The runtime path that produced this event ran without a
+            # task_manager AND the AsyncLocalRuntime ID-derivation path
+            # did not assign one.  Without a run_id we cannot partition
+            # the event into a run row; log at WARN and drop.  See
+            # ``rules/observability.md`` Rule 7 (no silent swallow).
+            logger.warning(
+                "history_store.record_event.skipped_no_run_id",
+                extra={
+                    "node_id_hash": _hash_short(event.node_id),
+                    "workflow_id": event.workflow_id,
+                },
+            )
+            return
+
+        # Read-redaction at write time (cross-cutting invariant 4).
+        redacted = redact_event_for_persistence(
+            event, classification_policy=self._policy
+        )
+
+        # Build the persisted JSON payload.  Per the spec the payload
+        # combines ``outputs`` + ``metadata`` after redaction; the raw
+        # event's classification summary already lives in metadata.
+        payload = {
+            "outputs": dict(redacted.outputs),
+            "metadata": dict(redacted.metadata),
+        }
+        payload_json = json.dumps(payload, default=str)
+
+        # The classified-field count rides at column-level so operators
+        # can run "show me runs whose events redacted >0 fields" without
+        # scanning the JSON blob.
+        classification_summary = redacted.metadata.get("classification_summary", {})
+        classified_field_count = int(
+            classification_summary.get("classified_field_count", 0)
+        )
+
+        ts_iso = redacted.ended_at.isoformat()
+        started_at_iso = redacted.started_at.isoformat()
+        node_id_hash = _hash_short(redacted.node_id)
+        is_terminal_failure = redacted.error is not None
+
+        async with self._conn.transaction() as tx:
+            # 1) Upsert the run row.  Status becomes "failed" on the
+            #    first error event; otherwise runs as "running" until
+            #    a caller explicitly marks it complete via the runtime's
+            #    own terminal-state path (W3+).  For W2 we only flip to
+            #    "failed" on a node error.
+            existing = await tx.fetchone(
+                f"SELECT status, terminal_at FROM {self._runs_table} "
+                f"WHERE run_id = ? AND tenant_id = ?",
+                redacted.run_id,
+                _tenant_partition(redacted.tenant_id),
+            )
+            if existing is None:
+                # First sight of this run.  Insert a fresh row.
+                status = "failed" if is_terminal_failure else "running"
+                terminal_at = ts_iso if is_terminal_failure else None
+                await tx.execute(
+                    f"INSERT INTO {self._runs_table} "
+                    f"(run_id, tenant_id, workflow_id, workflow_fingerprint, "
+                    f"started_at, terminal_at, status, idempotency_key) "
+                    f"VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    redacted.run_id,
+                    _tenant_partition(redacted.tenant_id),
+                    redacted.workflow_id,
+                    redacted.workflow_fingerprint,
+                    started_at_iso,
+                    terminal_at,
+                    status,
+                    redacted.idempotency_key,
+                )
+            elif is_terminal_failure and existing.get("terminal_at") is None:
+                # Update an in-flight run to failed terminal state.
+                await tx.execute(
+                    f"UPDATE {self._runs_table} "
+                    f"SET status = ?, terminal_at = ? "
+                    f"WHERE run_id = ? AND tenant_id = ?",
+                    "failed",
+                    ts_iso,
+                    redacted.run_id,
+                    _tenant_partition(redacted.tenant_id),
+                )
+
+            # 2) Append the per-node event.  ``event_seq`` is monotonic
+            #    per run — derived inside the same transaction so two
+            #    concurrent writers cannot collide.
+            seq_row = await tx.fetchone(
+                f"SELECT COALESCE(MAX(event_seq), 0) AS max_seq "
+                f"FROM {self._events_table} WHERE run_id = ?",
+                redacted.run_id,
+            )
+            next_seq = int(seq_row["max_seq"] if seq_row else 0) + 1
+
+            event_type = "node_failed" if is_terminal_failure else "node_completed"
+            await tx.execute(
+                f"INSERT INTO {self._events_table} "
+                f"(run_id, event_seq, node_id_hash, event_type, payload_json, "
+                f"classified_field_count, ts) "
+                f"VALUES (?, ?, ?, ?, ?, ?, ?)",
+                redacted.run_id,
+                next_seq,
+                node_id_hash,
+                event_type,
+                payload_json,
+                classified_field_count,
+                ts_iso,
+            )
+
+        # 3) Lazy retention sweep + per-tenant cap.  These run OUTSIDE
+        #    the transaction so they cannot rollback the write that
+        #    triggered them.  Every site that performs a destructive
+        #    sweep enters via the internal-eviction context to bypass
+        #    the public ``force_downgrade=True`` gate per Rule 7.
+        await self._lazy_retention_sweep()
+        await self._enforce_per_tenant_cap(_tenant_partition(redacted.tenant_id))
+
+    # ------------------------------------------------------------------
+    # Read API (every method tenant-isolated)
+    # ------------------------------------------------------------------
+    async def list_runs(
+        self,
+        *,
+        filter: Optional[Mapping[str, Any]] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """List runs filtered by ``filter`` (must include ``tenant_id``).
+
+        Cross-tenant reads are BLOCKED — a missing or empty
+        ``tenant_id`` raises ``ValueError``.  Index-backed query path:
+        ``(tenant_id, started_at DESC)`` for the unfiltered list,
+        ``(tenant_id, status, started_at DESC)`` for status-filtered.
+        """
+        filt = dict(filter or {})
+        tenant_id = filt.pop("tenant_id", None)
+        if not tenant_id:
+            raise ValueError(
+                "WorkflowHistoryStore.list_runs: filter MUST include "
+                "tenant_id (non-empty).  Cross-tenant reads are blocked "
+                "at the store layer per rules/tenant-isolation.md."
+            )
+        status_filter = filt.pop("status", None)
+        if filt:
+            # Refuse silently-ignored filter keys per
+            # ``rules/zero-tolerance.md`` Rule 3c — accepted kwarg with
+            # no consumer is a contract violation.
+            raise ValueError(
+                f"WorkflowHistoryStore.list_runs: unsupported filter keys "
+                f"{sorted(filt.keys())!r}.  Supported: tenant_id, status."
+            )
+        if not isinstance(limit, int) or limit <= 0:
+            raise ValueError("limit must be a positive integer")
+        if not isinstance(offset, int) or offset < 0:
+            raise ValueError("offset must be a non-negative integer")
+
+        if status_filter is not None:
+            rows = await self._conn.fetch(
+                f"SELECT run_id, tenant_id, workflow_id, workflow_fingerprint, "
+                f"started_at, terminal_at, status, idempotency_key "
+                f"FROM {self._runs_table} "
+                f"WHERE tenant_id = ? AND status = ? "
+                f"ORDER BY started_at DESC LIMIT ? OFFSET ?",
+                _tenant_partition(tenant_id),
+                status_filter,
+                limit,
+                offset,
+            )
+        else:
+            rows = await self._conn.fetch(
+                f"SELECT run_id, tenant_id, workflow_id, workflow_fingerprint, "
+                f"started_at, terminal_at, status, idempotency_key "
+                f"FROM {self._runs_table} "
+                f"WHERE tenant_id = ? "
+                f"ORDER BY started_at DESC LIMIT ? OFFSET ?",
+                _tenant_partition(tenant_id),
+                limit,
+                offset,
+            )
+        return [dict(r) for r in rows]
+
+    async def get_run(
+        self,
+        run_id: str,
+        *,
+        tenant_id: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        """Return one run row, tenant-scoped.  None if no match."""
+        if not run_id:
+            raise ValueError("get_run: run_id must be a non-empty string")
+        if not tenant_id:
+            raise ValueError(
+                "get_run: tenant_id MUST be a non-empty string.  Cross-"
+                "tenant reads are blocked at the store layer."
+            )
+        row = await self._conn.fetchone(
+            f"SELECT run_id, tenant_id, workflow_id, workflow_fingerprint, "
+            f"started_at, terminal_at, status, idempotency_key "
+            f"FROM {self._runs_table} WHERE run_id = ? AND tenant_id = ?",
+            run_id,
+            _tenant_partition(tenant_id),
+        )
+        return dict(row) if row else None
+
+    async def get_run_events(
+        self,
+        run_id: str,
+        *,
+        tenant_id: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        """Return all events for *run_id* in monotonic ``event_seq`` order.
+
+        Tenant scope is enforced by JOINing to the runs table — an event
+        whose run is owned by a different tenant returns no rows.  The
+        ``payload_json`` column is decoded back into a dict.
+        """
+        if not run_id:
+            raise ValueError("get_run_events: run_id must be a non-empty string")
+        if not tenant_id:
+            raise ValueError(
+                "get_run_events: tenant_id MUST be a non-empty string.  "
+                "Cross-tenant reads are blocked at the store layer."
+            )
+        # Tenant-scope check: confirm the run row exists for this tenant
+        # before returning any events.
+        run = await self._conn.fetchone(
+            f"SELECT 1 FROM {self._runs_table} " f"WHERE run_id = ? AND tenant_id = ?",
+            run_id,
+            _tenant_partition(tenant_id),
+        )
+        if run is None:
+            return []
+        rows = await self._conn.fetch(
+            f"SELECT id, run_id, event_seq, node_id_hash, event_type, "
+            f"payload_json, classified_field_count, ts "
+            f"FROM {self._events_table} "
+            f"WHERE run_id = ? ORDER BY event_seq ASC",
+            run_id,
+        )
+        result: List[Dict[str, Any]] = []
+        for row in rows:
+            event_dict = dict(row)
+            raw = event_dict.pop("payload_json", None)
+            try:
+                event_dict["payload"] = json.loads(raw) if raw else {}
+            except (TypeError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "history_store.get_run_events.payload_decode_failed",
+                    extra={
+                        "run_id": run_id,
+                        "event_seq": event_dict.get("event_seq"),
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                event_dict["payload"] = {}
+            result.append(event_dict)
+        return result
+
+    async def list_failed(
+        self,
+        *,
+        tenant_id: Optional[str],
+        since: Optional[Union[datetime, str]] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """List failed runs, tenant-scoped.  Index-backed via
+        ``(tenant_id, status, started_at DESC)``.
+        """
+        if not tenant_id:
+            raise ValueError("list_failed: tenant_id MUST be a non-empty string.")
+        if not isinstance(limit, int) or limit <= 0:
+            raise ValueError("limit must be a positive integer")
+        since_iso: Optional[str]
+        if since is None:
+            since_iso = None
+        elif isinstance(since, datetime):
+            since_iso = since.isoformat()
+        elif isinstance(since, str):
+            since_iso = since
+        else:
+            raise TypeError(
+                "list_failed: since must be a datetime, ISO-8601 string, " "or None"
+            )
+        if since_iso is not None:
+            rows = await self._conn.fetch(
+                f"SELECT run_id, tenant_id, workflow_id, workflow_fingerprint, "
+                f"started_at, terminal_at, status, idempotency_key "
+                f"FROM {self._runs_table} "
+                f"WHERE tenant_id = ? AND status = 'failed' "
+                f"AND started_at >= ? "
+                f"ORDER BY started_at DESC LIMIT ?",
+                _tenant_partition(tenant_id),
+                since_iso,
+                limit,
+            )
+        else:
+            rows = await self._conn.fetch(
+                f"SELECT run_id, tenant_id, workflow_id, workflow_fingerprint, "
+                f"started_at, terminal_at, status, idempotency_key "
+                f"FROM {self._runs_table} "
+                f"WHERE tenant_id = ? AND status = 'failed' "
+                f"ORDER BY started_at DESC LIMIT ?",
+                _tenant_partition(tenant_id),
+                limit,
+            )
+        return [dict(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Retention API
+    # ------------------------------------------------------------------
+    async def delete_runs_older_than(
+        self,
+        timestamp: Union[datetime, str],
+        *,
+        force_downgrade: bool = False,
+    ) -> int:
+        """Delete all runs whose ``terminal_at`` is older than *timestamp*.
+
+        In-flight runs (``terminal_at IS NULL``) are NEVER affected.
+        Cross-tenant — every tenant's expired runs are pruned.
+
+        Per ``rules/schema-migration.md`` MUST Rule 7 the destructive
+        downgrade-shape API requires ``force_downgrade=True``;
+        otherwise raises :class:`DowngradeRefusedError`.
+
+        The internal write-time eviction sweep bypasses the gate via
+        a contextvar — user-supplied calls MUST still pass the flag.
+        """
+        # The internal-eviction context is set ONLY inside this store's
+        # own write path.  User-supplied calls always see the default
+        # False and MUST satisfy the public ``force_downgrade`` gate.
+        if not force_downgrade and not _INTERNAL_EVICTION_CONTEXT.get():
+            raise DowngradeRefusedError(
+                "delete_runs_older_than() refused — destructive sweep of "
+                "workflow history rows.  Pass force_downgrade=True to "
+                "acknowledge data loss is irreversible."
+            )
+
+        if isinstance(timestamp, datetime):
+            ts_iso = timestamp.isoformat()
+        elif isinstance(timestamp, str):
+            ts_iso = timestamp
+        else:
+            raise TypeError(
+                "delete_runs_older_than: timestamp must be a datetime or "
+                "ISO-8601 string."
+            )
+
+        async with self._conn.transaction() as tx:
+            expired_runs = await tx.fetch(
+                f"SELECT run_id FROM {self._runs_table} "
+                f"WHERE terminal_at IS NOT NULL AND terminal_at < ?",
+                ts_iso,
+            )
+            run_ids = [r["run_id"] for r in expired_runs]
+            deleted = len(run_ids)
+            for run_id in run_ids:
+                await tx.execute(
+                    f"DELETE FROM {self._events_table} WHERE run_id = ?",
+                    run_id,
+                )
+                await tx.execute(
+                    f"DELETE FROM {self._runs_table} WHERE run_id = ?",
+                    run_id,
+                )
+
+        if deleted > 0:
+            logger.info(
+                "history_store.retention.swept",
+                extra={
+                    "attempted": deleted,
+                    "failed": 0,
+                    "before_ts": ts_iso,
+                },
+            )
+        return deleted
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    async def _lazy_retention_sweep(self) -> None:
+        """Drop runs whose ``terminal_at`` exceeds the retention window.
+
+        No-op when ``retention_days`` is None (disabled).  Bypasses the
+        ``force_downgrade`` gate via the internal-eviction context.
+        """
+        if self._retention_days is None:
+            return
+        cutoff = datetime.now(timezone.utc) - timedelta(days=self._retention_days)
+        token = _INTERNAL_EVICTION_CONTEXT.set(True)
+        try:
+            await self.delete_runs_older_than(cutoff)
+        finally:
+            _INTERNAL_EVICTION_CONTEXT.reset(token)
+
+    async def _enforce_per_tenant_cap(self, tenant_id: str) -> None:
+        """Evict the oldest runs for *tenant_id* until the cap is satisfied.
+
+        Per ``rules/observability.md`` Rule 7 a WARN log line is emitted
+        whenever ≥1 row is evicted — operators need bulk-failure
+        visibility (attempted/failed/sample fields).
+        """
+        count_row = await self._conn.fetchone(
+            f"SELECT COUNT(*) AS cnt FROM {self._runs_table} WHERE tenant_id = ?",
+            tenant_id,
+        )
+        count = int(count_row["cnt"] if count_row else 0)
+        excess = count - self._per_tenant_cap
+        if excess <= 0:
+            return
+
+        # Identify the N oldest runs and drop them inside a transaction.
+        oldest = await self._conn.fetch(
+            f"SELECT run_id, started_at FROM {self._runs_table} "
+            f"WHERE tenant_id = ? ORDER BY started_at ASC LIMIT ?",
+            tenant_id,
+            excess,
+        )
+        if not oldest:
+            return
+
+        sample_run_id = oldest[0]["run_id"]
+        async with self._conn.transaction() as tx:
+            for row in oldest:
+                run_id = row["run_id"]
+                await tx.execute(
+                    f"DELETE FROM {self._events_table} WHERE run_id = ?",
+                    run_id,
+                )
+                await tx.execute(
+                    f"DELETE FROM {self._runs_table} "
+                    f"WHERE run_id = ? AND tenant_id = ?",
+                    run_id,
+                    tenant_id,
+                )
+
+        logger.warning(
+            "history_store.per_tenant_cap.evicted",
+            extra={
+                "attempted": excess,
+                "failed": 0,
+                "tenant_id_hash": _hash_short(tenant_id),
+                "sample_run_id": sample_run_id,
+                "cap": self._per_tenant_cap,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concrete implementations
+# ---------------------------------------------------------------------------
+
+
+class _SharedSchemaInitializer:
+    """Mixin holding the dialect-portable DDL shared by both subclasses.
+
+    The DDL lives ONLY in ``initialize`` per ``rules/schema-migration.md``
+    MUST Rule 1.  Subclasses that need dialect-specific tweaks override
+    ``initialize`` and call ``_create_schema``.
+    """
+
+    async def _create_schema(self) -> None:
+        """Create the workflow_runs + workflow_run_events tables + indexes.
+
+        Per ``rules/dataflow-identifier-safety.md`` MUST Rule 1 every
+        dynamic identifier interpolated into DDL routes through
+        ``dialect.quote_identifier()``.  Per
+        ``rules/infrastructure-sql.md`` Rule 4 the binary/blob and JSON
+        column types come from the dialect helper, not hardcoded names.
+        """
+        # mypy: this mixin is consumed inside WorkflowHistoryStore so
+        # ``self._conn`` / ``self._runs_table`` / ``self._events_table``
+        # exist at runtime.
+        conn = self._conn  # type: ignore[attr-defined]
+        runs_table_quoted = conn.dialect.quote_identifier(
+            self._runs_table  # type: ignore[attr-defined]
+        )
+        events_table_quoted = conn.dialect.quote_identifier(
+            self._events_table  # type: ignore[attr-defined]
+        )
+        text_indexed = conn.dialect.text_column(indexed=True)
+        text_unindexed = conn.dialect.text_column(indexed=False)
+        # Per ``rules/infrastructure-sql.md`` MUST Rule 4 — the JSON
+        # payload uses the dialect's TEXT column type (Postgres TEXT,
+        # MySQL TEXT, SQLite TEXT) NOT the BLOB column.  The acceptance
+        # criterion explicitly mandates ``dialect.text_column()``.
+        # ``dialect.json_column_type()`` (JSONB on Postgres) would be
+        # better long-term but the architecture plan for W2 specifies
+        # TEXT-typed for portability across the three dialects.
+        json_column_type = text_unindexed
+
+        # workflow_runs
+        await conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {runs_table_quoted} (
+                run_id {text_indexed} PRIMARY KEY,
+                tenant_id {text_indexed} NOT NULL,
+                workflow_id {text_indexed} NOT NULL,
+                workflow_fingerprint {text_indexed} NOT NULL,
+                started_at {text_indexed} NOT NULL,
+                terminal_at TEXT,
+                status {text_indexed} NOT NULL,
+                idempotency_key TEXT
+            )
+            """
+        )
+
+        # workflow_run_events.  ``id`` uses the dialect's auto-id column
+        # so MySQL gets AUTO_INCREMENT, Postgres SERIAL, SQLite INTEGER
+        # PRIMARY KEY — per ``rules/infrastructure-sql.md`` MUST NOT
+        # clause "No AUTOINCREMENT in shared DDL".
+        await conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {events_table_quoted} (
+                {conn.dialect.auto_id_column()},
+                run_id {text_indexed} NOT NULL,
+                event_seq INTEGER NOT NULL,
+                node_id_hash {text_indexed} NOT NULL,
+                event_type {text_indexed} NOT NULL,
+                payload_json {json_column_type} NOT NULL,
+                classified_field_count INTEGER NOT NULL,
+                ts {text_indexed} NOT NULL,
+                UNIQUE(run_id, event_seq)
+            )
+            """
+        )
+
+        # Indexes per Wave 2 acceptance criteria.  All run via
+        # conn.create_index which routes through dialect.quote_identifier.
+        await conn.create_index(
+            f"idx_{self._runs_table}_tenant_started_at",  # type: ignore[attr-defined]
+            self._runs_table,  # type: ignore[attr-defined]
+            "tenant_id, started_at",
+        )
+        await conn.create_index(
+            f"idx_{self._runs_table}_tenant_run_id",  # type: ignore[attr-defined]
+            self._runs_table,  # type: ignore[attr-defined]
+            "tenant_id, run_id",
+        )
+        await conn.create_index(
+            f"idx_{self._runs_table}_tenant_status_started",  # type: ignore[attr-defined]
+            self._runs_table,  # type: ignore[attr-defined]
+            "tenant_id, status, started_at",
+        )
+        await conn.create_index(
+            f"idx_{self._events_table}_run_seq",  # type: ignore[attr-defined]
+            self._events_table,  # type: ignore[attr-defined]
+            "run_id, event_seq",
+        )
+
+
+class PostgresHistoryStore(_SharedSchemaInitializer, WorkflowHistoryStore):
+    """PostgreSQL-backed workflow history store.
+
+    Concrete subclass mainly for naming clarity — the dialect-portable
+    schema in :class:`_SharedSchemaInitializer` already handles the
+    PostgreSQL specifics (``SERIAL`` auto-id, ``TEXT`` columns,
+    parameterized ``$N`` placeholders via the ConnectionManager).
+    """
+
+    async def initialize(self) -> None:
+        """Create tables + indexes if not present."""
+        await self._create_schema()
+        self._initialized = True
+        logger.info(
+            "PostgresHistoryStore initialized " "(runs_table=%s, events_table=%s)",
+            self._runs_table,
+            self._events_table,
+        )
+
+
+class SQLiteHistoryStore(_SharedSchemaInitializer, WorkflowHistoryStore):
+    """SQLite-backed workflow history store.
+
+    Same dialect-portable schema as :class:`PostgresHistoryStore`; the
+    ``ConnectionManager`` translates ``?`` placeholders identity for
+    SQLite and emits ``INTEGER PRIMARY KEY`` (not ``AUTOINCREMENT`` —
+    per ``rules/infrastructure-sql.md`` MUST NOT clause).
+    """
+
+    async def initialize(self) -> None:
+        """Create tables + indexes if not present."""
+        await self._create_schema()
+        self._initialized = True
+        logger.info(
+            "SQLiteHistoryStore initialized " "(runs_table=%s, events_table=%s)",
+            self._runs_table,
+            self._events_table,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tiny helpers (no external surface)
+# ---------------------------------------------------------------------------
+
+
+# Tenant-partition sentinel for single-tenant deployments.  Per
+# ``rules/tenant-isolation.md`` MUST Rule 5 every row carries a non-NULL
+# tenant_id; single-tenant deployments use the literal "default" so the
+# index-backed query plan stays selective.
+_DEFAULT_TENANT = "default"
+
+
+def _tenant_partition(tenant_id: Optional[str]) -> str:
+    """Map ``None`` → ``"default"`` for the tenant column.
+
+    Single-tenant deployments don't carry a tenant context; the
+    ``"default"`` sentinel keeps the column NOT NULL and the indexes
+    selective, while still letting multi-tenant queries scope to a
+    specific tenant.
+    """
+    if tenant_id is None or tenant_id == "":
+        return _DEFAULT_TENANT
+    return tenant_id
+
+
+def _hash_short(value: str) -> str:
+    """Short SHA-256 hash for schema-revealing log fields per
+    ``rules/observability.md`` Rule 8 — never log raw node_id /
+    tenant_id at WARN+.
+    """
+    import hashlib
+
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:8]

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -813,15 +813,33 @@ class LocalRuntime(
         # === W1: Durable execution wiring ===
         # checkpoint_store + checkpoint_after_each_node drive per-node
         # checkpoint emission inside ``_execute_workflow_async``.
-        # history_store is the W2 placeholder kwarg — the W1 shard accepts
-        # it now so callers can pass it without breakage; the W2 shard
-        # wires the dispatch path. The hook registry serves both W1 (the
-        # runtime dispatches every NodeCompletionEvent) and downstream
-        # subscribers (W2 history store, metrics, audit).
+        # history_store is wired in W2 (this shard) — when non-None the
+        # runtime auto-registers ``history_store.record_event`` against
+        # the hook registry at construction time, so every node
+        # completion lands a row without any extra caller code. The
+        # hook registry serves both W1 (the runtime dispatches every
+        # NodeCompletionEvent) and downstream subscribers (W2 history
+        # store, metrics, audit).
         self._checkpoint_store = checkpoint_store
         self._checkpoint_after_each_node = bool(checkpoint_after_each_node)
         self._history_store = history_store
         self._hook_registry = NodeCompletionHookRegistry()
+        # W2 auto-subscribe: when a history store is provided, register
+        # its record_event coroutine as a hook subscriber so the runtime
+        # forwards every NodeCompletionEvent without the caller needing
+        # to call ``runtime.on_node_complete(history_store.record_event)``
+        # explicitly. Per ``orphan-detection.md`` MUST Rule 1 the
+        # facade ``history_store=`` kwarg lands its production call site
+        # in the same shard as the kwarg's wiring.
+        if history_store is not None:
+            record_event = getattr(history_store, "record_event", None)
+            if not callable(record_event):
+                raise TypeError(
+                    "LocalRuntime(history_store=...): the history_store "
+                    "must expose a callable 'record_event(event)' coroutine "
+                    "matching the WorkflowHistoryStore protocol."
+                )
+            self._hook_registry.register(record_event)
         # Per-run asyncio.Lock for parallel-node checkpoint atomicity.
         # LocalRuntime executes nodes sequentially in
         # ``_execute_workflow_async`` so the lock would normally be

--- a/tests/e2e/test_redaction_history_store.py
+++ b/tests/e2e/test_redaction_history_store.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-3 E2E: redaction at write-time invariant for the history store.
+
+Per ``rules/orphan-detection.md`` MUST Rule 2a (crypto-pair round-trip
+through facade) the cross-cutting invariant 4 (read-redaction at write
+time) MUST be exercised through the runtime facade against a real
+Postgres instance.  A classification-policy-tagged field in the event's
+``outputs`` MUST be hashed via ``format_record_id_for_event`` (HASH_PK)
+or replaced with the ``[REDACTED]`` sentinel BEFORE it lands in the
+``payload_json`` column.
+
+Concretely: the persisted bytes MUST NOT contain the raw classified
+value, AND the ``classified_field_count`` column MUST reflect the
+non-zero redaction.  Tier-2 unit tests cover the helper directly; this
+Tier-3 test pins the end-to-end facade contract.
+
+Requires PostgreSQL at ``TEST_PG_URL``; skips when unreachable.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+from typing import AsyncGenerator
+from urllib.parse import urlparse
+
+import pytest
+
+from kailash.db.connection import ConnectionManager
+from kailash.infrastructure.history_store import PostgresHistoryStore
+from kailash.runtime.async_local import AsyncLocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+PG_URL = os.environ.get(
+    "TEST_PG_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+
+
+def _is_pg_available() -> bool:
+    parsed = urlparse(PG_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2.0):
+            return True
+    except (OSError, ConnectionRefusedError, TimeoutError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_pg_available(),
+    reason=f"PostgreSQL not available at {PG_URL}",
+)
+
+
+@pytest.fixture
+async def pg_conn() -> AsyncGenerator[ConnectionManager, None]:
+    manager = ConnectionManager(PG_URL)
+    await manager.initialize()
+    for table in ("workflow_run_events", "workflow_runs"):
+        try:
+            await manager.execute(f"DROP TABLE IF EXISTS {table}")
+        except Exception:
+            pass
+    yield manager
+    for table in ("workflow_run_events", "workflow_runs"):
+        try:
+            await manager.execute(f"DROP TABLE IF EXISTS {table}")
+        except Exception:
+            pass
+    await manager.close()
+
+
+class _SsnRedactPolicy:
+    """Classification policy: REDACT the top-level ``result`` output of
+    the 'leak_node'.
+
+    Per :func:`~kailash.runtime.durable.redact_event_for_persistence`
+    the policy is consulted for every TOP-LEVEL field of the event's
+    ``outputs`` dict.  PythonCodeNode wraps user output under the
+    ``result`` key, so redacting the SSN+email payload means redacting
+    the entire ``result`` mapping at the top level.  The redaction helper
+    replaces the whole value with the ``[REDACTED]`` sentinel — the
+    nested SSN / email strings cannot leak through it.
+    """
+
+    def get_classification(self, node_id: str, field_name: str):
+        if node_id == "leak_node" and field_name == "result":
+            return "REDACT"
+        return None
+
+
+def _build_classified_workflow():
+    """One-node workflow whose output emits two classified fields under
+    the PythonCodeNode ``result`` wrapper."""
+    wb = WorkflowBuilder()
+    wb.add_node(
+        "PythonCodeNode",
+        "leak_node",
+        {
+            "code": (
+                "result = {" "'ssn': '999-88-7777', " "'email': 'alice@example.com'" "}"
+            )
+        },
+    )
+    return wb.build()
+
+
+@pytest.mark.e2e
+async def test_redaction_at_write_time_in_history_store(
+    pg_conn: ConnectionManager,
+):
+    """A classified field's raw value MUST NOT appear in the persisted
+    payload_json bytes.  Per cross-cutting invariant 4: read-redaction
+    at write time, NEVER re-redacted at read time.
+    """
+    history = PostgresHistoryStore(pg_conn, classification_policy=_SsnRedactPolicy())
+    await history.initialize()
+
+    workflow = _build_classified_workflow()
+    runtime = AsyncLocalRuntime(history_store=history)
+    _, run_id = await runtime.execute_workflow_async(
+        workflow,
+        inputs={},
+        idempotency_key=f"test_redact_{uuid.uuid4().hex[:8]}",
+    )
+
+    # Direct DB observation: the persisted payload_json column MUST NOT
+    # contain either of the raw classified values.  This is the
+    # write-time-redaction invariant — if the bytes leak, the audit
+    # log of every downstream consumer is poisoned.
+    rows = await pg_conn.fetch(
+        "SELECT payload_json, classified_field_count FROM workflow_run_events "
+        "WHERE run_id = ?",
+        run_id,
+    )
+    assert len(rows) == 1
+    payload_bytes = rows[0]["payload_json"]
+    assert (
+        "999-88-7777" not in payload_bytes
+    ), "Raw SSN leaked to payload_json — write-time redaction failed"
+    assert (
+        "alice@example.com" not in payload_bytes
+    ), "Raw email leaked to payload_json — write-time redaction failed"
+    # The top-level ``result`` field was classified → redacted →
+    # contributes 1 to the classified-field count.  PythonCodeNode wraps
+    # the user dict under ``result``, so the entire SSN+email payload
+    # is replaced as one unit (any nested raw bytes inside that dict
+    # disappear entirely from the persisted bytes).
+    assert rows[0]["classified_field_count"] >= 1
+
+    # Read-back through the facade: the [REDACTED] sentinel replaces the
+    # whole ``result`` mapping — callers never see the raw SSN / email.
+    events = await history.get_run_events(run_id, tenant_id="default")
+    assert len(events) == 1
+    outputs = events[0]["payload"]["outputs"]
+    assert outputs.get("result") == "[REDACTED]"

--- a/tests/integration/test_workflow_history_store_wiring.py
+++ b/tests/integration/test_workflow_history_store_wiring.py
@@ -1,0 +1,294 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 integration tests for WorkflowHistoryStore wiring.
+
+Per ``rules/facade-manager-detection.md`` MUST Rule 2 the wiring test
+file naming is ``test_<lowercase_manager_name>_wiring.py`` so the
+absence of the file is grep-able.  Per ``rules/testing.md`` § "3-Tier"
+NO mocking — every assertion observes a real PostgreSQL row.
+
+Exercises:
+
+* ``LocalRuntime(history_store=...)`` auto-subscribes the store's
+  ``record_event`` against the W1 hook registry, so executing a
+  workflow lands rows in ``workflow_runs`` + ``workflow_run_events``.
+* ``list_runs`` returns the run, ``get_run`` returns one row,
+  ``get_run_events`` returns the per-node event log.
+* The persisted ``payload_json`` round-trips back to a dict on read.
+
+Requires PostgreSQL at ``TEST_PG_URL`` (defaults to
+``postgresql://test_user:test_password@localhost:5434/kailash_test``).
+Tests skip when Postgres is unreachable so CI without docker still
+runs the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import uuid
+from typing import AsyncGenerator
+from urllib.parse import urlparse
+
+import pytest
+
+from kailash.db.connection import ConnectionManager
+from kailash.infrastructure.history_store import PostgresHistoryStore
+from kailash.runtime.async_local import AsyncLocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+# ---------------------------------------------------------------------------
+# Postgres availability
+# ---------------------------------------------------------------------------
+
+PG_URL = os.environ.get(
+    "TEST_PG_URL",
+    "postgresql://test_user:test_password@localhost:5434/kailash_test",
+)
+
+
+def _is_pg_available() -> bool:
+    parsed = urlparse(PG_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 5432
+    try:
+        with socket.create_connection((host, port), timeout=2.0):
+            return True
+    except (OSError, ConnectionRefusedError, TimeoutError):
+        return False
+
+
+# Skip every test in this module if Postgres is unreachable — history
+# persistence is the contract under test, and the dialect-portable
+# schema invariants only fire against Postgres.
+pytestmark = pytest.mark.skipif(
+    not _is_pg_available(),
+    reason=f"PostgreSQL not available at {PG_URL}",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def pg_conn() -> AsyncGenerator[ConnectionManager, None]:
+    """Yield a fresh PostgreSQL ConnectionManager and clean up after."""
+    manager = ConnectionManager(PG_URL)
+    await manager.initialize()
+    # Clean any lingering history rows from prior runs.
+    for table in ("workflow_run_events", "workflow_runs"):
+        try:
+            await manager.execute(f"DROP TABLE IF EXISTS {table}")
+        except Exception:
+            pass
+    yield manager
+    for table in ("workflow_run_events", "workflow_runs"):
+        try:
+            await manager.execute(f"DROP TABLE IF EXISTS {table}")
+        except Exception:
+            pass
+    await manager.close()
+
+
+@pytest.fixture
+async def history_store(
+    pg_conn: ConnectionManager,
+) -> AsyncGenerator[PostgresHistoryStore, None]:
+    """Yield an initialized PostgresHistoryStore against the test DB."""
+    store = PostgresHistoryStore(pg_conn)
+    await store.initialize()
+    yield store
+    await store.close()
+
+
+def _build_two_node_workflow():
+    """Two sequential PythonCodeNodes — minimal canonical pipeline."""
+    wb = WorkflowBuilder()
+    wb.add_node("PythonCodeNode", "step1", {"code": "result = {'value': 1}"})
+    wb.add_node(
+        "PythonCodeNode",
+        "step2",
+        {"code": "result = {'value': value + 1}"},
+    )
+    wb.add_connection("step1", "result.value", "step2", "value")
+    return wb.build()
+
+
+# ---------------------------------------------------------------------------
+# 1. Auto-subscribe + record_event end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_history_store_records_events_via_auto_subscribe(
+    pg_conn: ConnectionManager,
+    history_store: PostgresHistoryStore,
+):
+    """Constructing AsyncLocalRuntime(history_store=store) MUST auto-
+    subscribe store.record_event so executing a workflow lands rows
+    in workflow_runs + workflow_run_events.  Tier-2 invariant: the
+    rows are observable via a direct DB query, not just the store's
+    own read API.
+    """
+    workflow = _build_two_node_workflow()
+    idempotency_key = f"test_record_{uuid.uuid4().hex[:8]}"
+
+    runtime = AsyncLocalRuntime(history_store=history_store)
+    results, run_id = await runtime.execute_workflow_async(
+        workflow,
+        inputs={},
+        idempotency_key=idempotency_key,
+    )
+
+    # The execution succeeded.
+    assert "step2" in results
+
+    # Direct DB observation: workflow_runs has exactly one row.
+    runs = await pg_conn.fetch(
+        "SELECT run_id, status, idempotency_key FROM workflow_runs WHERE run_id = ?",
+        run_id,
+    )
+    assert len(runs) == 1
+    assert runs[0]["idempotency_key"] == idempotency_key
+
+    # Direct DB observation: workflow_run_events has one row per node
+    # (step1 + step2) with monotonic event_seq.
+    events = await pg_conn.fetch(
+        "SELECT event_seq, node_id_hash, event_type FROM workflow_run_events "
+        "WHERE run_id = ? ORDER BY event_seq ASC",
+        run_id,
+    )
+    assert len(events) == 2
+    assert events[0]["event_seq"] == 1
+    assert events[1]["event_seq"] == 2
+    assert all(e["event_type"] == "node_completed" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# 2. Read API: list_runs / get_run / get_run_events
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_history_store_list_runs_returns_executed_run(
+    pg_conn: ConnectionManager,
+    history_store: PostgresHistoryStore,
+):
+    workflow = _build_two_node_workflow()
+    runtime = AsyncLocalRuntime(history_store=history_store)
+    _, run_id = await runtime.execute_workflow_async(
+        workflow,
+        inputs={},
+        idempotency_key=f"test_list_{uuid.uuid4().hex[:8]}",
+    )
+
+    # The default tenant is "default" when no tenant context is set.
+    runs = await history_store.list_runs(filter={"tenant_id": "default"})
+    matching = [r for r in runs if r["run_id"] == run_id]
+    assert len(matching) == 1
+    assert matching[0]["status"] in ("running", "failed")  # status enum
+
+
+@pytest.mark.integration
+async def test_history_store_get_run_returns_one_row(
+    pg_conn: ConnectionManager,
+    history_store: PostgresHistoryStore,
+):
+    workflow = _build_two_node_workflow()
+    runtime = AsyncLocalRuntime(history_store=history_store)
+    _, run_id = await runtime.execute_workflow_async(
+        workflow,
+        inputs={},
+        idempotency_key=f"test_get_{uuid.uuid4().hex[:8]}",
+    )
+
+    row = await history_store.get_run(run_id, tenant_id="default")
+    assert row is not None
+    assert row["run_id"] == run_id
+
+
+@pytest.mark.integration
+async def test_history_store_get_run_events_returns_decoded_payloads(
+    pg_conn: ConnectionManager,
+    history_store: PostgresHistoryStore,
+):
+    """The payload_json column round-trips back to a dict on read —
+    callers see ``event["payload"]`` as a Python dict, not a string.
+    """
+    workflow = _build_two_node_workflow()
+    runtime = AsyncLocalRuntime(history_store=history_store)
+    _, run_id = await runtime.execute_workflow_async(
+        workflow,
+        inputs={},
+        idempotency_key=f"test_events_{uuid.uuid4().hex[:8]}",
+    )
+
+    events = await history_store.get_run_events(run_id, tenant_id="default")
+    assert len(events) == 2
+    # Every event has a decoded payload dict containing outputs+metadata.
+    for ev in events:
+        assert isinstance(ev["payload"], dict)
+        assert "outputs" in ev["payload"]
+        assert "metadata" in ev["payload"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Cross-tenant isolation: a different tenant sees no rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_history_store_tenant_isolation_blocks_cross_tenant_read(
+    pg_conn: ConnectionManager,
+    history_store: PostgresHistoryStore,
+):
+    """A run written under tenant_id='default' MUST NOT be visible to
+    a list_runs / get_run / get_run_events query scoped to a different
+    tenant.  Cross-tenant reads are BLOCKED at the store layer per
+    ``rules/tenant-isolation.md`` MUST Rule 5.
+    """
+    workflow = _build_two_node_workflow()
+    runtime = AsyncLocalRuntime(history_store=history_store)
+    _, run_id = await runtime.execute_workflow_async(
+        workflow,
+        inputs={},
+        idempotency_key=f"test_isolation_{uuid.uuid4().hex[:8]}",
+    )
+
+    # Different tenant: should NOT see the run.
+    runs_other = await history_store.list_runs(filter={"tenant_id": "tenant-other"})
+    assert all(r["run_id"] != run_id for r in runs_other)
+
+    row = await history_store.get_run(run_id, tenant_id="tenant-other")
+    assert row is None
+
+    events = await history_store.get_run_events(run_id, tenant_id="tenant-other")
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Indexes are present on the runs + events tables
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_history_store_indexes_present_on_runs_table(
+    pg_conn: ConnectionManager,
+    history_store: PostgresHistoryStore,
+):
+    """Per architecture plan §6 risk register the index set MUST include
+    (tenant_id, started_at), (tenant_id, run_id), (tenant_id, status,
+    started_at) on workflow_runs and (run_id, event_seq) on
+    workflow_run_events.  The Postgres pg_indexes view confirms.
+    """
+    rows = await pg_conn.fetch(
+        "SELECT indexname FROM pg_indexes "
+        "WHERE tablename IN ('workflow_runs', 'workflow_run_events')"
+    )
+    names = {r["indexname"] for r in rows}
+    assert "idx_workflow_runs_tenant_started_at" in names
+    assert "idx_workflow_runs_tenant_run_id" in names
+    assert "idx_workflow_runs_tenant_status_started" in names
+    assert "idx_workflow_run_events_run_seq" in names

--- a/tests/unit/test_workflow_history_store_unit.py
+++ b/tests/unit/test_workflow_history_store_unit.py
@@ -16,7 +16,6 @@ Tier 2 + Tier 3 tests against real Postgres land in
 
 from __future__ import annotations
 
-import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -49,7 +48,7 @@ class _DeterministicDialect:
     def quote_identifier(self, name: str) -> str:
         return f'"{name}"'
 
-    def text_column(self, indexed: bool = False) -> str:
+    def text_column(self, indexed: bool = False) -> str:  # noqa: ARG002
         return "TEXT"
 
     def blob_type(self) -> str:
@@ -85,14 +84,18 @@ class _RecordingConn:
         self.executes.append((query, args))
         return None
 
-    async def fetch(self, query: str, *args: Any) -> List[Dict[str, Any]]:
+    async def fetch(
+        self, query: str, *args: Any
+    ) -> List[Dict[str, Any]]:  # noqa: ARG002
         # Simple match by substring of query.
         for needle, rows in self._fetch_results.items():
             if needle in query:
                 return rows
         return []
 
-    async def fetchone(self, query: str, *args: Any) -> Optional[Dict[str, Any]]:
+    async def fetchone(
+        self, query: str, *args: Any
+    ) -> Optional[Dict[str, Any]]:  # noqa: ARG002
         if self._fetchone_queue:
             return self._fetchone_queue.pop(0)
         return None
@@ -117,10 +120,10 @@ class _RecordingConn:
         parent = self
 
         class _Cm:
-            async def __aenter__(self_inner):
+            async def __aenter__(self):
                 return parent._TxProxy(parent)
 
-            async def __aexit__(self_inner, exc_type, exc, tb):
+            async def __aexit__(self, exc_type, exc, tb):
                 return False
 
         return _Cm()

--- a/tests/unit/test_workflow_history_store_unit.py
+++ b/tests/unit/test_workflow_history_store_unit.py
@@ -1,0 +1,449 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-1 unit tests for ``kailash.infrastructure.history_store``.
+
+Per ``rules/testing.md`` § "3-Tier" Tier 1 may use deterministic
+adapters for the ConnectionManager surface — the tests here validate
+constructor invariants (table-name validation, retention bounds),
+the auto-subscribe wiring on LocalRuntime, the read-redaction
+write-time invariant, and the destructive-confirmation gate on
+``delete_runs_older_than``.
+
+Tier 2 + Tier 3 tests against real Postgres land in
+``tests/integration/test_workflow_history_store_wiring.py`` and
+``tests/e2e/test_redaction_history_store.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from kailash.infrastructure.history_store import (
+    DowngradeRefusedError,
+    PostgresHistoryStore,
+    SQLiteHistoryStore,
+    WorkflowHistoryStore,
+)
+from kailash.runtime.durable import NodeCompletionEvent
+
+# ---------------------------------------------------------------------------
+# Deterministic ConnectionManager adapter (Protocol-satisfying, NOT a mock)
+# ---------------------------------------------------------------------------
+#
+# Per ``rules/testing.md`` § "Protocol Adapters" a class that satisfies
+# the ConnectionManager surface at runtime with deterministic output is
+# NOT a mock — it is a behaviour-preserving adapter.  These tests use
+# the adapter ONLY to verify constructor / dispatch / redaction logic;
+# the dialect-portable schema + atomic-transaction guarantees are
+# exercised in Tier 2 against real Postgres.
+
+
+class _DeterministicDialect:
+    """Minimal QueryDialect surface used by the unit-level tests."""
+
+    def quote_identifier(self, name: str) -> str:
+        return f'"{name}"'
+
+    def text_column(self, indexed: bool = False) -> str:
+        return "TEXT"
+
+    def blob_type(self) -> str:
+        return "BLOB"
+
+    def auto_id_column(self) -> str:
+        return "id INTEGER PRIMARY KEY"
+
+    def json_column_type(self) -> str:
+        return "TEXT"
+
+    def translate_query(self, q: str) -> str:
+        return q
+
+
+class _RecordingConn:
+    """Records SQL + params so tests can assert query shape.
+
+    Implements the ConnectionManager surface used by WorkflowHistoryStore
+    (execute / fetch / fetchone / transaction / create_index / dialect).
+    The transaction context manager yields ``self`` so multi-statement
+    paths exercise the same recording.
+    """
+
+    def __init__(self, fetchone_results: Optional[List[Any]] = None) -> None:
+        self.dialect = _DeterministicDialect()
+        self.executes: List[tuple] = []
+        self.created_indexes: List[tuple] = []
+        self._fetchone_queue: List[Any] = list(fetchone_results or [])
+        self._fetch_results: Dict[str, List[Dict[str, Any]]] = {}
+
+    async def execute(self, query: str, *args: Any) -> Any:
+        self.executes.append((query, args))
+        return None
+
+    async def fetch(self, query: str, *args: Any) -> List[Dict[str, Any]]:
+        # Simple match by substring of query.
+        for needle, rows in self._fetch_results.items():
+            if needle in query:
+                return rows
+        return []
+
+    async def fetchone(self, query: str, *args: Any) -> Optional[Dict[str, Any]]:
+        if self._fetchone_queue:
+            return self._fetchone_queue.pop(0)
+        return None
+
+    async def create_index(self, name: str, table: str, columns: str) -> None:
+        self.created_indexes.append((name, table, columns))
+
+    class _TxProxy:
+        def __init__(self, parent: "_RecordingConn") -> None:
+            self._parent = parent
+
+        async def execute(self, query: str, *args: Any) -> Any:
+            return await self._parent.execute(query, *args)
+
+        async def fetch(self, query: str, *args: Any) -> List[Dict[str, Any]]:
+            return await self._parent.fetch(query, *args)
+
+        async def fetchone(self, query: str, *args: Any) -> Optional[Dict[str, Any]]:
+            return await self._parent.fetchone(query, *args)
+
+    def transaction(self):
+        parent = self
+
+        class _Cm:
+            async def __aenter__(self_inner):
+                return parent._TxProxy(parent)
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                return False
+
+        return _Cm()
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_rejects_invalid_runs_table() -> None:
+    conn = _RecordingConn()
+    with pytest.raises(ValueError, match=r"runs_table"):
+        SQLiteHistoryStore(conn, runs_table="bad-name; DROP TABLE x")
+
+
+def test_constructor_rejects_invalid_events_table() -> None:
+    conn = _RecordingConn()
+    with pytest.raises(ValueError, match=r"events_table"):
+        SQLiteHistoryStore(conn, events_table="0starts_with_digit")
+
+
+def test_constructor_accepts_valid_table_names() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(
+        conn,
+        runs_table="my_runs",
+        events_table="my_events",
+    )
+    assert store._runs_table == "my_runs"
+    assert store._events_table == "my_events"
+
+
+def test_constructor_rejects_bool_true_retention_days() -> None:
+    """retention_days=True is the silent-coerce-to-1 trap (zero-tolerance Rule 3c)."""
+    conn = _RecordingConn()
+    with pytest.raises(ValueError, match=r"retention_days=True"):
+        SQLiteHistoryStore(conn, retention_days=True)
+
+
+def test_constructor_accepts_false_retention_days() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn, retention_days=False)
+    assert store._retention_days is None
+
+
+def test_constructor_rejects_negative_retention_days() -> None:
+    conn = _RecordingConn()
+    with pytest.raises(ValueError, match=r"retention_days"):
+        SQLiteHistoryStore(conn, retention_days=-7)
+
+
+def test_constructor_rejects_zero_retention_days() -> None:
+    conn = _RecordingConn()
+    with pytest.raises(ValueError, match=r"retention_days"):
+        SQLiteHistoryStore(conn, retention_days=0)
+
+
+def test_constructor_rejects_negative_per_tenant_cap() -> None:
+    conn = _RecordingConn()
+    with pytest.raises(ValueError, match=r"per_tenant_cap"):
+        SQLiteHistoryStore(conn, per_tenant_cap=-1)
+
+
+# ---------------------------------------------------------------------------
+# Read API: cross-tenant reads are BLOCKED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_runs_requires_tenant_id() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    with pytest.raises(ValueError, match=r"tenant_id"):
+        await store.list_runs(filter={"status": "failed"})
+
+
+@pytest.mark.asyncio
+async def test_list_runs_rejects_unsupported_filter_keys() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    with pytest.raises(ValueError, match=r"unsupported filter keys"):
+        await store.list_runs(filter={"tenant_id": "t1", "bogus_key": "x"})
+
+
+@pytest.mark.asyncio
+async def test_get_run_requires_tenant_id() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    with pytest.raises(ValueError, match=r"tenant_id"):
+        await store.get_run("run-1", tenant_id=None)
+    with pytest.raises(ValueError, match=r"tenant_id"):
+        await store.get_run("run-1", tenant_id="")
+
+
+@pytest.mark.asyncio
+async def test_get_run_events_requires_tenant_id() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    with pytest.raises(ValueError, match=r"tenant_id"):
+        await store.get_run_events("run-1", tenant_id=None)
+
+
+@pytest.mark.asyncio
+async def test_list_failed_requires_tenant_id() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    with pytest.raises(ValueError, match=r"tenant_id"):
+        await store.list_failed(tenant_id=None)
+
+
+@pytest.mark.asyncio
+async def test_get_run_events_returns_empty_on_tenant_mismatch() -> None:
+    """Tenant-scope check: when the run row does not match the tenant,
+    the events query MUST return empty even if events exist for the run.
+    """
+    conn = _RecordingConn(fetchone_results=[None])  # run lookup returns None
+    store = SQLiteHistoryStore(conn)
+    rows = await store.get_run_events("run-1", tenant_id="t-other")
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# delete_runs_older_than: destructive confirmation gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_runs_older_than_refuses_without_force() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+    with pytest.raises(DowngradeRefusedError):
+        await store.delete_runs_older_than(cutoff)
+
+
+@pytest.mark.asyncio
+async def test_delete_runs_older_than_runs_with_force() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=1)
+    deleted = await store.delete_runs_older_than(cutoff, force_downgrade=True)
+    assert deleted == 0  # no rows in the deterministic adapter
+
+
+@pytest.mark.asyncio
+async def test_delete_runs_older_than_rejects_bad_timestamp_type() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    with pytest.raises(TypeError, match=r"timestamp"):
+        await store.delete_runs_older_than(12345, force_downgrade=True)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# record_event: read-redaction at write-time invariant
+# ---------------------------------------------------------------------------
+
+
+class _StubPolicy:
+    """Classification policy that REDACTs everything for the test node."""
+
+    def get_classification(self, node_id: str, field_name: str) -> Optional[str]:
+        if node_id == "secret_node":
+            return "REDACT"
+        return None
+
+
+@pytest.mark.asyncio
+async def test_record_event_routes_through_redaction_helper() -> None:
+    """The persisted payload MUST contain the [REDACTED] sentinel for
+    classified fields — not the raw value.  This pins the cross-cutting
+    invariant 4: read-redaction at write time.
+    """
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn, classification_policy=_StubPolicy())
+    store._initialized = True
+
+    event = NodeCompletionEvent(
+        run_id="run-redact-1",
+        workflow_id="wf-1",
+        workflow_fingerprint="fp-abc",
+        node_id="secret_node",
+        node_type="PythonCodeNode",
+        outputs={"ssn": "123-45-6789", "name": "Alice"},
+        started_at=datetime.now(timezone.utc),
+        ended_at=datetime.now(timezone.utc),
+        duration_ms=10,
+        tenant_id="t1",
+    )
+
+    await store.record_event(event)
+
+    # The first INSERT into workflow_run_events captures payload_json
+    # at args[4].  Find that statement and decode the JSON.
+    inserts = [
+        (q, args)
+        for (q, args) in conn.executes
+        if "workflow_run_events" in q and q.strip().startswith("INSERT")
+    ]
+    assert (
+        inserts
+    ), f"expected an INSERT into workflow_run_events; got {conn.executes!r}"
+    _, args = inserts[0]
+    payload_json = args[4]
+    payload = json.loads(payload_json)
+    # Both fields are classified → both replaced with the [REDACTED]
+    # sentinel.  The raw "123-45-6789" / "Alice" MUST NOT appear in
+    # the persisted bytes.
+    assert payload["outputs"]["ssn"] == "[REDACTED]"
+    assert payload["outputs"]["name"] == "[REDACTED]"
+    assert "123-45-6789" not in payload_json
+    assert "Alice" not in payload_json
+
+
+@pytest.mark.asyncio
+async def test_record_event_skips_when_run_id_is_none() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    store._initialized = True
+    event = NodeCompletionEvent(
+        run_id=None,
+        workflow_id="wf-1",
+        workflow_fingerprint="fp",
+        node_id="n1",
+        node_type="PythonCodeNode",
+        outputs={},
+        started_at=datetime.now(timezone.utc),
+        ended_at=datetime.now(timezone.utc),
+        duration_ms=1,
+        tenant_id="t1",
+    )
+    # Does not raise; emits a WARN log line and returns.
+    await store.record_event(event)
+    assert conn.executes == []
+
+
+@pytest.mark.asyncio
+async def test_record_event_raises_when_not_initialized() -> None:
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    # Do NOT call initialize().
+    event = NodeCompletionEvent(
+        run_id="run-1",
+        workflow_id="wf",
+        workflow_fingerprint="fp",
+        node_id="n",
+        node_type="PythonCodeNode",
+        outputs={},
+        started_at=datetime.now(timezone.utc),
+        ended_at=datetime.now(timezone.utc),
+        duration_ms=1,
+    )
+    with pytest.raises(RuntimeError, match=r"initialize"):
+        await store.record_event(event)
+
+
+# ---------------------------------------------------------------------------
+# LocalRuntime auto-subscribe wiring
+# ---------------------------------------------------------------------------
+
+
+def test_local_runtime_auto_subscribes_history_store() -> None:
+    """LocalRuntime(history_store=<store>) MUST register the store's
+    record_event with the W1 hook registry at construction time.
+    """
+    from kailash.runtime.local import LocalRuntime
+
+    class _RecordingStore:
+        def __init__(self) -> None:
+            self.calls: List[NodeCompletionEvent] = []
+
+        async def record_event(self, event: NodeCompletionEvent) -> None:
+            self.calls.append(event)
+
+    store = _RecordingStore()
+    runtime = LocalRuntime(history_store=store)
+    assert runtime._hook_registry.subscriber_count == 1
+
+
+def test_local_runtime_no_history_store_means_no_subscriber() -> None:
+    from kailash.runtime.local import LocalRuntime
+
+    runtime = LocalRuntime()
+    assert runtime._hook_registry.subscriber_count == 0
+
+
+def test_local_runtime_rejects_history_store_without_record_event() -> None:
+    from kailash.runtime.local import LocalRuntime
+
+    class _BadStore:
+        pass  # no record_event
+
+    with pytest.raises(TypeError, match=r"record_event"):
+        LocalRuntime(history_store=_BadStore())
+
+
+def test_async_local_runtime_inherits_history_store_subscribe() -> None:
+    """AsyncLocalRuntime(history_store=...) MUST inherit the same wiring
+    via super().__init__(**kwargs) — no separate registration needed.
+    """
+    from kailash.runtime.async_local import AsyncLocalRuntime
+
+    class _RecordingStore:
+        async def record_event(self, event: NodeCompletionEvent) -> None:
+            pass
+
+    store = _RecordingStore()
+    runtime = AsyncLocalRuntime(history_store=store)
+    assert runtime._hook_registry.subscriber_count == 1
+
+
+# ---------------------------------------------------------------------------
+# ABC contract
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_history_store_is_abstract() -> None:
+    """WorkflowHistoryStore is an ABC; cannot be instantiated directly."""
+    conn = _RecordingConn()
+    with pytest.raises(TypeError):
+        WorkflowHistoryStore(conn)  # type: ignore[abstract]
+
+
+def test_postgres_and_sqlite_subclass_workflow_history_store() -> None:
+    assert issubclass(PostgresHistoryStore, WorkflowHistoryStore)
+    assert issubclass(SQLiteHistoryStore, WorkflowHistoryStore)

--- a/tests/unit/test_workflow_history_store_unit.py
+++ b/tests/unit/test_workflow_history_store_unit.py
@@ -450,3 +450,75 @@ def test_workflow_history_store_is_abstract() -> None:
 def test_postgres_and_sqlite_subclass_workflow_history_store() -> None:
     assert issubclass(PostgresHistoryStore, WorkflowHistoryStore)
     assert issubclass(SQLiteHistoryStore, WorkflowHistoryStore)
+
+
+def test_get_or_create_run_lock_returns_same_lock_per_run_id() -> None:
+    """Per-run lock LRU cache returns the SAME asyncio.Lock for repeated
+    calls with the same ``run_id``.  The lock is the structural defense
+    against the ``MAX(event_seq) + 1`` race for concurrent record_event
+    calls per ``rules/zero-tolerance.md`` Rule 2 (no fake-classification
+    via missing serialisation guard).
+    """
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    lock_a1 = store._get_or_create_run_lock("run-A")
+    lock_a2 = store._get_or_create_run_lock("run-A")
+    lock_b = store._get_or_create_run_lock("run-B")
+    assert lock_a1 is lock_a2  # same run_id → same lock
+    assert lock_a1 is not lock_b  # different run_id → different lock
+
+
+def test_get_or_create_run_lock_lru_eviction_bounds_memory() -> None:
+    """The LRU cache evicts the least-recently-used entry once
+    ``_MAX_RUN_LOCKS`` is exceeded.  Mirrors the W1 ``_checkpoint_locks``
+    pattern in :mod:`kailash.runtime.local`.  Unbounded growth would
+    otherwise leak one Lock per unique ``run_id`` per
+    ``rules/infrastructure-sql.md`` Rule 7.
+    """
+    from kailash.infrastructure import history_store as hs_mod
+
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    # Patch the bound to a small number for the test.
+    original_bound = hs_mod._MAX_RUN_LOCKS
+    hs_mod._MAX_RUN_LOCKS = 3
+    try:
+        lock_1 = store._get_or_create_run_lock("run-1")
+        lock_2 = store._get_or_create_run_lock("run-2")
+        lock_3 = store._get_or_create_run_lock("run-3")
+        # Cache is now full.  Adding a 4th entry should evict run-1.
+        lock_4 = store._get_or_create_run_lock("run-4")
+        assert "run-1" not in store._run_locks
+        assert "run-2" in store._run_locks
+        assert "run-4" in store._run_locks
+        # Re-acquiring run-1 creates a NEW lock (the prior was evicted).
+        lock_1_again = store._get_or_create_run_lock("run-1")
+        assert lock_1_again is not lock_1
+    finally:
+        hs_mod._MAX_RUN_LOCKS = original_bound
+
+
+def test_get_or_create_run_lock_promotes_on_access() -> None:
+    """Accessing an existing entry promotes it to most-recently-used so
+    an active long-lived run is never evicted under bound pressure.
+    """
+    from kailash.infrastructure import history_store as hs_mod
+
+    conn = _RecordingConn()
+    store = SQLiteHistoryStore(conn)
+    original_bound = hs_mod._MAX_RUN_LOCKS
+    hs_mod._MAX_RUN_LOCKS = 3
+    try:
+        store._get_or_create_run_lock("run-1")
+        store._get_or_create_run_lock("run-2")
+        store._get_or_create_run_lock("run-3")
+        # Touch run-1 to promote it to MRU.
+        store._get_or_create_run_lock("run-1")
+        # Adding run-4 should now evict run-2 (LRU), not run-1.
+        store._get_or_create_run_lock("run-4")
+        assert "run-1" in store._run_locks
+        assert "run-2" not in store._run_locks
+        assert "run-3" in store._run_locks
+        assert "run-4" in store._run_locks
+    finally:
+        hs_mod._MAX_RUN_LOCKS = original_bound


### PR DESCRIPTION
## Summary

Wave 2 of the runtime-integration-trio: first-party persistent workflow history. Subscribes to W1's `runtime.on_node_complete` hook (shipped in v2.14.x) and persists per-node `NodeCompletionEvent` records to a queryable, tenant-isolated audit log. Closes #861.

## What ships

- `src/kailash/infrastructure/history_store.py` (NEW): `WorkflowHistoryStore` ABC + `PostgresHistoryStore` + `SQLiteHistoryStore` + `DowngradeRefusedError`. Dialect-portable schema, write-time redaction, retention TTL, per-tenant cap with WARN log, `force_downgrade=True` gate on destructive sweeps.
- `src/kailash/runtime/local.py` (lines 813-842): auto-subscribe `history_store.record_event` to the W1 hook registry when `LocalRuntime(history_store=...)` is non-None. `AsyncLocalRuntime` inherits via `super().__init__(**kwargs)`.
- `src/kailash/infrastructure/__init__.py`: re-exports the 4 new public symbols.
- 29 Tier-1 unit tests + 6 Tier-2 wiring tests (real Postgres) + 1 Tier-3 redaction sweep.

## Public surface

```python
from kailash.infrastructure.history_store import PostgresHistoryStore
from kailash.runtime.local import LocalRuntime

history = PostgresHistoryStore(conn_mgr, retention_days=30)
await history.initialize()

runtime = LocalRuntime(history_store=history)  # auto-subscribes record_event
results, run_id = runtime.execute(workflow.build())

# Read API (every method tenant-isolated)
runs = await history.list_runs(filter={"tenant_id": "t1", "status": "failed"})
events = await history.get_run_events(run_id, tenant_id="t1")
```

## Load-bearing invariants

1. **Tenant isolation** — every read filters by `tenant_id` from the runtime context; cross-tenant reads BLOCKED at the store layer (raise `ValueError` on missing tenant_id, JOIN with runs table for events fetch).
2. **Read-redaction at write-time** — `record_event` routes through `redact_event_for_persistence` BEFORE INSERT; classified PKs hashed via `format_record_id_for_event`.
3. **Retention** — 30-day TTL on `terminal_at` (NOT `started_at`); in-flight runs never truncated; eviction structurally confirmed via `force_downgrade=True` (typed `DowngradeRefusedError`).
4. **Indexes** — `(tenant_id, started_at DESC)`, `(tenant_id, run_id)`, `(tenant_id, status, started_at DESC)` on `workflow_runs`; `(run_id, event_seq)` on `workflow_run_events`. List_runs is bounded-time on multi-tenant tables.
5. **Per-run lock** — concurrent `record_event` calls for the same run_id serialised by `asyncio.Lock` LRU cache (mirrors W1 `_checkpoint_locks` pattern); `MAX(event_seq) + 1` race under READ COMMITTED structurally closed.

## Gate review

- **reviewer**: APPROVE_WITH_NITS (10 mechanical sweeps clean; 6 LLM-judgment items pass; 2 cosmetic NITs)
- **security-reviewer**: APPROVE_WITH_FINDINGS, then re-audited post-fix → CLOSURE_VERIFIED for H-1 + M-1
- M-2/M-3/L-1/L-2/L-3/L-4 audit findings deferred to follow-up issue (cited in commit `d4959811` body)

## Tests

```
tests/unit/test_workflow_history_store_unit.py        29 passed
tests/integration/test_workflow_history_store_wiring.py  6 collected (real Postgres)
tests/e2e/test_redaction_history_store.py             1 collected (real Postgres)
```

## Related issues

Closes #861.
Wave 1 (#860) shipped in v2.14.x.
Wave 3 (#862 W4 durable engine, W5 tier-3 crash-resume) unblocked by this merge.
Follow-up audit-finding hardening: tracking issue to be filed pre-release.
