### PR TITLE
feat(distributed): multi-queue routing producer surface (#911 Shard 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — issue #911 Shard 1: multi-queue routing producer surface
+
+`DistributedRuntime.execute(queue=...)` now accepts an optional logical
+queue name and routes the task to the corresponding Redis list. The
+canonical queue-name → Redis-list-key mapping lives in a new shared
+helper module (`src/kailash/runtime/_queue_keys.py`) so the producer
+and (Shard 2) consumer cannot drift out of byte-shape agreement.
+
+- `DistributedRuntime(default_queue="...")` sets the runtime's default
+  queue (defaults to `"default"`).
+- `runtime.execute(workflow, queue="fast")` enqueues to
+  `kailash:tasks:pending:fast`.
+- `runtime.execute(workflow)` enqueues to the legacy single-queue key
+  `kailash:tasks:pending` — byte-identical to pre-#911 deployments.
+- `TaskMessage.queue_name` round-trips through JSON; older-SDK messages
+  without the field deserialize as `"default"`. The default-queue wire
+  format omits `queue_name` so a worker on a pre-#911 SDK reads the
+  message unchanged.
+- `validate_queue_name` rejects empty / > 64-char / colon / slash /
+  whitespace / control-char / null-byte / non-str inputs at the entry
+  point, not deep in the dispatch path.
+
+Worker-side multi-queue dequeue is Shard 2; this Shard 1 only delivers
+the producer + helper module + JSON wire format.
+
 ## [2.18.1] - 2026-05-10
 
 ### Fixed — issue #917 LocalRuntime cleanup-path coroutine leak

--- a/src/kailash/runtime/_queue_keys.py
+++ b/src/kailash/runtime/_queue_keys.py
@@ -1,0 +1,79 @@
+"""Canonical Redis-list-key helpers for distributed task queues.
+
+Producer (``DistributedRuntime``) and consumer (``Worker``) MUST share a
+single source of truth for queue-name → Redis-list-key translation, so a
+producer that enqueues for queue ``"fast"`` and a worker dequeuing from
+``Worker(queues={"fast": 1})`` resolve to byte-identical Redis keys.
+
+Same structural defense as ``kailash.utils.url_credentials`` (one helper
+module, both directions): drift between two open-coded copies silently
+strands tasks on a queue no worker reads.
+
+Issue #911 Shard 1.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Base Redis list key for queued tasks. The "default" queue MUST resolve
+# to this exact byte string (NOT ``"kailash:tasks:pending:default"``) so
+# existing single-queue deployments do not orphan in-flight tasks on
+# their first deploy of the multi-queue SDK. Same back-compat-window
+# semantics as a ``zero-tolerance.md`` Rule 6a public-API rename.
+_QUEUE_KEY_BASE = "kailash:tasks:pending"
+
+DEFAULT_QUEUE_NAME = "default"
+
+_QUEUE_NAME_MAX_LEN = 64
+_QUEUE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+
+def validate_queue_name(name: str) -> None:
+    """Raise ``ValueError`` if ``name`` is not a safe queue name.
+
+    Allowed: 1–64 chars, ASCII letters / digits / hyphen / underscore.
+    Rejected: empty, > 64 chars, control chars, colons (Redis key
+    separator), slashes, whitespace, null bytes — anything that could
+    break the Redis-key shape or smuggle a different namespace prefix.
+
+    Issue #911 failure-point #8.
+    """
+    if not isinstance(name, str):
+        raise ValueError(f"queue name must be str, got {type(name).__name__}")
+    if not name:
+        raise ValueError("queue name must not be empty")
+    if len(name) > _QUEUE_NAME_MAX_LEN:
+        raise ValueError(
+            f"queue name too long: {len(name)} > {_QUEUE_NAME_MAX_LEN} chars"
+        )
+    if not _QUEUE_NAME_PATTERN.fullmatch(name):
+        raise ValueError(
+            "queue name must match [A-Za-z0-9_-]+ "
+            "(no colons, slashes, whitespace, control chars, or null bytes); "
+            f"got {name!r}"
+        )
+
+
+def make_queue_key(name: str = DEFAULT_QUEUE_NAME) -> str:
+    """Return the canonical Redis list key for ``name``.
+
+    The ``"default"`` queue maps to the legacy key ``"kailash:tasks:pending"``
+    (NO suffix) — load-bearing back-compat with single-queue deployments
+    that already have tasks enqueued under that exact byte string.
+
+    Non-default queues map to ``"kailash:tasks:pending:<name>"``.
+
+    Issue #911 failure-point #1, #2 (default-queue back-compat).
+    """
+    validate_queue_name(name)
+    if name == DEFAULT_QUEUE_NAME:
+        return _QUEUE_KEY_BASE
+    return f"{_QUEUE_KEY_BASE}:{name}"
+
+
+__all__ = [
+    "DEFAULT_QUEUE_NAME",
+    "make_queue_key",
+    "validate_queue_name",
+]

--- a/src/kailash/runtime/distributed.py
+++ b/src/kailash/runtime/distributed.py
@@ -46,6 +46,11 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
+from kailash.runtime._queue_keys import (
+    DEFAULT_QUEUE_NAME,
+    make_queue_key,
+    validate_queue_name,
+)
 from kailash.runtime._time_limits import (
     _TimeLimitClassifier,
     _validate_limits,
@@ -96,6 +101,12 @@ class TaskMessage:
             silently ignore it (forward-compat). The worker arms the
             timers at dequeue (NOT enqueue) so queue wait time does
             NOT consume the task's budget. Default ``None`` (no limit).
+        queue_name: Logical queue this task targets. Defaults to
+            ``"default"`` so legacy single-queue producers and workers
+            interoperate byte-for-byte (the default queue resolves to
+            the legacy Redis list key ``kailash:tasks:pending``).
+            Older-SDK ``TaskMessage`` JSON without ``queue_name``
+            deserializes as ``"default"``. Issue #911 Shard 1.
     """
 
     task_id: str = ""
@@ -106,6 +117,7 @@ class TaskMessage:
     attempts: int = 0
     max_attempts: int = 3
     execution_limits: Optional[Dict[str, float]] = None
+    queue_name: str = DEFAULT_QUEUE_NAME
 
     def to_json(self) -> str:
         """Serialize to JSON string for Redis storage.
@@ -127,6 +139,12 @@ class TaskMessage:
         }
         if self.execution_limits is not None:
             payload["execution_limits"] = self.execution_limits
+        # #911 Shard 1: emit queue_name only when non-default so the
+        # default-queue wire format stays byte-identical to pre-#911
+        # JSON. Older workers that don't know the field continue to
+        # parse default-queue messages unchanged.
+        if self.queue_name != DEFAULT_QUEUE_NAME:
+            payload["queue_name"] = self.queue_name
         return json.dumps(payload)
 
     @classmethod
@@ -513,27 +531,49 @@ class DistributedRuntime(BaseRuntime):
         queue: Optional[TaskQueue] = None,
         visibility_timeout: int = 300,
         result_ttl: int = 3600,
+        default_queue: str = DEFAULT_QUEUE_NAME,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self._redis_url = redis_url or os.environ.get("KAILASH_REDIS_URL", "")
+        # Producer-side default queue. Validated at construction so an
+        # invalid name fails loud instead of silently stranding tasks
+        # at first execute() call. Issue #911 Shard 1.
+        validate_queue_name(default_queue)
+        self._default_queue = default_queue
         self._queue = queue or TaskQueue(
             redis_url=self._redis_url,
+            queue_key=make_queue_key(default_queue),
             default_visibility_timeout=visibility_timeout,
             result_ttl=result_ttl,
         )
         self._visibility_timeout = visibility_timeout
         self._result_ttl = result_ttl
+        # Per-queue TaskQueue cache so every `execute(queue=...)` call
+        # routes through ONE TaskQueue instance per queue name (sharing
+        # the same Redis client, with the canonical Redis-list-key from
+        # ``make_queue_key``). The default-queue entry mirrors
+        # ``self._queue`` so legacy callers see no behavior change.
+        self._queues: Dict[str, TaskQueue] = {default_queue: self._queue}
 
     def close(self) -> None:
         """Release distributed runtime resources.
 
         Cleans up the task queue connection and any execution metadata.
+        Closes every per-queue TaskQueue instance the runtime created
+        through ``execute(queue=...)`` (#911 Shard 1) so multi-queue
+        runtimes do not leak Redis clients on shutdown.
         """
         self._execution_metadata.clear()
-        _close = getattr(self._queue, "close", None)
-        if _close is not None:
-            _close()
+        # Close every cached per-queue TaskQueue. ``self._queue`` is
+        # always present in ``self._queues`` under the default-queue
+        # name (seeded at __init__) so closing the cache covers both
+        # the legacy single-queue path and any new per-queue routes.
+        for tq in list(self._queues.values()):
+            _close = getattr(tq, "close", None)
+            if _close is not None:
+                _close()
+        self._queues.clear()
 
     def execute(
         self,
@@ -542,6 +582,7 @@ class DistributedRuntime(BaseRuntime):
         *,
         soft_time_limit: float | None = None,
         time_limit: float | None = None,
+        queue: Optional[str] = None,
         **kwargs,
     ) -> Tuple[Dict[str, Any], str]:
         """Submit a workflow to the distributed task queue.
@@ -564,7 +605,13 @@ class DistributedRuntime(BaseRuntime):
                 deadline fires, the task is requeued (NOT dead-lettered)
                 if ``attempts < max_attempts``; dead-lettered only after
                 exhaustion.
-            **kwargs: Additional execution options.
+            queue: Optional logical queue name for routing. Defaults to
+                this runtime's ``default_queue`` (constructor kwarg,
+                itself defaulting to ``"default"``). The
+                ``"default"`` queue resolves to the legacy Redis list
+                key ``kailash:tasks:pending`` for byte-identical
+                back-compat with single-queue deployments. Non-default
+                names get the suffix ``:<name>`` (issue #911 Shard 1).
 
         Returns:
             Tuple of (status_dict, run_id) where status_dict contains
@@ -586,6 +633,14 @@ class DistributedRuntime(BaseRuntime):
         """
         # #912 Shard 1: validate typed time-limit kwargs at the entry point.
         _validate_limits(soft_time_limit, time_limit)
+
+        # #911 Shard 1: resolve and validate the queue name BEFORE
+        # building any task or run-id metadata so an invalid queue
+        # raises ValueError from the public API surface, not from a
+        # half-constructed task.
+        queue_name = queue if queue is not None else self._default_queue
+        validate_queue_name(queue_name)
+        target_queue = self._queue_for(queue_name)
 
         run_id = self._generate_run_id()
         metadata = self._initialize_execution_metadata(workflow, run_id)
@@ -613,17 +668,40 @@ class DistributedRuntime(BaseRuntime):
             parameters=parameters or {},
             visibility_timeout=self._visibility_timeout,
             execution_limits=execution_limits,
+            queue_name=queue_name,
         )
 
-        self._queue.enqueue(task)
+        target_queue.enqueue(task)
 
         self._update_execution_metadata(run_id, {"status": "queued"})
 
         return {
             "status": "queued",
             "run_id": run_id,
-            "queue_length": self._queue.queue_length(),
+            "queue_length": target_queue.queue_length(),
+            "queue_name": queue_name,
         }, run_id
+
+    def _queue_for(self, queue_name: str) -> TaskQueue:
+        """Return (memoized) the TaskQueue routing to ``queue_name``.
+
+        Each named queue gets its own TaskQueue instance with a queue_key
+        derived through ``make_queue_key`` — guaranteeing producer +
+        worker share the canonical key. The default-queue entry is
+        seeded in ``__init__`` to alias ``self._queue`` so legacy
+        callers see no behavior change. Issue #911 Shard 1.
+        """
+        cached = self._queues.get(queue_name)
+        if cached is not None:
+            return cached
+        new_queue = TaskQueue(
+            redis_url=self._redis_url,
+            queue_key=make_queue_key(queue_name),
+            default_visibility_timeout=self._visibility_timeout,
+            result_ttl=self._result_ttl,
+        )
+        self._queues[queue_name] = new_queue
+        return new_queue
 
     def get_result(self, run_id: str) -> Optional[TaskResult]:
         """Poll for a task result by run_id.

--- a/tests/regression/test_911_default_queue_byte_compat.py
+++ b/tests/regression/test_911_default_queue_byte_compat.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: default-queue Redis-list-key byte-compat (#911 Shard 1).
+
+Pins the legacy ``_QUEUE_KEY = "kailash:tasks:pending"`` constant and
+the helper-derived default key. If a future refactor changes either
+side, this test fails LOUDLY before any production user is affected.
+
+Same failure-mode class as ``zero-tolerance.md`` Rule 6a public-API
+removal without deprecation cycle: a byte-shape change to the default
+Redis list key orphans every in-flight task on first deploy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.runtime._queue_keys import DEFAULT_QUEUE_NAME, make_queue_key
+from kailash.runtime.distributed import _QUEUE_KEY
+
+
+@pytest.mark.regression
+def test_default_queue_key_is_legacy_byte_string() -> None:
+    """The legacy single-queue Redis list key MUST stay byte-identical."""
+    assert _QUEUE_KEY == "kailash:tasks:pending"
+
+
+@pytest.mark.regression
+def test_make_queue_key_default_matches_legacy_constant() -> None:
+    """``make_queue_key("default")`` MUST equal the legacy ``_QUEUE_KEY``."""
+    assert make_queue_key(DEFAULT_QUEUE_NAME) == _QUEUE_KEY
+    assert make_queue_key("default") == "kailash:tasks:pending"
+
+
+@pytest.mark.regression
+def test_make_queue_key_default_no_suffix() -> None:
+    """The default queue MUST NOT get the ``:default`` suffix.
+
+    The asymmetry (default → no suffix; non-default → suffix) is the
+    load-bearing back-compat invariant for #911 Shard 1. If a refactor
+    makes the default-queue key ``"kailash:tasks:pending:default"``,
+    every existing single-queue deployment orphans on upgrade.
+    """
+    key = make_queue_key("default")
+    assert not key.endswith(":default")
+    assert key == "kailash:tasks:pending"
+
+
+@pytest.mark.regression
+def test_non_default_queue_gets_suffix() -> None:
+    """Non-default queues MUST get ``:<name>`` to namespace cleanly."""
+    assert make_queue_key("fast") == "kailash:tasks:pending:fast"
+    assert make_queue_key("slow") == "kailash:tasks:pending:slow"

--- a/tests/unit/runtime/test_queue_keys.py
+++ b/tests/unit/runtime/test_queue_keys.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-1 unit tests for the canonical queue-key helper module.
+
+Pins:
+
+* ``make_queue_key("default")`` → exact legacy byte string
+  ``"kailash:tasks:pending"`` (no suffix). Issue #911 failure-point #2
+  (default-queue back-compat).
+* Non-default names → ``"kailash:tasks:pending:<name>"``.
+* ``validate_queue_name`` rejects every documented bad input class
+  (failure-point #8): empty, > 64 chars, control chars, colons,
+  slashes, whitespace, null bytes, non-str types.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.runtime._queue_keys import (
+    DEFAULT_QUEUE_NAME,
+    make_queue_key,
+    validate_queue_name,
+)
+
+
+class TestMakeQueueKey:
+    """Byte-vector pins for the queue-key helper."""
+
+    def test_default_queue_byte_compat(self) -> None:
+        # Load-bearing: existing single-queue producers + workers share
+        # this exact Redis list key.
+        assert make_queue_key("default") == "kailash:tasks:pending"
+
+    def test_default_queue_via_constant(self) -> None:
+        # Same value via the public constant — guards against the
+        # constant drifting from the helper.
+        assert make_queue_key(DEFAULT_QUEUE_NAME) == "kailash:tasks:pending"
+
+    def test_default_queue_via_implicit_default(self) -> None:
+        # The function's own default-arg path resolves to the same key.
+        assert make_queue_key() == "kailash:tasks:pending"
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("fast", "kailash:tasks:pending:fast"),
+            ("slow", "kailash:tasks:pending:slow"),
+            ("slow_queue", "kailash:tasks:pending:slow_queue"),
+            ("a-b-c", "kailash:tasks:pending:a-b-c"),
+            ("Q1", "kailash:tasks:pending:Q1"),
+            ("x" * 64, "kailash:tasks:pending:" + "x" * 64),
+        ],
+    )
+    def test_non_default_queue_keys(self, name: str, expected: str) -> None:
+        assert make_queue_key(name) == expected
+
+
+class TestValidateQueueName:
+    """Negative-input pins for ``validate_queue_name``."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "default",
+            "fast",
+            "slow_queue",
+            "a-b-c",
+            "Q1",
+            "x" * 64,
+        ],
+    )
+    def test_accepts_valid_names(self, name: str) -> None:
+        # No exception — return value is None per Python convention for
+        # validators.
+        assert validate_queue_name(name) is None
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            validate_queue_name("")
+
+    def test_rejects_too_long(self) -> None:
+        with pytest.raises(ValueError, match="too long"):
+            validate_queue_name("x" * 65)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "with:colon",
+            "with/slash",
+            "with space",
+            "with\nnewline",
+            "with\ttab",
+            "with\x00nullbyte",
+            "with\x01control",
+            "with.dot",
+            "with#hash",
+            "unicode-ñ",
+        ],
+    )
+    def test_rejects_unsafe_chars(self, name: str) -> None:
+        with pytest.raises(ValueError, match=r"\[A-Za-z0-9_-\]"):
+            validate_queue_name(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            None,
+            123,
+            ["fast"],
+            {"queue": "fast"},
+            b"fast",
+        ],
+    )
+    def test_rejects_non_str_types(self, name: object) -> None:
+        with pytest.raises(ValueError, match="must be str"):
+            validate_queue_name(name)  # type: ignore[arg-type]

--- a/tests/unit/runtime/test_task_message_queue_name.py
+++ b/tests/unit/runtime/test_task_message_queue_name.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-1 unit tests for ``TaskMessage.queue_name`` (#911 Shard 1).
+
+Pins:
+
+* ``queue_name`` defaults to ``"default"``.
+* JSON round-trip preserves ``queue_name`` for non-default queues.
+* Older-SDK JSON without ``queue_name`` deserializes as ``"default"``.
+* Default-queue JSON OMITS ``queue_name`` so the wire format stays
+  byte-identical to pre-#911 messages (older workers parse them
+  unchanged).
+"""
+
+from __future__ import annotations
+
+import json
+
+from kailash.runtime.distributed import TaskMessage
+
+
+class TestTaskMessageQueueName:
+    def test_default_queue_name(self) -> None:
+        task = TaskMessage(task_id="t1")
+        assert task.queue_name == "default"
+
+    def test_round_trip_default_queue_omits_field(self) -> None:
+        # The default-queue wire format MUST NOT carry queue_name —
+        # older workers on a pre-#911 SDK have never seen the field
+        # and would otherwise need to ignore it.
+        task = TaskMessage(task_id="t1")
+        payload = json.loads(task.to_json())
+        assert "queue_name" not in payload
+
+    def test_round_trip_non_default_includes_field(self) -> None:
+        task = TaskMessage(task_id="t1", queue_name="fast")
+        payload = json.loads(task.to_json())
+        assert payload["queue_name"] == "fast"
+
+    def test_round_trip_preserves_queue_name(self) -> None:
+        original = TaskMessage(task_id="t1", queue_name="slow_queue")
+        restored = TaskMessage.from_json(original.to_json())
+        assert restored.queue_name == "slow_queue"
+
+    def test_legacy_json_deserializes_to_default_queue(self) -> None:
+        # Older-SDK JSON that has never written queue_name MUST
+        # deserialize as the default queue.
+        legacy = json.dumps(
+            {
+                "task_id": "t1",
+                "workflow_data": {},
+                "parameters": {},
+                "submitted_at": 1.0,
+                "visibility_timeout": 300,
+                "attempts": 0,
+                "max_attempts": 3,
+            }
+        )
+        restored = TaskMessage.from_json(legacy)
+        assert restored.queue_name == "default"
+
+    def test_round_trip_combines_with_execution_limits(self) -> None:
+        # #911 Shard 1 + #912 Shard 4 compose orthogonally.
+        original = TaskMessage(
+            task_id="t1",
+            queue_name="fast",
+            execution_limits={"soft": 2.0, "hard": 5.0},
+        )
+        restored = TaskMessage.from_json(original.to_json())
+        assert restored.queue_name == "fast"
+        assert restored.execution_limits == {"soft": 2.0, "hard": 5.0}


### PR DESCRIPTION
## Summary

Lands Shard 1 of issue #911 (multi-queue routing). Producer-side: `DistributedRuntime.execute(queue=...)` now routes the task to the named queue's Redis list via a single canonical helper module, plus `TaskMessage.queue_name` for the wire format. Worker-side multi-queue dequeue is Shard 2.

## Files

**New:**
- `src/kailash/runtime/_queue_keys.py` — `make_queue_key()` + `validate_queue_name()`. The `"default"` queue maps to the legacy `kailash:tasks:pending` key (no suffix) for byte-identical back-compat with single-queue deployments; non-default names get `:<name>` suffix.

**Modified:**
- `src/kailash/runtime/distributed.py` —
  - `TaskMessage.queue_name = "default"` field (additive default, JSON round-trip preserves; default-queue wire format omits the field so older workers parse pre-#911 messages unchanged)
  - `DistributedRuntime(default_queue="...")` constructor kwarg
  - `DistributedRuntime.execute(*, queue=...)` named kwarg (additive)
  - Per-queue `TaskQueue` cache so each name shares ONE instance with the canonical key
  - `close()` disposes every cached per-queue `TaskQueue`

**Tests (42 new + 720 regression sweep clean):**
- `tests/unit/runtime/test_queue_keys.py` (28 cases) — byte-vector pins for default/non-default keys; rejection for empty / >64 chars / control chars / colons / slashes / null bytes / non-str.
- `tests/unit/runtime/test_task_message_queue_name.py` (6 cases) — default field, default-omits-from-wire, round-trip preserves, legacy JSON → default, composes with `execution_limits`.
- `tests/regression/test_911_default_queue_byte_compat.py` (4 cases) — pins `_QUEUE_KEY = \"kailash:tasks:pending\"` and helper-derived default key. Loud failure on any future drift before users are hit.

## Amend-at-launch (per `specs-authority.md` MUST 5c)

The original Shard 1 plan asserted #912 Shard 1 would remove `**kwargs` from `BaseRuntime` and every subclass first, with the no-`**kwargs` signature invariant test pinned to that surface. Verification at launch: #912 Shard 1 only ADDED typed time-limit kwargs ON TOP of the existing `**kwargs` — it never removed them. `BaseRuntime.execute` still carries `**kwargs` today.

To preserve Liskov compatibility with `BaseRuntime`, Shard 1 keeps `**kwargs` in `DistributedRuntime.execute` and drops the no-`**kwargs` signature invariant test from this shard's scope. The cross-runtime `**kwargs` cleanup is now a future shard.

## Invariants delivered (5)

1. ✅ `make_queue_key(\"default\")` byte-for-byte equals `\"kailash:tasks:pending\"` (load-bearing back-compat)
2. ✅ `make_queue_key(name)` for non-default names returns `f\"{base}:{name}\"`
3. ✅ `validate_queue_name` raises `ValueError` on every documented bad input class
4. ✅ `DistributedRuntime.execute(queue=...)` routes via the helper — no inline string formatting
5. ✅ `TaskMessage.queue_name` round-trips through JSON; legacy messages deserialize as default

## Test plan

- [x] Tier-1 unit suite: 42 new tests pass
- [x] Regression suite: 720 distributed-runtime tests clean (no regressions)
- [x] Pre-commit hooks pass (Black/isort/Ruff/Tier-1 sweep)
- [ ] Reviewer + security-reviewer parallel gate review
- [ ] Auto-merge with `--admin` after CI green
- [ ] Shard 2 (Worker multi-queue dequeue) is the next pickup

## Related

Part of issue #911 (multi-queue routing). Builds on #912 wave (per-task time limits) which is in `kailash 2.18.1`. Composes orthogonally — a producer can supply BOTH `queue=\"slow\"` AND `soft_time_limit=300` independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)