### PR TITLE
docs(deploy): record kailash 2.20.1 release deployment

### DIFF
--- a/deploy/deployments/2026-05-10-v2.20.1.md
+++ b/deploy/deployments/2026-05-10-v2.20.1.md
@@ -2,10 +2,11 @@
 
 - **Date**: 2026-05-10
 - **Tag**: `v2.20.1`
+- **Merge SHA**: `44ec1211e78c1e50ab02798f588a8cc9d4a3bcec`
 - **Predecessor**: `v2.20.0` (merged earlier same day at `3fbdeb62`)
 - **PyPI**: https://pypi.org/project/kailash/2.20.1/
-- **Publish workflow**: TBD — recorded after tag-push triggers `publish-pypi.yml`.
-- **Clean-venv verification**: TBD — recorded after `pip install kailash==2.20.1` resolves and `_unwrap_node_failure` is reachable through `kailash.runtime.distributed`.
+- **Publish workflow**: run `25629380333` — success (Build kailash + Publish to PyPI + Create GitHub Release; TestPyPI skipped per patch policy).
+- **Clean-venv verification**: `kailash==2.20.1` installs from PyPI; `_unwrap_node_failure` + `Worker` importable through `kailash.runtime.distributed`.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Post-release deploy-doc completion for v2.20.1 — fills in the merge SHA, publish-workflow run ID, and clean-venv verification confirmation per `build-repo-release-discipline.md` MUST Rule 2.

- Merge SHA: `44ec1211e78c1e50ab02798f588a8cc9d4a3bcec`
- Publish workflow: run [25629380333](https://github.com/terrene-foundation/kailash-py/actions/runs/25629380333) — success (Build kailash + Publish to PyPI + Create GitHub Release; TestPyPI skipped per patch policy)
- Clean-venv: `kailash==2.20.1` installs from PyPI; `_unwrap_node_failure` + `Worker` importable through `kailash.runtime.distributed`

## Test plan

- [x] PyPI metadata at https://pypi.org/pypi/kailash/2.20.1/json shows version 2.20.1
- [x] Clean venv `pip install --no-cache-dir kailash==2.20.1` resolves
- [x] Import smoke: `from kailash.runtime.distributed import _unwrap_node_failure, Worker` succeeds; `kailash.__version__ == '2.20.1'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)