### PR TITLE
fix(dataflow): api_gateway_starter — sibling-sweep JWT_SECRET env-var + conftest (R2 /redteam, closes part of #996)

### DIFF
--- a/packages/kailash-dataflow/templates/api_gateway_starter/example_app/config.py
+++ b/packages/kailash-dataflow/templates/api_gateway_starter/example_app/config.py
@@ -9,6 +9,21 @@ from typing import List
 
 from pydantic import BaseModel, Field
 
+# JWT signing secret MUST come from the environment — fail loudly at import if
+# unset so deployments cannot ship with a known hardcoded key. The shared
+# envvar name is ``SAAS_STARTER_JWT_SECRET`` so api_gateway_starter and
+# saas_starter (which exchange tokens) verify with the same key.
+_JWT_SECRET_ENV = "SAAS_STARTER_JWT_SECRET"
+_jwt_secret_raw = os.environ.get(_JWT_SECRET_ENV)
+if not _jwt_secret_raw:
+    raise RuntimeError(
+        f"{_JWT_SECRET_ENV} environment variable is required. "
+        f"Set a cryptographically random value (>=32 bytes) before importing "
+        f"templates.api_gateway_starter.example_app.config. See README for "
+        f"production deployment."
+    )
+_JWT_SECRET: str = _jwt_secret_raw
+
 
 class Settings(BaseModel):
     """
@@ -16,7 +31,8 @@ class Settings(BaseModel):
 
     Environment Variables:
         DATABASE_URL: Database connection URL (default: ":memory:")
-        JWT_SECRET: Secret key for JWT token signing (required in production)
+        SAAS_STARTER_JWT_SECRET: Secret key for JWT token signing (REQUIRED,
+            shared with saas_starter; fail-loud at import if unset)
         ALLOWED_ORIGINS: Comma-separated list of allowed CORS origins (default: "*")
         RATE_LIMIT_REQUESTS: Maximum requests per window (default: 1000)
         RATE_LIMIT_WINDOW: Time window in seconds (default: 3600)
@@ -36,8 +52,8 @@ class Settings(BaseModel):
     )
 
     jwt_secret: str = Field(
-        default=os.getenv("JWT_SECRET", "change-this-secret-in-production"),
-        description="Secret key for JWT tokens",
+        default=_JWT_SECRET,
+        description="Secret key for JWT tokens (from SAAS_STARTER_JWT_SECRET)",
     )
 
     allowed_origins: List[str] = Field(

--- a/packages/kailash-dataflow/tests/integration/templates/api_gateway_starter/conftest.py
+++ b/packages/kailash-dataflow/tests/integration/templates/api_gateway_starter/conftest.py
@@ -1,0 +1,32 @@
+"""
+api_gateway_starter integration-test conftest.
+
+The api_gateway_starter template's config module reads ``SAAS_STARTER_JWT_SECRET``
+from the environment at import time and raises ``RuntimeError`` if unset
+(see ``packages/kailash-dataflow/templates/api_gateway_starter/example_app/config.py``).
+The Tier-2 test suite for api_gateway_starter imports that module via
+``from templates.api_gateway_starter.example_app.main import create_app`` and
+also exchanges tokens with saas_starter, so a 32+ byte test secret MUST be
+present BEFORE any test imports.
+
+This conftest uses ``os.environ.setdefault`` so:
+- Production deployments (which set ``SAAS_STARTER_JWT_SECRET`` to a real
+  value before pytest) are not overridden.
+- Local / CI runs without the variable get a 52-byte synthetic test secret.
+
+The test secret meets the >=32 byte floor mandated by RFC 7518 §3.2 and
+``rules/testing.md`` § "JWT Test Secrets >= 32 Bytes". Matches the value
+used by the sibling saas_starter conftest so cross-template token exchange
+(api_gateway verifies tokens signed by saas_starter) works without test
+infrastructure drift.
+
+Cross-reference: ``rules/security.md`` § "No Hardcoded Secrets" +
+``rules/env-models.md``.
+"""
+
+import os
+
+os.environ.setdefault(
+    "SAAS_STARTER_JWT_SECRET",
+    "test-secret-saas-starter-tier2-32bytes-minimum-floor",
+)

--- a/uv.lock
+++ b/uv.lock
@@ -1772,7 +1772,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.20.2"
+version = "2.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2097,7 +2097,7 @@ provides-extras = ["rlhf", "eval", "serve", "online", "rl-bridge", "all", "dev"]
 
 [[package]]
 name = "kailash-dataflow"
-version = "2.9.0"
+version = "2.9.9"
 source = { editable = "packages/kailash-dataflow" }
 dependencies = [
     { name = "asyncpg" },
@@ -2122,6 +2122,7 @@ security = [
 requires-dist = [
     { name = "aiokafka", marker = "extra == 'streaming'", specifier = ">=0.11" },
     { name = "aiomysql", marker = "extra == 'mysql'", specifier = ">=0.2.0" },
+    { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.19.0" },
     { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.19.0" },
     { name = "asyncpg", specifier = ">=0.28.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
@@ -2135,6 +2136,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'fabric'", specifier = ">=0.27" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "kailash", specifier = ">=2.18.0" },
+    { name = "kailash", extras = ["server"], marker = "extra == 'dev'" },
     { name = "kailash-dataflow", extras = ["fabric", "cloud", "excel", "parquet", "streaming"], marker = "extra == 'fabric-all'" },
     { name = "kailash-dataflow", extras = ["postgres-sync", "mysql", "sqlite", "mongo", "redis", "api", "security", "monitoring", "templates", "fabric-all"], marker = "extra == 'all'" },
     { name = "motor", marker = "extra == 'mongo'", specifier = ">=3.3.0" },
@@ -2152,6 +2154,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=4.5.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "sqlparse", specifier = ">=0.5.0" },


### PR DESCRIPTION
## Summary

Round 2 `/redteam` fix shard closing the api_gateway_starter sibling-sweep gap surfaced AFTER PR #1030 (the R1 fix shard) landed. Two convergent findings from Round 2 reviewer + security:

1. **Security HIGH (H-R2-1)** — `templates/api_gateway_starter/example_app/config.py:39` shipped hardcoded JWT_SECRET default `"change-this-secret-in-production"`. Same bug class as R1 C1 (saas_starter hardcoded defaults). R1 sweep was scoped to `saas_starter/` only; the sibling `api_gateway_starter/` template ships in the same package and was missed.
2. **Reviewer HIGH** — `tests/integration/templates/api_gateway_starter/` lacked a conftest after R1 added the fail-loud `RuntimeError` to `saas_starter/auth/jwt_auth.py`. The api_gateway test suite imports saas_starter's `JWT_SECRET` for cross-template token exchange (4 sites in `test_example_app.py`), so collection breaks across the dataflow tree without the env var (5882/6096 instead of 6126).

Per `autonomous-execution.md` MUST Rule 4 + `zero-tolerance.md` Rule 1a (Scanner-Surface Symmetry — "same on main" is BLOCKED). Both findings are same-bug-class as R1 + fit one shard.

## Fix (mirrors PR #1030 pattern exactly)

- `config.py`: reads `SAAS_STARTER_JWT_SECRET` (shared envvar — api_gateway and saas_starter exchange tokens so MUST share signing key); raises `RuntimeError` on missing; narrows `_JWT_SECRET: str` for Pydantic Field default.
- New `tests/integration/templates/api_gateway_starter/conftest.py`: `os.environ.setdefault` with a 52-byte test value matching the saas_starter sibling.

## Verification

```
SAAS_STARTER_JWT_SECRET="<test>" pytest tests/integration/templates/ → 70/70 pass
SAAS_STARTER_JWT_SECRET= python -c "from templates.api_gateway_starter.example_app import config"
  → RuntimeError: SAAS_STARTER_JWT_SECRET environment variable is required...
```

## Cross-SDK

kailash-rs likely has the same `api_gateway_starter` hardcoded pattern; flag for separate cross-SDK issue per `rules/cross-sdk-inspection.md` MUST Rule 1 (cross-repo work BLOCKED from this session per `rules/repo-scope-discipline.md` — needs kailash-rs context-switch).

## Related issues

Closes part of #996 (R2 /redteam findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
