### PR TITLE
release: kailash 2.18.0 — slim core (#890)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.18.0] - 2026-05-08
+
 ### Changed — BREAKING (slim core, #890)
 
 `pip install kailash` now ships a slim default of **13 packages** (down from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.17.0"
+version = "2.18.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.17.0"
+__version__ = "2.18.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep for **kailash 2.18.0** shipping the #890 slim-core refactor to PyPI.

- pyproject.toml::version 2.17.0 → 2.18.0
- src/kailash/__init__.py::__version__ 2.17.0 → 2.18.0
- CHANGELOG [Unreleased] § "Changed — BREAKING (slim core, #890)" promoted to [2.18.0] - 2026-05-08

Per `git.md` § Release-Prep PRs: this branch (`release/v2.18.0`) auto-skips the PR-gate matrix because the diff is metadata-only (pyproject.toml + CHANGELOG + __version__).

## What ships

- `pip install kailash` → **13 packages** (was 89, -85%)
- `pip install kailash[all]` → 165 packages (full back-compat — Fernet + Ed25519 + fastapi + providers + observability + redis + all DBs + telemetry preserved)
- 13 hard orphans deleted across 5 sub-package manifests
- Loud-failure ImportError + install hint on every lazy-loaded surface (WorkflowServer, trust.auth.jwt, SharePointGraph)
- Extras renamed (full migration table in CHANGELOG): `[postgres]` → `[db-postgres]`, `[mysql]` → `[db-mysql]`, `[http]` → `[http-client]`, `[mfa]` → `[auth]`, `[otel]` → `[telemetry]`, `[distributed]` → `[redis]`; `[cli]` and `[files]` removed (folded into core/server respectively).

## Release flow

1. ✓ Version bump (this PR)
2. CI auto-skip per release-branch convention
3. Admin merge
4. Push `v2.18.0` tag → triggers `publish-pypi.yml`
5. Clean-venv install verification

## Related issues

Closes #890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)