### PR TITLE
fix(runtime): #950 close LocalRuntime cleanup-race coroutine leak

### DIFF
--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -1560,37 +1560,90 @@ class LocalRuntime(
                                 f"(runtime {self._runtime_id})"
                             )
 
-                    # Dispose connection pools before closing the loop
+                    # Dispose connection pools before closing the loop.
                     if not loop.is_closed():
+                        # If another event loop is currently running (e.g.,
+                        # ``with LocalRuntime()`` inside an ``async def``
+                        # pytest-asyncio test, a Nexus handler, or any caller
+                        # holding an active asyncio loop), we cannot drive
+                        # ``loop.run_until_complete`` on our persistent loop
+                        # without raising ``RuntimeError: Cannot run the event
+                        # loop while another loop is running``. Worse, AsyncSQL
+                        # pools were created against the OUTER loop; disposing
+                        # them on our loop trips ``Task got Future attached to
+                        # a different loop`` and leaks the unawaited
+                        # ``wait_for`` coroutine that wraps the disconnect.
+                        # The outer loop owns the pool lifecycle in that path;
+                        # skip async cleanup here and let it close its pools
+                        # on its own teardown. Sync SQL cleanup still runs.
                         try:
-                            from kailash.nodes.data.async_sql import (
-                                AsyncSQLDatabaseNode,
+                            outer_running_loop = asyncio.get_running_loop()
+                        except RuntimeError:
+                            outer_running_loop = None
+
+                        if outer_running_loop is None:
+                            try:
+                                from kailash.nodes.data.async_sql import (
+                                    AsyncSQLDatabaseNode,
+                                )
+
+                                _clear_pools = getattr(
+                                    AsyncSQLDatabaseNode, "clear_shared_pools", None
+                                )
+                                if _clear_pools is not None:
+                                    # Wrap in an inner ``async def`` so only
+                                    # one coroutine escapes scope. Closing
+                                    # the wrapper cancels the inner
+                                    # ``wait_for`` cleanly if
+                                    # ``run_until_complete`` raises before
+                                    # consuming it — preventing the
+                                    # ``coroutine 'wait_for' was never
+                                    # awaited`` warning that surfaced when
+                                    # users adopted the
+                                    # ``with LocalRuntime()`` pattern.
+                                    async def _dispose_async_sql_pools() -> None:
+                                        try:
+                                            await asyncio.wait_for(
+                                                _clear_pools(graceful=True),
+                                                timeout=5.0,
+                                            )
+                                        except asyncio.TimeoutError:
+                                            logger.warning(
+                                                "Timeout disposing AsyncSQL "
+                                                "pools during shutdown for "
+                                                f"runtime {self._runtime_id}"
+                                            )
+
+                                    _dispose_coro = _dispose_async_sql_pools()
+                                    try:
+                                        loop.run_until_complete(_dispose_coro)
+                                    finally:
+                                        # No-op if the wrapper already ran to
+                                        # completion. Closes both the wrapper
+                                        # and any orphaned inner ``wait_for``
+                                        # if ``run_until_complete`` raised
+                                        # before driving the wrapper.
+                                        _close = getattr(_dispose_coro, "close", None)
+                                        if _close is not None:
+                                            try:
+                                                _close()
+                                            except Exception:
+                                                pass
+                            except Exception as e:
+                                logger.warning(
+                                    f"Error disposing AsyncSQL pools during shutdown: {e}"
+                                )
+                        else:
+                            # Outer loop owns the pools; we cannot dispose
+                            # safely from here. DEBUG (not WARN) because the
+                            # outer loop's teardown handles this.
+                            logger.debug(
+                                f"Skipping AsyncSQL pool cleanup for runtime "
+                                f"{self._runtime_id}: outer event loop is "
+                                f"running (loop_id={id(outer_running_loop)}); "
+                                "outer loop owns pool lifecycle"
                             )
 
-                            _clear_pools = getattr(
-                                AsyncSQLDatabaseNode, "clear_shared_pools", None
-                            )
-                            if _clear_pools is not None:
-                                _coro = _clear_pools(graceful=True)
-                                try:
-                                    loop.run_until_complete(
-                                        asyncio.wait_for(_coro, timeout=5.0)
-                                    )
-                                finally:
-                                    # Defensive: close the coroutine if it
-                                    # never started running (e.g., wait_for
-                                    # cancel/timeout race during shutdown).
-                                    # No-op if already awaited or exhausted.
-                                    _close = getattr(_coro, "close", None)
-                                    if _close is not None:
-                                        try:
-                                            _close()
-                                        except Exception:
-                                            pass
-                        except Exception as e:
-                            logger.warning(
-                                f"Error disposing AsyncSQL pools during shutdown: {e}"
-                            )
                         try:
                             from kailash.nodes.data.sql import SQLDatabaseNode
 

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -1576,6 +1576,20 @@ class LocalRuntime(
                         # The outer loop owns the pool lifecycle in that path;
                         # skip async cleanup here and let it close its pools
                         # on its own teardown. Sync SQL cleanup still runs.
+                        #
+                        # Residual constraint: ``AsyncSQLDatabaseNode._shared_pools``
+                        # is process-wide, not partitioned by loop. If a caller
+                        # used this same ``LocalRuntime`` instance synchronously
+                        # FIRST (creating pools whose reaper tasks bind to the
+                        # persistent loop), then re-entered ``__exit__`` from
+                        # inside an outer async loop, those persistent-loop-
+                        # owned pools will not be disposed by either path. The
+                        # outer loop's teardown won't reach them (different
+                        # loop); we skip them here. This is an unusual mixed-
+                        # mode pattern; the canonical fix (track which pools
+                        # this runtime created + WARN-log the leak signal)
+                        # is tracked separately so the wait_for warning fix
+                        # can ship now without expanding scope.
                         try:
                             outer_running_loop = asyncio.get_running_loop()
                         except RuntimeError:

--- a/tests/integration/runtime/test_async_local_dataflow_integration.py
+++ b/tests/integration/runtime/test_async_local_dataflow_integration.py
@@ -340,7 +340,11 @@ async def test_async_runtime_matches_local_runtime_dataflow(test_db):
 
     This test ensures parameter passing behavior is consistent between both runtimes.
     """
-    # Test with LocalRuntime
+    # Test with LocalRuntime — context-manager form per the
+    # ``LocalRuntime.execute()`` deprecation guidance. The cleanup-race
+    # ``RuntimeWarning`` that originally blocked this form (#950) was fixed
+    # in src/kailash/runtime/local.py; this call site is the one named in
+    # #950's acceptance criteria for re-adoption.
     local_workflow = WorkflowBuilder()
     local_workflow.add_node(
         "TestItemCreateNode",
@@ -348,8 +352,8 @@ async def test_async_runtime_matches_local_runtime_dataflow(test_db):
         {"id": "test-item-007", "name": "LocalRuntime Test", "status": "active"},
     )
 
-    local_runtime = LocalRuntime()
-    local_results, _ = local_runtime.execute(local_workflow.build())
+    with LocalRuntime() as local_runtime:
+        local_results, _ = local_runtime.execute(local_workflow.build())
     local_item = local_results["create_local"]
 
     # Test with AsyncLocalRuntime

--- a/tests/regression/test_issue_950_localruntime_context_manager.py
+++ b/tests/regression/test_issue_950_localruntime_context_manager.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: #950 -- ``with LocalRuntime()`` triggered "coroutine 'wait_for'
+was never awaited" RuntimeWarning on cleanup.
+
+The bug: ``LocalRuntime._cleanup_event_loop`` created the ``wait_for(...)``
+coroutine at outer scope, then called ``loop.run_until_complete(...)`` on it.
+When ``run_until_complete`` raised before consuming the wait_for coroutine
+(e.g. when an outer event loop is already running, as inside an
+``async def`` test under pytest-asyncio or a Nexus handler), the wait_for
+coroutine became unreachable and surfaced ``RuntimeWarning: coroutine
+'wait_for' was never awaited`` at GC.
+
+Adopting the SDK-recommended ``with LocalRuntime() as runtime:`` pattern
+(per the LocalRuntime.execute() deprecation message) made the warning
+visible across the test suite, blocking zero-tolerance Rule 1 (no new
+RuntimeWarnings).
+
+Fix: detect outer running loop and skip async cleanup (the outer loop owns
+the AsyncSQL pool lifecycle in that case). When no outer loop is running,
+wrap the wait_for in an inner ``async def`` so only one coroutine escapes
+scope; closing it cleans up the inner wait_for cleanly even if
+run_until_complete raises before consuming the wrapper.
+
+Acceptance criteria from issue #950:
+- ``with LocalRuntime() as runtime: runtime.execute(workflow.build())``
+  produces zero ``RuntimeWarning``s.
+- After fix, the in-test usage at
+  ``tests/integration/runtime/test_async_local_dataflow_integration.py::
+  test_async_runtime_matches_local_runtime_dataflow`` MUST be switchable
+  back to the ``with LocalRuntime()`` form without surfacing the warning.
+"""
+
+import asyncio
+import warnings
+
+import pytest
+
+from kailash.runtime import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+
+@pytest.mark.regression
+def test_localruntime_context_manager_clean_roundtrip_no_warning():
+    """Acceptance criterion 1: clean ``with LocalRuntime()`` round-trip
+    produces zero ``RuntimeWarning`` from the cleanup path.
+
+    Reproduces the user-facing scenario from the issue body verbatim.
+    """
+    wb = WorkflowBuilder()
+    wb.add_node("PythonCodeNode", "x", {"code": "result = 1"})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        with LocalRuntime() as runtime:
+            results, _ = runtime.execute(wb.build())
+        assert results["x"]["result"] == 1
+
+
+@pytest.mark.regression
+def test_localruntime_context_manager_inside_outer_loop_no_wait_for_warning():
+    """Acceptance criterion 2: ``with LocalRuntime()`` inside an outer
+    asyncio loop (the pytest-asyncio / Nexus / Jupyter case) MUST NOT
+    leak the wait_for coroutine.
+
+    This is the failure mode that originally surfaced #950: when
+    ``LocalRuntime.__exit__`` ran inside an outer running loop, the
+    persistent loop's ``run_until_complete`` raised "Cannot run the event
+    loop while another loop is running" before consuming the
+    ``asyncio.wait_for`` coroutine, leaving it unawaited.
+    """
+
+    async def _scenario() -> int:
+        wb = WorkflowBuilder()
+        wb.add_node("PythonCodeNode", "x", {"code": "result = 42"})
+        with LocalRuntime() as runtime:
+            results, _ = runtime.execute(wb.build())
+        return results["x"]["result"]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = asyncio.run(_scenario())
+
+    assert result == 42
+
+
+@pytest.mark.regression
+def test_localruntime_context_manager_repeated_no_warning():
+    """Multiple sequential ``with LocalRuntime()`` blocks MUST stay
+    warning-clean. Guards against "first run silent, second run leaks"
+    cleanup-state regressions in the persistent-loop disposal path.
+    """
+    wb = WorkflowBuilder()
+    wb.add_node("PythonCodeNode", "x", {"code": "result = 1"})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        for _ in range(3):
+            with LocalRuntime() as runtime:
+                results, _ = runtime.execute(wb.build())
+            assert results["x"]["result"] == 1


### PR DESCRIPTION
## Summary

`LocalRuntime._cleanup_event_loop` leaked an unawaited `asyncio.wait_for` coroutine when `__exit__` ran inside an outer running event loop (the `with LocalRuntime()` inside `async def` test pattern, Nexus handler, or Jupyter kernel), surfacing `RuntimeWarning: coroutine 'wait_for' was never awaited` from `src/kailash/runtime/local.py:1591`.

This blocked adoption of the SDK-recommended `with LocalRuntime() as runtime:` pattern across the test suite — the deprecation message `LocalRuntime.execute()` itself emits names that as the canonical API, but zero-tolerance Rule 1 prevents shipping with new RuntimeWarnings.

Two-part root-cause fix:

1. **Detect outer running loop**. When `asyncio.get_running_loop()` resolves to a loop, our persistent loop cannot run via `loop.run_until_complete` (raises `RuntimeError: Cannot run the event loop while another loop is running`), and the AsyncSQL pools were created against the outer loop anyway. Skip the async cleanup; the outer loop's own teardown owns those pools. Avoids both the wait_for leak and the unrelated cross-loop "Task got Future attached to a different loop" error.

2. **Wrap `wait_for` in an inner `async def`** when no outer loop is running. Only one coroutine escapes scope; closing it on any failure path cleans up the inner `wait_for` cleanly even if `run_until_complete` raises before driving the wrapper. Adds explicit `asyncio.TimeoutError` handling with structured WARN log + `runtime_id` context.

## Test plan

- [x] `tests/regression/test_issue_950_localruntime_context_manager.py` — three `pytest.warns`-strict regression tests covering the issue's verbatim repro, `with LocalRuntime()` inside `asyncio.run()`, and repeated `with` blocks
- [x] `tests/integration/runtime/test_async_local_dataflow_integration.py::test_async_runtime_matches_local_runtime_dataflow` — switched to `with LocalRuntime()` form per #950 acceptance criterion 3; passes warning-strict
- [x] `tests/unit/runtime/` — 698 tests pass
- [x] `tests/integration/runtime/test_async_local_dataflow_integration.py` — 9 tests pass with `-W error::RuntimeWarning`
- [x] Pre-commit hooks pass (Black, isort, Ruff, type annotations, Tier 1 unit tests)
- [ ] CI matrix (3.11/3.12/3.13/3.14 + PACT + infrastructure + CodeQL) — to be verified

## Cross-SDK inspection

Per `cross-sdk-inspection.md` Rule 1: kailash-rs has no Python-style context-manager surface; the equivalent disposition is Tokio's `Drop` impl on the Rust runtime — out of lane for this Python-only fix.

## Related issues

Closes #950.

🤖 Generated with [Claude Code](https://claude.com/claude-code)