### PR TITLE
feat(#912 Shard 1): additive typed time-limit kwargs + exception types

### DIFF
--- a/specs/core-runtime.md
+++ b/specs/core-runtime.md
@@ -79,6 +79,11 @@ def execute(
     parameters: dict[str, dict[str, Any]] | dict[str, Any] | None = None,
     cancellation_token: CancellationToken | None = None,
     search_attributes: dict[str, Any] | None = None,
+    *,
+    idempotency_key: str | None = None,
+    force_resume_with_drift: bool = False,
+    soft_time_limit: float | None = None,
+    time_limit: float | None = None,
     **kwargs: Any,
 ) -> tuple[dict[str, Any], str | None]
 ```
@@ -92,6 +97,8 @@ Execute a workflow synchronously.
 - `parameters` -- Optional parameter overrides. Can be `dict[str, dict[str, Any]]` (per-node: `{"node_id": {"param": value}}`) or `dict[str, Any]` (flat, injected into root nodes)
 - `cancellation_token` -- Optional token to request mid-execution cancellation
 - `search_attributes` -- Optional typed key-value pairs for indexing/querying workflow runs
+- `soft_time_limit` -- Optional advisory deadline in seconds. Validated at the entry point: `<= 0` raises `ValueError`; when both `soft_time_limit` and `time_limit` are set, `soft_time_limit` MUST be strictly less than `time_limit`.
+- `time_limit` -- Optional unconditional kill deadline in seconds. Same validation contract.
 
 **Returns**: `tuple[dict[str, Any], str | None]`
 
@@ -169,9 +176,14 @@ def execute(
     parameters=None,
     cancellation_token=None,
     search_attributes=None,
+    *,
+    soft_time_limit: float | None = None,
+    time_limit: float | None = None,
     **kwargs,
 ) -> tuple[dict[str, Any], str | None]
 ```
+
+The typed `soft_time_limit` and `time_limit` keyword-only parameters share the validation contract documented in §4.1.2. They are accepted on every concrete `BaseRuntime` subclass; deadline enforcement is handled by the runtime-internal time-limit wrapper that consumes the validated values.
 
 **Docker-safe override**: Prevents the parent's threading-based execution that causes Docker file descriptor issues. Uses `asyncio.run()` for pure async execution.
 

--- a/src/kailash/runtime/_time_limits.py
+++ b/src/kailash/runtime/_time_limits.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Time-limit validation helper for runtime ``execute*`` methods (#912 Shard 1).
+
+Issue #912 — per-task soft/hard time limits. This module owns the SINGLE
+validation surface every runtime entry point calls when accepting the
+typed ``soft_time_limit`` / ``time_limit`` kwargs. Centralising the check
+prevents drift across the 10 ``execute*`` methods on the runtime
+hierarchy (per ``security.md`` § Multi-Site Kwarg Plumbing — every
+caller of a security-relevant kwarg helper MUST share the same
+validation).
+
+Shard 1 lands the kwarg slot + validation. Shard 2 will add the
+deadline-arming wrapper (`arm_time_limits` / `arm_time_limits_async`)
+that consumes the validated values and raises
+:class:`~kailash.sdk_exceptions.SoftTimeLimitExceeded` /
+:class:`~kailash.sdk_exceptions.HardTimeLimitExceeded` at the right
+moments.
+"""
+
+from __future__ import annotations
+
+
+def _validate_limits(
+    soft_time_limit: float | None,
+    time_limit: float | None,
+) -> None:
+    """Validate the typed time-limit kwargs accepted by every runtime ``execute*``.
+
+    Called from every runtime entry point that accepts ``soft_time_limit``
+    / ``time_limit`` kwargs. Raises :class:`ValueError` with an
+    actionable message on caller error so the failure surfaces at the
+    entry point — NOT later from a timer thread where the traceback
+    points at internals.
+
+    Per the celery-style convention (see issue #912 brief): when both
+    kwargs are set, ``soft_time_limit`` MUST be strictly less than
+    ``time_limit`` so the soft signal precedes the hard kill with a
+    non-zero warning window.
+
+    Args:
+        soft_time_limit: Advisory deadline in seconds. ``None`` = no
+            soft limit. ``<= 0`` is invalid.
+        time_limit: Unconditional kill deadline in seconds. ``None`` =
+            no hard limit. ``<= 0`` is invalid.
+
+    Raises:
+        ValueError: If either kwarg is ``<= 0``, or if both are set and
+            ``soft_time_limit >= time_limit``.
+
+    Added in: v0.13.0 (issue #912 Shard 1).
+    """
+    if soft_time_limit is not None and soft_time_limit <= 0:
+        raise ValueError(
+            f"soft_time_limit MUST be > 0 when set (got {soft_time_limit!r}); "
+            f"pass None to disable the soft deadline"
+        )
+    if time_limit is not None and time_limit <= 0:
+        raise ValueError(
+            f"time_limit MUST be > 0 when set (got {time_limit!r}); "
+            f"pass None to disable the hard deadline"
+        )
+    if (
+        soft_time_limit is not None
+        and time_limit is not None
+        and soft_time_limit >= time_limit
+    ):
+        raise ValueError(
+            f"soft_time_limit ({soft_time_limit!r}) MUST be strictly less than "
+            f"time_limit ({time_limit!r}) so the advisory signal precedes the "
+            f"hard kill with a non-zero warning window"
+        )

--- a/src/kailash/runtime/access_controlled.py
+++ b/src/kailash/runtime/access_controlled.py
@@ -39,6 +39,7 @@ from kailash.access_control import (
     get_access_control_manager,
 )
 from kailash.nodes.base import Node
+from kailash.runtime._time_limits import _validate_limits
 from kailash.runtime.local import LocalRuntime
 from kailash.workflow import Workflow
 
@@ -127,14 +128,34 @@ class AccessControlledRuntime:
         self._node_outputs: dict[str, Any] = {}
 
     def execute(
-        self, workflow: Workflow, parameters: dict[str, Any] | None = None
+        self,
+        workflow: Workflow,
+        parameters: dict[str, Any] | None = None,
+        *,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
+        **kwargs: Any,
     ) -> tuple[Any, str | None]:
         """
         Execute workflow with access control.
 
         This method has the exact same signature as the standard runtime,
         ensuring complete compatibility.
+
+        Args:
+            workflow: Workflow to execute.
+            parameters: Optional parameter overrides per node.
+            soft_time_limit: Optional advisory deadline in seconds (#912
+                Shard 1 slot, forwarded to inner runtime).
+            time_limit: Optional unconditional kill deadline in seconds.
+            **kwargs: Forward-compatibility kwargs forwarded to inner runtime.
         """
+        # #912 Shard 1: validate the typed kwargs at this entry point too —
+        # the inner runtime will re-validate, but raising here keeps the
+        # traceback rooted at the user-facing AccessControlledRuntime call
+        # site rather than dipping into the wrapped runtime first.
+        _validate_limits(soft_time_limit, time_limit)
+
         # Only check access control if it's enabled
         if self.acm.enabled:
             # Check workflow-level access
@@ -147,7 +168,15 @@ class AccessControlledRuntime:
 
         # Execute with base runtime - it's managed via context manager
         # The base runtime's context manager is entered in __enter__ if we own it
-        return self.base_runtime.execute(workflow, parameters=parameters)
+        # Forward typed kwargs by name so the inner runtime sees them
+        # in the typed slot, not absorbed into its **kwargs.
+        return self.base_runtime.execute(
+            workflow,
+            parameters=parameters,
+            soft_time_limit=soft_time_limit,
+            time_limit=time_limit,
+            **kwargs,
+        )
 
     def close(self) -> None:
         """Close the runtime and clean up resources.

--- a/src/kailash/runtime/async_local.py
+++ b/src/kailash/runtime/async_local.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 from kailash.nodes.base import Node
 from kailash.nodes.base_async import AsyncNode
 from kailash.resources import ResourceRegistry
+from kailash.runtime._time_limits import _validate_limits
 from kailash.runtime.durable import (
     NodeCompletionEvent,
     build_checkpoint_key,
@@ -711,6 +712,9 @@ class AsyncLocalRuntime(LocalRuntime):
         parameters: Optional[Dict[str, Any]] = None,
         cancellation_token: Any = None,
         search_attributes: Optional[Dict[str, Any]] = None,
+        *,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
         **kwargs: Any,
     ) -> Tuple[Dict[str, Any], Optional[str]]:
         """
@@ -731,6 +735,9 @@ class AsyncLocalRuntime(LocalRuntime):
         Raises:
             RuntimeError: If called from async context (use execute_workflow_async instead)
         """
+        # #912 Shard 1: validate typed time-limit kwargs at the entry point.
+        _validate_limits(soft_time_limit, time_limit)
+
         # Check if we're already in an event loop
         try:
             loop = asyncio.get_running_loop()
@@ -811,6 +818,8 @@ class AsyncLocalRuntime(LocalRuntime):
         *,
         idempotency_key: Optional[str] = None,
         force_resume_with_drift: bool = False,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
     ) -> Tuple[Dict[str, Any], str]:
         """
         Execute workflow with native async support and production safeguards.
@@ -845,6 +854,9 @@ class AsyncLocalRuntime(LocalRuntime):
             asyncio.TimeoutError: If execution exceeds configured timeout
             WorkflowExecutionError: If execution fails
         """
+        # #912 Shard 1: validate typed time-limit kwargs at the entry point.
+        _validate_limits(soft_time_limit, time_limit)
+
         start_time = time.time()
 
         # Generate run_id for tracking (consistent with LocalRuntime)

--- a/src/kailash/runtime/base.py
+++ b/src/kailash/runtime/base.py
@@ -840,7 +840,14 @@ class BaseRuntime(ABC):
         self.close()
 
     @abstractmethod
-    def execute(self, workflow: Workflow, **kwargs):
+    def execute(
+        self,
+        workflow: Workflow,
+        *,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
+        **kwargs,
+    ):
         """
         Execute workflow (runtime-specific implementation).
 
@@ -852,7 +859,10 @@ class BaseRuntime(ABC):
                 self,
                 workflow: Workflow,
                 parameters: Optional[Dict] = None,
-                **kwargs
+                *,
+                soft_time_limit: float | None = None,
+                time_limit: float | None = None,
+                **kwargs,
             ) -> Tuple[Dict[str, Any], str]:
                 '''Execute workflow synchronously.'''
                 # Implementation
@@ -863,7 +873,10 @@ class BaseRuntime(ABC):
                 self,
                 workflow: Workflow,
                 parameters: Optional[Dict] = None,
-                **kwargs
+                *,
+                soft_time_limit: float | None = None,
+                time_limit: float | None = None,
+                **kwargs,
             ) -> Tuple[Dict[str, Any], str]:
                 '''Execute workflow asynchronously.'''
                 # Implementation
@@ -871,7 +884,19 @@ class BaseRuntime(ABC):
 
         Args:
             workflow: The workflow to execute
-            **kwargs: Additional execution parameters (runtime-specific)
+            soft_time_limit: Optional advisory deadline in seconds. When
+                reached, the running workflow is signalled via the
+                cancellation token; user code MAY catch
+                :class:`SoftTimeLimitExceeded`, finish in-flight work,
+                and exit cleanly before the hard limit fires.
+                Enforcement lands in #912 Shard 2.
+            time_limit: Optional unconditional kill deadline in seconds.
+                When ``time_limit + grace`` elapses, the wrapper raises
+                :class:`HardTimeLimitExceeded` regardless of
+                acknowledgement. Enforcement lands in #912 Shard 2.
+            **kwargs: Additional execution parameters (runtime-specific).
+                Retained per the additive #912 Shard 1 contract; a
+                future shard MAY tighten via a Rule 6a deprecation cycle.
 
         Returns:
             Tuple of (results_dict, run_id)

--- a/src/kailash/runtime/distributed.py
+++ b/src/kailash/runtime/distributed.py
@@ -46,6 +46,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
+from kailash.runtime._time_limits import _validate_limits
 from kailash.runtime.base import BaseRuntime
 from kailash.runtime.lifecycle_events import TaskEvent, TaskEventHandler
 from kailash.workflow import Workflow
@@ -503,6 +504,9 @@ class DistributedRuntime(BaseRuntime):
         self,
         workflow: Workflow,
         parameters: Optional[Dict[str, Any]] = None,
+        *,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
         **kwargs,
     ) -> Tuple[Dict[str, Any], str]:
         """Submit a workflow to the distributed task queue.
@@ -513,12 +517,21 @@ class DistributedRuntime(BaseRuntime):
         Args:
             workflow: The workflow to execute.
             parameters: Optional execution parameters.
+            soft_time_limit: Optional advisory deadline in seconds. Per
+                #912 Shard 1, the slot is accepted; serialisation onto
+                the ``TaskMessage`` wire format lands in Shard 4.
+            time_limit: Optional unconditional kill deadline in seconds.
+                Per #912 Shard 1, the slot is accepted; worker-side
+                enforcement lands in Shard 4.
             **kwargs: Additional execution options.
 
         Returns:
             Tuple of (status_dict, run_id) where status_dict contains
             ``{"status": "queued", "run_id": run_id, "queue_length": N}``.
         """
+        # #912 Shard 1: validate typed time-limit kwargs at the entry point.
+        _validate_limits(soft_time_limit, time_limit)
+
         run_id = self._generate_run_id()
         metadata = self._initialize_execution_metadata(workflow, run_id)
         self._execution_metadata[run_id] = metadata

--- a/src/kailash/runtime/docker.py
+++ b/src/kailash/runtime/docker.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from kailash.nodes.base import Node
+from kailash.runtime._time_limits import _validate_limits
 
 # BaseRuntime doesn't exist - we'll implement task tracking methods directly
 from kailash.sdk_exceptions import NodeConfigurationError, NodeExecutionError
@@ -567,6 +568,10 @@ class DockerRuntime:
         workflow: Workflow,
         inputs: dict[str, dict[str, Any]] | None = None,
         node_resource_limits: dict[str, dict[str, str]] | None = None,
+        *,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
+        **kwargs: Any,
     ) -> tuple[dict[str, dict[str, Any]], str | None]:
         """
         Execute a workflow using Docker containers.
@@ -575,10 +580,18 @@ class DockerRuntime:
             workflow: The workflow to execute.
             inputs: The inputs for each node.
             node_resource_limits: Resource limits for specific nodes.
+            soft_time_limit: Optional advisory deadline in seconds (#912
+                Shard 1 slot; out-of-process timer enforcement lands later).
+            time_limit: Optional unconditional kill deadline in seconds.
+            **kwargs: Forward-compatibility kwargs for additive #912 Shard 1
+                contract.
 
         Returns:
             Tuple of (execution_results, run_id).
         """
+        # #912 Shard 1: validate typed time-limit kwargs at the entry point.
+        _validate_limits(soft_time_limit, time_limit)
+
         # Create task run
         run_id = self._create_task_run(workflow)
 

--- a/src/kailash/runtime/durable.py
+++ b/src/kailash/runtime/durable.py
@@ -57,6 +57,8 @@ from typing import (
     Union,
 )
 
+from kailash.runtime._time_limits import _validate_limits
+
 # ExecutionMode — caller-explicit routing for DurableExecutionEngine.execute().
 # Default is None (auto-detect at build time: "both" with dispatcher,
 # "in_process_only" without). See DurableExecutionEngineBuilder.execution_mode.
@@ -1287,6 +1289,9 @@ class DurableExecutionEngine:
         force_resume_with_drift: bool = False,
         dispatch_kwargs: Optional[Mapping[str, Any]] = None,
         queue_name: str = "default",
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
+        **kwargs: Any,
     ) -> Tuple[Dict[str, Any], str]:
         """Execute *workflow* through the wrapped runtime and (optionally) dispatch.
 
@@ -1370,6 +1375,9 @@ class DurableExecutionEngine:
           MUST switch to ``"in_process_only"`` / ``"dispatch_only"`` to
           eliminate the race entirely.
         """
+        # #912 Shard 1: validate typed time-limit kwargs at the entry point.
+        _validate_limits(soft_time_limit, time_limit)
+
         effective_inputs: Dict[str, Any] = (
             dict(inputs) if isinstance(inputs, Mapping) else {}
         )
@@ -1404,11 +1412,15 @@ class DurableExecutionEngine:
         if do_in_process:
             # In-process execution. The runtime drives W1 (checkpoint emit)
             # and W2 (history record) via its own hook registry.
+            # Forward typed time-limit kwargs by name so the inner runtime
+            # honors them (#912 Shard 1).
             results, run_id = await self._runtime.execute_workflow_async(
                 workflow,
                 inputs=effective_inputs,
                 idempotency_key=effective_key,
                 force_resume_with_drift=force_resume_with_drift,
+                soft_time_limit=soft_time_limit,
+                time_limit=time_limit,
             )
             # If the dispatcher returned a hint, the schedule_id and the
             # in-process run_id are correlated via the engine's INFO log

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from kailash.runtime.shutdown import ShutdownCoordinator
 
 from kailash.nodes import Node
+from kailash.runtime._time_limits import _validate_limits
 from kailash.runtime.base import BaseRuntime
 from kailash.runtime.cancellation import CancellationToken
 from kailash.runtime.compatibility_reporter import CompatibilityReporter
@@ -934,6 +935,8 @@ class LocalRuntime(
         *,
         idempotency_key: Optional[str] = None,
         force_resume_with_drift: bool = False,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
         **kwargs: Any,
     ) -> tuple[dict[str, Any], str | None]:
         """
@@ -1008,6 +1011,11 @@ class LocalRuntime(
             - __enter__, __exit__: Context manager support
             - execute_async(): Async variant
         """
+        # Validate the typed time-limit kwargs at the entry point so caller
+        # bugs (negative values, soft >= hard) raise loudly here, not later
+        # from a timer thread (per #912 Shard 1; enforcement lands Shard 2).
+        _validate_limits(soft_time_limit, time_limit)
+
         # Emit deprecation warning for non-context-managed usage.
         # Externally-managed runtimes (frameworks that call close() at
         # their own shutdown) opt out via mark_externally_managed().

--- a/src/kailash/runtime/parallel.py
+++ b/src/kailash/runtime/parallel.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from kailash.nodes.base_async import AsyncNode
+from kailash.runtime._time_limits import _validate_limits
 from kailash.sdk_exceptions import (
     RuntimeExecutionError,
     WorkflowExecutionError,
@@ -68,6 +69,10 @@ class ParallelRuntime:
         workflow: Workflow,
         task_manager: TaskManager | None = None,
         parameters: dict[str, dict[str, Any]] | None = None,
+        *,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
+        **kwargs: Any,
     ) -> tuple[dict[str, Any], str | None]:
         """Execute a workflow with parallel node execution.
 
@@ -75,6 +80,11 @@ class ParallelRuntime:
             workflow: Workflow to execute
             task_manager: Optional task manager for tracking
             parameters: Optional parameter overrides per node
+            soft_time_limit: Optional advisory deadline in seconds (#912
+                Shard 1 slot; enforcement lands Shard 2).
+            time_limit: Optional unconditional kill deadline in seconds.
+            **kwargs: Forward-compatibility kwargs for additive #912 Shard 1
+                contract.
 
         Returns:
             Tuple of (results dict, run_id)
@@ -83,6 +93,9 @@ class ParallelRuntime:
             RuntimeExecutionError: If execution fails
             WorkflowValidationError: If workflow is invalid
         """
+        # #912 Shard 1: validate typed time-limit kwargs at the entry point.
+        _validate_limits(soft_time_limit, time_limit)
+
         if not workflow:
             raise RuntimeExecutionError("No workflow provided")
 

--- a/src/kailash/runtime/parallel_cyclic.py
+++ b/src/kailash/runtime/parallel_cyclic.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from kailash.nodes.base import Node
-from kailash.workflow.dag import CycleDetectedError
+from kailash.runtime._time_limits import _validate_limits
 from kailash.runtime.local import LocalRuntime
 from kailash.sdk_exceptions import RuntimeExecutionError, WorkflowExecutionError
 from kailash.tracking import TaskManager, TaskStatus
@@ -15,6 +15,7 @@ from kailash.tracking.metrics_collector import MetricsCollector
 from kailash.tracking.models import TaskMetrics
 from kailash.workflow import Workflow
 from kailash.workflow.cyclic_runner import CyclicWorkflowExecutor
+from kailash.workflow.dag import CycleDetectedError
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,10 @@ class ParallelCyclicRuntime:
         task_manager: TaskManager | None = None,
         parameters: dict[str, dict[str, Any]] | None = None,
         parallel_nodes: set[str] | None = None,
+        *,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
+        **kwargs: Any,
     ) -> tuple[dict[str, Any], str | None]:
         """Execute a workflow with parallel and cyclic support.
 
@@ -73,6 +78,11 @@ class ParallelCyclicRuntime:
             task_manager: Optional task manager for tracking
             parameters: Optional parameter overrides per node
             parallel_nodes: Set of node IDs that can be executed in parallel
+            soft_time_limit: Optional advisory deadline in seconds (#912
+                Shard 1 slot; enforcement lands Shard 2).
+            time_limit: Optional unconditional kill deadline in seconds.
+            **kwargs: Forward-compatibility kwargs for additive #912 Shard 1
+                contract.
 
         Returns:
             Tuple of (results dict, run_id)
@@ -81,6 +91,9 @@ class ParallelCyclicRuntime:
             RuntimeExecutionError: If execution fails
             WorkflowValidationError: If workflow is invalid
         """
+        # #912 Shard 1: validate typed time-limit kwargs at the entry point.
+        _validate_limits(soft_time_limit, time_limit)
+
         if not workflow:
             raise RuntimeExecutionError("No workflow provided")
 

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -974,6 +974,15 @@ class WorkflowScheduler:
         # ignored on the queue dispatch path with a documented rationale above.
         retry_spec: Optional[RetrySpec] = kwargs.pop(_RETRY_SPEC_KWARG, None)
 
+        # Pop the typed time-limit kwargs before forwarding so we can pass
+        # them by NAME to runtime.execute(...) — landing them in the typed
+        # signature slot rather than being absorbed by the runtime's
+        # **kwargs. Per #912 Shard 1: slots accepted now, deadline
+        # enforcement lands in Shards 2–3 (in-process wrapper +
+        # scheduler-side timer arming around the retry loop).
+        soft_time_limit: float | None = kwargs.pop("soft_time_limit", None)
+        time_limit: float | None = kwargs.pop("time_limit", None)
+
         if self._dispatcher is not None:
             await self._dispatch_to_queue(
                 workflow_builder=workflow_builder,
@@ -1007,7 +1016,14 @@ class WorkflowScheduler:
                     else contextlib.nullcontext(_runtime)
                 )
                 with _runtime_cm as runtime:
-                    results, actual_run_id = runtime.execute(workflow, **kwargs)
+                    # Pass typed time-limit kwargs by NAME so they land in
+                    # the runtime's typed signature slot (#912 Shard 1).
+                    results, actual_run_id = runtime.execute(
+                        workflow,
+                        soft_time_limit=soft_time_limit,
+                        time_limit=time_limit,
+                        **kwargs,
+                    )
                 # LocalRuntime swallows leaf-node failures into a result entry
                 # of shape ``{"failed": True, "error": str, "error_type": str}``
                 # rather than raising. For #910 the retry primitive MUST observe

--- a/src/kailash/sdk_exceptions.py
+++ b/src/kailash/sdk_exceptions.py
@@ -207,6 +207,64 @@ class ResourceLimitExceededError(RuntimeException):
     """
 
 
+class SoftTimeLimitExceeded(RuntimeException):
+    """Raised when a workflow exceeds its configured ``soft_time_limit``.
+
+    Soft time limits are advisory deadlines: when reached, the running
+    workflow is signalled via the cancellation token so user code MAY
+    catch this exception, finish the in-flight work, and exit cleanly
+    before the hard limit fires. The exception is a normal Python
+    exception and IS subject to the scheduler's retry primitive (see
+    issue #910 ``RetrySpec``) when raised inside a scheduled job.
+
+    Attributes:
+        message: Human-readable description of the deadline event.
+
+    Example::
+
+        from kailash.runtime.local import LocalRuntime
+        from kailash.sdk_exceptions import SoftTimeLimitExceeded
+
+        runtime = LocalRuntime()
+        try:
+            runtime.execute(workflow.build(), soft_time_limit=2.0, time_limit=10.0)
+        except SoftTimeLimitExceeded:
+            # Save partial work, write a checkpoint, return early.
+            ...
+
+    Sibling of :class:`HardTimeLimitExceeded`. NOT a subclass of
+    :class:`ResourceLimitExceededError` — time-limit exhaustion is
+    a different domain than resource-pool exhaustion.
+
+    Added in: v0.13.0 (issue #912 — per-task soft/hard time limits).
+    """
+
+
+class HardTimeLimitExceeded(RuntimeException):
+    """Raised when a workflow exceeds its configured ``time_limit`` plus grace.
+
+    Hard time limits are unconditional kills: when ``time_limit +
+    grace_seconds`` elapses, the wrapper raises ``HardTimeLimitExceeded``
+    regardless of whether the workflow has acknowledged the prior
+    ``SoftTimeLimitExceeded`` signal. This is the "task is dead" path
+    — operators rely on it to bound resource consumption from misbehaving
+    or runaway workflows.
+
+    On the distributed worker path (Shard 4), ``HardTimeLimitExceeded``
+    triggers a requeue (NOT immediate dead-letter) when the task has
+    remaining ``max_attempts``; dead-letter happens only after the
+    attempt budget is exhausted.
+
+    Attributes:
+        message: Human-readable description of the deadline event.
+
+    Sibling of :class:`SoftTimeLimitExceeded`. NOT a subclass of
+    :class:`ResourceLimitExceededError`.
+
+    Added in: v0.13.0 (issue #912 — per-task soft/hard time limits).
+    """
+
+
 class CircuitBreakerOpenError(RuntimeException):
     """Raised when circuit breaker is open.
 
@@ -453,3 +511,61 @@ class WorkflowCancelledError(WorkflowExecutionError):
 # Legacy exception name compatibility for tests and backwards compatibility
 KailashRuntimeError = RuntimeExecutionError
 KailashValidationError = NodeValidationError
+
+
+# Public exception API surface (per orphan-detection.md Rule 6).
+# `__all__` lists every public exception class + legacy alias so that
+# `from kailash.sdk_exceptions import *`, Sphinx autodoc, and static
+# analyzers (mypy --strict, CodeQL py/undefined-export) all resolve the
+# same set of public names. New exceptions MUST be added here in the
+# same PR that introduces them.
+__all__ = [
+    # Base
+    "KailashException",
+    # Node hierarchy
+    "NodeException",
+    "NodeValidationError",
+    "NodeExecutionError",
+    "NodeConfigurationError",
+    "SafetyViolationError",
+    "CodeExecutionError",
+    # Workflow hierarchy
+    "WorkflowException",
+    "WorkflowValidationError",
+    "WorkflowExecutionError",
+    "CyclicDependencyError",
+    "ConnectionError",
+    "CycleConfigurationError",
+    "WorkflowCancelledError",
+    "KailashWorkflowException",
+    # Runtime hierarchy
+    "RuntimeException",
+    "RuntimeExecutionError",
+    "ResourceLimitExceededError",
+    "SoftTimeLimitExceeded",
+    "HardTimeLimitExceeded",
+    "CircuitBreakerOpenError",
+    "ScheduleNotFound",
+    "RetryExhaustedException",
+    # Task hierarchy
+    "TaskException",
+    "TaskStateError",
+    # Storage hierarchy
+    "StorageException",
+    "KailashStorageError",
+    # Export / Import
+    "ExportException",
+    "ImportException",
+    # Configuration
+    "ConfigurationException",
+    "KailashConfigError",
+    # Other
+    "ManifestError",
+    "CLIException",
+    "VisualizationError",
+    "TemplateError",
+    "KailashNotFoundException",
+    # Legacy aliases
+    "KailashRuntimeError",
+    "KailashValidationError",
+]

--- a/tests/integration/test_runtime_signature_typed_kwargs.py
+++ b/tests/integration/test_runtime_signature_typed_kwargs.py
@@ -1,0 +1,155 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Integration: #912 Shard 1 runtime typed kwargs additive contract (Tier 2).
+
+Issue #912 — per-task soft/hard time limits. Shard 1 lands the typed
+kwargs SLOT on every runtime ``execute*`` method without enforcing the
+deadline yet (Shard 2 wires the timer). This Tier 2 test exercises the
+slot end-to-end:
+
+  * Real ``LocalRuntime`` + real ``WorkflowBuilder`` — no mocks.
+  * Asserts the typed kwarg is accepted at call time without raising.
+  * Asserts the additive ``**kwargs`` contract still absorbs unknown
+    kwargs (an unrecognised name MUST NOT raise TypeError until a
+    future shard with a Rule 6a deprecation cycle removes ``**kwargs``).
+  * Asserts validation fires on negative input.
+
+The test does NOT assert deadline enforcement — that is Shard 2's
+responsibility. Asserting enforcement here would silently mask Shard 2's
+absence per ``zero-tolerance.md`` Rule 3c (kwarg accepted but unused).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.access_control import UserContext
+from kailash.runtime.access_controlled import AccessControlledRuntime
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+
+def _user_context() -> UserContext:
+    """Construct a minimal UserContext for AccessControlledRuntime tests.
+
+    Access control is disabled by default at the manager level, so the
+    user identity does not gate execution — this fixture exists only to
+    satisfy the constructor.
+    """
+    return UserContext(
+        user_id="test-912-shard-1",
+        tenant_id="test-tenant",
+        email="test@example.com",
+        roles=["analyst"],
+    )
+
+
+def _trivial_workflow():
+    """Build the smallest possible workflow that LocalRuntime can execute.
+
+    Uses ``PythonCodeNode`` returning a constant — no external dependencies,
+    no DB, no network. Tier 2 because we exercise the real runtime, not
+    because of infrastructure heaviness.
+    """
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "PythonCodeNode",
+        "noop",
+        {"code": "result = {'ok': True}"},
+    )
+    return workflow.build()
+
+
+@pytest.mark.integration
+def test_local_runtime_accepts_soft_time_limit_kwarg():
+    """LocalRuntime.execute(...) MUST accept soft_time_limit without raising.
+
+    Per #912 Shard 1: slot lands now, enforcement lands in Shard 2.
+    """
+    workflow = _trivial_workflow()
+    with LocalRuntime() as runtime:
+        # No raise = signature accepts the kwarg.
+        results, _ = runtime.execute(workflow, soft_time_limit=2.0)
+    assert results is not None
+
+
+@pytest.mark.integration
+def test_local_runtime_accepts_time_limit_kwarg():
+    """LocalRuntime.execute(...) MUST accept time_limit without raising."""
+    workflow = _trivial_workflow()
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow, time_limit=10.0)
+    assert results is not None
+
+
+@pytest.mark.integration
+def test_local_runtime_accepts_both_typed_kwargs():
+    """Both kwargs together MUST work when soft < hard."""
+    workflow = _trivial_workflow()
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow, soft_time_limit=2.0, time_limit=10.0)
+    assert results is not None
+
+
+@pytest.mark.integration
+def test_local_runtime_kwargs_absorption_still_works():
+    """Per the additive Shard 1 contract, **kwargs MUST still absorb unknown kwargs.
+
+    A future shard with a Rule 6a deprecation cycle MAY remove **kwargs.
+    Until then, callers passing arbitrary kwargs continue to work.
+    """
+    workflow = _trivial_workflow()
+    with LocalRuntime() as runtime:
+        # Garbage kwarg silently absorbed by **kwargs — no TypeError.
+        results, _ = runtime.execute(workflow, garbage_kwarg_for_912=1)
+    assert results is not None
+
+
+@pytest.mark.integration
+def test_local_runtime_rejects_negative_soft_time_limit():
+    """Validation fires at the entry point, not at the timer thread."""
+    workflow = _trivial_workflow()
+    with LocalRuntime() as runtime:
+        with pytest.raises(ValueError):
+            runtime.execute(workflow, soft_time_limit=-1)
+
+
+@pytest.mark.integration
+def test_local_runtime_rejects_negative_time_limit():
+    """Validation fires at the entry point on negative hard limit too."""
+    workflow = _trivial_workflow()
+    with LocalRuntime() as runtime:
+        with pytest.raises(ValueError):
+            runtime.execute(workflow, time_limit=-1)
+
+
+@pytest.mark.integration
+def test_local_runtime_rejects_soft_ge_hard():
+    """``soft_time_limit >= time_limit`` is invalid — caller bug, raise loudly."""
+    workflow = _trivial_workflow()
+    with LocalRuntime() as runtime:
+        with pytest.raises(ValueError):
+            runtime.execute(workflow, soft_time_limit=10, time_limit=5)
+
+
+@pytest.mark.integration
+def test_access_controlled_runtime_accepts_typed_kwargs():
+    """AccessControlledRuntime forwards typed kwargs to its inner runtime.
+
+    Access-control manager defaults to disabled, so we exercise the
+    short-circuit path (acm.enabled is False without explicit setup),
+    still proving the wrapper accepts and forwards the typed kwargs.
+    """
+    workflow = _trivial_workflow()
+    with AccessControlledRuntime(user_context=_user_context()) as runtime:
+        results, _ = runtime.execute(workflow, soft_time_limit=2.0, time_limit=10.0)
+    assert results is not None
+
+
+@pytest.mark.integration
+def test_access_controlled_runtime_validates_typed_kwargs():
+    """AccessControlledRuntime MUST surface validation errors from typed kwargs."""
+    workflow = _trivial_workflow()
+    with AccessControlledRuntime(user_context=_user_context()) as runtime:
+        with pytest.raises(ValueError):
+            runtime.execute(workflow, soft_time_limit=-1)

--- a/tests/regression/test_issue_912_signature_invariants.py
+++ b/tests/regression/test_issue_912_signature_invariants.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: #912 typed time-limit kwargs (additive scope).
+
+Issue #912 introduces ``soft_time_limit`` / ``time_limit`` as keyword-only
+typed kwargs on every concrete BaseRuntime subclass. Per the corrected
+RC1 disposition (workspace journal 2026-05-09), Shard 1 is **additive
+only** — the existing ``**kwargs`` signature is preserved for one
+deprecation cycle (Rule 6a). A future shard will tighten the surface
+once the deprecation window closes.
+
+This test pins TWO invariants that, taken together, define the additive
+contract:
+
+  1. **Typed-kwarg presence**: every runtime's ``execute*`` method
+     exposes ``soft_time_limit`` and ``time_limit`` as KEYWORD_ONLY
+     parameters defaulting to ``None``. A future refactor that drops
+     either kwarg surface fails this test loudly.
+
+  2. **Backwards-compat ``**kwargs`` retention**: the abstract
+     ``BaseRuntime.execute`` and the three runtimes the brief explicitly
+     names as the producer surface (``LocalRuntime``,
+     ``AsyncLocalRuntime``, ``DistributedRuntime``) STILL accept
+     ``**kwargs``. A future shard that removes ``**kwargs`` without
+     a deprecation cycle (Rule 6a) fails this test.
+
+The cross-SDK invariant per ``cross-sdk-inspection.md`` Rule 3a is
+documented in workspaces/issue-912-task-time-limits/02-todos/todos.md
+§ "Cross-SDK alignment notes" — kailash-rs may eventually mirror with
+``WorkerConfig`` / ``DiagnosticsConfig`` time-limit slots.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+# Methods that MUST gain typed time-limit kwargs (Shard 1 surface).
+# Each entry: (import_path, attribute_name) where attribute_name is the
+# method on the imported class. async-ness is irrelevant for signature
+# inspection.
+_RUNTIME_METHOD_TARGETS: tuple[tuple[str, str, str], ...] = (
+    ("kailash.runtime.base", "BaseRuntime", "execute"),
+    ("kailash.runtime.local", "LocalRuntime", "execute"),
+    ("kailash.runtime.async_local", "AsyncLocalRuntime", "execute"),
+    ("kailash.runtime.async_local", "AsyncLocalRuntime", "execute_workflow_async"),
+    ("kailash.runtime.distributed", "DistributedRuntime", "execute"),
+    ("kailash.runtime.docker", "DockerRuntime", "execute"),
+    ("kailash.runtime.parallel", "ParallelRuntime", "execute"),
+    ("kailash.runtime.parallel_cyclic", "ParallelCyclicRuntime", "execute"),
+    ("kailash.runtime.access_controlled", "AccessControlledRuntime", "execute"),
+    ("kailash.runtime.durable", "DurableExecutionEngine", "execute"),
+)
+
+
+# Subset that MUST retain ``**kwargs`` per Rule 6a additive contract.
+# The brief explicitly names BaseRuntime + LocalRuntime + AsyncLocalRuntime +
+# DistributedRuntime as the producer surface that already accepted **kwargs;
+# additive scope keeps **kwargs alive on all of them.
+_KWARGS_RETAIN_TARGETS: tuple[tuple[str, str, str], ...] = (
+    ("kailash.runtime.base", "BaseRuntime", "execute"),
+    ("kailash.runtime.local", "LocalRuntime", "execute"),
+    ("kailash.runtime.async_local", "AsyncLocalRuntime", "execute"),
+    ("kailash.runtime.distributed", "DistributedRuntime", "execute"),
+)
+
+
+def _resolve_method(mod_path: str, cls_name: str, attr: str) -> Any:
+    import importlib
+
+    module = importlib.import_module(mod_path)
+    cls = getattr(module, cls_name)
+    return getattr(cls, attr)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("mod_path,cls_name,attr", _RUNTIME_METHOD_TARGETS)
+def test_runtime_method_exposes_soft_time_limit_kwarg(mod_path, cls_name, attr):
+    """Every runtime ``execute*`` method MUST accept ``soft_time_limit`` keyword-only."""
+    method = _resolve_method(mod_path, cls_name, attr)
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "soft_time_limit" in params, (
+        f"{cls_name}.{attr} MUST accept 'soft_time_limit' kwarg per #912 Shard 1; "
+        f"current signature: {sig}"
+    )
+    p = params["soft_time_limit"]
+    assert p.kind == inspect.Parameter.KEYWORD_ONLY, (
+        f"{cls_name}.{attr}::soft_time_limit MUST be KEYWORD_ONLY (got {p.kind.name}); "
+        f"positional-or-keyword would let callers pass it by mistake at the wrong slot"
+    )
+    assert p.default is None, (
+        f"{cls_name}.{attr}::soft_time_limit MUST default to None (got {p.default!r}); "
+        f"a non-None default would force every existing caller into time-limit semantics"
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("mod_path,cls_name,attr", _RUNTIME_METHOD_TARGETS)
+def test_runtime_method_exposes_time_limit_kwarg(mod_path, cls_name, attr):
+    """Every runtime ``execute*`` method MUST accept ``time_limit`` keyword-only."""
+    method = _resolve_method(mod_path, cls_name, attr)
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "time_limit" in params, (
+        f"{cls_name}.{attr} MUST accept 'time_limit' kwarg per #912 Shard 1; "
+        f"current signature: {sig}"
+    )
+    p = params["time_limit"]
+    assert (
+        p.kind == inspect.Parameter.KEYWORD_ONLY
+    ), f"{cls_name}.{attr}::time_limit MUST be KEYWORD_ONLY (got {p.kind.name})"
+    assert (
+        p.default is None
+    ), f"{cls_name}.{attr}::time_limit MUST default to None (got {p.default!r})"
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("mod_path,cls_name,attr", _KWARGS_RETAIN_TARGETS)
+def test_kwargs_still_present_per_additive_contract(mod_path, cls_name, attr):
+    """Per RC1 corrected scope, ``**kwargs`` MUST remain on the producer surface.
+
+    A future shard MAY remove ``**kwargs`` after a Rule 6a deprecation
+    cycle. Until that shard ships, removing ``**kwargs`` here would be a
+    silent BC break for every caller forwarding extra runtime-specific
+    kwargs.
+    """
+    method = _resolve_method(mod_path, cls_name, attr)
+    sig = inspect.signature(method)
+    var_keyword = [
+        p for p in sig.parameters.values() if p.kind == inspect.Parameter.VAR_KEYWORD
+    ]
+    assert var_keyword, (
+        f"{cls_name}.{attr} MUST retain **kwargs for the additive Shard 1 scope; "
+        f"current signature: {sig}. Removing **kwargs without a deprecation cycle "
+        f"violates zero-tolerance.md Rule 6a."
+    )

--- a/tests/unit/runtime/test_durable_engine_builder.py
+++ b/tests/unit/runtime/test_durable_engine_builder.py
@@ -89,15 +89,22 @@ class _FakeRuntime:
         *,
         idempotency_key: Optional[str] = None,
         force_resume_with_drift: bool = False,
+        soft_time_limit: float | None = None,
+        time_limit: float | None = None,
     ) -> Tuple[Dict[str, Any], str]:
         # Record what the engine forwarded so the tests can assert
         # delegate-only behaviour (no parallel state machine).
+        # soft_time_limit / time_limit recorded per #912 Shard 1 contract;
+        # the fake mirrors the AsyncLocalRuntime.execute_workflow_async
+        # Protocol surface that engine forwards through.
         self.execute_calls.append(
             {
                 "workflow": workflow,
                 "inputs": dict(inputs),
                 "idempotency_key": idempotency_key,
                 "force_resume_with_drift": force_resume_with_drift,
+                "soft_time_limit": soft_time_limit,
+                "time_limit": time_limit,
             }
         )
         return self._next_results, self._next_run_id
@@ -479,12 +486,16 @@ async def test_execute_without_dispatcher_does_not_enqueue():
     engine = DurableExecutionEngine.builder().runtime(_FakeRuntime).build()
     await engine.execute(object())
     # No dispatcher means the in-process path is the only one.
+    # soft_time_limit / time_limit are None when caller does not pass them
+    # (#912 Shard 1 additive contract — slot accepted, default None).
     assert engine.runtime.execute_calls == [
         {
             "workflow": engine.runtime.execute_calls[0]["workflow"],
             "inputs": {},
             "idempotency_key": None,
             "force_resume_with_drift": False,
+            "soft_time_limit": None,
+            "time_limit": None,
         }
     ]
 

--- a/tests/unit/test_sdk_exceptions_time_limits.py
+++ b/tests/unit/test_sdk_exceptions_time_limits.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests: SoftTimeLimitExceeded / HardTimeLimitExceeded exception types (#912).
+
+Issue #912 — per-task soft/hard time limits. Shard 1 lands the typed
+exception classes that downstream shards (Shard 2 wrapper, Shard 3
+scheduler, Shard 4 distributed) raise on deadline expiry.
+
+Invariants asserted here:
+  1. Both classes subclass ``RuntimeException`` (the canonical runtime
+     execution failure parent), NOT ``ResourceLimitExceededError``
+     (which would imply a pool/quota exhaustion semantic — wrong domain).
+  2. Both names are exported via ``kailash.sdk_exceptions.__all__`` so
+     ``from kailash.sdk_exceptions import *`` and Sphinx autodoc surface
+     them as part of the documented public API.
+  3. ``__cause__`` chaining is preserved when the timing wrapper raises
+     these from a lower-level ``WorkflowCancelledError`` — operators
+     reading the traceback see the original cancellation cause.
+"""
+
+import pytest
+
+from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
+    ResourceLimitExceededError,
+    RuntimeException,
+    SoftTimeLimitExceeded,
+)
+
+
+@pytest.mark.unit
+def test_soft_time_limit_exceeded_subclasses_runtime_exception():
+    """SoftTimeLimitExceeded MUST inherit from RuntimeException."""
+    assert issubclass(SoftTimeLimitExceeded, RuntimeException)
+
+
+@pytest.mark.unit
+def test_hard_time_limit_exceeded_subclasses_runtime_exception():
+    """HardTimeLimitExceeded MUST inherit from RuntimeException."""
+    assert issubclass(HardTimeLimitExceeded, RuntimeException)
+
+
+@pytest.mark.unit
+def test_soft_time_limit_exceeded_is_not_resource_limit_error():
+    """SoftTimeLimitExceeded is a sibling of ResourceLimitExceededError, not a subclass.
+
+    Time-limit exhaustion is a different domain than resource-pool
+    exhaustion. Conflating them via subclass would let
+    ``except ResourceLimitExceededError`` catch time-limit cases and
+    apply the wrong remediation (scale the pool, not extend the budget).
+    """
+    assert not issubclass(SoftTimeLimitExceeded, ResourceLimitExceededError)
+
+
+@pytest.mark.unit
+def test_hard_time_limit_exceeded_is_not_resource_limit_error():
+    """HardTimeLimitExceeded is a sibling of ResourceLimitExceededError, not a subclass."""
+    assert not issubclass(HardTimeLimitExceeded, ResourceLimitExceededError)
+
+
+@pytest.mark.unit
+def test_soft_time_limit_exceeded_preserves_cause_chain():
+    """Raising SoftTimeLimitExceeded ``from`` an inner exception preserves __cause__."""
+    inner = TimeoutError("workflow exceeded soft deadline")
+    try:
+        try:
+            raise inner
+        except TimeoutError as exc:
+            raise SoftTimeLimitExceeded("soft limit reached") from exc
+    except SoftTimeLimitExceeded as captured:
+        assert captured.__cause__ is inner
+
+
+@pytest.mark.unit
+def test_hard_time_limit_exceeded_preserves_cause_chain():
+    """Raising HardTimeLimitExceeded ``from`` an inner exception preserves __cause__."""
+    inner = TimeoutError("workflow exceeded hard deadline")
+    try:
+        try:
+            raise inner
+        except TimeoutError as exc:
+            raise HardTimeLimitExceeded("hard limit reached") from exc
+    except HardTimeLimitExceeded as captured:
+        assert captured.__cause__ is inner
+
+
+@pytest.mark.unit
+def test_soft_time_limit_exceeded_in_all():
+    """SoftTimeLimitExceeded MUST be in kailash.sdk_exceptions.__all__."""
+    import kailash.sdk_exceptions as mod
+
+    assert hasattr(mod, "__all__"), (
+        "kailash.sdk_exceptions MUST define __all__ to declare the public "
+        "exception API surface (per orphan-detection.md Rule 6)"
+    )
+    assert "SoftTimeLimitExceeded" in mod.__all__
+
+
+@pytest.mark.unit
+def test_hard_time_limit_exceeded_in_all():
+    """HardTimeLimitExceeded MUST be in kailash.sdk_exceptions.__all__."""
+    import kailash.sdk_exceptions as mod
+
+    assert hasattr(mod, "__all__"), (
+        "kailash.sdk_exceptions MUST define __all__ to declare the public "
+        "exception API surface (per orphan-detection.md Rule 6)"
+    )
+    assert "HardTimeLimitExceeded" in mod.__all__

--- a/tests/unit/test_time_limits_validation.py
+++ b/tests/unit/test_time_limits_validation.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests: _validate_limits helper for issue #912 typed time-limit kwargs.
+
+Issue #912 — per-task soft/hard time limits. Shard 1 lands the
+validation helper that every runtime entry point calls before accepting
+``soft_time_limit`` / ``time_limit`` kwargs. Shard 2 will wire actual
+deadline enforcement; this shard's helper guards the kwarg surface so
+caller errors (``time_limit=-1``) raise loudly at the entry point
+rather than silently or at the timer thread.
+
+Validation contract:
+  * ``None`` for either kwarg is permitted (no limit).
+  * Positive floats / ints are permitted.
+  * Zero or negative values raise ``ValueError`` with an actionable message.
+  * When BOTH kwargs are set, ``soft_time_limit`` MUST be strictly less
+    than ``time_limit`` — celery convention. Equal or inverted values
+    raise ``ValueError``.
+"""
+
+import pytest
+
+from kailash.runtime._time_limits import _validate_limits
+
+
+@pytest.mark.unit
+def test_validate_limits_both_none_is_silent():
+    """Default state — no limits configured — does not raise."""
+    _validate_limits(soft_time_limit=None, time_limit=None)
+
+
+@pytest.mark.unit
+def test_validate_limits_only_soft_positive_is_silent():
+    """Single positive soft limit, no hard limit — accepted."""
+    _validate_limits(soft_time_limit=2.0, time_limit=None)
+
+
+@pytest.mark.unit
+def test_validate_limits_only_hard_positive_is_silent():
+    """Single positive hard limit, no soft limit — accepted."""
+    _validate_limits(soft_time_limit=None, time_limit=5.0)
+
+
+@pytest.mark.unit
+def test_validate_limits_both_positive_with_soft_lt_hard_is_silent():
+    """Both set, soft strictly less than hard — accepted."""
+    _validate_limits(soft_time_limit=2.0, time_limit=5.0)
+
+
+@pytest.mark.unit
+def test_validate_limits_integer_values_accepted():
+    """Integer kwargs are accepted (callers MAY pass ``int`` or ``float``)."""
+    _validate_limits(soft_time_limit=2, time_limit=5)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("soft", [-1, -0.001, 0, 0.0])
+def test_validate_limits_rejects_non_positive_soft(soft):
+    """Soft limit ``<= 0`` raises ValueError."""
+    with pytest.raises(ValueError):
+        _validate_limits(soft_time_limit=soft, time_limit=None)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("hard", [-1, -0.001, 0, 0.0])
+def test_validate_limits_rejects_non_positive_hard(hard):
+    """Hard limit ``<= 0`` raises ValueError."""
+    with pytest.raises(ValueError):
+        _validate_limits(soft_time_limit=None, time_limit=hard)
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_soft_equal_to_hard():
+    """``soft_time_limit == time_limit`` is invalid (no warning window before kill)."""
+    with pytest.raises(ValueError):
+        _validate_limits(soft_time_limit=5.0, time_limit=5.0)
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_soft_greater_than_hard():
+    """``soft_time_limit > time_limit`` is invalid (soft would never fire)."""
+    with pytest.raises(ValueError):
+        _validate_limits(soft_time_limit=10.0, time_limit=5.0)
+
+
+@pytest.mark.unit
+def test_validate_limits_error_message_mentions_parameters():
+    """Error message MUST name the offending parameter for actionable feedback."""
+    with pytest.raises(ValueError, match="soft_time_limit|time_limit"):
+        _validate_limits(soft_time_limit=-1, time_limit=None)


### PR DESCRIPTION
## Summary

Lands Shard 1 of issue #912 (per-task soft/hard time limits) with the **additive-scope correction** approved 2026-05-09 PM:

- Adds `*, soft_time_limit: float | None = None, time_limit: float | None = None` keyword-only kwargs to every `BaseRuntime.execute(...)` subclass alongside the existing `**kwargs` (no removal).
- Adds `SoftTimeLimitExceeded` / `HardTimeLimitExceeded` (siblings of `ResourceLimitExceededError`, both subclass `RuntimeException`).
- Adds shared `_validate_limits()` helper; called from every runtime entry point.
- Updates `specs/core-runtime.md` §4.1.2 + §4.2.1 to reflect the new typed slots.

## Why additive (not removal)

The original `/todos` plan called for hard-removal of `**kwargs` from `BaseRuntime` subclasses. Two parallel deep-dive verification agents flagged that hard-removal in a minor version is BLOCKED by `zero-tolerance.md` Rule 6a — the rule mandates a `DeprecationWarning` shim covering one minor cycle plus a CHANGELOG migration entry before public-API removal. User approved the additive correction. Hard-removal is deferred to a separate next-major proposal that will ship the Rule 6a shim.

Decision recorded at `workspaces/issue-912-task-time-limits/journal/.pending/1778331381000-0-DECISION.md`.

## What this shard does NOT do (intentionally — downstream shards)

- No deadline enforcement — Shard 2's `arm_time_limits` / `arm_time_limits_async` wrapper.
- No `TaskMessage` wire-format serialisation — Shard 4 (`DistributedRuntime` + `Worker`).
- No scheduler `schedule_cron` / `schedule_interval` / `schedule_once` typed-kwarg surface — Shard 3.

The new kwargs are accepted at every runtime, validated by `_validate_limits()`, then ignored — Shards 2/3/4 wire the actual enforcement.

## Test plan

- [x] `tests/unit/test_sdk_exceptions_time_limits.py` — 8/8 pass (exception class shape + `__all__` + `__cause__` chain)
- [x] `tests/unit/test_time_limits_validation.py` — 16/16 pass (validation contract)
- [x] `tests/regression/test_issue_912_signature_invariants.py` — 24/24 pass (signature pin: typed kwargs PRESENT, `**kwargs` PRESENT on producer subclasses)
- [x] `tests/integration/test_runtime_signature_typed_kwargs.py` — 9/9 Tier-2 pass (real LocalRuntime + AccessControlledRuntime, no mocks)
- [x] Pre-commit hooks pass (Black, isort, Ruff, Tier 1 unit tests)
- [x] Wider unit/runtime suite: 660/660 pass, 3 pre-existing unrelated skips

## Notable divergences from the brief

1. **`__all__` did not exist in `sdk_exceptions.py`** — added a comprehensive `__all__` listing all 35 public exception classes per `orphan-detection.md` Rule 6.
2. **Class is `DurableExecutionEngine`, not `DurableRuntime`** — tests use the correct name.
3. **`scheduler.py` call site is line 1010, not 858** — actual `runtime.execute(workflow, **kwargs)` site updated.
4. **`DockerRuntime`, `ParallelRuntime`, `ParallelCyclicRuntime` lacked `**kwargs`** in their original signatures — added `**kwargs` alongside the typed kwargs so they uniformly accept the additive contract.
5. **One pre-existing test (`test_durable_engine_builder.py::_FakeRuntime`) updated** to mirror the new Protocol surface (Protocol-Satisfying Deterministic Adapter pattern per `testing.md`). Test intent (forwarding semantics) preserved.

## Pyright LSP cache note

New diagnostic warnings on the new test files (`test_sdk_exceptions_time_limits.py`, `test_time_limits_validation.py`) about "unknown import symbol" are Pyright LSP cache lag — the symbols exist (24/24 + 24/24 tests pass against them); Pyright will re-resolve on its next index pass. Pre-existing `async_local.py:1863 __del__` Pyright complaint is unchanged by this PR (untouched code path).

## Related issues

Part of the issue #912 / #911 / #913 wave. Shard 1 owns the signature surface; #911 Shard 1 (`queue=` kwarg) waits on this PR per `agents.md` § Parallel-Worktree Package Ownership.

Fixes — partial — #912 (Shard 1 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)