### PR TITLE
release(dataflow): 2.9.14 — write-protection enforcement + bulk_update bypass closure (#1050)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.9.14] — 2026-05-17 — write-protection enforcement on async hot path + bulk_update bypass closure (#1050)
+
 ### Changed
 
 - **`ProtectionViolation` now subclasses `kailash.sdk_exceptions.NodeExecutionError` (#1050)** —
@@ -54,6 +56,38 @@ ProtectionViolation)` site continues to match unchanged (subclass
   fix; blocking-where-it-should-block is the contract
   (`specs/dataflow-protection.md` §1). Operators relying on the broken
   no-op state MUST review their protection configs before upgrading.
+- **CRITICAL: `db.express.bulk_update` silently bypassed write-protection
+  (#1050, PR #1060)** — surfaced by the per-mutation Tier-2 enforcement
+  matrix added alongside the #1050 fix. `bulk_update` runs a per-record
+  loop calling `self.update(...)` inside `except Exception: failed_count
++= 1`. Once the #1050 wiring landed (this same release), the now-
+  correctly-raised `ProtectionViolation` was caught by that generic
+  per-row handler and folded into the silent `failed_count` — a read-
+  only-blocked `bulk_update` returned an empty `results` list with NO
+  exception, bypassing write-protection at the bulk_update Express
+  surface (spec invariant I5). Fixed by `except ProtectionViolation:
+raise` BEFORE the generic per-row catch, mirroring the sibling bulk
+  surfaces (`bulk_create` / `bulk_delete` / `bulk_upsert` already
+  propagate cleanly because they call `node.async_run` once, so the raise
+  propagates directly). Genuine per-row data failures still count into
+  `failed_count` and emit the WARN-level partial-failure log unchanged.
+  Same behavior-change framing as the #1050 fix above: code that
+  "worked" only because bulk_update silently dropped blocked rows will
+  now correctly raise `ProtectionViolation`. Tier-2 coverage:
+  `tests/integration/test_issue_1050_protection_mutation_matrix.py`
+  (14 file-SQLite + 14 PostgreSQL).
+
+### Fixed
+
+- **`count` operation over-blocked under read-only protection (#1050)**
+  — surfaced while wiring `check_operation` into the async hot path.
+  `WriteProtectionEngine._operation_mapping` had no entry for `count`,
+  so the generated `*CountNode` (`self.operation == "count"`) fell
+  through to `OperationType.CUSTOM_QUERY`, which `read_only_global` /
+  `production_safe` (allow only `{READ}`) block. `count` is a derived
+  scalar READ. Added `"count": OperationType.READ` to the mapping;
+  pinned by the matrix's NOT-blocked assertions for `read`/`list`/`count`
+  under read-only (spec invariant I7).
 
 ## [2.9.13] — 2026-05-17 — protection-middleware LocalRuntime CM deprecation + event-loop drain (#1045)
 

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.13"
+version = "2.9.14"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.13"
+__version__ = "2.9.14"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Bundles the #1050 security fixes shipped on main (PRs #1057, #1059, #1060) into a publishable kailash-dataflow patch release.

- **#1057** — `ProtectionViolation(NodeExecutionError)` re-base + async-path enforcement wiring (closes the original orphan; the safety switch now actually enforces) + restored gap-tests + spec
- **#1059** — Tier-2 workflow-runtime regression guard (permanent guard for the red-team CRITICAL the original fix-design missed)
- **#1060** — `bulk_update` I5 bypass closure (a SECOND live security defect surfaced by the per-mutation Tier-2 matrix — a read-only-blocked `bulk_update` was returning empty `results` with no exception, silently bypassing protection at that one surface) + per-mutation Tier-2 matrix + `count → OperationType.READ` enum fix

## Diff scope (metadata-only)

- `packages/kailash-dataflow/pyproject.toml` — `version = "2.9.14"`
- `packages/kailash-dataflow/src/dataflow/__init__.py` — `__version__ = "2.9.14"`
- `packages/kailash-dataflow/CHANGELOG.md` — `[2.9.14]` section consolidating the #1050 work + the bulk_update fix + the count enum fix under Security / Changed / Fixed (the PR #1060 commit landed without a CHANGELOG entry; this PR adds it per zero-tolerance Rule 5 atomicity)

Per `release/v*` branch convention (git.md), this PR auto-skips the PR-gate matrix.

## Behavior change (operator-visible)

Code that "worked" only because write-protection was a no-op (e.g. writes against a `production_safe`-configured production database that silently slipped through, or bulk_update calls that returned empty `results` with no exception when blocked) will now correctly raise `ProtectionViolation`. This is the fix — blocking-where-it-should-block is the contract (`specs/dataflow-protection.md` §1). **Operators relying on the broken no-op state MUST review their protection configs before upgrading.** No deprecation shim: a fake safety gate made real is not a public-API removal.

## Verification

- **Tier 1 unit suites** (kailash-dataflow): 38/38 PASS
- **Tier 2 workflow-runtime guard:** 4/4 PASS (sqlite_file × {LocalRuntime, AsyncLocalRuntime} + postgresql × {LocalRuntime, AsyncLocalRuntime}, real port-5434 PG)
- **Tier 2 per-mutation matrix:** 28/28 PASS (14 file-SQLite + 14 PostgreSQL)
- security-reviewer gate (on #1057 + #1060): APPROVE (zero CRITICAL/HIGH; no fail-open; sibling sweep clean; audit-on-block intact; no circular import; no taxonomy regression)
- reviewer gate (on #1057 + #1059 + #1060): APPROVE (all 9 invariants pass; AC complete; Tier-2 no-mock honored; state-persistence via read-back)
- cross-SDK kailash-rs inspection: feature absent — nothing to file upstream (issue #1050 AC#6 satisfied)
- Sibling-drift sweep: clean (all 8 packages at parity with PyPI; only kailash-dataflow needs releasing)

## Follow-ups (issue #1058)

Dead `AsyncSQLProtectionWrapper` deletion + validation-before-protection ordering on Express path + `upsert` → CUSTOM_QUERY enum gap + `_seed_initial_data` same-bug-class swallow + standalone bulk_update regression test name — all deliberately not bundled per shard-budget discipline.

## Related issues

Refs #1050 (closed in #1057), #1058 (follow-ups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)