### PR TITLE
chore(coc): land /sync-to-build delivery (trailing-space cleanup)

### DIFF
--- a/.claude/skills/02-dataflow/dataflow-gotchas.md
+++ b/.claude/skills/02-dataflow/dataflow-gotchas.md
@@ -110,7 +110,7 @@ async def db_fixture():
     db.close()  # Also fails!
 ```
 
-#### The Fix 
+#### The Fix
 
 ```python
 # ✅ CORRECT - Use async methods in async context

--- a/.claude/skills/02-dataflow/dataflow-multi-tenancy.md
+++ b/.claude/skills/02-dataflow/dataflow-multi-tenancy.md
@@ -57,7 +57,7 @@ workflow.add_node("OrderListNode", "list", {
 })
 ```
 
-## Auto-Wired Multi-Tenancy 
+## Auto-Wired Multi-Tenancy
 
 Multi-tenancy is now auto-wired into the engine via `QueryInterceptor`, which hooks into 8 SQL execution points:
 
@@ -80,7 +80,7 @@ async with TenantContextSwitch(db, tenant_id="tenant_abc"):
 - **Data Partitioning**: Separate data per tenant
 - **Security**: Prevents cross-tenant access
 - **Audit Trails**: Track tenant-specific changes
-- **Auto-Wired Interceptor**: QueryInterceptor at 8 SQL execution points 
+- **Auto-Wired Interceptor**: QueryInterceptor at 8 SQL execution points
 
 ## Documentation References
 

--- a/.claude/skills/02-dataflow/dataflow-queries.md
+++ b/.claude/skills/02-dataflow/dataflow-queries.md
@@ -138,7 +138,7 @@ results, run_id = runtime.execute(workflow.build())
 | `$null`   | `IS NULL`      | `{"deleted_at": {"$null": True}}`                        |
 | `$exists` | `IS NOT NULL`  | `{"email": {"$exists": True}}`                           |
 
-### Null Checking Operators 
+### Null Checking Operators
 
 **For soft-delete filtering and nullable field queries:**
 
@@ -153,7 +153,7 @@ workflow.add_node("PatientListNode", "deleted_patients", {
     "filter": {"deleted_at": {"$exists": True}}  # WHERE deleted_at IS NOT NULL
 })
 
-# Alternative: $eq with None also works 
+# Alternative: $eq with None also works
 workflow.add_node("PatientListNode", "active", {
     "filter": {"deleted_at": {"$eq": None}}  # Also generates IS NULL
 })

--- a/.claude/skills/17-gold-standards/gold-parameter-passing.md
+++ b/.claude/skills/17-gold-standards/gold-parameter-passing.md
@@ -130,7 +130,7 @@ class CustomNode(Node):
 - **Testing**: Testable parameter contracts
 - **Isolation**: Automatic scoping prevents data leakage
 
-## Parameter Naming 
+## Parameter Naming
 
 ### Using "metadata" as a Parameter Name
 


### PR DESCRIPTION
## Summary

Trailing-space removal on heading lines in four skill files — pure /sync-to-build delivery from loom. Landing per `coc-sync-landing.md` MUST-1 before resuming other session work.

## Files

- `.claude/skills/02-dataflow/dataflow-gotchas.md`
- `.claude/skills/02-dataflow/dataflow-multi-tenancy.md`
- `.claude/skills/02-dataflow/dataflow-queries.md`
- `.claude/skills/17-gold-standards/gold-parameter-passing.md`

Diff: 4 files, +6 −6 (cosmetic only).

## Test plan

- [x] Pre-commit hooks passed
- [x] No production-code changes — no test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)