### PR TITLE
fix(dataflow): issue #996 round-5 — saas_starter tenant hardening + LocalRuntime lifecycle

### DIFF
--- a/packages/kailash-dataflow/templates/api_gateway_starter/example_app/main.py
+++ b/packages/kailash-dataflow/templates/api_gateway_starter/example_app/main.py
@@ -11,8 +11,9 @@ Production-ready application demonstrating complete middleware stack integration
 Integrates all components from API Gateway Starter template with DataFlow for database operations.
 """
 
-from dataflow import DataFlow
 from fastapi import FastAPI, Request
+
+from dataflow import DataFlow
 from templates.api_gateway_starter.example_app.config import get_settings
 from templates.api_gateway_starter.example_app.models import register_models
 from templates.api_gateway_starter.example_app.routes.organizations import (
@@ -191,6 +192,7 @@ def create_app(db: DataFlow = None) -> FastAPI:
 
     # API key protected endpoints
     from fastapi import APIRouter
+
     from templates.api_gateway_starter.middleware.api_key_auth import api_key_required
 
     api_router = APIRouter(prefix="/api", tags=["api"])
@@ -213,13 +215,13 @@ def create_app(db: DataFlow = None) -> FastAPI:
             401: Missing or invalid API key
             403: Insufficient scopes
         """
+        from kailash.runtime import LocalRuntime
+        from kailash.workflow.builder import WorkflowBuilder
+
         from templates.api_gateway_starter.utils.responses import paginated_response
         from templates.api_gateway_starter.utils.validation import (
             validate_pagination_params,
         )
-
-        from kailash.runtime import LocalRuntime
-        from kailash.workflow.builder import WorkflowBuilder
 
         # Get organization from API key
         api_key_data = getattr(request.state, "api_key_data", {})
@@ -240,8 +242,10 @@ def create_app(db: DataFlow = None) -> FastAPI:
             },
         )
 
-        runtime = LocalRuntime()
-        results, _ = runtime.execute(workflow.build())
+        # Context-managed runtime per round-5 redteam F1 sibling sweep —
+        # bare LocalRuntime() leaks the connection pool until GC.
+        with LocalRuntime() as runtime:
+            results, _ = runtime.execute(workflow.build())
 
         users = results.get("list", [])
         total = len(users)

--- a/packages/kailash-dataflow/templates/api_gateway_starter/example_app/routes/organizations.py
+++ b/packages/kailash-dataflow/templates/api_gateway_starter/example_app/routes/organizations.py
@@ -4,8 +4,11 @@ Organization CRUD routes with authentication.
 All endpoints require JWT authentication.
 """
 
-from dataflow import DataFlow
 from fastapi import APIRouter, Request
+from kailash.runtime import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+from dataflow import DataFlow
 from templates.api_gateway_starter.middleware.rbac import require_role
 from templates.api_gateway_starter.utils.errors import (
     NOT_FOUND_ERROR,
@@ -21,9 +24,6 @@ from templates.api_gateway_starter.utils.validation import (
     validate_create_request,
     validate_pagination_params,
 )
-
-from kailash.runtime import LocalRuntime
-from kailash.workflow.builder import WorkflowBuilder
 
 
 def create_organization_router(db: DataFlow) -> APIRouter:
@@ -59,12 +59,13 @@ def create_organization_router(db: DataFlow) -> APIRouter:
             # Validate request
             validated = validate_create_request("Organization", org_data)
 
-            # Execute DataFlow workflow
+            # Execute DataFlow workflow. Context-managed runtime per
+            # round-5 redteam F1 sibling sweep.
             workflow = WorkflowBuilder()
             workflow.add_node("OrganizationCreateNode", "create", validated)
 
-            runtime = LocalRuntime()
-            results, _ = runtime.execute(workflow.build())
+            with LocalRuntime() as runtime:
+                results, _ = runtime.execute(workflow.build())
 
             org = results.get("create")
             if not org:
@@ -106,14 +107,15 @@ def create_organization_router(db: DataFlow) -> APIRouter:
             # Validate pagination
             offset, limit = validate_pagination_params(page, limit, max_limit=100)
 
-            # Execute DataFlow workflow
+            # Execute DataFlow workflow. Context-managed runtime per
+            # round-5 redteam F1 sibling sweep.
             workflow = WorkflowBuilder()
             workflow.add_node(
                 "OrganizationListNode", "list", {"limit": limit, "offset": offset}
             )
 
-            runtime = LocalRuntime()
-            results, _ = runtime.execute(workflow.build())
+            with LocalRuntime() as runtime:
+                results, _ = runtime.execute(workflow.build())
 
             organizations = results.get("list", [])
 
@@ -156,8 +158,9 @@ def create_organization_router(db: DataFlow) -> APIRouter:
             {"id": org_id, "raise_on_not_found": False},
         )
 
-        runtime = LocalRuntime()
-        results, _ = runtime.execute(workflow.build())
+        # Context-managed runtime per round-5 redteam F1 sibling sweep.
+        with LocalRuntime() as runtime:
+            results, _ = runtime.execute(workflow.build())
 
         org = results.get("read")
         if not org or org.get("found") is False or org.get("failed"):
@@ -189,7 +192,8 @@ def create_organization_router(db: DataFlow) -> APIRouter:
             401: Authentication error
             403: Authorization error
         """
-        # Execute DataFlow workflow
+        # Execute DataFlow workflow. Context-managed runtime per round-5
+        # redteam F1 sibling sweep.
         workflow = WorkflowBuilder()
         workflow.add_node(
             "OrganizationUpdateNode",
@@ -197,8 +201,8 @@ def create_organization_router(db: DataFlow) -> APIRouter:
             {"filter": {"id": org_id}, "fields": update_data},
         )
 
-        runtime = LocalRuntime()
-        results, _ = runtime.execute(workflow.build())
+        with LocalRuntime() as runtime:
+            results, _ = runtime.execute(workflow.build())
 
         org = results.get("update")
         if not org or org.get("failed"):
@@ -227,12 +231,13 @@ def create_organization_router(db: DataFlow) -> APIRouter:
             401: Authentication error
             403: Authorization error (non-owner)
         """
-        # Execute DataFlow workflow
+        # Execute DataFlow workflow. Context-managed runtime per round-5
+        # redteam F1 sibling sweep.
         workflow = WorkflowBuilder()
         workflow.add_node("OrganizationDeleteNode", "delete", {"id": org_id})
 
-        runtime = LocalRuntime()
-        results, _ = runtime.execute(workflow.build())
+        with LocalRuntime() as runtime:
+            results, _ = runtime.execute(workflow.build())
 
         deleted = results.get("delete")
         if not deleted or deleted.get("failed"):

--- a/packages/kailash-dataflow/templates/api_gateway_starter/example_app/routes/users.py
+++ b/packages/kailash-dataflow/templates/api_gateway_starter/example_app/routes/users.py
@@ -4,8 +4,11 @@ User CRUD routes with authentication and RBAC.
 All endpoints require JWT authentication and enforce role-based access control.
 """
 
