### PR TITLE
feat(#912 Shard 3): WorkflowScheduler time-limit plumbing

### DIFF
--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -1099,6 +1099,11 @@ class WorkflowScheduler:
             "cancellation_token", None
         )
         for attempt in range(1, max_attempts + 1):
+            # Bind cancellable=None at the TOP of every attempt so the
+            # `except Exception as exc:` block below can safely reference it
+            # even when an early-attempt failure (workflow.build() / runtime
+            # acquisition) skips the later `cancellable = None` assignment.
+            cancellable = None
             try:
                 workflow = workflow_builder.build()
                 # Context-manager form ensures the runtime is closed after each
@@ -1130,7 +1135,8 @@ class WorkflowScheduler:
                     )
                     else CancellationToken()
                 )
-                cancellable = None
+                # cancellable initialized at top of loop body; arm only if
+                # caller supplied at least one limit.
                 if soft_time_limit is not None or time_limit is not None:
                     # Arm threading.Timer deadlines around this attempt.
                     # Pass the user's token into runtime.execute(...) ONLY

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -54,7 +54,14 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Ty
 if TYPE_CHECKING:
     from kailash.runtime.dispatcher import Dispatcher
 
+from kailash.runtime._time_limits import (
+    _TimeLimitClassifier,
+    _validate_limits,
+    arm_time_limits,
+)
+from kailash.runtime.cancellation import CancellationToken
 from kailash.runtime.lifecycle_events import JobEvent, JobEventHandler
+from kailash.sdk_exceptions import HardTimeLimitExceeded, WorkflowCancelledError
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +76,16 @@ __all__ = [
 # `kwargs=` dict to ``_execute_workflow`` at fire time. Popped before the
 # remaining kwargs are forwarded to the runtime so user code never sees it.
 _RETRY_SPEC_KWARG = "_kailash_retry_spec"
+
+# Internal kwargs key used to thread the per-job (soft, hard) time-limit pair
+# through APScheduler's `kwargs=` dict to ``_execute_workflow`` at fire time.
+# Stored as a tuple ``(soft_time_limit, time_limit)`` so the wrapper helper
+# (issue #912 Shard 2) can arm both deadlines from one persisted value.
+# Popped before the remaining kwargs are forwarded to the runtime so user
+# code never sees it. Persistence in the kwargs dict (vs a sidecar) means
+# the values survive APScheduler jobstore reload after process restart —
+# brief AC #1 invariant 6 (issue #912).
+_TIME_LIMIT_KWARG = "_kailash_time_limits"
 
 
 @dataclass(frozen=True)
@@ -393,7 +410,19 @@ class WorkflowScheduler:
         timezone: str = "UTC",
         *,
         dispatch_via: Optional["Dispatcher"] = None,
+        default_soft_time_limit: Optional[float] = None,
+        default_time_limit: Optional[float] = None,
     ) -> None:
+        # Issue #912 Open Question Q1 (resolved): include default time-limit
+        # kwargs symmetric to a future Worker.__init__. Operators running the
+        # in-process scheduler often run a Worker pool too; asymmetric
+        # defaults are a sharp edge ("why does my cron job time out at 600s
+        # but my queued job at 300s?"). Per-task value wins; default
+        # fallthrough; final fallthrough is None (no limit).
+        # Validate at construction time so caller bugs (negative values,
+        # soft >= hard) raise loudly here rather than at every fire.
+        _validate_limits(default_soft_time_limit, default_time_limit)
+
         if not _check_apscheduler():
             raise ImportError(
                 "APScheduler is required for WorkflowScheduler. "
@@ -423,6 +452,10 @@ class WorkflowScheduler:
         self._schedules: Dict[str, ScheduleInfo] = {}
         self._timezone = timezone
         self._dispatcher: Optional["Dispatcher"] = dispatch_via
+        # Issue #912 Q1: store defaults for fallthrough at fire time. Per-task
+        # value wins over default; default falls through to None (no limit).
+        self._default_soft_time_limit: Optional[float] = default_soft_time_limit
+        self._default_time_limit: Optional[float] = default_time_limit
 
         # Per-job fire-time capture: APScheduler's EVENT_JOB_SUBMITTED listener
         # fires BEFORE the job callback with `event.scheduled_run_time`, the
@@ -503,6 +536,8 @@ class WorkflowScheduler:
         name: str = "",
         *,
         retry: Optional[RetrySpec] = None,
+        soft_time_limit: Optional[float] = None,
+        time_limit: Optional[float] = None,
         **kwargs: Any,
     ) -> str:
         """Schedule a workflow to run on a cron schedule.
@@ -548,7 +583,9 @@ class WorkflowScheduler:
 
         trigger = CronTrigger.from_crontab(cron_expression, timezone=self._timezone)
 
-        job_kwargs = self._compose_job_kwargs(kwargs, retry)
+        job_kwargs = self._compose_job_kwargs(
+            kwargs, retry, soft_time_limit, time_limit
+        )
         self._scheduler.add_job(
             self._execute_workflow,
             trigger=trigger,
@@ -583,6 +620,8 @@ class WorkflowScheduler:
         name: str = "",
         *,
         retry: Optional[RetrySpec] = None,
+        soft_time_limit: Optional[float] = None,
+        time_limit: Optional[float] = None,
         **kwargs: Any,
     ) -> str:
         """Schedule a workflow to run at a fixed interval.
@@ -610,7 +649,9 @@ class WorkflowScheduler:
 
         schedule_id = self._generate_schedule_id()
 
-        job_kwargs = self._compose_job_kwargs(kwargs, retry)
+        job_kwargs = self._compose_job_kwargs(
+            kwargs, retry, soft_time_limit, time_limit
+        )
         self._scheduler.add_job(
             self._execute_workflow,
             trigger="interval",
@@ -646,6 +687,8 @@ class WorkflowScheduler:
         name: str = "",
         *,
         retry: Optional[RetrySpec] = None,
+        soft_time_limit: Optional[float] = None,
+        time_limit: Optional[float] = None,
         **kwargs: Any,
     ) -> str:
         """Schedule a workflow to run once at a specific time.
@@ -670,7 +713,9 @@ class WorkflowScheduler:
         """
         schedule_id = self._generate_schedule_id()
 
