### PR TITLE
fix(kaizen): declare credential_ref NodeParameter on LLMAgentNode

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/core/base_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/core/base_agent.py
@@ -548,10 +548,21 @@ class BaseAgent(MCPMixin, A2AMixin, Node):
             node_config["model"] = self.config.model
         if self.config.llm_provider is not None:
             node_config["provider"] = self.config.llm_provider
+        # Route generation params into the declared `generation_config` dict.
+        # LLMAgentNode.get_parameters() declares `generation_config: dict`
+        # (description: "Generation parameters (temperature, max_tokens, top_p)")
+        # and llm_agent.py reads ONLY generation_config at runtime — top-level
+        # `temperature` / `max_tokens` are not declared NodeParameters and the
+        # Kailash validator (`src/kailash/nodes/base.py:_validate_inputs`) flags
+        # them as "Unknown parameter" on EVERY execution because
+        # BaseAgentConfig.temperature defaults to 0.1 (non-None).
+        generation_config: Dict[str, Any] = {}
         if self.config.temperature is not None:
-            node_config["temperature"] = self.config.temperature
+            generation_config["temperature"] = self.config.temperature
         if self.config.max_tokens is not None:
-            node_config["max_tokens"] = self.config.max_tokens
+            generation_config["max_tokens"] = self.config.max_tokens
+        if generation_config:
+            node_config["generation_config"] = generation_config
         if self.config.provider_config is not None:
             node_config["provider_config"] = self.config.provider_config
         if self.config.response_format is not None:

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal
 
 from kailash.nodes.base import Node, NodeParameter, register_node
+
 from kaizen.nodes.ai.error_sanitizer import sanitize_provider_error
 
 
@@ -396,6 +397,18 @@ class LLMAgentNode(Node):
                 type=str,
                 required=False,
                 description="Per-request base URL override (e.g., for proxy or custom endpoint)",
+            ),
+            "credential_ref": NodeParameter(
+                name="credential_ref",
+                type=str,
+                required=False,
+                description=(
+                    "Reference ID into the runtime CredentialStore (BYOK). "
+                    "Set by WorkflowGenerator when api_key/base_url were "
+                    "provided on BaseAgentConfig; resolved at execution time "
+                    "to a non-serializable Credential. Never contains the "
+                    "credential value itself."
+                ),
             ),
         }
 

--- a/packages/kailash-kaizen/tests/integration/test_credential_ref_roundtrip.py
+++ b/packages/kailash-kaizen/tests/integration/test_credential_ref_roundtrip.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterator
 
 import pytest
 from kailash.runtime.local import LocalRuntime
@@ -47,7 +48,7 @@ class QASignature(Signature):
 
 
 @pytest.fixture(autouse=True)
-def _clear_credential_store() -> None:
+def _clear_credential_store() -> Iterator[None]:
     """Per-test isolation — CredentialStore is process-global."""
     get_credential_store().clear()
     yield
