### PR TITLE
release(kailash-dataflow): 2.9.2 — wave-1 bundled (S2a + S-EV of #979)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,33 @@
 # DataFlow Changelog
 
+## [2.9.2] — 2026-05-14 — gallery to integration tier (S2a of #979)
+
+Patch release shipping the second shard of issue #979 DataFlow Unit Suite
+Triage Workstream-A. Test-tier reclassification only; no runtime API
+surface change and no `[dev]` extras change.
+
+### Changed
+
+- **`tests/unit/examples/test_example_gallery.py` → `tests/integration/examples/`**
+  (PR #983). The gallery exercises real workflows (~12s/test) which
+  violates `specs/testing-tiers.md` Tier-1 Contract Rule 1 (no
+  `AsyncLocalRuntime` / `WorkflowBuilder` top-imports) AND Rule 2
+  (no `tempfile.mktemp` for DB paths — was at line 28-30, the deadlock
+  source PR #976 surfaced). Closes AC#1 of issue #979.
+- **Removed vestigial `from unittest.mock import AsyncMock, MagicMock,
+patch` from the moved gallery** — none of the three symbols were
+  referenced anywhere in the file body; the integration tier's NO MOCKING
+  AST gate (`tests/integration/conftest.py::_module_imports_unittest_mock`,
+  load-bearing per `rules/testing.md`) required this dead-import removal
+  for clean collection.
+
+### Fixed
+
+- **Clean-venv `pytest tests/unit --collect-only`** no longer pulls the
+  gallery's `AsyncLocalRuntime` top-import — one fewer optional-dep
+  cascade surface for the #898 CI gate to navigate when it re-lands at
+  S6.
+
 ## [2.9.1] — 2026-05-14 — tier-1 test-config floor (S1 of #979)
 
 Patch release shipping the test-discipline floor for issue #979 DataFlow

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,32 +1,63 @@
 # DataFlow Changelog
 
-## [2.9.2] — 2026-05-14 — gallery to integration tier (S2a of #979)
+## [2.9.2] — 2026-05-14 — Workstream-A wave-1 (S2a + S-EV of #979)
 
-Patch release shipping the second shard of issue #979 DataFlow Unit Suite
-Triage Workstream-A. Test-tier reclassification only; no runtime API
-surface change and no `[dev]` extras change.
+Patch release bundling shards **S2a** (gallery move) and **S-EV** (events
+silent-fallback fix) of issue #979 DataFlow Unit Suite Triage Workstream-A.
+
+Wave-1 was merged in parallel before either release was cut; honest
+bundling per `rules/build-repo-release-discipline.md` Rule 2 (clean-venv
+installability is the done gate — both shards' changes flow into the wheel).
+
+### Fixed
+
+- **`DataFlowEventMixin._init_events` silent-fallback closed** (S-EV / PR #984).
+  Prior behavior swallowed `ImportError` on the `kailash.middleware.communication`
+  chain and left `_event_bus=None`, producing opaque `AttributeError` on
+  downstream `subscribe()` / `on_model_change()` calls. New behavior records
+  the original `ImportError` to a class-level `_event_bus_import_error`
+  attribute and raises a typed `DataFlowError` from `on_model_change` citing
+  the missing `kailash[server]` extra (per `rules/zero-tolerance.md` Rule 3a —
+  Typed Delegate Guards For None Backing Objects). `_emit_write_event`'s
+  documented `None`-noop preserved.
+- **Clean-venv `pytest tests/unit/features/test_dataflow_events.py`**
+  now passes 11/11 (previously 5/11 failed in a fresh
+  `pip install -e packages/kailash-dataflow[dev]` install).
 
 ### Changed
 
+- **`[dev]` extras now require `kailash[server]`** (S-EV / PR #984). The
+  events mixin imports `kailash.middleware.communication.backends.memory.InMemoryEventBus`;
+  Python loads `kailash.middleware/__init__.py` which eagerly imports
+  `kailash.nodes.admin.user_management` (bcrypt) and
+  `kailash.middleware.communication.api_gateway` (fastapi) — both from
+  the `[server]` extra. Same "tier-1 collection requires extra not
+  installed" pattern as 2.9.1's pytest-timeout + aiosqlite pins.
 - **`tests/unit/examples/test_example_gallery.py` → `tests/integration/examples/`**
-  (PR #983). The gallery exercises real workflows (~12s/test) which
+  (S2a / PR #983). The gallery exercises real workflows (~12s/test) which
   violates `specs/testing-tiers.md` Tier-1 Contract Rule 1 (no
   `AsyncLocalRuntime` / `WorkflowBuilder` top-imports) AND Rule 2
   (no `tempfile.mktemp` for DB paths — was at line 28-30, the deadlock
   source PR #976 surfaced). Closes AC#1 of issue #979.
-- **Removed vestigial `from unittest.mock import AsyncMock, MagicMock,
-patch` from the moved gallery** — none of the three symbols were
+- **Removed vestigial `from unittest.mock import AsyncMock, MagicMock, patch` from the moved gallery** — none of the three symbols were
   referenced anywhere in the file body; the integration tier's NO MOCKING
   AST gate (`tests/integration/conftest.py::_module_imports_unittest_mock`,
   load-bearing per `rules/testing.md`) required this dead-import removal
   for clean collection.
 
-### Fixed
+### Added
 
-- **Clean-venv `pytest tests/unit --collect-only`** no longer pulls the
-  gallery's `AsyncLocalRuntime` top-import — one fewer optional-dep
-  cascade surface for the #898 CI gate to navigate when it re-lands at
-  S6.
+- **`tests/regression/test_issue_979_s_ev_dataflow_events.py`** (S-EV).
+  Three new regression tests pinning: (a) `_init_events` records the
+  `ImportError` to `_event_bus_import_error`, (b) `on_model_change` raises
+  typed `DataFlowError` when bus is unavailable, (c) `_emit_write_event`
+  preserves None-noop semantics.
+
+### Notes
+
+- Closes AC#1 (S2a) + AC#2 (S-EV) of issue #979.
+- Wave-1 third shard (S3 — fabric move + conftest hook refinement) ships
+  separately as 2.9.3 (PR #985 + release/v2.9.3 pending CI).
 
 ## [2.9.1] — 2026-05-14 — tier-1 test-config floor (S1 of #979)
 

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.1"
+version = "2.9.2"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.1"
+__version__ = "2.9.2"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Patch release bundling **S2a** (gallery move) + **S-EV** (events silent-fallback fix) of issue #979 Workstream-A. Wave-1 parallel-merge landed both shards before either release was cut; per \`rules/build-repo-release-discipline.md\` Rule 2 (clean-venv installability is the done gate), the released wheel contains both shards' code — the CHANGELOG MUST honestly bundle them.

## Version anchors (zero-tolerance Rule 5)

- \`packages/kailash-dataflow/pyproject.toml\`: 2.9.1 → 2.9.2
- \`packages/kailash-dataflow/src/dataflow/__init__.py\`: \`__version__\` 2.9.1 → 2.9.2
- \`packages/kailash-dataflow/CHANGELOG.md\`: \`[2.9.2]\` bundled entry (S2a + S-EV)

## What ships

**S2a (PR #983)** — gallery move to integration tier
- \`tests/unit/examples/test_example_gallery.py\` → \`tests/integration/examples/\` (closes AC#1)
- Vestigial \`unittest.mock\` import removed for NO-MOCKING gate

**S-EV (PR #984)** — events silent-fallback fix
- \`dataflow.core.events.DataFlowEventMixin._init_events\` records ImportError; \`on_model_change\` raises typed \`DataFlowError\` (closes AC#2)
- \`[dev]\` extras now require \`kailash[server]\` — closes the clean-venv import gap
- 3 new regression tests under \`tests/regression/test_issue_979_s_ev_dataflow_events.py\`

## Branch convention

Branch \`release/v2.9.2\` per \`rules/git.md\` — PR-gate matrix auto-skips on metadata-only diff (the merge-back of S-EV's source files into release/v2.9.2 is functionally a no-op in PR-CI's diff view since main already has them).

## Release-cycle cadence

Wave-1 third shard (S3 — fabric move + conftest hook refinement) ships separately as **release/v2.9.3** (PR #985 in flight). Strict per-shard cadence holds going forward; this PR is a one-time wave-1 reconciliation.

## Related

- Issue #979 — DataFlow Unit Suite Triage
- PR #983 — S2a (merged cf4ebed7)
- PR #984 — S-EV (merged 04fc7037)