### PR TITLE
feat(#912 Shard 5): cross-cutting closer — CHANGELOG + docstrings + signature pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,102 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Per-Task Soft / Hard Time Limits (#912)
+
+`runtime.execute(workflow.build(), soft_time_limit=2.0, time_limit=5.0)`
+now bounds every workflow with a celery-style two-stage deadline contract:
+the soft limit raises a catchable exception so user code can save partial
+work and exit cleanly; the hard limit unconditionally aborts after a
+short grace window so operators can bound runaway resource consumption.
+
+#### New typed kwargs (additive — `**kwargs` retained one deprecation cycle)
+
+- **Every `BaseRuntime` subclass** — `LocalRuntime.execute`,
+  `AsyncLocalRuntime.execute` / `.execute_workflow_async`,
+  `DistributedRuntime.execute`, `DockerRuntime.execute`,
+  `ParallelRuntime.execute`, `ParallelCyclicRuntime.execute`,
+  `AccessControlledRuntime.execute`, `DurableExecutionEngine.execute` —
+  accept `soft_time_limit: float | None = None` and
+  `time_limit: float | None = None` as KEYWORD_ONLY parameters. Validated
+  at the entry point: negative values, non-finite values, and `soft >= hard`
+  raise `ValueError` immediately rather than later from a timer thread.
+- **`WorkflowScheduler.__init__`** — operator-level
+  `default_soft_time_limit: Optional[float] = None` and
+  `default_time_limit: Optional[float] = None` apply when a per-fire value
+  is unset. Per-fire value ALWAYS wins.
+- **`WorkflowScheduler.schedule_cron` / `.schedule_interval` / `.schedule_once`** —
+  per-fire `soft_time_limit` / `time_limit` KEYWORD_ONLY kwargs flow
+  through `RetrySpec` integration so retryable typed exceptions
+  re-classify correctly.
+- **`Worker.__init__`** — operator-level
+  `default_soft_time_limit: float | None = None`,
+  `default_time_limit: float | None = None`, and
+  `hard_time_limit_grace_seconds: float = 1.0` apply when a task's
+  `TaskMessage.execution_limits` does NOT specify the corresponding
+  limit. Per-task value ALWAYS wins. The `Worker` arms timers at
+  DEQUEUE (not enqueue) so queue wait time does NOT consume the task's
+  budget.
+
+#### New typed exceptions
+
+- `kailash.sdk_exceptions.SoftTimeLimitExceeded` — subclass of
+  `RuntimeException`. Catch to save partial work / write a checkpoint /
+  exit cleanly before the hard deadline fires.
+- `kailash.sdk_exceptions.HardTimeLimitExceeded` — subclass of
+  `RuntimeException`. Operator-facing path for runaway-task abort.
+  On the distributed worker path, triggers requeue (NOT immediate
+  dead-letter) when `attempts < max_attempts`; dead-letters only after
+  the attempt budget is exhausted.
+
+Both are exported from `kailash.sdk_exceptions` and importable as:
+
+```python
+from kailash.sdk_exceptions import SoftTimeLimitExceeded, HardTimeLimitExceeded
+```
+
+#### Distributed wire format — forward-compat
+
+`TaskMessage` (in `kailash.runtime.distributed`) gained an optional
+`execution_limits: Optional[Dict[str, float]] = None` field with shape
+`{"soft": <float>, "hard": <float>}` (either key may be omitted when the
+corresponding limit is None). Wire format is ONE optional field — workers
+running pre-2.19 SDK silently ignore the unknown payload key (forward
+compatible). Workers running 2.19 or newer read the field and arm timers
+at dequeue.
+
+#### `RetrySpec` integration
+
+`SoftTimeLimitExceeded` and `HardTimeLimitExceeded` flow through the
+`RetrySpec` retry classifier so a scheduled job that exceeds its soft
+limit can be retried with backoff per the spec, while a hard-limit kill
+goes to dead-letter (or requeue, on the distributed worker path).
+
+#### Migration
+
+Pure-additive scope — no breaking changes. Existing callers continue to
+work without passing the new kwargs. The wrapper layer is OFF by default
+(both kwargs default to None) so no implicit deadlines apply unless the
+caller explicitly opts in. The semantics are celery-style: soft limit
+warns and raises a catchable exception; hard limit is an unconditional
+abort after a short grace window.
+
+```python
+# Quickstart — opt-in per call:
+from kailash.runtime.local import LocalRuntime
+from kailash.sdk_exceptions import SoftTimeLimitExceeded
+
+runtime = LocalRuntime()
+try:
+    results, run_id = runtime.execute(
+        workflow.build(),
+        soft_time_limit=2.0,   # advisory; raises catchable exception
+        time_limit=5.0,         # hard kill (after grace)
+    )
+except SoftTimeLimitExceeded:
+    # Save partial work, write a checkpoint, return early.
+    ...
+```
+
 ## [2.18.0] - 2026-05-08
 
 ### Changed — BREAKING (slim core, #890)

--- a/specs/core-runtime.md
+++ b/specs/core-runtime.md
@@ -275,6 +275,58 @@ worker = Worker(redis_url="redis://localhost:6379/0", concurrency=4)
 await worker.start()  # Blocks, processing tasks
 ```
 
+#### 4.3.2 Per-Task Time Limits Through The Queue (#912)
+
+`DistributedRuntime.execute(soft_time_limit=, time_limit=)` validates and
+serializes per-task limits onto `TaskMessage.execution_limits`, an optional
+`Dict[str, float]` with shape `{"soft": <seconds>, "hard": <seconds>}`
+(either key omitted when its limit is `None`). The wire format is one
+optional dict so workers running pre-#912 SDK silently ignore the unknown
+payload key (forward-compatible). Workers running 2.19 or newer read the
+field and arm timers at DEQUEUE (not enqueue) so queue wait time does NOT
+consume the task's budget.
+
+`Worker.__init__` accepts operator-level defaults that apply only when a
+task does not specify its own:
+
+```python
+worker = Worker(
+    redis_url="redis://localhost:6379/0",
+    concurrency=4,
+    default_soft_time_limit=30.0,           # applied only if task has no soft
+    default_time_limit=60.0,                 # applied only if task has no hard
+    hard_time_limit_grace_seconds=2.0,       # wind-down before unconditional kill
+)
+```
+
+Per-task limits ALWAYS win over `Worker` defaults. `HardTimeLimitExceeded`
+on the worker triggers requeue (NOT immediate dead-letter) when
+`attempts < max_attempts`; dead-letter only after the attempt budget is
+exhausted.
+
+#### 4.3.3 WorkflowScheduler Per-Fire Time Limits (#912)
+
+`WorkflowScheduler.__init__` accepts operator-level defaults
+`default_soft_time_limit` / `default_time_limit` that fall through when a
+per-fire value is unset. Each `schedule_cron` / `schedule_interval` /
+`schedule_once` call accepts per-fire `soft_time_limit` / `time_limit`
+KEYWORD_ONLY kwargs that ALWAYS win over the scheduler defaults. Typed
+`SoftTimeLimitExceeded` / `HardTimeLimitExceeded` exceptions flow through
+`RetrySpec` (#910) classification so retryable timeouts re-fire with
+backoff and non-retryable ones bubble to APScheduler's job-error listener.
+
+```python
+scheduler = WorkflowScheduler(
+    job_store_path="schedules.db",
+    default_soft_time_limit=10.0,           # default for every fire
+    default_time_limit=30.0,
+)
+sid = scheduler.schedule_cron(
+    workflow, "*/5 * * * *",
+    soft_time_limit=2.0, time_limit=5.0,    # per-fire override
+)
+```
+
 ### 4.4 get_runtime Factory
 
 **Module**: `kailash.runtime`

--- a/src/kailash/runtime/async_local.py
+++ b/src/kailash/runtime/async_local.py
@@ -728,12 +728,35 @@ class AsyncLocalRuntime(LocalRuntime):
             workflow: Workflow to execute
             task_manager: Optional task manager for tracking
             parameters: Input parameters for the workflow
+            soft_time_limit: Optional advisory deadline in seconds (#912).
+                Raises :class:`~kailash.sdk_exceptions.SoftTimeLimitExceeded`
+                when reached; user code MAY catch and exit cleanly.
+            time_limit: Optional unconditional kill deadline in seconds (#912).
+                Raises :class:`~kailash.sdk_exceptions.HardTimeLimitExceeded`
+                after ``time_limit + grace`` regardless of acknowledgement.
 
         Returns:
             Tuple of (results dict, run_id)
 
         Raises:
             RuntimeError: If called from async context (use execute_workflow_async instead)
+            SoftTimeLimitExceeded: If ``soft_time_limit`` elapses.
+            HardTimeLimitExceeded: If ``time_limit + grace`` elapses.
+
+        Time-Limit Example::
+
+            from kailash.runtime.async_local import AsyncLocalRuntime
+            from kailash.sdk_exceptions import SoftTimeLimitExceeded
+
+            runtime = AsyncLocalRuntime()
+            try:
+                results, run_id = runtime.execute(
+                    workflow.build(),
+                    soft_time_limit=2.0,
+                    time_limit=5.0,
+                )
+            except SoftTimeLimitExceeded:
+                ...  # save partial work, exit cleanly
         """
         # #912 Shard 1: validate typed time-limit kwargs at the entry point.
         _validate_limits(soft_time_limit, time_limit)
@@ -840,6 +863,12 @@ class AsyncLocalRuntime(LocalRuntime):
             workflow: Workflow to execute
             inputs: Input data for the workflow
             context: Optional execution context
+            soft_time_limit: Optional advisory deadline in seconds (#912).
+                Raises :class:`~kailash.sdk_exceptions.SoftTimeLimitExceeded`
+                when reached; user code MAY catch and exit cleanly.
+            time_limit: Optional unconditional kill deadline in seconds (#912).
+                Raises :class:`~kailash.sdk_exceptions.HardTimeLimitExceeded`
+                after ``time_limit + grace``.
 
         Returns:
             Tuple of (results dict, run_id) - For compatibility with tests
@@ -853,6 +882,24 @@ class AsyncLocalRuntime(LocalRuntime):
         Raises:
             asyncio.TimeoutError: If execution exceeds configured timeout
             WorkflowExecutionError: If execution fails
+            SoftTimeLimitExceeded: If ``soft_time_limit`` elapses.
+            HardTimeLimitExceeded: If ``time_limit + grace`` elapses.
+
+        Time-Limit Example (async)::
+
+            from kailash.runtime.async_local import AsyncLocalRuntime
+            from kailash.sdk_exceptions import SoftTimeLimitExceeded
+
+            runtime = AsyncLocalRuntime()
+            try:
+                results, run_id = await runtime.execute_workflow_async(
+                    workflow.build(),
+                    inputs={},
+                    soft_time_limit=2.0,
+                    time_limit=5.0,
+                )
+            except SoftTimeLimitExceeded:
+                ...  # save partial work, exit cleanly
         """
         # #912 Shard 1: validate typed time-limit kwargs at the entry point.
         _validate_limits(soft_time_limit, time_limit)

--- a/src/kailash/runtime/distributed.py
+++ b/src/kailash/runtime/distributed.py
@@ -703,6 +703,18 @@ class Worker:
         ...     concurrency=4,
         ... )
         >>> await worker.start()  # Runs until stopped
+
+        # With operator-set defaults (#912 Shard 4) — per-task
+        # ``DistributedRuntime.execute(soft_time_limit=, time_limit=)``
+        # ALWAYS wins over these defaults; defaults apply only when the
+        # task did not set its own:
+        >>> worker = Worker(
+        ...     redis_url="redis://localhost:6379/0",
+        ...     concurrency=4,
+        ...     default_soft_time_limit=30.0,
+        ...     default_time_limit=60.0,
+        ...     hard_time_limit_grace_seconds=2.0,
+        ... )
     """
 
     def __init__(

--- a/src/kailash/runtime/distributed.py
+++ b/src/kailash/runtime/distributed.py
@@ -569,6 +569,20 @@ class DistributedRuntime(BaseRuntime):
         Returns:
             Tuple of (status_dict, run_id) where status_dict contains
             ``{"status": "queued", "run_id": run_id, "queue_length": N}``.
+
+        Time-Limit Example (per-task limits travel through the queue)::
+
+            from kailash.runtime.distributed import DistributedRuntime
+
+            runtime = DistributedRuntime(redis_url="redis://localhost:6379/0")
+            status, run_id = runtime.execute(
+                workflow,
+                soft_time_limit=2.0,   # advisory; raises SoftTimeLimitExceeded
+                time_limit=5.0,         # hard kill (after grace); requeue path
+            )
+            # The Worker arms the timers at DEQUEUE (not enqueue) so queue
+            # wait time does NOT consume the task's budget. Per-task limits
+            # ALWAYS win over Worker(default_*_time_limit) defaults.
         """
         # #912 Shard 1: validate typed time-limit kwargs at the entry point.
         _validate_limits(soft_time_limit, time_limit)

--- a/src/kailash/runtime/durable.py
+++ b/src/kailash/runtime/durable.py
@@ -1319,6 +1319,16 @@ class DurableExecutionEngine:
         queue_name:
             Target queue when a dispatcher is configured. Defaults to
             ``"default"``.
+        soft_time_limit:
+            Optional advisory deadline in seconds (#912). Forwarded to the
+            wrapped runtime. Raises
+            :class:`~kailash.sdk_exceptions.SoftTimeLimitExceeded` when reached;
+            user code MAY catch and exit cleanly before the hard kill fires.
+        time_limit:
+            Optional unconditional kill deadline in seconds (#912). Forwarded
+            to the wrapped runtime. Raises
+            :class:`~kailash.sdk_exceptions.HardTimeLimitExceeded` after
+            ``time_limit + grace`` regardless of soft-limit acknowledgement.
 
         Returns
         -------

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -955,6 +955,16 @@ class LocalRuntime(
             workflow: Workflow to execute.
             task_manager: Optional task manager for tracking.
             parameters: Optional parameter overrides per node.
+            soft_time_limit: Optional advisory deadline in seconds (#912).
+                When reached, the running workflow is signalled via the
+                cancellation token; user code MAY catch
+                :class:`~kailash.sdk_exceptions.SoftTimeLimitExceeded`,
+                finish in-flight work, and exit cleanly before the hard
+                limit fires.
+            time_limit: Optional unconditional kill deadline in seconds
+                (#912). When ``time_limit + grace`` elapses, the wrapper
+                raises :class:`~kailash.sdk_exceptions.HardTimeLimitExceeded`
+                regardless of soft-limit acknowledgement.
 
         Returns:
             Tuple of (results dict, run_id).
@@ -963,6 +973,34 @@ class LocalRuntime(
             RuntimeExecutionError: If execution fails.
             WorkflowValidationError: If workflow is invalid.
             PermissionError: If access control denies execution.
+            SoftTimeLimitExceeded: If ``soft_time_limit`` elapses and the
+                workflow does not exit before the hard deadline. Catch to
+                save partial work / write a checkpoint / exit cleanly.
+            HardTimeLimitExceeded: If ``time_limit + grace`` elapses
+                regardless of soft-limit acknowledgement. Operators rely on
+                this path to bound runaway resource consumption.
+
+        Time-Limit Example (celery-style soft-then-hard contract)::
+
+            from kailash.runtime.local import LocalRuntime
+            from kailash.sdk_exceptions import (
+                SoftTimeLimitExceeded,
+                HardTimeLimitExceeded,
+            )
+
+            runtime = LocalRuntime()
+            try:
+                results, run_id = runtime.execute(
+                    workflow.build(),
+                    soft_time_limit=2.0,   # warn-and-raise (catchable)
+                    time_limit=5.0,         # hard kill after grace
+                )
+            except SoftTimeLimitExceeded:
+                # Save partial work, write a checkpoint, return early.
+                ...
+            except HardTimeLimitExceeded:
+                # Operator-facing: task exceeded the hard kill deadline.
+                ...
 
         Resource Management:
             For proper resource cleanup in long-running applications, use

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -384,6 +384,14 @@ class WorkflowScheduler:
             When provided, every fired trigger enqueues a Task to the
             dispatcher instead of executing the workflow in-process.
             Default ``None`` preserves the existing in-process behavior.
+        default_soft_time_limit: Optional advisory deadline in seconds (#912)
+            applied when a schedule's per-fire ``soft_time_limit=`` is None.
+            Per-fire value ALWAYS wins; final fallthrough is None (no limit).
+            Validated at construction (negative / soft >= hard raises here,
+            not later from a timer thread).
+        default_time_limit: Optional unconditional kill deadline in seconds
+            (#912) applied when per-fire ``time_limit=`` is None. Per-fire
+            value ALWAYS wins; final fallthrough is None.
 
     Raises:
         ImportError: If APScheduler is not installed.
@@ -555,6 +563,16 @@ class WorkflowScheduler:
                 when set on a scheduler constructed with
                 ``dispatch_via=<Dispatcher>`` (queue-dispatch path) — worker-
                 side retry semantics are the dispatcher's contract.
+            soft_time_limit: Optional advisory deadline in seconds (#912).
+                Per-fire value wins over ``WorkflowScheduler(default_soft_time_limit=)``;
+                final fallthrough is None (no limit). Raises
+                :class:`~kailash.sdk_exceptions.SoftTimeLimitExceeded` when
+                reached; flows through ``RetrySpec`` retry classifier.
+            time_limit: Optional unconditional kill deadline in seconds (#912).
+                Per-fire value wins over ``WorkflowScheduler(default_time_limit=)``;
+                final fallthrough is None. Raises
+                :class:`~kailash.sdk_exceptions.HardTimeLimitExceeded` after
+                ``time_limit + grace``.
             **kwargs: Additional keyword arguments passed to the runtime on execution.
 
         Returns:
@@ -562,13 +580,20 @@ class WorkflowScheduler:
 
         Raises:
             ValueError: If the cron expression is invalid OR ``retry`` is
-                supplied alongside ``dispatch_via=`` on this scheduler.
+                supplied alongside ``dispatch_via=`` on this scheduler, OR
+                if ``soft_time_limit`` / ``time_limit`` are negative or
+                inconsistent (soft >= hard).
 
         Example:
             >>> sid = scheduler.schedule_cron(workflow, "0 */6 * * *")  # Every 6 hours
             >>> sid = scheduler.schedule_cron(
             ...     workflow, "30 2 * * 1",
             ...     retry=RetrySpec(max_retries=3, retry_on=(ConnectionError,)),
+            ... )
+            >>> # Per-fire time limits (#912):
+            >>> sid = scheduler.schedule_cron(
+            ...     workflow, "*/5 * * * *",
+            ...     soft_time_limit=2.0, time_limit=5.0,
             ... )
         """
         from apscheduler.triggers.cron import CronTrigger
@@ -631,16 +656,27 @@ class WorkflowScheduler:
             seconds: Interval in seconds between executions.
             name: Optional human-readable name for this schedule.
             retry: Optional :class:`RetrySpec` (#910); see :meth:`schedule_cron`.
+            soft_time_limit: Optional advisory deadline in seconds (#912);
+                see :meth:`schedule_cron` for the per-fire vs default
+                fallthrough contract.
+            time_limit: Optional unconditional kill deadline in seconds (#912);
+                see :meth:`schedule_cron`.
             **kwargs: Additional keyword arguments passed to the runtime on execution.
 
         Returns:
             A unique schedule_id.
 
         Raises:
-            ValueError: If seconds is not positive.
+            ValueError: If seconds is not positive OR if ``soft_time_limit`` /
+                ``time_limit`` are negative or inconsistent (soft >= hard).
 
         Example:
             >>> sid = scheduler.schedule_interval(workflow, seconds=300)  # Every 5 min
+            >>> # Per-fire time limits (#912):
+            >>> sid = scheduler.schedule_interval(
+            ...     workflow, seconds=60,
+            ...     soft_time_limit=2.0, time_limit=5.0,
+            ... )
         """
         if not math.isfinite(seconds) or seconds <= 0:
             raise ValueError(
@@ -698,18 +734,29 @@ class WorkflowScheduler:
             run_at: The datetime at which to execute the workflow.
             name: Optional human-readable name for this schedule.
             retry: Optional :class:`RetrySpec` (#910); see :meth:`schedule_cron`.
+            soft_time_limit: Optional advisory deadline in seconds (#912);
+                see :meth:`schedule_cron` for the per-fire vs default
+                fallthrough contract.
+            time_limit: Optional unconditional kill deadline in seconds (#912);
+                see :meth:`schedule_cron`.
             **kwargs: Additional keyword arguments passed to the runtime on execution.
 
         Returns:
             A unique schedule_id.
 
         Raises:
-            ValueError: If run_at is in the past.
+            ValueError: If run_at is in the past OR if ``soft_time_limit`` /
+                ``time_limit`` are negative or inconsistent (soft >= hard).
 
         Example:
             >>> from datetime import datetime, UTC
             >>> run_at = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
             >>> sid = scheduler.schedule_once(workflow, run_at=run_at)
+            >>> # Per-fire time limits (#912):
+            >>> sid = scheduler.schedule_once(
+            ...     workflow, run_at=run_at,
+            ...     soft_time_limit=2.0, time_limit=5.0,
+            ... )
         """
         schedule_id = self._generate_schedule_id()
 

--- a/src/kailash/sdk_exceptions.py
+++ b/src/kailash/sdk_exceptions.py
@@ -236,7 +236,7 @@ class SoftTimeLimitExceeded(RuntimeException):
     :class:`ResourceLimitExceededError` — time-limit exhaustion is
     a different domain than resource-pool exhaustion.
 
-    Added in: v0.13.0 (issue #912 — per-task soft/hard time limits).
+    Added in: v2.19.0 (issue #912 — per-task soft/hard time limits).
     """
 
 
@@ -261,7 +261,7 @@ class HardTimeLimitExceeded(RuntimeException):
     Sibling of :class:`SoftTimeLimitExceeded`. NOT a subclass of
     :class:`ResourceLimitExceededError`.
 
-    Added in: v0.13.0 (issue #912 — per-task soft/hard time limits).
+    Added in: v2.19.0 (issue #912 — per-task soft/hard time limits).
     """
 
 

--- a/tests/regression/test_issue_912_signature_invariants.py
+++ b/tests/regression/test_issue_912_signature_invariants.py
@@ -139,3 +139,210 @@ def test_kwargs_still_present_per_additive_contract(mod_path, cls_name, attr):
         f"current signature: {sig}. Removing **kwargs without a deprecation cycle "
         f"violates zero-tolerance.md Rule 6a."
     )
+
+
+# ---------------------------------------------------------------------------
+# Shard 3 — WorkflowScheduler signature pins
+# ---------------------------------------------------------------------------
+# Shard 3 wired ``default_soft_time_limit`` / ``default_time_limit`` onto
+# ``WorkflowScheduler.__init__`` AND ``soft_time_limit`` / ``time_limit`` onto
+# every public ``schedule_*`` entry-point. Per-task limits MUST win over
+# scheduler defaults; pins below structurally guarantee BOTH layers stay
+# wired so a future refactor that drops either layer fails loudly.
+_SCHEDULER_PER_FIRE_TARGETS: tuple[tuple[str, str, str], ...] = (
+    ("kailash.runtime.scheduler", "WorkflowScheduler", "schedule_cron"),
+    ("kailash.runtime.scheduler", "WorkflowScheduler", "schedule_interval"),
+    ("kailash.runtime.scheduler", "WorkflowScheduler", "schedule_once"),
+)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("mod_path,cls_name,attr", _SCHEDULER_PER_FIRE_TARGETS)
+def test_scheduler_method_exposes_soft_time_limit_kwarg(mod_path, cls_name, attr):
+    """Each ``WorkflowScheduler.schedule_*`` MUST accept ``soft_time_limit`` kw-only."""
+    method = _resolve_method(mod_path, cls_name, attr)
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "soft_time_limit" in params, (
+        f"{cls_name}.{attr} MUST accept 'soft_time_limit' kwarg per #912 Shard 3; "
+        f"current signature: {sig}"
+    )
+    p = params["soft_time_limit"]
+    assert (
+        p.kind == inspect.Parameter.KEYWORD_ONLY
+    ), f"{cls_name}.{attr}::soft_time_limit MUST be KEYWORD_ONLY (got {p.kind.name})"
+    assert (
+        p.default is None
+    ), f"{cls_name}.{attr}::soft_time_limit MUST default to None (got {p.default!r})"
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("mod_path,cls_name,attr", _SCHEDULER_PER_FIRE_TARGETS)
+def test_scheduler_method_exposes_time_limit_kwarg(mod_path, cls_name, attr):
+    """Each ``WorkflowScheduler.schedule_*`` MUST accept ``time_limit`` kw-only."""
+    method = _resolve_method(mod_path, cls_name, attr)
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "time_limit" in params, (
+        f"{cls_name}.{attr} MUST accept 'time_limit' kwarg per #912 Shard 3; "
+        f"current signature: {sig}"
+    )
+    p = params["time_limit"]
+    assert (
+        p.kind == inspect.Parameter.KEYWORD_ONLY
+    ), f"{cls_name}.{attr}::time_limit MUST be KEYWORD_ONLY (got {p.kind.name})"
+    assert (
+        p.default is None
+    ), f"{cls_name}.{attr}::time_limit MUST default to None (got {p.default!r})"
+
+
+@pytest.mark.regression
+def test_scheduler_init_exposes_default_soft_time_limit():
+    """``WorkflowScheduler.__init__`` MUST accept ``default_soft_time_limit`` kw-only.
+
+    Per #912 Shard 3 Q1: scheduler-default falls through to per-task value;
+    per-task value wins; final fallthrough is None (no limit).
+    """
+    method = _resolve_method(
+        "kailash.runtime.scheduler", "WorkflowScheduler", "__init__"
+    )
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "default_soft_time_limit" in params, (
+        f"WorkflowScheduler.__init__ MUST accept 'default_soft_time_limit' "
+        f"per #912 Shard 3; current signature: {sig}"
+    )
+    p = params["default_soft_time_limit"]
+    assert (
+        p.kind == inspect.Parameter.KEYWORD_ONLY
+    ), f"default_soft_time_limit MUST be KEYWORD_ONLY (got {p.kind.name})"
+    assert (
+        p.default is None
+    ), f"default_soft_time_limit MUST default to None (got {p.default!r})"
+
+
+@pytest.mark.regression
+def test_scheduler_init_exposes_default_time_limit():
+    """``WorkflowScheduler.__init__`` MUST accept ``default_time_limit`` kw-only."""
+    method = _resolve_method(
+        "kailash.runtime.scheduler", "WorkflowScheduler", "__init__"
+    )
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "default_time_limit" in params, (
+        f"WorkflowScheduler.__init__ MUST accept 'default_time_limit' "
+        f"per #912 Shard 3; current signature: {sig}"
+    )
+    p = params["default_time_limit"]
+    assert (
+        p.kind == inspect.Parameter.KEYWORD_ONLY
+    ), f"default_time_limit MUST be KEYWORD_ONLY (got {p.kind.name})"
+    assert (
+        p.default is None
+    ), f"default_time_limit MUST default to None (got {p.default!r})"
+
+
+# ---------------------------------------------------------------------------
+# Shard 4 — Worker signature + TaskMessage wire-format pins
+# ---------------------------------------------------------------------------
+# Shard 4 wired ``default_soft_time_limit`` / ``default_time_limit`` /
+# ``hard_time_limit_grace_seconds`` onto ``Worker.__init__`` AND added the
+# ``execution_limits`` field to ``TaskMessage``. Per-task limits ALWAYS win
+# over Worker defaults; the wire field is OPTIONAL so older workers running
+# pre-Shard-4 SDK silently ignore it (forward-compat).
+
+
+@pytest.mark.regression
+def test_worker_init_exposes_default_soft_time_limit():
+    """``Worker.__init__`` MUST accept ``default_soft_time_limit`` kw-only."""
+    method = _resolve_method("kailash.runtime.distributed", "Worker", "__init__")
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "default_soft_time_limit" in params, (
+        f"Worker.__init__ MUST accept 'default_soft_time_limit' "
+        f"per #912 Shard 4; current signature: {sig}"
+    )
+    p = params["default_soft_time_limit"]
+    assert (
+        p.kind == inspect.Parameter.KEYWORD_ONLY
+    ), f"default_soft_time_limit MUST be KEYWORD_ONLY (got {p.kind.name})"
+    assert (
+        p.default is None
+    ), f"default_soft_time_limit MUST default to None (got {p.default!r})"
+
+
+@pytest.mark.regression
+def test_worker_init_exposes_default_time_limit():
+    """``Worker.__init__`` MUST accept ``default_time_limit`` kw-only."""
+    method = _resolve_method("kailash.runtime.distributed", "Worker", "__init__")
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "default_time_limit" in params, (
+        f"Worker.__init__ MUST accept 'default_time_limit' "
+        f"per #912 Shard 4; current signature: {sig}"
+    )
+    p = params["default_time_limit"]
+    assert (
+        p.kind == inspect.Parameter.KEYWORD_ONLY
+    ), f"default_time_limit MUST be KEYWORD_ONLY (got {p.kind.name})"
+    assert (
+        p.default is None
+    ), f"default_time_limit MUST default to None (got {p.default!r})"
+
+
+@pytest.mark.regression
+def test_worker_init_exposes_hard_time_limit_grace_seconds():
+    """``Worker.__init__`` MUST accept ``hard_time_limit_grace_seconds`` kw-only.
+
+    Wind-down window between hard-deadline fire and unconditional kill;
+    default 1.0s; MUST be >= 0 (per #912 Shard 2 ``arm_time_limits`` contract).
+    """
+    method = _resolve_method("kailash.runtime.distributed", "Worker", "__init__")
+    sig = inspect.signature(method)
+    params = sig.parameters
+
+    assert "hard_time_limit_grace_seconds" in params, (
+        f"Worker.__init__ MUST accept 'hard_time_limit_grace_seconds' "
+        f"per #912 Shard 4; current signature: {sig}"
+    )
+    p = params["hard_time_limit_grace_seconds"]
+    assert (
+        p.kind == inspect.Parameter.KEYWORD_ONLY
+    ), f"hard_time_limit_grace_seconds MUST be KEYWORD_ONLY (got {p.kind.name})"
+    assert (
+        p.default == 1.0
+    ), f"hard_time_limit_grace_seconds MUST default to 1.0 (got {p.default!r})"
+
+
+@pytest.mark.regression
+def test_task_message_has_execution_limits_field():
+    """``TaskMessage`` dataclass MUST expose ``execution_limits`` for forward-compat.
+
+    Per #912 Shard 4: optional ``Dict[str, float]`` carrying per-task soft/hard
+    deadlines through the queue boundary. Shape is ONE optional dict (NOT two
+    separate fields) so older workers silently ignore the new field. Default
+    MUST be None so older-SDK ``TaskMessage.from_json()`` calls without the
+    field deserialize correctly.
+    """
+    import dataclasses
+    from kailash.runtime.distributed import TaskMessage
+
+    fields = {f.name: f for f in dataclasses.fields(TaskMessage)}
+    assert "execution_limits" in fields, (
+        f"TaskMessage MUST expose 'execution_limits' field per #912 Shard 4; "
+        f"current fields: {sorted(fields)}"
+    )
+    f = fields["execution_limits"]
+    # Default MUST be None so the wire format omits the field on the common
+    # no-limit path AND older workers running pre-Shard-4 SDK silently ignore
+    # the unknown payload key.
+    assert f.default is None, (
+        f"TaskMessage.execution_limits MUST default to None (got {f.default!r}) "
+        f"so the no-limit path stays compact and older workers ignore the field"
+    )

--- a/tests/regression/test_issue_912_signature_invariants.py
+++ b/tests/regression/test_issue_912_signature_invariants.py
@@ -331,6 +331,7 @@ def test_task_message_has_execution_limits_field():
     field deserialize correctly.
     """
     import dataclasses
+
     from kailash.runtime.distributed import TaskMessage
 
     fields = {f.name: f for f in dataclasses.fields(TaskMessage)}


### PR DESCRIPTION
## Summary

Closes the issue #912 wave (Shards 1+2+3+4 already merged). NO new behavior — only docs, CHANGELOG, signature pin tests, and spec updates.

- **CHANGELOG.md** — `[Unreleased]` entry documenting per-task soft/hard time limits across runtimes, scheduler, worker; new exceptions; RetrySpec integration; celery-style migration note + quickstart code block.
- **Docstrings** — celery-style examples added to canonical user-surface entry points (`LocalRuntime.execute`, `AsyncLocalRuntime.execute` + `execute_workflow_async`, `WorkflowScheduler` class + its three `schedule_*` methods, `Worker.__init__`, `DistributedRuntime.execute`, `DurableExecutionEngine.execute`); `Soft/HardTimeLimitExceeded` `Added in:` version corrected.
- **Signature pin tests** — extended `tests/regression/test_issue_912_signature_invariants.py` from 24 to 36 pins (+12) covering the Shard 3+4 surface (`WorkflowScheduler.__init__`, `schedule_cron`/`schedule_interval`/`schedule_once`, `Worker.__init__`, `TaskMessage.execution_limits`).
- **Spec** — `specs/core-runtime.md` §4.3.2 (queue per-task limits) + §4.3.3 (scheduler per-fire limits) added.

## Test plan

- [x] `tests/regression/test_issue_912_signature_invariants.py` — **36/36 pass** (12 new + 24 baseline)
- [x] **Full #912 regression suite** (8 test files, 110 tests) — **110 passed in 77.39s**
- [x] Pre-commit clean (Black, isort, Ruff, type-annotation lint, deprecated-log.warn check, debug-statement check, eval-usage check, blanket-noqa check, spec-drift gate, doc-style check, Tier-1 unit tests)

## Surfaced for follow-up (NOT introduced by this PR)

1. **Pre-existing `RuntimeWarning` from `local.py:1499`** — `AsyncSQLDatabaseNode.clear_shared_pools` and `wait_for` coroutine-never-awaited warnings originate from commit `1b2f14cdf` (March 2026), pre-dating #912 by 2+ months. Different bug class (AsyncSQL teardown inside `LocalRuntime` persistent-event-loop shutdown). Already tracked in #917 per session-notes.
2. **Workflow round-trip serialization gap** — surfaced by Shard 4 agent: `Workflow.to_dict()` → `from_dict()` strips `PythonCodeNode.code` because `Node.__init__` only stores `**kwargs` in `self.config`. Breaks 4 pre-existing PR #914 tests on main. Follow-up issue recommended (separate shard, touches workflow serialization across many node types).
3. **`cancellation_token` interaction** (Shard 3) — when time limits are armed, the scheduler creates its own token instead of using the user-supplied one. Documented in PR #923; needs `/codify` documentation pass.

## Version note

`Added in:` docstring uses `v2.19.0` assuming next minor bump from `kailash 2.18.0`. CHANGELOG entry lives under `[Unreleased]`; release-time bump will rename to actual version. If `/release` picks a different version, update both `sdk_exceptions.py` `Added in:` lines AND CHANGELOG header together.

## Issue closure

This is the cross-cutting closer for issue #912. Once merged, all 5 shards landed:

- Shard 1 (PR #921): typed kwargs + exceptions + validation
- Shard 2 (PR #922): timer wrapper + classifier
- Shard 3 (PR #923): scheduler plumbing
- Shard 4 (PR #924): distributed wire format + Worker
- Shard 5 (this PR): docs + CHANGELOG + pins

Fixes #912.

🤖 Generated with [Claude Code](https://claude.com/claude-code)