### PR TITLE
fix(dataflow): protection check fires before field validators on Express path (#1058 Shard 2)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
+++ b/packages/kailash-dataflow/src/dataflow/core/protection_middleware.py
@@ -337,13 +337,26 @@ def protect_dataflow_node(original_class: Type[Node]) -> Type[Node]:
             ``ProtectionViolation`` is a ``NodeExecutionError`` subclass
             (Shard 1a, issue #1050).
             """
+            # Issue #1058 Shard 2 — Express-path single-check discipline.
+            # When this sentinel is True, DataFlowExpress already ran the
+            # SAME ``protection_engine.check_operation(...)`` call via
+            # ``_check_protection_if_enabled`` BEFORE field validation /
+            # trust check / node construction. Skipping the inner check
+            # here preserves spec invariant I1 (single check per call) AND
+            # avoids double ``auditor.log_allowed`` entries on the happy
+            # path. The workflow-runtime path never sets this sentinel
+            # (Express owns node construction; the runtime instantiates
+            # generated nodes directly), so the inner check still fires
+            # there — workflow-path enforcement unchanged.
+            if getattr(self, "_express_protection_precheck_done", False):
+                pass
             # Get protection engine from DataFlow instance. Carried over
             # verbatim from the removed sync override: dataflow_instance is
             # injected post-construction (Express _create_node binds it;
             # the workflow node generator binds it in __init__), so the
             # hasattr guard is the documented fail-open posture when the
             # node is constructed before binding — NOT introduced here.
-            if hasattr(self, "dataflow_instance"):
+            elif hasattr(self, "dataflow_instance"):
                 df = self.dataflow_instance
 
                 if hasattr(df, "_protection_engine"):

--- a/packages/kailash-dataflow/src/dataflow/features/express.py
+++ b/packages/kailash-dataflow/src/dataflow/features/express.py
@@ -243,6 +243,46 @@ class DataFlowExpress:
     # Validation Helper (TSG-103)
     # ========================================================================
 
+    async def _check_protection_if_enabled(
+        self, model: str, operation: str, inputs: Dict[str, Any]
+    ) -> None:
+        """Express-layer write-protection pre-check (issue #1058 Shard 2).
+
+        Fires the same ``protection_engine.check_operation(...)`` call
+        that ``ProtectedNode.async_run`` runs inside the node, BUT BEFORE
+        ``_validate_if_enabled`` / ``_trust_check_write`` / ``_create_node``.
+        Closes the defense-in-depth gap where a blocked-write attacker
+        could trigger field-validator side effects (custom validators may
+        log, emit events, hit external services) before the protection
+        block fired.
+
+        Invariant I2 ("a blocked write never takes a connection") was
+        already held by the inner check (validation is in-process, no DB
+        connection acquired). This pre-check tightens the ordering so
+        validation never runs on a blocked write either.
+
+        Sentinel discipline (preserves spec invariant I1, single-check):
+        after this method returns without raising, the caller MUST set
+        ``node._express_protection_precheck_done = True`` on the
+        freshly-created node before invoking ``node.async_run`` — the
+        inner check in ``ProtectedNode.async_run`` honors that sentinel
+        and skips the duplicate ``check_operation`` call (avoiding double
+        ``auditor.log_allowed`` entries on the happy path).
+        """
+        protection_engine = getattr(self._db, "_protection_engine", None)
+        if protection_engine is None:
+            return
+        connection_string = getattr(self._db, "database_url", None)
+        # Context shape mirrors ProtectedNode.async_run (node_id / model_fields
+        # are not yet available pre-construction; auditor handles missing keys).
+        context = {"inputs": inputs}
+        protection_engine.check_operation(
+            operation=operation,
+            model_name=model,
+            connection_string=connection_string,
+            context=context,
+        )
+
     async def _validate_if_enabled(self, model: str, data: Dict[str, Any]) -> None:
         """Validate data against model field validators if enabled.
 
@@ -616,11 +656,20 @@ class DataFlowExpress:
         """
 
         async def _create():
+            # Issue #1058 Shard 2: protection precheck fires BEFORE
+            # _validate_if_enabled to prevent field-validator side
+            # effects on blocked writes. See _check_protection_if_enabled
+            # for the sentinel-discipline contract that preserves spec
+            # invariant I1 (single check, no double-audit) end-to-end.
+            await self._check_protection_if_enabled(model, "create", data)
             await self._validate_if_enabled(model, data)
             # Phase 5.11: trust access check before the write.
             plan = await self._trust_check_write(model, "create")
             try:
                 node = self._create_node(model, "Create")
+                # Sentinel honored by ProtectedNode.async_run to skip the
+                # duplicate check_operation call on the Express path.
+                node._express_protection_precheck_done = True
                 result = await node.async_run(**data)
             except Exception as exc:
                 await self._trust_record_failure(
@@ -801,11 +850,17 @@ class DataFlowExpress:
 
         async def _update():
             self._check_append_only(model, "update")
+            # Issue #1058 Shard 2: protection precheck fires BEFORE
+            # _validate_if_enabled (see create() for the contract).
+            await self._check_protection_if_enabled(
+                model, "update", {"id": id, "fields": fields}
+            )
             await self._validate_if_enabled(model, fields)
             # Phase 5.11: trust access check before the write.
             plan = await self._trust_check_write(model, "update")
             try:
                 node = self._create_node(model, "Update")
+                node._express_protection_precheck_done = True
                 result = await node.async_run(filter={"id": id}, fields=fields)
             except Exception as exc:
                 await self._trust_record_failure(
@@ -888,10 +943,14 @@ class DataFlowExpress:
 
         async def _delete():
             self._check_append_only(model, "delete")
+            # Issue #1058 Shard 2: protection precheck fires BEFORE any
+            # other side-effecting work (see create() for the contract).
+            await self._check_protection_if_enabled(model, "delete", {"id": id})
             # Phase 5.11: trust access check before the write.
             plan = await self._trust_check_write(model, "delete")
             try:
                 node = self._create_node(model, "Delete")
+                node._express_protection_precheck_done = True
                 result = await node.async_run(id=id)
             except Exception as exc:
                 await self._trust_record_failure(
@@ -1219,8 +1278,12 @@ class DataFlowExpress:
 
         async def _upsert():
             self._check_append_only(model, "upsert")
+            # Issue #1058 Shard 2: protection precheck fires BEFORE
+            # _validate_if_enabled (see create() for the contract).
+            await self._check_protection_if_enabled(model, "upsert", data)
             await self._validate_if_enabled(model, data)
             node = self._create_node(model, "Upsert")
+            node._express_protection_precheck_done = True
 
             # Simple upsert: use data as both create and update
             # Use id field for where clause by default
@@ -1304,7 +1367,12 @@ class DataFlowExpress:
 
         async def _upsert():
             self._check_append_only(model, "upsert")
+            # Issue #1058 Shard 2: protection precheck (see create()).
+            await self._check_protection_if_enabled(
+                model, "upsert", {"where": where, "create": create, "update": update}
+            )
             node = self._create_node(model, "Upsert")
+            node._express_protection_precheck_done = True
 
             params = {"where": where, "create": create, "update": update or create}
             if conflict_on:
@@ -1374,7 +1442,15 @@ class DataFlowExpress:
         """
 
         async def _bulk_create():
+            # Issue #1058 Shard 2: protection precheck (see create()).
+            # bulk_create has no _validate_if_enabled call today, but the
+            # precheck still lands here so a blocked bulk_create raises
+            # ProtectionViolation BEFORE _create_node / node.async_run.
+            await self._check_protection_if_enabled(
+                model, "bulk_create", {"data": records}
+            )
             node = self._create_node(model, "BulkCreate")
+            node._express_protection_precheck_done = True
             result = await node.async_run(data=records)
 
             # Model-scoped cache invalidation (TSG-104)
@@ -1518,7 +1594,10 @@ class DataFlowExpress:
 
         async def _bulk_delete():
             self._check_append_only(model, "bulk_delete")
+            # Issue #1058 Shard 2: protection precheck (see create()).
+            await self._check_protection_if_enabled(model, "bulk_delete", {"ids": ids})
             node = self._create_node(model, "BulkDelete")
+            node._express_protection_precheck_done = True
             # Convert IDs list to filter format expected by BulkDeleteNode
             result = await node.async_run(filter={"id": {"$in": ids}})
 
@@ -1595,7 +1674,12 @@ class DataFlowExpress:
             # entry point) also fail closed with AppendOnlyViolationError.
             # Removing this line would silently re-open the bypass.
             self._check_append_only(model, "bulk_upsert")
+            # Issue #1058 Shard 2: protection precheck (see create()).
+            await self._check_protection_if_enabled(
+                model, "bulk_upsert", {"data": records}
+            )
             node = self._create_node(model, "BulkUpsert")
+            node._express_protection_precheck_done = True
             # BulkUpsertNode accepts conflict_columns in its config.
             node.conflict_columns = conflict_fields
             node.batch_size = batch_size

--- a/packages/kailash-dataflow/tests/regression/test_issue_1058_shard2_protection_before_validation.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1058_shard2_protection_before_validation.py
@@ -1,0 +1,250 @@
+"""Regression: write-protection MUST fire BEFORE field validators on
+every Express mutation (issue #1058 Shard 2).
+
+The pre-fix ordering ran ``_validate_if_enabled`` BEFORE the protection
+check that lives inside ``ProtectedNode.async_run``. Under that order a
+blocked-write attacker could trigger field-validator side effects —
+custom validators may log, emit metrics, call external services — even
+when the write was about to be rejected. Invariant I2 ("a blocked
+write never takes a connection") still held because validation is
+in-process, so this was defense-in-depth ordering, not a bypass.
+Shard 2 closes the ordering gap by routing every Express mutation
+through ``DataFlowExpress._check_protection_if_enabled`` BEFORE the
+validator call.
+
+Spec anchor: ``specs/dataflow-protection.md`` §2 path 1 (Express);
+``rules/dataflow-classification.md`` validator-side-effect class.
+
+Tier 2 per ``rules/testing.md`` — real backend, no mocking. File-SQLite
+chosen because the contract is dialect-independent (the precheck lives
+in pure-Python ``express.py`` ahead of any SQL) and the test must run
+in any CI lane without the shared Docker stack.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any
+
+import pytest
+
+from dataflow.core.protected_engine import ProtectedDataFlow
+from dataflow.core.protection import ProtectionViolation
+from dataflow.validation.decorators import field_validator
+
+# Module-scope counter the validator increments. A bare list is used (not
+# an int) so the closure can mutate it without `nonlocal` ceremony —
+# pytest-isolated by being reset inside each test's fixture-free body.
+_VALIDATOR_INVOCATIONS: list[Any] = []
+
+
+def _side_effecting_validator(value: Any) -> bool:
+    """A validator with an observable side effect.
+
+    Models the failure mode this rule guards against — a custom
+    validator that does work (logs, emits, hits an external service)
+    BEFORE the protection block fires. Returns True so validation
+    would pass on its own merits if the protection layer ever let
+    control reach it.
+    """
+    _VALIDATOR_INVOCATIONS.append(value)
+    return True
+
+
+@pytest.fixture(autouse=True)
+def _reset_validator_counter():
+    """Per-test reset of the module-scope validator-invocation log."""
+    _VALIDATOR_INVOCATIONS.clear()
+    yield
+    _VALIDATOR_INVOCATIONS.clear()
+
+
+def _make_protected_db(tmp_subdir: str) -> ProtectedDataFlow:
+    """Construct a ProtectedDataFlow over a fresh file-SQLite DB."""
+    tmpdir = tempfile.mkdtemp(prefix=f"issue1058_shard2_{tmp_subdir}_")
+    return ProtectedDataFlow(
+        database_url=f"sqlite:///{tmpdir}/test.db",
+        enable_protection=True,
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_create_protection_fires_before_field_validators():
+    """Blocked ``express.create`` MUST raise ``ProtectionViolation``
+    WITHOUT invoking any registered field validator.
+
+    Pre-fix sequence (defense-in-depth gap):
+      1. ``_validate_if_enabled`` runs → side-effecting validator fires.
+      2. ``_trust_check_write`` runs.
+      3. ``node.async_run`` runs → ``ProtectionViolation`` raised.
+
+    Post-fix sequence (Shard 2):
+      1. ``_check_protection_if_enabled`` runs → ``ProtectionViolation``.
+         Validator is NEVER called.
+    """
+    db = _make_protected_db("create")
+
+    @db.model
+    @field_validator("title", _side_effecting_validator)
+    class Issue1058Shard2Doc:
+        id: str
+        title: str
+
+    try:
+        await db.initialize()
+        db.enable_read_only_mode("issue #1058 Shard 2 ordering guard")
+
+        with pytest.raises(ProtectionViolation):
+            await db.express.create(
+                "Issue1058Shard2Doc",
+                {"id": "doc-1", "title": "blocked-create"},
+            )
+
+        # The load-bearing assertion: protection ran AHEAD of validation.
+        # If the validator had been invoked, the side-effect log would
+        # contain "blocked-create" and the pre-fix ordering would be back.
+        assert _VALIDATOR_INVOCATIONS == [], (
+            "Field validator fired on a blocked create — protection "
+            "precheck regressed behind _validate_if_enabled. See issue "
+            "#1058 Shard 2."
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_update_protection_fires_before_field_validators():
+    """Blocked ``express.update`` MUST NOT invoke field validators.
+
+    Parallel test to ``create`` — same contract on the update surface
+    so a future refactor that moves the precheck on create but forgets
+    update fails loudly here.
+    """
+    db = _make_protected_db("update")
+
+    @db.model
+    @field_validator("title", _side_effecting_validator)
+    class Issue1058Shard2UpdateDoc:
+        id: str
+        title: str
+
+    try:
+        await db.initialize()
+        # Seed a row under permissive protection so update has a real
+        # target. The seeding create is allowed; the validator fires
+        # legitimately here.
+        await db.express.create(
+            "Issue1058Shard2UpdateDoc",
+            {"id": "doc-1", "title": "original"},
+        )
+        # Reset the counter AFTER seeding so the assertion isolates the
+        # blocked-update behavior, not the seeding side effect.
+        _VALIDATOR_INVOCATIONS.clear()
+
+        db.enable_read_only_mode("issue #1058 Shard 2 update ordering guard")
+
+        with pytest.raises(ProtectionViolation):
+            await db.express.update(
+                "Issue1058Shard2UpdateDoc",
+                "doc-1",
+                {"title": "blocked-update"},
+            )
+
+        assert _VALIDATOR_INVOCATIONS == [], (
+            "Field validator fired on a blocked update — protection "
+            "precheck regressed behind _validate_if_enabled. See issue "
+            "#1058 Shard 2."
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_upsert_protection_fires_before_field_validators():
+    """Blocked ``express.upsert`` MUST NOT invoke field validators.
+
+    Third mutation surface — upsert is the failure-mode entry point
+    that the audit specifically called out as silently re-opening
+    in any future refactor that copies the create/update pattern
+    without porting the precheck. The test pins the contract.
+    """
+    db = _make_protected_db("upsert")
+
+    @db.model
+    @field_validator("title", _side_effecting_validator)
+    class Issue1058Shard2UpsertDoc:
+        id: str
+        title: str
+
+    try:
+        await db.initialize()
+        db.enable_read_only_mode("issue #1058 Shard 2 upsert ordering guard")
+
+        with pytest.raises(ProtectionViolation):
+            await db.express.upsert(
+                "Issue1058Shard2UpsertDoc",
+                {"id": "doc-1", "title": "blocked-upsert"},
+            )
+
+        assert _VALIDATOR_INVOCATIONS == [], (
+            "Field validator fired on a blocked upsert — protection "
+            "precheck regressed behind _validate_if_enabled. See issue "
+            "#1058 Shard 2."
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+async def test_allowed_create_does_not_double_check_protection():
+    """Happy-path ``express.create`` MUST run the protection check
+    exactly ONCE (Express precheck), NOT twice.
+
+    Pin invariant I1 (single check, no double-audit) end-to-end. Pre-
+    fix the audit log would have one allow entry per Express mutation
+    (from ``ProtectedNode.async_run``). Post-fix with the precheck
+    AND no sentinel-skip in ``ProtectedNode.async_run``, the audit
+    log would have TWO entries per mutation. The sentinel-skip is
+    what keeps the count at one.
+    """
+    db = _make_protected_db("happy_path")
+
+    @db.model
+    class Issue1058Shard2HappyDoc:
+        id: str
+        title: str
+
+    try:
+        await db.initialize()
+        # Snapshot the auditor's event log BEFORE the create. Pre-test
+        # noise (initialization, seeding) is irrelevant — we measure
+        # the delta the single create produces.
+        protection_engine = getattr(db, "_protection_engine", None)
+        assert (
+            protection_engine is not None
+        ), "ProtectedDataFlow MUST wire a protection engine"
+        before = len(protection_engine.config.auditor.events)
+
+        await db.express.create(
+            "Issue1058Shard2HappyDoc",
+            {"id": "doc-1", "title": "permitted-create"},
+        )
+
+        after = len(protection_engine.config.auditor.events)
+        delta = after - before
+        assert delta == 1, (
+            f"Express create produced {delta} protection-audit events; "
+            f"expected exactly 1 (single-check invariant I1). A delta of "
+            f"2 indicates the sentinel-skip in ProtectedNode.async_run "
+            f"regressed and the Express precheck is double-checking."
+        )
+    finally:
+        db.close()

--- a/specs/dataflow-protection.md
+++ b/specs/dataflow-protection.md
@@ -122,9 +122,21 @@ Conformance to I1–I9 is verified by the Tier-1/2 suite at
 `isinstance(exc, NodeExecutionError)` taxonomy pin) and the per-mutation
 Tier-2 matrix.
 
-Single-call-site invariant: `WriteProtectionEngine.check_operation` is
-invoked from exactly one production site — `ProtectedNode.async_run`
-(`protection_middleware.py`). Every real path (`db.express.*`,
-`LocalRuntime.execute`, `AsyncLocalRuntime.execute_async`, raw
-`node.execute()` against generated nodes) converges on `async_run()`
-and hits that single call. No parallel enforcement surface exists.
+Call-site map (issue #1058 Shard 2):
+`WriteProtectionEngine.check_operation` is invoked from exactly two
+production sites — `DataFlowExpress._check_protection_if_enabled`
+(`features/express.py`) for the Express path AND
+`ProtectedNode.async_run` (`protection_middleware.py`) for the
+workflow-runtime and raw-node paths. The Express precheck fires BEFORE
+field validation, trust check, and node construction — closing the
+defense-in-depth ordering gap where a blocked write could trigger
+field-validator side effects (custom validators may log, emit metrics,
+hit external services). The sentinel
+`node._express_protection_precheck_done`, set by Express after a
+successful precheck, signals `ProtectedNode.async_run` to skip the
+inner call — preserving spec invariant I1 (exactly one
+`check_operation` per logical user operation, with one
+`auditor.log_allowed` entry per allow on the happy path). The
+workflow-runtime path never sets the sentinel (the runtime instantiates
+generated nodes directly), so the inner check still fires there —
+workflow-path enforcement unchanged.


### PR DESCRIPTION
## Summary

- Closes the defense-in-depth ordering gap from #1058 item 2: `_validate_if_enabled` ran ahead of the protection check, so blocked writes could trigger custom-validator side effects (logs, metrics, external calls). Invariant I2 already held (validation in-process, no DB connection on blocked write); this is the ordering tightening the issue body called out.
- Every Express mutation (`create` / `update` / `delete` / `upsert` / `upsert_advanced` / `bulk_create` / `bulk_delete` / `bulk_upsert`) now routes through `DataFlowExpress._check_protection_if_enabled` BEFORE validation / trust / node construction. A sentinel on the node skips the inner `ProtectedNode.async_run` check on the Express path — preserving spec invariant I1 (single check per logical user operation) and avoiding double `auditor.log_allowed` entries on the happy path.
- `bulk_update` is intentionally NOT prechecked at the outer level — it delegates per-row to `update()` which does its own precheck; outer precheck would create a per-row double-check.

## Test plan

- [x] New Tier-2 regression test `tests/regression/test_issue_1058_shard2_protection_before_validation.py` (4 cases): blocked create/update/upsert MUST NOT invoke a side-effecting field validator; allowed create MUST produce exactly one audit entry (single-check invariant).
- [x] Full #1050 mutation matrix (33 tests, file-SQLite + PostgreSQL 5434) green.
- [x] #1058 Shard 1 propagation regression green.
- [x] Workflow-runtime protection paths green (sentinel never set on runtime-instantiated nodes → enforcement unchanged).
- [x] Broader 46-test protection + classification sweep green.

Spec `specs/dataflow-protection.md` updated in the same commit to describe the two-call-site shape and the sentinel-skip discipline (per specs-authority.md Rule 5).

## Related issues

Refs #1058 (items 2/3/4 remain — Shards 3+4 follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)