### PR TITLE
release(kailash-dataflow): 2.9.4 — Layer D PG-requiring unit tests audit + move (#979 S4)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,43 @@
 # DataFlow Changelog
 
+## [2.9.4] — 2026-05-14 — Layer D PG-requiring unit tests audit + move (S4 of #979)
+
+Patch release shipping shard **S4** of issue #979 DataFlow Unit Suite Triage
+Workstream-A. Test-tier reclassification for PostgreSQL-requiring "unit" tests
+
+- one `pytest.importorskip` gate; no runtime API surface change.
+
+### Changed
+
+- **12 PG-requiring test files moved `tests/unit/` → `tests/integration/`** (PR #988).
+  Closes AC#4 + AC#5 of issue #979 — the moved files violated `specs/testing-tiers.md`
+  Tier-1 Rule 1 (no real PostgreSQL connections, no `IntegrationTestSuite` import
+  in tier-1). Moves preserve git history via rename detection.
+- **`tests/unit/testing/test_tdd_support.py`** — bare `import asyncpg` replaced
+  with `asyncpg = pytest.importorskip("asyncpg")` so clean-venv `[dev]`-only
+  installs do not ImportError at collection time.
+
+### Audited (kept in tier-1)
+
+Eight files audited per the S4 plan's Category-C protocol — PostgreSQL URLs
+were config-only (no real connections opened); files stay in tier-1.
+Receipt at `workspaces/issue-979-dataflow-unit-triage/journal/0008-DECISION-s4-category-c-audit.md`
+per `rules/verify-resource-existence.md` MUST-4.
+
+### Preserved
+
+- `tests/unit/templates/test_saas_tenancy.py` stays in tier-1 (100% mocked,
+  meets tier-1 contract — explicit per S4 plan).
+
+### Known follow-up
+
+9 of the 12 moved files contain `@patch`/`MagicMock`/`unittest.mock` calls
+(byte-identical to pre-move state on `main` `d655038e`). These now sit in
+the integration tier where `specs/testing-tiers.md` § Tier-2 Rule 1 mandates
+NO MOCKING. Tracked as a separate Workstream-B follow-up issue with
+value-anchor citing the spec; out of #979 brief scope (AC#4 + AC#5 did not
+mandate tier-2 mock-free rewrite).
+
 ## [2.9.3] — 2026-05-14 — fabric to integration + conftest refinement (S3 of #979)
 
 Patch release shipping shard **S3** of issue #979 DataFlow Unit Suite Triage

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.3"
+version = "2.9.4"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.3"
+__version__ = "2.9.4"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Patch release shipping shard **S4** of issue #979 Workstream-A. PostgreSQL-requiring "unit" tests reclassified to integration tier + one `pytest.importorskip` gate. **No runtime API surface change.**

## Version anchors (zero-tolerance Rule 5)

- `packages/kailash-dataflow/pyproject.toml`: 2.9.3 → 2.9.4
- `packages/kailash-dataflow/src/dataflow/__init__.py`: `__version__` 2.9.3 → 2.9.4
- `packages/kailash-dataflow/CHANGELOG.md`: `[2.9.4]` entry prepended

## What ships (S4 / PR #988, merged)

- 12 PG-requiring test files moved `tests/unit/` → `tests/integration/` (git mv, history-preserving)
- 1 importorskip gate on `tests/unit/testing/test_tdd_support.py:16`: `asyncpg = pytest.importorskip("asyncpg")`
- 8 Category-C files audited; receipt at `workspaces/issue-979-dataflow-unit-triage/journal/0008-DECISION-s4-category-c-audit.md` per `rules/verify-resource-existence.md` MUST-4
- `tests/unit/templates/test_saas_tenancy.py` preserved in tier-1 (100% mocked per S4 plan)
- AC#4 + AC#5 of #979 closed

## Known follow-up (not blocking)

9 of the 12 moved files contain `@patch`/`MagicMock` calls — byte-identical to pre-move state on `main` `d655038e`. Now sitting in integration tier where `specs/testing-tiers.md` § Tier-2 Rule 1 mandates NO MOCKING. Tracked as Workstream-B follow-up with value-anchor; out of #979 brief scope.

## Workstream-A status

Wave-1 complete (S2a + S-EV in 2.9.2 / S3 in 2.9.3). Wave-2 in flight: S4 ships here as 2.9.4; S5a tempfile refactor ships next in 2.9.5; S6 gate shard closes Workstream-A.

## Branch convention

`release/v2.9.4` per `rules/git.md` § Release-Prep PRs MUST Use `release/v*` — PR-gate matrix auto-skips on metadata-only diff.

## Related

- Issue #979 — DataFlow Unit Suite Triage
- PR #988 — S4 primary work (merged 88dc590e)