### PR TITLE
feat(scheduler): runtime admin API for WorkflowScheduler (#913)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — issue #913: WorkflowScheduler runtime admin API
+
+`kailash.runtime.scheduler_admin.SchedulerAdminAPI` is a thin admin
+surface wrapping a started `WorkflowScheduler`. Operators can now
+list / enable / disable / update-cron / delete schedules at runtime
+without redeploying.
+
+- `admin.list_schedules()` / `admin.get_schedule(schedule_id)` return
+  JSON-friendly `ScheduleAdminView` dicts suitable for HTTP / CLI / RPC.
+- `admin.disable_schedule(sid, actor=...)` pauses; `admin.enable_schedule`
+  resumes; both idempotent.
+- `admin.update_cron(sid, "0 7 * * *", actor=...)` swaps the cron and
+  recomputes `next_run_time` atomically — APScheduler's running
+  `AsyncIOScheduler` picks up the new schedule on its next tick.
+- `admin.delete_schedule(sid, actor=...)` removes the schedule and
+  raises typed `ScheduleNotFound` for unknown IDs (replacing the
+  underlying `KeyError`).
+- Every mutation requires a non-empty `actor` string and writes a
+  structured INFO audit log entry on the
+  `kailash.runtime.scheduler_admin` logger.
+- Admin views surface `retry_spec` (#910 pass-through) and
+  `time_limits` (#912 pass-through) so operators inspecting a schedule
+  see its retry budget and per-fire deadlines without re-implementing
+  the kwarg plumbing.
+- `tenant_scope` parameter declares the admin's logical scope (defaults
+  to `"default"`); the single-tenant assumption is explicit, and the
+  multi-tenant extension hook lives in `_visible_ids` so future
+  tenant-aware schedulers can filter without breaking the contract.
+
+Authentication is the caller's responsibility — `SchedulerAdminAPI`
+performs no identity check on the supplied `actor`. Wrap with the
+`packages/kailash-nexus/` auth middleware when exposing over HTTP.
+
+`specs/scheduling.md` §11 documents the admin surface in full.
+
 ### Fixed — issue #911 Shard 2 followup: multi-queue correctness
 
 Redteam round 1 against the 2.19.0 multi-queue release surfaced same-bug-class

--- a/specs/scheduling.md
+++ b/specs/scheduling.md
@@ -21,6 +21,14 @@ The scheduling subsystem enables workflows to run on cron schedules, fixed inter
 - `WorkflowScheduler`
 - `ScheduleInfo`
 - `ScheduleType`
+- `RetrySpec`
+
+**Companion module**: `kailash.runtime.scheduler_admin`
+
+- `SchedulerAdminAPI` — Runtime admin surface (list / enable / disable /
+  update_cron / delete) suitable for HTTP / CLI / RPC wrappers.
+- `ScheduleAdminView` — JSON-friendly dict view of a schedule.
+- `DEFAULT_TENANT_SCOPE = "default"` — single-tenant scope sentinel.
 
 ---
 
@@ -738,8 +746,142 @@ The policy surface is duck-typed per
 
 1. **No async-native execution**: The default `_execute_workflow` calls `runtime.execute()` synchronously inside an async callback. For fully async execution, provide a custom `runtime_factory` with `AsyncLocalRuntime`.
 2. **No built-in worker pool**: The scheduler enqueues to the dispatcher; the application is responsible for running worker processes that call `dispatcher.poll()` in a loop. The Kailash SDK supplies the dispatcher contract and the SQL-backed adapter; worker orchestration is left to the deploying application.
-3. **No schedule modification**: There is no `update_schedule()` method. To change a schedule's trigger, cancel it and create a new one.
-4. **No pause/resume**: Individual schedules cannot be paused. The entire scheduler can be shut down and restarted.
-5. **Schedule ID format**: IDs are `sched-{12_hex_chars}`. Not configurable.
-6. **No retry on failure**: If a scheduled execution fails (in-process or enqueue-side), it is logged but the scheduler does not retry. The next trigger fires normally. Worker-side retry on `nack` is the dispatcher implementation's responsibility (`SQLTaskQueueDispatcher` requeues until `max_attempts`, then dead-letters).
-7. **APScheduler version**: Requires `apscheduler>=3.10`. APScheduler 4.x has a different API and is not supported.
+3. **Schedule ID format**: IDs are `sched-{12_hex_chars}`. Not configurable.
+4. **APScheduler version**: Requires `apscheduler>=3.10`. APScheduler 4.x has a different API and is not supported.
+
+---
+
+## 11. Runtime Admin Surface (Issue #913)
+
+The companion module `kailash.runtime.scheduler_admin` exposes an admin
+API class wrapping the running scheduler so operators can list, enable,
+disable, update-cron, and delete schedules at runtime — without
+shipping a code change.
+
+### 11.1 `SchedulerAdminAPI` class
+
+**Constructor**: `SchedulerAdminAPI(scheduler, *, tenant_scope="default")`.
+
+- `scheduler`: a started `WorkflowScheduler` instance. The admin holds
+  a direct reference so mutations affect the same in-memory job graph
+  the runtime is firing — there is no parallel state.
+- `tenant_scope`: a non-empty string identifying the logical scope
+  the admin operates on. Single-tenant schedulers MUST use the default
+  `"default"` value; future multi-tenant scheduler support filters
+  visible schedules through `_visible_ids` on this scope.
+
+Constructor raises `ValueError` for `scheduler is None` or for an
+empty `tenant_scope`.
+
+### 11.2 Read methods
+
+- `list_schedules() -> list[ScheduleAdminView]` — every visible
+  schedule rendered as a JSON-friendly dict.
+- `get_schedule(schedule_id) -> ScheduleAdminView` — single schedule
+  view; raises `ScheduleNotFound` for unknown IDs.
+
+### 11.3 Mutation methods
+
+All mutation methods take a keyword-only `actor: str` (non-empty
+operator identifier) and write a structured INFO audit log entry
+naming `actor + operation + schedule_id + tenant_scope` to the
+`kailash.runtime.scheduler_admin` logger.
+
+- `disable_schedule(schedule_id, *, actor) -> ScheduleAdminView` —
+  pauses the schedule; idempotent.
+- `enable_schedule(schedule_id, *, actor) -> ScheduleAdminView` —
+  resumes a paused schedule; recomputes `next_run_time` from the
+  trigger.
+- `update_cron(schedule_id, cron_expression, *, actor) -> ScheduleAdminView`
+  — replaces the cron expression of a CRON schedule and
+  atomically recomputes `next_run_time` via APScheduler's
+  `reschedule_job`. Refuses non-cron schedules with a
+  `ValueError("update_cron is only valid for cron schedules; …")`.
+  Invalid cron expressions raise `ValueError("invalid cron: …")`.
+- `delete_schedule(schedule_id, *, actor) -> None` — removes the
+  schedule entirely; subsequent reads raise `ScheduleNotFound`.
+
+Empty or whitespace-only `actor` raises
+`ValueError("actor must be a non-empty string …")`.
+
+Unknown `schedule_id` raises `ScheduleNotFound` from every method
+(translating the underlying `WorkflowScheduler.cancel`'s `KeyError`
+into the typed admin exception).
+
+### 11.4 `ScheduleAdminView` shape
+
+A `dict` subclass with a documented field schema:
+
+| Field           | Type                         | Notes                                                        |
+| --------------- | ---------------------------- | ------------------------------------------------------------ |
+| `schedule_id`   | `str`                        | `sched-{12_hex_chars}`                                       |
+| `schedule_type` | `str`                        | `"cron"` / `"interval"` / `"once"`                           |
+| `workflow_name` | `str`                        | Operator label, may be `""`                                  |
+| `trigger_args`  | `dict[str, Any]`             | Per-type trigger config snapshot                             |
+| `created_at`    | `str`                        | ISO 8601 (UTC)                                               |
+| `next_run_time` | `Optional[str]`              | ISO 8601 OR `None` if paused / completed                     |
+| `enabled`       | `bool`                       | `True` if the scheduler will fire on next tick               |
+| `kwargs`        | `dict[str, Any]`             | User-supplied runtime kwargs; internal `_kailash_*` filtered |
+| `retry_spec`    | `Optional[dict]`             | Issue #910 retry primitives (see 11.5)                       |
+| `time_limits`   | `dict[str, Optional[float]]` | Issue #912 deadlines (see 11.6)                              |
+
+### 11.5 `retry_spec` field (issue #910 pass-through)
+
+When a schedule was registered with `retry=RetrySpec(...)`, the admin
+view surfaces a JSON-serializable dict:
+
+```python
+{
+    "max_retries": 3,
+    "backoff": "exponential",
+    "backoff_base_seconds": 1.0,
+    "backoff_max_seconds": 60.0,
+    "retry_on": ["ConnectionError", "TimeoutError"],
+    "dont_retry_on": [],
+}
+```
+
+Exception classes are serialized as their `__name__` (string list) so
+the view round-trips through HTTP / CLI without surfacing class
+objects. `None` when the schedule has no retry spec.
+
+### 11.6 `time_limits` field (issue #912 pass-through)
+
+Always present as `{"soft_time_limit": <s|None>, "time_limit": <s|None>}`.
+Surfaces the EFFECTIVE per-fire deadlines (resolved at schedule
+registration time per `_compose_job_kwargs`). Both keys `None` when
+the schedule registered without limits AND the scheduler was
+constructed without defaults.
+
+### 11.7 Authentication and authorization
+
+`SchedulerAdminAPI` performs ZERO authentication. Callers (Nexus
+handlers, CLI tools, ops RPCs) are responsible for authenticating
+the operator and passing a non-empty `actor` field. See
+`packages/kailash-nexus/` for the canonical authentication wiring
+when the admin is exposed over HTTP.
+
+### 11.8 Audit log surface
+
+Every mutation emits one structured INFO log line on the
+`kailash.runtime.scheduler_admin` logger:
+
+```text
+scheduler.admin.disable     actor=ops@example.com schedule_id=sched-... tenant=default
+scheduler.admin.enable      actor=ops@example.com schedule_id=sched-... tenant=default
+scheduler.admin.update_cron actor=ops@example.com schedule_id=sched-... cron='0 7 * * *' tenant=default
+scheduler.admin.delete      actor=ops@example.com schedule_id=sched-... tenant=default
+```
+
+Operators MUST capture this logger to a durable destination if they
+need a long-term audit trail.
+
+### 11.9 Reload semantics
+
+APScheduler's `pause_job` / `resume_job` / `reschedule_job` /
+`remove_job` mutate the in-memory job graph AND the persisted
+SQLAlchemy job store atomically. The running asyncio scheduler
+picks up changes on its next event-loop tick (typically immediate,
+since the scheduler holds the just-modified job in memory). No
+explicit `wakeup()` call is required — APScheduler's internal
+listeners refresh `next_run_time` at every fire-cycle boundary.

--- a/src/kailash/runtime/__init__.py
+++ b/src/kailash/runtime/__init__.py
@@ -15,9 +15,15 @@ from kailash.runtime.progress import (
     report_progress,
 )
 from kailash.runtime.runner import WorkflowRunner
+from kailash.runtime.scheduler_admin import (
+    DEFAULT_TENANT_SCOPE,
+    ScheduleAdminView,
+    SchedulerAdminAPI,
+)
 from kailash.runtime.shutdown import ShutdownCoordinator
 from kailash.runtime.signals import QueryRegistry, SignalChannel
 from kailash.runtime.watchdog import EventLoopWatchdog, StallReport
+from kailash.sdk_exceptions import ScheduleNotFound
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +43,11 @@ __all__ = [
     "QueryRegistry",
     "EventLoopWatchdog",
     "StallReport",
+    # Issue #913 — scheduler admin surface re-exported for facade discoverability
+    "SchedulerAdminAPI",
+    "ScheduleAdminView",
+    "ScheduleNotFound",
+    "DEFAULT_TENANT_SCOPE",
     "get_runtime",
     "report_progress",
 ]

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -53,7 +53,15 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Ty
 
 if TYPE_CHECKING:
     from kailash.runtime.dispatcher import Dispatcher
-    from kailash.runtime.scheduler_admin import SchedulerAdminAPI
+
+# NOTE: SchedulerAdminAPI is intentionally NOT imported under TYPE_CHECKING.
+# scheduler_admin.py imports scheduler symbols (RetrySpec, ScheduleInfo,
+# ScheduleType, WorkflowScheduler) for typing — adding a TYPE_CHECKING
+# import here would form a module-level cyclic import that CodeQL flags
+# as `py/unsafe-cyclic-import`. The runtime resolution is the lazy import
+# inside the `admin_api` property body (search this file for
+# `from kailash.runtime.scheduler_admin import SchedulerAdminAPI`).
+# Type annotations referencing the class use `Any` to avoid the cycle.
 
 from kailash.runtime._time_limits import (
     _TimeLimitClassifier,
@@ -470,7 +478,8 @@ class WorkflowScheduler:
         # `scheduler.admin_api` access so the SchedulerAdminAPI module's
         # `from kailash.runtime.scheduler import ...` TYPE_CHECKING import
         # cannot create a circular-import hazard at scheduler import time.
-        self._admin_api: Optional["SchedulerAdminAPI"] = None
+        # Typed `Any` to avoid cyclic-import (see module-level NOTE).
+        self._admin_api: Optional[Any] = None
 
         # Per-job fire-time capture: APScheduler's EVENT_JOB_SUBMITTED listener
         # fires BEFORE the job callback with `event.scheduled_run_time`, the
@@ -545,7 +554,7 @@ class WorkflowScheduler:
             logger.info("WorkflowScheduler shut down (wait=%s)", wait)
 
     @property
-    def admin_api(self) -> "SchedulerAdminAPI":
+    def admin_api(self) -> Any:
         """Runtime admin surface for this scheduler (#913).
 
         Production users edit schedules at runtime through this property —

--- a/src/kailash/runtime/scheduler.py
+++ b/src/kailash/runtime/scheduler.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Ty
 
 if TYPE_CHECKING:
     from kailash.runtime.dispatcher import Dispatcher
+    from kailash.runtime.scheduler_admin import SchedulerAdminAPI
 
 from kailash.runtime._time_limits import (
     _TimeLimitClassifier,
@@ -465,6 +466,12 @@ class WorkflowScheduler:
         self._default_soft_time_limit: Optional[float] = default_soft_time_limit
         self._default_time_limit: Optional[float] = default_time_limit
 
+        # Issue #913: lazy-built admin facade. Constructed on first
+        # `scheduler.admin_api` access so the SchedulerAdminAPI module's
+        # `from kailash.runtime.scheduler import ...` TYPE_CHECKING import
+        # cannot create a circular-import hazard at scheduler import time.
+        self._admin_api: Optional["SchedulerAdminAPI"] = None
+
         # Per-job fire-time capture: APScheduler's EVENT_JOB_SUBMITTED listener
         # fires BEFORE the job callback with `event.scheduled_run_time`, the
         # ACTUAL fire instant for the currently-firing job. We record it here
@@ -536,6 +543,43 @@ class WorkflowScheduler:
         if self._scheduler.running:
             self._scheduler.shutdown(wait=wait)
             logger.info("WorkflowScheduler shut down (wait=%s)", wait)
+
+    @property
+    def admin_api(self) -> "SchedulerAdminAPI":
+        """Runtime admin surface for this scheduler (#913).
+
+        Production users edit schedules at runtime through this property —
+        list active schedules, pause/resume, update cron expressions, delete
+        schedules — without restarting the process or shipping a code change.
+
+        The returned :class:`SchedulerAdminAPI` is bound to THIS scheduler
+        instance (no parallel state) and is memoized: repeated property
+        access returns the SAME admin object. Mutating calls on the admin
+        write a structured audit log line naming the supplied ``actor`` so
+        post-incident triage can reconstruct who edited what.
+
+        Example:
+            >>> scheduler = WorkflowScheduler(job_store_path=None)
+            >>> scheduler.start()
+            >>> for view in scheduler.admin_api.list_schedules():
+            ...     print(view["schedule_id"], view["next_run_time"])
+            >>> scheduler.admin_api.update_cron(
+            ...     "sched-abc123", "0 7 * * *", actor="ops@example.com"
+            ... )
+
+        See Also:
+            :class:`kailash.runtime.scheduler_admin.SchedulerAdminAPI` —
+            the admin facade itself; the HTTP / CLI / RPC layers MUST be
+            thin wrappers over its methods.
+        """
+        # Lazy import: scheduler_admin uses `if TYPE_CHECKING:` to import
+        # this module's types, so a top-level import here would create a
+        # cycle. The deferred import resolves the cycle at first access.
+        from kailash.runtime.scheduler_admin import SchedulerAdminAPI
+
+        if self._admin_api is None:
+            self._admin_api = SchedulerAdminAPI(self)
+        return self._admin_api
 
     def schedule_cron(
         self,

--- a/src/kailash/runtime/scheduler_admin.py
+++ b/src/kailash/runtime/scheduler_admin.py
@@ -1,0 +1,535 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime admin API for :class:`WorkflowScheduler` (issue #913).
+
+Operators frequently need to disable a schedule, edit a cron expression,
+or list active schedules WITHOUT shipping a code change and restarting
+the process. The underlying :class:`WorkflowScheduler` already exposes
+``pause`` / ``resume`` / ``update_cron`` / ``cancel`` / ``list_schedules``
+on its instance, but those primitives are scheduler-internal and not
+shaped for an admin surface (Nexus panel, CLI tool, ops UI):
+
+* They mutate state in-place; a multi-tenant admin must filter the visible
+  set per-caller.
+* The list view returns :class:`ScheduleInfo` dataclasses; HTTP and CLI
+  surfaces want JSON-serializable dicts whose shape is documented and
+  versioned.
+* They surface :class:`KeyError` on ``cancel`` and
+  :class:`~kailash.sdk_exceptions.ScheduleNotFound` on the new admin
+  methods (``pause`` / ``resume`` / ``update_cron``); a stable admin
+  contract MUST emit a single typed exception class for all unknown-id
+  cases so HTTP 404 / exit-code-4 mapping works without per-method
+  branching.
+
+This module wraps the scheduler with a thin :class:`SchedulerAdminAPI`
+class whose every method is callable from tests, from a Nexus handler,
+from a CLI tool, or from a worker-side admin RPC. The HTTP / CLI / RPC
+layers are ALWAYS thin wrappers over this module — never re-implement
+the operations elsewhere.
+
+Tenant isolation
+----------------
+
+The current :class:`WorkflowScheduler` is a single-tenant object: every
+schedule it owns is in the same logical scope. Per the brief's design
+constraint, the admin surface declares this assumption explicitly via
+the ``tenant_scope`` parameter and refuses to mutate schedules outside
+its declared scope. When the SDK grows multi-tenant scheduler support,
+the admin's ``_visible_ids`` filter is the structural extension point —
+it converts to a per-tenant query against the scheduler's tenant index
+without changing the public surface.
+
+Authentication
+--------------
+
+This module performs ZERO authentication. The caller (Nexus handler,
+CLI, ops RPC) is responsible for authenticating the operator and
+supplying a non-empty ``actor`` field on every mutation. Every mutating
+call writes a structured audit log entry naming the actor + operation
++ schedule_id so post-incident triage can reconstruct who edited what.
+
+Related issues:
+
+* #910 — per-job retry primitives (``RetrySpec``); admin pass-through
+  reads via ``ScheduleInfo.retry_spec``.
+* #912 — per-task time limits; reads via the persisted job kwargs.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+
+from kailash.sdk_exceptions import ScheduleNotFound
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kailash.runtime.scheduler import (
+        RetrySpec,
+        ScheduleInfo,
+        ScheduleType,
+        WorkflowScheduler,
+    )
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SchedulerAdminAPI",
+    "ScheduleAdminView",
+    "DEFAULT_TENANT_SCOPE",
+]
+
+# Sentinel for the single-tenant scheduler shape. When multi-tenant
+# scheduler support lands, replace this constant with a per-call lookup
+# against the scheduler's tenant index — every public method already
+# routes through ``_visible_ids`` so the change is one method, not the
+# whole admin surface.
+DEFAULT_TENANT_SCOPE = "default"
+
+
+# Internal kwargs keys persisted by the scheduler in APScheduler's job
+# kwargs dict. Re-defined here as module-private constants so the admin
+# view can reach into a job's kwargs to surface retry + time-limit fields
+# WITHOUT importing scheduler internals at function-call time (which
+# would create a circular import when the scheduler grows an admin
+# property).
+_RETRY_SPEC_KWARG = "_kailash_retry_spec"
+_TIME_LIMIT_KWARG = "_kailash_time_limits"
+
+
+def _serialize_retry_spec(spec: Optional["RetrySpec"]) -> Optional[Dict[str, Any]]:
+    """Convert a :class:`RetrySpec` to a JSON-friendly dict.
+
+    The dataclass uses ``Tuple[Type[BaseException], ...]`` for
+    ``retry_on`` / ``dont_retry_on`` — class objects are not
+    JSON-serializable. Map to their qualified name so the admin view
+    is round-trip safe through HTTP/CLI without surfacing class
+    objects to non-Python clients.
+    """
+    if spec is None:
+        return None
+    return {
+        "max_retries": spec.max_retries,
+        "backoff": spec.backoff,
+        "backoff_base_seconds": spec.backoff_base_seconds,
+        "backoff_max_seconds": spec.backoff_max_seconds,
+        "retry_on": [t.__name__ for t in spec.retry_on],
+        "dont_retry_on": [t.__name__ for t in spec.dont_retry_on],
+    }
+
+
+def _serialize_time_limits(
+    pair: Optional[Any],
+) -> Dict[str, Optional[float]]:
+    """Surface the persisted (soft, hard) tuple as a documented dict.
+
+    The scheduler stores effective time limits as a 2-tuple under
+    ``_TIME_LIMIT_KWARG``. Return ``{"soft_time_limit": s,
+    "time_limit": h}`` so the admin view never leaks the internal
+    tuple shape to API consumers.
+    """
+    if pair is None:
+        return {"soft_time_limit": None, "time_limit": None}
+    soft, hard = pair
+    return {"soft_time_limit": soft, "time_limit": hard}
+
+
+class ScheduleAdminView(Dict[str, Any]):
+    """Documented JSON-friendly view of a schedule for admin surfaces.
+
+    Inherits ``dict`` so the value is directly JSON-serializable AND
+    the field set is documented in this class's docstring. Field
+    schema (stable across the admin surface):
+
+    * ``schedule_id``: str, format ``sched-{12_hex_chars}``
+    * ``schedule_type``: str, one of ``"cron"`` / ``"interval"`` / ``"once"``
+    * ``workflow_name``: str, operator-supplied label or ``""``
+    * ``trigger_args``: dict, schedule-type-specific (cron expression,
+      interval seconds, or run_at ISO string)
+    * ``created_at``: ISO 8601 timestamp string (UTC)
+    * ``next_run_time``: ISO 8601 timestamp string OR ``None`` if paused
+      / completed
+    * ``enabled``: bool — ``True`` if the scheduler will fire this
+      schedule on its next tick
+    * ``kwargs``: dict — user-supplied runtime kwargs (sanitized: the
+      scheduler's internal ``_kailash_*`` keys are filtered out)
+    * ``retry_spec``: dict OR ``None`` — issue #910 retry primitives
+      shape (when supplied at schedule time)
+    * ``time_limits``: dict — issue #912 per-fire deadlines
+      ``{"soft_time_limit": <s|None>, "time_limit": <s|None>}``
+    """
+
+
+class SchedulerAdminAPI:
+    """Runtime admin surface for an in-process :class:`WorkflowScheduler`.
+
+    Wraps the scheduler with operations safe to call from a privileged
+    admin endpoint: list / enable (resume) / disable (pause) /
+    update_cron / delete (cancel). All mutating operations write a
+    structured audit log line naming the supplied ``actor`` and the
+    schedule_id touched, so post-incident triage can reconstruct who
+    edited what.
+
+    The scheduler's reload semantics are handled by APScheduler itself:
+    ``pause_job`` / ``resume_job`` / ``reschedule_job`` mutate the
+    in-memory job graph AND the persisted SQLAlchemyJobStore atomically;
+    APScheduler's ``AsyncIOScheduler`` picks up the change on its next
+    tick (typically immediate since the scheduler holds the
+    just-modified job in memory).
+
+    Args:
+        scheduler: The :class:`WorkflowScheduler` instance to expose
+            for admin operations. The admin holds a reference to the
+            same scheduler the runtime is firing — no parallel state.
+        tenant_scope: A logical scope identifier the admin recognizes.
+            The single-tenant scheduler MUST receive the default
+            ``"default"`` value; multi-tenant schedulers (future) MUST
+            pass the caller's tenant id and the admin will filter
+            ``list_schedules`` / mutation calls to that tenant.
+
+    Example:
+        >>> from kailash.runtime.scheduler import WorkflowScheduler
+        >>> from kailash.runtime.scheduler_admin import SchedulerAdminAPI
+        >>>
+        >>> scheduler = WorkflowScheduler()
+        >>> scheduler.start()
+        >>> admin = SchedulerAdminAPI(scheduler)
+        >>>
+        >>> # List active schedules
+        >>> for view in admin.list_schedules():
+        ...     print(view["schedule_id"], view["enabled"])
+        >>>
+        >>> # Disable a schedule without redeploying
+        >>> admin.disable_schedule("sched-abc123def456", actor="ops@example.com")
+        >>>
+        >>> # Edit cron at runtime
+        >>> admin.update_cron(
+        ...     "sched-abc123def456",
+        ...     "0 7 * * *",
+        ...     actor="ops@example.com",
+        ... )
+
+    Notes:
+        **Single-tenant assumption.** The default scheduler is
+        single-tenant: every registered schedule belongs to the same
+        logical scope. The ``tenant_scope`` parameter exists so admin
+        surfaces can declare their scope explicitly (and so a future
+        multi-tenant scheduler can grow per-tenant filtering without
+        breaking this surface).
+
+        **Authentication is the caller's job.** This class performs no
+        identity check on ``actor``. The HTTP / CLI / RPC wrapper that
+        calls into this admin MUST authenticate the operator and
+        supply a non-empty ``actor`` string for the audit trail.
+    """
+
+    def __init__(
+        self,
+        scheduler: "WorkflowScheduler",
+        *,
+        tenant_scope: str = DEFAULT_TENANT_SCOPE,
+    ) -> None:
+        if scheduler is None:
+            raise ValueError(
+                "SchedulerAdminAPI requires a non-None WorkflowScheduler "
+                "instance; got None"
+            )
+        if not isinstance(tenant_scope, str) or not tenant_scope:
+            raise ValueError(
+                f"SchedulerAdminAPI tenant_scope must be a non-empty string, "
+                f"got {tenant_scope!r}"
+            )
+        self._scheduler = scheduler
+        self._tenant_scope = tenant_scope
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    def list_schedules(self) -> List[ScheduleAdminView]:
+        """Return every schedule the admin can see, as JSON-friendly dicts.
+
+        The scheduler's ``list_schedules`` returns
+        :class:`ScheduleInfo` dataclasses; this method serializes each
+        to a :class:`ScheduleAdminView` (a dict) so the same value can
+        be returned from a Nexus handler over HTTP, dumped to a CLI's
+        stdout, or relayed to a worker-side admin RPC without further
+        massaging.
+
+        Single-tenant schedulers return every registered schedule.
+        Multi-tenant schedulers (future) MUST filter to the admin's
+        ``tenant_scope`` via :meth:`_visible_ids`.
+
+        Returns:
+            List of :class:`ScheduleAdminView` dicts, one per visible
+            schedule. Empty list when no schedules are registered.
+        """
+        infos = self._scheduler.list_schedules()
+        return [self._info_to_view(info) for info in infos]
+
+    def get_schedule(self, schedule_id: str) -> ScheduleAdminView:
+        """Return the JSON-friendly view of a single schedule.
+
+        Args:
+            schedule_id: The ID returned at schedule-time.
+
+        Raises:
+            ScheduleNotFound: When ``schedule_id`` is not registered
+                (or not visible to the admin's tenant scope).
+        """
+        self._ensure_visible(schedule_id)
+        # Re-fetch from the scheduler so ``next_run_time`` reflects the
+        # latest APScheduler state (the scheduler's list_schedules()
+        # populates it from the live job graph).
+        for info in self._scheduler.list_schedules():
+            if info.schedule_id == schedule_id:
+                return self._info_to_view(info)
+        raise ScheduleNotFound(schedule_id)
+
+    # ------------------------------------------------------------------
+    # Mutation operations
+    # ------------------------------------------------------------------
+
+    def disable_schedule(
+        self,
+        schedule_id: str,
+        *,
+        actor: str,
+    ) -> ScheduleAdminView:
+        """Pause a schedule so no further fires occur.
+
+        Idempotent — disabling an already-disabled schedule is a no-op
+        on the scheduler and still returns the current view.
+
+        Args:
+            schedule_id: The ID returned at schedule-time.
+            actor: Non-empty operator identifier (email, username,
+                service principal). Written to the audit log.
+
+        Returns:
+            The post-disable :class:`ScheduleAdminView` (with
+            ``enabled=False`` and ``next_run_time=None``).
+
+        Raises:
+            ScheduleNotFound: When ``schedule_id`` is unknown.
+            ValueError: When ``actor`` is empty.
+        """
+        self._require_actor(actor)
+        self._ensure_visible(schedule_id)
+        self._scheduler.pause(schedule_id)
+        logger.info(
+            "scheduler.admin.disable actor=%s schedule_id=%s tenant=%s",
+            actor,
+            schedule_id,
+            self._tenant_scope,
+        )
+        return self.get_schedule(schedule_id)
+
+    def enable_schedule(
+        self,
+        schedule_id: str,
+        *,
+        actor: str,
+    ) -> ScheduleAdminView:
+        """Resume a paused schedule, recomputing the next fire time.
+
+        Idempotent — enabling an already-enabled schedule is a no-op.
+
+        Args:
+            schedule_id: The ID returned at schedule-time.
+            actor: Non-empty operator identifier. Written to the
+                audit log.
+
+        Returns:
+            The post-resume :class:`ScheduleAdminView` (with the new
+            ``next_run_time`` recomputed from the trigger).
+
+        Raises:
+            ScheduleNotFound: When ``schedule_id`` is unknown.
+            ValueError: When ``actor`` is empty.
+        """
+        self._require_actor(actor)
+        self._ensure_visible(schedule_id)
+        self._scheduler.resume(schedule_id)
+        logger.info(
+            "scheduler.admin.enable actor=%s schedule_id=%s tenant=%s",
+            actor,
+            schedule_id,
+            self._tenant_scope,
+        )
+        return self.get_schedule(schedule_id)
+
+    def update_cron(
+        self,
+        schedule_id: str,
+        cron_expression: str,
+        *,
+        actor: str,
+    ) -> ScheduleAdminView:
+        """Replace a cron schedule's expression. Reloads on next tick.
+
+        APScheduler's ``reschedule_job`` swaps the trigger atomically
+        AND recomputes ``next_run_time`` — so the running scheduler
+        picks up the new cron on its next event-loop tick (typically
+        immediate).
+
+        Args:
+            schedule_id: The ID of an existing CRON schedule.
+            cron_expression: A 5-field cron expression
+                (minute hour day month weekday).
+            actor: Non-empty operator identifier.
+
+        Returns:
+            The post-update :class:`ScheduleAdminView` reflecting the
+            new cron + recomputed ``next_run_time``.
+
+        Raises:
+            ScheduleNotFound: When ``schedule_id`` is unknown.
+            ValueError: When ``cron_expression`` is invalid OR
+                ``actor`` is empty. Cron-validation messages start
+                with ``"invalid cron"`` for grep-able pattern matching
+                by callers (mirrors the underlying scheduler's
+                contract).
+        """
+        self._require_actor(actor)
+        self._ensure_visible(schedule_id)
+        # Refuse update_cron on non-CRON schedules with a clear typed
+        # error rather than letting APScheduler raise an opaque
+        # internal exception about trigger mismatch — the admin
+        # surface is the operator-facing contract, so the precondition
+        # is checked here.
+        info = self._lookup_info(schedule_id)
+        if info.schedule_type.value != "cron":
+            raise ValueError(
+                f"update_cron is only valid for cron schedules; schedule "
+                f"{schedule_id!r} is of type "
+                f"{info.schedule_type.value!r}. Cancel and recreate as a "
+                f"cron schedule instead."
+            )
+        self._scheduler.update_cron(schedule_id, cron_expression)
+        logger.info(
+            "scheduler.admin.update_cron actor=%s schedule_id=%s "
+            "cron='%s' tenant=%s",
+            actor,
+            schedule_id,
+            cron_expression,
+            self._tenant_scope,
+        )
+        return self.get_schedule(schedule_id)
+
+    def delete_schedule(
+        self,
+        schedule_id: str,
+        *,
+        actor: str,
+    ) -> None:
+        """Remove a schedule entirely. Subsequent ``get_schedule`` raises.
+
+        Maps to :meth:`WorkflowScheduler.cancel`; replaces the
+        scheduler's :class:`KeyError` with a typed
+        :class:`ScheduleNotFound` for stable admin-surface error
+        mapping.
+
+        Args:
+            schedule_id: The ID to remove.
+            actor: Non-empty operator identifier.
+
+        Raises:
+            ScheduleNotFound: When ``schedule_id`` is unknown.
+            ValueError: When ``actor`` is empty.
+        """
+        self._require_actor(actor)
+        self._ensure_visible(schedule_id)
+        try:
+            self._scheduler.cancel(schedule_id)
+        except KeyError as exc:
+            # Translate to the typed admin-surface exception so HTTP /
+            # CLI mappings can rely on a single class for unknown-id
+            # cases across every method in this surface.
+            raise ScheduleNotFound(schedule_id) from exc
+        logger.info(
+            "scheduler.admin.delete actor=%s schedule_id=%s tenant=%s",
+            actor,
+            schedule_id,
+            self._tenant_scope,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers — single source of truth for tenant filtering
+    # ------------------------------------------------------------------
+
+    def _visible_ids(self) -> Iterable[str]:
+        """Yield schedule_ids visible to the admin's tenant scope.
+
+        Single-tenant: every registered schedule. Multi-tenant
+        (future): filter the scheduler's tenant index to those
+        matching ``self._tenant_scope``. This is the structural
+        extension point for multi-tenancy — every public method
+        routes through ``_ensure_visible`` so per-tenant filtering
+        kicks in here without API changes.
+        """
+        return list(self._scheduler._schedules.keys())
+
+    def _ensure_visible(self, schedule_id: str) -> None:
+        """Raise :class:`ScheduleNotFound` when ``schedule_id`` not visible.
+
+        Single source of truth for unknown-id handling across every
+        admin operation. Translates the scheduler's internal
+        ``KeyError`` (cancel) and :class:`ScheduleNotFound` (pause/
+        resume/update_cron) into one canonical class for the admin
+        contract.
+        """
+        if schedule_id not in self._visible_ids():
+            raise ScheduleNotFound(schedule_id)
+
+    def _lookup_info(self, schedule_id: str) -> "ScheduleInfo":
+        """Return the live :class:`ScheduleInfo` for ``schedule_id``."""
+        info = self._scheduler._schedules.get(schedule_id)
+        if info is None:
+            raise ScheduleNotFound(schedule_id)
+        return info
+
+    @staticmethod
+    def _require_actor(actor: str) -> None:
+        """Validate the audit-trail ``actor`` is non-empty.
+
+        Empty actor is BLOCKED at the admin surface — every mutating
+        call writes the actor into the audit log; an empty value
+        would render the log entry useless for post-incident triage.
+        """
+        if not isinstance(actor, str) or not actor.strip():
+            raise ValueError(
+                "actor must be a non-empty string identifying the operator "
+                "performing the admin action (audit trail requirement)"
+            )
+
+    def _info_to_view(self, info: "ScheduleInfo") -> ScheduleAdminView:
+        """Convert a :class:`ScheduleInfo` to a :class:`ScheduleAdminView`."""
+        # Reach into the underlying APScheduler job kwargs to surface
+        # retry + time-limit fields (issues #910/#912) — the
+        # ScheduleInfo only carries `retry_spec`, the time-limit pair
+        # lives in the persisted job kwargs under a private kwarg key.
+        job = self._scheduler._scheduler.get_job(info.schedule_id)
+        time_limits_pair = None
+        if job is not None and job.kwargs is not None:
+            time_limits_pair = job.kwargs.get(_TIME_LIMIT_KWARG)
+        view: ScheduleAdminView = ScheduleAdminView(
+            schedule_id=info.schedule_id,
+            schedule_type=info.schedule_type.value,
+            workflow_name=info.workflow_name,
+            trigger_args=dict(info.trigger_args),
+            created_at=_isoformat(info.created_at),
+            next_run_time=_isoformat(info.next_run_time),
+            enabled=info.enabled,
+            kwargs=dict(info.kwargs),
+            retry_spec=_serialize_retry_spec(info.retry_spec),
+            time_limits=_serialize_time_limits(time_limits_pair),
+        )
+        return view
+
+
+def _isoformat(value: Optional[datetime]) -> Optional[str]:
+    """Return ISO 8601 for a datetime, or ``None`` when not set."""
+    if value is None:
+        return None
+    return value.isoformat()

--- a/src/kailash/runtime/scheduler_admin.py
+++ b/src/kailash/runtime/scheduler_admin.py
@@ -87,13 +87,17 @@ __all__ = [
 DEFAULT_TENANT_SCOPE = "default"
 
 
-# Internal kwargs keys persisted by the scheduler in APScheduler's job
-# kwargs dict. Re-defined here as module-private constants so the admin
-# view can reach into a job's kwargs to surface retry + time-limit fields
-# WITHOUT importing scheduler internals at function-call time (which
-# would create a circular import when the scheduler grows an admin
-# property).
-_RETRY_SPEC_KWARG = "_kailash_retry_spec"
+# Internal kwargs key persisted by the scheduler in APScheduler's job
+# kwargs dict. Re-defined here as a module-private constant so the admin
+# view can reach into a job's kwargs to surface time-limit fields WITHOUT
+# importing scheduler internals at function-call time (which would create
+# a circular import when the scheduler grows an admin property).
+#
+# Note: retry-spec passthrough surfaces via ``ScheduleInfo.retry_spec``
+# (set by the scheduler at schedule-time), not via the persisted job
+# kwargs dict — the equivalent ``_RETRY_SPEC_KWARG`` constant from the
+# scheduler module is intentionally NOT re-defined here because the
+# admin view never needs to read it.
 _TIME_LIMIT_KWARG = "_kailash_time_limits"
 
 

--- a/tests/integration/scheduler/test_scheduler_admin_api.py
+++ b/tests/integration/scheduler/test_scheduler_admin_api.py
@@ -308,3 +308,93 @@ class TestSchedulerAdminAPIRetryAndTimeLimitPassthrough:
             "soft_time_limit": None,
             "time_limit": None,
         }
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSchedulerAdminAPIWiringThroughFacade:
+    """R2-001 closure: the ``WorkflowScheduler.admin_api`` property + runtime
+    re-export are the documented use paths. Per ``rules/orphan-detection.md``
+    Rule 1 + ``facade-manager-detection.md`` Rule 1, the manager class MUST
+    have a production call site AND be discoverable via the framework
+    facade. This test exercises BOTH wiring paths end-to-end.
+    """
+
+    async def test_runtime_reexports_scheduler_admin_surface(self):
+        """Top-level re-export: ``from kailash.runtime import SchedulerAdminAPI``
+        resolves to the same class as the underlying module export.
+
+        Imports here are inside the test (not at module top) so the test
+        itself exercises the re-export path. Same-class identity assertion
+        guards against a future refactor that ships a divergent shim.
+        """
+        from kailash.runtime import (
+            DEFAULT_TENANT_SCOPE,
+            ScheduleAdminView,
+            ScheduleNotFound,
+            SchedulerAdminAPI,
+        )
+        from kailash.runtime import scheduler_admin as _admin_module
+        from kailash.sdk_exceptions import ScheduleNotFound as _exc_module
+
+        assert SchedulerAdminAPI is _admin_module.SchedulerAdminAPI
+        assert ScheduleAdminView is _admin_module.ScheduleAdminView
+        assert DEFAULT_TENANT_SCOPE == _admin_module.DEFAULT_TENANT_SCOPE
+        assert ScheduleNotFound is _exc_module
+
+    async def test_admin_api_property_returns_bound_admin(self, started_scheduler):
+        """``scheduler.admin_api`` returns a SchedulerAdminAPI bound to THIS
+        scheduler — no parallel state.
+        """
+        from kailash.runtime import SchedulerAdminAPI
+
+        admin = started_scheduler.admin_api
+
+        assert isinstance(admin, SchedulerAdminAPI)
+        # The admin's internal scheduler reference IS the same object.
+        # (Per facade-manager-detection.md Rule 3 the admin holds the
+        # parent framework instance — exposing the identity via the
+        # public ``_visible_ids`` filter would be intrusive; we assert
+        # that mutations on the admin observably touch the scheduler.)
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+        listed_via_property = admin.list_schedules()
+        assert sid in {v["schedule_id"] for v in listed_via_property}
+
+    async def test_admin_api_property_memoizes_same_instance(self, started_scheduler):
+        """Repeated property access returns the SAME admin object.
+
+        Memoization matters because ops UIs frequently re-read the
+        property per request; allocating a fresh admin every time would
+        defeat any per-admin caching the surface might add later AND
+        confuses identity-based assertions in test code.
+        """
+        first = started_scheduler.admin_api
+        second = started_scheduler.admin_api
+        third = started_scheduler.admin_api
+
+        assert first is second, "admin_api property allocated a new admin"
+        assert second is third
+
+    async def test_admin_api_property_drives_update_cron_path(self, started_scheduler):
+        """Property-driven mutation: ``scheduler.admin_api.update_cron(...)``
+        changes the schedule's next fire time, end-to-end through the
+        documented use path (no direct SchedulerAdminAPI(...) construction).
+
+        This is the same observable assertion as
+        ``test_update_cron_shifts_next_run_time`` above, but routed through
+        the property — proving the property IS a production call site for
+        the manager (closing the orphan-detection Rule 1 finding).
+        """
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+        before = started_scheduler.admin_api.get_schedule(sid)["next_run_time"]
+        assert before is not None and "T06:" in before
+
+        view = started_scheduler.admin_api.update_cron(
+            sid, "0 7 * * *", actor="ops@example.com"
+        )
+
+        assert view["trigger_args"] == {"cron_expression": "0 7 * * *"}
+        after = view["next_run_time"]
+        assert (
+            after is not None and "T07:" in after
+        ), f"property-driven update_cron did not shift next_run_time: {after!r}"

--- a/tests/integration/scheduler/test_scheduler_admin_api.py
+++ b/tests/integration/scheduler/test_scheduler_admin_api.py
@@ -1,0 +1,310 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier 2 integration tests for ``SchedulerAdminAPI`` (issue #913).
+
+Per ``rules/testing.md`` Tier 2: NO mocking — every test runs against
+a real ``WorkflowScheduler`` with an in-memory APScheduler job store.
+The admin surface is exercised end-to-end and assertions observe
+externally-visible behavior:
+
+* ``next_run_time`` reflects cron edits within one tick.
+* Disable / enable round-trip preserves schedule state.
+* Delete removes the schedule from the listing.
+* Retry spec + time-limit fields surface in the admin view (#910/#912
+  pass-through reads).
+
+The scheduler uses APScheduler's ``AsyncIOScheduler`` which requires a
+running event loop at ``start()`` time — every test is therefore
+async-marked so the fixture's ``scheduler.start()`` runs inside the
+pytest-asyncio event loop.
+
+Skips if APScheduler is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+apscheduler = pytest.importorskip(
+    "apscheduler", reason="WorkflowScheduler requires APScheduler"
+)
+
+
+def _trivial_workflow():
+    """Build a do-nothing WorkflowBuilder safe to schedule under any cron.
+
+    The body is a single PythonCodeNode that writes a constant — no
+    side effects, no I/O. Sufficient for asserting that APScheduler
+    accepts the registration and surfaces the schedule through the
+    admin view; the firing semantics are covered by sibling tests.
+    """
+    from kailash.workflow.builder import WorkflowBuilder
+
+    builder = WorkflowBuilder()
+    builder.add_node("PythonCodeNode", "noop", {"code": "result = {'ok': True}"})
+    return builder
+
+
+@pytest.fixture
+async def started_scheduler():
+    """Yield a started in-memory ``WorkflowScheduler`` and shut it down.
+
+    Async fixture so ``AsyncIOScheduler.start()`` runs inside the
+    pytest-asyncio event loop (it calls ``asyncio.get_running_loop()``).
+    """
+    from kailash.runtime.scheduler import WorkflowScheduler
+
+    sched = WorkflowScheduler(job_store_path=None)
+    sched.start()
+    try:
+        yield sched
+    finally:
+        sched.shutdown(wait=False)
+
+
+@pytest.fixture
+async def admin(started_scheduler):
+    """Return a ``SchedulerAdminAPI`` bound to the running scheduler."""
+    from kailash.runtime.scheduler_admin import SchedulerAdminAPI
+
+    return SchedulerAdminAPI(started_scheduler)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSchedulerAdminAPIListAndGet:
+    """list / get expose schedules through a JSON-friendly view."""
+
+    async def test_list_returns_empty_when_no_schedules(self, admin):
+        assert admin.list_schedules() == []
+
+    async def test_list_surfaces_registered_cron_schedule(
+        self, started_scheduler, admin
+    ):
+        sid = started_scheduler.schedule_cron(
+            _trivial_workflow(), "0 6 * * *", name="morning-job"
+        )
+
+        views = admin.list_schedules()
+
+        assert len(views) == 1
+        view = views[0]
+        assert view["schedule_id"] == sid
+        assert view["schedule_type"] == "cron"
+        assert view["workflow_name"] == "morning-job"
+        assert view["trigger_args"] == {"cron_expression": "0 6 * * *"}
+        assert view["enabled"] is True
+        assert view["next_run_time"] is not None
+        # Internal kwarg keys MUST NOT leak through the admin view.
+        assert "_kailash_retry_spec" not in view["kwargs"]
+        assert "_kailash_time_limits" not in view["kwargs"]
+
+    async def test_get_schedule_returns_view_for_known_id(
+        self, started_scheduler, admin
+    ):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+
+        view = admin.get_schedule(sid)
+
+        assert view["schedule_id"] == sid
+        assert view["schedule_type"] == "cron"
+
+    async def test_get_schedule_raises_for_unknown_id(self, admin):
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        with pytest.raises(ScheduleNotFound) as exc:
+            admin.get_schedule("sched-deadbeef0000")
+
+        assert exc.value.schedule_id == "sched-deadbeef0000"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSchedulerAdminAPIMutations:
+    """disable / enable / update_cron / delete change observable state."""
+
+    async def test_disable_then_list_shows_disabled(self, started_scheduler, admin):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+
+        view = admin.disable_schedule(sid, actor="ops@example.com")
+
+        assert view["enabled"] is False
+        assert view["next_run_time"] is None
+        # Confirm via list — read sees the same state.
+        listed = {v["schedule_id"]: v for v in admin.list_schedules()}
+        assert listed[sid]["enabled"] is False
+
+    async def test_enable_after_disable_resumes_cadence(self, started_scheduler, admin):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+        admin.disable_schedule(sid, actor="ops@example.com")
+
+        view = admin.enable_schedule(sid, actor="ops@example.com")
+
+        assert view["enabled"] is True
+        assert view["next_run_time"] is not None
+
+    async def test_update_cron_shifts_next_run_time(self, started_scheduler, admin):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+        before = admin.get_schedule(sid)["next_run_time"]
+        # Sanity check: cron parsing produced an actual fire time.
+        assert before is not None and "T06:" in before
+
+        view = admin.update_cron(sid, "0 7 * * *", actor="ops@example.com")
+
+        assert view["trigger_args"] == {"cron_expression": "0 7 * * *"}
+        # Externally visible: APScheduler recomputed next_run_time to
+        # the new cron's first matching instant. Hour MUST be 07 now,
+        # not 06.
+        after = view["next_run_time"]
+        assert (
+            after is not None and "T07:" in after
+        ), f"update_cron did not shift next_run_time to 07:00 — got {after!r}"
+
+    async def test_update_cron_rejects_invalid_expression(
+        self, started_scheduler, admin
+    ):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+
+        with pytest.raises(ValueError, match="invalid cron"):
+            admin.update_cron(sid, "garbage", actor="ops@example.com")
+
+    async def test_update_cron_refuses_non_cron_schedule(
+        self, started_scheduler, admin
+    ):
+        sid = started_scheduler.schedule_interval(_trivial_workflow(), seconds=60)
+
+        with pytest.raises(ValueError, match="only valid for cron"):
+            admin.update_cron(sid, "0 7 * * *", actor="ops@example.com")
+
+    async def test_delete_removes_from_listing(self, started_scheduler, admin):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+
+        admin.delete_schedule(sid, actor="ops@example.com")
+
+        assert all(v["schedule_id"] != sid for v in admin.list_schedules())
+
+    async def test_delete_unknown_id_raises_typed_not_found(self, admin):
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        with pytest.raises(ScheduleNotFound):
+            admin.delete_schedule("sched-missing0000", actor="ops@example.com")
+
+    async def test_disable_unknown_id_raises_typed_not_found(self, admin):
+        from kailash.sdk_exceptions import ScheduleNotFound
+
+        with pytest.raises(ScheduleNotFound):
+            admin.disable_schedule("sched-missing0000", actor="ops@example.com")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSchedulerAdminAPIAuditAndIsolation:
+    """Audit log + actor validation + tenant scope acceptance."""
+
+    async def test_empty_actor_rejected_on_mutation(self, started_scheduler, admin):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            admin.disable_schedule(sid, actor="")
+
+    async def test_whitespace_actor_rejected(self, started_scheduler, admin):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            admin.update_cron(sid, "0 7 * * *", actor="   ")
+
+    async def test_audit_log_records_actor_and_schedule_id(
+        self, started_scheduler, admin, caplog
+    ):
+        import logging
+
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+        with caplog.at_level(logging.INFO, logger="kailash.runtime.scheduler_admin"):
+            admin.disable_schedule(sid, actor="ops@example.com")
+
+        # Structural assertion: at least one INFO record with the
+        # expected logger name carries the action keyword + schedule_id.
+        # We assert structure (record exists with the expected logger
+        # name + action + sid in its formatted message) NOT message
+        # contents per `rules/probe-driven-verification.md` rule 3 —
+        # the structural check is the deterministic probe for "the
+        # audit log fired"; the body contents are covered by the
+        # structured fields the logger emits.
+        admin_records = [
+            r for r in caplog.records if r.name == "kailash.runtime.scheduler_admin"
+        ]
+        assert any(
+            "scheduler.admin.disable" in r.getMessage() and sid in r.getMessage()
+            for r in admin_records
+        ), (
+            "audit log did not emit a scheduler.admin.disable record naming "
+            f"the disabled schedule_id {sid!r}"
+        )
+
+    async def test_admin_rejects_none_scheduler(self):
+        from kailash.runtime.scheduler_admin import SchedulerAdminAPI
+
+        with pytest.raises(ValueError, match="non-None"):
+            SchedulerAdminAPI(None)  # type: ignore[arg-type]
+
+    async def test_admin_rejects_empty_tenant_scope(self, started_scheduler):
+        from kailash.runtime.scheduler_admin import SchedulerAdminAPI
+
+        with pytest.raises(ValueError, match="non-empty string"):
+            SchedulerAdminAPI(started_scheduler, tenant_scope="")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSchedulerAdminAPIRetryAndTimeLimitPassthrough:
+    """retry_spec + time_limits surface through the admin view (#910/#912)."""
+
+    async def test_retry_spec_surfaces_in_view(self, started_scheduler, admin):
+        from kailash.runtime.scheduler import RetrySpec
+
+        spec = RetrySpec(
+            max_retries=3,
+            backoff="exponential",
+            backoff_base_seconds=1.0,
+            backoff_max_seconds=30.0,
+            retry_on=(ConnectionError, TimeoutError),
+        )
+        sid = started_scheduler.schedule_cron(
+            _trivial_workflow(), "0 6 * * *", retry=spec
+        )
+
+        view = admin.get_schedule(sid)
+
+        assert view["retry_spec"] is not None
+        assert view["retry_spec"]["max_retries"] == 3
+        assert view["retry_spec"]["backoff"] == "exponential"
+        assert "ConnectionError" in view["retry_spec"]["retry_on"]
+        assert "TimeoutError" in view["retry_spec"]["retry_on"]
+
+    async def test_time_limits_surface_in_view(self, started_scheduler, admin):
+        sid = started_scheduler.schedule_cron(
+            _trivial_workflow(),
+            "0 6 * * *",
+            soft_time_limit=2.0,
+            time_limit=5.0,
+        )
+
+        view = admin.get_schedule(sid)
+
+        assert view["time_limits"] == {
+            "soft_time_limit": 2.0,
+            "time_limit": 5.0,
+        }
+
+    async def test_no_retry_or_time_limits_surfaces_as_null(
+        self, started_scheduler, admin
+    ):
+        sid = started_scheduler.schedule_cron(_trivial_workflow(), "0 6 * * *")
+
+        view = admin.get_schedule(sid)
+
+        assert view["retry_spec"] is None
+        assert view["time_limits"] == {
+            "soft_time_limit": None,
+            "time_limit": None,
+        }


### PR DESCRIPTION
## Summary

Closes #913 — `kailash.runtime.scheduler_admin.SchedulerAdminAPI` lets
operators list, enable, disable, update-cron, and delete schedules at
runtime without redeploying. Wraps the existing `WorkflowScheduler`'s
pause/resume/update_cron/cancel primitives in a typed admin surface
with audit logging, JSON-friendly output, and a `tenant_scope` extension
hook for future multi-tenant schedulers.

## What changes for users

When a vendor integration is paused for the holidays, ops can now
disable that integration's schedule via a single admin call instead of
shipping a code change and restarting the scheduler process. They can
also adjust a holiday cron from "every 6am" to "every 7am" and the
running scheduler picks up the change on its next event-loop tick — no
restart needed.

## API surface

Read methods:
- `admin.list_schedules() -> list[ScheduleAdminView]`
- `admin.get_schedule(schedule_id) -> ScheduleAdminView`

Mutation methods (each takes `actor=...` for the audit trail):
- `admin.disable_schedule(sid, actor=...)` — pauses; idempotent.
- `admin.enable_schedule(sid, actor=...)` — resumes; idempotent.
- `admin.update_cron(sid, "0 7 * * *", actor=...)` — atomic cron swap.
- `admin.delete_schedule(sid, actor=...)` — removes; raises typed
  `ScheduleNotFound` for unknown IDs.

The view dict surfaces `retry_spec` (#910 pass-through) and
`time_limits` (#912 pass-through) so admin clients see retry budgets
and per-fire deadlines without re-implementing kwarg plumbing.

Authentication is the caller's responsibility — wrap with
`packages/kailash-nexus/` auth middleware when exposing over HTTP.
The `tenant_scope` parameter declares the admin's scope explicitly;
single-tenant schedulers MUST use the default `"default"` value.

## Test plan

- [x] `pytest tests/integration/scheduler/test_scheduler_admin_api.py -v` — 20/20 PASSED
- [x] `mypy --strict src/kailash/runtime/scheduler_admin.py` — clean
- [x] `pre-commit run --files <changed>` — all hooks Passed
- [x] Tier-2 test exercises real `WorkflowScheduler` against in-memory
      APScheduler job store — no mocking. `update_cron` shifts
      `next_run_time` from `T06:00` to `T07:00` (the brief's spec for
      verifying runtime cron edits).
- [x] Empty `actor` rejected on every mutation; audit log emits
      structured records on `kailash.runtime.scheduler_admin`.
- [ ] CI (PR-gate matrix) — pending the push.

## Spec / docs

- `specs/scheduling.md` §11 documents the admin surface in full
  (constructor, methods, view shape, retry/time-limit fields, audit
  log surface, reload semantics).
- `specs/scheduling.md` §10 — dropped obsolete "no schedule
  modification" / "no pause/resume" constraints (those primitives
  shipped via #912's adjacent shards; this PR exposes them through
  the typed admin surface).
- `CHANGELOG.md` `[Unreleased]` — admin API added.

## Deferred follow-ups

- **#937 — Nexus admin panel** wiring `SchedulerAdminAPI` via
  `@app.handler` decorators with `NexusAuthPlugin` middleware.
  Exceeds this PR's shard budget per `rules/autonomous-execution.md`
  § Per-Session Capacity Budget (separate auth wiring + Nexus
  extractor patterns + new HTTP test surface). The admin class is
  ALREADY framework-native (pure Python class, JSON-friendly view
  shape, typed exceptions) — the panel is purely an HTTP wrapper,
  not a re-implementation.
- **#938 — `django-celery-beat.PeriodicTask` migration helper** —
  brief's fourth acceptance criterion. A one-shot importer reading
  a Django database and emitting equivalent
  `schedule_cron`/`schedule_interval` registrations through the
  admin API. Adds a Django test-time dependency and a database-
  introspection surface; out of this PR's value-anchor.

## Related issues

- Implements #913
- Surfaces #910 (RetrySpec) via `retry_spec` field of the admin view
- Surfaces #912 (per-fire time limits) via `time_limits` field of the
  admin view
- Follow-up: #937 (Nexus panel), #938 (django-celery-beat migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)