-from dataflow import DataFlow
 from fastapi import APIRouter, HTTPException, Request
+from kailash.runtime import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+from dataflow import DataFlow
 from templates.api_gateway_starter.middleware.rbac import require_role
 from templates.api_gateway_starter.utils.errors import (
     NOT_FOUND_ERROR,
@@ -21,9 +24,6 @@ from templates.api_gateway_starter.utils.validation import (
     validate_create_request,
     validate_pagination_params,
 )
-
-from kailash.runtime import LocalRuntime
-from kailash.workflow.builder import WorkflowBuilder
 
 
 def create_user_router(db: DataFlow) -> APIRouter:
@@ -126,8 +126,11 @@ def create_user_router(db: DataFlow) -> APIRouter:
                 },
             )
 
-            runtime = LocalRuntime()
-            results, _ = runtime.execute(workflow.build())
+            # Context-managed runtime per round-5 redteam F1 — bare
+            # LocalRuntime() leaks connections + background tasks until
+            # GC and triggers the kailash v0.12 hard-removal warning.
+            with LocalRuntime() as runtime:
+                results, _ = runtime.execute(workflow.build())
 
             users = results.get("list", [])
 

--- a/packages/kailash-dataflow/templates/api_gateway_starter/example_app/routes/users.py
+++ b/packages/kailash-dataflow/templates/api_gateway_starter/example_app/routes/users.py
@@ -63,12 +63,13 @@ def create_user_router(db: DataFlow) -> APIRouter:
             # Validate request
             validated = validate_create_request("User", user_data)
 
-            # Execute DataFlow workflow
+            # Execute DataFlow workflow. Context-managed runtime per
+            # round-5 redteam F1 sibling sweep.
             workflow = WorkflowBuilder()
             workflow.add_node("UserCreateNode", "create", validated)
 
-            runtime = LocalRuntime()
-            results, _ = runtime.execute(workflow.build())
+            with LocalRuntime() as runtime:
+                results, _ = runtime.execute(workflow.build())
 
             user = results.get("create")
             if not user:
@@ -178,8 +179,9 @@ def create_user_router(db: DataFlow) -> APIRouter:
             {"id": user_id, "raise_on_not_found": False},
         )
 
-        runtime = LocalRuntime()
-        results, _ = runtime.execute(workflow.build())
+        # Context-managed runtime per round-5 redteam F1 sibling sweep.
+        with LocalRuntime() as runtime:
+            results, _ = runtime.execute(workflow.build())
 
         user = results.get("read")
         if not user or user.get("found") is False or user.get("failed"):
@@ -221,14 +223,18 @@ def create_user_router(db: DataFlow) -> APIRouter:
         # by dialect (PostgreSQL RETURNING gives the full row; SQLite /
         # MySQL without RETURNING give only ``{updated, rows_affected,
         # id}``). Reading back makes the response body dialect-invariant.
+        # Context-managed runtimes per round-5 redteam F1 sibling sweep —
+        # the two sequential workflows (update + read-back) get their own
+        # context manager each since they're already separated for DAG
+        # ordering reasons; each MUST close its pool deterministically.
         update_workflow = WorkflowBuilder()
         update_workflow.add_node(
             "UserUpdateNode",
             "update",
             {"filter": {"id": user_id}, "fields": update_data},
         )
-        update_runtime = LocalRuntime()
-        update_results, _ = update_runtime.execute(update_workflow.build())
+        with LocalRuntime() as update_runtime:
+            update_results, _ = update_runtime.execute(update_workflow.build())
 
         update_result = update_results.get("update")
         if not update_result or update_result.get("failed"):
@@ -246,8 +252,8 @@ def create_user_router(db: DataFlow) -> APIRouter:
             "read",
             {"id": user_id, "raise_on_not_found": False},
         )
-        read_runtime = LocalRuntime()
-        read_results, _ = read_runtime.execute(read_workflow.build())
+        with LocalRuntime() as read_runtime:
+            read_results, _ = read_runtime.execute(read_workflow.build())
 
         user = read_results.get("read") or update_result
         return success_response(user)
@@ -267,12 +273,13 @@ def create_user_router(db: DataFlow) -> APIRouter:
             401: Authentication error
             403: Authorization error (non-admin)
         """
-        # Execute DataFlow workflow
+        # Execute DataFlow workflow. Context-managed runtime per round-5
+        # redteam F1 sibling sweep.
         workflow = WorkflowBuilder()
         workflow.add_node("UserDeleteNode", "delete", {"id": user_id})
 
-        runtime = LocalRuntime()
-        results, _ = runtime.execute(workflow.build())
+        with LocalRuntime() as runtime:
+            results, _ = runtime.execute(workflow.build())
 
         deleted = results.get("delete")
         if not deleted or deleted.get("failed"):

--- a/packages/kailash-dataflow/templates/saas_starter/integrations/webhooks.py
+++ b/packages/kailash-dataflow/templates/saas_starter/integrations/webhooks.py
@@ -6,8 +6,8 @@ Simplified webhook handling with direct Python functions.
 Functions:
 - create_webhook_event(db, organization_id, event_type, payload) - Log webhook event
 - get_webhook_events(db, organization_id, filters) - Query webhook events
-- retry_failed_webhook(db, event_id) - Retry webhook
-- mark_webhook_delivered(db, event_id) - Mark as delivered
+- retry_failed_webhook(db, event_id, organization_id) - Retry webhook (tenant-scoped)
+- mark_webhook_delivered(db, event_id, organization_id) - Mark as delivered (tenant-scoped)
 - verify_webhook_signature(payload, signature, secret) - Verify webhook signature
 
 Architecture:
@@ -128,19 +128,26 @@ def get_webhook_events(
     return list_result if isinstance(list_result, list) else []
 
 
-def retry_failed_webhook(db, event_id: str) -> Optional[Dict]:
+def retry_failed_webhook(db, event_id: str, organization_id: str) -> Optional[Dict]:
     """
-    Retry failed webhook.
+    Retry failed webhook (tenant-scoped).
 
     Args:
         db: DataFlow instance
         event_id: Webhook event ID to retry
+        organization_id: Tenant organization ID. REQUIRED — every
+            read/update filter is scoped by ``(id, organization_id)``
+            so a caller cannot retry a webhook event belonging to
+            another tenant even if they know or guess its event_id.
+            Returns ``None`` if no event matches the (event_id,
+            organization_id) pair.
 
     Returns:
-        Updated webhook event dict
+        Updated webhook event dict, or ``None`` when no event matches
+        the tenant-scoped filter.
 
     Example:
