### PR TITLE
fix(runtime): close orphaned wait_for + clear_shared_pools coroutines on cleanup (#942)

### DIFF
--- a/src/kailash/runtime/async_local.py
+++ b/src/kailash/runtime/async_local.py
@@ -1913,7 +1913,25 @@ class AsyncLocalRuntime(LocalRuntime):
 
             _clear_pools = getattr(AsyncSQLDatabaseNode, "clear_shared_pools", None)
             if _clear_pools is not None:
-                await asyncio.wait_for(_clear_pools(graceful=True), timeout=5.0)
+                # Bind the inner coroutine so we can close it in
+                # ``finally`` if ``asyncio.wait_for`` raises BEFORE
+                # driving it (e.g., monkeypatched wait_for that
+                # swallows its coro arg, or CancelledError mid-await).
+                # Without this, the orphaned coroutine emits
+                # ``RuntimeWarning: coroutine 'clear_shared_pools'
+                # was never awaited``. Sibling fix to LocalRuntime
+                # ``_cleanup_event_loop`` and ``_execute_sync``
+                # teardown paths landed for issue #942.
+                _inner = _clear_pools(graceful=True)
+                try:
+                    await asyncio.wait_for(_inner, timeout=5.0)
+                finally:
+                    _inner_close = getattr(_inner, "close", None)
+                    if _inner_close is not None:
+                        try:
+                            _inner_close()
+                        except Exception:
+                            pass
         except Exception as e:
             logger.warning(f"Error disposing AsyncSQL pools during cleanup: {e}")
         try:

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -1616,9 +1616,21 @@ class LocalRuntime(
                                     # users adopted the
                                     # ``with LocalRuntime()`` pattern.
                                     async def _dispose_async_sql_pools() -> None:
+                                        # Bind the inner coroutine to a local
+                                        # name so that if ``asyncio.wait_for``
+                                        # raises BEFORE driving it (broken /
+                                        # monkeypatched wait_for that swallows
+                                        # its coro arg), the ``finally`` block
+                                        # can close the inner coroutine and
+                                        # suppress the
+                                        # ``coroutine 'clear_shared_pools' was
+                                        # never awaited`` warning. Issue #917
+                                        # closed the outer wrapper; #942
+                                        # closes the inner coroutine.
+                                        _inner = _clear_pools(graceful=True)
                                         try:
                                             await asyncio.wait_for(
-                                                _clear_pools(graceful=True),
+                                                _inner,
                                                 timeout=5.0,
                                             )
                                         except asyncio.TimeoutError:
@@ -1627,6 +1639,15 @@ class LocalRuntime(
                                                 "pools during shutdown for "
                                                 f"runtime {self._runtime_id}"
                                             )
+                                        finally:
+                                            _inner_close = getattr(
+                                                _inner, "close", None
+                                            )
+                                            if _inner_close is not None:
+                                                try:
+                                                    _inner_close()
+                                                except Exception:
+                                                    pass
 
                                     _dispose_coro = _dispose_async_sql_pools()
                                     try:
@@ -2053,22 +2074,71 @@ class LocalRuntime(
                             AsyncSQLDatabaseNode, "clear_shared_pools", None
                         )
                         if _clear_pools is not None:
-                            loop.run_until_complete(
-                                asyncio.wait_for(
-                                    _clear_pools(graceful=True),
-                                    timeout=5.0,
-                                )
-                            )
-                    except Exception:
-                        pass
+                            # Wrap in an inner ``async def`` so only one
+                            # coroutine escapes scope. Closing the wrapper
+                            # cancels the inner ``wait_for`` cleanly if
+                            # ``run_until_complete`` raises before
+                            # consuming it — preventing the ``coroutine
+                            # 'wait_for' was never awaited`` warning
+                            # tracked in issue #942.
+                            async def _dispose_async_sql_pools() -> None:
+                                # Bind the inner coroutine so we can
+                                # close it in ``finally`` if
+                                # ``asyncio.wait_for`` raises before
+                                # driving it (e.g., monkeypatched
+                                # wait_for that swallows its arg).
+                                # See sibling fix in
+                                # ``_cleanup_event_loop`` above.
+                                _inner = _clear_pools(graceful=True)
+                                try:
+                                    await asyncio.wait_for(
+                                        _inner,
+                                        timeout=5.0,
+                                    )
+                                except asyncio.TimeoutError:
+                                    logger.warning(
+                                        "Timeout disposing AsyncSQL pools "
+                                        "during _execute_sync teardown"
+                                    )
+                                finally:
+                                    _inner_close = getattr(_inner, "close", None)
+                                    if _inner_close is not None:
+                                        try:
+                                            _inner_close()
+                                        except Exception:
+                                            pass
+
+                            _dispose_coro = _dispose_async_sql_pools()
+                            try:
+                                loop.run_until_complete(_dispose_coro)
+                            finally:
+                                # No-op if the wrapper already ran to
+                                # completion. Closes both the wrapper
+                                # and any orphaned inner ``wait_for``
+                                # if ``run_until_complete`` raised
+                                # before driving the wrapper.
+                                _close = getattr(_dispose_coro, "close", None)
+                                if _close is not None:
+                                    try:
+                                        _close()
+                                    except Exception:
+                                        pass
+                    except Exception as e:
+                        logger.warning(
+                            f"Error disposing AsyncSQL pools during "
+                            f"_execute_sync teardown: {e}"
+                        )
                     try:
                         from kailash.nodes.data.sql import SQLDatabaseNode
 
                         _cleanup = getattr(SQLDatabaseNode, "cleanup_pools", None)
                         if _cleanup is not None:
                             _cleanup()
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning(
+                            f"Error disposing SQL pools during "
+                            f"_execute_sync teardown: {e}"
+                        )
                 if loop:
                     loop.close()
 

--- a/tests/regression/test_issue_942_execute_sync_wait_for_warning.py
+++ b/tests/regression/test_issue_942_execute_sync_wait_for_warning.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 regression for issue #942 — LocalRuntime._execute_sync's pool-cleanup
+``finally`` block must not leak an un-awaited ``wait_for`` coroutine when
+``loop.run_until_complete`` raises before driving the wrapper.
+
+Per ``rules/zero-tolerance.md`` Rule 1 the warning MUST be fixed (not
+deferred). Per the issue's acceptance criteria the regression test runs
+under ``-W error::RuntimeWarning`` so any drop in the cleanup path flips
+the warning to a typed exception that the test catches.
+
+Sibling of ``tests/integration/runtime/test_local_runtime_exit_cleanup.py``
+which covers the ``_cleanup_event_loop`` path on ``__exit__`` / ``close``.
+This file covers the OTHER cleanup site — ``_execute_sync.finally`` —
+that lives inside the worker-thread that ``LocalRuntime.execute`` spawns
+when called from within an existing event loop (pytest-asyncio, Nexus,
+Jupyter, Kaizen agent loop).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import warnings
+
+import pytest
+
+from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_execute_sync_from_async_context_no_wait_for_warning() -> None:
+    """The cleanup ``finally`` in ``_execute_sync`` MUST NOT leak the
+    ``wait_for`` coroutine.
+
+    Reproduces the failure mode from issue #942: when ``runtime.execute``
+    is called from within an existing event loop (e.g., pytest-asyncio
+    test, Nexus handler), the runtime spawns a worker thread that creates
+    its own loop, runs the workflow, and tears down the loop in
+    ``finally``. The pre-fix cleanup passed ``asyncio.wait_for(...)``
+    directly to ``loop.run_until_complete``; if the run_until_complete
+    raised or the loop was closing, the inner ``wait_for`` coroutine was
+    GC'd un-awaited, surfacing as
+    ``RuntimeWarning: coroutine 'wait_for' was never awaited``.
+
+    Post-fix the cleanup wraps in an inner ``async def`` and explicitly
+    closes the wrapper coroutine, mirroring the ``_cleanup_event_loop``
+    pattern that already fixed the sibling cleanup path.
+    """
+    # pytest-asyncio active loop → LocalRuntime.execute MUST take the
+    # _execute_sync path (worker thread + nested loop).
+    asyncio.get_running_loop()
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+
+        # Drive the runtime synchronously from inside the async test.
+        # `run_in_executor` mirrors how production callers (workers,
+        # Nexus handlers) reach the sync path.
+        def _run_sync() -> dict:
+            runtime = LocalRuntime()
+            wf = WorkflowBuilder()
+            wf.add_node(
+                "PythonCodeNode",
+                "noop",
+                {"code": "result = {'ok': True}"},
+            )
+            results, _ = runtime.execute(wf.build())
+            return results
+
+        results = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+        assert results["noop"]["result"]["ok"] is True
+
+        offenders = [
+            str(w.message)
+            for w in recorded
+            if issubclass(w.category, RuntimeWarning)
+            and "never awaited" in str(w.message).lower()
+            and ("wait_for" in str(w.message) or "clear_shared_pools" in str(w.message))
+        ]
+        assert not offenders, (
+            "_execute_sync finally-block left an un-awaited coroutine "
+            f"(issue #942 regression). Offenders: {offenders}"
+        )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_execute_sync_wait_for_failure_does_not_leak_coroutine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force the failure mode in the issue body: ``asyncio.wait_for``
+    raises before scheduling the inner coroutine, so the inner coroutine
+    is constructed but never awaited.
+
+    Pre-fix: ``_execute_sync.finally`` constructed ``_clear_pools(...)``
+    inline as the first argument to ``wait_for``; if ``wait_for`` raised
+    before its body awaited the coroutine, the coroutine was GC'd and
+    Python emitted ``RuntimeWarning: coroutine ... was never awaited``.
+
+    Post-fix: the cleanup ``finally`` block explicitly closes the wrapper
+    coroutine, which in turn closes the orphaned inner ``wait_for`` and
+    ``_clear_pools`` coroutines, so no warning surfaces.
+    """
+    real_clear = AsyncSQLDatabaseNode.clear_shared_pools
+    real_wait_for = asyncio.wait_for
+
+    # Sanity: ensure the cleanup path will construct a coroutine.
+    assert asyncio.iscoroutinefunction(real_clear)
+
+    def failing_wait_for(coro, timeout):  # noqa: D401
+        # Simulate a wait_for that fails BEFORE driving its inner coro
+        # AND does NOT close the coro arg — this is the worst-case
+        # contract violation the post-fix ``finally`` block must defend
+        # against (close the inner coroutine even when wait_for orphans
+        # it). Pre-fix this leaks ``coro`` un-awaited; post-fix the
+        # wrapper's ``finally`` closes ``_inner`` defensively.
+        raise asyncio.TimeoutError("simulated cancel-before-start")
+
+    monkeypatch.setattr(asyncio, "wait_for", failing_wait_for)
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+
+        def _run_sync() -> dict:
+            runtime = LocalRuntime()
+            wf = WorkflowBuilder()
+            wf.add_node(
+                "PythonCodeNode",
+                "noop",
+                {"code": "result = {'ok': True}"},
+            )
+            results, _ = runtime.execute(wf.build())
+            return results
+
+        results = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+        assert results["noop"]["result"]["ok"] is True
+
+        # Restore wait_for so subsequent tests are unaffected.
+        monkeypatch.setattr(asyncio, "wait_for", real_wait_for)
+
+        offenders = [
+            str(w.message)
+            for w in recorded
+            if issubclass(w.category, RuntimeWarning)
+            and "never awaited" in str(w.message).lower()
+        ]
+        assert not offenders, (
+            "wait_for cancel-before-start path left a coroutine un-awaited "
+            f"(issue #942 regression). Offenders: {offenders}"
+        )

--- a/tests/regression/test_issue_942_execute_sync_wait_for_warning.py
+++ b/tests/regression/test_issue_942_execute_sync_wait_for_warning.py
@@ -25,6 +25,7 @@ import warnings
 import pytest
 
 from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+from kailash.runtime.async_local import AsyncLocalRuntime
 from kailash.runtime.local import LocalRuntime
 from kailash.workflow.builder import WorkflowBuilder
 
@@ -150,4 +151,70 @@ async def test_execute_sync_wait_for_failure_does_not_leak_coroutine(
         assert not offenders, (
             "wait_for cancel-before-start path left a coroutine un-awaited "
             f"(issue #942 regression). Offenders: {offenders}"
+        )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_async_local_runtime_cleanup_wait_for_failure_does_not_leak_coroutine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same-bug-class sibling of #942 in ``AsyncLocalRuntime.cleanup()``.
+
+    ``AsyncLocalRuntime`` is the production-async runtime used by Docker /
+    FastAPI / Nexus deployments — see ``rules/patterns.md`` § "Async vs Sync
+    Runtime". Its ``cleanup()`` coroutine disposed AsyncSQL pools via
+    ``await asyncio.wait_for(_clear_pools(graceful=True), timeout=5.0)``.
+    When ``asyncio.wait_for`` raises BEFORE driving the inner coroutine
+    (broken / monkeypatched wait_for that swallows its coro arg, or
+    CancelledError mid-await), the inner ``_clear_pools(graceful=True)``
+    coroutine is orphaned and Python emits
+    ``RuntimeWarning: coroutine 'clear_shared_pools' was never awaited``.
+
+    This is the SAME failure-mode class as the two sites already fixed in
+    ``LocalRuntime`` (``_cleanup_event_loop`` and ``_execute_sync``
+    teardown) and the fix shape is identical: bind the inner coroutine to
+    a local var and close it in ``finally``.
+
+    The test forces the failure mode by monkeypatching ``asyncio.wait_for``
+    to raise BEFORE driving its coroutine argument. Pre-fix this leaks
+    the ``clear_shared_pools`` coroutine un-awaited; post-fix the
+    ``finally`` block closes ``_inner`` defensively so no warning surfaces.
+    """
+    real_clear = AsyncSQLDatabaseNode.clear_shared_pools
+    real_wait_for = asyncio.wait_for
+
+    # Sanity: ensure the cleanup path will construct a coroutine.
+    assert asyncio.iscoroutinefunction(real_clear)
+
+    def failing_wait_for(coro, timeout):  # noqa: D401
+        # Simulate a wait_for that fails BEFORE driving its inner coro
+        # AND does NOT close the coro arg. Pre-fix this leaks ``coro``
+        # un-awaited; post-fix the cleanup's ``finally`` block closes
+        # ``_inner`` defensively.
+        raise asyncio.TimeoutError("simulated cancel-before-start")
+
+    monkeypatch.setattr(asyncio, "wait_for", failing_wait_for)
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+
+        runtime = AsyncLocalRuntime()
+        try:
+            await runtime.cleanup()
+        finally:
+            # Restore wait_for so subsequent tests are unaffected.
+            monkeypatch.setattr(asyncio, "wait_for", real_wait_for)
+
+        offenders = [
+            str(w.message)
+            for w in recorded
+            if issubclass(w.category, RuntimeWarning)
+            and "never awaited" in str(w.message).lower()
+            and ("wait_for" in str(w.message) or "clear_shared_pools" in str(w.message))
+        ]
+        assert not offenders, (
+            "AsyncLocalRuntime.cleanup() left an un-awaited coroutine when "
+            f"asyncio.wait_for raised pre-drive (issue #942 sibling). "
+            f"Offenders: {offenders}"
         )


### PR DESCRIPTION
## Summary

Closes the `RuntimeWarning: coroutine 'wait_for' was never awaited` failure tracked in #942 by closing two adjacent cleanup-path coroutine leaks in `LocalRuntime`.

## Root cause

Two cleanup paths in `src/kailash/runtime/local.py` constructed `asyncio.wait_for(_clear_pools(graceful=True), ...)` and passed it to `loop.run_until_complete`. When `wait_for` raised before driving its inner coroutine (broken-loop / monkey-patched wait_for that swallows its coro arg), the inner `_clear_pools(graceful=True)` coroutine was created but never awaited, surfacing as the RuntimeWarning.

1. `_execute_sync.finally` (line 2056) — top-level `wait_for` had no wrapper at all; pre-fix is the originating site for #942.
2. `_cleanup_event_loop._dispose_async_sql_pools` (line 1618) — the #917 fix added an `async def` wrapper and closed the wrapper coroutine, but the inner `_clear_pools(...)` was built inline as a `wait_for` argument and had no close path.

## Fix

Both wrappers now bind the inner coroutine to a local name (`_inner = _clear_pools(graceful=True)`) and close it in `finally`. Mirrors the existing wrapper-close pattern.

Also replaced silent `except: pass` with `logger.warning` per `rules/observability.md` MUST-not "Log-and-continue without action".

## Acceptance criteria (issue #942)

- [x] Identify the un-awaited coroutine (`_clear_pools(graceful=True)` constructed inline as `wait_for` arg in two cleanup paths).
- [x] Either await it OR close it on cleanup race (closed via inner-coroutine `finally`).
- [x] Confirm `RuntimeWarning` no longer surfaces in `pytest tests/integration/runtime/test_worker_lifecycle_hooks_wiring.py -W error::RuntimeWarning` (4/4 pass).

## Tier-2 regression coverage

New `tests/regression/test_issue_942_execute_sync_wait_for_warning.py`:
- `test_execute_sync_from_async_context_no_wait_for_warning` — drives `_execute_sync` from inside pytest-asyncio (sync-from-async path).
- `test_execute_sync_wait_for_failure_does_not_leak_coroutine` — worst-case: monkeypatched `wait_for` that raises without closing its arg.

Pre-existing `tests/integration/runtime/test_local_runtime_exit_cleanup.py::test_exit_handles_wait_for_failure_without_un_awaited_warning` (the #917 regression that was failing on main) now passes — the inner-coroutine close in `_cleanup_event_loop` fixes the gap.

## Test plan

- [x] `pytest tests/integration/runtime/test_worker_lifecycle_hooks_wiring.py -W error::RuntimeWarning -v` — 4 passed
- [x] `pytest tests/integration/runtime/test_local_runtime_exit_cleanup.py -W error::RuntimeWarning -v` — 3 passed (was 1 failing pre-fix)
- [x] `pytest tests/regression/test_issue_942_execute_sync_wait_for_warning.py -W error::RuntimeWarning -v` — 2 passed
- [x] pre-commit hooks (Tier-1 unit suite + lint + format) — passed on both commits

## Related issues

Fixes #942.

Sibling of #917 (commit `45cb813f`) — closed the outer wrapper; this PR closes the inner coroutine leak the #917 fix left behind, and extends the same pattern to the `_execute_sync.finally` cleanup site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)