### PR TITLE
test(runtime): widen #912 time-limit Tier-2 elapsed bound for cold-start

### DIFF
--- a/tests/integration/runtime/test_async_local_runtime_time_limits.py
+++ b/tests/integration/runtime/test_async_local_runtime_time_limits.py
@@ -89,8 +89,10 @@ async def test_async_local_runtime_soft_time_limit_raises_on_sleeping_workflow()
     elapsed = time.monotonic() - start
 
     assert exc_info.type in (SoftTimeLimitExceeded, HardTimeLimitExceeded)
-    # Bound elapsed below 4s so we know we didn't hang.
-    assert elapsed < 4.0, (
+    # Bound elapsed below 10s so we know we didn't hang. Loose enough
+    # to absorb cold-start overhead (PythonCodeNode subprocess + import
+    # warm-up); the no-wiring failure mode hits pytest's 30s timeout.
+    assert elapsed < 10.0, (
         f"raise MUST happen by post-completion poll, not hang; "
         f"elapsed={elapsed:.2f}s, exc={type(exc_info.value).__name__}"
     )
@@ -109,8 +111,10 @@ async def test_async_local_runtime_hard_time_limit_raises_after_grace():
     elapsed = time.monotonic() - start
 
     # Hard kill at 0.5s + 1.0s grace = ~1.5s; workflow completes at 2s.
+    # 10s upper bound absorbs cold-start overhead (see soft-limit test
+    # rationale); no-wiring failure mode hits pytest's 30s timeout.
     assert (
-        elapsed < 4.0
+        elapsed < 10.0
     ), f"hard kill MUST raise by post-completion poll; elapsed={elapsed:.2f}s"
 
 

--- a/tests/integration/runtime/test_local_runtime_time_limits.py
+++ b/tests/integration/runtime/test_local_runtime_time_limits.py
@@ -104,9 +104,16 @@ def test_local_runtime_soft_time_limit_raises_on_sleeping_workflow():
     # blocking sleep means we wait the full 2s, but the typed
     # exception MUST be raised (NOT the unstubbed quickstart success).
     assert exc_info.type in (SoftTimeLimitExceeded, HardTimeLimitExceeded)
-    # Bound elapsed below 4s so we know we didn't hang waiting on a
-    # never-firing timer (the no-wiring failure mode).
-    assert elapsed < 4.0, (
+    # Bound elapsed below 10s so we know we didn't hang waiting on a
+    # never-firing timer (the no-wiring failure mode would hit pytest's
+    # 30s timeout). The bound is loose enough to absorb cold-start
+    # overhead — PythonCodeNode subprocess + import-cache warm-up can
+    # add several seconds beyond the 2s workflow sleep on a fresh
+    # interpreter. The test's purpose is "did the timer fire at all",
+    # which the typed exception assertion already proves; the elapsed
+    # bound only guards against the no-wiring "completes successfully"
+    # path masquerading as a typed-exception raise.
+    assert elapsed < 10.0, (
         f"raise MUST happen by post-completion poll, not hang; "
         f"elapsed={elapsed:.2f}s, exc={type(exc_info.value).__name__}"
     )
@@ -132,7 +139,10 @@ def test_local_runtime_hard_time_limit_raises_after_grace():
 
     # Hard kill at 0.5s + 1.0s grace = 1.5s; the blocking sleep
     # finishes at 2.0s, so the post-completion poll fires at ~2s.
-    assert elapsed < 4.0, (
+    # 10s upper bound absorbs cold-start overhead (see soft-limit test
+    # above for rationale); the no-wiring failure mode hits pytest's
+    # 30s timeout, not this bound.
+    assert elapsed < 10.0, (
         f"hard kill MUST raise by post-completion poll; " f"elapsed={elapsed:.2f}s"
     )
 


### PR DESCRIPTION
## Summary

- Widens the elapsed-time upper bound in two #912 Tier-2 wiring tests from `< 4.0s` to `< 10.0s` so cold-start runs of the full 89-test #912 suite don't flake the assertion when PythonCodeNode subprocess + import warm-up overhead pushes elapsed past 4s (observed: 4.59s on a fresh interpreter; passes on every focused / warm rerun).
- Bound's actual purpose ("did the timer fire at all, vs hang on a never-firing timer") is preserved — the no-wiring failure mode hits pytest's 30s timeout, which is the real upper bound. 10s gives ~8s of headroom above the 2.0s workflow sleep, which is the legitimate runtime cost of the PythonCodeNode subprocess on a cold interpreter.

## /redteam Round 2 — Convergence

PR #926 (Shard 6 corrective, merged 2026-05-10) shipped the F-1+F-2 wiring fix that Round 1 surfaced. This PR closes the residual flake in the Tier-2 tests it landed.

Round 2 audit verdict (both gate-reviewers ran in parallel against this branch, HEAD `cea2624f`):

| Finding | Round 1 | Round 2 |
|---|---|---|
| F-1 (HIGH): `LocalRuntime.execute` accepts time-limit kwargs but never arms timer | NEEDS-FIX | **CLOSED** — `local.py:1107-1241` arms + classifies + post-completion polls + finally disarms |
| F-2 (HIGH): `arm_time_limits_async` orphan helper | NEEDS-FIX | **CLOSED** — 2 production callers (`async_local.py:932`, `parallel.py:124`) |
| F-3 (MEDIUM): CHANGELOG quickstart promised behavior the code did not perform | NEEDS-FIX | **CLOSED** — quickstart smoke against 2s sleeper raises `HardTimeLimitExceeded` at elapsed=3.35s |
| Security threat surface (7 vectors) | — | **0 findings** — signal-free design, single validator, idempotent disarm, token isolation, no info leak |
| New findings (Round 2) | — | **0 HIGH / 0 MEDIUM**; 1 LOW informational (pre-existing v0.10.1 `DeprecationWarning`, properly scoped to the v0.12.0 migration shard, NOT introduced by #912) |

Audit reports:
- `workspaces/issue-912-task-time-limits/04-validate/spec-coverage-v3.md` (gate reviewer)
- `workspaces/issue-912-task-time-limits/04-validate/security-coverage-v3.md` (security-reviewer)

## Test plan

- [x] `pytest tests/integration/runtime/test_local_runtime_time_limits.py tests/integration/runtime/test_async_local_runtime_time_limits.py tests/regression/test_issue_912_signature_invariants.py tests/unit/test_sdk_exceptions_time_limits.py tests/unit/test_time_limits_validation.py tests/unit/test_time_limits_wrapper_unit.py` — 89 passed, 9.92s
- [x] Quickstart smoke: `runtime.execute(workflow, soft_time_limit=0.5, time_limit=1.0)` against 2s `PythonCodeNode` raises `HardTimeLimitExceeded` at elapsed=3.35s
- [x] `pytest --collect-only` across runtime test dirs — 657 tests, exit 0
- [x] Signature pin sweep — every runtime entry point still accepts `soft_time_limit` / `time_limit`
- [x] DDL grep (`schema-migration.md` Rule 1a) — clean

## Related issues

Followup to #912 (closed). The F-1+F-2+F-3 wiring fix shipped in #926; this PR closes the residual Tier-2 flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)