### PR TITLE
fix(dataflow): close aiosqlite :memory: Connection leak on DataFlow close (#1051)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -5883,23 +5883,46 @@ class DataFlow(DataFlowEventMixin):
                         fetch_mode="all",
                         validate_queries=False,
                     )
-                    result = node.execute()
-                    # AsyncSQLDatabaseNode returns {"result": {"data": [...], ...}}.
-                    # Unwrap "data" for fetchall() and convert each dict row to a
-                    # tuple to match the DB-API 2.0 contract that most callers
-                    # expect from cursor.fetchall().
-                    self._last_rows = []
                     try:
-                        data = (result or {}).get("result", {}).get("data", [])
-                        if isinstance(data, list):
-                            for row in data:
-                                if isinstance(row, dict):
-                                    self._last_rows.append(tuple(row.values()))
-                                else:
-                                    self._last_rows.append(row)
-                    except Exception:
+                        result = node.execute()
+                        # AsyncSQLDatabaseNode returns
+                        # {"result": {"data": [...], ...}}. Unwrap "data" for
+                        # fetchall() and convert each dict row to a tuple to
+                        # match the DB-API 2.0 contract that most callers
+                        # expect from cursor.fetchall().
                         self._last_rows = []
-                    return result
+                        try:
+                            data = (result or {}).get("result", {}).get("data", [])
+                            if isinstance(data, list):
+                                for row in data:
+                                    if isinstance(row, dict):
+                                        self._last_rows.append(tuple(row.values()))
+                                    else:
+                                        self._last_rows.append(row)
+                        except Exception:
+                            self._last_rows = []
+                        return result
+                    finally:
+                        # Issue #1051: this wrapper spins a FRESH node per
+                        # execute() and discards it. The node's :memory:
+                        # adapter connection would otherwise survive to GC
+                        # and emit aiosqlite ResourceWarning. The node's
+                        # async teardown is cleanup() (NOT close — close is
+                        # on EnterpriseConnectionPool, a different class);
+                        # cleanup() tears down every adapter the node owns
+                        # (#1051 Change C _owned_adapters). Resolve cleanup()
+                        # first, fall back to close(); bridge to this sync
+                        # method via async_safe_run, matching engine.close().
+                        # Best-effort: a teardown failure must never mask
+                        # the query result/error this method returns/raises.
+                        try:
+                            teardown = getattr(node, "cleanup", None) or getattr(
+                                node, "close", None
+                            )
+                            if callable(teardown):
+                                async_safe_run(teardown())
+                        except Exception:
+                            pass
 
                 def fetchall(self):
                     return list(self._last_rows)
@@ -10015,15 +10038,26 @@ class DataFlow(DataFlowEventMixin):
                 pass
             self._lightweight_pool = None
 
-        # Issue #1002 — clean up cached AsyncSQLDatabaseNode instances (Express API uses these).
-        # Mirrors close_async() lines 10116-10127. node.close() is async; bridge via async_safe_run
-        # so the sync DataFlow.close() path (e.g. `with DataFlow(...) as db:` __exit__) does not
-        # leak nodes whose __del__ would emit PytestUnraisableExceptionWarning at GC.
+        # Issue #1002 / #1051 — clean up cached AsyncSQLDatabaseNode instances
+        # (Express API uses these). The node's async teardown method is
+        # cleanup() (NOT close — close lives on EnterpriseConnectionPool, a
+        # different class). The pre-#1051 guard `hasattr(node, "close")` was
+        # always False for AsyncSQLDatabaseNode, so this teardown was a silent
+        # no-op since #1002 and the node's _owned_adapters (#1051 Change C)
+        # never disconnected — every cached :memory: adapter connection leaked
+        # to GC. Resolve cleanup() first (the real method); fall back to
+        # close() for any other cached object that legitimately has one.
+        # cleanup() is async; bridge via async_safe_run so the sync
+        # DataFlow.close() path (`with DataFlow(...) as db:` __exit__) does
+        # not leak nodes whose __del__ emits PytestUnraisableExceptionWarning.
         if hasattr(self, "_async_sql_node_cache") and self._async_sql_node_cache:
             for db_type, (node, _) in list(self._async_sql_node_cache.items()):
                 try:
