### PR TITLE
fix(dataflow): protected-runtime LocalRuntime CM deprecation + event-loop drain (#1045)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
+++ b/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
@@ -112,6 +112,25 @@ class DataFlowProtectionMixin:
         super().__init__(*args, **kwargs)
         self._protection_config = protection_config or WriteProtectionConfig()
         self._protection_engine = WriteProtectionEngine(self._protection_config)
+        # Issue #1045 — every ProtectedDataFlowRuntime returned by
+        # create_protected_runtime() calls mark_externally_managed() in its
+        # __init__ (the Shard A deprecation fix). mark_externally_managed()
+        # deliberately SKIPS atexit.register(self._cleanup_event_loop)
+        # (kailash.runtime.local.LocalRuntime._get_persistent_loop) —
+        # transferring cleanup responsibility to the owning framework. The
+        # owner MUST close() each runtime at teardown or its persistent
+        # asyncio event loop leaks (one per create_protected_runtime() call).
+        #
+        # This is the same owner-tracks-then-drains invariant every sibling
+        # mark_externally_managed() call site already honors:
+        #   - engine.py:883  -> self._sync_runtime_singleton, drained in
+        #     DataFlow.close()/close_async() (engine.py rt.close() loop)
+        #   - auto_migration_system.py:279/1074/1703 -> self._explicit_runtime,
+        #     drained in their close()
+        # ProtectedDataFlowRuntime is structurally different (it IS the
+        # runtime, not a wrapper holding one) and create_protected_runtime()
+        # returns a fresh instance per call, so the owner tracks the LIST.
+        self._protected_runtimes: list = []
 
     def set_protection_config(self, config: WriteProtectionConfig):
         """Update the protection configuration."""
@@ -165,10 +184,89 @@ class DataFlowProtectionMixin:
         return self._protection_config.auditor.events
 
     def create_protected_runtime(self, **runtime_kwargs) -> ProtectedDataFlowRuntime:
-        """Create a runtime with protection enforcement."""
-        return ProtectedDataFlowRuntime(
+        """Create a runtime with protection enforcement.
+
+        The returned runtime is registered on this owning DataFlow so
+        ``close()`` / ``close_async()`` can drain its persistent event loop
+        at teardown (issue #1045). ``ProtectedDataFlowRuntime`` opts out of
+        ``atexit`` cleanup via ``mark_externally_managed()`` — without this
+        registration the loop would leak.
+        """
+        runtime = ProtectedDataFlowRuntime(
             protection_config=self._protection_config, **runtime_kwargs
         )
+        # Track for owner-driven cleanup. Plain list (not WeakSet): the
+        # owner is the sole lifecycle authority for these runtimes, and a
+        # weak ref would let the loop be collected without close(), which
+        # is the leak itself.
+        runtimes = getattr(self, "_protected_runtimes", None)
+        if runtimes is None:
+            # Defensive: a subclass may construct the runtime before the
+            # mixin __init__ ran (unusual, but the attribute MUST exist
+            # before the first append or the drain in close() misses it).
+            self._protected_runtimes = runtimes = []
+        runtimes.append(runtime)
+        return runtime
+
+    def _drain_protected_runtimes(self) -> None:
+        """Close every runtime handed out by create_protected_runtime().
+
+        Sync — ``LocalRuntime.close()`` is synchronous (it joins the
+        persistent loop thread / closes the loop). Idempotent: each
+        runtime's own ref-count logic makes a second close() a no-op, and
+        the tracking list is cleared so a second drain is empty. Safe to
+        call from both close() and close_async().
+        """
+        runtimes = getattr(self, "_protected_runtimes", None)
+        if not runtimes:
+            return
+        for runtime in list(runtimes):
+            try:
+                runtime.close()
+            except Exception as e:
+                # Mirror the sibling-pattern disposition in
+                # DataFlow.close() (engine.py rt.close() loop): a failure
+                # closing one externally-managed runtime MUST NOT abort the
+                # rest of teardown. Logged, not swallowed silently
+                # (rules/zero-tolerance.md Rule 3 / observability.md).
+                logger.warning(
+                    "protection_middleware.error_closing_protected_runtime",
+                    extra={
+                        "runtime_id": getattr(runtime, "_runtime_id", "unknown"),
+                        "error": str(e),
+                    },
+                )
+        runtimes.clear()
+
+    def close(self) -> None:
+        """Drain protected runtimes, then delegate to DataFlow.close().
+
+        Cooperative-MRO override. ``ProtectedDataFlow`` resolves
+        ``DataFlowProtectionMixin -> DataFlow``; draining BEFORE
+        ``super().close()`` releases the protection runtimes' loops while
+        the rest of the engine is still live, matching the
+        release-subsystems-first ordering DataFlow.close() already uses.
+        """
+        self._drain_protected_runtimes()
+        # super() may not define close() in every composition; guard so the
+        # mixin is safe if applied to a base without it.
+        parent_close = getattr(super(), "close", None)
+        if callable(parent_close):
+            parent_close()
+
+    async def close_async(self) -> None:
+        """Async-context teardown: drain protected runtimes, then delegate.
+
+        ``LocalRuntime.close()`` is sync, so the drain itself is sync; only
+        the delegation to ``DataFlow.close_async()`` is awaited. Mirrors the
+        sync ``close()`` ordering (drain first, engine last).
+        """
+        self._drain_protected_runtimes()
+        parent_close_async = getattr(super(), "close_async", None)
+        if parent_close_async is not None:
+            result = parent_close_async()
+            if result is not None:
+                await result
 
 
 def protect_dataflow_node(original_class: Type[Node]) -> Type[Node]:

--- a/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
+++ b/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
@@ -106,6 +106,13 @@ class DataFlowProtectionMixin:
     without requiring inheritance changes.
     """
 
+    # Tracks every ProtectedDataFlowRuntime returned by
+    # create_protected_runtime() so close()/close_async() can drain their
+    # externally-managed event loops (issue #1045). Class-level annotation so
+    # static analysis resolves the attribute through the ProtectedDataFlow
+    # MRO; the real value is assigned in __init__ below.
+    _protected_runtimes: list
+
     def __init__(
         self, *args, protection_config: Optional[WriteProtectionConfig] = None, **kwargs
     ):

--- a/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
+++ b/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
@@ -47,17 +47,24 @@ class ProtectedDataFlowRuntime(LocalRuntime):
         self.mark_externally_managed()
         self.protection_engine = WriteProtectionEngine(protection_config)
 
-    def execute(self, workflow, task_manager=None, parameters=None):
-        """Override execute to handle ProtectionViolations specially."""
+    def execute(self, workflow, task_manager=None, parameters=None, *args, **kwargs):
+        """Override execute to handle ProtectionViolations specially.
+
+        Forwards every positional/keyword argument transparently to
+        ``LocalRuntime.execute`` so callers passing ``idempotency_key``,
+        ``time_limit``, ``cancellation_token`` etc. on the protection-enforced
+        path are not silently dropped (signature parity with the base).
+        """
         # Call parent execute which returns (results, run_id)
-        results, run_id = super().execute(workflow, task_manager, parameters)
+        results, run_id = super().execute(
+            workflow, task_manager, parameters, *args, **kwargs
+        )
 
         # Check results for protection violations
-        for node_id, node_result in results.items():
+        for node_result in results.values():
             if isinstance(node_result, dict):
                 # Check if this node failed with a protection violation
                 error_msg = node_result.get("error", "")
-                error_type = node_result.get("error_type", "")
                 failed = node_result.get("failed", False)
 
                 if failed and (
@@ -173,6 +180,12 @@ def protect_dataflow_node(original_class: Type[Node]) -> Type[Node]:
     """
 
     class ProtectedNode(original_class):
+        # Injected post-construction by DataFlow's node-generation machinery
+        # (the generated node is bound to its owning DataFlow instance there).
+        # Declared so static analysis knows the attribute exists; every read
+        # is still hasattr()-guarded because it is absent until injection.
+        dataflow_instance: Any
+
         def run(self, **kwargs) -> Dict[str, Any]:
             """Override run to add protection checks."""
             logger.debug(
@@ -258,8 +271,12 @@ def protect_dataflow_node(original_class: Type[Node]) -> Type[Node]:
                             )
                             raise
 
-            # Execute original method if protection passes
-            return super().run(**kwargs)
+            # Execute original method if protection passes.
+            # original_class is ALWAYS a concrete generated DataFlow node at
+            # runtime (the decorator only wraps concrete *Node classes); the
+            # Type[Node] parameter annotation makes pyright treat Node.run as
+            # abstract. Static-analysis expressiveness gap, not a real bug.
+            return super().run(**kwargs)  # pyright: ignore[reportAbstractUsage]
 
     # Preserve class metadata
     ProtectedNode.__name__ = original_class.__name__

--- a/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
+++ b/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
@@ -33,6 +33,18 @@ class ProtectedDataFlowRuntime(LocalRuntime):
 
     def __init__(self, protection_config: WriteProtectionConfig, **kwargs):
         super().__init__(**kwargs)
+        # ProtectedDataFlowRuntime is a long-lived, framework-held runtime:
+        # DataFlow constructs it via create_protected_runtime() and drives
+        # execute() directly without the `with LocalRuntime() as rt:` context
+        # manager. Without this opt-out, LocalRuntime.execute() emits a
+        # DeprecationWarning ("without context manager ... error in v0.12.0")
+        # on every protection-enforced workflow run. mark_externally_managed()
+        # is the SDK-blessed opt-out for exactly this framework-ownership case
+        # (see kailash.runtime.local.LocalRuntime.mark_externally_managed,
+        # issue #478) and is the established DataFlow convention (engine.py,
+        # auto_migration_system.py, connection_adapter.py). The owning caller
+        # is responsible for close() at teardown.
+        self.mark_externally_managed()
         self.protection_engine = WriteProtectionEngine(protection_config)
 
     def execute(self, workflow, task_manager=None, parameters=None):

--- a/packages/kailash-dataflow/tests/regression/test_issue_1045_protected_runtime_close.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1045_protected_runtime_close.py
@@ -49,9 +49,11 @@ async-SQL-node-cache path), NOT the protected-runtime event-loop leak this
 shard closes. These tests therefore assert the event-loop drain
 behaviorally and do not force GC of the aiosqlite connection into the test
 body (which would surface the unrelated pre-existing leak). The aiosqlite
-leak is tracked as a follow-up — see the shard report.
+:memory: teardown leak is tracked as issue #1051 (distinct bug class,
+DataFlow.close() core lifecycle, out of this shard's budget).
 
-See issue #1045, rules/dataflow-pool.md Rule 5 (no orphan runtimes),
+See issue #1045, issue #1051 (deferred aiosqlite :memory: teardown),
+rules/dataflow-pool.md Rule 5 (no orphan runtimes),
 rules/zero-tolerance.md Rule 1 (warnings are errors).
 """
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_1045_protected_runtime_close.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1045_protected_runtime_close.py
@@ -1,0 +1,256 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test: ProtectedDataFlow.close() must drain the persistent
+event loops of every ProtectedDataFlowRuntime it handed out (issue #1045).
+
+``ProtectedDataFlowRuntime.__init__`` calls ``mark_externally_managed()``
+(Shard A's deprecation fix). ``mark_externally_managed()``
+(``kailash.runtime.local.LocalRuntime``) does two things:
+
+1. sets ``_externally_managed = True`` (suppresses the CM DeprecationWarning
+   — guarded by the sibling test
+   ``test_issue_1045_protection_runtime_cm_deprecation.py``), AND
+2. SKIPS ``atexit.register(self._cleanup_event_loop)`` in
+   ``_get_persistent_loop`` (``local.py`` ~L1474-1482) — the opt-out
+   deliberately transfers cleanup responsibility to the owning framework.
+
+Before the fix, ``DataFlowProtectionMixin.create_protected_runtime()``
+returned a FRESH, untracked runtime per call, and ``ProtectedDataFlow``
+only inherited ``DataFlow.close()`` — which drains
+``_sync_runtime_singleton`` / ``_loop_runtime_cache`` / ``_runtime_override``
+but NEVER the protected runtimes. Net: each protected runtime's persistent
+asyncio event loop was no longer atexit-cleaned AND nothing else closed it
+→ a per-protected-runtime event-loop leak. That is the exact
+``ResourceWarning`` class issue #1045 is chartered to close.
+
+The fix tracks every runtime returned by ``create_protected_runtime()`` on
+the owning ``DataFlowProtectionMixin`` and drains them (``runtime.close()``)
+in cooperative-MRO ``close()`` / ``close_async()`` overrides — the same
+owner-tracks-then-drains invariant every sibling
+``mark_externally_managed()`` call site already honors (``engine.py:883`` ->
+``self._sync_runtime_singleton`` drained in ``DataFlow.close()``;
+``auto_migration_system.py`` -> ``self._explicit_runtime`` drained in
+``close()``).
+
+These tests exercise the REAL protection ``execute()`` path against a real
+(SQLite) DataFlow instance, capture the persistent loop the runtime
+allocated, and assert ``ProtectedDataFlow.close()`` / ``close_async()``
+actually closed it (``loop.is_closed()`` + ``_persistent_loop is None``).
+The behavioral loop-closed assertion is the structural proof; it holds
+under ``-W error::ResourceWarning``.
+
+Scope boundary: a separate, pre-existing ``aiosqlite.core.Connection ...
+was deleted before being closed`` ResourceWarning is emitted by the
+``ProtectedDataFlow`` + ``sqlite:///:memory:`` + ``runtime.execute()`` path
+(visible on the EXISTING ``test_issue_1045_protection_runtime_cm_
+deprecation.py`` too — it predates this shard). That is a DISTINCT bug
+class (SQLite connection teardown in ``DataFlow.close()``'s ``:memory:`` /
+async-SQL-node-cache path), NOT the protected-runtime event-loop leak this
+shard closes. These tests therefore assert the event-loop drain
+behaviorally and do not force GC of the aiosqlite connection into the test
+body (which would surface the unrelated pre-existing leak). The aiosqlite
+leak is tracked as a follow-up — see the shard report.
+
+See issue #1045, rules/dataflow-pool.md Rule 5 (no orphan runtimes),
+rules/zero-tolerance.md Rule 1 (warnings are errors).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_wf = pytest.importorskip("kailash.workflow.builder")
+WorkflowBuilder = _wf.WorkflowBuilder
+
+from dataflow.core.protected_engine import ProtectedDataFlow
+from dataflow.core.protection_middleware import ProtectedDataFlowRuntime
+
+
+def _drive_persistent_loop(runtime: ProtectedDataFlowRuntime) -> None:
+    """Run a trivial workflow so the runtime allocates its persistent loop.
+
+    The execution OUTCOME is irrelevant (the :memory: table may not exist
+    — protection is left permissive so no ProtectionViolation short-
+    circuits, and LocalRuntime.execute() allocates the persistent loop
+    before workflow execution either way). What matters is that
+    ``runtime._persistent_loop`` becomes a live, non-closed loop.
+    """
+    workflow = WorkflowBuilder()
+    workflow.add_node(
+        "Issue1045CloseModelCreateNode",
+        "create_it",
+        {"name": "regression", "value": 1045},
+    )
+    try:
+        runtime.execute(workflow.build())
+    except Exception:
+        # Outcome irrelevant — see docstring.
+        pass
+
+
+@pytest.mark.regression
+class TestIssue1045ProtectedRuntimeClose:
+    """ProtectedDataFlow.close()/close_async() drain protected runtimes."""
+
+    def test_close_drains_protected_runtime_persistent_loop(self):
+        """Behavioral: a used protected runtime's persistent event loop is
+        closed by ProtectedDataFlow.close().
+
+        This is the leak issue #1045's residual targets — without the fix
+        the captured loop stays OPEN forever after the owning DataFlow is
+        closed, because mark_externally_managed() skipped atexit and nothing
+        else closes it.
+        """
+        db = ProtectedDataFlow(
+            database_url="sqlite:///:memory:", enable_protection=True
+        )
+
+        @db.model
+        class Issue1045CloseModel:
+            id: int
+            name: str
+            value: int
+
+        runtime = db.create_protected_runtime()
+        assert isinstance(runtime, ProtectedDataFlowRuntime)
+
+        _drive_persistent_loop(runtime)
+
+        # The runtime must have allocated a persistent loop (the thing that
+        # leaks). If this is None the test is not exercising the leak.
+        loop = runtime._persistent_loop
+        assert loop is not None, (
+            "ProtectedDataFlowRuntime did not allocate a persistent event "
+            "loop; the leak surface is not being exercised."
+        )
+        assert not loop.is_closed(), "loop unexpectedly closed before db.close()"
+
+        db.close()
+
+        # The fix: ProtectedDataFlow.close() drains tracked runtimes.
+        assert loop.is_closed(), (
+            "ProtectedDataFlow.close() did NOT close the protected runtime's "
+            "persistent event loop (issue #1045 regression). "
+            "create_protected_runtime() registration or the close() drain "
+            "was likely dropped."
+        )
+        assert runtime._persistent_loop is None, (
+            "_cleanup_event_loop did not run for the protected runtime; "
+            "_persistent_loop should be None after owner-driven close()."
+        )
+
+    def test_close_drains_multiple_protected_runtimes(self):
+        """Every runtime from create_protected_runtime() is drained, not
+        just the most recent one.
+
+        create_protected_runtime() returns a FRESH runtime per call; the
+        owner tracks the LIST. A fix that only closes the latest runtime
+        still leaks the earlier ones.
+        """
+        db = ProtectedDataFlow(
+            database_url="sqlite:///:memory:", enable_protection=True
+        )
+
+        @db.model
+        class Issue1045CloseModel:
+            id: int
+            name: str
+            value: int
+
+        runtimes = [db.create_protected_runtime() for _ in range(3)]
+        loops = []
+        for rt in runtimes:
+            _drive_persistent_loop(rt)
+            assert rt._persistent_loop is not None
+            loops.append(rt._persistent_loop)
+
+        db.close()
+
+        for idx, loop in enumerate(loops):
+            assert loop.is_closed(), (
+                f"protected runtime #{idx} persistent loop NOT closed by "
+                f"ProtectedDataFlow.close() — only-latest-runtime drain "
+                f"(issue #1045 regression)."
+            )
+
+    async def test_close_async_drains_protected_runtimes(self):
+        """Async-context teardown path: close_async() drains protected
+        runtimes and is reachable on the cooperative-MRO chain.
+
+        FastAPI lifespan / pytest-asyncio fixtures call close_async(), not
+        close(). The cooperative-MRO override MUST exist on BOTH paths or
+        async deployments never drain the protected runtimes at all.
+
+        Note on scope: a *sync* ``LocalRuntime.execute()`` invoked while an
+        outer event loop is already running (this test runs under
+        pytest-asyncio) does NOT allocate ``runtime._persistent_loop`` — it
+        detects the running outer loop and takes the no-persistent-loop
+        path (``local.py`` outer-loop branch). The persistent-loop leak
+        therefore only manifests in the SYNC-context path, fully asserted
+        by ``test_close_drains_protected_runtime_persistent_loop`` /
+        ``test_close_drains_multiple_protected_runtimes``. What this async
+        test guards is the OTHER half of the contract: that
+        ``close_async()`` exists on the mixin, runs the drain, clears the
+        tracking list, and delegates to ``DataFlow.close_async()`` without
+        raising — i.e. the async deployment path is wired, not just sync.
+        """
+        db = ProtectedDataFlow(
+            database_url="sqlite:///:memory:", enable_protection=True
+        )
+
+        @db.model
+        class Issue1045CloseModel:
+            id: int
+            name: str
+            value: int
+
+        runtime = db.create_protected_runtime()
+        assert isinstance(runtime, ProtectedDataFlowRuntime)
+        # Owner registered it (the precondition for the drain).
+        assert runtime in db._protected_runtimes
+
+        await db.close_async()
+
+        # The drain ran on the async path: the tracking list is emptied
+        # (the structural proof close_async() called _drain_protected_
+        # runtimes, NOT merely that DataFlow.close_async() ran). If the
+        # mixin's close_async() override were missing, MRO would resolve
+        # straight to DataFlow.close_async() and the list would still hold
+        # the runtime.
+        assert db._protected_runtimes == [], (
+            "ProtectedDataFlow.close_async() did NOT drain the protected "
+            "runtime tracking list (issue #1045 regression — the async "
+            "deployment path bypasses the drain)."
+        )
+        # Idempotent second close_async() must not raise.
+        await db.close_async()
+
+    def test_protected_runtimes_tracked_on_owner(self):
+        """Structural invariant: create_protected_runtime() registers the
+        runtime on the owner.
+
+        If a future refactor drops the ``self._protected_runtimes.append``
+        in create_protected_runtime() (or the list init in __init__), the
+        drain in close() silently misses every runtime and the leak
+        re-opens with NO behavioral test failure on the cleanup path that
+        no longer runs. This invariant fails loudly at that point.
+        """
+        db = ProtectedDataFlow(
+            database_url="sqlite:///:memory:", enable_protection=True
+        )
+        try:
+            assert hasattr(db, "_protected_runtimes"), (
+                "DataFlowProtectionMixin.__init__ no longer initializes "
+                "_protected_runtimes — the close() drain has nothing to "
+                "iterate (issue #1045 regression)."
+            )
+            r1 = db.create_protected_runtime()
+            r2 = db.create_protected_runtime()
+            tracked = db._protected_runtimes
+            assert r1 in tracked and r2 in tracked, (
+                "create_protected_runtime() no longer registers the runtime "
+                "on the owner; ProtectedDataFlow.close() cannot drain an "
+                "untracked runtime (issue #1045 regression)."
+            )
+        finally:
+            db.close()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1045_protection_runtime_cm_deprecation.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1045_protection_runtime_cm_deprecation.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test: ProtectedDataFlowRuntime must not emit the LocalRuntime
+"without context manager" DeprecationWarning (issue #1045).
+
+``ProtectedDataFlowRuntime(LocalRuntime)`` is a long-lived, framework-held
+runtime. DataFlow constructs it via ``create_protected_runtime()`` and drives
+``execute()`` directly — it is never used through the
+``with LocalRuntime() as rt:`` context manager.
+
+``LocalRuntime.execute()`` (src/kailash/runtime/local.py) emits
+
+    DeprecationWarning: LocalRuntime.execute() without context manager or
+    explicit close() is deprecated. ... This will become an error in v0.12.0.
+
+on every call unless the runtime is context-managed, atexit-registered, OR
+externally managed. Before the fix, ``ProtectedDataFlowRuntime.__init__``
+called ``super().__init__(**kwargs)`` without declaring external management,
+so the protection-enforcement hot path emitted this DeprecationWarning on
+every protected workflow run — and would hard-fail in v0.12.0.
+
+The fix calls ``self.mark_externally_managed()`` in ``__init__`` — the
+SDK-blessed opt-out for framework-owned runtimes (see
+``kailash.runtime.local.LocalRuntime.mark_externally_managed``, issue #478)
+and the established DataFlow convention.
+
+This test exercises the real protection ``execute()`` path against a real
+(SQLite) DataFlow instance and asserts NO ``DeprecationWarning`` mentioning
+the context-manager contract is emitted. The runtime-tuple contract and the
+ProtectionViolation behavior are verified by the existing protection suites;
+this test guards only the deprecation surface.
+
+See issue #1045, rules/zero-tolerance.md Rule 1 (warnings are errors).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+_wf = pytest.importorskip("kailash.workflow.builder")
+WorkflowBuilder = _wf.WorkflowBuilder
+
+from dataflow.core.protected_engine import ProtectedDataFlow
+from dataflow.core.protection_middleware import ProtectedDataFlowRuntime
+
+
+def _cm_deprecation_warnings(records):
+    """Return DeprecationWarnings whose message is the LocalRuntime
+    'without context manager' contract warning (the issue #1045 surface).
+
+    Structural substring match against the SDK's own fixed warning string
+    (kailash.runtime.local.LocalRuntime.execute) — NOT a semantic probe of
+    model output. This is the exact text the SDK emits; matching it is the
+    structural assertion that the deprecation gate did/didn't fire.
+    """
+    out = []
+    for r in records:
+        if issubclass(r.category, DeprecationWarning) and (
+            "without context manager" in str(r.message)
+        ):
+            out.append(r)
+    return out
+
+
+@pytest.mark.regression
+class TestIssue1045ProtectionRuntimeCMDeprecation:
+    """ProtectedDataFlowRuntime opts out of the CM deprecation."""
+
+    def test_protected_runtime_is_marked_externally_managed(self):
+        """Structural invariant: the runtime declares external management.
+
+        If a future refactor drops ``mark_externally_managed()`` from
+        ``__init__``, ``_externally_managed`` flips back to False and the
+        DeprecationWarning re-fires on every protected execute(). This
+        invariant fails loudly at that point.
+        """
+        db = ProtectedDataFlow(
+            database_url="sqlite:///:memory:", enable_protection=True
+        )
+        try:
+            runtime = db.create_protected_runtime()
+            assert isinstance(runtime, ProtectedDataFlowRuntime)
+            assert getattr(runtime, "_externally_managed", False) is True, (
+                "ProtectedDataFlowRuntime must be externally managed so "
+                "LocalRuntime.execute() does not emit the CM DeprecationWarning "
+                "(issue #1045). mark_externally_managed() was likely dropped "
+                "from __init__."
+            )
+        finally:
+            db.close()
+
+    def test_protected_execute_emits_no_cm_deprecation_warning(self):
+        """Behavioral: running a workflow through the protection runtime
+        emits no 'without context manager' DeprecationWarning.
+
+        Protection is left at the permissive default (NOT read-only) so the
+        execute() path is exercised without a ProtectionViolation short-
+        circuiting it. The deprecation gate in LocalRuntime.execute() runs
+        before workflow execution, so even if the :memory: workflow errors
+        (e.g. table not yet created), the warning surface is still exercised.
+        """
+        db = ProtectedDataFlow(
+            database_url="sqlite:///:memory:", enable_protection=True
+        )
+        try:
+
+            @db.model
+            class Issue1045Model:
+                id: int
+                name: str
+                value: int
+
+            runtime = db.create_protected_runtime()
+            assert isinstance(runtime, ProtectedDataFlowRuntime)
+
+            workflow = WorkflowBuilder()
+            workflow.add_node(
+                "Issue1045ModelCreateNode",
+                "create_it",
+                {"name": "regression", "value": 1045},
+            )
+
+            with warnings.catch_warnings(record=True) as records:
+                warnings.simplefilter("always")
+                try:
+                    runtime.execute(workflow.build())
+                except Exception:
+                    # Execution outcome (success / table-missing / protection)
+                    # is irrelevant to this regression. The deprecation gate
+                    # runs at the top of execute(), before any of that.
+                    pass
+
+            offenders = _cm_deprecation_warnings(records)
+            assert not offenders, (
+                "ProtectedDataFlowRuntime.execute() emitted the LocalRuntime "
+                "context-manager DeprecationWarning (issue #1045 regression). "
+                f"Offending message: {str(offenders[0].message)!r}"
+            )
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary

Two production fixes on the DataFlow protection middleware (`packages/kailash-dataflow/src/dataflow/core/protection_middleware.py`), both in the `#1045` ResourceWarning/DeprecationWarning class:

1. **LocalRuntime context-manager deprecation** — `ProtectedDataFlowRuntime` ran `super().execute()` without the context-manager protocol, emitting `DeprecationWarning: LocalRuntime.execute() without context manager … error in v0.12.0` on every protection-enforced run. Fixed via the SDK-blessed `mark_externally_managed()` opt-out (the established convention at 6 sibling DataFlow call sites; issue #478).
2. **Per-protected-runtime event-loop leak** — `mark_externally_managed()` deliberately skips the atexit cleanup, transferring teardown to the owner. `ProtectedDataFlow` now tracks every `create_protected_runtime()` and drains them in `close()`/`close_async()` (owner-tracks-then-drains, matching `engine.py:883` / `auto_migration_system.py`).

Also: pre-existing pyright errors on the same `execute()` method closed (signature parity `*args/**kwargs`, dynamic-attr annotations, dead-local removal — zero-tolerance Rule 1a scanner-symmetry).

## Tests

`tests/regression/test_issue_1045_protection_runtime_cm_deprecation.py` (2) + `tests/regression/test_issue_1045_protected_runtime_close.py` (4) — behavioral, real SQLite, no mocking, falsification-confirmed (revert the fix → tests fail). 41 protection tests pass under `-W error::ResourceWarning`. pyright clean.

## Gate reviews

reviewer + security-reviewer: SHIP (initial Shard A pass + focused close()-delta re-review). Cooperative-MRO verified; drain is idempotent, non-aborting, no new security surface.

## Related issues

Part of #1045 (closes the deprecation + protected-runtime-leak halves; the test-fixture-migration half is the sibling PR).
Surfaced + filed as separate workstreams:
- #1050 — CRITICAL: ProtectedDataFlow write-protection not enforced on the async `db.express`/workflow hot path (`check_operation` orphan).
- #1051 — MEDIUM: pre-existing aiosqlite `:memory:` Connection teardown leak in `DataFlow.close()` core lifecycle (distinct bug class, out of this shard's budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)