### PR TITLE
style(align): pre-commit normalize sweep

### DIFF
--- a/packages/kailash-align/src/kailash_align/__init__.py
+++ b/packages/kailash-align/src/kailash_align/__init__.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from kailash_align._version import __version__
+from kailash_align.bridge import BridgeConfig, KaizenModelBridge
+from kailash_align.config import OnPremConfig
 
 # Eager imports for symbols flagged by CodeQL
 # py/modification-of-default-value when declared in __all__ via lazy
@@ -15,9 +17,7 @@ from kailash_align._version import __version__
 # resolves it. These modules are cheap to import (no torch / no
 # transformers load) so eager-import is safe.
 from kailash_align.merge import AdapterMerger
-from kailash_align.bridge import BridgeConfig, KaizenModelBridge
 from kailash_align.onprem import OnPremModelCache
-from kailash_align.config import OnPremConfig
 
 # TYPE_CHECKING eager imports for symbols that wrap HEAVY dependencies
 # (torch / transformers / peft / vllm). These are lazily-resolved at
@@ -27,8 +27,6 @@ from kailash_align.config import OnPremConfig
 # to resolve the names declared in __all__, closing the
 # py/undefined-export finding without forcing eager runtime imports.
 if TYPE_CHECKING:  # pragma: no cover — static-analysis only
-    from kailash_align.registry import AdapterRegistry
-    from kailash_align.pipeline import AlignmentPipeline, AlignmentResult
     from kailash_align.config import (
         AdapterSignature,
         AlignmentConfig,
@@ -43,18 +41,13 @@ if TYPE_CHECKING:  # pragma: no cover — static-analysis only
         ServingConfig,
         SFTConfig,
     )
-    from kailash_align.evaluator import (
-        AlignmentEvaluator,
-        EvalResult,
-        TaskResult,
-    )
-    from kailash_align.serving import AlignmentServing
+    from kailash_align.evaluator import AlignmentEvaluator, EvalResult, TaskResult
+    from kailash_align.gpu_memory import GPUMemoryEstimate, estimate_training_memory
     from kailash_align.method_registry import METHOD_REGISTRY
+    from kailash_align.pipeline import AlignmentPipeline, AlignmentResult
+    from kailash_align.registry import AdapterRegistry
     from kailash_align.rewards import RewardRegistry, reward_registry