-                    if hasattr(node, "close") and callable(node.close):
-                        async_safe_run(node.close())
+                    teardown = getattr(node, "cleanup", None) or getattr(
+                        node, "close", None
+                    )
+                    if callable(teardown):
+                        async_safe_run(teardown())
                 except Exception as e:
                     logger.debug(
                         "engine.error_closing_cached_sql_node_for",
@@ -10158,12 +10192,20 @@ class DataFlow(DataFlowEventMixin):
                 pass
             self._lightweight_pool = None
 
-        # Clean up cached AsyncSQLDatabaseNode instances (Express API uses these)
+        # Clean up cached AsyncSQLDatabaseNode instances (Express API uses
+        # these). #1051: the node's async teardown is cleanup(), not close()
+        # — resolve cleanup() first, fall back to close() for other cached
+        # objects. The pre-#1051 hasattr(node,"close") guard silently skipped
+        # AsyncSQLDatabaseNode teardown (#1051 Change C's _owned_adapters
+        # disconnect never ran → cached :memory: connection leaked to GC).
         if hasattr(self, "_async_sql_node_cache") and self._async_sql_node_cache:
             for db_type, (node, _) in list(self._async_sql_node_cache.items()):
                 try:
-                    if hasattr(node, "close") and callable(node.close):
-                        await node.close()
+                    teardown = getattr(node, "cleanup", None) or getattr(
+                        node, "close", None
+                    )
+                    if callable(teardown):
+                        await teardown()
                 except Exception as e:
                     logger.debug(
                         "engine.error_closing_cached_sql_node_for",

--- a/packages/kailash-dataflow/tests/regression/test_issue_1051_memory_connection_leak.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1051_memory_connection_leak.py
@@ -1,0 +1,173 @@
+"""Regression: aiosqlite :memory: Connection leaked on DataFlow close (#1051).
+
+Root cause was multi-sited (all in core SDK
+`kailash.nodes.data.async_sql` + `dataflow.core.engine`):
+
+- A: `SQLiteAdapter._get_connection()` created a fresh `aiosqlite.connect()`
+  per `:memory:` query and never closed it (`disconnect()` only closed
+  `self._pool`, which is None for `:memory:`).
+- B: `ProductionSQLiteAdapter.disconnect()` short-circuited on the
+  `_enterprise_pool` branch and never reached `super().disconnect()`, so
+  the inherited `:memory:` connection was never closed.
+- C: a node could create several adapters; only the last was torn down.
+- D: the per-execute DDL-wrapper node was discarded without teardown.
+- E (keystone): `engine.py` close()/close_async() guarded the cached-node
+  teardown on `hasattr(node, "close")` — but `AsyncSQLDatabaseNode`'s
+  teardown method is `cleanup()`, NOT `close()` (close lives on
+  `EnterpriseConnectionPool`). The guard was always False, so the
+  teardown — and C's `_owned_adapters` disconnect — never ran. Fixed by
+  resolving `cleanup()` first.
+
+Every per-query / cached `:memory:` connection survived to GC where
+`aiosqlite.Connection.__del__` emitted
+`ResourceWarning: ... was deleted before being closed`.
+
+These tests pin the acceptance criterion the #1045 close() regression
+test deliberately omitted as out-of-scope.
+
+Tier-2 — NO MOCKING. Real DataFlow / ProtectedDataFlow, real `:memory:`,
+real `runtime.execute()`, real GC. Structural assertion (live
+aiosqlite.Connection count via gc) — not lexical scanning of the warning
+text (probe-driven-verification.md Rule 3).
+"""
+
+import gc
+import warnings
+
+import pytest
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+
+def _live_aiosqlite_connections():
+    """Structural probe: count live aiosqlite Connection objects."""
+    return [
+        o
+        for o in gc.get_objects()
+        if type(o).__module__ == "aiosqlite.core" and type(o).__name__ == "Connection"
+    ]
+
+
+@pytest.mark.regression
+def test_issue_1051_dataflow_memory_no_aiosqlite_resourcewarning():
+    """DataFlow(:memory:) + workflow + close() leaks zero aiosqlite conns."""
+    from dataflow import DataFlow
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ResourceWarning)
+
+        db = DataFlow("sqlite:///:memory:")
+
+        @db.model
+        class Widget1051:
+            name: str
+
+        wf = WorkflowBuilder()
+        wf.add_node("Widget1051CreateNode", "c", {"name": "alpha"})
+        # The leak fires regardless of whether the query itself succeeds;
+        # tolerate query-level failure so the test pins ONLY the leak.
+        # Context-managed runtime — avoids the LocalRuntime deprecation
+        # warning and is the documented resource-clean pattern.
+        try:
+            with LocalRuntime() as runtime:
+                runtime.execute(wf.build())
+        except Exception:
+            pass
+
+        db.close()
+        del db, Widget1051
+        gc.collect()  # ResourceWarning->error escalates here if leak present
+
+    leaked = _live_aiosqlite_connections()
+    assert not leaked, (
+        f"{len(leaked)} aiosqlite Connection(s) leaked past DataFlow.close() "
+        f"(#1051). _get_connection() must reuse one tracked :memory: "
+        f"connection and disconnect() must await-close it."
+    )
+
+
+@pytest.mark.regression
+def test_issue_1051_protecteddataflow_memory_no_aiosqlite_resourcewarning():
+    """ProtectedDataFlow(:memory:) + workflow + close() — the #1045-omitted AC.
+
+    ProtectedDataFlow lives at dataflow.core.protected_engine (the issue
+    body's `from dataflow import ProtectedDataFlow` was wrong).
+    """
+    from dataflow.core.protected_engine import ProtectedDataFlow
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ResourceWarning)
+
+        db = ProtectedDataFlow("sqlite:///:memory:")
+
+        @db.model
+        class Gadget1051:
+            name: str
+
+        wf = WorkflowBuilder()
+        wf.add_node("Gadget1051CreateNode", "c", {"name": "beta"})
+        try:
+            with LocalRuntime() as runtime:
+                runtime.execute(wf.build())
+        except Exception:
+            pass
+
+        db.close()
+        del db, Gadget1051
+        gc.collect()
+
+    leaked = _live_aiosqlite_connections()
+    assert not leaked, (
+        f"{len(leaked)} aiosqlite Connection(s) leaked past "
+        f"ProtectedDataFlow.close() (#1051)."
+    )
+
+
+@pytest.mark.regression
+def test_issue_1051_node_teardown_method_name_invariant():
+    """Structural invariant pinning the Change-E keystone.
+
+    The #1051 keystone bug: engine.py guarded cached-node teardown on
+    `hasattr(node, "close")`, but `AsyncSQLDatabaseNode`'s async teardown
+    method is `cleanup()` — `close()` is a *different class*
+    (`EnterpriseConnectionPool`). The guard was always False, so teardown
+    never ran. The fix resolves `getattr(cleanup) or getattr(close)`.
+
+    This test fails loudly if a future refactor renames `cleanup` (which
+    would re-break the teardown silently) — refactor-invariants discipline
+    + cross-sdk-inspection.md §3a structural-invariant pattern.
+    """
+    from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+    # The node's teardown method is `cleanup` (async). If this name
+    # changes, engine.py's `getattr(node, "cleanup", ...)` resolution
+    # silently breaks and the #1051 leak returns.
+    assert hasattr(AsyncSQLDatabaseNode, "cleanup"), (
+        "AsyncSQLDatabaseNode.cleanup() is gone — engine.py's #1051 "
+        "cached-node teardown resolves `cleanup` first; a rename re-opens "
+        "the aiosqlite :memory: leak silently. Update both together."
+    )
+    assert callable(getattr(AsyncSQLDatabaseNode, "cleanup")), (
+        "AsyncSQLDatabaseNode.cleanup is not callable — #1051 teardown "
+        "contract broken."
+    )
+
+    # Mirror the EXACT resolution engine.py close()/close_async() use, so
+    # this test pins the contract the production teardown depends on.
+    # Construction alone opens no connection (no execute() call), so no
+    # teardown is needed here — this probe pins only the method-name
+    # resolution engine.py's teardown depends on.
+    node = AsyncSQLDatabaseNode(
+        node_id="invariant_probe",
+        connection_string="sqlite:///:memory:",
+        database_type="sqlite",
+        query="SELECT 1",
+        fetch_mode="all",
+        validate_queries=False,
+    )
+    teardown = getattr(node, "cleanup", None) or getattr(node, "close", None)
+    assert callable(teardown), (
+        "engine.py's `getattr(node,'cleanup') or getattr(node,'close')` "
+        "resolves to a non-callable for AsyncSQLDatabaseNode — the "
+        "#1051 cached-node teardown is a silent no-op again."
+    )

