### PR TITLE
fix(dataflow): Shard 3 — tail-cleanup + asyncio-mark + flake fix + runtime cache release (#1002)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -10055,15 +10055,43 @@ class DataFlow(DataFlowEventMixin):
                 self._memory_connection = None
 
         # M2-001: Close the shared runtime LAST (actual cleanup at ref_count=0)
-        if hasattr(self, "runtime") and self.runtime is not None:
+        #
+        # Issue #1002 — the `self.runtime` property resolves to ONE runtime
+        # for the CURRENT context (async loop OR sync singleton). The
+        # instance may hold others in `_loop_runtime_cache` (one per
+        # event-loop the instance saw) AND `_sync_runtime_singleton`
+        # concurrently. Closing only `self.runtime` leaks every cached
+        # runtime EXCEPT the one bound to the calling context — those
+        # leaked LocalRuntime references kept aiosqlite threads alive at
+        # `_Py_Finalize` time, producing the post-summary hang.
+        #
+        # Iterate every cached runtime (override + loop cache + sync
+        # singleton) and close each. Each runtime's own ref-count logic
+        # handles double-close safely.
+        runtimes_to_close = []
+        override = getattr(self, "_runtime_override", None)
+        if override is not None:
+            runtimes_to_close.append(("override", override))
+        loop_cache = getattr(self, "_loop_runtime_cache", None) or {}
+        for loop_id, rt in list(loop_cache.items()):
+            runtimes_to_close.append((f"loop[{loop_id}]", rt))
+        sync_singleton = getattr(self, "_sync_runtime_singleton", None)
+        if sync_singleton is not None:
+            runtimes_to_close.append(("sync_singleton", sync_singleton))
+        for label, rt in runtimes_to_close:
             try:
-                self.runtime.close()
+                rt.close()
             except Exception as e:
                 logger.debug(
-                    "engine.error_closing_shared_runtime", extra={"error": str(e)}
+                    "engine.error_closing_shared_runtime",
+                    extra={"runtime": label, "error": str(e)},
                 )
-            finally:
-                self.runtime = None
+        # Clear caches so the runtime property returns None on subsequent
+        # access (mirrors the pre-fix `self.runtime = None` assignment).
+        if hasattr(self, "_loop_runtime_cache"):
+            self._loop_runtime_cache = {}
+        self._sync_runtime_singleton = None
+        self._runtime_override = None
 
     async def close_async(self):
         """Close database connections and clean up resources (async version).
@@ -10175,16 +10203,33 @@ class DataFlow(DataFlowEventMixin):
             finally:
                 self._audit_backend = None
 
-        # M2-001: Close the shared runtime LAST (actual cleanup at ref_count=0)
-        if hasattr(self, "runtime") and self.runtime is not None:
+        # M2-001 + issue #1002: Close ALL cached runtimes (override + per-loop
+        # cache + sync singleton). The `self.runtime` property resolves to one
+        # runtime; closing only it leaks every other cached runtime, keeping
+        # aiosqlite worker threads alive at `_Py_Finalize` time and producing
+        # the post-summary hang. Mirrors the sync close() fix at L10058.
+        runtimes_to_close = []
+        override = getattr(self, "_runtime_override", None)
+        if override is not None:
+            runtimes_to_close.append(("override", override))
+        loop_cache = getattr(self, "_loop_runtime_cache", None) or {}
+        for loop_id, rt in list(loop_cache.items()):
+            runtimes_to_close.append((f"loop[{loop_id}]", rt))
+        sync_singleton = getattr(self, "_sync_runtime_singleton", None)
+        if sync_singleton is not None:
+            runtimes_to_close.append(("sync_singleton", sync_singleton))
+        for label, rt in runtimes_to_close:
             try:
-                self.runtime.close()
+                rt.close()
             except Exception as e:
                 logger.debug(
-                    "engine.error_closing_shared_runtime", extra={"error": str(e)}
+                    "engine.error_closing_shared_runtime",
+                    extra={"runtime": label, "error": str(e)},
                 )
-            finally:
-                self.runtime = None
+        if hasattr(self, "_loop_runtime_cache"):
+            self._loop_runtime_cache = {}
+        self._sync_runtime_singleton = None
+        self._runtime_override = None
 
         logger.debug(
             "engine.dataflow_instance_closed_async",

--- a/packages/kailash-dataflow/tests/regression/test_issue_1002_close_releases_all_cached_runtimes.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1002_close_releases_all_cached_runtimes.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for issue #1002 — DataFlow.close() / close_async() MUST close
+EVERY cached runtime, not only `self.runtime`.
+
+Per ``workspaces/issue-1002-aiosqlite-fixture-cleanup/journal/0006-DISCOVERY-...md``
+and commit ``e79fca27``: the `runtime` property resolves to ONE runtime for the
+calling context (override OR per-loop AsyncLocalRuntime OR sync singleton). An
+instance can hold all three concurrently if it has been accessed from a sync
+context, an async-loop A, and via the `_runtime_override` setter. Pre-fix,
+`close()` / `close_async()` only closed `self.runtime` — the other two leaked
+LocalRuntime references kept aiosqlite background threads alive at
+``_Py_Finalize`` time, producing the post-pytest-summary hang.
+
+This test exercises the cache-clearing contract directly: prime all three
+runtime caches with recording stubs, run close() / close_async(), assert (a)
+each cached runtime had close() invoked, AND (b) all three caches are emptied.
+
+Tier 1 — no real database. Protocol-Satisfying stubs per
+``rules/testing.md`` § "3-Tier Testing" carve-out (deterministic adapter
+satisfying the `runtime.close()` shape, not a mock).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from kailash.runtime.async_local import AsyncLocalRuntime
+from kailash.runtime.local import LocalRuntime
+
+from dataflow import DataFlow
+
+pytestmark = [pytest.mark.regression]
+
+
+class _RecordingRuntime:
+    """Protocol-satisfying recording stub matching ``LocalRuntime.close()``
+    and ``AsyncLocalRuntime.close()`` shape (both are synchronous on the
+    Kailash runtime surface — see ``src/kailash/runtime/*.py``)."""
+
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+def _prime_all_runtime_caches(
+    db: DataFlow,
+) -> tuple[_RecordingRuntime, _RecordingRuntime, _RecordingRuntime]:
+    """Prime ``_runtime_override`` + one ``_loop_runtime_cache`` entry +
+    ``_sync_runtime_singleton`` with distinct recording stubs. Returns the
+    three stubs so the caller can assert close() invocation."""
+    override = _RecordingRuntime()
+    per_loop = _RecordingRuntime()
+    sync_singleton = _RecordingRuntime()
+
+    # Protocol-Satisfying-Adapter cast per rules/testing.md § "Protocol Adapters":
+    # the engine's cleanup loop only invokes .close(), which all three stubs
+    # implement. cast() makes the structural-typing contract explicit for
+    # pyright without forcing a nominal-type inheritance.
+    db._runtime_override = cast(LocalRuntime, override)
+    # _loop_runtime_cache is keyed by loop-id (int); use a sentinel int.
+    if not hasattr(db, "_loop_runtime_cache") or db._loop_runtime_cache is None:
+        db._loop_runtime_cache = {}
+    db._loop_runtime_cache[0] = cast(AsyncLocalRuntime, per_loop)
+    db._sync_runtime_singleton = cast(LocalRuntime, sync_singleton)
+
+    return override, per_loop, sync_singleton
+
+
+def test_sync_close_releases_all_cached_runtimes() -> None:
+    """``DataFlow.close()`` MUST close every cached runtime AND clear all
+    three caches. Pre-fix, only ``self.runtime`` was closed — leaking the
+    other two cached references."""
+    db = DataFlow(":memory:", auto_migrate=False)
+    try:
+        override, per_loop, sync_singleton = _prime_all_runtime_caches(db)
+
+        assert override.close_count == 0
+        assert per_loop.close_count == 0
+        assert sync_singleton.close_count == 0
+
+        db.close()
+
+        assert (
+            override.close_count >= 1
+        ), "sync close() did not close _runtime_override — issue #1002 regressed"
+        assert (
+            per_loop.close_count >= 1
+        ), "sync close() did not close _loop_runtime_cache entry — issue #1002 regressed"
+        assert (
+            sync_singleton.close_count >= 1
+        ), "sync close() did not close _sync_runtime_singleton — issue #1002 regressed"
+        assert db._runtime_override is None
+        assert db._loop_runtime_cache == {}
+        assert db._sync_runtime_singleton is None
+    finally:
+        if not db._closed:
+            db.close()
+
+
+@pytest.mark.asyncio
+async def test_async_close_releases_all_cached_runtimes() -> None:
+    """``DataFlow.close_async()`` MUST also close every cached runtime —
+    parity with the sync ``close()`` fix is the structural defense per
+    ``rules/patterns.md`` § "Paired Public Surface — Consistent Async-ness"."""
+    db = DataFlow(":memory:", auto_migrate=False)
+    try:
+        override, per_loop, sync_singleton = _prime_all_runtime_caches(db)
+
+        await db.close_async()
+
+        assert override.close_count >= 1
+        assert per_loop.close_count >= 1
+        assert sync_singleton.close_count >= 1
+        assert db._runtime_override is None
+        assert db._loop_runtime_cache == {}
+        assert db._sync_runtime_singleton is None
+    finally:
+        if not db._closed:
+            db.close()
+
+
+def test_sync_close_tolerates_runtime_close_failure_and_still_clears_caches() -> None:
+    """Per the fix's per-runtime ``try/except: logger.debug``, one runtime
+    raising in close() MUST NOT block the others, AND all three caches
+    MUST still be emptied."""
+
+    class _FailingRuntime:
+        def close(self) -> None:
+            raise RuntimeError("simulated runtime close failure")
+
+    good_override = _RecordingRuntime()
+    bad_loop = _FailingRuntime()
+    good_sync = _RecordingRuntime()
+
+    db = DataFlow(":memory:", auto_migrate=False)
+    try:
+        db._runtime_override = cast(LocalRuntime, good_override)
+        db._loop_runtime_cache = {0: cast(AsyncLocalRuntime, bad_loop)}
+        db._sync_runtime_singleton = cast(LocalRuntime, good_sync)
+
+        db.close()  # MUST NOT raise
+
+        assert (
+            good_override.close_count == 1
+        ), "sibling cleanup blocked by failing runtime"
+        assert good_sync.close_count == 1, "sibling cleanup blocked by failing runtime"
+        assert db._runtime_override is None
+        assert db._loop_runtime_cache == {}
+        assert db._sync_runtime_singleton is None
+    finally:
+        if not db._closed:
+            db.close()

--- a/packages/kailash-dataflow/tests/unit/context_aware/test_instance_isolation.py
+++ b/packages/kailash-dataflow/tests/unit/context_aware/test_instance_isolation.py
@@ -13,9 +13,8 @@ Tests that multiple DataFlow instances maintain proper isolation:
 
 Uses SQLite file-based databases via pytest's tmp_path fixture
 (NOT tempfile.NamedTemporaryFile per specs/testing-tiers.md Tier-1
-Rule 2). DataFlow instances are wrapped in try/finally db.close()
-to prevent the DataFlow.__del__ deadlock the canonical fixtures
-were designed to avoid.
+Rule 2). DataFlow instances use sync `with` context manager to
+prevent the DataFlow.__del__ ResourceWarning class fix (see #1002).
 """
 
 import pytest
@@ -30,10 +29,10 @@ class TestInstanceStateIsolation:
 
     def test_two_instances_have_separate_models(self, tmp_path):
         """Two DataFlow instances have independent model registries."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}") as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}") as db2,
+        ):
 
             @db1.model
             class User:
@@ -50,16 +49,13 @@ class TestInstanceStateIsolation:
             # db2 should only have Product
             assert "Product" in db2.get_models()
             assert "User" not in db2.get_models()
-        finally:
-            db1.close()
-            db2.close()
 
     def test_model_count_independent(self, tmp_path):
         """Model counts are independent between instances."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}") as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}") as db2,
+        ):
 
             @db1.model
             class A:
@@ -75,16 +71,13 @@ class TestInstanceStateIsolation:
 
             assert len(db1.get_models()) == 2
             assert len(db2.get_models()) == 1
-        finally:
-            db1.close()
-            db2.close()
 
     def test_instances_with_same_model_name(self, tmp_path):
         """Same model name in different instances are independent."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}") as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}") as db2,
+        ):
 
             @db1.model
             class User:
@@ -98,9 +91,6 @@ class TestInstanceStateIsolation:
             # Both should have User model but they're separate
             assert "User" in db1.get_models()
             assert "User" in db2.get_models()
-        finally:
-            db1.close()
-            db2.close()
 
 
 @pytest.mark.unit
@@ -109,10 +99,10 @@ class TestNodeRegistrationIsolation:
 
     def test_generated_nodes_isolated(self, tmp_path):
         """Generated nodes are isolated to their DataFlow instance."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}") as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}") as db2,
+        ):
 
             @db1.model
             class Order:
@@ -124,15 +114,10 @@ class TestNodeRegistrationIsolation:
             # db2 should not have Order nodes in its instance
             # (though global registry may have them)
             assert "Order" not in db2.get_models()
-        finally:
-            db1.close()
-            db2.close()
 
     def test_all_eleven_operations_generated_per_model(self, tmp_path):
         """Each model generates all 11 operation nodes."""
-        db = DataFlow(f"sqlite:///{tmp_path / 'db.db'}")
-
-        try:
+        with DataFlow(f"sqlite:///{tmp_path / 'db.db'}") as db:
 
             @db.model
             class Item:
@@ -154,8 +139,6 @@ class TestNodeRegistrationIsolation:
 
             for node_name in expected_ops:
                 assert node_name in db._nodes, f"{node_name} should be registered"
-        finally:
-            db.close()
 
 
 @pytest.mark.unit
@@ -164,23 +147,20 @@ class TestWorkflowBinderIsolation:
 
     def test_workflow_binders_are_instance_scoped(self, tmp_path):
         """Each DataFlow instance has its own workflow binder."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}") as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}") as db2,
+        ):
             assert db1._workflow_binder is not db2._workflow_binder
             assert db1._workflow_binder.dataflow_instance is db1
             assert db2._workflow_binder.dataflow_instance is db2
-        finally:
-            db1.close()
-            db2.close()
 
     def test_workflows_dont_leak_between_instances(self, tmp_path):
         """Workflows created in one instance don't appear in another."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}") as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}") as db2,
+        ):
             wf1 = db1.create_workflow("workflow_1")
             wf2 = db2.create_workflow("workflow_2")
 
@@ -190,16 +170,13 @@ class TestWorkflowBinderIsolation:
 
             assert "workflow_2" in db2._workflow_binder.list_workflows()
             assert "workflow_1" not in db2._workflow_binder.list_workflows()
-        finally:
-            db1.close()
-            db2.close()
 
     def test_available_nodes_isolated(self, tmp_path):
         """get_available_nodes() returns only the instance's models."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}") as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}") as db2,
+        ):
 
             @db1.model
             class Alpha:
@@ -217,9 +194,6 @@ class TestWorkflowBinderIsolation:
 
             assert "Beta" in nodes2
             assert "Alpha" not in nodes2
-        finally:
-            db1.close()
-            db2.close()
 
 
 @pytest.mark.unit
@@ -228,26 +202,23 @@ class TestTenantContextIsolation:
 
     def test_tenant_contexts_are_independent(self, tmp_path):
         """Each DataFlow instance has its own tenant context."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}", multi_tenant=True)
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}", multi_tenant=True)
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}", multi_tenant=True) as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}", multi_tenant=True) as db2,
+        ):
             ctx1 = db1.tenant_context
             ctx2 = db2.tenant_context
 
             assert ctx1 is not ctx2
             assert ctx1.dataflow_instance is db1
             assert ctx2.dataflow_instance is db2
-        finally:
-            db1.close()
-            db2.close()
 
     def test_tenant_registrations_isolated(self, tmp_path):
         """Tenant registrations are isolated between instances."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}", multi_tenant=True)
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}", multi_tenant=True)
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}", multi_tenant=True) as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}", multi_tenant=True) as db2,
+        ):
             db1.tenant_context.register_tenant("tenant-a", "Tenant A")
             db2.tenant_context.register_tenant("tenant-b", "Tenant B")
 
@@ -256,16 +227,13 @@ class TestTenantContextIsolation:
 
             assert db2.tenant_context.is_tenant_registered("tenant-b")
             assert not db2.tenant_context.is_tenant_registered("tenant-a")
-        finally:
-            db1.close()
-            db2.close()
 
     def test_tenant_switches_isolated(self, tmp_path):
         """Tenant context switches in one instance don't affect another."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}", multi_tenant=True)
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}", multi_tenant=True)
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}", multi_tenant=True) as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}", multi_tenant=True) as db2,
+        ):
             db1.tenant_context.register_tenant("tenant-1", "Tenant 1")
             db2.tenant_context.register_tenant("tenant-2", "Tenant 2")
 
@@ -273,9 +241,6 @@ class TestTenantContextIsolation:
                 # db2 should still have no active context
                 assert db1.tenant_context.get_current_tenant() == "tenant-1"
                 # Note: Context variable is shared, but registration is not
-        finally:
-            db1.close()
-            db2.close()
 
 
 @pytest.mark.unit
@@ -284,29 +249,34 @@ class TestCloseCleanupIsolation:
 
     def test_close_one_instance_other_remains_usable(self, tmp_path):
         """Closing one DataFlow instance doesn't affect another."""
+        # NOTE: This test explicitly tests close() ordering; use try/finally
+        # since we need to call db1.close() mid-test before db2 cleanup.
         db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
         db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
 
-        @db1.model
-        class Model1:
-            value: str
+        try:
 
-        @db2.model
-        class Model2:
-            value: str
+            @db1.model
+            class Model1:
+                value: str
 
-        # Close db1
-        db1.close()
+            @db2.model
+            class Model2:
+                value: str
 
-        # db2 should still work
-        assert "Model2" in db2.get_models()
-        wf = db2.create_workflow()
-        assert wf is not None
+            # Close db1
+            db1.close()
 
-        db2.close()
+            # db2 should still work
+            assert "Model2" in db2.get_models()
+            wf = db2.create_workflow()
+            assert wf is not None
+        finally:
+            db2.close()
 
     def test_models_persist_after_other_instance_closes(self, tmp_path):
         """Models in one instance persist after another instance closes."""
+        # NOTE: This test explicitly closes db1 mid-test; use try/finally for db2.
         db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
         db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
 
@@ -332,52 +302,40 @@ class TestSequentialInstanceCreationDestruction:
         """Sequential instances with same URL are independent."""
         url = f"sqlite:///{tmp_path / 'seq_same.db'}"
 
-        db1 = DataFlow(url)
+        with DataFlow(url) as db1:
 
-        @db1.model
-        class First:
-            value: str
-
-        db1.close()
+            @db1.model
+            class First:
+                value: str
 
         # Create new instance with same URL
-        db2 = DataFlow(url)
+        with DataFlow(url) as db2:
 
-        @db2.model
-        class Second:
-            value: str
+            @db2.model
+            class Second:
+                value: str
 
-        try:
             # db2 is a fresh instance (though schema may persist in file)
             assert "Second" in db2.get_models()
-        finally:
-            db2.close()
 
     def test_multiple_sequential_instances(self, tmp_path):
         """Multiple sequential instances work correctly."""
         url = f"sqlite:///{tmp_path / 'seq_multi.db'}"
 
         for i in range(3):
-            db = DataFlow(url)
-
-            try:
+            with DataFlow(url) as db:
                 # Define model unique to this iteration
                 # Can't dynamically name classes easily, but we can verify instance works
                 assert db is not None
                 assert db._models is not None or db.get_models() is not None
-            finally:
-                db.close()
 
     def test_rapid_creation_destruction_cycle(self, tmp_path):
         """Rapid creation/destruction cycle doesn't cause issues."""
         url = f"sqlite:///{tmp_path / 'rapid.db'}"
 
         for _ in range(5):
-            db = DataFlow(url)
-            try:
+            with DataFlow(url) as db:
                 assert db is not None
-            finally:
-                db.close()
 
 
 @pytest.mark.unit
@@ -386,10 +344,10 @@ class TestModelRegistrationIsolation:
 
     def test_model_fields_isolated(self, tmp_path):
         """Model field metadata is isolated between instances."""
-        db1 = DataFlow(f"sqlite:///{tmp_path / 'db1.db'}")
-        db2 = DataFlow(f"sqlite:///{tmp_path / 'db2.db'}")
-
-        try:
+        with (
+            DataFlow(f"sqlite:///{tmp_path / 'db1.db'}") as db1,
+            DataFlow(f"sqlite:///{tmp_path / 'db2.db'}") as db2,
+        ):
 
             @db1.model
             class Record:
@@ -403,15 +361,10 @@ class TestModelRegistrationIsolation:
             # Each instance should have its own field metadata
             assert "Record" in db1.get_models()
             assert "Record" in db2.get_models()
-        finally:
-            db1.close()
-            db2.close()
 
     def test_model_decorator_returns_correct_class(self, tmp_path):
         """@db.model decorator returns the decorated class unchanged."""
-        db = DataFlow(f"sqlite:///{tmp_path / 'decorator.db'}")
-
-        try:
+        with DataFlow(f"sqlite:///{tmp_path / 'decorator.db'}") as db:
 
             @db.model
             class TestClass:
@@ -420,14 +373,10 @@ class TestModelRegistrationIsolation:
             # The decorator should return the class
             assert TestClass is not None
             assert hasattr(TestClass, "__annotations__")
-        finally:
-            db.close()
 
     def test_multiple_models_per_instance(self, tmp_path):
         """Multiple models can be registered to the same instance."""
-        db = DataFlow(f"sqlite:///{tmp_path / 'multi_models.db'}")
-
-        try:
+        with DataFlow(f"sqlite:///{tmp_path / 'multi_models.db'}") as db:
 
             @db.model
             class ModelA:
@@ -446,5 +395,3 @@ class TestModelRegistrationIsolation:
             assert "ModelA" in models
             assert "ModelB" in models
             assert "ModelC" in models
-        finally:
-            db.close()

--- a/packages/kailash-dataflow/tests/unit/context_aware/test_performance_benchmarks.py
+++ b/packages/kailash-dataflow/tests/unit/context_aware/test_performance_benchmarks.py
@@ -181,23 +181,17 @@ class TestDataFlowInitializationPerformance:
 
         start = time.time()
 
-        db = DataFlow(f"sqlite:///{db_path}", multi_tenant=True)
+        with DataFlow(f"sqlite:///{db_path}", multi_tenant=True) as db:
+            elapsed = time.time() - start
 
-        elapsed = time.time() - start
-
-        try:
             assert elapsed < 10.0, f"Init took {elapsed:.2f}s"
             assert db.tenant_context is not None
-        finally:
-            db.close()
 
     def test_tenant_context_access_after_init(self, tmp_path):
         """Accessing tenant_context after init is fast."""
         db_path = tmp_path / "tenant_ctx_access.db"
 
-        db = DataFlow(f"sqlite:///{db_path}", multi_tenant=True)
-
-        try:
+        with DataFlow(f"sqlite:///{db_path}", multi_tenant=True) as db:
             start = time.time()
 
             for _ in range(1000):
@@ -206,8 +200,6 @@ class TestDataFlowInitializationPerformance:
             elapsed = time.time() - start
 
             assert elapsed < 10.0, f"1000 accesses took {elapsed:.2f}s"
-        finally:
-            db.close()
 
 
 @pytest.mark.unit

--- a/packages/kailash-dataflow/tests/unit/core/test_architecture_validation.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_architecture_validation.py
@@ -9,6 +9,7 @@ from dataclasses import asdict
 from pathlib import Path
 
 import pytest
+
 from dataflow import DataFlow
 from dataflow.core.config import (
     DatabaseConfig,
@@ -61,24 +62,26 @@ class TestArchitecturalRefactoring:
     def test_dataflow_initialization_patterns(self):
         """Test all supported DataFlow initialization patterns."""
         # Pattern 1: Zero-config (uses defaults)
-        db1 = DataFlow()
-        assert db1.config is not None
-        assert db1.config.database is not None
+        with DataFlow() as db1:
+            assert db1.config is not None
+            assert db1.config.database is not None
 
         # Pattern 2: Direct database URL
-        db2 = DataFlow(database_url="sqlite:///:memory:")
-        assert db2.config.database.url == "sqlite:///:memory:"
+        with DataFlow(database_url="sqlite:///:memory:") as db2:
+            assert db2.config.database.url == "sqlite:///:memory:"
 
         # Pattern 3: Structured configuration
         config = DataFlowConfig(database=DatabaseConfig(url="sqlite:///:memory:"))
-        db3 = DataFlow(config=config)
-        assert db3.config.database.url == "sqlite:///:memory:"
+        with DataFlow(config=config) as db3:
+            assert db3.config.database.url == "sqlite:///:memory:"
 
         # Pattern 4: Mixed parameters
-        db4 = DataFlow(database_url="sqlite:///:memory:", pool_size=15, monitoring=True)
-        assert db4.config.database.url == "sqlite:///:memory:"
-        assert db4.config.database.pool_size == 15
-        assert db4.config.monitoring.enabled is True
+        with DataFlow(
+            database_url="sqlite:///:memory:", pool_size=15, monitoring=True
+        ) as db4:
+            assert db4.config.database.url == "sqlite:///:memory:"
+            assert db4.config.database.pool_size == 15
+            assert db4.config.monitoring.enabled is True
 
     def test_configuration_validation(self):
         """Test that configuration validation works correctly."""
@@ -189,22 +192,22 @@ class TestDocumentationAlignment:
     def test_claude_md_patterns_work(self):
         """Test that patterns shown in CLAUDE.md actually work."""
         # Test the basic pattern from CLAUDE.md
-        db = DataFlow()  # Zero config - creates SQLite automatically
-        assert db.config is not None
+        with DataFlow() as db:  # Zero config - creates SQLite automatically
+            assert db.config is not None
 
         # Test production pattern from CLAUDE.md
-        db_prod = DataFlow(
+        with DataFlow(
             database_url="postgresql://user:pass@localhost/db", pool_size=20
-        )
-        assert db_prod.config.database.url == "postgresql://user:pass@localhost/db"
-        assert db_prod.config.database.pool_size == 20
+        ) as db_prod:
+            assert db_prod.config.database.url == "postgresql://user:pass@localhost/db"
+            assert db_prod.config.database.pool_size == 20
 
     def test_decision_matrix_examples(self):
         """Test that decision matrix examples from docs work."""
         # Test quick prototype pattern
         quick_config = DataFlowConfig(environment=Environment.DEVELOPMENT)
-        db_quick = DataFlow(config=quick_config)
-        assert db_quick.config.environment == Environment.DEVELOPMENT
+        with DataFlow(config=quick_config) as db_quick:
+            assert db_quick.config.environment == Environment.DEVELOPMENT
 
         # Test enterprise pattern
         enterprise_config = DataFlowConfig(
@@ -221,9 +224,9 @@ class TestDocumentationAlignment:
                 alert_on_connection_exhaustion=True,
             ),
         )
-        db_enterprise = DataFlow(config=enterprise_config)
-        assert db_enterprise.config.security.multi_tenant is True
-        assert db_enterprise.config.monitoring.enabled is True
+        with DataFlow(config=enterprise_config) as db_enterprise:
+            assert db_enterprise.config.security.multi_tenant is True
+            assert db_enterprise.config.monitoring.enabled is True
 
 
 class TestRegressionPrevention:
@@ -236,26 +239,27 @@ class TestRegressionPrevention:
             database=DatabaseConfig(url="sqlite:///:memory:", pool_size=10),
             monitoring=MonitoringConfig(enabled=True),
         )
-        db = DataFlow(config=config)
-        assert db.config.database.pool_size == 10
+        with DataFlow(config=config) as db:
+            assert db.config.database.pool_size == 10
 
         # Mixed approach should also work (backward compatibility)
-        db2 = DataFlow(database_url="sqlite:///:memory:", pool_size=15, monitoring=True)
-        assert db2.config.database.pool_size == 15
-        assert db2.config.monitoring.enabled is True
+        with DataFlow(
+            database_url="sqlite:///:memory:", pool_size=15, monitoring=True
+        ) as db2:
+            assert db2.config.database.pool_size == 15
+            assert db2.config.monitoring.enabled is True
 
     def test_configuration_immutability_after_init(self):
         """Test that configuration is properly managed after initialization."""
         config = DataFlowConfig(database=DatabaseConfig(url="sqlite:///:memory:"))
-        db = DataFlow(config=config)
+        with DataFlow(config=config) as db:
+            # Configuration should be accessible
+            assert db.config.database.url == "sqlite:///:memory:"
 
-        # Configuration should be accessible
-        assert db.config.database.url == "sqlite:///:memory:"
-
-        # Modifying original config shouldn't affect initialized instance
-        config.database.pool_size = 999
-        # DataFlow should have its own copy or be unaffected
-        assert db.config.database.pool_size != 999
+            # Modifying original config shouldn't affect initialized instance
+            config.database.pool_size = 999
+            # DataFlow should have its own copy or be unaffected
+            assert db.config.database.pool_size != 999
 
     def test_environment_specific_defaults(self):
         """Test that environment-specific defaults work correctly."""

--- a/packages/kailash-dataflow/tests/unit/core/test_dataflow_2026_001_fixes.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_dataflow_2026_001_fixes.py
@@ -24,7 +24,8 @@ class TestGenericTypeMapping:
         """Create DataFlow instance for type mapping tests."""
         from dataflow import DataFlow
 
-        return DataFlow("sqlite:///:memory:", auto_migrate=False)
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as db:
+            yield db
 
     def test_list_str_maps_to_jsonb_postgresql(self, dataflow):
         """List[str] should map to JSONB in PostgreSQL."""
@@ -107,7 +108,8 @@ class TestDDLDefaultValueHandling:
         """Create DataFlow instance for DDL tests."""
         from dataflow import DataFlow
 
-        return DataFlow("sqlite:///:memory:", auto_migrate=False)
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as db:
+            yield db
 
     def test_empty_list_default_postgresql(self, dataflow):
         """Empty list default should produce valid PostgreSQL DDL."""
@@ -247,7 +249,8 @@ class TestUnknownKwargsValidation:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            _ = DataFlow("sqlite:///:memory:", skip_registry=True, auto_migrate=False)
+            with DataFlow("sqlite:///:memory:", skip_registry=True, auto_migrate=False):
+                pass
 
             # Should have at least one warning
             assert len(w) >= 1
@@ -267,7 +270,10 @@ class TestUnknownKwargsValidation:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            _ = DataFlow("sqlite:///:memory:", skip_migration=True, auto_migrate=False)
+            with DataFlow(
+                "sqlite:///:memory:", skip_migration=True, auto_migrate=False
+            ):
+                pass
 
             df_warnings = [x for x in w if "DF-CFG-001" in str(x.message)]
             assert len(df_warnings) == 1
@@ -283,9 +289,10 @@ class TestUnknownKwargsValidation:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            _ = DataFlow(
+            with DataFlow(
                 "sqlite:///:memory:", connection_pool_size=10, auto_migrate=False
-            )
+            ):
+                pass
 
             df_warnings = [x for x in w if "DF-CFG-001" in str(x.message)]
             assert len(df_warnings) == 1
@@ -301,7 +308,10 @@ class TestUnknownKwargsValidation:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            _ = DataFlow("sqlite:///:memory:", enable_metrics=True, auto_migrate=False)
+            with DataFlow(
+                "sqlite:///:memory:", enable_metrics=True, auto_migrate=False
+            ):
+                pass
 
             df_warnings = [x for x in w if "DF-CFG-001" in str(x.message)]
             assert len(df_warnings) == 1
@@ -317,12 +327,13 @@ class TestUnknownKwargsValidation:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            _ = DataFlow(
+            with DataFlow(
                 "sqlite:///:memory:",
                 my_unknown_param="value",
                 another_unknown=123,
                 auto_migrate=False,
-            )
+            ):
+                pass
 
             df_warnings = [x for x in w if "DF-CFG-001" in str(x.message)]
             assert len(df_warnings) == 1
@@ -339,14 +350,15 @@ class TestUnknownKwargsValidation:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            _ = DataFlow(
+            with DataFlow(
                 "sqlite:///:memory:",
                 batch_size=100,
                 schema_cache_enabled=True,
                 schema_cache_ttl=3600,
                 use_namespaced_nodes=True,
                 auto_migrate=False,
-            )
+            ):
+                pass
 
             # Should not have DF-CFG-001 warnings
             df_warnings = [x for x in w if "DF-CFG-001" in str(x.message)]
@@ -359,13 +371,14 @@ class TestUnknownKwargsValidation:
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
-            _ = DataFlow(
+            with DataFlow(
                 "sqlite:///:memory:",
                 skip_registry=True,
                 skip_migration=True,
                 unknown_param=123,
                 auto_migrate=False,
-            )
+            ):
+                pass
 
             # Should have exactly one DF-CFG-001 warning
             df_warnings = [x for x in w if "DF-CFG-001" in str(x.message)]
@@ -386,7 +399,8 @@ class TestDDLGenerationIntegration:
         """Create DataFlow instance."""
         from dataflow import DataFlow
 
-        return DataFlow("sqlite:///:memory:", auto_migrate=False)
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as db:
+            yield db
 
     def test_model_with_list_field_generates_valid_ddl(self, dataflow):
         """Model with List[str] field should generate valid DDL."""
@@ -446,7 +460,8 @@ class TestEdgeCases:
         """Create DataFlow instance."""
         from dataflow import DataFlow
 
-        return DataFlow("sqlite:///:memory:", auto_migrate=False)
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as db:
+            yield db
 
     def test_deeply_nested_dict_default(self, dataflow):
         """Deeply nested dict default should serialize correctly."""
@@ -505,7 +520,8 @@ class TestSQLEscapingEdgeCases:
         """Create DataFlow instance."""
         from dataflow import DataFlow
 
-        return DataFlow("sqlite:///:memory:", auto_migrate=False)
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as db:
+            yield db
 
     def test_single_quote_in_json_default_is_escaped(self, dataflow):
         """Single quotes in JSON default must be SQL-escaped to prevent syntax errors."""
@@ -628,7 +644,8 @@ class TestFrozenSetTypeMapping:
         """Create DataFlow instance."""
         from dataflow import DataFlow
 
-        return DataFlow("sqlite:///:memory:", auto_migrate=False)
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as db:
+            yield db
 
     def test_frozenset_str_maps_to_jsonb_postgresql(self, dataflow):
         """FrozenSet[str] should map to JSONB in PostgreSQL."""
@@ -660,7 +677,8 @@ class TestComplexTypeScenarios:
         """Create DataFlow instance."""
         from dataflow import DataFlow
 
-        return DataFlow("sqlite:///:memory:", auto_migrate=False)
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as db:
+            yield db
 
     def test_deeply_nested_mixed_types_default(self, dataflow):
         """Complex nested structure with all JSON types should serialize correctly."""

--- a/packages/kailash-dataflow/tests/unit/core/test_fabric_only_mode.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_fabric_only_mode.py
@@ -18,29 +18,29 @@ class TestFabricOnlyDetection:
     """DataFlow._fabric_only property detection."""
 
     def test_no_sources_no_models_is_not_fabric_only(self):
-        db = DataFlow()
-        assert not db._fabric_only
+        with DataFlow() as db:
+            assert not db._fabric_only
 
     def test_sources_no_models_no_url_is_fabric_only(self):
-        db = DataFlow()
-        db._sources["loans"] = {"adapter": None}
-        assert db._fabric_only
+        with DataFlow() as db:
+            db._sources["loans"] = {"adapter": None}
+            assert db._fabric_only
 
     def test_sources_with_models_is_not_fabric_only(self):
-        db = DataFlow()
-        db._sources["loans"] = {"adapter": None}
-        db._models["Loan"] = object()
-        assert not db._fabric_only
+        with DataFlow() as db:
+            db._sources["loans"] = {"adapter": None}
+            db._models["Loan"] = object()
+            assert not db._fabric_only
 
     def test_explicit_database_url_is_not_fabric_only(self):
-        db = DataFlow(database_url="sqlite:///:memory:")
-        db._sources["loans"] = {"adapter": None}
-        assert not db._fabric_only
+        with DataFlow(database_url="sqlite:///:memory:") as db:
+            db._sources["loans"] = {"adapter": None}
+            assert not db._fabric_only
 
     def test_products_without_models_is_fabric_only(self):
-        db = DataFlow()
-        db._products["dashboard"] = object()
-        assert db._fabric_only
+        with DataFlow() as db:
+            db._products["dashboard"] = object()
+            assert db._fabric_only
 
 
 class TestFabricOnlyInitialize:
@@ -49,12 +49,15 @@ class TestFabricOnlyInitialize:
     @pytest.mark.asyncio
     async def test_initialize_returns_true_without_db(self):
         db = DataFlow()
-        db._sources["loans"] = {"adapter": None}
-        result = await db.initialize()
-        assert result is True
+        try:
+            db._sources["loans"] = {"adapter": None}
+            result = await db.initialize()
+            assert result is True
+        finally:
+            await db.close_async()
 
     def test_ensure_connected_skips_db(self):
-        db = DataFlow()
-        db._sources["loans"] = {"adapter": None}
-        db._ensure_connected()
-        assert db._connected is True
+        with DataFlow() as db:
+            db._sources["loans"] = {"adapter": None}
+            db._ensure_connected()
+            assert db._connected is True

--- a/packages/kailash-dataflow/tests/unit/core/test_lazy_connection.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_lazy_connection.py
@@ -20,179 +20,156 @@ class TestLazyConnection:
         from dataflow import DataFlow
 
         # Use a URL that would fail if actually connected to
-        db = DataFlow(
+        with DataFlow(
             "postgresql://nonexistent:password@192.0.2.1:5432/fake_db",
             enable_connection_pooling=False,  # Skip pool entirely for this test
-        )
+        ) as db:
+            # Verify we're in the not-yet-connected state
+            assert db._connected is False
+            assert db._pending_table_creations == []
 
-        # Verify we're in the not-yet-connected state
-        assert db._connected is False
-        assert db._pending_table_creations == []
-
-        # Verify models dict is initialized (metadata structures ready)
-        assert db._models == {}
-        assert db._registered_models == {}
-
-        db.close()
+            # Verify models dict is initialized (metadata structures ready)
+            assert db._models == {}
+            assert db._registered_models == {}
 
     def test_model_decorator_without_connection(self):
         """@db.model should register schema without connecting to database."""
         from dataflow import DataFlow
 
-        db = DataFlow(
+        with DataFlow(
             "postgresql://nonexistent:password@192.0.2.1:5432/fake_db",
             enable_connection_pooling=False,
-        )
+        ) as db:
 
-        @db.model
-        class User:
-            id: str
-            name: str
-            email: str
+            @db.model
+            class User:
+                id: str
+                name: str
+                email: str
 
-        # Model registered in metadata
-        assert "User" in db._models
-        assert "User" in db._registered_models
+            # Model registered in metadata
+            assert "User" in db._models
+            assert "User" in db._registered_models
 
-        # But no connection happened
-        assert db._connected is False
+            # But no connection happened
+            assert db._connected is False
 
-        # Table creation deferred
-        assert "User" in db._pending_table_creations
+            # Table creation deferred
+            assert "User" in db._pending_table_creations
 
-        # Nodes generated (metadata-only, no DB)
-        assert any("User" in key for key in db._nodes)
-
-        db.close()
+            # Nodes generated (metadata-only, no DB)
+            assert any("User" in key for key in db._nodes)
 
     def test_multiple_models_without_connection(self):
         """Multiple @db.model decorators should all work without connecting."""
         from dataflow import DataFlow
 
-        db = DataFlow(
+        with DataFlow(
             "postgresql://nonexistent:password@192.0.2.1:5432/fake_db",
             enable_connection_pooling=False,
-        )
+        ) as db:
 
-        @db.model
-        class Organization:
-            id: str
-            name: str
+            @db.model
+            class Organization:
+                id: str
+                name: str
 
-        @db.model
-        class User:
-            id: str
-            name: str
-            org_id: str
+            @db.model
+            class User:
+                id: str
+                name: str
+                org_id: str
 
-        @db.model
-        class Project:
-            id: str
-            title: str
-            owner_id: str
+            @db.model
+            class Project:
+                id: str
+                title: str
+                owner_id: str
 
-        assert db._connected is False
-        assert len(db._models) == 3
-        assert len(db._pending_table_creations) == 3
+            assert db._connected is False
+            assert len(db._models) == 3
+            assert len(db._pending_table_creations) == 3
 
-        db.close()
-
-    def test_ensure_connected_idempotent(self):
+    def test_ensure_connected_idempotent(self, tmp_path):
         """_ensure_connected() should be idempotent — safe to call multiple times."""
         from dataflow import DataFlow
 
-        # Use SQLite which doesn't require a running server
-        db = DataFlow("sqlite:///test_lazy.db")
+        # Use SQLite which doesn't require a running server.
+        # tmp_path ensures the file is cleaned up by pytest automatically.
+        db_path = tmp_path / "test_lazy.db"
+        with DataFlow(f"sqlite:///{db_path}") as db:
 
-        @db.model
-        class Item:
-            id: str
-            name: str
+            @db.model
+            class Item:
+                id: str
+                name: str
 
-        assert db._connected is False
+            assert db._connected is False
 
-        # First call connects
-        db._ensure_connected()
-        assert db._connected is True
-        assert db._pending_table_creations == []  # Cleared after processing
+            # First call connects
+            db._ensure_connected()
+            assert db._connected is True
+            assert db._pending_table_creations == []  # Cleared after processing
 
-        # Second call is a no-op
-        db._ensure_connected()
-        assert db._connected is True
-
-        db.close()
-
-        # Cleanup
-        import os
-
-        if os.path.exists("test_lazy.db"):
-            os.remove("test_lazy.db")
+            # Second call is a no-op
+            db._ensure_connected()
+            assert db._connected is True
 
     def test_close_without_connecting(self):
         """close() should work even if never connected."""
         from dataflow import DataFlow
 
-        db = DataFlow(
+        with DataFlow(
             "postgresql://nonexistent:password@192.0.2.1:5432/fake_db",
             enable_connection_pooling=False,
-        )
+        ) as db:
 
-        @db.model
-        class User:
-            id: str
-            name: str
+            @db.model
+            class User:
+                id: str
+                name: str
 
-        # Never connected
-        assert db._connected is False
+            # Never connected
+            assert db._connected is False
 
-        # close() should not raise
-        db.close()
+        # __exit__ called close() on a never-connected instance and did not raise.
 
     def test_schema_cache_initialized_without_connection(self):
         """Schema cache (in-memory) should be ready without DB connection."""
         from dataflow import DataFlow
 
-        db = DataFlow(
+        with DataFlow(
             "postgresql://nonexistent:password@192.0.2.1:5432/fake_db",
             enable_connection_pooling=False,
-        )
-
-        # Schema cache is initialized (it's pure in-memory, no DB needed)
-        assert db._schema_cache is not None
-        assert db._connected is False
-
-        db.close()
+        ) as db:
+            # Schema cache is initialized (it's pure in-memory, no DB needed)
+            assert db._schema_cache is not None
+            assert db._connected is False
 
     def test_config_accessible_without_connection(self):
         """Config properties should be accessible without triggering connection."""
         from dataflow import DataFlow
 
-        db = DataFlow(
+        with DataFlow(
             "postgresql://nonexistent:password@192.0.2.1:5432/fake_db",
             enable_connection_pooling=False,
-        )
-
-        # These should all work without connecting
-        assert db.config is not None
-        assert db.config.database is not None
-        assert db._auto_migrate is True
-        assert db.runtime is not None
-        assert db._connected is False
-
-        db.close()
+        ) as db:
+            # These should all work without connecting
+            assert db.config is not None
+            assert db.config.database is not None
+            assert db._auto_migrate is True
+            assert db.runtime is not None
+            assert db._connected is False
 
     def test_pool_stats_without_connection(self):
         """pool_stats() should return zeros without requiring connection."""
         from dataflow import DataFlow
 
-        db = DataFlow(
+        with DataFlow(
             "postgresql://nonexistent:password@192.0.2.1:5432/fake_db",
             enable_connection_pooling=False,
-        )
-
-        # pool_stats should work without connection (returns zeros)
-        stats = db.pool_stats()
-        assert stats is not None
-        assert db._connected is False
-
-        db.close()
+        ) as db:
+            # pool_stats should work without connection (returns zeros)
+            stats = db.pool_stats()
+            assert stats is not None
+            assert db._connected is False

--- a/packages/kailash-dataflow/tests/unit/core/test_pool_defaults.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_pool_defaults.py
@@ -78,40 +78,40 @@ class TestDataFlowInitPoolSize:
         """DataFlow created without pool_size passes None to DatabaseConfig (TODO-00)."""
         from dataflow import DataFlow
 
-        df = DataFlow("sqlite:///:memory:", auto_migrate=False)
-        # The DatabaseConfig should NOT have pool_size=20
-        # If pool_size was explicitly set to 20, get_pool_size would return 20
-        # regardless of environment. We need to check the raw pool_size attribute.
-        db_config = df.config.database
-        # After TODO-00: pool_size should be None (not 20) when user didn't specify it
-        assert db_config.pool_size is None, (
-            f"Expected pool_size=None (user didn't specify), "
-            f"got pool_size={db_config.pool_size}. "
-            f"TODO-00: Remove hardcoded pool_size=20 from DataFlow.__init__"
-        )
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as df:
+            # The DatabaseConfig should NOT have pool_size=20
+            # If pool_size was explicitly set to 20, get_pool_size would return 20
+            # regardless of environment. We need to check the raw pool_size attribute.
+            db_config = df.config.database
+            # After TODO-00: pool_size should be None (not 20) when user didn't specify it
+            assert db_config.pool_size is None, (
+                f"Expected pool_size=None (user didn't specify), "
+                f"got pool_size={db_config.pool_size}. "
+                f"TODO-00: Remove hardcoded pool_size=20 from DataFlow.__init__"
+            )
 
     def test_explicit_pool_size_is_preserved(self):
         """DataFlow created with explicit pool_size preserves it."""
         from dataflow import DataFlow
 
-        df = DataFlow("sqlite:///:memory:", pool_size=42, auto_migrate=False)
-        assert df.config.database.pool_size == 42
+        with DataFlow("sqlite:///:memory:", pool_size=42, auto_migrate=False) as df:
+            assert df.config.database.pool_size == 42
 
     def test_pool_max_overflow_default_is_none(self):
         """pool_max_overflow defaults to None, not 30 (TODO-04a)."""
         from dataflow import DataFlow
 
-        df = DataFlow("sqlite:///:memory:", auto_migrate=False)
-        # After TODO-04a, the max_overflow should come from get_max_overflow(),
-        # not from the hardcoded default of 30
-        db_config = df.config.database
-        # If user didn't set max_overflow, it should be None on the config
-        # (letting get_max_overflow calculate it)
-        assert db_config.max_overflow is None or db_config.max_overflow != 30, (
-            f"Expected max_overflow to not be the old hardcoded 30, "
-            f"got max_overflow={db_config.max_overflow}. "
-            f"TODO-04a: Make pool_max_overflow Optional[int] = None"
-        )
+        with DataFlow("sqlite:///:memory:", auto_migrate=False) as df:
+            # After TODO-04a, the max_overflow should come from get_max_overflow(),
+            # not from the hardcoded default of 30
+            db_config = df.config.database
+            # If user didn't set max_overflow, it should be None on the config
+            # (letting get_max_overflow calculate it)
+            assert db_config.max_overflow is None or db_config.max_overflow != 30, (
+                f"Expected max_overflow to not be the old hardcoded 30, "
+                f"got max_overflow={db_config.max_overflow}. "
+                f"TODO-04a: Make pool_max_overflow Optional[int] = None"
+            )
 
 
 class TestDataFlowConfigConnectionPoolSize:
@@ -187,12 +187,12 @@ class TestDatabaseAdapterDefaults:
 
     def test_adapter_pool_size_accepts_none(self):
         """DatabaseAdapter should accept None for pool_size (TODO-03)."""
-        from dataflow.adapters.base import DatabaseAdapter
-
         # DatabaseAdapter is abstract, but we can check kwargs handling
         # by instantiating a concrete subclass or checking the code
         import ast
         import inspect
+
+        from dataflow.adapters.base import DatabaseAdapter
 
         source = inspect.getsource(DatabaseAdapter.__init__)
         # The source should contain kwargs.get("pool_size") without a default of 10

--- a/packages/kailash-dataflow/tests/unit/core/test_pool_stats_provider.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_pool_stats_provider.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -20,18 +21,22 @@ import pytest
 
 from dataflow.core.pool_monitor import pool_stats_dict
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
+@contextmanager
 def _make_dataflow(url: str = "sqlite:///:memory:", **kwargs):
     """Create a minimal DataFlow instance for unit tests.
 
     Uses auto_migrate=False and startup_validation=False to avoid
     side-effects.  Connection pooling is disabled by default so that
     the DataFlow constructor does not attempt real pool creation.
+
+    Yields the DataFlow inside a context manager so the underlying
+    aiosqlite connection / pool resources are released at scope exit
+    (issue #1002 — Tier-1 inline-construction migration).
     """
     from dataflow import DataFlow
 
@@ -41,7 +46,8 @@ def _make_dataflow(url: str = "sqlite:///:memory:", **kwargs):
         "enable_connection_pooling": False,
     }
     defaults.update(kwargs)
-    return DataFlow(url, **defaults)
+    with DataFlow(url, **defaults) as df:
+        yield df
 
 
 # ===========================================================================
@@ -59,19 +65,19 @@ class TestMakePoolStatsProvider:
     def test_provider_returns_zeros_when_no_pool(self):
         """When _shared_pools is empty, provider returns pool_stats_dict with
         the configured max_size/max_overflow and active=0, idle=0."""
-        df = _make_dataflow()
-        provider = df._make_pool_stats_provider(pool_size=8, max_overflow=4)
+        with _make_dataflow() as df:
+            provider = df._make_pool_stats_provider(pool_size=8, max_overflow=4)
 
-        with patch(
-            "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools", {}
-        ):
-            stats = provider()
+            with patch(
+                "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools", {}
+            ):
+                stats = provider()
 
-        assert stats["active"] == 0
-        assert stats["idle"] == 0
-        assert stats["max"] == 8
-        assert stats["max_overflow"] == 4
-        assert stats["utilization"] == 0.0
+            assert stats["active"] == 0
+            assert stats["idle"] == 0
+            assert stats["max"] == 8
+            assert stats["max_overflow"] == 4
+            assert stats["utilization"] == 0.0
 
     # -----------------------------------------------------------------------
     # 2. asyncpg pool (PostgreSQL)
@@ -81,28 +87,30 @@ class TestMakePoolStatsProvider:
         """Mock an adapter in _shared_pools with an asyncpg-style
         connection_pool (get_size / get_idle_size).  Verify active and
         idle are computed correctly."""
-        df = _make_dataflow(url="postgresql://user:pass@localhost/testdb")
-        provider = df._make_pool_stats_provider(pool_size=10, max_overflow=5)
+        with _make_dataflow(url="postgresql://user:pass@localhost/testdb") as df:
+            provider = df._make_pool_stats_provider(pool_size=10, max_overflow=5)
 
-        mock_pool = MagicMock()
-        mock_pool.get_size.return_value = 8
-        mock_pool.get_idle_size.return_value = 3
+            mock_pool = MagicMock()
+            mock_pool.get_size.return_value = 8
+            mock_pool.get_idle_size.return_value = 3
 
-        mock_adapter = MagicMock()
-        mock_adapter.connection_pool = mock_pool
+            mock_adapter = MagicMock()
+            mock_adapter.connection_pool = mock_pool
 
-        shared_pools = {"postgresql://user:pass@localhost/testdb": (mock_adapter, 1)}
+            shared_pools = {
+                "postgresql://user:pass@localhost/testdb": (mock_adapter, 1)
+            }
 
-        with patch(
-            "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
-            shared_pools,
-        ):
-            stats = provider()
+            with patch(
+                "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
+                shared_pools,
+            ):
+                stats = provider()
 
-        assert stats["active"] == 5  # 8 - 3
-        assert stats["idle"] == 3
-        assert stats["max"] == 10
-        assert stats["max_overflow"] == 5
+            assert stats["active"] == 5  # 8 - 3
+            assert stats["idle"] == 3
+            assert stats["max"] == 10
+            assert stats["max_overflow"] == 5
 
     # -----------------------------------------------------------------------
     # 3. SQLAlchemy QueuePool
@@ -111,37 +119,39 @@ class TestMakePoolStatsProvider:
     def test_provider_reads_sqlalchemy_queuepool(self):
         """Mock an adapter with a SQLAlchemy QueuePool-style object that
         has checkedout/checkedin/size/overflow methods."""
-        df = _make_dataflow(url="postgresql://user:pass@localhost/testdb")
-        provider = df._make_pool_stats_provider(pool_size=20, max_overflow=10)
+        with _make_dataflow(url="postgresql://user:pass@localhost/testdb") as df:
+            provider = df._make_pool_stats_provider(pool_size=20, max_overflow=10)
 
-        mock_pool = MagicMock(spec=[])  # no spec — we add attrs explicitly
-        mock_pool.checkedout = MagicMock(return_value=7)
-        mock_pool.checkedin = MagicMock(return_value=13)
-        mock_pool.size = MagicMock(return_value=20)
-        mock_pool.overflow = MagicMock(return_value=2)
-        mock_pool._max_overflow = 10
+            mock_pool = MagicMock(spec=[])  # no spec — we add attrs explicitly
+            mock_pool.checkedout = MagicMock(return_value=7)
+            mock_pool.checkedin = MagicMock(return_value=13)
+            mock_pool.size = MagicMock(return_value=20)
+            mock_pool.overflow = MagicMock(return_value=2)
+            mock_pool._max_overflow = 10
 
-        # Remove asyncpg-style attributes so the SQLAlchemy branch is chosen
-        # (QueuePool has checkedout/checkedin but NOT get_size/get_idle_size)
-        assert not hasattr(mock_pool, "get_size")
-        assert not hasattr(mock_pool, "get_idle_size")
+            # Remove asyncpg-style attributes so the SQLAlchemy branch is chosen
+            # (QueuePool has checkedout/checkedin but NOT get_size/get_idle_size)
+            assert not hasattr(mock_pool, "get_size")
+            assert not hasattr(mock_pool, "get_idle_size")
 
-        mock_adapter = MagicMock(spec=[])
-        mock_adapter.connection_pool = mock_pool
+            mock_adapter = MagicMock(spec=[])
+            mock_adapter.connection_pool = mock_pool
 
-        shared_pools = {"postgresql://user:pass@localhost/testdb": (mock_adapter, 1)}
+            shared_pools = {
+                "postgresql://user:pass@localhost/testdb": (mock_adapter, 1)
+            }
 
-        with patch(
-            "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
-            shared_pools,
-        ):
-            stats = provider()
+            with patch(
+                "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
+                shared_pools,
+            ):
+                stats = provider()
 
-        assert stats["active"] == 7
-        assert stats["idle"] == 13
-        assert stats["max"] == 20
-        assert stats["overflow"] == 2
-        assert stats["max_overflow"] == 10
+            assert stats["active"] == 7
+            assert stats["idle"] == 13
+            assert stats["max"] == 20
+            assert stats["overflow"] == 2
+            assert stats["max_overflow"] == 10
 
     # -----------------------------------------------------------------------
     # 4. SQLite adapter with _pool_stats
@@ -155,31 +165,31 @@ class TestMakePoolStatsProvider:
         to be truthy before it reaches the _pool_stats branch.  For SQLite
         adapters, _pool is typically the aiosqlite connection object (truthy)
         but lacks asyncpg/QueuePool methods."""
-        df = _make_dataflow(url="sqlite:///test.db")
-        provider = df._make_pool_stats_provider(pool_size=5, max_overflow=2)
+        with _make_dataflow(url="sqlite:///test.db") as df:
+            provider = df._make_pool_stats_provider(pool_size=5, max_overflow=2)
 
-        pool_stats_obj = SimpleNamespace(active_connections=2, idle_connections=3)
+            pool_stats_obj = SimpleNamespace(active_connections=2, idle_connections=3)
 
-        # The pool object must be truthy but must NOT have asyncpg
-        # (get_size/get_idle_size) or SQLAlchemy (checkedout/checkedin) attrs.
-        sqlite_pool = SimpleNamespace()  # bare object, no special methods
-        mock_adapter = MagicMock(spec=[])
-        mock_adapter._pool_stats = pool_stats_obj
-        mock_adapter.connection_pool = None
-        mock_adapter._pool = sqlite_pool  # truthy, no asyncpg/QueuePool methods
+            # The pool object must be truthy but must NOT have asyncpg
+            # (get_size/get_idle_size) or SQLAlchemy (checkedout/checkedin) attrs.
+            sqlite_pool = SimpleNamespace()  # bare object, no special methods
+            mock_adapter = MagicMock(spec=[])
+            mock_adapter._pool_stats = pool_stats_obj
+            mock_adapter.connection_pool = None
+            mock_adapter._pool = sqlite_pool  # truthy, no asyncpg/QueuePool methods
 
-        shared_pools = {"sqlite:///test.db": (mock_adapter, 1)}
+            shared_pools = {"sqlite:///test.db": (mock_adapter, 1)}
 
-        with patch(
-            "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
-            shared_pools,
-        ):
-            stats = provider()
+            with patch(
+                "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
+                shared_pools,
+            ):
+                stats = provider()
 
-        assert stats["active"] == 2
-        assert stats["idle"] == 3
-        assert stats["max"] == 5
-        assert stats["max_overflow"] == 2
+            assert stats["active"] == 2
+            assert stats["idle"] == 3
+            assert stats["max"] == 5
+            assert stats["max_overflow"] == 2
 
     # -----------------------------------------------------------------------
     # 5. Scoped to database URL
@@ -188,30 +198,30 @@ class TestMakePoolStatsProvider:
     def test_provider_scoped_to_database_url(self):
         """When _shared_pools has pools for multiple URLs, the provider
         only reads the one matching the DataFlow's URL."""
-        df = _make_dataflow(url="postgresql://user:pass@localhost/mydb")
-        provider = df._make_pool_stats_provider(pool_size=10, max_overflow=5)
+        with _make_dataflow(url="postgresql://user:pass@localhost/mydb") as df:
+            provider = df._make_pool_stats_provider(pool_size=10, max_overflow=5)
 
-        # Pool for a *different* URL
-        other_pool = MagicMock()
-        other_pool.get_size.return_value = 99
-        other_pool.get_idle_size.return_value = 1
-        other_adapter = MagicMock()
-        other_adapter.connection_pool = other_pool
+            # Pool for a *different* URL
+            other_pool = MagicMock()
+            other_pool.get_size.return_value = 99
+            other_pool.get_idle_size.return_value = 1
+            other_adapter = MagicMock()
+            other_adapter.connection_pool = other_pool
 
-        shared_pools = {
-            "postgresql://user:pass@other-host/otherdb": (other_adapter, 1),
-        }
+            shared_pools = {
+                "postgresql://user:pass@other-host/otherdb": (other_adapter, 1),
+            }
 
-        with patch(
-            "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
-            shared_pools,
-        ):
-            stats = provider()
+            with patch(
+                "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
+                shared_pools,
+            ):
+                stats = provider()
 
-        # Should NOT have read from the other pool — falls through to zeros
-        assert stats["active"] == 0
-        assert stats["idle"] == 0
-        assert stats["max"] == 10
+            # Should NOT have read from the other pool — falls through to zeros
+            assert stats["active"] == 0
+            assert stats["idle"] == 0
+            assert stats["max"] == 10
 
     # -----------------------------------------------------------------------
     # 6. Exception handling
@@ -220,24 +230,24 @@ class TestMakePoolStatsProvider:
     def test_provider_handles_exception_gracefully(self):
         """When accessing pool stats raises an exception, the provider
         returns the fallback zeros dict rather than propagating."""
-        df = _make_dataflow(url="postgresql://user:pass@localhost/testdb")
-        provider = df._make_pool_stats_provider(pool_size=10, max_overflow=5)
+        with _make_dataflow(url="postgresql://user:pass@localhost/testdb") as df:
+            provider = df._make_pool_stats_provider(pool_size=10, max_overflow=5)
 
-        # Patch _shared_pools.items() to raise during iteration
-        mock_pools = MagicMock()
-        mock_pools.items.side_effect = RuntimeError("simulated concurrent mutation")
+            # Patch _shared_pools.items() to raise during iteration
+            mock_pools = MagicMock()
+            mock_pools.items.side_effect = RuntimeError("simulated concurrent mutation")
 
-        with patch(
-            "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
-            mock_pools,
-        ):
-            stats = provider()
+            with patch(
+                "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
+                mock_pools,
+            ):
+                stats = provider()
 
-        # Fallback: zeros with configured sizes
-        assert stats["active"] == 0
-        assert stats["idle"] == 0
-        assert stats["max"] == 10
-        assert stats["max_overflow"] == 5
+            # Fallback: zeros with configured sizes
+            assert stats["active"] == 0
+            assert stats["idle"] == 0
+            assert stats["max"] == 10
+            assert stats["max_overflow"] == 5
 
     # -----------------------------------------------------------------------
     # 7. Snapshot via list() prevents RuntimeError
@@ -247,41 +257,41 @@ class TestMakePoolStatsProvider:
         """Verify that the provider calls list() on .items() to snapshot
         the dict.  A dict that mutates during bare iteration would raise
         RuntimeError, but snapshot with list() prevents that."""
-        df = _make_dataflow(url="sqlite:///:memory:")
-        provider = df._make_pool_stats_provider(pool_size=5, max_overflow=2)
+        with _make_dataflow(url="sqlite:///:memory:") as df:
+            provider = df._make_pool_stats_provider(pool_size=5, max_overflow=2)
 
-        # Create a real dict so list(dict.items()) works, but .items()
-        # returning a view that is mutated during iteration would fail.
-        # We verify correctness indirectly: if the provider did NOT
-        # snapshot, iterating the view during mutation would raise.
+            # Create a real dict so list(dict.items()) works, but .items()
+            # returning a view that is mutated during iteration would fail.
+            # We verify correctness indirectly: if the provider did NOT
+            # snapshot, iterating the view during mutation would raise.
 
-        call_count = 0
-        real_dict = {}
+            call_count = 0
+            real_dict = {}
 
-        class MutatingDict(dict):
-            """Dict whose items() returns a view that will be mutated
-            during iteration — list() of items prevents the error."""
+            class MutatingDict(dict):
+                """Dict whose items() returns a view that will be mutated
+                during iteration — list() of items prevents the error."""
 
-            def items(self):
-                # Return a snapshot via the real dict. If the code under
-                # test called list() on this, iteration is safe.
-                nonlocal call_count
-                call_count += 1
-                return super().items()
+                def items(self):
+                    # Return a snapshot via the real dict. If the code under
+                    # test called list() on this, iteration is safe.
+                    nonlocal call_count
+                    call_count += 1
+                    return super().items()
 
-        shared = MutatingDict()
+            shared = MutatingDict()
 
-        with patch(
-            "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
-            shared,
-        ):
-            stats = provider()
+            with patch(
+                "kailash.nodes.data.async_sql.AsyncSQLDatabaseNode._shared_pools",
+                shared,
+            ):
+                stats = provider()
 
-        # items() was called (the provider accessed it)
-        assert call_count >= 1
-        # Should still return valid fallback stats
-        assert stats["active"] == 0
-        assert stats["max"] == 5
+            # items() was called (the provider accessed it)
+            assert call_count >= 1
+            # Should still return valid fallback stats
+            assert stats["active"] == 0
+            assert stats["max"] == 5
 
 
 # ===========================================================================
@@ -296,42 +306,40 @@ class TestHealthCheckPoolIntegration:
     def test_health_check_includes_pool_stats(self):
         """When _pool_monitor is set and returns stats, health_check
         includes a 'pool' key in the response."""
-        df = _make_dataflow()
+        with _make_dataflow() as df:
+            mock_monitor = MagicMock()
+            mock_monitor.get_stats.return_value = pool_stats_dict(
+                active=3, idle=7, max_size=10
+            )
+            df._pool_monitor = mock_monitor
 
-        mock_monitor = MagicMock()
-        mock_monitor.get_stats.return_value = pool_stats_dict(
-            active=3, idle=7, max_size=10
-        )
-        df._pool_monitor = mock_monitor
-
-        result = df.health_check()
-        assert "pool" in result
-        assert result["pool"]["active"] == 3
-        assert result["pool"]["idle"] == 7
+            result = df.health_check()
+            assert "pool" in result
+            assert result["pool"]["active"] == 3
+            assert result["pool"]["idle"] == 7
 
     def test_health_check_degraded_at_95_percent(self):
         """When pool utilization >= 0.95, health_check status becomes
         'degraded'."""
-        df = _make_dataflow()
+        with _make_dataflow() as df:
+            mock_monitor = MagicMock()
+            mock_monitor.get_stats.return_value = pool_stats_dict(
+                active=19, idle=1, max_size=20
+            )
+            df._pool_monitor = mock_monitor
 
-        mock_monitor = MagicMock()
-        mock_monitor.get_stats.return_value = pool_stats_dict(
-            active=19, idle=1, max_size=20
-        )
-        df._pool_monitor = mock_monitor
-
-        result = df.health_check()
-        assert result["status"] == "degraded"
-        assert result["components"]["pool"] == "exhaustion_imminent"
+            result = df.health_check()
+            assert result["status"] == "degraded"
+            assert result["components"]["pool"] == "exhaustion_imminent"
 
     def test_health_check_ok_without_monitor(self):
         """When _pool_monitor is None, the response does not contain
         a 'pool' key."""
-        df = _make_dataflow()
-        assert df._pool_monitor is None
+        with _make_dataflow() as df:
+            assert df._pool_monitor is None
 
-        result = df.health_check()
-        assert "pool" not in result
+            result = df.health_check()
+            assert "pool" not in result
 
 
 # ===========================================================================
@@ -345,27 +353,26 @@ class TestPoolStatsPublicAPI:
     def test_pool_stats_with_monitor(self):
         """pool_stats() delegates to _pool_monitor.get_stats() when the
         monitor is present."""
-        df = _make_dataflow()
+        with _make_dataflow() as df:
+            expected = pool_stats_dict(active=4, idle=6, max_size=10)
+            mock_monitor = MagicMock()
+            mock_monitor.get_stats.return_value = expected
+            df._pool_monitor = mock_monitor
 
-        expected = pool_stats_dict(active=4, idle=6, max_size=10)
-        mock_monitor = MagicMock()
-        mock_monitor.get_stats.return_value = expected
-        df._pool_monitor = mock_monitor
-
-        result = df.pool_stats()
-        assert result == expected
-        mock_monitor.get_stats.assert_called_once()
+            result = df.pool_stats()
+            assert result == expected
+            mock_monitor.get_stats.assert_called_once()
 
     def test_pool_stats_without_monitor(self):
         """pool_stats() returns zeros when no monitor is configured."""
-        df = _make_dataflow()
-        assert df._pool_monitor is None
+        with _make_dataflow() as df:
+            assert df._pool_monitor is None
 
-        result = df.pool_stats()
-        assert result["active"] == 0
-        assert result["idle"] == 0
-        assert result["max"] == 0
-        assert result["utilization"] == 0.0
+            result = df.pool_stats()
+            assert result["active"] == 0
+            assert result["idle"] == 0
+            assert result["max"] == 0
+            assert result["utilization"] == 0.0
 
 
 class TestExecuteRawLightweight:
@@ -374,8 +381,8 @@ class TestExecuteRawLightweight:
     @pytest.mark.asyncio
     async def test_execute_raw_lightweight_not_configured(self):
         """Raises RuntimeError when _lightweight_pool is None."""
-        df = _make_dataflow()
-        assert df._lightweight_pool is None
+        with _make_dataflow() as df:
+            assert df._lightweight_pool is None
 
-        with pytest.raises(RuntimeError, match="Lightweight pool not configured"):
-            await df.execute_raw_lightweight("SELECT 1")
+            with pytest.raises(RuntimeError, match="Lightweight pool not configured"):
+                await df.execute_raw_lightweight("SELECT 1")

--- a/packages/kailash-dataflow/tests/unit/core/test_table_name_pluralization.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_table_name_pluralization.py
@@ -24,7 +24,8 @@ class TestTableNamePluralization:
     @pytest.fixture
     def db(self):
         """Create a DataFlow instance for testing."""
-        return DataFlow(":memory:", test_mode=True, auto_migrate=False)
+        with DataFlow(":memory:", test_mode=True, auto_migrate=False) as db:
+            yield db
 
     # ============================================================
     # Standard pluralization (add 's')
@@ -56,9 +57,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     # ============================================================
     # Words ending in 'y' preceded by consonant -> 'ies'
@@ -128,9 +129,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     def test_vowel_y_pluralization(self, db):
         """Test words ending in 'y' preceded by a vowel -> just add 's'."""
@@ -151,9 +152,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     # ============================================================
     # Words ending in 's', 'x', 'z', 'ch', 'sh' -> add 'es'
@@ -207,9 +208,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     # ============================================================
     # Irregular plurals
@@ -243,9 +244,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     def test_latin_greek_irregular_plurals(self, db):
         """Test Latin/Greek origin irregular plurals."""
@@ -283,9 +284,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     def test_unchanged_plurals(self, db):
         """Test words that don't change between singular and plural."""
@@ -314,9 +315,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     def test_uncountable_nouns(self, db):
         """Test uncountable nouns that stay singular."""
@@ -339,9 +340,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     # ============================================================
     # CamelCase to snake_case conversion
@@ -365,9 +366,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     def test_acronyms_in_names(self, db):
         """Test handling of acronyms in class names."""
@@ -382,9 +383,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     # ============================================================
     # Compound words with underscores
@@ -407,9 +408,9 @@ class TestTableNamePluralization:
         ]
         for word, expected in test_cases:
             result = db._pluralize(word)
-            assert result == expected, (
-                f"_pluralize('{word}') -> '{result}', expected '{expected}'"
-            )
+            assert (
+                result == expected
+            ), f"_pluralize('{word}') -> '{result}', expected '{expected}'"
 
     # ============================================================
     # -o endings
@@ -440,9 +441,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
     # ============================================================
     # Real-world model name examples
@@ -520,9 +521,9 @@ class TestTableNamePluralization:
         ]
         for model_name, expected_table in test_cases:
             result = db._class_name_to_table_name(model_name)
-            assert result == expected_table, (
-                f"{model_name} -> {result}, expected {expected_table}"
-            )
+            assert (
+                result == expected_table
+            ), f"{model_name} -> {result}, expected {expected_table}"
 
 
 class TestPluralizationRegression:
@@ -531,7 +532,8 @@ class TestPluralizationRegression:
     @pytest.fixture
     def db(self):
         """Create a DataFlow instance for testing."""
-        return DataFlow(":memory:", test_mode=True, auto_migrate=False)
+        with DataFlow(":memory:", test_mode=True, auto_migrate=False) as db:
+            yield db
 
     def test_summary_not_summarys(self, db):
         """Verify Summary -> summaries, not summarys (the original bug)."""
@@ -542,9 +544,9 @@ class TestPluralizationRegression:
     def test_category_not_categorys(self, db):
         """Verify Category -> categories, not categorys."""
         result = db._class_name_to_table_name("Category")
-        assert result == "categories", (
-            f"Category should be 'categories', got '{result}'"
-        )
+        assert (
+            result == "categories"
+        ), f"Category should be 'categories', got '{result}'"
         assert result != "categorys", "Category should NOT be 'categorys'"
 
     def test_entity_not_entitys(self, db):
@@ -614,7 +616,7 @@ class TestPluralizationRegression:
 
         for model_name, correct, incorrect in known_issues:
             result = db._class_name_to_table_name(model_name)
-            assert result == correct, (
-                f"{model_name} should be '{correct}', got '{result}'"
-            )
+            assert (
+                result == correct
+            ), f"{model_name} should be '{correct}', got '{result}'"
             assert result != incorrect, f"{model_name} should NOT be '{incorrect}'"

--- a/packages/kailash-dataflow/tests/unit/performance/test_simple_coverage_boost.py
+++ b/packages/kailash-dataflow/tests/unit/performance/test_simple_coverage_boost.py
@@ -11,177 +11,145 @@ from dataflow import DataFlow
 from dataflow.core.config import DataFlowConfig
 
 
+def _test_db_url() -> str:
+    """Resolve the test PostgreSQL URL for the coverage suite."""
+    import os
+
+    return os.getenv(
+        "TEST_DATABASE_URL",
+        "postgresql://test_user:test_password@localhost:5434/kailash_test",
+    )
+
+
 class TestDataFlowCoreEngineCoverage:
     """Simple tests for core engine methods that definitely exist."""
 
     def test_dataflow_initialization_variations(self):
         """Test various DataFlow initialization patterns."""
-        import os
-
-        db_url = os.getenv(
-            "TEST_DATABASE_URL",
-            "postgresql://test_user:test_password@localhost:5434/kailash_test",
-        )
+        db_url = _test_db_url()
 
         # Basic initialization
-        db1 = DataFlow(db_url, existing_schema_mode=True)
-        assert db1 is not None
+        with DataFlow(db_url, existing_schema_mode=True) as db1:
+            assert db1 is not None
 
         # With configuration parameters
-        db2 = DataFlow(
+        with DataFlow(
             db_url,
             existing_schema_mode=True,
             auto_migrate=False,
             monitoring=True,
             debug=False,
-        )
-        assert db2 is not None
+        ) as db2:
+            assert db2 is not None
 
         # With enterprise features
-        db3 = DataFlow(
-            db_url, existing_schema_mode=True, multi_tenant=False, cache_enabled=True
-        )
-        assert db3 is not None
+        with DataFlow(
+            db_url,
+            existing_schema_mode=True,
+            multi_tenant=False,
+            cache_enabled=True,
+        ) as db3:
+            assert db3 is not None
 
     def test_model_management_methods(self):
         """Test model management methods that exist."""
-        import os
+        with DataFlow(_test_db_url(), existing_schema_mode=True) as db:
 
-        db_url = os.getenv(
-            "TEST_DATABASE_URL",
-            "postgresql://test_user:test_password@localhost:5434/kailash_test",
-        )
-        db = DataFlow(db_url, existing_schema_mode=True)
+            # Test initial state
+            models = db.get_models()
+            assert isinstance(models, dict)
+            assert len(models) == 0
 
-        # Test initial state
-        models = db.get_models()
-        assert isinstance(models, dict)
-        assert len(models) == 0
+            model_names = db.list_models()
+            assert isinstance(model_names, list)
+            assert len(model_names) == 0
 
-        model_names = db.list_models()
-        assert isinstance(model_names, list)
-        assert len(model_names) == 0
+            # Register a model
+            @db.model
+            class TestUser:
+                name: str
+                email: str
+                active: bool = True
 
-        # Register a model
-        @db.model
-        class TestUser:
-            name: str
-            email: str
-            active: bool = True
+            # Check registration worked
+            models = db.get_models()
+            assert "TestUser" in models
+            assert models["TestUser"] == TestUser
 
-        # Check registration worked
-        models = db.get_models()
-        assert "TestUser" in models
-        assert models["TestUser"] == TestUser
+            model_names = db.list_models()
+            assert "TestUser" in model_names
 
-        model_names = db.list_models()
-        assert "TestUser" in model_names
-
-        # Test model info
-        info = db.get_model_info("TestUser")
-        assert info is not None
-        assert isinstance(info, dict)
+            # Test model info
+            info = db.get_model_info("TestUser")
+            assert info is not None
+            assert isinstance(info, dict)
 
     def test_enterprise_feature_properties(self):
         """Test that enterprise feature properties exist and are accessible."""
-        import os
+        with DataFlow(_test_db_url(), existing_schema_mode=True) as db:
+            # These should exist and not be None
+            assert db.bulk is not None
+            assert db.transactions is not None
+            assert db.connection is not None
 
-        db_url = os.getenv(
-            "TEST_DATABASE_URL",
-            "postgresql://test_user:test_password@localhost:5434/kailash_test",
-        )
-        db = DataFlow(db_url, existing_schema_mode=True)
-
-        # These should exist and not be None
-        assert db.bulk is not None
-        assert db.transactions is not None
-        assert db.connection is not None
-
-        # Test that they have expected types
-        assert hasattr(db.bulk, "__class__")
-        assert hasattr(db.transactions, "__class__")
-        assert hasattr(db.connection, "__class__")
+            # Test that they have expected types
+            assert hasattr(db.bulk, "__class__")
+            assert hasattr(db.transactions, "__class__")
+            assert hasattr(db.connection, "__class__")
 
     def test_configuration_access(self):
         """Test configuration object access."""
-        import os
-
-        db_url = os.getenv(
-            "TEST_DATABASE_URL",
-            "postgresql://test_user:test_password@localhost:5434/kailash_test",
-        )
-        db = DataFlow(db_url, existing_schema_mode=True)
-
-        assert db.config is not None
-        assert hasattr(db.config, "database")
-        assert db.config.database is not None
+        with DataFlow(_test_db_url(), existing_schema_mode=True) as db:
+            assert db.config is not None
+            assert hasattr(db.config, "database")
+            assert db.config.database is not None
 
     def test_model_decorator_with_different_types(self):
         """Test model decorator with various field types."""
-        import os
+        with DataFlow(_test_db_url(), existing_schema_mode=True) as db:
 
-        db_url = os.getenv(
-            "TEST_DATABASE_URL",
-            "postgresql://test_user:test_password@localhost:5434/kailash_test",
-        )
-        db = DataFlow(db_url, existing_schema_mode=True)
+            @db.model
+            class TypeTestModel:
+                id: int
+                name: str
+                price: float
+                active: bool
+                created_at: object  # Generic type
 
-        @db.model
-        class TypeTestModel:
-            id: int
-            name: str
-            price: float
-            active: bool
-            created_at: object  # Generic type
+            # Should be registered
+            assert "TypeTestModel" in db.get_models()
 
-        # Should be registered
-        assert "TypeTestModel" in db.get_models()
-
-        # Should have model info
-        info = db.get_model_info("TypeTestModel")
-        assert info is not None
+            # Should have model info
+            info = db.get_model_info("TypeTestModel")
+            assert info is not None
 
     def test_schema_discovery_method_exists(self):
         """Test that schema discovery method exists (even if it fails)."""
-        import os
+        with DataFlow(_test_db_url(), existing_schema_mode=True) as db:
+            # Method should exist
+            assert callable(db.discover_schema)
 
-        db_url = os.getenv(
-            "TEST_DATABASE_URL",
-            "postgresql://test_user:test_password@localhost:5434/kailash_test",
-        )
-        db = DataFlow(db_url, existing_schema_mode=True)
-
-        # Method should exist
-        assert callable(db.discover_schema)
-
-        # Calling it may fail due to no real DB, but method should exist
-        try:
-            schema = db.discover_schema()
-            assert isinstance(schema, dict)
-        except Exception:
-            # Expected - no real database connection
-            pass
+            # Calling it may fail due to no real DB, but method should exist
+            try:
+                schema = db.discover_schema()
+                assert isinstance(schema, dict)
+            except Exception:
+                # Expected - no real database connection
+                pass
 
     def test_register_schema_as_models_method_exists(self):
         """Test that dynamic model registration method exists."""
-        import os
+        with DataFlow(_test_db_url(), existing_schema_mode=True) as db:
+            # Method should exist
+            assert callable(db.register_schema_as_models)
 
-        db_url = os.getenv(
-            "TEST_DATABASE_URL",
-            "postgresql://test_user:test_password@localhost:5434/kailash_test",
-        )
-        db = DataFlow(db_url, existing_schema_mode=True)
-
-        # Method should exist
-        assert callable(db.register_schema_as_models)
-
-        # Calling it may fail due to no real DB, but method should exist
-        try:
-            result = db.register_schema_as_models()
-            assert isinstance(result, dict)
-        except Exception:
-            # Expected - no real database connection
-            pass
+            # Calling it may fail due to no real DB, but method should exist
+            try:
+                result = db.register_schema_as_models()
+                assert isinstance(result, dict)
+            except Exception:
+                # Expected - no real database connection
+                pass
 
 
 class TestMultiTenancyModuleBasic:
@@ -207,13 +175,7 @@ class TestMultiTenancyModuleBasic:
             assert config is not None
             assert config.tenant_id == "test-tenant"
 
-            import os
-
-            db_url = os.getenv(
-                "TEST_DATABASE_URL",
-                "postgresql://test_user:test_password@localhost:5434/kailash_test",
-            )
-            manager = TenantManager(db_url)
+            manager = TenantManager(_test_db_url())
             assert manager is not None
 
             registry = TenantRegistry()
@@ -322,16 +284,9 @@ class TestAutoMigrationSystemBasic:
     def test_auto_migration_system_import(self):
         """Test auto-migration system import and basic functionality."""
         try:
-            # Test creation with connection string
-            import os
-
             from dataflow.migrations.auto_migration_system import AutoMigrationSystem
 
-            db_url = os.getenv(
-                "TEST_DATABASE_URL",
-                "postgresql://test_user:test_password@localhost:5434/kailash_test",
-            )
-            migration_system = AutoMigrationSystem(db_url)
+            migration_system = AutoMigrationSystem(_test_db_url())
             assert migration_system is not None
 
             # Check for expected methods that actually exist

--- a/packages/kailash-dataflow/tests/unit/templates/test_saas_starter_auth.py
+++ b/packages/kailash-dataflow/tests/unit/templates/test_saas_starter_auth.py
@@ -108,23 +108,28 @@ class TestSaaSDataModels:
 
     @pytest.fixture
     def saas_dataflow(self, test_database_url):
-        """Create DataFlow with SaaS models."""
-        db = DataFlow(
+        """Create DataFlow with SaaS models.
+
+        NOTE: Whole file is `pytest.mark.skip`-ped (see pytestmark above);
+        this fixture never executes. Migrated to yield+close for hygiene
+        per issue #1002.
+        """
+        with DataFlow(
             test_database_url,
             auto_migrate=False,
             migration_enabled=False,
             cache_enabled=False,
-        )
+        ) as db:
 
-        # Import models from template
-        from saas_starter.models import register_models
+            # Import models from template
+            from saas_starter.models import register_models
 
-        register_models(db)
+            register_models(db)
 
-        # Explicitly create tables for SQLite file database
-        db.create_tables(database_type="sqlite")
+            # Explicitly create tables for SQLite file database
+            db.create_tables(database_type="sqlite")
 
-        return db
+            yield db
 
     def test_organization_model_structure(self, saas_dataflow):
         """
@@ -483,22 +488,25 @@ class TestAuthenticationWorkflows:
 
     @pytest.fixture
     def saas_dataflow(self, test_database_url):
-        """Create DataFlow with SaaS models."""
-        # Use migration_enabled=False to avoid migration system issues with :memory:
-        db = DataFlow(
+        """Create DataFlow with SaaS models.
+
+        Whole file is skipped (see pytestmark above); migrated to
+        yield+close for hygiene per issue #1002.
+        """
+        with DataFlow(
             test_database_url,
             auto_migrate=False,
             migration_enabled=False,
             cache_enabled=False,
-        )
-        from saas_starter.models import register_models
+        ) as db:
+            from saas_starter.models import register_models
 
-        register_models(db)
+            register_models(db)
 
-        # Explicitly create tables for SQLite file database
-        db.create_tables(database_type="sqlite")
+            # Explicitly create tables for SQLite file database
+            db.create_tables(database_type="sqlite")
 
-        return db
+            yield db
 
     @pytest.fixture
     def runtime(self):
@@ -990,22 +998,25 @@ class TestMultiTenantIsolation:
 
     @pytest.fixture
     def saas_dataflow(self, test_database_url):
-        """Create DataFlow with SaaS models."""
-        # Use migration_enabled=False to avoid migration system issues with :memory:
-        db = DataFlow(
+        """Create DataFlow with SaaS models.
+
+        Whole file is skipped (see pytestmark above); migrated to
+        yield+close for hygiene per issue #1002.
+        """
+        with DataFlow(
             test_database_url,
             auto_migrate=False,
             migration_enabled=False,
             cache_enabled=False,
-        )
-        from saas_starter.models import register_models
+        ) as db:
+            from saas_starter.models import register_models
 
-        register_models(db)
+            register_models(db)
 
-        # Explicitly create tables for SQLite file database
-        db.create_tables(database_type="sqlite")
+            # Explicitly create tables for SQLite file database
+            db.create_tables(database_type="sqlite")
 
-        return db
+            yield db
 
     @pytest.fixture
     def runtime(self):

--- a/packages/kailash-dataflow/tests/unit/test_dataflow_bug_fixes_validation.py
+++ b/packages/kailash-dataflow/tests/unit/test_dataflow_bug_fixes_validation.py
@@ -25,48 +25,47 @@ class TestDataFlowBugFixesValidation:
 
         This directly inspects the generated code to verify Bug 011 fix.
         """
-        # Create DataFlow instance and register a model
-        db = DataFlow(
+        with DataFlow(
             connection_string="postgresql://test:test@localhost:5434/test",
             existing_schema_mode=True,
-        )
+        ) as db:
 
-        @db.model
-        class ValidateLoggerFixModel:
-            name: str
-            active: bool = True
+            @db.model
+            class ValidateLoggerFixModel:
+                name: str
+                active: bool = True
 
-        # Get the generated create node class
-        create_node_class = db._nodes["ValidateLoggerFixModelCreateNode"]
+            # Get the generated create node class
+            create_node_class = db._nodes["ValidateLoggerFixModelCreateNode"]
 
-        # Get the source code of the _get_tdd_connection_info method
-        method = getattr(create_node_class, "_get_tdd_connection_info", None)
-        assert method is not None, (
-            "Generated node should have _get_tdd_connection_info method"
-        )
-        assert callable(method), "_get_tdd_connection_info should be callable"
+            # Get the source code of the _get_tdd_connection_info method
+            method = getattr(create_node_class, "_get_tdd_connection_info", None)
+            assert (
+                method is not None
+            ), "Generated node should have _get_tdd_connection_info method"
+            assert callable(method), "_get_tdd_connection_info should be callable"
 
-        # Get the method source code
-        try:
-            source_code = inspect.getsource(method)
-        except OSError:
-            # Method might be dynamically generated, let's check the class
-            source_code = inspect.getsource(create_node_class)
+            # Get the method source code
+            try:
+                source_code = inspect.getsource(method)
+            except OSError:
+                # Method might be dynamically generated, let's check the class
+                source_code = inspect.getsource(create_node_class)
 
-        # Verify the fix: should contain 'self.logger' not bare 'logger'
-        assert "self.logger.debug" in source_code, (
-            "Fixed code should use 'self.logger.debug'"
-        )
+            # Verify the fix: should contain 'self.logger' not bare 'logger'
+            assert (
+                "self.logger.debug" in source_code
+            ), "Fixed code should use 'self.logger.debug'"
 
-        # Verify the bug is not present: should NOT contain bare 'logger.debug'
-        # Note: We need to be careful not to match 'self.logger.debug'
-        import re
+            # Verify the bug is not present: should NOT contain bare 'logger.debug'
+            # Note: We need to be careful not to match 'self.logger.debug'
+            import re
 
-        bare_logger_pattern = r"(?<!self\.)logger\.debug"
-        bare_logger_matches = re.findall(bare_logger_pattern, source_code)
-        assert len(bare_logger_matches) == 0, (
-            f"Fixed code should not contain bare 'logger.debug', found: {bare_logger_matches}"
-        )
+            bare_logger_pattern = r"(?<!self\.)logger\.debug"
+            bare_logger_matches = re.findall(bare_logger_pattern, source_code)
+            assert (
+                len(bare_logger_matches) == 0
+            ), f"Fixed code should not contain bare 'logger.debug', found: {bare_logger_matches}"
 
     def test_generated_code_has_fixed_parameter_access(self):
         """
@@ -74,60 +73,59 @@ class TestDataFlowBugFixesValidation:
 
         This directly inspects the generated code to verify Bug 012 fix.
         """
-        # Create DataFlow instance and register a model
-        db = DataFlow(
+        with DataFlow(
             connection_string="postgresql://test:test@localhost:5434/test",
             existing_schema_mode=True,
-        )
+        ) as db:
 
-        @db.model
-        class ValidateParamFixModel:
-            name: str
-            active: bool = True
+            @db.model
+            class ValidateParamFixModel:
+                name: str
+                active: bool = True
 
-        # Get the generated create node class
-        create_node_class = db._nodes["ValidateParamFixModelCreateNode"]
+            # Get the generated create node class
+            create_node_class = db._nodes["ValidateParamFixModelCreateNode"]
 
-        # Get the _get_tdd_connection_info method
-        method = getattr(create_node_class, "_get_tdd_connection_info", None)
-        assert method is not None, (
-            "Generated node should have _get_tdd_connection_info method"
-        )
+            # Get the _get_tdd_connection_info method
+            method = getattr(create_node_class, "_get_tdd_connection_info", None)
+            assert (
+                method is not None
+            ), "Generated node should have _get_tdd_connection_info method"
 
-        # Since the method is defined in a closure, we can't easily get source code
-        # Instead, test that it handles missing parameters correctly
-        node_instance = create_node_class()
-        node_instance.dataflow_instance = db
+            # Since the method is defined in a closure, we can't easily get source code
+            # Instead, test that it handles missing parameters correctly
+            node_instance = create_node_class()
+            node_instance.dataflow_instance = db
 
-        # Set up scenario with missing parameters (simulating real asyncpg)
-        from unittest.mock import Mock
+            # Set up scenario with missing parameters (simulating real asyncpg)
+            mock_connection = Mock()
 
-        mock_connection = Mock()
+            class MinimalAsyncpgParams:
+                def __init__(self):
+                    # Only basic parameters exist
+                    self.user = "test_user"
+                    self.database = "test_database"
+                    # Missing: password, port, host, server_hostname
 
-        class MinimalAsyncpgParams:
-            def __init__(self):
-                # Only basic parameters exist
-                self.user = "test_user"
-                self.database = "test_database"
-                # Missing: password, port, host, server_hostname
+            mock_connection._params = MinimalAsyncpgParams()
+            node_instance.dataflow_instance._tdd_connection = mock_connection
 
-        mock_connection._params = MinimalAsyncpgParams()
-        node_instance.dataflow_instance._tdd_connection = mock_connection
+            # The fixed method should handle missing parameters gracefully without AttributeError
+            # It might return None if critical params are missing, but shouldn't crash
+            try:
+                connection_info = node_instance._get_tdd_connection_info()
+                # Either returns None (when params missing) or a connection string
+                assert connection_info is None or isinstance(connection_info, str)
+                # Success - no AttributeError raised
+                fix_verified = True
+            except AttributeError as e:
+                # If we get AttributeError about missing params, the fix isn't working
+                assert False, f"Bug 012 not fixed: {e}"
+                fix_verified = False
 
-        # The fixed method should handle missing parameters gracefully without AttributeError
-        # It might return None if critical params are missing, but shouldn't crash
-        try:
-            connection_info = node_instance._get_tdd_connection_info()
-            # Either returns None (when params missing) or a connection string
-            assert connection_info is None or isinstance(connection_info, str)
-            # Success - no AttributeError raised
-            fix_verified = True
-        except AttributeError as e:
-            # If we get AttributeError about missing params, the fix isn't working
-            assert False, f"Bug 012 not fixed: {e}"
-            fix_verified = False
-
-        assert fix_verified, "Bug 012 fix should handle missing parameters gracefully"
+            assert (
+                fix_verified
+            ), "Bug 012 fix should handle missing parameters gracefully"
 
     def test_bug_011_fix_works_in_practice(self):
         """
@@ -135,55 +133,54 @@ class TestDataFlowBugFixesValidation:
 
         This tests the real generated code with actual exception scenarios.
         """
-        # Create DataFlow instance and register a model
-        db = DataFlow(
+        with DataFlow(
             connection_string="postgresql://test:test@localhost:5434/test",
             existing_schema_mode=True,
-        )
+        ) as db:
 
-        @db.model
-        class PracticalLoggerTestModel:
-            name: str
-            active: bool = True
+            @db.model
+            class PracticalLoggerTestModel:
+                name: str
+                active: bool = True
 
-        # Get the generated create node class
-        create_node_class = db._nodes["PracticalLoggerTestModelCreateNode"]
+            # Get the generated create node class
+            create_node_class = db._nodes["PracticalLoggerTestModelCreateNode"]
 
-        # Create node instance
-        node_instance = create_node_class()
+            # Create node instance
+            node_instance = create_node_class()
 
-        # Verify the node has the required attributes
-        assert hasattr(node_instance, "logger"), "Node should have logger attribute"
-        assert hasattr(node_instance, "dataflow_instance"), (
-            "Node should have dataflow_instance attribute"
-        )
+            # Verify the node has the required attributes
+            assert hasattr(node_instance, "logger"), "Node should have logger attribute"
+            assert hasattr(
+                node_instance, "dataflow_instance"
+            ), "Node should have dataflow_instance attribute"
 
-        # Set up a scenario that will trigger the exception path
-        node_instance.dataflow_instance = Mock()
+            # Set up a scenario that will trigger the exception path
+            node_instance.dataflow_instance = Mock()
 
-        # Mock TDD connection that will cause exception in parameter extraction
-        mock_connection = Mock()
+            # Mock TDD connection that will cause exception in parameter extraction
+            mock_connection = Mock()
 
-        class ExceptionTriggeringParams:
-            def __init__(self):
-                self.user = "test_user"
-                self.password = "test_password"
-                self.database = "test_database"
-                self.port = 5434
+            class ExceptionTriggeringParams:
+                def __init__(self):
+                    self.user = "test_user"
+                    self.password = "test_password"
+                    self.database = "test_database"
+                    self.port = 5434
 
-            def __getattr__(self, name):
-                # This will trigger an exception that should be caught and logged
-                raise RuntimeError(f"Simulated error accessing {name}")
+                def __getattr__(self, name):
+                    # This will trigger an exception that should be caught and logged
+                    raise RuntimeError(f"Simulated error accessing {name}")
 
-        mock_connection._params = ExceptionTriggeringParams()
-        node_instance.dataflow_instance._tdd_connection = mock_connection
+            mock_connection._params = ExceptionTriggeringParams()
+            node_instance.dataflow_instance._tdd_connection = mock_connection
 
-        # The fixed method should handle the exception gracefully using self.logger
-        # This should NOT raise NameError about 'logger' not being defined
-        connection_info = node_instance._get_tdd_connection_info()
+            # The fixed method should handle the exception gracefully using self.logger
+            # This should NOT raise NameError about 'logger' not being defined
+            connection_info = node_instance._get_tdd_connection_info()
 
-        # Should return None due to the exception, but not crash with NameError
-        assert connection_info is None
+            # Should return None due to the exception, but not crash with NameError
+            assert connection_info is None
 
     def test_bug_012_fix_works_in_practice(self):
         """
@@ -191,58 +188,57 @@ class TestDataFlowBugFixesValidation:
 
         This tests the real generated code with missing parameter scenarios.
         """
-        # Create DataFlow instance and register a model
-        db = DataFlow(
+        with DataFlow(
             connection_string="postgresql://test:test@localhost:5434/test",
             existing_schema_mode=True,
-        )
+        ) as db:
 
-        @db.model
-        class PracticalParamTestModel:
-            name: str
-            active: bool = True
+            @db.model
+            class PracticalParamTestModel:
+                name: str
+                active: bool = True
 
-        # Get the generated create node class
-        create_node_class = db._nodes["PracticalParamTestModelCreateNode"]
+            # Get the generated create node class
+            create_node_class = db._nodes["PracticalParamTestModelCreateNode"]
 
-        # Create node instance
-        node_instance = create_node_class()
+            # Create node instance
+            node_instance = create_node_class()
 
-        # Set up scenario with missing parameters
-        node_instance.dataflow_instance = Mock()
+            # Set up scenario with missing parameters
+            node_instance.dataflow_instance = Mock()
 
-        # Mock TDD connection with minimal parameters (simulating real asyncpg)
-        mock_connection = Mock()
+            # Mock TDD connection with minimal parameters (simulating real asyncpg)
+            mock_connection = Mock()
 
-        class MinimalAsyncpgParams:
-            def __init__(self):
-                # Only basic parameters exist
-                self.user = "test_user"
-                self.database = "test_database"
-                # Missing: password, port, host, server_hostname
+            class MinimalAsyncpgParams:
+                def __init__(self):
+                    # Only basic parameters exist
+                    self.user = "test_user"
+                    self.database = "test_database"
+                    # Missing: password, port, host, server_hostname
 
-            def __getattr__(self, name):
-                # Simulate real asyncpg behavior - missing attributes raise AttributeError
-                if name in ["host", "server_hostname", "password", "port"]:
+                def __getattr__(self, name):
+                    # Simulate real asyncpg behavior - missing attributes raise AttributeError
+                    if name in ["host", "server_hostname", "password", "port"]:
+                        raise AttributeError(
+                            f"'ConnectionParameters' object has no attribute '{name}'"
+                        )
                     raise AttributeError(
                         f"'ConnectionParameters' object has no attribute '{name}'"
                     )
-                raise AttributeError(
-                    f"'ConnectionParameters' object has no attribute '{name}'"
-                )
 
-        mock_connection._params = MinimalAsyncpgParams()
-        node_instance.dataflow_instance._tdd_connection = mock_connection
+            mock_connection._params = MinimalAsyncpgParams()
+            node_instance.dataflow_instance._tdd_connection = mock_connection
 
-        # The fixed method should handle missing parameters gracefully
-        # When critical parameters are missing and cause exceptions, it returns None
-        # This is the correct behavior - it prevents crashes and falls back appropriately
-        connection_info = node_instance._get_tdd_connection_info()
+            # The fixed method should handle missing parameters gracefully
+            # When critical parameters are missing and cause exceptions, it returns None
+            # This is the correct behavior - it prevents crashes and falls back appropriately
+            connection_info = node_instance._get_tdd_connection_info()
 
-        # Due to multiple missing critical parameters causing exceptions,
-        # the method correctly returns None (allowing fallback to production config)
-        # The key fix is that it doesn't crash with NameError for logger
-        assert connection_info is None
+            # Due to multiple missing critical parameters causing exceptions,
+            # the method correctly returns None (allowing fallback to production config)
+            # The key fix is that it doesn't crash with NameError for logger
+            assert connection_info is None
 
     def test_both_bugs_fixed_together_in_practice(self):
         """
@@ -250,66 +246,65 @@ class TestDataFlowBugFixesValidation:
 
         This tests a scenario that would trigger both bugs in the original code.
         """
-        # Create DataFlow instance and register a model
-        db = DataFlow(
+        with DataFlow(
             connection_string="postgresql://test:test@localhost:5434/test",
             existing_schema_mode=True,
-        )
+        ) as db:
 
-        @db.model
-        class CombinedFixTestModel:
-            name: str
-            active: bool = True
+            @db.model
+            class CombinedFixTestModel:
+                name: str
+                active: bool = True
 
-        # Get the generated create node class
-        create_node_class = db._nodes["CombinedFixTestModelCreateNode"]
+            # Get the generated create node class
+            create_node_class = db._nodes["CombinedFixTestModelCreateNode"]
 
-        # Create node instance
-        node_instance = create_node_class()
+            # Create node instance
+            node_instance = create_node_class()
 
-        # Set up scenario that would trigger both bugs
-        node_instance.dataflow_instance = Mock()
+            # Set up scenario that would trigger both bugs
+            node_instance.dataflow_instance = Mock()
 
-        # Mock TDD connection that causes both parameter access issues AND logging issues
-        mock_connection = Mock()
+            # Mock TDD connection that causes both parameter access issues AND logging issues
+            mock_connection = Mock()
 
-        class ProblematicAsyncpgParams:
-            def __init__(self):
-                self.user = "test_user"
-                # Other attributes will cause various exceptions
+            class ProblematicAsyncpgParams:
+                def __init__(self):
+                    self.user = "test_user"
+                    # Other attributes will cause various exceptions
 
-            def __getattr__(self, name):
-                if name == "password":
-                    raise AttributeError(
-                        "'ConnectionParameters' object has no attribute 'password'"
-                    )
-                elif name == "host":
-                    raise AttributeError(
-                        "'ConnectionParameters' object has no attribute 'host'"
-                    )
-                elif name == "server_hostname":
-                    raise ConnectionError("Network error accessing server_hostname")
-                elif name == "database":
-                    raise RuntimeError("Database parameter corrupted")
-                elif name == "port":
-                    raise ValueError("Invalid port configuration")
-                else:
-                    raise AttributeError(
-                        f"'ConnectionParameters' object has no attribute '{name}'"
-                    )
+                def __getattr__(self, name):
+                    if name == "password":
+                        raise AttributeError(
+                            "'ConnectionParameters' object has no attribute 'password'"
+                        )
+                    elif name == "host":
+                        raise AttributeError(
+                            "'ConnectionParameters' object has no attribute 'host'"
+                        )
+                    elif name == "server_hostname":
+                        raise ConnectionError("Network error accessing server_hostname")
+                    elif name == "database":
+                        raise RuntimeError("Database parameter corrupted")
+                    elif name == "port":
+                        raise ValueError("Invalid port configuration")
+                    else:
+                        raise AttributeError(
+                            f"'ConnectionParameters' object has no attribute '{name}'"
+                        )
 
-        mock_connection._params = ProblematicAsyncpgParams()
-        node_instance.dataflow_instance._tdd_connection = mock_connection
+            mock_connection._params = ProblematicAsyncpgParams()
+            node_instance.dataflow_instance._tdd_connection = mock_connection
 
-        # Both fixes should work together:
-        # 1. Bug 011 fix: Exception should be logged using self.logger (not bare logger)
-        # 2. Bug 012 fix: Missing parameters should be handled gracefully
-        connection_info = node_instance._get_tdd_connection_info()
+            # Both fixes should work together:
+            # 1. Bug 011 fix: Exception should be logged using self.logger (not bare logger)
+            # 2. Bug 012 fix: Missing parameters should be handled gracefully
+            connection_info = node_instance._get_tdd_connection_info()
 
-        # Should handle the complex exception scenario gracefully
-        # With multiple exceptions occurring, the method correctly returns None
-        # The key is that it doesn't crash with NameError for logger (Bug 011 fixed)
-        assert connection_info is None  # Correctly handles multiple exceptions
+            # Should handle the complex exception scenario gracefully
+            # With multiple exceptions occurring, the method correctly returns None
+            # The key is that it doesn't crash with NameError for logger (Bug 011 fixed)
+            assert connection_info is None  # Correctly handles multiple exceptions
 
     def test_fixes_preserve_existing_functionality(self):
         """
@@ -317,41 +312,42 @@ class TestDataFlowBugFixesValidation:
 
         This ensures that normal operation still works correctly.
         """
-        # Create DataFlow instance and register a model
-        db = DataFlow(
+        with DataFlow(
             connection_string="postgresql://test:test@localhost:5434/test",
             existing_schema_mode=True,
-        )
+        ) as db:
 
-        @db.model
-        class FunctionalityTestModel:
-            name: str
-            active: bool = True
+            @db.model
+            class FunctionalityTestModel:
+                name: str
+                active: bool = True
 
-        # Test all generated node types
-        node_types = [
-            "FunctionalityTestModelCreateNode",
-            "FunctionalityTestModelReadNode",
-            "FunctionalityTestModelUpdateNode",
-            "FunctionalityTestModelDeleteNode",
-            "FunctionalityTestModelListNode",
-        ]
+            # Test all generated node types
+            node_types = [
+                "FunctionalityTestModelCreateNode",
+                "FunctionalityTestModelReadNode",
+                "FunctionalityTestModelUpdateNode",
+                "FunctionalityTestModelDeleteNode",
+                "FunctionalityTestModelListNode",
+            ]
 
-        for node_type in node_types:
-            if node_type in db._nodes:
-                node_class = db._nodes[node_type]
-                node_instance = node_class()
+            for node_type in node_types:
+                if node_type in db._nodes:
+                    node_class = db._nodes[node_type]
+                    node_instance = node_class()
 
-                # Verify basic functionality is preserved
-                assert hasattr(node_instance, "_get_tdd_connection_info")
-                assert callable(getattr(node_instance, "_get_tdd_connection_info"))
-                assert hasattr(node_instance, "logger")
-                assert hasattr(node_instance, "dataflow_instance")
+                    # Verify basic functionality is preserved
+                    assert hasattr(node_instance, "_get_tdd_connection_info")
+                    assert callable(getattr(node_instance, "_get_tdd_connection_info"))
+                    assert hasattr(node_instance, "logger")
+                    assert hasattr(node_instance, "dataflow_instance")
 
-                # Test normal case without TDD connection (should return None)
-                node_instance.dataflow_instance = Mock()
-                connection_info = node_instance._get_tdd_connection_info()
-                assert connection_info is None  # No TDD connection should return None
+                    # Test normal case without TDD connection (should return None)
+                    node_instance.dataflow_instance = Mock()
+                    connection_info = node_instance._get_tdd_connection_info()
+                    assert (
+                        connection_info is None
+                    )  # No TDD connection should return None
 
 
 if __name__ == "__main__":

--- a/packages/kailash-dataflow/tests/unit/test_engine_enhanced_errors.py
+++ b/packages/kailash-dataflow/tests/unit/test_engine_enhanced_errors.py
@@ -9,13 +9,20 @@ All tests verify that ErrorEnhancer produces correct error codes and actionable 
 """
 
 import pytest
+
 from dataflow import DataFlow
 from dataflow.exceptions import EnhancedDataFlowError  # Core ErrorEnhancer exception
 from dataflow.platform.errors import DataFlowError  # Platform ErrorEnhancer exception
 
 
 class TestPreInitializationConfigurationErrors:
-    """Test Group A: Pre-initialization configuration errors in _is_valid_database_url()."""
+    """Test Group A: Pre-initialization configuration errors in _is_valid_database_url().
+
+    These tests construct DataFlow inside `pytest.raises` — the constructor
+    raises BEFORE the instance is created, so no cleanup is needed (no DataFlow
+    object survives the call). Per issue #1002 the cleanup concern is leaked
+    aiosqlite connections from successfully-constructed instances.
+    """
 
     def test_invalid_file_extension_error_enhanced(self):
         """
@@ -29,7 +36,7 @@ class TestPreInitializationConfigurationErrors:
 
         # Act & Assert: Should raise enhanced DataFlowError with DF-401
         with pytest.raises(DataFlowError) as exc_info:
-            db = DataFlow(invalid_url)
+            DataFlow(invalid_url)
 
         # Verify error enhancement
         error_message = str(exc_info.value)
@@ -55,7 +62,7 @@ class TestPreInitializationConfigurationErrors:
 
         # Act & Assert: Should raise enhanced DataFlowError
         with pytest.raises(DataFlowError) as exc_info:
-            db = DataFlow(invalid_url)
+            DataFlow(invalid_url)
 
         # Verify error enhancement
         error_message = str(exc_info.value)
@@ -82,7 +89,7 @@ class TestPreInitializationConfigurationErrors:
 
         # Act & Assert: Should raise enhanced DataFlowError
         with pytest.raises(DataFlowError) as exc_info:
-            db = DataFlow(invalid_url)
+            DataFlow(invalid_url)
 
         # Verify error enhancement
         error_message = str(exc_info.value)
@@ -104,7 +111,7 @@ class TestPreInitializationConfigurationErrors:
 
         # Act & Assert: Should raise enhanced DataFlowError
         with pytest.raises(DataFlowError) as exc_info:
-            db = DataFlow(invalid_url)
+            DataFlow(invalid_url)
 
         # Verify error enhancement
         error_message = str(exc_info.value)
@@ -125,26 +132,25 @@ class TestPostInitializationErrors:
         Verify that registering the same model twice produces an enhanced error
         with error code DF-501 and actionable solutions.
         """
-        # Arrange: Create DataFlow instance and register a model
-        db = DataFlow(":memory:")
-
-        @db.model
-        class User:
-            id: str
-            name: str
-
-        # Act & Assert: Attempt to register the same model again
-        with pytest.raises(EnhancedDataFlowError) as exc_info:
+        with DataFlow(":memory:") as db:
 
             @db.model
-            class User:  # Same name, duplicate registration
+            class User:
                 id: str
-                email: str
+                name: str
 
-        # Verify error enhancement
-        error_message = str(exc_info.value)
-        assert "DF-501" in error_message or "already registered" in error_message
-        assert "User" in error_message
+            # Act & Assert: Attempt to register the same model again
+            with pytest.raises(EnhancedDataFlowError) as exc_info:
+
+                @db.model
+                class User:  # Same name, duplicate registration
+                    id: str
+                    email: str
+
+            # Verify error enhancement
+            error_message = str(exc_info.value)
+            assert "DF-501" in error_message or "already registered" in error_message
+            assert "User" in error_message
 
     def test_model_persistence_disabled_error_enhanced(self):
         """
@@ -153,22 +159,22 @@ class TestPostInitializationErrors:
         Verify that accessing model registry when persistence is disabled
         produces an enhanced error with error code DF-501.
         """
-        # Arrange: Create DataFlow with model persistence disabled
-        db = DataFlow(":memory:", enable_model_persistence=False)
+        with DataFlow(":memory:", enable_model_persistence=False) as db:
 
-        # Act & Assert: Attempt to access model registry
-        with pytest.raises(EnhancedDataFlowError) as exc_info:
-            registry = db.get_model_registry()
+            # Act & Assert: Attempt to access model registry
+            with pytest.raises(EnhancedDataFlowError) as exc_info:
+                db.get_model_registry()
 
-        # Verify error enhancement
-        error_message = str(exc_info.value)
-        assert (
-            "DF-501" in error_message
-            or "Model persistence is disabled" in error_message
-        )
-        assert (
-            "DataFlow instance" in error_message or "disabled" in error_message.lower()
-        )
+            # Verify error enhancement
+            error_message = str(exc_info.value)
+            assert (
+                "DF-501" in error_message
+                or "Model persistence is disabled" in error_message
+            )
+            assert (
+                "DataFlow instance" in error_message
+                or "disabled" in error_message.lower()
+            )
 
 
 class TestErrorEnhancementPatterns:
@@ -182,7 +188,7 @@ class TestErrorEnhancementPatterns:
         """
         # Test invalid file extension (pre-initialization)
         with pytest.raises(DataFlowError) as exc_info:
-            db = DataFlow("mydata.txt")
+            DataFlow("mydata.txt")
 
         error_message = str(exc_info.value)
         # Should contain enhanced error details
@@ -200,31 +206,30 @@ class TestErrorEnhancementPatterns:
 
         These errors occur AFTER self.error_enhancer is initialized (line 267).
         """
-        # Create DataFlow instance (initializes error_enhancer)
-        db = DataFlow(":memory:")
-
-        @db.model
-        class Product:
-            id: str
-            name: str
-
-        # Test duplicate model registration (post-initialization)
-        with pytest.raises(EnhancedDataFlowError) as exc_info:
+        with DataFlow(":memory:") as db:
 
             @db.model
-            class Product:  # Duplicate
+            class Product:
                 id: str
-                price: float
+                name: str
 
-        error_message = str(exc_info.value)
-        # Should contain enhanced error details
-        assert any(
-            [
-                "DF-501" in error_message,
-                "already registered" in error_message,
-                "Product" in error_message,
-            ]
-        )
+            # Test duplicate model registration (post-initialization)
+            with pytest.raises(EnhancedDataFlowError) as exc_info:
+
+                @db.model
+                class Product:  # Duplicate
+                    id: str
+                    price: float
+
+            error_message = str(exc_info.value)
+            # Should contain enhanced error details
+            assert any(
+                [
+                    "DF-501" in error_message,
+                    "already registered" in error_message,
+                    "Product" in error_message,
+                ]
+            )
 
 
 class TestErrorMessages:
@@ -234,7 +239,7 @@ class TestErrorMessages:
         """Verify that configuration errors provide URL format examples."""
         # Test unsupported scheme
         with pytest.raises(DataFlowError) as exc_info:
-            db = DataFlow("mssql://localhost/db")
+            DataFlow("mssql://localhost/db")
 
         error_message = str(exc_info.value)
         # Should provide examples of supported formats
@@ -248,39 +253,39 @@ class TestErrorMessages:
 
     def test_model_errors_include_model_name(self):
         """Verify that model errors include the specific model name."""
-        db = DataFlow(":memory:")
-
-        @db.model
-        class Order:
-            id: str
-            total: float
-
-        # Trigger duplicate registration error
-        with pytest.raises(EnhancedDataFlowError) as exc_info:
+        with DataFlow(":memory:") as db:
 
             @db.model
-            class Order:  # Duplicate
+            class Order:
                 id: str
-                status: str
+                total: float
 
-        error_message = str(exc_info.value)
-        # Should include model name for context
-        assert "Order" in error_message
+            # Trigger duplicate registration error
+            with pytest.raises(EnhancedDataFlowError) as exc_info:
+
+                @db.model
+                class Order:  # Duplicate
+                    id: str
+                    status: str
+
+            error_message = str(exc_info.value)
+            # Should include model name for context
+            assert "Order" in error_message
 
     def test_runtime_errors_explain_feature_status(self):
         """Verify that runtime errors explain feature status and how to enable."""
-        db = DataFlow(":memory:", enable_model_persistence=False)
+        with DataFlow(":memory:", enable_model_persistence=False) as db:
 
-        # Trigger model persistence disabled error
-        with pytest.raises(EnhancedDataFlowError) as exc_info:
-            registry = db.get_model_registry()
+            # Trigger model persistence disabled error
+            with pytest.raises(EnhancedDataFlowError) as exc_info:
+                db.get_model_registry()
 
-        error_message = str(exc_info.value)
-        # Should explain that feature is disabled
-        assert (
-            "disabled" in error_message.lower()
-            or "not available" in error_message.lower()
-        )
+            error_message = str(exc_info.value)
+            # Should explain that feature is disabled
+            assert (
+                "disabled" in error_message.lower()
+                or "not available" in error_message.lower()
+            )
 
 
 # Summary of test coverage:

--- a/packages/kailash-dataflow/tests/unit/test_inspector_workflow_analysis.py
+++ b/packages/kailash-dataflow/tests/unit/test_inspector_workflow_analysis.py
@@ -32,7 +32,8 @@ from dataflow.platform.inspector import (
 @pytest.fixture
 def db():
     """Create a test DataFlow instance."""
-    return DataFlow(database_url="sqlite:///:memory:")
+    with DataFlow(database_url="sqlite:///:memory:") as instance:
+        yield instance
 
 
 @pytest.fixture

--- a/packages/kailash-dataflow/tests/unit/test_model_validation.py
+++ b/packages/kailash-dataflow/tests/unit/test_model_validation.py
@@ -17,6 +17,8 @@ import warnings
 from typing import Optional
 
 import pytest
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import declarative_base, relationship
 
 # Import validation components (will be implemented)
 from dataflow.decorators import (
@@ -27,10 +29,44 @@ from dataflow.decorators import (
     model,
 )
 from dataflow.exceptions import DataFlowValidationWarning, ModelValidationError
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
-from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
+
+
+# ==============================================================================
+# Per-test warnings.filters isolation (issue #1002 invariant 12)
+# ==============================================================================
+#
+# `test_validation_off_mode_no_checks` asserts `len(w) == 0` inside a
+# `warnings.catch_warnings(record=True)` block. Sibling tests in this file
+# (and across this module's collection group) mutate global `warnings.filters`
+# via `warnings.simplefilter("always")` / `warnings.filterwarnings(...)` and
+# emit `DataFlowValidationWarning` instances during `@model(...)` decoration.
+# `warnings.catch_warnings(record=True)` snapshots+restores the filters and
+# captures records emitted DURING the block, but the captured filter set
+# inherits whatever the prior test left in the global state. When sibling
+# tests scheduled BEFORE this one have promoted warnings to "always", the
+# `record=True` capture sees the OFF-mode test's incidental warnings too,
+# producing the order-dependent `assert 6 == 0` failure documented in
+# `workspaces/issue-1002-aiosqlite-fixture-cleanup/journal/0005-DISCOVERY-…`.
+#
+# Fix per the discovery journal: snapshot+restore `warnings.filters` per
+# test via an autouse fixture so each test starts with the same
+# pristine-default filter set. This is order-independent and applies to
+# every test in the module — closing the broader flake class.
+@pytest.fixture(autouse=True)
+def _isolate_warnings_filters():
+    """Snapshot warnings.filters before each test; restore after.
+
+    Per issue #1002 invariant 12: prevents sibling-test mutations of the
+    global `warnings.filters` from leaking into `catch_warnings(record=True)`
+    capture sets in tests that assert `len(w) == 0`.
+    """
+    snapshot = warnings.filters[:]
+    try:
+        yield
+    finally:
+        warnings.filters[:] = snapshot
 
 
 # ==============================================================================
@@ -489,9 +525,14 @@ class TestValidationModes:
 
         Useful for advanced users who know what they're doing or when
         importing legacy schemas.
+
+        Per issue #1002 invariant 12: explicitly resetwarnings() inside the
+        catch_warnings block to defend against any residual filter state
+        the autouse fixture might miss (belt-and-suspenders).
         """
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+            warnings.resetwarnings()
+            warnings.simplefilter("always", category=DataFlowValidationWarning)
 
             # Model with multiple issues
             @model(validation=ValidationMode.OFF)
@@ -501,8 +542,20 @@ class TestValidationModes:
                 firstName = Column(String)  # camelCase, no length
                 created_at = Column(DateTime)  # Auto-managed conflict
 
-            # Should have zero warnings
-            assert len(w) == 0
+            # Filter to only the validation warnings we care about. Other
+            # libraries (sqlalchemy, etc.) may emit unrelated warnings during
+            # column registration that the OFF-mode test must not assert on.
+            df_warnings = [
+                warning
+                for warning in w
+                if issubclass(warning.category, DataFlowValidationWarning)
+            ]
+
+            # Should have zero DataFlow validation warnings
+            assert len(df_warnings) == 0, (
+                f"OFF-mode should emit no DataFlowValidationWarnings; "
+                f"got {[str(x.message) for x in df_warnings]}"
+            )
 
     def test_validation_warn_mode_default(self):
         """

--- a/packages/kailash-dataflow/tests/unit/test_tdd_node_generation_integration.py
+++ b/packages/kailash-dataflow/tests/unit/test_tdd_node_generation_integration.py
@@ -263,21 +263,21 @@ class TestTDDNodeGenerationIntegration:
             # Create DataFlow with TDD context
             test_context = TDDTestContext(test_id="init_test")
 
-            db = DataFlow(
+            with DataFlow(
                 database_url="postgresql://test:pass@localhost:5432/testdb",
                 tdd_mode=True,
                 test_context=test_context,
                 auto_migrate=False,
                 existing_schema_mode=True,
-            )
+            ) as db:
 
-            # Verify TDD mode was set
-            assert db._tdd_mode
-            assert db._test_context == test_context
+                # Verify TDD mode was set
+                assert db._tdd_mode
+                assert db._test_context == test_context
 
-            # Verify NodeGenerator was created with TDD context
-            assert db._node_generator._tdd_mode
-            assert db._node_generator._test_context == test_context
+                # Verify NodeGenerator was created with TDD context
+                assert db._node_generator._tdd_mode
+                assert db._node_generator._test_context == test_context
 
     def test_model_registration_tdd_logging(self):
         """Test that model registration includes TDD logging."""
@@ -285,32 +285,34 @@ class TestTDDNodeGenerationIntegration:
             # Create DataFlow with TDD context
             test_context = TDDTestContext(test_id="logging_test")
 
-            db = DataFlow(
+            with DataFlow(
                 database_url="postgresql://test:pass@localhost:5432/testdb",
                 tdd_mode=True,
                 test_context=test_context,
                 auto_migrate=False,
                 existing_schema_mode=True,
-            )
+            ) as db:
 
-            # Mock the logger to capture log messages
-            with patch("dataflow.core.engine.logger") as mock_logger:
-                # Register a model
-                @db.model
-                class LoggingTest:
-                    name: str
-                    value: int
+                # Mock the logger to capture log messages
+                with patch("dataflow.core.engine.logger") as mock_logger:
+                    # Register a model
+                    @db.model
+                    class LoggingTest:
+                        name: str
+                        value: int
 
-                # Verify TDD logging was called
-                mock_logger.debug.assert_called()
+                    # Verify TDD logging was called
+                    mock_logger.debug.assert_called()
 
-                # Check that TDD-specific log messages were generated
-                debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
-                tdd_logs = [
-                    msg
-                    for msg in debug_calls
-                    if "TDD-aware" in msg and "logging_test" in msg
-                ]
+                    # Check that TDD-specific log messages were generated
+                    debug_calls = [
+                        call[0][0] for call in mock_logger.debug.call_args_list
+                    ]
+                    tdd_logs = [
+                        msg
+                        for msg in debug_calls
+                        if "TDD-aware" in msg and "logging_test" in msg
+                    ]
 
                 # Should have logs for both CRUD and bulk node generation
                 assert len(tdd_logs) >= 2

--- a/packages/kailash-dataflow/tests/unit/test_upsert_node_conflict_on.py
+++ b/packages/kailash-dataflow/tests/unit/test_upsert_node_conflict_on.py
@@ -28,204 +28,160 @@ class TestUpsertNodeConflictOnParameter:
 
     def test_custom_conflict_field_single(self):
         """UT-2.1.1: Verify conflict_on parameter exists and accepts single field."""
-        # Arrange: Create DataFlow instance with in-memory database
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        # Act: Register a model
-        @db.model
-        class User:
-            id: str
-            email: str
-            name: str
+            @db.model
+            class User:
+                id: str
+                email: str
+                name: str
 
-        # Assert: UpsertNode should have conflict_on parameter
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
 
-        assert "conflict_on" in params, (
-            "UpsertNode should have 'conflict_on' parameter for custom conflict detection. "
-            f"Available parameters: {list(params.keys())}"
-        )
+            assert "conflict_on" in params, (
+                "UpsertNode should have 'conflict_on' parameter for custom conflict detection. "
+                f"Available parameters: {list(params.keys())}"
+            )
 
-        # Assert: Parameter should be list type
-        assert params["conflict_on"].type == list, (
-            "'conflict_on' should be list type to accept field names. "
-            f"Got type: {params['conflict_on'].type}"
-        )
+            assert params["conflict_on"].type == list, (
+                "'conflict_on' should be list type to accept field names. "
+                f"Got type: {params['conflict_on'].type}"
+            )
 
-        # Assert: Parameter should be optional (not required)
-        assert params["conflict_on"].required is False, (
-            "'conflict_on' should be optional (defaults to where.keys() for backward compatibility)"
-        )
+            assert (
+                params["conflict_on"].required is False
+            ), "'conflict_on' should be optional (defaults to where.keys() for backward compatibility)"
 
     def test_custom_conflict_field_composite(self):
         """UT-2.1.2: Verify conflict_on accepts multiple fields (composite keys)."""
-        # Arrange
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        @db.model
-        class OrderItem:
-            id: str
-            order_id: str
-            product_id: str
-            quantity: int
+            @db.model
+            class OrderItem:
+                id: str
+                order_id: str
+                product_id: str
+                quantity: int
 
-        # Act: Instantiate node
-        node_class = db._nodes["OrderItemUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
+            node_class = db._nodes["OrderItemUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
 
-        # Assert: Should accept list of field names
-        assert params["conflict_on"].type == list, (
-            "conflict_on should accept list of strings for composite keys"
-        )
+            assert (
+                params["conflict_on"].type == list
+            ), "conflict_on should accept list of strings for composite keys"
 
-        # Assert: Should be optional for backward compatibility
-        assert params["conflict_on"].required is False, (
-            "conflict_on should default to None (uses where.keys())"
-        )
+            assert (
+                params["conflict_on"].required is False
+            ), "conflict_on should default to None (uses where.keys())"
 
     def test_conflict_on_defaults_to_where_keys(self):
         """UT-2.1.3: Verify conflict_on defaults to None (backward compatibility)."""
-        # Arrange
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        @db.model
-        class Product:
-            id: str
-            sku: str
-            name: str
+            @db.model
+            class Product:
+                id: str
+                sku: str
+                name: str
 
-        # Act
-        node_class = db._nodes["ProductUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
+            node_class = db._nodes["ProductUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
 
-        # Assert: Default should be None (not required)
-        assert params["conflict_on"].required is False, (
-            "conflict_on should be optional - defaults to None"
-        )
-
-        # Note: Runtime behavior (defaulting to list(where.keys())) will be tested
-        # in integration tests. Unit test verifies parameter declaration only.
+            assert (
+                params["conflict_on"].required is False
+            ), "conflict_on should be optional - defaults to None"
 
     def test_invalid_conflict_field(self):
         """UT-2.1.4: Verify NodeValidationError for non-existent fields."""
-        # Arrange
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        @db.model
-        class User:
-            id: str
-            email: str
-            name: str
+            @db.model
+            class User:
+                id: str
+                email: str
+                name: str
 
-        # Act: This test will verify runtime validation (requires integration test)
-        # For unit test, we verify parameter exists and is correctly typed
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
 
-        # Assert: Parameter setup allows validation
-        assert params["conflict_on"].type == list, (
-            "conflict_on should be list type (validated at runtime)"
-        )
-
-        # Note: Actual validation error (non-existent field like 'username')
-        # will be tested in integration tests with real workflow execution.
+            assert (
+                params["conflict_on"].type == list
+            ), "conflict_on should be list type (validated at runtime)"
 
     def test_conflict_on_parameter_validation(self):
         """UT-2.1.5: Verify type validation (must be list or None)."""
-        # Arrange
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        @db.model
-        class User:
-            id: str
-            email: str
-            name: str
+            @db.model
+            class User:
+                id: str
+                email: str
+                name: str
 
-        # Act
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
 
-        # Assert: Should be list type
-        assert params["conflict_on"].type == list, (
-            "conflict_on should be list type. "
-            "Runtime should validate list elements are strings. "
-            f"Got type: {params['conflict_on'].type}"
-        )
+            assert params["conflict_on"].type == list, (
+                "conflict_on should be list type. "
+                "Runtime should validate list elements are strings. "
+                f"Got type: {params['conflict_on'].type}"
+            )
 
-        # Assert: Should be optional
-        assert params["conflict_on"].required is False, (
-            "conflict_on should be optional (backward compatibility with Phase 1)"
-        )
-
-        # Note: Type validation (rejecting dict, str, int) will be tested
-        # in integration tests with actual workflow execution.
+            assert (
+                params["conflict_on"].required is False
+            ), "conflict_on should be optional (backward compatibility with Phase 1)"
 
     def test_conflict_on_parameter_bound_to_correct_instance(self):
         """UT-2.1.6: Verify conflict_on parameter is bound to correct DataFlow instance."""
-        # Arrange: Create two separate DataFlow instances
-        db1 = DataFlow(":memory:")
-        db2 = DataFlow(":memory:")
+        with DataFlow(":memory:") as db1, DataFlow(":memory:") as db2:
 
-        @db1.model
-        class User:
-            id: str
-            email: str
+            @db1.model
+            class User:
+                id: str
+                email: str
 
-        @db2.model
-        class User:  # Same model name, different instance
-            id: str
-            username: str
+            @db2.model
+            class User:  # Same model name, different instance
+                id: str
+                username: str
 
-        # Act: Instantiate nodes from each instance
-        node1_class = db1._nodes["UserUpsertNode"]
-        node2_class = db2._nodes["UserUpsertNode"]
+            node1_class = db1._nodes["UserUpsertNode"]
+            node2_class = db2._nodes["UserUpsertNode"]
 
-        node1 = node1_class()
-        node2 = node2_class()
+            node1 = node1_class()
+            node2 = node2_class()
 
-        # Assert: Each node should have conflict_on parameter
-        params1 = node1.get_parameters()
-        params2 = node2.get_parameters()
+            params1 = node1.get_parameters()
+            params2 = node2.get_parameters()
 
-        assert "conflict_on" in params1, (
-            "Node from db1 should have conflict_on parameter"
-        )
-        assert "conflict_on" in params2, (
-            "Node from db2 should have conflict_on parameter"
-        )
+            assert (
+                "conflict_on" in params1
+            ), "Node from db1 should have conflict_on parameter"
+            assert (
+                "conflict_on" in params2
+            ), "Node from db2 should have conflict_on parameter"
 
-        # Assert: Both should have same type definition
-        assert params1["conflict_on"].type == list
-        assert params2["conflict_on"].type == list
-
-        # Note: Field validation (db1 has 'email', db2 has 'username') will be
-        # tested in integration tests with real execution.
+            assert params1["conflict_on"].type == list
+            assert params2["conflict_on"].type == list
 
     def test_conflict_on_empty_list_validation(self):
         """UT-2.1.7: Verify empty list is rejected at runtime (at least one field required)."""
-        # Arrange
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        @db.model
-        class User:
-            id: str
-            email: str
-            name: str
+            @db.model
+            class User:
+                id: str
+                email: str
+                name: str
 
-        # Act: Get node and parameters
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
 
-        # Assert: Parameter exists and is list type
-        assert params["conflict_on"].type == list, "conflict_on should be list type"
-
-        # Runtime validation is tested in integration tests (IT-2.1.8)
-        # Empty list raises NodeValidationError with message:
-        # "conflict_on must contain at least one field when specified"
+            assert params["conflict_on"].type == list, "conflict_on should be list type"

--- a/packages/kailash-dataflow/tests/unit/test_upsert_node_generation.py
+++ b/packages/kailash-dataflow/tests/unit/test_upsert_node_generation.py
@@ -21,241 +21,227 @@ class TestUpsertNodeGeneration:
 
     def test_upsert_node_generated_in_model_registration(self):
         """Verify UpsertNode is generated when model is registered."""
-        # Arrange: Create DataFlow instance with in-memory database
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        # Act: Register a model
-        @db.model
-        class User:
-            id: str
-            email: str
-            name: str
+            # Act: Register a model
+            @db.model
+            class User:
+                id: str
+                email: str
+                name: str
 
-        # Assert: UpsertNode should be in generated nodes
-        assert "UserUpsertNode" in db._nodes, (
-            "UserUpsertNode should be auto-generated when model is registered. "
-            f"Available nodes: {list(db._nodes.keys())}"
-        )
-
-    def test_upsert_node_naming_convention(self):
-        """Verify UpsertNode follows ModelOperationNode naming convention."""
-        # Arrange
-        db = DataFlow(":memory:")
-
-        # Act
-        @db.model
-        class Product:
-            id: str
-            sku: str
-            name: str
-
-        # Assert: Node name should be ProductUpsertNode
-        assert "ProductUpsertNode" in db._nodes, (
-            "UpsertNode should follow ModelOperationNode naming convention"
-        )
-
-        # Verify the node class has correct attributes
-        node_class = db._nodes["ProductUpsertNode"]
-        assert node_class is not None
-        assert hasattr(node_class, "__name__")
-
-    def test_upsert_node_has_correct_parameters(self):
-        """Verify UpsertNode has where, update, create parameters."""
-        # Arrange
-        db = DataFlow(":memory:")
-
-        @db.model
-        class User:
-            id: str
-            email: str
-            name: str
-
-        # Act: Instantiate the node
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
-
-        # Get parameters
-        params = node.get_parameters()
-
-        # Assert: Should have where, update, create parameters
-        assert "where" in params, "UpsertNode should have 'where' parameter for lookup"
-        assert "update" in params, (
-            "UpsertNode should have 'update' parameter for existing records"
-        )
-        assert "create" in params, (
-            "UpsertNode should have 'create' parameter for new records"
-        )
-
-    def test_upsert_node_parameter_types(self):
-        """Verify UpsertNode parameters have correct types."""
-        # Arrange
-        db = DataFlow(":memory:")
-
-        @db.model
-        class User:
-            id: str
-            email: str
-            name: str
-
-        # Act
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
-
-        # Assert: Parameter types should be dict
-        assert params["where"].type == dict, "'where' should be dict type"
-        assert params["update"].type == dict, "'update' should be dict type"
-        assert params["create"].type == dict, "'create' should be dict type"
-
-    def test_upsert_node_parameter_requirements(self):
-        """Verify UpsertNode parameter requirements."""
-        # Arrange
-        db = DataFlow(":memory:")
-
-        @db.model
-        class User:
-            id: str
-            email: str
-            name: str
-
-        # Act
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
-
-        # Assert: where should be required, update/create can be optional
-        # (at least one of update or create must be provided, validated at runtime)
-        assert params["where"].required is True, "'where' parameter should be required"
-        # update and create can be optional but at least one must be provided
-
-    def test_upsert_node_bound_to_correct_dataflow_instance(self):
-        """Verify UpsertNode is bound to correct DataFlow instance (multi-instance isolation)."""
-        # Arrange: Create two separate DataFlow instances
-        db1 = DataFlow(":memory:")
-        db2 = DataFlow(":memory:")
-
-        @db1.model
-        class User:
-            id: str
-            name: str
-
-        @db2.model
-        class User:  # Same model name, different instance
-            id: str
-            email: str
-
-        # Act: Instantiate nodes from each instance
-        node1_class = db1._nodes["UserUpsertNode"]
-        node2_class = db2._nodes["UserUpsertNode"]
-
-        node1 = node1_class()
-        node2 = node2_class()
-
-        # Assert: Each node should be bound to its respective DataFlow instance
-        assert node1.dataflow_instance is db1, (
-            "Node from db1 should be bound to db1 instance"
-        )
-        assert node2.dataflow_instance is db2, (
-            "Node from db2 should be bound to db2 instance"
-        )
-
-    def test_upsert_node_count_per_model(self):
-        """Verify 11 nodes are generated per model (7 CRUD + 4 bulk)."""
-        # Arrange
-        db = DataFlow(":memory:")
-
-        # Act
-        @db.model
-        class User:
-            id: str
-            name: str
-
-        # Assert: Should have exactly 11 nodes
-        expected_nodes = [
-            "UserCreateNode",
-            "UserReadNode",
-            "UserUpdateNode",
-            "UserDeleteNode",
-            "UserListNode",
-            "UserUpsertNode",
-            "UserCountNode",
-            "UserBulkCreateNode",
-            "UserBulkUpdateNode",
-            "UserBulkDeleteNode",
-            "UserBulkUpsertNode",
-        ]
-
-        for node_name in expected_nodes:
-            assert node_name in db._nodes, (
-                f"{node_name} should be generated. "
+            # Assert: UpsertNode should be in generated nodes
+            assert "UserUpsertNode" in db._nodes, (
+                "UserUpsertNode should be auto-generated when model is registered. "
                 f"Available nodes: {list(db._nodes.keys())}"
             )
 
-        # Count user-related nodes (should be 11: 7 CRUD + 4 Bulk)
-        user_nodes = [name for name in db._nodes.keys() if name.startswith("User")]
-        assert len(user_nodes) == 11, (
-            f"Should have exactly 11 nodes per model (7 CRUD + 4 Bulk), got {len(user_nodes)}: {user_nodes}"
-        )
+    def test_upsert_node_naming_convention(self):
+        """Verify UpsertNode follows ModelOperationNode naming convention."""
+        with DataFlow(":memory:") as db:
+
+            @db.model
+            class Product:
+                id: str
+                sku: str
+                name: str
+
+            # Assert: Node name should be ProductUpsertNode
+            assert (
+                "ProductUpsertNode" in db._nodes
+            ), "UpsertNode should follow ModelOperationNode naming convention"
+
+            # Verify the node class has correct attributes
+            node_class = db._nodes["ProductUpsertNode"]
+            assert node_class is not None
+            assert hasattr(node_class, "__name__")
+
+    def test_upsert_node_has_correct_parameters(self):
+        """Verify UpsertNode has where, update, create parameters."""
+        with DataFlow(":memory:") as db:
+
+            @db.model
+            class User:
+                id: str
+                email: str
+                name: str
+
+            # Act: Instantiate the node
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
+
+            # Get parameters
+            params = node.get_parameters()
+
+            # Assert: Should have where, update, create parameters
+            assert (
+                "where" in params
+            ), "UpsertNode should have 'where' parameter for lookup"
+            assert (
+                "update" in params
+            ), "UpsertNode should have 'update' parameter for existing records"
+            assert (
+                "create" in params
+            ), "UpsertNode should have 'create' parameter for new records"
+
+    def test_upsert_node_parameter_types(self):
+        """Verify UpsertNode parameters have correct types."""
+        with DataFlow(":memory:") as db:
+
+            @db.model
+            class User:
+                id: str
+                email: str
+                name: str
+
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
+
+            # Assert: Parameter types should be dict
+            assert params["where"].type == dict, "'where' should be dict type"
+            assert params["update"].type == dict, "'update' should be dict type"
+            assert params["create"].type == dict, "'create' should be dict type"
+
+    def test_upsert_node_parameter_requirements(self):
+        """Verify UpsertNode parameter requirements."""
+        with DataFlow(":memory:") as db:
+
+            @db.model
+            class User:
+                id: str
+                email: str
+                name: str
+
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
+
+            # Assert: where should be required, update/create can be optional
+            # (at least one of update or create must be provided, validated at runtime)
+            assert (
+                params["where"].required is True
+            ), "'where' parameter should be required"
+            # update and create can be optional but at least one must be provided
+
+    def test_upsert_node_bound_to_correct_dataflow_instance(self):
+        """Verify UpsertNode is bound to correct DataFlow instance (multi-instance isolation)."""
+        with DataFlow(":memory:") as db1, DataFlow(":memory:") as db2:
+
+            @db1.model
+            class User:
+                id: str
+                name: str
+
+            @db2.model
+            class User:  # Same model name, different instance
+                id: str
+                email: str
+
+            # Act: Instantiate nodes from each instance
+            node1_class = db1._nodes["UserUpsertNode"]
+            node2_class = db2._nodes["UserUpsertNode"]
+
+            node1 = node1_class()
+            node2 = node2_class()
+
+            # Assert: Each node should be bound to its respective DataFlow instance
+            assert (
+                node1.dataflow_instance is db1
+            ), "Node from db1 should be bound to db1 instance"
+            assert (
+                node2.dataflow_instance is db2
+            ), "Node from db2 should be bound to db2 instance"
+
+    def test_upsert_node_count_per_model(self):
+        """Verify 11 nodes are generated per model (7 CRUD + 4 bulk)."""
+        with DataFlow(":memory:") as db:
+
+            @db.model
+            class User:
+                id: str
+                name: str
+
+            # Assert: Should have exactly 11 nodes
+            expected_nodes = [
+                "UserCreateNode",
+                "UserReadNode",
+                "UserUpdateNode",
+                "UserDeleteNode",
+                "UserListNode",
+                "UserUpsertNode",
+                "UserCountNode",
+                "UserBulkCreateNode",
+                "UserBulkUpdateNode",
+                "UserBulkDeleteNode",
+                "UserBulkUpsertNode",
+            ]
+
+            for node_name in expected_nodes:
+                assert node_name in db._nodes, (
+                    f"{node_name} should be generated. "
+                    f"Available nodes: {list(db._nodes.keys())}"
+                )
+
+            # Count user-related nodes (should be 11: 7 CRUD + 4 Bulk)
+            user_nodes = [name for name in db._nodes.keys() if name.startswith("User")]
+            assert (
+                len(user_nodes) == 11
+            ), f"Should have exactly 11 nodes per model (7 CRUD + 4 Bulk), got {len(user_nodes)}: {user_nodes}"
 
     def test_upsert_node_operation_attribute(self):
         """Verify UpsertNode has correct operation attribute."""
-        # Arrange
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        @db.model
-        class User:
-            id: str
-            name: str
+            @db.model
+            class User:
+                id: str
+                name: str
 
-        # Act
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
 
-        # Assert: operation should be "upsert"
-        assert hasattr(node, "operation"), "Node should have operation attribute"
-        assert node.operation == "upsert", (
-            f"Operation should be 'upsert', got '{node.operation}'"
-        )
+            # Assert: operation should be "upsert"
+            assert hasattr(node, "operation"), "Node should have operation attribute"
+            assert (
+                node.operation == "upsert"
+            ), f"Operation should be 'upsert', got '{node.operation}'"
 
     def test_upsert_node_model_name_attribute(self):
         """Verify UpsertNode has correct model_name attribute."""
-        # Arrange
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        @db.model
-        class Product:
-            id: str
-            sku: str
+            @db.model
+            class Product:
+                id: str
+                sku: str
 
-        # Act
-        node_class = db._nodes["ProductUpsertNode"]
-        node = node_class()
+            node_class = db._nodes["ProductUpsertNode"]
+            node = node_class()
 
-        # Assert: model_name should match registered model
-        assert hasattr(node, "model_name"), "Node should have model_name attribute"
-        assert node.model_name == "Product", (
-            f"model_name should be 'Product', got '{node.model_name}'"
-        )
+            # Assert: model_name should match registered model
+            assert hasattr(node, "model_name"), "Node should have model_name attribute"
+            assert (
+                node.model_name == "Product"
+            ), f"model_name should be 'Product', got '{node.model_name}'"
 
     def test_upsert_node_database_url_parameter(self):
         """Verify UpsertNode has database_url parameter for connection override."""
-        # Arrange
-        db = DataFlow(":memory:")
+        with DataFlow(":memory:") as db:
 
-        @db.model
-        class User:
-            id: str
-            name: str
+            @db.model
+            class User:
+                id: str
+                name: str
 
-        # Act
-        node_class = db._nodes["UserUpsertNode"]
-        node = node_class()
-        params = node.get_parameters()
+            node_class = db._nodes["UserUpsertNode"]
+            node = node_class()
+            params = node.get_parameters()
 
-        # Assert: Should have database_url parameter
-        assert "database_url" in params, (
-            "UpsertNode should have 'database_url' parameter for connection override"
-        )
-        assert params["database_url"].required is False, (
-            "database_url should be optional (uses instance default if not provided)"
-        )
+            # Assert: Should have database_url parameter
+            assert (
+                "database_url" in params
+            ), "UpsertNode should have 'database_url' parameter for connection override"
+            assert (
+                params["database_url"].required is False
+            ), "database_url should be optional (uses instance default if not provided)"

--- a/packages/kailash-dataflow/tests/unit/testing/test_performance_regression_suite.py
+++ b/packages/kailash-dataflow/tests/unit/testing/test_performance_regression_suite.py
@@ -714,9 +714,16 @@ def test_concurrent_regression_testing(regression_suite):
     assert all(r.execution_time_ms < 100.0 for r in results)  # All under 100ms
 
 
-@pytest.mark.asyncio
 def test_async_regression_testing(regression_suite):
-    """Test regression testing with async operations."""
+    """Test regression testing with async operations.
+
+    NOTE: `@pytest.mark.asyncio` was removed (was applied to a sync function).
+    The test body is synchronous — it passes a nested `async def async_operation`
+    callable into `regression_suite.run_regression_test`, which handles its
+    own event loop / awaiting. The function body itself does not await,
+    so the asyncio marker fired a PytestWarning. Issue #1002 invariant 10
+    (asyncio-mark hygiene) per zero-tolerance.md Rule 1.
+    """
 
     async def async_operation(delay_ms: int):
         """Async operation for testing."""

--- a/packages/kailash-dataflow/tests/unit/testing/test_tdd_performance_benchmark.py
+++ b/packages/kailash-dataflow/tests/unit/testing/test_tdd_performance_benchmark.py
@@ -87,17 +87,21 @@ def performance_validator():
 
 @pytest.fixture
 async def tdd_transaction_dataflow():
-    """Mock fixture for TDD transaction dataflow."""
+    """Mock fixture for TDD transaction dataflow.
+
+    NOTE: This whole file is `pytest.mark.skip`-ped (see pytestmark above),
+    so this fixture never executes. Migrated to yield+close for hygiene.
+    """
     import uuid
     from unittest.mock import Mock
 
     from dataflow import DataFlow
 
     # Create a simple in-memory dataflow for testing
-    df = DataFlow(":memory:")
-    context = Mock()
-    context.test_id = "test_" + str(uuid.uuid4())[:8]
-    return df, context
+    with DataFlow(":memory:") as df:
+        context = Mock()
+        context.test_id = "test_" + str(uuid.uuid4())[:8]
+        yield df, context
 
 
 @pytest.mark.asyncio
@@ -372,9 +376,7 @@ async def test_tdd_seeded_data_performance(performance_validator, tmp_path):
 
     # Create DataFlow with pre-seeded data
     db_path = tmp_path / "seeded_data.db"
-    df = DataFlow(f"sqlite:///{db_path}")
-
-    try:
+    with DataFlow(f"sqlite:///{db_path}") as df:
         # Define models (simulating pre-seeded schema)
         @df.model
         class User:
@@ -434,8 +436,6 @@ async def test_tdd_seeded_data_performance(performance_validator, tmp_path):
         # Simulate operations that would use the seeded data
         # In a real TDD scenario, this data would already be in the database
         await asyncio.sleep(0.001)  # Minimal processing time
-    finally:
-        df.close()
 
     end_time = time.time()
     duration_ms = (end_time - start_time) * 1000
@@ -461,13 +461,11 @@ async def test_tdd_connection_reuse_performance(performance_validator, tmp_path)
     db_path = tmp_path / "connection_reuse.db"
 
     # DataFlow manages its own connection pool
-    df = DataFlow(
+    with DataFlow(
         f"sqlite:///{db_path}",
         pool_size=5,  # Simulate connection pool
         pool_max_overflow=0,
-    )
-
-    try:
+    ) as df:
         # Perform multiple operations simulating connection reuse
         for i in range(5):
             # Each operation would reuse connections from the pool
@@ -483,8 +481,6 @@ async def test_tdd_connection_reuse_performance(performance_validator, tmp_path)
                 # SQLite doesn't have true connection pooling like PostgreSQL
                 # But the test validates the performance pattern
                 pass
-    finally:
-        df.close()
 
     end_time = time.time()
     duration_ms = (end_time - start_time) * 1000


### PR DESCRIPTION
## Summary

Shard 3 of issue #1002 (AC#1 + AC#2 of #1000). Closes the long tail of inline DataFlow constructions + two pre-existing test-hygiene defects + the Core SDK runtime-cache leak.

| Commit | What |
|---|---|
| `b4020e91` | `tests/unit/{context_aware,upsert,engine_errors}` — Batch 1 of fixture cleanups |
| `5b67811b` | `tests/unit/{lazy_connection,upsert_conflict,architecture,2026_001_fixes}` — Batch 2 |
| `ebd7446e` | Tail batch + asyncio-mark hygiene fix at `test_performance_regression_suite.py:717` (invariant 10) |
| `5acd9e8d` | `warnings.filters` isolation in `test_validation_off_mode_no_checks` per journal/0005 (invariant 12) |
| `e79fca27` | **Core SDK fix**: `DataFlow.close()` / `close_async()` now releases ALL cached runtimes (`_runtime_override`, `_loop_runtime_cache`, `_sync_runtime_singleton`), not just `self.runtime`. Root-cause fix for the `_Py_Finalize` post-pytest-summary hang per journal/0006. |
| `30198679` | 3-probe behavioral regression test for the runtime-cache cleanup (sync + async parity + partial-failure tolerance) |

**Total scope migrated**: 19 of 24 enumerated tail files (5 out-of-scope: `MockDataFlow` / `FakeDataFlow` / `ProtectedDataFlow` / `_StubDataFlow` / docstring-only matches per pre-flight grep). Plus 2 test-hygiene fixes + 1 Core SDK runtime cleanup fix.

## Invariant 11 gate (AC#2: \"local pytest exits cleanly within 2 min\") — PASSES

Two consecutive full-unit-suite runs at branch HEAD:

\`\`\`
Run 1: 3274 passed, 87 skipped, 47 warnings in 92.20s (0:01:32), EXIT 0
Run 2: 3274 passed, 87 skipped, 47 warnings in 91.58s (0:01:31), EXIT 0
\`\`\`

**AC#2 is now verifiable AND passing.** Shard 4a's entry gate (\"local pytest exits clean ≤120s without setsid\") will be satisfied once this PR merges.

## Forest

Brief value-anchor (verbatim from `briefs/00-brief.md:39`):
> \"Local pytest exits cleanly (no \`_Py_Finalize\` hang) within 2 min\"

After this PR merges, Shard 4a adds the regression test against subprocess pytest, Shard 4b removes the setsid wrapper from CI, release/v2.9.8 ships.

## Test plan

- [x] Full unit suite: 3274 passed in ≤92.2s wall-clock under \`--timeout=120 -p no:cacheprovider\` (two consecutive runs, both EXIT 0)
- [x] New runtime-cache regression test (3 probes): all PASS under \`-W error::ResourceWarning\`
- [x] Pre-existing AsyncSQLDatabaseNode-cache regression test from Shard 2: still PASS
- [x] Invariant 12 verification: \`test_validation_off_mode_no_checks\` passes 10/10 with `-p no:randomly --count=10`
- [ ] Tier-1 DataFlow Unit Suite CI lane green
- [ ] Reviewer + security-reviewer parallel approval

## Related issues

Refs: #1002, #1000

Shard 4b closes #1000 AC#3 (and by extension #1002) by removing the setsid wrapper.