### PR TITLE
fix(trust): byte-stable canonical bytes for hash chain (#959)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — issue #959: trust-plane canonical bytes are now byte-stable
+
+`DecisionRecord.content_hash`, `ReasoningTrace.content_hash`, and
+`plane.models.ConstraintEnvelope.envelope_hash` now use
+`kailash.trust.signing.crypto.serialize_for_signing()` to produce
+canonical bytes for SHA-256 hashing. The prior `json.dumps(..., default=str)`
+canon serialized datetimes, Decimals, and UUIDs via Python's `str()` form,
+which is implementation-defined and not byte-stable across Python versions
+or cross-SDK boundaries (kailash-py ↔ kailash-rs). The replacement is an
+explicit-type whitelist: `datetime`/`date`/`time` → `.isoformat()`,
+`Decimal` → `str()` with full precision preserved (e.g. `Decimal("1.50")`
+serializes as `"1.50"` not `"1.5"`), `UUID` → 8-4-4-4-12 hex,
+`Enum` → `.value`, `bytes` → base64. Unsupported types now raise
+`TypeError` at signing time rather than silently coercing via `str()`.
+
+`TrustProject.verify(strict=True)` now raises
+`kailash.trust.plane.exceptions.ChainHashMismatchError` on the first
+decision-record hash mismatch (typed `.details` carries `record_id`,
+`stored_hash`, `computed_hash`, `record_type="decision"`). Default mode
+(`strict=False`, backward-compatible) continues to populate
+`integrity_issues` and set `chain_valid=False` in the returned report, AND
+now emits a structured WARN log line (`trust_chain.hash_mismatch`) per the
+log-triage gate. Both modes are exercised by the new Tier 2 regression
+test at `tests/regression/test_issue_959_trust_canonical_bytes.py`.
+
+### Migration — re-anchor existing audit chains on upgrade
+
+Audit chains signed by kailash 2.20.2 or earlier MAY fail re-verification
+after upgrading because the canonical-bytes serializer changed. This is
+loud-and-actionable behavior:
+
+- In default `verify()` mode, the returned report shows `chain_valid=False`
+  with `integrity_issues` listing every mismatched record. Operators see
+  the issue and decide whether to re-anchor (re-sign the chain with the
+  new canon) or accept the audit-trail break.
+- In `verify(strict=True)` mode, the first mismatch raises
+  `ChainHashMismatchError` immediately with full record context in
+  `.details`.
+
+There is intentionally no `legacy_default_str_fallback` flag — perpetuating
+the broken canon ships the problem forward and breaks cross-SDK byte
+parity. Re-anchoring is the safe disposition for any chain that may
+have been signed with the implementation-defined prior canon.
+
+Records containing only native JSON primitives (str, int, float, bool,
+None, list, dict) are unaffected. Records containing custom classes that
+previously relied on `default=str` to coerce them now raise `TypeError`
+at signing time — declare a `to_dict()` method or serializer on those
+dataclasses.
+
+### Added — cross-SDK fixture for kailash-rs
+
+A new cross-SDK byte-pin fixture lives at
+`tests/test-vectors/trust-plane-canonical.json`. kailash-rs SHOULD vendor
+this file per `cross-sdk-inspection.md` Rule 4a so the Python and Rust
+implementations both reproduce the same canonical bytes and SHA-256 hex
+for the eight pinned vectors (ASCII payload, UTC datetime, non-UTC
+datetime, Decimal precision, UUID, Unicode BMP, above-BMP emoji,
+empty-dict sentinel).
+
+### Out of scope for this release — deferred no-verifier `default=str` sites
+
+The audit at workspace-time identified five additional `default=str`
+signing-shape sites under `src/kailash/trust/` that have NO active
+re-verifier consuming the canonical bytes. They produce SHA-256 digests
+that are stored or used as audit/dedup sentinels but are not subsequently
+re-derived for chain-integrity verification. These sites are byte-stable
+within a single Python version but are NOT guaranteed cross-SDK or
+cross-version stable; cross-SDK forensic correlation will be added in a
+follow-up issue:
+
+- `src/kailash/trust/enforce/selective_disclosure.py:47` — `_hash_value`
+  redaction sentinel.
+- `src/kailash/trust/enforce/selective_disclosure.py:279` —
+  `_compute_chain_hash` (compact canon already symmetric with verifier).
+- `src/kailash/trust/enforce/selective_disclosure.py:341` —
+  `export_for_witness` sign payload.
+- `src/kailash/trust/enforce/selective_disclosure.py:385` — mirror of
+  `:341` in `verify_signature`.
+- `src/kailash/trust/enforce/decorators.py:305` — `_hash_result` for the
+  `@verified` decorator's integrity hash (audit-log dedup only).
+
+Touching these sites is non-load-bearing for #959's primary scope
+(silent verification failure) — the change is cross-SDK parity hygiene
+only. A cross-SDK follow-up issue will land per
+`cross-sdk-inspection.md` Rule 1 with user gate per
+`upstream-issue-hygiene.md`.
+
 ## [2.20.2] - 2026-05-11
 
 ### Fixed — issue #950: LocalRuntime cleanup-race coroutine leak

--- a/src/kailash/trust/plane/exceptions.py
+++ b/src/kailash/trust/plane/exceptions.py
@@ -38,6 +38,8 @@ __all__ = [
     "KeyExpiredError",
     "SigningError",
     "VerificationError",
+    # Chain integrity
+    "ChainHashMismatchError",
     # Constraint / budget
     "ConstraintViolationError",
     "BudgetExhaustedError",
@@ -239,6 +241,61 @@ class VerificationError(KeyManagerError):
 
 
 # ---------------------------------------------------------------------------
+# Chain integrity exceptions
+# ---------------------------------------------------------------------------
+
+
+class ChainHashMismatchError(TrustPlaneError):
+    """Raised when a trust-chain record's stored hash diverges from a
+    re-derivation over the same record's canonical bytes.
+
+    Distinct from ``VerificationError`` (Ed25519 signature failure) — this
+    error signals that the canonical-bytes serialization of the record
+    produces a different SHA-256 digest than the one persisted with the
+    record. Causes include cross-version canonical-bytes drift (the bug
+    fixed by issue #959), tampering with the stored payload, or downstream
+    re-serialization that did not route through ``serialize_for_signing``.
+
+    Attributes:
+        record_id: Identifier of the record whose hash failed to match.
+        stored_hash: Hex-encoded SHA-256 hash persisted with the record.
+        computed_hash: Hex-encoded SHA-256 hash freshly re-derived from
+            the record's canonical bytes.
+        record_type: One of ``"decision"``, ``"milestone"``,
+            ``"delegation"``, or ``"reasoning_trace"``.
+    """
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        record_id: str = "",
+        stored_hash: str = "",
+        computed_hash: str = "",
+        record_type: str = "",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        # Defaults keep the cross-exception-hierarchy contract simple
+        # (every `TrustPlaneError` is constructable with a bare message)
+        # while preserving typed attributes for production callers that
+        # supply them via keyword.
+        self.record_id = record_id
+        self.stored_hash = stored_hash
+        self.computed_hash = computed_hash
+        self.record_type = record_type
+        super().__init__(
+            message,
+            details=details
+            or {
+                "record_id": record_id,
+                "stored_hash": stored_hash,
+                "computed_hash": computed_hash,
+                "record_type": record_type,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
 # Constraint / budget exceptions
 # ---------------------------------------------------------------------------
 
@@ -333,4 +390,7 @@ class TLSSyslogError(TrustPlaneError):
 
 # Re-exported from shared location to avoid circular imports.
 # _locking.py defines the class; plane.exceptions re-exports for backward compat.
-from kailash.trust._locking import LockTimeoutError as LockTimeoutError  # noqa: F401
+# E402 silenced: late import is required to break the import cycle with _locking.
+from kailash.trust._locking import (  # noqa: F401, E402
+    LockTimeoutError as LockTimeoutError,
+)

--- a/src/kailash/trust/plane/models.py
+++ b/src/kailash/trust/plane/models.py
@@ -1,8 +1,5 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
-
-from __future__ import annotations
-
 """Data models for TrustPlane.
 
 Domain models wrapping EATP primitives:
@@ -13,8 +10,9 @@ Domain models wrapping EATP primitives:
 - ProjectManifest: Persistent project state
 """
 
+from __future__ import annotations
+
 import hashlib
-import json
 import logging
 import math
 import secrets
@@ -22,6 +20,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
+
+from kailash.trust.signing.crypto import serialize_for_signing
 
 logger = logging.getLogger(__name__)
 
@@ -295,7 +295,13 @@ class ConstraintEnvelope:
         )
 
     def envelope_hash(self) -> str:
-        """SHA-256 of constraint content for tamper detection."""
+        """SHA-256 of constraint content for tamper detection.
+
+        Canonical bytes come from ``serialize_for_signing`` (issue #959):
+        byte-stable across Python versions and cross-SDK boundaries. Replaces
+        the prior ``json.dumps(..., default=str)`` canon which serialized
+        datetimes / Decimals / UUIDs via ``str()`` — implementation-defined.
+        """
         payload = {
             "operational": self.operational.to_dict(),
             "data_access": self.data_access.to_dict(),
@@ -303,9 +309,7 @@ class ConstraintEnvelope:
             "temporal": self.temporal.to_dict(),
             "communication": self.communication.to_dict(),
         }
-        return hashlib.sha256(
-            json.dumps(payload, sort_keys=True, default=str).encode()
-        ).hexdigest()
+        return hashlib.sha256(serialize_for_signing(payload).encode()).hexdigest()
 
     def is_tighter_than(self, other: "ConstraintEnvelope") -> bool:
         """Check if this envelope is at least as tight as another.
@@ -817,8 +821,14 @@ class DecisionRecord:
         )
 
     def content_hash(self) -> str:
-        """SHA-256 of the decision content for tamper detection."""
-        payload = json.dumps(self.to_dict(), sort_keys=True, default=str)
+        """SHA-256 of the decision content for tamper detection.
+
+        Canonical bytes come from ``serialize_for_signing`` (issue #959):
+        byte-stable across Python versions and cross-SDK boundaries. Replaces
+        the prior ``json.dumps(..., default=str)`` canon which serialized
+        datetimes / Decimals / UUIDs via ``str()`` — implementation-defined.
+        """
+        payload = serialize_for_signing(self.to_dict())
         return hashlib.sha256(payload.encode()).hexdigest()
 
 

--- a/src/kailash/trust/plane/project.py
+++ b/src/kailash/trust/plane/project.py
@@ -56,6 +56,7 @@ from kailash.trust.enforce.strict import HeldBehavior, StrictEnforcer, Verdict
 from kailash.trust.operations import CapabilityRequest, TrustKeyManager, TrustOperations
 from kailash.trust.plane.exceptions import (
     BudgetExhaustedError,
+    ChainHashMismatchError,
     ConstraintViolationError,
     TrustPlaneError,
 )
@@ -1013,7 +1014,7 @@ class TrustProject:
         logger.info("Recorded milestone %s (%s)", version, milestone.milestone_id)
         return milestone.milestone_id
 
-    async def verify(self) -> dict[str, Any]:
+    async def verify(self, *, strict: bool = False) -> dict[str, Any]:
         """Verify the project's trust chain integrity.
 
         Performs three levels of verification:
@@ -1022,13 +1023,29 @@ class TrustProject:
         3. Decision content hash verification (detect tampered decision records)
         4. Key consistency check
 
+        Args:
+            strict: When ``True``, raise ``ChainHashMismatchError`` on the FIRST
+                decision-record hash mismatch (fails fast for programmatic
+                callers). When ``False`` (default), continue iterating and
+                populate ``integrity_issues`` + ``chain_valid=False`` in the
+                returned report (existing bulk-audit behavior). Either mode
+                emits a WARN log line per ``observability.md`` Rule 5 when a
+                mismatch is detected.
+
         Returns:
-            Verification report dictionary
+            Verification report dictionary (only when ``strict=False`` or no
+            mismatch detected).
+
+        Raises:
+            ChainHashMismatchError: When ``strict=True`` and a decision
+                record's stored hash diverges from a fresh re-derivation.
+                ``.details`` carries ``record_id``, ``stored_hash``,
+                ``computed_hash``, ``record_type="decision"``.
         """
         async with self._async_lock:
-            return await self._verify_locked()
+            return await self._verify_locked(strict=strict)
 
-    async def _verify_locked(self) -> dict[str, Any]:
+    async def _verify_locked(self, *, strict: bool = False) -> dict[str, Any]:
         integrity_issues: list[str] = []
         chain_valid = True
 
@@ -1079,6 +1096,25 @@ class TrustProject:
             record = DecisionRecord.from_dict(data)
             computed_hash = record.content_hash()
             if stored_hash and not hmac_mod.compare_digest(stored_hash, computed_hash):
+                # WARN log per observability.md Rule 5 (log triage gate) +
+                # Rule 8 (no schema-revealing field values at WARN — record_id
+                # is the identifier, not classified content).
+                logger.warning(
+                    "trust_chain.hash_mismatch",
+                    extra={
+                        "record_id": record.decision_id,
+                        "record_type": "decision",
+                        "file": df.name,
+                    },
+                )
+                if strict:
+                    raise ChainHashMismatchError(
+                        f"decision record {record.decision_id} hash mismatch",
+                        record_id=record.decision_id,
+                        stored_hash=stored_hash,
+                        computed_hash=computed_hash,
+                        record_type="decision",
+                    )
                 integrity_issues.append(f"{df.name}: hash mismatch (tampered?)")
                 chain_valid = False
 

--- a/src/kailash/trust/reasoning/traces.py
+++ b/src/kailash/trust/reasoning/traces.py
@@ -24,7 +24,6 @@ Key design decisions:
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -154,14 +153,21 @@ class ReasoningTrace:
                     f"{_MAX_ALTERNATIVE_LEN} characters, got {len(alt)}"
                 )
         if len(self.evidence) > _MAX_EVIDENCE_ITEMS:
-            raise ValueError(f"evidence exceeds maximum of {_MAX_EVIDENCE_ITEMS} items, got {len(self.evidence)}")
-        if self.methodology is not None and len(self.methodology) > _MAX_METHODOLOGY_LEN:
+            raise ValueError(
+                f"evidence exceeds maximum of {_MAX_EVIDENCE_ITEMS} items, got {len(self.evidence)}"
+            )
+        if (
+            self.methodology is not None
+            and len(self.methodology) > _MAX_METHODOLOGY_LEN
+        ):
             raise ValueError(
                 f"methodology exceeds maximum length of {_MAX_METHODOLOGY_LEN} characters, got {len(self.methodology)}"
             )
         if self.confidence is not None:
             if not (0.0 <= self.confidence <= 1.0):
-                raise ValueError(f"confidence must be between 0.0 and 1.0 inclusive, got {self.confidence}")
+                raise ValueError(
+                    f"confidence must be between 0.0 and 1.0 inclusive, got {self.confidence}"
+                )
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -256,11 +262,22 @@ class ReasoningTrace:
         same trace always produces the same hash regardless of field
         insertion order.
 
+        Canonical bytes come from ``serialize_for_signing`` (issue #959):
+        byte-stable across Python versions and cross-SDK boundaries. Replaces
+        the prior ``json.dumps(..., default=str)`` canon which serialized
+        datetimes / Decimals / UUIDs via ``str()`` — implementation-defined.
+
         Returns:
             Raw SHA-256 digest (32 bytes).
         """
+        # Late import to break the cycle:
+        # ``kailash.trust.signing.crypto`` imports ``ReasoningTrace`` at
+        # module scope for sign_reasoning_trace(); a module-scope import here
+        # would close the cycle.
+        from kailash.trust.signing.crypto import serialize_for_signing
+
         payload = self.to_signing_payload()
-        serialized = json.dumps(payload, sort_keys=True, default=str)
+        serialized = serialize_for_signing(payload)
         return hashlib.sha256(serialized.encode("utf-8")).digest()
 
     def content_hash_hex(self) -> str:

--- a/src/kailash/trust/signing/crypto.py
+++ b/src/kailash/trust/signing/crypto.py
@@ -12,8 +12,10 @@ import base64
 import hashlib
 import json
 import secrets
+import uuid
 from dataclasses import asdict, dataclass, is_dataclass
-from datetime import datetime
+from datetime import date, datetime, time
+from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple, Union
 
@@ -239,7 +241,27 @@ def serialize_for_signing(obj: Any) -> str:
     """
 
     def convert(item: Any) -> Any:
-        """Recursively convert objects to JSON-serializable types."""
+        """Recursively convert objects to JSON-serializable types.
+
+        Type whitelist for byte-stable canonical bytes (issue #959):
+
+        * dataclasses → asdict() recursively
+        * dict → recursively, keys sorted
+        * frozenset / set → sorted list
+        * list / tuple → recursively
+        * datetime / date / time → isoformat() (canonical Python form)
+        * Decimal → str() with full precision preserved (e.g. ``Decimal("1.50")``
+          serializes as ``"1.50"``, NOT ``"1.5"``)
+        * UUID → hex string (``str(u)`` produces the canonical 8-4-4-4-12 form)
+        * Enum → ``.value``
+        * bytes → base64
+
+        Native JSON primitives (str, int, float, bool, None) pass through
+        unchanged. ANY other type is left for ``json.dumps`` to reject with
+        ``TypeError`` — there is no ``default=str`` fallback, because
+        ``str(obj)`` is implementation-defined and breaks cross-version /
+        cross-SDK byte parity.
+        """
         if is_dataclass(item) and not isinstance(item, type):
             return convert(asdict(item))
         elif isinstance(item, dict):
@@ -248,8 +270,12 @@ def serialize_for_signing(obj: Any) -> str:
             return [convert(i) for i in sorted(item)]
         elif isinstance(item, (list, tuple)):
             return [convert(i) for i in item]
-        elif isinstance(item, datetime):
+        elif isinstance(item, (datetime, date, time)):
             return item.isoformat()
+        elif isinstance(item, Decimal):
+            return str(item)
+        elif isinstance(item, uuid.UUID):
+            return str(item)
         elif isinstance(item, Enum):
             return item.value
         elif isinstance(item, bytes):

--- a/tests/regression/test_issue_959_trust_canonical_bytes.py
+++ b/tests/regression/test_issue_959_trust_canonical_bytes.py
@@ -1,0 +1,517 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #959 — trust-plane canonical-bytes byte pins.
+
+The trust-plane hash-chain helpers (``DecisionRecord.content_hash``,
+``ReasoningTrace.content_hash``, and
+``plane.models.ConstraintEnvelope.envelope_hash``) build canonical bytes via
+``kailash.trust.signing.crypto.serialize_for_signing`` and feed them into
+SHA-256. Cross-SDK signature parity (kailash-py ↔ kailash-rs) requires
+byte-for-byte identical output for identical inputs — otherwise the SAME
+logical record signed on Python verifies-differently on Rust and chain-hash
+audit fails silently.
+
+These tests pin the canonical-bytes shape AND the SHA-256 output for
+representative input vectors covering: ASCII, UTC datetime, tz-aware
+datetime, Decimal, UUID, Unicode BMP, above-BMP emoji, the empty-dict
+sentinel, and a negative case (unsupported type rejection). One
+``TestCrossSDKFixtureParity`` class auto-iterates the vendored fixture
+``tests/test-vectors/trust-plane-canonical.json`` for kailash-rs to mirror
+per ``cross-sdk-inspection.md`` Rule 4a.
+
+Plus a verifier-behavior class pinning the ``strict=True`` raise contract
+on ``TrustProject.verify`` (issue-959 silent-fallback fix).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, datetime, time, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from kailash.trust.plane.exceptions import ChainHashMismatchError
+from kailash.trust.plane.models import ConstraintEnvelope, DecisionRecord, DecisionType
+from kailash.trust.reasoning.traces import ConfidentialityLevel, ReasoningTrace
+from kailash.trust.signing.crypto import serialize_for_signing
+
+# Path to the cross-SDK canonical fixture this test pins. See
+# ``tests/test-vectors/trust-plane-canonical.json`` for the contract; the
+# sibling kailash-rs binding consumes the same file per
+# ``rules/cross-sdk-inspection.md`` Rule 4a.
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "test-vectors"
+    / "trust-plane-canonical.json"
+)
+
+
+def _sha256_hex(s: str) -> str:
+    """Compute SHA-256 hex digest of a UTF-8 string. Mirrors the production
+    hash path used by ``DecisionRecord.content_hash`` /
+    ``ConstraintEnvelope.envelope_hash``."""
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Vector V1 — ASCII keys/values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV1AsciiPayload:
+    """Pin canonical bytes + SHA-256 for a minimal ASCII-only payload.
+
+    Sanity check that the canonical helper emits the expected compact form
+    (``sort_keys=True``, no whitespace, ``ensure_ascii=True``) for the
+    common case. Non-ASCII codepoints are exercised by V6/V7 below.
+    """
+
+    EXPECTED_CANONICAL_JSON: str = '{"action":"approve","agent":"a1","cost":42}'
+    EXPECTED_SHA256: str = _sha256_hex(EXPECTED_CANONICAL_JSON)
+
+    def _payload(self) -> dict:
+        return {"agent": "a1", "action": "approve", "cost": 42}
+
+    def test_canonical_json_byte_equal(self) -> None:
+        actual = serialize_for_signing(self._payload())
+        assert actual == self.EXPECTED_CANONICAL_JSON
+
+    def test_sha256_matches_pinned(self) -> None:
+        actual = _sha256_hex(serialize_for_signing(self._payload()))
+        assert actual == self.EXPECTED_SHA256
+
+
+# ---------------------------------------------------------------------------
+# Vector V2 — UTC datetime preserves ISO-8601 with explicit +00:00 suffix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV2UtcDatetime:
+    EXPECTED_CANONICAL_JSON: str = '{"ts":"2026-01-01T00:00:00+00:00"}'
+    EXPECTED_SHA256: str = _sha256_hex(EXPECTED_CANONICAL_JSON)
+
+    def _payload(self) -> dict:
+        return {"ts": datetime(2026, 1, 1, tzinfo=timezone.utc)}
+
+    def test_canonical_json_byte_equal(self) -> None:
+        assert serialize_for_signing(self._payload()) == self.EXPECTED_CANONICAL_JSON
+
+    def test_sha256_matches_pinned(self) -> None:
+        assert (
+            _sha256_hex(serialize_for_signing(self._payload())) == self.EXPECTED_SHA256
+        )
+
+
+# ---------------------------------------------------------------------------
+# Vector V3 — non-UTC tz-aware datetime preserves offset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV3NonUtcDatetime:
+    EXPECTED_CANONICAL_JSON: str = '{"ts":"2026-01-01T12:00:00+08:00"}'
+    EXPECTED_SHA256: str = _sha256_hex(EXPECTED_CANONICAL_JSON)
+
+    def _payload(self) -> dict:
+        return {
+            "ts": datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=8)))
+        }
+
+    def test_canonical_json_byte_equal(self) -> None:
+        assert serialize_for_signing(self._payload()) == self.EXPECTED_CANONICAL_JSON
+
+    def test_sha256_matches_pinned(self) -> None:
+        assert (
+            _sha256_hex(serialize_for_signing(self._payload())) == self.EXPECTED_SHA256
+        )
+
+
+# ---------------------------------------------------------------------------
+# Vector V4 — Decimal preserves precision (issue-959 core: Decimal("1.50")
+# MUST serialize as "1.50" not "1.5")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV4DecimalPreservesPrecision:
+    EXPECTED_CANONICAL_JSON: str = '{"amount":"1.50","zero":"0"}'
+    EXPECTED_SHA256: str = _sha256_hex(EXPECTED_CANONICAL_JSON)
+
+    def _payload(self) -> dict:
+        return {"amount": Decimal("1.50"), "zero": Decimal("0")}
+
+    def test_decimal_emits_with_trailing_zero(self) -> None:
+        """``Decimal("1.50")`` MUST emit ``"1.50"`` not ``"1.5"`` — this is
+        the byte-identity contract issue #959 fixes."""
+        actual = serialize_for_signing(self._payload())
+        assert '"1.50"' in actual
+        assert (
+            '"1.5"' not in actual or '"1.50"' in actual
+        )  # 1.5 only as substring of 1.50
+
+    def test_canonical_json_byte_equal(self) -> None:
+        assert serialize_for_signing(self._payload()) == self.EXPECTED_CANONICAL_JSON
+
+    def test_sha256_matches_pinned(self) -> None:
+        assert (
+            _sha256_hex(serialize_for_signing(self._payload())) == self.EXPECTED_SHA256
+        )
+
+    def test_distinct_decimal_precisions_produce_distinct_canonical(self) -> None:
+        """``Decimal("1.5")`` and ``Decimal("1.50")`` MUST produce distinct
+        canonical bytes — they are different Decimal instances per spec."""
+        a = serialize_for_signing({"x": Decimal("1.5")})
+        b = serialize_for_signing({"x": Decimal("1.50")})
+        assert a != b
+        assert a == '{"x":"1.5"}'
+        assert b == '{"x":"1.50"}'
+
+
+# ---------------------------------------------------------------------------
+# Vector V5 — UUID canonical 8-4-4-4-12 form
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV5Uuid:
+    EXPECTED_CANONICAL_JSON: str = '{"id":"00000000-0000-0000-0000-000000000001"}'
+    EXPECTED_SHA256: str = _sha256_hex(EXPECTED_CANONICAL_JSON)
+
+    def _payload(self) -> dict:
+        return {"id": UUID("00000000-0000-0000-0000-000000000001")}
+
+    def test_canonical_json_byte_equal(self) -> None:
+        assert serialize_for_signing(self._payload()) == self.EXPECTED_CANONICAL_JSON
+
+    def test_sha256_matches_pinned(self) -> None:
+        assert (
+            _sha256_hex(serialize_for_signing(self._payload())) == self.EXPECTED_SHA256
+        )
+
+
+# ---------------------------------------------------------------------------
+# Vector V6 — Unicode BMP (e.g. CJK) is preserved as-is (not escaped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV6UnicodeBmp:
+    """Unicode BMP characters are emitted as ``\\uXXXX`` escape sequences
+    (``json.dumps`` ``ensure_ascii=True`` default — same as
+    ``cross-sdk-inspection.md`` Rule 4's PACT/TraceEvent contracts)."""
+
+    EXPECTED_CANONICAL_JSON: str = '{"name":"\\u6f22\\u5b57"}'
+    EXPECTED_SHA256: str = _sha256_hex(EXPECTED_CANONICAL_JSON)
+
+    def _payload(self) -> dict:
+        return {"name": "漢字"}
+
+    def test_canonical_json_byte_equal(self) -> None:
+        actual = serialize_for_signing(self._payload())
+        assert actual == self.EXPECTED_CANONICAL_JSON
+        # Verify the bytes are ASCII-safe (the ensure_ascii=True contract)
+        assert (
+            actual.isascii()
+        ), "canonical bytes MUST be ASCII-only for cross-SDK byte parity"
+
+    def test_sha256_matches_pinned(self) -> None:
+        assert (
+            _sha256_hex(serialize_for_signing(self._payload())) == self.EXPECTED_SHA256
+        )
+
+
+# ---------------------------------------------------------------------------
+# Vector V7 — above-BMP emoji
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV7AboveBmpEmoji:
+    """Above-BMP codepoints are emitted as UTF-16 surrogate-pair escapes,
+    matching ``cross-sdk-inspection.md`` Rule 4's PACT contract."""
+
+    EXPECTED_CANONICAL_JSON: str = '{"flag":"\\ud83c\\udf89"}'
+    EXPECTED_SHA256: str = _sha256_hex(EXPECTED_CANONICAL_JSON)
+
+    def _payload(self) -> dict:
+        return {"flag": "🎉"}
+
+    def test_canonical_json_byte_equal(self) -> None:
+        assert serialize_for_signing(self._payload()) == self.EXPECTED_CANONICAL_JSON
+
+    def test_sha256_matches_pinned(self) -> None:
+        assert (
+            _sha256_hex(serialize_for_signing(self._payload())) == self.EXPECTED_SHA256
+        )
+
+
+# ---------------------------------------------------------------------------
+# Vector V8 — ReasoningTrace.content_hash (T05)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV8ReasoningTraceContentHash:
+    """Pin the hash output of ``ReasoningTrace.content_hash`` for a
+    representative trace built with stable fields (no UUID, no Decimal)."""
+
+    EXPECTED_SHA256_HEX: str = (
+        "9152497d56e367541417d4a277531c7e21cd9a693a2937a4feaebaf2fb619c2a"
+    )
+
+    def _trace(self) -> ReasoningTrace:
+        return ReasoningTrace(
+            decision="approve-deployment",
+            rationale="all checks green",
+            confidentiality=ConfidentialityLevel.PUBLIC,
+            timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            evidence=[{"src": "ci", "id": "abc"}],
+            methodology="risk_assessment",
+            confidence=0.95,
+        )
+
+    def test_content_hash_is_deterministic(self) -> None:
+        t = self._trace()
+        assert t.content_hash() == t.content_hash()
+
+    def test_content_hash_matches_pinned(self) -> None:
+        assert self._trace().content_hash().hex() == self.EXPECTED_SHA256_HEX
+
+
+# ---------------------------------------------------------------------------
+# Vector V9 — plane.models.ConstraintEnvelope.envelope_hash (T06)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestV9PlaneConstraintEnvelopeHash:
+    EXPECTED_SHA256_HEX: str = (
+        "d47812fb45378d1950b3f32ea0eaf2f94312e34cd58d2e3e38312bfe9af30166"
+    )
+
+    def _envelope(self) -> ConstraintEnvelope:
+        return ConstraintEnvelope.from_legacy(["no-deploy", "no-prod"], "agent-1")
+
+    def test_envelope_hash_is_deterministic(self) -> None:
+        e = self._envelope()
+        assert e.envelope_hash() == e.envelope_hash()
+
+    def test_envelope_hash_matches_pinned(self) -> None:
+        assert self._envelope().envelope_hash() == self.EXPECTED_SHA256_HEX
+
+
+# ---------------------------------------------------------------------------
+# Sentinel — empty dict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestEmptyDictSentinel:
+    EXPECTED_CANONICAL_JSON: str = "{}"
+    EXPECTED_SHA256: str = _sha256_hex(EXPECTED_CANONICAL_JSON)
+
+    def test_empty_dict_canonical(self) -> None:
+        assert serialize_for_signing({}) == self.EXPECTED_CANONICAL_JSON
+
+    def test_empty_dict_sha256(self) -> None:
+        assert _sha256_hex(serialize_for_signing({})) == self.EXPECTED_SHA256
+
+
+# ---------------------------------------------------------------------------
+# Negative — unsupported types raise TypeError, not silent coerce
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestNegativeRejectsUnsupportedType:
+    """Issue #959 contract: unsupported types MUST raise at signing time,
+    NOT be silently coerced via ``str()`` (the prior ``default=str`` bug)."""
+
+    def test_custom_class_raises_type_error(self) -> None:
+        class Custom:
+            def __init__(self) -> None:
+                self.x = 1
+
+        with pytest.raises(TypeError):
+            serialize_for_signing({"obj": Custom()})
+
+    def test_complex_number_raises(self) -> None:
+        with pytest.raises(TypeError):
+            serialize_for_signing({"z": complex(1, 2)})
+
+
+# ---------------------------------------------------------------------------
+# Whitelist hardening — date / time / Decimal pass through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestSerializerWhitelistHandlesAllRequiredTypes:
+    """Whitelist contract: every type in the documented list MUST round-trip
+    deterministically. This pins the helper's public contract."""
+
+    def test_date_emits_isoformat(self) -> None:
+        out = serialize_for_signing({"d": date(2026, 1, 1)})
+        assert out == '{"d":"2026-01-01"}'
+
+    def test_time_emits_isoformat(self) -> None:
+        out = serialize_for_signing({"t": time(12, 0, 0)})
+        assert out == '{"t":"12:00:00"}'
+
+    def test_decimal_string_preserves_trailing_zero(self) -> None:
+        out = serialize_for_signing({"x": Decimal("0.10")})
+        assert out == '{"x":"0.10"}'
+
+    def test_uuid_lowercase_hex(self) -> None:
+        u = UUID("12345678-1234-5678-1234-567812345678")
+        out = serialize_for_signing({"u": u})
+        assert out == '{"u":"12345678-1234-5678-1234-567812345678"}'
+
+
+# ---------------------------------------------------------------------------
+# Verifier-behavior pin — strict=True raises, default warns + summary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestVerifyIntegrityRaisesOnMismatchInStrictMode:
+    """Issue #959 silent-fallback fix: ``TrustProject.verify(strict=True)``
+    raises ``ChainHashMismatchError`` on a tampered decision record instead
+    of silently flipping ``chain_valid=False``."""
+
+    async def _make_project_with_tampered_decision(self, tmp_path: Path):
+        """Set up: create a TrustProject, record one decision, tamper the
+        on-disk decision JSON to break its stored content_hash. Returns
+        ``(project, decision_id)``."""
+        from kailash.trust.plane.project import TrustProject
+
+        project = await TrustProject.create(
+            trust_dir=tmp_path,
+            project_name="issue-959 verify-strict test",
+            author="agent-1",
+            constraints=["no-prod"],
+        )
+        decision = DecisionRecord(
+            decision_type=DecisionType.SCOPE,
+            decision="approve",
+            rationale="all checks green",
+            author="agent-1",
+            cost=0.0,
+        )
+        decision_id = await project.record_decision(decision)
+        # Tamper: rewrite the decision JSON with a different `decision`,
+        # leaving the original content_hash field intact so it diverges.
+        # File name is "{seq:04d}-{decision_id}.json"; glob to find it.
+        candidates = list((tmp_path / "decisions").glob(f"*-{decision_id}.json"))
+        assert (
+            len(candidates) == 1
+        ), f"decision file MUST exist after record; found {candidates!r}"
+        decision_file = candidates[0]
+        data = json.loads(decision_file.read_text())
+        data["decision"] = "tampered!"  # break the stored hash
+        decision_file.write_text(json.dumps(data))
+        return project, decision_id
+
+    @pytest.mark.asyncio
+    async def test_strict_mode_raises_on_tampered_record(self, tmp_path: Path) -> None:
+        project, decision_id = await self._make_project_with_tampered_decision(tmp_path)
+        with pytest.raises(ChainHashMismatchError) as exc_info:
+            await project.verify(strict=True)
+        assert exc_info.value.record_type == "decision"
+        assert exc_info.value.record_id == decision_id
+        assert exc_info.value.computed_hash != exc_info.value.stored_hash
+
+    @pytest.mark.asyncio
+    async def test_default_mode_reports_summary_does_not_raise(
+        self, tmp_path: Path
+    ) -> None:
+        project, _ = await self._make_project_with_tampered_decision(tmp_path)
+        report = await project.verify()
+        assert report["chain_valid"] is False
+        assert any("hash mismatch" in issue for issue in report["integrity_issues"])
+
+
+# ---------------------------------------------------------------------------
+# Cross-SDK fixture parity (per cross-sdk-inspection.md Rule 4a)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestCrossSDKFixtureParity:
+    """Iterate the vendored ``tests/test-vectors/trust-plane-canonical.json``
+    and assert every vector's pinned canonical-bytes / SHA-256 reproduces
+    via this SDK's ``serialize_for_signing`` + ``hashlib.sha256``. The
+    sibling kailash-rs binding consumes the same file."""
+
+    @pytest.fixture(scope="class")
+    def fixture(self) -> dict:
+        assert _FIXTURE_PATH.exists(), (
+            f"cross-SDK trust-plane fixture missing at {_FIXTURE_PATH}; "
+            "this fixture is the cross-SDK byte contract per issue #959"
+        )
+        return json.loads(_FIXTURE_PATH.read_text())
+
+    def test_fixture_loads_with_required_floor(self, fixture: dict) -> None:
+        assert fixture["contract"] == "trust-plane-canonical-bytes"
+        # ≥3 byte-vectors + sentinels per cross-sdk-inspection.md Rule 4.
+        assert len(fixture["vectors"]) >= 7
+
+    def _reify_input(self, input_repr: dict) -> dict:
+        """Reify input_repr scalar tags into Python objects.
+
+        The fixture stores typed values via small tags (``{"$type": ..., "$value": ...}``)
+        so the JSON file can hold them losslessly. This reifier turns them
+        back into the Python objects the helper expects. Top-level fixture
+        input is always a dict.
+        """
+
+        def reify(node: Any) -> Any:
+            if isinstance(node, dict):
+                if set(node.keys()) == {"$type", "$value"}:
+                    t = node["$type"]
+                    v = node["$value"]
+                    if t == "datetime":
+                        return datetime.fromisoformat(v)
+                    if t == "date":
+                        return date.fromisoformat(v)
+                    if t == "time":
+                        return time.fromisoformat(v)
+                    if t == "decimal":
+                        return Decimal(v)
+                    if t == "uuid":
+                        return UUID(v)
+                    raise ValueError(f"unknown $type {t!r} in fixture")
+                return {k: reify(v) for k, v in node.items()}
+            if isinstance(node, list):
+                return [reify(x) for x in node]
+            return node
+
+        out = reify(input_repr)
+        assert isinstance(out, dict), "fixture input_repr top-level must be a dict"
+        return out
+
+    def test_every_vector_canonical_json_byte_equal(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            payload = self._reify_input(v["input_repr"])
+            actual = serialize_for_signing(payload)
+            assert actual == v["expected_canonical_json"], (
+                f"vector {v['name']}: canonical-bytes divergence — "
+                f"got {actual!r}, expected {v['expected_canonical_json']!r}"
+            )
+
+    def test_every_vector_sha256_matches(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            payload = self._reify_input(v["input_repr"])
+            actual = _sha256_hex(serialize_for_signing(payload))
+            assert actual == v["expected_sha256"], (
+                f"vector {v['name']}: SHA-256 divergence — "
+                f"got {actual}, expected {v['expected_sha256']}"
+            )

--- a/tests/test-vectors/trust-plane-canonical.json
+++ b/tests/test-vectors/trust-plane-canonical.json
@@ -1,0 +1,84 @@
+{
+  "contract": "trust-plane-canonical-bytes",
+  "version": "1.0.0",
+  "spec_ref": "specs/trust-crypto.md §12.2",
+  "issue": "https://github.com/terrene-foundation/kailash-py/issues/959",
+  "description": "Cross-SDK canonical-bytes byte-pin vectors for the trust-plane signing helper (kailash.trust.signing.crypto.serialize_for_signing). Both kailash-py and kailash-rs MUST produce byte-identical canonical_json and identical SHA-256 hex for every vector. Typed scalars are tagged ({\"$type\": ..., \"$value\": ...}) so the JSON file holds them losslessly. Each SDK's reifier turns tags back into the language's native object before feeding the serializer. Canonical bytes are ASCII-only (json ensure_ascii=True default) for byte-stable cross-SDK output.",
+  "tag_schema": {
+    "datetime": "ISO-8601 string with explicit tz; e.g. 2026-01-01T00:00:00+00:00",
+    "date": "YYYY-MM-DD",
+    "time": "HH:MM:SS[.ffffff]",
+    "decimal": "lexical Decimal string preserving precision; e.g. '1.50' not '1.5'",
+    "uuid": "8-4-4-4-12 hex; e.g. 00000000-0000-0000-0000-000000000001"
+  },
+  "vectors": [
+    {
+      "name": "V1_ascii_payload",
+      "input_repr": {
+        "agent": "a1",
+        "action": "approve",
+        "cost": 42
+      },
+      "expected_canonical_json": "{\"action\":\"approve\",\"agent\":\"a1\",\"cost\":42}",
+      "expected_sha256": "3d8562fdd4e63efd07d9de2b3a96bc03f04a179b9b75efd4cd42280240760147"
+    },
+    {
+      "name": "V2_utc_datetime",
+      "input_repr": {
+        "ts": { "$type": "datetime", "$value": "2026-01-01T00:00:00+00:00" }
+      },
+      "expected_canonical_json": "{\"ts\":\"2026-01-01T00:00:00+00:00\"}",
+      "expected_sha256": "b1a289d1082ef3def8eb27ce27519099e69d92875225c01408851b0777b22988"
+    },
+    {
+      "name": "V3_non_utc_datetime",
+      "input_repr": {
+        "ts": { "$type": "datetime", "$value": "2026-01-01T12:00:00+08:00" }
+      },
+      "expected_canonical_json": "{\"ts\":\"2026-01-01T12:00:00+08:00\"}",
+      "expected_sha256": "6bfe8d60a649caf78eaa26a4a0d7ebf7db48562e97bcf36eb7d240df97e8ec8b"
+    },
+    {
+      "name": "V4_decimal_precision_preserved",
+      "input_repr": {
+        "amount": { "$type": "decimal", "$value": "1.50" },
+        "zero": { "$type": "decimal", "$value": "0" }
+      },
+      "expected_canonical_json": "{\"amount\":\"1.50\",\"zero\":\"0\"}",
+      "expected_sha256": "84119573c58750982476c1f83ba891c32278c2893a8a498fc14794ce7825345d"
+    },
+    {
+      "name": "V5_uuid",
+      "input_repr": {
+        "id": {
+          "$type": "uuid",
+          "$value": "00000000-0000-0000-0000-000000000001"
+        }
+      },
+      "expected_canonical_json": "{\"id\":\"00000000-0000-0000-0000-000000000001\"}",
+      "expected_sha256": "2dc5f9c55037c706dbbeee318933924c80a78eeff51d5f0d9310ced9801bfe6b"
+    },
+    {
+      "name": "V6_unicode_bmp",
+      "input_repr": {
+        "name": "漢字"
+      },
+      "expected_canonical_json": "{\"name\":\"\\u6f22\\u5b57\"}",
+      "expected_sha256": "0741d59cd3e8fad3121a875d0494b9db41d7116c30db65a83ea6f10509316d18"
+    },
+    {
+      "name": "V7_above_bmp_emoji",
+      "input_repr": {
+        "flag": "🎉"
+      },
+      "expected_canonical_json": "{\"flag\":\"\\ud83c\\udf89\"}",
+      "expected_sha256": "4ae22bd28ca5ffea28a6e299edefd66aff5cd192a58b7b05a425ad37a963f118"
+    },
+    {
+      "name": "EmptyDict_sentinel",
+      "input_repr": {},
+      "expected_canonical_json": "{}",
+      "expected_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    }
+  ]
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1772,7 +1772,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.20.0"
+version = "2.20.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Routes `DecisionRecord.content_hash`, `ReasoningTrace.content_hash`, and `plane.models.ConstraintEnvelope.envelope_hash` through `serialize_for_signing` instead of `json.dumps(..., default=str)`. The prior canon was not byte-stable across Python versions or cross-SDK boundaries (datetimes / Decimals / UUIDs serialized via implementation-defined `str()`).
- `serialize_for_signing` gains explicit handlers for `Decimal` / `UUID` / `date` / `time`; unsupported types now raise `TypeError` at signing time instead of silently coercing.
- `TrustProject.verify(strict=True)` raises typed `ChainHashMismatchError` on hash mismatch; default mode preserves bulk-audit summary AND adds a structured WARN log line.
- Cross-SDK byte-pin fixture at `tests/test-vectors/trust-plane-canonical.json` (8 vectors per `cross-sdk-inspection.md` Rule 4a) for kailash-rs to vendor.

## Scope correction

The original issue body cited 4 storage files (`store/sqlite.py`, `store/postgres.py`, `posture_store.py`, `chain_store/sqlite.py`) as the canonical-bytes signing surface. Workspace audit confirmed these are pure-storage paths (no rehash, no verifier) — out of scope for #959. The true active-verifier-consuming sites are the 3 files this PR touches. Five additional no-verifier `default=str` sites under `enforce/` are explicitly deferred in CHANGELOG (cross-SDK parity hygiene; no silent verification failure).

## Test plan

- [x] `tests/regression/test_issue_959_trust_canonical_bytes.py` — 33 byte-pin + strict/default + negative tests
- [x] Sibling regressions (`test_issue_756`, `test_issue_757`, `test_issue_731`) still pass
- [x] Full trust suite: 5946 passed, 1 fixed (`test_all_exceptions_have_details` — `ChainHashMismatchError` now accepts a bare-message constructor per the cross-deliverable hierarchy contract)
- [x] Pre-commit: black + isort + ruff + JSON + Tier 1 unit + docstyle all green
- [x] reviewer agent: APPROVE_WITH_NITS (1 MEDIUM addressed in same shard)
- [x] security-reviewer agent: APPROVE_WITH_NITS (1 LOW docstring addressed in same shard); no CRIT/HIGH

## Migration

Audit chains signed by kailash ≤2.20.2 will fail re-verification on upgrade — operators see `chain_valid=False` + `integrity_issues` and re-anchor. Intentional clean break (no legacy fallback flag). Full migration discussion in CHANGELOG.md `## [Unreleased] § Migration`.

## Related issues

Fixes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)