### PR TITLE
docs(deploy): record kailash 2.20.2 release deployment

### DIFF
--- a/deploy/deployments/2026-05-11-v2.20.2.md
+++ b/deploy/deployments/2026-05-11-v2.20.2.md
@@ -1,0 +1,189 @@
+# kailash 2.20.2 — 2026-05-11
+
+Single-package patch release bundling 7 PRs merged since v2.20.1: #876 W2 audit
+hardening (#955), #882 mock-kwarg drift fix (#957), #876 follow-on optional-extra
+import-guard sweep (#956 + #958), #950 LocalRuntime cleanup-race fix (#952),
+#912 time-limit Tier-2 bound widening (#954), #948 / #949 test-infrastructure
+fixes (#951).
+
+## Release scope (build-repo-release-discipline.md Rule 3)
+
+| Package          | main   | PyPI   | Release |
+| ---------------- | ------ | ------ | ------- |
+| kailash          | 2.20.2 | 2.20.1 | YES     |
+| kailash-dataflow | 2.9.0  | 2.9.0  | NO      |
+| kailash-nexus    | 2.6.3  | 2.6.3  | NO      |
+| kailash-kaizen   | 2.21.0 | 2.21.0 | NO      |
+| kailash-mcp      | 0.2.14 | 0.2.14 | NO      |
+| kailash-ml       | 1.7.4  | 1.7.4  | NO      |
+| kailash-align    | 0.7.1  | 0.7.1  | NO      |
+| kailash-pact     | 0.12.0 | 0.12.0 | NO      |
+
+Only the root `kailash` package advanced since 2.20.1; no sibling drift.
+
+## Substantive changes
+
+### #876 W2 audit hardening (PR #955)
+
+- **Typed `MissingRunIdError`** — `WorkflowHistoryStore.record_event` raises a
+  typed exception when an incoming event has no `run_id`. The runtime
+  subscriber-error handler (`durable.NodeCompletionSubscribers.dispatch_async`)
+  observes the typed cause before the generic `Exception` fallback, emits
+  `history_store.record_event.dropped` WARN + `record_history_store_dropped`
+  metric, and preserves forward-progress.
+- **Hashing-symmetry across `history_store.*` WARN emissions** — every
+  record-level identifier in WARN+ lines (`run_id`, `workflow_id`, `node_id`,
+  `sample_run_id`) now hashes via the 8-char SHA-256 prefix helper `_hash_short`,
+  paired with a metric counter increment on `MetricsBridge`. Four sites covered:
+  `record_event.dropped`, `get_run_events.payload_decode_failed`,
+  `per_tenant_cap.evicted`, `retention.swept`. Closes the schema-revealing-field
+  leak gradient per `observability.md` Rule 8.
+- **Audit-log payload type whitelist** — `WorkflowHistoryStore.record_event`
+  serializes payloads via the explicit-type whitelist `_audit_safe_default`.
+  `default=str` is gone. **User-visible behaviour change:** nodes returning
+  `set` / `frozenset` / `bytes` / `bytearray` / `memoryview` / custom-class
+  instances in `outputs` or `metadata` now raise `TypeError` at audit-write
+  time. Fix at node boundary (e.g. `return {"items": list(my_set)}`).
+- **Tenant-scoped `delete_runs_older_than`** — new keyword-only
+  `tenant_id: Optional[str] = None` kwarg. When set, the sweep is scoped to one
+  tenant via `_tenant_partition(tenant_id)`. When `None`, cross-tenant default
+  preserved.
+- **Statement-count-bounded sweeps** — `delete_runs_older_than` and
+  `_enforce_per_tenant_cap` now execute exactly two batched `DELETE` statements
+  per transaction (events first, runs second). Was `1 SELECT + 2N DELETEs` per
+  expired/excess run; new shape is constant in `N`.
+- **Retention sweep throttle** — `WorkflowHistoryStore.__init__` accepts
+  `sweep_interval_seconds: float = 30.0`. Consecutive `record_event`
+  invocations within the interval short-circuit before any SQL round-trip.
+  Per-tenant for the cap check; global for the retention sweep. Pass
+  `sweep_interval_seconds=0.0` to restore per-event behaviour.
+
+### #950 LocalRuntime cleanup-race coroutine leak (PR #952)
+
+`LocalRuntime` cleanup path no longer leaks coroutines when cleanup runs
+concurrently with the workflow loop's tail. The fix gates cleanup on event-loop
+state and awaits residual coroutines in-loop when the loop is still alive.
+
+### #882 DurableExecutionEngine routing-test mock-kwarg drift (PR #957)
+
+`_FakeRuntime.execute_workflow_async` in
+`tests/regression/test_issue_882_durable_execution_mode.py` was missing the
+`soft_time_limit` / `time_limit` kwargs that
+`DurableExecutionEngine.execute` now forwards. The mock now mirrors the
+canonical `AsyncLocalRuntime.execute_workflow_async` signature and records both
+kwargs in `execute_calls`. A new behavioural regression test asserts the
+engine forwards both kwargs — structural defense against the silent-fallback
+failure mode in `zero-tolerance.md` Rule 3c.
+
+### #876 follow-on optional-extra import guards (PRs #956 + #958)
+
+Every module-scope import of an optional-extra package (FastAPI / Starlette /
+Uvicorn / aiohttp / aiohttp-cors / bcrypt / PyJWT) in production source now
+raises an actionable `ImportError` naming the correct
+`pip install 'kailash[<extra>]'` recipe. 25 sites swept across two waves (3
+in PR #956, 22 in PR #958). Structural invariant test at
+`tests/regression/test_optional_extra_import_guards.py` AST-walks every
+module under `src/kailash/`; the `_KNOWN_VIOLATIONS` allowlist is now empty.
+
+### #912 time-limit Tier-2 bound widening (PR #954)
+
+Cold-start CI runner first-import penalty intermittently pushed elapsed past
+the original threshold. Bound widened with explicit rationale; no behaviour
+change in the runtime.
+
+### #948 / #949 test-infrastructure fixes (PR #951)
+
+- `#948`: drop orphan `_patch_worker_execute_skip_roundtrip` call in the
+  distributed-runtime suite — helper deleted in prior refactor, one call site
+  survived.
+- `#949`: fix tuple-unpack on `execute_workflow_async` return value + ListNode
+  key in `tests/regression/`. Runtime started returning `(results, run_id)`
+  in 2.16.0; this regression test still used the pre-tuple shape.
+
+## Release flow
+
+1. Release-prep PR #960 from `release/v2.20.2` — auto-skipped PR-gate matrix
+   per `git.md` release-prep convention (`!startsWith(github.head_ref,
+'release/')` workflow gate); only `build` ran, green.
+2. Admin-merge PR #960 at `72348c2d` (2026-05-11T00:26:40Z).
+3. Pre-release security review (mandatory per `deployment.md`):
+   security-reviewer delta-checked cumulative diff `v2.20.1..HEAD` —
+   **APPROVED, zero CRITICAL/HIGH/MEDIUM findings**. One LOW-grade non-blocking
+   advisory: `MissingRunIdError.node_id` attribute is retained raw on the
+   exception instance; sites that re-emit via `repr(exc)` or `exc.node_id`
+   bypass the WARN-line hashing. Docstring already documents this; downstream
+   consumers using `_hash_short` at re-emission sites are unaffected.
+4. Tag `v2.20.2` annotated, pushed to origin — triggered `publish-pypi.yml`
+   workflow run `25644055537` via OIDC trusted publisher.
+5. TestPyPI skipped per patch-release exception with explicit human approval.
+6. Production PyPI publish: workflow run `25644055537` — **success** at
+   2026-05-11T00:29:41Z. GitHub Release `kailash 2.20.2` created automatically
+   by the workflow (`isDraft: false`, `isPrerelease: false`).
+
+## Clean-venv install verification
+
+```bash
+$ uv venv /tmp/verify-kailash-2202 --python 3.13 --clear
+$ uv pip install --python /tmp/verify-kailash-2202/bin/python --refresh \
+    "kailash==2.20.2"
+[1st attempt — PyPI cache lag, expected per build-repo-release-discipline.md Rule 2]
+[2nd attempt after ~60s — visible on PyPI, install succeeded]
+
+$ /tmp/verify-kailash-2202/bin/python -c "
+import kailash
+print('version:', kailash.__version__)
+from kailash.sdk_exceptions import MissingRunIdError
+print('MissingRunIdError:', MissingRunIdError.__module__)
+from kailash.infrastructure.history_store import WorkflowHistoryStore
+import inspect
+sig = inspect.signature(WorkflowHistoryStore.__init__)
+print('sweep_interval_seconds in __init__:', 'sweep_interval_seconds' in sig.parameters)
+print('delete_runs_older_than signature:', list(inspect.signature(WorkflowHistoryStore.delete_runs_older_than).parameters))
+"
+version: 2.20.2
+MissingRunIdError: kailash.sdk_exceptions
+sweep_interval_seconds in __init__: True
+delete_runs_older_than signature: ['self', 'timestamp', 'tenant_id', 'force_downgrade']
+
+# Import-guard behavioural verification (server extra not installed):
+$ /tmp/verify-kailash-2202/bin/python -c "
+try:
+    from kailash.api.gateway import WorkflowAPIGateway
+except ImportError as e:
+    print('expected ImportError:', str(e)[:120])
+"
+expected ImportError: kailash.api.gateway requires server dependencies (httpx, fastapi, starlette). Install with: pip install 'kailash[server]
+```
+
+All five verification axes pass:
+
+- `kailash.__version__` reports `2.20.2`
+- New typed exception `MissingRunIdError` importable from
+  `kailash.sdk_exceptions`
+- `WorkflowHistoryStore.__init__` accepts `sweep_interval_seconds` parameter
+- `WorkflowHistoryStore.delete_runs_older_than` signature includes the new
+  `tenant_id` + `force_downgrade` parameters
+- Optional-extra import guard fires with the actionable error message naming
+  the correct `kailash[server]` install recipe — the same pattern applies to
+  all 25 swept sites
+
+## Cross-SDK parity
+
+#876 work is Python-specific (asyncio + history-store SQL surfaces); no
+equivalent surface exists in `kailash-rs` at this version. #950 cleanup-race is
+asyncio-specific. #882 mock-kwarg drift is test-only.
+
+#876 follow-on optional-extra import guards: `kailash-rs` uses Cargo features
+for the equivalent optional-dependency pattern; the `ImportError` failure mode
+is Python-specific. No cross-SDK action.
+
+## Follow-ups surfaced (not blocking)
+
+- Issue #959 (filed in same session as 2.20.2 cut): `security/trust: pin
+canonical bytes for trust-plane signing — replace default=str`. HIGH-severity
+  cross-version / cross-SDK hash-chain divergence risk at four trust-plane
+  sites. Out-of-scope for 2.20.2 (different module tree, requires byte-vector
+  pinning per `cross-sdk-inspection.md` Rule 4).
+- LOW advisory from pre-release security review: `MissingRunIdError.node_id`
+  raw attribute access. Document in a future minor release if the re-emission
+  pattern proliferates.


### PR DESCRIPTION
Routine post-release documentation per  convention. Records the 2.20.2 release flow: PR #960 merged → tag v2.20.2 → publish-pypi.yml run 25644055537 success → PyPI 2.20.2 → clean-venv install verified.

Pre-release security review: **APPROVED**, zero CRITICAL/HIGH/MEDIUM. One LOW-grade non-blocking advisory (already docstring-documented).

No sibling drift — only root `kailash` advanced since 2.20.1.

## Test plan

- [x] Deployment record cites verified workflow run ID (25644055537)
- [x] Clean-venv install verification command output included
- [x] Pre-commit (markdown formatter) green
- [ ] CI (auto-skipped path-filter for docs-only diff)