### PR TITLE
release: kailash-dataflow 2.9.14 → 2.9.15

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 ## [Unreleased]
 
+## [2.9.15] — 2026-05-17 — remove dead AsyncSQLProtectionWrapper + global monkeypatch (#1058 Shard 1)
+
+### Removed
+
+- **`AsyncSQLProtectionWrapper` class deleted from `dataflow.core.protection_middleware` (#1058 Shard 1)** —
+  the class did `node_class.execute = protected_execute` on the core
+  `kailash.nodes.data.AsyncSQLDatabaseNode` class, a Python-process-wide
+  global side effect with last-wins binding semantics. Every consumer of
+  `AsyncSQLDatabaseNode` in the process (including non-protected DataFlow
+  instances and direct SDK users) had its `execute` rebound against
+  whichever `ProtectedDataFlow` was constructed most recently — so only
+  the latest instance's protection engine actually fired. After the #1050
+  fix wired protection into `ProtectedNode.async_run`, every real path
+  (`db.express.*`, `LocalRuntime.execute`, `AsyncLocalRuntime.execute_async`,
+  raw `node.execute()` against generated nodes) converges on `async_run()`
+  and hits one `check_operation` call there — making the AsyncSQL wrapper
+  both dead and harmful. Removed per `orphan-detection.md` §3 ("removed =
+  deleted, not deprecated"). No deprecation cycle: the wrapper carried no
+  contract any caller could have correctly relied on; the global monkeypatch
+  shape was the failure mode the deletion fixes.
+- The `_wrap_async_sql_node()` method on `ProtectedDataFlow` and the
+  unconditional invocation from `ProtectedDataFlow.__init__` are removed
+  in the same commit.
+
+### Added
+
+- **Standalone regression test for `bulk_update` protection propagation
+  (`tests/regression/test_issue_1058_bulk_update_propagates_not_swallowed.py`)** —
+  isolates the swallow-vs-propagate failure mode the 2.9.14 `bulk_update`
+  fix at `express.py:1461-1477` prevents. The per-mutation matrix at
+  `tests/integration/test_issue_1050_protection_mutation_matrix.py` covers
+  `bulk_update` parametrically; this test gives the contract its own named,
+  grep-able owner so a future regression has one obvious place to fail.
+
+### Changed
+
+- `specs/dataflow-protection.md` updated to describe the
+  single-call-site invariant `check_operation` now upholds
+  (`ProtectedNode.async_run` is the one and only production call site),
+  replacing the stale paragraph that acknowledged the now-removed
+  `AsyncSQLProtectionWrapper` as "dead code on the protected-write path".
+
+### Impact
+
+No user-visible API change. The removal eliminates a correctness hazard
+for any deployment that constructs more than one `ProtectedDataFlow` in
+the same Python process (the prior global monkeypatch meant only the
+most recently constructed instance's protection rules were enforced
+through the AsyncSQL path).
+
 ## [2.9.14] — 2026-05-17 — write-protection enforcement on async hot path + bulk_update bypass closure (#1050)
 
 ### Changed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.14"
+version = "2.9.15"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.14"
+__version__ = "2.9.15"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
## Summary

Patch release for **kailash-dataflow 2.9.15** bundling PR #1062 (#1058 Shard 1: remove dead `AsyncSQLProtectionWrapper` + global monkeypatch).

Metadata-only diff (pyproject.toml + `__init__.py::__version__` + CHANGELOG). PR-gate matrix auto-skips per `release/v*` branch convention (`rules/git.md` MUST).

## What ships

- **Removed**: `AsyncSQLProtectionWrapper` class and its `node_class.execute = protected_execute` Python-process-wide monkeypatch on `kailash.nodes.data.AsyncSQLDatabaseNode`. The global class mutation with last-wins binding meant multi-instance `ProtectedDataFlow` deployments only enforced through the most recently constructed engine's protection rules. The surviving `ProtectedNode.async_run` check (sole `check_operation` call site) covers every real path.
- **Added**: standalone regression test for the `bulk_update` swallow-vs-propagate contract (`tests/regression/test_issue_1058_bulk_update_propagates_not_swallowed.py`).
- **Changed**: `specs/dataflow-protection.md` updated to describe the single-call-site invariant; stale "AsyncSQLProtectionWrapper is dead code" paragraph removed.

## Impact

No user-visible API change. Correctness improvement for any deployment that constructs more than one `ProtectedDataFlow` in the same Python process.

## Test plan

- [x] PR #1062 already ran full CI matrix green (Python 3.11/3.12/3.13/3.14, PACT 3.11, DataFlow Tier 1, test-with-infrastructure, CodeQL, Analyze Python, Spec drift sweep).
- [x] All 8 sibling packages confirmed at PyPI parity before release (no sibling drift to sweep).
- [ ] CI on this metadata-only diff (auto-skip via `release/v*` per `rules/git.md`).
- [ ] Tag `dataflow-v2.9.15` + verify clean-venv `pip install kailash-dataflow==2.9.15` post-merge.

## Related issues

Bundles: #1062 (closed by merge — #1058 Shard 1).
Tracks: #1058 (3 of 5 acceptance items remain open for subsequent shards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)