### PR TITLE
fix(dataflow): remove dead AsyncSQLProtectionWrapper + global monkeypatch (#1058 Shard 1)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/protected_engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/protected_engine.py
@@ -11,11 +11,7 @@ from typing import Any, Dict, Optional, Type
 from .engine import DataFlow
 from .nodes import NodeGenerator
 from .protection import WriteProtectionConfig, WriteProtectionEngine
-from .protection_middleware import (
-    AsyncSQLProtectionWrapper,
-    DataFlowProtectionMixin,
-    ProtectedDataFlowRuntime,
-)
+from .protection_middleware import DataFlowProtectionMixin, ProtectedDataFlowRuntime
 
 logger = logging.getLogger(__name__)
 
@@ -114,9 +110,6 @@ class ProtectedDataFlow(DataFlowProtectionMixin, DataFlow):
             # Replace node generator with protected version
             self._node_generator = ProtectedNodeGenerator(self)
 
-            # Wrap AsyncSQLDatabaseNode if available
-            self._wrap_async_sql_node()
-
             logger.info("DataFlow write protection enabled")
         else:
             self._protection_config = None
@@ -159,18 +152,6 @@ class ProtectedDataFlow(DataFlowProtectionMixin, DataFlow):
                     )
 
         return result
-
-    def _wrap_async_sql_node(self):
-        """Wrap AsyncSQLDatabaseNode with protection checks."""
-        try:
-            from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
-
-            if self._protection_engine:
-                wrapper = AsyncSQLProtectionWrapper(self._protection_engine)
-                wrapper.wrap_async_sql_node(AsyncSQLDatabaseNode)
-                logger.debug("AsyncSQLDatabaseNode wrapped with protection")
-        except ImportError:
-            logger.warning("AsyncSQLDatabaseNode not available for protection wrapping")
 
     def create_workflow(self, workflow_id: str = None, **kwargs):
         """

--- a/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
+++ b/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
@@ -6,7 +6,6 @@ Provides runtime enforcement through node execution interception.
 """
 
 import logging
-from functools import wraps
 from typing import Any, Dict, Optional, Type
 
 from kailash.nodes.base import Node
@@ -452,63 +451,3 @@ def protect_dataflow_node(original_class: Type[Node]) -> Type[Node]:
     ProtectedNode.__module__ = original_class.__module__
 
     return ProtectedNode
-
-
-class AsyncSQLProtectionWrapper:
-    """
-    Wrapper for AsyncSQLDatabaseNode to add write protection.
-
-    This wrapper intercepts AsyncSQLDatabaseNode creation and execution
-    to enforce write protection at the lowest level.
-    """
-
-    def __init__(self, protection_engine: WriteProtectionEngine):
-        self.protection_engine = protection_engine
-
-    def wrap_async_sql_node(self, node_class: Type):
-        """Wrap AsyncSQLDatabaseNode with protection checks."""
-        original_execute = node_class.execute
-        protection_engine = self.protection_engine  # Capture in closure
-        detect_operation = self._detect_operation_from_sql  # Capture in closure
-
-        @wraps(original_execute)
-        def protected_execute(node_self, **kwargs):
-            # Analyze SQL to determine operation type
-            query = kwargs.get("query", "")
-            operation = detect_operation(query)  # Use captured function
-
-            # Extract connection information
-            connection_string = kwargs.get("connection_string", "")
-
-            # Check protection
-            try:
-                protection_engine.check_operation(  # Use captured engine
-                    operation=operation,
-                    connection_string=connection_string,
-                    context={"query": query, "params": kwargs.get("params", {})},
-                )
-            except ProtectionViolation:
-                raise
-
-            # Execute if protection passes
-            return original_execute(node_self, **kwargs)
-
-        node_class.execute = protected_execute
-        return node_class
-
-    def _detect_operation_from_sql(self, query: str) -> str:
-        """Detect operation type from SQL query."""
-        query = query.strip().upper()
-
-        if query.startswith("SELECT") or query.startswith("WITH"):
-            return "read"
-        elif query.startswith("INSERT"):
-            return "create"
-        elif query.startswith("UPDATE"):
-            return "update"
-        elif query.startswith("DELETE"):
-            return "delete"
-        elif any(query.startswith(stmt) for stmt in ["CREATE", "ALTER", "DROP"]):
-            return "custom_query"
-        else:
-            return "custom_query"

