### PR TITLE
release(kailash): 2.21.0 — LocalRuntime AsyncSQL pool tracking + cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.0] - 2026-05-13
+
+### Added — issue #953: LocalRuntime-owned AsyncSQL pool tracking
+
+`LocalRuntime` now tracks AsyncSQL connection pools it instantiates, enabling
+deterministic cleanup at runtime teardown. Pools created via `LocalRuntime`
+register with the runtime instance; `runtime.cleanup()` (and `__aexit__` in
+async contexts) drains the registered pools before returning. This closes the
+class of leaks where AsyncSQL pools survived runtime teardown and held
+connections open against the database.
+
+`src/kailash/runtime/local.py` grew the pool-tracking machinery; `src/kailash/runtime/async_local.py` and `src/kailash/edge/resource/resource_pools.py` received
+small adjustments to honor the new ownership contract.
+
+### Fixed — issue #942 sibling: orphaned `wait_for` + `clear_shared_pools` coroutines
+
+`AsyncLocalRuntime._execute_sync` and the shared-pools cleanup path no longer
+leak `wait_for` coroutines on shutdown. Previously, an exception during
+`wait_for` could leave the underlying coroutine pending, surfacing as
+`RuntimeWarning: coroutine '...' was never awaited` in CI and in production
+process-exit logs. Both paths now explicitly close orphaned coroutines on
+cleanup.
+
+### CI / DataFlow test repairs
+
+Test-only / CI-only changes since 2.20.3 (no consumer-visible behavior change,
+included in this release for completeness because they ship in the wheel's
+sdist alongside the runtime fixes above):
+
+- DataFlow unit test repairs: inspector workflow analysis + error handling
+  tests aligned to current API, express_cache v2 key format, migration impact
+  reporter tests repaired, SaaS API key ListNode response shape unwrapped,
+  MongoDB connection tests gated on optional `motor` driver.
+- CI: `[security]` extra installed for cryptography in test_signed_audit
+  collection; DataFlow test step timeout raised to 15 min; pytest-timeout
+  flag removed.
+
 ## [2.20.3] - 2026-05-11
 
 ### Changed — issue #959: trust-plane canonical bytes are now byte-stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.20.3"
+version = "2.21.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.20.3"
+__version__ = "2.21.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Cuts core kailash **2.21.0** to ship runtime fixes accumulated on main since the 2.20.3 tag.

## Scope

- `pyproject.toml::version` → `2.21.0`
- `src/kailash/__init__.py::__version__` → `"2.21.0"`
- `CHANGELOG.md` → new `[2.21.0] - 2026-05-13` section

## Why a minor bump

- `feat(runtime)` #953: LocalRuntime-owned AsyncSQL pool tracking → deterministic pool cleanup on runtime teardown.
- `fix(runtime)` #942 sibling: close orphaned `wait_for` coroutines on AsyncLocalRuntime cleanup.
- DataFlow unit test repairs + CI hygiene also ride in this wheel (no consumer-visible behavior change).

A `feat()` warrants a minor bump per semver and per zero-tolerance.md Rule 5 (atomic version-anchor consistency).

## Release scope check (build-repo-release-discipline MUST-3)

| Package          | main → PyPI | Release this cycle? |
|------------------|-------------|---------------------|
| kailash          | 2.20.3 → 2.21.0 | **YES** (this PR) |
| kailash-dataflow | 2.9.0 = 2.9.0   | no                |
| kailash-nexus    | 2.6.3 = 2.6.3   | no                |
| kailash-kaizen   | 2.21.0 = 2.21.0 | no                |
| kailash-mcp      | 0.2.14 = 0.2.14 | no                |
| kailash-ml       | 1.7.4 = 1.7.4   | no                |
| kailash-align    | 0.7.1 = 0.7.1   | no                |
| kailash-pact     | 0.12.0 = 0.12.0 | no                |

Only core kailash needs a release this cycle.

## Branch convention

`release/v2.21.0` per git.md MUST — triggers PR-gate auto-skip on metadata-only diff.

## Test plan

- [ ] CI path-filter auto-skips PR-gate matrix on release-prep branch.
- [ ] After merge: tag v2.21.0, push, watch publish-pypi.yml.
- [ ] Clean-venv install verifies `pip install kailash==2.21.0` succeeds AND `python -c "import kailash; assert kailash.__version__ == '2.21.0'"` passes.
- [ ] Record deploy entry at `deploy/deployments/2026-05-13-v2.21.0.md`.

## Related issues

Ships fixes for #953 and #942-sibling.