### PR TITLE
fix(runtime): #941 fire retry/final hooks on leaf-node failures

### DIFF
--- a/src/kailash/runtime/distributed.py
+++ b/src/kailash/runtime/distributed.py
@@ -36,6 +36,7 @@ Example:
 from __future__ import annotations
 
 import asyncio
+import builtins
 import inspect
 import json
 import logging
@@ -861,6 +862,43 @@ def _parse_queue_spec(raw: Any) -> Tuple[int, int]:
     return concurrency_raw, vt_raw
 
 
+# Wrappers the SDK adds around user / node errors. When recovering the
+# user-meaningful root cause from a recorded node failure we walk past these
+# so retry-classification consumers see ZeroDivisionError, ValueError, etc.
+# instead of the SDK's bookkeeping exception.
+_SDK_WRAPPER_EXC_NAMES = frozenset({"NodeExecutionError", "WorkflowExecutionError"})
+
+
+def _unwrap_node_failure(payload: Dict[str, Any], node_id: str) -> BaseException:
+    """Return the user-meaningful exception for a recorded node failure.
+
+    LocalRuntime stores the actual exception object under ``_exception`` when
+    a leaf node fails (see ``runtime.local`` issue #941 fix). This helper
+    walks ``__cause__`` then ``__context__`` past SDK wrapper exceptions to
+    surface the user's original error type. Falls back to reconstructing
+    by name if ``_exception`` is missing (defensive — older callers, JSON
+    round-trip, etc.) and finally to ``RuntimeError`` if nothing else fits.
+    """
+
+    exc = payload.get("_exception")
+    if isinstance(exc, BaseException):
+        seen: set[int] = set()
+        current: Optional[BaseException] = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            if type(current).__name__ not in _SDK_WRAPPER_EXC_NAMES:
+                return current
+            current = current.__cause__ or current.__context__
+        return exc
+
+    error_type_name = payload.get("error_type") or "RuntimeError"
+    error_msg = payload.get("error") or f"node '{node_id}' failed"
+    exc_cls = getattr(builtins, error_type_name, None)
+    if not (isinstance(exc_cls, type) and issubclass(exc_cls, BaseException)):
+        exc_cls = RuntimeError
+    return exc_cls(error_msg)
+
+
 class Worker:
     """Task queue worker that dequeues and executes workflows.
 
@@ -1610,6 +1648,21 @@ class Worker:
         if cancellation_token is not None:
             kwargs["cancellation_token"] = cancellation_token
         results, run_id = runtime.execute(built, **kwargs)
+
+        # Issue #941: LocalRuntime._should_stop_on_error returns False when a
+        # failed node has no downstream dependents, so the node-level failure
+        # is recorded in results (`failed: True, error_type, error, _exception`)
+        # and the runtime returns NORMALLY. The worker's retry/final
+        # classification at _execute_task only fires on raised exceptions; a
+        # silently-recorded failure looks like success and the lifecycle-hooks
+        # contract breaks (retry/failure events never fire). Re-raise the
+        # user-meaningful root exception so the classifier sees the disposition
+        # the user sees in the runtime logs.
+        for node_id, payload in results.items():
+            if not (isinstance(payload, dict) and payload.get("failed") is True):
+                continue
+            raise _unwrap_node_failure(payload, node_id)
+
         return results
 
     # -- Heartbeat --

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -3118,11 +3118,19 @@ class LocalRuntime(
 
                     raise WorkflowExecutionError(error_msg) from e
                 else:
-                    # Continue execution but record error
+                    # Continue execution but record error.
+                    # Issue #941: preserve the actual exception object under a
+                    # private key so callers (e.g. distributed Worker retry
+                    # classification) can re-raise the original error and walk
+                    # its __cause__/__context__ chain to recover the user-
+                    # meaningful root exception (the SDK wraps user errors in
+                    # NodeExecutionError, which hides ZeroDivisionError etc.
+                    # from lifecycle-hook consumers).
                     results[node_id] = {
                         "error": str(e),
                         "error_type": type(e).__name__,
                         "failed": True,
+                        "_exception": e,
                     }
 
         # Clean up workflow context

--- a/tests/regression/test_issue_941_retry_classification_unwrap.py
+++ b/tests/regression/test_issue_941_retry_classification_unwrap.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #941 — retry classification preserves user
+exception type after LocalRuntime swallows leaf-node failures.
+
+Surfaced by /redteam Round 2 against PR #940 (the #929 round-trip
+serialization fix). Once #929 unblocked workflow construction, the lifecycle-
+hooks test ``test_failure_path_classifies_retry_vs_final`` exposed a separate
+gap: ``LocalRuntime._should_stop_on_error`` returns ``False`` when a failed
+node has no downstream dependents, so the runtime records the failure in
+``results`` and returns NORMALLY. The distributed Worker's retry/final
+classification only fires on raised exceptions, so a silently-recorded leaf
+failure looked like success and ``on_task_retry`` / ``on_task_failure``
+handlers never ran.
+
+Two regressions guarded here:
+
+1. **Leaf-node failures propagate as exceptions.** ``Worker._execute_workflow_sync``
+   now scans the recorded ``results`` for any ``failed: True`` payload and
+   raises so the upstream classifier can fire retry vs final.
+
+2. **User-meaningful exception type survives SDK wrapping.** ``PythonCodeNode``
+   wraps user errors in ``NodeExecutionError`` (chained via ``__context__``).
+   ``Worker._execute_workflow_sync`` walks the cause/context chain past SDK
+   wrappers so ``failure_event.exception`` carries the user's original error
+   type (``ZeroDivisionError`` / ``ValueError`` / etc.), not the bookkeeping
+   ``NodeExecutionError``.
+
+Per ``rules/testing.md`` § "Behavioral Regression Tests Over Source-Grep",
+these tests CALL the function and assert raise/return — they do NOT grep
+source for literal substrings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kailash.runtime.distributed import TaskMessage, Worker, _unwrap_node_failure
+from kailash.sdk_exceptions import NodeExecutionError
+from kailash.workflow.builder import WorkflowBuilder
+
+
+def _failing_workflow(code: str):
+    """1-node Python workflow whose body raises the requested exception."""
+
+    builder = WorkflowBuilder()
+    builder.add_node(
+        "PythonCodeNode",
+        "fail",
+        {"name": "fail", "code": code},
+    )
+    return builder.build()
+
+
+@pytest.mark.regression
+def test_unwrap_returns_user_exception_when_present_in_chain():
+    """Walks past NodeExecutionError to surface ZeroDivisionError."""
+
+    try:
+        try:
+            raise ZeroDivisionError("intentional")
+        except ZeroDivisionError:
+            raise NodeExecutionError("Code execution failed: intentional")
+    except NodeExecutionError as wrapper:
+        payload = {
+            "failed": True,
+            "error": str(wrapper),
+            "error_type": "NodeExecutionError",
+            "_exception": wrapper,
+        }
+        unwrapped = _unwrap_node_failure(payload, "fail")
+
+    assert isinstance(unwrapped, ZeroDivisionError), (
+        f"_unwrap_node_failure MUST surface the user's original exception "
+        f"type past the SDK wrapper; got {type(unwrapped).__name__}"
+    )
+    assert str(unwrapped) == "intentional"
+
+
+@pytest.mark.regression
+def test_unwrap_returns_wrapper_when_chain_is_only_wrapper():
+    """When the chain has nothing user-meaningful, return the wrapper itself."""
+
+    wrapper = NodeExecutionError("standalone wrapper, no cause")
+    payload = {
+        "failed": True,
+        "error": str(wrapper),
+        "error_type": "NodeExecutionError",
+        "_exception": wrapper,
+    }
+    unwrapped = _unwrap_node_failure(payload, "fail")
+
+    assert unwrapped is wrapper, (
+        "When the chain contains no non-wrapper exception, _unwrap_node_failure "
+        "MUST return the wrapper rather than fabricate a different type."
+    )
+
+
+@pytest.mark.regression
+def test_unwrap_falls_back_to_named_builtin_when_exception_object_absent():
+    """JSON round-trip strips the exception object — reconstruct by name."""
+
+    payload = {
+        "failed": True,
+        "error": "boom",
+        "error_type": "ValueError",
+    }
+    unwrapped = _unwrap_node_failure(payload, "fail")
+
+    assert isinstance(unwrapped, ValueError)
+    assert str(unwrapped) == "boom"
+
+
+@pytest.mark.regression
+def test_unwrap_falls_back_to_runtimeerror_for_unknown_type_name():
+    """Unknown / non-builtin error_type names degrade to RuntimeError."""
+
+    payload = {
+        "failed": True,
+        "error": "boom",
+        "error_type": "DefinitelyNotABuiltin",
+    }
+    unwrapped = _unwrap_node_failure(payload, "fail")
+
+    assert isinstance(unwrapped, RuntimeError)
+    assert str(unwrapped) == "boom"
+
+
+@pytest.mark.regression
+def test_unwrap_handles_self_referential_chain_without_infinite_loop():
+    """A pathological self-referential cause chain MUST terminate."""
+
+    wrapper = NodeExecutionError("loop")
+    wrapper.__cause__ = wrapper  # pathological
+    payload = {
+        "failed": True,
+        "error": "loop",
+        "error_type": "NodeExecutionError",
+        "_exception": wrapper,
+    }
+    unwrapped = _unwrap_node_failure(payload, "fail")
+
+    # The walk visits `wrapper`, sees it is a wrapper, follows __cause__ back
+    # to itself, detects the cycle, and falls back to the original exception.
+    assert unwrapped is wrapper
+
+
+@pytest.mark.regression
+def test_execute_workflow_sync_raises_on_leaf_node_failure():
+    """LocalRuntime swallows leaf failures; the Worker MUST re-raise."""
+
+    worker = Worker(redis_url="redis://localhost:6380", concurrency=1)
+    workflow_dict = _failing_workflow(
+        "raise ZeroDivisionError('intentional')"
+    ).to_dict()
+    task = TaskMessage(
+        task_id="regression-941-leaf",
+        workflow_data=workflow_dict,
+        parameters={},
+        attempts=1,
+        max_attempts=2,
+    )
+
+    runtime = worker._get_runtime()
+
+    # The user-meaningful exception type MUST survive past the SDK wrapper.
+    with pytest.raises(ZeroDivisionError, match="intentional"):
+        worker._execute_workflow_sync(runtime, task)
+
+
+@pytest.mark.regression
+def test_execute_workflow_sync_succeeds_when_no_node_fails():
+    """Success path stays untouched: no failed payloads, no raise."""
+
+    worker = Worker(redis_url="redis://localhost:6380", concurrency=1)
+    workflow_dict = _failing_workflow("result = 7 * 6").to_dict()
+    task = TaskMessage(
+        task_id="regression-941-success",
+        workflow_data=workflow_dict,
+        parameters={},
+        attempts=1,
+        max_attempts=2,
+    )
+
+    runtime = worker._get_runtime()
+    results = worker._execute_workflow_sync(runtime, task)
+
+    # Successful execution returns the runtime's results dict — no failed
+    # payloads — and no exception escapes.
+    assert isinstance(results, dict)
+    assert all(
+        not (isinstance(v, dict) and v.get("failed") is True) for v in results.values()
+    )


### PR DESCRIPTION
## Summary

- `Worker._execute_workflow_sync` now re-raises when `LocalRuntime` silently records a leaf-node failure (`failed: True` in `results`) so the existing retry/final classification block in `_execute_task` actually fires `on_task_retry` / `on_task_failure` handlers.
- The user-meaningful exception type survives past SDK wrappers (`NodeExecutionError`, `WorkflowExecutionError`): the new `_unwrap_node_failure` helper walks `__cause__` then `__context__`, with cycle detection, so `failure_event.exception` reflects the user's original error (`ZeroDivisionError`, `ValueError`, …).
- `LocalRuntime` records the actual exception object under a private `_exception` key in the recorded failure payload so the worker can introspect the chain. Older callers that JSON-serialize the result dict are unaffected (the helper falls back to reconstructing by name).

## Why

`LocalRuntime._should_stop_on_error` returns `False` when the failed node has no downstream dependents (the typical single-node distributed task shape). The runtime records the failure in `results` and returns NORMALLY — the worker's existing `except Exception` block at `_execute_task` never fires, so no retry/final event is dispatched. The lifecycle-hooks contract advertised in #913 / #859 (and pinned by `tests/integration/runtime/test_worker_lifecycle_hooks_wiring.py::test_failure_path_classifies_retry_vs_final`) silently broke for the most common task shape.

Surfaced by /redteam Round 2 against PR #940 (the #929 round-trip serialization fix). Pre-#940 the test failed at workflow construction (Class G); post-#940 the leaf-failure gap (Class H) became visible.

## Test plan

- [x] `tests/integration/runtime/test_worker_lifecycle_hooks_wiring.py::TestWorkerLifecycleHooksWiring::test_failure_path_classifies_retry_vs_final` (the Tier-2 contract this PR fixes) — PASS
- [x] Full `tests/integration/runtime/test_worker_lifecycle_hooks_wiring.py` (4 tests) — PASS
- [x] `tests/integration/runtime/test_distributed_time_limits.py` + `test_worker_multi_queue.py` — PASS (1 pre-existing `_patch_worker_execute_skip_roundtrip` failure on main `9d03c0a4`, out of scope)
- [x] Full `tests/unit/runtime/` (701 tests) — PASS / 3 skipped, 0 regressions
- [x] New regression suite `tests/regression/test_issue_941_retry_classification_unwrap.py` (7 tests) — PASS
  - `_unwrap_node_failure` walks the chain past wrappers
  - Falls back to wrapper / named builtin / RuntimeError as appropriate
  - Pathological self-referential cause chain terminates
  - `_execute_workflow_sync` raises `ZeroDivisionError` (not `NodeExecutionError`) on leaf-node failure
  - Success path is unchanged
- [x] `pre-commit run` (Black, isort, Ruff, type-annotations, eval-usage, Tier-1 unit tests, …) — PASS

## Cross-SDK

Per `rules/cross-sdk-inspection.md` Rule 1, the equivalent kailash-rs Worker / Tokio executor surface needs the same audit: does the Rust runtime swallow leaf-node failures? Filing a cross-SDK companion is user-gated per `rules/upstream-issue-hygiene.md` MUST-1 — flagging here, not auto-filing.

## Related issues

Fixes #941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)