### PR TITLE
test(dataflow): B-2f remove tenancy skip — STAYS tier-1 per ATTACK-6 (partial #996)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -1,5 +1,17 @@
 # DataFlow Changelog
 
+## [Unreleased]
+
+### Tests
+
+- **B-2f (#996 partial)** — `test_saas_tenancy.py` STAYS in tier-1 with the
+  `pytestmark.skip` block removed. The file is 100% mocked, pure-Python,
+  and meets the tier-1 contract per ATTACK-6 R2 verification (workspace
+  `issue-979-dataflow-unit-triage/02-plans/02-amendments-v2-post-redteam-r1r2.md`
+  line 264-266). 10 tests now collect and pass. Sibling 5 SaaS-starter
+  files (api_keys / starter_auth / starter_jwt / subscriptions / webhooks)
+  remain skipped pending B-2a..B-2e sub-shards for tier-2 rewrite + move.
+
 ## [2.9.9] — 2026-05-15 — \_Py_Finalize CI hang fully closed; setsid wrapper removed (final closure of #1000 / #1002 / #1010)
 
 Closes brief AC#3 of issue #1000 (verbatim): "Verify on CI: remove the

--- a/packages/kailash-dataflow/tests/unit/templates/test_saas_tenancy.py
+++ b/packages/kailash-dataflow/tests/unit/templates/test_saas_tenancy.py
@@ -28,14 +28,13 @@ from typing import Dict, List, Optional
 
 import pytest
 
-# Tier-1 gate per issue #979 brief AC#5 + specs/testing-tiers.md § Tier-1
-# Rule 1 — bare top-imports of `LocalRuntime` + `WorkflowBuilder` plus
-# `runtime.execute(workflow)` against aiosqlite hangs the GH-runner
-# py3.11 worker (brief failure-layer #3). Rewrite scheduled as B-2 per
-# `workspaces/issue-979-dataflow-unit-triage/todos/active/00-INDEX.md`.
-pytestmark = pytest.mark.skip(
-    reason="Tier-1 spec violation (LocalRuntime + WorkflowBuilder top-imports); rewrite scheduled in Workstream-B B-2 per issue #979 brief AC#5"
-)
+# File STAYS in tier-1 per `workspaces/issue-979-dataflow-unit-triage/02-plans/
+# 02-amendments-v2-post-redteam-r1r2.md:264-266` ATTACK-6 R2 verification:
+# 100% mocked, pure-Python, meets the tier-1 contract. Mocking IS allowed
+# at tier-1 per `specs/testing-tiers.md` § Tier-1 Rule 4. Sibling 5 saas
+# tests (api_keys / starter_auth / starter_jwt / subscriptions / webhooks)
+# are deferred to follow-up sub-shards B-2a..B-2e for the move-to-integration
+# rewrite per `value-prioritization.md` MUST-2 sharding.
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "../../../templates")
 if TEMPLATES_DIR not in sys.path:


### PR DESCRIPTION
## Summary

B-2f sub-shard of #996 — remove `pytestmark.skip` from `test_saas_tenancy.py`. File STAYS in tier-1 per the OPTION-C′ plan invariant.

## Value-anchor (verbatim from `workspaces/issue-979-dataflow-unit-triage/02-plans/02-amendments-v2-post-redteam-r1r2.md:264-266`)

> "S2c (in Workstream-B if OPTION-C′) keeps it in tier-1, not the move list. If OPTION-A: S2c excludes tenancy from MOVE; keeps it in tier-1."

Plus session-note trap: "test_saas_tenancy.py MUST STAY in tier-1 (R2 ATTACK-6 verified: 100% mocked, pure-Python, meets contract)."

## Re-shard rationale (rest of #996 deferred to B-2a..B-2e)

Issue #996 originally bundled 6 files for "move + rewrite to NO MOCKING per Tier-2 contract." The actual scope on inspection: 3,536 LOC + 112 mock sites across 5 files — about 7× the per-session capacity budget per `rules/autonomous-execution.md` MUST-1. Plus the auth file imports `saas_starter.*` modules under `try/except ImportError → TEMPLATE_AVAILABLE = False`, hinting at a possible orphan-template surface that warrants per-file disposition.

Per `rules/sweep-completeness.md` MUST-1 (substitution-decision human gate) + `rules/value-prioritization.md` MUST-2 (decompose, don't defer fittable-pick), the user authorized re-sharding into 6 sub-shards:

| Sub-shard | Scope | Status |
|-----------|-------|--------|
| **B-2f** (this PR) | Remove tenancy skip — STAYS tier-1 | **Shipped** |
| B-2a | `test_saas_starter_jwt.py` (400 LOC, 7 mocks — smallest, JWT crypto) | Deferred |
| B-2b | `test_saas_api_keys.py` (580 LOC, 35 mocks) | Deferred |
| B-2c | `test_saas_subscriptions.py` (541 LOC, 30 mocks) | Deferred |
| B-2d | `test_saas_webhooks.py` (640 LOC, 40 mocks) | Deferred |
| B-2e | `test_saas_starter_auth.py` (1,375 LOC; check `TEMPLATE_AVAILABLE = False` orphan signal first) | Deferred |

Each deferred sub-shard carries a value-anchor citing brief AC#5 and stays open under #996 until landed.

## Verification

- `pytest packages/kailash-dataflow/tests/unit/templates/test_saas_tenancy.py --collect-only -q` → exit 0, 10 tests collected
- `pytest packages/kailash-dataflow/tests/unit/templates/test_saas_tenancy.py -x` → 10 passed in 0.07s
- Pre-commit hooks all pass on the diff (Black, isort, Ruff, type annotations, etc.)

## Pyright reportMissingImports — pre-existing false positive

The file uses `sys.path.insert(0, "../../../templates")` at line 41 to make the saas_starter package importable at runtime. Pyright cannot statically trace that path hack and reports `Import "saas_starter.tenancy.isolation" could not be resolved` at 10 import sites. Confirmed false positives — runtime imports resolve correctly (10 tests collect and pass).

## Related issues

Partial closure of #996 (B-2 of #979 Workstream-B). Sibling sub-shards B-2a..B-2e remain open under #996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)