### PR TITLE
docs(deploy): record kailash-dataflow 2.9.1 release deployment

### DIFF
--- a/deploy/deployments/2026-05-14-dataflow-v2.9.1.md
+++ b/deploy/deployments/2026-05-14-dataflow-v2.9.1.md
@@ -1,0 +1,106 @@
+# kailash-dataflow 2.9.1 — 2026-05-14
+
+Patch release of `kailash-dataflow` shipping the test-discipline floor that
+S1 of issue #979 (DataFlow Unit Suite Triage Workstream-A) merged at
+`38463d62` via PR #980. First shard of seven; downstream shards
+(S2a / S-EV / S3 / S4 / S5a / S6) follow the same strict per-shard cadence
+authorized by the user 2026-05-14.
+
+Wheel byte content for `import dataflow` is identical to 2.9.0 at runtime.
+Only `pip install kailash-dataflow[dev]` resolution changed (two new pins
+for the Tier-1 contract) and the dead pyproject pytest/coverage blocks
+were removed in favor of `pytest.ini` as the single source of truth.
+
+## Release scope (build-repo-release-discipline.md Rule 3)
+
+| Package          | main   | PyPI   | Release |
+| ---------------- | ------ | ------ | ------- |
+| kailash          | 2.21.0 | 2.21.0 | NO      |
+| kailash-dataflow | 2.9.1  | 2.9.0  | YES     |
+| kailash-nexus    | 2.6.3  | 2.6.3  | NO      |
+| kailash-kaizen   | 2.21.0 | 2.21.0 | NO      |
+| kailash-mcp      | 0.2.14 | 0.2.14 | NO      |
+| kailash-ml       | 1.7.4  | 1.7.4  | NO      |
+| kailash-align    | 0.7.1  | 0.7.1  | NO      |
+| kailash-pact     | 0.12.0 | 0.12.0 | NO      |
+
+Only `kailash-dataflow` advanced since the prior cycle; no sibling drift.
+
+## Substantive changes
+
+### S1 of issue #979 — Tier-1 test-config floor
+
+`packages/kailash-dataflow/pyproject.toml` + `packages/kailash-dataflow/pytest.ini`:
+
+- Added `pytest-timeout>=2.3.0` to `[project.optional-dependencies].dev`
+  (PR #976 failure-layer 1 — clean-venv install was missing the plugin
+  that `pytest.ini::timeout` directive depends on).
+- Added `aiosqlite>=0.19.0` to `[project.optional-dependencies].dev`
+  (Tier-1 canonical fixtures `memory_dataflow` / `file_dataflow` import
+  it at module scope; a clean install couldn't load the conftest without
+  it). Same-shard amendment per `autonomous-execution.md` MUST-4 (same
+  failure-class as `pytest-timeout`; landed in S1 rather than deferred).
+- Consolidated pytest + coverage config in `pytest.ini`; deleted the dead
+  `[tool.pytest.ini_options]` and `[tool.coverage.run]` blocks from
+  `pyproject.toml` (pytest.ini already won file precedence — the pyproject
+  blocks were silent-drift surfaces for any contributor editing them).
+- Added `timeout = 120` + `timeout_method = thread` to `pytest.ini`
+  (CRIT-B: a hung test now produces a per-test traceback instead of
+  consuming the job's 6-hour wall-clock).
+- Sole marker-filter location: `pytest.ini::addopts` carries
+  `-m "not (requires_postgres or requires_mysql or requires_redis or
+requires_docker)"`. CI integration jobs override via
+  `-o "addopts="`, not by injecting another `-m`.
+
+### Spec edit — `specs/testing-tiers.md` Rule 6
+
+Amended Tier-1 Contract Rule 6 to record the rule "each package MUST pin
+every Tier-1 infra driver its canonical fixtures import at module scope"
+and to mark `pytest-forked` OPTIONAL (R1 redteam falsified the "archived
+upstream" claim AND verified zero consumer in DataFlow).
+
+### Tests added
+
+`packages/kailash-dataflow/tests/regression/test_issue_979_s1_preconditions.py`
+ships 5 structural invariants (`@pytest.mark.regression`,
+`@pytest.mark.unit`) that lock the dev-extras pins, pytest.ini timeout +
+marker filter, consolidated-config invariant, and asyncio loop-scope keys
+against regression. All 5 invariants verified green in editable AND
+clean-verification venv.
+
+## Process trail
+
+| Artifact         | Reference                                                                  |
+| ---------------- | -------------------------------------------------------------------------- |
+| Implementation   | PR #980 (commit `38463d62`) — `feat/issue-979-s1-preconditions`            |
+| Release-prep     | PR #981 (commit `fdf9f156`) — `release/v2.9.1` (auto-skipped PR-gate)      |
+| Merge commit     | `bb5cb51a`                                                                 |
+| Tag              | `dataflow-v2.9.1` at `bb5cb51a`                                            |
+| Publish workflow | Run `25813939337` — Publish to PyPI — success                              |
+| Workspace        | `workspaces/issue-979-dataflow-unit-triage/` (analysis, plans, journal/06) |
+
+## Verification (build-repo-release-discipline.md Rule 2)
+
+Clean-venv install on `/tmp/s1-verify` (Python 3.14):
+
+```
+uv pip install --refresh "kailash-dataflow==2.9.1" --python /tmp/s1-verify/bin/python
+/tmp/s1-verify/bin/python -c "
+import dataflow; print('version:', dataflow.__version__)
+import pytest_timeout, aiosqlite; print('plugin-deps ok')
+"
+# version: 2.9.1
+# plugin-deps ok: pytest_timeout, aiosqlite
+```
+
+Reviewer + security-reviewer gates on PR #980 both returned APPROVE.
+
+## Notes
+
+- Per `git.md` § Branch Protection + prior session's flagged correction
+  ("next deploy record MUST go through a chore PR"), this record lands
+  via PR rather than direct-push to main.
+- The remaining six shards of Workstream-A (S2a / S-EV / S3 / S4 / S5a / S6)
+  will follow the same loop: feat/ PR → admin-merge → release/v\* PR →
+  `/release`. The next sibling-drift sweep at session start will enumerate
+  scope per `build-repo-release-discipline.md` Rule 3.


### PR DESCRIPTION
## Summary

Deploy record for kailash-dataflow 2.9.1 published 2026-05-14. First shard release of the seven-shard #979 Workstream-A workstream.

Records:
- Release scope (sibling-drift table at cut time)
- Substantive changes (S1 + same-shard aiosqlite amendment + spec edit + tests)
- Process trail (PR #980 / PR #981 / tag dataflow-v2.9.1 / publish run 25813939337)
- Verification evidence (clean-venv install + import check)

## Why a chore PR

Per \`git.md\` § Branch Protection and the prior session's flagged correction in \`.session-notes\`:

> \"I direct-pushed \`21ba8e6a\` (deploy record) to main via admin bypass — \`git.md\` says PR-only. Next deploy record MUST go through a chore PR.\"

This is the corrected pattern.

## Test plan

- [x] Pre-commit clean on the new file.
- [x] No source changes; docs-only addition under \`deploy/deployments/\`.
- [ ] PR-gate CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)