--- a/packages/kailash-dataflow/tests/regression/test_issue_1058_bulk_update_propagates_not_swallowed.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1058_bulk_update_propagates_not_swallowed.py
@@ -1,0 +1,120 @@
+"""Regression: ``Express.bulk_update`` MUST re-raise ``ProtectionViolation``
+— never fold it into ``failed_count``.
+
+Issue #1058 (post-#1050 follow-up).
+
+The per-record loop in ``bulk_update`` has ``try / except Exception:
+failed_count += 1`` for legitimate per-row data failures. Without the
+explicit ``except ProtectionViolation: raise`` shim added by the #1050
+workstream (express.py:1461-1477), a write-protection block on the
+nested ``self.update()`` call would be caught by that generic clause,
+swallowed into ``failed_count``, and ``bulk_update`` would return an
+empty results list with NO exception — silently bypassing
+write-protection at the bulk_update Express surface.
+
+This file is the standalone, grep-able regression guard for that
+specific failure mode. The mutation matrix at
+``tests/integration/test_issue_1050_protection_mutation_matrix.py``
+covers ``bulk_update`` parametrically with seven sibling mutations;
+this test isolates the *swallow-vs-propagate* contract so the failure
+mode is named in one place and one place only:
+
+    pytest -k bulk_update_protection_violation_propagates_not_swallowed
+
+Spec anchor: ``specs/dataflow-protection.md`` §2 path 1 + I5 — Express
+MUST surface protection violations as exceptions, not result dicts.
+
+Tier 2 per ``rules/testing.md`` — real backend, no mocking. File-SQLite
+chosen because (a) the contract is dialect-independent (the fix lives
+in pure-Python ``express.py`` between the loop and the per-record
+``await self.update(...)`` call, with no SQL involved), and (b) the
+test must run in any CI lane without the shared Docker stack.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import pytest
+
+from dataflow.core.protected_engine import ProtectedDataFlow
+from dataflow.core.protection import ProtectionViolation
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_bulk_update_protection_violation_propagates_not_swallowed():
+    """Read-only-protected ``bulk_update`` MUST raise ``ProtectionViolation``
+    AND leave every row unchanged.
+
+    Pre-fix failure mode this guards against:
+
+      results = await db.express.bulk_update(model, [...])
+      # would return [] silently; failed_count = 1; NO exception;
+      # caller has no signal that write-protection blocked the call.
+
+    Post-fix contract:
+
+      with pytest.raises(ProtectionViolation):
+          await db.express.bulk_update(model, [...])
+      # AND the seeded rows are unchanged.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="issue1058_bulk_update_propagates_")
+    db = ProtectedDataFlow(
+        database_url=f"sqlite:///{tmpdir}/test.db",
+        enable_protection=True,
+    )
+
+    @db.model  # noqa: B903 — DataFlow model decorator
+    class Issue1058Doc:
+        id: str
+        title: str
+
+    try:
+        await db.initialize()
+
+        # Seed two baseline rows under permissive protection so the
+        # bulk_update call below has real targets and the
+        # "rows unchanged after blocked write" assertion is meaningful.
+        await db.express.create("Issue1058Doc", {"id": "seed-1", "title": "original-1"})
+        await db.express.create("Issue1058Doc", {"id": "seed-2", "title": "original-2"})
+
+        # Engage global read-only protection at BLOCK level. Every
+        # mutation surface MUST now raise — including bulk_update,
+        # whose per-record loop must NOT swallow the violation into
+        # failed_count.
+        db.enable_read_only_mode("issue #1058 bulk_update propagation guard")
+
+        # Contract — propagation: the violation MUST surface to the
+        # caller, NOT fold into a silent empty-results return.
+        with pytest.raises(ProtectionViolation):
+            await db.express.bulk_update(
+                "Issue1058Doc",
+                [
+                    {"id": "seed-1", "title": "MUTATED-1"},
+                    {"id": "seed-2", "title": "MUTATED-2"},
+                ],
+            )
+
+        # State-persistence verification (rules/testing.md § State
+        # Persistence Verification): the blocked bulk_update left every
+        # row exactly as it was. A pre-fix swallow would have left
+        # `failed_count = 2` and `results = []` — undetectable from
+        # the caller and therefore undetectable here without explicit
+        # read-back through the same Express surface a user would use.
+        survived_1 = await db.express.read("Issue1058Doc", "seed-1")
+        assert survived_1 is not None
+        assert survived_1["title"] == "original-1", (
+            "bulk_update mutated seed-1 despite read-only protection — "
+            "the propagation contract bypassed (violation swallowed)"
+        )
+
+        survived_2 = await db.express.read("Issue1058Doc", "seed-2")
+        assert survived_2 is not None
+        assert survived_2["title"] == "original-2", (
+            "bulk_update mutated seed-2 despite read-only protection — "
+            "the propagation contract bypassed (violation swallowed)"
+        )
+    finally:
+        db.close()

