### PR TITLE
chore(release): kailash 2.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.20.1] - 2026-05-10
+
+### Fixed — issue #941: retry/final lifecycle hooks on leaf-node failures
+
+`Worker._execute_workflow_sync` now re-raises when `LocalRuntime`
+silently records a leaf-node failure in its `results` dict. The
+underlying runtime's `_should_stop_on_error` returns `False` when
+the failed node has no downstream dependents (the typical 1-node
+distributed task shape), so the runtime records `failed: True` and
+returns NORMALLY — meaning the Worker's retry/final classification
+at `_execute_task` never fired and `on_task_retry` /
+`on_task_failure` handlers never ran.
+
+The user-meaningful exception type now survives past SDK wrappers.
+The new private `_unwrap_node_failure` helper walks `__cause__` then
+`__context__`, with cycle detection, so `failure_event.exception`
+carries the user's original error type (`ZeroDivisionError`,
+`ValueError`, …) rather than the bookkeeping `NodeExecutionError`.
+
+`LocalRuntime` now stores the actual exception object under a
+private `_exception` key in the recorded failure payload so the
+worker can introspect the chain. Older callers that JSON-serialize
+the result dict are unaffected — the helper falls back to
+reconstructing by name when `_exception` is absent.
+
+Surfaced by /redteam Round 2 against PR #940 (the #929 round-trip
+serialization fix). Pre-#940 the lifecycle-hooks Tier-2 contract
+test failed at workflow construction (Class G); post-#940 the
+leaf-failure gap (Class H) became visible.
+
+PR #945 (merged at `48a41ed1`).
+
 ## [2.20.0] - 2026-05-10
 
 ### Added — issue #913: WorkflowScheduler runtime admin API

--- a/deploy/deployments/2026-05-10-v2.20.1.md
+++ b/deploy/deployments/2026-05-10-v2.20.1.md
@@ -1,0 +1,58 @@
+# Deployment Record — kailash 2.20.1
+
+- **Date**: 2026-05-10
+- **Tag**: `v2.20.1`
+- **Predecessor**: `v2.20.0` (merged earlier same day at `3fbdeb62`)
+- **PyPI**: https://pypi.org/project/kailash/2.20.1/
+- **Publish workflow**: TBD — recorded after tag-push triggers `publish-pypi.yml`.
+- **Clean-venv verification**: TBD — recorded after `pip install kailash==2.20.1` resolves and `_unwrap_node_failure` is reachable through `kailash.runtime.distributed`.
+
+## Scope
+
+Single-issue patch follow-up to 2.20.0.
+
+### fix(runtime) — issue #941 — retry/final lifecycle hooks on leaf-node failures
+
+PR #945 (merged at `48a41ed1`).
+
+`Worker._execute_workflow_sync` now re-raises when `LocalRuntime` silently records a leaf-node failure in its `results` dict. The underlying runtime's `_should_stop_on_error` returns `False` when the failed node has no downstream dependents — the typical 1-node distributed task shape — so the runtime stored `failed: True` and returned NORMALLY. The Worker's retry/final classification at `_execute_task` only fires on raised exceptions; a silently-recorded failure looked like success and `on_task_retry` / `on_task_failure` handlers never ran.
+
+The user-meaningful exception type now survives past SDK wrappers. The new private `_unwrap_node_failure` helper walks `__cause__` then `__context__`, with cycle detection, so `failure_event.exception` carries the user's original error type (`ZeroDivisionError`, `ValueError`, …) rather than the bookkeeping `NodeExecutionError`.
+
+`LocalRuntime` now stores the actual exception object under a private `_exception` key in the recorded failure payload so the worker can introspect the chain. Older callers that JSON-serialize the result dict are unaffected — the helper falls back to reconstructing the type by name when `_exception` is absent.
+
+Surfaced by /redteam Round 2 against PR #940 (the #929 round-trip serialization fix). Pre-#940 the lifecycle-hooks Tier-2 contract test (`test_failure_path_classifies_retry_vs_final`) failed at workflow construction (Class G); post-#940 the leaf-failure gap (Class H) became visible — different bug class per `autonomous-execution.md` Per-Session Capacity Budget Rule 1.
+
+## Quality gates
+
+- **Target Tier-2 contract test**: `tests/integration/runtime/test_worker_lifecycle_hooks_wiring.py::TestWorkerLifecycleHooksWiring::test_failure_path_classifies_retry_vs_final` — PASS (was the original repro).
+- **Lifecycle-hooks module** (4 tests): PASS.
+- **Distributed runtime modules** (`test_worker_lifecycle_hooks_wiring.py`, `test_worker_multi_queue.py`, `test_distributed_time_limits.py`): 42 PASS / 1 pre-existing failure (`test_per_queue_processing_isolation` `NameError: _patch_worker_execute_skip_roundtrip` — fails identically on main `9d03c0a4`, predates session).
+- **Runtime unit tests** (701 tests): PASS / 3 skipped, 0 regressions from this change.
+- **New regression suite** (`tests/regression/test_issue_941_retry_classification_unwrap.py`, 7 tests): PASS — covers chain-walk, wrapper return when chain is wrapper-only, named-builtin reconstruction, RuntimeError fallback for unknown type, self-referential cycle termination, leaf-node raise behavior, success-path no-op.
+- **Pre-commit (Black / isort / Ruff / type annotations / Tier-1 unit tests)**: PASS.
+- **PR #945 CI**: all checks green (Python 3.11/3.12/3.13/3.14, test-with-infrastructure, Trust Unit Tests, PACT Python 3.11, CodeQL, Analyze Python).
+
+## Tracked follow-ups
+
+| Issue | Title                                                                                             | Origin                                              |
+| ----- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| #937  | Nexus admin panel for `SchedulerAdminAPI`                                                         | Deferred from #913 per shard budget (carry-forward) |
+| #938  | django-celery-beat → kailash schedule store migration helper                                      | Deferred from #913 per shard budget (carry-forward) |
+| #942  | Pre-existing `RuntimeWarning: coroutine 'wait_for' was never awaited` on AsyncSQL pool shutdown   | Pre-existing per Rule 1c (carry-forward)            |
+| TBD   | `test_dataflow_create_node_with_async_runtime` indexes tuple as dict                              | Pre-existing on `9d03c0a4`; surfaced this session   |
+| TBD   | `test_per_queue_processing_isolation` references undefined `_patch_worker_execute_skip_roundtrip` | Pre-existing on `9d03c0a4`; surfaced this session   |
+
+## Pre-existing drift (out of scope)
+
+- **README.md / docs/index.rst stale ecosystem-version table.** Last updated `8706c4b6` (2026-05-07); shows kailash Core SDK at `v0.12.5` / `v2.1.0` while actual is 2.20.x. Pre-existing institutional drift; documentation hygiene sweep belongs in a separate session (or `/sync py` cycle from loom). Not blocking 2.20.1 PyPI release.
+- **#893 / #927 still open as duplicates of the #929 round-trip fix shipped in 2.20.0.** Closure recommendation surfaced in this session's Q1 dispatch but deferred per user direction (single-pick #941). Closure with citing commit `3fbdeb62` is the next housekeeping item.
+
+## Cross-SDK
+
+Per `cross-sdk-inspection.md` Rule 1, the equivalent kailash-rs Worker / Tokio executor likely has the same gap. Filing the cross-SDK companion is user-gated per `upstream-issue-hygiene.md` MUST-1; flagged for a follow-up `loom/` session.
+
+## Post-release follow-ups
+
+- **COC template pin** — `kailash-coc-claude-py`'s `kailash>=` pin was already noted at 2.20.0 deploy as out-of-scope; the 2.20.1 bump widens the gap by one patch but the disposition is unchanged (handled in `loom/` via `/sync py`).
+- **Sphinx docs deploy** — Build Documentation workflow runs on tag push; first run is auto-cancelled by `concurrency: cancel-in-progress`, second is canonical.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.20.0"
+version = "2.20.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.20.0"
+__version__ = "2.20.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Patch release for #941. Bumps `kailash` 2.20.0 → 2.20.1 with `Worker._execute_workflow_sync` re-raising on leaf-node failures + user-exception unwrapping (PR #945, merged at `48a41ed1`).