-        >>> event = retry_failed_webhook(db, "evt_123")
+        >>> event = retry_failed_webhook(db, "evt_123", "org_456")
         >>> print(event["retry_count"])
         1
     """
@@ -148,11 +155,19 @@ def retry_failed_webhook(db, event_id: str) -> Optional[Dict]:
     # subscriptions.py both use the ``*ListNode`` + ``filter={"id":...}``
     # idiom over the ``*ReadNode`` direct-id form for cross-dialect
     # consistency; we follow the same pattern here.
+    #
+    # Tenant-isolation: every filter binds BOTH ``id`` AND
+    # ``organization_id`` so a cross-tenant ``event_id`` returns no rows
+    # and the function returns ``None`` BEFORE any update fires. Per
+    # round-5 redteam MED-1a finding.
     read_workflow = WorkflowBuilder()
     read_workflow.add_node(
         "WebhookEventListNode",
         "read_event",
-        {"filter": {"id": event_id}, "limit": 1},
+        {
+            "filter": {"id": event_id, "organization_id": organization_id},
+            "limit": 1,
+        },
     )
 
     # Single runtime context spans both the read + update workflows so the
@@ -186,7 +201,7 @@ def retry_failed_webhook(db, event_id: str) -> Optional[Dict]:
             "WebhookEventUpdateNode",
             "update_event",
             {
-                "filter": {"id": event_id},
+                "filter": {"id": event_id, "organization_id": organization_id},
                 "fields": {
                     "retry_count": new_retry_count,
                     "status": new_status,
@@ -204,7 +219,10 @@ def retry_failed_webhook(db, event_id: str) -> Optional[Dict]:
         readback_workflow.add_node(
             "WebhookEventListNode",
             "readback_event",
-            {"filter": {"id": event_id}, "limit": 1},
+            {
+                "filter": {"id": event_id, "organization_id": organization_id},
+                "limit": 1,
+            },
         )
         readback_results, _ = runtime.execute(readback_workflow.build())
         readback_list = readback_results.get("readback_event") or {}
@@ -214,31 +232,42 @@ def retry_failed_webhook(db, event_id: str) -> Optional[Dict]:
     return readback_records[0] if readback_records else None
 
 
-def mark_webhook_delivered(db, event_id: str) -> Optional[Dict]:
+def mark_webhook_delivered(db, event_id: str, organization_id: str) -> Optional[Dict]:
     """
-    Mark webhook as delivered.
+    Mark webhook as delivered (tenant-scoped).
 
     Args:
         db: DataFlow instance
         event_id: Webhook event ID
+        organization_id: Tenant organization ID. REQUIRED — the update
+            filter binds BOTH ``id`` AND ``organization_id`` so a caller
+            cannot mark a webhook event from another tenant as
+            delivered even if they know or guess its event_id.
+            Returns ``None`` if no event matches the (event_id,
+            organization_id) pair.
 
     Returns:
-        Updated webhook event dict with status="delivered"
+        Updated webhook event dict with status="delivered", or ``None``
+        when no event matches the tenant-scoped filter.
 
     Example:
-        >>> event = mark_webhook_delivered(db, "evt_123")
+        >>> event = mark_webhook_delivered(db, "evt_123", "org_456")
         >>> print(event["status"])
         delivered
     """
     # DataFlow ``*UpdateNode`` reads ``filter`` (singular). See
     # api_keys.py::revoke_api_key for the same gotcha — ``filters``
     # (plural) is silently dropped and raises UPDATE_NODE_MISSING_FILTER_ID.
+    #
+    # Tenant-isolation: the update + read-back filters BOTH bind
+    # ``organization_id`` so a cross-tenant ``event_id`` is a no-op and
+    # returns ``None``. Per round-5 redteam MED-1b finding.
     workflow = WorkflowBuilder()
     workflow.add_node(
         "WebhookEventUpdateNode",
         "update_event",
         {
-            "filter": {"id": event_id},
+            "filter": {"id": event_id, "organization_id": organization_id},
             "fields": {"status": "delivered", "delivered_at": datetime.now()},
         },
     )
@@ -253,7 +282,10 @@ def mark_webhook_delivered(db, event_id: str) -> Optional[Dict]:
         readback_workflow.add_node(
             "WebhookEventListNode",
             "readback_event",
-            {"filter": {"id": event_id}, "limit": 1},
+            {
+                "filter": {"id": event_id, "organization_id": organization_id},
+                "limit": 1,
+            },
         )
         readback_results, _ = runtime.execute(readback_workflow.build())
         readback_list = readback_results.get("readback_event") or {}

--- a/packages/kailash-dataflow/templates/saas_starter/security/api_keys.py
+++ b/packages/kailash-dataflow/templates/saas_starter/security/api_keys.py
@@ -23,7 +23,7 @@ Architecture:
 import hashlib
 import secrets
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from kailash.runtime import LocalRuntime
@@ -202,13 +202,23 @@ def verify_api_key(db, api_key: str) -> Dict:
     # Check if key is expired. SQLite returns DATETIME columns as ISO-format
     # strings (no native datetime type); PostgreSQL returns datetime objects.
     # Normalize to datetime so the comparison works on both backends.
+    #
+    # Timezone-safety: PostgreSQL ``TIMESTAMP WITH TIME ZONE`` returns
+    # tz-aware datetimes; aiosqlite-with-detect_types may return either
+    # tz-aware or naive depending on the stored ISO string. A naive
+    # ``datetime.now()`` raises ``TypeError: can't compare offset-naive and
+    # offset-aware datetimes`` whenever expires_at is tz-aware. Normalize
+    # naive values to UTC so both backends compare safely against
+    # ``datetime.now(timezone.utc)``. Per round-5 redteam MED-2 finding.
     expires_at = key_record.get("expires_at")
     if isinstance(expires_at, str):
         try:
             expires_at = datetime.fromisoformat(expires_at)
         except ValueError:
             expires_at = None
-    if expires_at and expires_at < datetime.now():
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    if expires_at and expires_at < datetime.now(timezone.utc):
         return {"valid": False, "error": "API key has expired"}
 
     # Return key info

--- a/packages/kailash-dataflow/templates/saas_starter/tenancy/isolation.py
+++ b/packages/kailash-dataflow/templates/saas_starter/tenancy/isolation.py
@@ -40,25 +40,30 @@ def get_user_organization(db, user_id: str) -> Optional[Dict]:
         ...     print(org["name"])
         Acme Corp
     """
-    # First, get the user to find organization_id
+    # First, get the user to find organization_id. Use LocalRuntime as a
+    # context manager per round-5 redteam F1 — bare LocalRuntime() leaks
+    # connections + background tasks until GC and triggers the kailash
+    # v0.12 hard-removal deprecation warning. The same runtime context
+    # spans BOTH the user read and the organization read so the
+    # connection pool is shared.
     workflow = WorkflowBuilder()
     workflow.add_node("UserReadNode", "read_user", {"id": user_id})
 
-    runtime = LocalRuntime()
-    results, _ = runtime.execute(workflow.build())
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build())
 
-    user = results.get("read_user")
-    if not user:
-        return None
+        user = results.get("read_user")
+        if not user:
+            return None
 
-    # Now get the organization
-    org_workflow = WorkflowBuilder()
-    org_workflow.add_node(
-        "OrganizationReadNode", "read_org", {"id": user["organization_id"]}
-    )
+        # Now get the organization
+        org_workflow = WorkflowBuilder()
+        org_workflow.add_node(
+            "OrganizationReadNode", "read_org", {"id": user["organization_id"]}
+        )
 
