### PR TITLE
release(kailash-dataflow): 2.9.5 — V5 tempfile→canonical fixture refactor (#979 S5a)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,43 @@
 # DataFlow Changelog
 
+## [2.9.5] — 2026-05-14 — V5 tempfile→canonical fixture refactor (S5a of #979)
+
+Patch release shipping shard **S5a** of issue #979 DataFlow Unit Suite Triage
+Workstream-A. Tier-1 unit-test fixture hygiene refactor — replaces ad-hoc
+`tempfile.NamedTemporaryFile(suffix=".db", ...)` + `DataFlow(...)` instantiation
+with the canonical `tmp_path` fixture + `try/finally db.close()` pattern across
+5 files (~60 sites). **No runtime API surface change.**
+
+### Changed
+
+- **`tests/unit/migrations/test_sync_ddl_executor.py`** — 9 sites refactored to
+  `tmp_path` (the `asyncio.get_running_loop()` assertion that gates the
+  sync-DDL-vs-async-loop invariant is preserved unchanged).
+- **`tests/unit/core/test_async_sql_sqlite.py`** — 1 site refactored.
+- **`tests/unit/testing/test_tdd_performance_benchmark.py`** — 4 sites refactored
+  with explicit `try/finally db.close()`.
+- **`tests/unit/context_aware/test_performance_benchmarks.py`** — 2 sites
+  refactored (multi-tenant mode preserved).
+- **`tests/unit/context_aware/test_instance_isolation.py`** — ~44 paired
+  isolation-test sites refactored.
+
+### Why
+
+Closes the `__del__` deadlock class that PR #976 kept rediscovering. The
+canonical fixture's `try/finally db.close()` ensures cleanup runs on test
+failure (where ad-hoc `DataFlow(f"sqlite:///{tmp.name}")` previously leaked to
+GC, allowing `__del__` to deadlock per the documented `engine.py` commit
+`2c98e7b3` issue).
+
+Anchored on `specs/testing-tiers.md` § Tier-1 Contract Rule 2 verbatim:
+"`tempfile.NamedTemporaryFile(suffix=\".db\", ...)` for DB paths" is BLOCKED.
+
+### Verified
+
+Mechanical invariant — zero `tempfile.*\.db` hits in test code after this
+release; the only remaining `tempfile.` reference is a documentation
+docstring intentionally citing the rejected pattern.
+
 ## [2.9.4] — 2026-05-14 — Layer D PG-requiring unit tests audit + move (S4 of #979)
 
 Patch release shipping shard **S4** of issue #979 DataFlow Unit Suite Triage

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.4"
+version = "2.9.5"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.4"
+__version__ = "2.9.5"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Patch release shipping shard **S5a** of issue #979 Workstream-A. Tier-1 unit-test fixture hygiene refactor — ~60 sites across 5 files moved from ad-hoc `tempfile.NamedTemporaryFile(suffix=".db")` + `DataFlow(...)` instantiation to the canonical `tmp_path` fixture + `try/finally db.close()` pattern. **No runtime API surface change.**

## Version anchors (zero-tolerance Rule 5)

- `packages/kailash-dataflow/pyproject.toml`: 2.9.4 → 2.9.5
- `packages/kailash-dataflow/src/dataflow/__init__.py`: `__version__` 2.9.4 → 2.9.5
- `packages/kailash-dataflow/CHANGELOG.md`: `[2.9.5]` entry prepended

## What ships (S5a / PR #989, merged)

- `tests/unit/migrations/test_sync_ddl_executor.py` — 9 sites refactored (`asyncio.get_running_loop()` assertion preserved)
- `tests/unit/core/test_async_sql_sqlite.py` — 1 site
- `tests/unit/testing/test_tdd_performance_benchmark.py` — 4 sites
- `tests/unit/context_aware/test_performance_benchmarks.py` — 2 sites
- `tests/unit/context_aware/test_instance_isolation.py` — ~44 paired isolation-test sites

## Why

Closes the `__del__` deadlock class PR #976 kept rediscovering. Ad-hoc `DataFlow(...)` instantiation without yield+close fixture caused the `__del__` deadlock that produced 15-minute hangs (per `packages/kailash-dataflow/tests/unit/conftest.py:75` docstring + `engine.py` commit `2c98e7b3`).

Anchored on `specs/testing-tiers.md` § Tier-1 Contract Rule 2 verbatim.

## Mechanical invariant

`grep -rn 'tempfile\.\(mktemp\|NamedTemporaryFile\).*\.db' packages/kailash-dataflow/tests/unit/` returns zero hits in test code post-merge. The only remaining `tempfile.` reference is a documentation docstring at `test_instance_isolation.py:15` intentionally citing the rejected pattern.

## Workstream-A status

Wave-1 complete (S2a + S-EV in 2.9.2 / S3 in 2.9.3). Wave-2 ships S4 + S5a separately per `.session-notes` cadence (no bundling — explicit user gate not given for wave-2 bundle): S4 shipped as 2.9.4 (PR #990, tag `dataflow-v2.9.4`); S5a ships here as 2.9.5. S6 (gate re-land + DEFENSE-2/3 + CLAUDE.md edit) closes Workstream-A next session.

## Branch convention

`release/v2.9.5` per `rules/git.md` § Release-Prep PRs MUST Use `release/v*` — PR-gate matrix auto-skips on metadata-only diff.

## Related

- Issue #979 — DataFlow Unit Suite Triage
- PR #989 — S5a primary work (merged fb43fb39)
- PR #990 — 2.9.4 release (merged 8ba52ba0, tag `dataflow-v2.9.4` pushed)