### PR TITLE
chore(release): kailash 2.20.2 — #876 W2 audit + #882 mock fix + import-guard sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added — issue #876: hashing-symmetry across history_store.* log emissions + metric counters
+## [2.20.2] - 2026-05-11
+
+### Fixed — issue #950: LocalRuntime cleanup-race coroutine leak
+
+`LocalRuntime` cleanup path no longer leaks coroutines when the cleanup
+runs concurrently with the workflow loop's tail. The race window was
+that the synchronous cleanup spawned an asyncio.run on a coroutine the
+running loop still owned references to — surfacing as `coroutine was
+never awaited` warnings at GC under load. The fix gates the cleanup on
+event-loop state and awaits the residual coroutines in-loop when the
+loop is still alive. Residual sync-then-async pool-leak constraint is
+documented at `src/kailash/runtime/local.py`.
+
+### Fixed — issue #882: DurableExecutionEngine routing test — mock-kwarg drift
+
+`_FakeRuntime.execute_workflow_async` in
+`tests/regression/test_issue_882_durable_execution_mode.py` was missing
+the `soft_time_limit` and `time_limit` keyword-only kwargs that
+`DurableExecutionEngine.execute` now forwards (added by the #876 / #912
+plumbing in `durable.py`). The mock now mirrors the canonical
+`AsyncLocalRuntime.execute_workflow_async` signature and records both
+kwargs in `execute_calls`. A new behavioral regression test asserts
+the engine forwards the kwargs to the runtime — structural defense
+against the silent-fallback failure mode in
+`rules/zero-tolerance.md` Rule 3c (Documented Kwargs Accepted But
+Unused).
+
+### Fixed — issue #876 follow-on: actionable error on optional-extra imports
+
+Every module-scope import of an optional-extra package (FastAPI /
+Starlette / Uvicorn / aiohttp / aiohttp-cors / bcrypt / PyJWT) in
+production source now raises an actionable `ImportError` naming the
+correct `pip install 'kailash[<extra>]'` recipe — instead of a bare
+`ModuleNotFoundError` that gave clean-install users no signal. 25
+sites swept in total (3 in the first wave, 22 in the second sibling
+sweep), with a structural invariant test
+(`tests/regression/test_optional_extra_import_guards.py`) AST-walking
+every Python module in `src/kailash/` to gate future regressions.
+
+The `_KNOWN_VIOLATIONS` allowlist is now empty — going forward, any
+new module-scope optional-extra import without a `try/except
+ImportError` guard surfaces as a test failure, not silently absorbed.
+
+### Test — issue #912: widen time-limit Tier-2 elapsed bound for cold-start
+
+Tier-2 time-limit tests at `tests/integration/runtime/test_local_
+runtime_time_limits.py` had a tight elapsed-time bound that
+intermittently failed on cold-start CI runners (slow first-import
+penalty pushing elapsed past the original threshold). Bound widened
+with explicit rationale in the test comment; no behaviour change in
+the runtime.
+
+### Test — issues #948, #949: pre-existing test infrastructure fixes
+
+- `#948`: drop orphan `_patch_worker_execute_skip_roundtrip` call in
+  the distributed-runtime suite — the helper had been deleted in a
+  prior refactor but one call site survived, blocking collection.
+- `#949`: fix tuple-unpack on `execute_workflow_async` return value
+  plus ListNode key in `tests/regression/`. The runtime started
+  returning `(results, run_id)` two-tuple in 2.16.0; the regression
+  test still used the pre-tuple return shape.
+
+### Added — issue #876: hashing-symmetry across history_store.\* log emissions + metric counters
 
 Every `history_store.*` log emission at WARN level or higher now hashes
 record-level identifiers (`run_id`, `workflow_id`, `node_id`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.20.1"
+version = "2.20.2"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.20.1"
+__version__ = "2.20.2"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep PR cutting kailash 2.20.2 (patch) — bundles 7 PRs merged since v2.20.1 (#955, #952, #957, #956, #958, #954, #951). No breaking changes; all fixes + test infrastructure.

Per \`git.md\` § "Release-Prep PRs MUST Use \`release/v*\` Branch Convention" — branched from \`release/v2.20.2\`, which auto-skips the full PR-gate matrix per \`if: !startsWith(github.head_ref, 'release/')\` workflow gate.

## Release scope (per build-repo-release-discipline.md Rule 3)

| Package         | main   | PyPI   | Release |
|-----------------|--------|--------|---------|
| kailash         | 2.20.2 | 2.20.1 | YES     |
| kailash-dataflow| 2.9.0  | 2.9.0  | NO      |
| kailash-nexus   | 2.6.3  | 2.6.3  | NO      |
| kailash-kaizen  | 2.21.0 | 2.21.0 | NO      |
| kailash-mcp     | 0.2.14 | 0.2.14 | NO      |
| kailash-ml      | 1.7.4  | 1.7.4  | NO      |
| kailash-align   | 0.7.1  | 0.7.1  | NO      |
| kailash-pact    | 0.12.0 | 0.12.0 | NO      |

Only the root kailash package advanced since 2.20.1; no sibling drift.

## What's in 2.20.2

**Fixed**:
- \`#950\` LocalRuntime cleanup-race coroutine leak (PR #952)
- \`#882\` DurableExecutionEngine routing-test mock-kwarg drift (PR #957) — \`_FakeRuntime\` now mirrors \`AsyncLocalRuntime.execute_workflow_async\` signature
- \`#876\` follow-on: 25 module-scope optional-extra imports now raise actionable \`ImportError\` naming \`kailash[<extra>]\` (PR #956 first 3, PR #958 remaining 22)

**Added (issue #876 W2 audit hardening, PR #955)**:
- Hashing-symmetry across \`history_store.*\` WARN emissions + metric counters
- Typed \`MissingRunIdError\` + tenant-scoped \`delete_runs_older_than\` + batched DELETE
- Audit-log payload type whitelist (replaces \`default=str\`) — see CHANGELOG Migration section
- Retention sweep throttle (\`sweep_interval_seconds=30.0\` default; \`=0.0\` restores per-event behaviour)

**Test**:
- \`#912\` time-limit Tier-2 elapsed bound widened for cold-start (PR #954)
- \`#948 / #949\` pre-existing test-infrastructure fixes (PR #951)

## Migration prose

CHANGELOG \`[2.20.2]\` § "Changed — issue #876: audit-log payload type whitelist (replaces default=str)" documents the one user-visible behaviour change: nodes returning \`set\` / \`frozenset\` / \`bytes\` / \`bytearray\` / \`memoryview\` / custom-class instances in their \`outputs\` or \`metadata\` now raise \`TypeError\` at audit-write time rather than silently round-tripping as \`str()\` repr. Fix at node boundary (e.g. \`return {"items": list(my_set)}\`).

## Test plan

- [x] Pre-commit (black/isort/ruff/Tier-1) green
- [x] CHANGELOG entries verified against PR list
- [x] Version anchors atomic: \`pyproject.toml::version == src/kailash/__init__.py::__version__ == 2.20.2\`
- [x] Release scope enumerated (only root \`kailash\` advanced; no sibling drift)
- [ ] CI green on release/v2.20.2 (PR-gate matrix auto-skipped per branch convention)
- [ ] **YOUR AUTHORIZATION**: cut PyPI release after merge — \`/release\` runs against this PR's tag

## Related issues

Closes the release-prep half of #876, #882, #950, #912, #948, #949 (PRs already merged; this PR bundles + ships).