-    org_results, _ = runtime.execute(org_workflow.build())
-    return org_results.get("read_org")
+        org_results, _ = runtime.execute(org_workflow.build())
+        return org_results.get("read_org")
 
 
 def filter_by_organization(filters: Dict, organization_id: str) -> Dict:
@@ -107,8 +112,9 @@ def list_organization_users(db, organization_id: str) -> List[Dict]:
         "UserListNode", "list_users", {"filters": {"organization_id": organization_id}}
     )
 
-    runtime = LocalRuntime()
-    results, _ = runtime.execute(workflow.build())
+    # Context-managed runtime per round-5 redteam F1 (resource hygiene).
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build())
 
     return results.get("list_users", [])
 
@@ -134,8 +140,9 @@ def check_user_belongs_to_org(db, user_id: str, organization_id: str) -> bool:
     workflow = WorkflowBuilder()
     workflow.add_node("UserReadNode", "read_user", {"id": user_id})
 
-    runtime = LocalRuntime()
-    results, _ = runtime.execute(workflow.build())
+    # Context-managed runtime per round-5 redteam F1 (resource hygiene).
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow.build())
 
     user = results.get("read_user")
     if not user:
@@ -162,24 +169,27 @@ def switch_user_organization(db, user_id: str, new_org_id: str) -> Optional[Dict
         ...     print(user["organization_id"])
         org_789
     """
-    # First, verify new organization exists
+    # First, verify new organization exists. Context-managed runtime per
+    # round-5 redteam F1 — both the org-verify read and the user update
+    # share ONE LocalRuntime context so the connection pool is shared
+    # and the deprecation warning is silenced.
     org_workflow = WorkflowBuilder()
     org_workflow.add_node("OrganizationReadNode", "read_org", {"id": new_org_id})
 
-    runtime = LocalRuntime()
-    org_results, _ = runtime.execute(org_workflow.build())
+    with LocalRuntime() as runtime:
+        org_results, _ = runtime.execute(org_workflow.build())
 
-    org = org_results.get("read_org")
-    if not org:
-        return None  # Organization doesn't exist
+        org = org_results.get("read_org")
+        if not org:
+            return None  # Organization doesn't exist
 
-    # Update user's organization_id
-    update_workflow = WorkflowBuilder()
-    update_workflow.add_node(
-        "UserUpdateNode",
-        "update_user",
-        {"filters": {"id": user_id}, "fields": {"organization_id": new_org_id}},
-    )
+        # Update user's organization_id
+        update_workflow = WorkflowBuilder()
+        update_workflow.add_node(
+            "UserUpdateNode",
+            "update_user",
+            {"filters": {"id": user_id}, "fields": {"organization_id": new_org_id}},
+        )
 
-    update_results, _ = runtime.execute(update_workflow.build())
-    return update_results.get("update_user")
+        update_results, _ = runtime.execute(update_workflow.build())
+        return update_results.get("update_user")

--- a/packages/kailash-dataflow/tests/integration/templates/saas_starter/test_api_keys.py
+++ b/packages/kailash-dataflow/tests/integration/templates/saas_starter/test_api_keys.py
@@ -597,7 +597,16 @@ class TestAPIKeyExpirationTimezoneSafety:
         suffix. Pre-fix, comparing naive < datetime.now(UTC) raised
         TypeError; post-fix the naive value is upgraded to UTC via
         replace(tzinfo=timezone.utc) before comparison.
+
+        Production contract: the fix treats naive expires_at values
+        as UTC (per the brief: "Normalize naive aiosqlite-returned
+        strings to UTC for safe comparison"). Storing a NAIVE datetime
+        that was computed in LOCAL time would mis-shift the comparison;
+        the canonical store form is therefore UTC naive
+        (``datetime.utcnow() - timedelta``).
         """
+        from datetime import timezone as _timezone
+
         from kailash.runtime import LocalRuntime
         from kailash.workflow.builder import WorkflowBuilder
 
@@ -610,18 +619,21 @@ class TestAPIKeyExpirationTimezoneSafety:
         plain_key = created["key"]
         key_id = created["record"]["id"]
 
-        # Stamp a NAIVE datetime in the past. On SQLite this stores as
-        # an ISO string with no tz suffix and round-trips back as a
-        # naive datetime (or as the same ISO string, depending on the
-        # adapter — verify_api_key handles both cases).
-        naive_past = datetime.now() - timedelta(hours=2)
+        # Stamp a NAIVE-UTC datetime in the past. We compute the value
+        # tz-aware in UTC then strip the tzinfo — this models the
+        # storage shape SQLite returns from a column that was originally
+        # written as tz-aware UTC but round-tripped through TEXT storage
+        # without tz suffix (the exact production failure mode).
+        naive_utc_past = (datetime.now(_timezone.utc) - timedelta(hours=2)).replace(
+            tzinfo=None
+        )
         workflow = WorkflowBuilder()
         workflow.add_node(
             "APIKeyUpdateNode",
             "expire_key",
             {
                 "filter": {"id": key_id},
-                "fields": {"expires_at": naive_past},
+                "fields": {"expires_at": naive_utc_past},
             },
         )
         with LocalRuntime() as runtime:

--- a/packages/kailash-dataflow/tests/integration/templates/saas_starter/test_api_keys.py
+++ b/packages/kailash-dataflow/tests/integration/templates/saas_starter/test_api_keys.py
@@ -491,3 +491,147 @@ class TestAPIKeyRateLimiting:
         assert result["valid"] is True
         assert "rate_limit" in result
         assert result["rate_limit"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Round-5 timezone-safety regression tests — MED-2
+#
+# verify_api_key compares expires_at against datetime.now(). Pre-fix the
+# right-hand side was naive — a tz-aware expires_at (PostgreSQL
+# TIMESTAMP WITH TIME ZONE, aiosqlite-with-detect_types) raised
+# TypeError instead of returning the documented expired-key error.
+#
+# The two tests below exercise BOTH branches of the normalization fix:
+#  - tz-aware expires_at compares cleanly (no TypeError)
+#  - naive expires_at is normalized to UTC then compared cleanly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestAPIKeyExpirationTimezoneSafety:
+    """Round-5 MED-2 regression: tz-aware datetime comparison for expires_at."""
+
+    def test_verify_api_key_handles_tz_aware_expired(self, db, org_id):
+        """A tz-aware expires_at in the past MUST return the expired-error,
+        NOT raise TypeError."""
+        from datetime import timezone as _timezone
+
+        from kailash.runtime import LocalRuntime
+        from kailash.workflow.builder import WorkflowBuilder
+
+        from templates.saas_starter.security.api_keys import (
+            create_api_key,
+            verify_api_key,
+        )
+
+        created = create_api_key(db, org_id, "TZ-Aware Expired", ["read"])
+        plain_key = created["key"]
+        key_id = created["record"]["id"]
+
+        # Stamp a tz-aware (UTC) expires_at in the past.
+        tz_aware_past = datetime.now(_timezone.utc) - timedelta(hours=1)
+        workflow = WorkflowBuilder()
+        workflow.add_node(
+            "APIKeyUpdateNode",
+            "expire_key",
+            {
+                "filter": {"id": key_id},
+                "fields": {"expires_at": tz_aware_past},
+            },
+        )
+        with LocalRuntime() as runtime:
+            runtime.execute(workflow.build())
+
+        # Pre-fix this raised TypeError because datetime.now() returned a
+        # naive datetime and tz-aware < naive comparison is illegal.
+        result = verify_api_key(db, plain_key)
+
+        assert result is not None, "verify_api_key MUST NOT raise"
+        assert result["valid"] is False
+        assert "expired" in result.get("error", "").lower()
+
+    def test_verify_api_key_handles_tz_aware_not_expired(self, db, org_id):
+        """A tz-aware expires_at in the future MUST verify successfully
+        (positive control proving the tz-aware path is exercised)."""
+        from datetime import timezone as _timezone
+
+        from kailash.runtime import LocalRuntime
+        from kailash.workflow.builder import WorkflowBuilder
+
+        from templates.saas_starter.security.api_keys import (
+            create_api_key,
+            verify_api_key,
+        )
+
+        created = create_api_key(db, org_id, "TZ-Aware Future", ["read"])
+        plain_key = created["key"]
+        key_id = created["record"]["id"]
+
+        # Stamp a tz-aware (UTC) expires_at in the future.
+        tz_aware_future = datetime.now(_timezone.utc) + timedelta(hours=1)
+        workflow = WorkflowBuilder()
+        workflow.add_node(
+            "APIKeyUpdateNode",
+            "set_expires",
+            {
+                "filter": {"id": key_id},
+                "fields": {"expires_at": tz_aware_future},
+            },
+        )
+        with LocalRuntime() as runtime:
+            runtime.execute(workflow.build())
+
+        result = verify_api_key(db, plain_key)
+
+        assert result is not None, "verify_api_key MUST NOT raise"
+        assert result["valid"] is True, "Future-expiry key MUST validate"
+        assert result["organization_id"] == org_id
+
+    def test_verify_api_key_handles_naive_string_expired(self, db, org_id):
+        """A naive ISO-string expires_at (the aiosqlite path) MUST be
+        normalized to UTC and compared cleanly without TypeError.
+
+        SQLite stores DATETIME columns as TEXT and returns them as ISO
+        strings; verify_api_key parses with datetime.fromisoformat,
+        which produces a NAIVE datetime when the string has no tz
+        suffix. Pre-fix, comparing naive < datetime.now(UTC) raised
+        TypeError; post-fix the naive value is upgraded to UTC via
+        replace(tzinfo=timezone.utc) before comparison.
+        """
+        from kailash.runtime import LocalRuntime
+        from kailash.workflow.builder import WorkflowBuilder
+
+        from templates.saas_starter.security.api_keys import (
+            create_api_key,
+            verify_api_key,
+        )
+
+        created = create_api_key(db, org_id, "Naive String Expired", ["read"])
+        plain_key = created["key"]
+        key_id = created["record"]["id"]
+
+        # Stamp a NAIVE datetime in the past. On SQLite this stores as
+        # an ISO string with no tz suffix and round-trips back as a
+        # naive datetime (or as the same ISO string, depending on the
+        # adapter — verify_api_key handles both cases).
+        naive_past = datetime.now() - timedelta(hours=2)
+        workflow = WorkflowBuilder()
+        workflow.add_node(
+            "APIKeyUpdateNode",
+            "expire_key",
+            {
+                "filter": {"id": key_id},
+                "fields": {"expires_at": naive_past},
+            },
+        )
+        with LocalRuntime() as runtime:
+            runtime.execute(workflow.build())
+
+        # Pre-fix this raised TypeError on PostgreSQL (tz-aware row +
+        # naive datetime.now()); post-fix the naive expires_at branch
+        # is normalized to UTC and the comparison runs cleanly.
+        result = verify_api_key(db, plain_key)
+
+        assert result is not None, "verify_api_key MUST NOT raise"
+        assert result["valid"] is False
+        assert "expired" in result.get("error", "").lower()

--- a/packages/kailash-dataflow/tests/integration/templates/saas_starter/test_webhooks_integration.py
+++ b/packages/kailash-dataflow/tests/integration/templates/saas_starter/test_webhooks_integration.py
@@ -458,3 +458,151 @@ async def test_webhook_event_ordering(db):
     assert all(
         e.get("created_at") is not None for e in result
     ), "Every event should have an auto-managed created_at"
+
+
+# ---------------------------------------------------------------------------
+# Round-5 tenant-isolation regression tests — MED-1a / MED-1b
+#
+# Cross-tenant mutation defense: retry_failed_webhook and
+# mark_webhook_delivered MUST refuse to mutate a row whose
+# (event_id, organization_id) pair does not match. The test seeds an
+# event under tenant A, calls the helper with tenant B's organization_id,
+# and asserts BOTH (a) the helper returns None AND (b) the row in the
+# database is bit-for-bit unchanged on every column the helper would
+# otherwise touch.
+#
+# Per rules/testing.md § State Persistence Verification + rules/facade-
+# manager-detection.md MUST Rule 1: exercises the helper through the
+# template facade against a real DataFlow backend.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_retry_failed_webhook_rejects_cross_tenant_event_id(db):
+    """Round-5 MED-1a regression: retry_failed_webhook with another
+    tenant's organization_id MUST return None AND leave the row's
+    retry_count / status / last_retry_at unchanged.
+    """
+    tenant_a = "org_tenant_a"
+    tenant_b = "org_tenant_b"
+    event_id = "evt_cross_tenant_retry"
+
+    # Seed a pending event under tenant A. retry_count starts at 0.
+    await db.express.create(
+        "WebhookEvent",
+        _make_event(
+            id=event_id,
+            organization_id=tenant_a,
+            status="pending",
+            retry_count=0,
+        ),
+    )
+
+    # Snapshot the pre-call row state from tenant A's perspective.
+    before = await db.express.read("WebhookEvent", event_id)
+    assert before is not None
+    assert before["organization_id"] == tenant_a
+    assert before["status"] == "pending"
+    assert before["retry_count"] == 0
+    last_retry_before = before.get("last_retry_at")
+
+    # Call retry_failed_webhook with tenant B's organization_id. The
+    # tenant-scoped filter (id, organization_id) returns no rows, so
+    # the helper returns None and no UPDATE fires.
+    result = retry_failed_webhook(db, event_id, tenant_b)
+    assert result is None, "Cross-tenant retry MUST return None"
+
+    # Verify the row is unchanged from tenant A's perspective.
+    after = await db.express.read("WebhookEvent", event_id)
+    assert after is not None, "Event must still exist after cross-tenant call"
+    assert after["organization_id"] == tenant_a, "organization_id unchanged"
+    assert after["status"] == "pending", "status MUST NOT have changed"
+    assert after["retry_count"] == 0, "retry_count MUST NOT have incremented"
+    assert (
+        after.get("last_retry_at") == last_retry_before
+    ), "last_retry_at MUST NOT have been written"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mark_webhook_delivered_rejects_cross_tenant_event_id(db):
+    """Round-5 MED-1b regression: mark_webhook_delivered with another
+    tenant's organization_id MUST return None AND leave the row's
+    status / delivered_at unchanged.
+    """
+    tenant_a = "org_tenant_a"
+    tenant_b = "org_tenant_b"
+    event_id = "evt_cross_tenant_deliver"
+
+    await db.express.create(
+        "WebhookEvent",
+        _make_event(
+            id=event_id,
+            organization_id=tenant_a,
+            status="pending",
+        ),
+    )
+
+    before = await db.express.read("WebhookEvent", event_id)
+    assert before is not None
+    assert before["status"] == "pending"
+    delivered_at_before = before.get("delivered_at")
+
+    # Cross-tenant call MUST be a no-op.
+    result = mark_webhook_delivered(db, event_id, tenant_b)
+    assert result is None, "Cross-tenant mark-delivered MUST return None"
+
+    after = await db.express.read("WebhookEvent", event_id)
+    assert after is not None, "Event must still exist"
+    assert after["organization_id"] == tenant_a, "organization_id unchanged"
+    assert after["status"] == "pending", "status MUST NOT have flipped to delivered"
+    assert (
+        after.get("delivered_at") == delivered_at_before
+    ), "delivered_at MUST NOT have been written"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_retry_failed_webhook_succeeds_with_matching_tenant(db):
+    """Round-5 MED-1a positive control: the matching-tenant call still
+    works (proves the cross-tenant rejection is not over-broad)."""
+    tenant_a = "org_tenant_a"
+    event_id = "evt_matching_tenant_retry"
+
+    await db.express.create(
+        "WebhookEvent",
+        _make_event(
+            id=event_id,
+            organization_id=tenant_a,
+            status="failed",
+            retry_count=0,
+        ),
+    )
+
+    result = retry_failed_webhook(db, event_id, tenant_a)
+    assert result is not None, "Matching-tenant retry MUST succeed"
+    assert result["retry_count"] == 1, "retry_count incremented"
+    assert result["status"] == "pending", "status flipped to pending"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mark_webhook_delivered_succeeds_with_matching_tenant(db):
+    """Round-5 MED-1b positive control: matching-tenant call still works."""
+    tenant_a = "org_tenant_a"
+    event_id = "evt_matching_tenant_deliver"
+
+    await db.express.create(
+        "WebhookEvent",
+        _make_event(
+            id=event_id,
+            organization_id=tenant_a,
+            status="pending",
+        ),
+    )
+
+    result = mark_webhook_delivered(db, event_id, tenant_a)
+    assert result is not None, "Matching-tenant deliver MUST succeed"
+    assert result["status"] == "delivered", "status flipped to delivered"
+    assert result.get("delivered_at") is not None, "delivered_at written"

--- a/packages/kailash-dataflow/tests/integration/templates/saas_starter/test_webhooks_integration.py
+++ b/packages/kailash-dataflow/tests/integration/templates/saas_starter/test_webhooks_integration.py
@@ -232,12 +232,17 @@ async def test_get_webhook_events(db):
 async def test_retry_failed_webhook(db):
     """retry_failed_webhook increments retry_count + flips status to pending."""
     event_id = "evt_failed"
+    org_id = "org_456"
     await db.express.create(
         "WebhookEvent",
-        _make_event(id=event_id, status="failed", retry_count=0),
+        _make_event(
+            id=event_id, organization_id=org_id, status="failed", retry_count=0
+        ),
     )
 
-    retry_failed_webhook(db, event_id)
+    # organization_id is REQUIRED per round-5 tenant-isolation hardening
+    # (MED-1a); see webhooks.py::retry_failed_webhook docstring.
+    retry_failed_webhook(db, event_id, org_id)
 
     # Read-back per rules/testing.md § State Persistence Verification.
     after = await db.express.read("WebhookEvent", event_id)
@@ -251,12 +256,15 @@ async def test_retry_failed_webhook(db):
 async def test_mark_webhook_delivered(db):
     """mark_webhook_delivered sets status=delivered + delivered_at."""
     event_id = "evt_123"
+    org_id = "org_456"
     await db.express.create(
         "WebhookEvent",
-        _make_event(id=event_id, status="pending"),
+        _make_event(id=event_id, organization_id=org_id, status="pending"),
     )
 
-    mark_webhook_delivered(db, event_id)
+    # organization_id is REQUIRED per round-5 tenant-isolation hardening
+    # (MED-1b); see webhooks.py::mark_webhook_delivered docstring.
+    mark_webhook_delivered(db, event_id, org_id)
 
     after = await db.express.read("WebhookEvent", event_id)
     assert after is not None, "Webhook event should still exist after delivery"
@@ -345,12 +353,16 @@ async def test_webhook_retry_logic(db):
     flips to ``failed`` per the gate at webhooks.py:153.
     """
     event_id = "evt_retry_test"
+    org_id = "org_456"
     await db.express.create(
         "WebhookEvent",
-        _make_event(id=event_id, status="pending", retry_count=2),
+        _make_event(
+            id=event_id, organization_id=org_id, status="pending", retry_count=2
+        ),
     )
 
-    retry_failed_webhook(db, event_id)
+    # organization_id is REQUIRED per round-5 tenant-isolation hardening.
+    retry_failed_webhook(db, event_id, org_id)
 
     after = await db.express.read("WebhookEvent", event_id)
     assert after is not None, "Webhook event should still exist after retry"
@@ -371,6 +383,7 @@ async def test_webhook_delivery_tracking(db):
     via the mocked runtime side_effect.
     """
     event_id = "evt_track"
+    org_id = "org_456"
     attempts = [
         {
             "timestamp": (datetime.now() - timedelta(minutes=5)).isoformat(),
@@ -386,12 +399,13 @@ async def test_webhook_delivery_tracking(db):
     await db.express.create(
         "WebhookEvent",
         {
-            **_make_event(id=event_id, status="pending"),
+            **_make_event(id=event_id, organization_id=org_id, status="pending"),
             "delivery_attempts": attempts,
         },
     )
 
-    mark_webhook_delivered(db, event_id)
+    # organization_id is REQUIRED per round-5 tenant-isolation hardening.
+    mark_webhook_delivered(db, event_id, org_id)
 
     after = await db.express.read("WebhookEvent", event_id)
     assert after is not None, "Webhook event should still exist"

--- a/packages/kailash-dataflow/tests/integration/templates/test_template_loc_hygiene.py
+++ b/packages/kailash-dataflow/tests/integration/templates/test_template_loc_hygiene.py
@@ -1,0 +1,160 @@
+"""Round-5 redteam F1 regression: structural sweep over template
+sources asserting every LocalRuntime() construction is paired with a
+`with` context manager.
+
+Origin: round-5 redteam surfaced FOUR call sites in
+``saas_starter/tenancy/isolation.py`` AND one sibling in
+``api_gateway_starter/example_app/routes/users.py`` where
+``runtime = LocalRuntime()`` was constructed bare (no ``with`` block),
+leaking connections + background tasks until garbage collection AND
+triggering the kailash v0.12 hard-removal deprecation warning on every
+call. The fix wraps each in ``with LocalRuntime() as runtime:`` so the
+runtime's __exit__ closes the pool deterministically.
+
+This is the LOCK on the fix per ``rules/refactor-invariants.md`` MUST
+Rule 1 — without a regression test, the next session's edit could
+re-introduce the bare construction with no signal. Per
+``rules/probe-driven-verification.md`` Rule 3 (structural sweeps are
+the canonical no-LLM verification form), this is a grep-based AST-level
+structural sweep — not a semantic probe.
+
+Scope: the SaaS Starter + api_gateway_starter template trees ONLY.
+Production SDK code (src/kailash/, src/dataflow/) is out of scope
+because it does NOT teach bare-LocalRuntime patterns through
+documented helpers — the templates DO (they are the canonical
+"copy this to your project" surface), so the regression risk is
+higher there.
+
+Per ``rules/testing.md`` § Audit Mode and ``rules/orphan-detection.md``
+Rule 1a, structural sweeps over source belong in the test suite when
+the sweep verifies an absolute state that is not reachable through
+function calls.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+# Repo root, derived from the location of THIS test file. Resolves the
+# worktree path correctly even when invoked from a different cwd (per
+# ``rules/worktree-isolation.md`` § 3a — tool roots bound to __file__
+# resolve to whichever checkout owns the test binary, which is exactly
+# the behavior we want for this sweep).
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_TEMPLATE_ROOTS = [
+    _REPO_ROOT / "packages/kailash-dataflow/templates/saas_starter",
+    _REPO_ROOT / "packages/kailash-dataflow/templates/api_gateway_starter",
+]
+
+# Regex matches ``LocalRuntime()`` (and ``LocalRuntime(...)`` with args)
+# only when the line is NOT inside a ``with`` statement. The two-phase
+# check below is AST-based, not pure-regex, but we use this pattern for
+# a fast pre-filter.
+_LOCAL_RUNTIME_CALL = re.compile(r"\bLocalRuntime\s*\(")
+
+
+def _find_bare_localruntime_constructions(source: str, filepath: Path) -> list[str]:
+    """Walk the AST and return a list of "filepath:line — context"
+    strings for every ``LocalRuntime()`` construction that is NOT
+    inside a ``with`` statement context manager.
+
+    The AST walk is the canonical structural form per
+    ``rules/testing.md`` § "__all__ / Re-export Symbol Counts Use
+    Structural Enumeration, Not Grep" — text grep cannot distinguish
+    ``LocalRuntime()`` inside a ``with`` block from a bare assignment;
+    AST node parents make the distinction.
+    """
+    bare_sites: list[str] = []
+
+    try:
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError as exc:
+        pytest.fail(f"Cannot parse {filepath}: {exc}")
+
+    # Build a parent map so we can ask: is this ast.Call node inside a
+    # ``with`` block via its parent chain? Python's ast module does not
+    # set parent pointers by default.
+    parent_of: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parent_of[child] = parent
+
+    def _is_inside_with(node: ast.AST) -> bool:
+        """Walk up the parent chain; if any ancestor is an ast.With
+        AND this node is in its ``items`` (the context-manager
+        expressions, not the body), then this is a ``with
+        LocalRuntime()`` call."""
+        current = node
+        while current in parent_of:
+            parent = parent_of[current]
+            if isinstance(parent, ast.withitem):
+                # withitem nodes hold the context-manager expression
+                return True
+            # Allow walking up at most a few levels — we don't want
+            # ``with X: LocalRuntime()`` in the body to count as inside.
+            # Specifically: stop at function/class/module boundaries.
+            if isinstance(
+                parent,
+                (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module),
+            ):
+                return False
+            current = parent
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match both `LocalRuntime(...)` (Name) and `runtime.LocalRuntime(...)`
+        # (Attribute). The templates only use the bare-Name form, but
+        # check both for completeness.
+        called_name: str | None = None
+        if isinstance(func, ast.Name):
+            called_name = func.id
+        elif isinstance(func, ast.Attribute):
+            called_name = func.attr
+        if called_name != "LocalRuntime":
+            continue
+        if _is_inside_with(node):
+            continue
+        # Bare construction found.
+        try:
+            rel = filepath.relative_to(_REPO_ROOT)
+        except ValueError:
+            rel = filepath
+        bare_sites.append(f"{rel}:{node.lineno}")
+
+    return bare_sites
+
+
+@pytest.mark.integration
+def test_template_files_use_context_managed_localruntime():
+    """Round-5 F1 regression: every ``LocalRuntime()`` construction in
+    the saas_starter + api_gateway_starter template trees MUST live
+    inside a ``with`` context manager.
+
+    A bare ``runtime = LocalRuntime()`` leaks the runtime's connection
+    pool and triggers the kailash v0.12 hard-removal warning. This
+    test fails loudly if a future edit re-introduces the bare pattern.
+    """
+    violations: list[str] = []
+
+    for root in _TEMPLATE_ROOTS:
+        assert root.exists(), f"Template root not found: {root}"
+        for py_file in root.rglob("*.py"):
+            source = py_file.read_text(encoding="utf-8")
+            # Fast pre-filter — skip files that don't mention LocalRuntime
+            # at all so we don't AST-parse the whole template tree.
+            if not _LOCAL_RUNTIME_CALL.search(source):
+                continue
+            violations.extend(_find_bare_localruntime_constructions(source, py_file))
+
+    assert not violations, (
+        "Round-5 F1 regression: bare LocalRuntime() construction found in "
+        "template tree (expected ALL inside `with` context manager):\n"
+        + "\n".join(f"  - {v}" for v in violations)
+    )

--- a/packages/kailash-dataflow/tests/unit/templates/test_saas_tenancy.py
+++ b/packages/kailash-dataflow/tests/unit/templates/test_saas_tenancy.py
@@ -90,6 +90,10 @@ class TestMultiTenantIsolation:
         mock_workflow = MagicMock()
         mock_workflow.build.return_value = MagicMock()
         mock_runtime = MagicMock()
+        # Round-5: isolation.py wraps LocalRuntime() in `with` context manager;
+        # mock must support __enter__/__exit__ returning the same configured mock.
+        mock_runtime.__enter__.return_value = mock_runtime
+        mock_runtime.__exit__.return_value = None
 
         # First call returns user, second call returns org
         mock_runtime.execute.side_effect = [
@@ -188,6 +192,10 @@ class TestMultiTenantIsolation:
         mock_workflow = MagicMock()
         mock_workflow.build.return_value = MagicMock()
         mock_runtime = MagicMock()
+        # Round-5: isolation.py wraps LocalRuntime() in `with` context manager;
+        # mock must support __enter__/__exit__ returning the same configured mock.
+        mock_runtime.__enter__.return_value = mock_runtime
+        mock_runtime.__exit__.return_value = None
         mock_runtime.execute.return_value = ({"list_users": users_data}, "run_id_123")
 
         import saas_starter.tenancy.isolation
@@ -247,6 +255,10 @@ class TestMultiTenantIsolation:
         mock_workflow = MagicMock()
         mock_workflow.build.return_value = MagicMock()
         mock_runtime = MagicMock()
+        # Round-5: isolation.py wraps LocalRuntime() in `with` context manager;
+        # mock must support __enter__/__exit__ returning the same configured mock.
+        mock_runtime.__enter__.return_value = mock_runtime
+        mock_runtime.__exit__.return_value = None
         mock_runtime.execute.return_value = ({"read_user": user_data}, "run_id_123")
 
         import saas_starter.tenancy.isolation
@@ -298,6 +310,10 @@ class TestMultiTenantIsolation:
         mock_workflow = MagicMock()
         mock_workflow.build.return_value = MagicMock()
         mock_runtime = MagicMock()
+        # Round-5: isolation.py wraps LocalRuntime() in `with` context manager;
+        # mock must support __enter__/__exit__ returning the same configured mock.
+        mock_runtime.__enter__.return_value = mock_runtime
+        mock_runtime.__exit__.return_value = None
         mock_runtime.execute.return_value = ({"read_user": user_data}, "run_id_123")
 
         import saas_starter.tenancy.isolation
@@ -357,6 +373,10 @@ class TestMultiTenantIsolation:
         mock_workflow = MagicMock()
         mock_workflow.build.return_value = MagicMock()
         mock_runtime = MagicMock()
+        # Round-5: isolation.py wraps LocalRuntime() in `with` context manager;
+        # mock must support __enter__/__exit__ returning the same configured mock.
+        mock_runtime.__enter__.return_value = mock_runtime
+        mock_runtime.__exit__.return_value = None
         mock_runtime.execute.side_effect = [
             ({"read_org": org_data}, "run_id_1"),
             ({"update_user": updated_user}, "run_id_2"),
@@ -405,6 +425,10 @@ class TestMultiTenantIsolation:
         mock_workflow = MagicMock()
         mock_workflow.build.return_value = MagicMock()
         mock_runtime = MagicMock()
+        # Round-5: isolation.py wraps LocalRuntime() in `with` context manager;
+        # mock must support __enter__/__exit__ returning the same configured mock.
+        mock_runtime.__enter__.return_value = mock_runtime
+        mock_runtime.__exit__.return_value = None
         mock_runtime.execute.return_value = ({"read_org": None}, "run_id_123")
 
         import saas_starter.tenancy.isolation
@@ -485,6 +509,10 @@ class TestMultiTenantIsolation:
         mock_workflow = MagicMock()
         mock_workflow.build.return_value = MagicMock()
         mock_runtime = MagicMock()
+        # Round-5: isolation.py wraps LocalRuntime() in `with` context manager;
+        # mock must support __enter__/__exit__ returning the same configured mock.
+        mock_runtime.__enter__.return_value = mock_runtime
+        mock_runtime.__exit__.return_value = None
         mock_runtime.execute.return_value = ({"read_user": user_data}, "run_id_123")
 
         import saas_starter.tenancy.isolation
@@ -546,6 +574,10 @@ class TestMultiTenantIsolation:
         mock_workflow = MagicMock()
         mock_workflow.build.return_value = MagicMock()
         mock_runtime = MagicMock()
+        # Round-5: isolation.py wraps LocalRuntime() in `with` context manager;
+        # mock must support __enter__/__exit__ returning the same configured mock.
+        mock_runtime.__enter__.return_value = mock_runtime
+        mock_runtime.__exit__.return_value = None
         mock_runtime.execute.return_value = ({"list_users": org_a_users}, "run_id_123")
 
         import saas_starter.tenancy.isolation


### PR DESCRIPTION
## Summary

Round-5 same-class MEDIUM fix-immediately shard for issue #996 — closes the 4 MED findings R4 surfaced against the wave-of-3 merges (#1032 / #1033 / #1034):

- **MED-1a, MED-1b** — Cross-tenant mutation on `retry_failed_webhook` + `mark_webhook_delivered`. The `WebhookEventUpdateNode` filter was `{"id": event_id}` only; an attacker with a guessed/leaked event_id from another tenant could mutate the cross-tenant row's retry_count / status / delivered_at. Both helpers now accept `organization_id` as a required parameter and every read / update / read-back filter includes the tenant predicate.
- **MED-2** — `validate_api_key` compared `expires_at` to a naive `datetime.now()`. PostgreSQL returns tz-aware datetimes (and aiosqlite returns naive strings); the comparison raised `TypeError` on the tz-aware branch. Now normalizes naive parsed strings to UTC and compares against `datetime.now(timezone.utc)`.
- **F1 (16 sites)** — Bare `LocalRuntime()` constructions not wrapped in context managers. The brief scoped this to 5 sites (4 in `isolation.py` + 1 in api_gateway `users.py`); the regression-detector AST sweep added by this PR caught 11 additional sites in the api_gateway template tree (`users.py`, `organizations.py`, `main.py`). All 16 fixed in one shard per `rules/autonomous-execution.md` MUST Rule 4 (same-bug-class within shard budget).

## Regression tests (Tier-2, real infrastructure)

8 new tests + 1 AST-walking template hygiene invariant:

| Test | Catches |
|---|---|
| `test_retry_failed_webhook_rejects_cross_tenant_event_id` | MED-1a |
| `test_retry_failed_webhook_succeeds_with_matching_tenant` | MED-1a positive control |
| `test_mark_webhook_delivered_rejects_cross_tenant_event_id` | MED-1b |
| `test_mark_webhook_delivered_succeeds_with_matching_tenant` | MED-1b positive control |
| `test_verify_api_key_handles_tz_aware_expired` | MED-2 |
| `test_verify_api_key_handles_tz_aware_not_expired` | MED-2 positive control |
| `test_verify_api_key_handles_naive_string_expired` | MED-2 naive-UTC branch |
| `test_template_files_use_context_managed_localruntime` | F1 invariant (AST grep across all 5 template files) |

All 8 pass against the existing real-infra fixture pattern (37 passes total across the two modified test files; no regressions).

## Caller sweep

The new required parameter `organization_id` on `retry_failed_webhook` and `mark_webhook_delivered` is plumbed through every caller in the same PR per `rules/security.md` § "Multi-Site Kwarg Plumbing":

- 4 pre-existing test sites in `test_webhooks_integration.py` updated
- 2 new cross-tenant rejection tests + 2 new positive-control tests pass 3 args
- 2 docstring example signatures updated to match
- No 2-arg call sites remain anywhere in `templates/` or `tests/`

## Scope notes

- 9 files changed, +648 / -99
- Public-signature change on template helpers (`organization_id` required) is permitted under `rules/zero-tolerance.md` Rule 6a — these are SaaS starter template helpers (not stable public API); only call sites are the in-PR tests + docstring examples
- 19 pre-existing pyright unused-parameter findings on template scaffolding (commit \`b553104c6\`) are out-of-scope; follow-up issue tracks template-wide pyright hygiene

## Related issues

Closes #996 (round-5 fix-immediately closure for the issue's remaining MED findings).