### PR TITLE
fix(deps): #876 follow-on — sweep remaining 22 sibling optional-extra import sites

### DIFF
--- a/src/kailash/api/tests/test_workflow_api_404.py
+++ b/src/kailash/api/tests/test_workflow_api_404.py
@@ -9,7 +9,17 @@ This is expected behavior - we write tests FIRST, then implement.
 """
 
 import pytest
-from fastapi.testclient import TestClient
+
+# `fastapi` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    from fastapi.testclient import TestClient
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.api.tests.test_workflow_api_404 requires server dependencies "
+        "(fastapi). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from kailash.api.workflow_api import WorkflowAPI
 from kailash.workflow.builder import WorkflowBuilder

--- a/src/kailash/api/workflow_api.py
+++ b/src/kailash/api/workflow_api.py
@@ -11,10 +11,25 @@ from contextlib import asynccontextmanager
 from enum import Enum
 from typing import Any
 
-import uvicorn
+# `fastapi`, `starlette`, and `uvicorn` are OPTIONAL dependencies under the
+# `server` extra (pyproject.toml). Per `rules/dependencies.md` § "Declared =
+# Imported": optional-extra imports MUST raise loudly with an actionable
+# error naming the extra — bare `ModuleNotFoundError` leaves a clean-install
+# user with no signal that `kailash[server]` is the correct install.
+try:
+    import uvicorn
+    from fastapi import BackgroundTasks, FastAPI
+    from starlette.exceptions import HTTPException
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, StreamingResponse
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.api.workflow_api requires server dependencies (fastapi, "
+        "starlette, uvicorn). Install with: pip install 'kailash[server]'"
+    ) from exc
 
-logger = logging.getLogger(__name__)
-from fastapi import BackgroundTasks, FastAPI
+from pydantic import BaseModel, Field
+
 from kailash.runtime.local import LocalRuntime
 from kailash.utils.lifespan import (
     drive_router_lifespan_shutdown,
@@ -22,10 +37,8 @@ from kailash.utils.lifespan import (
 )
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
-from pydantic import BaseModel, Field
-from starlette.exceptions import HTTPException
-from starlette.requests import Request
-from starlette.responses import JSONResponse, StreamingResponse
+
+logger = logging.getLogger(__name__)
 
 
 class ExecutionMode(str, Enum):

--- a/src/kailash/channels/api_channel.py
+++ b/src/kailash/channels/api_channel.py
@@ -4,10 +4,19 @@ import asyncio
 import logging
 from typing import Any, Dict, Optional
 
-import uvicorn
-from starlette.exceptions import HTTPException
-from starlette.requests import Request
-from starlette.responses import Response
+# `uvicorn` and `starlette` are OPTIONAL dependencies under the `server` extra.
+# Per `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    import uvicorn
+    from starlette.exceptions import HTTPException
+    from starlette.requests import Request
+    from starlette.responses import Response
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.channels.api_channel requires server dependencies (starlette, "
+        "uvicorn). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from ..servers import EnterpriseWorkflowServer
 from ..workflow import Workflow

--- a/src/kailash/channels/mcp/http.py
+++ b/src/kailash/channels/mcp/http.py
@@ -26,7 +26,16 @@ from __future__ import annotations
 import asyncio
 from typing import Optional
 
-import aiohttp
+# `aiohttp` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    import aiohttp
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.channels.mcp.http requires server dependencies (aiohttp). "
+        "Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from .base import ProtocolError, Transport, TransportError, validate_url
 

--- a/src/kailash/channels/mcp/sse.py
+++ b/src/kailash/channels/mcp/sse.py
@@ -27,7 +27,16 @@ import asyncio
 import json
 from typing import Optional
 
-import aiohttp
+# `aiohttp` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    import aiohttp
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.channels.mcp.sse requires server dependencies (aiohttp). "
+        "Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from .base import ProtocolError, Transport, TransportError, validate_url
 

--- a/src/kailash/client/enhanced_client.py
+++ b/src/kailash/client/enhanced_client.py
@@ -10,7 +10,16 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
-import aiohttp
+# `aiohttp` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    import aiohttp
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.client.enhanced_client requires server dependencies (aiohttp). "
+        "Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from ..gateway.resource_resolver import ResourceReference
 

--- a/src/kailash/edge/migration/edge_migrator.py
+++ b/src/kailash/edge/migration/edge_migrator.py
@@ -16,7 +16,16 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-import aiohttp
+# `aiohttp` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    import aiohttp
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.edge.migration.edge_migrator requires server dependencies "
+        "(aiohttp). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 logger = logging.getLogger(__name__)
 

--- a/src/kailash/gateway/api.py
+++ b/src/kailash/gateway/api.py
@@ -9,8 +9,18 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
-from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, HTTPException
-from fastapi.responses import JSONResponse
+# `fastapi` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, HTTPException
+    from fastapi.responses import JSONResponse
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.gateway.api requires server dependencies (fastapi). "
+        "Install with: pip install 'kailash[server]'"
+    ) from exc
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from ..resources.registry import ResourceRegistry

--- a/src/kailash/middleware/auth/auth_manager.py
+++ b/src/kailash/middleware/auth/auth_manager.py
@@ -13,11 +13,23 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-import jwt
-from fastapi import Depends
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from starlette.exceptions import HTTPException
-from starlette.requests import Request
+# `jwt`, `fastapi`, and `starlette` are OPTIONAL dependencies. PyJWT ships with
+# both the `server` extra (middleware needs it) and the `trust` extra (SSO
+# needs it); fastapi/starlette ship only with `server`. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports MUST
+# raise loudly with an actionable error naming the extra.
+try:
+    import jwt
+    from fastapi import Depends
+    from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+    from starlette.exceptions import HTTPException
+    from starlette.requests import Request
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.middleware.auth.auth_manager requires server dependencies "
+        "(PyJWT, fastapi, starlette). "
+        "Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from ...nodes.admin import PermissionCheckNode
 from ...nodes.data import AsyncSQLDatabaseNode

--- a/src/kailash/middleware/communication/api_gateway.py
+++ b/src/kailash/middleware/communication/api_gateway.py
@@ -15,9 +15,19 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
-from fastapi import Depends, FastAPI, HTTPException, Request, WebSocket
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+# `fastapi` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    from fastapi import Depends, FastAPI, HTTPException, Request, WebSocket
+    from fastapi.middleware.cors import CORSMiddleware
+    from fastapi.responses import JSONResponse
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.middleware.communication.api_gateway requires server "
+        "dependencies (fastapi). Install with: pip install 'kailash[server]'"
+    ) from exc
+
 from pydantic import BaseModel, Field
 
 from ...nodes.base import NodeRegistry

--- a/src/kailash/middleware/communication/realtime.py
+++ b/src/kailash/middleware/communication/realtime.py
@@ -14,9 +14,18 @@ from datetime import datetime, timezone
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Set, Union
 from urllib.parse import parse_qs
 
-from starlette.requests import Request
-from starlette.responses import Response, StreamingResponse
-from starlette.websockets import WebSocket, WebSocketDisconnect
+# `starlette` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    from starlette.requests import Request
+    from starlette.responses import Response, StreamingResponse
+    from starlette.websockets import WebSocket, WebSocketDisconnect
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.middleware.communication.realtime requires server "
+        "dependencies (starlette). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from ...nodes.api import HTTPRequestNode
 from ...nodes.security import CredentialManagerNode

--- a/src/kailash/middleware/gateway/durable_gateway.py
+++ b/src/kailash/middleware/gateway/durable_gateway.py
@@ -13,9 +13,18 @@ import logging
 from datetime import UTC, datetime
 from typing import Any, Callable, Dict, List, Optional
 
-from starlette.exceptions import HTTPException
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+# `starlette` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    from starlette.exceptions import HTTPException
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, Response
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.middleware.gateway.durable_gateway requires server "
+        "dependencies (starlette). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from kailash.api.gateway import WorkflowAPIGateway
 

--- a/src/kailash/nodes/admin/user_management.py
+++ b/src/kailash/nodes/admin/user_management.py
@@ -25,7 +25,16 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Union
 from uuid import uuid4
 
-import bcrypt
+# `bcrypt` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    import bcrypt
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.nodes.admin.user_management requires server dependencies "
+        "(bcrypt). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.data import SQLDatabaseNode

--- a/src/kailash/nodes/api/http.py
+++ b/src/kailash/nodes/api/http.py
@@ -10,7 +10,20 @@ import time
 from enum import Enum
 from typing import Any
 
-import aiohttp
+# `aiohttp` is an OPTIONAL dependency under the `server` extra. `requests` ships
+# under `http-client` AND `server`. Per `rules/dependencies.md` § "Declared =
+# Imported": optional-extra imports MUST raise loudly with an actionable error
+# naming the extra. (`requests` is not in _OPTIONAL_PACKAGES — it's transitively
+# pulled by the server stack and the http-client extra; only `aiohttp` is
+# guarded here.)
+try:
+    import aiohttp
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.nodes.api.http requires server dependencies (aiohttp). "
+        "Install with: pip install 'kailash[server]'"
+    ) from exc
+
 import requests
 from pydantic import BaseModel
 

--- a/src/kailash/nodes/monitoring/connection_dashboard.py
+++ b/src/kailash/nodes/monitoring/connection_dashboard.py
@@ -34,8 +34,18 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Deque, Dict, List, Optional, Set
 
-import aiohttp_cors
-from aiohttp import web
+# `aiohttp` and `aiohttp_cors` are OPTIONAL dependencies under the `server`
+# extra. Per `rules/dependencies.md` § "Declared = Imported": optional-extra
+# imports MUST raise loudly with an actionable error naming the extra.
+try:
+    import aiohttp_cors
+    from aiohttp import web
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.nodes.monitoring.connection_dashboard requires server "
+        "dependencies (aiohttp, aiohttp-cors). "
+        "Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from kailash.nodes.base import Node, NodeParameter, register_node
 
@@ -224,7 +234,6 @@ class ConnectionDashboardNode(Node):
     def run(self, **kwargs) -> dict[str, Any]:
         """Execute the node's logic (Node ABC contract)."""
         return self.execute(**kwargs)
