### PR TITLE
fix(dataflow): close S-EV silent-fallback in DataFlowEventMixin._init_events (#979 S-EV)

### DIFF
--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -143,6 +143,21 @@ dev = [
     # the "tier-1 collection requires extra not installed" gap that
     # PR #976's failure-layer family produced.
     "aiosqlite>=0.19.0",
+    # kailash[server]: issue #979 / S-EV (test_dataflow_events.py — PR #976
+    # AC#2). dataflow.core.events.DataFlowEventMixin._init_events imports
+    # kailash.middleware.communication.backends.memory.InMemoryEventBus.
+    # Python's import machinery runs kailash.middleware/__init__.py which
+    # eagerly imports kailash.nodes.admin.user_management (requires bcrypt)
+    # and kailash.middleware.communication.api_gateway (requires fastapi)
+    # — both from the [server] extra. Without this pin, clean-venv
+    # `pip install -e packages/kailash-dataflow[dev]` produces 5 failures
+    # in tests/unit/features/test_dataflow_events.py because _init_events
+    # cannot resolve InMemoryEventBus. Same "tier-1 collection requires
+    # extra not installed" gap pattern as the aiosqlite + pytest-timeout
+    # pins above. Per zero-tolerance.md Rule 3a, the events.py mixin now
+    # surfaces a typed DataFlowError on _event_bus=None, but the test fixture
+    # needs the real bus to exercise the subscribe path.
+    "kailash[server]",
     "black>=23.0.0",
     "isort>=5.12.0",
     "flake8>=6.0.0",

--- a/packages/kailash-dataflow/src/dataflow/core/events.py
+++ b/packages/kailash-dataflow/src/dataflow/core/events.py
@@ -48,21 +48,50 @@ class DataFlowEventMixin:
     """
 
     _event_bus: Any = None  # Set by _init_events()
+    _event_bus_import_error: Optional[ImportError] = (
+        None  # Set by _init_events() on failure
+    )
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     def _init_events(self) -> None:
-        """Initialize the event bus.  Called once in ``DataFlow.__init__``."""
+        """Initialize the event bus.  Called once in ``DataFlow.__init__``.
+
+        The ``InMemoryEventBus`` lives under ``kailash.middleware`` whose
+        ``__init__.py`` eagerly imports ``kailash.nodes.admin.user_management``
+        (requires ``bcrypt``) and ``kailash.middleware.communication.api_gateway``
+        (requires ``fastapi``) -- both from the ``kailash[server]`` extra.
+
+        Per ``rules/zero-tolerance.md`` Rule 3a (Typed Delegate Guards For
+        None Backing Objects), an ``ImportError`` here MUST NOT be silently
+        swallowed -- the resulting opaque ``AttributeError`` on later
+        ``_event_bus.subscribe()`` calls hides the real failure (missing
+        ``[server]`` extra) behind a None-backing-object trap that blocks
+        N tests with no actionable signal.
+
+        When ``InMemoryEventBus`` is unavailable, ``_event_bus`` remains
+        ``None`` AND every method that would touch it raises a typed
+        ``DataFlowError`` naming the missing extra. The deferred failure
+        keeps ``DataFlow.__init__`` runnable on a kailash core install
+        (no events) while making the actionable signal visible at the
+        first subscribe / on_model_change call site.
+        """
         try:
             from kailash.middleware.communication.backends.memory import (
                 InMemoryEventBus,
             )
 
             self._event_bus = InMemoryEventBus()
-        except ImportError:
+            self._event_bus_import_error: Optional[ImportError] = None
+        except ImportError as exc:
+            # Defer the typed-error surface to subscribe / on_model_change
+            # callsites (Rule 3a). Storing the original ImportError preserves
+            # the actionable diagnostic ("install kailash[server]") for the
+            # raise site below without re-importing.
             self._event_bus = None
+            self._event_bus_import_error = exc
 
     # ------------------------------------------------------------------
     # Emission
@@ -93,8 +122,9 @@ class DataFlowEventMixin:
         if self._event_bus is None:
             return
 
-        from dataflow.classification.event_payload import format_record_id_for_event
         from kailash.middleware.communication.domain_event import DomainEvent
+
+        from dataflow.classification.event_payload import format_record_id_for_event
 
         policy = getattr(self, "_classification_policy", None)
         safe_record_id = format_record_id_for_event(
@@ -145,12 +175,28 @@ class DataFlowEventMixin:
             List of subscription IDs (one per write operation type).
 
         Raises:
-            DataFlowConfigError: If called before ``db.initialize()``.
+            DataFlowError: If called before ``db.initialize()`` OR if the
+                event bus was not initialised (typically because
+                ``kailash[server]`` is missing -- see ``_init_events``).
         """
         if not getattr(self, "_connected", False):
             from dataflow.exceptions import DataFlowError
 
             raise DataFlowError("on_model_change() requires db.initialize() first")
+
+        # Rule 3a typed guard: surface the missing-extra signal here instead
+        # of letting AttributeError propagate from ``None.subscribe(...)``.
+        if self._event_bus is None:
+            from dataflow.exceptions import DataFlowError
+
+            cause = self._event_bus_import_error
+            hint = (
+                "kailash.middleware EventBus failed to import. Install the "
+                "server extra: pip install 'kailash[server]'"
+            )
+            if cause is not None:
+                raise DataFlowError(f"{hint} (underlying: {cause})") from cause
+            raise DataFlowError(hint)
 
         sub_ids: List[str] = []
         for op in WRITE_OPERATIONS:

--- a/packages/kailash-dataflow/tests/regression/test_issue_979_s_ev_dataflow_events.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_979_s_ev_dataflow_events.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for issue #979 / Workstream-A S-EV (test_dataflow_events).
+
+Maps to ``briefs/00-brief.md:41-42`` AC#2 — "tests/unit/features/
+test_dataflow_events.py — 4+ test failures from PR #976 investigation
+diagnosed and fixed."
+
+Root cause diagnosed in clean-venv reproduction
+(`workspaces/issue-979-dataflow-unit-triage/journal/0007-DECISION-s-ev-resolution.md`):
+
+1. ``DataFlowEventMixin._init_events`` imports
+   ``kailash.middleware.communication.backends.memory.InMemoryEventBus``.
+2. Python's import machinery runs ``kailash.middleware/__init__.py`` which
+   eagerly imports ``kailash.nodes.admin.user_management`` (requires
+   ``bcrypt``) AND ``kailash.middleware.communication.api_gateway``
+   (requires ``fastapi``) — both from the ``kailash[server]`` extra.
+3. ``kailash-dataflow[dev]`` did NOT declare ``kailash[server]``, so a
+   clean ``pip install -e packages/kailash-dataflow[dev]`` left the
+   import broken.
+4. ``_init_events`` swallowed the ``ImportError`` silently and set
+   ``_event_bus = None``. Per ``rules/zero-tolerance.md`` Rule 3a (Typed
+   Delegate Guards), the silent fallback then produced
+   ``AttributeError: 'NoneType' object has no attribute 'subscribe'`` on
+   every subsequent ``_event_bus.subscribe(...)`` call — opaque, with
+   no actionable hint pointing at the missing extra.
+
+The fix has two layers:
+
+* **Dep layer** — added ``kailash[server]`` to
+  ``packages/kailash-dataflow/pyproject.toml::[dev]`` so clean-venv
+  installs resolve the EventBus surface.
+* **Code layer** — ``DataFlowEventMixin._init_events`` now records the
+  ``ImportError`` into ``_event_bus_import_error`` AND
+  ``on_model_change`` raises a typed ``DataFlowError`` naming the
+  ``kailash[server]`` extra when ``_event_bus`` is ``None``.
+
+These regressions are STRUCTURAL — config-text + function-signature
+checks — per ``rules/probe-driven-verification.md`` MUST Rule 3.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = PACKAGE_ROOT / "pyproject.toml"
+
+
+@pytest.mark.regression
+def test_kailash_server_extra_pinned_in_dev() -> None:
+    """``[dev]`` extras MUST declare ``kailash[server]`` so a clean-venv
+    install resolves the InMemoryEventBus chain.
+
+    Layer 1 of the S-EV fix. Without this pin, the import in
+    ``DataFlowEventMixin._init_events`` fails on a clean install of
+    ``kailash-dataflow[dev]`` because ``kailash[server]`` (bcrypt +
+    fastapi + uvicorn + cryptography) is not transitively required.
+
+    Uses ``tomllib`` (3.11+) to parse the TOML structurally — grep
+    against the raw text mis-matches because dependency lines contain
+    embedded ``]`` characters that confuse naive substring searches.
+    """
+    import tomllib
+
+    with PYPROJECT.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    dev_extras = data.get("project", {}).get("optional-dependencies", {}).get("dev", [])
+    # Tolerate any specifier (>=X, ==X, no specifier) — the existence
+    # of a dep whose name component is exactly ``kailash[server]`` is
+    # the contract.
+    has_server = any(
+        entry.split(";")[0].strip().split(">=")[0].split("==")[0].strip()
+        == "kailash[server]"
+        for entry in dev_extras
+    )
+    assert has_server, (
+        "kailash-dataflow[dev] MUST include 'kailash[server]' so the "
+        "InMemoryEventBus chain resolves on clean-venv install. "
+        "Per S-EV / issue #979 root-cause. Current dev extras: "
+        f"{dev_extras}"
+    )
+
+
+@pytest.mark.regression
+def test_event_mixin_records_import_error_attribute() -> None:
+    """``DataFlowEventMixin`` MUST declare ``_event_bus_import_error``
+    so ``on_model_change`` can surface a typed error citing the missing
+    extra instead of letting ``AttributeError`` propagate from
+    ``None.subscribe(...)``.
+
+    Per ``rules/zero-tolerance.md`` Rule 3a (Typed Delegate Guards For
+    None Backing Objects).
+    """
+    from dataflow.core.events import DataFlowEventMixin
+
+    # Class-level default MUST exist so a fresh instance can be queried
+    # before ``_init_events`` runs.
+    assert hasattr(DataFlowEventMixin, "_event_bus_import_error"), (
+        "DataFlowEventMixin MUST declare _event_bus_import_error at "
+        "class scope so the typed-guard branch in on_model_change can "
+        "read it without an AttributeError of its own."
+    )
+    assert DataFlowEventMixin._event_bus_import_error is None
+
+
+@pytest.mark.regression
+def test_on_model_change_raises_typed_error_when_bus_missing() -> None:
+    """``on_model_change`` MUST raise ``DataFlowError`` (not the opaque
+    ``AttributeError: NoneType.subscribe``) when ``_event_bus`` is
+    ``None``. The error message MUST name the ``kailash[server]`` extra
+    so the user can act on it.
+    """
+    from dataflow.core.events import DataFlowEventMixin
+    from dataflow.exceptions import DataFlowError
+
+    class _Stub(DataFlowEventMixin):
+        _connected = True
+
+    stub = _Stub()
+    # Simulate the ImportError path WITHOUT actually breaking the
+    # process import. We mimic the post-_init_events state where
+    # _event_bus is None and the import-error is recorded.
+    stub._event_bus = None
+    stub._event_bus_import_error = ImportError("simulated missing dep")
+
+    with pytest.raises(DataFlowError) as excinfo:
+        stub.on_model_change("User", lambda evt: None)
+
+    msg = str(excinfo.value)
+    assert "kailash[server]" in msg, (
+        "on_model_change MUST cite the kailash[server] extra so the "
+        "user knows how to fix the missing dep. Got: " + msg
+    )

--- a/workspaces/issue-979-dataflow-unit-triage/journal/0007-DECISION-s-ev-resolution.md
+++ b/workspaces/issue-979-dataflow-unit-triage/journal/0007-DECISION-s-ev-resolution.md
@@ -1,0 +1,85 @@
+# 0007 — DECISION — S-EV: test_dataflow_events.py diagnosed + fixed
+
+**Date:** 2026-05-14
+**Shard:** S-EV (Workstream-A, briefs/00-brief.md:41-42 AC#2)
+**Branch:** `feat/issue-979-s-ev-dataflow-events`
+**Disposition:** Branch A (real bug, fix shipped). Layer-2 OOM hypothesis from journal/0001 was wrong.
+
+## Verdict
+
+The brief's "4+ test failures from PR #976 investigation" claim was **TRUE** — 5 of 11 tests in `packages/kailash-dataflow/tests/unit/features/test_dataflow_events.py` failed in clean-venv reproduction. The journal/0001 hypothesis "Branch B (no reproduction) most likely" was incorrect.
+
+Failure receipt (clean venv `/tmp/s-ev-verify`, pre-fix):
+
+```
+$ /tmp/s-ev-verify/bin/pytest packages/kailash-dataflow/tests/unit/features/test_dataflow_events.py -v
+...
+FAILED test_init_events_creates_bus              — assert None is not None
+FAILED test_emit_publishes_domain_event_with_payload — AttributeError: 'NoneType' object has no attribute 'subscribe'
+FAILED test_emit_correct_field_name_is_payload   — AttributeError: 'NoneType' object has no attribute 'subscribe'
+FAILED test_subscribes_all_8_write_operations    — AttributeError: 'NoneType' object has no attribute 'subscribe'
+FAILED test_on_model_change_receives_events      — AttributeError: 'NoneType' object has no attribute 'subscribe'
+=========================== 5 failed, 6 passed ==========================
+```
+
+## Root Cause
+
+`DataFlowEventMixin._init_events` (`packages/kailash-dataflow/src/dataflow/core/events.py:56`) imports `kailash.middleware.communication.backends.memory.InMemoryEventBus`. Python's import machinery runs `kailash.middleware/__init__.py` which eagerly imports:
+
+- `kailash.nodes.admin.user_management` → requires `bcrypt` (from `kailash[server]`)
+- `kailash.middleware.communication.api_gateway` → requires `fastapi` + `uvicorn` (from `kailash[server]`)
+
+`kailash-dataflow[dev]` did NOT declare `kailash[server]`. Clean-venv install → `ImportError` → `_init_events` silently sets `_event_bus = None` → downstream `subscribe(...)` calls produce opaque `AttributeError: NoneType.subscribe`.
+
+This is a zero-tolerance Rule 3a violation — "Typed Delegate Guards For None Backing Objects."
+
+## Fix (two layers)
+
+**Layer 1 — Code (`packages/kailash-dataflow/src/dataflow/core/events.py`):**
+- `_init_events` now records the `ImportError` into `_event_bus_import_error` (class-level default `None`).
+- `on_model_change` raises typed `DataFlowError` citing the `kailash[server]` extra when `_event_bus is None` — replaces opaque `AttributeError`.
+- `_emit_write_event`'s existing `_event_bus is None` early-return is preserved (documented no-op contract; see `test_emit_when_bus_is_none`).
+
+**Layer 2 — Dep declaration (`packages/kailash-dataflow/pyproject.toml`):**
+- Added `kailash[server]` to `[dev]` extras alongside `aiosqlite` and `pytest-timeout` — same "tier-1 collection requires extra not installed" pattern PR #976 established.
+
+**Regression test (`packages/kailash-dataflow/tests/regression/test_issue_979_s_ev_dataflow_events.py`):**
+- 3 tests covering: (a) `[dev]` pin presence via `tomllib` parse, (b) `_event_bus_import_error` class attribute exists, (c) `on_model_change` raises `DataFlowError` citing `kailash[server]` when `_event_bus is None`.
+
+## Verification
+
+```
+$ /tmp/s-ev-cleanverify/bin/pytest \
+    packages/kailash-dataflow/tests/unit/features/test_dataflow_events.py \
+    packages/kailash-dataflow/tests/regression/test_issue_979_s_ev_dataflow_events.py -v
+...
+============================== 14 passed in 1.70s ==============================
+```
+
+Fresh `/tmp/s-ev-cleanverify` venv with ONLY `pip install -e packages/kailash-dataflow[dev]` (no manual bcrypt/fastapi). All 11 original tests + 3 new regression tests green.
+
+## Capacity Budget
+
+- LOC: ~80 (events.py ~40, pyproject.toml ~14, regression test ~120 — well under 200 budget)
+- Invariants: 3 (Rule 3a typed guard, dep declared = imported, regression coverage)
+- Call-graph hops: 2 (`_init_events` ↔ `on_model_change` ↔ user-facing surface)
+
+Within shard budget. No decomposition needed.
+
+## Files Changed
+
+```
+packages/kailash-dataflow/src/dataflow/core/events.py            (+40, -3)
+packages/kailash-dataflow/pyproject.toml                          (+14)
+packages/kailash-dataflow/tests/regression/test_issue_979_s_ev_dataflow_events.py  (+120, new)
+workspaces/issue-979-dataflow-unit-triage/journal/0007-DECISION-s-ev-resolution.md  (this file)
+```
+
+## Cross-References
+
+- Brief AC#2: `briefs/00-brief.md:41-42`
+- Plan source: `workspaces/issue-979-dataflow-unit-triage/02-plans/02-amendments-v2-post-redteam-r1r2.md` § S-EV
+- Prior assumption (corrected): `journal/0001-DISCOVERY-brief-verification.md:96-126` Layer 5
+- Pattern reference: `rules/zero-tolerance.md` Rule 3a (Typed Delegate Guards)
+- Pattern reference: `rules/dependencies.md` § Declared = Imported
+- Sibling pattern: existing `[dev]` pins for `pytest-timeout` + `aiosqlite` (S1 / PR #976)


### PR DESCRIPTION
## Summary

Closes AC#2 of issue #979: `tests/unit/features/test_dataflow_events.py` had 5 reproducible failures in clean-venv `pip install -e packages/kailash-dataflow[dev]`. Root cause was a silent-fallback in `DataFlowEventMixin._init_events` — the journal/0001 Layer-5 "Branch B / no reproduction" hypothesis was wrong; failures reproduced cleanly when the diagnosis ran in a fresh venv.

## Root cause

`dataflow.core.events.DataFlowEventMixin._init_events` imports `kailash.middleware.communication.backends.memory.InMemoryEventBus`. Python loads `kailash.middleware/__init__.py` which eagerly imports `kailash.nodes.admin.user_management` (requires `bcrypt`) and `kailash.middleware.communication.api_gateway` (requires `fastapi`) — both from `kailash[server]`. `kailash-dataflow[dev]` did NOT declare `kailash[server]`, so `ImportError` was swallowed (`except ImportError: pass`-equivalent), leaving `_event_bus=None`. Downstream `.subscribe()` produced opaque `AttributeError` — a `rules/zero-tolerance.md` Rule 3a violation (Typed Delegate Guards For None Backing Objects).

## Two-layer fix

**1. Code (`packages/kailash-dataflow/src/dataflow/core/events.py`):**
- `_init_events` records the `ImportError` into class-level `_event_bus_import_error`.
- `on_model_change` raises a typed `DataFlowError` citing `kailash[server]` when bus is `None`.
- `_emit_write_event`'s documented `None`-noop behaviour preserved (the typed surface is at the user-facing subscribe path; emission is internal).

**2. Dep (`packages/kailash-dataflow/pyproject.toml`):**
- `kailash[server]` added to `[dev]` extras alongside `aiosqlite` + `pytest-timeout` — same "tier-1 collection requires extra not installed" pattern that S1 (PR #980) established.

## Verification

Clean `/tmp/s-ev-cleanverify` venv with ONLY `pip install -e packages/kailash-dataflow[dev]`:
- Pre-fix: 5 of 11 tests in `test_dataflow_events.py` failed.
- Post-fix: **14 passed in 1.70s** (11 original + 3 new regression tests in `tests/regression/test_issue_979_s_ev_dataflow_events.py`).

Receipt: `workspaces/issue-979-dataflow-unit-triage/journal/0007-DECISION-s-ev-resolution.md` (pre/post fix command output).

## Acceptance criteria (all met)

- [x] Failures reproduced in clean-venv
- [x] Root cause diagnosed (silent ImportError swallow → None-backing-object trap)
- [x] Production-code fix per \`rules/zero-tolerance.md\` Rule 3a + Rule 4 (fix-not-workaround)
- [x] Regression test under \`tests/regression/test_issue_979_s_ev_dataflow_events.py\` per \`rules/testing.md\` § Regression
- [x] Journal entry records disposition with command output receipt per \`rules/verify-resource-existence.md\` MUST-4

## Capacity

~80 LOC load-bearing logic, 3 invariants, 2 call-graph hops — within shard budget. No decomposition needed.

## Shard discipline

Shard S-EV of issue #979 Workstream-A. S1 (test-config floor) shipped as kailash-dataflow 2.9.1 (PR #980 + release/v2.9.1). S-EV runs in parallel wave-1 with S2a (PR #983) and S3 (in progress). Per strict per-shard release cadence authorized 2026-05-14: after merge, cut \`release/v2.9.3\` → \`/release\`.

## Related

- Issue #979 — DataFlow Unit Suite Triage
- PR #976 — closure comment for the 5-iteration debug (5-layer failure)
- PR #983 — S2a (gallery move, parallel wave-1)
- \`rules/zero-tolerance.md\` Rule 3a — Typed Delegate Guards