--- a/packages/kailash-dataflow/tests/regression/test_issue_1051_memory_connection_leak.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1051_memory_connection_leak.py
@@ -40,7 +40,7 @@ from kailash.workflow.builder import WorkflowBuilder
 
 
 def _live_aiosqlite_connections():
-    """Structural probe: count live aiosqlite Connection objects."""
+    """Structural probe: live aiosqlite Connection objects."""
     return [
         o
         for o in gc.get_objects()
@@ -48,10 +48,25 @@ def _live_aiosqlite_connections():
     ]
 
 
+def _live_aiosqlite_ids():
+    """Set of id()s of currently-live aiosqlite Connection objects.
+
+    The assertion is a BEFORE/AFTER delta (Security LOW-4): a global
+    "zero live connections" assertion is contaminated by any OTHER test
+    in the same process that leaves an aiosqlite Connection alive (false
+    failure here, or another test's leak masking this one). Counting only
+    Connections that did NOT exist before this test ran isolates the
+    regression to THIS test's lifecycle.
+    """
+    return {id(o) for o in _live_aiosqlite_connections()}
+
+
 @pytest.mark.regression
 def test_issue_1051_dataflow_memory_no_aiosqlite_resourcewarning():
     """DataFlow(:memory:) + workflow + close() leaks zero aiosqlite conns."""
     from dataflow import DataFlow
