### PR TITLE
test(dataflow): TDD-mode docs-pipeline Tier-2 regression (#1022)

### DIFF
--- a/packages/kailash-dataflow/docs/adr/ADR-017-test-mode-api-spec.md
+++ b/packages/kailash-dataflow/docs/adr/ADR-017-test-mode-api-spec.md
@@ -1,6 +1,7 @@
 # ADR-017: Test Mode API Specification
 
 ## Document Purpose
+
 This document provides the **complete API specification** for DataFlow test mode enhancements. It defines method signatures, parameters, return types, usage patterns, and integration points for implementing ADR-017 testing improvements.
 
 ---
@@ -12,6 +13,7 @@ This document provides the **complete API specification** for DataFlow test mode
 **Location**: `/packages/kailash-dataflow/src/dataflow/core/engine.py`
 
 **Current Signature** (lines 34-62):
+
 ```python
 def __init__(
     self,
@@ -26,6 +28,7 @@ def __init__(
 ```
 
 **Enhanced Signature** (NEW):
+
 ```python
 def __init__(
     self,
@@ -67,6 +70,7 @@ def __init__(
 ```
 
 **Implementation Details**:
+
 ```python
 # In DataFlow.__init__() after config initialization:
 
@@ -98,6 +102,7 @@ if self._test_mode:
 **Return Value**: DataFlow instance
 
 **Raises**:
+
 - `ValueError`: If database_url is invalid
 - `ConnectionError`: If initial connection fails (when applicable)
 
@@ -108,6 +113,7 @@ if self._test_mode:
 **Location**: `/packages/kailash-dataflow/src/dataflow/core/engine.py`
 
 **Method Signature**:
+
 ```python
 def _detect_test_environment(self) -> bool:
     """Detect if running in test environment.
@@ -153,6 +159,7 @@ def _detect_test_environment(self) -> bool:
 **Location**: `/packages/kailash-dataflow/src/dataflow/core/engine.py`
 
 **Class Attributes**:
+
 ```python
 class DataFlow:
     """Main DataFlow interface."""
@@ -163,6 +170,7 @@ class DataFlow:
 ```
 
 **Method: enable_test_mode()**
+
 ```python
 @classmethod
 def enable_test_mode(cls) -> None:
@@ -198,6 +206,7 @@ def enable_test_mode(cls) -> None:
 ```
 
 **Method: disable_test_mode()**
+
 ```python
 @classmethod
 def disable_test_mode(cls) -> None:
@@ -216,6 +225,7 @@ def disable_test_mode(cls) -> None:
 ```
 
 **Method: is_test_mode_enabled()**
+
 ```python
 @classmethod
 def is_test_mode_enabled(cls) -> Optional[bool]:
@@ -240,6 +250,7 @@ def is_test_mode_enabled(cls) -> Optional[bool]:
 ```
 
 **Integration with Constructor**:
+
 ```python
 # In DataFlow.__init__(), modify test mode detection:
 
@@ -263,6 +274,7 @@ else:
 **Location**: `/packages/kailash-dataflow/src/dataflow/core/engine.py`
 
 **Method: cleanup_stale_pools()**
+
 ```python
 async def cleanup_stale_pools(self) -> Dict[str, Any]:
     """Proactively detect and cleanup stale connection pools.
@@ -336,6 +348,7 @@ async def cleanup_stale_pools(self) -> Dict[str, Any]:
 ```
 
 **Method: cleanup_all_pools()**
+
 ```python
 async def cleanup_all_pools(self, force: bool = False) -> Dict[str, Any]:
     """Cleanup all connection pools managed by DataFlow.
@@ -417,6 +430,7 @@ async def cleanup_all_pools(self, force: bool = False) -> Dict[str, Any]:
 ```
 
 **Method: get_cleanup_metrics()**
+
 ```python
 def get_cleanup_metrics(self) -> Dict[str, Any]:
     """Get connection pool lifecycle metrics.
@@ -488,9 +502,10 @@ def get_cleanup_metrics(self) -> Dict[str, Any]:
 
 **Location**: `/src/kailash/nodes/data/async_sql.py`
 
-**Method: _cleanup_closed_loop_pools() Enhancement**
+**Method: \_cleanup_closed_loop_pools() Enhancement**
 
 **Current Implementation** (lines 4034-4072):
+
 ```python
 @classmethod
 def _cleanup_closed_loop_pools(cls) -> int:
@@ -499,6 +514,7 @@ def _cleanup_closed_loop_pools(cls) -> int:
 ```
 
 **Enhanced Implementation**:
+
 ```python
 @classmethod
 async def _cleanup_closed_loop_pools(cls) -> int:
@@ -596,6 +612,7 @@ async def _cleanup_closed_loop_pools(cls) -> int:
 **Method: clear_shared_pools() Enhancement**
 
 **Current Implementation** (lines 4072-4073):
+
 ```python
 @classmethod
 async def clear_shared_pools(cls) -> None:
@@ -603,6 +620,7 @@ async def clear_shared_pools(cls) -> None:
 ```
 
 **Enhanced Implementation**:
+
 ```python
 @classmethod
 async def clear_shared_pools(cls, graceful: bool = True) -> Dict[str, Any]:
@@ -692,6 +710,7 @@ async def clear_shared_pools(cls, graceful: bool = True) -> Dict[str, Any]:
 **Location**: `/packages/kailash-dataflow/src/dataflow/core/nodes.py`
 
 **Node Generation Enhancement**:
+
 ```python
 class NodeGenerator:
     """Generate workflow nodes from models."""
@@ -754,7 +773,10 @@ async def test_user_crud():
     })
 
     runtime = AsyncLocalRuntime()
-    results, _ = await runtime.execute_workflow_async(workflow.build())
+    # `inputs` is a required parameter of execute_workflow_async.
+    results, _ = await runtime.execute_workflow_async(
+        workflow.build(), inputs={}
+    )
 
     assert results["create"]["name"] == "Alice"
 
@@ -987,6 +1009,7 @@ async def test_cleanup_error_handling():
 **File**: `/packages/kailash-dataflow/src/dataflow/core/engine.py`
 
 **Integration Steps**:
+
 1. Add `test_mode` and `test_mode_aggressive_cleanup` parameters to `__init__`
 2. Add `_test_mode` and `_test_mode_aggressive_cleanup` instance attributes
 3. Add `_global_test_mode` and `_global_test_mode_lock` class attributes
@@ -1001,6 +1024,7 @@ async def test_cleanup_error_handling():
 **File**: `/src/kailash/nodes/data/async_sql.py`
 
 **Integration Steps**:
+
 1. Enhance `_cleanup_closed_loop_pools()` with async design (lines 4034-4072)
 2. Enhance `clear_shared_pools()` with metrics (lines 4072-4073)
 3. Add graceful shutdown handling
@@ -1013,6 +1037,7 @@ async def test_cleanup_error_handling():
 **File**: `/packages/kailash-dataflow/src/dataflow/core/nodes.py`
 
 **Integration Steps**:
+
 1. Modify `NodeGenerator.generate_nodes()` to pass test mode
 2. Add test mode binding to generated node classes
 3. Ensure test mode propagates to all CRUD nodes
@@ -1022,6 +1047,7 @@ async def test_cleanup_error_handling():
 **File**: `/packages/kailash-dataflow/src/dataflow/core/config.py`
 
 **Integration Steps** (Optional):
+
 1. Add `test_mode_config` section to `DataFlowConfig`
 2. Add test mode configuration options
 3. Document test mode settings
@@ -1033,6 +1059,7 @@ async def test_cleanup_error_handling():
 ### 4.1 Zero Breaking Changes
 
 **Guarantees**:
+
 - All existing code works without modifications
 - `test_mode=None` (default) maintains auto-detection behavior
 - New parameters have sensible defaults
@@ -1040,6 +1067,7 @@ async def test_cleanup_error_handling():
 - Production code unaffected (test mode changes only)
 
 **Validation**:
+
 ```python
 # Existing code continues to work
 db = DataFlow("postgresql://...")  # ✓ Works exactly as before
@@ -1062,11 +1090,13 @@ db = DataFlow("postgresql://...", test_mode=False)  # ✓ New feature
 ### 5.1 Graceful Degradation
 
 All cleanup methods use graceful degradation:
+
 - Errors are logged, not raised
 - Partial cleanup succeeds even if some pools fail
 - Metrics capture failure details for debugging
 
 **Example**:
+
 ```python
 # Even if one pool fails, others are cleaned
 metrics = await db.cleanup_all_pools()
@@ -1078,6 +1108,7 @@ metrics = await db.cleanup_all_pools()
 ### 5.2 Error Patterns
 
 **Pattern 1: No Event Loop**
+
 ```python
 # If no event loop available, cleanup returns early
 metrics = await db.cleanup_stale_pools()
@@ -1085,12 +1116,14 @@ metrics = await db.cleanup_stale_pools()
 ```
 
 **Pattern 2: Closed Adapter**
+
 ```python
 # If adapter is already closed, logs warning and continues
 # No exception raised, cleanup continues for remaining pools
 ```
 
 **Pattern 3: Invalid Pool Key**
+
 ```python
 # If pool key format is invalid, logs warning and skips
 # Remaining pools are still processed
@@ -1105,6 +1138,7 @@ metrics = await db.cleanup_stale_pools()
 **Location**: `/packages/kailash-dataflow/tests/test_test_mode.py`
 
 **Test Cases**:
+
 ```python
 # Test 1: Auto-detection works
 def test_auto_detect_pytest_environment():
@@ -1146,6 +1180,7 @@ async def test_cleanup_metrics():
 **Location**: `/packages/kailash-dataflow/tests/integration/test_test_mode_integration.py`
 
 **Test Cases**:
+
 ```python
 # Test 1: Fixture pattern works
 @pytest.mark.asyncio
@@ -1176,6 +1211,7 @@ async def test_pool_reuse(db_module):
 **Location**: `/packages/kailash-dataflow/tests/e2e/test_documentation_examples.py`
 
 **Test Cases**:
+
 ```python
 # Run all documentation examples
 @pytest.mark.e2e
@@ -1193,10 +1229,12 @@ def test_all_documentation_examples():
 ### 7.1 Overhead
 
 **Test Mode Detection**: <1ms
+
 - Environment variable lookup: ~0.1ms
 - sys.modules check: ~0.1ms
 
 **Cleanup Operations**:
+
 - `cleanup_stale_pools()`: <50ms for 10 pools
 - `cleanup_all_pools()`: <100ms for 10 pools
 - `get_cleanup_metrics()`: <1ms
@@ -1204,11 +1242,13 @@ def test_all_documentation_examples():
 ### 7.2 Optimization
 
 **Connection Pooling**: Maintained
+
 - Test mode doesn't disable connection pooling
 - Pools are shared within event loop
 - Only stale pools are cleaned
 
 **Lazy Cleanup**: Opt-in
+
 - Aggressive cleanup is opt-in via `test_mode_aggressive_cleanup`
 - Default behavior: cleanup on explicit call only
 
@@ -1221,6 +1261,7 @@ def test_all_documentation_examples():
 **Location**: `/packages/kailash-dataflow/docs/api/test_mode.md`
 
 **Sections**:
+
 - Test mode overview
 - API reference (all methods)
 - Usage patterns
@@ -1231,6 +1272,7 @@ def test_all_documentation_examples():
 **Location**: `/packages/kailash-dataflow/docs/testing/`
 
 **Files**:
+
 - `README.md` - Overview
 - `fixture-patterns.md` - Pytest fixtures (CORE)
 - `setup-guide.md` - Initial setup
@@ -1241,6 +1283,7 @@ def test_all_documentation_examples():
 **Location**: `/packages/kailash-dataflow/docs/testing/examples/`
 
 **Files**:
+
 - `basic_test.py` - Simple CRUD test
 - `conftest.py` - Fixture definitions
 - `transaction_test.py` - Rollback pattern
@@ -1275,6 +1318,7 @@ def test_all_documentation_examples():
 **Status**: Proposed
 
 **Next Steps**:
+
 1. Technical review by DataFlow maintainers
 2. API review for consistency
 3. Implementation approval

--- a/packages/kailash-dataflow/tests/regression/test_readme_tdd_mode_quickstart.py
+++ b/packages/kailash-dataflow/tests/regression/test_readme_tdd_mode_quickstart.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 end-to-end regression for the docs-taught TDD-mode pipeline.
+
+Issue #1022. Value-anchor — `rules/testing.md` § "MUST: End-to-End
+Pipeline Regression Above Unit + Integration" (verbatim): "Every
+canonical pipeline the docs teach (README Quick Start, tutorial,
+3-line example) MUST have a Tier-2+ regression test executing
+DOCS-EXACT code against real infra, asserting the final user-visible
+outcome."
+
+The `DataFlow(tdd_mode=True)` + `@db.model` + `WorkflowBuilder` +
+`AsyncLocalRuntime.execute_workflow_async()` pipeline is documented as
+the canonical (Recommended) test-mode pattern in
+`packages/kailash-dataflow/docs/adr/ADR-017-test-mode-api-spec.md`
+§ 2.1. Before this test, no file in `tests/regression/` exercised it
+end-to-end. The closest existing test
+(`tests/unit/core/test_tdd_mode_propagates_to_node_generator.py`,
+renamed from `test_real_tdd_integration.py` in PR #1021) patches 7
+internal init phases — it asserts constructor metadata propagation,
+NOT pipeline behavior. A future refactor of the node-generation or
+runtime-execution path could break the user-facing quick-start with
+zero test signal; this regression closes that gap.
+
+DOCS-EXACT fidelity: the pipeline shape (model → WorkflowBuilder →
+`<Model>CreateNode` → AsyncLocalRuntime → assert created field) mirrors
+ADR-017 § 2.1 verbatim. The ONLY deviations are mandated by the test
+rules, not by choice:
+- DB URL comes from the `IntegrationTestSuite` real-Postgres harness,
+  NOT the doc's literal `"postgresql://localhost/test_db"`
+  (`tests/CLAUDE.md`: "NEVER hardcode database URLs").
+- `tdd_mode=True` is passed EXPLICITLY rather than relying on pytest
+  auto-detection, because #1022's acceptance names the explicit
+  constructor kwarg as the API surface under regression.
+- The model/table name is uniquified per test for isolation
+  (`rules/testing.md` § Rules — isolated DBs).
+
+Tier 2 (real PostgreSQL, NO mocking) per `rules/testing.md`
+§ "3-Tier Testing". Skips cleanly when the shared PG infra on port
+5434 is unreachable.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+from kailash.runtime import AsyncLocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+from dataflow import DataFlow
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+pytestmark = [pytest.mark.regression, pytest.mark.integration]
+
+
+@pytest.fixture
+async def pg_test_suite():
+    """IntegrationTestSuite against real Postgres (port 5434).
+
+    Skips cleanly when the shared SDK Docker infra is unreachable —
+    matches the integration-tier canonical-harness behavior.
+    """
+    suite = IntegrationTestSuite()
+    try:
+        async with suite.session():
+            yield suite
+    except Exception as exc:  # pragma: no cover - infra-availability guard
+        pytest.skip(
+            f"Cannot reach PostgreSQL test infra: {type(exc).__name__}: {exc}. "
+            f"Ensure shared SDK Docker is running on port 5434."
+        )
+
+
+async def test_readme_tdd_mode_quickstart_executes_end_to_end(pg_test_suite):
+    """DOCS-EXACT: DataFlow(tdd_mode=True) + @db.model + WorkflowBuilder
+    + AsyncLocalRuntime executes end-to-end against real Postgres and the
+    created record is both returned AND persisted (read-back verified).
+
+    Pipeline mirrors ADR-017 § 2.1 (the Recommended test-mode pattern).
+    """
+    # Unique model/table for isolation (rules/testing.md § Rules).
+    suffix = f"{int(time.time() * 1_000_000)}{uuid.uuid4().hex[:6]}"
+    model_name = f"QuickstartUser{suffix}"
+
+    # ---- DOCS-EXACT pipeline (ADR-017 § 2.1) -----------------------
+    # tdd_mode=True passed explicitly (issue #1022 API surface);
+    # URL from the real-PG harness (tests/CLAUDE.md mandate).
+    db = DataFlow(pg_test_suite.config.url, tdd_mode=True)
+    try:
+        UserModel = type(
+            model_name,
+            (),
+            {
+                "__annotations__": {"id": str, "name": str},
+            },
+        )
+        db.model(UserModel)
+
+        await db.initialize()
+
+        workflow = WorkflowBuilder()
+        workflow.add_node(
+            f"{model_name}CreateNode",
+            "create",
+            {"id": "user-1", "name": "Alice"},
+        )
+
+        runtime = AsyncLocalRuntime()
+        # `inputs` is a REQUIRED parameter of execute_workflow_async (no
+        # default). ADR-017 § 2.1 omitted it (doc bug — fixed in the same
+        # commit as this regression); the canonical call per the repo
+        # CLAUDE.md § Critical Execution Rules passes `inputs={}`.
+        results, _ = await runtime.execute_workflow_async(workflow.build(), inputs={})
+
+        # Final user-visible outcome (ADR-017 § 2.1's own assertion shape).
+        assert results["create"]["name"] == "Alice", (
+            f"TDD-mode quick-start regression: CreateNode returned "
+            f"{results.get('create')!r}; docs-taught pipeline broken."
+        )
+        assert results["create"]["id"] == "user-1"
+
+        # Read-back verification — the record actually persisted, not
+        # just echoed by the node (rules/testing.md § State Persistence
+        # Verification). Independent read via the express surface.
+        persisted = await db.express.read(model_name, "user-1")
+        assert persisted is not None, (
+            "TDD-mode quick-start regression: record not persisted — "
+            "CreateNode returned success but read-back found nothing."
+        )
+        assert persisted["name"] == "Alice"
+    finally:
+        await db.close_async()


### PR DESCRIPTION
## Summary
- Adds the Tier-2 end-to-end regression for the docs-taught `DataFlow(tdd_mode=True)` + `@db.model` + `WorkflowBuilder` + `AsyncLocalRuntime` pipeline (ADR-017 §2.1, the "Recommended" test-mode pattern). Per `rules/testing.md` § "MUST: End-to-End Pipeline Regression" — every docs-taught canonical pipeline MUST have a Tier-2+ DOCS-EXACT regression asserting the final user-visible outcome.
- The closest existing test (`test_tdd_mode_propagates_to_node_generator.py`) patches 7 internal init phases — constructor metadata, NOT pipeline behavior. This closes the genuine gap.
- Real Postgres via `IntegrationTestSuite` (Tier 2, NO mocking), read-back verification of persistence, unique model name per test for isolation. Verified green against shared PG infra (1.12s).

## Same-commit doc fix (autonomous-execution Rule 4 — adjacent same-class)
ADR-017 §2.1 showed `execute_workflow_async(workflow.build())` but `inputs` is a **REQUIRED parameter (no default)** — any user copying the "Recommended" pattern verbatim hits `TypeError`. Corrected the ADR to pass `inputs={}`, matching the repo CLAUDE.md canonical call and this regression test. DOCS-EXACT requires doc and test to agree on the *working* API; the test is the source of truth.

## Test plan
- [x] `pytest tests/regression/test_readme_tdd_mode_quickstart.py` — 1 passed, 1.12s (real PG :5434)
- [x] read-back verification asserts persistence, not just node return
- [x] `pre-commit run --files <changed>` — all hooks pass incl. isort + Tier-1 unit tests

## Related issues
Closes #1022. Value-anchor: `rules/testing.md` § E2E Pipeline Regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)