### PR TITLE
chore: dodge python-use-type-annotations hook + refresh session-notes

### DIFF
--- a/.session-notes
+++ b/.session-notes
@@ -1,73 +1,61 @@
-# Session Notes — 2026-04-30 (housekeeping pass)
+# Session Notes — 2026-05-13
 
 ## Where we are
 
-Sweep cycle (`SWEEP-2026-04-30.md` + `SWEEP-6-spec-drift-2026-04-30.md`) is
-fully closed. Housekeeping pass committed two artifacts:
-
-- `SWEEP-6-spec-drift-2026-04-30.md` — promoted to tracked file (paired
-  audit record alongside `SWEEP-2026-04-30.md`); the 7 HIGH spec-drift
-  findings live here in case the per-issue summaries lose detail.
-- `.claude/learning/learning-codified.json::deferred_to_next_cycle`
-  pruned from 3 → 2 entries (cross-SDK kailash-rs#673/#674/#675 all
-  CLOSED — verified 2026-04-30). The 2 remaining items are both live
-  and verified.
-
-Workspaces `kailash-ml-1.5.x-followup/` and `issues-712-714/` were
-already moved to `workspaces/_archive/` before this session — sweep
-finding [Sweep 10] was correct at audit time but resolved itself before
-housekeeping started.
+PR #971 (COC sync loom 2.29.4 → v1.0.9) merged 2026-05-12 via owner-workflow.
+Follow-up PR #973 (COC sync 2026-05-13, commit `e0753ca2`) landed the
+30-file `.claude/`-only changeset (24 deletions of deprecated guides + 6
+hook/settings/SKILL mods) on main via `gh pr merge --admin`. PR for residual cleanup (11 cosmetic comment-dodge files
++ this `.session-notes` refresh) on branch `chore/post-coc-cleanup-2026-05-13`,
+not yet pushed. Round-1 parallel /redteam (cosmetic-audit + secrets-scan
++ session-notes-accuracy) converged clean; no commits in this session per
+BUILD-repo discipline.
 
 ## Read first
 
-1. `SWEEP-2026-04-30.md` — primary sweep deliverable; § "Recommended
-   next session scope" still ranks Tier B / actionable-issue-cluster /
-   infra-debt
-2. `SWEEP-6-spec-drift-2026-04-30.md` — 7 HIGH spec-drift findings
-   (4 unresolved + 3 fixed/triaged); now committed
-3. GH open issues — actionable cluster: #731, #711, #673, #643;
-   filed-this-session tracking issues: #740, #741; hard-blocked
-   external: #693 / #630 / #596
+1. `workspaces/redteam-coc-sync-1.0.9/04-validate/round-3-convergence.md` — full
+   per-round findings + inline-fix manifest from the 1.0.9 sync.
+2. `workspaces/redteam-coc-sync-1.0.9/loom-upstream-issue-body.md` — paste this
+   into a loom session to file the MED/LOW bundle there (cross-repo from here
+   is BLOCKED per `rules/repo-scope-discipline.md`).
+3. `git status --short` — surfaces the residual WIP awaiting disposition
+   (12 cosmetic edits + 13 untracked workspace/script artifacts).
+4. `gh issue view 972` — eval-check exclude maintenance follow-up (still OPEN).
+5. `CLAUDE.md` § directive 5 + #970 — `[trust]` extra wording still load-bearing
+   for open issue from prior session.
 
 ## In-flight state
 
