### PR TITLE
release(dataflow): cut v2.9.8 — partial closure of #1000 + #1002

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,71 @@
 # DataFlow Changelog
 
+## [2.9.8] — 2026-05-15 — Test-fixture + engine close() cleanup (partial closure of #1000 / #1002)
+
+Closes the leak-class half of issue #1002 (AC#1, AC#4) and adds engine
+production-path fixes. The CI-side AC#3 (remove `setsid` wrapper from
+`unified-ci.yml::test-dataflow`) remains DEFERRED to follow-up issue
+#1010 because the underlying `_Py_Finalize` post-summary hang is
+cross-platform (Linux/Python 3.11 + macOS) and not fully closed by the
+fixes in this release. Issue #1010 tracks the remaining diagnostic
+phases (H1 `LocalRuntime.__del__` core SDK violation, H2
+`SyncExpress` orphan daemon thread, H3 `AsyncSQLDatabaseNode._shared_pools`
+never cleared by `DataFlow.close()`).
+
+### Fixed
+
+- **Test fixture cleanup contract** (issue #1002 AC#1) — 156 inline
+  `DataFlow` / `AsyncRedisCacheAdapter` constructions across 28 unit
+  test files migrated to fixture / context-manager / try-finally
+  cleanup patterns per the contract at `specs/testing-tiers.md` §2 and
+  `rules/patterns.md` § Async Resource Cleanup. Sites:
+  - Shard 1: 67 sites in 5 high-density files (PR #1004)
+  - Shard 2: 45 sites in 4 mid-density + adapter files (PR #1005)
+  - Shard 3: 44 sites in 19 of 24 tail files + `warnings.filters`
+    isolation in `test_validation_off_mode_no_checks` + asyncio-mark
+    hygiene in `test_performance_regression_suite` (PR #1006)
+- **`DataFlow.close()` AsyncSQLDatabaseNode cache cleanup** —
+  `packages/kailash-dataflow/src/dataflow/core/engine.py::close()` now
+  iterates `_async_sql_node_cache` and closes each cached node via
+  `async_safe_run(node.close())`, matching the existing `close_async()`
+  block. Previously sync `close()` left cached nodes leaked at GC,
+  emitting `PytestUnraisableExceptionWarning` from
+  `AsyncSQLDatabaseNode.__del__`. Behavioral regression at
+  `packages/kailash-dataflow/tests/regression/test_issue_1002_sync_close_closes_async_sql_node_cache.py`
+  (3 probes: direct cache prime, sync context-manager teardown,
+  partial-failure tolerance).
+- **`DataFlow.close()` / `close_async()` release ALL cached runtimes** —
+  previously only `self.runtime` was closed; now every entry of
+  `_runtime_override`, `_loop_runtime_cache`, `_sync_runtime_singleton`
+  is closed and the caches cleared. Leaked `LocalRuntime` references
+  previously kept aiosqlite background threads alive past
+  `_Py_Finalize`. Behavioral regression at
+  `packages/kailash-dataflow/tests/regression/test_issue_1002_close_releases_all_cached_runtimes.py`
+  (3 probes: sync + async parity + partial-failure tolerance).
+
+### Added
+
+- **`packages/kailash-dataflow/tests/regression/test_pytest_exits_clean.py`**
+  (issue #1002 AC#4) — subprocess-based regression test that invokes
+  pytest against `tests/unit/cache/` and asserts clean exit within
+  budget. Subset chosen: 4 Redis + cache adapter test files. **Known
+  coverage gap** — the cache subset does not exercise the engine
+  close() / runtime-cache cleanup paths the engine-side fixes above
+  closed; coverage broadening tracked in issue #1010 Phase C.
+
+### Known limitations (deferred to #1010)
+
+- **CI `test-dataflow` lane still runs under `setsid` wrapper** —
+  removing the wrapper exposes a residual `_Py_Finalize` post-summary
+  hang that reproduces on both Linux/Python 3.11 (CI) and macOS
+  (intermittently). Root-cause candidates H1/H2/H3 identified in
+  `/redteam` Round 1; diagnostic + fix work scheduled for issue #1010.
+- **`packages/kailash-dataflow/tests/regression/` NOT exercised by any
+  CI step** — the 3 regression tests above are dark on PR CI. Wiring
+  blocked by an unrelated pre-existing failure
+  (`test_issue_753_psycopg2_dep_declared` policy conflict between #753
+  baseline-dep and #890 audit). Both tracked in #1010.
+
 ## [2.9.7] — 2026-05-14 — Structural `__del__` rule compliance (partial closure of #1000)
 
 Closes 9 `__del__` rule violations per `rules/patterns.md` § Async Resource

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.7"
+version = "2.9.8"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.7"
+__version__ = "2.9.8"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Release-prep PR for kailash-dataflow 2.9.8. **Partial closure** of issues #1000 + #1002:

- ✅ AC#1 (fixtures close DataFlow/connection instances) — landed via PRs #1004, #1005, #1006
- ✅ AC#4 (same-PR regression test) — landed via PR #1007
- ⏳ AC#3 (remove setsid wrapper from CI) — **DEFERRED to issue #1010**
- ⏳ AC#5 (CHANGELOG on the release that lands the fix) — THIS PR

This release ships the test-fixture + engine close() cleanup work. Issues #1000 + #1002 stay OPEN until #1010 closes the cross-platform `_Py_Finalize` residual hang that PR #1008 surfaced.

## Diff (metadata-only)

| File | Change |
|---|---|
| `packages/kailash-dataflow/pyproject.toml` | `version = "2.9.7"` → `"2.9.8"` |
| `packages/kailash-dataflow/src/dataflow/__init__.py` | `__version__ = "2.9.7"` → `"2.9.8"` |
| `packages/kailash-dataflow/CHANGELOG.md` | New `[2.9.8] — 2026-05-15` section reflecting partial closure |

Atomic version bump per `rules/zero-tolerance.md` Rule 5.

## Branch convention

`release/v2.9.8` per `rules/git.md` § Release-Prep — triggers `if: !startsWith(github.head_ref, 'release/')` auto-skip on PR-gate matrix per `rules/ci-runners.md` MUST Rule 8. Saves ~45 min × matrix-size of CI.

## CHANGELOG accuracy

The `[2.9.8]` section is HONEST about partial closure:
- Names the 3 ACs CLOSED (AC#1, AC#4, AC#5)
- Names the 1 AC DEFERRED (AC#3 → issue #1010)
- Names the known coverage gap on `test_pytest_exits_clean.py` (the cache subset doesn't exercise the engine close() / runtime-cache cleanup paths — tracked in #1010 F1)
- Names the regression-tests-dark-in-CI gap (#1010 F2)
- Names the cross-platform residual hang root-cause candidates (#1010 H1/H2/H3)

This prevents the false-claim trap where the CHANGELOG advertises "full closure" while CI still relies on the setsid workaround.

## Sibling-package release scope

Enumerated at session start per `rules/build-repo-release-discipline.md` § 3. ALL siblings at main == PyPI (zero drift). Only kailash-dataflow needs the bump.

| Package | main | PyPI | Release? |
|---|---|---|---|
| kailash | 2.21.0 | 2.21.0 | — |
| kailash-align | 0.7.1 | 0.7.1 | — |
| **kailash-dataflow** | **2.9.7→2.9.8** | **2.9.7** | **YES (this PR)** |
| kailash-kaizen | 2.21.0 | 2.21.0 | — |
| kailash-mcp | 0.2.14 | 0.2.14 | — |
| kailash-ml | 1.7.4 | 1.7.4 | — |
| kailash-nexus | 2.6.3 | 2.6.3 | — |
| kailash-pact | 0.12.0 | 0.12.0 | — |
| kaizen-agents | 0.9.7 | 0.9.7 | — |

## Test plan

- [x] Atomic version bump verified (both pyproject.toml AND `__init__.py` updated in same commit)
- [x] CHANGELOG entry references both #1000 and #1002 + #1010
- [x] Branch convention satisfies `release/v*` auto-skip
- [x] /redteam Round 1+2 convergent on the merged work (findings in #1010)
- [ ] Security-reviewer signoff on the version-bump PR
- [ ] CI auto-skip verified (PR-gate matrix should NOT fire)
- [ ] After merge: push `dataflow-v2.9.8` tag; verify publish-pypi.yml workflow runs
- [ ] After PyPI publish: clean-venv `pip install --no-cache-dir kailash-dataflow==2.9.8` reports `__version__ == "2.9.8"`
- [ ] Issues #1000 / #1002 STAY OPEN (do NOT close); they close when #1010 closes

## Related issues

Refs: #1000, #1002, #1010, #1004, #1005, #1006, #1007, #1008 (closed without merge)