### PR TITLE
feat(scheduler): pause/resume/update_cron control methods (issue #913 Shard 0)

### DIFF
--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -722,6 +722,158 @@ class WorkflowScheduler:
 
         logger.info("Cancelled schedule: %s", schedule_id)
 
+    def pause(self, schedule_id: str) -> None:
+        """Pause a scheduled workflow without removing it.
+
+        Sets the underlying APScheduler job's ``next_run_time`` to ``None``
+        so no further fires occur until :meth:`resume` is called. The schedule
+        remains registered in :attr:`_schedules` and recoverable via
+        :meth:`list_schedules` (with ``enabled=False``). Idempotent — calling
+        ``pause`` twice on an already-paused schedule succeeds with no-op.
+
+        Args:
+            schedule_id: The ID returned by ``schedule_cron`` /
+                ``schedule_interval`` / ``schedule_once``.
+
+        Raises:
+            ScheduleNotFound: If ``schedule_id`` is not registered with this
+                scheduler. Typed exception (``RuntimeException`` subclass) so
+                admin surfaces (Nexus handlers, CLIs) can map cleanly to
+                HTTP 404 / exit code 4 etc.
+
+        Example:
+            >>> sid = scheduler.schedule_cron(workflow, "0 6 * * *")
+            >>> scheduler.pause(sid)         # halt fires
+            >>> scheduler.pause(sid)         # idempotent — no-op
+            >>> scheduler.resume(sid)        # resume from now
+        """
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        if schedule_id not in self._schedules:
+            raise ScheduleNotFound(schedule_id)
+
+        # APScheduler's `pause_job` is naturally idempotent: a second call on
+        # an already-paused job is a no-op (next_run_time stays None). We
+        # still reflect the state on our cached ScheduleInfo for callers
+        # that don't immediately list_schedules() afterwards.
+        self._scheduler.pause_job(schedule_id)
+        info = self._schedules[schedule_id]
+        info.enabled = False
+        info.next_run_time = None
+
+        logger.info("Paused schedule: %s", schedule_id)
+
+    def resume(self, schedule_id: str) -> None:
+        """Resume a paused schedule, recomputing the next fire from current cron/interval.
+
+        On resume, APScheduler recomputes ``next_run_time`` from the trigger
+        (cron / interval / date) — so the next fire is "now" forward, NOT
+        the paused-at timestamp. Idempotent — calling ``resume`` twice on an
+        already-running schedule succeeds with no-op.
+
+        Args:
+            schedule_id: The ID returned by ``schedule_cron`` /
+                ``schedule_interval`` / ``schedule_once``.
+
+        Raises:
+            ScheduleNotFound: If ``schedule_id`` is not registered.
+
+        Example:
+            >>> scheduler.resume(sid)        # recomputes next_run_time
+            >>> scheduler.resume(sid)        # idempotent — no-op
+        """
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        if schedule_id not in self._schedules:
+            raise ScheduleNotFound(schedule_id)
+
+        # APScheduler's `resume_job` recomputes next_run_time from the
+        # trigger; second call on an already-running job is a no-op
+        # (next_run_time already advanced via the trigger). The recomputed
+        # fire time reflects "now forward" — interval triggers MOVE the
+        # next fire to roughly now+interval, NOT the paused-at instant.
+        self._scheduler.resume_job(schedule_id)
+        job = self._scheduler.get_job(schedule_id)
+        info = self._schedules[schedule_id]
+        if job is not None and job.next_run_time is not None:
+            info.enabled = True
+            info.next_run_time = job.next_run_time
+        else:
+            # Once-schedules whose run_at has passed return a job with
+            # next_run_time=None even after resume — the trigger has
+            # nothing left to fire. Reflect that honestly.
+            info.enabled = False
+            info.next_run_time = None
+
+        logger.info("Resumed schedule: %s", schedule_id)
+
+    def update_cron(self, schedule_id: str, cron_expression: str) -> None:
+        """Replace a cron schedule's expression and recompute next-fire.
+
+        Validates the new cron expression with the same 5-field check used
+        by :meth:`schedule_cron`, then atomically swaps the trigger via
+        APScheduler's ``reschedule_job`` so subsequent fires use the new
+        cron. ``ScheduleInfo.trigger_args`` is updated to reflect the new
+        expression so :meth:`list_schedules` returns the current state.
+
+        Args:
+            schedule_id: The ID returned by ``schedule_cron``.
+            cron_expression: A cron expression string with 5 fields
+                (minute hour day_of_month month day_of_week).
+
+        Raises:
+            ScheduleNotFound: If ``schedule_id`` is not registered.
+            ValueError: If ``cron_expression`` is not a valid 5-field cron
+                expression. Message starts with ``"invalid cron"`` for
+                grep-able matching by admin surfaces.
+
+        Example:
+            >>> sid = scheduler.schedule_cron(workflow, "0 6 * * *")
+            >>> scheduler.update_cron(sid, "0 */2 * * *")  # every 2 hours
+        """
+        from apscheduler.triggers.cron import CronTrigger
+
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        if schedule_id not in self._schedules:
+            raise ScheduleNotFound(schedule_id)
+
+        # Validate field count BEFORE handing to APScheduler so the error
+        # message stays uniform with `schedule_cron`'s validator. Bare
+        # `CronTrigger.from_crontab` accepts some variants we'd rather
+        # reject up-front for consistency.
+        parts = cron_expression.strip().split()
+        if len(parts) != 5:
+            raise ValueError(
+                f"invalid cron: expression must have exactly 5 fields "
+                f"(minute hour day month weekday), got {len(parts)}: "
+                f"'{cron_expression}'"
+            )
+        try:
+            trigger = CronTrigger.from_crontab(cron_expression, timezone=self._timezone)
+        except ValueError as exc:
+            # Re-raise with the canonical `invalid cron` prefix so admin
+            # callers can pattern-match on the message.
+            raise ValueError(f"invalid cron: {exc}") from exc
+
+        # `reschedule_job` swaps the trigger atomically AND recomputes
+        # next_run_time from the new trigger — exactly the semantic an
+        # operator expects when editing the cron at runtime.
+        self._scheduler.reschedule_job(schedule_id, trigger=trigger)
+
+        info = self._schedules[schedule_id]
+        info.trigger_args = {"cron_expression": cron_expression}
+        job = self._scheduler.get_job(schedule_id)
+        if job is not None:
+            info.next_run_time = job.next_run_time
+            info.enabled = job.next_run_time is not None
+
+        logger.info(
+            "Updated schedule cron: id=%s, cron='%s'",
+            schedule_id,
+            cron_expression,
+        )
+
     def list_schedules(self) -> List[ScheduleInfo]:
         """List all active schedules.
 

--- a/src/kailash/sdk_exceptions.py
+++ b/src/kailash/sdk_exceptions.py
@@ -217,6 +217,29 @@ class CircuitBreakerOpenError(RuntimeException):
     """
 
 
+class ScheduleNotFound(RuntimeException):
+    """Raised when a schedule control operation references an unknown schedule_id.
+
+    Issued by ``WorkflowScheduler`` admin methods (``pause`` / ``resume`` /
+    ``update_cron``) when the supplied ``schedule_id`` does not match any
+    registered schedule. The typed exception lets ops surfaces (Nexus admin
+    handlers, CLI tools) distinguish "schedule never existed / already
+    cancelled" from generic runtime failures so they can return HTTP 404 vs
+    500 cleanly.
+
+    Sibling of ``KeyError`` raised by ``WorkflowScheduler.cancel`` for
+    backwards compatibility — new admin surfaces SHOULD prefer
+    ``ScheduleNotFound`` for stable semantics across SDK versions.
+
+    Attributes:
+        schedule_id: The unknown schedule identifier the caller supplied.
+    """
+
+    def __init__(self, schedule_id: str, message: str | None = None) -> None:
+        self.schedule_id = schedule_id
+        super().__init__(message or f"Schedule {schedule_id!r} not found")
+
+
 class RetryExhaustedException(RuntimeException):
     """Raised when all retry attempts are exhausted for an operation.
 

--- a/tests/integration/runtime/test_scheduler_control_methods.py
+++ b/tests/integration/runtime/test_scheduler_control_methods.py
@@ -1,0 +1,365 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 wiring tests for ``WorkflowScheduler`` admin control methods (#913).
+
+Covers ``pause`` / ``resume`` / ``update_cron`` end-to-end against a real
+APScheduler ``AsyncIOScheduler`` with an in-memory job store. Per
+``rules/testing.md`` Tier 2: NO mocking of the scheduler; assertions
+observe externally-visible behaviour (fire counts, ``next_run_time``
+deltas, raised exceptions). Per ``rules/orphan-detection.md`` Rule 2,
+the new methods are wired into the framework's hot path
+(``self._scheduler.pause_job`` / ``resume_job`` / ``reschedule_job``)
+and Tier 2 MUST observe the externally-visible effect.
+
+Skips if APScheduler is not installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+apscheduler = pytest.importorskip(
+    "apscheduler", reason="WorkflowScheduler requires APScheduler"
+)
+
+
+def _counter_workflow(counter_path: str):
+    """Build a WorkflowBuilder whose every fire increments a tempfile counter.
+
+    The counter file is the test's state surface; deterministic — no
+    randomness, no clocks, no network. Reading the file at any point
+    gives an exact fire count for assertions.
+    """
+    from kailash.workflow.builder import WorkflowBuilder
+
+    code = (
+        f"import os\n"
+        f"_p = {counter_path!r}\n"
+        f"_n = 0\n"
+        f"if os.path.exists(_p):\n"
+        f"    with open(_p) as _f:\n"
+        f"        _n = int(_f.read().strip() or '0')\n"
+        f"_n += 1\n"
+        f"with open(_p, 'w') as _f:\n"
+        f"    _f.write(str(_n))\n"
+        f"result = {{'attempts': _n}}\n"
+    )
+    builder = WorkflowBuilder()
+    builder.add_node("PythonCodeNode", "start", {"code": code})
+    return builder
+
+
+def _read_counter(counter_path: str) -> int:
+    import os
+
+    if not os.path.exists(counter_path):
+        return 0
+    with open(counter_path) as f:
+        return int(f.read().strip() or "0")
+
+
+async def _wait_until(predicate, *, timeout: float, poll: float = 0.05) -> bool:
+    """Poll ``predicate`` until True or ``timeout`` expires.
+
+    Bounded-timeout helper so tests never hang on a stuck scheduler.
+    Returns True if the predicate became True before the timeout, False
+    otherwise — caller asserts on the returned bool plus follow-up state.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(poll)
+    return predicate()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSchedulerControlMethods:
+    """End-to-end tests for pause / resume / update_cron."""
+
+    # ------------------------------------------------------------------
+    # pause / resume — observable behaviour against a running scheduler
+    # ------------------------------------------------------------------
+
+    async def test_pause_skips_fires_resume_restarts(self, tmp_path):
+        """Pause halts all fires; resume restarts cadence from now-forward."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        counter = str(tmp_path / "pause_resume.cnt")
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            schedule_id = scheduler.schedule_interval(
+                _counter_workflow(counter),
+                seconds=0.5,
+                name="pause-resume",
+            )
+
+            # Allow at least one fire so we have a non-zero baseline before pause.
+            assert await _wait_until(
+                lambda: _read_counter(counter) >= 1, timeout=3.0
+            ), f"baseline fire never happened (counter={_read_counter(counter)})"
+            baseline = _read_counter(counter)
+
+            # Pause and observe: counter MUST NOT advance for ≥ 2× the cron interval
+            # (1.0s for a 0.5s interval). We sample at the end so a single early
+            # fire scheduled before pause cannot mask the assertion.
+            scheduler.pause(schedule_id)
+            await asyncio.sleep(1.2)
+            after_pause = _read_counter(counter)
+            assert after_pause == baseline, (
+                f"pause did not halt fires: baseline={baseline}, "
+                f"after_pause={after_pause} (interval=0.5s, slept 1.2s)"
+            )
+
+            # Resume; observable effect: at least one new fire within 2× interval.
+            scheduler.resume(schedule_id)
+            assert await _wait_until(
+                lambda: _read_counter(counter) > after_pause, timeout=3.0
+            ), (
+                f"resume did not restart fires: after_pause={after_pause}, "
+                f"current={_read_counter(counter)}"
+            )
+
+            scheduler.cancel(schedule_id)
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_resume_recomputes_next_fire_from_now(self, tmp_path):
+        """After pause, resume's next_run_time MUST be 'now' forward, not the paused-at instant."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        counter = str(tmp_path / "resume_recompute.cnt")
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            schedule_id = scheduler.schedule_interval(
+                _counter_workflow(counter),
+                seconds=60,  # long interval so we observe the next_run_time, not fires
+                name="resume-recompute",
+            )
+
+            # Capture the original next_run_time set at schedule time.
+            before_pause = scheduler.list_schedules()
+            before_paused_nft = next(
+                s.next_run_time for s in before_pause if s.schedule_id == schedule_id
+            )
+            assert before_paused_nft is not None
+
+            scheduler.pause(schedule_id)
+            paused_state = scheduler.list_schedules()
+            paused_nft = next(
+                s.next_run_time for s in paused_state if s.schedule_id == schedule_id
+            )
+            assert paused_nft is None, "pause should clear next_run_time"
+
+            # Sleep enough that the recomputed next_run_time MUST be later than
+            # the original (which was 60s out from schedule-time).
+            await asyncio.sleep(0.5)
+            scheduler.resume(schedule_id)
+
+            after_resume = scheduler.list_schedules()
+            after_resume_nft = next(
+                s.next_run_time for s in after_resume if s.schedule_id == schedule_id
+            )
+            assert after_resume_nft is not None, "resume should recompute next_run_time"
+            # Recomputed time MUST be at or after the original (cadence advanced
+            # from "now" forward, NOT from the paused-at instant). On a 60s
+            # interval the recomputed time should be approx now+60s.
+            assert after_resume_nft >= before_paused_nft, (
+                f"resume did not recompute forward: "
+                f"original={before_paused_nft} resumed={after_resume_nft}"
+            )
+
+            scheduler.cancel(schedule_id)
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_pause_idempotent(self, tmp_path):
+        """pause() twice on an already-paused schedule succeeds with no-op."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            schedule_id = scheduler.schedule_interval(
+                _counter_workflow(str(tmp_path / "idem_pause.cnt")),
+                seconds=60,
+                name="idem-pause",
+            )
+
+            scheduler.pause(schedule_id)  # first
+            scheduler.pause(schedule_id)  # second — MUST NOT raise
+
+            state = next(
+                s for s in scheduler.list_schedules() if s.schedule_id == schedule_id
+            )
+            assert state.enabled is False
+            assert state.next_run_time is None
+
+            scheduler.cancel(schedule_id)
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_resume_idempotent(self, tmp_path):
+        """resume() twice on a running schedule succeeds with no-op."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            schedule_id = scheduler.schedule_interval(
+                _counter_workflow(str(tmp_path / "idem_resume.cnt")),
+                seconds=60,
+                name="idem-resume",
+            )
+
+            scheduler.resume(schedule_id)  # first — running already, no-op
+            scheduler.resume(schedule_id)  # second — still no-op
+
+            state = next(
+                s for s in scheduler.list_schedules() if s.schedule_id == schedule_id
+            )
+            assert state.enabled is True
+            assert state.next_run_time is not None
+
+            scheduler.cancel(schedule_id)
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_pause_unknown_schedule_raises_schedule_not_found(self):
+        """pause() on an unknown schedule_id raises ScheduleNotFound."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            with pytest.raises(ScheduleNotFound) as excinfo:
+                scheduler.pause("sched-does-not-exist")
+            assert excinfo.value.schedule_id == "sched-does-not-exist"
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_resume_unknown_schedule_raises_schedule_not_found(self):
+        """resume() on an unknown schedule_id raises ScheduleNotFound."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            with pytest.raises(ScheduleNotFound) as excinfo:
+                scheduler.resume("sched-also-missing")
+            assert excinfo.value.schedule_id == "sched-also-missing"
+        finally:
+            scheduler.shutdown(wait=False)
+
+    # ------------------------------------------------------------------
+    # update_cron — replace trigger and recompute next-fire
+    # ------------------------------------------------------------------
+
+    async def test_update_cron_replaces_trigger(self, tmp_path):
+        """update_cron swaps the trigger; subsequent fires use the new cron."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        counter = str(tmp_path / "update_cron.cnt")
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            # Original cron: only fires once a year (deliberately rare so the
+            # only fires we observe come from the post-update trigger).
+            schedule_id = scheduler.schedule_cron(
+                _counter_workflow(counter),
+                "0 0 1 1 *",  # midnight Jan 1
+                name="update-cron",
+            )
+
+            # No fires yet — the original cron's next instant is months/years out.
+            assert _read_counter(counter) == 0
+
+            # Update to "every minute" — APScheduler's CronTrigger will compute
+            # the next fire to within ≤60s. We observe trigger_args change AND
+            # the next_run_time advance to a much sooner instant.
+            #
+            # NOTE: list_schedules() returns the SAME ScheduleInfo objects it
+            # caches — so we snapshot the field BEFORE updating, otherwise
+            # the same object's `next_run_time` mutates underfoot.
+            before_info = next(
+                s for s in scheduler.list_schedules() if s.schedule_id == schedule_id
+            )
+            before_nft = before_info.next_run_time
+            before_args = dict(before_info.trigger_args)
+            assert before_args == {"cron_expression": "0 0 1 1 *"}
+
+            scheduler.update_cron(schedule_id, "* * * * *")
+            after_info = next(
+                s for s in scheduler.list_schedules() if s.schedule_id == schedule_id
+            )
+
+            assert after_info.trigger_args == {
+                "cron_expression": "* * * * *"
+            }, f"trigger_args not updated: {after_info.trigger_args}"
+            assert after_info.next_run_time is not None
+            assert after_info.next_run_time < before_nft, (
+                f"new cron did not bring next_run_time forward: "
+                f"old={before_nft}, new={after_info.next_run_time}"
+            )
+
+            scheduler.cancel(schedule_id)
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_update_cron_unknown_schedule_raises_schedule_not_found(self):
+        """update_cron() on an unknown schedule_id raises ScheduleNotFound."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            with pytest.raises(ScheduleNotFound) as excinfo:
+                scheduler.update_cron("sched-missing", "0 0 * * *")
+            assert excinfo.value.schedule_id == "sched-missing"
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_update_cron_invalid_expr_raises_value_error(self, tmp_path):
+        """update_cron() rejects malformed cron with ValueError('invalid cron')."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            schedule_id = scheduler.schedule_cron(
+                _counter_workflow(str(tmp_path / "bad_cron.cnt")),
+                "0 0 * * *",
+                name="bad-cron",
+            )
+
+            # Wrong field count: 4 fields rather than 5.
+            with pytest.raises(ValueError, match="invalid cron"):
+                scheduler.update_cron(schedule_id, "0 0 * *")
+
+            # Wrong field syntax: APScheduler's CronTrigger rejects "99" hour.
+            with pytest.raises(ValueError, match="invalid cron"):
+                scheduler.update_cron(schedule_id, "0 99 * * *")
+
+            # Original schedule still intact after failed updates.
+            state = next(
+                s for s in scheduler.list_schedules() if s.schedule_id == schedule_id
+            )
+            assert state.trigger_args == {"cron_expression": "0 0 * * *"}, (
+                f"failed update_cron should NOT mutate trigger_args: "
+                f"{state.trigger_args}"
+            )
+
+            scheduler.cancel(schedule_id)
+        finally:
+            scheduler.shutdown(wait=False)


### PR DESCRIPTION
## Summary

Adds the runtime schedule-editing surface to ``WorkflowScheduler`` so ops
can pause, resume, and edit the cron of a registered schedule without a
code deploy. This closes the operational regression vs celery +
django-celery-beat noted in #913 by giving the scheduler the primitives
on which Shards 1-4 will build the Nexus admin handlers.

Fixes a piece of #913.

## Shard 0 of 5

This is the first of five shards for issue #913 (admin API for
``WorkflowScheduler``). Shard 0 lands the Core SDK control surface;
Shards 1-4 will build the Nexus admin handlers (HTTP list / pause /
resume / update-cron) on top of these methods.

## What this PR adds

**3 new methods on ``WorkflowScheduler``** (``src/kailash/runtime/scheduler.py``):

- ``pause(schedule_id)`` — halts further fires; idempotent (no-op on
  already-paused). Updates cached ``ScheduleInfo`` so ``list_schedules``
  reports ``enabled=False`` / ``next_run_time=None``.
- ``resume(schedule_id)`` — recomputes ``next_run_time`` from the
  trigger so cadence is from-now-forward (NOT paused-at instant).
  Idempotent.
- ``update_cron(schedule_id, expr)`` — validates cron expression
  up-front, atomically swaps the trigger via
  ``APScheduler.reschedule_job``, recomputes next-fire, updates
  ``ScheduleInfo.trigger_args``.

**1 new exception class** (``src/kailash/sdk_exceptions.py``):

- ``ScheduleNotFound(RuntimeException)`` — raised by all three control
  methods when the supplied ``schedule_id`` is not registered. Typed so
  Nexus admin handlers (Shards 1-4) can map cleanly to HTTP 404 vs 500.
  Carries the failing ``schedule_id`` as an attribute.

## Tier-2 test coverage

``tests/integration/runtime/test_scheduler_control_methods.py`` — 9
integration tests against a real APScheduler ``AsyncIOScheduler`` with
in-memory job store (NO mocking per testing.md Tier 2):

- ``test_pause_skips_fires_resume_restarts`` — observes counter does
  NOT advance during pause (≥ 2× the 0.5s interval), advances after
  resume.
- ``test_resume_recomputes_next_fire_from_now`` — pauses a 60s-interval
  schedule, sleeps, resumes; asserts new ``next_run_time`` is at-or-after
  the original (cadence advanced from now-forward).
- ``test_pause_idempotent`` / ``test_resume_idempotent`` — second call
  on same state is a no-op (asserts cached state stays consistent).
- ``test_pause_unknown_schedule_raises_schedule_not_found`` /
  ``test_resume_unknown_schedule_raises_schedule_not_found`` /
  ``test_update_cron_unknown_schedule_raises_schedule_not_found`` —
  typed exception path with ``schedule_id`` attribute round-trip.
- ``test_update_cron_replaces_trigger`` — original cron fires once a
  year; update to ``"* * * * *"`` advances ``next_run_time`` to within
  a minute and reflects new ``trigger_args``.
- ``test_update_cron_invalid_expr_raises_value_error`` — wrong field
  count AND APScheduler-rejected hour value both raise
  ``ValueError("invalid cron: ...")``; original schedule intact after
  failed updates.

All 9 new tests pass. Pre-existing 20 scheduler integration tests (retry
primitives, lifecycle hooks) still pass — no regressions.

## Coordination with #912 Shard 1 (parallel wave)

This shard touches ``WorkflowScheduler`` methods + adds one exception
class. The sibling Shard 1 (#912) edits ``BaseRuntime`` /
``LocalRuntime`` / ``AsyncLocalRuntime`` / ``DistributedRuntime``
``execute(...)`` signatures and adds different exception classes
(``SoftTimeLimitExceeded`` / ``HardTimeLimitExceeded``) to the same
``sdk_exceptions.py`` file. Both edits are additive in the exceptions
module; no conflict expected at merge.

## Cross-SDK alignment

Descriptive only — kailash-rs has its own scheduler surface; runtime
schedule editing parity for the Rust side is a separate workstream
tracked in that repo per repo-scope-discipline.

## Test plan

- [x] ``pytest tests/integration/runtime/test_scheduler_control_methods.py`` — 9/9 pass
- [x] ``pytest tests/integration/runtime/test_scheduler*.py`` — 29/29 pass (no regressions)
- [x] ``pytest --collect-only -q tests/`` — exit 0 (17112 tests collected)
- [x] ``pre-commit run --files <changed>`` — all hooks pass (Black / isort / Ruff / type annotations / etc.)
- [ ] CI matrix green