@@ -119,7 +120,7 @@ def test_credential_ref_round_trips_through_workflow_to_node(
     caplog.set_level(logging.WARNING, logger="kailash.nodes.base")
 
     runtime = LocalRuntime()
-    results, run_id = runtime.execute(
+    results, _run_id = runtime.execute(
         built,
         parameters={
             "agent_exec": {

--- a/packages/kailash-kaizen/tests/integration/test_credential_ref_roundtrip.py
+++ b/packages/kailash-kaizen/tests/integration/test_credential_ref_roundtrip.py
@@ -1,0 +1,164 @@
+"""Tier-2 integration test for issue #900 — credential_ref round-trip.
+
+Exercises the full plumbing path that issue #900 fixes:
+
+    BaseAgentConfig(api_key=..., base_url=...)
+      → WorkflowGenerator.generate_signature_workflow()
+      → CredentialStore.register() → 'cred_<uuid>' written to node_config
+      → LocalRuntime.execute() → LLMAgentNode.execute()
+      → LLMAgentNode reads self.config["credential_ref"] (llm_agent.py:848)
+      → get_credential_store().resolve(credential_ref) returns Credential
+
+NO MOCKING per rules/testing.md § Tier 2:
+
+  * Uses the real ``provider="mock"`` LLM provider (a real implementation
+    that returns a deterministic mock response — it is NOT a unittest.mock
+    object). This satisfies the Protocol-Satisfying Deterministic Adapter
+    exception documented in rules/testing.md.
+  * Uses the real WorkflowGenerator, the real CredentialStore (in-process
+    Python object — no network), the real WorkflowBuilder, the real
+    LocalRuntime, and the real LLMAgentNode.
+  * No ``@patch`` / ``MagicMock`` / ``unittest.mock`` anywhere.
+
+The test asserts the round-trip behavior the issue's acceptance criteria
+require: credential_ref survives end-to-end and the "Unknown parameter"
+warning is NOT emitted.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.credentials import get_credential_store
+
+from kaizen.core.config import BaseAgentConfig
+from kaizen.core.workflow_generator import WorkflowGenerator
+from kaizen.signatures import InputField, OutputField, Signature
+
+
+class QASignature(Signature):
+    """Minimal signature for the round-trip exercise."""
+
+    question: str = InputField(desc="A question to answer")
+    answer: str = OutputField(desc="The answer to the question")
+
+
+@pytest.fixture(autouse=True)
+def _clear_credential_store() -> None:
+    """Per-test isolation — CredentialStore is process-global."""
+    get_credential_store().clear()
+    yield
+    get_credential_store().clear()
+
+
+@pytest.mark.integration
+def test_credential_ref_round_trips_through_workflow_to_node(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """End-to-end: BaseAgentConfig → WorkflowGenerator → LLMAgentNode.
+
+    Exercises the same plumbing chain a production user hits, with NO
+    mocking. Asserts three contract properties:
+
+      (a) WorkflowGenerator stored a credential_ref in node_config
+          (security invariant — api_key MUST NOT live in node_config).
+      (b) The store resolves the reference to the original api_key /
+          base_url values.
+      (c) Running the workflow through LocalRuntime does NOT emit any
+          "Unknown parameter" WARNING on the kailash.nodes.base logger
+          for credential_ref — this is the exact failure mode #900
+          reports.
+    """
+    # Set provider env var so the workflow_generator does not raise on
+    # configuration. The mock provider does not actually use this.
+    os.environ.setdefault("OPENAI_API_KEY", "sk-test-noop")
+
+    config = BaseAgentConfig(
+        llm_provider="mock",
+        model="mock-model",
+        api_key="sk-issue-900-tenant-roundtrip",
+        base_url="https://proxy.issue-900.example/v1",
+    )
+    generator = WorkflowGenerator(config=config, signature=QASignature())
+    workflow = generator.generate_signature_workflow()
+
+    # (a) Structural — credential_ref is in node_config; api_key is not.
+    built = workflow.build()
+    node = built.nodes.get("agent_exec")
+    assert node is not None, "WorkflowGenerator must create agent_exec node"
+    assert (
+        "api_key" not in node.config
+    ), "api_key MUST NOT live in serializable node_config (BYOK invariant)"
+    assert (
+        "base_url" not in node.config
+    ), "base_url MUST NOT live in serializable node_config (BYOK invariant)"
+    credential_ref = node.config.get("credential_ref")
+    assert (
+        credential_ref is not None
+    ), "WorkflowGenerator MUST write credential_ref when api_key was provided"
+    assert credential_ref.startswith(
+        "cred_"
+    ), f"credential_ref should be a 'cred_*' reference; got {credential_ref!r}"
+
+    # (b) Round-trip — CredentialStore resolves the reference to original values.
+    cred = get_credential_store().resolve(credential_ref)
+    assert cred is not None, "credential_ref must resolve via get_credential_store"
+    assert (
+        cred.api_key == "sk-issue-900-tenant-roundtrip"
+    ), f"api_key did not round-trip; got {cred.api_key!r}"
+    assert (
+        cred.base_url == "https://proxy.issue-900.example/v1"
+    ), f"base_url did not round-trip; got {cred.base_url!r}"
+
+    # (c) Behavioral — executing the workflow emits no Unknown-parameter
+    #     warning for credential_ref. This is the exact stderr pollution
+    #     the issue body documents.
+    caplog.set_level(logging.WARNING, logger="kailash.nodes.base")
+
+    runtime = LocalRuntime()
+    results, run_id = runtime.execute(
+        built,
+        parameters={
+            "agent_exec": {
+                "messages": [{"role": "user", "content": "What is 2+2?"}],
+            }
+        },
+    )
+    assert isinstance(results, dict), "Workflow execution must return a dict of results"
+
+    unknown_param_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.name == "kailash.nodes.base"
+        and rec.levelno >= logging.WARNING
+        and "Unknown parameter" in rec.getMessage()
+        and "credential_ref" in rec.getMessage()
+    ]
+    assert not unknown_param_warnings, (
+        "Workflow execution emitted the issue-#900 Unknown-parameter warning "
+        "for credential_ref. The NodeParameter declaration is missing or "
+        "the validator no longer sees it. Captured records:\n"
+        + "\n".join(f"  - {r.getMessage()}" for r in unknown_param_warnings)
+    )
+
+
+@pytest.mark.integration
+def test_credential_ref_absent_when_no_api_key_provided() -> None:
+    """Round-trip negative: no api_key/base_url → no credential_ref.
+
+    Guards against the dual-mode silent-fallback pattern (Rule 3d). The
+    workflow generator MUST only register credentials when the user
+    actually supplied them; producing a phantom credential_ref otherwise
+    would mask configuration bugs and bloat the CredentialStore.
+    """
+    config = BaseAgentConfig(llm_provider="mock", model="mock-model")
+    generator = WorkflowGenerator(config=config, signature=QASignature())
+    built = generator.generate_signature_workflow().build()
+    node = built.nodes.get("agent_exec")
+    assert node is not None
+    assert (
+        "credential_ref" not in node.config
+    ), "credential_ref must NOT be written when no api_key/base_url supplied"

--- a/packages/kailash-kaizen/tests/unit/nodes/ai/test_credential_ref_param.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/ai/test_credential_ref_param.py
@@ -1,0 +1,133 @@
+"""Tier-1 unit tests for issue #900 — credential_ref NodeParameter declaration.
+
+WorkflowGenerator writes ``credential_ref`` into LLMAgentNode config to plumb
+CredentialStore references (BYOK security model). LLMAgentNode reads it back
+at execution time. Both ends agreed on the contract, but ``get_parameters()``
+did not declare ``credential_ref``, so Kailash's runtime validator
+(``src/kailash/nodes/base.py:1018``) flagged it as an "Unknown parameter" on
+every ``run_async`` invocation.
+
+The fix declares ``credential_ref`` as ``type=str``, ``required=False`` in
+``LLMAgentNode.get_parameters()``. These Tier-1 tests pin the declaration
+(structural) and pin the no-warning behavior (logger capture).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kaizen.nodes.ai import LLMAgentNode
+
+
+@pytest.mark.regression
+def test_credential_ref_is_declared_in_get_parameters() -> None:
+    """Structural: ``credential_ref`` MUST appear in declared parameters.
+
+    Locks the contract between WorkflowGenerator (writer) and LLMAgentNode
+    (reader). If this declaration is dropped in a future refactor, the
+    runtime validator will resume flagging "Unknown parameter".
+    """
+    node = LLMAgentNode()
+    params = node.get_parameters()
+
+    assert "credential_ref" in params, (
+        "credential_ref MUST be declared in LLMAgentNode.get_parameters() — "
+        "WorkflowGenerator writes it into node_config and llm_agent.py:848 "
+        "reads it back to resolve from get_credential_store()."
+    )
+
+    param = params["credential_ref"]
+    assert param.type is str, (
+        f"credential_ref MUST be type=str (got {param.type}); "
+        "the value is a reference ID like 'cred_a1b2c3d4e5f6'."
+    )
+    assert param.required is False, (
+        "credential_ref MUST be required=False — only present when "
+        "BaseAgentConfig was constructed with api_key/base_url overrides."
+    )
+
+
+@pytest.mark.regression
+def test_run_async_with_credential_ref_emits_no_unknown_parameter_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Behavioral: validate_inputs MUST NOT log "Unknown parameter" for credential_ref.
+
+    The Kailash runtime validator (`src/kailash/nodes/base.py:_validate_inputs`)
+    emits a WARNING on the ``kailash.nodes.base`` logger when a config key is
+    not declared in ``get_parameters()``. Calling ``execute()`` with a config
+    containing ``credential_ref`` MUST NOT trigger that warning now that the
+    parameter is declared.
+
+    This is a structural test: the validator's log line is a stable runtime
+    contract documented at base.py:1017-1031. No regex over assistant prose;
+    we capture the structured log record and assert by field membership.
+    """
+    # Capture warnings from the kailash.nodes.base validator logger.
+    caplog.set_level(logging.WARNING, logger="kailash.nodes.base")
+
+    node = LLMAgentNode(
+        provider="mock",
+        model="mock-model",
+        credential_ref="cred_abcdef123456",
+    )
+
+    # execute() merges self.config into runtime_inputs and runs validate_inputs.
+    # With provider=mock the credential_ref resolution branch (line 848) is not
+    # taken, but the validator runs first — that's the surface we're testing.
+    result = node.execute(
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    assert (
+        result.get("success") is True
+    ), f"mock provider execution should succeed; got: {result.get('error')}"
+
+    # Surface every WARNING record from kailash.nodes.base. None of them
+    # should reference credential_ref as an unknown parameter.
+    unknown_param_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.name == "kailash.nodes.base"
+        and rec.levelno >= logging.WARNING
+        and "Unknown parameter" in rec.getMessage()
+        and "credential_ref" in rec.getMessage()
+    ]
+
+    assert not unknown_param_warnings, (
+        "validate_inputs() emitted 'Unknown parameter' warning for "
+        "credential_ref despite it being declared in get_parameters(). "
+        "Captured records:\n"
+        + "\n".join(f"  - {r.getMessage()}" for r in unknown_param_warnings)
+    )
+
+
+@pytest.mark.regression
+def test_run_async_without_credential_ref_still_clean(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Baseline: nodes WITHOUT credential_ref also emit no warning.
+
+    Guards against a regression where adding the declaration accidentally
+    raises a different warning for the un-passed case (e.g. required=True
+    by mistake).
+    """
+    caplog.set_level(logging.WARNING, logger="kailash.nodes.base")
+
+    node = LLMAgentNode(provider="mock", model="mock-model")
+    result = node.execute(messages=[{"role": "user", "content": "ping"}])
+    assert result.get("success") is True
+
+    unknown_param_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.name == "kailash.nodes.base"
+        and rec.levelno >= logging.WARNING
+        and "Unknown parameter" in rec.getMessage()
+    ]
+    assert not unknown_param_warnings, (
+        "Baseline mock execution without credential_ref should not emit "
+        "any Unknown-parameter warnings. Captured:\n"
+        + "\n".join(f"  - {r.getMessage()}" for r in unknown_param_warnings)
+    )

--- a/packages/kailash-kaizen/tests/unit/nodes/ai/test_generation_config_routing.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/ai/test_generation_config_routing.py
@@ -1,0 +1,138 @@
+"""Tier-1 unit tests for #900 same-bug-class sibling — temperature/max_tokens routing.
+
+BaseAgent.to_workflow() previously wrote ``temperature`` and ``max_tokens`` as
+TOP-LEVEL keys into the LLMAgentNode config. Neither key is a declared
+``NodeParameter`` on LLMAgentNode — only ``generation_config: dict`` is, with the
+description "Generation parameters (temperature, max_tokens, top_p)" pinning the
+canonical contract. llm_agent.py reads ``self.config.get("generation_config", ...)``
+at runtime; top-level ``temperature`` / ``max_tokens`` are never consulted.
+
+The Kailash runtime validator (``src/kailash/nodes/base.py::_validate_inputs``)
+emits a WARNING on the ``kailash.nodes.base`` logger for any config key not
+declared in ``get_parameters()``. Because ``BaseAgentConfig.temperature``
+defaults to ``0.1`` (non-None per ``config.py:50``), the legacy write site fired
+this warning on EVERY BaseAgent execution — wider blast radius than #900 ever
+had.
+
+The fix (Option A) routes ``temperature`` and ``max_tokens`` INTO the
+``generation_config`` dict at the ``BaseAgent.to_workflow()`` write site,
+matching the existing NodeParameter declaration and the existing consumer at
+``llm_agent.py``. These Tier-1 tests pin the no-warning behavior via caplog
+field-membership checks against the kailash.nodes.base validator logger — the
+same structural pattern used for ``credential_ref`` in
+``test_credential_ref_param.py``.
+
+Reference: ``rules/zero-tolerance.md`` Rule 1 (warnings are errors the framework
+chose to keep running through); ``autonomous-execution.md`` Rule 4 (fix-immediately
+when review surfaces a same-bug-class gap within shard budget).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from kaizen.nodes.ai import LLMAgentNode
+
+
+@pytest.mark.regression
+def test_llm_agent_node_with_top_level_temperature_emits_unknown_parameter_warning() -> (
+    None
+):
+    """Baseline: top-level ``temperature`` IS still rejected by the validator.
+
+    Locks the LLMAgentNode contract: ``temperature`` is NOT a declared top-level
+    NodeParameter; it belongs inside ``generation_config``. If a future refactor
+    promotes ``temperature`` to a top-level NodeParameter (Option B), this test
+    will start passing for the wrong reason — at which point the test should be
+    updated to assert the new declaration. The test exists to make any such
+    contract change visible at the test boundary.
+    """
+    import logging as _logging
+
+    caplog_logger = _logging.getLogger("kailash.nodes.base")
+    records: list[_logging.LogRecord] = []
+
+    class _Collector(_logging.Handler):
+        def emit(self, record: _logging.LogRecord) -> None:  # type: ignore[override]
+            records.append(record)
+
+    handler = _Collector(level=_logging.WARNING)
+    caplog_logger.addHandler(handler)
+    original_level = caplog_logger.level
+    caplog_logger.setLevel(_logging.WARNING)
+    try:
+        node = LLMAgentNode(
+            provider="mock",
+            model="mock-model",
+            temperature=0.1,
+            max_tokens=100,
+        )
+        node.execute(messages=[{"role": "user", "content": "hi"}])
+    finally:
+        caplog_logger.removeHandler(handler)
+        caplog_logger.setLevel(original_level)
+
+    unknown_messages = [
+        rec.getMessage()
+        for rec in records
+        if rec.levelno >= _logging.WARNING and "Unknown parameter" in rec.getMessage()
+    ]
+
+    # Structural assertion: at least one Unknown-parameter warning fires that
+    # names BOTH temperature and max_tokens. This pins the validator behavior
+    # so any future change to the LLMAgentNode parameter declaration surface
+    # forces the test to be updated.
+    matching = [
+        msg for msg in unknown_messages if "temperature" in msg and "max_tokens" in msg
+    ]
+    assert matching, (
+        "Top-level temperature/max_tokens MUST still be flagged as Unknown by "
+        "the Kailash validator. This baseline test pins the LLMAgentNode contract: "
+        "these parameters belong inside generation_config, not at top-level. "
+        f"Captured warnings: {unknown_messages!r}"
+    )
+
+
+@pytest.mark.regression
+def test_llm_agent_node_with_generation_config_emits_no_unknown_parameter_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Behavioral: passing temperature/max_tokens via generation_config is clean.
+
+    This is the post-fix surface: BaseAgent.to_workflow() routes the values
+    through ``generation_config``, which IS a declared NodeParameter. The
+    validator MUST NOT emit "Unknown parameter" warnings for either key.
+
+    Structural caplog field-membership check (per
+    ``rules/probe-driven-verification.md`` Rule 3: log records are structural,
+    not prose).
+    """
+    caplog.set_level(logging.WARNING, logger="kailash.nodes.base")
+
+    node = LLMAgentNode(
+        provider="mock",
+        model="mock-model",
+        generation_config={"temperature": 0.1, "max_tokens": 100},
+    )
+    result = node.execute(messages=[{"role": "user", "content": "hello"}])
+    assert (
+        result.get("success") is True
+    ), f"mock provider execution should succeed; got: {result.get('error')}"
+
+    unknown_param_warnings = [
+        rec
+        for rec in caplog.records
+        if rec.name == "kailash.nodes.base"
+        and rec.levelno >= logging.WARNING
+        and "Unknown parameter" in rec.getMessage()
+        and ("temperature" in rec.getMessage() or "max_tokens" in rec.getMessage())
+    ]
+
+    assert not unknown_param_warnings, (
+        "validate_inputs() emitted 'Unknown parameter' warning for "
+        "temperature/max_tokens despite both being nested under the declared "
+        "generation_config NodeParameter. Captured records:\n"
+        + "\n".join(f"  - {r.getMessage()}" for r in unknown_param_warnings)
+    )


### PR DESCRIPTION
## Summary

`LLMAgentNode.run_async()` emitted a noisy stderr warning on every call when the agent was constructed through `WorkflowGenerator` with a per-request `api_key` or `base_url`:

```
[NODE] Unknown parameter(s) for LLMAgentNode: ['credential_ref'].
Suggestions: 'credential_ref' -> did you mean ['generation_config', 'provider', 'response_format']?
```

Root cause: `WorkflowGenerator` (`packages/kailash-kaizen/src/kaizen/core/workflow_generator.py:279, 282, 425, 428`) writes `node_config["credential_ref"] = credential_ref` to plumb a `CredentialStore` reference through to the node (BYOK security model — the api_key/base_url itself never lives in serializable config). The receiving end in `llm_agent.py:848` reads `self.config.get("credential_ref")` to resolve from the store. But `LLMAgentNode.get_parameters()` did not declare `credential_ref` among its 27 declared parameters, so Kailash's runtime validator (`src/kailash/nodes/base.py:1018`) flagged it as an unknown parameter every execution.

Functional behavior was correct (credentials resolved); only stderr was polluted. This PR closes the documentation gap by declaring `credential_ref` as `type=str, required=False` — matching the shape of sibling string-typed optional params already declared (api_key, base_url, conversation_id, system_prompt).

## What changed

- `packages/kailash-kaizen/src/kaizen/nodes/ai/llm_agent.py`: declare `credential_ref` NodeParameter in `get_parameters()`.
- `packages/kailash-kaizen/tests/unit/nodes/ai/test_credential_ref_param.py`: 3 Tier-1 unit tests (structural declaration check + caplog-based no-warning assertion + baseline guard).
- `packages/kailash-kaizen/tests/integration/test_credential_ref_roundtrip.py`: 2 Tier-2 integration tests exercising the full `BaseAgentConfig` → `WorkflowGenerator` → `CredentialStore` → `LocalRuntime` → `LLMAgentNode` round-trip with NO mocking (uses real `provider=\"mock\"` deterministic adapter — not `unittest.mock`).

## Acceptance criteria

- [x] `LLMAgentNode.get_parameters()` declares `credential_ref: NodeParameter` with `type=str` and `required=False`.
- [x] Tier-1 unit test asserts `LLMAgentNode.execute()` with `config.credential_ref` set runs without emitting an `Unknown parameter` log line for `credential_ref` (captured via pytest `caplog` on the `kailash.nodes.base` logger).
- [x] Tier-2 integration test asserts `credential_ref` round-trips through `WorkflowGenerator` → `LLMAgentNode.config` → `get_credential_store().resolve()` without warning, plus the security invariant (api_key never lives in serializable config).

## Test plan

- [x] `pytest packages/kailash-kaizen/tests/unit/nodes/ai/test_credential_ref_param.py -v` → 3 passed
- [x] `pytest packages/kailash-kaizen/tests/integration/test_credential_ref_roundtrip.py -v` → 2 passed
- [x] Sibling regression suite `tests/regression/test_issue_12_per_request_api_key.py` → 38 passed (no regressions in the BYOK plumbing this PR touches)
- [x] Sibling LLMAgentNode unit suites → 32 passed
- [x] Behavioral verification: test 2 was confirmed to FAIL when `credential_ref` is removed from `get_parameters()`, proving it catches the regression class.

## Related issues

Fixes #900