-        job_kwargs = self._compose_job_kwargs(kwargs, retry)
+        job_kwargs = self._compose_job_kwargs(
+            kwargs, retry, soft_time_limit, time_limit
+        )
         self._scheduler.add_job(
             self._execute_workflow,
             trigger="date",
@@ -893,14 +938,18 @@ class WorkflowScheduler:
         return list(self._schedules.values())
 
     def _compose_job_kwargs(
-        self, user_kwargs: Dict[str, Any], retry: Optional[RetrySpec]
+        self,
+        user_kwargs: Dict[str, Any],
+        retry: Optional[RetrySpec],
+        soft_time_limit: Optional[float] = None,
+        time_limit: Optional[float] = None,
     ) -> Dict[str, Any]:
-        """Merge a user-supplied kwargs dict with the internal retry spec key.
+        """Merge a user-supplied kwargs dict with the internal retry + time-limit keys.
 
         Returns a NEW dict — does NOT mutate ``user_kwargs`` so the caller's
         ScheduleInfo.kwargs reflects only the user-visible kwargs (the
-        ``_kailash_retry_spec`` key is internal and MUST NOT leak into
-        :class:`ScheduleInfo` view).
+        ``_kailash_retry_spec`` and ``_kailash_time_limits`` keys are
+        internal and MUST NOT leak into :class:`ScheduleInfo` view).
 
         Refuses to silently overwrite a user-supplied key with the same name
         — this would be ``zero-tolerance.md`` Rule 3 silent fallback class.
@@ -911,10 +960,30 @@ class WorkflowScheduler:
         dispatcher's domain (worker-side retry semantics owned by #911 /
         #912). Silently dropping the spec would be a ``zero-tolerance.md``
         Rule 3c violation (documented kwarg accepted but unused).
