### PR TITLE
chore(coc): commit /analyze + /todos plans for #911 / #912 / #913

### DIFF
--- a/workspaces/issue-911-multi-queue-routing/01-analyze/architecture-plan.md
+++ b/workspaces/issue-911-multi-queue-routing/01-analyze/architecture-plan.md
@@ -1,0 +1,331 @@
+# Issue #911: multi-queue routing in WorkflowScheduler
+
+> Phase 01 (`/analyze`) deliverable. Read-only — no code edits, no PRs, no issues filed.
+
+## Brief summary
+
+Issue #911 (`feat(distributed): multi-queue routing in DistributedRuntime + Worker`) asks for first-class multi-queue routing primitives in the distributed runtime so a single `DistributedRuntime` instance can route different workflows to different logical queues (`fast`, `slow`, `analysis`), and a single `Worker` process can dequeue from a `{queue_name: concurrency}` map with per-queue concurrency limits — equivalent to celery's `-Q queue1,queue2 -c 4` semantics.
+
+Today the producer side (`DistributedRuntime`) has no queue parameter, the consumer side (`Worker`) consumes a single TaskQueue, and `TaskQueue.__init__` takes a single `queue_key` (Redis list name) per instance. The `Task` dataclass at `src/kailash/runtime/dispatcher.py:127` and the SQL-backed `SQLTaskQueue` at `src/kailash/infrastructure/task_queue.py:143` already carry a `queue_name: str = "default"` field — i.e. partial multi-queue scaffolding exists at the queue-payload layer but is NOT plumbed through the producer/consumer surfaces in `runtime/distributed.py`. The work for #911 is to extend the producer + consumer + Redis `TaskQueue` to honor `queue_name`, compose with the lifecycle hooks landed in #915 and the `RetrySpec` retry primitive landed in #916, and preserve the current single-queue default so the change is non-breaking.
+
+## Brief corrections
+
+The user-supplied prompt asserted that issue **#912 is a "signature cleanup" of `DistributedRuntime.execute(workflow, parameters=None, **kwargs)`** that #911 should layer on top of. That framing is **incorrect\*\*. Verified:
+
+| Brief claim                                                                      | Verdict | Evidence                                                                                                                                                                                                                                                                 |
+| -------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| "#912 replaces `**kwargs` with explicit typed kwargs"                            | FALSE   | `gh issue view 912` — issue #912 is `feat(runtime): per-task soft/hard time limits in Worker + WorkflowScheduler`. It proposes adding `soft_time_limit=N, time_limit=M` kwargs, NOT cleaning up the existing `**kwargs`.                                                 |
+| "`DistributedRuntime.execute` at `distributed.py:480-520` silently drops kwargs" | TRUE    | `src/kailash/runtime/distributed.py:502-544` — `def execute(self, workflow, parameters=None, **kwargs)` accepts `**kwargs` and never reads them after the signature. This IS a silent-drop bug per `zero-tolerance.md` Rule 3c, but it is NOT the subject of issue #912. |
+| "TaskQueue.**init** takes a single `queue_key`"                                  | TRUE    | `src/kailash/runtime/distributed.py:178` — `queue_key: str = _QUEUE_KEY`. One Redis list per `TaskQueue` instance.                                                                                                                                                       |
+| "Worker dequeues from one queue"                                                 | TRUE    | `src/kailash/runtime/distributed.py:625` — `self._queue = queue or TaskQueue(...)`. Single queue reference, no multi-queue map.                                                                                                                                          |
+| "DistributedRuntime has no `queue_name` parameter today"                         | TRUE    | `src/kailash/runtime/distributed.py:474-490` — constructor has no `queue_name`/`queue` routing param, only a single optional `TaskQueue`.                                                                                                                                |
+| "`Task` dataclass has no concept of queue name today"                            | FALSE   | `src/kailash/runtime/dispatcher.py:127` — `queue_name: str = "default"` already exists. The scheduler-side dispatcher path already plumbs queue_name; only the Redis-side `TaskQueue` + `DistributedRuntime` + `Worker` are missing the wiring.                          |
+| "SQLTaskQueue has no concept of queue name today"                                | FALSE   | `src/kailash/infrastructure/task_queue.py:143,243,332` — `queue_name` is a column on the `task_queue` table and a parameter on `enqueue()` / `dequeue()` / `requeue_stale()` / `get_stats()` / `purge_completed()`.                                                      |
+
+**Implication for the plan**: the user's framing of "#911 reuses #912's cleaned signature" cannot be honored as-stated because #912 is not a signature-cleanup workstream. The `**kwargs` silent-drop bug at `distributed.py:502-544` IS real and IS a `zero-tolerance.md` Rule 3c violation, but it is in-scope for #911 itself: the queue routing surface this plan introduces is the moment to convert `**kwargs` into the named, consumed kwargs the surface advertises. This plan therefore (a) treats `queue_name=` as the first explicit named kwarg added to the surface and (b) preserves the existing `parameters=` shape but converts the dangling `**kwargs` into a documented forwarding boundary — see § "API surface" below.
+
+## Upstream dependency on #912
+
+There is no upstream dependency on #912 for issue #911. #912 is **per-task soft/hard time limits** on a different axis (task duration, not task routing). The two issues compose orthogonally: a producer can supply BOTH `queue_name="slow"` AND `soft_time_limit=300` independently. If #912 lands first, the queue-routing surface MUST accept `soft_time_limit=` / `time_limit=` as forwardable kwargs without overloading their semantics. If #912 lands later, this plan's named-kwarg discipline (every accepted kwarg has a consumer) MUST extend to `soft_time_limit=` / `time_limit=` then.
+
+The actual upstream dependencies for #911 are:
+
+1. **#915 — lifecycle hooks** (already merged, `feat(scheduler): /redteam round-2 — observability + ctx-manager (#910)` 2026-05-09 commit `dc182dcc`). The new `Worker.on_task_*` registries at `src/kailash/runtime/distributed.py:640-644` (`_hooks_prerun`, `_hooks_postrun`, `_hooks_success`, `_hooks_retry`, `_hooks_failure`) MUST receive the queue name in the `TaskEvent` payload so handlers can route to per-queue alerting (e.g. dashboard `slow_queue_failure_rate`).
+2. **#916 — retry primitives** (already merged, `feat(scheduler): per-job retry primitives via RetrySpec (#910)` commit `3bd3445e`). The `RetrySpec` dataclass at `src/kailash/runtime/scheduler.py:74-210` and the in-process retry loop at `_execute_workflow:838-925` are scheduler-internal — `RetrySpec` is BLOCKED from queue-dispatch path today (`scheduler.py:768-774`). #911's queue routing MUST NOT silently re-route this BLOCK; the dispatcher-side retry contract remains the dispatcher's domain.
+
+## Failure-point analysis
+
+Numbered failure points; each is `condition → consequence → mitigation`. Drives the test plan.
+
+### 1. Queue selection determinism
+
+**Condition.** Producer calls `runtime.execute(wf, queue="fast")`. The producer SDK and the Worker MUST both agree on a canonical Redis-list key (`kailash:tasks:pending:fast` vs `kailash:tasks:fast` vs `fast`) — drift between producer and consumer silently strands tasks on a queue no Worker dequeues from.
+
+**Consequence.** Tasks enqueued forever pending; users see "queued" status in `get_result()` indefinitely and assume worker exhaustion. The masking-helper-failure-on-success class (`observability.md` Rule 6.1) at the routing layer.
+
+**Mitigation.** Single canonical helper `_make_queue_key(queue_name) -> str` co-located in `runtime/distributed.py` AND `infrastructure/task_queue.py` (or, preferably, exported once from a new helper module so both producer + consumer import the same function — same structural defense as `kailash.utils.url_credentials` in `security.md` § "Credential Decode Helpers"). Tier 2 round-trip test: producer enqueues with `queue_name="fast"`, consumer dequeues from a `Worker(queues={"fast": 1})` and asserts the task is the same one. Structural invariant test: `_make_queue_key("fast")` returns the byte-for-byte expected string `kailash:tasks:pending:fast` (pin the format).
+
+### 2. Default queue compatibility (single-queue users today)
+
+**Condition.** Existing users have `DistributedRuntime(redis_url=...)` and `Worker(redis_url=...)` running in production today. The shipped Redis list key is `_QUEUE_KEY = "kailash:tasks:pending"` (`distributed.py:56`).
+
+**Consequence.** A naive change to `kailash:tasks:pending:default` orphans every in-flight task already enqueued under the old key. Same failure-mode class as `zero-tolerance.md` Rule 6a public-API removal without deprecation cycle.
+
+**Mitigation.** The "default" queue MUST resolve to the EXACT existing `_QUEUE_KEY` string (`kailash:tasks:pending`) — i.e. `_make_queue_key("default")` returns `"kailash:tasks:pending"`, NOT `"kailash:tasks:pending:default"`. Non-default queues get the suffix: `_make_queue_key("fast")` returns `"kailash:tasks:pending:fast"`. Pin this asymmetry in the structural invariant test. Cross-SDK note: kailash-rs MUST adopt the same asymmetry per `cross-sdk-inspection.md` Rule 4 (byte-pin vectors).
+
+### 3. Queue-priority inversion / starvation
+
+**Condition.** `Worker(queues={"fast": 8, "slow": 2})` polls multiple queues. The dequeue loop picks queues in some order. If the loop is naive ("for queue in queues: try dequeue"), a slow-queue task that's polled FIRST under a `BLMOVE timeout=2` blocks the worker for 2s before the fast-queue is even consulted — under load, fast-queue tasks accumulate.
+
+**Consequence.** "Multi-queue worker" silently behaves as a sequential N-queue serializer. The advertised "slow task does not block fast task pickup" acceptance criterion in #911 fails. Same class as `zero-tolerance.md` Rule 2 fake-dispatch (the dispatcher accepts queue names but no branch in the dispatcher fires them in parallel).
+
+**Mitigation.** Per-queue independent dequeue tasks: a `Worker` with `queues={"fast": 8, "slow": 2}` spawns ONE asyncio dequeue-loop task per queue, each with its own concurrency semaphore sized to the per-queue concurrency. Polling is `BLMOVE` per-queue in parallel, NOT a serialized round-robin. Tier 2 test: enqueue 1 slow-task that sleeps 30s + 100 fast-tasks; assert `fast` tasks complete with median latency < 1s and the slow-task completes around 30s.
+
+### 4. Per-queue concurrency budget vs visibility timeout
+
+**Condition.** A queue declared with `concurrency=2` and `visibility_timeout=300` (default) holds at most 2 tasks claimed per worker. If a third producer enqueues, the third task waits — which is correct. But if a worker holds a task longer than `visibility_timeout` (legitimate slow-queue work > 5 min), Redis re-delivers the same task to a sibling worker.
+
+**Consequence.** Slow-queue users get duplicate execution silently. Dashboards show 2× completion count.
+
+**Mitigation.** `Worker(queues=...)` MUST accept per-queue `visibility_timeout` overrides via the dict syntax `queues={"slow": {"concurrency": 2, "visibility_timeout": 1800}, "fast": 8}` — bare int means "concurrency only, default visibility_timeout". Document this in the `queues=` parameter docstring with a code example. Tier 2 test: slow queue with `visibility_timeout=10` against a 30-sec workflow observes re-delivery; same test with `visibility_timeout=60` observes single delivery.
+
+### 5. Queue persistence on resume / multi-instance scheduler dedup
+
+**Condition.** A scheduler dispatches a job at planned-fire-time T to queue `slow`. The scheduler crashes; a second scheduler instance fires the same job at T+ε. Per `scheduler.py:780-832`, both scheduler instances compute the same `task_id = compute_task_id(schedule_id, planned_fire_time)`. Today the dispatch path is queue-agnostic; tomorrow with #911, the SECOND fire might pick a different queue if the scheduler's queue-resolver depends on instance-local state.
+
+**Consequence.** Same task_id ends up on TWO queues, defeating queue-layer dedup. `Task.queue_name` is currently part of the dataclass but NOT part of `compute_task_id` (`dispatcher.py:45-78`). Consequence: queue routing must be a deterministic function of (schedule_id) AND must be persisted with the schedule, NOT computed at fire time from a mutable scheduler-local table.
+
+**Mitigation.** `WorkflowScheduler.schedule_*` accepts `queue=` at schedule-registration time; the value is persisted into APScheduler's job-store kwargs alongside `_kailash_retry_spec`. Fire-time dispatch reads `queue` from the persisted kwargs — every scheduler instance computing for the same `schedule_id` resolves to the SAME queue. `compute_task_id` does NOT change (only `(schedule_id, planned_fire_time)` is hashed) — this is correct because two schedulers MUST agree on the queue too, which they do via persisted job kwargs. Tier 2 test: schedule a job with `queue="slow"`, verify APScheduler-stored kwargs include the queue, simulate scheduler restart, verify the resumed schedule still dispatches to `slow`.
+
+### 6. Lifecycle-event correlation across queues
+
+**Condition.** Worker handlers registered via `on_task_success(handler)` (`distributed.py:700`) receive a `TaskEvent` dataclass. Today `TaskEvent` carries `task_id`, `workflow_name`, `attempt`, `worker_id`, `elapsed_ms`, `exception` (`lifecycle_events.py:36-63`). It does NOT carry `queue_name`.
+
+**Consequence.** A handler that wants to alert "slow queue failure rate > X" cannot tell which queue the failed task came from. Operators add a side-channel grep on `task_id` against an external table — institutional debt.
+
+**Mitigation.** Add `queue_name: Optional[str] = None` to `TaskEvent` (`frozen=True` dataclass — additive only, default None preserves serialization). Worker `_execute_task` populates `queue_name` from `task.queue_name` (already on the `Task` dataclass at `dispatcher.py:127`) OR from the TaskMessage queue origin (need to add the field on `TaskMessage` at `distributed.py:64-99`). Tier 2 test: handler registered via `on_task_success` receives `event.queue_name == "slow"` for a task enqueued to `slow`.
+
+### 7. Worker registry observability per queue
+
+**Condition.** Today `_WORKER_SET_KEY = "kailash:workers"` (`distributed.py:61`) is a flat set. With multi-queue, an operator wants to know "how many workers are polling `slow`?".
+
+**Consequence.** No way to dashboard per-queue worker capacity. Falls under `observability.md` § Mandatory Log Points 4 (state transitions, config loads MUST log which file/env var was used) — multi-queue worker registration without queue tags is invisible.
+
+**Mitigation.** `_send_heartbeat` at `distributed.py:1020-1038` already records `worker_id`, `timestamp`, `active_tasks`, `concurrency`. Extend the heartbeat JSON to include `queues: {"fast": 8, "slow": 2}` (the per-queue concurrency map). Add a `get_status()` per-queue breakdown. Log line `worker.start` MUST emit at INFO with `queues=...` per `observability.md` Rule 4.
+
+### 8. Queue name validation (injection / control-character safety)
+
+**Condition.** `queue_name` ends up as a substring of a Redis list key (`kailash:tasks:pending:<queue_name>`) AND as a column value in `SQLTaskQueue` (`infrastructure/task_queue.py:243` — `VARCHAR DEFAULT 'default'`). A malicious or accidental queue name like `"fast\nDROP TABLE"` or `"fast:other_user_queue"` is structurally able to leak into the key namespace.
+
+**Consequence.** Redis key collision / namespace squatting. Same failure-mode class as `dataflow-identifier-safety.md` (uncited but conceptually identical) — declared identifier strings MUST be sanitized at the validation gate.
+
+**Mitigation.** A typed validator: `_validate_queue_name(name: str) -> str` raises `ValueError` if name doesn't match `^[a-zA-Z0-9_-]{1,64}$`. Called once at every entry point: `runtime.execute(queue=)`, `Worker(queues=)`, `scheduler.schedule_*(queue=)`. Tier 1 unit test enumerates passing + rejecting cases (control chars, colons, slashes, empty, > 64 chars).
+
+### 9. Missing-queue / typo soft-fail behaviour
+
+**Condition.** Producer calls `runtime.execute(wf, queue="fasst")` (typo). No worker is polling `fasst`.
+
+**Consequence.** Task sits forever; user sees "queued" status. Mirrors failure point 1 but the cause is producer-side, not framework-side.
+
+**Mitigation.** Producer-side: enqueue ALWAYS succeeds — Redis enqueue cannot validate worker presence atomically. But the producer MUST log `runtime.execute.start` at INFO with `queue=fasst, run_id=...` per `observability.md` Rule 1 so the user can grep their own logs. Worker-side: `Worker.start()` logs `worker.queues_registered queue_names=[...]` so the deployment topology is greppable. Documented operator workflow: `runtime.get_queue_status(queue="fasst")` returns `{"pending": N, "processing": 0, "workers": 0}` — `workers: 0` is the missing-queue tell.
+
+### 10. Cross-SDK alignment (kailash-rs)
+
+**Condition.** Per `cross-sdk-inspection.md` Rule 1, every issue found / fixed in one SDK MUST inspect the other. Multi-queue routing is a cross-cutting infrastructure primitive, not a Python idiom.
+
+**Consequence.** If kailash-rs ships its own `DistributedRuntime` with a different queue-key format (`kailash::tasks::fast` vs `kailash:tasks:pending:fast`), users running both SDKs against the same Redis cannot share queues; cross-language dashboards drift.
+
+**Mitigation.** This plan documents the canonical `_make_queue_key` shape (point 2 above). Per `cross-sdk-inspection.md` Rule 4, when the Rust SDK ships its equivalent, it MUST consume the SAME helper output and pin ≥3 byte-vectors against the Python output. Descriptive only in this plan — NO filing recommendation per repo-scope-discipline (we are in `kailash-py`, not orchestrating `kailash-rs`).
+
+## API surface
+
+Defaults preserve current single-queue semantics across every entry point. New named kwargs only.
+
+### Producer: `DistributedRuntime`
+
+```python
+class DistributedRuntime(BaseRuntime):
+    def __init__(
+        self,
+        redis_url: str = "",
+        queue: Optional[TaskQueue] = None,
+        visibility_timeout: int = 300,
+        result_ttl: int = 3600,
+        *,
+        default_queue: str = "default",  # NEW: producer default for unqualified .execute() calls
+        **kwargs,
+    ): ...
+
+    def execute(
+        self,
+        workflow: Workflow,
+        parameters: Optional[Dict[str, Any]] = None,
+        *,
+        queue: Optional[str] = None,  # NEW: routes to this queue; None → self._default_queue
+    ) -> Tuple[Dict[str, Any], str]: ...
+    # NOTE: existing `**kwargs` REMOVED — every kwarg this surface accepts must be
+    # consumed (per zero-tolerance.md Rule 3c). If/when issue #912 lands soft_time_limit/
+    # time_limit, those become explicit named kwargs the same way.
+```
+
+### Consumer: `Worker`
+
+```python
+QueueSpec = Union[int, Mapping[str, Any]]  # bare int = concurrency; mapping = full per-queue config
+
+class Worker:
+    def __init__(
+        self,
+        redis_url: str = "",
+        queue: Optional[TaskQueue] = None,  # legacy single-queue path; mutually exclusive with queues=
+        concurrency: int = 1,
+        heartbeat_interval: int = 30,
+        dead_worker_timeout: int = 90,
+        worker_id: Optional[str] = None,
+        runtime_factory: Optional[Callable] = None,
+        *,
+        queues: Optional[Mapping[str, QueueSpec]] = None,  # NEW: {"fast": 8, "slow": {"concurrency": 2, "visibility_timeout": 1800}}
+    ): ...
+```
+
+Defaults preserve today's behavior: `Worker(redis_url=..., concurrency=N)` resolves to `queues={"default": N}` internally. Mutual-exclusion: passing BOTH `queue=<TaskQueue>` AND `queues=...` raises `ValueError` at construction (named-kwarg discipline; do NOT silently prefer one).
+
+### Scheduler integration: `WorkflowScheduler.schedule_*`
+
+```python
+def schedule_cron(
+    self, workflow_builder, cron_expression, name="",
+    *, retry: Optional[RetrySpec] = None,
+    queue: Optional[str] = None,  # NEW: persisted into job kwargs alongside _kailash_retry_spec
+    **kwargs,
+) -> str: ...
+```
+
+The internal `_compose_job_kwargs` at `scheduler.py:743-778` extends to thread `queue` via a sibling sentinel `_KAILASH_QUEUE_KWARG = "_kailash_queue"`. At fire-time, `_dispatch_to_queue` (`scheduler.py:1018-1104`) constructs a `Task(queue_name=queue or "default", ...)` — the existing `Task.queue_name` field at `dispatcher.py:127` is finally honored on the producer side. Composes with `RetrySpec` exactly as `RetrySpec` composes today: `RetrySpec` is in-process only and remains BLOCKED on `dispatch_via=` per `scheduler.py:768-774`; `queue=` is queue-dispatch only. The two are orthogonal.
+
+### Lifecycle event payload extension
+
+```python
+@dataclass(frozen=True)
+class TaskEvent:
+    task_id: str
+    workflow_name: Optional[str]
+    attempt: int
+    max_attempts: int
+    worker_id: str
+    elapsed_ms: Optional[float] = None
+    exception: Optional[BaseException] = None
+    timestamp: float = field(default_factory=time.time)
+    queue_name: Optional[str] = None  # NEW: routes lifecycle events to per-queue alerters
+```
+
+Additive default-None field on a frozen dataclass — backward compatible for every handler that destructures `event.task_id` etc.
+
+### Helper module: `kailash.runtime._queue_keys`
+
+```python
+# NEW FILE: src/kailash/runtime/_queue_keys.py
+_DEFAULT_QUEUE = "default"
+_QUEUE_KEY_BASE = "kailash:tasks:pending"
+_PROCESSING_KEY_BASE = "kailash:tasks:processing"
+
+def make_queue_key(queue_name: str) -> str:
+    """Producer/consumer-shared canonical Redis-list-key shape.
+
+    Default queue resolves to the legacy unsuffixed key for back-compat
+    (per failure-point #2). Named queues append `:<name>`.
+    """
+    validate_queue_name(queue_name)
+    if queue_name == _DEFAULT_QUEUE:
+        return _QUEUE_KEY_BASE  # "kailash:tasks:pending" — the existing live key
+    return f"{_QUEUE_KEY_BASE}:{queue_name}"
+
+def make_processing_key(queue_name: str) -> str: ...
+def validate_queue_name(name: str) -> None: ...  # raises on invalid
+```
+
+`distributed.py` MUST import + use this helper (no inline string format); same for any future Rust SDK port (cross-SDK byte-shape parity per `cross-sdk-inspection.md` Rule 4).
+
+## Implementation sketch
+
+Sized per `autonomous-execution.md` Per-Session Capacity Budget. Three shards, each ≤ 500 LOC load-bearing logic, each ≤ 5–10 invariants, each describable in 3 sentences.
+
+### Shard 1 — Helper module + producer plumbing (~300 LOC, 5 invariants)
+
+**Files**: `src/kailash/runtime/_queue_keys.py` (new, ~80 LOC), `src/kailash/runtime/distributed.py` (TaskQueue + DistributedRuntime, ~150 LOC delta), `tests/unit/runtime/test_queue_keys.py` (new, ~80 LOC).
+
+**Invariants**: (1) `make_queue_key("default")` byte-for-byte equals existing `_QUEUE_KEY`. (2) `validate_queue_name` rejects the documented bad set. (3) `DistributedRuntime.execute(queue=...)` routes via the helper. (4) `**kwargs` removed from `execute` signature; `queue=` is the single new explicit kwarg. (5) `TaskMessage` gains a `queue_name: str = "default"` field, additive on a non-frozen dataclass with default — JSON round-trip preserves it.
+
+**Sentence**: "Add the canonical key helper, plumb queue name through TaskMessage and DistributedRuntime.execute, and remove the silent-drop `**kwargs`."
+
+### Shard 2 — Worker multi-queue dequeue loop (~450 LOC, 8 invariants)
+
+**Files**: `src/kailash/runtime/distributed.py` (Worker class, ~250 LOC delta), `tests/integration/runtime/test_worker_multi_queue.py` (new, ~200 LOC). Real Redis Tier 2.
+
+**Invariants**: (1) `Worker(concurrency=N)` and `Worker(queues={"default": N})` are externally indistinguishable (legacy parity). (2) Per-queue dequeue tasks are independent asyncio tasks. (3) Per-queue semaphores enforce per-queue concurrency. (4) Per-queue visibility-timeout overrides honored. (5) Mutually-exclusive `queue=` and `queues=` raise at construction. (6) Slow-queue task MUST NOT block fast-queue dequeue (the acceptance-criteria #3 from issue #911). (7) Heartbeat JSON includes `queues={...}`. (8) Lifecycle hooks receive `event.queue_name`.
+
+**Sentence**: "Replace the single-queue dequeue loop with one asyncio task per declared queue, each with its own semaphore and visibility timeout, and thread `queue_name` through every lifecycle event."
+
+### Shard 3 — Scheduler dispatch composition + lifecycle event extension (~250 LOC, 5 invariants)
+
+**Files**: `src/kailash/runtime/scheduler.py` (`schedule_cron/interval/once` + `_compose_job_kwargs` + `_dispatch_to_queue`, ~120 LOC delta), `src/kailash/runtime/lifecycle_events.py` (TaskEvent additive field, ~5 LOC), `tests/integration/runtime/test_scheduler_queue_routing.py` (new, ~150 LOC).
+
+**Invariants**: (1) `schedule_cron(..., queue=)` persists queue into APScheduler job kwargs. (2) Fire-time dispatch reads queue from persisted kwargs (deterministic across scheduler instances per failure-point #5). (3) Composing `queue=` with `dispatch_via=None` raises `ValueError` (queue routing requires a dispatcher). (4) Composing `queue=` with `retry=RetrySpec(...)` raises `ValueError` (retry is in-process; queue is dispatcher-side; the pair is meaningless together — same shape as the existing `retry + dispatch_via` BLOCK at `scheduler.py:768-774`). (5) `TaskEvent.queue_name` is populated end-to-end through Worker → handler.
+
+**Sentence**: "Persist queue routing as a scheduler kwarg via the same _kailash_\*\_kwarg sentinel pattern as retry, dispatch via the existing Task(queue_name=) field, and extend the lifecycle event payload."
+
+**Total**: ~1,000 LOC across 3 shards, ~500 of which is tests. Within the 3-shard / single-session capacity per `autonomous-execution.md` Rule 1. Each shard has an executable feedback loop (pytest tier-2 with real Redis), so each may use up to 3–5× the base budget per Rule 3.
+
+## Test plan
+
+### Tier 1 (unit)
+
+- `tests/unit/runtime/test_queue_keys.py`
+  - `make_queue_key("default") == "kailash:tasks:pending"` (byte-pin for back-compat)
+  - `make_queue_key("fast") == "kailash:tasks:pending:fast"`
+  - `make_queue_key("slow") == "kailash:tasks:pending:slow"`
+  - `make_processing_key("default") == "kailash:tasks:processing"`
+  - `validate_queue_name` accepts: `"default"`, `"fast"`, `"slow_queue"`, `"a-b-c"`, `"x" * 64`
+  - `validate_queue_name` rejects: `""`, `"x" * 65`, `"with space"`, `"with:colon"`, `"with/slash"`, `"with\nnewline"`, `"with\x00null"`
+
+- `tests/unit/runtime/test_distributed_runtime_signature_invariant.py` (new structural invariant per `cross-sdk-inspection.md` Rule 3a)
+  - `inspect.signature(DistributedRuntime.execute).parameters` contains `workflow, parameters, queue` and NO `**kwargs` — pin the surface so future refactors can't regrow the silent-drop.
+
+### Tier 2 (integration, real Redis)
+
+- `tests/integration/runtime/test_worker_multi_queue.py`
+  - **Slow-queue does not block fast-queue (#911 acceptance criterion 3).** Spawn `Worker(queues={"fast": 4, "slow": 1})`. Enqueue 1 slow task that sleeps 30s + 100 fast tasks. Assert all 100 fast tasks complete within 5 wall-seconds while the slow task is still processing.
+  - **Per-queue concurrency.** `Worker(queues={"fast": 2})` polls 5 fast-tasks; assert at most 2 are in `processing` state at any sample point.
+  - **Per-queue visibility timeout.** `Worker(queues={"slow": {"concurrency": 1, "visibility_timeout": 5}})` polls a 30-sec workflow; assert the same task gets re-delivered to a sibling worker after the 5s timeout.
+  - **Default queue back-compat.** `Worker(concurrency=N)` and a producer that previously ran against `_QUEUE_KEY = "kailash:tasks:pending"` interoperate byte-for-byte against `Worker(queues={"default": N})` — same Redis list key.
+  - **Mutual-exclusion at construction.** `Worker(queue=tq, queues={"default": 1})` raises `ValueError`.
+
+- `tests/integration/runtime/test_scheduler_queue_routing.py`
+  - **Queue persists across scheduler restart.** Schedule a cron job with `queue="slow"`, kill the scheduler, restart from the same SQLite job-store, verify the next fire dispatches to the `slow` queue.
+  - **Compose with lifecycle hooks.** Register `on_task_success(handler)`; enqueue via scheduler with `queue="slow"`; assert `handler` received `event.queue_name == "slow"`.
+  - **Compose with retry: BLOCKED.** `scheduler.schedule_cron(..., retry=RetrySpec(...), queue="slow")` raises `ValueError` (the existing `retry + dispatch_via` BLOCK extends to `retry + queue`).
+
+- `tests/integration/runtime/test_distributed_runtime_queue_kwarg.py`
+  - Producer enqueue with `queue="fast"` arrives on `Worker(queues={"fast": 1})`.
+  - Producer enqueue with default queue arrives on `Worker(concurrency=1)` (legacy).
+  - Producer enqueue with unknown queue (no worker polling it) sits pending; `runtime.get_queue_status(queue="unknown")` returns `pending=1, workers=0`.
+
+### Regression
+
+- `tests/regression/test_911_default_queue_byte_compat.py` — pin the EXISTING `_QUEUE_KEY = "kailash:tasks:pending"` constant. If a future refactor changes the legacy key, every existing user's in-flight tasks orphan; this regression test loudly fails first.
+
+## Cross-SDK alignment
+
+Descriptive only — kailash-rs is a sibling repo and cross-repo work is BLOCKED per `repo-scope-discipline.md`.
+
+The Rust SDK exposes its own `DistributedRuntime` and `Worker` types. Cross-SDK alignment per `cross-sdk-inspection.md` Rule 3 (EATP D6: matching semantics, independent implementation):
+
+- The canonical Redis key shape `kailash:tasks:pending[:queue_name]` MUST be IDENTICAL byte-for-byte across both SDKs so a Python-side producer can enqueue and a Rust-side worker can dequeue (and vice versa). Per `cross-sdk-inspection.md` Rule 4, the test vectors (`make_queue_key("default")`, `make_queue_key("fast")`, `make_queue_key("a-b-c")`) MUST be pinned in both SDKs as raw byte strings, not abstract assertions.
+- The `Worker(queues={...})` map shape is a Python idiom; the Rust equivalent (`HashMap<String, QueueSpec>` or a typed builder) is the same data model in Rust idiom.
+- Lifecycle event extension `TaskEvent.queue_name: Option<String>` mirrors the Python additive default-None field.
+
+A Rust-side implementer reading this plan reproduces the surface in Rust idiom; the byte-shape contract on Redis is what this plan pins. **No issue is filed against `kailash-rs` from this repo's session.**
+
+## Open questions for the human
+
+These need a gate decision before `/todos`:
+
+1. **Helper module location.** New file `src/kailash/runtime/_queue_keys.py` or absorb into `src/kailash/utils/`? The helper is one tiny module either way; `runtime/` keeps it co-located with the consumer, `utils/` keeps it cross-package available. Recommendation: `runtime/` — both producer and consumer live in `runtime/`.
+2. **`**kwargs`removal scope.** This plan removes`**kwargs`from`DistributedRuntime.execute`to close`zero-tolerance.md`Rule 3c silent-drop. The same`**kwargs`exists on`BaseRuntime.execute` (`runtime/base.py`) and other runtime subclasses. Should this plan close ALL silent-drop kwargs across `runtime/`(broader scope, +200 LOC, +1 shard), or scope strictly to`DistributedRuntime`? Recommendation: scope strictly — sibling-site sweep is a separate workstream that deserves its own analysis.
+3. **`queues=` default-queue alias.** Should `Worker(concurrency=N)` ALWAYS forward to `queues={"default": N}` internally (single canonical code path), or keep the legacy single-queue branch as a separate code path? Recommendation: forward — one code path is structurally simpler and closes the parity invariant by construction.
+4. **Per-queue-concurrency pre-emption.** When ALL queues' semaphores are saturated, should the worker stop polling Redis (back-pressure) or keep polling and immediately re-queue? Recommendation: stop polling — keeps Redis cheap and matches celery's behaviour.
+5. **#912 sequencing**. If the human authoritatively wants #912 (soft/hard time limits) landed BEFORE #911, then #911's plan adds `soft_time_limit=` / `time_limit=` as named kwargs on `DistributedRuntime.execute` in the same shard rather than in #912's standalone shard. If #912 lands after #911, neither shard changes. Recommendation: human decides which lands first; this plan is correct under either ordering.
+
+## Effort estimate
+
+Per `autonomous-execution.md`, effort is in **autonomous execution cycles** (sessions), not human-days.
+
+- **Shard 1** (helper + producer): 1 session, ~half-session if Shard 2 follows in parallel.
+- **Shard 2** (Worker multi-queue): 1 session — this is the highest-invariant shard (per-queue tasks + per-queue semaphores + per-queue visibility timeouts + lifecycle events). Real-Redis tier-2 feedback loop multiplies capacity per Rule 3.
+- **Shard 3** (scheduler composition): 1 session — small LOC delta but high cross-rule invariant count (RetrySpec composition, lifecycle hooks, persistence on resume).
+
+**Total: 3 sessions** (one per shard). Sequential because Shard 2 + 3 both depend on Shard 1's helper module + `TaskMessage.queue_name` field. Worktree isolation NOT required (no Cargo lock contention; Python editable install) but recommended per `agents.md` MUST: Worktree Agents Commit Incremental Progress so each shard's progress is durable.
+
+If the human elects to also fold #912 (soft/hard time limits) into the same plan, add **+1 session** (Shard 4). If the human elects to sweep the broader `**kwargs` silent-drop across all `BaseRuntime` subclasses, add **+1 session** (Shard 5).
+
+Gate-level reviews (`reviewer` + `security-reviewer` per `agents.md` § Quality Gates) run as parallel background agents at the end of `/implement` and do NOT count toward shard sessions — they cost near-zero parent context.

--- a/workspaces/issue-911-multi-queue-routing/02-todos/todos.md
+++ b/workspaces/issue-911-multi-queue-routing/02-todos/todos.md
@@ -1,0 +1,264 @@
+# Issue #911 /todos: multi-queue routing
+
+> Phase 02 (`/todos`) deliverable. READ-ONLY — no production code edits, no branches, no PRs in this phase. Output is the human-gate input before `/implement`.
+
+## Root-cause decisions (user-approved 2026-05-09)
+
+Four root-cause decisions were surfaced from the open questions in `01-analyze/architecture-plan.md` § "Open questions for the human" plus the session-notes-line-5 sequencing claim. Each was approved by the user on 2026-05-09.
+
+**RC1 — `**kwargs`removal scope: BROAD sweep across all`BaseRuntime` subclasses, OWNED BY #912 Shard 1.\*\*
+
+#911 does NOT own the `**kwargs` removal anymore. #912 Shard 1 lands the broad sweep across `BaseRuntime` and every subclass (`LocalRuntime`, `AsyncLocalRuntime`, `DistributedRuntime`, `ParallelRuntime`, etc.) FIRST. #911 Shard 1 builds on the cleaned typed-kwargs surface and ADDS `queue=` as one more typed kwarg. This deletes the original "Shard 1 owns `**kwargs` removal" line from the `01-analyze/architecture-plan.md` § "Implementation sketch" Shard 1. Total LOC for #911 drops by ~50–80 LOC (the silent-drop removal on `DistributedRuntime.execute` is no longer in scope here; it lives in #912 Shard 1).
+
+**RC2 — `kailash.errors` namespace: not applicable to #911.**
+
+The proposed `kailash.errors` namespace consolidation is owned by #912 only. No new module is created for #911. #912 adds typed exceptions to `src/kailash/sdk_exceptions.py` per the existing module's conventions; no namespace migration affects #911.
+
+**RC3 — PACT integration: not applicable to #911.**
+
+PACT envelope integration (D/T/R clearance threading through queue dispatch) is in scope for #913 (admin API + governance) only, not for #911. The queue-routing primitive is governance-agnostic; PACT-aware routing is a #913 concern that consumes #911's primitives.
+
+**RC4 — `pause`/`resume`/`update_cron` scheduler methods: not applicable to #911.**
+
+The `WorkflowScheduler.pause(schedule_id)` / `resume(schedule_id)` / `update_cron(schedule_id, new_cron)` administrative surface is owned by #913 Shard 0 only, not #911. #911 only adds the `queue=` kwarg to the existing `schedule_*` methods; the administrative methods are out of scope.
+
+## Dependency on #912 Shard 1
+
+**#911 Shard 1 launches AFTER #912 Shard 1 merges.** This is the single load-bearing sequencing constraint.
+
+Why this changes #911's plan:
+
+- The `01-analyze/architecture-plan.md` § "Implementation sketch" Shard 1 originally bundled the `**kwargs` removal on `DistributedRuntime.execute` together with the helper module + queue-routing producer plumbing. Per RC1, the `**kwargs` removal is now #912 Shard 1's job (broad sweep across all `BaseRuntime` subclasses).
+- `#912 Shard 1` lands a clean typed-kwarg surface on `DistributedRuntime.execute(workflow, parameters=None, *, soft_time_limit=None, time_limit=None)` with NO trailing `**kwargs`. #911 Shard 1 then ADDS `queue: Optional[str] = None` as one additional named kwarg to the same surface.
+- `Worker.__init__` is also touched by #912 Shard 1 (typed-kwarg cleanup on Worker — this plan assumes #912's broad sweep covers Worker too; if #912 scopes narrower, the orchestrator MUST surface the gap at /implement launch per `specs-authority.md` MUST-5c amend-at-launch).
+- Per `agents.md` § "Parallel-Worktree Package Ownership Coordination", `Worker.__init__` and `WorkflowScheduler.schedule_*` are SHARED collision points between #912 and #911. Option B wave 2 sequencing handles them: #912 Shard 1 lands first (wave 1), THEN #911 Shard 1 layers on top (wave 2). No simultaneous parallel work on these surfaces.
+
+If #912 Shard 1 has not merged at #911 Shard 1 launch time, the orchestrator MUST stop and re-sequence per `coc-sync-landing.md` (wait for upstream merge to land cleanly before building on top).
+
+## Default-queue back-compat invariant
+
+The single most load-bearing invariant of this entire plan: `make_queue_key("default")` MUST return byte-for-byte the EXACT existing `_QUEUE_KEY` string `"kailash:tasks:pending"` — NOT `"kailash:tasks:pending:default"`. Non-default queues get the `:<name>` suffix (e.g. `make_queue_key("fast") == "kailash:tasks:pending:fast"`).
+
+**Why this matters in plain language:** existing users have tasks already enqueued in production today on the Redis list `kailash:tasks:pending`. If `make_queue_key("default")` returns a different string, every in-flight task orphans on first deploy of the new code — same failure-mode class as a public-API removal without a deprecation cycle (`zero-tolerance.md` Rule 6a).
+
+**Pinned by these regression tests (paths the implementer MUST author):**
+
+1. `tests/regression/test_911_default_queue_byte_compat.py` — pins the legacy `_QUEUE_KEY = "kailash:tasks:pending"` constant. Asserts `make_queue_key("default")` returns this exact byte string. If a future refactor changes either side, this regression fires before any user is affected.
+2. `tests/unit/runtime/test_queue_keys.py` — Tier-1 unit tests for the helper module. Includes positive byte-vector assertions for `default`, `fast`, `slow_queue`, `a-b-c`, AND negative `validate_queue_name` cases (control chars, colons, slashes, > 64 chars) per failure-point #8 in the analyze plan.
+
+## Shard plan
+
+Three shards, each within `autonomous-execution.md` § Per-Session Capacity Budget MUST Rule 1 (≤500 LOC load-bearing logic, ≤5–10 invariants, ≤3–4 call-graph hops, describable in 3 sentences).
+
+### Shard 1 — Helper module + producer plumbing (lighter post-RC1)
+
+**Value-anchor:** delivers the canonical Redis-list-key shape that producer + consumer (and any future Rust SDK port) MUST share so multi-queue routing can be byte-identical across SDKs — the user explicitly asked for queue routing in issue #911 acceptance criteria, and this shard is the foundation every other shard layers on. (Anchored in user-approved sequence per `.session-notes:5` → "#912, then #911 (multi-queue routing)" + `01-analyze/architecture-plan.md` § "Implementation sketch" Shard 1.)
+
+**Files touched:**
+
+- `src/kailash/runtime/_queue_keys.py` (NEW, ~80 LOC)
+- `src/kailash/runtime/distributed.py` (TaskMessage + DistributedRuntime constructor + DistributedRuntime.execute, ~80 LOC delta — REDUCED from analyze plan's ~150 LOC because the `**kwargs` removal is no longer in #911's scope per RC1)
+- `tests/unit/runtime/test_queue_keys.py` (NEW, ~80 LOC)
+- `tests/unit/runtime/test_distributed_runtime_signature_invariant.py` (NEW, ~30 LOC — pins the post-#912 + post-#911 signature shape: `workflow, parameters, soft_time_limit, time_limit, queue` and NO `**kwargs`)
+
+**Invariants (5):**
+
+1. `make_queue_key("default")` byte-for-byte equals existing `_QUEUE_KEY = "kailash:tasks:pending"` (load-bearing back-compat).
+2. `make_queue_key(name)` for any non-`"default"` name returns `f"{_QUEUE_KEY_BASE}:{name}"`.
+3. `validate_queue_name` raises `ValueError` on the documented bad set (empty, > 64 chars, control chars, colons, slashes, newlines, null bytes) per failure-point #8.
+4. `DistributedRuntime.execute(queue=...)` routes via the helper — no inline string formatting; helper is the single canonical key source.
+5. `TaskMessage` gains `queue_name: str = "default"` as an additive non-frozen-dataclass default field; JSON serialize/deserialize round-trip preserves it for legacy messages too (default fills missing field).
+
+**LOC estimate (load-bearing logic):** ~150 LOC (helper module + TaskMessage field + execute signature plumbing). Plus ~110 LOC tests. Well under 500 LOC budget.
+
+**Tests required (Tier 1 + Tier 2 + regression):**
+
+- Tier 1: `tests/unit/runtime/test_queue_keys.py` — byte-vector assertions for `default` / `fast` / `slow_queue` / `a-b-c` / `"x" * 64`; rejection assertions for empty / > 64 / control-chars / colons / slashes / newlines / nulls.
+- Tier 1: `tests/unit/runtime/test_distributed_runtime_signature_invariant.py` — `inspect.signature(DistributedRuntime.execute).parameters` contains exactly `{"self", "workflow", "parameters", "soft_time_limit", "time_limit", "queue"}` and NO `VAR_KEYWORD` parameter (no `**kwargs`).
+- **Regression:** `tests/regression/test_911_default_queue_byte_compat.py` — pins `_QUEUE_KEY = "kailash:tasks:pending"` AND `make_queue_key("default") == "kailash:tasks:pending"`. Loud failure on any future drift.
+
+**Dependencies:** **MUST land AFTER #912 Shard 1** (the typed-kwargs surface). Without #912's prior merge, `DistributedRuntime.execute` still has `**kwargs` and #911's invariant 4 cannot be enforced.
+
+**Worktree assignment:** Option B wave 2 — Shard 1 launches as a single worktree agent in wave 2, after #912 Shard 1 has landed in wave 1. Worktree path: `.claude/worktrees/issue-911-shard-1` per `worktree-isolation.md` MUST-1+6 (explicit branch name `feat/issue-911-shard-1-helper-producer`). Pre-flight merge-base check against `main` post-#912-merge per Rule 5.
+
+**Same-class fix-immediately gaps within shard:** none anticipated for Shard 1 — the helper module is self-contained; the silent-drop `**kwargs` (the prior same-class gap) is moved to #912's shard per RC1. If reviewer surfaces a sibling "queue-format string drift" in `infrastructure/task_queue.py` (the SQL-backed sibling), `autonomous-execution.md` MUST Rule 4 obligates same-shard fix if within 300 LOC budget — likely yes; the SQL queue's `queue_name` column already exists and consumes the helper trivially.
+
+### Shard 2 — Worker multi-queue dequeue loop
+
+**Value-anchor:** delivers the "slow task does not block fast task pickup" acceptance criterion #3 from issue #911 — the user-stated reason for filing the issue — by replacing the single-queue dequeue loop with one asyncio task per queue and per-queue concurrency semaphores. Without Shard 2, multi-queue routing is half-built (producer ships to queues, consumer can't read from them in parallel). (Anchored in user-approved sequence per `.session-notes:5` + issue #911 acceptance criteria as the user-authored brief.)
+
+**Files touched:**
+
+- `src/kailash/runtime/distributed.py` (Worker class — `__init__`, `_dequeue_loop`, `_send_heartbeat`, `_execute_task`, ~250 LOC delta)
+- `src/kailash/runtime/lifecycle_events.py` (TaskEvent additive `queue_name` field, ~3 LOC — split into Shard 3 if cleaner; included here because Worker populates it)
+- `tests/integration/runtime/test_worker_multi_queue.py` (NEW, ~250 LOC, real Redis Tier 2)
+
+**Invariants (8):**
+
+1. `Worker(concurrency=N)` and `Worker(queues={"default": N})` are externally indistinguishable (legacy parity) — same Redis list key (default-queue back-compat byte-vector), same heartbeat shape minus the `queues` field.
+2. Per-queue dequeue tasks are independent asyncio tasks (one per declared queue), NOT a serialized round-robin.
+3. Per-queue semaphores enforce per-queue concurrency caps independently.
+4. Per-queue `visibility_timeout` overrides via dict syntax `queues={"slow": {"concurrency": 2, "visibility_timeout": 1800}}` are honored (failure-point #4).
+5. Mutually-exclusive `queue=<TaskQueue>` and `queues={...}` raise `ValueError` at construction (named-kwarg discipline; do NOT silently prefer one).
+6. Slow-queue task does NOT block fast-queue dequeue (failure-point #3 / acceptance criterion 3).
+7. Heartbeat JSON includes `queues={"fast": 8, "slow": 2}` per failure-point #7.
+8. Lifecycle hooks (`on_task_*`) receive `event.queue_name` populated from `task.queue_name` (failure-point #6).
+
+**LOC estimate (load-bearing logic):** ~450 LOC (Worker `__init__` rewrite + dequeue-loop fanout + heartbeat extension + lifecycle-event population). Plus ~250 LOC tests. Under 500 LOC budget; close to ceiling, justified by the per-queue feedback loop (real Redis Tier-2 multiplies capacity 3-5× per `autonomous-execution.md` MUST Rule 3).
+
+**Tests required (Tier 2 with real Redis):**
+
+- **Slow-queue does not block fast-queue (#911 acceptance criterion 3):** spawn `Worker(queues={"fast": 4, "slow": 1})`. Enqueue 1 slow task that sleeps 30s + 100 fast tasks. Assert all 100 fast tasks complete within 5 wall-seconds while the slow task is still processing.
+- **Per-queue concurrency:** `Worker(queues={"fast": 2})` polls 5 fast-tasks; assert at most 2 are in `processing` state at any sample point.
+- **Per-queue visibility timeout:** `Worker(queues={"slow": {"concurrency": 1, "visibility_timeout": 5}})` polls a 30-sec workflow; assert the same task gets re-delivered to a sibling worker after the 5s timeout.
+- **Default queue back-compat (load-bearing):** `Worker(concurrency=N)` and a producer that previously enqueued against `_QUEUE_KEY = "kailash:tasks:pending"` interoperate byte-for-byte against `Worker(queues={"default": N})` — same Redis list key, same task processed.
+- **Mutual-exclusion at construction:** `Worker(queue=tq, queues={"default": 1})` raises `ValueError`.
+
+**Dependencies:** Shard 1 (helper module + TaskMessage.queue_name) MUST land first; Shard 2 cannot dequeue from per-queue keys without `make_queue_key`. #912 Shard 1's `Worker.__init__` typed-kwarg cleanup MUST also land first if it touches `Worker` (likely yes per RC1's broad sweep scope).
+
+**Worktree assignment:** Option B wave 2 second slot. Worktree path: `.claude/worktrees/issue-911-shard-2` per `worktree-isolation.md` MUST-1+6 (branch `feat/issue-911-shard-2-worker-multi-queue`). Pre-flight merge-base check against `feat/issue-911-shard-1-helper-producer` post-merge.
+
+**Same-class fix-immediately gaps within shard:** if reviewer surfaces a sibling "queue routing not threaded through `_send_heartbeat` despite registry needing it for failure-point #7" or "mutual-exclusion missing for the construction-via-factory path", both are same-bug-class (queue routing through Worker surface) and ≤80 LOC each — fix in same shard per `autonomous-execution.md` MUST Rule 4.
+
+### Shard 3 — Scheduler dispatch composition + lifecycle event extension
+
+**Value-anchor:** delivers queue-routing-as-scheduler-kwarg so cron/interval/once jobs can route to slow vs fast queues with deterministic persistence across scheduler restarts (failure-point #5), AND extends the `TaskEvent` payload with `queue_name` for per-queue alerting handlers — both are required for the user's stated need ("a single Worker process can dequeue from a `{queue_name: concurrency}` map" implies the scheduler can target those queues). (Anchored in user-approved sequence per `.session-notes:5` + issue #911 acceptance criteria.)
+
+**Files touched:**
+
+- `src/kailash/runtime/scheduler.py` (`schedule_cron` / `schedule_interval` / `schedule_once` signatures, `_compose_job_kwargs`, `_dispatch_to_queue`, ~120 LOC delta)
+- `src/kailash/runtime/lifecycle_events.py` (`TaskEvent.queue_name` additive default-None field — done in Shard 2 if cleaner; finalised here if not)
+- `tests/integration/runtime/test_scheduler_queue_routing.py` (NEW, ~150 LOC, real APScheduler + real Redis Tier 2)
+
+**Invariants (5):**
+
+1. `schedule_cron(..., queue="slow")` persists `queue` into APScheduler job kwargs via the `_KAILASH_QUEUE_KWARG = "_kailash_queue"` sentinel pattern (mirrors the existing `_kailash_retry_spec` pattern from #916).
+2. Fire-time dispatch reads `queue` from persisted kwargs — deterministic across scheduler instances per failure-point #5 (`compute_task_id` does NOT change; queue is a separate axis hashed only via the persisted job kwargs).
+3. Composing `queue=` with `dispatch_via=None` raises `ValueError` (queue routing requires a dispatcher; same shape as the existing `retry + dispatch_via` BLOCK at `scheduler.py:768-774`).
+4. **`retry + queue` BLOCK (load-bearing):** `scheduler.schedule_cron(..., retry=RetrySpec(...), queue="slow")` raises `ValueError` with a message referencing both kwargs. RetrySpec is in-process only; queue is dispatcher-side; the pair is meaningless together.
+5. `TaskEvent.queue_name` is populated end-to-end (scheduler → Task → TaskMessage → Worker → handler) for queue-dispatched jobs.
+
+**LOC estimate (load-bearing logic):** ~250 LOC (schedule\_\* signature plumbing + `_compose_job_kwargs` + `_dispatch_to_queue` + the `retry + queue` BLOCK + TaskEvent field). Plus ~150 LOC tests.
+
+**Tests required (Tier 2 with real Redis + real APScheduler):**
+
+- **Queue persists across scheduler restart:** schedule a cron job with `queue="slow"`, kill the scheduler process, restart from the same SQLite job-store, verify the next fire dispatches to the `slow` queue (failure-point #5).
+- **Compose with lifecycle hooks:** register `on_task_success(handler)`; enqueue via scheduler with `queue="slow"`; assert `handler` received `event.queue_name == "slow"` (failure-point #6).
+- **`retry + queue` BLOCK regression (load-bearing):** `scheduler.schedule_cron(..., retry=RetrySpec(max_attempts=3), queue="slow")` raises `ValueError`. Assert error message references both `retry` and `queue` kwargs by name. Mirrors `tests/unit/runtime/scheduler/test_retry_dispatch_blocked.py` (existing pattern from #916 RetrySpec landing).
+
+**Dependencies:** Shard 1 (helper) AND Shard 2 (Worker queue handling, since the scheduler dispatches into queues that Workers consume). Sequential: Shard 3 launches AFTER Shard 1 + Shard 2 merge.
+
+**Worktree assignment:** Option B wave 3 (after Shard 1 + Shard 2 land). Worktree path: `.claude/worktrees/issue-911-shard-3` per `worktree-isolation.md` MUST-1+6 (branch `feat/issue-911-shard-3-scheduler-composition`). Pre-flight merge-base check against `main` post-Shard-1+2-merge.
+
+**Same-class fix-immediately gaps within shard:** if reviewer surfaces sibling `pause + queue` / `resume + queue` interactions (RC4 — out of scope for #911 but the surface might demand thinking), defer to #913 Shard 0 per RC4 — those methods don't exist yet. If reviewer surfaces missing queue-name validation at the scheduler-side `schedule_*` entry points (failure-point #8 — should have called `validate_queue_name` from Shard 1 here too), that's same-bug-class and one-line fix; same-shard per Rule 4.
+
+## Tier-2 test plan
+
+Consolidated view of the integration tests across all three shards, with paths and assertions.
+
+### Shard 1 tests
+
+**`tests/unit/runtime/test_queue_keys.py`** (Tier 1)
+
+- `make_queue_key("default") == "kailash:tasks:pending"` (load-bearing back-compat byte vector)
+- `make_queue_key("fast") == "kailash:tasks:pending:fast"`
+- `make_queue_key("slow") == "kailash:tasks:pending:slow"`
+- `make_processing_key("default") == "kailash:tasks:processing"`
+- `validate_queue_name` accepts: `"default"`, `"fast"`, `"slow_queue"`, `"a-b-c"`, `"x" * 64`
+- `validate_queue_name` rejects: `""`, `"x" * 65`, `"with space"`, `"with:colon"`, `"with/slash"`, `"with\nnewline"`, `"with\x00null"`
+
+**`tests/unit/runtime/test_distributed_runtime_signature_invariant.py`** (Tier 1, structural per `cross-sdk-inspection.md` Rule 3a)
+
+- `inspect.signature(DistributedRuntime.execute)` contains exactly `{"self", "workflow", "parameters", "soft_time_limit", "time_limit", "queue"}` and NO `VAR_KEYWORD` parameter.
+- Pins the surface against `**kwargs` regrowth.
+
+**`tests/regression/test_911_default_queue_byte_compat.py`** (Regression — load-bearing)
+
+- Pins `_QUEUE_KEY = "kailash:tasks:pending"` constant.
+- Pins `make_queue_key("default") == "kailash:tasks:pending"`.
+- Pins `make_queue_key("default") != "kailash:tasks:pending:default"` (the failure mode if the asymmetry is forgotten).
+
+### Shard 2 tests
+
+**`tests/integration/runtime/test_worker_multi_queue.py`** (Tier 2, real Redis)
+
+- **Slow-queue does not block fast-queue (acceptance criterion 3):** spawn `Worker(queues={"fast": 4, "slow": 1})`; enqueue 1 slow-30s + 100 fast tasks; assert all 100 fast complete < 5s wall while slow still processing.
+- **Per-queue concurrency:** `Worker(queues={"fast": 2})` against 5 fast tasks; assert ≤2 in `processing` at any sample.
+- **Per-queue visibility timeout:** `Worker(queues={"slow": {"concurrency": 1, "visibility_timeout": 5}})` against a 30s task; assert re-delivery to sibling worker after 5s.
+- **Default queue back-compat (load-bearing):** producer-side enqueue against legacy `_QUEUE_KEY = "kailash:tasks:pending"` interoperates with `Worker(queues={"default": N})` AND `Worker(concurrency=N)` (both shapes produce same Redis-list-key reads).
+- **Mutual-exclusion at construction:** `Worker(queue=tq, queues={"default": 1})` raises `ValueError`.
+
+### Shard 3 tests
+
+**`tests/integration/runtime/test_scheduler_queue_routing.py`** (Tier 2, real APScheduler + Redis)
+
+- **Queue persists across scheduler restart:** schedule with `queue="slow"`; kill + restart; verify next fire dispatches to `slow`.
+- **Compose with lifecycle hooks:** `on_task_success(handler)` receives `event.queue_name == "slow"` for queue-dispatched job.
+- **`retry + queue` BLOCK (load-bearing):** `scheduler.schedule_cron(..., retry=RetrySpec(...), queue="slow")` raises `ValueError`; assert error message references both kwargs.
+
+### Test discipline
+
+Per `rules/testing.md` (kailash-py): NO mocking in Tier 2/3. Tests use real Redis (`docker-compose.test.yml` infrastructure already in place per existing Tier 2 test conventions in `tests/integration/runtime/`). Tier 1 unit tests are pure-Python with no infrastructure.
+
+## Cross-SDK alignment notes
+
+**Descriptive only — kailash-rs is a sibling repo and cross-repo work is BLOCKED per `repo-scope-discipline.md`. No issue is filed against `kailash-rs` from this session.**
+
+The Rust SDK (kailash-rs) exposes its own `DistributedRuntime` and `Worker` types. Cross-SDK alignment per `cross-sdk-inspection.md` Rule 3 (matching semantics, independent implementation):
+
+- The canonical Redis key shape `kailash:tasks:pending[:queue_name]` MUST be IDENTICAL byte-for-byte across both SDKs so a Python-side producer can enqueue and a Rust-side worker can dequeue (and vice versa).
+- The byte-vector regression test `tests/regression/test_911_default_queue_byte_compat.py` MUST be replicated as a Rust test pinning the same byte string. The Rust SDK's analog of `make_queue_key` MUST return the same byte string for the same input. Per `cross-sdk-inspection.md` Rule 4, the test vectors MUST be pinned in BOTH SDKs as raw byte strings, NOT abstract assertions.
+- The `Worker(queues={...})` map shape is a Python idiom; the Rust equivalent (`HashMap<String, QueueSpec>` or a typed builder) is the same data model in Rust idiom.
+- `TaskEvent.queue_name: Option<String>` mirrors the Python additive default-None field.
+
+A Rust-side implementer reading the analyze + todos plans reproduces the surface in Rust idiom. The byte-shape contract on Redis is what this plan pins. Filing the cross-SDK tracking issue against `kailash-rs` (if needed) is the user's call from a kailash-rs session, not from this session.
+
+## Open questions for human gate before /implement
+
+These need a gate decision before `/implement` launches:
+
+**Q1 — `lifecycle_events.py::TaskEvent.queue_name` placement: Shard 2 or Shard 3?**
+
+Recommendation: **Shard 2.** Worker is the producer of `TaskEvent` (via `_execute_task`); the field is populated when the Worker reads `task.queue_name` from the dequeued message. Doing it in Shard 2 keeps the additive field with its populator. Shard 3 only validates the field is honored end-to-end via the integration test.
+
+Implications: places ~3 LOC of `lifecycle_events.py` delta in Shard 2 instead of Shard 3 — Shard 2 stays under 500 LOC budget either way. Trade-off: if Shard 3 lands first (it won't given the dependency chain, but in theory), the field would already exist; doing it in Shard 2 is the natural place.
+
+Cons: Shard 3's integration test depends on the field existing in Shard 2 — slight coupling, but Shard 3 already depends on Shard 2 per the plan.
+
+**Q2 — `Worker(concurrency=N)` legacy-path forwarding: forward to `queues={"default": N}` (single canonical path) OR keep legacy single-queue branch separate?**
+
+Recommendation: **forward to `queues={"default": N}`.** One canonical code path is structurally simpler and closes the parity invariant by construction (Shard 2 invariant 1 falls out of the design rather than needing test enforcement). Per `01-analyze/architecture-plan.md` § "Open questions" Q3 — the analyze plan also recommended forward.
+
+Implications: simpler Worker code (~30 LOC less than the dual-path version), one fewer code branch to maintain, Shard 2 invariant 1 (legacy-parity) becomes structurally enforced rather than test-enforced.
+
+Cons: a single `Worker(concurrency=N)` user who happened to inspect `worker._queues` (private attribute, but still) sees `{"default": N}` instead of `None` — minimal blast radius given underscore-prefixed attribute.
+
+**Q3 — Per-queue back-pressure when all semaphores are saturated: stop polling Redis OR keep polling and immediately re-queue?**
+
+Recommendation: **stop polling.** Matches celery's behaviour, keeps Redis cheap, prevents thrashing. Per `01-analyze/architecture-plan.md` § "Open questions" Q4.
+
+Implications: Worker holds an asyncio condition variable per queue; the dequeue loop awaits the semaphore release before BLMOVE-polling Redis. Slightly more complex than the polling-and-requeue path but produces lower Redis QPS under load.
+
+Cons: a saturated queue does not consume Redis network until a slot frees; transient mis-tuning (concurrency too low) is harder to diagnose because the "I'm saturated" state is silent. Mitigation: the heartbeat already records `active_tasks` and `concurrency`; saturation is `active_tasks >= concurrency` and IS dashboard-able from heartbeat data alone.
+
+**Q4 — Should #911 Shard 3 land `pause`/`resume`/`update_cron` if the implementer is already touching `WorkflowScheduler.schedule_*`?**
+
+Recommendation: **NO — keep RC4 boundary.** RC4 explicitly assigns the administrative methods to #913 Shard 0. Even though Shard 3 is touching the scheduler, the methods are out of scope per the user-approved RC. If the implementer surfaces an in-shard same-class gap (e.g., the queue-kwarg pattern at `schedule_*` could be reused by the missing `pause`/`resume`), file as a `#913` follow-up with a value-anchor citing the user's #913 brief — do NOT silently absorb into #911.
+
+Implications: discipline boundary preserved; #913 lands cleanly with no overlap; #911 stays at three shards.
+
+Cons: a future #913 implementer reads two cross-issue plans to land the admin surface — one extra read; minimal cost.
+
+## Effort estimate
+
+Per `autonomous-execution.md` § Per-Session Capacity Budget, effort is in **autonomous execution cycles** (sessions), not human-days. Each shard is one Opus session in a worktree.
+
+- **Shard 1** (helper + producer plumbing, post-RC1 lighter scope): **~half a session** if the helper module is self-contained AND #912 Shard 1's typed-kwarg surface has already merged. Real-time feedback loop (Tier-1 unit tests on the helper module) per `autonomous-execution.md` MUST Rule 3 multiplies capacity 3-5×.
+- **Shard 2** (Worker multi-queue dequeue loop): **~1 session** — highest-invariant shard in the plan (8 invariants + per-queue asyncio fanout + per-queue semaphores + per-queue visibility timeouts + lifecycle hooks). Real-Redis Tier-2 feedback loop multiplies capacity per Rule 3.
+- **Shard 3** (scheduler composition + lifecycle event): **~1 session** — small LOC delta but high cross-rule invariant count (RetrySpec composition with `retry + queue` BLOCK, lifecycle hooks, persistence on restart).
+
+**Total: ~2.5 sessions** (Shard 1 + Shard 2 + Shard 3, sequential due to shared `Worker.__init__` and `WorkflowScheduler.schedule_*` collision points with #912 already mitigated by Option B wave 2 sequencing).
+
+Gate-level reviews (`reviewer` + `security-reviewer` per `agents.md` § Quality Gates) run as parallel background agents at the end of `/implement` and do NOT count toward shard sessions — they cost near-zero parent context.
+
+If RC1 changes (e.g., #912 Shard 1's broad sweep does NOT cover `Worker.__init__`), the orchestrator MUST surface the gap at /implement launch per `specs-authority.md` MUST-5c amend-at-launch and EITHER add a typed-kwarg sub-shard to #911 Shard 2 (re-estimating to ~1.5 sessions) OR coordinate back to #912 to extend its sweep. Per `agents.md` § Parallel-Worktree Package Ownership Coordination, the version-owner / no-edit-coordination boundary is between #912 and #911 implementers — orchestrator gate before /implement.

--- a/workspaces/issue-912-task-time-limits/01-analyze/architecture-plan.md
+++ b/workspaces/issue-912-task-time-limits/01-analyze/architecture-plan.md
@@ -1,0 +1,537 @@
+# Issue #912: per-task soft/hard time limits
+
+## Brief summary
+
+Issue #912 asks for celery-style `soft_time_limit` (warn, raise a catchable
+exception inside the running workflow) and `time_limit` (hard kill, requeue)
+primitives at two execution surfaces: `DistributedRuntime.execute(...)` (the
+producer side) and `Worker._execute_workflow_sync(...)` (the consumer side).
+The brief comment on the issue notes #912 is a sibling of #910 (RetrySpec) —
+both are per-task execution-control primitives — and asks for the two
+primitives to interact correctly: when a task hits a soft limit and the
+runtime raises `SoftTimeLimitExceeded`, the retry classifier MUST treat it as
+retryable (or not) per the producer's `RetrySpec.retry_on` decision, not via
+a hidden hard-coded branch.
+
+In addition, the brief implicitly asks (per the session-notes line 10 + the
+`zero-tolerance.md` Rule 3c framing) to replace
+`DistributedRuntime.execute(workflow, parameters=None, **kwargs)` — which
+silently drops every kwarg today — with explicit typed kwargs. The first two
+new typed kwargs are `soft_time_limit` and `time_limit`; #911 (multi-queue)
+will reuse the cleaned signature in its turn.
+
+## Brief corrections
+
+Re-grep / re-verification of every factual claim in the issue body and its
+sibling references against `2210f724` (current `main`):
+
+| Brief claim                                                                              | Verdict                                                                                                                                                                                                                                                                                            | Evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DistributedRuntime.execute(workflow, parameters=None, **kwargs)` silently drops kwargs. | TRUE.                                                                                                                                                                                                                                                                                              | `src/kailash/runtime/distributed.py:502-544` — body uses only `workflow` and `parameters`; `**kwargs` is captured but never read in the function body.                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `Worker._execute_workflow_sync` is the worker-side execution path.                       | TRUE.                                                                                                                                                                                                                                                                                              | `src/kailash/runtime/distributed.py:977-996` — sync helper that builds and executes the workflow in a thread-pool executor.                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `WorkflowScheduler` job-execution path is the in-process retry loop.                     | TRUE.                                                                                                                                                                                                                                                                                              | `src/kailash/runtime/scheduler.py:780-957` — `_execute_workflow` retry loop wraps `runtime.execute(workflow, **kwargs)` at line 858.                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Brief refers to `Worker._execute_workflow_sync` (not `_execute_task`).                   | TRUE.                                                                                                                                                                                                                                                                                              | The synthetic blocking call is at `distributed.py:880`; `_execute_task` (line 839) is the `asyncio.Task` body that wraps it. The wrap point for hard kills (cancellation of the asyncio task) is `_execute_task`; the wrap point for soft limits (raising INSIDE the workflow thread) is around `_execute_workflow_sync`. Both wrap points exist; the brief named one.                                                                                                                                                                                     |
+| Soft-limit exception type lives at `kailash.errors.SoftTimeLimitExceeded`.               | PARTIALLY UNCLEAR. The repo does NOT currently expose a `kailash.errors` namespace (`grep -rn "from kailash.errors" src/` returns zero hits). The canonical exception home is `kailash.sdk_exceptions` (e.g. `WorkflowCancelledError` at `sdk_exceptions.py:406`, `RuntimeException` at line 185). | `src/kailash/sdk_exceptions.py:185,406`. The decision is whether to (a) add `SoftTimeLimitExceeded` + `HardTimeLimitExceeded` to `sdk_exceptions.py` and re-export under a NEW `kailash.errors` shim that lazy-imports from `sdk_exceptions`, or (b) just add them to `sdk_exceptions.py` and adjust the brief's import path. The plan below picks (a) with a `kailash.errors` namespace re-exporting from `sdk_exceptions.py` so the brief's example code works verbatim AND the module-discovery surface stays aligned with the existing exception home. |
+| #910 (RetrySpec) and #914 (lifecycle hooks) just merged.                                 | TRUE.                                                                                                                                                                                                                                                                                              | `git log --oneline -3 origin/main` shows `dc182dcc` (#910 round-2), `23565d7b` (#910 round-1), `3bd3445e` (#910 main), and PR #915 (#914) merged immediately prior.                                                                                                                                                                                                                                                                                                                                                                                        |
+| `_execute_workflow` is the same wrap point #912 touches as #910/#914.                    | TRUE.                                                                                                                                                                                                                                                                                              | The retry loop body at `scheduler.py:838-925` is exactly where the soft/hard timer needs to wrap each attempt. Collision risk against #916 was called out in `.session-notes:18-20` and is now resolved (#916 merged).                                                                                                                                                                                                                                                                                                                                     |
+| Existing `CancellationToken` handles cooperative cancellation between nodes.             | TRUE.                                                                                                                                                                                                                                                                                              | `src/kailash/runtime/cancellation.py:31-135` — token is checked between node executions; the existing `WorkflowCancelledError` path is the natural model the soft-limit path should imitate (cooperative raise inside the runtime).                                                                                                                                                                                                                                                                                                                        |
+| #911 reuses #912's signature cleanup.                                                    | TRUE per session-notes line 6.                                                                                                                                                                                                                                                                     | #911's brief (`gh issue view 911`) proposes `DistributedRuntime.execute(workflow, queue: str = "default")`. That third typed kwarg is exactly the next item after `soft_time_limit` / `time_limit` on the signature.                                                                                                                                                                                                                                                                                                                                       |
+
+No FALSE claims; one UNCLEAR (exception module path) resolved into the plan.
+
+## Failure-point analysis
+
+1. **Timeout-during-retry interaction.** Condition: a scheduled job has
+   `RetrySpec(max_retries=3)` AND `soft_time_limit=300`. Attempt 1 raises
+   `SoftTimeLimitExceeded` at t=300s. Consequence (today, naive
+   implementation): the retry classifier doesn't know about the new
+   exception type; either every soft-limit raise becomes a retry (defeating
+   `dont_retry_on`), or none do (defeating `retry_on=(SoftTimeLimitExceeded,)`).
+   Mitigation: `SoftTimeLimitExceeded` MUST be a normal `Exception` subclass
+   that `RetrySpec.is_retryable()` evaluates symmetrically to any other
+   exception. Operators who want "soft-limit triggers retry" pass
+   `retry_on=(SoftTimeLimitExceeded, ConnectionError)`; operators who want
+   "soft-limit means give up" pass
+   `dont_retry_on=(SoftTimeLimitExceeded,)`. Per `zero-tolerance.md` Rule 3c
+   the new kwargs MUST be consumed in every branch they reach.
+
+2. **Hard-limit cancellation vs `CancellationToken` semantics.** Condition:
+   a hard limit fires while the workflow is mid-node. Consequence:
+   APScheduler runs in a single process; cancelling the asyncio task that
+   owns the runtime call may leave node-side resources (DB connections, file
+   handles) in an inconsistent state. Mitigation: hard limit MUST go through
+   the existing `CancellationToken` path — set the token, give the runtime a
+   small grace window (config: `hard_time_limit_grace_seconds`, default 5s)
+   to observe the cancellation between nodes, then raise
+   `HardTimeLimitExceeded` from the wrapper. NEVER `SIGTERM` the worker
+   process from in-process scheduler — only the queue path's worker
+   `Worker._execute_task` may take that route (and only by setting
+   `task.attempts < task.max_attempts` so the requeue path activates), per
+   the brief's "task is requeued and a fresh worker picks it up" line. The
+   wrapper MUST propagate `WorkflowCancelledError` cause-chain into
+   `HardTimeLimitExceeded` so triage gets both layers.
+
+3. **Async vs sync runtime divergence.** Condition: scheduler runs against a
+   `LocalRuntime` (sync `runtime.execute(...)` at `scheduler.py:858`) vs an
+   `AsyncLocalRuntime` (`await runtime.execute_workflow_async(...)`).
+   Consequence: a soft-limit timer that uses `signal.SIGALRM` works in main
+   thread sync code only — fails for the worker's executor-thread sync path
+   AND for every async-runtime path. Mitigation: the timer MUST be
+   thread-/loop-safe, NOT signal-based. Implementation: a background
+   `asyncio.create_task` (async path) OR a `threading.Timer` (sync path) that
+   calls `cancellation_token.cancel(reason="soft_time_limit_exceeded")` at
+   the deadline. The runtime's existing inter-node `token.check()` raises
+   `WorkflowCancelledError`; the scheduler wrapper catches it and re-raises
+   as `SoftTimeLimitExceeded` with the original as `__cause__`. Same
+   plumbing for hard limit + `HardTimeLimitExceeded`. Per
+   `patterns.md` § "Paired Public Surface" the `soft_time_limit`/`time_limit`
+   kwargs MUST be accepted at every entry point that reaches the wrap
+   (sync + async + queue) — no "sync supported, async coming later" split.
+
+4. **Persistence on resume — hard limits across restart.** Condition: the
+   scheduler is using `SQLiteJobStore`; the process crashes mid-soft-limit
+   timer. Consequence: on resume, the timer is gone; the workflow runs
+   without time limits even though the schedule was registered with them.
+   Mitigation: timer state is in-memory and rebuilt at fire time, not at
+   schedule time. The `soft_time_limit` / `time_limit` values themselves are
+   persisted as part of the APScheduler `kwargs=` dict (same pattern as
+   `_RETRY_SPEC_KWARG` for #910 — see `scheduler.py:71` and the
+   `_compose_job_kwargs` helper at `scheduler.py:744-778`). When APScheduler
+   re-fires a missed job after restart, the kwargs are replayed from the
+   jobstore and the timer is freshly armed. No durable timer infra needed.
+
+5. **Cross-SDK alignment with kailash-rs.** Condition: kailash-rs already
+   has or will have an equivalent `Worker` + scheduler surface. Consequence:
+   if the Python SDK adds `soft_time_limit` and the Rust SDK adds
+   `soft_timeout_secs`, cross-SDK forensic correlation breaks (different
+   field names + different exception type names). Mitigation: keyword names
+   in this plan match celery (`soft_time_limit`, `time_limit`) which is the
+   industry standard, and the exception names follow celery's
+   `SoftTimeLimitExceeded` precedent. Cross-SDK alignment work is descriptive
+   only per `repo-scope-discipline.md` — no filing recommendation in this
+   session. (See § Cross-SDK alignment below.)
+
+6. **Soft-limit firing inside a non-yielding C extension.** Condition: a
+   `PythonCodeNode` runs a tight numpy loop or a `time.sleep(3600)` (the
+   brief's repro). Consequence: the inter-node `token.check()` is never
+   reached; the soft limit timer fires, sets the token, but the workflow
+   doesn't observe it until the current node returns. Mitigation:
+   `SoftTimeLimitExceeded` IS the cooperative half — the brief explicitly
+   says "catchable exception in the running workflow" — so a node that never
+   yields control simply does not see the soft limit until it exits.
+   `time_limit` (hard) is the backstop; at hard-limit deadline +
+   `hard_time_limit_grace_seconds` the wrapper raises
+   `HardTimeLimitExceeded` regardless of node yield state. This is
+   functionally equivalent to celery's "soft = cooperative, hard = process
+   kill" semantics translated to Python's coop-cancel idiom. Document the
+   limitation in the docstring.
+
+7. **`DistributedRuntime.execute` enqueues — the timer is enforced where?**
+   Condition: producer side calls
+   `runtime.execute(wf, soft_time_limit=300, time_limit=600)`; the workflow
+   gets serialized + enqueued to Redis; a worker dequeues it 30 minutes
+   later. Consequence: if the timer started at producer side, the budget is
+   already blown by the time the worker picks it up. Mitigation: the producer
+   serializes the LIMITS into the `TaskMessage.parameters` (or a new
+   dedicated `TaskMessage.execution_limits` field) — NOT the deadline
+   timestamp. The worker's `_execute_task` arms the timer at dequeue time so
+   the budget covers execution wall-clock, not queue-wait wall-clock. (Celery
+   does the same: `time_limit` is per-execution, not per-submission.)
+   Additive new field on `TaskMessage` keeps the JSON wire format
+   forward-compatible — workers running an older SDK ignore the field.
+
+8. **Worker-default vs producer-override semantics.** Condition: the brief's
+   acceptance criterion #2 says "`Worker` constructor accepts default soft /
+   hard limits applied to all dequeued tasks unless overridden by the
+   producer." Consequence: the precedence rule MUST be unambiguous —
+   per-task value (from `TaskMessage`) wins; falls through to
+   `Worker(default_soft_time_limit=, default_time_limit=)`; falls through to
+   `None` (no limit). Implementation: `Worker.__init__` adds
+   `default_soft_time_limit`, `default_time_limit`,
+   `hard_time_limit_grace_seconds` kwargs; `_execute_task` reads the
+   per-task value first and falls back to the default. Same precedence
+   pattern as `TaskMessage.visibility_timeout` vs
+   `TaskQueue.default_visibility_timeout` at `distributed.py:223-224`.
+
+9. **Signal-based fallback BLOCKED.** Condition: a future agent considers
+   wrapping `_execute_workflow_sync` with `signal.SIGALRM` or
+   `multiprocessing.Process(target=..., timeout=...)`. Consequence: SIGALRM
+   only works on the main thread on Unix; multiprocessing-Process double-pays
+   the workflow construction cost AND breaks `LocalRuntime`'s shared state.
+   Mitigation: the implementation MUST use `CancellationToken` +
+   `threading.Timer` / `asyncio.create_task`. Document this in the
+   implementation comment (BLOCKED rationalization) so a future Round-2
+   /redteam doesn't reopen.
+
+10. **Soft-limit and hard-limit interaction.** Condition: operator passes
+    `soft_time_limit=600`, `time_limit=300` (hard < soft, nonsensical).
+    Consequence (today, naive): both timers fire; the order of raising is
+    ambiguous. Mitigation: the wrapper validates at entry — if
+    `time_limit is not None and soft_time_limit is not None and
+soft_time_limit >= time_limit`, raise `ValueError` with a typed message.
+    Same validation pattern as `RetrySpec.__post_init__` at
+    `scheduler.py:140-181`.
+
+## API surface
+
+### New typed kwargs
+
+`DistributedRuntime.execute` (currently the silent-drop offender at
+`distributed.py:502-544`):
+
+```python
+def execute(
+    self,
+    workflow: Workflow,
+    parameters: Optional[Dict[str, Any]] = None,
+    *,
+    soft_time_limit: Optional[float] = None,  # seconds; None = no soft limit
+    time_limit: Optional[float] = None,        # seconds; None = no hard limit
+) -> Tuple[Dict[str, Any], str]:
+```
+
+The `**kwargs` is removed. Callers that were passing arbitrary kwargs (today
+silently dropped) get a `TypeError` — this is the desired
+`zero-tolerance.md` Rule 3c outcome. #911's `queue=` kwarg lands on top of
+this signature in the next workstream.
+
+`Worker.__init__` (currently at `distributed.py:614-644`):
+
+```python
+def __init__(
+    self,
+    redis_url: str = "",
+    queue: Optional[TaskQueue] = None,
+    concurrency: int = 1,
+    heartbeat_interval: int = 30,
+    dead_worker_timeout: int = 90,
+    worker_id: Optional[str] = None,
+    runtime_factory: Optional[Callable] = None,
+    *,
+    default_soft_time_limit: Optional[float] = None,
+    default_time_limit: Optional[float] = None,
+    hard_time_limit_grace_seconds: float = 5.0,
+):
+```
+
+`WorkflowScheduler.schedule_cron` / `schedule_interval` / `schedule_once`
+(currently at `scheduler.py:499`, `579`, `642`) — additive `*,
+soft_time_limit: Optional[float] = None, time_limit: Optional[float] = None`
+on each, plumbed through `_compose_job_kwargs` next to `_RETRY_SPEC_KWARG`
+into `_execute_workflow`.
+
+### New exceptions
+
+In `kailash/sdk_exceptions.py`:
+
+```python
+class SoftTimeLimitExceeded(RuntimeException):
+    """Raised inside a running workflow when soft_time_limit elapses.
+    Catchable by user code; allows graceful wind-down before hard limit."""
+
+class HardTimeLimitExceeded(RuntimeException):
+    """Raised by the runtime wrapper when time_limit elapses. The runtime
+    has already cancelled the workflow via CancellationToken; this is the
+    final propagating exception. NOT catchable by node-level user code."""
+```
+
+In a NEW `kailash/errors.py` module (re-export shim per `framework-first.md`
+§ "Drive The Data, Not The Dispatch" — keep one canonical home, expose at
+the convenient path the brief expects):
+
+```python
+from kailash.sdk_exceptions import (
+    SoftTimeLimitExceeded,
+    HardTimeLimitExceeded,
+    WorkflowCancelledError,  # for triage parity
+)
+
+__all__ = [
+    "SoftTimeLimitExceeded",
+    "HardTimeLimitExceeded",
+    "WorkflowCancelledError",
+]
+```
+
+This honors `orphan-detection.md` Rule 6 (every public module-scope import
+appears in `__all__`) and `dependencies.md` § "Declared = Imported".
+
+### Soft vs hard semantics
+
+| Aspect      | Soft (`soft_time_limit`)                                                                                                                                                                                                                     | Hard (`time_limit`)                                                                                                                                                                                                                                                                                                   |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mechanism   | Background `threading.Timer` (sync) / `asyncio.create_task` (async) sets `CancellationToken`. Runtime observes between nodes and raises. Wrapper catches `WorkflowCancelledError` and re-raises as `SoftTimeLimitExceeded` with `__cause__`. | Same mechanism + a `hard_time_limit_grace_seconds` (default 5s) wait. After grace, wrapper raises `HardTimeLimitExceeded` UNCONDITIONALLY (does not wait for the runtime to observe the token). Worker-path: `Worker._execute_task` interprets `HardTimeLimitExceeded` as "requeue if attempts remain" per the brief. |
+| User-facing | Catchable; user code may `try/except SoftTimeLimitExceeded:` and clean up.                                                                                                                                                                   | Effectively non-catchable inside node code (the wrapper raises after the runtime call returns). Surfaces to `Worker._execute_task` for requeue OR to `WorkflowScheduler._execute_workflow` for retry-classifier.                                                                                                      |
+| Default     | `None` (no limit)                                                                                                                                                                                                                            | `None` (no limit)                                                                                                                                                                                                                                                                                                     |
+| Validation  | Must be `> 0` and `< time_limit` if both set.                                                                                                                                                                                                | Must be `> 0`.                                                                                                                                                                                                                                                                                                        |
+
+### Default behavior
+
+`None` means "no limit"; the brief gives no guidance on a workspace-wide
+default and `autonomous-execution.md` per-session-budget reasoning suggests
+zero default to avoid surprising existing schedules. Operators opt in.
+
+## Implementation sketch
+
+Surface area + sequencing:
+
+1. **Shard 1 — exceptions + errors namespace** (boilerplate, ~40 LOC, 1
+   invariant: `kailash.errors` re-export resolves; same kind as `__all__`).
+   - `src/kailash/sdk_exceptions.py`: add `SoftTimeLimitExceeded`,
+     `HardTimeLimitExceeded` subclassing `RuntimeException`.
+   - `src/kailash/errors.py`: NEW file, re-exports.
+   - Update top-level `src/kailash/__init__.py` if it currently re-exports
+     from `sdk_exceptions` (verify).
+
+2. **Shard 2 — `_execute_with_time_limits` wrapper helper** (load-bearing,
+   ~120 LOC, 5 invariants: token cancel, async/sync dispatch, grace period,
+   exception type mapping, no-signal-based path). Lives in a new
+   `src/kailash/runtime/_time_limits.py`. Two callables:
+   - `def arm_time_limits(token, *, soft_time_limit, time_limit, grace) -> Cancellable`
+     — sync path; returns an object whose `.disarm()` cancels both timers
+     in the `finally` block.
+   - `async def arm_time_limits_async(token, *, soft_time_limit, time_limit, grace) -> Cancellable`
+     — async path; uses `asyncio.create_task` of `asyncio.sleep`.
+     Both share a `_TimeLimitClassifier(soft_deadline, hard_deadline) -> Type[Exception]`
+     that converts a `WorkflowCancelledError` raised by the runtime back into
+     `SoftTimeLimitExceeded` / `HardTimeLimitExceeded` based on which deadline
+     was reached first (compare `time.monotonic()` against stored deadlines).
+
+3. **Shard 3 — `WorkflowScheduler` plumbing** (load-bearing, ~150 LOC, 6
+   invariants: signature parity across 3 schedule\_\* methods, kwargs threading
+   per `_RETRY_SPEC_KWARG` precedent, in-process retry-loop interaction with
+   exception classifier, queue-dispatch path forwards the limits to
+   `Task.kwargs`, retry-classifier sees soft-limit as a normal exception,
+   validation at entry).
+   - `_TIME_LIMIT_KWARG = "_kailash_time_limits"` constant alongside
+     `_RETRY_SPEC_KWARG` at `scheduler.py:71`.
+   - `_compose_job_kwargs` (line 744) gains `soft_time_limit` /
+     `time_limit` parameters; threads a tuple `(soft, hard)` under the
+     internal key.
+   - `_execute_workflow` (line 780) pops the internal key, arms timers
+     around `runtime.execute(...)` at line 858 inside the existing retry
+     loop. Each retry attempt re-arms a fresh timer (no carry-over).
+   - `schedule_cron`, `schedule_interval`, `schedule_once` accept the new
+     kwargs and call the updated `_compose_job_kwargs`.
+
+4. **Shard 4 — `DistributedRuntime` + `Worker` plumbing** (load-bearing,
+   ~180 LOC, 7 invariants: producer-side sets execution_limits on
+   `TaskMessage`, wire format JSON forward-compat,
+   `Worker._execute_task` arms timers at dequeue, default fallback chain,
+   `HardTimeLimitExceeded` triggers requeue not dead-letter, lifecycle hook
+   `on_task_retry` fires on hard-limit-with-attempts-remaining,
+   `on_task_failure` fires on dead-letter).
+   - `TaskMessage` gains `execution_limits: Optional[Dict[str, float]] =
+None` (`{"soft": 300.0, "hard": 600.0}` shape — dict so the wire
+     format is one new optional field rather than two). `to_json` /
+     `from_json` updates accordingly.
+   - `DistributedRuntime.execute` typed-kwargs signature (signature
+     replacement, see § API surface).
+   - `Worker.__init__` adds the three new kwargs.
+   - `Worker._execute_task` (line 839) computes effective limits =
+     per-task limits OR worker defaults, arms timers around the
+     `run_in_executor(_execute_workflow_sync)` call at line 878, catches
+     `HardTimeLimitExceeded`, treats it as a retryable failure (existing
+     `nack` path requeues if `attempts < max_attempts`).
+
+5. **Shard 5 — tests** (Tier 2 integration + structural invariant; ~250
+   LOC; tests sub-package-local). See § Test plan.
+
+Total: ~740 LOC across 4 production files + 2 new files (errors.py,
+\_time_limits.py) + 5 test files. Per `autonomous-execution.md` § Per-Session
+Capacity Budget, each shard fits the ≤500 LOC / ≤5–10 invariants /
+≤3–4 call-graph hops bound. No shard exceeds the budget.
+
+## Test plan
+
+Tier 2 integration (real APScheduler in-memory job store + real
+`LocalRuntime`; per `testing.md` Tier 2 contract; per
+`facade-manager-detection.md` Rule 1 Manager-shape Tier-2 wiring):
+
+1. **`tests/integration/test_scheduler_time_limits.py`**
+   - `test_soft_time_limit_raises_in_workflow`: schedule a workflow whose
+     PythonCodeNode sleeps 5s; `soft_time_limit=2`; assert
+     `SoftTimeLimitExceeded` propagates out of `_execute_workflow` (caught
+     via the APScheduler error listener — same wiring as RetrySpec tests at
+     `tests/regression/test_scheduler_retry_primitives.py`).
+   - `test_hard_time_limit_raises_after_grace`: same workflow,
+     `time_limit=2`, `hard_time_limit_grace_seconds=1`; assert
+     `HardTimeLimitExceeded` raised at ~3s wall-clock.
+   - `test_soft_then_hard_propagation`: `soft_time_limit=2, time_limit=4`;
+     assert soft fires first; if user catches it and continues sleeping,
+     hard fires at 4+grace.
+   - `test_retryspec_classifies_soft_as_retryable_on_demand`: combine
+     `retry=RetrySpec(retry_on=(SoftTimeLimitExceeded,), max_retries=2)`
+     with `soft_time_limit=2`; assert the workflow is retried on soft
+     limit, NOT on hard.
+   - `test_retryspec_dontretry_on_soft_overrides`: same but
+     `dont_retry_on=(SoftTimeLimitExceeded,)`; assert no retry.
+
+2. **`tests/integration/test_distributed_time_limits.py`** (real Redis
+   per the existing `tests/integration/test_distributed_*` pattern):
+   - `test_producer_time_limits_serialize_to_taskmessage`: enqueue with
+     `soft_time_limit=300, time_limit=600`; dequeue raw via
+     `TaskQueue.dequeue`; assert `task.execution_limits ==
+{"soft": 300.0, "hard": 600.0}`.
+   - `test_worker_arms_timers_at_dequeue_not_at_enqueue`: enqueue with
+     `time_limit=2`; sleep 3s before starting the worker; assert the worker
+     still gets the full 2s budget (NOT 0s, which would prove producer-side
+     timing).
+   - `test_hard_limit_triggers_requeue`: workflow that sleeps 10s;
+     `time_limit=2`, `max_attempts=3`; assert task is processed by 2
+     workers (consumed twice from the queue) before dead-lettering on
+     attempt 3.
+   - `test_worker_default_overridden_by_per_task`: `Worker(default_time_limit=10)`;
+     enqueue with `time_limit=2`; assert effective limit is 2s, not 10s.
+   - `test_lifecycle_hooks_fire_on_hard_limit`: register
+     `on_task_retry` + `on_task_failure`; assert `on_task_retry` fires on
+     hard-limit retries 1-2, `on_task_failure` fires on the dead-letter
+     after attempt 3 (proves cross-feature interaction with #914).
+
+3. **`tests/regression/test_issue_912_signature_invariants.py`**
+   (per `cross-sdk-inspection.md` Rule 3a — pin the signature so a future
+   refactor cannot silently re-introduce `**kwargs`):
+
+   ```python
+   def test_distributed_runtime_execute_signature():
+       """Pin DistributedRuntime.execute(...) typed kwargs surface.
+       If this fails, the cross-SDK kailash-rs equivalent surface MUST be
+       re-audited per cross-sdk-inspection.md Rule 3a."""
+       import inspect
+       from kailash.runtime.distributed import DistributedRuntime
+       sig = inspect.signature(DistributedRuntime.execute)
+       params = list(sig.parameters.values())
+       names = [p.name for p in params]
+       assert names == [
+           "self", "workflow", "parameters",
+           "soft_time_limit", "time_limit",
+       ], f"signature drifted: {sig}"
+       # No VAR_KEYWORD (the **kwargs that #912 removes)
+       assert not any(
+           p.kind is inspect.Parameter.VAR_KEYWORD for p in params
+       ), f"DistributedRuntime.execute regrew **kwargs: {sig}"
+
+   def test_worker_init_default_time_limit_kwargs():
+       """Pin Worker default_*_time_limit + grace kwargs."""
+       import inspect
+       from kailash.runtime.distributed import Worker
+       sig = inspect.signature(Worker.__init__)
+       names = list(sig.parameters)
+       for required in (
+           "default_soft_time_limit", "default_time_limit",
+           "hard_time_limit_grace_seconds",
+       ):
+           assert required in names, (
+               f"Worker.__init__ missing {required}: {sig}"
+           )
+
+   def test_kailash_errors_namespace_exposes_soft_and_hard():
+       """The brief documents kailash.errors.SoftTimeLimitExceeded as
+       the public import path. Pin it so a future move back to
+       sdk_exceptions does not break user code."""
+       from kailash.errors import (
+           SoftTimeLimitExceeded, HardTimeLimitExceeded,
+       )
+       from kailash.sdk_exceptions import RuntimeException
+       assert issubclass(SoftTimeLimitExceeded, RuntimeException)
+       assert issubclass(HardTimeLimitExceeded, RuntimeException)
+   ```
+
+All Tier-2 tests use the established
+`tests/regression/test_scheduler_retry_primitives.py` `tmp_path` + tempfile
+counter pattern (per `.session-notes:25` — `PythonCodeNode` sandbox blocks
+`tests.*` imports).
+
+## Cross-SDK alignment
+
+`kailash-rs` has its own scheduler + worker surface. The cross-SDK
+equivalent of #912 would be:
+
+- An `enum DiagnosticKind` style typed result for soft vs hard timeout
+  (Rust's structural exhaustiveness guards the dispatch in a way Python
+  lacks per `zero-tolerance.md` Rule 2 fake-dispatch evidence).
+- A `WorkerConfig { default_soft_time_limit: Option<Duration>,
+default_time_limit: Option<Duration>, hard_time_limit_grace: Duration }`.
+- The same producer-side / dequeue-side timing distinction (#7 above);
+  Rust's `tokio::time::timeout` is the natural primitive.
+- Exception names: Rust does not use exceptions; the surface is
+  `Result<_, WorkflowError>` with `WorkflowError::SoftTimeLimitExceeded`
+  and `WorkflowError::HardTimeLimitExceeded` variants for symmetry.
+
+Per `repo-scope-discipline.md`, this is descriptive-only. NO filing
+recommendation; if the user wants the cross-SDK issue filed, they open
+Claude Code in `kailash-rs` and decide there. Per
+`cross-sdk-inspection.md` Rule 3a, the structural-invariant test in
+§ Test plan #3 is the local defense — if a future Python refactor grows
+the signature toward a Rust-shape `**kwargs` accept-all, the test fails
+loudly and forces a re-audit.
+
+## Open questions for the human
+
+These need a gate before `/todos`:
+
+1. **Default behavior on workspace-wide level.** Should
+   `default_soft_time_limit` / `default_time_limit` be configurable at
+   `WorkflowScheduler.__init__` AND at `Worker.__init__`, or only at the
+   `Worker`? The brief specifies `Worker`; adding the scheduler symmetry
+   is cheap (~20 LOC) but expands the API surface. Recommendation: add at
+   both (mirrors celery's `task_soft_time_limit` global + per-task
+   override). Cost: 0 sessions either way, structural-only.
+
+2. **`kailash.errors` namespace.** The brief documents the import path as
+   `kailash.errors.SoftTimeLimitExceeded`. The plan creates a new
+   `kailash/errors.py` re-export module pointing to `sdk_exceptions.py`.
+   Alternative: keep callers on `kailash.sdk_exceptions` (one canonical
+   path; no namespace duplication). Recommendation: create
+   `kailash.errors` because (a) the brief's example code uses it, (b)
+   `errors` is the more discoverable name, (c) the re-export shim
+   (~10 LOC) keeps `sdk_exceptions.py` as the single home. Cost: 0
+   sessions; one extra file.
+
+3. **Hard-limit behavior in `WorkflowScheduler` (not `Worker`).** The
+   brief's repro is a `DistributedRuntime` example — there the requeue
+   semantics are clean (the worker's `_execute_task` nack path). For the
+   in-process scheduler path (`scheduler.py:_execute_workflow`), there
+   IS no requeue — the job is registered, fires on schedule, retries via
+   `RetrySpec` if configured. Question: should `HardTimeLimitExceeded` in
+   the scheduler path (a) propagate through APScheduler's job-error
+   listener (matching today's exception path; user opts into RetrySpec
+   for retries) or (b) silently consume the exception and fire the next
+   scheduled instance (matching celery's hard-kill-on-task-but-job-keeps-running
+   semantic for cron)? Recommendation: (a). Rationale: `RetrySpec`
+   already exists and is the typed retry primitive; HardTimeLimitExceeded
+   should compose with it cleanly, not bypass it. Cost: 0 sessions; a
+   docstring decision.
+
+4. **Soft-limit timer cost.** A `threading.Timer` per attempt costs ~one
+   thread; for high-throughput workers (concurrency=64), 64 Timer threads
+   feels heavy. Alternative: one `asyncio` background task per worker
+   that scans for elapsed deadlines on a tick. Recommendation: timer per
+   task is fine for v1 (matches celery's per-task sigalrm); revisit if
+   profiling shows thread contention. Cost: deferred optimization, no
+   /todos impact.
+
+## Effort estimate
+
+Per `autonomous-execution.md` § Autonomous Execution Cycles:
+
+| Shard                                                                       | Cycles            | Notes                                                                                              |
+| --------------------------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------- |
+| 1 (exceptions + namespace)                                                  | 0.1               | Boilerplate; can land in same shard as #2.                                                         |
+| 2 (`_time_limits.py` wrapper)                                               | 0.5               | Load-bearing async/sync dispatch; needs careful test of grace-window edge cases.                   |
+| 3 (`WorkflowScheduler` plumbing)                                            | 0.4               | Mechanical extension of the existing `_RETRY_SPEC_KWARG` pattern.                                  |
+| 4 (`DistributedRuntime` + `Worker` plumbing)                                | 0.6               | Wire-format change on `TaskMessage` is the highest-risk surface; requires forward-compat thinking. |
+| 5 (tests Tier 2 + invariant)                                                | 0.4               | Pattern-matched on existing scheduler-retry + lifecycle-hook tests.                                |
+| /redteam round-1 (orphan + facade-manager + signature sweeps)               | 0.3               | Per agents.md MUST gate.                                                                           |
+| /redteam round-2 (closure parity if round-1 produces FORWARDED rows)        | 0.2               | Bash+Read specialist required per agents.md.                                                       |
+| /codify (rule extracts if any new BLOCKED-rationalization patterns surface) | 0.1               | Only if the timer-thread alternative is rejected with new evidence.                                |
+| **Total**                                                                   | **~2.5 sessions** | Well under the 10x-throughput equivalent of "33–50 human-days = 3–5 days parallel".                |
+
+Single autonomous session can complete shards 1+2+3 (in-process scheduler
+path); a follow-up session completes shards 4+5 + redteam. Parallelization
+is possible (shards 3 and 4 are independent given the wrapper helper from
+shard 2 lands first), reducing wall-clock to ~1.5 sessions if
+worktree-isolated per `agents.md` § "Worktree Isolation".
+
+The plan stays inside the `~500 LOC load-bearing / ≤5–10 invariants`
+budget per shard. No shard requires sub-shard splitting.

--- a/workspaces/issue-912-task-time-limits/02-todos/todos.md
+++ b/workspaces/issue-912-task-time-limits/02-todos/todos.md
@@ -1,0 +1,443 @@
+# Issue #912 /todos: per-task soft/hard time limits
+
+Phase: 02 (todos) — written 2026-05-09. Read-only phase. Awaits human gate.
+Branch base: `main` @ `d5d84dbd` (post-#915 merge).
+Architecture plan: `workspaces/issue-912-task-time-limits/01-analyze/architecture-plan.md`.
+
+## Root-cause decisions (user-approved 2026-05-09)
+
+The /analyze gate surfaced 4 root-cause questions. The user resolved all 4
+before /todos. The decisions are baked in below; /implement does NOT re-debate
+them. Restated verbatim from the approval message:
+
+**RC1 — `**kwargs`removal scope: BROAD sweep across all`BaseRuntime`subclasses.** Grep`def execute(.\*\*\*kwargs)`across`src/kailash/runtime/`.
+EVERY hit (LocalRuntime, AsyncLocalRuntime, DistributedRuntime, DockerRuntime,
+etc.) gets typed kwargs in this issue's Shard 1. If sweep exceeds 500 LOC /
+10 invariants, split into Shard 0 (BaseRuntime sweep, typing convention) +
+Shard 1 (time-limit kwargs on cleaned surface). Per `cross-sdk-inspection.md`Rule 3a, EVERY runtime's typed signature gets a structural-invariant test
+pinning the signature so a future refactor cannot silently re-grow`\*\*kwargs`.
+
+**RC2 — `kailash.errors` namespace: NO new module, NO shim.** Add
+`SoftTimeLimitExceeded` and `HardTimeLimitExceeded` directly to
+`src/kailash/sdk_exceptions.py`. Do NOT create `src/kailash/errors.py`
+re-export shim (`feedback_no_shims.md` blocks). The brief example will be
+updated to `from kailash.sdk_exceptions import SoftTimeLimitExceeded`. The
+rename `sdk_exceptions.py → errors.py` is a major-version-class change
+deferred to a separate proposal (zero-tolerance.md Rule 6a + no-shim
+conflict).
+
+**RC3 — PACT integration: not applicable to #912.** (Used in #913 only.)
+
+**RC4 — `pause`/`resume`/`update_cron` scheduler methods: not applicable to
+#912.** (Owned by #913 Shard 0.)
+
+## Broad-sweep grep results (RC1)
+
+`grep -RnE 'def\s+execute\s*\([^)]*\*\*kwargs' src/kailash/runtime/` plus a
+manual signature read of every `class *Runtime`. Production methods that
+currently accept `**kwargs`:
+
+| #   | Class                                       | File                                 | Line | Disposition under RC1                                                                                                              |
+| --- | ------------------------------------------- | ------------------------------------ | ---- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `BaseRuntime.execute` (abstract)            | `src/kailash/runtime/base.py`        | 843  | Tighten abstract signature: `def execute(self, workflow, *, parameters=None, soft_time_limit=None, time_limit=None) -> Tuple`.     |
+| 2   | `LocalRuntime.execute`                      | `src/kailash/runtime/local.py`       | 927  | Drop `**kwargs`; promote keyword-only typed kwargs (already partially keyword-only after `*,`). Add `soft_time_limit, time_limit`. |
+| 3   | `AsyncLocalRuntime.execute` (sync override) | `src/kailash/runtime/async_local.py` | 707  | Drop `**kwargs`; mirror parent + `soft_time_limit, time_limit`.                                                                    |
+| 4   | `DistributedRuntime.execute`                | `src/kailash/runtime/distributed.py` | 502  | Drop `**kwargs` (silent-drop offender per brief). Add `soft_time_limit, time_limit`. PRIMARY producer surface for #912.            |
+
+Methods that DO NOT carry `**kwargs` (typed already — additive `*,
+soft_time_limit, time_limit` only, no removal needed):
+
+| Class                                      | File                                       | Line | Action                                                                          |
+| ------------------------------------------ | ------------------------------------------ | ---- | ------------------------------------------------------------------------------- |
+| `AsyncLocalRuntime.execute_workflow_async` | `src/kailash/runtime/async_local.py`       | 806  | Keyword-only typed already. Add `soft_time_limit, time_limit`.                  |
+| `DockerRuntime.execute`                    | `src/kailash/runtime/docker.py`            | 565  | Add `soft_time_limit, time_limit` (additive; out-of-process timer enforcement). |
+| `ParallelRuntime.execute` (async)          | `src/kailash/runtime/parallel.py`          | 66   | Add `soft_time_limit, time_limit`.                                              |
+| `ParallelCyclicRuntime.execute`            | `src/kailash/runtime/parallel_cyclic.py`   | 62   | Add `soft_time_limit, time_limit`.                                              |
+| `AccessControlledRuntime.execute`          | `src/kailash/runtime/access_controlled.py` | 129  | Add `soft_time_limit, time_limit` (forwards to inner runtime).                  |
+| `DurableRuntime.execute` (async)           | `src/kailash/runtime/durable.py`           | 1281 | Add `soft_time_limit, time_limit`.                                              |
+
+**Forwarding callsite (must update or signature drift):**
+
+- `src/kailash/runtime/scheduler.py:858` — `runtime.execute(workflow, **kwargs)` inside the retry loop. Will need to pop `soft_time_limit`/`time_limit` from `kwargs` and pass them as named arguments (or restructure to call `_execute_with_time_limits` wrapper helper introduced in Shard 2).
+
+**Sweep size estimate:**
+
+- `**kwargs` removal: 4 production classes × ~3 LOC change each = ~12 LOC mechanical signature changes.
+- Additive `soft_time_limit, time_limit` keyword-only kwargs across 10 execute methods: 10 × ~4 LOC = ~40 LOC mechanical.
+- Signature-invariant tests (Rule 3a): 10 methods × ~10 LOC test = ~100 LOC test.
+- Total signature-only surface ≈ 152 LOC. Well under the 500 LOC load-bearing budget.
+
+**Conclusion:** Single Shard 1 is feasible. Shard 0 split NOT required. The
+sweep is mechanical signature work, not load-bearing logic; per
+`autonomous-execution.md` § Per-Session Capacity Budget Rule 2 ("size by
+complexity, not LOC alone"), the invariant count for Shard 1 is dominated
+by the time-limit wrapper logic in Shard 2, NOT the signature sweep.
+
+## Shard plan
+
+Five shards. Sequential dependencies: Shard 1 → Shard 2 → Shards 3 + 4
+(parallel) → Shard 5. Shard 1 is the **signature-owner** for #912 per
+`agents.md` § Parallel-Worktree Package Ownership Coordination — #911
+(`queue=` kwarg) MUST wait for Shard 1 to merge.
+
+---
+
+### Shard 1 — Exception types + broad-sweep typed-kwargs cleanup
+
+**Value-anchor:** Closes the silent-drop offender at
+`distributed.py:502-544` per the user's 2026-05-09 approval ("RC1: BROAD
+sweep across all BaseRuntime subclasses"); aligns the producer-side
+execution surface with `zero-tolerance.md` Rule 3c so #911 (queue=) can
+land on a cleaned signature without re-fighting the same battle. The user
+brief at `gh issue view 912` is the load-bearing source: per-task
+soft/hard time limits cannot land cleanly while every runtime advertises
+`**kwargs` and silently drops everything; soft/hard timing is the
+specific value, the signature cleanup is the structural prerequisite.
+
+**Files touched:**
+
+- `src/kailash/sdk_exceptions.py` — add `SoftTimeLimitExceeded`, `HardTimeLimitExceeded` (~20 LOC).
+- `src/kailash/runtime/base.py` (line 843) — tighten abstract signature to keyword-only typed.
+- `src/kailash/runtime/local.py` (line 927) — drop `**kwargs`; promote typed kwargs; add `soft_time_limit`, `time_limit` (placeholders accepted, not yet enforced — enforcement is Shard 2's helper).
+- `src/kailash/runtime/async_local.py` (lines 707 + 806) — same treatment for both `execute` and `execute_workflow_async`.
+- `src/kailash/runtime/distributed.py` (line 502) — drop `**kwargs`; add the two typed kwargs.
+- `src/kailash/runtime/docker.py` (line 565) — additive only.
+- `src/kailash/runtime/parallel.py` (line 66) — additive only.
+- `src/kailash/runtime/parallel_cyclic.py` (line 62) — additive only.
+- `src/kailash/runtime/access_controlled.py` (line 129) — additive only; forward to inner runtime.
+- `src/kailash/runtime/durable.py` (line 1281) — additive only.
+- `src/kailash/runtime/scheduler.py` (line 858) — pop `soft_time_limit`/`time_limit` from `kwargs` before forwarding (placeholder; enforcement lands Shard 3).
+
+**Invariants (8):**
+
+1. Every runtime's `execute(...)` signature lists `soft_time_limit` and `time_limit` as keyword-only `Optional[float]` defaulting to `None`.
+2. No `**kwargs` survives in any `BaseRuntime` subclass after this shard (4 removals — Base/Local/Async/Distributed).
+3. `SoftTimeLimitExceeded` and `HardTimeLimitExceeded` subclass `RuntimeException`; they live in `kailash.sdk_exceptions` (NO `kailash.errors` shim per RC2).
+4. Both exceptions are exported in `sdk_exceptions.__all__`.
+5. The placeholder kwargs are accepted but not yet wired (validation only — `if value is not None and value <= 0: raise ValueError`); enforcement is Shard 2's wrapper.
+6. `scheduler.py:858` no longer forwards `**kwargs` blindly to `runtime.execute`; it explicitly threads `parameters` plus the two new kwargs (others raise `TypeError`).
+7. The validation `soft_time_limit < time_limit` (when both set) lives in a single helper called from every entry point — no duplicated validation across 10 runtimes.
+8. Cross-SDK alignment: keyword names match celery (`soft_time_limit`, `time_limit`); exception names match celery's `SoftTimeLimitExceeded`. NO Rust/cross-repo filing per `repo-scope-discipline.md`.
+
+**LOC estimate:** ~60 LOC load-bearing (validation helper + scheduler `kwargs` un-forwarding) + ~120 LOC mechanical (signature additions across 10 methods + 2 exception classes). Net ~180 LOC. Well under 500.
+
+**Tests required (Tier 2 + structural invariant):**
+
+- `tests/regression/test_issue_912_signature_invariants.py` (NEW) — pin every runtime's typed signature; assert `**kwargs` absent on the 4 cleaned classes; assert `soft_time_limit`/`time_limit` accepted on all 10 methods. ~150 LOC.
+- `tests/integration/test_runtime_signature_typed_kwargs.py` (NEW) — for each runtime, assert `runtime.execute(workflow, parameters={...}, soft_time_limit=2)` does not raise on signature; assert `runtime.execute(workflow, garbage_kwarg=1)` raises `TypeError`. ~80 LOC.
+- `tests/unit/test_sdk_exceptions_time_limits.py` (NEW) — `SoftTimeLimitExceeded` / `HardTimeLimitExceeded` subclass `RuntimeException`; `__cause__` chaining preserved. ~40 LOC.
+
+**Dependencies:** None. This shard owns the signature surface; everything downstream follows.
+
+**Worktree assignment:** Wave 1 (Option B parallel plan). Branch `feat/issue-912-shard-1-typed-kwargs-sweep`. Worktree path `.claude/worktrees/issue-912-shard-1`. Pre-flight per `worktree-isolation.md` Rule 5 (merge-base = current `main` HEAD). Launches in parallel with `feat/issue-913-shard-0-scheduler-methods` (independent surface — scheduler `pause`/`resume`/`update_cron`).
+
+**In-shard same-class fixes** (per `autonomous-execution.md` MUST Rule 4): if reviewer surfaces additional `**kwargs` carve-outs (e.g., a private `_execute_internal` helper) AND they fit the budget, fix in same shard.
+
+---
+
+### Shard 2 — `_time_limits.py` wrapper helper
+
+**Value-anchor:** Soft/hard limit ENFORCEMENT (the actual user-asked-for
+behavior in #912's body) requires a thread-/loop-safe wrapper that arms a
+`CancellationToken` at the deadline. Without this helper, Shard 1's typed
+kwargs are accepted but ignored — the same fake-dispatch failure-mode
+class as `zero-tolerance.md` Rule 2 fake-dispatch evidence. The user's
+brief explicitly requests "celery-style soft_time_limit (warn, raise a
+catchable exception inside the running workflow)" — Shard 2 is what
+makes that promise true.
+
+**Files touched:**
+
+- `src/kailash/runtime/_time_limits.py` (NEW) — wrapper helper module. Two callables:
+  - `arm_time_limits(token, *, soft_time_limit, time_limit, grace_seconds) -> _Cancellable` (sync, uses `threading.Timer`).
+  - `arm_time_limits_async(token, *, soft_time_limit, time_limit, grace_seconds) -> _Cancellable` (async, uses `asyncio.create_task` + `asyncio.sleep`).
+  - `_TimeLimitClassifier` — converts `WorkflowCancelledError` raised by the runtime back into `SoftTimeLimitExceeded` / `HardTimeLimitExceeded` based on which deadline was reached first (compare `time.monotonic()` against stored deadlines).
+  - `_validate_limits(soft, hard) -> None` — single source of validation (`> 0`, `soft < hard`); called from every runtime entry point.
+
+**Invariants (5):**
+
+1. Timer is **NEVER** signal-based (`signal.SIGALRM` BLOCKED — fails outside main thread, fails on Windows). Use `threading.Timer` (sync) / `asyncio.create_task` (async).
+2. Timer arms at the call to `arm_time_limits()`, NOT at scheduler-registration time. This means re-fired jobs after restart get a fresh budget.
+3. Disarm in `finally` block — both timers are explicitly cancelled when the wrapped block exits, regardless of success/failure.
+4. The wrapper preserves cause chain: the runtime raises `WorkflowCancelledError`; the classifier wraps it as `SoftTimeLimitExceeded(...) from original`.
+5. Hard-limit enforcement: after `time_limit + grace_seconds`, the wrapper raises `HardTimeLimitExceeded` UNCONDITIONALLY (does not wait for the runtime to observe the token — the grace window is the runtime's chance to wind down cleanly).
+
+**LOC estimate:** ~150 LOC load-bearing (timer plumbing + classifier + validation). Net well under 500.
+
+**Tests required:**
+
+- `tests/integration/test_time_limits_wrapper.py` (NEW) — Tier 2 (real `LocalRuntime` + real `CancellationToken`):
+  - `test_soft_limit_raises_after_deadline` — workflow sleeps 5s; soft=2s; assert `SoftTimeLimitExceeded` raised at ~2s.
+  - `test_hard_limit_raises_after_grace` — workflow sleeps 5s; hard=2s, grace=1s; assert `HardTimeLimitExceeded` raised at ~3s.
+  - `test_validation_rejects_negative` — `_validate_limits(soft=-1, hard=None)` raises `ValueError`.
+  - `test_validation_rejects_soft_ge_hard` — `_validate_limits(soft=10, hard=5)` raises `ValueError`.
+  - `test_async_wrapper_no_signal_fallback` — assert `arm_time_limits_async` works inside `asyncio.run()` (proves no signal usage).
+  - `test_disarm_releases_timer_thread` — assert no zombie threads after exit.
+  - ~200 LOC total.
+
+**Dependencies:** Shard 1 (needs `SoftTimeLimitExceeded`/`HardTimeLimitExceeded` types).
+
+**Worktree assignment:** Wave 2 (sequential after Shard 1 merges). Branch `feat/issue-912-shard-2-time-limits-wrapper`.
+
+---
+
+### Shard 3 — `WorkflowScheduler` plumbing
+
+**Value-anchor:** In-process scheduler is the surface most kailash-py
+users touch first (cron jobs, `schedule_interval`, `schedule_once`); the
+brief's Acceptance Criterion #1 says soft/hard limits must work through
+this surface AND interact correctly with the just-merged `RetrySpec`
+(#910). Without this shard, scheduled jobs can be retry-controlled but
+not time-limited — half a feature.
+
+**Files touched:**
+
+- `src/kailash/runtime/scheduler.py`:
+  - Add `_TIME_LIMIT_KWARG = "_kailash_time_limits"` constant alongside `_RETRY_SPEC_KWARG` at line 71.
+  - `_compose_job_kwargs` (line 744) — accept `soft_time_limit`/`time_limit` parameters; thread a tuple `(soft, hard)` under the internal key.
+  - `_execute_workflow` (line 780) — pop the internal key; arm timers around `runtime.execute(...)` at line 858 inside the existing retry loop. Each retry attempt re-arms a fresh timer (no carry-over).
+  - `schedule_cron` (line 499), `schedule_interval` (line 579), `schedule_once` (line 642) — accept the new keyword-only kwargs; call updated `_compose_job_kwargs`.
+  - Optionally `WorkflowScheduler.__init__` accepts `default_soft_time_limit`/`default_time_limit` (per architecture-plan Open Question #1; recommendation: include for celery-symmetry; flag user-gated at /implement).
+
+**Invariants (6):**
+
+1. Signature parity across `schedule_cron`, `schedule_interval`, `schedule_once` (all three accept the same two new kwargs in the same position).
+2. `RetrySpec` interaction: `SoftTimeLimitExceeded` is a normal exception in the retry classifier — `RetrySpec(retry_on=(SoftTimeLimitExceeded,))` retries; `RetrySpec(dont_retry_on=(SoftTimeLimitExceeded,))` does NOT.
+3. Each retry attempt re-arms a fresh timer (NO carry-over from prior attempt's elapsed time).
+4. Validation at scheduler-registration time, not at fire time (catches operator error before the job runs once).
+5. `HardTimeLimitExceeded` propagates through APScheduler's job-error listener (per architecture-plan Open Question #3 recommendation: Option (a) — compose with RetrySpec, don't bypass).
+6. Persistence: limits are persisted in APScheduler `kwargs=` dict (same pattern as `_RETRY_SPEC_KWARG`); replayed from jobstore on restart.
+
+**LOC estimate:** ~180 LOC load-bearing (kwargs threading + retry-loop integration + 3 schedule\_\* methods).
+
+**Tests required:**
+
+- `tests/integration/test_scheduler_time_limits.py` (NEW):
+  - `test_soft_time_limit_raises_in_workflow` — schedule workflow that sleeps 5s; soft=2s; assert `SoftTimeLimitExceeded` propagates via APScheduler error listener.
+  - `test_hard_time_limit_raises_after_grace` — same workflow; hard=2s, grace=1s; assert `HardTimeLimitExceeded` at ~3s.
+  - `test_soft_then_hard_propagation` — soft=2, hard=4; user code catches soft and continues sleeping; hard fires at 4+grace.
+  - `test_retryspec_classifies_soft_as_retryable_on_demand` — `RetrySpec(retry_on=(SoftTimeLimitExceeded,), max_retries=2)` + `soft_time_limit=2`; assert workflow retried.
+  - `test_retryspec_dontretry_on_soft_overrides` — `dont_retry_on=(SoftTimeLimitExceeded,)`; assert no retry.
+  - `test_each_retry_arms_fresh_timer` — soft=2, max_retries=3; assert each attempt sees full 2s budget.
+  - ~250 LOC total. Use established `tests/regression/test_scheduler_retry_primitives.py` `tmp_path` + tempfile counter pattern (PythonCodeNode sandbox blocks `tests.*` imports).
+
+**Dependencies:** Shard 1 (typed kwargs), Shard 2 (wrapper helper). Once those land, Shard 3 + Shard 4 are independent (parallelizable).
+
+**Worktree assignment:** Wave 3 (parallel with Shard 4). Branch `feat/issue-912-shard-3-scheduler-time-limits`.
+
+---
+
+### Shard 4 — `DistributedRuntime` + `Worker` plumbing
+
+**Value-anchor:** Brief Acceptance Criterion #2 explicitly names
+`DistributedRuntime.execute(...)` (producer side) and Acceptance Criterion
+#2 names `Worker.__init__(default_soft_time_limit=, default_time_limit=)`
+
+- "task is requeued on hard limit" (consumer side). Without this shard,
+  soft/hard limits work in-process but break the moment a workflow is
+  serialized to Redis. The wire-format addition is the highest-risk
+  surface; this shard owns it.
+
+**Files touched:**
+
+- `src/kailash/runtime/distributed.py`:
+  - `TaskMessage` dataclass — add `execution_limits: Optional[Dict[str, float]] = None` (`{"soft": 300.0, "hard": 600.0}` shape — single optional dict for forward-compat with workers running older SDK).
+  - `TaskMessage.to_json` / `from_json` — serialize/deserialize the new field.
+  - `DistributedRuntime.execute` (line 502) — already typed by Shard 1; populate `task.execution_limits` from the typed kwargs at enqueue time.
+  - `Worker.__init__` (line 614) — add `default_soft_time_limit, default_time_limit, hard_time_limit_grace_seconds` keyword-only kwargs.
+  - `Worker._execute_task` (line 839) — compute effective limits = per-task limits OR worker defaults; arm timers around `run_in_executor(_execute_workflow_sync)` at line 878; catch `HardTimeLimitExceeded`; treat as retryable failure (existing nack path requeues if `attempts < max_attempts`).
+  - Lifecycle hook integration (#914 just merged): `on_task_retry` fires on hard-limit-with-attempts-remaining; `on_task_failure` fires on dead-letter.
+
+**Invariants (7):**
+
+1. Producer-side serializes limits onto `TaskMessage`, NOT the deadline timestamp (timer arms at dequeue, not enqueue — so queue wait doesn't burn budget).
+2. Wire format: `execution_limits` is one optional dict, not two separate fields → workers running older SDK silently ignore unknown field (forward-compat).
+3. Default fallback chain: per-task value (from `TaskMessage`) wins; falls through to `Worker(default_*)`; falls through to `None` (no limit). Same precedence as `TaskMessage.visibility_timeout` vs `TaskQueue.default_visibility_timeout`.
+4. `HardTimeLimitExceeded` triggers requeue (NOT dead-letter) when `attempts < max_attempts`; dead-letter only after exhaustion.
+5. Lifecycle hook `on_task_retry` fires on hard-limit-with-attempts-remaining (per #914 contract).
+6. Lifecycle hook `on_task_failure` fires on the dead-letter after attempts exhausted.
+7. Producer-side `runtime.execute(...)` no longer accepts arbitrary `**kwargs` (Shard 1 invariant 2 propagates); typed signature only.
+
+**LOC estimate:** ~220 LOC load-bearing (TaskMessage wire format + Worker plumbing + lifecycle hook integration).
+
+**Tests required:**
+
+- `tests/integration/test_distributed_time_limits.py` (NEW; real Redis per existing `tests/integration/test_distributed_*` pattern):
+  - `test_producer_time_limits_serialize_to_taskmessage` — enqueue with `soft_time_limit=300, time_limit=600`; dequeue raw via `TaskQueue.dequeue`; assert `task.execution_limits == {"soft": 300.0, "hard": 600.0}`.
+  - `test_worker_arms_timers_at_dequeue_not_at_enqueue` — enqueue with `time_limit=2`; sleep 3s before starting worker; assert worker still gets full 2s budget (proves dequeue-side arming).
+  - `test_hard_limit_triggers_requeue` — workflow sleeps 10s; `time_limit=2`, `max_attempts=3`; assert task processed by 2 workers before dead-lettering on attempt 3.
+  - `test_worker_default_overridden_by_per_task` — `Worker(default_time_limit=10)`; enqueue with `time_limit=2`; effective is 2s.
+  - `test_lifecycle_hooks_fire_on_hard_limit` — register `on_task_retry` + `on_task_failure`; assert `on_task_retry` fires on retries 1-2, `on_task_failure` fires on dead-letter at attempt 3.
+  - `test_taskmessage_wire_format_forward_compat` — older-SDK-style `TaskMessage` JSON without `execution_limits` field deserializes cleanly with `execution_limits is None`.
+  - ~280 LOC total.
+
+**Dependencies:** Shard 1, Shard 2. Independent of Shard 3 (different surface). Parallelizable with Shard 3.
+
+**Worktree assignment:** Wave 3 (parallel with Shard 3). Branch `feat/issue-912-shard-4-distributed-time-limits`.
+
+---
+
+### Shard 5 — Cross-cutting: docs, CHANGELOG, signature-invariant pin tests
+
+**Value-anchor:** A user reading `gh issue view 912` for the feature
+release notes needs (a) a CHANGELOG entry, (b) docstring on every public
+surface, (c) a signature-invariant pin so the next refactor doesn't
+regrow `**kwargs`. Without Shard 5, the feature is implemented but
+discoverable only by reading the source.
+
+**Files touched:**
+
+- `CHANGELOG.md` — entry under next minor version: per-task soft/hard time limits, `**kwargs` removal scope, exception types, `Worker.__init__` defaults.
+- Docstrings on every changed signature (Shards 1, 3, 4) — celery-style examples.
+- `tests/regression/test_issue_912_signature_invariants.py` — finalize per-runtime signature pins (drafted in Shard 1; finalize after Shards 3+4 land).
+- `docs/`-side: spec section if `specs/_index.md` references runtime execution surface (verify at /implement; SKIP if no relevant spec file exists).
+
+**Invariants (4):**
+
+1. Every public method touched by Shards 1-4 has an updated docstring including a `soft_time_limit` / `time_limit` example.
+2. CHANGELOG entry follows the existing format (see #910 entry as template).
+3. Signature-invariant test (Rule 3a) covers all 10 runtime `execute*` methods (NOT just the 4 cleaned ones).
+4. Brief example code in `gh issue view 912` body is reflected accurately in the CHANGELOG migration note (`from kailash.sdk_exceptions import SoftTimeLimitExceeded`, NOT `from kailash.errors`).
+
+**LOC estimate:** ~80 LOC docs/CHANGELOG + ~150 LOC tests = ~230 LOC. Mostly boilerplate; well under 500.
+
+**Tests required:** Signature-invariant pin tests (mostly authored in Shard 1; finalize here).
+
+**Dependencies:** Shards 1+2+3+4 must merge before Shard 5 ships (it's the cross-cutting closer).
+
+**Worktree assignment:** Wave 4 (sequential after Shards 3+4 merge). Branch `feat/issue-912-shard-5-docs-and-pins`.
+
+---
+
+## Tier-2 test plan (consolidated)
+
+| Test file                                                  | Shard | Asserts                                                                              |
+| ---------------------------------------------------------- | ----- | ------------------------------------------------------------------------------------ |
+| `tests/regression/test_issue_912_signature_invariants.py`  | 1, 5  | Every runtime's typed signature; no `**kwargs` on 4 cleaned classes.                 |
+| `tests/integration/test_runtime_signature_typed_kwargs.py` | 1     | `runtime.execute(..., garbage_kwarg=1)` raises `TypeError` on each runtime.          |
+| `tests/unit/test_sdk_exceptions_time_limits.py`            | 1     | `SoftTimeLimitExceeded` / `HardTimeLimitExceeded` subclass `RuntimeException`.       |
+| `tests/integration/test_time_limits_wrapper.py`            | 2     | Helper raises soft / hard at correct deadlines; no signal usage; no zombie threads.  |
+| `tests/integration/test_scheduler_time_limits.py`          | 3     | End-to-end scheduler path; RetrySpec interaction; per-attempt fresh timer.           |
+| `tests/integration/test_distributed_time_limits.py`        | 4     | Wire format; producer-vs-worker timing; requeue on hard; lifecycle hook integration. |
+
+All Tier-2 tests use real infrastructure per `rules/testing.md` Tier 2/3
+NO-MOCKING contract (real `LocalRuntime`, real APScheduler in-memory job
+store, real Redis for distributed tests, real `CancellationToken`).
+
+## Cross-SDK alignment notes
+
+Per `repo-scope-discipline.md` MUST NOT clauses, this section is
+**descriptive only** — no filing recommendation, no cross-repo `gh`
+invocation. The kailash-rs equivalent surface (when/if added) would mirror:
+
+- `WorkerConfig { default_soft_time_limit: Option<Duration>, default_time_limit: Option<Duration>, hard_time_limit_grace: Duration }`.
+- Producer-side / dequeue-side timing distinction matches Python.
+- Exception names → enum variants: `WorkflowError::SoftTimeLimitExceeded`, `WorkflowError::HardTimeLimitExceeded`.
+- Rust's `tokio::time::timeout` is the natural primitive (vs Python's `threading.Timer` / `asyncio.create_task`).
+
+The structural-invariant test in Shard 1 (`test_distributed_runtime_execute_signature`)
+is the local defense per `cross-sdk-inspection.md` Rule 3a — if a future
+Python refactor regrows `**kwargs`, the test fails loudly and forces a
+re-audit before merge.
+
+## Open questions for human gate before /implement
+
+The 4 RC questions are decided. Two genuinely-blocking implementation
+questions remain. Recommendation given for each per
+`recommendation-quality.md` MUST-1.
+
+### Q1: Default behavior on `WorkflowScheduler.__init__` (architecture-plan Q1)
+
+**Question:** Should `WorkflowScheduler.__init__` accept
+`default_soft_time_limit` / `default_time_limit` symmetric to
+`Worker.__init__`?
+
+**Recommendation:** YES, include in Shard 3.
+
+**Why:** Mirrors celery's `task_soft_time_limit` global + per-call override.
+Cost is ~20 LOC. Symmetry matters because operators running the in-process
+scheduler often run a Worker pool too, and asymmetric defaults are a sharp
+edge ("why does my cron job time out at 600s but my queued job at 300s?").
+
+**Cons:** Expands API surface by 2 kwargs on the scheduler constructor.
+Tiny, but real.
+
+**Alternative:** Worker-only, scheduler defaults to `None`. Cheaper
+implementation, surprising semantics.
+
+### Q2: `HardTimeLimitExceeded` disposition in scheduler retry loop (architecture-plan Q3)
+
+**Question:** When `HardTimeLimitExceeded` fires inside
+`WorkflowScheduler._execute_workflow`'s retry loop, should it (a)
+propagate through APScheduler's job-error listener AND compose with
+`RetrySpec` for retries, OR (b) be silently consumed and the next
+scheduled instance fires normally?
+
+**Recommendation:** Option (a) — compose with RetrySpec.
+
+**Why:** `RetrySpec` is the typed retry primitive that just landed (#910);
+hard-limit cleanly composes. Option (b) bypasses RetrySpec and creates a
+hidden control-flow path, which is exactly the "fake-dispatch" failure
+mode `zero-tolerance.md` Rule 2 blocks.
+
+**Cons:** Operators who want celery's "hard kill = task dead, cron
+continues" semantic must explicitly write
+`RetrySpec(dont_retry_on=(HardTimeLimitExceeded,))`. Slightly more verbose
+but more typed.
+
+**Alternative:** Option (b). Compatible with celery defaults but bypasses
+the retry primitive.
+
+These two questions are not blocking architecturally — Shards 1, 2, 4 and
+the test scaffolding can proceed regardless. They affect only the 6 LOC
+of Shard 3 plumbing. If the user wants to defer Q1/Q2 to /implement, the
+recommended-default decisions above land; the user can override during
+/implement gate review.
+
+## Effort estimate (autonomous execution cycles)
+
+| Shard                                                               | Cycles            | Worktree wave                  | Notes                                                                   |
+| ------------------------------------------------------------------- | ----------------- | ------------------------------ | ----------------------------------------------------------------------- |
+| 1 — Exceptions + broad-sweep typed-kwargs                           | 0.4               | Wave 1 (parallel #913 Shard 0) | Mechanical signature work + 2 exception classes + scheduler kwarg-pop.  |
+| 2 — `_time_limits.py` wrapper helper                                | 0.5               | Wave 2 (sequential)            | Load-bearing async/sync dispatch; careful grace-window edge cases.      |
+| 3 — `WorkflowScheduler` plumbing                                    | 0.4               | Wave 3 (parallel S4)           | Mechanical extension of `_RETRY_SPEC_KWARG` pattern.                    |
+| 4 — `DistributedRuntime` + `Worker` plumbing                        | 0.6               | Wave 3 (parallel S3)           | TaskMessage wire-format change is highest-risk surface.                 |
+| 5 — Docs, CHANGELOG, signature pins                                 | 0.2               | Wave 4 (sequential)            | Cross-cutting closer.                                                   |
+| /redteam round-1 (orphan + signature sweep)                         | 0.3               | Wave 5 (sequential)            | Per `agents.md` MUST gate.                                              |
+| /redteam round-2 (closure parity if round-1 produces FORWARDED)     | 0.2               | Wave 5 (sequential)            | Bash+Read specialist required per `agents.md`.                          |
+| /codify (rule extracts if BLOCKED-rationalization patterns surface) | 0.1               | Optional                       | Only if timer-thread alternative is rejected with new evidence.         |
+| **Total**                                                           | **~2.7 sessions** |                                | Wall-clock with parallel worktrees ~1.7 sessions (Waves 1+2+3 overlap). |
+
+Per `autonomous-execution.md` § 10x Throughput Multiplier: equivalent
+human-team estimate would inflate this to ~30-50 human-days; the 10x
+multiplier converts to ~3 days parallel autonomous, which is consistent
+with the ~2.7-session estimate.
+
+## Signature-owner declaration (per `agents.md` § Parallel-Worktree Package Ownership)
+
+**Issue #912 owns:**
+
+- The `BaseRuntime`-subclass `execute(...)` signature shape.
+- The `*, soft_time_limit, time_limit` keyword-only kwarg slot ordering.
+- The `Worker.__init__` `default_*_time_limit` + `hard_time_limit_grace_seconds` slot.
+- `kailash.sdk_exceptions.SoftTimeLimitExceeded` / `HardTimeLimitExceeded`.
+
+**Collision with #911 (multi-queue):** #911's brief proposes
+`runtime.execute(workflow, queue: str = "default")`. That third typed
+kwarg lands AFTER #912's two — slot ordering is
+`*, soft_time_limit, time_limit, queue` (alphabetical-ish; matches
+celery convention). #911 MUST wait for #912 Shard 1 to merge before
+opening its PR; otherwise the two agents fight over the same signature
+line and one set of edits silently loses.
+
+**Collision with #913 (lifecycle hooks for scheduler):** #913 Shard 0
+adds `pause`/`resume`/`update_cron` scheduler methods (RC4) — independent
+surface. Parallel-launchable with #912 Shard 1 in Wave 1.
+
+## Plan ready for human gate
+
+Per `communication.md` § Approval Gates:
+
+- Does this cover everything you described in the brief? (cleaned `**kwargs`, soft/hard time limits, RetrySpec interaction, Worker defaults, lifecycle-hook integration)
+- Is anything here that you didn't ask for? (the docs/CHANGELOG shard is procedural, not user-asked — acceptable to skip if you'd rather it be batched into the release PR, but recommended to keep separate so the release-prep PR stays metadata-only per `git.md`)
+- Is anything missing that you expected to see? (the architecture plan's Q1 "WorkflowScheduler defaults" and Q3 "HardTimeLimitExceeded disposition" are surfaced as Open Questions above with recommended defaults; if you want a different default, name it and Shard 3's slot fills accordingly)

--- a/workspaces/issue-913-admin-api/01-analyze/architecture-plan.md
+++ b/workspaces/issue-913-admin-api/01-analyze/architecture-plan.md
@@ -1,0 +1,261 @@
+# Issue #913: admin API for WorkflowScheduler
+
+## Brief summary
+
+Issue #913 asks for a runtime administration surface over `kailash.runtime.scheduler.WorkflowScheduler`. Today, schedules are created in code (`scheduler.schedule_cron(workflow, "0 6 * * *")`) and persisted via APScheduler's SQLAlchemy job store; ops cannot list, pause, resume, edit cron expressions, or delete schedules without redeploying the scheduler process. Celery + django-celery-beat sets the comparison: a `PeriodicTask` row is editable in Django admin, the beat process picks up changes on the next reload tick. The brief asks for the same operational property in Kailash.
+
+The deliverable is a `WorkflowScheduler.AdminAPI` exposed through the Kailash framework stack:
+operations to list / enable / disable / update cron / delete schedules; transports HTTP + CLI + MCP via Nexus's multi-channel `@app.handler`; authentication via Nexus's JWT/auth surface; authorization via PACT envelopes (or Nexus AuthGuard role checks where PACT is not deployed); a Tier 2 integration test that exercises the full edit → next-fire path; and an optional migration helper from `django-celery-beat`'s `PeriodicTask` table.
+
+## Brief corrections
+
+The brief's claims were verified against the current source. The most material correction is on the schedule-mutation surface:
+
+| Claim                                                                                                                    | Verdict                                      | Citation                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| "`WorkflowScheduler` uses APScheduler's `SQLAlchemyJobStore` with a SQLite backend"                                      | TRUE                                         | `src/kailash/runtime/scheduler.py:404, 416` (`from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore` ... `SQLAlchemyJobStore(url=f"sqlite:///{job_store_path}")`)                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| "Job definitions are process-internal: ops cannot add, remove, or modify schedules at runtime through any admin surface" | PARTIALLY TRUE                               | The Python API surface (`schedule_cron` / `schedule_interval` / `schedule_once` / `cancel` / `list_schedules`) at `src/kailash/runtime/scheduler.py:499, 579, 642, 703, 725` lets you add/remove/list at runtime IN-PROCESS. There is NO modify-cron path (`modify_schedule` / `pause` / `resume` / `update_cron` are not implemented). There is NO HTTP / CLI / MCP exposure of any of these methods. The brief's framing is correct from an ops-surface perspective; from an in-process programmatic perspective, three of the five operations exist (list, add, cancel) but two are missing entirely (pause/resume, update-cron). |
+| "Celery's `django-celery-beat` provides this via Django admin: a `PeriodicTask` row is editable in the UI"               | TRUE (industry context, no citation in repo) | descriptive only                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| "Optional integration with Nexus so the admin surface ships as a framework-native panel"                                 | FRAMEWORK-VERIFIED                           | Nexus `@app.handler` at `packages/kailash-nexus/src/nexus/core.py:2738` exposes a function across HTTP + CLI + MCP simultaneously; this IS the multi-channel surface the brief calls for.                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| "Auth split: Nexus owns authentication … PACT owns authorization"                                                        | TRUE (rule-anchored)                         | `rules/framework-first.md` § ABSOLUTE table; `packages/kailash-nexus/src/nexus/auth/guards.py:90, 117, 239` provides `AuthGuard.RequireRole` / `RequirePermission`; `packages/kailash-pact/src/pact/engine.py` provides `GovernanceEngine` for envelope-based authz.                                                                                                                                                                                                                                                                                                                                                                 |
+
+Brief corrections to record in `/todos`:
+
+- The plan MUST add `pause`, `resume`, and `update_cron` to the in-process `WorkflowScheduler` surface BEFORE wiring them through Nexus. The brief implicitly assumes these exist; they do not.
+- APScheduler natively supports `pause_job(id)` / `resume_job(id)` / `reschedule_job(id, trigger=...)`, so the in-process additions are thin facades; they do NOT require a new persistence layer.
+
+## Framework choice: Nexus
+
+Per `rules/framework-first.md` § ABSOLUTE Work-Domain → Framework Binding:
+
+> **HTTP API, REST, gateway, middleware, login, sessions, websockets** → MANDATORY framework: **Nexus**
+> **MCP servers, tools, resources, transports, exposing APIs as LLM tools** → MANDATORY framework: **MCP**
+
+Nexus's `@app.handler` decorator (`packages/kailash-nexus/src/nexus/core.py:2738`) is the canonical Kailash way to expose ONE function across HTTP + CLI + MCP at once. Raw FastAPI / Flask / aiohttp is BLOCKED.
+
+The admin API surface MUST be expressed as Nexus handlers:
+
+- Each admin operation (list, get, pause, resume, update_cron, delete, stats) is one `@app.handler("scheduler.admin.<op>", guard=...)` registration.
+- HTTP transport publishes them at `/api/scheduler/admin/<op>` per Nexus's standard handler route layout.
+- CLI transport exposes them as `nexus scheduler admin <op>` subcommands automatically (Nexus's CLI channel mirrors handler names).
+- MCP transport exposes them as MCP tools so an agent can `pause_schedule(schedule_id="sched-abc")` through any MCP client.
+
+PACT enters at the authorization layer (see § Auth + governance below). The scheduler surface itself (the in-process `pause` / `resume` / `update_cron` additions) is NOT a Nexus concern — it lives in `src/kailash/runtime/scheduler.py` and is plain Python.
+
+## Failure-point analysis
+
+1. **Unauthenticated admin endpoints** — Condition: any of the admin handlers ships without `guard=` and Nexus is started without `enable_auth=True`. Consequence: anyone reachable on the API port can pause every production schedule. Mitigation: every admin handler MUST take a non-`None` `guard=AuthGuard.RequirePermission("scheduler:admin")` (or RBAC-equivalent), AND the integration test MUST construct Nexus with `enable_auth=True` and assert 401/403 on missing/insufficient credentials. Per `rules/security.md` § Multi-Site Kwarg Plumbing — every handler in the same PR.
+
+2. **Authenticated-but-unauthorized mutation** — Condition: a user with a valid JWT but no `scheduler:admin` permission calls `scheduler.admin.update_cron`. Consequence: the user can rewrite cron expressions across tenants. Mitigation: PACT envelope check via the GovernanceEngine for mutating ops (pause / resume / update_cron / delete); read ops (list / get / stats) require only `scheduler:read`. Per `rules/framework-first.md` auth-split, Nexus AuthGuard handles role/permission strings; PACT handles structured envelope/clearance evaluation if the deployment uses governed agents.
+
+3. **Schedule mutation racing with in-flight fires** — Condition: ops calls `update_cron(sched-X, "0 7 * * *")` while `_execute_workflow(sched-X)` is mid-flight on the previous trigger. APScheduler reschedules the job's trigger, but the in-flight fire continues to completion. Consequence: the operator believes the new cron took effect immediately; in reality the in-flight fire still runs to completion under the OLD planned_fire_time. This is correct APScheduler behavior but is a footgun for the operator. Mitigation: every admin mutation handler returns the schedule's `next_run_time` AFTER the mutation so the operator can see the new effective time; the response body MUST also include `in_flight_run_ids` (any run_ids currently executing that schedule's previous trigger). The lifecycle event hooks from #914 (`_hooks_job_success` / `_hooks_job_error`, `lifecycle_events.py:JobEvent`) are the structural source for "is the schedule currently firing".
+
+4. **Idempotency of mutating commands** — Condition: a network retry causes `pause(sched-X)` to fire twice; OR a deploy-time replay causes `delete(sched-X)` to be called against a schedule that was already deleted. Consequence: opaque APScheduler exceptions (`JobLookupError`, `JobIdAlreadyExists`) propagate as HTTP 500 INTERNAL_ERROR per `rules/nexus-http-status-convention.md` Rule 1 — but this is a CLIENT semantic error, not a server bug. Mitigation: every admin handler MUST treat "already in target state" as success (pause-already-paused → 200 with `state: "paused"`), and "schedule not found" as 404 with `code: "SCHEDULE_NOT_FOUND"` (per the frozen NexusError taxonomy at `nexus-http-status-convention.md` Rule 1, this requires either `HandlerNotFound` reuse OR a new variant `SCHEDULE_NOT_FOUND` added to the SDK error type in the same PR per `nexus-http-status-convention.md` MUST NOT § "Add a new NexusError variant without updating both status_code() and error_code()…"). Decision: add new variant `ScheduleNotFound → 404 SCHEDULE_NOT_FOUND` in the same PR.
+
+5. **Audit trail gap on admin actions** — Condition: an operator pauses a critical revenue-driving schedule and the action is not recorded. Consequence: a few hours later, ops asks "who paused billing.weekly_invoice?" and there is no answer. Mitigation: every mutating admin handler MUST emit a structured INFO log line per `rules/observability.md` § 4 (state transitions / auth events) with `actor_user_id`, `action`, `schedule_id`, `before_state`, `after_state`, AND emit a PACT audit envelope when PACT is configured. Read ops emit DEBUG only.
+
+6. **Multi-instance scheduler drift** — Condition: two scheduler instances share the same SQLAlchemy job store; ops pauses a schedule via the admin API on instance A; instance B's in-memory `_schedules` dict still says enabled. Consequence: when instance B's APScheduler reloads from job store, it sees the paused state — but `list_schedules()` on instance B returns stale `enabled=True` until reload. Mitigation: `list_schedules()` already re-reads `next_run_time` from APScheduler at call time (`scheduler.py:732-739`); the admin API MUST always read state through `scheduler.list_schedules()` / `scheduler._scheduler.get_job()` — NEVER return cached `_schedules` dict directly. Document this explicitly in the handler docstrings.
+
+7. **Cron-expression validation drift** — Condition: ops PUT a cron expression like `"0 6 * * 1-5,7"` (5-field with comma+range). Consequence: APScheduler's `CronTrigger.from_crontab` may accept it, may reject it; operator sees opaque `ValueError`. Mitigation: the `update_cron` handler MUST validate via `CronTrigger.from_crontab(expr, timezone=tz)` BEFORE writing, mirror the existing 5-field check in `schedule_cron` (`scheduler.py:542-547`), and on failure return `400 INVALID_INPUT` with the original cron string in the error message. Per `nexus-http-status-convention.md` § 5, `ValueError` from a Nexus handler maps to `400 INVALID_INPUT`.
+
+8. **Job-store SQLite write lock contention** — Condition: a high-frequency admin caller (dashboard polling `list_schedules` every 1s) competes with the scheduler's own job-store writes. Consequence: SQLite `database is locked` errors surface intermittently. Mitigation: `list_schedules()` only reads; APScheduler's job store is WAL-mode (per `scheduler.py:_secure_init_sqlite_jobstore` lines 297-302), so reads do not block writes. The admin API SHOULD cache `list_schedules()` results for ≤2s on the read path; mutations MUST always write through. This is an optimization, not a correctness fix.
+
+9. **Lifecycle-event hook leak via admin actions** — Condition: a user-registered `on_job_success` hook (#914) calls back into the admin API to delete the schedule that just fired. Consequence: APScheduler's listener machinery is mid-iteration; calling `cancel()` from inside a listener can corrupt the listener list. Mitigation: the admin handlers' delete operation MUST schedule the actual `_scheduler.remove_job()` call via `asyncio.get_running_loop().call_soon(...)` when invoked from within an APScheduler listener context. Detection: use `inspect.stack()` to check whether `_on_job_lifecycle_event` is on the stack; if so, defer. This is a defensive measure — most use cases will not trigger it.
+
+10. **Migration helper assumptions about Django ORM** — Condition: a user with `django-celery-beat`-style schedules wants the migration helper. Consequence: pulling Django + django-celery-beat into the scheduler package would violate `rules/dependencies.md` (heavy optional dep). Mitigation: the migration helper takes a list of dicts (the user's caller serializes their `PeriodicTask` rows via Django, then passes the dicts to `migrate_from_celery_beat([{name, cron, enabled, kwargs}, ...])`). Kailash imports nothing Django-specific. Document the conversion shape in the helper's docstring.
+
+## API surface
+
+### Admin operations (each = one `@app.handler` registration)
+
+| Operation                       | Handler name                               | Read/Write | Returns                                                                     |
+| ------------------------------- | ------------------------------------------ | ---------- | --------------------------------------------------------------------------- |
+| List all schedules              | `scheduler.admin.list`                     | R          | `list[ScheduleInfoDTO]`                                                     |
+| Get one schedule                | `scheduler.admin.get`                      | R          | `ScheduleInfoDTO`                                                           |
+| Pause a schedule                | `scheduler.admin.pause`                    | W          | `{schedule_id, state, next_run_time}`                                       |
+| Resume a schedule               | `scheduler.admin.resume`                   | W          | `{schedule_id, state, next_run_time}`                                       |
+| Update cron expression          | `scheduler.admin.update_cron`              | W          | `{schedule_id, cron_expression, next_run_time}`                             |
+| Delete a schedule               | `scheduler.admin.delete`                   | W          | `{schedule_id, deleted: true}`                                              |
+| Scheduler stats                 | `scheduler.admin.stats`                    | R          | `{total, enabled, paused, types: {cron, interval, once}, fire_times_count}` |
+| Recent fires (lifecycle stream) | `scheduler.admin.recent_fires`             | R          | `list[JobEventDTO]` (last N events from #914 hooks)                         |
+| Migration helper                | `scheduler.admin.migrate_from_celery_beat` | W          | `{imported: N, errors: [...]}`                                              |
+
+`ScheduleInfoDTO` mirrors `ScheduleInfo` (`scheduler.py:326`) but JSON-serializable: `schedule_id`, `schedule_type` (str), `workflow_name`, `trigger_args` (dict), `created_at` (ISO string), `next_run_time` (ISO string or null), `enabled` (bool), `kwargs` (dict, with `_kailash_retry_spec` redacted), `retry_spec` (dict or null — `RetrySpec.__dict__` minus exception types, with `retry_on_names` / `dont_retry_on_names` for class names).
+
+### Transports
+
+Per Nexus's design (`packages/kailash-nexus/src/nexus/core.py:2738`):
+
+- **HTTP**: `POST /api/handlers/scheduler.admin.<op>` with JSON body `{schedule_id, ...}`; `GET` for read ops.
+- **CLI**: `nexus call scheduler.admin.list` / `nexus call scheduler.admin.pause --schedule-id=sched-abc`. Nexus's CLI channel auto-derives flag names from handler signatures.
+- **MCP**: each handler is exposed as an MCP tool. Agents call `scheduler.admin.list({})` and receive structured output.
+
+### In-process scheduler additions (load-bearing for the handlers)
+
+Three new methods on `WorkflowScheduler` that the handlers wrap:
+
+```python
+def pause(self, schedule_id: str) -> ScheduleInfo: ...
+def resume(self, schedule_id: str) -> ScheduleInfo: ...
+def update_cron(self, schedule_id: str, cron_expression: str) -> ScheduleInfo: ...
+```
+
+Each delegates to APScheduler:
+
+- `pause` → `self._scheduler.pause_job(schedule_id)`; updates `_schedules[id].enabled = False`.
+- `resume` → `self._scheduler.resume_job(schedule_id)`.
+- `update_cron` → validate 5-field, build new `CronTrigger`, call `self._scheduler.reschedule_job(schedule_id, trigger=new_trigger)`; refresh `_schedules[id].trigger_args` AND emit a state-transition log line per `observability.md` § 4.
+
+A typed `ScheduleNotFoundError` (KeyError subclass + new `NexusError.ScheduleNotFound`) is raised when `schedule_id` is unknown. Per `rules/zero-tolerance.md` Rule 3a typed-delegate-guard pattern.
+
+## Auth + governance
+
+### Authentication (Nexus owns)
+
+- The Nexus instance hosting these handlers MUST be constructed with `enable_auth=True` (forced when `NEXUS_ENV=production` per `nexus/core.py:351`).
+- JWT middleware (`nexus.auth.jwt.JWTMiddleware`) populates `request.state.user` with an `AuthenticatedUser` carrying `roles` and `permissions`.
+- The migration deprecation note at `nexus/auth/__init__.py:19-23` says auth is moving to `kailash.trust.auth`; the plan SHOULD prefer `kailash.trust.auth` imports if available at implementation time.
+
+### Authorization (PACT or AuthGuard)
+
+Two-layer authz:
+
+1. **Per-handler AuthGuard (always present)** — every mutating handler is registered with `guard=AuthGuard.RequirePermission("scheduler:admin")`; read handlers with `guard=AuthGuard.RequirePermission("scheduler:read")`. AuthGuard fires before the handler runs (per `nexus/core.py:2832` — `_wrap_with_guard` wraps the handler before workflow construction so all transports get the guard).
+
+2. **Optional PACT envelope (when configured)** — when PACT's `GovernanceEngine` is registered as a Nexus middleware, mutating handlers ALSO check the operator's envelope clearance for the `scheduler:write` action. PACT integration is opt-in: if the user has not installed `kailash-pact`, the admin API still works with AuthGuard alone.
+
+### Audit trail
+
+- Every mutating handler call emits a structured INFO log line via `kailash.observability.logger` with fields `actor_user_id` (from `request.state.user.user_id`), `actor_roles`, `action` (= handler name), `schedule_id`, `before_state` (snapshot of pre-mutation `ScheduleInfo`), `after_state` (post-mutation snapshot), `correlation_id` (per `observability.md` Rule 2).
+- When PACT is configured, the SAME mutation also writes a PACT audit envelope through `pact.engine.GovernanceEngine.audit(...)`.
+- Read handlers emit DEBUG only (no audit row per `observability.md` Rule 8 — schema-revealing field names).
+
+## Implementation sketch
+
+The work splits into 4 shards, each within the per-session capacity budget (`autonomous-execution.md` § Per-Session Capacity Budget: ≤500 LOC load-bearing, ≤5–10 invariants, ≤3–4 call-graph hops, describable in ≤3 sentences):
+
+### Shard 1 — In-process scheduler additions (~250 LOC, 5 invariants)
+
+**Files**:
+
+- `src/kailash/runtime/scheduler.py` — add `pause()`, `resume()`, `update_cron()`, `stats()`, `recent_fires()`; add `ScheduleNotFoundError` typed exception.
+- `tests/unit/runtime/test_scheduler_admin_methods.py` — Tier 1 unit tests for each method against an in-memory job store.
+
+**Invariants**: (1) APScheduler delegation correctness; (2) `_schedules` dict stays in sync with APScheduler state; (3) `KeyError`/`JobLookupError` translates to typed `ScheduleNotFoundError`; (4) idempotency (pause-already-paused returns success); (5) cron validation matches the existing 5-field check at `scheduler.py:542-547`.
+
+**Sentence form**: "Add three idempotent admin methods (pause/resume/update_cron), one stats method, and one recent_fires method to `WorkflowScheduler`, with typed exceptions and APScheduler delegation."
+
+### Shard 2 — Nexus admin handler module (~300 LOC, 7 invariants)
+
+**Files**:
+
+- `src/kailash/runtime/scheduler_admin.py` (new) — `register_admin_handlers(app: Nexus, scheduler: WorkflowScheduler)` function that registers all handlers on the supplied Nexus app.
+- `src/kailash/runtime/_admin_dto.py` (new) — `ScheduleInfoDTO`, `JobEventDTO` JSON-serializable dataclasses + `from_schedule_info(...)` / `from_job_event(...)` converters.
+- `tests/integration/test_scheduler_admin_handlers.py` — Tier 2 test against real Nexus + real WorkflowScheduler + real APScheduler + temp SQLite.
+
+**Invariants**: (1) every handler has a non-None `guard=`; (2) NexusError taxonomy preserved (404 for unknown schedule, 400 for invalid cron, 500 only for our bugs); (3) DTO redaction strips `_kailash_retry_spec` from kwargs; (4) DTO never leaks exception types as repr strings (use `__name__` instead); (5) every mutation logs at INFO with audit fields; (6) every mutation returns post-mutation state via `list_schedules()` (NOT cached `_schedules`); (7) HTTP/CLI/MCP all reach the same handler.
+
+**Sentence form**: "Register Nexus handlers for nine admin operations under `scheduler.admin.*`, each guarded by AuthGuard, returning JSON DTOs, with structured audit logging."
+
+### Shard 3 — NexusError variant + migration helper (~200 LOC, 4 invariants)
+
+**Files**:
+
+- `src/kailash/nexus_errors.py` (or wherever `NexusError` lives) — add `ScheduleNotFound` variant with `status_code() → 404` and `error_code() → "SCHEDULE_NOT_FOUND"`.
+- `src/kailash/runtime/scheduler_admin.py` — wire the variant to the handler error path.
+- `src/kailash/runtime/scheduler_migrate.py` (new) — `migrate_from_celery_beat(scheduler, periodic_tasks: list[dict]) -> dict` helper.
+- `tests/unit/test_nexus_error_schedule_not_found.py` + `tests/integration/test_celery_beat_migration.py`.
+
+**Invariants**: (1) variant addition follows `nexus-http-status-convention.md` MUST NOT (both `status_code()` AND `error_code()` updated in same commit); (2) migration helper depends on zero Django imports; (3) migration helper supports CRON-only PeriodicTasks in v1 (interval/clocked deferred to v2); (4) migration is idempotent — re-running with the same tasks does not duplicate.
+
+**Sentence form**: "Add `SCHEDULE_NOT_FOUND` to the NexusError taxonomy and write a Django-free migration helper that converts a list of celery-beat-shaped dicts into Kailash schedules."
+
+### Shard 4 — Documentation + cross-channel parity tests (~150 LOC, 3 invariants)
+
+**Files**:
+
+- `packages/kailash-nexus/docs/scheduler-admin.md` (new) — usage docs.
+- `tests/integration/test_scheduler_admin_cross_channel.py` — same operation through HTTP, CLI, and MCP returns byte-equivalent DTO shape.
+- `tests/regression/test_scheduler_admin_loc_invariants.py` — per `rules/refactor-invariants.md` (the new module's LOC ceiling).
+
+**Invariants**: (1) HTTP/CLI/MCP return identical DTOs; (2) docs reference real handler names + status codes from the frozen `nexus-http-status-convention.md` table; (3) module sizes stay under their declared ceilings.
+
+**Sentence form**: "Document the admin API and add a cross-channel parity test that exercises the same handler through every transport."
+
+### Total estimate
+
+- ~900 LOC across 4 shards, sharded by `/todos`, plan to land in 4 PRs (one per shard) so each PR stays under the 500-LOC load-bearing threshold.
+- Shards 1, 3, 4 have executable feedback loops (unit + integration tests). Shard 2 has the heaviest invariant load — it is exactly at the budget cap and SHOULD NOT be expanded mid-session.
+
+## Test plan
+
+### Tier 2 integration tests (real Nexus, real APScheduler, real SQLite)
+
+Per `rules/testing.md` Tier 2 (NO mocking) and `rules/orphan-detection.md` Rule 2 (every wired manager has a Tier 2 test). Per `rules/facade-manager-detection.md` Rule 2 the test file is named `test_scheduler_admin_handlers_wiring.py`.
+
+1. **`test_admin_list_returns_all_schedules`** — Construct `WorkflowScheduler` against a temp SQLite, schedule three workflows (cron + interval + once), construct Nexus with `enable_auth=False` (test mode), register admin handlers, call `scheduler.admin.list` over HTTP — assert all three appear with correct types and `next_run_time`.
+2. **`test_admin_pause_then_resume_changes_next_run_time`** — Schedule a cron at `"*/5 * * * *"`, capture `next_run_time`, call `scheduler.admin.pause`, assert `enabled=False` AND `next_run_time=None`; call `scheduler.admin.resume`, assert `enabled=True` AND new `next_run_time` is in the future.
+3. **`test_admin_update_cron_changes_next_fire`** — Schedule at `"0 6 * * *"` (06:00 daily), call `update_cron(sched, "0 7 * * *")`, assert `next_run_time` advanced to the 07:00 slot. This is the brief's literal acceptance criterion.
+4. **`test_admin_delete_removes_schedule`** — Delete a schedule, assert subsequent `list` excludes it AND APScheduler's `get_job(id)` returns None.
+5. **`test_admin_unknown_schedule_returns_404`** — Call any operation with `schedule_id="sched-nonexistent"`, assert HTTP 404 + body `{"error": "...", "code": "SCHEDULE_NOT_FOUND"}`.
+6. **`test_admin_invalid_cron_returns_400`** — Call `update_cron` with `"not a cron"`, assert HTTP 400 + body `{"error": "...", "code": "INVALID_INPUT"}`.
+7. **`test_admin_idempotent_pause`** — Pause twice; assert second call returns 200 with same DTO.
+8. **`test_admin_stats_reflects_state`** — Schedule N items; call `stats`; assert counts match.
+9. **`test_admin_recent_fires_returns_lifecycle_events`** — Register handlers, fire schedules, call `recent_fires`; assert `JobEventDTO` shape matches #914's `JobEvent`.
+10. **`test_admin_cross_channel_parity`** (Shard 4) — Call `list` over HTTP, CLI invocation, and MCP tool invocation; assert all three return byte-equivalent DTO JSON.
+
+### Auth tests (with `enable_auth=True`)
+
+1. **`test_admin_unauthenticated_returns_401`** — Construct Nexus with `enable_auth=True`, call admin handler with no JWT; assert 401.
+2. **`test_admin_insufficient_permission_returns_403`** — JWT carries `permissions=["scheduler:read"]`; call mutating handler; assert 403.
+3. **`test_admin_read_with_read_permission_succeeds`** — JWT carries `permissions=["scheduler:read"]`; call `scheduler.admin.list`; assert 200.
+4. **`test_admin_admin_permission_passes_all_handlers`** — JWT carries `permissions=["scheduler:admin"]`; assert all nine handlers return 200.
+
+### RBAC tests (PACT-integrated path, optional fixture)
+
+When `kailash-pact` is installed, an additional fixture constructs `GovernanceEngine` and asserts that envelope clearance gates fire for mutating ops. These tests are skipped when PACT is absent (per `rules/dependencies.md` § Foundation-Only Dependencies; PACT is an optional sibling package).
+
+### Tier 1 unit tests
+
+Per shard 1 — unit tests against in-memory APScheduler for `pause`, `resume`, `update_cron`, `stats`, `recent_fires`, and `ScheduleNotFoundError` typed exception.
+
+### Audit log assertion test
+
+Per `observability.md` Rule 5 — a test that captures stdlib `logging` output during a mutation and asserts the structured fields (`actor_user_id`, `action`, `before_state`, `after_state`, `correlation_id`).
+
+## Cross-SDK alignment
+
+Per `rules/cross-sdk-inspection.md` Rule 1 — kailash-rs (Rust SDK) ALSO has a workflow scheduler surface. The Rust scheduler's admin API would be the symmetric feature. The Rust SDK lives in `esperie/kailash-rs` and is OUT OF SCOPE for this kailash-py session per `rules/repo-scope-discipline.md`. This plan does NOT recommend filing a kailash-rs issue from this session — that decision belongs to the user when they next open Claude Code in `kailash-rs`. Descriptive only:
+
+- The Rust SDK's equivalent surface would expose `Scheduler::pause(id)` / `resume(id)` / `update_cron(id, expr)` plus an Axum handler module that is the Rust analog of Shard 2.
+- The Rust SDK has no APScheduler — its scheduler is a native implementation, so the in-process admin methods would touch its internal job store directly rather than delegating.
+- Cross-SDK semantic parity (per `rules/cross-sdk-inspection.md` Rule 3 EATP D6) requires that the JSON DTO shape returned by HTTP handlers be byte-equivalent across both SDKs. The DTOs defined in Shard 2 should be authored with this in mind so the Rust port can vendor them per `cross-sdk-inspection.md` Rule 4a (sibling-canonical fixtures vendored, not re-authored).
+
+## Open questions for the human
+
+These need a human gate BEFORE `/todos` so the plan does not lock in a decision the user will reverse:
+
+1. **Permission name strings** — proposed `scheduler:read` and `scheduler:admin`. Should these be `scheduler.read` / `scheduler.admin` (dot-separated) or `kailash.scheduler.admin` (hierarchical)? The handler examples in `nexus/auth/guards.py:21` use unqualified names like `"admin"`; the handler examples elsewhere use colon-separated names like `"orgs:delete"` (`guards.py:29`). User pick.
+
+2. **PACT integration: required or optional?** — The plan assumes PACT is optional (AuthGuard alone suffices when PACT is not installed). Alternative: require PACT for all admin operations. The brief's "Acceptance criteria" makes no PACT mention; the `framework-first.md` auth-split splits authn (Nexus) from authz (PACT) but both are framework-first defaults, not hard requirements. User pick.
+
+3. **Admin handler namespace** — proposed `scheduler.admin.*`. Alternative names: `kailash.scheduler.*` (matches Python module path), `admin.scheduler.*` (matches `@app.handler("admin.reset", ...)` example in `core.py:2774`), or just `scheduler.*` (then read vs write split by permission). User pick — affects every URL, CLI command, MCP tool name.
+
+4. **Migration helper scope** — v1 plan: CRON `PeriodicTask` only. Should interval and clocked PeriodicTasks be in v1 too? They double the helper's surface but match brief's "Migration helper from `django-celery-beat`'s `PeriodicTask` table" without qualifier. User pick.
+
+5. **Multi-instance coordination** — The plan accepts the "stale list_schedules across instances until reload" behavior (failure-point #6) and documents it. Alternative: add a multi-instance coordination layer (Redis pub-sub, advisory locks). This is a much larger feature (separate session). User pick on whether to scope-add or accept current behavior.
+
+6. **Recent-fires retention** — `scheduler.admin.recent_fires` would return the last N JobEvents. What's N? Bounded ring buffer in memory (per `rules/infrastructure-sql.md` Rule 7 bounded-stores), persistent in SQLite, or NoneType (don't ship recent_fires in v1)? User pick.
+
+## Effort estimate
+
+Per `rules/autonomous-execution.md` § Per-Session Capacity Budget — autonomous execution cycles, NOT human-days.
+
+- **Shard 1** (in-process additions + unit tests): 1 session, ~250 LOC. Feedback loop: pytest. Multiplier 3-5× applies.
+- **Shard 2** (Nexus admin handlers + Tier 2 integration): 1 session, ~300 LOC. Feedback loop: pytest with real Nexus. Heaviest invariant load (7); at the budget cap.
+- **Shard 3** (NexusError variant + migration helper): 1 session, ~200 LOC. Two distinct bug classes — variant addition AND migration helper. Could fold into Shard 2 if the user prefers, but separation respects the per-PR review gate.
+- **Shard 4** (cross-channel parity test + docs): 1 session, ~150 LOC. Lightest shard.
+
+**Total: 4 autonomous execution cycles**, executed serially because Shards 2-4 depend on Shard 1's surface. Could parallelize Shards 3 and 4 once Shard 2 lands. With #912 (per-task time limits, OPEN at session start) running in parallel on a different surface, no scheduling conflict — admin API is independent per the user's sequencing note in the prompt.
+
+End-to-end real wall-clock from `/analyze` to `/release`: ~4 sessions if run serially, ~3 sessions if Shards 3+4 parallelize after Shard 2.

--- a/workspaces/issue-913-admin-api/02-todos/todos.md
+++ b/workspaces/issue-913-admin-api/02-todos/todos.md
@@ -1,0 +1,434 @@
+# Issue #913 /todos: admin API for WorkflowScheduler
+
+**Workspace**: `workspaces/issue-913-admin-api/`
+**Branch base SHA at /todos time**: `d5d84dbd` (`main` HEAD, 2026-05-09)
+**Architecture plan source**: `workspaces/issue-913-admin-api/01-analyze/architecture-plan.md`
+**Sequencing**: Option B — Shard 0 launches in parallel with #912 Shard 1 NOW; Shards 1+ sequence after Shard 0 merges.
+
+---
+
+## Root-cause decisions (user-approved 2026-05-09)
+
+These four decisions are baked into every shard below. Restated verbatim from the user's gate at the close of `/analyze`:
+
+**RC1 — `**kwargs` removal scope: not applicable to #913.\*\* (Owned by #912.) The admin API does not introduce new variadic-kwargs signatures; #912's per-task time-limit work owns that surface separately.
+
+**RC2 — `kailash.errors` namespace: not applicable to #913.** (Owned by #912; no new module, exceptions go to `sdk_exceptions.py`.) New typed exceptions for #913 (`ScheduleNotFoundError`) live in the existing scheduler exception module path; no new top-level error namespace is introduced.
+
+**RC3 — PACT integration: REQUIRED.** Add `kailash-pact` as a required dep for kailash-nexus admin handlers. Every admin handler MUST emit a PACT envelope; `GovernanceEngine` performs RBAC + audit (per `pact-governance.md` D/T/R: Decide what op, Trust whose envelope, Record audit row). Nexus AuthGuard handles authn (token + permission string `scheduler:admin`). PACT is NOT optional. The `framework-first.md` table mandates PACT for admin/governance/RBAC/policy work.
+
+**RC4 — `pause`/`resume`/`update_cron` scheduler methods: YES, AS #913 Shard 0.** Per `autonomous-execution.md` MUST Rule 4 (Fix-Immediately within shard budget). Land 3 new methods directly on `WorkflowScheduler` in `src/kailash/runtime/scheduler.py`: `pause(schedule_id)`, `resume(schedule_id)`, `update_cron(schedule_id, new_cron_expr)`. ~150 LOC, ≤3 invariants per method. Each method gets a Tier-2 integration test (start scheduler → schedule job → call method → assert observable state change → cancel). Shard 0 launches BEFORE any Nexus handler shard.
+
+---
+
+## Brief-gap verification
+
+Verified at `/todos` time against `src/kailash/runtime/scheduler.py` at SHA `d5d84dbd`:
+
+| Method           | Present? | Evidence                                                                      |
+| ---------------- | -------- | ----------------------------------------------------------------------------- |
+| `schedule_cron`  | YES      | `src/kailash/runtime/scheduler.py:499`                                        |
+| `cancel`         | YES      | `src/kailash/runtime/scheduler.py:703`                                        |
+| `list_schedules` | YES      | `src/kailash/runtime/scheduler.py:725`                                        |
+| `pause`          | **NO**   | `grep -n 'def pause' src/kailash/runtime/scheduler.py` returns no match       |
+| `resume`         | **NO**   | `grep -n 'def resume' src/kailash/runtime/scheduler.py` returns no match      |
+| `update_cron`    | **NO**   | `grep -n 'def update_cron' src/kailash/runtime/scheduler.py` returns no match |
+
+**Conclusion**: The brief's framing is accurate — `WorkflowScheduler` exposes add/cancel/list today, but lacks the three modify operations the admin API requires. Shard 0 closes that gap before Nexus handlers can wrap them.
+
+---
+
+## Framework choice — Nexus + PACT
+
+Per `rules/framework-first.md` § ABSOLUTE Work-Domain → Framework Binding:
+
+- **HTTP API, REST, gateway, middleware, login, sessions, websockets** → **Nexus** (MANDATORY)
+- **Governance, RBAC, policy, access control, envelopes, audit** → **PACT** (MANDATORY)
+- **MCP servers, tools, resources, transports, exposing APIs as LLM tools** → **MCP** (MANDATORY) — auto-included via Nexus's `@app.handler` multi-channel surface
+
+**Auth split (frozen)**: Nexus owns authentication (JWT token validation, session population). PACT owns authorization (RBAC, envelope-based clearance, structured audit). Per RC3 above, PACT is required, not optional.
+
+Raw FastAPI / Flask / aiohttp is BLOCKED. Optional-PACT codepaths are BLOCKED.
+
+The in-process scheduler additions (Shard 0 — `pause`/`resume`/`update_cron`) are plain Python on `WorkflowScheduler`; they are NOT a Nexus or PACT concern at the runtime layer. The Nexus handler module (Shards 1+) wraps these methods.
+
+---
+
+## Shard plan
+
+### Shard 0 — In-process scheduler methods (`pause` / `resume` / `update_cron`)
+
+**Value-anchor**: User's brief gate at close of `/analyze` (RC4, 2026-05-09): "land 3 new methods directly on `WorkflowScheduler` … BEFORE any Nexus handler shard." The Nexus admin handlers cannot wrap operations the runtime does not expose; Shard 0 closes the runtime-surface gap that makes the entire admin-API workstream possible. Without these methods, every operator action (pause a runaway billing job, update a cron after DST change, resume after maintenance) is impossible without a process restart — the brief's literal acceptance criterion fails.
+
+**Files touched**:
+
+- `src/kailash/runtime/scheduler.py` — add three new methods on `WorkflowScheduler` class.
+- `src/kailash/runtime/_scheduler_exceptions.py` (new, OR add to existing exception module) — `ScheduleNotFoundError(KeyError)` typed exception.
+- `tests/integration/runtime/test_scheduler_admin_methods.py` (new) — 3 Tier-2 integration tests exercising real APScheduler + temp SQLite job store.
+- `tests/unit/runtime/test_scheduler_admin_methods_unit.py` (new) — 3 Tier-1 unit tests for fast feedback.
+
+**Method signatures (frozen at /todos time)**:
+
+```python
+def pause(self, schedule_id: str) -> ScheduleInfo: ...
+def resume(self, schedule_id: str) -> ScheduleInfo: ...
+def update_cron(self, schedule_id: str, cron_expression: str) -> ScheduleInfo: ...
+```
+
+**Invariants (≤3 per method, 9 total — within shard budget)**:
+
+`pause(schedule_id)`:
+
+1. **Idempotency** — calling `pause` on an already-paused schedule returns success with `enabled=False`; no APScheduler exception raised.
+2. **No-effect-when-already-target** — second call MUST NOT re-emit a state-transition log line; INFO-level log fires once on the first transition only.
+3. **Typed-error on unknown ID** — `schedule_id` not in `_schedules` raises `ScheduleNotFoundError`, NOT bare `KeyError` or `JobLookupError`.
+
+`resume(schedule_id)`: 4. **Idempotency** — calling `resume` on an already-running schedule returns success with `enabled=True`; no exception. 5. **Preserves-cron-next-fire-on-resume** — after pause→resume, `next_run_time` is computed against the trigger's `next_fire_time(now)`, not the pre-pause stored value; verified by asserting `next_run_time > now`. 6. **Typed-error on unknown ID** — same as pause, raises `ScheduleNotFoundError`.
+
+`update_cron(schedule_id, cron_expression)`: 7. **Cron-validation-before-write** — invalid cron raises `ValueError` BEFORE any `_schedules` mutation or APScheduler call; mirrors the 5-field check at `scheduler.py:542-547`. 8. **Atomic state update** — on success, BOTH `_schedules[id].trigger_args` AND APScheduler's stored trigger reflect the new cron; verified by asserting `next_run_time` advanced to the new slot. 9. **Typed-error on unknown ID** — raises `ScheduleNotFoundError`; ValueError reserved for invalid cron.
+
+**LOC estimate**: ~150 LOC scheduler.py (3 methods × ~40 LOC each + ~30 LOC for typed-exception module + observability).
+
+**Tests required (Tier-2 integration tests, real APScheduler + temp SQLite job store, NO mocking per `rules/testing.md`)**:
+
+1. `test_admin_pause_then_resume_changes_next_run_time` — schedule cron `*/5 * * * *`, capture `next_run_time`, call `pause` (assert `enabled=False, next_run_time=None`), call `resume` (assert `enabled=True, next_run_time > now`).
+2. `test_admin_update_cron_advances_next_fire` — schedule at `0 6 * * *`, call `update_cron(sched, "0 7 * * *")`, assert `next_run_time` advanced to the 07:00 slot. Brief's literal acceptance criterion.
+3. `test_admin_idempotent_pause_and_unknown_id` — pause twice (second is no-op success); call `pause("sched-nonexistent")` → assert `ScheduleNotFoundError` raised; same for `resume` and `update_cron`.
+
+**Tier-1 unit tests (in-memory MemoryJobStore for fast iteration)**:
+
+- `test_pause_idempotent_unit` — fast structural check.
+- `test_update_cron_validates_5_field_unit` — invalid-cron `ValueError` BEFORE `_schedules` mutation (assert dict unchanged on raise).
+- `test_schedule_not_found_error_is_subclass_of_keyerror` — typed exception relationship.
+
+**Dependencies**:
+
+- None blocking (Shard 0 is the prereq for everything else).
+- Lifecycle event hooks from #914 (`_hooks_job_success` / `_hooks_job_error`) are NOT required for Shard 0; Shard 0 only adds runtime methods. `recent_fires` admin handler in Shards 1+ depends on #914.
+
+**Worktree assignment**:
+
+- **Branch**: `feat/issue-913-shard-0-scheduler-methods`
+- **Worktree path**: `.claude/worktrees/issue-913-shard-0/` (per `worktree-isolation.md` Rules 1, 5, 6)
+- **Base SHA**: `d5d84dbd` (`main`, pinned at /todos time per Rule 5)
+- **Sequencing**: parallel with `#912 Shard 1` (independent surface — #912 touches per-task time limits in a different scheduler region; Shard 0 adds new methods, no edit-overlap)
+- **Pre-flight verify at launch**: `git rev-parse main` matches `d5d84dbd` OR pin to current main HEAD before worktree creation
+
+---
+
+### Shard 1 — Nexus handler skeleton + AuthGuard + PACT envelope wiring
+
+**Value-anchor**: Architecture plan § "API surface" + RC3 (user-approved 2026-05-09): every admin handler routes through Nexus's `@app.handler` multi-channel surface AND through PACT's `GovernanceEngine.verify_action()` for envelope-based RBAC + audit. Without this scaffold, every handler in Shards 2+ would reinvent auth/audit wiring (the multi-site kwarg failure mode `rules/security.md` § "Multi-Site Kwarg Plumbing" warns against). Centralizing auth + envelope construction in one wrapper closes that class structurally.
+
+**Files touched**:
+
+- `packages/kailash-nexus/src/nexus/admin/__init__.py` (new module) — package exports.
+- `packages/kailash-nexus/src/nexus/admin/scheduler_handlers.py` (new) — `register_scheduler_admin_handlers(app, scheduler, governance_engine)` registration function + envelope-construction helper.
+- `packages/kailash-nexus/src/nexus/admin/_envelope.py` (new) — PACT envelope construction helper (D/T/R address from JWT subject, action from handler name, context dict).
+- `packages/kailash-nexus/src/nexus/admin/_dto.py` (new) — `ScheduleInfoDTO` JSON-serializable dataclass + `from_schedule_info()` converter (redacts `_kailash_retry_spec` per architecture plan § "API surface").
+- `packages/kailash-nexus/src/nexus/errors.py` — add `ScheduleNotFoundError` variant (404 / `SCHEDULE_NOT_FOUND`).
+- `packages/kailash-nexus/pyproject.toml` — add `kailash-pact` to required `dependencies`.
+- `packages/kailash-nexus/src/nexus/admin/tests/test_envelope_construction_unit.py` (new) — Tier-1 unit tests.
+- `tests/integration/nexus/test_scheduler_admin_authguard_wiring.py` (new) — Tier-2 AuthGuard wiring test.
+- `tests/integration/nexus/test_scheduler_admin_pact_envelope_wiring.py` (new) — Tier-2 PACT envelope construction + audit row test.
+
+**Invariants (8 total, at-budget)**:
+
+1. **AuthGuard non-None** — every handler registration MUST pass a non-None `guard=AuthGuard.RequirePermission(...)`; registration code raises `ConfigError` if the guard is None at `register_scheduler_admin_handlers()` time. Closes the unauthenticated-endpoint failure mode (architecture plan § FP-1).
+2. **Envelope construction always fires** — every mutating handler call MUST construct a PACT envelope BEFORE the scheduler op runs; verified by asserting `governance_engine.verify_action()` was called for every mutation in the Tier-2 test.
+3. **Envelope verdict is BLOCKED-fail-closed** — `governance_engine.verify_action()` returning anything other than ALLOWED (or its non-blocked equivalents) MUST short-circuit with HTTP 403 + `code: "FORBIDDEN"`; the underlying scheduler method MUST NOT run.
+4. **Audit row exists post-mutation** — every successful mutating handler emits BOTH a structured INFO log line AND a PACT audit envelope; verified by asserting an audit-store row with `action`, `actor_user_id`, `before_state`, `after_state`, `correlation_id` (per `rules/observability.md` Rule 2).
+5. **DTO redaction** — `ScheduleInfoDTO.from_schedule_info()` strips `_kailash_retry_spec` from `kwargs`, replacing with the spec's `__dict__` minus exception-type repr (`retry_on_names` / `dont_retry_on_names` only).
+6. **Manager-shape Tier-2 wiring test** — per `rules/facade-manager-detection.md` MUST Rule 1, the `governance_engine` is a `*Engine` shape; the wiring test imports it through Nexus, runs a real op, asserts an audit row exists in the real audit store.
+7. **Read-vs-write permission split** — `scheduler.admin.list` / `.get` / `.stats` use `AuthGuard.RequirePermission("scheduler:read")`; `pause` / `resume` / `update_cron` / `delete` use `"scheduler:admin"`.
+8. **NexusError taxonomy preserved** — `ScheduleNotFoundError` raised by Shard-0 methods maps to HTTP 404 with body `{"error": "...", "code": "SCHEDULE_NOT_FOUND"}` per `rules/nexus-http-status-convention.md` Rules 1 + 2.
+
+**LOC estimate**: ~280 LOC across new module + envelope helper + DTO + error variant + tests (at the per-shard cap; do NOT expand mid-session per `rules/autonomous-execution.md`).
+
+**Tests required (Tier-2, real Nexus + real WorkflowScheduler + real GovernanceEngine + temp SQLite, NO mocking)**:
+
+1. `test_authguard_blocks_unauthenticated_request` — Nexus with `enable_auth=True`; call admin handler with no JWT → assert 401.
+2. `test_authguard_blocks_insufficient_permission` — JWT with `permissions=["scheduler:read"]`; call mutating handler → assert 403.
+3. `test_pact_envelope_constructed_for_every_mutation` — call `pause` over HTTP; assert `governance_engine` recorded a `verify_action(role_address, action="scheduler.admin.pause", context={...})` call.
+4. `test_pact_audit_row_persisted_post_mutation` — call `pause` over HTTP; assert one PACT audit-store row exists with the expected `actor_user_id`, `before_state`, `after_state`.
+5. `test_pact_blocked_verdict_short_circuits_mutation` — construct an envelope that BLOCKs `scheduler:write`; call `pause`; assert HTTP 403 AND assert the underlying schedule's `enabled` did NOT change (mutation never ran).
+6. `test_schedule_not_found_returns_404_with_code` — call any handler with `schedule_id="sched-nonexistent"`; assert HTTP 404 + body `{"error": "...", "code": "SCHEDULE_NOT_FOUND"}` per the frozen taxonomy.
+7. `test_dto_redacts_retry_spec` — schedule with `_kailash_retry_spec` in kwargs; call `list`; assert response DTO does not contain that key, and `retry_spec` field reflects only `retry_on_names` / `dont_retry_on_names` (not exception class repr).
+8. `test_governance_engine_wiring_through_facade` — per `rules/facade-manager-detection.md` Rule 1; imports `governance_engine` through Nexus's admin module, runs a real mutation, asserts the engine actually fired (manager-shape wiring test).
+
+**Dependencies**:
+
+- **Shard 0 merged** — handlers cannot wrap `pause`/`resume`/`update_cron` until they exist on `WorkflowScheduler`.
+- `kailash-pact` package available in monorepo (already present at `packages/kailash-pact/`); ADD as required dep in `kailash-nexus/pyproject.toml`.
+- `GovernanceEngine` from `kailash.trust.pact.engine` (lives at `src/kailash/trust/pact/engine.py:196`).
+- Nexus `AuthGuard.RequirePermission` (lives at `packages/kailash-nexus/src/nexus/auth/guards.py:117, 239, 258`).
+
+**Worktree assignment**:
+
+- **Branch**: `feat/issue-913-shard-1-nexus-pact-skeleton`
+- **Worktree path**: `.claude/worktrees/issue-913-shard-1/`
+- **Base SHA**: HEAD of `main` after Shard 0 merges (pin at launch time, NOT at /todos time, per `rules/specs-authority.md` MUST Rule 5c amend-at-launch).
+- **Sequencing**: serial AFTER Shard 0 merges to main.
+
+---
+
+### Shard 2 — Read-side admin handlers (list / get / stats)
+
+**Value-anchor**: Architecture plan § "API surface" — operators need to see what's scheduled before they can act. The brief's first acceptance criterion ("list, enable/disable, update cron, delete schedules") opens with list. Read handlers are the most-called surface (dashboard polling) and the lowest-blast-radius group, so they validate the Shard 1 scaffold under load before any mutating handler ships.
+
+**Files touched**:
+
+- `packages/kailash-nexus/src/nexus/admin/scheduler_handlers.py` — implement 3 handlers (`scheduler.admin.list`, `.get`, `.stats`).
+- `packages/kailash-nexus/src/nexus/admin/_dto.py` — extend with `StatsDTO`.
+- `tests/integration/nexus/test_scheduler_admin_read_handlers.py` (new) — Tier-2 read-handler integration tests.
+
+**Invariants (5)**:
+
+1. **Always read through `list_schedules()`** — handlers MUST call `scheduler.list_schedules()` (which re-reads `next_run_time` from APScheduler at call time per `scheduler.py:732-739`); MUST NOT return cached `_schedules` dict directly. Closes the multi-instance drift FP-6.
+2. **Read permission only** — all 3 handlers register with `AuthGuard.RequirePermission("scheduler:read")`.
+3. **DEBUG-only audit** — read handlers emit DEBUG (NOT INFO/WARN) per `rules/observability.md` Rule 8 (schema-revealing field names at DEBUG); no PACT audit envelope written for read ops (PACT audit rows are for state changes only).
+4. **HTTP/CLI/MCP parity** — same handler responds correctly to all three transports; verified by Tier-2 test that calls `list` over HTTP, then over the CLI channel, then via MCP tool, and asserts byte-equivalent DTO output.
+5. **Stats counts match list output** — `stats` returns `{total, enabled, paused, types: {cron, interval, once}, fire_times_count}` consistent with the same scheduler's `list` output (no parallel state).
+
+**LOC estimate**: ~180 LOC (3 read handlers + DTO + tests).
+
+**Tests required**:
+
+1. `test_admin_list_returns_all_schedules` — schedule three workflows (cron + interval + once), call `list` → assert all three present with correct types and `next_run_time`.
+2. `test_admin_get_returns_one_schedule` — `get(sched_id)` returns the same DTO as the matching entry in `list`.
+3. `test_admin_stats_reflects_state` — schedule N items, pause some, call `stats` → assert counts match `list` output.
+4. `test_admin_list_cross_channel_parity` — same call over HTTP, CLI, MCP returns byte-equivalent JSON.
+5. `test_admin_read_does_not_emit_pact_audit_envelope` — call `list`; assert audit store has zero new rows.
+
+**Dependencies**: Shard 1 merged (AuthGuard + PACT scaffold + DTO).
+
+**Worktree assignment**:
+
+- **Branch**: `feat/issue-913-shard-2-read-handlers`
+- **Worktree path**: `.claude/worktrees/issue-913-shard-2/`
+- **Base SHA**: HEAD of `main` after Shard 1 merges.
+- **Sequencing**: serial AFTER Shard 1.
+
+---
+
+### Shard 3 — Write-side admin handlers (pause / resume / update_cron / delete)
+
+**Value-anchor**: Architecture plan § "API surface" + brief's literal acceptance criteria. Mutating operations are why operators come to the admin API — pausing a runaway billing job at 03:00, updating a cron after a DST change, deleting a deprecated schedule. Without these, the workstream's brief is unmet.
+
+**Files touched**:
+
+- `packages/kailash-nexus/src/nexus/admin/scheduler_handlers.py` — implement 4 mutating handlers.
+- `tests/integration/nexus/test_scheduler_admin_write_handlers.py` (new) — Tier-2 write-handler integration tests.
+
+**Invariants (7)**:
+
+1. **Admin permission** — all 4 handlers register with `AuthGuard.RequirePermission("scheduler:admin")`.
+2. **PACT envelope for every mutation** — `governance_engine.verify_action()` fires before scheduler op (inherited from Shard 1 scaffold).
+3. **Idempotency on ALREADY-IN-TARGET-STATE** — `pause` on already-paused returns 200 with current DTO (NOT a 5xx); same for `resume` on already-running. Closes FP-4.
+4. **404 on unknown ID** — every handler returning 404 with `code: "SCHEDULE_NOT_FOUND"` (inherited from Shard 1).
+5. **400 on invalid cron** — `update_cron` validates BEFORE writing; invalid cron returns 400 with `code: "INVALID_INPUT"` (per `rules/nexus-http-status-convention.md` Rule 5 legacy contract). Cites the original cron string in the error message.
+6. **Response includes `next_run_time` AND `in_flight_run_ids`** — every successful mutation returns the post-mutation DTO with new `next_run_time` plus any `in_flight_run_ids` (run_ids currently executing the schedule's previous trigger). Closes FP-3 mutation-during-fire footgun.
+7. **State-transition log + audit on EVERY mutation** — INFO log with `actor_user_id`, `action`, `before_state`, `after_state`, `correlation_id`; PACT audit envelope persisted (per `rules/observability.md` Rule 4 + RC3).
+
+**LOC estimate**: ~220 LOC (4 mutating handlers + tests).
+
+**Tests required**:
+
+1. `test_admin_pause_changes_state` — call `pause`, assert `enabled=False, next_run_time=None`, audit row exists.
+2. `test_admin_resume_recomputes_next_run_time` — pause then resume, assert `next_run_time > now`.
+3. `test_admin_update_cron_changes_next_fire` — change cron from `0 6 * * *` to `0 7 * * *`, assert `next_run_time` advances to 07:00 slot. Brief's literal acceptance.
+4. `test_admin_delete_removes_schedule` — call `delete(sched)`, assert subsequent `list` excludes it AND APScheduler's `get_job(id)` returns None.
+5. `test_admin_idempotent_pause_returns_200` — pause twice, second call returns 200 with same DTO; audit row count = 1 (only first-transition logs).
+6. `test_admin_invalid_cron_returns_400_with_input_code` — call `update_cron(sched, "not a cron")`, assert HTTP 400 + body `{"error": "...", "code": "INVALID_INPUT"}`.
+7. `test_admin_mutation_during_in_flight_fire` — start a long-running schedule, call `update_cron` mid-flight, assert response includes `in_flight_run_ids` populated (not empty).
+8. `test_admin_pact_blocked_verdict_short_circuits_delete` — envelope BLOCKs scheduler:write, call `delete`, assert 403 AND schedule still exists.
+
+**Dependencies**: Shard 2 merged (read handlers proven; scaffold validated under read-load).
+
+**Worktree assignment**:
+
+- **Branch**: `feat/issue-913-shard-3-write-handlers`
+- **Worktree path**: `.claude/worktrees/issue-913-shard-3/`
+- **Base SHA**: HEAD of `main` after Shard 2 merges.
+- **Sequencing**: serial AFTER Shard 2.
+
+---
+
+### Shard 4 — Migration helper (`migrate_from_celery_beat`)
+
+**Value-anchor**: Architecture plan § "API surface" + brief's optional acceptance criterion ("Migration helper from `django-celery-beat`'s `PeriodicTask` table"). Operators with existing celery-beat deployments are the SDK's natural conversion audience; without this helper, every migration is a hand-rolled script that drifts. The helper imports zero Django code (per architecture plan FP-10) — operators serialize their `PeriodicTask` rows in their own Django process and pass the dicts to the helper.
+
+**Files touched**:
+
+- `packages/kailash-nexus/src/nexus/admin/scheduler_migrate.py` (new) — `migrate_from_celery_beat(scheduler, periodic_tasks: list[dict]) -> dict`.
+- `packages/kailash-nexus/src/nexus/admin/scheduler_handlers.py` — register `scheduler.admin.migrate_from_celery_beat` handler wrapping the helper.
+- `tests/integration/nexus/test_scheduler_admin_migration.py` (new) — Tier-2 migration tests.
+
+**Invariants (4)**:
+
+1. **Zero Django imports** — `grep -n 'import django\|from django' packages/kailash-nexus/src/nexus/admin/scheduler_migrate.py` returns no matches.
+2. **CRON-only in v1** — interval / clocked PeriodicTasks raise `ValueError` with a clear "deferred to v2" message; the helper's docstring documents the supported shape.
+3. **Idempotent re-run** — calling `migrate_from_celery_beat` twice with the same `periodic_tasks` list does NOT duplicate schedules (verified by asserting `list_schedules()` count unchanged on second call).
+4. **Admin permission** — handler registered with `AuthGuard.RequirePermission("scheduler:admin")` (mutation).
+
+**LOC estimate**: ~170 LOC (helper + handler + tests).
+
+**Tests required**:
+
+1. `test_migrate_from_celery_beat_imports_cron_tasks` — pass 3 dicts shaped like Django `PeriodicTask` rows (CRON), assert 3 schedules registered with correct cron expressions.
+2. `test_migrate_helper_is_idempotent` — call twice with same input; second call returns `{imported: 0, errors: []}` with no duplicate schedules.
+3. `test_migrate_interval_task_returns_error_with_v2_note` — pass an interval-shaped dict; assert it appears in the `errors:` list with a "deferred to v2" message.
+4. `test_migrate_helper_imports_no_django` — grep test runs at test time as a structural invariant.
+
+**Dependencies**: Shard 3 merged (write handlers exist; migration helper is just bulk `schedule_cron` calls with idempotency).
+
+**Worktree assignment**:
+
+- **Branch**: `feat/issue-913-shard-4-migrate-helper`
+- **Worktree path**: `.claude/worktrees/issue-913-shard-4/`
+- **Base SHA**: HEAD of `main` after Shard 3 merges.
+- **Sequencing**: serial AFTER Shard 3 (could parallelize with a hypothetical Shard 5 docs-shard if desired; see Open Questions Q4).
+
+---
+
+## Tier-2 test plan summary
+
+Per `rules/testing.md` Tier 2 (NO mocking) + `rules/orphan-detection.md` Rule 2 (every wired manager has a Tier 2 test) + `rules/facade-manager-detection.md` Rule 2 (test file naming):
+
+**Scheduler-method tests** (Shard 0):
+
+- `tests/integration/runtime/test_scheduler_admin_methods.py` — pause/resume/update_cron/idempotency/typed-error coverage against real APScheduler + temp SQLite.
+
+**AuthGuard tests** (Shard 1):
+
+- `tests/integration/nexus/test_scheduler_admin_authguard_wiring.py` — 401/403 paths against real Nexus with `enable_auth=True`.
+
+**PACT envelope + audit tests** (Shard 1):
+
+- `tests/integration/nexus/test_scheduler_admin_pact_envelope_wiring.py` — envelope construction, BLOCKED-verdict short-circuit, audit-row persistence.
+
+**Read handler tests** (Shard 2):
+
+- `tests/integration/nexus/test_scheduler_admin_read_handlers.py` — list/get/stats + cross-channel parity (HTTP/CLI/MCP).
+
+**Write handler tests** (Shard 3):
+
+- `tests/integration/nexus/test_scheduler_admin_write_handlers.py` — pause/resume/update_cron/delete + idempotency + 404/400 error variants.
+
+**Migration tests** (Shard 4):
+
+- `tests/integration/nexus/test_scheduler_admin_migration.py` — CRON imports + idempotency + interval-deferred behavior.
+
+**Manager-shape wiring test** (per `rules/facade-manager-detection.md` Rule 2):
+
+- `tests/integration/nexus/test_scheduler_admin_governance_engine_wiring.py` — exercises `governance_engine` end-to-end; named per the rule's `_wiring.py` convention.
+
+---
+
+## NexusError taxonomy update
+
+Per `rules/nexus-http-status-convention.md` MUST NOT clause ("Add a new `NexusError` variant without updating both `status_code()` and `error_code()` in the SDK in the same commit"):
+
+**New variant** (lands in Shard 1, single commit):
+
+| `NexusError` variant | HTTP status | Error code (JSON body) |
+| -------------------- | ----------- | ---------------------- |
+| `ScheduleNotFound`   | 404         | `SCHEDULE_NOT_FOUND`   |
+
+**Implementation**: subclass `NexusError` in `packages/kailash-nexus/src/nexus/errors.py` with `status_code: int = 404` and `error_code: str = "SCHEDULE_NOT_FOUND"`. Mirror the existing `NotFoundError` (line 130, status 404, code `not_found`) shape. Body shape preserved bit-for-bit per Rule 2.
+
+**Reuse vs new**: the architecture plan (§ FP-4) considered reusing `HandlerNotFound` but rejected it because operators reading the dashboard `code: "HANDLER_NOT_FOUND"` would investigate Nexus routing, not scheduler state. Adding the variant is correct; the cost is one row in the frozen taxonomy.
+
+---
+
+## Dependency declarations
+
+**`kailash-pact` becomes a required dep for kailash-nexus admin handlers** (RC3, lands in Shard 1):
+
+`packages/kailash-nexus/pyproject.toml` — add `kailash-pact` to the `dependencies` list (NOT to `[project.optional-dependencies.dev]` per `rules/python-environment.md` Rule 4 — sub-package test deps stay in their own pyproject; the runtime dep belongs in the runtime `dependencies` list).
+
+```toml
+# kailash-nexus/pyproject.toml
+[project]
+dependencies = [
+    "kailash-pact >= <current-min-version>",   # required for admin handlers (PACT envelope + audit)
+    # ... other deps ...
+]
+```
+
+**Why required, not optional**: Per RC3, every admin handler MUST emit a PACT envelope. Marking PACT optional would create a silent-fallback path where the handler runs without envelope construction when PACT is absent — exactly the failure mode `rules/zero-tolerance.md` Rule 3 + `rules/security.md` § "Multi-Site Kwarg Plumbing" prohibit. Required-dep makes the contract explicit at install time.
+
+**`apscheduler`** — already a kailash-runtime dep; no change.
+
+**No phantom transitive caps** — per `rules/dependencies.md` § "Phantom Transitive Deps" — kailash-nexus does not directly import APScheduler; the constraint stays in kailash-runtime.
+
+---
+
+## Cross-SDK alignment notes (descriptive only)
+
+Per `rules/repo-scope-discipline.md` — kailash-rs (Rust SDK) ALSO has a workflow scheduler surface. The Rust scheduler's admin API would be the symmetric feature, but **filing a kailash-rs issue from THIS session is BLOCKED**. That decision belongs to the user when they next open Claude Code in `kailash-rs`.
+
+Descriptive observations only:
+
+- The Rust SDK's equivalent surface would expose `Scheduler::pause(id)` / `resume(id)` / `update_cron(id, expr)` plus an Axum (or equivalent) handler module that is the Rust analog of Shard 1+.
+- The Rust SDK has no APScheduler — its scheduler is a native implementation, so the in-process admin methods would touch its internal job store directly rather than delegating to a third-party library.
+- Cross-SDK semantic parity (per `rules/cross-sdk-inspection.md` § EATP D6 and Rule 4a) requires the JSON DTO shape returned by HTTP handlers to be byte-equivalent across both SDKs. The DTOs defined in Shard 1 should be authored with this in mind so the Rust port can vendor them per `cross-sdk-inspection.md` Rule 4a (sibling-canonical fixtures vendored, not re-authored).
+- Status taxonomy parity: `ScheduleNotFound → 404 SCHEDULE_NOT_FOUND` should be the same row in the Rust `NexusError` enum when that work happens upstream.
+
+These notes are workspace-record material only. No issue filing, no upstream action from this session.
+
+---
+
+## Open questions for human gate before /implement
+
+These are the BLOCKING-class questions — items that, if reversed by the user post-`/todos`, require a plan rewrite. Architecture-plan § "Open questions" had 6 questions; RC1–RC4 closed two of them (Q2 PACT-required and Q4 migration-helper-scope). Three remain:
+
+**Q1 — Permission name strings**: Proposed `scheduler:admin` and `scheduler:read` (colon-separated, matching the existing `orgs:delete` example at `packages/kailash-nexus/src/nexus/auth/guards.py:29`). Alternatives: `scheduler.admin` (dot-separated) or `kailash.scheduler.admin` (hierarchical).
+
+I recommend **`scheduler:admin` and `scheduler:read`** (colon-separated, matching existing Nexus convention). Implications: every admin handler registration uses this pair; migration tests assert both strings; downstream consumers' RBAC config files MUST use the same form. Pros: matches existing Nexus AuthGuard examples (`orgs:delete`, `agents:create`); operators learn one convention. Cons: differs from Python module path (`kailash.scheduler.admin`), so operators reading code may briefly mis-spell the permission. Recommendation stands because in-codebase precedent outweighs the path-vs-permission cosmetic mismatch.
+
+**Q2 — Admin handler namespace**: Proposed `scheduler.admin.*` (e.g., `scheduler.admin.list`, `scheduler.admin.pause`). Alternatives: `kailash.scheduler.*` (matches Python module path), `admin.scheduler.*` (matches `@app.handler("admin.reset", ...)` example at `packages/kailash-nexus/src/nexus/core.py:2774`), or `scheduler.*` (read vs write split by permission alone, no `admin.` segment).
+
+I recommend **`scheduler.admin.*`** (e.g., `scheduler.admin.list`, `scheduler.admin.pause`). Implications: every URL becomes `/api/handlers/scheduler.admin.<op>`; every CLI command becomes `nexus call scheduler.admin.<op>`; every MCP tool name carries `scheduler.admin.` prefix. Pros: clear separation between user-facing scheduler operations (none today) and admin operations; matches the `admin.reset` example precedent in core.py:2774. Cons: one extra segment in every URL/command/tool name (mild verbosity). Recommendation stands — the `.admin.` segment is the operator's signal that "this is a privileged surface."
+
+**Q3 — Recent-fires retention scope**: The architecture plan (§ "API surface") includes `scheduler.admin.recent_fires` returning the last N JobEvents from #914's lifecycle hooks. Open: what is N? Bounded ring buffer in memory (per `rules/infrastructure-sql.md` Rule 7 bounded-stores), persistent in SQLite, or NOT shipped in v1 (defer to v2)?
+
+I recommend **defer `recent_fires` to a v2 follow-up issue, drop from #913 scope**. Implications: Shard 2 (read handlers) ships only `list` / `get` / `stats`, not `recent_fires`; the architecture plan's `JobEventDTO` is unused in v1; #914 lifecycle hooks remain a separate workstream until v2. Pros: removes the unanswered N-question that would otherwise gate Shard 2; respects per-session capacity budget (Shard 2 stays at ~180 LOC instead of growing to ~270 with ring-buffer plumbing); brief's acceptance criteria do NOT mention recent-fires (it's a stretch goal from the architecture plan, not the user's brief). Cons: operators wanting "what fired in the last hour" must wait for v2; the `JobEventDTO` work in this plan becomes orphaned (delete it from this plan's deliverables — see `rules/orphan-detection.md` Rule 3). Recommendation stands because Q3 is unanswerable today (in-memory N is a design call the user has not made) and shipping without `recent_fires` does not break the brief.
+
+---
+
+## Effort estimate
+
+Per `rules/autonomous-execution.md` § Per-Session Capacity Budget — autonomous execution cycles, NOT human-days:
+
+- **Shard 0** (scheduler methods + Tier-2 tests, parallel with #912 Shard 1): 1 session, ~150 LOC, 9 invariants. Feedback loop: pytest. Multiplier 3-5× applies (real APScheduler is fast).
+- **Shard 1** (Nexus + AuthGuard + PACT + DTO + error variant): 1 session, ~280 LOC, 8 invariants. AT THE BUDGET CAP — heaviest invariant load. Do NOT expand mid-session.
+- **Shard 2** (read handlers): 1 session, ~180 LOC, 5 invariants. Light shard.
+- **Shard 3** (write handlers): 1 session, ~220 LOC, 7 invariants. Mid-budget.
+- **Shard 4** (migration helper): 1 session, ~170 LOC, 4 invariants. Light shard.
+
+**Total: 5 autonomous execution cycles**, with Shard 0 running in parallel with #912 Shard 1 (saves 1 wall-clock unit).
+
+End-to-end real wall-clock from this `/todos` to `/release`:
+
+- **Serial path**: ~5 sessions (Shard 0 → Shard 1 → Shard 2 → Shard 3 → Shard 4).
+- **Parallel-with-#912 path**: ~5 sessions still (Shard 0 lives in the same wall-clock unit as #912 Shard 1; subsequent shards are sequential because Shards 2–4 each depend on the prior shard's surface).
+- **Aggressive parallel**: Shards 2 (read) and 4 (migration helper) could parallelize after Shard 1 ships, since Shard 4's helper is bulk `schedule_cron` calls with idempotency — does not require Shard 3's mutating handlers. That brings the wall-clock to ~4 sessions if the user authorizes a 2-shard wave per `rules/worktree-isolation.md` Rule 4 (≤3 in a wave).
+
+**Risk class**: Shard 1 is the highest-risk shard (8 invariants at the cap, new module, new dep, new error variant, multi-site kwarg plumbing through every handler). If Shard 1 takes 1.5 sessions, the total slips to ~5.5–6 — within tolerance.
+
+---
+
+## Self-attestation — value-anchor + dependency receipts
+
+Per `rules/value-prioritization.md` MUST Rule 2, every shard above carries a value-anchor citing a Rule-1 user-anchored source:
+
+- Shard 0: user's RC4 gate of 2026-05-09.
+- Shard 1: architecture plan § "API surface" + RC3 user gate.
+- Shard 2: architecture plan § "API surface" + brief's literal acceptance criterion ("list").
+- Shard 3: architecture plan § "API surface" + brief's literal acceptance criterion ("enable/disable, update cron, delete").
+- Shard 4: architecture plan § "API surface" + brief's optional acceptance criterion ("Migration helper").
+
+Per `rules/specs-authority.md` MUST Rule 5c, the orchestrator at /implement launch time MUST cross-check todo claims against the then-current canonical spec AND prior merged shards' state — amend at launch if drift exists. Any drift between this /todos plan and main HEAD at launch time is the orchestrator's responsibility to reconcile in the launch prompt, NOT to leave for the agent to discover mid-implementation.
+
+Per `rules/upstream-issue-hygiene.md` — NO upstream issue filing from this /todos session. Cross-SDK alignment notes are descriptive only; they do not authorize action in this or any other repo session.


### PR DESCRIPTION
## Summary

Commits the workspace plans (`/analyze` architecture-plan.md + `/todos` todos.md) for issues #911 (multi-queue routing), #912 (per-task time limits), #913 (admin API). 6 files, 2270 insertions.

## Why

Prior session generated these plans via background agents but never committed them. When subsequent /implement worktree agents branched off `main`, they couldn't see the plans (worktree-bootstrap gap surfaced when #912 Shard 1 agent halted with "todos.md not found").

This is COC-workflow infrastructure landing on main so future worktrees can read their shard plan from the branch base.

## Related issues

- Refs #911, #912, #913 (planning artifacts)
- Refs #917 (LocalRuntime __exit__ tracking issue, filed earlier this session)