### PR TITLE
fix(#912 Shard 6): in-process enforcement + input-validation hardening (corrective)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,101 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Hardened — issue #912 corrective gate (Shard 6)
+
+The /redteam Round 1 audit on the merged #912 wave (PRs #921-#925) caught
+two ship-blocking failure modes that this corrective shard fixes:
+
+#### Fixed — In-process runtime enforcement was missing
+
+Five in-process runtimes — `LocalRuntime`, `AsyncLocalRuntime`,
+`ParallelRuntime`, `ParallelCyclicRuntime`, `DockerRuntime` — accepted
+`soft_time_limit` / `time_limit` kwargs in their public signatures,
+called `_validate_limits()`, and then dropped the kwargs on the floor
+without ever arming `arm_time_limits`. The README quickstart::
+
+    runtime = LocalRuntime()
+    runtime.execute(workflow.build(), soft_time_limit=2)
+
+silently never raised `SoftTimeLimitExceeded` against a 5-second
+workflow. Same fake-dispatch failure mode as `zero-tolerance.md`
+Rule 2 § "Fake dispatch": the docstring promised the contract; the
+code did not deliver.
+
+Wired in this shard:
+
+- `LocalRuntime.execute` — `arm_time_limits` (sync threading.Timer)
+  layered on a fresh `CancellationToken`, classifier on
+  `WorkflowCancelledError`, post-completion poll for hard-deadline-
+  fired-after-success.
+- `AsyncLocalRuntime.execute_workflow_async` — `arm_time_limits_async`
+  (asyncio task) with the same pattern. Typed `SoftTimeLimitExceeded`
+  / `HardTimeLimitExceeded` exceptions added above the broad
+  `except Exception` re-wrap so they propagate untouched.
+- `ParallelRuntime.execute` — `arm_time_limits_async` around the
+  parallel-DAG path; typed exception passthrough.
+- `ParallelCyclicRuntime.execute` — `arm_time_limits` around all three
+  execution paths (cyclic / parallel-DAG / LocalRuntime fallback);
+  typed kwargs forwarded to `LocalRuntime` for defense-in-depth.
+- `DockerRuntime.execute` — `arm_time_limits` around the per-node
+  container loop. Per-node-boundary poll: between containers, check
+  if the hard timer fired during the previous container and raise.
+  Documented constraint: long-running single-node Docker workflows
+  cannot be interrupted mid-container (the timer cannot inject into
+  a running `docker run` subprocess); multi-node workflows DO get
+  the full deadline contract at every node boundary.
+- `AccessControlledRuntime.execute` and `DurableExecutionEngine.execute`
+  required NO changes — both already forward typed kwargs by name
+  to their inner runtime's execute call, so the in-process wiring
+  above fires automatically through them.
+
+#### Fixed — Input-validation bypass at the Worker dequeue boundary
+
+Three security findings were paired with the in-process gap:
+
+1. **NaN / Inf bypass `_validate_limits`** — `float('inf') > 0` is
+   True; `float('nan') <= 0` is False. Both slipped through the
+   original sign-check and would arm `Timer(inf, ...)` (sleeps
+   forever, workflow uncancellable) or `Timer(nan, ...)` (raises
+   from a daemon thread with no traceback to the caller).
+   `_validate_limits` now rejects non-finite values via
+   `math.isfinite()` at every entry point.
+2. **Worker accepts arbitrary `execution_limits` dict shape** — a
+   malicious or mis-coded producer could send arbitrary shapes on
+   the wire (`{"soft": "DROP TABLE"}`, `{"soft": [1, 2, 3]}`,
+   `{"hard": -1}`). Without dequeue-side validation, the bad value
+   flowed to `arm_time_limits` and surfaced as TypeError /
+   ValueError from a daemon thread. Added
+   `Worker._validate_execution_limits_dict` static helper, called
+   from `Worker._effective_time_limits` at dequeue. Validates dict-
+   or-None, key types (rejects bool because Python's bool subclasses
+   int), then delegates to `_validate_limits` for finite + sign +
+   ordering. Unknown keys silently ignored for forward-compat.
+3. **`grace_seconds` was unvalidated** — negative grace fires the
+   hard kill BEFORE the soft signal (inverting the celery
+   contract); NaN crashes the daemon thread. `_validate_limits`
+   now accepts an optional `grace_seconds` parameter and validates
+   it; `arm_time_limits` / `arm_time_limits_async` /
+   `Worker.__init__` all forward the value so caller error raises
+   at the entry point.
+
+#### Tests
+
+- `tests/unit/test_time_limits_validation.py` — 12 new finite-check
+  + grace_seconds cases.
+- `tests/integration/runtime/test_local_runtime_time_limits.py` (new)
+  — 8 Tier-2 cases covering soft/hard enforcement on real
+  `LocalRuntime` plus all entry-point validation paths.
+- `tests/integration/runtime/test_async_local_runtime_time_limits.py`
+  (new) — 7 Tier-2 cases mirroring the LocalRuntime suite for the
+  async path.
+- `tests/integration/runtime/test_distributed_time_limits.py` — 11
+  new Worker dequeue-validation cases (no Redis required for the
+  validation surface).
+
+Full #912 regression suite: 149 passed; Tier-1 sweep matching CI:
+3915 passed, 4 skipped, 0 failures.
+
 ### Added — Per-Task Soft / Hard Time Limits (#912)
 
 `runtime.execute(workflow.build(), soft_time_limit=2.0, time_limit=5.0)`

--- a/src/kailash/runtime/_time_limits.py
+++ b/src/kailash/runtime/_time_limits.py
@@ -71,6 +71,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import threading
 import time
 from dataclasses import dataclass, field
@@ -91,6 +92,7 @@ logger = logging.getLogger(__name__)
 def _validate_limits(
     soft_time_limit: float | None,
     time_limit: float | None,
+    grace_seconds: float | None = None,
 ) -> None:
     """Validate the typed time-limit kwargs accepted by every runtime ``execute*``.
 
@@ -107,26 +109,53 @@ def _validate_limits(
 
     Args:
         soft_time_limit: Advisory deadline in seconds. ``None`` = no
-            soft limit. ``<= 0`` is invalid.
+            soft limit. ``<= 0`` and non-finite (``NaN`` / ``±inf``) are
+            invalid — :class:`threading.Timer` would either sleep forever
+            (``inf``) or crash from a daemon thread (``NaN``).
         time_limit: Unconditional kill deadline in seconds. ``None`` =
-            no hard limit. ``<= 0`` is invalid.
+            no hard limit. ``<= 0`` and non-finite are invalid.
+        grace_seconds: Optional wind-down window between the hard
+            deadline and the unconditional raise. ``None`` (the default)
+            skips the grace check — callers that don't pass a grace
+            value want the helper's default applied at arm-time. When
+            set, MUST be ``>= 0`` AND finite. ``grace_seconds < 0``
+            would make the hard timer fire BEFORE ``time_limit``,
+            inverting the celery-style soft-then-hard contract.
 
     Raises:
-        ValueError: If either kwarg is ``<= 0``, or if both are set and
-            ``soft_time_limit >= time_limit``.
+        ValueError: If either time-limit kwarg is ``<= 0`` or non-finite,
+            or if both are set and ``soft_time_limit >= time_limit``,
+            or if ``grace_seconds`` is negative or non-finite.
 
-    Added in: v0.13.0 (issue #912 Shard 1).
+    Added in: v0.13.0 (issue #912 Shard 1). Extended by issue #912
+    Shard 6 to reject NaN / Inf and to validate ``grace_seconds`` so
+    every entry-point call surfaces caller error before any timer
+    thread is started.
     """
-    if soft_time_limit is not None and soft_time_limit <= 0:
-        raise ValueError(
-            f"soft_time_limit MUST be > 0 when set (got {soft_time_limit!r}); "
-            f"pass None to disable the soft deadline"
-        )
-    if time_limit is not None and time_limit <= 0:
-        raise ValueError(
-            f"time_limit MUST be > 0 when set (got {time_limit!r}); "
-            f"pass None to disable the hard deadline"
-        )
+    if soft_time_limit is not None:
+        if not math.isfinite(soft_time_limit):
+            raise ValueError(
+                f"soft_time_limit MUST be finite when set (got {soft_time_limit!r}); "
+                f"NaN sleeps forever from a daemon thread, ±inf is "
+                f"unbounded — pass None to disable the soft deadline"
+            )
+        if soft_time_limit <= 0:
+            raise ValueError(
+                f"soft_time_limit MUST be > 0 when set (got {soft_time_limit!r}); "
+                f"pass None to disable the soft deadline"
+            )
+    if time_limit is not None:
+        if not math.isfinite(time_limit):
+            raise ValueError(
+                f"time_limit MUST be finite when set (got {time_limit!r}); "
+                f"NaN sleeps forever from a daemon thread, ±inf is "
+                f"unbounded — pass None to disable the hard deadline"
+            )
+        if time_limit <= 0:
+            raise ValueError(
+                f"time_limit MUST be > 0 when set (got {time_limit!r}); "
+                f"pass None to disable the hard deadline"
+            )
     if (
         soft_time_limit is not None
         and time_limit is not None
@@ -137,6 +166,18 @@ def _validate_limits(
             f"time_limit ({time_limit!r}) so the advisory signal precedes the "
             f"hard kill with a non-zero warning window"
         )
+    if grace_seconds is not None:
+        if not math.isfinite(grace_seconds):
+            raise ValueError(
+                f"grace_seconds MUST be finite when set (got {grace_seconds!r}); "
+                f"NaN crashes the daemon thread, ±inf is unbounded"
+            )
+        if grace_seconds < 0:
+            raise ValueError(
+                f"grace_seconds MUST be >= 0 when set (got {grace_seconds!r}); "
+                f"a negative grace would fire the hard kill BEFORE the soft "
+                f"signal, inverting the celery-style soft-then-hard contract"
+            )
 
 
 @dataclass
@@ -287,9 +328,12 @@ def arm_time_limits(
             its docstring for the contract). NO timer was started
             when this raises.
 
-    Added in: v0.13.0 (issue #912 Shard 2).
+    Added in: v0.13.0 (issue #912 Shard 2). Extended by Shard 6 to
+    forward ``grace_seconds`` through the validator so caller error
+    (negative / NaN / Inf grace) surfaces at this entry point instead
+    of from a daemon thread later.
     """
-    _validate_limits(soft_time_limit, time_limit)
+    _validate_limits(soft_time_limit, time_limit, grace_seconds=grace_seconds)
 
     armed_at = time.monotonic()
     cancellable = _Cancellable(
@@ -381,9 +425,12 @@ def arm_time_limits_async(
         ValueError: If ``_validate_limits`` rejects the inputs.
         RuntimeError: If called outside a running event loop.
 
-    Added in: v0.13.0 (issue #912 Shard 2).
+    Added in: v0.13.0 (issue #912 Shard 2). Extended by Shard 6 to
+    forward ``grace_seconds`` through the validator so caller error
+    (negative / NaN / Inf grace) surfaces at this entry point instead
+    of from an asyncio task later.
     """
-    _validate_limits(soft_time_limit, time_limit)
+    _validate_limits(soft_time_limit, time_limit, grace_seconds=grace_seconds)
 
     loop = asyncio.get_running_loop()  # raises RuntimeError outside a loop
 

--- a/src/kailash/runtime/async_local.py
+++ b/src/kailash/runtime/async_local.py
@@ -29,7 +29,12 @@ from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 from kailash.nodes.base import Node
 from kailash.nodes.base_async import AsyncNode
 from kailash.resources import ResourceRegistry
-from kailash.runtime._time_limits import _validate_limits
+from kailash.runtime._time_limits import (
+    _TimeLimitClassifier,
+    _validate_limits,
+    arm_time_limits_async,
+)
+from kailash.runtime.cancellation import CancellationToken
 from kailash.runtime.durable import (
     NodeCompletionEvent,
     build_checkpoint_key,
@@ -43,7 +48,13 @@ from kailash.runtime.durable import (
 )
 from kailash.runtime.execution_tracker import ExecutionTracker
 from kailash.runtime.local import LocalRuntime
-from kailash.sdk_exceptions import RuntimeExecutionError, WorkflowExecutionError
+from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
+    RuntimeExecutionError,
+    SoftTimeLimitExceeded,
+    WorkflowCancelledError,
+    WorkflowExecutionError,
+)
 from kailash.tracking import TaskManager, TaskStatus
 
 logger = logging.getLogger(__name__)
@@ -904,6 +915,26 @@ class AsyncLocalRuntime(LocalRuntime):
         # #912 Shard 1: validate typed time-limit kwargs at the entry point.
         _validate_limits(soft_time_limit, time_limit)
 
+        # #912 Shard 6: arm asyncio-task-based deadlines around the
+        # in-process async execution path. Mirrors the LocalRuntime
+        # pattern but uses arm_time_limits_async (asyncio tasks) so the
+        # timers run on the same event loop as the workflow. The
+        # cancellation token is layered onto a fresh CancellationToken
+        # so the timers don't poison any user-supplied token; the soft
+        # timer cancels the token, and the post-completion poll raises
+        # SoftTimeLimitExceeded / HardTimeLimitExceeded per Shard 2
+        # invariant 5 (hard kill is non-negotiable).
+        _has_time_limit = soft_time_limit is not None or time_limit is not None
+        _attempt_token: CancellationToken | None = None
+        cancellable = None
+        if _has_time_limit:
+            _attempt_token = CancellationToken()
+            cancellable = arm_time_limits_async(
+                _attempt_token,
+                soft_time_limit=soft_time_limit,
+                time_limit=time_limit,
+            )
+
         start_time = time.time()
 
         # Generate run_id for tracking (consistent with LocalRuntime)
@@ -1029,6 +1060,27 @@ class AsyncLocalRuntime(LocalRuntime):
                     else tracker_result
                 )
 
+            # #912 Shard 6: post-completion poll for hard-deadline-fired-
+            # after-success (Shard 2 invariant 5). Even when the workflow
+            # returned cleanly, the asyncio timer task may have set the
+            # hard flag — the kill is non-negotiable.
+            if cancellable is not None:
+                if cancellable.hard_deadline_reached:
+                    raise HardTimeLimitExceeded(
+                        f"workflow exceeded hard time limit "
+                        f"(time_limit={cancellable.time_limit}s + "
+                        f"grace_seconds={cancellable.grace_seconds}s)"
+                    )
+                if (
+                    _attempt_token is not None
+                    and _attempt_token.is_cancelled
+                    and cancellable.soft_time_limit is not None
+                ):
+                    raise SoftTimeLimitExceeded(
+                        f"workflow exceeded soft time limit "
+                        f"(soft_time_limit={cancellable.soft_time_limit}s)"
+                    )
+
             # P0 Component 1: Return tuple (results, run_id) for consistency
             # This matches LocalRuntime.execute() return structure
             return (results, run_id)
@@ -1041,6 +1093,27 @@ class AsyncLocalRuntime(LocalRuntime):
             await context.cancel_all_tasks()
             raise  # Re-raise TimeoutError
 
+        except WorkflowCancelledError as cancel_exc:
+            # #912 Shard 6: classify time-limit cancellations into the
+            # typed deadline subclass. The runtime observed our token
+            # cancelled and raised; if our timers were armed, classify.
+            context.metrics.error_count += 1
+            if cancellable is not None:
+                classified = _TimeLimitClassifier(cancellable).classify(cancel_exc)
+                if classified is not cancel_exc:
+                    raise classified from cancel_exc
+            raise
+
+        except (SoftTimeLimitExceeded, HardTimeLimitExceeded):
+            # #912 Shard 6: typed deadline exceptions MUST propagate
+            # untouched. Without this catch-and-re-raise above the
+            # broad `except Exception`, the time-limit raise would
+            # be swallowed and re-wrapped as WorkflowExecutionError —
+            # callers could not catch the typed exception that the
+            # docstring promises.
+            context.metrics.error_count += 1
+            raise
+
         except WorkflowExecutionError:
             # Re-raise WorkflowExecutionError without wrapping (includes trust verification errors)
             context.metrics.error_count += 1
@@ -1052,6 +1125,11 @@ class AsyncLocalRuntime(LocalRuntime):
             raise WorkflowExecutionError(f"Async execution failed: {e}") from e
 
         finally:
+            # #912 Shard 6: always release the asyncio timer tasks. Safe
+            # to call on the no-limits path (cancellable is None then).
+            if cancellable is not None:
+                cancellable.disarm()
+
             # CARE-017: Reset trust context token
             if trust_token is not None:
                 from kailash.runtime.trust.context import _runtime_trust_context

--- a/src/kailash/runtime/async_local.py
+++ b/src/kailash/runtime/async_local.py
@@ -1095,8 +1095,9 @@ class AsyncLocalRuntime(LocalRuntime):
 
         except WorkflowCancelledError as cancel_exc:
             # #912 Shard 6: classify time-limit cancellations into the
-            # typed deadline subclass. The runtime observed our token
-            # cancelled and raised; if our timers were armed, classify.
+            # subclass that names the deadline. The runtime observed
+            # our token cancelled and raised; if our timers were armed,
+            # classify.
             context.metrics.error_count += 1
             if cancellable is not None:
                 classified = _TimeLimitClassifier(cancellable).classify(cancel_exc)

--- a/src/kailash/runtime/distributed.py
+++ b/src/kailash/runtime/distributed.py
@@ -731,11 +731,16 @@ class Worker:
         default_time_limit: float | None = None,
         hard_time_limit_grace_seconds: float = 1.0,
     ):
-        # #912 Shard 4: validate Worker-default time limits at construction so
-        # bad configuration surfaces here, NOT later from a timer thread on
-        # the first dequeue. Reuses the Shard 1 validator so the contract
-        # stays single-sourced (per security.md § Multi-Site Kwarg Plumbing).
-        _validate_limits(default_soft_time_limit, default_time_limit)
+        # #912 Shard 4 + Shard 6: validate Worker-default time limits AND
+        # the grace_seconds at construction so bad configuration surfaces
+        # here, NOT later from a timer thread on the first dequeue.
+        # Reuses the Shard 1 validator so the contract stays single-
+        # sourced (per security.md § Multi-Site Kwarg Plumbing).
+        _validate_limits(
+            default_soft_time_limit,
+            default_time_limit,
+            grace_seconds=hard_time_limit_grace_seconds,
+        )
 
         self._redis_url = redis_url or os.environ.get("KAILASH_REDIS_URL", "")
         self._queue = queue or TaskQueue(redis_url=self._redis_url)
@@ -874,6 +879,80 @@ class Worker:
         name = wf_data.get("name")
         return name if isinstance(name, str) and name else None
 
+    @staticmethod
+    def _validate_execution_limits_dict(
+        d: Optional[Any],
+    ) -> Optional[Dict[str, float]]:
+        """Validate the shape + content of ``TaskMessage.execution_limits``.
+
+        Per #912 Shard 6 security finding F2: a malicious producer can
+        send arbitrary shapes (``{"soft": "DROP TABLE"}`` /
+        ``{"hard": -1}`` / ``{"soft": [1, 2, 3]}``) on the wire. Without
+        validation at dequeue, the bad value flows to ``arm_time_limits``
+        and surfaces as a TypeError / ValueError from a daemon timer
+        thread — far from the entry point, with no actionable traceback.
+
+        Validation rules (all enforced):
+
+        * ``None`` → return ``None`` (no per-task override; worker
+          defaults will apply).
+        * Non-dict → raise ``ValueError`` with the actual type so the
+          operator can grep the dead-letter for the offending shape.
+        * Unknown keys outside ``{"soft", "hard"}`` → silently ignored
+          (forward-compat with future fields). Keys are NOT raised on
+          to keep the wire format additive.
+        * ``"soft"`` / ``"hard"`` values: MUST be ``int`` or ``float``
+          (NOT ``bool`` — Python's ``bool`` is a subclass of ``int``
+          but a True/False time limit is nonsense). Non-numeric values
+          (``str``, ``list``, ``dict``) raise ``ValueError``.
+        * Numeric values: forwarded to ``_validate_limits`` so the
+          finite-check + ``> 0`` + ``soft < hard`` invariants apply
+          identically to the in-process path.
+
+        Returns:
+            The validated dict (with only ``soft`` / ``hard`` keys), or
+            ``None`` when the input was ``None``.
+
+        Raises:
+            ValueError: If the dict shape, key types, or numeric values
+                violate the contract. Message names the offending field
+                so dead-letter triage can grep the wire payload.
+        """
+        if d is None:
+            return None
+        if not isinstance(d, dict):
+            raise ValueError(
+                f"TaskMessage.execution_limits MUST be dict or None, "
+                f"got {type(d).__name__!r}: {d!r}"
+            )
+        validated: Dict[str, float] = {}
+        for key in ("soft", "hard"):
+            if key not in d:
+                continue
+            value = d[key]
+            # bool is a subclass of int; explicitly reject because
+            # `True` would round-trip through validation as 1.0 second
+            # which is nonsense for a time-limit semantics.
+            if isinstance(value, bool):
+                raise ValueError(
+                    f"TaskMessage.execution_limits[{key!r}] MUST be "
+                    f"numeric (int / float), got bool: {value!r}"
+                )
+            if not isinstance(value, (int, float)):
+                raise ValueError(
+                    f"TaskMessage.execution_limits[{key!r}] MUST be "
+                    f"numeric (int / float), got {type(value).__name__!r}: "
+                    f"{value!r}"
+                )
+            validated[key] = float(value)
+        # Run through the canonical validator so finite-check +
+        # `> 0` + `soft < hard` apply identically to in-process path.
+        _validate_limits(
+            validated.get("soft"),
+            validated.get("hard"),
+        )
+        return validated
+
     def _effective_time_limits(
         self, task: TaskMessage
     ) -> Tuple[Optional[float], Optional[float]]:
@@ -883,11 +962,20 @@ class Worker:
         ``TaskMessage.execution_limits``) wins over ``Worker(default_*)``;
         falls through to ``None`` (no limit) when neither is set.
 
+        Per #912 Shard 6 security finding F2: validate the per-task
+        dict at dequeue so a malicious producer cannot smuggle bad
+        shapes into the timer-arm code path.
+
         Returns:
             ``(effective_soft, effective_hard)`` — either may be ``None``
             when neither the per-task dict nor the Worker default sets it.
+
+        Raises:
+            ValueError: If the per-task ``execution_limits`` dict has a
+                bad shape or non-finite / non-positive values.
         """
-        per_task = task.execution_limits or {}
+        validated = self._validate_execution_limits_dict(task.execution_limits)
+        per_task = validated or {}
         soft = per_task.get("soft", self._default_soft_time_limit)
         hard = per_task.get("hard", self._default_time_limit)
         return soft, hard

--- a/src/kailash/runtime/docker.py
+++ b/src/kailash/runtime/docker.py
@@ -24,7 +24,15 @@ from pathlib import Path
 from typing import Any
 
 from kailash.nodes.base import Node
-from kailash.runtime._time_limits import _validate_limits
+from kailash.runtime._time_limits import (
+    _validate_limits,
+    arm_time_limits,
+)
+from kailash.runtime.cancellation import CancellationToken
+from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
+    SoftTimeLimitExceeded,
+)
 
 # BaseRuntime doesn't exist - we'll implement task tracking methods directly
 from kailash.sdk_exceptions import NodeConfigurationError, NodeExecutionError
@@ -592,6 +600,27 @@ class DockerRuntime:
         # #912 Shard 1: validate typed time-limit kwargs at the entry point.
         _validate_limits(soft_time_limit, time_limit)
 
+        # #912 Shard 6: arm threading.Timer-based deadlines around the
+        # per-node container-execution loop. Docker exec is out-of-
+        # process — the timers cannot inject into a running `docker run`
+        # subprocess — so the practical contract is: between nodes, we
+        # check the cancellation token + hard-deadline flag and raise.
+        # Long-running single-node Docker workflows do NOT get
+        # interrupted mid-container; that's an inherent constraint of
+        # the out-of-process model and is documented on the kwarg
+        # docstring above. Multi-node Docker workflows DO get the
+        # full deadline contract per-node-boundary.
+        _has_time_limit = soft_time_limit is not None or time_limit is not None
+        cancellable = None
+        _attempt_token: CancellationToken | None = None
+        if _has_time_limit:
+            _attempt_token = CancellationToken()
+            cancellable = arm_time_limits(
+                _attempt_token,
+                soft_time_limit=soft_time_limit,
+                time_limit=time_limit,
+            )
+
         # Create task run
         run_id = self._create_task_run(workflow)
 
@@ -600,94 +629,141 @@ class DockerRuntime:
         node_resource_limits = node_resource_limits or {}
 
         try:
-            # Validate workflow
-            workflow.validate(runtime_parameters=inputs)
+            try:
+                # Validate workflow
+                workflow.validate(runtime_parameters=inputs)
 
-            # Get execution order
-            execution_order = workflow.get_execution_order()
+                # Get execution order
+                execution_order = workflow.get_execution_order()
 
-            # Track results
-            results = {}
+                # Track results
+                results = {}
 
-            # Prepare all node wrappers and build images
-            logger.info("Preparing Docker containers for workflow execution")
-            for node_id, node in workflow.nodes.items():
-                self.node_wrappers[node_id] = DockerNodeWrapper(
-                    node=node,
-                    node_id=node_id,
-                    base_image=self.base_image,
-                    work_dir=self.work_dir / node_id,
-                    sdk_path=self.sdk_path,
-                )
-
-                # Build image
-                self.node_wrappers[node_id].build_image()
-
-            # Execute nodes in order
-            logger.info(f"Executing workflow in order: {execution_order}")
-            for node_id in execution_order:
-                logger.info(f"Executing node: {node_id}")
-
-                # Get node wrapper
-                wrapper = self.node_wrappers[node_id]
-
-                # Update task status
-                self._update_task_status(run_id, node_id, "running")
-
-                # Get node inputs
-                node_inputs = inputs.get(node_id, {}).copy()
-
-                # Add inputs from upstream nodes
-                _conn_map = getattr(workflow.connections, "get", lambda *a: {})(
-                    node_id, {}
-                )
-                for upstream_id, mapping in (
-                    _conn_map.items() if isinstance(_conn_map, dict) else []
-                ):
-                    if upstream_id in results:
-                        for dest_param, src_param in mapping.items():
-                            if src_param in results[upstream_id]:
-                                node_inputs[dest_param] = results[upstream_id][
-                                    src_param
-                                ]
-
-                # Prepare inputs
-                wrapper.prepare_inputs(node_inputs)
-
-                # Get resource limits for this node
-                resource_limits = None
-                if node_id in node_resource_limits:
-                    resource_limits = node_resource_limits[node_id]
-                elif self.resource_limits:
-                    resource_limits = self.resource_limits
-
-                # Run the container
-                success = wrapper.run_container(
-                    network=self.network_name, resource_limits=resource_limits
-                )
-
-                # Get results
-                if success:
-                    results[node_id] = wrapper.get_results()
-                    self._update_task_status(
-                        run_id, node_id, "completed", results[node_id]
+                # Prepare all node wrappers and build images
+                logger.info("Preparing Docker containers for workflow execution")
+                for node_id, node in workflow.nodes.items():
+                    self.node_wrappers[node_id] = DockerNodeWrapper(
+                        node=node,
+                        node_id=node_id,
+                        base_image=self.base_image,
+                        work_dir=self.work_dir / node_id,
+                        sdk_path=self.sdk_path,
                     )
-                else:
-                    self._update_task_status(
-                        run_id, node_id, "failed", {"error": "Execution failed"}
+
+                    # Build image
+                    self.node_wrappers[node_id].build_image()
+
+                # Execute nodes in order
+                logger.info(f"Executing workflow in order: {execution_order}")
+                for node_id in execution_order:
+                    # Per-node-boundary check: did the hard timer fire
+                    # while we were running the previous container?
+                    if cancellable is not None:
+                        if cancellable.hard_deadline_reached:
+                            raise HardTimeLimitExceeded(
+                                f"workflow exceeded hard time limit "
+                                f"(time_limit={cancellable.time_limit}s + "
+                                f"grace_seconds={cancellable.grace_seconds}s)"
+                            )
+                        if (
+                            _attempt_token is not None
+                            and _attempt_token.is_cancelled
+                            and cancellable.soft_time_limit is not None
+                        ):
+                            raise SoftTimeLimitExceeded(
+                                f"workflow exceeded soft time limit "
+                                f"(soft_time_limit={cancellable.soft_time_limit}s)"
+                            )
+
+                    logger.info(f"Executing node: {node_id}")
+
+                    # Get node wrapper
+                    wrapper = self.node_wrappers[node_id]
+
+                    # Update task status
+                    self._update_task_status(run_id, node_id, "running")
+
+                    # Get node inputs
+                    node_inputs = inputs.get(node_id, {}).copy()
+
+                    # Add inputs from upstream nodes
+                    _conn_map = getattr(workflow.connections, "get", lambda *a: {})(
+                        node_id, {}
                     )
-                    raise NodeExecutionError(f"Node {node_id} execution failed")
+                    for upstream_id, mapping in (
+                        _conn_map.items() if isinstance(_conn_map, dict) else []
+                    ):
+                        if upstream_id in results:
+                            for dest_param, src_param in mapping.items():
+                                if src_param in results[upstream_id]:
+                                    node_inputs[dest_param] = results[upstream_id][
+                                        src_param
+                                    ]
 
-            # Mark run as completed
-            self._complete_task_run(run_id, "completed")
+                    # Prepare inputs
+                    wrapper.prepare_inputs(node_inputs)
 
-            return results, run_id
+                    # Get resource limits for this node
+                    resource_limits = None
+                    if node_id in node_resource_limits:
+                        resource_limits = node_resource_limits[node_id]
+                    elif self.resource_limits:
+                        resource_limits = self.resource_limits
 
-        except Exception as e:
-            # Handle errors
-            logger.error(f"Workflow execution failed: {e}")
-            self._complete_task_run(run_id, "failed", {"error": str(e)})
-            raise
+                    # Run the container
+                    success = wrapper.run_container(
+                        network=self.network_name, resource_limits=resource_limits
+                    )
+
+                    # Get results
+                    if success:
+                        results[node_id] = wrapper.get_results()
+                        self._update_task_status(
+                            run_id, node_id, "completed", results[node_id]
+                        )
+                    else:
+                        self._update_task_status(
+                            run_id, node_id, "failed", {"error": "Execution failed"}
+                        )
+                        raise NodeExecutionError(f"Node {node_id} execution failed")
+
+                # Final post-completion poll (Shard 2 invariant 5).
+                if cancellable is not None:
+                    if cancellable.hard_deadline_reached:
+                        raise HardTimeLimitExceeded(
+                            f"workflow exceeded hard time limit "
+                            f"(time_limit={cancellable.time_limit}s + "
+                            f"grace_seconds={cancellable.grace_seconds}s)"
+                        )
+                    if (
+                        _attempt_token is not None
+                        and _attempt_token.is_cancelled
+                        and cancellable.soft_time_limit is not None
+                    ):
+                        raise SoftTimeLimitExceeded(
+                            f"workflow exceeded soft time limit "
+                            f"(soft_time_limit={cancellable.soft_time_limit}s)"
+                        )
+
+                # Mark run as completed
+                self._complete_task_run(run_id, "completed")
+
+                return results, run_id
+
+            except (SoftTimeLimitExceeded, HardTimeLimitExceeded):
+                # Typed deadline exceptions MUST propagate untouched.
+                self._complete_task_run(
+                    run_id, "failed", {"error": "Time limit exceeded"}
+                )
+                raise
+            except Exception as e:
+                # Handle errors
+                logger.error(f"Workflow execution failed: {e}")
+                self._complete_task_run(run_id, "failed", {"error": str(e)})
+                raise
+        finally:
+            if cancellable is not None:
+                cancellable.disarm()
 
     def cleanup(self):
         """Clean up Docker resources."""

--- a/src/kailash/runtime/docker.py
+++ b/src/kailash/runtime/docker.py
@@ -24,18 +24,16 @@ from pathlib import Path
 from typing import Any
 
 from kailash.nodes.base import Node
-from kailash.runtime._time_limits import (
-    _validate_limits,
-    arm_time_limits,
-)
+from kailash.runtime._time_limits import _validate_limits, arm_time_limits
 from kailash.runtime.cancellation import CancellationToken
-from kailash.sdk_exceptions import (
-    HardTimeLimitExceeded,
-    SoftTimeLimitExceeded,
-)
 
 # BaseRuntime doesn't exist - we'll implement task tracking methods directly
-from kailash.sdk_exceptions import NodeConfigurationError, NodeExecutionError
+from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
+    NodeConfigurationError,
+    NodeExecutionError,
+    SoftTimeLimitExceeded,
+)
 from kailash.tracking.manager import TaskManager
 from kailash.workflow.graph import Workflow
 

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -53,7 +53,11 @@ if TYPE_CHECKING:
     from kailash.runtime.shutdown import ShutdownCoordinator
 
 from kailash.nodes import Node
-from kailash.runtime._time_limits import _validate_limits
+from kailash.runtime._time_limits import (
+    _TimeLimitClassifier,
+    _validate_limits,
+    arm_time_limits,
+)
 from kailash.runtime.base import BaseRuntime
 from kailash.runtime.cancellation import CancellationToken
 from kailash.runtime.compatibility_reporter import CompatibilityReporter
@@ -93,7 +97,9 @@ from kailash.runtime.validation.error_categorizer import ErrorCategorizer
 from kailash.runtime.validation.metrics import get_metrics_collector
 from kailash.runtime.validation.suggestion_engine import ValidationSuggestionEngine
 from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
     RuntimeExecutionError,
+    SoftTimeLimitExceeded,
     WorkflowCancelledError,
     WorkflowExecutionError,
     WorkflowValidationError,
@@ -1050,8 +1056,8 @@ class LocalRuntime(
             - execute_async(): Async variant
         """
         # Validate the typed time-limit kwargs at the entry point so caller
-        # bugs (negative values, soft >= hard) raise loudly here, not later
-        # from a timer thread (per #912 Shard 1; enforcement lands Shard 2).
+        # bugs (negative values, soft >= hard, NaN/Inf) raise loudly here,
+        # not later from a timer thread (per #912 Shard 1 + Shard 6).
         _validate_limits(soft_time_limit, time_limit)
 
         # Emit deprecation warning for non-context-managed usage.
@@ -1082,81 +1088,159 @@ class LocalRuntime(
             "force_resume_with_drift": force_resume_with_drift,
         }
 
+        # #912 Shard 6: arm threading.Timer-based deadlines around the
+        # in-process execution path. Mirrors the scheduler.py pattern:
+        #
+        # 1. When at least one limit is set, layer a FRESH cancellation
+        #    token under our control over whatever the user passed; the
+        #    soft timer cancels our token, the runtime's per-node poll
+        #    observes it and raises WorkflowCancelledError, the classifier
+        #    converts that to SoftTimeLimitExceeded / HardTimeLimitExceeded.
+        # 2. The hard-deadline flag is checked in `finally` so even a
+        #    workflow that ran to completion AFTER the deadline fired
+        #    raises HardTimeLimitExceeded (Shard 2 invariant 5).
+        # 3. The no-limits path stays allocation-free — no token wrap,
+        #    no timer arm, no try/except classifier overhead.
+        _has_time_limit = soft_time_limit is not None or time_limit is not None
+        _attempt_token: CancellationToken | None
+        cancellable = None
+        if _has_time_limit:
+            # Use a NEW token so the timers don't poison the user's token.
+            # The user's token is honored only when no limits are armed
+            # (the scheduler.py:1145-1184 pattern; the docstring of every
+            # runtime.execute() makes the trade-off explicit).
+            _attempt_token = CancellationToken()
+            cancellable = arm_time_limits(
+                _attempt_token,
+                soft_time_limit=soft_time_limit,
+                time_limit=time_limit,
+            )
+        else:
+            _attempt_token = cancellation_token
+
         try:
             try:
-                # Check if we're already in an event loop
-                loop = asyncio.get_running_loop()
-                # If we're in an event loop, run synchronously instead
-                if effective_trust_ctx is not None:
-                    from kailash.runtime.trust.context import runtime_trust_context
+                try:
+                    # Check if we're already in an event loop
+                    loop = asyncio.get_running_loop()
+                    # If we're in an event loop, run synchronously instead
+                    if effective_trust_ctx is not None:
+                        from kailash.runtime.trust.context import (
+                            runtime_trust_context,
+                        )
 
-                    with runtime_trust_context(effective_trust_ctx):
-                        return self._execute_sync(
+                        with runtime_trust_context(effective_trust_ctx):
+                            results = self._execute_sync(
+                                workflow=workflow,
+                                task_manager=task_manager,
+                                parameters=parameters,
+                                cancellation_token=_attempt_token,
+                                search_attributes=search_attributes,
+                                **durable_kwargs,
+                            )
+                    else:
+                        results = self._execute_sync(
                             workflow=workflow,
                             task_manager=task_manager,
                             parameters=parameters,
-                            cancellation_token=cancellation_token,
+                            cancellation_token=_attempt_token,
                             search_attributes=search_attributes,
                             **durable_kwargs,
                         )
-                else:
-                    return self._execute_sync(
-                        workflow=workflow,
-                        task_manager=task_manager,
-                        parameters=parameters,
-                        cancellation_token=cancellation_token,
-                        search_attributes=search_attributes,
-                        **durable_kwargs,
-                    )
-            except RuntimeError:
-                # No event loop running, use persistent loop
-                loop = self._ensure_event_loop()
+                except RuntimeError:
+                    # No event loop running, use persistent loop
+                    loop = self._ensure_event_loop()
 
-                # CARE-017: Verify workflow trust before execution (async path)
-                if effective_trust_ctx is not None:
-                    from kailash.runtime.trust.context import (
-                        TrustVerificationMode,
-                        runtime_trust_context,
-                    )
-
-                    # Run verification before execution if verifier is configured
-                    if (
-                        self._trust_verification_mode != TrustVerificationMode.DISABLED
-                        and self._trust_verifier is not None
-                    ):
-                        allowed = loop.run_until_complete(
-                            self._verify_workflow_trust(workflow, effective_trust_ctx)
+                    # CARE-017: Verify workflow trust before execution (async path)
+                    if effective_trust_ctx is not None:
+                        from kailash.runtime.trust.context import (
+                            TrustVerificationMode,
+                            runtime_trust_context,
                         )
-                        if not allowed:
-                            raise WorkflowExecutionError(
-                                "Trust verification denied workflow execution"
-                            )
 
-                    # Run the async execution in the persistent loop with trust context
-                    with runtime_trust_context(effective_trust_ctx):
-                        return loop.run_until_complete(
+                        # Run verification before execution if verifier is configured
+                        if (
+                            self._trust_verification_mode
+                            != TrustVerificationMode.DISABLED
+                            and self._trust_verifier is not None
+                        ):
+                            allowed = loop.run_until_complete(
+                                self._verify_workflow_trust(
+                                    workflow, effective_trust_ctx
+                                )
+                            )
+                            if not allowed:
+                                raise WorkflowExecutionError(
+                                    "Trust verification denied workflow execution"
+                                )
+
+                        # Run the async execution in the persistent loop with trust context
+                        with runtime_trust_context(effective_trust_ctx):
+                            results = loop.run_until_complete(
+                                self._execute_async(
+                                    workflow=workflow,
+                                    task_manager=task_manager,
+                                    parameters=parameters,
+                                    cancellation_token=_attempt_token,
+                                    search_attributes=search_attributes,
+                                    **durable_kwargs,
+                                )
+                            )
+                    else:
+                        # Run the async execution in the persistent loop
+                        results = loop.run_until_complete(
                             self._execute_async(
                                 workflow=workflow,
                                 task_manager=task_manager,
                                 parameters=parameters,
-                                cancellation_token=cancellation_token,
+                                cancellation_token=_attempt_token,
                                 search_attributes=search_attributes,
                                 **durable_kwargs,
                             )
                         )
-                else:
-                    # Run the async execution in the persistent loop
-                    return loop.run_until_complete(
-                        self._execute_async(
-                            workflow=workflow,
-                            task_manager=task_manager,
-                            parameters=parameters,
-                            cancellation_token=cancellation_token,
-                            search_attributes=search_attributes,
-                            **durable_kwargs,
-                        )
+            except WorkflowCancelledError as exc:
+                # The runtime observed the cancelled token and raised.
+                # When time-limit timers were armed, classify into the
+                # typed deadline subclass; otherwise it's a user-driven
+                # cancellation and propagates as-is.
+                if cancellable is not None:
+                    classified = _TimeLimitClassifier(cancellable).classify(exc)
+                    if classified is not exc:
+                        raise classified from exc
+                raise
+
+            # Post-completion poll for hard-deadline-fired-after-success
+            # (Shard 2 invariant 5). Even when the workflow returned
+            # cleanly, the timer may have fired between the runtime's
+            # last poll and our return — the hard kill is non-negotiable.
+            if cancellable is not None:
+                if cancellable.hard_deadline_reached:
+                    raise HardTimeLimitExceeded(
+                        f"workflow exceeded hard time limit "
+                        f"(time_limit={cancellable.time_limit}s + "
+                        f"grace_seconds={cancellable.grace_seconds}s)"
                     )
+                # Soft fired but workflow ran to completion without a
+                # poll between nodes (single-node workflow whose body
+                # blocks past the soft deadline). Promote so callers
+                # observe the celery-style soft signal.
+                if (
+                    _attempt_token is not None
+                    and _attempt_token.is_cancelled
+                    and cancellable.soft_time_limit is not None
+                ):
+                    raise SoftTimeLimitExceeded(
+                        f"workflow exceeded soft time limit "
+                        f"(soft_time_limit={cancellable.soft_time_limit}s)"
+                    )
+
+            return results
         finally:
+            # Always release the timers AND clear the credential store —
+            # the timer cancel is idempotent so the disarm is safe even
+            # on the no-limits path (cancellable is None then).
+            if cancellable is not None:
+                cancellable.disarm()
             # BYOK hardening: clear credential store after execution completes
             from kailash.workflow.credentials import get_credential_store
 

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -1125,9 +1125,7 @@ class LocalRuntime(
                     loop = asyncio.get_running_loop()
                     # If we're in an event loop, run synchronously instead
                     if effective_trust_ctx is not None:
-                        from kailash.runtime.trust.context import (
-                            runtime_trust_context,
-                        )
+                        from kailash.runtime.trust.context import runtime_trust_context
 
                         with runtime_trust_context(effective_trust_ctx):
                             results = self._execute_sync(
@@ -1201,8 +1199,8 @@ class LocalRuntime(
             except WorkflowCancelledError as exc:
                 # The runtime observed the cancelled token and raised.
                 # When time-limit timers were armed, classify into the
-                # typed deadline subclass; otherwise it's a user-driven
-                # cancellation and propagates as-is.
+                # subclass that names the deadline; otherwise it's a
+                # user-driven cancellation and propagates as-is.
                 if cancellable is not None:
                     classified = _TimeLimitClassifier(cancellable).classify(exc)
                     if classified is not exc:

--- a/src/kailash/runtime/parallel.py
+++ b/src/kailash/runtime/parallel.py
@@ -12,9 +12,17 @@ from datetime import UTC, datetime
 from typing import Any
 
 from kailash.nodes.base_async import AsyncNode
-from kailash.runtime._time_limits import _validate_limits
+from kailash.runtime._time_limits import (
+    _TimeLimitClassifier,
+    _validate_limits,
+    arm_time_limits_async,
+)
+from kailash.runtime.cancellation import CancellationToken
 from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
     RuntimeExecutionError,
+    SoftTimeLimitExceeded,
+    WorkflowCancelledError,
     WorkflowExecutionError,
     WorkflowValidationError,
 )
@@ -102,70 +110,130 @@ class ParallelRuntime:
         run_id = None
         start_time = time.time()
 
-        try:
-            # Validate workflow
-            workflow.validate(runtime_parameters=parameters)
-
-            # Initialize semaphore for concurrent execution control
-            self.semaphore = asyncio.Semaphore(self.max_workers)
-
-            # Initialize tracking
-            if task_manager:
-                try:
-                    run_id = task_manager.create_run(
-                        workflow_name=workflow.name,
-                        metadata={
-                            "parameters": parameters,
-                            "debug": self.debug,
-                            "runtime": "parallel",
-                            "max_workers": self.max_workers,
-                        },
-                    )
-                except Exception as e:
-                    self.logger.warning(f"Failed to create task run: {e}")
-                    # Continue without tracking
-
-            # Execute workflow with parallel node execution
-            results = await self._execute_workflow_parallel(
-                workflow=workflow,
-                task_manager=task_manager,
-                run_id=run_id,
-                parameters=parameters or {},
+        # #912 Shard 6: arm asyncio-task-based deadlines around the
+        # parallel execution path (mirrors the AsyncLocalRuntime
+        # wiring). When at least one limit is set, we layer a fresh
+        # cancellation token; the soft timer cancels it; the post-
+        # completion poll raises the typed deadline exception per
+        # Shard 2 invariant 5.
+        _has_time_limit = soft_time_limit is not None or time_limit is not None
+        cancellable = None
+        _attempt_token: CancellationToken | None = None
+        if _has_time_limit:
+            _attempt_token = CancellationToken()
+            cancellable = arm_time_limits_async(
+                _attempt_token,
+                soft_time_limit=soft_time_limit,
+                time_limit=time_limit,
             )
 
-            # Mark run as completed
-            if task_manager and run_id:
-                try:
-                    end_time = time.time()
-                    execution_time = end_time - start_time
-                    task_manager.update_run_status(run_id, "completed")
-                except Exception as e:
-                    self.logger.warning(f"Failed to update run status: {e}")
+        try:
+            try:
+                # Validate workflow
+                workflow.validate(runtime_parameters=parameters)
 
-            return results, run_id
+                # Initialize semaphore for concurrent execution control
+                self.semaphore = asyncio.Semaphore(self.max_workers)
 
-        except WorkflowValidationError:
-            # Re-raise validation errors as-is
-            if task_manager and run_id:
-                try:
-                    task_manager.update_run_status(
-                        run_id, "failed", error="Validation failed"
-                    )
-                except Exception:
-                    pass
-            raise
-        except Exception as e:
-            # Mark run as failed
-            if task_manager and run_id:
-                try:
-                    task_manager.update_run_status(run_id, "failed", error=str(e))
-                except Exception:
-                    pass
+                # Initialize tracking
+                if task_manager:
+                    try:
+                        run_id = task_manager.create_run(
+                            workflow_name=workflow.name,
+                            metadata={
+                                "parameters": parameters,
+                                "debug": self.debug,
+                                "runtime": "parallel",
+                                "max_workers": self.max_workers,
+                            },
+                        )
+                    except Exception as e:
+                        self.logger.warning(f"Failed to create task run: {e}")
+                        # Continue without tracking
 
-            # Wrap other errors in RuntimeExecutionError
-            raise RuntimeExecutionError(
-                f"Parallel workflow execution failed: {type(e).__name__}: {e}"
-            ) from e
+                # Execute workflow with parallel node execution
+                results = await self._execute_workflow_parallel(
+                    workflow=workflow,
+                    task_manager=task_manager,
+                    run_id=run_id,
+                    parameters=parameters or {},
+                )
+
+                # Mark run as completed
+                if task_manager and run_id:
+                    try:
+                        end_time = time.time()
+                        execution_time = end_time - start_time
+                        task_manager.update_run_status(run_id, "completed")
+                    except Exception as e:
+                        self.logger.warning(f"Failed to update run status: {e}")
+
+                # #912 Shard 6: post-completion poll for hard-deadline-
+                # fired-after-success / soft-fired-but-completed.
+                if cancellable is not None:
+                    if cancellable.hard_deadline_reached:
+                        raise HardTimeLimitExceeded(
+                            f"workflow exceeded hard time limit "
+                            f"(time_limit={cancellable.time_limit}s + "
+                            f"grace_seconds={cancellable.grace_seconds}s)"
+                        )
+                    if (
+                        _attempt_token is not None
+                        and _attempt_token.is_cancelled
+                        and cancellable.soft_time_limit is not None
+                    ):
+                        raise SoftTimeLimitExceeded(
+                            f"workflow exceeded soft time limit "
+                            f"(soft_time_limit={cancellable.soft_time_limit}s)"
+                        )
+
+                return results, run_id
+
+            except (SoftTimeLimitExceeded, HardTimeLimitExceeded):
+                # Typed deadline exceptions MUST propagate untouched
+                # above the broad except below.
+                if task_manager and run_id:
+                    try:
+                        task_manager.update_run_status(
+                            run_id, "failed", error="Time limit exceeded"
+                        )
+                    except Exception:
+                        pass
+                raise
+            except WorkflowCancelledError as cancel_exc:
+                # Classify token-cancellation into the typed deadline
+                # subclass when timers were armed.
+                if cancellable is not None:
+                    classified = _TimeLimitClassifier(cancellable).classify(cancel_exc)
+                    if classified is not cancel_exc:
+                        raise classified from cancel_exc
+                raise
+            except WorkflowValidationError:
+                # Re-raise validation errors as-is
+                if task_manager and run_id:
+                    try:
+                        task_manager.update_run_status(
+                            run_id, "failed", error="Validation failed"
+                        )
+                    except Exception:
+                        pass
+                raise
+            except Exception as e:
+                # Mark run as failed
+                if task_manager and run_id:
+                    try:
+                        task_manager.update_run_status(run_id, "failed", error=str(e))
+                    except Exception:
+                        pass
+
+                # Wrap other errors in RuntimeExecutionError
+                raise RuntimeExecutionError(
+                    f"Parallel workflow execution failed: {type(e).__name__}: {e}"
+                ) from e
+        finally:
+            # Always release timer tasks even on the no-limit path.
+            if cancellable is not None:
+                cancellable.disarm()
 
     async def _execute_workflow_parallel(
         self,

--- a/src/kailash/runtime/parallel_cyclic.py
+++ b/src/kailash/runtime/parallel_cyclic.py
@@ -7,9 +7,20 @@ from datetime import UTC, datetime
 from typing import Any
 
 from kailash.nodes.base import Node
-from kailash.runtime._time_limits import _validate_limits
+from kailash.runtime._time_limits import (
+    _TimeLimitClassifier,
+    _validate_limits,
+    arm_time_limits,
+)
+from kailash.runtime.cancellation import CancellationToken
 from kailash.runtime.local import LocalRuntime
-from kailash.sdk_exceptions import RuntimeExecutionError, WorkflowExecutionError
+from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
+    RuntimeExecutionError,
+    SoftTimeLimitExceeded,
+    WorkflowCancelledError,
+    WorkflowExecutionError,
+)
 from kailash.tracking import TaskManager, TaskStatus
 from kailash.tracking.metrics_collector import MetricsCollector
 from kailash.tracking.models import TaskMetrics
@@ -97,32 +108,94 @@ class ParallelCyclicRuntime:
         if not workflow:
             raise RuntimeExecutionError("No workflow provided")
 
+        # #912 Shard 6: arm threading.Timer-based deadlines around the
+        # parallel/cyclic execution path. The fallback to LocalRuntime
+        # would re-arm the same limits via its own wiring, but doing
+        # the arm here covers the parallel-DAG and cyclic paths that
+        # never reach LocalRuntime.execute. Layer a fresh cancellation
+        # token to keep timer state out of any user-supplied token.
+        _has_time_limit = soft_time_limit is not None or time_limit is not None
+        cancellable = None
+        _attempt_token: CancellationToken | None = None
+        if _has_time_limit:
+            _attempt_token = CancellationToken()
+            cancellable = arm_time_limits(
+                _attempt_token,
+                soft_time_limit=soft_time_limit,
+                time_limit=time_limit,
+            )
+
         try:
-            # Validate workflow
-            workflow.validate(runtime_parameters=parameters)
+            try:
+                # Validate workflow
+                workflow.validate(runtime_parameters=parameters)
 
-            # Check for cycles first
-            if self.enable_cycles and workflow.has_cycles():
-                self.logger.info(
-                    "Cyclic workflow detected, checking for parallel execution opportunities"
-                )
-                return self._execute_cyclic_workflow(workflow, task_manager, parameters)
+                # Check for cycles first
+                if self.enable_cycles and workflow.has_cycles():
+                    self.logger.info(
+                        "Cyclic workflow detected, checking for parallel execution opportunities"
+                    )
+                    results = self._execute_cyclic_workflow(
+                        workflow, task_manager, parameters
+                    )
+                # Check for parallel execution opportunities in DAG workflows
+                elif parallel_nodes or self._can_execute_in_parallel(workflow):
+                    self.logger.info("Parallel execution opportunities detected")
+                    results = self._execute_parallel_dag(
+                        workflow, task_manager, parameters, parallel_nodes
+                    )
+                else:
+                    # Fall back to standard local runtime. Forward typed
+                    # kwargs by name so the inner runtime's wiring also
+                    # arms its own timers (defense-in-depth — the inner
+                    # arm is still cheap and honors the same contract).
+                    self.logger.info("Using standard local runtime execution")
+                    results = self.local_runtime.execute(
+                        workflow,
+                        task_manager,
+                        parameters,
+                        soft_time_limit=soft_time_limit,
+                        time_limit=time_limit,
+                    )
 
-            # Check for parallel execution opportunities in DAG workflows
-            if parallel_nodes or self._can_execute_in_parallel(workflow):
-                self.logger.info("Parallel execution opportunities detected")
-                return self._execute_parallel_dag(
-                    workflow, task_manager, parameters, parallel_nodes
-                )
+                # Post-completion poll for hard-deadline-fired-after-success
+                # / soft-fired-but-completed.
+                if cancellable is not None:
+                    if cancellable.hard_deadline_reached:
+                        raise HardTimeLimitExceeded(
+                            f"workflow exceeded hard time limit "
+                            f"(time_limit={cancellable.time_limit}s + "
+                            f"grace_seconds={cancellable.grace_seconds}s)"
+                        )
+                    if (
+                        _attempt_token is not None
+                        and _attempt_token.is_cancelled
+                        and cancellable.soft_time_limit is not None
+                    ):
+                        raise SoftTimeLimitExceeded(
+                            f"workflow exceeded soft time limit "
+                            f"(soft_time_limit={cancellable.soft_time_limit}s)"
+                        )
 
-            # Fall back to standard local runtime
-            self.logger.info("Using standard local runtime execution")
-            return self.local_runtime.execute(workflow, task_manager, parameters)
+                return results
 
-        except Exception as e:
-            raise RuntimeExecutionError(
-                f"Parallel runtime execution failed: {e}"
-            ) from e
+            except (SoftTimeLimitExceeded, HardTimeLimitExceeded):
+                # Typed deadline exceptions MUST propagate untouched
+                # above the broad except below.
+                raise
+            except WorkflowCancelledError as cancel_exc:
+                if cancellable is not None:
+                    classified = _TimeLimitClassifier(cancellable).classify(cancel_exc)
+                    if classified is not cancel_exc:
+                        raise classified from cancel_exc
+                raise
+            except Exception as e:
+                raise RuntimeExecutionError(
+                    f"Parallel runtime execution failed: {e}"
+                ) from e
+        finally:
+            if cancellable is not None:
+                cancellable.disarm()
 
     def _execute_cyclic_workflow(
         self,

--- a/tests/integration/runtime/test_async_local_runtime_time_limits.py
+++ b/tests/integration/runtime/test_async_local_runtime_time_limits.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 wiring tests for #912 Shard 6 — AsyncLocalRuntime in-process time-limit enforcement.
+
+Per ``rules/testing.md`` Tier 2 contract: NO mocking, real
+AsyncLocalRuntime, real workflow execution against in-process infra.
+
+The /redteam Round 1 audit caught that AsyncLocalRuntime accepted
+``soft_time_limit`` / ``time_limit`` kwargs but never armed
+``arm_time_limits_async`` — only ``_validate_limits`` ran, then the
+kwargs were dropped. The Time-Limit Example docstring promised the
+enforcement; the code did not deliver. Same fake-dispatch failure mode
+as ``zero-tolerance.md`` Rule 2 § "Fake dispatch".
+
+This test suite verifies the wiring END-TO-END through the public
+``AsyncLocalRuntime.execute_workflow_async()`` API:
+
+* Soft / hard time limits actually fire against a sleeping workflow.
+* No-limit path completes normally.
+* Validation errors raise at the entry point with typed ``ValueError``.
+
+Tests use a single-node ``PythonCodeNode`` workflow with
+``asyncio.sleep`` so the asyncio timer task can interrupt cleanly on
+the same event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from kailash.runtime.async_local import AsyncLocalRuntime
+from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
+    SoftTimeLimitExceeded,
+)
+from kailash.workflow.builder import WorkflowBuilder
+
+
+def _async_sleeping_workflow(sleep_seconds: float):
+    """Build a 1-node workflow whose body blocks for ``sleep_seconds``.
+
+    Uses blocking ``time.sleep`` to mirror real CPU-bound or
+    third-party-blocking workloads. The asyncio timer fires its flag
+    on the event loop; the post-completion poll converts the flag
+    into the typed exception even when the workflow body completes.
+    """
+    builder = WorkflowBuilder()
+    builder.add_node(
+        "PythonCodeNode",
+        "sleeper",
+        {"code": f"import time as _t; _t.sleep({sleep_seconds!r}); result = 'done'"},
+    )
+    return builder.build()
+
+
+def _instant_workflow():
+    """Build a 1-node workflow that returns immediately."""
+    builder = WorkflowBuilder()
+    builder.add_node(
+        "PythonCodeNode",
+        "instant",
+        {"code": "result = 42"},
+    )
+    return builder.build()
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end enforcement — soft + hard time limits actually fire
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_local_runtime_soft_time_limit_raises_on_sleeping_workflow():
+    """``soft_time_limit`` MUST raise typed deadline exception on sleeping workflow.
+
+    The timer's asyncio task fires on the same event loop; the
+    post-completion poll converts the flag into the typed exception
+    even when the blocking node completes naturally.
+    """
+    runtime = AsyncLocalRuntime()
+    workflow = _async_sleeping_workflow(sleep_seconds=2.0)
+
+    start = time.monotonic()
+    with pytest.raises((SoftTimeLimitExceeded, HardTimeLimitExceeded)) as exc_info:
+        await runtime.execute_workflow_async(
+            workflow, inputs={}, soft_time_limit=0.5, time_limit=1.0
+        )
+    elapsed = time.monotonic() - start
+
+    assert exc_info.type in (SoftTimeLimitExceeded, HardTimeLimitExceeded)
+    # Bound elapsed below 4s so we know we didn't hang.
+    assert elapsed < 4.0, (
+        f"raise MUST happen by post-completion poll, not hang; "
+        f"elapsed={elapsed:.2f}s, exc={type(exc_info.value).__name__}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_local_runtime_hard_time_limit_raises_after_grace():
+    """``time_limit`` MUST raise HardTimeLimitExceeded after time_limit + grace."""
+    runtime = AsyncLocalRuntime()
+    workflow = _async_sleeping_workflow(sleep_seconds=2.0)
+
+    start = time.monotonic()
+    with pytest.raises(HardTimeLimitExceeded):
+        await runtime.execute_workflow_async(workflow, inputs={}, time_limit=0.5)
+    elapsed = time.monotonic() - start
+
+    # Hard kill at 0.5s + 1.0s grace = ~1.5s; workflow completes at 2s.
+    assert (
+        elapsed < 4.0
+    ), f"hard kill MUST raise by post-completion poll; elapsed={elapsed:.2f}s"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_local_runtime_no_limits_passes_through():
+    """``execute_workflow_async()`` without limits — no false fire."""
+    runtime = AsyncLocalRuntime()
+    workflow = _instant_workflow()
+
+    results, run_id = await runtime.execute_workflow_async(workflow, inputs={})
+
+    assert results is not None
+    assert "instant" in results
+
+
+# --------------------------------------------------------------------------- #
+# Entry-point validation (Shard 6 finite-check + grace_seconds hardening)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_local_runtime_validation_rejects_negative_soft():
+    """``execute_workflow_async(soft_time_limit=-1)`` raises ValueError at entry."""
+    runtime = AsyncLocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="soft_time_limit"):
+        await runtime.execute_workflow_async(workflow, inputs={}, soft_time_limit=-1)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_local_runtime_validation_rejects_nan_soft():
+    """``execute_workflow_async(soft_time_limit=NaN)`` raises ValueError (Shard 6 F1)."""
+    runtime = AsyncLocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="finite"):
+        await runtime.execute_workflow_async(
+            workflow, inputs={}, soft_time_limit=float("nan")
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_local_runtime_validation_rejects_inf_hard():
+    """``execute_workflow_async(time_limit=Inf)`` raises ValueError (Shard 6 F1)."""
+    runtime = AsyncLocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="finite"):
+        await runtime.execute_workflow_async(
+            workflow, inputs={}, time_limit=float("inf")
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_local_runtime_validation_rejects_soft_geq_hard():
+    """``execute_workflow_async(soft=5, hard=5)`` raises ValueError."""
+    runtime = AsyncLocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="strictly less"):
+        await runtime.execute_workflow_async(
+            workflow, inputs={}, soft_time_limit=5.0, time_limit=5.0
+        )

--- a/tests/integration/runtime/test_async_local_runtime_time_limits.py
+++ b/tests/integration/runtime/test_async_local_runtime_time_limits.py
@@ -32,10 +32,7 @@ import time
 import pytest
 
 from kailash.runtime.async_local import AsyncLocalRuntime
-from kailash.sdk_exceptions import (
-    HardTimeLimitExceeded,
-    SoftTimeLimitExceeded,
-)
+from kailash.sdk_exceptions import HardTimeLimitExceeded, SoftTimeLimitExceeded
 from kailash.workflow.builder import WorkflowBuilder
 
 

--- a/tests/integration/runtime/test_distributed_time_limits.py
+++ b/tests/integration/runtime/test_distributed_time_limits.py
@@ -712,3 +712,229 @@ async def test_worker_default_validation_rejects_invalid(_flush_redis):
             default_soft_time_limit=10.0,
             default_time_limit=5.0,
         )
+
+
+# --------------------------------------------------------------------------- #
+# Shard 6 — Worker dequeue-side execution_limits validation (security F2 + F3)
+#
+# These tests do NOT need Redis — they exercise _validate_execution_limits_dict
+# and Worker.__init__ validation directly. The producer-side enqueue path
+# accepts typed kwargs and validates them; the dequeue-side path receives an
+# arbitrary dict from the wire (a malicious or mis-coded producer can send
+# arbitrary shapes) and MUST validate before reaching arm_time_limits.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+def test_worker_rejects_non_dict_execution_limits():
+    """Non-dict execution_limits raises ValueError with actionable message.
+
+    Security finding F2: a malicious producer can send
+    ``execution_limits = "not-a-dict"`` on the wire. Without
+    validation, the bad value flows to arm_time_limits and raises
+    AttributeError from a daemon thread.
+    """
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(redis_url=REDIS_URL)
+    bad_task = TaskMessage(
+        task_id="bad-shape-1",
+        execution_limits="not-a-dict",  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match="MUST be dict or None"):
+        worker._effective_time_limits(bad_task)
+
+
+@pytest.mark.integration
+def test_worker_rejects_negative_execution_limits():
+    """Negative execution_limits values raise ValueError at dequeue."""
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(redis_url=REDIS_URL)
+    bad_task = TaskMessage(
+        task_id="bad-neg-1",
+        execution_limits={"soft": -1.0, "hard": 1.0},
+    )
+
+    with pytest.raises(ValueError, match="soft_time_limit"):
+        worker._effective_time_limits(bad_task)
+
+
+@pytest.mark.integration
+def test_worker_rejects_non_numeric_execution_limits_value():
+    """Non-numeric execution_limits values raise ValueError at dequeue.
+
+    Security finding F2: a malicious producer can send
+    ``{"soft": "DROP TABLE", "hard": 1}`` on the wire. Without
+    validation, the string flows to arm_time_limits where it raises
+    a TypeError on the threading.Timer() call.
+    """
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(redis_url=REDIS_URL)
+    bad_task = TaskMessage(
+        task_id="bad-type-1",
+        execution_limits={"soft": "DROP TABLE", "hard": 1.0},  # type: ignore[dict-item]
+    )
+
+    with pytest.raises(ValueError, match="MUST be numeric"):
+        worker._effective_time_limits(bad_task)
+
+
+@pytest.mark.integration
+def test_worker_rejects_list_execution_limits_value():
+    """``{"soft": [1, 2, 3]}`` raises ValueError at dequeue."""
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(redis_url=REDIS_URL)
+    bad_task = TaskMessage(
+        task_id="bad-list-1",
+        execution_limits={"soft": [1, 2, 3], "hard": 5.0},  # type: ignore[dict-item]
+    )
+
+    with pytest.raises(ValueError, match="MUST be numeric"):
+        worker._effective_time_limits(bad_task)
+
+
+@pytest.mark.integration
+def test_worker_rejects_bool_execution_limits_value():
+    """``{"soft": True}`` raises ValueError — bool is a stand-in for missing.
+
+    Python's ``bool`` is a subclass of ``int``; without an explicit
+    bool-rejection, ``True`` would round-trip as ``1.0`` second which
+    is nonsense for a time-limit semantics.
+    """
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(redis_url=REDIS_URL)
+    bad_task = TaskMessage(
+        task_id="bad-bool-1",
+        execution_limits={"soft": True, "hard": 5.0},  # type: ignore[dict-item]
+    )
+
+    with pytest.raises(ValueError, match="MUST be numeric"):
+        worker._effective_time_limits(bad_task)
+
+
+@pytest.mark.integration
+def test_worker_rejects_nan_execution_limits():
+    """``{"soft": NaN}`` raises ValueError — NaN bypasses ``<= 0`` check.
+
+    Security finding F1 + F2 paired: NaN slipped through the original
+    sign-check; the Shard 6 finite-check rejects it via the canonical
+    _validate_limits.
+    """
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(redis_url=REDIS_URL)
+    bad_task = TaskMessage(
+        task_id="bad-nan-1",
+        execution_limits={"soft": float("nan"), "hard": 5.0},
+    )
+
+    with pytest.raises(ValueError, match="finite"):
+        worker._effective_time_limits(bad_task)
+
+
+@pytest.mark.integration
+def test_worker_rejects_inf_execution_limits():
+    """``{"hard": Inf}`` raises ValueError — Inf would Timer-sleep forever."""
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(redis_url=REDIS_URL)
+    bad_task = TaskMessage(
+        task_id="bad-inf-1",
+        execution_limits={"hard": float("inf")},
+    )
+
+    with pytest.raises(ValueError, match="finite"):
+        worker._effective_time_limits(bad_task)
+
+
+@pytest.mark.integration
+def test_worker_silently_ignores_unknown_execution_limits_keys():
+    """Unknown keys in execution_limits are silently ignored (forward-compat).
+
+    Wire format contract: workers MUST tolerate new fields a future
+    producer might add (e.g., ``{"soft": 1, "hard": 5, "burst": 0.5}``)
+    so an old worker doesn't crash on a new producer's payload.
+    """
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(redis_url=REDIS_URL)
+    forward_compat_task = TaskMessage(
+        task_id="forward-compat-1",
+        execution_limits={"soft": 1.0, "hard": 5.0, "future_field": "value"},  # type: ignore[dict-item]
+    )
+
+    soft, hard = worker._effective_time_limits(forward_compat_task)
+    assert soft == 1.0
+    assert hard == 5.0
+
+
+@pytest.mark.integration
+def test_worker_init_validates_grace_seconds_negative():
+    """Worker(hard_time_limit_grace_seconds=-1) raises ValueError at construction.
+
+    Security finding F3: negative grace would fire the hard kill BEFORE
+    the soft signal, inverting the celery contract.
+    """
+    from kailash.runtime.distributed import Worker
+
+    with pytest.raises(ValueError, match="grace_seconds"):
+        Worker(
+            redis_url=REDIS_URL,
+            default_soft_time_limit=1.0,
+            default_time_limit=5.0,
+            hard_time_limit_grace_seconds=-1.0,
+        )
+
+
+@pytest.mark.integration
+def test_worker_init_validates_grace_seconds_nan():
+    """Worker(hard_time_limit_grace_seconds=NaN) raises ValueError at construction."""
+    from kailash.runtime.distributed import Worker
+
+    with pytest.raises(ValueError, match="finite"):
+        Worker(
+            redis_url=REDIS_URL,
+            default_soft_time_limit=1.0,
+            default_time_limit=5.0,
+            hard_time_limit_grace_seconds=float("nan"),
+        )
+
+
+@pytest.mark.integration
+def test_worker_init_validates_grace_seconds_inf():
+    """Worker(hard_time_limit_grace_seconds=Inf) raises ValueError at construction."""
+    from kailash.runtime.distributed import Worker
+
+    with pytest.raises(ValueError, match="finite"):
+        Worker(
+            redis_url=REDIS_URL,
+            default_soft_time_limit=1.0,
+            default_time_limit=5.0,
+            hard_time_limit_grace_seconds=float("inf"),
+        )
+
+
+@pytest.mark.integration
+def test_worker_per_task_validation_does_not_break_no_limit_path():
+    """Task with execution_limits=None passes through to Worker defaults cleanly.
+
+    Regression guard: the validation path MUST NOT raise on the
+    no-per-task-override common path.
+    """
+    from kailash.runtime.distributed import TaskMessage, Worker
+
+    worker = Worker(
+        redis_url=REDIS_URL,
+        default_soft_time_limit=2.0,
+        default_time_limit=5.0,
+    )
+    task = TaskMessage(task_id="no-override-1", execution_limits=None)
+
+    soft, hard = worker._effective_time_limits(task)
+    assert soft == 2.0
+    assert hard == 5.0

--- a/tests/integration/runtime/test_local_runtime_time_limits.py
+++ b/tests/integration/runtime/test_local_runtime_time_limits.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 wiring tests for #912 Shard 6 — LocalRuntime in-process time-limit enforcement.
+
+Per ``rules/testing.md`` Tier 2 contract: NO mocking, real LocalRuntime,
+real workflow execution against in-process infra (no external services).
+
+The /redteam Round 1 audit caught that LocalRuntime accepted
+``soft_time_limit`` / ``time_limit`` kwargs but never armed
+``arm_time_limits`` — only ``_validate_limits`` ran, then the kwargs
+were dropped. The README quickstart::
+
+    runtime = LocalRuntime()
+    runtime.execute(workflow.build(), soft_time_limit=2)
+
+silently failed: a workflow that ran longer than 2s would never raise
+``SoftTimeLimitExceeded``. Same fake-dispatch failure mode as
+``zero-tolerance.md`` Rule 2 § "Fake dispatch".
+
+This test suite verifies the wiring END-TO-END through the public
+``LocalRuntime.execute()`` API:
+
+* Soft / hard time limits actually fire against a sleeping workflow.
+* No-limit path completes normally (no allocation overhead, no false
+  positives).
+* Validation errors (negative / NaN / Inf) raise at the entry point
+  with the typed ``ValueError`` per Shard 6 input-validation hardening.
+
+Tests use a single-node ``PythonCodeNode`` workflow that sleeps
+deterministically. We construct workflows in-process (no
+``Workflow.to_dict()`` round-trip) to sidestep the pre-existing
+``PythonCodeNode.code`` serialization gap noted in the Shard-4 tests.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from kailash.runtime.local import LocalRuntime
+from kailash.sdk_exceptions import (
+    HardTimeLimitExceeded,
+    SoftTimeLimitExceeded,
+)
+from kailash.workflow.builder import WorkflowBuilder
+
+
+def _sleeping_workflow(sleep_seconds: float):
+    """Build a 1-node workflow whose body blocks for ``sleep_seconds``.
+
+    Uses ``time.sleep`` (blocking) so the time-limit timer is the only
+    way to interrupt — mirrors a real workload that doesn't poll
+    cancellation between sub-steps.
+    """
+    builder = WorkflowBuilder()
+    builder.add_node(
+        "PythonCodeNode",
+        "sleeper",
+        {"code": f"import time as _t; _t.sleep({sleep_seconds!r}); result = 'done'"},
+    )
+    return builder.build()
+
+
+def _instant_workflow():
+    """Build a 1-node workflow that returns immediately."""
+    builder = WorkflowBuilder()
+    builder.add_node(
+        "PythonCodeNode",
+        "instant",
+        {"code": "result = 42"},
+    )
+    return builder.build()
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end enforcement — soft + hard time limits actually fire
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+def test_local_runtime_soft_time_limit_raises_on_sleeping_workflow():
+    """``soft_time_limit`` MUST raise (Soft|Hard)TimeLimitExceeded against a sleeping workflow.
+
+    The README quickstart promise — runtime arms a soft + hard timer,
+    the workflow's blocking sleep does NOT poll the cancellation
+    token, so the soft signal cannot interrupt mid-sleep. The hard
+    timer fires its flag, and the post-completion poll in
+    ``LocalRuntime.execute`` raises ``HardTimeLimitExceeded`` per
+    Shard 2 invariant 5 (hard kill is non-negotiable).
+
+    Single-node workflows whose body blocks past the soft deadline
+    raise the typed deadline exception AT completion (the runtime's
+    inter-node poll never fires for a 1-node workflow). Multi-node
+    workflows or workflows whose nodes poll cancellation observe the
+    soft signal earlier.
+    """
+    runtime = LocalRuntime()
+    workflow = _sleeping_workflow(sleep_seconds=2.0)
+
+    start = time.monotonic()
+    with pytest.raises((SoftTimeLimitExceeded, HardTimeLimitExceeded)) as exc_info:
+        runtime.execute(workflow, soft_time_limit=0.5, time_limit=1.0)
+    elapsed = time.monotonic() - start
+
+    # The deadline raise MUST fire by the post-completion poll. The
+    # blocking sleep means we wait the full 2s, but the typed
+    # exception MUST be raised (NOT the unstubbed quickstart success).
+    assert exc_info.type in (SoftTimeLimitExceeded, HardTimeLimitExceeded)
+    # Bound elapsed below 4s so we know we didn't hang waiting on a
+    # never-firing timer (the no-wiring failure mode).
+    assert elapsed < 4.0, (
+        f"raise MUST happen by post-completion poll, not hang; "
+        f"elapsed={elapsed:.2f}s, exc={type(exc_info.value).__name__}"
+    )
+
+
+@pytest.mark.integration
+def test_local_runtime_hard_time_limit_raises_after_grace():
+    """``time_limit`` MUST raise HardTimeLimitExceeded after time_limit + grace.
+
+    No soft limit — only hard. The hard timer's flag fires
+    unconditionally after grace; the post-completion poll in
+    ``LocalRuntime.execute`` raises ``HardTimeLimitExceeded`` even
+    when the workflow's body completes "successfully" (the deadline
+    elapsed during the blocking node).
+    """
+    runtime = LocalRuntime()
+    workflow = _sleeping_workflow(sleep_seconds=2.0)
+
+    start = time.monotonic()
+    with pytest.raises(HardTimeLimitExceeded):
+        runtime.execute(workflow, time_limit=0.5)
+    elapsed = time.monotonic() - start
+
+    # Hard kill at 0.5s + 1.0s grace = 1.5s; the blocking sleep
+    # finishes at 2.0s, so the post-completion poll fires at ~2s.
+    assert elapsed < 4.0, (
+        f"hard kill MUST raise by post-completion poll; " f"elapsed={elapsed:.2f}s"
+    )
+
+
+@pytest.mark.integration
+def test_local_runtime_no_limits_passes_through():
+    """``runtime.execute(workflow.build())`` without limits — no timer arms, no false fire.
+
+    The no-limit path is the most-common path; it MUST stay
+    allocation-free (no token wrap, no timer thread) AND MUST NOT
+    raise spurious SoftTimeLimitExceeded / HardTimeLimitExceeded for
+    a workflow that completes naturally.
+    """
+    runtime = LocalRuntime()
+    workflow = _instant_workflow()
+
+    results, run_id = runtime.execute(workflow)
+
+    assert results is not None
+    assert "instant" in results
+    assert results["instant"]["result"] == 42
+
+
+# --------------------------------------------------------------------------- #
+# Entry-point validation (Shard 6 finite-check + grace_seconds hardening)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+def test_local_runtime_validation_rejects_negative_soft():
+    """``runtime.execute(soft_time_limit=-1)`` raises ValueError at entry point.
+
+    The validator is the single source of truth — caller error MUST
+    raise here, not later from a timer thread.
+    """
+    runtime = LocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="soft_time_limit"):
+        runtime.execute(workflow, soft_time_limit=-1)
+
+
+@pytest.mark.integration
+def test_local_runtime_validation_rejects_negative_hard():
+    """``runtime.execute(time_limit=-1)`` raises ValueError at entry point."""
+    runtime = LocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="time_limit"):
+        runtime.execute(workflow, time_limit=-1)
+
+
+@pytest.mark.integration
+def test_local_runtime_validation_rejects_nan_soft():
+    """``runtime.execute(soft_time_limit=NaN)`` raises ValueError (Shard 6 F1).
+
+    NaN bypassed the original ``<= 0`` check; the finite-check added
+    in Shard 6 catches it at the entry point so ``Timer(nan, ...)``
+    is never armed.
+    """
+    runtime = LocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="finite"):
+        runtime.execute(workflow, soft_time_limit=float("nan"))
+
+
+@pytest.mark.integration
+def test_local_runtime_validation_rejects_inf_hard():
+    """``runtime.execute(time_limit=Inf)`` raises ValueError (Shard 6 F1).
+
+    Inf bypassed the original ``<= 0`` check; without the finite-check,
+    ``Timer(inf, ...)`` would sleep forever and the workflow would be
+    uncancellable.
+    """
+    runtime = LocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="finite"):
+        runtime.execute(workflow, time_limit=float("inf"))
+
+
+@pytest.mark.integration
+def test_local_runtime_validation_rejects_soft_geq_hard():
+    """``runtime.execute(soft_time_limit=5, time_limit=5)`` raises ValueError.
+
+    Celery-style soft-then-hard contract: the soft signal MUST precede
+    the hard kill with a non-zero warning window.
+    """
+    runtime = LocalRuntime()
+    workflow = _instant_workflow()
+
+    with pytest.raises(ValueError, match="strictly less"):
+        runtime.execute(workflow, soft_time_limit=5.0, time_limit=5.0)

--- a/tests/integration/runtime/test_local_runtime_time_limits.py
+++ b/tests/integration/runtime/test_local_runtime_time_limits.py
@@ -39,10 +39,7 @@ import time
 import pytest
 
 from kailash.runtime.local import LocalRuntime
-from kailash.sdk_exceptions import (
-    HardTimeLimitExceeded,
-    SoftTimeLimitExceeded,
-)
+from kailash.sdk_exceptions import HardTimeLimitExceeded, SoftTimeLimitExceeded
 from kailash.workflow.builder import WorkflowBuilder
 
 

--- a/tests/unit/test_time_limits_validation.py
+++ b/tests/unit/test_time_limits_validation.py
@@ -88,3 +88,112 @@ def test_validate_limits_error_message_mentions_parameters():
     """Error message MUST name the offending parameter for actionable feedback."""
     with pytest.raises(ValueError, match="soft_time_limit|time_limit"):
         _validate_limits(soft_time_limit=-1, time_limit=None)
+
+
+# -----------------------------------------------------------------
+# Issue #912 Shard 6 — finite-check + grace_seconds validation
+# -----------------------------------------------------------------
+#
+# Security finding (redteam Round 1 F1): NaN/Inf bypass _validate_limits.
+# `float('inf') > 0` is True; `not (float('nan') <= 0)` is True. Both
+# pass the original `<= 0` check. The first arms a `Timer(inf, ...)`
+# that sleeps forever; the second arms `Timer(nan, ...)` which raises
+# from the daemon thread with no traceback to the caller.
+#
+# Security finding F3: grace_seconds was unvalidated. A negative grace
+# fires the hard timer BEFORE the soft signal (inverting the contract);
+# a NaN grace crashes the daemon thread at fire time.
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_nan_soft():
+    """NaN soft limit raises ValueError at the entry point.
+
+    `float('nan') <= 0` is False (NaN is unordered) so the original
+    sign-check would silently let NaN through. Catch it via
+    math.isfinite() before any timer is armed.
+    """
+    with pytest.raises(ValueError, match="finite"):
+        _validate_limits(soft_time_limit=float("nan"), time_limit=None)
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_nan_hard():
+    """NaN hard limit raises ValueError at the entry point."""
+    with pytest.raises(ValueError, match="finite"):
+        _validate_limits(soft_time_limit=None, time_limit=float("nan"))
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_inf_soft():
+    """Positive infinity soft limit raises ValueError.
+
+    `Timer(inf, ...)` sleeps forever; the soft signal would never fire
+    and the workflow could not be cancelled.
+    """
+    with pytest.raises(ValueError, match="finite"):
+        _validate_limits(soft_time_limit=float("inf"), time_limit=None)
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_inf_hard():
+    """Positive infinity hard limit raises ValueError."""
+    with pytest.raises(ValueError, match="finite"):
+        _validate_limits(soft_time_limit=None, time_limit=float("inf"))
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_neg_inf_soft():
+    """Negative infinity soft limit raises ValueError (not finite)."""
+    with pytest.raises(ValueError, match="finite"):
+        _validate_limits(soft_time_limit=float("-inf"), time_limit=None)
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_neg_inf_hard():
+    """Negative infinity hard limit raises ValueError (not finite)."""
+    with pytest.raises(ValueError, match="finite"):
+        _validate_limits(soft_time_limit=None, time_limit=float("-inf"))
+
+
+@pytest.mark.unit
+def test_validate_limits_grace_none_is_silent():
+    """grace_seconds=None (default) skips the grace check."""
+    _validate_limits(soft_time_limit=2.0, time_limit=5.0, grace_seconds=None)
+
+
+@pytest.mark.unit
+def test_validate_limits_grace_zero_is_accepted():
+    """grace_seconds=0 is accepted (operator MAY choose no wind-down)."""
+    _validate_limits(soft_time_limit=2.0, time_limit=5.0, grace_seconds=0.0)
+
+
+@pytest.mark.unit
+def test_validate_limits_grace_positive_is_accepted():
+    """grace_seconds=positive-finite is accepted."""
+    _validate_limits(soft_time_limit=2.0, time_limit=5.0, grace_seconds=1.5)
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_negative_grace():
+    """Negative grace_seconds inverts the contract — raises ValueError."""
+    with pytest.raises(ValueError, match="grace_seconds"):
+        _validate_limits(soft_time_limit=2.0, time_limit=5.0, grace_seconds=-1)
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_nan_grace():
+    """NaN grace_seconds crashes the daemon thread — raises ValueError."""
+    with pytest.raises(ValueError, match="finite"):
+        _validate_limits(
+            soft_time_limit=2.0, time_limit=5.0, grace_seconds=float("nan")
+        )
+
+
+@pytest.mark.unit
+def test_validate_limits_rejects_inf_grace():
+    """Infinite grace_seconds is unbounded — raises ValueError."""
+    with pytest.raises(ValueError, match="finite"):
+        _validate_limits(
+            soft_time_limit=2.0, time_limit=5.0, grace_seconds=float("inf")
+        )


### PR DESCRIPTION
## Why this PR exists

The `/redteam` Round 1 audit on the merged #912 wave (PRs #921-#925) caught two ship-blockers per the 5-shard close-out:

1. **HIGH (spec-compliance)**: 5 in-process runtimes (LocalRuntime, AsyncLocalRuntime, DockerRuntime, ParallelRuntime, ParallelCyclicRuntime) accepted `soft_time_limit`/`time_limit` kwargs but ONLY called `_validate_limits()` and dropped them. The kwargs were never armed. Only Worker (Shard 4) and scheduler (Shard 3) actually wired enforcement. The README quickstart `runtime = LocalRuntime(); runtime.execute(workflow.build(), soft_time_limit=2)` was silently broken — exactly the fake-dispatch failure mode of `zero-tolerance.md` Rule 2. Verified pre-fix: `grep "arm_time_limits" src/kailash/runtime/local.py` returned ZERO hits.

2. **3 HIGH/MEDIUM (security-review)** — same input-validation bug class:
   - `float('inf')` and `float('nan')` bypassed `_validate_limits` (passes `> 0` / `not <= 0`); `Timer(inf, ...)` sleeps forever, `Timer(nan, ...)` crashes from a daemon thread.
   - Worker accepted arbitrary `execution_limits` dict shape from Redis (no type / range / shape validation on dequeue).
   - `grace_seconds` was accepted but never validated (`< 0` made hard fire BEFORE soft; NaN crashed daemon thread).

User approved Shard 6 to fix all 5 in one shot per `autonomous-execution.md` MUST Rule 4 (Fix-Immediately).

## What this PR delivers

### Group A — In-process runtime enforcement wiring

- `LocalRuntime.execute` — `arm_time_limits` around `_execute_sync`/`_execute_async` dispatch + classifier + post-completion poll + finally disarm. Mirrors the scheduler.py canonical pattern.
- `AsyncLocalRuntime.execute_workflow_async` — `arm_time_limits_async` (closes orphan helper); typed `Soft/HardTimeLimitExceeded` re-raise added ABOVE the broad `except Exception → WorkflowExecutionError` so they propagate untouched (was being silently rewrapped).
- `ParallelRuntime` (async) — `arm_time_limits_async` around the parallel-DAG execution.
- `ParallelCyclicRuntime` (sync) — `arm_time_limits` around cyclic / parallel-DAG / LocalRuntime fallback paths.
- `DockerRuntime` — `arm_time_limits` around the per-node container loop with per-node-boundary poll. **Documented constraint**: out-of-process timer cannot inject into a running `docker run` subprocess; long-running single-node Docker workflows do NOT get interrupted mid-container. Future enhancement: `subprocess.run(timeout=remaining)` per container exec.
- `AccessControlledRuntime` and `DurableExecutionEngine` — NO source changes needed. Both already forward typed kwargs by name to inner runtimes whose new wiring fires automatically.

### Group B — Input validation hardening

- `_validate_limits` extended with `math.isfinite()` check on soft + hard, plus optional `grace_seconds` (validates `>= 0` AND `isfinite`).
- `arm_time_limits` / `arm_time_limits_async` forward `grace_seconds` through the validator → caller errors surface at the entry point, not from a daemon thread.
- `Worker._validate_execution_limits_dict` static helper rejects: non-dict (`ValueError`), non-numeric values, `bool`, non-finite, `<= 0`. Unknown keys silently ignored (forward-compat parity with `from_json`).
- `Worker._effective_time_limits` calls the helper before values reach `arm_time_limits_async`.
- `Worker.__init__` calls `_validate_limits(default_soft, default_hard, grace_seconds=hard_time_limit_grace_seconds)` so operator misconfig surfaces at construction.

### Group C — Tier-2 regression tests (close the coverage gap)

- `tests/integration/runtime/test_local_runtime_time_limits.py` (NEW, 8 tests) — the test the README quickstart asserts works.
- `tests/integration/runtime/test_async_local_runtime_time_limits.py` (NEW, 7 tests) — async equivalent.
- `tests/integration/runtime/test_distributed_time_limits.py` extended (+11 Worker validation tests).
- `tests/unit/test_time_limits_validation.py` extended (+12 finite + grace_seconds cases).

## Test plan

- [x] **Full #912 regression suite (10 files, 149 tests): 149 passed in 85s**
- [x] Tier-1 CI-parity sweep: 3915 passed / 4 skipped / 0 failed in 19s
- [x] Pre-commit clean on every changed file
- [x] No #922-style Tier-1 hang reproduces

## Notes for reviewers

- `AsyncLocalRuntime`'s broad `except Exception → WorkflowExecutionError` was silently rewrapping typed deadline exceptions. Fix: re-raise `Soft/HardTimeLimitExceeded` above the broad catch.
- DockerRuntime's mid-container kill is a fundamental subprocess constraint, not a bug. Documented in the kwarg docstring + in-loop comment.
- Single-node blocking workflows surface the deadline at the post-completion poll (Python timers cannot interrupt `time.sleep` mid-call) — same constraint as scheduler's Shard 3 contract.

## Pyright LSP cache lag

Same pattern as #921-#925 — "unknown import symbol" warnings on new code are LSP cache lag; tests pass against the symbols.

## Issue closure

This is the genuine close-out for #912 — the 5-shard wave shipped the surface; this corrective shard makes the implementation actually deliver the documented behavior across every BaseRuntime subclass.

Fixes #912.

🤖 Generated with [Claude Code](https://claude.com/claude-code)