### PR TITLE
release(kailash-dataflow): cut 2.9.7 — partial closure of #1000

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,55 @@
 # DataFlow Changelog
 
+## [2.9.7] — 2026-05-14 — Structural `__del__` rule compliance (partial closure of #1000)
+
+Closes 9 `__del__` rule violations per `rules/patterns.md` § Async Resource
+Cleanup. Issue #1000 originated from `AsyncRedisCacheAdapter.__del__`
+emitting `logger.debug(...)` from inside a GC finalizer — deadlocking
+against the root logging lock already held by the finalizer thread. The
+same bug class was found in 8 sibling sites calling `self.close()` from
+`__del__`. All 9 sites now emit `ResourceWarning` only.
+
+### Fixed
+
+- **`__del__` GC finalizer deadlock** (issue #1000, AC#1, #2, #4):
+  - `cache/async_redis_adapter.py` — replaces `executor.shutdown(wait=False)
+    - logger.debug(...)`with`ResourceWarning` emission + safe sync drain.
+  - 8 sibling sites stop invoking `self.close()` from `__del__`:
+    `core/model_registry.py`, `gateway_integration.py`, three sites in
+    `migrations/auto_migration_system.py`, `migrations/schema_state_manager.py`,
+    `testing/dataflow_test_utils.py`, `utils/connection_adapter.py`.
+  - 2 fabric `__del__` signatures tightened with `_warnings=warnings`
+    default (`fabric/runtime.py`, `fabric/pipeline.py`) for interpreter-
+    shutdown safety.
+
+### Added
+
+- **AST-walk regression**: `tests/unit/test_del_no_close.py` — sweeps every
+  `__del__` in the dataflow source tree and asserts no body invokes
+  `close()`/`close_async()`/`cleanup()`/`stop()`/`drain()` or any logger
+  emission. Prevents reintroduction of the deadlock pattern.
+- **Contract tests for `AsyncRedisCacheAdapter`**: 5 new tests in
+  `tests/unit/cache/test_async_redis_adapter.py` covering `close_async`
+  semantics, idempotency, `ResourceWarning` emission, and the sync-drain
+  invariant in `__del__`.
+
+### Behavior change
+
+- `AsyncRedisCacheAdapter` now exposes `await adapter.close_async()` as the
+  deterministic-cleanup path. Callers who let the adapter be garbage-
+  collected without closing it will see a `ResourceWarning` rather than
+  silent deadlock — per `rules/patterns.md`'s "loud leak vs silent
+  deadlock" trade-off.
+
+### Deferred to issue #1002
+
+- **AC#3 of #1000** ("remove the setsid wrapper, confirm pytest exits
+  cleanly") is NOT delivered in this release. The CI `setsid` wrapper in
+  `.github/workflows/unified-ci.yml::test-dataflow` remains — it protects
+  against a distinct post-pytest `_Py_Finalize` hang caused by test
+  fixtures leaking aiosqlite background threads (separate root cause from
+  the `__del__` deadlock). Tracked in #1002 as a multi-shard cleanup.
+
 ## [2.9.6] — 2026-05-14 — Re-apply #898 CI gate + DEFENSE-2/3 + spec alignment (S6 of #979)
 
 Final patch of issue #979 Workstream-A. Re-applies the #898 CI gate that PR

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.6"
+version = "2.9.7"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.6"
+__version__ = "2.9.7"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Metadata-only release-prep PR per `rules/git.md` § "Release-Prep PRs MUST Use `release/v*`" (auto-skips PR-gate matrix). Bumps:

- `packages/kailash-dataflow/pyproject.toml::version` → `2.9.7`
- `packages/kailash-dataflow/src/dataflow/__init__.py::__version__` → `2.9.7`
- `packages/kailash-dataflow/CHANGELOG.md` → adds `[2.9.7]` entry

## Closes

- #1000 AC#1, #2, #4 (PR #1001 shipped the structural fix)

## Deferred to #1002

- #1000 AC#3 — remove CI setsid wrapper. Different root cause (test-fixture aiosqlite thread leaks); multi-shard scope.

## Sibling release sweep

All 7 sibling packages already in sync with PyPI — no cascading releases needed:

| Package | main | PyPI |
|---|---|---|
| kailash | 2.21.0 | 2.21.0 |
| kailash-nexus | 2.6.3 | 2.6.3 |
| kailash-kaizen | 2.21.0 | 2.21.0 |
| kailash-mcp | 0.2.14 | 0.2.14 |
| kailash-ml | 1.7.4 | 1.7.4 |
| kailash-align | 0.7.1 | 0.7.1 |
| kailash-pact | 0.12.0 | 0.12.0 |

## Test plan

- [ ] PR auto-skips PR-gate matrix (release/v* branch convention)
- [ ] Owner admin-merge
- [ ] Tag `dataflow-v2.9.7` push triggers `publish-pypi.yml`
- [ ] Clean-venv install verification: `kailash-dataflow==2.9.7` importable

🤖 Generated with [Claude Code](https://claude.com/claude-code)