-    from kailash_align.gpu_memory import (
-        GPUMemoryEstimate,
-        estimate_training_memory,
-    )
+    from kailash_align.serving import AlignmentServing
     from kailash_align.vllm_backend import (
         GenerationBackend,
         HFGenerationBackend,

--- a/packages/kailash-align/src/kailash_align/agents/__init__.py
+++ b/packages/kailash-align/src/kailash_align/agents/__init__.py
@@ -8,6 +8,9 @@ tools are dumb data endpoints.
 """
 from __future__ import annotations
 
+from kailash_align.agents.data_curation import DataCurationAgent
+from kailash_align.agents.eval_interpreter import EvalInterpreterAgent
+
 # Eager imports for CodeQL py/modification-of-default-value —
 # rules/orphan-detection.md §6 mandates that every __all__ entry resolve
 # to a module-scope import. Each sub-module lazy-imports kaizen at call
@@ -15,9 +18,7 @@ from __future__ import annotations
 # NOT pull in kailash-kaizen; the ImportError is still raised later when
 # the agent is instantiated without the [agents] extra.
 from kailash_align.agents.strategist import AlignmentStrategistAgent
-from kailash_align.agents.data_curation import DataCurationAgent
 from kailash_align.agents.training_config import TrainingConfigAgent
-from kailash_align.agents.eval_interpreter import EvalInterpreterAgent
 
 __all__ = [
     "AlignmentStrategistAgent",

--- a/packages/kailash-align/src/kailash_align/agents/orchestrator.py
+++ b/packages/kailash-align/src/kailash_align/agents/orchestrator.py
@@ -47,8 +47,8 @@ async def alignment_workflow(
     Returns:
         Dict with strategy, curation, config, and optionally interpretation.
     """
-    from kailash_align.agents.strategist import AlignmentStrategistAgent
     from kailash_align.agents.data_curation import DataCurationAgent
+    from kailash_align.agents.strategist import AlignmentStrategistAgent
     from kailash_align.agents.training_config import TrainingConfigAgent
 
     # Step 1: Strategy

--- a/packages/kailash-align/src/kailash_align/config.py
+++ b/packages/kailash-align/src/kailash_align/config.py
@@ -80,7 +80,8 @@ class LoRAConfig:
 
     def to_peft_config(self):
         """Convert to peft.LoraConfig. Lazy import to avoid loading peft at config time."""
-        from peft import LoraConfig as PeftLoraConfig, TaskType
+        from peft import LoraConfig as PeftLoraConfig
+        from peft import TaskType
 
         return PeftLoraConfig(
             r=self.rank,

--- a/packages/kailash-align/src/kailash_align/diagnostics/alignment.py
+++ b/packages/kailash-align/src/kailash_align/diagnostics/alignment.py
@@ -302,9 +302,7 @@ class AlignmentDiagnostics:
             raise ValueError("base_policy and tuned_policy must be same length")
         label = label or self._label
 
-        kls = [
-            self._kl_from_logprobs(b, t) for b, t in zip(base_policy, tuned_policy)
-        ]
+        kls = [self._kl_from_logprobs(b, t) for b, t in zip(base_policy, tuned_policy)]
         kl_mean = _mean(kls)
 
         if preferences:
@@ -417,9 +415,7 @@ class AlignmentDiagnostics:
                 if k not in {"step", "reward", "kl", "kl_divergence", "loss"}
             }
             self._training_log.append(
-                _TrainingStep(
-                    step=step, reward=reward, kl=kl, loss=loss, extras=extras
-                )
+                _TrainingStep(step=step, reward=reward, kl=kl, loss=loss, extras=extras)
             )
             rows.append({"step": step, "reward": reward, "kl": kl, "loss": loss})
         df = pl.DataFrame(rows) if rows else _empty_training_df()
@@ -916,12 +912,8 @@ class AlignmentDiagnostics:
             # Loss trend: compare first vs last quintile.
             if train_df.height >= 10:
                 quintile = max(1, train_df.height // 5)
-                early_loss = float(
-                    train_df["loss"].head(quintile).mean() or 0.0
-                )
-                late_loss = float(
-                    train_df["loss"].tail(quintile).mean() or 0.0
-                )
+                early_loss = float(train_df["loss"].head(quintile).mean() or 0.0)
+                late_loss = float(train_df["loss"].tail(quintile).mean() or 0.0)
                 if not math.isnan(early_loss) and not math.isnan(late_loss):
                     if late_loss > early_loss * 1.1:
                         severity = "WARNING"
@@ -1013,7 +1005,9 @@ class AlignmentDiagnostics:
         # Fast path: torch + trl available (both in kailash-align base deps).
         try:
             import torch  # noqa: PLC0415
-            from trl.trainer.utils import kl_divergence as trl_kl  # type: ignore[import-not-found]  # noqa: PLC0415
+            from trl.trainer.utils import (  # type: ignore[import-not-found]  # noqa: PLC0415
+                kl_divergence as trl_kl,
+            )
         except ImportError:
             return _kl_closed_form(p_logprobs, q_logprobs)
         except Exception:  # pragma: no cover — defensive for odd trl builds

--- a/packages/kailash-align/src/kailash_align/evaluator.py
+++ b/packages/kailash-align/src/kailash_align/evaluator.py
@@ -8,10 +8,9 @@ lm-eval is an OPTIONAL dependency ([eval] extra).
 """
 from __future__ import annotations
 
-import json
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from kailash_align.config import QUICK_TASKS, STANDARD_TASKS, EvalConfig

--- a/packages/kailash-align/src/kailash_align/method_registry.py
+++ b/packages/kailash-align/src/kailash_align/method_registry.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import importlib
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from kailash_align.exceptions import AlignmentError, TrainingError
 

--- a/packages/kailash-align/src/kailash_align/ml/__init__.py
+++ b/packages/kailash-align/src/kailash_align/ml/__init__.py
@@ -55,7 +55,9 @@ the 32b vocabulary while the return type is the actual W30 dataclass.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+
+from kailash_align.ml._lora_callback import LoRALightningCallback, lora_callback_for
+from kailash_align.ml._trajectory import trajectory_from_alignment_run
 
 # Eager re-exports from the W30 rl_bridge — orphan-detection.md §6
 # mandates every __all__ entry resolve at module scope. The rl_bridge
@@ -63,17 +65,10 @@ from typing import TYPE_CHECKING, Any, Optional
 # when ``kailash-ml[rl]>=1.1`` is missing (see
 # ``kailash_align.rl_bridge.__init__``), so the import chain either
 # succeeds cleanly or fails early with an actionable extra name.
-from kailash_align.rl_bridge import (
-    DPOAdapter as DPOTrainer,
-    OnlineDPOAdapter as OnlineDPOTrainer,
-    PPORLHFAdapter as PPOTrainer,
-    RLOOAdapter as RLOOTrainer,
-)
-from kailash_align.ml._lora_callback import (
-    LoRALightningCallback,
-    lora_callback_for,
-)
-from kailash_align.ml._trajectory import trajectory_from_alignment_run
+from kailash_align.rl_bridge import DPOAdapter as DPOTrainer
+from kailash_align.rl_bridge import OnlineDPOAdapter as OnlineDPOTrainer
+from kailash_align.rl_bridge import PPORLHFAdapter as PPOTrainer
+from kailash_align.rl_bridge import RLOOAdapter as RLOOTrainer
 
 # W6-016 — single-source-in-ml mandate (spec §7): TrajectorySchema is
 # the canonical bundle defined in kailash_ml.rl and re-exported here so
@@ -82,9 +77,6 @@ from kailash_align.ml._trajectory import trajectory_from_alignment_run
 # rules/orphan-detection.md §6 (every __all__ entry resolves at
 # module-scope import).
 from kailash_ml.rl import TrajectorySchema
-
-if TYPE_CHECKING:  # pragma: no cover — typing-only imports
-    from kailash_ml.rl import RLLineage  # re-exported via trajectory_from_alignment_run
 
 logger = logging.getLogger(__name__)
 

--- a/packages/kailash-align/src/kailash_align/ml/_lora_callback.py
+++ b/packages/kailash-align/src/kailash_align/ml/_lora_callback.py
@@ -58,7 +58,7 @@ import math
 from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:  # pragma: no cover — typing only
-    import pytorch_lightning as pl  # type: ignore[import-not-found]
+    pass  # type: ignore[import-not-found]
 
 logger = logging.getLogger(__name__)
 

--- a/packages/kailash-align/src/kailash_align/ml/_trajectory.py
+++ b/packages/kailash-align/src/kailash_align/ml/_trajectory.py
@@ -38,7 +38,6 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover — typing only
-    from kailash_align.pipeline import AlignmentResult
     from kailash_ml.rl import RLLineage
 
 logger = logging.getLogger(__name__)

--- a/packages/kailash-align/src/kailash_align/onprem.py
+++ b/packages/kailash-align/src/kailash_align/onprem.py
@@ -273,9 +273,9 @@ class SetupChecklist:
             )
             lines.append(f"- [ ] **Step {item.step}**: {item.description}{size_note}")
             if item.command:
-                lines.append(f"  ```bash")
+                lines.append("  ```bash")
                 lines.append(f"  {item.command}")
-                lines.append(f"  ```")
+                lines.append("  ```")
             lines.append("")
         return "\n".join(lines)
 

--- a/packages/kailash-align/src/kailash_align/pipeline.py
+++ b/packages/kailash-align/src/kailash_align/pipeline.py
@@ -244,10 +244,9 @@ class AlignmentPipeline:
             reward_funcs: Resolved reward functions for online methods.
         """
         import torch
+        from kailash_align.method_registry import _lazy_import, get_method
         from peft import PeftModel, get_peft_model
         from transformers import AutoModelForCausalLM, AutoTokenizer
-
-        from kailash_align.method_registry import _lazy_import, get_method
 
         method = get_method(method_name)
 

--- a/packages/kailash-align/src/kailash_align/rewards.py
+++ b/packages/kailash-align/src/kailash_align/rewards.py
@@ -8,8 +8,8 @@ See ALN-220 and red team C2 for security rationale.
 """
 from __future__ import annotations
 
-import math
 import logging
+import math
 from typing import Any, Protocol, runtime_checkable
 
 from kailash_align.exceptions import AlignmentError
@@ -38,7 +38,7 @@ class RewardFunction(Protocol):
     and their corresponding prompts, and return one float score per completion.
 
     Security: reward functions are Python objects passed programmatically.
-    NO serialization (pickle), NO string-based dynamic import, NO eval().
+    NO serialization (pickle), NO string-based dynamic import, NO `eval` calls.
     """
 
     def __call__(
@@ -105,7 +105,7 @@ class RewardRegistry:
     Security constraints (red team C2):
     - NO pickle serialization of reward functions
     - NO importlib.import_module() from user-provided strings for rewards
-    - NO eval() or exec() on reward function definitions
+    - NO `eval` or `exec` invocations on reward function definitions
     - Config files reference reward functions by NAME only
     - RewardRegistry is in-process only (not distributed)
     """
@@ -162,8 +162,7 @@ class RewardRegistry:
         if name not in self._registry:
             available = sorted(self._registry.keys())
             raise KeyError(
-                f"Reward function '{name}' not registered. "
-                f"Available: {available}"
+                f"Reward function '{name}' not registered. " f"Available: {available}"
             )
         return self._registry[name]
 
@@ -208,7 +207,9 @@ def exact_match_reward(
         raise RewardValidationError(
             f"expected has {len(expected)} items but got {len(completions)} completions"
         )
-    return [1.0 if c.strip() == e.strip() else 0.0 for c, e in zip(completions, expected)]
+    return [
+        1.0 if c.strip() == e.strip() else 0.0 for c, e in zip(completions, expected)
+    ]
 
 
 @reward_registry.register("contains_answer")

--- a/packages/kailash-align/tests/conftest.py
+++ b/packages/kailash-align/tests/conftest.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import pytest
-
 from kailash_align.config import AdapterSignature
 from kailash_align.registry import AdapterRegistry
 

--- a/packages/kailash-align/tests/integration/ml/test_align_ml_lora_callback_wiring.py
+++ b/packages/kailash-align/tests/integration/ml/test_align_ml_lora_callback_wiring.py
@@ -25,10 +25,8 @@ Lightning API shape.
 from __future__ import annotations
 
 import importlib
-import math
 
 import pytest
-
 
 try:
     importlib.import_module("pytorch_lightning")

--- a/packages/kailash-align/tests/integration/ml/test_align_ml_trajectory_unification_wiring.py
+++ b/packages/kailash-align/tests/integration/ml/test_align_ml_trajectory_unification_wiring.py
@@ -24,14 +24,13 @@ from __future__ import annotations
 
 import pytest
 
-
 pytestmark = pytest.mark.integration
 
 
 def test_trajectory_round_trips_via_w30_schema() -> None:
     """AlignmentResult → RLLineage → dict → RLLineage equality."""
-    from kailash_align.pipeline import AlignmentResult
     from kailash_align.ml import trajectory_from_alignment_run
+    from kailash_align.pipeline import AlignmentResult
     from kailash_ml.rl import RLLineage
 
     # Real AlignmentResult instance — uses the actual dataclass, not a mock
@@ -72,8 +71,8 @@ def test_trajectory_round_trips_via_w30_schema() -> None:
 
 def test_trajectory_preserves_tenant_when_supplied_via_hasattr() -> None:
     """When the caller attaches ``tenant_id`` to the run, it flows through."""
-    from kailash_align.pipeline import AlignmentResult
     from kailash_align.ml import trajectory_from_alignment_run
+    from kailash_align.pipeline import AlignmentResult
 
     result = AlignmentResult(
         adapter_name="multi-tenant-lora",
@@ -103,8 +102,8 @@ def test_trajectory_single_source_on_ml_side() -> None:
     silently violate spec §7 (single source in ml); this assertion is
     the structural defense.
     """
-    from kailash_align.pipeline import AlignmentResult
     from kailash_align.ml import trajectory_from_alignment_run
+    from kailash_align.pipeline import AlignmentResult
     from kailash_ml.rl import RLLineage
 
     result = AlignmentResult(

--- a/packages/kailash-align/tests/integration/ml/test_trajectory_round_trip.py
+++ b/packages/kailash-align/tests/integration/ml/test_trajectory_round_trip.py
@@ -21,10 +21,9 @@ import json
 from datetime import datetime, timezone
 
 import pytest
-
-from kailash_align.ml import TrajectorySchema as AlignTrajectorySchema
 from kailash_align.config import AlignmentConfig
 from kailash_align.exceptions import TrainingError
+from kailash_align.ml import TrajectorySchema as AlignTrajectorySchema
 from kailash_align.pipeline import AlignmentPipeline
 from kailash_ml.rl import (
     EpisodeRecord,
@@ -34,7 +33,6 @@ from kailash_ml.rl import (
     TrajectorySchema,
 )
 from kailash_ml.rl.trainer import RLTrainingResult
-
 
 # ----------------------------------------------------------------------
 # Fixtures

--- a/packages/kailash-align/tests/integration/test_alignment_diagnostics_wiring.py
+++ b/packages/kailash-align/tests/integration/test_alignment_diagnostics_wiring.py
@@ -16,9 +16,9 @@ import math
 
 import polars as pl
 import pytest
+from kailash_align.diagnostics import AlignmentDiagnostics
 
 from kailash.diagnostics.protocols import Diagnostic
-from kailash_align.diagnostics import AlignmentDiagnostics
 
 
 @pytest.mark.integration

--- a/packages/kailash-align/tests/test_bridge.py
+++ b/packages/kailash-align/tests/test_bridge.py
@@ -10,12 +10,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from kailash_align.bridge import (
-    BridgeConfig,
-    BridgeNotReadyError,
-    KaizenModelBridge,
-)
+from kailash_align.bridge import BridgeConfig, BridgeNotReadyError, KaizenModelBridge
 
 
 class TestBridgeConfigDefaults:

--- a/packages/kailash-align/tests/test_config.py
+++ b/packages/kailash-align/tests/test_config.py
@@ -3,10 +3,7 @@
 """Tests for AlignmentConfig and sub-configs."""
 from __future__ import annotations
 
-import math
-
 import pytest
-
 from kailash_align.config import (
     AdapterSignature,
     AlignmentConfig,
@@ -16,7 +13,6 @@ from kailash_align.config import (
     _validate_finite,
     _validate_positive,
 )
-
 
 # --- Validation Utilities ---
 

--- a/packages/kailash-align/tests/test_evaluator.py
+++ b/packages/kailash-align/tests/test_evaluator.py
@@ -5,19 +5,16 @@ from __future__ import annotations
 
 import sys
 from types import ModuleType
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-
-from kailash_align.config import EvalConfig, QUICK_TASKS, STANDARD_TASKS
+from kailash_align.config import QUICK_TASKS, STANDARD_TASKS, EvalConfig
 from kailash_align.evaluator import (
     AlignmentEvaluator,
     EvalResult,
     TaskResult,
     _resolve_tasks,
 )
-from kailash_align.exceptions import EvaluationError
-
 
 # --- TaskResult tests ---
 

--- a/packages/kailash-align/tests/test_evaluator_smoke.py
+++ b/packages/kailash-align/tests/test_evaluator_smoke.py
@@ -8,12 +8,7 @@ Runs without torch/transformers/lm_eval installed.
 """
 from __future__ import annotations
 
-import sys
-from types import ModuleType
-from unittest.mock import AsyncMock, MagicMock, patch
-
 import pytest
-
 from kailash_align.config import QUICK_TASKS, STANDARD_TASKS, EvalConfig
 from kailash_align.evaluator import (
     AlignmentEvaluator,
@@ -21,7 +16,6 @@ from kailash_align.evaluator import (
     TaskResult,
     _resolve_tasks,
 )
-from kailash_align.exceptions import EvaluationError
 
 
 class TestQuickPresetContents:

--- a/packages/kailash-align/tests/test_merge.py
+++ b/packages/kailash-align/tests/test_merge.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import pytest
-
 from kailash_align.exceptions import MergeError
 from kailash_align.merge import AdapterMerger, merge_adapter
 

--- a/packages/kailash-align/tests/test_method_registry.py
+++ b/packages/kailash-align/tests/test_method_registry.py
@@ -6,11 +6,7 @@ Tier 1 unit tests -- no torch, TRL, or GPU dependencies required.
 """
 from __future__ import annotations
 
-import math
-import warnings
-
 import pytest
-
 from kailash_align.config import (
     AdapterSignature,
     AlignmentConfig,
@@ -29,7 +25,6 @@ from kailash_align.method_registry import (
     register_method,
     validate_method_name,
 )
-
 
 # =============================================================================
 # Section 1: Method Registry

--- a/packages/kailash-align/tests/test_onprem.py
+++ b/packages/kailash-align/tests/test_onprem.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from kailash_align.config import OnPremConfig
 from kailash_align.exceptions import CacheNotFoundError
 from kailash_align.onprem import CachedModel, OnPremModelCache
@@ -90,7 +89,7 @@ class TestOnPremModelCacheInit:
     def test_creates_cache_directory(self, tmp_path):
         cache_dir = tmp_path / "new-cache"
         assert not cache_dir.exists()
-        cache = OnPremModelCache(cache_dir=str(cache_dir))
+        OnPremModelCache(cache_dir=str(cache_dir))
         assert cache_dir.exists()
 
     def test_cache_dir_property(self, tmp_path):

--- a/packages/kailash-align/tests/test_pipeline.py
+++ b/packages/kailash-align/tests/test_pipeline.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from kailash_align.config import AlignmentConfig
 from kailash_align.exceptions import TrainingError
 from kailash_align.pipeline import AlignmentPipeline, AlignmentResult

--- a/packages/kailash-align/tests/test_registry.py
+++ b/packages/kailash-align/tests/test_registry.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import pytest
-
 from kailash_align.config import AdapterSignature
 from kailash_align.exceptions import AdapterNotFoundError, AlignmentError
 from kailash_align.registry import AdapterRegistry, AdapterVersion

--- a/packages/kailash-align/tests/test_serving_smoke.py
+++ b/packages/kailash-align/tests/test_serving_smoke.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from kailash_align.config import ServingConfig
 from kailash_align.exceptions import ServingError
 from kailash_align.serving import (

--- a/packages/kailash-align/tests/unit/ml/test_align_ml_namespace.py
+++ b/packages/kailash-align/tests/unit/ml/test_align_ml_namespace.py
@@ -19,12 +19,7 @@ import pytest
 
 def test_align_ml_exports_four_bridge_adapters() -> None:
     """The four W30 rl_bridge adapters re-export under spec §2 names."""
-    from kailash_align.ml import (
-        DPOTrainer,
-        OnlineDPOTrainer,
-        PPOTrainer,
-        RLOOTrainer,
-    )
+    from kailash_align.ml import DPOTrainer, OnlineDPOTrainer, PPOTrainer, RLOOTrainer
 
     # Spec §2 canonical names MUST resolve to the W30 storage-module classes
     from kailash_align.rl_bridge import (

--- a/packages/kailash-align/tests/unit/rl_bridge/test_all_adapters_satisfy_protocol.py
+++ b/packages/kailash-align/tests/unit/rl_bridge/test_all_adapters_satisfy_protocol.py
@@ -21,7 +21,6 @@ def test_every_registered_adapter_satisfies_protocol():
     """For each name in BRIDGE_ADAPTERS, __make_for_test__() → Protocol-conformant."""
     # Import side effect populates the registry.
     import kailash_align.rl_bridge  # noqa: F401
-
     from kailash_ml.rl.align_adapter import BRIDGE_ADAPTERS
     from kailash_ml.rl.protocols import RLLifecycleProtocol
 
@@ -66,7 +65,6 @@ def test_every_registered_adapter_satisfies_protocol():
 def test_class_level_attrs_match_registration_name():
     """adapter_cls.name == the key it is registered under in BRIDGE_ADAPTERS."""
     import kailash_align.rl_bridge  # noqa: F401
-
     from kailash_ml.rl.align_adapter import BRIDGE_ADAPTERS
 
     mismatches = [
@@ -84,7 +82,6 @@ def test_class_level_attrs_match_registration_name():
 def test_every_adapter_declares_rlhf_paradigm():
     """All v1-scope bridge adapters are paradigm='rlhf'."""
     import kailash_align.rl_bridge  # noqa: F401
-
     from kailash_ml.rl.align_adapter import BRIDGE_ADAPTERS
 
     wrong = [
@@ -101,7 +98,6 @@ def test_every_adapter_declares_rlhf_paradigm():
 def test_buffer_kind_is_rollout_or_preference():
     """v1-scope bridge adapters use rollout or preference buffers (spec §9)."""
     import kailash_align.rl_bridge  # noqa: F401
-
     from kailash_ml.rl.align_adapter import BRIDGE_ADAPTERS
 
     allowed = {"rollout", "preference"}

--- a/packages/kailash-align/tests/unit/rl_bridge/test_dpo_adapter.py
+++ b/packages/kailash-align/tests/unit/rl_bridge/test_dpo_adapter.py
@@ -19,8 +19,6 @@ the underlying TRL plumbing. This test file proves:
 """
 from __future__ import annotations
 
-import math
-
 import pytest
 
 pytestmark = pytest.mark.unit

--- a/packages/kailash-align/tests/unit/rl_bridge/test_registry_population.py
+++ b/packages/kailash-align/tests/unit/rl_bridge/test_registry_population.py
@@ -18,7 +18,6 @@ def test_import_registers_all_four_adapters():
     """Importing the bridge populates BRIDGE_ADAPTERS with the v1 names."""
     # Fresh import of the bridge package — side effect registers adapters.
     import kailash_align.rl_bridge  # noqa: F401 — imported for side effect
-
     from kailash_ml.rl.align_adapter import BRIDGE_ADAPTERS
 
     expected = {"dpo", "ppo-rlhf", "rloo", "online-dpo"}
@@ -35,7 +34,6 @@ def test_import_registers_all_four_adapters():
 def test_registered_classes_match_adapter_types():
     """Each registered entry is the expected adapter class."""
     import kailash_align.rl_bridge  # noqa: F401
-
     from kailash_align.rl_bridge._dpo import DPOAdapter
     from kailash_align.rl_bridge._online_dpo import OnlineDPOAdapter
     from kailash_align.rl_bridge._ppo_rlhf import PPORLHFAdapter
@@ -51,7 +49,6 @@ def test_registered_classes_match_adapter_types():
 def test_resolve_bridge_adapter_returns_class():
     """km.rl_train's resolver finds every registered adapter by name."""
     import kailash_align.rl_bridge  # noqa: F401
-
     from kailash_ml.rl.align_adapter import resolve_bridge_adapter
 
     for name in ("dpo", "ppo-rlhf", "rloo", "online-dpo"):

--- a/packages/kailash-align/tests/unit/test_alignment_diagnostics_unit.py
+++ b/packages/kailash-align/tests/unit/test_alignment_diagnostics_unit.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import math
 
 import pytest
+from kailash_align.diagnostics import AlignmentDiagnostics
 
 from kailash.diagnostics.protocols import Diagnostic
-from kailash_align.diagnostics import AlignmentDiagnostics
 
 
 def test_protocol_conformance() -> None:


### PR DESCRIPTION
## Summary

Mechanical pre-commit normalize sweep across 33 `packages/kailash-align/` files. No semantic changes:

- **black**: collapse multi-line list comprehensions / call-args that fit one line; wrap one over-long import.
- **isort**: alphabetize TYPE_CHECKING blocks; drop redundant blank lines between import groups in tests.
- **ruff F401**: drop unused imports (`Optional`, `math`, `typing.Any/Optional/TYPE_CHECKING` in ml/__init__.py, the Sphinx-only `RLLineage` TYPE_CHECKING import — Sphinx `:class:` directives use fully-qualified paths).
- **ruff F841**: drop unused `cache = ` binding in test_onprem.py; the `OnPremModelCache(...)` call is exercised for its directory-creation side effect.
- **rewards.py docstring reword**: two doc-strings explicitly forbidding `eval()` were tripping the `python-no-eval` pygrep hook as literal-substring false-positives. Reworded to ``eval`` calls`` / ``eval`` invocations`` per `git.md` § Pre-commit comment-syntax matchers. Pre-existing from `e45df5e5` (2026-04-01, grounded per zero-tolerance Rule 1c).

## Why

Pre-commit had been left uncommitted across the package; the same hooks would auto-apply this on any future align PR, surfacing as noise alongside future shards. Landing it now removes ambient drift.

Stage scope: `packages/kailash-align/` only. Other in-tree drift (`.kailash_ml/`, `docs/`, `examples/`, `.session-notes`) intentionally left unstaged per `coc-sync-landing.md` MUST Rule 2 (explicit-paths discipline) — that drift is unrelated to this sweep.

## Test plan

- [x] Pre-commit hooks pass (black, isort, ruff, eval-check, Tier-1 unit tests, doc-style)
- [ ] PR-gate path-skip on `packages/kailash-align/` only diff
- [ ] Admin-merge per chore PR pattern