### PR TITLE
chore(release): kailash 2.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.20.3] - 2026-05-11
+
 ### Changed — issue #959: trust-plane canonical bytes are now byte-stable
 
 `DecisionRecord.content_hash`, `ReasoningTrace.content_hash`, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.20.2"
+version = "2.20.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.20.2"
+__version__ = "2.20.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- Release-prep PR for kailash 2.20.3. Bumps version anchors and dates CHANGELOG.
- Code change ships on PR #962 (already merged, commit `e08e8b81`).

## Test plan

- [x] Branched from `release/v*` per `git.md` convention — PR-gate matrix auto-skips.
- [x] Two version anchors atomic (pyproject.toml + `__init__.py`).
- [x] CHANGELOG entry moved from `## [Unreleased]` to `## [2.20.3] - 2026-05-11`.

## Related issues

Closes #959 once published to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)