### PR TITLE
fix(distributed): per-queue processing isolation + observability + resource cleanup (#911 followup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — issue #911 Shard 2 followup: multi-queue correctness
+
+Redteam round 1 against the 2.19.0 multi-queue release surfaced same-bug-class
+gaps in the Worker / DistributedRuntime surface. Multi-queue users now see
+correct per-queue processing counts, per-queue observability for queue-status
+snapshots, released Redis clients on shutdown, and validated queue names at
+the scheduler-dispatcher boundary.
+
+- **Per-queue processing isolation** — every named queue now owns its own
+  Redis processing list (`kailash:tasks:processing:<name>`). Pre-fix every
+  named queue shared `kailash:tasks:processing`, so per-queue stale-task
+  recovery rolled up across queues and `Worker.get_status()["queues"]` reported
+  identical aggregate processing counts for every queue. The default queue
+  still resolves to the legacy bare key for byte-identical back-compat with
+  single-queue deployments. (R1-001 / R1-002)
+- **`DistributedRuntime.get_queue_status()` reports every queue** — the
+  response now includes a `"queues"` map with per-queue pending / processing
+  counts for every cached named queue. The top-level `pending` / `processing`
+  fields keep reporting the default queue for back-compat with single-queue
+  dashboards. Pre-fix multi-queue producers had zero observability into named
+  queues. (R1-003)
+- **`TaskQueue.close()` releases the lazily-created Redis client** —
+  `DistributedRuntime.close()` now actually frees the Redis client every named
+  queue lazily constructed. Pre-fix multi-queue runtimes leaked one client per
+  named queue on shutdown. (R1-005)
+- **`dispatcher.Task` validates `queue_name` at construction** — the
+  scheduler-dispatcher path now uses the same canonical validator as the
+  distributed-runtime path, closing the silent bypass a
+  scheduler→dispatcher→distributed-runtime bridge could carry. (R1-006)
+
 ## [2.19.0] - 2026-05-10
 
 ### Added — issue #911 Shard 1: multi-queue routing producer surface

--- a/src/kailash/runtime/_queue_keys.py
+++ b/src/kailash/runtime/_queue_keys.py
@@ -22,6 +22,7 @@ import re
 # their first deploy of the multi-queue SDK. Same back-compat-window
 # semantics as a ``zero-tolerance.md`` Rule 6a public-API rename.
 _QUEUE_KEY_BASE = "kailash:tasks:pending"
+_PROCESSING_KEY_BASE = "kailash:tasks:processing"
 
 DEFAULT_QUEUE_NAME = "default"
 
@@ -72,8 +73,34 @@ def make_queue_key(name: str = DEFAULT_QUEUE_NAME) -> str:
     return f"{_QUEUE_KEY_BASE}:{name}"
 
 
+def make_processing_key(name: str = DEFAULT_QUEUE_NAME) -> str:
+    """Return the canonical Redis processing-list key for ``name``.
+
+    Mirrors :func:`make_queue_key` for the in-flight side of the BLMOVE
+    pattern. Without per-queue processing keys, every named queue would
+    share the legacy ``"kailash:tasks:processing"`` list — defeating
+    per-queue stale-recovery (one queue's stuck tasks would re-queue
+    everywhere) and making per-queue processing-count observability
+    return identical aggregates for every queue.
+
+    The ``"default"`` queue maps to the legacy key
+    ``"kailash:tasks:processing"`` (NO suffix) — load-bearing back-compat
+    with single-queue deployments that already have in-flight tasks
+    under that exact byte string.
+
+    Non-default queues map to ``"kailash:tasks:processing:<name>"``.
+
+    Issue #911 Shard 2 followup — R1-001/R1-002 redteam findings.
+    """
+    validate_queue_name(name)
+    if name == DEFAULT_QUEUE_NAME:
+        return _PROCESSING_KEY_BASE
+    return f"{_PROCESSING_KEY_BASE}:{name}"
+
+
 __all__ = [
     "DEFAULT_QUEUE_NAME",
+    "make_processing_key",
     "make_queue_key",
     "validate_queue_name",
 ]

--- a/src/kailash/runtime/dispatcher.py
+++ b/src/kailash/runtime/dispatcher.py
@@ -35,6 +35,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, AsyncIterator, Dict, Optional
 
+from kailash.runtime._queue_keys import validate_queue_name
+
 __all__ = [
     "Dispatcher",
     "Task",
@@ -126,6 +128,21 @@ class Task:
     planned_fire_time: str
     queue_name: str = "default"
     kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate ``queue_name`` against the canonical queue-name policy.
+
+        The scheduler-dispatcher path (#859) and the distributed-runtime
+        path (#911) both carry a ``queue_name`` field. Pre-#911-Shard-2
+        only the distributed path validated; an invalid name in this
+        ``Task`` could ride through to a downstream bridge and silently
+        strand work on a malformed Redis key. Validating here closes the
+        bypass at the dispatcher boundary so the dataclass cannot be
+        constructed in an unsafe state.
+
+        Issue #911 Shard 2 followup — R1-006 redteam finding.
+        """
+        validate_queue_name(self.queue_name)
 
 
 class Dispatcher(ABC):

--- a/src/kailash/runtime/distributed.py
+++ b/src/kailash/runtime/distributed.py
@@ -48,6 +48,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 from kailash.runtime._queue_keys import (
     DEFAULT_QUEUE_NAME,
+    make_processing_key,
     make_queue_key,
     validate_queue_name,
 )
@@ -501,6 +502,30 @@ class TaskQueue:
         except Exception:
             return False
 
+    def close(self) -> None:
+        """Release the lazily-created Redis client.
+
+        ``_get_client`` constructs a ``redis.Redis`` connection pool on
+        first use; multi-queue runtimes that route through ``_queue_for``
+        accumulate one client per named queue. ``DistributedRuntime.close``
+        iterates ``self._queues`` and calls this method on each cached
+        TaskQueue so shutdown does not leak per-queue Redis clients.
+
+        Idempotent — calling ``close()`` twice is a no-op.
+
+        Issue #911 Shard 2 followup — R1-005 redteam finding.
+        """
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "TaskQueue.close: ignoring error from Redis client close: %s",
+                    exc,
+                )
+            finally:
+                self._client = None
+
 
 class DistributedRuntime(BaseRuntime):
     """Runtime that enqueues workflows to a distributed task queue.
@@ -544,6 +569,7 @@ class DistributedRuntime(BaseRuntime):
         self._queue = queue or TaskQueue(
             redis_url=self._redis_url,
             queue_key=make_queue_key(default_queue),
+            processing_key=make_processing_key(default_queue),
             default_visibility_timeout=visibility_timeout,
             result_ttl=result_ttl,
         )
@@ -697,6 +723,7 @@ class DistributedRuntime(BaseRuntime):
         new_queue = TaskQueue(
             redis_url=self._redis_url,
             queue_key=make_queue_key(queue_name),
+            processing_key=make_processing_key(queue_name),
             default_visibility_timeout=self._visibility_timeout,
             result_ttl=self._result_ttl,
         )
@@ -717,13 +744,43 @@ class DistributedRuntime(BaseRuntime):
     def get_queue_status(self) -> Dict[str, Any]:
         """Get current queue status metrics.
 
+        Returns the default queue's pending / processing counts at the
+        top level for back-compat with single-queue dashboards, plus a
+        ``queues`` map with per-queue counts for every cached named
+        queue (#911 Shard 2 followup — R1-003 redteam finding). The
+        default queue always appears in ``queues`` under the
+        configured ``default_queue`` name (typically ``"default"``).
+
         Returns:
-            Dictionary with pending and processing counts.
+            Dictionary with the shape::
+
+                {
+                    "pending": <int>,
+                    "processing": <int>,
+                    "redis_available": <bool>,
+                    "queues": {
+                        "<name>": {"pending": <int>, "processing": <int>},
+                        ...
+                    },
+                }
         """
+        per_queue: Dict[str, Dict[str, int]] = {}
+        for name, tq in self._queues.items():
+            try:
+                per_queue[name] = {
+                    "pending": tq.queue_length(),
+                    "processing": tq.processing_length(),
+                }
+            except Exception as exc:
+                logger.warning(
+                    "get_queue_status: failed to read queue %r: %s", name, exc
+                )
+                per_queue[name] = {"pending": -1, "processing": -1}
         return {
             "pending": self._queue.queue_length(),
             "processing": self._queue.processing_length(),
             "redis_available": self._queue.ping(),
+            "queues": per_queue,
         }
 
     def _serialize_workflow(self, workflow: Workflow) -> Dict[str, Any]:
@@ -929,6 +986,7 @@ class Worker:
                 tq = TaskQueue(
                     redis_url=self._redis_url,
                     queue_key=make_queue_key(name),
+                    processing_key=make_processing_key(name),
                     default_visibility_timeout=vt,
                 )
                 self._queue_specs[name] = _QueueSpec(

--- a/tests/integration/runtime/test_worker_multi_queue.py
+++ b/tests/integration/runtime/test_worker_multi_queue.py
@@ -419,3 +419,204 @@ async def test_lifecycle_event_carries_queue_name(_flush_redis) -> None:
 
     assert captured, f"on_task_success never fired for run_id={run_id}"
     assert captured[0].queue_name == "fast"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — #911 Shard 2 redteam followup (R1-001..R1-007)
+# ---------------------------------------------------------------------------
+
+
+@skip_no_redis
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_per_queue_processing_isolation(_flush_redis) -> None:
+    """R1-001/R1-002: per-queue processing lists are isolated.
+
+    Pre-fix every named TaskQueue shared one Redis processing list, so
+    Worker.get_status() reported identical aggregate processing counts
+    for every queue. Now each queue has its own processing key — start
+    a slow task on each queue, observe per-queue counts diverge.
+    """
+    from kailash.runtime.distributed import DistributedRuntime, Worker
+
+    runtime = DistributedRuntime(redis_url=REDIS_URL)
+    wf = _build_minimal_workflow()
+
+    # 1 task on "fast", 1 on "slow". With concurrency=1 each, both
+    # in-flight simultaneously and the per-queue processing list
+    # MUST be isolated (1 row per queue, not 2 rows on a shared key).
+    _, fast_id = runtime.execute(wf, queue="fast")
+    _, slow_id_a = runtime.execute(wf, queue="slow")
+
+    # 3.0s sleep is short enough that worker.stop() can wait for the
+    # in-flight task to finish naturally — we only need the task in
+    # flight for ~1s to take the per-queue snapshot.
+    worker = Worker(
+        redis_url=REDIS_URL,
+        queues={"fast": 1, "slow": 1},
+        heartbeat_interval=600,
+        dead_worker_timeout=600,
+        runtime_factory=_make_sleeping_runtime_factory(3.0),
+    )
+    _patch_worker_execute_skip_roundtrip(worker, sleep_seconds=3.0)
+
+    worker_task = asyncio.create_task(worker.start())
+    try:
+        # Wait for both queues to have a task in-flight.
+        deadline = time.monotonic() + 3.0
+        status: dict = {}
+        while time.monotonic() < deadline:
+            status = worker.get_status()
+            queues = status.get("queues", {})
+            if (
+                queues.get("fast", {}).get("processing", 0) >= 1
+                and queues.get("slow", {}).get("processing", 0) >= 1
+            ):
+                break
+            await asyncio.sleep(0.05)
+
+        queues = status["queues"]
+        # Per-queue processing counts MUST reflect each queue's own
+        # in-flight work — NOT the shared aggregate across all queues.
+        # Pre-fix every queue saw the SUM of all queues' processing
+        # rows (2 here); post-fix each sees its own (1).
+        assert queues["fast"]["processing"] == 1, queues
+        assert queues["slow"]["processing"] == 1, queues
+        # Both queues have nothing pending (only one task each, both
+        # dequeued).
+        assert queues["fast"]["pending"] == 0, queues
+        assert queues["slow"]["pending"] == 0, queues
+    finally:
+        await worker.stop()
+        # 15s ceiling gives the in-flight 3.0s task room to complete.
+        await asyncio.wait_for(worker_task, timeout=15.0)
+
+    _ = (fast_id, slow_id_a)
+
+
+@skip_no_redis
+@pytest.mark.integration
+def test_get_queue_status_reports_per_queue(_flush_redis) -> None:
+    """R1-003: DistributedRuntime.get_queue_status() iterates _queues.
+
+    Pre-fix only the default queue's pending/processing was reported;
+    multi-queue producers had zero observability into named queues.
+    """
+    from kailash.runtime.distributed import DistributedRuntime
+
+    runtime = DistributedRuntime(redis_url=REDIS_URL)
+    wf = _build_minimal_workflow()
+
+    # Enqueue 3 to "fast", 5 to "slow". 0 on default.
+    for _ in range(3):
+        runtime.execute(wf, queue="fast")
+    for _ in range(5):
+        runtime.execute(wf, queue="slow")
+
+    status = runtime.get_queue_status()
+    assert "queues" in status, status
+    per_queue = status["queues"]
+
+    # Each named queue reports its own pending count (no worker has
+    # consumed anything yet).
+    assert per_queue["fast"]["pending"] == 3, per_queue
+    assert per_queue["fast"]["processing"] == 0, per_queue
+    assert per_queue["slow"]["pending"] == 5, per_queue
+    assert per_queue["slow"]["processing"] == 0, per_queue
+
+    # Top-level back-compat fields still report the default queue
+    # (which has zero pending here).
+    assert status["pending"] == 0, status
+    assert status["processing"] == 0, status
+
+    runtime.close()
+
+
+@skip_no_redis
+@pytest.mark.integration
+def test_close_releases_per_queue_redis_clients(_flush_redis) -> None:
+    """R1-005: DistributedRuntime.close() releases each TaskQueue's client.
+
+    Pre-fix DistributedRuntime.close() called getattr(tq, "close", None)
+    against TaskQueue instances that had no close() — silently leaking
+    one Redis client per named queue.
+    """
+    from kailash.runtime.distributed import DistributedRuntime
+
+    runtime = DistributedRuntime(redis_url=REDIS_URL)
+
+    # Touch three queue names so _queue_for caches three TaskQueue
+    # instances + force each to construct a Redis client.
+    for name in ("alpha", "beta", "gamma"):
+        tq = runtime._queue_for(name)
+        # Touch a method that triggers _get_client.
+        tq.queue_length()
+        assert tq._client is not None, f"{name!r} client never constructed"
+
+    cached = list(runtime._queues.items())
+    runtime.close()
+
+    # Each cached TaskQueue's _client MUST be None after close.
+    for name, tq in cached:
+        assert tq._client is None, f"{name!r} client leaked: {tq._client!r}"
+
+
+@pytest.mark.integration
+def test_queue_for_memoizes_per_name() -> None:
+    """R1-007: ``DistributedRuntime._queue_for`` caches per name.
+
+    Construction-only test — no Redis traffic — so it does not need
+    skip_no_redis. Asserts the cache returns the same TaskQueue
+    instance for a repeated name and a different instance for a
+    different name (per the manager-shape collection contract per
+    facade-manager-detection.md Rule 1).
+    """
+    from kailash.runtime.distributed import DistributedRuntime
+
+    runtime = DistributedRuntime(redis_url=REDIS_URL)
+    q1 = runtime._queue_for("fast")
+    q2 = runtime._queue_for("fast")
+    assert q1 is q2, "_queue_for did not memoize same-name lookups"
+    q3 = runtime._queue_for("slow")
+    assert q3 is not q1, "_queue_for returned same instance for different name"
+
+
+@pytest.mark.integration
+def test_dispatcher_task_validates_queue_name() -> None:
+    """R1-006: ``dispatcher.Task`` validates queue_name at construction.
+
+    Pre-fix the Task dataclass accepted any string in ``queue_name``
+    while the distributed-runtime path validated. A scheduler →
+    dispatcher → distributed-runtime bridge could carry a malformed
+    name through. Now Task.__post_init__ validates uniformly.
+    """
+    from kailash.runtime.dispatcher import Task
+
+    # Default queue_name="default" is valid.
+    valid = Task(
+        task_id="t1",
+        schedule_id="s1",
+        workflow_blob=b"{}",
+        planned_fire_time="2026-05-10T00:00:00+00:00",
+    )
+    assert valid.queue_name == "default"
+
+    # Colon is BLOCKED — same policy as the producer side.
+    with pytest.raises(ValueError, match=r"\[A-Za-z0-9_-\]"):
+        Task(
+            task_id="t2",
+            schedule_id="s2",
+            workflow_blob=b"{}",
+            planned_fire_time="2026-05-10T00:00:00+00:00",
+            queue_name="invalid:name:with:colons",
+        )
+
+    # Empty queue name BLOCKED.
+    with pytest.raises(ValueError, match="must not be empty"):
+        Task(
+            task_id="t3",
+            schedule_id="s3",
+            workflow_blob=b"{}",
+            planned_fire_time="2026-05-10T00:00:00+00:00",
+            queue_name="",
+        )


### PR DESCRIPTION
## Summary

Same-bug-class followup to PR #933 (#911 Shard 2). Redteam round 1
surfaced 5 correctness gaps in the 2.19.0 multi-queue release that
fit one shard budget. Per `rules/autonomous-execution.md` MUST Rule 4,
they ship in this same shard rather than as deferred follow-up issues.

## What changed for users

- **Multi-queue stale-task recovery actually works.** Each named queue
  now owns its own Redis processing list, so a stuck task in `slow`
  re-queues to `slow` (not to every queue this worker reads).
- **`Worker.get_status()["queues"][...]["processing"]` returns the
  correct count per queue.** Pre-fix every queue saw the SUM of every
  queue's in-flight rows.
- **`DistributedRuntime.get_queue_status()` reports every named queue.**
  A new `"queues"` map carries per-queue pending / processing; the
  top-level `pending` / `processing` keep reporting the default queue
  for back-compat with single-queue dashboards.
- **`DistributedRuntime.close()` actually releases per-queue Redis
  clients.** Pre-fix every named queue leaked one client on shutdown.
- **`dispatcher.Task` validates `queue_name` at construction.** Closes
  a silent bypass at the scheduler-dispatcher boundary.

## Findings → fixes

| Finding | Severity | Fix |
|---|---|---|
| R1-001 — every TaskQueue shared `_PROCESSING_KEY` | HIGH (correctness) | `make_processing_key(name)` helper + per-queue `processing_key=` at every multi-queue construction site (`DistributedRuntime` default, `_queue_for`, Worker queues path) |
| R1-002 — `Worker.get_status()` reported aggregate processing as per-queue | HIGH (correctness) | Falls out of R1-001 once per-queue processing keys are in place |
| R1-003 — `DistributedRuntime.get_queue_status()` only reported default queue | HIGH (observability) | Iterate `self._queues`, return `"queues"` map + preserve top-level for back-compat |
| R1-005 — `TaskQueue.close()` missing | LOW (resource leak) | Add explicit `close()` releasing the lazily-constructed Redis client; `DistributedRuntime.close()`'s defensive `getattr` now actually fires |
| R1-006 — `dispatcher.Task.queue_name` bypassed `validate_queue_name` | LOW (hygiene) | `Task.__post_init__` calls the canonical validator; uniform across scheduler-dispatcher and distributed-runtime paths |
| R1-007 — `_queue_for` memoization untested | MED (Tier-2 gap) | New construction-only test asserts same-name returns same instance |

## Test plan

- [x] `pytest tests/integration/runtime/test_worker_multi_queue.py` — 17 passed
- [x] `pytest tests/integration/runtime/test_distributed_time_limits.py tests/integration/test_workflow_scheduler_dispatch_wiring.py` — 38 passed
- [x] `pytest tests/unit/runtime/` — 698 passed, 3 skipped
- [x] Pre-commit on every changed file — clean
- [x] `mypy --strict` on changed files — no new errors (pre-existing untyped-function errors in `distributed.py` are unchanged)

## Tests added

- `test_per_queue_processing_isolation` (R1-001/R1-002): asserts per-queue `processing` counts diverge across simultaneous in-flight tasks
- `test_get_queue_status_reports_per_queue` (R1-003): asserts named queues appear in `"queues"` map with their own counts
- `test_close_releases_per_queue_redis_clients` (R1-005): asserts every cached TaskQueue's `_client` is None after `close()`
- `test_queue_for_memoizes_per_name` (R1-007): asserts `_queue_for` cache returns same instance for repeated names
- `test_dispatcher_task_validates_queue_name` (R1-006): asserts `Task(...)` raises on colon + empty names

## Cross-SDK

Per `rules/cross-sdk-inspection.md` MUST Rule 1: kailash-rs does not
yet ship a multi-queue distributed runtime — no equivalent surface to
inspect for the same bug class. If/when the Rust SDK adds this, the
`make_processing_key` per-queue isolation discipline applies.

Refs #911. Origin: redteam round 1 against PR #933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)