### PR TITLE
release: kailash 2.21.3 + kailash-dataflow 2.9.18 (Wave A #1070/#1047/#1068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.3] - 2026-05-18
+
+### Fixed
+
+- **`SQLiteAdapter` transaction state not reset on aborted `begin_transaction()` (#1070)** — `asyncio.CancelledError` is a `BaseException`, not an `Exception`; the auto-transaction wrappers caught `except Exception:`, so a coroutine cancelled between `begin_transaction()` and `commit_transaction()` skipped `rollback_transaction()`, leaving `_transaction_depth` unreset. The next `begin_transaction()` on the shared `:memory:` connection then took a poisoned SAVEPOINT branch (reproduced: an aborted transaction's uncommitted row leaked into the next transaction). Added `_abort_begin()` (resets depth/savepoint-counter + `ROLLBACK`, never closes the `:memory:` connection) and switched both auto-transaction wrappers to `except BaseException:`. Fixes #1070.
+
+### Documentation
+
+- Documented the constant-time-comparison expectation for caller-supplied `JWTConfig.api_key_validator` (docstring + `specs/security-auth.md` §2.2; no behavior change). Fixes #1068.
+
 ## [2.21.2] - 2026-05-18
 
 ### Fixed

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.9.18] — 2026-05-18 — sanitizer set/tuple type-confusion fix (#1047)
+
+### Fixed
+
+- **set/tuple type-confusion bypass in the input sanitizer (#1047)** — a str-declared field receiving a `set`/`tuple` was silently `str()`-coerced (bypassing the type-confusion gate) instead of raising `ValueError` per the security Sanitizer Contract Rule 2. `dict`/`list` already conformed; `set`/`tuple` were the only violators. Fixed on both the single-value and bulk paths by adding `set, tuple` to `sanitize_sql_input`'s `safe_types` so the existing type-confusion gate sees the real container and raises. Added tier-1 sanitizer-contract test coverage (Rules 1+2+3). Fixes #1047.
+
 ## [2.9.17] — 2026-05-18 — aiosqlite :memory: connection leak fix (#1051)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.17"
+version = "2.9.18"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.17"
+__version__ = "2.9.18"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.21.2"
+version = "2.21.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -80,7 +80,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.21.2"
+__version__ = "2.21.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Metadata-only release cut for the 3 merged Wave A fixes (PRs #1075/#1074/#1073).

- **kailash 2.21.2 → 2.21.3** — #1070 SQLiteAdapter transaction-abort state reset (reproduced data corruption: aborted-txn row leaked into next txn) + #1068 constant-time `api_key_validator` doc/spec hardening.
- **kailash-dataflow 2.9.17 → 2.9.18** — #1047/#1047b set/tuple type-confusion sanitizer bypass closed (single + bulk) + tier-1 contract tests.

`kailash-dataflow` `kailash>=2.21.2` floor intentionally NOT bumped (#1047b is self-contained in dataflow `nodes.py`, independent of #1070's core change — `deployment.md` no gratuitous bump). kailash published first for ordering safety.

Version + CHANGELOG atomic per `zero-tolerance.md` Rule 5. Code already redteam-converged per-Wave-A-PR.

## Related issues

Release for #1070 #1047 #1068 (all merged + closed; this publishes the fixes to PyPI).

## Test plan

- [x] code merged green (PRs #1075/#1074/#1073, full matrix)
- [ ] kailash 2.21.3 + kailash-dataflow 2.9.18 clean-venv verified post-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)