### PR TITLE
fix(runtime): DurableExecutionEngine execution_mode opt-in (#882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.1] - 2026-05-08
+
+### Fixed
+
+- **`DurableExecutionEngine.execute()` enqueue/in-process race documented + caller-controlled (#882)** — the pre-fix engine always enqueued a fire-time `Task` BEFORE running the workflow in-process when both a dispatcher and a runtime were configured. The class docstring claimed "task_id idempotency prevents double-execution by the worker" — but `task_id` PRIMARY KEY idempotency only prevents duplicate ENQUEUE; it does not prevent two different actors (the in-process engine and a worker polling the queue) from each running the same enqueued task once. Between enqueue and the in-process path emitting its first checkpoint, a worker that picks up the task can start executing nodes that the in-process path will then re-execute. The in-tree `SQLTaskQueueDispatcher` worker + W1 checkpoint resume contain the blast radius (the second runner short-circuits via the checkpoint store), but the docstring misframed which defense was load-bearing and there was no caller-explicit way to opt out of the race. New `DurableExecutionEngineBuilder.execution_mode("in_process_only" | "dispatch_only" | "both")` setter is the explicit caller-intent surface. Default behaviour is preserved: omitting `.execution_mode(...)` auto-detects `"both"` when a dispatcher is configured and `"in_process_only"` otherwise, so every pre-2.16.1 call site continues to work without modification. New public read-only property `engine.execution_mode` surfaces the resolved mode. Explicit `"both"` and `"dispatch_only"` raise `ValueError` at `.build()` time when no dispatcher is configured (was previously a runtime surprise at the first `execute()` call). Class + `execute()` docstrings rewritten to correctly describe the layered defense (`task_id` PK idempotency = duplicate-enqueue prevention; W1 checkpoint resume = duplicate-execution short-circuit; race window between the two). 12 Tier-1 regression tests in `tests/regression/test_issue_882_durable_execution_mode.py`. Closes #882.
+
 ## [2.16.0] - 2026-05-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.16.0"
+version = "2.16.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -79,7 +79,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.16.0"
+__version__ = "2.16.1"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/runtime/durable.py
+++ b/src/kailash/runtime/durable.py
@@ -44,7 +44,28 @@ import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Callable, Dict, List, Mapping, Optional, Tuple, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
+
+# ExecutionMode — caller-explicit routing for DurableExecutionEngine.execute().
+# Default is None (auto-detect at build time: "both" with dispatcher,
+# "in_process_only" without). See DurableExecutionEngineBuilder.execution_mode.
+ExecutionMode = Literal["in_process_only", "dispatch_only", "both"]
+_VALID_EXECUTION_MODES: Tuple[ExecutionMode, ...] = (
+    "in_process_only",
+    "dispatch_only",
+    "both",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1126,13 +1147,18 @@ class DurableExecutionEngine:
       hook registry at construction time. The engine does NOT call
       ``runtime.on_node_complete(history_store.record_event)`` separately
       — doing so would double-register the subscriber.
-    * ``dispatcher`` is consulted ONLY when configured. When set,
-      :meth:`execute` enqueues a fire-time :class:`Task` via the
-      dispatcher in addition to running the workflow in-process. The
-      enqueue is best-effort observability of the run; dispatcher
-      failures emit a WARN log and do NOT abort the in-process
-      execution. Future: a worker-pool variant that defers execution
-      entirely to the dispatcher would override :meth:`execute`.
+    * ``dispatcher`` is consulted only when configured AND
+      :attr:`execution_mode` selects a dispatching path
+      (``"both"`` or ``"dispatch_only"``). When set under ``"both"``,
+      :meth:`execute` enqueues a fire-time :class:`Task` BEFORE running
+      the workflow in-process; the enqueue and the in-process run race,
+      and the structural defense is layered (dispatcher PRIMARY KEY
+      idempotency on ``task_id`` prevents duplicate enqueue; W1
+      checkpoint resume short-circuits the second runner). Callers
+      who need to eliminate the race entirely set
+      ``execution_mode="in_process_only"`` (skip enqueue) or
+      ``"dispatch_only"`` (skip the in-process runtime call). See
+      :meth:`execute` Routing notes (issue #882).
 
     Immutability
     ------------
@@ -1151,6 +1177,7 @@ class DurableExecutionEngine:
         idempotency_key_default: Optional[str],
         runtime_factory: Callable[..., Any],
         runtime_kwargs: Optional[Mapping[str, Any]],
+        execution_mode: ExecutionMode,
     ) -> None:
         """Construct an engine. Use :meth:`builder` for the public path."""
         # Build the wrapped runtime via the caller-supplied factory,
@@ -1190,6 +1217,7 @@ class DurableExecutionEngine:
         self._history_store = history_store
         self._dispatcher = dispatcher
         self._idempotency_key_default = idempotency_key_default
+        self._execution_mode: ExecutionMode = execution_mode
 
     # -- Public properties ---------------------------------------------
 
@@ -1229,6 +1257,17 @@ class DurableExecutionEngine:
     def idempotency_key_default(self) -> Optional[str]:
         """The default idempotency key applied when ``execute`` omits it."""
         return self._idempotency_key_default
+
+    @property
+    def execution_mode(self) -> ExecutionMode:
+        """The resolved execution mode for ``execute()`` calls.
+
+        One of ``"in_process_only"``, ``"dispatch_only"``, or ``"both"``.
+        Set explicitly via :meth:`DurableExecutionEngineBuilder.execution_mode`,
+        or auto-detected at build time (``"both"`` when a dispatcher is
+        configured, ``"in_process_only"`` otherwise).
+        """
+        return self._execution_mode
 
     # -- Builder factory -----------------------------------------------
 
@@ -1292,6 +1331,44 @@ class DurableExecutionEngine:
         who want best-effort dispatch should construct a custom
         :class:`~kailash.runtime.dispatcher.Dispatcher` whose ``enqueue``
         catches its own failures.
+
+        Routing — execution_mode contract (issue #882)
+        ----------------------------------------------
+        The branch taken is determined by :attr:`execution_mode`:
+
+        * ``"in_process_only"`` — runs in-process; skips enqueue even if
+          a dispatcher is configured. Returns ``(results, run_id)`` from
+          the wrapped runtime.
+        * ``"dispatch_only"`` — enqueues only; the wrapped runtime is
+          NOT invoked. Returns ``({}, schedule_id)`` so callers can
+          correlate downstream worker output via
+          ``engine.history.get_run(schedule_id, ...)``. The empty
+          ``results`` dict is the explicit "no in-process completion"
+          sentinel.
+        * ``"both"`` — enqueues AND runs in-process. The two paths race;
+          structural defenses below contain the blast radius.
+
+        When ``"both"`` is configured, two actors (the in-process engine
+        and a worker polling the queue) hold claims to the same task at
+        once. The structural defenses are layered:
+
+        * Dispatcher ``task_id`` PRIMARY KEY idempotency (``Dispatcher``
+          MUST Rule 1) prevents duplicate ENQUEUE — but does NOT prevent
+          two different runners from each executing the same enqueued
+          task once.
+        * W1 checkpoint resume short-circuits the second runner: when
+          the in-process path completes a node and emits a checkpoint
+          under the same ``idempotency_key``, the worker's subsequent
+          ``runtime.execute_workflow_async(idempotency_key=...)`` resolves
+          to the checkpoint and skips the already-completed nodes.
+        * Race window: between enqueue and the in-process path emitting
+          its first checkpoint, a worker that picks up the task can
+          start executing nodes that the in-process path will then
+          re-execute. The in-tree :class:`SQLTaskQueueDispatcher` worker
+          + W1 checkpoint resume contain this; custom Dispatchers MUST
+          honor the same ``idempotency_key`` resume contract or callers
+          MUST switch to ``"in_process_only"`` / ``"dispatch_only"`` to
+          eliminate the race entirely.
         """
         effective_inputs: Dict[str, Any] = (
             dict(inputs) if isinstance(inputs, Mapping) else {}
@@ -1302,16 +1379,20 @@ class DurableExecutionEngine:
             else self._idempotency_key_default
         )
 
+        do_dispatch = self._execution_mode in ("dispatch_only", "both")
+        do_in_process = self._execution_mode in ("in_process_only", "both")
+
         # Dispatch happens BEFORE in-process execution when configured —
         # the W3 contract treats enqueue as the durable record of intent.
         # If the dispatcher rejects the enqueue, in-process execution does
-        # NOT proceed (the operator surfaced a real error). Workers polling
-        # the queue will pick up the same task; idempotency on the
-        # dispatcher's ``task_id`` (Dispatcher MUST Rule 1) prevents
-        # double-execution by the worker if the in-process engine already
-        # ran the workflow.
+        # NOT proceed (the operator surfaced a real error). See the
+        # docstring "Routing" section for the full layered-defense story
+        # against the enqueue/in-process race window.
         run_id_hint: Optional[str] = None
-        if self._dispatcher is not None:
+        if do_dispatch:
+            # Builder.build() guarantees self._dispatcher is not None for
+            # any mode where do_dispatch is True; the typed delegate guard
+            # in _enqueue_for_run carries the actionable error message.
             run_id_hint = await self._enqueue_for_run(
                 workflow=workflow,
                 inputs=effective_inputs,
@@ -1320,30 +1401,51 @@ class DurableExecutionEngine:
                 queue_name=queue_name,
             )
 
-        # In-process execution. The runtime drives W1 (checkpoint emit)
-        # and W2 (history record) via its own hook registry.
-        results, run_id = await self._runtime.execute_workflow_async(
-            workflow,
-            inputs=effective_inputs,
-            idempotency_key=effective_key,
-            force_resume_with_drift=force_resume_with_drift,
-        )
-        # If the dispatcher returned a hint, the schedule_id and the
-        # in-process run_id are correlated via the engine's WARN log line
-        # so operators reading queue rows can find the matching history
-        # row without spelunking.
-        if run_id_hint is not None:
-            logger.info(
-                "durable.engine.execute.dispatched_and_executed",
-                extra={
-                    "schedule_id": run_id_hint,
-                    "run_id": run_id,
-                    "queue_name": queue_name,
-                    "has_history_store": self._history_store is not None,
-                    "has_checkpoint_store": self._checkpoint_store is not None,
-                },
+        if do_in_process:
+            # In-process execution. The runtime drives W1 (checkpoint emit)
+            # and W2 (history record) via its own hook registry.
+            results, run_id = await self._runtime.execute_workflow_async(
+                workflow,
+                inputs=effective_inputs,
+                idempotency_key=effective_key,
+                force_resume_with_drift=force_resume_with_drift,
             )
-        return results, run_id
+            # If the dispatcher returned a hint, the schedule_id and the
+            # in-process run_id are correlated via the engine's INFO log
+            # line so operators reading queue rows can find the matching
+            # history row without spelunking.
+            if run_id_hint is not None:
+                logger.info(
+                    "durable.engine.execute.dispatched_and_executed",
+                    extra={
+                        "schedule_id": run_id_hint,
+                        "run_id": run_id,
+                        "queue_name": queue_name,
+                        "has_history_store": self._history_store is not None,
+                        "has_checkpoint_store": self._checkpoint_store is not None,
+                    },
+                )
+            return results, run_id
+
+        # dispatch_only — return the schedule_id as the run identifier so
+        # callers can correlate worker output via the history store. The
+        # empty ``results`` dict is the explicit "no in-process completion"
+        # sentinel; callers SHOULD branch on execution_mode rather than on
+        # results-emptiness to distinguish dispatch-only from a real run
+        # that produced no node outputs.
+        logger.info(
+            "durable.engine.execute.dispatched_only",
+            extra={
+                "schedule_id": run_id_hint,
+                "queue_name": queue_name,
+                "has_history_store": self._history_store is not None,
+                "has_checkpoint_store": self._checkpoint_store is not None,
+            },
+        )
+        # run_id_hint is non-None here because do_dispatch was True;
+        # cast for the typed return contract.
+        assert run_id_hint is not None  # noqa: S101 — invariant from do_dispatch
+        return {}, run_id_hint
 
     # -- Internals -----------------------------------------------------
 
@@ -1462,6 +1564,9 @@ class DurableExecutionEngineBuilder:
         self._idempotency_key_default: Optional[str] = None
         self._runtime_factory: Optional[Callable[..., Any]] = None
         self._runtime_kwargs: Dict[str, Any] = {}
+        # None = auto-detect at build() (preserves pre-issue-882 behaviour:
+        # "both" with dispatcher, "in_process_only" without).
+        self._execution_mode: Optional[ExecutionMode] = None
 
     # -- Setters --------------------------------------------------------
 
@@ -1524,6 +1629,44 @@ class DurableExecutionEngineBuilder:
         self._runtime_factory = runtime_factory
         return self
 
+    def execution_mode(self, mode: ExecutionMode) -> "DurableExecutionEngineBuilder":
+        """Set the execution-routing contract for ``execute()`` (issue #882).
+
+        ``"in_process_only"``
+            Run the workflow in-process; skip the dispatcher even if
+            :meth:`dispatch_via` is also set. Eliminates the
+            enqueue/in-process race entirely. The dispatcher (if
+            configured) is retained on the engine for inspection
+            (``engine.dispatcher``) but ``execute()`` does not enqueue.
+
+        ``"dispatch_only"``
+            Enqueue the task; do NOT invoke the wrapped runtime.
+            ``execute()`` returns ``({}, schedule_id)``. Requires a
+            dispatcher — :meth:`build` raises ``ValueError`` if no
+            dispatcher is configured.
+
+        ``"both"``
+            Enqueue AND run in-process. The two paths race; W1
+            checkpoint resume + dispatcher PRIMARY KEY idempotency
+            contain the blast radius for the in-tree
+            :class:`SQLTaskQueueDispatcher`. Custom Dispatchers MUST
+            honor the same ``idempotency_key`` resume contract.
+            Requires a dispatcher — :meth:`build` raises if absent.
+
+        Calling ``.execution_mode(None)`` (or omitting the call) defers
+        to the auto-detect at :meth:`build` time:
+        ``"both"`` when a dispatcher is configured, ``"in_process_only"``
+        otherwise. This is the pre-issue-882 default and matches
+        existing call-site behaviour.
+        """
+        if mode is not None and mode not in _VALID_EXECUTION_MODES:
+            raise ValueError(
+                f"DurableExecutionEngineBuilder.execution_mode(): mode must "
+                f"be one of {_VALID_EXECUTION_MODES} or None, got {mode!r}"
+            )
+        self._execution_mode = mode
+        return self
+
     def runtime_kwargs(
         self, kwargs: Mapping[str, Any]
     ) -> "DurableExecutionEngineBuilder":
@@ -1573,6 +1716,26 @@ class DurableExecutionEngineBuilder:
         else:
             factory = self._runtime_factory
 
+        # Resolve execution_mode. None = auto-detect (issue #882): "both"
+        # when a dispatcher is configured, "in_process_only" otherwise.
+        # Explicit "both" / "dispatch_only" REQUIRE a dispatcher; raise
+        # ValueError to surface the misconfiguration at build time rather
+        # than at the first execute() call.
+        if self._execution_mode is None:
+            effective_mode: ExecutionMode = (
+                "both" if self._dispatcher is not None else "in_process_only"
+            )
+        else:
+            effective_mode = self._execution_mode
+            if effective_mode in ("both", "dispatch_only") and self._dispatcher is None:
+                raise ValueError(
+                    "DurableExecutionEngineBuilder.build(): execution_mode="
+                    f"{effective_mode!r} requires a dispatcher; call "
+                    ".dispatch_via(<Dispatcher>) before .build(), or use "
+                    'execution_mode="in_process_only" for runtime-only '
+                    "execution."
+                )
+
         return DurableExecutionEngine(
             checkpoint_store=self._checkpoint_store,
             history_store=self._history_store,
@@ -1580,4 +1743,5 @@ class DurableExecutionEngineBuilder:
             idempotency_key_default=self._idempotency_key_default,
             runtime_factory=factory,
             runtime_kwargs=self._runtime_kwargs,
+            execution_mode=effective_mode,
         )

--- a/tests/regression/test_issue_882_durable_execution_mode.py
+++ b/tests/regression/test_issue_882_durable_execution_mode.py
@@ -1,0 +1,373 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #882 — DurableExecutionEngine execution_mode.
+
+Pre-fix: ``DurableExecutionEngine.execute()`` always enqueued a task
+BEFORE running in-process when both a dispatcher and a runtime were
+configured. Workers polling the queue could pick up the enqueued task
+and start running BEFORE the in-process path completed; the engine's
+docstring claimed ``task_id`` PRIMARY KEY idempotency prevented
+double-execution, but PK idempotency only prevents duplicate ENQUEUE,
+not duplicate EXECUTION by two different actors.
+
+Post-fix: ``DurableExecutionEngineBuilder.execution_mode(...)`` is the
+explicit caller-intent surface. Three modes:
+
+* ``"in_process_only"`` — skip enqueue even if a dispatcher is set;
+  eliminates the race entirely.
+* ``"dispatch_only"`` — skip the in-process runtime call; require the
+  caller to plumb worker output downstream.
+* ``"both"`` — current pre-fix behaviour; the layered W1 checkpoint
+  resume + dispatcher PK idempotency contain the blast radius for
+  the in-tree :class:`SQLTaskQueueDispatcher`. Custom Dispatchers MUST
+  honor the ``idempotency_key`` resume contract or callers MUST
+  switch to one of the other two modes.
+
+Default behaviour is preserved: omitting ``.execution_mode(...)``
+auto-detects ``"both"`` when a dispatcher is configured and
+``"in_process_only"`` otherwise — every pre-fix call site continues
+to work without modification.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+import pytest
+
+from kailash.runtime.durable import DurableExecutionEngine
+from kailash.workflow.builder import WorkflowBuilder
+
+pytestmark = pytest.mark.regression
+
+
+# ---------------------------------------------------------------------------
+# Deterministic protocol-satisfying adapters (Tier-1 per testing.md exception)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    """Records ``execute_workflow_async`` invocations.
+
+    Issue #882 specifically tests the ROUTING decision in
+    ``DurableExecutionEngine.execute`` — whether the wrapped runtime
+    was invoked at all. Recording the call list is the contract.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.constructor_kwargs: Dict[str, Any] = dict(kwargs)
+        self.execute_calls: List[Dict[str, Any]] = []
+
+    async def execute_workflow_async(
+        self,
+        workflow: Any,
+        inputs: Mapping[str, Any],
+        *,
+        idempotency_key: Optional[str] = None,
+        force_resume_with_drift: bool = False,
+    ) -> Tuple[Dict[str, Any], str]:
+        self.execute_calls.append(
+            {
+                "workflow": workflow,
+                "inputs": dict(inputs),
+                "idempotency_key": idempotency_key,
+                "force_resume_with_drift": force_resume_with_drift,
+            }
+        )
+        return {"step1": {"result": {"value": 1}}}, "run_fake_001"
+
+
+class _FakeDispatcher:
+    """Records ``enqueue`` invocations; satisfies the Dispatcher ABC shape."""
+
+    def __init__(self) -> None:
+        self.enqueued: List[Any] = []
+
+    async def enqueue(self, task: Any) -> None:
+        self.enqueued.append(task)
+
+    def poll(self, _queue_name: str = "default"):  # pragma: no cover - unused
+        async def _empty():
+            if False:  # pragma: no cover
+                yield None
+
+        return _empty()
+
+    async def ack(self, _task_id: str) -> None:  # pragma: no cover - unused
+        return None
+
+    async def nack(self, _task_id: str, *, _reason: str) -> None:
+        # pragma: no cover - unused
+        return None
+
+
+def _build_minimal_workflow():
+    wb = WorkflowBuilder()
+    wb.add_node("PythonCodeNode", "step1", {"code": "result = {'value': 1}"})
+    return wb.build()
+
+
+# ---------------------------------------------------------------------------
+# Builder validation — execution_mode opt-in surface
+# ---------------------------------------------------------------------------
+
+
+def test_issue_882_invalid_mode_raises_value_error():
+    """Builder rejects unknown mode strings at the setter call.
+
+    Failure mode this prevents: a typo (``"in-process"``,
+    ``"in_process"`` without ``_only``) silently falls through to None
+    and surfaces as a routing surprise at execute() time. The setter
+    raises immediately so the typo is caught in the chain.
+    """
+    builder = DurableExecutionEngine.builder()
+    with pytest.raises(ValueError, match="execution_mode.*must be one of"):
+        builder.execution_mode("in-process")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="execution_mode.*must be one of"):
+        builder.execution_mode("dispatch")  # type: ignore[arg-type]
+
+
+def test_issue_882_dispatch_only_without_dispatcher_raises_at_build():
+    """``dispatch_only`` is meaningless without a dispatcher; reject at build.
+
+    The caller said "send everything to the queue, do not run in-process";
+    without a queue there is nowhere to send. Catching at build time is
+    cheaper than catching at the first execute() call.
+    """
+    builder = (
+        DurableExecutionEngine.builder()
+        .runtime(_FakeRuntime)
+        .execution_mode("dispatch_only")
+    )
+    with pytest.raises(ValueError, match="execution_mode='dispatch_only'"):
+        builder.build()
+
+
+def test_issue_882_both_without_dispatcher_raises_at_build():
+    """Explicit ``both`` requires a dispatcher.
+
+    Auto-detected ``both`` (mode=None + dispatcher set) produces ``both``;
+    auto-detected ``in_process_only`` (mode=None + no dispatcher) produces
+    ``in_process_only``. Explicit ``both`` is the caller saying "I want
+    BOTH paths to run", which requires a dispatcher to dispatch through.
+    """
+    builder = (
+        DurableExecutionEngine.builder().runtime(_FakeRuntime).execution_mode("both")
+    )
+    with pytest.raises(ValueError, match="execution_mode='both'"):
+        builder.build()
+
+
+def test_issue_882_in_process_only_without_dispatcher_succeeds():
+    """``in_process_only`` is valid without a dispatcher — the default shape."""
+    engine = (
+        DurableExecutionEngine.builder()
+        .runtime(_FakeRuntime)
+        .execution_mode("in_process_only")
+        .build()
+    )
+    assert engine.execution_mode == "in_process_only"
+    assert engine.dispatcher is None
+
+
+def test_issue_882_default_mode_with_dispatcher_auto_detects_both():
+    """Pre-issue-882 default behaviour: dispatcher present → ``both``."""
+    engine = (
+        DurableExecutionEngine.builder()
+        .runtime(_FakeRuntime)
+        .dispatch_via(_FakeDispatcher())
+        .build()
+    )
+    assert engine.execution_mode == "both"
+
+
+def test_issue_882_default_mode_without_dispatcher_auto_detects_in_process_only():
+    """Pre-issue-882 default behaviour: no dispatcher → ``in_process_only``."""
+    engine = DurableExecutionEngine.builder().runtime(_FakeRuntime).build()
+    assert engine.execution_mode == "in_process_only"
+
+
+# ---------------------------------------------------------------------------
+# Routing — execute() respects execution_mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_882_in_process_only_skips_enqueue_even_with_dispatcher():
+    """The bug fix: ``in_process_only`` with a dispatcher SKIPS enqueue.
+
+    Pre-fix: when the dispatcher was configured, enqueue ALWAYS fired.
+    Post-fix: explicit ``in_process_only`` keeps the dispatcher reachable
+    via ``engine.dispatcher`` for inspection but does not invoke it on
+    execute(). Eliminates the enqueue/in-process race entirely for
+    callers who have a dispatcher configured globally but want a
+    specific run to stay synchronous.
+    """
+    runtime_holder: List[_FakeRuntime] = []
+
+    def factory(**kwargs: Any) -> _FakeRuntime:
+        rt = _FakeRuntime(**kwargs)
+        runtime_holder.append(rt)
+        return rt
+
+    dispatcher = _FakeDispatcher()
+    engine = (
+        DurableExecutionEngine.builder()
+        .runtime(factory)
+        .dispatch_via(dispatcher)
+        .execution_mode("in_process_only")
+        .build()
+    )
+    workflow = _build_minimal_workflow()
+    _, run_id = await engine.execute(workflow, idempotency_key="k1")
+
+    # Runtime ran exactly once; dispatcher was NOT invoked.
+    assert len(runtime_holder[0].execute_calls) == 1
+    assert runtime_holder[0].execute_calls[0]["idempotency_key"] == "k1"
+    assert dispatcher.enqueued == []
+
+    # Engine still surfaces the dispatcher for inspection.
+    assert engine.dispatcher is dispatcher
+    assert run_id == "run_fake_001"
+
+
+@pytest.mark.asyncio
+async def test_issue_882_dispatch_only_skips_runtime_returns_schedule_id():
+    """``dispatch_only`` invokes ONLY the dispatcher; returns ``({}, schedule_id)``.
+
+    Eliminates the race from the other side: caller defers all execution
+    to the worker pool and gets a schedule_id back to correlate downstream
+    output via the history store.
+    """
+    runtime_holder: List[_FakeRuntime] = []
+
+    def factory(**kwargs: Any) -> _FakeRuntime:
+        rt = _FakeRuntime(**kwargs)
+        runtime_holder.append(rt)
+        return rt
+
+    dispatcher = _FakeDispatcher()
+    engine = (
+        DurableExecutionEngine.builder()
+        .runtime(factory)
+        .dispatch_via(dispatcher)
+        .execution_mode("dispatch_only")
+        .build()
+    )
+    workflow = _build_minimal_workflow()
+    results, run_id = await engine.execute(workflow, idempotency_key="dispatch_k1")
+
+    # Dispatcher fired exactly once; runtime was NOT invoked.
+    assert len(dispatcher.enqueued) == 1
+    enqueued_task = dispatcher.enqueued[0]
+    assert runtime_holder[0].execute_calls == []
+
+    # ({}, schedule_id) sentinel — empty results dict + schedule_id as run_id.
+    assert results == {}
+    assert run_id == enqueued_task.schedule_id
+    assert run_id.startswith("engine.")
+
+
+@pytest.mark.asyncio
+async def test_issue_882_both_mode_invokes_both_paths_in_order():
+    """Explicit ``"both"`` matches pre-issue-882 default-with-dispatcher.
+
+    Regression lock: the existing default behaviour (the path that
+    introduced the race the issue describes) MUST still work for
+    callers who explicitly opt in. The structural defense for this
+    mode is layered (W1 checkpoint resume + dispatcher PK idempotency)
+    and is documented in the engine docstring; this test verifies the
+    routing wiring, not the race-window defense itself.
+    """
+    runtime_holder: List[_FakeRuntime] = []
+
+    def factory(**kwargs: Any) -> _FakeRuntime:
+        rt = _FakeRuntime(**kwargs)
+        runtime_holder.append(rt)
+        return rt
+
+    dispatcher = _FakeDispatcher()
+    engine = (
+        DurableExecutionEngine.builder()
+        .runtime(factory)
+        .dispatch_via(dispatcher)
+        .execution_mode("both")
+        .build()
+    )
+    workflow = _build_minimal_workflow()
+    results, run_id = await engine.execute(workflow, idempotency_key="both_k1")
+
+    # Both paths fired.
+    assert len(dispatcher.enqueued) == 1
+    assert len(runtime_holder[0].execute_calls) == 1
+    # Real results from the in-process path; not the schedule_id sentinel.
+    assert results == {"step1": {"result": {"value": 1}}}
+    assert run_id == "run_fake_001"
+
+
+@pytest.mark.asyncio
+async def test_issue_882_default_with_dispatcher_matches_explicit_both():
+    """Default + dispatcher == explicit ``"both"`` (backward-compat anchor).
+
+    Pre-issue-882 callers who construct ``builder().dispatch_via(d).build()``
+    without ``.execution_mode(...)`` MUST continue to get the both-paths
+    behaviour. This regression test pins that contract.
+    """
+    runtime_holder: List[_FakeRuntime] = []
+
+    def factory(**kwargs: Any) -> _FakeRuntime:
+        rt = _FakeRuntime(**kwargs)
+        runtime_holder.append(rt)
+        return rt
+
+    dispatcher = _FakeDispatcher()
+    engine = (
+        DurableExecutionEngine.builder()
+        .runtime(factory)
+        .dispatch_via(dispatcher)
+        .build()  # no .execution_mode(...) — auto-detect
+    )
+    assert engine.execution_mode == "both"
+    workflow = _build_minimal_workflow()
+    await engine.execute(workflow, idempotency_key="default_k1")
+    assert len(dispatcher.enqueued) == 1
+    assert len(runtime_holder[0].execute_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_issue_882_default_without_dispatcher_runs_in_process_only():
+    """Default + no dispatcher == ``in_process_only`` (backward-compat anchor)."""
+    runtime_holder: List[_FakeRuntime] = []
+
+    def factory(**kwargs: Any) -> _FakeRuntime:
+        rt = _FakeRuntime(**kwargs)
+        runtime_holder.append(rt)
+        return rt
+
+    engine = DurableExecutionEngine.builder().runtime(factory).build()
+    assert engine.execution_mode == "in_process_only"
+    workflow = _build_minimal_workflow()
+    results, run_id = await engine.execute(workflow, idempotency_key="solo_k1")
+    assert len(runtime_holder[0].execute_calls) == 1
+    assert results == {"step1": {"result": {"value": 1}}}
+    assert run_id == "run_fake_001"
+
+
+def test_issue_882_engine_execution_mode_property_exposed():
+    """``engine.execution_mode`` is a public read-only property.
+
+    Surfaces the resolved mode for callers who construct the engine via
+    a factory and want to verify the routing without re-deriving it.
+    """
+    engine = (
+        DurableExecutionEngine.builder()
+        .runtime(_FakeRuntime)
+        .execution_mode("in_process_only")
+        .build()
+    )
+    assert engine.execution_mode == "in_process_only"
+    # Property is read-only — no setter exposed (engine is immutable).
+    assert isinstance(
+        type(DurableExecutionEngine).__dict__.get("execution_mode")
+        or DurableExecutionEngine.__dict__["execution_mode"],
+        property,
+    )


### PR DESCRIPTION
## Summary

Closes #882. The pre-fix engine always enqueued a Task BEFORE running the workflow in-process when both a dispatcher and a runtime were configured. The class docstring claimed task_id idempotency prevented double-execution, but task_id PRIMARY KEY idempotency only prevents duplicate ENQUEUE — two different actors (in-process engine + worker polling the queue) could each run the same enqueued task once.

## What changed

- New .execution_mode(mode) setter on DurableExecutionEngineBuilder — caller-explicit routing surface:
  - "in_process_only" — runs in-process; skips enqueue even if a dispatcher is configured. Eliminates the race entirely.
  - "dispatch_only" — enqueues only; skips the wrapped runtime. Returns ({}, schedule_id).
  - "both" — pre-fix behaviour; the structural defenses (W1 checkpoint resume + dispatcher PK idempotency) are documented honestly.
- New engine.execution_mode read-only property — surfaces the resolved mode.
- Builder validation at build() — explicit "both" / "dispatch_only" raise ValueError when no dispatcher is configured.
- Default behaviour preserved — omitting .execution_mode(...) auto-detects: "both" with dispatcher, "in_process_only" without. Every pre-2.16.1 call site continues to work unchanged.
- Docstring rewrites (class + execute()) — correctly describe the layered defense.

## Tests

- tests/regression/test_issue_882_durable_execution_mode.py — 12 Tier-1 tests
- All 654 tests/unit/runtime/ tests pass (3 infra-skipped, unrelated)

## Version

kailash 2.16.0 → 2.16.1 (pyproject.toml + __init__.py::__version__) + CHANGELOG entry, per build-repo-release-discipline.md MUST Rule 5.

## Related issues

Closes #882