- `pyproject.toml::version` → `2.20.1`
- `src/kailash/__init__.py::__version__` → `2.20.1`
- `CHANGELOG.md` → `## [2.20.1] - 2026-05-10` Fixed entry citing #941 / PR #945
- `deploy/deployments/2026-05-10-v2.20.1.md` → deployment record (mirrors 2.20.0 doc shape)

Diff is strictly metadata-only — version anchors, CHANGELOG, deploy doc — so the `release/v*` branch convention auto-skips the PR-gate matrix per `git.md` MUST rule.

## Test plan

- [x] PR #945 (the #941 fix) merged at `48a41ed1`; full CI green pre-merge
- [x] Tier-2 contract test `test_failure_path_classifies_retry_vs_final` PASS post-fix
- [x] 7 new regression tests in `tests/regression/test_issue_941_retry_classification_unwrap.py` PASS
- [x] Pre-commit clean on this release-prep diff (Black, isort, Ruff, doc style, Tier-1 unit tests)
- [ ] Tag-push triggers `publish-pypi.yml` after admin-merge
- [ ] Clean-venv install of `kailash==2.20.1` resolves; `_unwrap_node_failure` reachable via `kailash.runtime.distributed`

## Release scope (per build-repo-release-discipline.md MUST Rule 3)

| Package | main | PyPI | Release |
| --- | --- | --- | --- |
| kailash | 2.20.1 | 2.20.0 | YES |
| kailash-align | 0.7.1 | 0.7.1 | NO |
| kailash-dataflow | 2.9.0 | 2.9.0 | NO |
| kailash-kaizen | 2.21.0 | 2.21.0 | NO |
| kailash-mcp | 0.2.14 | 0.2.14 | NO |
| kailash-ml | 1.7.4 | 1.7.4 | NO |
| kailash-nexus | 2.6.3 | 2.6.3 | NO |
| kailash-pact | 0.12.0 | 0.12.0 | NO |
| kaizen-agents | 0.9.7 | 0.9.7 | NO |

No sibling drift to sweep this cycle.

## Related issues

Closes #941 (already closed by PR #945; this release publishes the fix to PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)