+
+        Time-limit resolution (#912 Shard 3):
+
+        * Per-task ``soft_time_limit`` / ``time_limit`` win over the
+          ``WorkflowScheduler(default_*=)`` defaults.
+        * Defaults fall through to None (no limit).
+        * Validates the EFFECTIVE pair via ``_validate_limits`` so per-task
+          values that combine illegally with defaults raise here, not from
+          the timer thread at fire time. (Validation at registration time,
+          not at fire time — brief AC #1 invariant 4.)
+        * The effective ``(soft, hard)`` tuple is threaded under
+          ``_TIME_LIMIT_KWARG`` only when at least one bound is set; a
+          fully-None pair is skipped to keep the persisted kwargs dict
+          minimal and the no-limits path indistinguishable from the
+          legacy (pre-#912) jobstore entries.
         """
         if _RETRY_SPEC_KWARG in user_kwargs:
             raise ValueError(
                 f"kwarg name {_RETRY_SPEC_KWARG!r} is reserved for internal "
+                f"use; rename your runtime kwarg to avoid the collision"
+            )
+        if _TIME_LIMIT_KWARG in user_kwargs:
+            raise ValueError(
+                f"kwarg name {_TIME_LIMIT_KWARG!r} is reserved for internal "
                 f"use; rename your runtime kwarg to avoid the collision"
             )
         if retry is not None and self._dispatcher is not None:
@@ -924,9 +993,25 @@ class WorkflowScheduler:
                 "the dispatcher's contract; pass retry=None and configure "
                 "retries on the worker / dispatcher layer instead."
             )
+
+        # Per-task value wins; default fallthrough; final fallthrough is None.
+        # Resolution happens HERE (registration time) so the validation below
+        # catches "per-task soft=10 + default hard=5" before the job runs.
+        effective_soft = (
+            soft_time_limit
+            if soft_time_limit is not None
+            else self._default_soft_time_limit
+        )
+        effective_hard = (
+            time_limit if time_limit is not None else self._default_time_limit
+        )
+        _validate_limits(effective_soft, effective_hard)
+
         merged = dict(user_kwargs)
         if retry is not None:
             merged[_RETRY_SPEC_KWARG] = retry
+        if effective_soft is not None or effective_hard is not None:
+            merged[_TIME_LIMIT_KWARG] = (effective_soft, effective_hard)
         return merged
 
     async def _execute_workflow(
@@ -974,14 +1059,22 @@ class WorkflowScheduler:
         # ignored on the queue dispatch path with a documented rationale above.
         retry_spec: Optional[RetrySpec] = kwargs.pop(_RETRY_SPEC_KWARG, None)
 
-        # Pop the typed time-limit kwargs before forwarding so we can pass
-        # them by NAME to runtime.execute(...) — landing them in the typed
-        # signature slot rather than being absorbed by the runtime's
-        # **kwargs. Per #912 Shard 1: slots accepted now, deadline
-        # enforcement lands in Shards 2–3 (in-process wrapper +
-        # scheduler-side timer arming around the retry loop).
-        soft_time_limit: float | None = kwargs.pop("soft_time_limit", None)
-        time_limit: float | None = kwargs.pop("time_limit", None)
+        # Pop the internal time-limit pair before forwarding kwargs anywhere.
+        # The pair is the EFFECTIVE (per-task or default) value resolved at
+        # _compose_job_kwargs time; the wrapper helper consumes it to arm
+        # threading.Timer deadlines around the runtime call below.
+        # Per #912 Shard 3: this is the consumer of the internal kwarg key
+        # added in this shard. Earlier shards (1) accepted typed kwargs at
+        # every runtime.execute(...) and (2) wrote arm_time_limits + the
+        # _TimeLimitClassifier; this shard wires arming around the retry
+        # loop so each attempt re-arms a fresh timer (invariant 3).
+        _time_limit_pair: Optional[Tuple[Optional[float], Optional[float]]] = (
+            kwargs.pop(_TIME_LIMIT_KWARG, None)
+        )
+        if _time_limit_pair is not None:
+            soft_time_limit, time_limit = _time_limit_pair
+        else:
+            soft_time_limit, time_limit = None, None
 
         if self._dispatcher is not None:
             await self._dispatch_to_queue(
@@ -992,10 +1085,19 @@ class WorkflowScheduler:
             )
             return
 
-        # In-process fallback (existing behavior + retry primitive #910).
+        # In-process fallback (existing behavior + retry primitive #910 +
+        # time-limit enforcement #912 Shard 3).
         logger.info("Scheduled execution starting: run_id=%s", run_id)
         max_attempts = 1 + (retry_spec.max_retries if retry_spec else 0)
         last_exc: Optional[BaseException] = None
+        # If the user passed their own cancellation_token in kwargs, honor it
+        # — but the time-limit timers MUST get their own token to cancel,
+        # otherwise the scheduler would corrupt user-side cancellation
+        # semantics by setting reasons on the user's token. Pop user's token
+        # so we can layer ours on top per-attempt without conflicting.
+        _user_cancellation_token: Optional[CancellationToken] = kwargs.pop(
+            "cancellation_token", None
+        )
         for attempt in range(1, max_attempts + 1):
             try:
                 workflow = workflow_builder.build()
@@ -1015,50 +1117,113 @@ class WorkflowScheduler:
                     if hasattr(_runtime, "__enter__")
                     else contextlib.nullcontext(_runtime)
                 )
-                with _runtime_cm as runtime:
-                    # Pass typed time-limit kwargs by NAME so they land in
-                    # the runtime's typed signature slot (#912 Shard 1).
-                    results, actual_run_id = runtime.execute(
-                        workflow,
+                # FRESH cancellation token per attempt — invariant 3
+                # (each retry re-arms a fresh timer with full budget). Re-using
+                # the prior attempt's token would carry over its `cancelled`
+                # state and cause the new attempt to abort instantly.
+                _attempt_token: Optional[CancellationToken] = (
+                    _user_cancellation_token
+                    if (
+                        _user_cancellation_token is not None
+                        and soft_time_limit is None
+                        and time_limit is None
+                    )
+                    else CancellationToken()
+                )
+                cancellable = None
+                if soft_time_limit is not None or time_limit is not None:
+                    # Arm threading.Timer deadlines around this attempt.
+                    # Pass the user's token into runtime.execute(...) ONLY
+                    # when no time-limit timers are armed (above branch);
+                    # otherwise the scheduler-side token is the one the
+                    # timers cancel.
+                    cancellable = arm_time_limits(
+                        _attempt_token,
                         soft_time_limit=soft_time_limit,
                         time_limit=time_limit,
-                        **kwargs,
                     )
-                # LocalRuntime swallows leaf-node failures into a result entry
-                # of shape ``{"failed": True, "error": str, "error_type": str}``
-                # rather than raising. For #910 the retry primitive MUST observe
-                # that recorded failure as if it were a propagated exception —
-                # otherwise a node-level raise on a scheduled job is invisible
-                # to retry semantics. Synthesize a typed exception from the
-                # first recorded failure so the retryable-classifier sees the
-                # correct exception type.
-                node_failure = self._extract_node_failure(results)
-                if node_failure is not None:
-                    raise node_failure
-                # Successful-retry observability: when a job succeeds on
-                # attempt > 1, the success path is structurally a "degraded
-                # but recovered" outcome — operators want to dashboard this
-                # separately from first-attempt successes. Emit a symmetric
-                # WARN to the exhausted-retries WARN below so alerting
-                # pipelines see retry recoveries (per `observability.md`
-                # Rule 7's bulk-op summary-WARN pattern).
-                if attempt > 1:
-                    logger.warning(
-                        "Scheduled execution recovered after retries: "
-                        "run_id=%s schedule_id=%s attempts=%d/%d",
+                try:
+                    with _runtime_cm as runtime:
+                        # Pass typed time-limit kwargs by NAME so they land in
+                        # the runtime's typed signature slot (#912 Shard 1).
+                        # Pass the cancellation_token so the runtime's inter-
+                        # node check observes the soft-timer's cancel and
+                        # raises WorkflowCancelledError, which the classifier
+                        # below converts to SoftTimeLimitExceeded.
+                        results, actual_run_id = runtime.execute(
+                            workflow,
+                            cancellation_token=_attempt_token,
+                            soft_time_limit=soft_time_limit,
+                            time_limit=time_limit,
+                            **kwargs,
+                        )
+                    # LocalRuntime swallows leaf-node failures into a result entry
+                    # of shape ``{"failed": True, "error": str, "error_type": str}``
+                    # rather than raising. For #910 the retry primitive MUST observe
+                    # that recorded failure as if it were a propagated exception —
+                    # otherwise a node-level raise on a scheduled job is invisible
+                    # to retry semantics. Synthesize a typed exception from the
+                    # first recorded failure so the retryable-classifier sees the
+                    # correct exception type.
+                    node_failure = self._extract_node_failure(results)
+                    if node_failure is not None:
+                        raise node_failure
+                    # Successful-retry observability: when a job succeeds on
+                    # attempt > 1, the success path is structurally a "degraded
+                    # but recovered" outcome — operators want to dashboard this
+                    # separately from first-attempt successes. Emit a symmetric
+                    # WARN to the exhausted-retries WARN below so alerting
+                    # pipelines see retry recoveries (per `observability.md`
+                    # Rule 7's bulk-op summary-WARN pattern).
+                    if attempt > 1:
+                        logger.warning(
+                            "Scheduled execution recovered after retries: "
+                            "run_id=%s schedule_id=%s attempts=%d/%d",
+                            actual_run_id,
+                            schedule_id,
+                            attempt,
+                            max_attempts,
+                        )
+                    logger.info(
+                        "Scheduled execution completed: "
+                        "run_id=%s, results_count=%d, attempt=%d/%d",
                         actual_run_id,
-                        schedule_id,
+                        len(results) if results else 0,
                         attempt,
                         max_attempts,
                     )
-                logger.info(
-                    "Scheduled execution completed: run_id=%s, results_count=%d, attempt=%d/%d",
-                    actual_run_id,
-                    len(results) if results else 0,
-                    attempt,
-                    max_attempts,
-                )
-                return
+                    # Per Shard 2 invariant 5: even if the workflow returned
+                    # cleanly (because no node poll observed the cancel),
+                    # the timers may have fired. Promote to typed exception.
+                    # Hard wins over soft when both fired (more severe).
+                    if cancellable is not None:
+                        if cancellable.hard_deadline_reached:
+                            raise HardTimeLimitExceeded(
+                                f"workflow exceeded hard time limit "
+                                f"(time_limit={cancellable.time_limit}s + "
+                                f"grace_seconds={cancellable.grace_seconds}s)"
+                            )
+                        # Soft fired (token.is_cancelled set) but the workflow
+                        # ran to completion without polling between nodes —
+                        # this happens for single-node workflows whose node
+                        # blocks past the soft deadline. Promote so the user
+                        # still observes the celery-style soft signal.
+                        if (
+                            _attempt_token is not None
+                            and _attempt_token.is_cancelled
+                            and cancellable.soft_time_limit is not None
+                        ):
+                            from kailash.sdk_exceptions import SoftTimeLimitExceeded
+
+                            raise SoftTimeLimitExceeded(
+                                f"workflow exceeded soft time limit "
+                                f"(soft_time_limit="
+                                f"{cancellable.soft_time_limit}s)"
+                            )
+                    return
+                finally:
+                    if cancellable is not None:
+                        cancellable.disarm()
             except asyncio.CancelledError:
                 # Scheduler shutdown / job cancellation MUST propagate cleanly —
                 # the `except Exception` below would catch CancelledError on
@@ -1066,9 +1231,28 @@ class WorkflowScheduler:
                 # retry loop swallow shutdown. Re-raise BEFORE the broad except.
                 raise
             except Exception as exc:
-                last_exc = exc
-                # Non-retryable: skip ahead to the bubble-up below.
-                if retry_spec is None or not retry_spec.is_retryable(exc):
+                # The runtime observed the cancellation token's set-state OR
+                # a generic exception bubbled. For WorkflowCancelledError,
+                # the classifier converts our time-limit-armed cancel into
+                # SoftTimeLimitExceeded / HardTimeLimitExceeded so RetrySpec
+                # filters can match the typed subclass. Generic exceptions
+                # pass through unchanged. After classification, all paths
+                # share the same retry-decision + backoff logic so retries
+                # of time-limit-exceeded attempts apply the same sleep
+                # discipline as retries of any other exception.
+                if isinstance(exc, WorkflowCancelledError) and cancellable is not None:
+                    classifier = _TimeLimitClassifier(cancellable)
+                    last_exc = classifier.classify(exc)
+                    # Preserve cause chain (Shard 2 invariant 4): when the
+                    # classifier returned a typed subclass, attach the
+                    # original WorkflowCancelledError as __cause__ so
+                    # operators see both in the traceback.
+                    if last_exc is not exc:
+                        last_exc.__cause__ = exc
+                else:
+                    last_exc = exc
+                # Non-retryable: skip ahead to bubble-up below.
+                if retry_spec is None or not retry_spec.is_retryable(last_exc):
                     break
                 # Retryable AND budget remaining: DEBUG-level per-attempt log
                 # (per `observability.md` MUST NOT § log-spam-in-hot-loops —
@@ -1084,7 +1268,7 @@ class WorkflowScheduler:
                         max_attempts,
                         run_id,
                         schedule_id,
-                        type(exc).__name__,
+                        type(last_exc).__name__,
                         backoff_seconds,
                     )
                     await asyncio.sleep(backoff_seconds)

--- a/tests/integration/runtime/test_scheduler_time_limits.py
+++ b/tests/integration/runtime/test_scheduler_time_limits.py
@@ -1,0 +1,673 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 wiring tests for ``WorkflowScheduler`` time-limit plumbing (#912 Shard 3).
+
+Per ``rules/testing.md`` Tier 2: NO mocking; uses a real APScheduler
+``AsyncIOScheduler`` with an in-memory job store and a real
+``PythonCodeNode`` workflow exercising real ``threading.Timer`` deadlines
+through the ``arm_time_limits`` wrapper landed in Shard 2.
+
+Brief Acceptance Criterion #1 (issue #912): scheduled workflows honor
+``soft_time_limit`` / ``time_limit`` AND interact correctly with
+``RetrySpec`` (#910).
+
+Per ``rules/orphan-detection.md`` Rule 2: the time-limit primitive is
+wired into the framework's hot path (``_execute_workflow``), so Tier 2
+MUST observe the externally-visible effect (workflow raised
+``SoftTimeLimitExceeded`` / ``HardTimeLimitExceeded``, retry attempts
+re-armed fresh, defaults overridden per-task).
+
+Skips if APScheduler is not installed.
+
+The PythonCodeNode counter pattern follows
+``test_scheduler_retry_primitives.py``: a ``tmp_path`` tempfile is the
+state surface (``tests.*`` imports are sandbox-blocked).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+apscheduler = pytest.importorskip(
+    "apscheduler", reason="WorkflowScheduler requires APScheduler"
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Workflow builders — file-counter pattern (sandbox-safe)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _sleeping_workflow(*, sleep_seconds: float, counter_path: str):
+    """Build a workflow that sleeps then increments a tempfile counter.
+
+    Records the attempt count so tests can verify retry behavior. The
+    sleep is what soft/hard time limits cancel. Sandbox blocks
+    ``tests.*`` imports — ``os`` and ``time`` are permitted.
+    """
+    from kailash.workflow.builder import WorkflowBuilder
+
+    code = (
+        f"import os\n"
+        f"import time\n"
+        f"_p = {counter_path!r}\n"
+        f"_n = 0\n"
+        f"if os.path.exists(_p):\n"
+        f"    with open(_p) as _f:\n"
+        f"        _n = int(_f.read().strip() or '0')\n"
+        f"_n += 1\n"
+        f"with open(_p, 'w') as _f:\n"
+        f"    _f.write(str(_n))\n"
+        f"time.sleep({sleep_seconds})\n"
+        f"result = {{'attempts': _n}}\n"
+    )
+    builder = WorkflowBuilder()
+    builder.add_node("PythonCodeNode", "start", {"code": code})
+    return builder
+
+
+def _soft_catching_workflow(*, total_sleep: float, counter_path: str):
+    """Build a workflow that catches SoftTimeLimitExceeded then keeps sleeping.
+
+    Used to prove the hard timer fires UNCONDITIONALLY at
+    ``time_limit + grace_seconds`` even when user code intercepts the
+    soft signal — Shard 2 wrapper invariant 5.
+    """
+    from kailash.workflow.builder import WorkflowBuilder
+
+    code = (
+        f"import os\n"
+        f"import time\n"
+        f"_p = {counter_path!r}\n"
+        f"with open(_p, 'w') as _f:\n"
+        f"    _f.write('1')\n"
+        f"# Sleep in small chunks so the cooperative cancel signal we install\n"
+        f"# at the workflow seam fires between chunks. The PythonCodeNode\n"
+        f"# itself does NOT poll the cancellation token — it's the runtime's\n"
+        f"# inter-node check that observes the soft cancel. We sleep in chunks\n"
+        f"# only to keep the absolute time bound tight.\n"
+        f"_remaining = {total_sleep}\n"
+        f"while _remaining > 0:\n"
+        f"    _step = min(0.05, _remaining)\n"
+        f"    time.sleep(_step)\n"
+        f"    _remaining -= _step\n"
+        f"result = {{'slept': {total_sleep}}}\n"
+    )
+    builder = WorkflowBuilder()
+    builder.add_node("PythonCodeNode", "start", {"code": code})
+    return builder
+
+
+def _read_counter(counter_path: str) -> int:
+    import os
+
+    if not os.path.exists(counter_path):
+        return 0
+    with open(counter_path) as f:
+        return int(f.read().strip() or "0")
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Test class
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSchedulerTimeLimits:
+    """Verify WorkflowScheduler honors soft/hard time limits end-to-end."""
+
+    # ─────────────────────────────────────────────────────────────
+    # MUST-INV-4: Validation at registration time, not at fire time
+    # ─────────────────────────────────────────────────────────────
+
+    async def test_validation_at_registration_negative_soft_raises(self, tmp_path):
+        """``soft_time_limit <= 0`` raises at schedule_cron time, not at fire."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        try:
+            wf = _sleeping_workflow(
+                sleep_seconds=0.01, counter_path=str(tmp_path / "noop.cnt")
+            )
+            with pytest.raises(ValueError, match="soft_time_limit"):
+                scheduler.schedule_cron(wf, "* * * * *", soft_time_limit=-1.0)
+        finally:
+            # Scheduler not started — nothing to shut down.
+            pass
+
+    async def test_validation_at_registration_soft_ge_hard_raises(self, tmp_path):
+        """``soft_time_limit >= time_limit`` raises immediately."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        try:
+            wf = _sleeping_workflow(
+                sleep_seconds=0.01, counter_path=str(tmp_path / "noop.cnt")
+            )
+            with pytest.raises(ValueError, match="strictly less than"):
+                scheduler.schedule_interval(
+                    wf, seconds=60, soft_time_limit=10.0, time_limit=5.0
+                )
+            with pytest.raises(ValueError, match="strictly less than"):
+                scheduler.schedule_once(
+                    wf,
+                    run_at=__import__("datetime").datetime(
+                        2099, 1, 1, tzinfo=__import__("datetime").UTC
+                    ),
+                    soft_time_limit=10.0,
+                    time_limit=5.0,
+                )
+        finally:
+            pass
+
+    async def test_validation_in_init_defaults_raises(self):
+        """``WorkflowScheduler(default_soft_time_limit=, default_time_limit=)``
+        validates at construction time so operator errors surface immediately."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        with pytest.raises(ValueError, match="soft_time_limit"):
+            WorkflowScheduler(job_store_path=None, default_soft_time_limit=-1.0)
+        with pytest.raises(ValueError, match="strictly less than"):
+            WorkflowScheduler(
+                job_store_path=None,
+                default_soft_time_limit=10.0,
+                default_time_limit=5.0,
+            )
+
+    # ─────────────────────────────────────────────────────────────
+    # MUST-INV-1: Signature parity across schedule_* methods
+    # ─────────────────────────────────────────────────────────────
+
+    async def test_signature_parity_across_three_methods(self):
+        """All three schedule_* methods accept ``soft_time_limit`` and
+        ``time_limit`` as keyword-only kwargs in the same position.
+
+        Structural invariant per ``rules/cross-sdk-inspection.md`` Rule 3a —
+        prevents a future refactor from drifting the signature on one
+        method and silently breaking the others.
+        """
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        for method_name in ("schedule_cron", "schedule_interval", "schedule_once"):
+            sig = inspect.signature(getattr(WorkflowScheduler, method_name))
+            params = sig.parameters
+            assert (
+                "soft_time_limit" in params
+            ), f"{method_name} MUST accept soft_time_limit"
+            assert "time_limit" in params, f"{method_name} MUST accept time_limit"
+            assert (
+                params["soft_time_limit"].kind == inspect.Parameter.KEYWORD_ONLY
+            ), f"{method_name}.soft_time_limit MUST be keyword-only"
+            assert (
+                params["time_limit"].kind == inspect.Parameter.KEYWORD_ONLY
+            ), f"{method_name}.time_limit MUST be keyword-only"
+            assert (
+                params["soft_time_limit"].default is None
+            ), f"{method_name}.soft_time_limit default MUST be None"
+            assert (
+                params["time_limit"].default is None
+            ), f"{method_name}.time_limit default MUST be None"
+
+    async def test_init_accepts_default_kwargs(self):
+        """``WorkflowScheduler.__init__`` accepts ``default_soft_time_limit``
+        + ``default_time_limit`` keyword-only kwargs (Open Question Q1)."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        sig = inspect.signature(WorkflowScheduler.__init__)
+        params = sig.parameters
+        assert "default_soft_time_limit" in params
+        assert "default_time_limit" in params
+        assert params["default_soft_time_limit"].kind == inspect.Parameter.KEYWORD_ONLY
+        assert params["default_time_limit"].kind == inspect.Parameter.KEYWORD_ONLY
+        assert params["default_soft_time_limit"].default is None
+        assert params["default_time_limit"].default is None
+
+    # ─────────────────────────────────────────────────────────────
+    # MUST-INV-6: Persistence in APScheduler kwargs dict
+    # ─────────────────────────────────────────────────────────────
+
+    async def test_persistence_in_kwargs_dict(self, tmp_path):
+        """Time-limit values are persisted in the APScheduler job's
+        ``kwargs`` dict so they survive restart/reload from jobstore.
+
+        Same pattern as ``_RETRY_SPEC_KWARG`` (#910): time-limit pair is
+        threaded under an internal sentinel key in the job's persisted
+        kwargs dict.
+        """
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            wf = _sleeping_workflow(
+                sleep_seconds=0.01, counter_path=str(tmp_path / "noop.cnt")
+            )
+            schedule_id = scheduler.schedule_interval(
+                wf,
+                seconds=60,
+                soft_time_limit=2.0,
+                time_limit=5.0,
+            )
+            job = scheduler._scheduler.get_job(schedule_id)
+            assert job is not None
+            # The internal sentinel key MUST appear in the persisted kwargs.
+            from kailash.runtime.scheduler import _TIME_LIMIT_KWARG
+
+            assert _TIME_LIMIT_KWARG in job.kwargs, (
+                f"time-limit pair MUST be persisted under {_TIME_LIMIT_KWARG!r} "
+                f"in APScheduler kwargs; got keys: {list(job.kwargs.keys())}"
+            )
+            stored = job.kwargs[_TIME_LIMIT_KWARG]
+            assert stored == (
+                2.0,
+                5.0,
+            ), f"persisted time-limit pair MUST be (soft, hard); got {stored!r}"
+        finally:
+            scheduler.shutdown(wait=False)
+
+    # ─────────────────────────────────────────────────────────────
+    # Brief AC #1: soft / hard limits fire end-to-end
+    # ─────────────────────────────────────────────────────────────
+
+    async def test_soft_time_limit_raises_in_workflow(self, tmp_path):
+        """A workflow that sleeps 5s with ``soft_time_limit=1`` raises
+        ``SoftTimeLimitExceeded`` at the FIRE level (visible to APScheduler's
+        job-error listener)."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+        from kailash.sdk_exceptions import SoftTimeLimitExceeded
+
+        counter = str(tmp_path / "soft.cnt")
+        observed: list[BaseException] = []
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+
+        from apscheduler.events import EVENT_JOB_ERROR
+
+        def _listener(event):
+            if event.exception is not None:
+                observed.append(event.exception)
+
+        scheduler._scheduler.add_listener(_listener, EVENT_JOB_ERROR)
+
+        try:
+            scheduler.schedule_interval(
+                _sleeping_workflow(sleep_seconds=5.0, counter_path=counter),
+                seconds=60,
+                soft_time_limit=1.0,
+            )
+            # Wait up to ~3s for the soft deadline to fire and the workflow
+            # to bubble.
+            for _ in range(30):
+                if observed:
+                    break
+                await asyncio.sleep(0.1)
+
+            assert (
+                observed
+            ), "expected EVENT_JOB_ERROR to fire with SoftTimeLimitExceeded"
+            # First (and only) bubble MUST be SoftTimeLimitExceeded — NOT a
+            # bare WorkflowCancelledError, NOT a wrapping RuntimeError.
+            assert isinstance(observed[0], SoftTimeLimitExceeded), (
+                f"expected SoftTimeLimitExceeded; got "
+                f"{type(observed[0]).__name__}: {observed[0]}"
+            )
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_hard_time_limit_raises_after_grace(self, tmp_path):
+        """``time_limit=1`` + grace=0.5 → workflow that sleeps 5s raises
+        ``HardTimeLimitExceeded`` at ~1.5s.
+
+        ``HardTimeLimitExceeded`` is the structurally-distinct exception
+        per Shard 1; the assertion verifies the wrapper's polled-flag
+        path actually fires (Shard 2 invariant 5).
+        """
+        from kailash.runtime.scheduler import WorkflowScheduler
+        from kailash.sdk_exceptions import HardTimeLimitExceeded
+
+        counter = str(tmp_path / "hard.cnt")
+        observed: list[BaseException] = []
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+
+        from apscheduler.events import EVENT_JOB_ERROR
+
+        def _listener(event):
+            if event.exception is not None:
+                observed.append(event.exception)
+
+        scheduler._scheduler.add_listener(_listener, EVENT_JOB_ERROR)
+
+        try:
+            scheduler.schedule_interval(
+                _soft_catching_workflow(total_sleep=5.0, counter_path=counter),
+                seconds=60,
+                time_limit=1.0,
+            )
+            # Allow up to ~5s for the hard deadline + grace to elapse and the
+            # workflow to bubble (the workflow itself sleeps 5s; hard fires
+            # before that).
+            for _ in range(80):
+                if observed:
+                    break
+                await asyncio.sleep(0.1)
+
+            assert (
+                observed
+            ), "expected EVENT_JOB_ERROR to fire with HardTimeLimitExceeded"
+            assert isinstance(observed[0], HardTimeLimitExceeded), (
+                f"expected HardTimeLimitExceeded; got "
+                f"{type(observed[0]).__name__}: {observed[0]}"
+            )
+        finally:
+            scheduler.shutdown(wait=False)
+
+    # ─────────────────────────────────────────────────────────────
+    # MUST-INV-2: RetrySpec interaction
+    # ─────────────────────────────────────────────────────────────
+
+    async def test_retryspec_classifies_soft_as_retryable_on_demand(self, tmp_path):
+        """``RetrySpec(retry_on=(SoftTimeLimitExceeded,))`` retries on soft."""
+        from kailash.runtime.scheduler import RetrySpec, WorkflowScheduler
+        from kailash.sdk_exceptions import SoftTimeLimitExceeded
+
+        counter = str(tmp_path / "soft_retry.cnt")
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            scheduler.schedule_interval(
+                _sleeping_workflow(sleep_seconds=5.0, counter_path=counter),
+                seconds=60,
+                soft_time_limit=1.0,
+                retry=RetrySpec(
+                    max_retries=2,
+                    retry_on=(SoftTimeLimitExceeded,),
+                    backoff_base_seconds=0.05,
+                    backoff_max_seconds=0.1,
+                ),
+            )
+
+            # Each attempt sleeps the full 1s budget then bubbles. With
+            # 1 + max_retries = 3 attempts at ~1s each, the counter MUST
+            # increment to 3 within ~5s.
+            for _ in range(80):
+                if _read_counter(counter) >= 3:
+                    break
+                await asyncio.sleep(0.1)
+
+            attempts = _read_counter(counter)
+            assert attempts >= 3, (
+                f"expected >= 3 attempts (1 + max_retries=2 retries on Soft); "
+                f"got {attempts}"
+            )
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_retryspec_dontretry_on_soft_overrides(self, tmp_path):
+        """``RetrySpec(dont_retry_on=(SoftTimeLimitExceeded,))`` does NOT
+        retry on soft even when ``retry_on`` would match."""
+        from kailash.runtime.scheduler import RetrySpec, WorkflowScheduler
+        from kailash.sdk_exceptions import SoftTimeLimitExceeded
+
+        counter = str(tmp_path / "soft_no_retry.cnt")
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            scheduler.schedule_interval(
+                _sleeping_workflow(sleep_seconds=5.0, counter_path=counter),
+                seconds=60,
+                soft_time_limit=1.0,
+                retry=RetrySpec(
+                    max_retries=5,
+                    retry_on=(Exception,),
+                    dont_retry_on=(SoftTimeLimitExceeded,),
+                    backoff_base_seconds=0.05,
+                ),
+            )
+
+            # First fire happens within ~2s; soft fires at 1s; NO retry
+            # because dont_retry_on overrides. Counter stays at 1.
+            await asyncio.sleep(2.5)
+
+            attempts = _read_counter(counter)
+            assert (
+                attempts == 1
+            ), f"expected exactly 1 attempt (dont_retry_on suppresses); got {attempts}"
+        finally:
+            scheduler.shutdown(wait=False)
+
+    # ─────────────────────────────────────────────────────────────
+    # MUST-INV-3: Each retry attempt re-arms a fresh timer
+    # ─────────────────────────────────────────────────────────────
+
+    async def test_each_retry_arms_fresh_timer(self, tmp_path):
+        """Each retry attempt sees the FULL ``soft_time_limit`` budget.
+
+        Without per-attempt re-arming, the second retry's elapsed budget
+        would already include attempt 1's wall-clock — soft would fire
+        immediately and the workflow would not even start. Asserts the
+        wrapper is called fresh inside the retry loop.
+
+        Builds a workflow that records the wall-clock elapsed during
+        each attempt; if every attempt records >= 0.5s of useful work,
+        the timer is re-armed correctly.
+        """
+        import os
+
+        from kailash.runtime.scheduler import RetrySpec, WorkflowScheduler
+        from kailash.sdk_exceptions import SoftTimeLimitExceeded
+        from kailash.workflow.builder import WorkflowBuilder
+
+        elapsed_log = str(tmp_path / "elapsed.log")
+        counter = str(tmp_path / "fresh_timer.cnt")
+
+        # Workflow records the per-attempt sleep duration before bubbling.
+        # The runtime cancels via the cooperative inter-node check; the
+        # PythonCodeNode itself runs to completion within attempt N's
+        # budget — but the OUTER `runtime.execute` raises after the node
+        # finishes. We use the elapsed_log to confirm each attempt got
+        # the full budget.
+        code = (
+            f"import os\n"
+            f"import time\n"
+            f"_p = {counter!r}\n"
+            f"_log = {elapsed_log!r}\n"
+            f"_n = 0\n"
+            f"if os.path.exists(_p):\n"
+            f"    with open(_p) as _f:\n"
+            f"        _n = int(_f.read().strip() or '0')\n"
+            f"_n += 1\n"
+            f"with open(_p, 'w') as _f:\n"
+            f"    _f.write(str(_n))\n"
+            f"_t0 = time.monotonic()\n"
+            f"time.sleep(2.0)\n"
+            f"_dt = time.monotonic() - _t0\n"
+            f"with open(_log, 'a') as _f:\n"
+            f"    _f.write(f'attempt={{_n}} dt={{_dt:.2f}}\\n')\n"
+            f"result = {{'attempts': _n}}\n"
+        )
+        builder = WorkflowBuilder()
+        builder.add_node("PythonCodeNode", "start", {"code": code})
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            scheduler.schedule_interval(
+                builder,
+                seconds=60,
+                soft_time_limit=1.0,
+                retry=RetrySpec(
+                    max_retries=2,
+                    retry_on=(SoftTimeLimitExceeded,),
+                    backoff_base_seconds=0.05,
+                    backoff_max_seconds=0.1,
+                ),
+            )
+
+            for _ in range(120):
+                if _read_counter(counter) >= 3:
+                    break
+                await asyncio.sleep(0.1)
+
+            attempts = _read_counter(counter)
+            assert attempts >= 3, f"expected >= 3 attempts; got {attempts}"
+
+            # Each attempt slept ~2s (within the 1s soft budget OR the wrapper
+            # cancels mid-sleep but the inner sleep wallclock still records).
+            # The key invariant: each attempt actually ran (no instant-abort
+            # from a stale timer carried over from prior attempt).
+            assert os.path.exists(elapsed_log), "elapsed log MUST exist"
+            with open(elapsed_log) as f:
+                lines = [ln for ln in f.read().splitlines() if ln]
+            assert len(lines) >= 3, (
+                f"expected >= 3 elapsed entries (one per attempt); "
+                f"got {len(lines)}: {lines}"
+            )
+            # Each attempt actually got runtime — the dt for each is > 0.5s,
+            # which would be impossible if a stale timer cancelled the next
+            # attempt at t=0.
+            for line in lines:
+                # Format: 'attempt=N dt=X.XX'
+                dt_str = line.split("dt=")[1]
+                dt = float(dt_str)
+                assert dt >= 0.5, (
+                    f"each attempt MUST get >= 0.5s of runtime (proves "
+                    f"timer re-armed); got line {line!r}"
+                )
+        finally:
+            scheduler.shutdown(wait=False)
+
+    # ─────────────────────────────────────────────────────────────
+    # Defaults: per-task wins over WorkflowScheduler defaults
+    # ─────────────────────────────────────────────────────────────
+
+    async def test_default_time_limit_overridden_by_per_task(self, tmp_path):
+        """``WorkflowScheduler(default_time_limit=10)`` + per-task
+        ``time_limit=1`` → effective hard limit is 1s (per-task wins)."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+        from kailash.sdk_exceptions import HardTimeLimitExceeded
+
+        counter = str(tmp_path / "default_override.cnt")
+        observed: list[BaseException] = []
+
+        scheduler = WorkflowScheduler(
+            job_store_path=None,
+            default_time_limit=10.0,  # would never fire within test window
+        )
+        scheduler.start()
+
+        from apscheduler.events import EVENT_JOB_ERROR
+
+        def _listener(event):
+            if event.exception is not None:
+                observed.append(event.exception)
+
+        scheduler._scheduler.add_listener(_listener, EVENT_JOB_ERROR)
+
+        try:
+            scheduler.schedule_interval(
+                _soft_catching_workflow(total_sleep=5.0, counter_path=counter),
+                seconds=60,
+                time_limit=1.0,  # per-task overrides default 10.0
+            )
+            # Per-task wins: hard fires at ~1s + 1s grace = 2s.
+            for _ in range(40):
+                if observed:
+                    break
+                await asyncio.sleep(0.1)
+
+            assert observed, "expected per-task time_limit=1 to fire"
+            assert isinstance(observed[0], HardTimeLimitExceeded), (
+                f"expected HardTimeLimitExceeded from per-task; got "
+                f"{type(observed[0]).__name__}: {observed[0]}"
+            )
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_default_time_limit_applies_when_no_per_task(self, tmp_path):
+        """When per-task ``time_limit`` is None, the scheduler default applies.
+
+        Sized so the default's hard deadline + grace fires within the
+        test window. Workflow sleeps 5s; default time_limit=1.0; grace=1s
+        → hard fires at ~2s.
+        """
+        from kailash.runtime.scheduler import WorkflowScheduler
+        from kailash.sdk_exceptions import HardTimeLimitExceeded
+
+        counter = str(tmp_path / "default_applies.cnt")
+        observed: list[BaseException] = []
+
+        scheduler = WorkflowScheduler(
+            job_store_path=None,
+            default_time_limit=1.0,
+        )
+        scheduler.start()
+
+        from apscheduler.events import EVENT_JOB_ERROR
+
+        def _listener(event):
+            if event.exception is not None:
+                observed.append(event.exception)
+
+        scheduler._scheduler.add_listener(_listener, EVENT_JOB_ERROR)
+
+        try:
+            scheduler.schedule_interval(
+                _soft_catching_workflow(total_sleep=5.0, counter_path=counter),
+                seconds=60,
+                # NO per-task time_limit — default MUST apply.
+            )
+            for _ in range(40):
+                if observed:
+                    break
+                await asyncio.sleep(0.1)
+
+            assert (
+                observed
+            ), "expected default_time_limit=1 to fire when per-task is None"
+            assert isinstance(observed[0], HardTimeLimitExceeded), (
+                f"expected HardTimeLimitExceeded from default; got "
+                f"{type(observed[0]).__name__}: {observed[0]}"
+            )
+        finally:
+            scheduler.shutdown(wait=False)
+
+    async def test_no_default_no_per_task_no_limit(self, tmp_path):
+        """When neither default nor per-task time-limit is set, the
+        workflow runs to completion — no spurious HardTimeLimitExceeded."""
+        from kailash.runtime.scheduler import WorkflowScheduler
+
+        counter = str(tmp_path / "no_limits.cnt")
+
+        scheduler = WorkflowScheduler(job_store_path=None)
+        scheduler.start()
+        try:
+            scheduler.schedule_interval(
+                _sleeping_workflow(sleep_seconds=0.2, counter_path=counter),
+                seconds=60,
+            )
+            # Wait for one fire to complete fully.
+            for _ in range(40):
+                if _read_counter(counter) >= 1:
+                    break
+                await asyncio.sleep(0.1)
+            # Give the workflow time to fully complete its 0.2s sleep.
+            await asyncio.sleep(0.5)
+
+            attempts = _read_counter(counter)
+            assert (
+                attempts >= 1
+            ), f"expected workflow to complete at least once; got {attempts}"
+        finally:
+            scheduler.shutdown(wait=False)

--- a/tests/integration/runtime/test_scheduler_time_limits.py
+++ b/tests/integration/runtime/test_scheduler_time_limits.py
@@ -300,7 +300,7 @@ class TestSchedulerTimeLimits:
         try:
             scheduler.schedule_interval(
                 _sleeping_workflow(sleep_seconds=5.0, counter_path=counter),
-                seconds=60,
+                seconds=1,
                 soft_time_limit=1.0,
             )
             # Wait up to ~3s for the soft deadline to fire and the workflow
@@ -350,7 +350,7 @@ class TestSchedulerTimeLimits:
         try:
             scheduler.schedule_interval(
                 _soft_catching_workflow(total_sleep=5.0, counter_path=counter),
-                seconds=60,
+                seconds=1,
                 time_limit=1.0,
             )
             # Allow up to ~5s for the hard deadline + grace to elapse and the
@@ -387,7 +387,7 @@ class TestSchedulerTimeLimits:
         try:
             scheduler.schedule_interval(
                 _sleeping_workflow(sleep_seconds=5.0, counter_path=counter),
-                seconds=60,
+                seconds=1,
                 soft_time_limit=1.0,
                 retry=RetrySpec(
                     max_retries=2,
@@ -426,7 +426,7 @@ class TestSchedulerTimeLimits:
         try:
             scheduler.schedule_interval(
                 _sleeping_workflow(sleep_seconds=5.0, counter_path=counter),
-                seconds=60,
+                seconds=1,
                 soft_time_limit=1.0,
                 retry=RetrySpec(
                     max_retries=5,
@@ -505,7 +505,7 @@ class TestSchedulerTimeLimits:
         try:
             scheduler.schedule_interval(
                 builder,
-                seconds=60,
+                seconds=1,
                 soft_time_limit=1.0,
                 retry=RetrySpec(
                     max_retries=2,
@@ -578,7 +578,7 @@ class TestSchedulerTimeLimits:
         try:
             scheduler.schedule_interval(
                 _soft_catching_workflow(total_sleep=5.0, counter_path=counter),
-                seconds=60,
+                seconds=1,
                 time_limit=1.0,  # per-task overrides default 10.0
             )
             # Per-task wins: hard fires at ~1s + 1s grace = 2s.
@@ -625,7 +625,7 @@ class TestSchedulerTimeLimits:
         try:
             scheduler.schedule_interval(
                 _soft_catching_workflow(total_sleep=5.0, counter_path=counter),
-                seconds=60,
+                seconds=1,
                 # NO per-task time_limit — default MUST apply.
             )
             for _ in range(40):
@@ -655,7 +655,7 @@ class TestSchedulerTimeLimits:
         try:
             scheduler.schedule_interval(
                 _sleeping_workflow(sleep_seconds=0.2, counter_path=counter),
-                seconds=60,
+                seconds=1,
             )
             # Wait for one fire to complete fully.
             for _ in range(40):


### PR DESCRIPTION
## Summary

Lands Shard 3 of issue #912 — `WorkflowScheduler` plumbing for per-job soft/hard time limits. Builds on Shards 1+2 (PRs #921, #922).

- `WorkflowScheduler.__init__` accepts `default_soft_time_limit` / `default_time_limit` keyword-only kwargs.
- `schedule_cron` / `schedule_interval` / `schedule_once` accept the same two kwargs at signature parity.
- Per-task value wins over scheduler default; falls through to None.
- `_compose_job_kwargs` threads a `(soft, hard)` tuple under internal `_TIME_LIMIT_KWARG = "_kailash_time_limits"` for APScheduler jobstore replay (Invariant 6 — limits persist across scheduler restart).
- `_execute_workflow` arms `arm_time_limits()` per attempt with a fresh `CancellationToken` (Invariant 3 — no carry-over across retries).
- `_TimeLimitClassifier` converts `WorkflowCancelledError` → `SoftTimeLimitExceeded` / `HardTimeLimitExceeded`; typed exceptions flow through the existing `RetrySpec.is_retryable` filter (Invariant 2).
- Validation at registration time, not fire time (Invariant 4).

## Single-node workflow soft-cancel semantic

Shard 2's wrapper docstring states: "the runtime observes the cancelled token at its NEXT poll" — but the runtime polls only between nodes. Single-node workflows never observe soft. To honor brief AC #1, this shard adds a post-completion poll of `cancellable.hard_deadline_reached` and `token.is_cancelled` to promote a clean return to `SoftTimeLimitExceeded` for soft-armed single-node workflows. This is a correctness extension of the Shard 2 contract; the wrapper's design assumes inter-node polling.

## `cancellation_token` interaction

A user passing `cancellation_token=` to `schedule_cron` etc. now sees subtle behavior — when time limits are armed, the scheduler creates its own token instead of using the user's (the timer needs a token it owns to fire `cancel()`). The user's token is preserved and used when no time limits are armed. This matches the brief's intent (time limits MUST work) but the interaction needs `/codify` documentation.

## Test plan

- [x] `tests/integration/runtime/test_scheduler_time_limits.py` — **14/14 pass** (Tier 2)
- [x] Shard 1 + 2 regression suites: 48/48 still pass
- [x] Wider Tier 1 unit sweep on `tests/unit/runtime/`: 643 pass / 20 skip / 0 fail
- [x] Pre-commit clean

## Pyright LSP cache lag

Same pattern as PRs #921/#922 — Pyright "unknown import symbol" warnings on the new test file are LSP cache lag (the symbols exist; tests pass against them). The one real Pyright issue (`cancellable possibly unbound` at scheduler.py:1248-1249) was fixed by hoisting `cancellable = None` to the top of the attempt loop body so early-attempt failures (workflow.build() raising) hit the `except` branch with `cancellable` bound.

## Related issues

Part of issue #912 wave (Shards 1+2+3 of 5 now landed/landing). Parallel with Shard 4 (PR to follow). Shard 5 (docs + CHANGELOG + signature pins) is the cross-cutting closer after both Shard 3 + 4 merge.

Fixes — partial — #912 (Shard 3 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)