+
+    before_ids = _live_aiosqlite_ids()
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", ResourceWarning)
@@ -78,11 +93,11 @@ def test_issue_1051_dataflow_memory_no_aiosqlite_resourcewarning():
         del db, Widget1051
         gc.collect()  # ResourceWarning->error escalates here if leak present
 
-    leaked = _live_aiosqlite_connections()
-    assert not leaked, (
-        f"{len(leaked)} aiosqlite Connection(s) leaked past DataFlow.close() "
-        f"(#1051). _get_connection() must reuse one tracked :memory: "
-        f"connection and disconnect() must await-close it."
+    new_leaked = [c for c in _live_aiosqlite_connections() if id(c) not in before_ids]
+    assert not new_leaked, (
+        f"{len(new_leaked)} NEW aiosqlite Connection(s) leaked past "
+        f"DataFlow.close() (#1051). _get_connection() must reuse one tracked "
+        f":memory: connection and disconnect() must await-close it."
     )
 
 
@@ -94,6 +109,8 @@ def test_issue_1051_protecteddataflow_memory_no_aiosqlite_resourcewarning():
     body's `from dataflow import ProtectedDataFlow` was wrong).
     """
     from dataflow.core.protected_engine import ProtectedDataFlow
+
+    before_ids = _live_aiosqlite_ids()
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", ResourceWarning)
@@ -116,9 +133,9 @@ def test_issue_1051_protecteddataflow_memory_no_aiosqlite_resourcewarning():
         del db, Gadget1051
         gc.collect()
 
-    leaked = _live_aiosqlite_connections()
-    assert not leaked, (
-        f"{len(leaked)} aiosqlite Connection(s) leaked past "
+    new_leaked = [c for c in _live_aiosqlite_connections() if id(c) not in before_ids]
+    assert not new_leaked, (
+        f"{len(new_leaked)} NEW aiosqlite Connection(s) leaked past "
         f"ProtectedDataFlow.close() (#1051)."
     )
 

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -4399,7 +4399,25 @@ class AsyncSQLDatabaseNode(AsyncNode):
         # Tracked before connect() so a connect-retry that discards this
         # adapter and builds another still leaves this one reachable for
         # teardown.
-        self._owned_adapters.append(adapter)
+        #
+        # Bounded growth (#1051 redteam MEDIUM-1): a long-lived *cached*
+        # node under connect-retry / pool churn calls _create_adapter()
+        # repeatedly while cleanup() only runs at engine close — an
+        # unbounded reference accumulation. Dedupe by identity (the
+        # runtime-coordination path delegates here, so the same adapter
+        # can arrive twice) and cap the retained list; when over cap the
+        # oldest entries are stale retry-discards — best-effort disconnect
+        # (idempotent) + drop so a reference bound never becomes a handle
+        # leak.
+        if not any(a is adapter for a in self._owned_adapters):
+            self._owned_adapters.append(adapter)
+        _OWNED_ADAPTERS_CAP = 32
+        while len(self._owned_adapters) > _OWNED_ADAPTERS_CAP:
+            stale = self._owned_adapters.pop(0)
+            try:
+                await asyncio.wait_for(stale.disconnect(), timeout=1.0)
+            except (Exception, asyncio.TimeoutError):
+                pass  # Best effort — stale retry-discard; never block create
 
         # Retry connection with exponential backoff
         last_error = None
@@ -6092,8 +6110,15 @@ class AsyncSQLDatabaseNode(AsyncNode):
             for _adapter in self._owned_adapters:
                 try:
                     await asyncio.wait_for(_adapter.disconnect(), timeout=1.0)
-                except (Exception, asyncio.TimeoutError):
-                    pass  # Best effort cleanup
+                except (Exception, asyncio.TimeoutError) as e:
+                    # Best effort cleanup — but log at DEBUG for parity with
+                    # the sibling cached-node teardown in engine.py
+                    # (observability.md Rule 5: teardown swallows still emit
+                    # a DEBUG breadcrumb so a stuck disconnect is diagnosable).
+                    logger.debug(
+                        "async_sql.owned_adapter_disconnect_failed",
+                        extra={"error": str(e)},
+                    )
             self._owned_adapters.clear()
 
     def __del__(self, _warnings=warnings):

--- a/src/kailash/nodes/data/async_sql.py
+++ b/src/kailash/nodes/data/async_sql.py
@@ -46,7 +46,6 @@ from enum import Enum
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Union
 
 import yaml
-
 from kailash.nodes.base import NodeParameter, register_node
 from kailash.nodes.base_async import AsyncNode
 from kailash.nodes.data.exceptions import PoolExhaustedError
@@ -1692,6 +1691,24 @@ class SQLiteAdapter(DatabaseAdapter):
         for connection reuse and bounded thread count.
         """
         assert self._aiosqlite is not None
+        if self._is_memory_db:
+            # Issue #1051: one reused connection per adapter instance for
+            # :memory:. The non-pool memory path (execute/execute_many/
+            # begin_transaction) calls _get_connection() per query; creating
+            # a fresh aiosqlite.connect() each time leaked every one of them
+            # because disconnect() only closes self._pool, which is None for
+            # :memory: by design. The "shared connection for memory databases"
+            # comments and the "don't close shared memory connections"
+            # transaction paths already assume a single reused connection —
+            # self._connection (set None at __init__) is the tracking slot
+            # this completes. disconnect() now owns its lifecycle.
+            if self._connection is None:
+                self._connection = await self._aiosqlite.connect(
+                    self._db_path, **self._connect_kwargs
+                )
+                self._connection.row_factory = self._aiosqlite.Row
+                await self._configure_connection(self._connection)
+            return self._connection
         conn = await self._aiosqlite.connect(self._db_path, **self._connect_kwargs)
         conn.row_factory = self._aiosqlite.Row
         await self._configure_connection(conn)
@@ -1702,6 +1719,14 @@ class SQLiteAdapter(DatabaseAdapter):
         if self._pool is not None:
             await self._pool.close()
             self._pool = None
+        # Issue #1051: close the reused :memory: connection (untracked by the
+        # pool path, which is None for :memory:). Without this it survives to
+        # GC and aiosqlite.Connection.__del__ emits a ResourceWarning.
+        if self._connection is not None:
+            try:
+                await self._connection.close()
+            finally:
+                self._connection = None
 
     async def execute(
         self,
@@ -2384,10 +2409,21 @@ class ProductionSQLiteAdapter(SQLiteAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect enterprise pool."""
-        if self._enterprise_pool:
-            await self._enterprise_pool.close()
-            self._enterprise_pool = None
-        else:
+        try:
+            if self._enterprise_pool:
+                await self._enterprise_pool.close()
+                self._enterprise_pool = None
+        finally:
+            # Issue #1051: ProductionSQLiteAdapter inherits SQLiteAdapter's
+            # _get_connection()/begin_transaction(), so the :memory:
+            # transaction path populates the inherited self._connection
+            # slot — which _enterprise_pool does NOT own. The pre-fix
+            # if/else only reached super().disconnect() (the connection
+            # close) when _enterprise_pool was None; on a connected adapter
+            # it is always set, so the inherited :memory: connection leaked
+            # to GC. super().disconnect() is idempotent (guards on
+            # self._connection is not None), so calling it unconditionally
+            # is safe.
             await super().disconnect()
 
 
@@ -3668,6 +3704,13 @@ class AsyncSQLDatabaseNode(AsyncNode):
 
     def __init__(self, **config):
         self._adapter: Optional[DatabaseAdapter] = None
+        # Issue #1051: a single node can create more than one adapter over
+        # its lifetime (retry path, runtime-pool fallback). close() used to
+        # disconnect only self._adapter (the last), orphaning the prior
+        # adapters — each holding an open :memory: connection that leaked to
+        # GC. Every adapter built by _create_adapter() is registered here so
+        # close() can tear all of them down.
+        self._owned_adapters: list[DatabaseAdapter] = []
         self._connected = False
         # Extract access control manager before passing to parent
         self.access_control_manager = config.pop("access_control_manager", None)
@@ -4350,6 +4393,13 @@ class AsyncSQLDatabaseNode(AsyncNode):
             adapter = ProductionSQLiteAdapter(db_config)
         else:
             raise NodeExecutionError(f"Unsupported database type: {db_type}")
+
+        # Issue #1051: register every adapter this node builds so close()
+        # can disconnect ALL of them (not just the last self._adapter).
+        # Tracked before connect() so a connect-retry that discards this
+        # adapter and builds another still leaves this one reachable for
+        # teardown.
+        self._owned_adapters.append(adapter)
 
         # Retry connection with exponential backoff
         last_error = None
@@ -6030,6 +6080,21 @@ class AsyncSQLDatabaseNode(AsyncNode):
 
             self._connected = False
             self._adapter = None
+
+        # Issue #1051: disconnect every adapter this node created, not just
+        # the last self._adapter handled above. Connect-retry / runtime-pool
+        # fallback can build several ProductionSQLiteAdapters, each holding
+        # an open inherited :memory: connection; only one ever became
+        # self._adapter. Best-effort, guarded, idempotent (disconnect()
+        # guards on its own state). Runs regardless of self._connected so
+        # orphaned adapters are still torn down.
+        if self._owned_adapters:
+            for _adapter in self._owned_adapters:
+                try:
+                    await asyncio.wait_for(_adapter.disconnect(), timeout=1.0)
+                except (Exception, asyncio.TimeoutError):
+                    pass  # Best effort cleanup
+            self._owned_adapters.clear()
 
     def __del__(self, _warnings=warnings):
         """Warn and attempt sync cleanup if node is GC'd while still connected."""


### PR DESCRIPTION
## Summary

`DataFlow`/`ProtectedDataFlow(sqlite:///:memory:)` that ran a workflow then `close()`/`close_async()` leaked every aiosqlite `Connection` it opened (`ResourceWarning` at GC; resource exhaustion in long-lived processes). Multi-sited root cause, instrumented survivor count **3/4 → 1 → 0**:

- **A** `SQLiteAdapter._get_connection()` created a fresh `aiosqlite.connect()` per `:memory:` query, untracked; `disconnect()` only closed `self._pool` (None for `:memory:`). Now reuses one tracked `self._connection`; `disconnect()` awaits-closes it.
- **B** `ProductionSQLiteAdapter.disconnect()` short-circuited on the `_enterprise_pool` branch, never reaching `super().disconnect()`. Now `try/finally: await super().disconnect()` (idempotent).
- **C** a node could build several adapters; `cleanup()` tore down only the last. Node now tracks `_owned_adapters` (deduped + bounded) and `cleanup()` disconnects all.
- **D** the per-execute DDL-wrapper node was discarded without teardown; now closed in a `finally`.
- **E (keystone)** `engine.py` close()/close_async() guarded the cached-node teardown on `hasattr(node,"close")` — but the node's async teardown is `cleanup()` (`close` is on `EnterpriseConnectionPool`, a different class). The guard was always False, so the teardown — and C's `_owned_adapters` disconnect — had been a **silent no-op since #1002**. Now resolves `getattr(cleanup) or getattr(close)`; stale comment corrected.

No production code outside the leak path; correlated "no such table" symptom deliberately not chased (out of #1051 scope).

## Validation

- Tier-2 regression (real DataFlow + ProtectedDataFlow + `:memory:` + `runtime.execute` + `del`/`gc` under `-W error::ResourceWarning`, structural before/after gc-delta probe) + a method-name structural invariant pinning `cleanup()` so a future rename re-breaks loudly. **3 passed, 0 NEW survivors, 0 warnings.**
- `/redteam` round 1 **CONVERGED** — reviewer + security-reviewer (parallel gate agents), zero CRIT/HIGH. Non-vacuity definitively proven (pre-fix 4+8 survivors → 0). Adjacent #1002/#1010/#1045 aiosqlite regressions green (15 passed). Collection clean. `patterns.md` `__del__` deadlock-origin rule honored (unchanged).
- Redteam same-class follow-ups landed in commit 2: bounded `_owned_adapters` growth (cap-32 + evict-disconnect), observability-parity `logger.debug`, gc before/after delta.

## Related issues

Fixes #1051. Pre-existing transaction-abort `_transaction_depth`-reset defect (security-reviewer MEDIUM-2, **different bug class, not introduced here**) tracked separately. Cross-SDK: kailash-rs SQLite-teardown name-mismatch audit recommended (user-filed from a kailash-rs session per repo-scope-discipline).

## Test plan

- [x] `pytest packages/kailash-dataflow/tests/regression/test_issue_1051_memory_connection_leak.py -W error::ResourceWarning` → 3 passed
- [x] non-vacuity proven (parent-checkout: 4+8 survivors → 0)
- [x] #1002/#1010/#1045 aiosqlite regressions green
- [x] `pytest --collect-only` clean (single-path)
- [x] /redteam reviewer + security-reviewer converged

🤖 Generated with [Claude Code](https://claude.com/claude-code)