### PR TITLE
docs(deploy): record kailash 2.20.3 release deployment

### DIFF
--- a/deploy/deployments/2026-05-11-v2.20.3.md
+++ b/deploy/deployments/2026-05-11-v2.20.3.md
@@ -1,0 +1,126 @@
+# kailash 2.20.3 — 2026-05-11
+
+Single-package patch release shipping the issue #959 fix — trust-plane
+canonical bytes are now byte-stable across Python versions and cross-SDK
+boundaries (kailash-py ↔ kailash-rs).
+
+## Release scope (build-repo-release-discipline.md Rule 3)
+
+| Package          | main   | PyPI   | Release |
+| ---------------- | ------ | ------ | ------- |
+| kailash          | 2.20.3 | 2.20.2 | YES     |
+| kailash-dataflow | 2.9.0  | 2.9.0  | NO      |
+| kailash-nexus    | 2.6.3  | 2.6.3  | NO      |
+| kailash-kaizen   | 2.21.0 | 2.21.0 | NO      |
+| kailash-mcp      | 0.2.14 | 0.2.14 | NO      |
+| kailash-ml       | 1.7.4  | 1.7.4  | NO      |
+| kailash-align    | 0.7.1  | 0.7.1  | NO      |
+| kailash-pact     | 0.12.0 | 0.12.0 | NO      |
+| kaizen-agents    | 0.9.7  | 0.9.7  | NO      |
+
+Only the root `kailash` package advanced since 2.20.2; no sibling drift.
+
+## Substantive changes
+
+### #959 trust-plane canonical bytes are byte-stable (PR #962)
+
+`DecisionRecord.content_hash`, `ReasoningTrace.content_hash`, and
+`plane.models.ConstraintEnvelope.envelope_hash` now route through
+`kailash.trust.signing.crypto.serialize_for_signing` instead of
+`json.dumps(..., default=str)`. The prior canon serialized
+datetimes / Decimals / UUIDs via Python's `str()` form, which is
+implementation-defined and not byte-stable across Python versions or
+cross-SDK boundaries.
+
+`serialize_for_signing` gains explicit handlers for `Decimal` / `UUID` /
+`date` / `time` so the whitelist covers every type trust-plane records
+use; unsupported types now raise `TypeError` at signing time rather than
+silently coercing.
+
+`TrustProject.verify(strict=True)` raises typed `ChainHashMismatchError`
+on the first per-record hash mismatch (`.details` carries `record_id`,
+`stored_hash`, `computed_hash`, `record_type`). Default mode (backward
+compatible) preserves the bulk-audit summary report AND adds a
+structured WARN log line per `observability.md` Rule 5 + 8.
+
+The Tier-2 regression test at
+`tests/regression/test_issue_959_trust_canonical_bytes.py` pins canonical
+bytes and SHA-256 hex for: ASCII payload, UTC datetime, non-UTC
+datetime, `Decimal("1.50")` precision, UUID, Unicode BMP, above-BMP
+emoji, empty-dict sentinel — plus negative-type rejection and the
+strict/default verifier split.
+
+Cross-SDK byte-pin fixture at `tests/test-vectors/trust-plane-canonical.json`
+(8 vectors) for kailash-rs to vendor per `cross-sdk-inspection.md` Rule
+4a. Cross-SDK follow-up issue draft staged in
+`workspaces/issue-959-trust-canonical-bytes/04-validate/cross-sdk-issue-draft.md`,
+awaiting user gate per `upstream-issue-hygiene.md` before filing.
+
+### Migration impact
+
+Audit chains signed by kailash ≤2.20.2 will fail re-verification after
+upgrade — the loud-and-actionable path: `verify()` reports
+`chain_valid=False` + `integrity_issues`; operators re-anchor or accept
+the audit-trail break. `verify(strict=True)` raises
+`ChainHashMismatchError` immediately. There is intentionally no
+`legacy_default_str_fallback` flag — perpetuating the broken canon
+ships the problem forward and breaks cross-SDK byte parity.
+
+Records containing only native JSON primitives (str, int, float, bool,
+None, list, dict) are unaffected. Records containing custom classes
+that previously relied on `default=str` to coerce them now raise
+`TypeError` — declare a `to_dict()` method or serializer on those
+dataclasses.
+
+### Out-of-scope deferrals (explicit in CHANGELOG)
+
+Five additional `default=str` signing-shape sites under `enforce/` have
+NO active re-verifier consuming the canonical bytes. They are
+byte-stable within a single Python version but not cross-SDK guaranteed.
+Touching them is non-load-bearing for #959's primary scope; cross-SDK
+parity hygiene will land in a follow-up cross-SDK issue.
+
+## Release cycle audit trail
+
+- Code PR: #962 (merged commit `e08e8b81`)
+- Release-prep PR: #963 (merged commit `08cee132`)
+- Publish workflow: run `25676123777` succeeded; PyPI metadata at
+  `https://pypi.org/pypi/kailash/2.20.3/json` reflects
+  `kailash-2.20.3-py3-none-any.whl`.
+- Tag pushed: `v2.20.3` (singular tag push per `deployment.md` § "Multi-Package
+  Release Tags Pushed Individually").
+- Clean-venv install verification: `uv pip install --refresh
+kailash[trust]==2.20.3` succeeded after one PyPI-cache-lag retry;
+  `from kailash.trust.plane.exceptions import ChainHashMismatchError`
+  imports cleanly; `serialize_for_signing` pins reproduce.
+- Gate-level reviews: reviewer (APPROVE_WITH_NITS, 1 MEDIUM fixed
+  same-shard) + security-reviewer (APPROVE_WITH_NITS, 1 LOW fixed
+  same-shard). Zero CRIT / HIGH findings on either.
+
+## Verification
+
+```bash
+uv pip install --refresh "kailash[trust]==2.20.3"
+python -c "from kailash.trust.plane.exceptions import ChainHashMismatchError; print(ChainHashMismatchError)"
+python -c "
+from kailash.trust.signing.crypto import serialize_for_signing
+from decimal import Decimal
+out = serialize_for_signing({'amount': Decimal('1.50')})
+assert out == '{\"amount\":\"1.50\"}', out
+print('canonical-bytes pin OK')
+"
+```
+
+## Outstanding next actions
+
+- Cross-SDK follow-up issue for `esperie/kailash-rs` — draft staged,
+  awaiting explicit user gate per `upstream-issue-hygiene.md` MUST Rule
+  1. Draft body at
+     `workspaces/issue-959-trust-canonical-bytes/04-validate/cross-sdk-issue-draft.md`.
+- Latent gap noted during verification: `pip install kailash` (no
+  extras) raises `ModuleNotFoundError: filelock` when consumer imports
+  `kailash.trust.plane.*`. This is pre-existing on 2.20.2 — not
+  introduced by 2.20.3. Trust namespace is opt-in via `pip install
+kailash[trust]` by design. Worth a follow-up issue if the design
+  intent is base-install completeness per CLAUDE.md "standard deps"
+  language, but out of #959 scope.


### PR DESCRIPTION
## Summary

- Records the kailash 2.20.3 release deployment (issue #959 fix).
- Documents release scope, substantive changes, migration impact, deferrals, and the verification audit trail.

## Test plan

- [x] Docs-only diff (`deploy/deployments/2026-05-11-v2.20.3.md`) — no source / no test / no spec changes.
- [x] PR-gate matrix should auto-skip via path-filter (deployments dir is docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)