### PR TITLE
release: kailash 2.21.2 + kailash-dataflow 2.9.17 (#1051 aiosqlite :memory: leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.2] - 2026-05-18
+
+### Fixed
+
+- **aiosqlite `:memory:` connection leaked on `DataFlow`/`ProtectedDataFlow` `close()` (#1051)** — multi-sited fix: untracked per-query `:memory:` connection is now reused and closed; `ProductionSQLiteAdapter.disconnect` handles both branches; node `_owned_adapters` teardown; engine cached-node teardown resolved `cleanup()` vs the dead `hasattr(close)` guard. Fixes #1051.
+
 ## [2.21.1] - 2026-05-16
 
 ### Fixed

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.9.17] — 2026-05-18 — aiosqlite :memory: connection leak fix (#1051)
+
+### Fixed
+
+- **aiosqlite `:memory:` connection leaked on `DataFlow`/`ProtectedDataFlow` `close()` (#1051)** — multi-sited fix in `engine.py`: untracked per-query `:memory:` connection is now reused and closed; `ProductionSQLiteAdapter.disconnect` handles both branches; node `_owned_adapters` teardown; engine cached-node teardown resolved `cleanup()` vs the dead `hasattr(close)` guard. Fixes #1051.
+
 ## [2.9.16] — 2026-05-17 — protection ordering + UPSERT enum + import_file swallow (#1058 Shards 2 + 3 + 4)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.16"
+version = "2.9.17"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.18.0",
+    "kailash>=2.21.2",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.16"
+__version__ = "2.9.17"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.21.1"
+version = "2.21.2"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.21.1"
+__version__ = "2.21.2"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- Bumps `kailash` 2.21.1 → **2.21.2** and `kailash-dataflow` 2.9.16 → **2.9.17**
- Updates both CHANGELOGs dated 2026-05-18
- Advances dataflow dep floor to `kailash>=2.21.2` (engine.py Change E depends on async_sql.py Change C)
- Metadata-only diff — no source changes in this PR

## Related issues

Fixes #1051

## Implementation

Merged via PR #1069 (impl commits `3093c5e41` + `4d90221fb`).

## Test plan

- [ ] CI auto-skips PR-gate matrix (branch starts with `release/`)
- [ ] Admin-merge then push tags individually: `v2.21.2`, then `dataflow-v2.9.17` after kailash 2.21.2 appears on PyPI