--- a/packages/kailash-dataflow/tests/unit/test_protection_system_critical_gaps.py
+++ b/packages/kailash-dataflow/tests/unit/test_protection_system_critical_gaps.py
@@ -66,7 +66,6 @@ from dataflow.core.protection import (
     WriteProtectionEngine,
 )
 from dataflow.core.protection_middleware import (
-    AsyncSQLProtectionWrapper,
     ProtectedDataFlowRuntime,
     protect_dataflow_node,
 )
@@ -532,47 +531,6 @@ class TestProtectionSystemCriticalGaps:
             pass
         except Exception as e:
             pytest.fail(f"Connection string resolution in protection check failed: {e}")
-
-    def test_async_sql_node_protection_wrapper_gap(self, protected_readonly_dataflow):
-        """Test: AsyncSQLDatabaseNode protection wrapping fails."""
-        db, test_model = protected_readonly_dataflow
-
-        # Test the AsyncSQLProtectionWrapper
-        protection_engine = db._protection_engine
-        assert (
-            protection_engine is not None
-        ), "db._protection_engine is None — protection wiring invariant"
-        wrapper = AsyncSQLProtectionWrapper(protection_engine)
-
-        # Mock AsyncSQLDatabaseNode for testing
-        class MockAsyncSQLNode:
-            def execute(self, **kwargs):
-                return {"result": {"data": [{"id": 1}]}}
-
-        # Test 1: Wrapper should be able to wrap the node class
-        try:
-            wrapped_class = wrapper.wrap_async_sql_node(MockAsyncSQLNode)
-            assert wrapped_class is not None
-        except Exception as e:
-            pytest.fail(f"AsyncSQL node wrapping failed: {e}")
-
-        # Test 2: Test SQL operation detection
-        create_query = "INSERT INTO test_table (name) VALUES ('test')"
-        operation = wrapper._detect_operation_from_sql(create_query)
-        assert operation == "create"
-
-        read_query = "SELECT * FROM test_table"
-        operation = wrapper._detect_operation_from_sql(read_query)
-        assert operation == "read"
-
-        # Test 3: Test wrapped execution with protection
-        wrapped_node = wrapped_class()
-
-        with pytest.raises(ProtectionViolation):
-            wrapped_node.execute(
-                query="INSERT INTO test_table (name) VALUES ('test')",
-                connection_string="sqlite:///:memory:",
-            )
 
 
 class TestProtectionSystemRobustNodeDetection:

--- a/specs/dataflow-protection.md
+++ b/specs/dataflow-protection.md
@@ -120,7 +120,11 @@ Conformance to I1–I9 is verified by the Tier-1/2 suite at
 `packages/kailash-dataflow/tests/unit/test_protection_system_critical_gaps.py`
 (end-to-end `runtime.execute(workflow.build())` enforcement +
 `isinstance(exc, NodeExecutionError)` taxonomy pin) and the per-mutation
