### PR TITLE
release: kailash 2.21.1 + kailash-dataflow 2.9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.1] - 2026-05-16
+
+### Fixed
+
+- **`verify_envelope` premature `DeprecationWarning` (trust)** — `verify_envelope`
+  emitted a `DeprecationWarning` on the `alg_id=None` path, but that is the ONLY
+  supported calling convention (a non-default `alg_id` raises `NotImplementedError`
+  — the ISS-31 wire-format gate). Deprecating the only working path is incorrect;
+  the warning had no migration target and referenced now-closed #604. It was also
+  asymmetric with `sign_envelope` (quiet via `coerce_algorithm_id`). `verify_envelope`
+  now mirrors `sign_envelope` — unconditional `coerce_algorithm_id(alg_id)`, quiet on
+  the default, `NotImplementedError` on non-default, before any HMAC work. The HMAC
+  verification path (`hmac.compare_digest`), fail-closed semantics, and the ISS-31
+  gate are unchanged (verified by security-reviewer gate-review — no findings above
+  LOW). Removed the now-dead `_LEGACY_HMAC_ENVELOPE_WARNED` global, the orphaned
+  `import warnings as _warnings`, the unused `ALGORITHM_DEFAULT` import, and synced
+  the `verify_envelope` docstring to the no-warning behavior. This warning was
+  self-inflicted (the project's own `test_envelope_round_trip.py` triggered it) and
+  failed `-W error`, blocking the Tier-1 pre-commit gate for every kailash-dataflow
+  PR. The `alg_id` wire format remains tracked by ISS-31, unchanged.
+
 ## [2.21.0] - 2026-05-13
 
 ### Added — issue #953: LocalRuntime-owned AsyncSQL pool tracking

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [Unreleased]
 
+## [2.9.12] — 2026-05-16 — migration-tracking NameError fix + #979 test hardening
+
+### Fixed
+
+- **`schema_state_manager` `NameError: async_safe_run` (#853)** — applying
+  numbered migrations against PostgreSQL raised
+  `NameError: name 'async_safe_run' is not defined` on the
+  migration-history audit-row insert. The DDL applied successfully but
+  the tracking write failed, so migrations were misreported as failed.
+  Root cause: `dataflow/migrations/schema_state_manager.py` called
+  `async_safe_run()` at two sync→async bridge sites but never imported
+  it. Fixed by adding the module-top import (no circular import —
+  `dataflow.core.async_utils` imports only stdlib). Cross-SDK: kailash-py
+  equivalent of HANA #90. Also removed 3 grep-confirmed-unused imports
+  (`asyncio`, `time`, `typing.Set`) in the same file. Tier-1 regression
+  test pins the module-namespace binding + AST-verifies every call site
+  is import-backed.
+
+### Added (test hardening — no wheel-content change beyond the #853 fix)
+
+- **5-layer regression scaffolding (#999)** —
+  `tests/regression/test_issue_979_layer{1..5}.py` permanently prevent
+  the PR-#976 5-layer CI failure (pytest-timeout pin, no-hypothesis-OOM,
+  no bare tier-1 runtime import, fabric gated/moved, no PG tier-1
+  import) from silently re-landing.
+- **`db.express` async tier-1 smoke (#998)** —
+  `tests/unit/test_db_express_async_smoke.py` closes the gap where the
+  express CRUD surface was integration-only; read-back verification of
+  every mutation.
+- **TDD-mode docs-pipeline Tier-2 regression (#1022)** —
+  `tests/regression/test_readme_tdd_mode_quickstart.py` exercises the
+  ADR-017 §2.1 `DataFlow(tdd_mode=True)` pipeline end-to-end against real
+  PostgreSQL. Also corrected an ADR-017 §2.1 doc bug
+  (`execute_workflow_async` `inputs=` was required but undocumented).
+
+### Changed
+
+- **Pyright orphan-cleanup cascade (#1026)** — deleted 4 orphan test
+  files importing `dataflow.validators.*` (deleted in DataFlow 2.0;
+  no replacement — verified absent from all of `src/`) + removed their
+  stale `conftest.py` `collect_ignore` parking (orphan-detection Rule 3
+  anti-pattern) + 3 `assert-not-None` guards + DataFlow-close test
+  teardown hygiene. Follow-up #1045 tracks the residual aiosqlite
+  test-side ResourceWarning (documented #1002/#1010 class).
+
 ## [2.9.11] — 2026-05-16 — api_gateway_starter template type-safety + rate-limit hardening
 
 Closes 6 basic-mode pyright findings in `templates/api_gateway_starter/` — real

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.11"
+version = "2.9.12"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.11"
+__version__ = "2.9.12"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.21.0"
+version = "2.21.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.21.0"
+__version__ = "2.21.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary
Metadata-only release-prep (4 version anchors + 2 CHANGELOGs) for the #979/#853 cluster (7 PRs merged this session).

- **kailash-dataflow 2.9.11 → 2.9.12** — #853 production bug fix (migration-tracking `NameError`, cross-SDK HANA #90) + #999/#998/#1022/#1026 test hardening.
- **kailash 2.21.0 → 2.21.1** — `verify_envelope` premature-`DeprecationWarning` removal (#1042) + docstring sync (#1048); restores `-W error` cleanliness.

Both patch releases. `/redteam` converged (reviewer + security-reviewer gate agents — no findings above LOW; the one LOW fixed in #1048). No sibling drift (other 6 packages: 0 src-commits since `dataflow-v2.9.11`).

Patch releases skip TestPyPI per `deployment.md` exception with explicit human authorization (release authorized by repo owner this session).

## Test plan
- [x] Version consistency atomic (pyproject + `__init__` for both packages — zero-tolerance Rule 5)
- [x] Metadata-only diff → `release/v*` branch auto-skips PR-gate matrix
- [x] `pre-commit run --files <staged>` — all pass incl. Tier-1 + doc-style
- [ ] On merge: tags `dataflow-v2.9.12` + `v2.21.1` pushed individually → publish-pypi → clean-venv verify

## Related issues
Ships fixes for #853 #999 #998 #1022 #1026 + envelope #1042/#1048. Follow-ups tracked: #1045 #1047.

🤖 Generated with [Claude Code](https://claude.com/claude-code)