### PR TITLE
release(kailash-dataflow): cut 2.9.1 — tier-1 test-config floor (#979 S1)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,50 @@
 # DataFlow Changelog
 
+## [2.9.1] — 2026-05-14 — tier-1 test-config floor (S1 of #979)
+
+Patch release shipping the test-discipline floor for issue #979 DataFlow
+Unit Suite Triage Workstream-A. Wheel content is unchanged at runtime —
+only `pip install kailash-dataflow[dev]` resolution is affected (two new
+pins for the unit-test contract). No public API surface change.
+
+### Changed
+
+- **`[dev]` extras now require `pytest-timeout>=2.3.0`** — pins the plugin
+  pytest.ini's `timeout = 120` directive depends on. Without this pin,
+  a clean-venv install reproducing CI silently lost per-test timeout
+  enforcement and the originating-failure-mode (5-layer hang) of
+  PR #976 could surface again on any fresh CI runner.
+- **`[dev]` extras now require `aiosqlite>=0.19.0`** — required by the
+  Tier-1 canonical fixtures (`memory_dataflow`, `file_dataflow` per
+  `specs/testing-tiers.md`) which back every unit test. Without it, a
+  clean-venv `pytest tests/unit --collect-only` cannot even load the
+  conftest.
+- **Consolidated `pytest.ini` as the single source of truth** for
+  pytest config. Removed dead `[tool.pytest.ini_options]` and
+  `[tool.coverage.run]` sections from `pyproject.toml` (pytest.ini
+  already won file precedence — the pyproject blocks were silent
+  drift surfaces for any contributor editing them).
+- **Sole marker-filter location**: `pytest.ini::addopts` now carries
+  `-m "not (requires_postgres or requires_mysql or requires_redis or
+requires_docker)"`. Integration/E2E CI jobs override via
+  `-o "addopts="`, not by injecting another `-m`.
+- **Per-test timeout enforced**: `pytest.ini` declares
+  `timeout = 120` + `timeout_method = thread`.
+
+### Tests
+
+- Added `tests/regression/test_issue_979_s1_preconditions.py` —
+  5 structural invariants (`@pytest.mark.regression`,
+  `@pytest.mark.unit`) lock the dev-extras pins, pytest.ini timeout
+  - marker filter, consolidated-config invariant, and asyncio
+    loop-scope keys against regression.
+
+### Behavior unchanged
+
+- No `dataflow` runtime API change; `import dataflow` resolves
+  identically. Wheel byte content is identical (test infrastructure
+  changes don't ship in the wheel).
+
 ## [2.9.0] — 2026-05-09 — slim install + audit-store loud failure
 
 Minor bump aligning kailash-dataflow with the kailash 2.18.0 slim-core

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.0"
+version = "2.9.1"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.0"
+__version__ = "2.9.1"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Release-prep PR for **kailash-dataflow 2.9.1** — patch shipping the test-discipline floor merged by S1 (PR #980, commit 38463d62) of the #979 DataFlow Unit Suite Triage workstream.

Metadata-only diff. Auto-skips PR-gate matrix per the workflow's \`release/v*\` head-ref guard.

## What ships

- \`packages/kailash-dataflow/pyproject.toml::version\` 2.9.0 → 2.9.1
- \`packages/kailash-dataflow/src/dataflow/__init__.py::__version__\` 2.9.0 → 2.9.1
- \`packages/kailash-dataflow/CHANGELOG.md\` — 2.9.1 entry documenting:
  - \`pytest-timeout>=2.3.0\` + \`aiosqlite>=0.19.0\` pinned in \`[dev]\` extras (Tier-1 contract)
  - \`pytest.ini\` consolidated as sole source of pytest + coverage config
  - Sole marker-filter location at \`pytest.ini::addopts\` (CRIT-B)
  - Per-test \`timeout = 120\` + \`timeout_method = thread\` enforced

## Why patch (not minor)

\`import dataflow\` API surface is unchanged. Wheel byte content is identical at runtime (dev extras only affect \`pip install -e [dev]\` resolution; tests aren't packaged). Patch is the right increment.

## Cadence

Per \`build-repo-release-discipline.md\` Rule 1 with strict per-shard cadence authorized 2026-05-14. Each downstream shard (S2a / S-EV / S3 / S4 / S5a / S6) will follow the same loop: feat/ PR → admin-merge → release/v* PR → /release.

## Related issues

Refs #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)