### PR TITLE
docs(nexus-auth): document constant-time api_key_validator expectation (#1068)

### DIFF
--- a/.redteam-convergence-1068.md
+++ b/.redteam-convergence-1068.md
@@ -1,0 +1,59 @@
+# Issue #1068 — /redteam convergence note
+
+**Scope:** doc/spec-only hardening (Nexus `JWTConfig.api_key_validator`
+constant-time-comparison expectation). No behavioral code change — the SDK
+delegates the comparison to the caller and cannot enforce it. The redteam is
+accuracy + non-phantom-citation verification, NOT test-suite convergence
+(stated explicitly per the task brief).
+
+## Round 1 — accuracy + citation + example validity
+
+- **spec-accuracy split-state scan** (`rg -i 'phase-1.*phase-2|promised.*current|
+scaffold.*later|TBD|to.be.wired|accessor.pending' specs/security-auth.md`):
+  CLEAN — zero matches. No split-state framing introduced.
+- **Citation resolution** — every symbol named in the new spec §2.2 prose +
+  JWTConfig docstring resolves against the worktree tree:
+  - `JWTConfig` → `src/kailash/trust/auth/jwt.py:52`
+  - `JWTConfig.api_key_validator` field → `src/kailash/trust/auth/jwt.py:141`
+  - `nexus.auth.jwt.JWTMiddleware` → `packages/kailash-nexus/src/nexus/auth/jwt.py:40`
+  - validator consumption site → `packages/kailash-nexus/src/nexus/auth/jwt.py:150`
+    (`if self.config.api_key_validator:`)
+  - `secrets.compare_digest` / `hmac.compare_digest` — stdlib, real.
+    Zero phantom citations.
+- **§2.2 citation accuracy** — `### 2.2 API Key Authentication` is a real
+  heading (`specs/security-auth.md:173`); the new validator-contract content
+  is at lines 193–206 inside §2.2 (before §2.3 at the prior boundary).
+- **Example validity (`ast.parse`)** — all three edited examples parse as
+  valid Python:
+  - JWTConfig docstring `::` literal block (dedented) — OK
+  - `specs/security-auth.md` §2.2 fenced ```python block — OK
+  - `custom_endpoints.md` `verify_api_key` fenced ```python block — OK
+  - All three use `secrets.compare_digest`; zero surviving `==`/`!=`
+    API-key comparison examples in `packages/kailash-nexus/docs/`,
+    `specs/security-auth.md`, `src/kailash/trust/auth/jwt.py`.
+
+## Round 2 — render + structural confirmation
+
+- Worktree `jwt.py` parses as a whole module (docstring literal-block + new
+  field doc are syntactically valid; pre-commit Black/Ruff/isort + Tier-1
+  unit tests passed on the commit).
+- `JWTConfig.__doc__` (via AST against the worktree file) contains the
+  `api_key_validator` field doc, the "constant time" phrasing, the
+  `secrets.compare_digest` example, and the previously-undocumented sibling
+  fields (`api_key_header`, `api_key_enabled`, `max_token_age_seconds`,
+  `on_token_validated`) — Attributes block is now complete.
+
+## Verdict
+
+**CONVERGED — 0 phantom citations, 0 CRIT/HIGH, all examples valid Python,
+spec-accuracy CLEAN.** No further rounds required: the change is doc/spec
+only, every citation resolves, and no test-suite axis applies.
+
+## SDK-internal `==` check (in-scope code-fix sweep)
+
+The SDK consumer (`nexus/auth/jwt.py:150-184`) delegates the comparison to
+the caller's `api_key_validator(api_key)` — it does NOT perform its own `==`
+key comparison. Webhook HMAC paths (`nexus/transports/webhook.py:122,208`)
+already use `hmac.compare_digest`. No SDK-internal `==` key comparison found
+→ no behavioral code fix in scope (consistent with the issue's doc/spec-only
+framing).

--- a/packages/kailash-nexus/docs/technical/custom_endpoints.md
+++ b/packages/kailash-nexus/docs/technical/custom_endpoints.md
@@ -5,12 +5,14 @@
 Nexus allows you to register custom REST endpoints using the `@app.endpoint()` decorator. These endpoints are API-channel only (not available in CLI or MCP) and provide full FastAPI functionality including path parameters, query parameters, request validation, and automatic OpenAPI documentation.
 
 Custom endpoints enable you to:
+
 - Create specialized API routes beyond standard workflow execution
 - Integrate with external systems using familiar REST patterns
 - Build CRUD operations for resources
 - Implement custom business logic with workflow integration
 
 **When to use custom endpoints:**
+
 - Resource-specific operations (e.g., `/api/conversations/{id}`)
 - Complex query patterns not suited for standard workflow input
 - Integration with existing REST APIs
@@ -54,6 +56,7 @@ app.run()
 ```
 
 **Usage:**
+
 ```bash
 curl http://localhost:8000/api/users/u123
 # Response: {"user_id": "u123", "name": "John Doe", "email": "u123@example.com"}
@@ -118,6 +121,7 @@ app.run()
 ```
 
 **Usage:**
+
 ```bash
 # Create conversation
 curl -X POST http://localhost:8000/api/conversations \
@@ -161,6 +165,7 @@ app.run()
 ```
 
 **Usage:**
+
 ```bash
 # Valid request
 curl http://localhost:8000/api/items/abc123/versions/5
@@ -227,6 +232,7 @@ app.run()
 ```
 
 **Usage:**
+
 ```bash
 curl -X POST http://localhost:8000/api/chat/conv123/message \
   -H "Content-Type: application/json" \
@@ -262,6 +268,7 @@ app.run()
 ```
 
 **Rate limit behavior:**
+
 - Rate limits are per-client IP address
 - Uses 1-minute rolling window
 - Returns 429 status code when exceeded
@@ -324,6 +331,7 @@ app.run()
 ```
 
 **Usage:**
+
 ```bash
 # Set preferences
 curl -X POST http://localhost:8000/api/preferences \
@@ -588,9 +596,11 @@ def endpoint(
   - `deprecated` (bool): Mark endpoint as deprecated
 
 **Returns:**
+
 - Decorator function that registers the endpoint with FastAPI
 
 **Raises:**
+
 - `RuntimeError`: If gateway not initialized (called before `app.run()`)
 - `ValueError`: If invalid HTTP method provided
 
@@ -604,19 +614,23 @@ async def _execute_workflow(
 ```
 
 **Parameters:**
+
 - **workflow_name** (str): Name of registered workflow
 - **inputs** (Dict[str, Any]): Input data for workflow execution
 
 **Returns:**
+
 - Dict[str, Any]: Workflow execution results
 
 **Raises:**
+
 - `HTTPException(404)`: If workflow not found
 - `HTTPException(413)`: If input data exceeds 10MB
 - `HTTPException(400)`: If input contains dangerous keys
 - `HTTPException(500)`: If workflow execution fails
 
 **Security Features:**
+
 - Input size validation (max 10MB)
 - Dangerous key filtering (prevents code injection)
 - Key length validation (max 256 chars)
@@ -641,6 +655,7 @@ async def authenticated_endpoint():
 ```
 
 **Rate limiting features:**
+
 - Per-client IP address tracking
 - 1-minute rolling window
 - Automatic cleanup (prevents memory leaks)
@@ -865,11 +880,21 @@ async def get_users_v2():
 ### 5. Leverage FastAPI Dependency Injection
 
 ```python
+import os
+import secrets
+
 from fastapi import Depends, Header, HTTPException
 
+EXPECTED_API_KEY = os.environ["SERVICE_API_KEY"]
+
 async def verify_api_key(x_api_key: str = Header(...)):
-    """Dependency to verify API key."""
-    if x_api_key != "secret-key":
+    """Dependency to verify API key.
+
+    Uses ``secrets.compare_digest`` for a constant-time comparison: a plain
+    ``x_api_key != EXPECTED_API_KEY`` short-circuits on the first differing
+    byte, which is a remote-timing oracle for byte-by-byte key recovery.
+    """
+    if not secrets.compare_digest(x_api_key, EXPECTED_API_KEY):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return x_api_key
 

--- a/specs/security-auth.md
+++ b/specs/security-auth.md
@@ -190,6 +190,21 @@ API keys are generated and managed through the `MiddlewareAuthManager` (`kailash
 - API keys are disabled when `enable_api_keys=False` in the auth manager -- calls to `create_api_key()` or `verify_api_key()` return HTTP 400.
 - API key rotation is handled by `RotatingCredentialNode` which supports configurable rotation intervals.
 
+**Caller-supplied validator contract:** The Nexus header path (`X-API-Key`) authenticates keys through a caller-supplied callable, `kailash.trust.auth.jwt.JWTConfig.api_key_validator`, consumed by `nexus.auth.jwt.JWTMiddleware`. Its signature is `(api_key: str) -> bool | dict` (an awaitable is also accepted): a falsey return rejects the key (HTTP 401), `True` accepts it, and a claims dict accepts it and populates the authenticated user.
+
+The validator MUST compare the presented key against the stored/expected key in **constant time** using `secrets.compare_digest` (or `hmac.compare_digest`) -- never the `==` / `!=` operator. A plain `==` comparison short-circuits on the first differing byte, leaking key-prefix length under a remote-timing oracle and allowing byte-by-byte key recovery. The SDK delegates the comparison to the caller's callable and cannot enforce it; the constant-time requirement is the caller's responsibility. Canonical form:
+
+```python
+import secrets
+
+STORED_API_KEY = os.environ["SERVICE_API_KEY"]
+
+def validate(api_key: str) -> bool:
+    return secrets.compare_digest(api_key, STORED_API_KEY)
+```
+
+`secrets.compare_digest` is also length-safe -- it does not reveal, via timing, whether the presented key matched the expected length.
+
 ### 2.3 SSO Integration
 
 The trust-plane SSO layer (`kailash.trust.auth.sso`) provides pluggable OAuth2/OIDC integration.
@@ -495,4 +510,3 @@ Default strategy is `hybrid`.
 `kailash.trust.auth.session` provides the SSO CSRF state store. See Section 2.3 for details.
 
 ---
-

--- a/src/kailash/trust/auth/jwt.py
+++ b/src/kailash/trust/auth/jwt.py
@@ -67,6 +67,46 @@ class JWTConfig:
         jwks_cache_ttl: JWKS cache TTL in seconds (default: 3600)
         verify_exp: Verify token expiration (default: True)
         leeway: Leeway in seconds for exp/nbf claims (default: 0)
+        api_key_header: Header name for API key auth (default: X-API-Key)
+        api_key_enabled: Enable API key authentication (default: False)
+        api_key_validator: Caller-supplied callable invoked to authenticate
+            an API key presented in the ``api_key_header``. Signature is
+            ``(api_key: str) -> bool | dict`` (an awaitable is also accepted);
+            return a falsey value to reject, ``True`` to accept, or a claims
+            dict to accept and populate the authenticated user.
+
+            SECURITY -- the validator MUST compare the presented key against
+            the stored/expected key in **constant time** using
+            ``secrets.compare_digest`` (or ``hmac.compare_digest``), NOT the
+            ``==`` operator. A plain ``==`` (or ``!=``) comparison
+            short-circuits on the first differing byte, leaking key-prefix
+            length under a remote-timing oracle and letting an attacker
+            recover the key one byte at a time. The SDK delegates the
+            comparison to this callable and cannot enforce it; the caller is
+            responsible for using a constant-time comparison::
+
+                import secrets
+
+                STORED_API_KEY = os.environ["SERVICE_API_KEY"]
+
+                def validate(api_key: str) -> bool:
+                    # constant-time: does NOT short-circuit on first
+                    # differing byte (unlike ``api_key == STORED_API_KEY``)
+                    return secrets.compare_digest(api_key, STORED_API_KEY)
+
+                config = JWTConfig(
+                    secret="your-secret-key-at-least-32-chars!",
+                    api_key_enabled=True,
+                    api_key_validator=validate,
+                )
+
+            ``secrets.compare_digest`` is also length-safe: it does not
+            reveal, via timing, whether the presented key matched the
+            expected length.
+        max_token_age_seconds: Absolute token age cap independent of the
+            ``exp`` claim (optional)
+        on_token_validated: Post-validation hook for stale detection / audit
+            (optional)
     """
 
     secret: Optional[str] = None


### PR DESCRIPTION
## Summary

Doc/spec hardening (the #1056 redteam follow-up). The SDK delegates API-key comparison to a caller-supplied `JWTConfig.api_key_validator` and structurally cannot enforce constant-time comparison — so it now steers callers to the safe pattern everywhere the contract is described/exemplified:

- `src/kailash/trust/auth/jwt.py` — `JWTConfig` docstring: full validator contract + `secrets.compare_digest` example (also completes the previously-undocumented Attributes block).
- `specs/security-auth.md` §2.2 — validator constant-time MUST + canonical form.
- `packages/kailash-nexus/docs/technical/custom_endpoints.md` — replaced the only `!=`/hardcoded-secret API-key example with env-sourced + `secrets.compare_digest`.

No behavioral code change (SDK consumer already delegates; webhook HMAC already uses `hmac.compare_digest`). CONVERGED — 0 phantom citations, all examples valid Python, spec-accuracy CLEAN.

## Related issues

Fixes #1068. Cross-SDK: equivalent kailash-rs validator-contract hardening recommended (user-filed from a kailash-rs session per repo-scope-discipline).

## Test plan

- [x] spec §2.2 citation resolves; split-state scan clean
- [x] all 3 edited examples parse as valid Python (ast)
- [x] pre-commit (Black/Ruff/isort/Tier-1/spec-drift/doc-style) green every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)