### PR TITLE
release(dataflow): v2.9.0 — slim install + audit-store loud failure

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,50 @@
 # DataFlow Changelog
 
+## [2.9.0] — 2026-05-09 — slim install + audit-store loud failure
+
+Minor bump aligning kailash-dataflow with the kailash 2.18.0 slim-core
+refactor (#890). Default install drops 17 transitive packages; database
+drivers move behind per-DB extras. `kailash-dataflow[all]` preserves the
+pre-2.9.0 install verbatim.
+
+### Changed
+
+- **Slim default install** — `pip install kailash-dataflow` now installs
+  only `kailash>=2.18.0`, sqlalchemy, asyncpg, click, sqlparse. asyncpg
+  stays core because the migrations module imports it at module scope;
+  every other driver is opt-in.
+- **Database driver extras** — `[postgres-sync]` (psycopg2-binary),
+  `[mysql]` (aiomysql), `[sqlite]` (aiosqlite), `[mongo]` (motor +
+  pymongo[srv]), `[redis]`. Pick what your app uses.
+- **Functional extras** — `[api]` (fastapi), `[security]` (cryptography),
+  `[monitoring]` (psutil), `[templates]` (PyJWT + pydantic + fastapi for
+  SaaS / API gateway starter scaffolds).
+- **Backwards-compat umbrella** — `pip install 'kailash-dataflow[all]'`
+  preserves the full pre-2.9.0 install for users not ready to migrate.
+- **Floor bump** — `kailash>=2.16.0` → `kailash>=2.18.0` to match the
+  slim-core release surface.
+
+### Fixed
+
+- **fix(security): audit-store signing fails loudly when cryptography is
+  missing** (`src/dataflow/trust/audit.py:350-360`) — a configured signing
+  key with the `[security]` extra uninstalled now raises `ImportError`
+  with the install hint instead of silently degrading the audit path.
+  Per `zero-tolerance.md` Rule 3 — no silent fallback on security paths.
+
+### Migration
+
+If your app uses MySQL / SQLite / MongoDB / Redis drivers OR audit-record
+signing OR the SaaS template, install the appropriate extras:
+
+| Old install                                   | New install                                |
+| --------------------------------------------- | ------------------------------------------ |
+| `pip install kailash-dataflow` (with MySQL)   | `pip install 'kailash-dataflow[mysql]'`    |
+| `pip install kailash-dataflow` (with SQLite)  | `pip install 'kailash-dataflow[sqlite]'`   |
+| `pip install kailash-dataflow` (with MongoDB) | `pip install 'kailash-dataflow[mongo]'`    |
+| `pip install kailash-dataflow` (signing keys) | `pip install 'kailash-dataflow[security]'` |
+| (any of the above; full preserve)             | `pip install 'kailash-dataflow[all]'`      |
+
 ## [2.8.1] — 2026-05-07 — append-only enforcement orphan polish
 
 Patch bump shipping defense-in-depth around the append-only model contract from 2.8.0. No public API change.

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.8.1"
+version = "2.9.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.16.0",
+    "kailash>=2.18.0",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.8.1"
+__version__ = "2.9.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/tests/unit/fabric/test_resource_warning.py
+++ b/packages/kailash-dataflow/tests/unit/fabric/test_resource_warning.py
@@ -175,7 +175,16 @@ class TestPipelineExecutorResourceWarning:
 
 
 class TestConnectionManagerResourceWarning:
-    """ConnectionManager.__del__ must warn when the pool is still initialized."""
+    """ConnectionManager.__del__ is a no-op since #835.
+
+    Pre-#835, ConnectionManager retained ``self._adapter`` owning an asyncpg
+    pool, and ``__del__`` emitted ``ResourceWarning`` when the manager was
+    GC'd while still initialized. Post-#835 (PR #856), ``initialize_pool`` is
+    a transient reachability check; long-lived pools are owned by
+    ``AsyncSQLDatabaseNode._get_adapter()`` and reaped via
+    ``WeakValueDictionary`` on loop close. The leak surface this finalizer
+    used to guard does not exist on ConnectionManager anymore.
+    """
 
     def _make_manager(self, initialized: bool):
         from dataflow.utils.connection import ConnectionManager
@@ -185,8 +194,13 @@ class TestConnectionManagerResourceWarning:
         manager._adapter = MagicMock() if initialized else None
         return manager
 
-    def test_warns_when_initialized(self):
-        """An initialized ConnectionManager that is GC'd leaks DB connections."""
+    def test_no_op_when_initialized(self):
+        """Post-#835: __del__ is a no-op even when initialized=True.
+
+        ConnectionManager no longer owns the pool, so there is no leak surface
+        for the finalizer to warn about. The leak coverage moved to
+        AsyncSQLDatabaseNode + the registry reaper.
+        """
         manager = self._make_manager(initialized=True)
 
         with warnings.catch_warnings(record=True) as caught:
@@ -194,10 +208,7 @@ class TestConnectionManagerResourceWarning:
             manager.__del__()
 
             resource = [w for w in caught if issubclass(w.category, ResourceWarning)]
-            assert len(resource) == 1
-            message = str(resource[0].message)
-            assert "Unclosed ConnectionManager" in message
-            assert "close_all_connections" in message
+            assert resource == []
 
     def test_silent_when_not_initialized(self):
         """A never-initialized ConnectionManager must NOT warn."""


### PR DESCRIPTION
## Summary

- **kailash-dataflow 2.9.0** — minor bump mirroring the kailash 2.18.0 (#890) slim-core refactor at the dataflow layer
- **Default install** drops 17 transitive packages; database drivers (`mysql`, `sqlite`, `mongo`, `redis`) and functional surfaces (`security`, `api`, `monitoring`, `templates`) move behind opt-in extras; `kailash-dataflow[all]` umbrella preserves the pre-2.9.0 install verbatim
- **fix(security)**: audit-store signing now raises a typed `ImportError` with install hint when `cryptography` (now in `[security]` extra) is missing — no silent fallback per `zero-tolerance.md` Rule 3
- **Floor bump**: `kailash>=2.16.0` → `kailash>=2.18.0`
- **Test sweep**: closes the orphaned ResourceWarning test from PR #856 (issue #835) — `ConnectionManager.__del__` is intentionally a no-op since #835 moved pool ownership to `AsyncSQLDatabaseNode`, but the Phase 6.4 ResourceWarning test was left asserting old behavior

## Migration

| Old install | New install |
|---|---|
| `pip install kailash-dataflow` (with MySQL) | `pip install 'kailash-dataflow[mysql]'` |
| `pip install kailash-dataflow` (with SQLite) | `pip install 'kailash-dataflow[sqlite]'` |
| `pip install kailash-dataflow` (with MongoDB) | `pip install 'kailash-dataflow[mongo]'` |
| `pip install kailash-dataflow` (signing keys) | `pip install 'kailash-dataflow[security]'` |
| (any of the above; full preserve) | `pip install 'kailash-dataflow[all]'` |

Full migration table in `packages/kailash-dataflow/CHANGELOG.md` § [2.9.0].

## Scope discipline

- This is a metadata-only release-prep PR per `git.md` Release-Prep PRs convention — opened from `release/v2.9.0-dataflow` to trigger the PR-gate auto-skip
- The test sweep is in scope as a same-class fix-immediately per `autonomous-execution.md` Rule 4 — the test asserts behavior that PR #856 (issue #835) intentionally removed
- Pre-existing test debt outside this scope (11 unit tests across 5 dataflow subsystems failing on main, silent because CI doesn't gate on `packages/kailash-dataflow/tests/unit/`) is documented in #898

## Test plan

- [x] Pre-flight `packages/kailash-dataflow/tests/unit/trust/` (CI's gating scope): 94/94 pass
- [x] Pre-flight `tests/unit/fabric/test_resource_warning.py`: 10/10 pass (was 9/10 with `test_warns_when_initialized` failing on main; now `test_no_op_when_initialized` covers the post-#835 contract)
- [x] Pre-commit hooks pass (ruff, type annotations, no debug statements, etc.)
- [x] Asyncpg-at-module-scope claim in pyproject.toml verified — 17 migrations files import asyncpg at module scope; staying core is correct
- [ ] PR-gate workflow auto-skips the matrix per `release/v*` convention
- [ ] Admin-merge after path-filter auto-skip
- [ ] `/release` for kailash-dataflow 2.9.0 — separate authorization required per `feedback_no_auto_cicd.md`
- [ ] Clean-venv install verification per `build-repo-release-discipline.md` Rule 2

## Related

- Closes none directly (consolidation release of #890 phase-2 dataflow work)
- Tracks: #898 (pre-existing test debt + CI gating gap)
- Companion: PR #856 / issue #835 (test sweep this PR completes)
- Mirrors: kailash 2.18.0 release shape (#897)