### PR TITLE
chore(release): kailash 2.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.18.1] - 2026-05-10
+
 ### Fixed — issue #917 LocalRuntime cleanup-path coroutine leak
 
 `LocalRuntime._cleanup_event_loop` (also reached via `__exit__` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.18.0"
+version = "2.18.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.18.0"
+__version__ = "2.18.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Patch release of kailash 2.18.1 — closes the merged-not-released gap accumulated since 2.18.0 (cut 2026-05-08).

## Scope

- **#912 wave (PRs #921-#926)**: per-task soft/hard time limits across LocalRuntime, AsyncLocalRuntime, ParallelRuntime, ParallelCyclicRuntime, DockerRuntime, WorkflowScheduler, and DistributedRuntime/Worker. Shard 6 closed the in-process enforcement gap surfaced by /redteam Round 1.
- **#917 (PR #930)**: `LocalRuntime` cleanup-path no longer leaks `AsyncSQLDatabaseNode.clear_shared_pools` as un-awaited coroutine under `wait_for` cancel-before-start race.
- **COC artifact sync (PR #928)**: loom 2.28.2 → 2.29.0 skill-audit cleanup. No wheel content change (only `.claude/` artifacts).

## Diff

Metadata-only release-prep:
- `pyproject.toml::version` → 2.18.1
- `src/kailash/__init__.py::__version__` → 2.18.1
- `CHANGELOG.md` 2.18.1 section heading

Per `git.md` § "Release-Prep PRs MUST Use release/v* Branch Convention" — branched from `release/v2.18.1` to auto-skip the PR-gate matrix.

## Test plan

- [x] Pre-commit hooks pass (Black/isort/Ruff/Tier-1 tests)
- [x] CHANGELOG version section in place
- [x] Pyproject + __init__ version anchors aligned (atomic per `zero-tolerance.md` Rule 5)
- [ ] Auto-merge with `--admin` (release-prep auto-skip path)
- [ ] Tag push triggers `publish-pypi.yml` (one tag per push per `deployment.md` § "Multi-Package Release Tags Pushed Individually" — single-tag here)
- [ ] Clean-venv install verification per `build-repo-release-discipline.md` Rule 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)