### PR TITLE
docs(deploy): record kailash 2.20.0 release

### DIFF
--- a/deploy/deployments/2026-05-10-v2.20.0.md
+++ b/deploy/deployments/2026-05-10-v2.20.0.md
@@ -1,0 +1,65 @@
+# Deployment Record — kailash 2.20.0
+
+- **Date**: 2026-05-10
+- **Tag**: `v2.20.0`
+- **Merge SHA**: `3fbdeb62b63d51330598dff3e3a352ecc259ae77`
+- **Predecessor**: `v2.19.0` (merged earlier same day at `310c7ea5`)
+- **PyPI**: https://pypi.org/project/kailash/2.20.0/
+- **Publish workflow**: run `25625026216` — success (kailash + GitHub Release; TestPyPI skipped per release-prep-PR pattern)
+- **Clean-venv verification**: `kailash==2.20.0` installable from PyPI, `SchedulerAdminAPI` / `ScheduleAdminView` / `ScheduleNotFound` importable through the `kailash.runtime` facade.
+
+## Scope
+
+Three workstreams that landed in main during the same session as the cut.
+
+### feat(scheduler) — issue #913 — `WorkflowScheduler` runtime admin API
+
+PR #936 (merged at `71699b3d`).
+
+`SchedulerAdminAPI` is the framework-agnostic admin surface for a started `WorkflowScheduler`. Operators list / enable / disable / update-cron / delete schedules at runtime without redeploying. Surface is wired via:
+
+- `WorkflowScheduler.admin_api` property — lazy-constructed, memoized `SchedulerAdminAPI` bound to the scheduler.
+- Top-level re-exports from `kailash.runtime`: `SchedulerAdminAPI`, `ScheduleAdminView`, `ScheduleNotFound`, `DEFAULT_TENANT_SCOPE` so production users have a discoverable import path.
+
+Every mutation requires a non-empty `actor` string and writes a structured INFO audit log. Admin views surface `retry_spec` (#910) and `time_limits` (#912) pass-through reads.
+
+### fix(workflow) — issue #929 — `Workflow.to_dict()→from_dict()` round-trip serialization
+
+PR #940 (merged at `dfaf9310`). Closes the silent data-loss gap that affected all 44 Node subclasses, not just `PythonCodeNode`.
+
+Fix at `Node.__init_subclass__`: every Node subclass installs a per-class `__init__` wrapper that captures bound parameters into `self.config` after the subclass's own init runs. `Workflow.to_dict()` then serializes the full set; `Workflow.from_dict()` reconstructs faithfully. Future Node subclasses inherit the protection automatically.
+
+Also removed the `_patch_worker_execute_skip_roundtrip` workaround the 2.19.0 multi-queue Tier-2 tests had carried; tests now exercise the real round-trip path.
+
+### fix(distributed) — issue #911 followup — multi-queue correctness
+
+PR #939 (merged at `90be5dd8`). Closes redteam round-1 findings against the multi-queue routing surface shipped in 2.19.0:
+
+- **R1-001/R1-002**: per-queue processing key (`make_processing_key(name)`) so each named queue owns its own Redis processing list. Pre-fix every named queue shared `kailash:tasks:processing`, so per-queue stale-task recovery rolled up across queues and `Worker.get_status()` reported identical aggregate counts for every queue.
+- **R1-003**: `DistributedRuntime.get_queue_status()` now returns a `"queues"` map with per-queue pending/processing alongside the back-compat top-level fields.
+- **R1-005**: `TaskQueue.close()` releases the lazily-constructed Redis client. `DistributedRuntime.close()` now actually frees one client per named queue.
+- **R1-006**: `dispatcher.Task.__post_init__` calls `validate_queue_name`, closing the silent bypass at the scheduler-dispatcher boundary.
+- **R1-007**: Tier-2 test `test_queue_for_memoizes_per_name` covers the `_queues: Dict[str, TaskQueue]` cache invariant.
+
+## Quality gates
+
+- **/redteam round 1** (against 2.19.0): 7 findings, all VERIFIED resolved in PR #939.
+- **/redteam round 2** (against the three-PR stack): 0 CRIT, 0 unresolved HIGH.
+  - R2-001 (admin facade orphan) fixed same-shard via the production-path wiring above.
+  - R2-002 retry-event classification (surfaced by #929 fix) → tracked as #941, different bug class per autonomous-execution.md Per-Session Capacity Budget.
+  - R2-004 AsyncSQL pool shutdown `RuntimeWarning` → tracked as #942, pre-existing (commit `1b2f14cdf`, 2026-03-09; predates session per Rule 1c).
+
+## Tracked follow-ups
+
+| Issue | Title                                                                                           | Origin                                   |
+| ----- | ----------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| #937  | Nexus admin panel for `SchedulerAdminAPI`                                                       | Deferred from #913 per shard budget      |
+| #938  | django-celery-beat → kailash schedule store migration helper                                    | Deferred from #913 per shard budget      |
+| #941  | Retry event not classified when node raises non-recoverable error                               | Surfaced by #929 fix unblocking the test |
+| #942  | Pre-existing `RuntimeWarning: coroutine 'wait_for' was never awaited` on AsyncSQL pool shutdown | Pre-existing per Rule 1c                 |
+
+## Post-release follow-ups
+
+- **COC template pin** — `kailash-coc-claude-py`'s `kailash>=` pin should bump to `>=2.20.0`. NOT done from this session (out of scope per `rules/repo-scope-discipline.md`); will land in a `loom/` session via `/sync py`.
+- **Docs deploy** — Sphinx `Build Documentation` workflow runs on tag push; verify the published version matches.
+- **PR cleanup** — agent-locked worktrees under `.claude/worktrees/agent-*` will be auto-cleaned by the harness.


### PR DESCRIPTION
Captures the deployment record per release-runbook Step 7. Carve-out applies (docs-only diff under `deploy/deployments/`); no `/release` needed.