-
 
     async def execute(self, input_data: Dict[str, Any]) -> Dict[str, Any]:  # type: ignore[override]
         """Execute dashboard action.

--- a/src/kailash/nodes/transaction/participant_transport.py
+++ b/src/kailash/nodes/transaction/participant_transport.py
@@ -19,7 +19,16 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
-import aiohttp
+# `aiohttp` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    import aiohttp
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.nodes.transaction.participant_transport requires server "
+        "dependencies (aiohttp). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 if TYPE_CHECKING:
     from kailash.nodes.transaction.two_phase_commit import TwoPhaseCommitParticipant

--- a/src/kailash/servers/connection_metrics_router.py
+++ b/src/kailash/servers/connection_metrics_router.py
@@ -17,7 +17,16 @@ import logging
 import time
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter
+# `fastapi` is an OPTIONAL dependency under the `server` extra. Per
+# `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    from fastapi import APIRouter
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.servers.connection_metrics_router requires server dependencies "
+        "(fastapi). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 logger = logging.getLogger(__name__)
 

--- a/src/kailash/servers/durable_workflow_server.py
+++ b/src/kailash/servers/durable_workflow_server.py
@@ -12,9 +12,18 @@ import logging
 from datetime import UTC, datetime
 from typing import Any, Callable, Dict, List, Optional
 
-from starlette.exceptions import HTTPException
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response, StreamingResponse
+# `starlette` is an OPTIONAL dependency under the `server` extra (via fastapi).
+# Per `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    from starlette.exceptions import HTTPException
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, Response, StreamingResponse
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.servers.durable_workflow_server requires server dependencies "
+        "(starlette). Install with: pip install 'kailash[server]'"
+    ) from exc
 
 from ..middleware.gateway.checkpoint_manager import CheckpointManager
 from ..middleware.gateway.deduplicator import RequestDeduplicator

--- a/src/kailash/servers/workflow_server.py
+++ b/src/kailash/servers/workflow_server.py
@@ -12,11 +12,21 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from typing import Any, Awaitable, Callable, Optional
 
-from fastapi import FastAPI
+# `fastapi` and `starlette` are OPTIONAL dependencies under the `server` extra.
+# Per `rules/dependencies.md` § "Declared = Imported": optional-extra imports
+# MUST raise loudly with an actionable error naming the extra.
+try:
+    from fastapi import FastAPI
+    from starlette.middleware.cors import CORSMiddleware
+    from starlette.requests import Request
+    from starlette.websockets import WebSocket
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.servers.workflow_server requires server dependencies (fastapi, "
+        "starlette). Install with: pip install 'kailash[server]'"
+    ) from exc
+
 from pydantic import BaseModel, Field
-from starlette.middleware.cors import CORSMiddleware
-from starlette.requests import Request
-from starlette.websockets import WebSocket
 
 from ..api.workflow_api import WorkflowAPI
 from ..runtime.shutdown import ShutdownCoordinator

--- a/src/kailash/trust/auth/sso/apple.py
+++ b/src/kailash/trust/auth/sso/apple.py
@@ -19,8 +19,18 @@ import time
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
-import jwt
-from jwt import PyJWKClient
+# `PyJWT` (imported as `jwt`) is an OPTIONAL dependency. It ships under BOTH
+# the `trust` extra (SSO + sign/verify) AND the `server` extra (middleware
+# auth). Per `rules/dependencies.md` § "Declared = Imported": optional-extra
+# imports MUST raise loudly with an actionable error naming the extra.
+try:
+    import jwt
+    from jwt import PyJWKClient
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.trust.auth.sso.apple requires PyJWT. "
+        "Install with: pip install 'kailash[trust]' (or 'kailash[server]')"
+    ) from exc
 
 from kailash.trust.auth.sso.base import (
     BaseSSOProvider,

--- a/src/kailash/trust/auth/sso/azure.py
+++ b/src/kailash/trust/auth/sso/azure.py
@@ -17,8 +17,18 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
-import jwt
-from jwt import PyJWKClient
+# `PyJWT` (imported as `jwt`) is an OPTIONAL dependency. It ships under BOTH
+# the `trust` extra (SSO + sign/verify) AND the `server` extra (middleware
+# auth). Per `rules/dependencies.md` § "Declared = Imported": optional-extra
+# imports MUST raise loudly with an actionable error naming the extra.
+try:
+    import jwt
+    from jwt import PyJWKClient
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.trust.auth.sso.azure requires PyJWT. "
+        "Install with: pip install 'kailash[trust]' (or 'kailash[server]')"
+    ) from exc
 
 from kailash.trust.auth.sso.base import (
     BaseSSOProvider,

--- a/src/kailash/trust/auth/sso/google.py
+++ b/src/kailash/trust/auth/sso/google.py
@@ -12,8 +12,18 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
-import jwt
-from jwt import PyJWKClient
+# `PyJWT` (imported as `jwt`) is an OPTIONAL dependency. It ships under BOTH
+# the `trust` extra (SSO + sign/verify) AND the `server` extra (middleware
+# auth). Per `rules/dependencies.md` § "Declared = Imported": optional-extra
+# imports MUST raise loudly with an actionable error naming the extra.
+try:
+    import jwt
+    from jwt import PyJWKClient
+except ImportError as exc:  # pragma: no cover — covered by structural invariant test
+    raise ImportError(
+        "kailash.trust.auth.sso.google requires PyJWT. "
+        "Install with: pip install 'kailash[trust]' (or 'kailash[server]')"
+    ) from exc
 
 from kailash.trust.auth.sso.base import (
     BaseSSOProvider,

--- a/tests/regression/test_optional_extra_import_guards.py
+++ b/tests/regression/test_optional_extra_import_guards.py
@@ -82,22 +82,14 @@ _OPTIONAL_PACKAGES = frozenset(
 # with an actionable error message. The test verifies the wrap is present.
 _FIXED_SITES = frozenset(
     {
+        # First wave (PR #956): the 3 sites surfaced during #876 follow-up.
         "src/kailash/core/pool/sqlite_pool.py",
         "src/kailash/trust/migrations/eatp_human_origin.py",
         "src/kailash/api/gateway.py",
-    }
-)
-
-
-# Modules with module-scope optional-extra imports that are NOT YET wrapped.
-# Pre-existing same-class violations (sibling sweep of the 3 fixed sites).
-# Each is a follow-up shard. When fixed, MOVE the entry to _FIXED_SITES.
-#
-# Discovery: AST sweep on 2026-05-10 against src/kailash/ found 25 total
-# module-scope optional-extra imports; 3 fixed in this same shard
-# (_FIXED_SITES); remaining 22 listed here as same-class follow-on debt.
-_KNOWN_VIOLATIONS = frozenset(
-    {
+        # Second wave: sibling sweep of the 22 _KNOWN_VIOLATIONS allowlist
+        # entries. Same try/except pattern as the first wave per
+        # rules/dependencies.md § "Declared = Imported" / "__init__.py
+        # Module-Scope Imports Honor The Manifest".
         # FastAPI / Starlette / Uvicorn — server extra
         "src/kailash/api/workflow_api.py",
         "src/kailash/api/tests/test_workflow_api_404.py",
@@ -120,12 +112,20 @@ _KNOWN_VIOLATIONS = frozenset(
         "src/kailash/nodes/transaction/participant_transport.py",
         # bcrypt — server extra
         "src/kailash/nodes/admin/user_management.py",
-        # PyJWT — server extra
+        # PyJWT — server extra (also satisfied by trust extra)
         "src/kailash/trust/auth/sso/azure.py",
         "src/kailash/trust/auth/sso/google.py",
         "src/kailash/trust/auth/sso/apple.py",
     }
 )
+
+
+# All sites listed in _KNOWN_VIOLATIONS at PR #956 landing have been fixed
+# (second-wave sweep). The empty allowlist makes
+# test_no_new_unguarded_optional_extra_imports the only gate going forward —
+# any new module-scope optional-extra import without a guard surfaces as a
+# new violator, not silently absorbed into the allowlist.
+_KNOWN_VIOLATIONS: frozenset[str] = frozenset()
 
 
 def _enumerate_module_scope_optional_imports(file_path: Path) -> list[tuple[str, int]]:


### PR DESCRIPTION
## Summary

PR #956 fixed 3 sites where module-scope imports of optional-extra packages raised bare \`ModuleNotFoundError\` on clean install. The same commit recorded **22 sibling same-class violations** in \`tests/regression/test_optional_extra_import_guards.py::_KNOWN_VIOLATIONS\` as follow-on debt. This PR closes that debt — wrapping every remaining site with the same \`try/except ImportError\` pattern that names the correct \`pip install 'kailash[<extra>]'\` recipe.

Per \`rules/dependencies.md\` § "Declared = Imported": optional-extra imports MUST raise loudly with an actionable error naming the extra. Bare \`ModuleNotFoundError\` leaves clean-install users with no signal that \`kailash[<extra>]\` is the correct install.

## Sites fixed (22 total)

**FastAPI / Starlette / Uvicorn (server extra)** — 11 sites
**aiohttp / aiohttp-cors (server extra)** — 7 sites
**bcrypt (server extra)** — 1 site
**PyJWT (trust extra; also under server)** — 3 sites

Full path list in the commit body.

## Invariant test

\`tests/regression/test_optional_extra_import_guards.py\` moves all 22 paths from \`_KNOWN_VIOLATIONS\` to \`_FIXED_SITES\`. \`_KNOWN_VIOLATIONS\` is now **empty** — going forward, any new module-scope optional-extra import without a guard surfaces as a new violator via \`test_no_new_unguarded_optional_extra_imports\`, not silently absorbed into the allowlist.

## Test plan

- [x] \`pytest tests/regression/test_optional_extra_import_guards.py\` → 3/3 pass (was 3/3 with 22 known violations; now 3/3 with 0)
- [x] 21/21 smoke-import of every touched module
- [x] \`pytest tests/regression/test_optional_extra_import_guards.py tests/integration/middleware/ tests/unit/middleware/ tests/integration/test_durable_execution_engine_wiring.py\` → 53/53 pass
- [x] Pre-commit (black/isort/ruff/Tier-1) green
- [ ] CI matrix (Python 3.11-3.14 × ubuntu/windows) green

## Related issues

Same-bug-class follow-on of #876 / PR #956. Closes the \`_KNOWN_VIOLATIONS\` allowlist that PR #956 left as debt.