### PR TITLE
fix(runtime): close clear_shared_pools coroutine on cleanup race (#917)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — issue #917 LocalRuntime cleanup-path coroutine leak
+
+`LocalRuntime._cleanup_event_loop` (also reached via `__exit__` and
+`close()`) constructed `AsyncSQLDatabaseNode.clear_shared_pools(graceful=True)`
+inline as the first argument to `asyncio.wait_for(...)`. Under any path
+where `wait_for` raises before its body awaits the inner coroutine
+(timeout, cancel-before-start race during shutdown), the coroutine was
+GC'd un-awaited and Python emitted::
+
+    RuntimeWarning: coroutine 'AsyncSQLDatabaseNode.clear_shared_pools'
+    was never awaited
+
+Fixed by capturing the coroutine in a local variable and adding a
+`finally` block that explicitly closes it — a no-op when `wait_for`
+ran the coroutine to completion or cancellation, but a structural
+guarantee that cancel-before-start cannot leak.
+
+Tier-2 regression at
+`tests/integration/runtime/test_local_runtime_exit_cleanup.py` runs
+under `python -W error::RuntimeWarning` and includes a deterministic
+repro of the cancel-before-start race that pre-fix flips a
+`RuntimeWarning` into a typed test failure.
+
 ### Hardened — issue #912 corrective gate (Shard 6)
 
 The /redteam Round 1 audit on the merged #912 wave (PRs #921-#925) caught
@@ -88,7 +111,7 @@ Three security findings were paired with the in-process gap:
 #### Tests
 
 - `tests/unit/test_time_limits_validation.py` — 12 new finite-check
-  + grace_seconds cases.
+  - grace_seconds cases.
 - `tests/integration/runtime/test_local_runtime_time_limits.py` (new)
   — 8 Tier-2 cases covering soft/hard enforcement on real
   `LocalRuntime` plus all entry-point validation paths.

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -1571,12 +1571,22 @@ class LocalRuntime(
                                 AsyncSQLDatabaseNode, "clear_shared_pools", None
                             )
                             if _clear_pools is not None:
-                                loop.run_until_complete(
-                                    asyncio.wait_for(
-                                        _clear_pools(graceful=True),
-                                        timeout=5.0,
+                                _coro = _clear_pools(graceful=True)
+                                try:
+                                    loop.run_until_complete(
+                                        asyncio.wait_for(_coro, timeout=5.0)
                                     )
-                                )
+                                finally:
+                                    # Defensive: close the coroutine if it
+                                    # never started running (e.g., wait_for
+                                    # cancel/timeout race during shutdown).
+                                    # No-op if already awaited or exhausted.
+                                    _close = getattr(_coro, "close", None)
+                                    if _close is not None:
+                                        try:
+                                            _close()
+                                        except Exception:
+                                            pass
                         except Exception as e:
                             logger.warning(
                                 f"Error disposing AsyncSQL pools during shutdown: {e}"

--- a/tests/integration/runtime/test_local_runtime_exit_cleanup.py
+++ b/tests/integration/runtime/test_local_runtime_exit_cleanup.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 regression for issue #917 — LocalRuntime.__exit__ must not leave
+``AsyncSQLDatabaseNode.clear_shared_pools`` coroutine un-awaited under the
+``wait_for`` cancel/timeout race during shutdown.
+
+Per ``rules/zero-tolerance.md`` Rule 1 the warning MUST be fixed (not
+deferred) — and per the issue's acceptance criteria the regression test
+runs under ``-W error::RuntimeWarning`` so any drop in the cleanup path
+flips the warning to a typed exception that the test catches.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import warnings
+
+import pytest
+
+from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+
+@pytest.mark.integration
+def test_exit_does_not_leave_clear_shared_pools_coroutine_un_awaited() -> None:
+    """The ``__exit__`` cleanup path MUST fully await or close the
+    ``AsyncSQLDatabaseNode.clear_shared_pools`` coroutine.
+
+    Reproduces the failure mode from issue #917: when the runtime is
+    exited under context-manager-driven shutdown that may race the
+    cleanup, the inner coroutine constructed eagerly as an argument to
+    ``asyncio.wait_for`` was being GC'd un-awaited, emitting a
+    ``RuntimeWarning: coroutine 'AsyncSQLDatabaseNode.clear_shared_pools'
+    was never awaited``.
+
+    This test executes a minimal workflow inside a ``with LocalRuntime()``
+    block and asserts no ``RuntimeWarning`` mentioning
+    ``clear_shared_pools`` is recorded.
+    """
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+
+        with LocalRuntime() as runtime:
+            wf = WorkflowBuilder()
+            wf.add_node(
+                "PythonCodeNode",
+                "noop",
+                {"code": "result = {'ok': True}"},
+            )
+            results, _ = runtime.execute(wf.build())
+            assert results["noop"]["result"]["ok"] is True
+
+        # __exit__ has now run the cleanup path; no un-awaited-coroutine
+        # warning must surface.
+        offenders = [
+            str(w.message)
+            for w in recorded
+            if issubclass(w.category, RuntimeWarning)
+            and "clear_shared_pools" in str(w.message)
+            and "never awaited" in str(w.message).lower()
+        ]
+        assert not offenders, (
+            "LocalRuntime.__exit__ left clear_shared_pools coroutine "
+            f"un-awaited (issue #917 regression). Offenders: {offenders}"
+        )
+
+
+@pytest.mark.integration
+def test_exit_handles_wait_for_failure_without_un_awaited_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force the failure mode in the issue body: ``asyncio.wait_for``
+    fails before scheduling the inner coroutine, so the inner coroutine
+    is referenced but never awaited.
+
+    Pre-fix the cleanup path constructs ``_clear_pools(graceful=True)``
+    inline as the first argument to ``wait_for``; if ``wait_for`` raises
+    before its body awaits the coroutine, the coroutine is GC'd and
+    Python emits ``RuntimeWarning: coroutine ... was never awaited``.
+
+    Post-fix the ``finally`` block explicitly closes the coroutine when
+    it is still in the ``CORO_CREATED`` state, so no warning surfaces.
+    """
+
+    real_clear = AsyncSQLDatabaseNode.clear_shared_pools
+
+    real_wait_for = asyncio.wait_for
+
+    def failing_wait_for(coro, timeout):
+        # Simulate a wait_for that raises *before* it can await ``coro``
+        # — pre-fix this leaks ``coro`` un-awaited; post-fix the
+        # ``finally`` block closes ``coro`` defensively.
+        raise asyncio.TimeoutError("simulated cancel-before-start")
+
+    monkeypatch.setattr(asyncio, "wait_for", failing_wait_for)
+
+    # Ensure clear_shared_pools is a coroutine function so the
+    # cleanup path constructs a coroutine (default state on a fresh
+    # AsyncSQLDatabaseNode class).
+    assert asyncio.iscoroutinefunction(real_clear)
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+
+        runtime = LocalRuntime()
+        wf = WorkflowBuilder()
+        wf.add_node(
+            "PythonCodeNode",
+            "noop",
+            {"code": "result = {'ok': True}"},
+        )
+        results, _ = runtime.execute(wf.build())
+        assert results["noop"]["result"]["ok"] is True
+
+        runtime.close()
+
+        # Restore wait_for so subsequent tests are unaffected.
+        monkeypatch.setattr(asyncio, "wait_for", real_wait_for)
+
+        offenders = [
+            str(w.message)
+            for w in recorded
+            if issubclass(w.category, RuntimeWarning)
+            and "never awaited" in str(w.message).lower()
+        ]
+        assert not offenders, (
+            "wait_for cancel-before-start path left a coroutine un-awaited "
+            f"(issue #917 regression). Offenders: {offenders}"
+        )
+
+
+@pytest.mark.integration
+def test_explicit_close_does_not_leave_coroutine_un_awaited() -> None:
+    """Same invariant via explicit ``close()`` — the alternative shutdown
+    path that also runs ``_cleanup_event_loop``."""
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+
+        runtime = LocalRuntime()
+        wf = WorkflowBuilder()
+        wf.add_node(
+            "PythonCodeNode",
+            "noop",
+            {"code": "result = {'ok': True}"},
+        )
+        results, _ = runtime.execute(wf.build())
+        assert results["noop"]["result"]["ok"] is True
+
+        runtime.close()
+
+        offenders = [
+            str(w.message)
+            for w in recorded
+            if issubclass(w.category, RuntimeWarning)
+            and "clear_shared_pools" in str(w.message)
+            and "never awaited" in str(w.message).lower()
+        ]
+        assert not offenders, (
+            "LocalRuntime.close() left clear_shared_pools coroutine "
+            f"un-awaited (issue #917 regression). Offenders: {offenders}"
+        )


### PR DESCRIPTION
## Summary

Fixes #917 — the `LocalRuntime` cleanup path was leaking `AsyncSQLDatabaseNode.clear_shared_pools(graceful=True)` as an un-awaited coroutine under the `asyncio.wait_for` cancel-before-start race during shutdown. Per `zero-tolerance.md` Rule 1 the warning MUST be fixed; this PR closes it structurally.

**Root cause** (`src/kailash/runtime/local.py:1570-1583`): the coroutine was constructed inline as the first positional argument to `asyncio.wait_for(...)`. If `wait_for` raises (timeout, cancel-before-start) before its body awaits the inner coroutine, the coroutine reference is dropped and Python's GC emits the `RuntimeWarning: coroutine '...clear_shared_pools' was never awaited`.

**Fix**: capture the coroutine in a local variable, run `wait_for` inside a `try`/`finally`, explicitly call `_coro.close()` in `finally`. The close is a no-op when the coroutine ran to completion or cancellation (CORO_CLOSED state); when `wait_for` failed before awaiting (CORO_CREATED state), the close prevents the un-awaited GC warning.

## Pre-existing — not in scope

- `tests/integration/runtime/test_local.py::TestLocalRuntimeExecution::test_execute_simple_workflow` fails on main today with `AttributeError: 'WorkflowDAG' object attribute 'in_edges' is read-only` (Mock on read-only attribute). Provenance: line authored 2025-07-17 (`40728f16a`) — predates this session by 297 days. Filed in advance per zero-tolerance Rule 1c provenance grounding; orthogonal bug class to async cleanup. Not addressed in this PR.

## Test plan

- [x] New regression `tests/integration/runtime/test_local_runtime_exit_cleanup.py` (3 tests) passes under `python -W error::RuntimeWarning`
- [x] `test_exit_handles_wait_for_failure_without_un_awaited_warning` deterministically reproduces the bug — fails without the fix with the exact warning message from #917, passes with the fix
- [x] Targeted regression sweep of LocalRuntime / AsyncLocalRuntime test suites: 44 passed, 0 regressions
- [ ] Auto-merge with `--admin` on CI green / path-filter auto-skip per owner workflow

## Closes

Closes #917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)