### PR TITLE
test(dataflow): gate banned top-imports in 4 unit inspector files (closes #995)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,19 @@
 # DataFlow Changelog
 
+## [Unreleased]
+
+### Tests
+
+- test(dataflow): gate banned top-imports in 4 unit inspector files (#995)
+  — added `pytest.importorskip("kailash.workflow.builder")` gates in
+  `tests/unit/test_inspector_realtime_debugging.py`,
+  `tests/unit/test_inspector_parameter_tracing.py`, and
+  `tests/unit/test_inspector_workflow_analysis.py` per
+  `specs/testing-tiers.md` §Tier-1 Rule 1.
+  `tests/unit/test_inspector.py` already had no banned top-imports
+  (the WorkflowBuilder import lives inside a fixture); no edit needed.
+  Closes part of issue #995 (#979 Workstream-B shard B-1).
+
 ## [2.9.9] — 2026-05-15 — \_Py_Finalize CI hang fully closed; setsid wrapper removed (final closure of #1000 / #1002 / #1010)
 
 Closes brief AC#3 of issue #1000 (verbatim): "Verify on CI: remove the

--- a/packages/kailash-dataflow/tests/unit/test_inspector_parameter_tracing.py
+++ b/packages/kailash-dataflow/tests/unit/test_inspector_parameter_tracing.py
@@ -11,9 +11,14 @@ Tests:
 """
 
 import pytest
-from dataflow.platform.inspector import Inspector, ParameterTrace
 
-from kailash.workflow.builder import WorkflowBuilder
+# Per specs/testing-tiers.md §Tier-1 Rule 1, gate banned top-imports behind
+# pytest.importorskip so tier-1 collection succeeds in a clean [dev]-only
+# install (without the full kailash core runtime) — closes part of #995.
+_kw = pytest.importorskip("kailash.workflow.builder")
+WorkflowBuilder = _kw.WorkflowBuilder
+
+from dataflow.platform.inspector import Inspector, ParameterTrace
 
 
 class MockWorkflow:

--- a/packages/kailash-dataflow/tests/unit/test_inspector_realtime_debugging.py
+++ b/packages/kailash-dataflow/tests/unit/test_inspector_realtime_debugging.py
@@ -14,14 +14,19 @@ Tests:
 """
 
 import pytest
+
+# Per specs/testing-tiers.md §Tier-1 Rule 1, gate banned top-imports behind
+# pytest.importorskip so tier-1 collection succeeds in a clean [dev]-only
+# install (without the full kailash core runtime) — closes part of #995.
+_kw = pytest.importorskip("kailash.workflow.builder")
+WorkflowBuilder = _kw.WorkflowBuilder
+
 from dataflow.platform.inspector import (
     BreakpointInfo,
     ExecutionEvent,
     Inspector,
     RuntimeState,
 )
-
-from kailash.workflow.builder import WorkflowBuilder
 
 
 class MockWorkflow:

--- a/packages/kailash-dataflow/tests/unit/test_inspector_workflow_analysis.py
+++ b/packages/kailash-dataflow/tests/unit/test_inspector_workflow_analysis.py
@@ -15,7 +15,12 @@ Tests dataclasses and methods:
 """
 
 import pytest
-from kailash.workflow.builder import WorkflowBuilder
+
+# Per specs/testing-tiers.md §Tier-1 Rule 1, gate banned top-imports behind
+# pytest.importorskip so tier-1 collection succeeds in a clean [dev]-only
+# install (without the full kailash core runtime) — closes part of #995.
+_kw = pytest.importorskip("kailash.workflow.builder")
+WorkflowBuilder = _kw.WorkflowBuilder
 
 from dataflow import DataFlow
 from dataflow.platform.inspector import (


### PR DESCRIPTION
## Summary

Shard B-1 of #979 Workstream-B (closes #995). Adds tier-1 import gates to 4
unit inspector test files in `packages/kailash-dataflow/tests/unit/` so a
clean `[dev]`-only install (without the full kailash core runtime) can
collect them as skips instead of collection failures.

## Value-anchor (verbatim from `workspaces/issue-979-dataflow-unit-triage/briefs/00-brief.md:48-50`)

> "Any remaining tier-1 test that imports `motor`, `psycopg`, or other DB
> drivers is either gated behind `importorskip` OR moved to
> `tests/integration/`."

## Spec authority (verbatim from `specs/testing-tiers.md:26-40`)

> ### 1. No external infrastructure at import or run time
>
> The following MUST NOT appear in any `tests/unit/` file unless gated by
> `pytest.importorskip(...)` at module top:
> - `import asyncpg` / `import psycopg` / `import psycopg2` / `import pymysql`
> - `import aiomysql` / `import motor` / `import redis`
> - `from kailash.runtime import AsyncLocalRuntime` (real workflow runtime)
> - `from kailash.workflow.builder import WorkflowBuilder` (real workflow builder)
> - `from tests.infrastructure.test_harness import IntegrationTestSuite`

## Per-file decisions

| File | Banned top-imports | Disposition |
|------|--------------------|-------------|
| `tests/unit/test_inspector.py` | none (WorkflowBuilder is in fixture, not module top) | no edit |
| `tests/unit/test_inspector_realtime_debugging.py` | `from kailash.workflow.builder import WorkflowBuilder` | gated via `pytest.importorskip` |
| `tests/unit/test_inspector_parameter_tracing.py` | `from kailash.workflow.builder import WorkflowBuilder` | gated via `pytest.importorskip` |
| `tests/unit/test_inspector_workflow_analysis.py` | `from kailash.workflow.builder import WorkflowBuilder` | gated via `pytest.importorskip` |

`from dataflow import DataFlow` and `from dataflow.platform.inspector import ...`
stay at module top — they are NOT in the spec's banned list. The dataflow
package itself ships with the `[dev]` install.

## Verification

- `pytest packages/kailash-dataflow/tests/unit/ --collect-only -q` → exit 0
  (3488 tests collected in 0.82s).
- 4 commits on this branch: 3 file edits + 1 CHANGELOG.
- No file moved out of `tests/unit/`; gates only.
- Tests-only diff strictly under `packages/kailash-dataflow/tests/unit/` +
  `packages/kailash-dataflow/CHANGELOG.md` (carve-out per
  `build-repo-release-discipline.md` §1a — no version bump required).

## Related issues

Closes #995 (part of #979 Workstream-B shard B-1).