### PR TITLE
release: kailash-dataflow 2.9.13

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+## [2.9.13] — 2026-05-17 — protection-middleware LocalRuntime CM deprecation + event-loop drain (#1045)
+
+### Fixed
+
+- **`ProtectedDataFlowRuntime` LocalRuntime context-manager deprecation
+  (#1045)** — every protection-enforced run emitted
+  `DeprecationWarning: LocalRuntime.execute() without context manager …
+error in v0.12.0`. `ProtectedDataFlowRuntime` is a long-lived,
+  framework-held runtime; fixed via the SDK-blessed
+  `LocalRuntime.mark_externally_managed()` opt-out (the established
+  convention at 6 sibling DataFlow call sites; issue #478). Without this
+  the protection hot path becomes a hard runtime error in v0.12.0. The
+  `execute()` override now also forwards `*args/**kwargs` to the parent
+  (the prior signature silently dropped `idempotency_key` /
+  `time_limit` / `cancellation_token` on the protection path).
+- **Per-protected-runtime event-loop leak (#1045)** —
+  `mark_externally_managed()` deliberately skips the atexit cleanup,
+  transferring teardown to the owner. `ProtectedDataFlow` now tracks
+  every `create_protected_runtime()` and drains them in
+  `close()` / `close_async()` (owner-tracks-then-drains, matching the
+  existing `engine.py` / `auto_migration_system.py` pattern). The drain
+  is idempotent, per-runtime exception-isolated (WARN-logged, never
+  swallowed), and never aborts `DataFlow`'s own teardown.
+
+### Notes
+
+- Surfaced + filed as separate tracked workstreams (distinct bug
+  classes, out of this fix's scope): **#1050** (CRITICAL — write
+  protection not enforced on the async `db.express` / workflow hot
+  path; `check_operation` is an orphan there) and **#1051** (a
+  pre-existing aiosqlite `:memory:` Connection teardown leak in
+  `DataFlow.close()` core lifecycle).
+
 ## [2.9.12] — 2026-05-16 — migration-tracking NameError fix + #979 test hardening
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.12"
+version = "2.9.13"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.12"
+__version__ = "2.9.13"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Patch release of **kailash-dataflow** `2.9.12 → 2.9.13`. Metadata-only diff (version anchors + CHANGELOG); the production code already merged via PR #1052 / #1053.

Ships the #1045 protection-middleware fixes:
- LocalRuntime context-manager deprecation opt-out via SDK-blessed `mark_externally_managed()` (prevents a v0.12.0 hard break on the protection hot path) + `*args/**kwargs` signature parity.
- Per-protected-runtime event-loop leak drain in `ProtectedDataFlow.close()`/`close_async()`.

No core SDK bump (zero `src/kailash/` changes) → no framework dependency-pin cascade. All 8 sibling packages at PyPI parity (no sibling-drift sweep). Both gates SHIP; 42 protection tests green on main under `-W error::ResourceWarning`; pyright 0/0. TestPyPI skipped per patch-release exception with explicit human authorization.

Branch follows `release/v*` convention → PR-gate matrix auto-skips (metadata-only).

## Related issues

Releases the fix for #1045 (closed by PR #1052/#1053). Filed follow-ups: #1050 (CRITICAL write-protection orphan), #1051 (MEDIUM aiosqlite :memory: teardown) — separate workstreams, not in this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)