### PR TITLE
test(nexus): pin API-key header-only invariant + query-token decode (#1056)

### DIFF
--- a/packages/kailash-nexus/tests/integration/test_jwt_query_param_decode_cross_sdk.py
+++ b/packages/kailash-nexus/tests/integration/test_jwt_query_param_decode_cross_sdk.py
@@ -1,0 +1,110 @@
+"""Tier-2 cross-SDK alignment for kailash-rs#998 / kailash-py#1056.
+
+kailash-rs#998 found its Nexus query-string API-key decoder hand-rolled a
+percent-decode with two bugs: (1) invalid-UTF-8 -> returned the still-encoded
+string instead of rejecting; (2) no NUL-byte guard. Python Nexus exposes NO
+query-string API-key path (header-only; see the companion structural-invariant
+regression test). The ONLY server-side query-string credential decode surface
+in Python Nexus is JWT *token* extraction for WebSockets
+(`JWTConfig.token_query_param`, `nexus/auth/jwt.py:294-298`), which routes
+through Starlette's stdlib percent-decode -- NOT a hand-rolled unquote().
+
+These tests exercise that equivalent decode surface against the three
+issue-#1056 acceptance scenarios, proving the Rust bug class does not manifest
+here: malformed query tokens are rejected (NUL, invalid-UTF-8) and a valid
+percent-encoded token round-trips through the decoder (no raw-encoded
+fallback).
+
+Tier 2 -- NO MOCKING. Real Nexus app, real JWT middleware, real ASGI flow.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import jwt as pyjwt
+import pytest
+from fastapi import APIRouter, Depends
+from starlette.testclient import TestClient
+
+from nexus import Nexus
+from nexus.auth.dependencies import get_current_user
+from nexus.auth.jwt import JWTConfig, JWTMiddleware
+
+SECRET = "issue-1056-cross-sdk-secret-key-at-least-32-chars"
+QUERY_PARAM = "access_token"
+
+
+def _make_token(sub="user-1056", secret=SECRET):
+    """Create a real HS256 JWT."""
+    payload = {
+        "sub": sub,
+        "email": "user@example.com",
+        "exp": int((datetime.now(timezone.utc) + timedelta(minutes=60)).timestamp()),
+        "iat": int(datetime.now(timezone.utc).timestamp()),
+    }
+    return pyjwt.encode(payload, secret, algorithm="HS256")
+
+
+@pytest.fixture
+def query_token_client():
+    """Nexus app whose JWT middleware accepts a token via query param."""
+    app = Nexus(enable_durability=False)
+    app.add_middleware(
+        JWTMiddleware,
+        config=JWTConfig(secret=SECRET, token_query_param=QUERY_PARAM),
+    )
+
+    router = APIRouter()
+
+    @router.get("/whoami")
+    def whoami(user=Depends(get_current_user)):
+        return {"sub": user.user_id}
+
+    app.include_router(router, prefix="/api")
+    assert app.fastapi_app is not None  # always set post-init; narrows type
+    return TestClient(app.fastapi_app)
+
+
+class TestQueryParamDecodeCrossSDK:
+    """kailash-rs#998 / #1056 -- the Rust query-string decode bug class."""
+
+    def test_nul_byte_query_token_is_rejected(self, query_token_client):
+        """`?access_token=%00x` -> NUL after decode -> auth rejected (401).
+
+        Mirrors Rust bug #2's *post-fix* expected behavior: a NUL-containing
+        credential MUST be rejected, never silently accepted/truncated.
+        """
+        resp = query_token_client.get(f"/api/whoami?{QUERY_PARAM}=%00x")
+        assert resp.status_code == 401
+
+    def test_invalid_utf8_query_token_is_rejected_not_raw_fallback(
+        self, query_token_client
+    ):
+        """`?access_token=%FF%FE` -> invalid UTF-8 -> auth rejected (401).
+
+        Mirrors Rust bug #1's absence: the decoder MUST NOT fall back to the
+        still-percent-encoded string. `%FF%FE` is invalid UTF-8; Starlette's
+        stdlib decode lossy-replaces it -- it never returns the literal
+        "%FF%FE", and the result is not a valid JWT -> 401. A non-401 here
+        would mean the still-encoded string leaked through as a credential.
+        """
+        resp = query_token_client.get(f"/api/whoami?{QUERY_PARAM}=%FF%FE")
+        assert resp.status_code == 401
+
+    def test_valid_percent_encoded_token_round_trips(self, query_token_client):
+        """Fully percent-encoded valid JWT -> decode happens -> auth succeeds.
+
+        Every byte of a valid token is percent-escaped. If the decoder had
+        the Rust raw-fallback bug it would pass the still-encoded blob to JWT
+        verification -> signature failure -> 401. A 200 proves the percent
+        decode genuinely ran (no raw-encoded fallback).
+        """
+        token = _make_token(sub="user-roundtrip")
+        # quote() treats the base64url alphabet (incl. '.', '-', '_') as
+        # always-safe, so it would NOT change a JWT. Force every byte to a
+        # percent-escape so the decode must genuinely run for auth to pass.
+        encoded = "".join(f"%{b:02X}" for b in token.encode("ascii"))
+        assert encoded != token  # sanity: encoding actually changed the bytes
+
+        resp = query_token_client.get(f"/api/whoami?{QUERY_PARAM}={encoded}")
+        assert resp.status_code == 200
+        assert resp.json()["sub"] == "user-roundtrip"

--- a/packages/kailash-nexus/tests/regression/test_issue_1056_apikey_header_only_invariant.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1056_apikey_header_only_invariant.py
@@ -1,0 +1,110 @@
+"""Structural invariant: Nexus API-key auth is header-only (#1056).
+
+cross-sdk-inspection.md §3a item 2 -- pin the signature/shape that prevents
+the kailash-rs#998 bug class (hand-rolled query-string API-key percent-decode)
+from existing in Python Nexus. If a future PR ports a `?api_key=` decoder from
+the Rust side, BOTH assertions below fail and the failure message points the
+next agent back to #1056 / kailash-rs#998 for a cross-SDK re-audit.
+
+This is a verify-and-pin disposition (severity NOT-AFFECTED): there is no
+production-code fix because there is no vulnerable surface. The value is
+regression-prevention only -- mirrors the issue #525 / PR #528 precedent.
+
+@pytest.mark.regression -- behavioral/structural, never deleted.
+"""
+
+import dataclasses
+
+import pytest
+from fastapi import APIRouter, Depends
+from starlette.testclient import TestClient
+
+from nexus import Nexus
+from nexus.auth.dependencies import get_current_user
+from nexus.auth.jwt import JWTConfig, JWTMiddleware
+
+_APIKEY_SECRET = "issue-1056-apikey-invariant-secret-at-least-32-chars"
+_VALID_KEY = "valid-api-key-1056"
+
+# The ONLY API-key-related fields the contract permits. `specs/security-auth.md
+# §2.2`: "Client sends X-API-Key header." A query-string API-key field
+# (e.g. `api_key_query_param`) appearing here is the bug class returning.
+_ALLOWED_APIKEY_FIELDS = {"api_key_header", "api_key_enabled", "api_key_validator"}
+
+
+@pytest.mark.regression
+def test_jwtconfig_has_no_query_string_apikey_field():
+    """JWTConfig exposes no `api_key_query_param`-style field.
+
+    Enumerates dataclass fields structurally (not grep). Any field whose name
+    contains 'api_key' must be one of the three header-path fields. A new
+    api-key field -> a new (likely query-string) decode surface -> the Rust
+    bug class becomes reachable -> cross-SDK re-audit required.
+    """
+    field_names = {f.name for f in dataclasses.fields(JWTConfig)}
+    apikey_fields = {n for n in field_names if "api_key" in n}
+    extra = apikey_fields - _ALLOWED_APIKEY_FIELDS
+    assert not extra, (
+        f"JWTConfig grew API-key field(s) {sorted(extra)} beyond the "
+        f"header-only contract {sorted(_ALLOWED_APIKEY_FIELDS)}. If this is a "
+        f"query-string API-key path, the kailash-rs#998 percent-decode bug "
+        f"class is now reachable in Python Nexus -- re-audit per "
+        f"cross-sdk-inspection.md §3a and kailash-py#1056 before shipping."
+    )
+
+
+@pytest.fixture
+def apikey_client():
+    """Nexus app with API-key auth enabled and a real validator."""
+    app = Nexus(enable_durability=False)
+    app.add_middleware(
+        JWTMiddleware,
+        config=JWTConfig(
+            secret=_APIKEY_SECRET,
+            api_key_enabled=True,
+            api_key_validator=lambda k: k == _VALID_KEY,
+        ),
+    )
+    router = APIRouter()
+
+    @router.get("/whoami")
+    def whoami(user=Depends(get_current_user)):
+        return {"uid": user.user_id}
+
+    app.include_router(router, prefix="/api")
+    assert app.fastapi_app is not None  # always set post-init; narrows type
+    return TestClient(app.fastapi_app)
+
+
+@pytest.mark.regression
+def test_apikey_in_header_authenticates(apikey_client):
+    """Baseline: a valid API key in the X-API-Key header authenticates.
+
+    Proves the test exercises the real api-key auth path (not a vacuous
+    always-401 assertion in the query-string test below).
+    """
+    resp = apikey_client.get("/api/whoami", headers={"X-API-Key": _VALID_KEY})
+    assert resp.status_code == 200
+
+
+@pytest.mark.regression
+def test_apikey_in_query_string_does_not_authenticate(apikey_client):
+    """Behavioral invariant: a valid API key in the QUERY STRING is NOT honored.
+
+    cross-sdk-inspection.md §3a item 2 -- pins the bug-class absence
+    behaviorally (refactor-resilient; testing.md "behavioral over
+    source-grep"). The same key that authenticates via header MUST fail via
+    `?X-API-Key=` and `?api_key=`. If a future PR ports the kailash-rs#998
+    query-string API-key decoder, one of these flips to 200 and this test
+    fails -- forcing a cross-SDK re-audit per #1056.
+    """
+    for param in ("X-API-Key", "api_key", "apikey"):
+        resp = apikey_client.get(f"/api/whoami?{param}={_VALID_KEY}")
+        assert resp.status_code == 401, (
+            f"API key supplied via query param '?{param}=' authenticated "
+            f"(status {resp.status_code}). Python Nexus API-key auth MUST be "
+            f"header-only (specs/security-auth.md §2.2). This is the "
+            f"kailash-rs#998 query-string credential-decode bug class "
+            f"appearing in Python Nexus -- re-audit per "
+            f"cross-sdk-inspection.md §3a + kailash-py#1056 before shipping."
+        )


### PR DESCRIPTION
## Summary

Cross-SDK alignment with esperie/kailash-rs#998. The Rust Nexus query-string API-key decoder had two bugs (invalid-UTF-8 → still-encoded raw fallback; no NUL-byte guard). **Python Nexus is NOT-AFFECTED**: it exposes no query-string API-key path — API-key auth is header-only by spec (`security-auth.md §2.2`) and config (`JWTConfig` has no `api_key_query_param` field). Per `cross-sdk-inspection.md §3a` the disposition is **tests-only** — no production code; inventing the surface is BLOCKED (`verify-resource-existence.md` MUST-3).

- **Tier-2** `test_jwt_query_param_decode_cross_sdk.py` — exercises the only query-string credential decode surface (`token_query_param`, Starlette stdlib decode) against the three #1056 acceptance scenarios: NUL (`%00x`) rejected, invalid-UTF-8 (`%FF%FE`) rejected (no raw fallback), fully percent-encoded valid token round-trips. Real Nexus app + real ASGI, no mocking.
- **Regression** `test_issue_1056_apikey_header_only_invariant.py` — structural (`dataclasses.fields(JWTConfig)`) + behavioral (`?X-API-Key=`/`?api_key=` MUST NOT authenticate while header does) invariant. If a future PR ports the Rust query-string decoder, these fail loudly and point back to #1056 + kailash-rs#998.

Severity re-assessed MEDIUM → NOT-AFFECTED (regression-pinning value only). Mirrors the #525 / PR #528 precedent.

## Validation

- 6/6 tests pass; `pytest --collect-only` clean (2341 nexus tests, exit 0)
- /redteam Round 1 **CONVERGED** — reviewer + security-reviewer (parallel gate agents) both zero CRIT/HIGH/MED; load-bearing "header-only" claim independently re-verified TRUE across full nexus auth tree
- Zero production code changed (tests-only)

## Related issues

Cross-SDK alignment: this is the Python verification of esperie/kailash-rs#998. Does NOT close #1056 (closure is human-gated pending review of the NOT-AFFECTED disposition).

## Test plan

- [x] `pytest packages/kailash-nexus/tests/integration/test_jwt_query_param_decode_cross_sdk.py packages/kailash-nexus/tests/regression/test_issue_1056_apikey_header_only_invariant.py` → 6 passed
- [x] `pytest --collect-only -q packages/kailash-nexus/tests/` → exit 0
- [x] /redteam reviewer + security-reviewer converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)