-Tier-2 matrix. The `AsyncSQLProtectionWrapper` sync closure
-(`protection_middleware.py:485`) is now dead code on the protected-write
-path; its removal is tracked as a separate follow-up (distinct bug
-class, not part of the enforcement-wiring contract).
+Tier-2 matrix.
+
+Single-call-site invariant: `WriteProtectionEngine.check_operation` is
+invoked from exactly one production site — `ProtectedNode.async_run`
+(`protection_middleware.py`). Every real path (`db.express.*`,
+`LocalRuntime.execute`, `AsyncLocalRuntime.execute_async`, raw
+`node.execute()` against generated nodes) converges on `async_run()`
+and hits that single call. No parallel enforcement surface exists.


### PR DESCRIPTION
## Summary

First follow-up shard for issue #1058 (the consolidated follow-up to #1050 / PR #1057 / kailash-dataflow 2.9.14).

- **Deletes** the dead `AsyncSQLProtectionWrapper` class + its caller wiring in `ProtectedDataFlow.__init__`. After #1050 wired protection into `ProtectedNode.async_run`, every real path (`db.express.*`, `LocalRuntime.execute`, `AsyncLocalRuntime.execute_async`, raw `node.execute()`) converges on `async_run()` and hits exactly one `check_operation` call. The pre-#1050 wrapper does `node_class.execute = protected_execute` on the core `AsyncSQLDatabaseNode` — a **global Python-process side effect** rebinding `execute` for every consumer, against the *last-constructed* `ProtectedDataFlow`'s engine. Worse than dead. Per `orphan-detection.md` §3 (removed = deleted), deletion in this PR — not a deprecation cycle.
- **Sweeps** the wrapper test (`test_async_sql_node_protection_wrapper_gap`) + its import in the same commit per `orphan-detection.md` Rule 4.
- **Adds** the standalone `test_bulk_update_protection_violation_propagates_not_swallowed` regression test that #1058's deferred list names. The matrix at `test_issue_1050_protection_mutation_matrix.py` covers `bulk_update` parametrically as one of seven mutations; this file isolates the *swallow-vs-propagate* failure mode (the per-record `except Exception: failed_count += 1` would have swallowed protection blocks into an empty results list without the `except ProtectionViolation: raise` shim at `express.py:1461-1477`).

Closes acceptance items 1 + 5 from #1058. Items 2 (validation-before-protection ordering on Express), 3 (`upsert` → `CUSTOM_QUERY` enum gap), and 4 (`_seed_initial_data` swallow) remain open in subsequent shards.

## Verification

- `grep check_operation packages/kailash-dataflow/src/dataflow/core/protection_middleware.py` → **1 hit** (the live `ProtectedNode.async_run` call at line 418). AC #1 satisfied.
- 8/8 unit protection critical-gap tests + the new regression PASS.
- 28/28 #1050 mutation-matrix parametrizations (14 file-SQLite + 14 PG-5434) + 4/4 workflow-runtime tests PASS — no regression from wrapper deletion.
- 37/37 unit `-k protection` PASS.

## Test plan

- [x] Unit: `pytest packages/kailash-dataflow/tests/unit/ -k protection`
- [x] Tier 2 (file-SQLite): `pytest packages/kailash-dataflow/tests/integration/test_issue_1050_protection_mutation_matrix.py`
- [x] Tier 2 (PostgreSQL on port 5434): same file, both dialects
- [x] Tier 2 workflow-runtime: `pytest packages/kailash-dataflow/tests/integration/test_issue_1050_workflow_runtime_protection.py`
- [x] New regression: `pytest packages/kailash-dataflow/tests/regression/test_issue_1058_bulk_update_propagates_not_swallowed.py`
- [ ] CI matrix on PR (auto)

## Related issues

Refs #1058 (Shard 1 — items 1 + 5).
Follow-up to #1050 (closed by PR #1057 / merge `344400235`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)