-- Cross-SDK draft issues (kailash-rs#WebhookSigner-companion +
-  kailash-rs#MountInfo-orphan-port) drafted in this session as text
-  blocks but **not filed** per `rules/upstream-issue-hygiene.md` MUST
-  Rule 1 (per-issue human approval required). Drafts visible in the
-  conversation; user can approve filing or surface in next kailash-rs
-  session.
-- `kailash-rs#707` (DDL parity for #714) handoff still open at the
-  Rust repo for the next kailash-rs session.
-
-## Deferred-codify list (post-pruning)
-
-Two entries remain in `deferred_to_next_cycle`:
-
-1. **Pyright errors on `dataflow/core/engine.py`** — verified live
-   2026-04-30: 5 errors (production import of tests.fixtures, undefined
-   `TenantContextSwitch` at module scope despite local-import at L654,
-   `discovered_schema`/`asyncio` possibly-unbound flow-control issues).
-   Recommend opening `dataflow-engine-pyright-cleanup` workspace; out
-   of shard scope to fix in this housekeeping pass.
-2. **Pre-commit hook upward-`.venv` resolution** — still unresolved;
-   workaround `git -c core.hooksPath=/dev/null commit ...` documented
-   in `rules/git.md` § Pre-Commit Hook Workarounds.
+- 11 modified files in `packages/` + `src/` were pure pre-commit
+  `python-use-type-annotations` hook-dodge edits (comment rewords removing
+  `# type` substring per `rules/git.md` § Discipline) + one verified-dead
+  unused-import removal in `pact/engine.py`. Landed on
+  `chore/post-coc-cleanup-2026-05-13` as commit `7abe1a2c`.
+- 3 cited-but-listed-obsolete rules preserved on disk pending loom-manifest
+  fix: `.claude/rules/independence.md`, `terrene-naming.md`, `documentation.md`.
 
 ## Traps
 
-- Pre-commit auto-stash hook still flaky for multi-file commits;
-  same `core.hooksPath=/dev/null` workaround applies to this session's
-  housekeeping commit if it triggers.
-- `release/v*` PR-gate skip clause not yet adopted by kailash-py
-  workflows — release-prep PRs still pay the full matrix CI cost.
-- Mint-blocked issues #596 / #630 and M2-blocked #693 stay open
-  upstream until their gating spec lands.
+- `.claude/hooks/lib/` is gitignored (`.gitignore:62` `lib/`) so the H-2 fix to
+  `violation-patterns.js` (matchAll loop) is on disk but uncommittable.
+  Surfaces as CRIT in loom-upstream issue body. Same gitignore exclusion means
+  every developer needs `/sync-to-build` to populate hook libs locally.
+- Pre-commit `auto-stash` conflicts on 167-file COC-sync staged sets; the
+  documented `core.hooksPath=/dev/null` workaround per `rules/git.md` works.
+- `pre-commit run --all-files` auto-fixes trailing whitespace across ~1700 SDK
+  source files. This session reverted that drift via `git checkout -- .` after
+  staging redteam-fix paths — don't run `--all-files` again without intent.
 
 ## Open questions for the human
 
-- File the 2 cross-SDK kailash-rs issues drafted this session?
-  (Drafts in conversation; per `upstream-issue-hygiene.md` MUST Rule
-  1, requires explicit per-issue approval before `gh issue create`.)
-- Open `dataflow-engine-pyright-cleanup` workspace next session?
-  (5 confirmed errors + 56 warnings; single-shard scope.)
+- Disposition for the 3 preserved-but-obsoleted rules: file loom issue (body
+  ready) to fix the manifest, or accept them as load-bearing baseline?
+- Push `chore/post-coc-cleanup-2026-05-13` (commits `7abe1a2c` + the
+  `.session-notes` refresh follow-up) and open PR? Awaiting confirmation.
+- 13 untracked items split across 3 buckets: (a) `deploy/deployments/2026-05-07-v2.15.0.md`
+  + `scripts/{check-manifest-parity.sh,migrate.py}` are real new artifacts; (b) `workspaces/_template/*`
+  is template scaffolding; (c) the seven active-workspace trees
+  (`architecture-presentation`, `issue-871-...`, `issue-876-...`,
+  `issue-912-...`, `issue-959-...`, `redteam-coc-sync-1.0.9`,
+  `runtime-integration-trio`) each belong with their owning issue's PR.
+- #970 (prior session) still open — `[trust]` extra docs/deps positioning.

--- a/packages/kailash-dataflow/src/dataflow/ml/_feature_source.py
+++ b/packages/kailash-dataflow/src/dataflow/ml/_feature_source.py
@@ -31,10 +31,7 @@ import logging
 from datetime import datetime
 from typing import Any, List, Optional
 
-from dataflow.ml._errors import (
-    FeatureSourceError,
-    TenantRequiredError,
-)
+from dataflow.ml._errors import FeatureSourceError, TenantRequiredError
 
 logger = logging.getLogger(__name__)
 
@@ -211,8 +208,8 @@ def ml_feature_source(
 
     group_name = _group_name(feature_group)
 
-    # Tenant strict mode — missing tenant on a multi-tenant group is a
-    # typed error (`rules/tenant-isolation.md` § 2).
+    # Tenant strict mode — missing tenant on a multi-tenant group
+    # raises a typed error per `rules/tenant-isolation.md` § 2.
     if _is_multi_tenant_group(feature_group) and tenant_id is None:
         raise TenantRequiredError(
             f"FeatureGroup {group_name!r} is multi_tenant=True; tenant_id is required"

--- a/packages/kailash-kaizen/src/kaizen/llm/client.py
+++ b/packages/kailash-kaizen/src/kaizen/llm/client.py
@@ -40,14 +40,8 @@ import logging
 from typing import List, Optional
 
 import httpx
-
 from kaizen.llm.deployment import EmbedOptions, LlmDeployment, WireProtocol
-from kaizen.llm.errors import (
-    InvalidResponse,
-    ProviderError,
-    RateLimited,
-    Timeout,
-)
+from kaizen.llm.errors import InvalidResponse, ProviderError, RateLimited, Timeout
 from kaizen.llm.http_client import LlmHttpClient
 from kaizen.llm.redaction import redact_messages
 from kaizen.llm.wire_protocols import ollama_embeddings, openai_embeddings
@@ -304,9 +298,7 @@ class LlmClient:
                 "LlmClient.from_deployment(...) or LlmClient.from_env() first"
             )
         if not isinstance(texts, list):
-            raise TypeError(
-                f"texts must be list[str]; got {type(texts).__name__}"
-            )
+            raise TypeError(f"texts must be list[str]; got {type(texts).__name__}")
         if options is not None and not isinstance(options, EmbedOptions):
             raise TypeError(
                 f"options must be EmbedOptions; got {type(options).__name__}"
@@ -344,7 +336,7 @@ class LlmClient:
                 deployment_preset=wire.name,
                 timeout=60.0,
             )
-        assert http_client is not None  # type narrower
+        assert http_client is not None  # narrowing for type-checker
 
         try:
             # Build request, let auth strategy install its header.
@@ -357,7 +349,9 @@ class LlmClient:
                 request["headers"].setdefault(k, v)
 
             auth_kind = (
-                auth.auth_strategy_kind() if hasattr(auth, "auth_strategy_kind") else None
+                auth.auth_strategy_kind()
+                if hasattr(auth, "auth_strategy_kind")
+                else None
             )
             logger.info(
                 "llm.embed.start",

--- a/packages/kailash-kaizen/tests/cross_sdk_parity/test_from_env_precedence_matches_rust.py
+++ b/packages/kailash-kaizen/tests/cross_sdk_parity/test_from_env_precedence_matches_rust.py
@@ -29,7 +29,6 @@ import threading
 from pathlib import Path
 
 import pytest
-
 from kaizen.llm.errors import InvalidUri, NoKeysConfigured
 from kaizen.llm.from_env import (
     ENV_DEPLOYMENT_URI,
@@ -38,7 +37,6 @@ from kaizen.llm.from_env import (
     SUPPORTED_SCHEMES,
     resolve_env_deployment,
 )
-
 
 # Module-scope lock per testing.md § "Env-Var Test Isolation" -- every
 # test in this file mutates process-level LLM env vars; serialize to
@@ -143,8 +141,8 @@ def test_selector_tier_wins_over_legacy(monkeypatch) -> None:
     monkeypatch.setenv(ENV_SELECTOR, "anthropic")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-legacy-openai")
     # Selector requires ANTHROPIC_API_KEY + ANTHROPIC_MODEL; deliberately
-    # leave ANTHROPIC_MODEL unset so the selector path raises the expected
-    # typed error AND we know the legacy OpenAI fallback was NOT taken.
+    # leave ANTHROPIC_MODEL unset so the selector path raises the
+    # expected typed error AND we know the legacy OpenAI fallback was NOT taken.
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic")
 
     from kaizen.llm.errors import MissingCredential

--- a/packages/kailash-ml/src/kailash_ml/rl/_rl_train.py
+++ b/packages/kailash-ml/src/kailash_ml/rl/_rl_train.py
@@ -340,8 +340,8 @@ def _run_bridge_adapter(
         "tenant_id": tenant_id,
     }
     # DPO-family adapters require ``preference_dataset``; PPO-RLHF
-    # requires ``reward_model``. Surface the missing kwarg as a
-    # typed ValueError BEFORE constructing the adapter so the caller
+    # requires ``reward_model``. Surface the missing kwarg with
+    # a typed ValueError BEFORE constructing the adapter so the caller
     # gets an actionable message (not a TypeError from the adapter
     # __init__). Per ``rules/zero-tolerance.md`` Rule 3 (no silent
     # fallbacks).

--- a/packages/kailash-ml/src/kailash_ml/tracking/registry.py
+++ b/packages/kailash-ml/src/kailash_ml/tracking/registry.py
@@ -54,7 +54,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional
 
 if TYPE_CHECKING:
-    import polars as pl  # type-checker-only; runtime import is lazy inside methods
+    import polars as pl  # for static analyzers only; runtime import is lazy inside methods
 
 from kailash_ml._result import TrainingResult
 from kailash_ml.errors import fingerprint_classified_value

--- a/packages/kailash-ml/tests/integration/test_dl_diagnostics_wiring.py
+++ b/packages/kailash-ml/tests/integration/test_dl_diagnostics_wiring.py
@@ -343,7 +343,7 @@ def test_dl_diagnostics_grad_cam_returns_heatmap() -> None:
     # grad_cam moves `input_tensor.to(self.device)` internally before the
     # forward pass, so if the device-resolver picks MPS (darwin-arm
     # default) while the model lives on CPU, F.conv2d sees mismatched
-    # types. Pin both to CPU: override diag.device + move model to CPU.
+    # dtypes. Pin both to CPU: override diag.device + move model to CPU.
     # CI Linux default is CPU anyway; this makes the local Mac run
     # deterministic.
     cpu = torch.device("cpu")

--- a/packages/kailash-nexus/src/nexus/service_client.py
+++ b/packages/kailash-nexus/src/nexus/service_client.py
@@ -237,7 +237,7 @@ class ServiceClient:
             headers={"X-Client": "my-app"},
         )
 
-        user = await client.get("/users/42")          # typed JSON
+        user = await client.get("/users/42")          # parsed JSON dict
         resp = await client.get_raw("/healthz")        # HttpResponse, no status check
 
     Layer order (issue #473 NN1): the SSRF private-IP / metadata check runs
@@ -410,8 +410,8 @@ class ServiceClient:
             )
         except InvalidEndpointError as exc:
             # SSRF rejection at URL-parse or connect time. Translate into
-            # the transport-layer ServiceClientHttpError so callers get one
-            # typed surface for every "request did not reach upstream"
+            # the transport-layer ServiceClientHttpError so callers get
+            # one typed surface for every "request did not reach upstream"
             # condition.
             raise ServiceClientHttpError(f"request blocked: {exc}", cause=exc) from exc
         except httpx.TimeoutException as exc:

--- a/packages/kailash-nexus/src/nexus/typed_service_client.py
+++ b/packages/kailash-nexus/src/nexus/typed_service_client.py
@@ -53,10 +53,7 @@ import logging
 import typing
 from typing import Any, Callable, Mapping, Optional, Type, TypeVar
 
-from .service_client import (
-    ServiceClient,
-    ServiceClientDeserializeError,
-)
+from .service_client import ServiceClient, ServiceClientDeserializeError
 
 logger = logging.getLogger(__name__)
 
@@ -117,8 +114,8 @@ def _default_decode(payload: Any, model_cls: Type[M]) -> M:
 
     # Structural dataclass validation — catch wrong-type fields before they
     # land in the instance. ``cls(**payload)`` for a dataclass does NOT
-    # type-check; an ``email: str`` field receiving an integer constructs
-    # fine and surfaces as a string-formatting bug far from the API
+    # validate the annotations; an ``email: str`` field receiving an integer
+    # constructs fine and surfaces as a string-formatting bug far from the API
     # boundary. We check dataclass fields against resolved annotations so
     # drift is caught at the deserialisation step.
     if dataclasses.is_dataclass(model_cls):
@@ -218,7 +215,9 @@ def _default_decode(payload: Any, model_cls: Type[M]) -> M:
 def _is_optional(annotation: Any) -> bool:
     """Return True if the annotation is ``Optional[X]`` / ``X | None``."""
     origin = typing.get_origin(annotation)
-    if origin is typing.Union or origin is getattr(__import__("types"), "UnionType", None):
+    if origin is typing.Union or origin is getattr(
+        __import__("types"), "UnionType", None
+    ):
         args = typing.get_args(annotation)
         return type(None) in args
     return False
@@ -337,9 +336,7 @@ class TypedServiceClient(ServiceClient):
                 f"model_cls must be a class (got {type(model_cls).__name__})"
             )
         if not callable(decoder):
-            raise TypeError(
-                f"decoder must be callable (got {type(decoder).__name__})"
-            )
+            raise TypeError(f"decoder must be callable (got {type(decoder).__name__})")
         self._decoders[model_cls] = decoder
         logger.debug(
             "nexus.typed_service_client.register_decoder",

--- a/packages/kailash-pact/src/pact/costs.py
+++ b/packages/kailash-pact/src/pact/costs.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 logger = logging.getLogger(__name__)
 
-if TYPE_CHECKING:  # type-only forward reference
+if TYPE_CHECKING:  # forward reference for typechecker only
     from pact.governance.results import ConsumptionReport
 
 __all__ = ["CostTracker"]

--- a/packages/kailash-pact/src/pact/engine.py
+++ b/packages/kailash-pact/src/pact/engine.py
@@ -903,7 +903,6 @@ class PactEngine:
             since: Skip anchors timestamped before this UTC datetime.
             until: Skip anchors timestamped after this UTC datetime.
         """
-        from pact.governance.results import ChainVerificationResult
 
         async with self._submit_lock:
             return self._verify_audit_chain_locked(
@@ -1123,7 +1122,7 @@ class PactEngine:
             )
 
         # --- by role_address (thread-safe: compute_envelope acquires lock) ---
-        assert role_address is not None  # type-narrowing for mypy
+        assert role_address is not None  # narrowing for mypy
         try:
             envelope = self._governance.compute_envelope(role_address)
         except Exception as exc:

--- a/src/kailash/edge/resource/resource_pools.py
+++ b/src/kailash/edge/resource/resource_pools.py
@@ -53,7 +53,7 @@ class ResourceRequest:
 
     request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     requester: str = ""
-    resources: Dict[str, float] = field(default_factory=dict)  # type -> amount
+    resources: Dict[str, float] = field(default_factory=dict)  # resource-name -> amount
     priority: int = 5  # 1-10, higher is more important
     duration: Optional[int] = None  # Seconds, None = indefinite
     preemptible: bool = True


### PR DESCRIPTION
## Summary
Post-COC-sync (PR #973) cleanup of residual working-tree state:
- **`7abe1a2c`** — reword 11 files' comments to remove the `# type` substring that triggers the pre-commit `python-use-type-annotations` pygrep matcher (per `rules/git.md` § Discipline). Also removes one verified-dead duplicate import in `pact/engine.py`.
- **`5266384d`** — refresh `.session-notes` after PR #973 landed; replace stale `git diff --cached` pointer + 41-staged-changeset claims with current state; correct off-by-one ("six" → "seven" active workspaces).

No runtime behavior change. AST parses verified across all 11 files. Kaizen test collection unaffected (Round-1 /redteam verified).

## Verification

Validated through 3 /redteam rounds (parallel agents Round 1 + sequential convergence checks Round 2-3):
- Cosmetic-only: every diff hunk classified as (a) `# type` substring removal, (b) black/isort reflow, or (c) verified-dead import removal
- Secrets/PII scan on untracked artifacts: clean (no PRs for those here; they belong with their owning issue's PRs)
- `.session-notes` claims: every PR number, commit SHA, file count, and bucket-split verified against current `git status` / `gh` queries

## Test plan
- [ ] Path-filter CI (most checks should auto-skip on `.session-notes`-only + comment-only changes)
- [ ] `Analyze Python` + `test-with-infrastructure` (forced runs) pass
- [ ] Admin-merge after CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)