### PR TITLE
chore(release): kailash 2.19.0 — multi-queue routing (#911)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.19.0] - 2026-05-10
+
 ### Added — issue #911 Shard 1: multi-queue routing producer surface
 
 `DistributedRuntime.execute(queue=...)` now accepts an optional logical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.18.1"
+version = "2.19.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.18.1"
+__version__ = "2.19.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Minor release of kailash 2.19.0 — closes the #911 multi-queue routing wave end-to-end.

## Scope

- **Shard 1 (PR #932)**: producer-side `DistributedRuntime.execute(queue=...)` + canonical queue-key helper module + `TaskMessage.queue_name` JSON wire format.
- **Shard 2 (PR #933)**: consumer-side `Worker(queues={\"fast\": 8, \"slow\": 2})` — per-queue independent dequeue loops with independent semaphores. Closes acceptance criterion 3 (\"slow task does not block fast task pickup\").
- `TaskEvent.queue_name` populated on every lifecycle hook for per-queue alerting.

Both shards ship together so users get the complete feature in one release. Shipping Shard 1 alone would create a footgun where `queue=\"fast\"` enqueues to a Redis list no current Worker reads.

## Back-compat

- Default-queue Redis list key (`kailash:tasks:pending`) stays byte-identical for single-queue deployments.
- Legacy `Worker(concurrency=N)` / `Worker(queue=tq)` indistinguishable from `Worker(queues={\"default\": N})`.
- Default-queue JSON wire format omits `queue_name` so older Workers parse pre-#911 messages unchanged.

## Diff

Metadata-only release-prep:
- `pyproject.toml::version` → 2.19.0
- `src/kailash/__init__.py::__version__` → 2.19.0
- `CHANGELOG.md` 2.19.0 section heading

Per `git.md` § \"Release-Prep PRs MUST Use release/v\*\" — branched from `release/v2.19.0` to auto-skip the PR-gate matrix.

## Test plan

- [x] Pre-commit hooks pass
- [x] Pyproject + __init__ version anchors aligned (atomic per `zero-tolerance.md` Rule 5)
- [ ] Auto-merge with `--admin` (release-prep auto-skip path)
- [ ] Tag push triggers `publish-pypi.yml`
- [ ] Clean-venv install verification per `build-repo-release-discipline.md` Rule 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)