### PR TITLE
fix(api): restore kaizen.api shim + suppress @app.handler instance-API warning (#1071)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`kaizen.api` restored as a deprecation shim (#1071)** — the structural-split refactor (#75) relocated the unified Agent API from `kaizen.api` to `kaizen_agents.api` and removed `kaizen.api` outright with no deprecation cycle. `from kaizen.api import Agent` raised `ModuleNotFoundError` on every published release — a hard break for every downstream caller on first `pip install --upgrade`. `kaizen.api` is now restored as a PEP 562 deprecation shim: every public symbol that historically lived under `kaizen.api` resolves through it and emits a `DeprecationWarning` naming the new import path on attribute access. The shim will be removed in a future major release.
+
+### Migration — `kaizen.api` → `kaizen`
+
+| Old (deprecated)                  | New                                      |
+| --------------------------------- | ---------------------------------------- |
+| `from kaizen.api import Agent`    | `from kaizen import Agent`               |
+| `from kaizen.api import <symbol>` | `from kaizen_agents.api import <symbol>` |
+
+Where `<symbol>` is any of the historical secondary surface: `AgentConfig`, `AgentResult`, `ToolCallRecord`, `CapabilityPresets`, `AgentCapabilities`, `ExecutionMode`, `MemoryDepth`, `ToolAccess`, `ConfigurationError`, `validate_configuration`, `validate_model_runtime_compatibility`, `resolve_memory_shortcut`, `resolve_runtime_shortcut`, `resolve_tool_access_shortcut`. `Agent` resolves through `kaizen` so the `kaizen_agents` → `kaizen.core.agents` fallback chain is preserved on installs without the optional `kaizen-agents` package.
+
 ## [2.21.0] — 2026-05-09 — slim-core decoupling: 9 core deps + provider/observability/db/cache/rag extras (#890)
 
 Minor release shipping the kailash-kaizen side of the kailash 2.18.0 / #890 slim-core decoupling. **Install-shape breaking change** — kaizen drops from 29 → 9 core dependencies. Provider SDKs (Azure, Google, token counters), observability (Prometheus/OpenTelemetry/structlog), database (aiosqlite/asyncpg), cache (Redis), RAG (numpy/Pillow), research-validator (GitPython), and HTTP server (FastAPI/uvicorn) all move to opt-in extras. The new `[all]` umbrella preserves the pre-2.21.0 default install for users who do not want to enumerate which subsystem they consume.

--- a/packages/kailash-kaizen/src/kaizen/api/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/api/__init__.py
@@ -1,0 +1,115 @@
+"""Deprecated compatibility shim for the historical ``kaizen.api`` module.
+
+The unified Agent API historically lived under ``kaizen.api`` (``from
+kaizen.api import Agent``). The structural-split refactor (#75) relocated the
+canonical async Agent API to ``kaizen_agents.api`` and re-exported the primary
+entry point at the package root (``from kaizen import Agent``). The
+``kaizen.api`` module was removed outright with no deprecation cycle, so
+``from kaizen.api import Agent`` began raising ``ModuleNotFoundError`` on every
+published release — a hard break for every downstream caller on first
+``pip install --upgrade``.
+
+This module restores ``kaizen.api`` as a deprecation shim per the SDK's
+remove-fully discipline (``rules/zero-tolerance.md`` Rule 6a): every public
+symbol that historically lived under ``kaizen.api`` resolves through this
+module and emits a ``DeprecationWarning`` naming the new import path on
+attribute access.
+
+Migration
+---------
+    # Old (deprecated):
+    from kaizen.api import Agent
+
+    # New:
+    from kaizen import Agent
+
+The historical surface (recovered from the pre-#75 ``kaizen/api/__init__.py``
+and the canonical ``kaizen_agents/api/__init__.py``):
+
+    Agent, AgentConfig, AgentResult, ToolCallRecord, CapabilityPresets,
+    AgentCapabilities, ExecutionMode, MemoryDepth, ToolAccess,
+    ConfigurationError, validate_configuration,
+    validate_model_runtime_compatibility, resolve_memory_shortcut,
+    resolve_runtime_shortcut, resolve_tool_access_shortcut
+
+``Agent`` resolves through ``kaizen`` itself so the established
+``kaizen_agents`` → ``kaizen.core.agents`` fallback chain is preserved on
+installs without the optional ``kaizen-agents`` package. Every other symbol
+lived only in the canonical ``kaizen_agents.api`` module; resolving one of
+them without ``kaizen-agents`` installed raises a typed ``ImportError`` that
+names the missing package and the new import path.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+# Public symbols that historically lived under ``kaizen.api``. ``Agent`` is
+# resolved via ``kaizen`` (preserving the kaizen_agents → CoreAgent fallback);
+# every other symbol lived only in ``kaizen_agents.api``.
+_KAIZEN_ROOT_SYMBOLS = frozenset({"Agent"})
+_KAIZEN_AGENTS_API_SYMBOLS = frozenset(
+    {
+        "AgentConfig",
+        "AgentResult",
+        "ToolCallRecord",
+        "CapabilityPresets",
+        "AgentCapabilities",
+        "ExecutionMode",
+        "MemoryDepth",
+        "ToolAccess",
+        "ConfigurationError",
+        "validate_configuration",
+        "validate_model_runtime_compatibility",
+        "resolve_memory_shortcut",
+        "resolve_runtime_shortcut",
+        "resolve_tool_access_shortcut",
+    }
+)
+
+__all__ = sorted(_KAIZEN_ROOT_SYMBOLS | _KAIZEN_AGENTS_API_SYMBOLS)
+
+
+def __getattr__(name: str) -> object:
+    """Resolve a historical ``kaizen.api`` symbol, emitting a deprecation.
+
+    PEP 562 module ``__getattr__`` so the ``DeprecationWarning`` fires on
+    attribute access (including ``from kaizen.api import Agent``), not merely
+    on package import.
+    """
+    if name in _KAIZEN_ROOT_SYMBOLS:
+        warnings.warn(
+            f"'kaizen.api.{name}' is deprecated and will be removed in a "
+            f"future major release. Import from 'kaizen' instead: "
+            f"'from kaizen import {name}'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        import kaizen
+
+        return getattr(kaizen, name)
+
+    if name in _KAIZEN_AGENTS_API_SYMBOLS:
+        warnings.warn(
+            f"'kaizen.api.{name}' is deprecated and will be removed in a "
+            f"future major release. Import from 'kaizen_agents.api' instead: "
+            f"'from kaizen_agents.api import {name}'.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        try:
+            import kaizen_agents.api as _kaizen_agents_api
+        except ImportError as exc:  # pragma: no cover - optional sibling
+            raise ImportError(
+                f"'kaizen.api.{name}' requires the optional 'kaizen-agents' "
+                f"package. Install it ('pip install kaizen-agents') and import "
+                f"from 'kaizen_agents.api' instead: "
+                f"'from kaizen_agents.api import {name}'."
+            ) from exc
+        return getattr(_kaizen_agents_api, name)
+
+    raise AttributeError(f"module 'kaizen.api' has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return list(__all__)

--- a/packages/kailash-kaizen/tests/regression/test_issue_1071_kaizen_api_shim.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1071_kaizen_api_shim.py
@@ -1,0 +1,112 @@
+"""Regression test for issue #1071 Gap A — kaizen.api deprecation shim.
+
+The structural-split refactor (#75) moved the unified Agent API from
+``kaizen.api`` to ``kaizen_agents.api`` and removed ``kaizen.api`` outright
+with no deprecation cycle, so ``from kaizen.api import Agent`` began raising
+``ModuleNotFoundError`` on every published release. This test pins the
+deprecation-shim contract:
+
+- ``from kaizen.api import Agent`` succeeds AND emits a ``DeprecationWarning``
+  naming the new import path (``from kaizen import Agent``).
+- Every historical secondary symbol resolves through the shim with its own
+  ``DeprecationWarning``.
+- Unknown attributes raise ``AttributeError`` (not silent ``None``).
+
+Tier 2 — real imports, no mocking.
+"""
+
+import warnings
+
+import pytest
+
+
+def test_from_kaizen_api_import_agent_succeeds_and_warns():
+    """`from kaizen.api import Agent` resolves AND emits a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        from kaizen.api import Agent  # noqa: PLC0415 — exercising the shim
+
+    assert Agent is not None
+    # Agent must be the same object kaizen exports (the canonical entry point).
+    import kaizen
+
+    assert Agent is kaizen.Agent
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert dep_warnings, "kaizen.api.Agent access emitted no DeprecationWarning"
+    msg = str(dep_warnings[0].message)
+    assert "kaizen.api" in msg
+    assert "from kaizen import Agent" in msg
+
+
+def test_kaizen_api_agent_attribute_access_warns():
+    """`pytest.warns(DeprecationWarning)` on attribute access (PEP 562)."""
+    import kaizen.api
+
+    with pytest.warns(DeprecationWarning, match="from kaizen import Agent"):
+        _ = kaizen.api.Agent
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    [
+        "AgentConfig",
+        "AgentResult",
+        "ToolCallRecord",
+        "CapabilityPresets",
+        "AgentCapabilities",
+        "ExecutionMode",
+        "MemoryDepth",
+        "ToolAccess",
+        "ConfigurationError",
+        "validate_configuration",
+        "validate_model_runtime_compatibility",
+        "resolve_memory_shortcut",
+        "resolve_runtime_shortcut",
+        "resolve_tool_access_shortcut",
+    ],
+)
+def test_historical_secondary_symbols_resolve_and_warn(symbol):
+    """Every historical secondary symbol resolves through the shim + warns."""
+    import kaizen.api
+
+    with pytest.warns(DeprecationWarning, match="kaizen_agents.api"):
+        resolved = getattr(kaizen.api, symbol)
+    assert resolved is not None
+
+    # Parity: the shim resolves the SAME object as the canonical module.
+    import kaizen_agents.api
+
+    assert resolved is getattr(kaizen_agents.api, symbol)
+
+
+def test_unknown_attribute_raises_attribute_error():
+    """Unknown attributes raise AttributeError, never silent None."""
+    import kaizen.api
+
+    with pytest.raises(AttributeError, match="has no attribute"):
+        _ = kaizen.api.NoSuchSymbol
+
+
+def test_dunder_all_covers_full_historical_surface():
+    """__all__ enumerates the full recovered historical surface (15 symbols)."""
+    import kaizen.api
+
+    expected = {
+        "Agent",
+        "AgentConfig",
+        "AgentResult",
+        "ToolCallRecord",
+        "CapabilityPresets",
+        "AgentCapabilities",
+        "ExecutionMode",
+        "MemoryDepth",
+        "ToolAccess",
+        "ConfigurationError",
+        "validate_configuration",
+        "validate_model_runtime_compatibility",
+        "resolve_memory_shortcut",
+        "resolve_runtime_shortcut",
+        "resolve_tool_access_shortcut",
+    }
+    assert set(kaizen.api.__all__) == expected

--- a/packages/kailash-nexus/tests/regression/test_issue_1071_handler_no_instance_warning.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1071_handler_no_instance_warning.py
@@ -1,0 +1,143 @@
+"""Regression test for issue #1071 Gap B — @app.handler() instance-API warning.
+
+`nexus.Nexus().handler("name")` builds its workflow internally via
+`make_handler_workflow` → `WorkflowBuilder.add_node_instance(node, id)`, which
+historically emitted the consumer-facing instance-API advisory
+("Instance-based API usage detected ...") once per registered handler — scaling
+to hundreds of spurious UserWarnings per process for CORRECT decorator use.
+The consumer wrote zero instance `add_node` calls; the advisory was a false
+positive.
+
+The root-cause fix routes the decorator's internal registration through
+`add_node_instance(node, id, _internal=True)`, which suppresses the advisory
+ONLY for the SDK-internal path. Genuine consumer instance-API misuse never
+sets `_internal` and MUST still warn.
+
+Tier 2 — real Nexus + real WorkflowBuilder, no mocking.
+"""
+
+import warnings
+
+import pytest
+
+_ADVISORY = "Instance-based API usage detected"
+
+
+def _instance_warnings(caught):
+    return [w for w in caught if _ADVISORY in str(w.message)]
+
+
+def test_app_handler_decorator_emits_no_instance_api_warning():
+    """@app.handler() registration MUST NOT emit the instance-API advisory."""
+    from nexus import Nexus
+
+    app = Nexus()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @app.handler("greet")
+            async def greet(name: str) -> dict:
+                return {"message": f"hi {name}"}
+
+        assert _instance_warnings(caught) == [], (
+            "@app.handler() emitted the consumer-facing instance-API advisory; "
+            "the decorator-internal registration path must set _internal=True"
+        )
+    finally:
+        app.close()
+
+
+def test_register_handler_programmatic_emits_no_instance_api_warning():
+    """The non-decorator register_handler() path is also internal — no advisory."""
+    from nexus import Nexus
+
+    app = Nexus()
+    try:
+
+        async def ping(payload: str = "") -> dict:
+            return {"pong": payload}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            app.register_handler("ping", ping)
+
+        assert _instance_warnings(caught) == []
+    finally:
+        app.close()
+
+
+def test_genuine_consumer_instance_add_node_still_warns():
+    """Genuine consumer add_node(<instance>, id) MUST still emit the advisory.
+
+    The fix must NOT blanket-suppress the advisory — only the SDK-internal
+    decorator path. This guards against the over-broad-suppression failure.
+    """
+    from kailash.nodes.base import Node
+    from kailash.workflow.builder import WorkflowBuilder
+
+    class _ConsumerNode(Node):
+        def get_parameters(self):
+            return {}
+
+        def run(self, **kwargs):
+            return {}
+
+        async def async_run(self, **kwargs):
+            return {}
+
+    builder = WorkflowBuilder()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        builder.add_node(_ConsumerNode(), "consumer_node")
+
+    assert len(_instance_warnings(caught)) == 1, (
+        "genuine consumer add_node(<instance>) must still warn — the "
+        "_internal bypass must not leak to the consumer path"
+    )
+
+
+def test_genuine_consumer_add_node_instance_still_warns():
+    """Public add_node_instance() default (no _internal) MUST still warn."""
+    from kailash.nodes.base import Node
+    from kailash.workflow.builder import WorkflowBuilder
+
+    class _ConsumerNode(Node):
+        def get_parameters(self):
+            return {}
+
+        def run(self, **kwargs):
+            return {}
+
+        async def async_run(self, **kwargs):
+            return {}
+
+    builder = WorkflowBuilder()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        builder.add_node_instance(_ConsumerNode(), "consumer_node")
+
+    assert len(_instance_warnings(caught)) == 1
+
+
+def test_internal_flag_suppresses_only_when_explicitly_set():
+    """add_node_instance(..., _internal=True) suppresses; default warns."""
+    from kailash.nodes.base import Node
+    from kailash.workflow.builder import WorkflowBuilder
+
+    class _N(Node):
+        def get_parameters(self):
+            return {}
+
+        def run(self, **kwargs):
+            return {}
+
+        async def async_run(self, **kwargs):
+            return {}
+
+    builder = WorkflowBuilder()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        builder.add_node_instance(_N(), "n_internal", _internal=True)
+
+    assert _instance_warnings(caught) == []

--- a/packages/kailash-nexus/tests/regression/test_issue_1071_handler_no_instance_warning.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1071_handler_no_instance_warning.py
@@ -141,3 +141,32 @@ def test_internal_flag_suppresses_only_when_explicitly_set():
         builder.add_node_instance(_N(), "n_internal", _internal=True)
 
     assert _instance_warnings(caught) == []
+
+
+def test_internal_flag_is_keyword_only_positional_rejected() -> None:
+    """`_internal` MUST be keyword-only — positional True cannot suppress.
+
+    Defense against a misguided caller writing
+    ``builder.add_node_instance(node, "id", True)`` to silence the warning
+    positionally. The flag is documented as SDK-internal; making it
+    keyword-only converts "the underscore prefix is convention" into a
+    structural Python signature constraint enforced at call time, closing
+    the security-reviewer HIGH MUST-VERIFY surfaced in the #1071 gate.
+    """
+    from kailash.nodes.base import Node, NodeParameter
+    from kailash.workflow.builder import WorkflowBuilder
+
+    class _N(Node):
+        def get_parameters(self) -> dict[str, NodeParameter]:
+            return {}
+
+        def run(self, **kwargs):
+            return {}
+
+        async def async_run(self, **kwargs):
+            return {}
+
+    builder = WorkflowBuilder()
+    with pytest.raises(TypeError):
+        # Positional True for _internal MUST raise — keyword-only enforces this.
+        builder.add_node_instance(_N(), "n_positional", True)  # type: ignore[misc]

--- a/src/kailash/nodes/handler.py
+++ b/src/kailash/nodes/handler.py
@@ -287,7 +287,12 @@ def make_handler_workflow(
     params = _derive_params_from_signature(handler)
 
     builder = WorkflowBuilder()
-    builder.add_node_instance(node, node_id)
+    # _internal=True: this is the SDK's own @app.handler() / register_handler()
+    # registration path wrapping a user function in a HandlerNode. The consumer
+    # wrote zero instance add_node() calls, so the instance-API advisory would
+    # be a false positive (issue #1071 Gap B). Genuine consumer instance-API
+    # misuse never reaches this path and still warns.
+    builder.add_node_instance(node, node_id, _internal=True)
 
     # Build identity input mapping if not provided
     if input_mapping is None:

--- a/src/kailash/workflow/builder.py
+++ b/src/kailash/workflow/builder.py
@@ -364,7 +364,11 @@ class WorkflowBuilder:
         return node_id
 
     def _add_node_instance(
-        self, node_instance: "Node", node_id: str | None, _internal: bool = False
+        self,
+        node_instance: "Node",
+        node_id: str | None,
+        *,
+        _internal: bool = False,
     ) -> str:
         """Handle instance pattern: add_node(node_instance, 'node_id').
 
@@ -508,6 +512,7 @@ class WorkflowBuilder:
         self,
         node_instance: Any,
         node_id: str | None = None,
+        *,
         _internal: bool = False,
     ) -> str:
         """
@@ -518,10 +523,12 @@ class WorkflowBuilder:
         Args:
             node_instance: Pre-configured node instance
             node_id: Unique identifier for this node (auto-generated if not provided)
-            _internal: Internal flag — when True, suppresses the consumer-facing
-                instance-API advisory. Set ONLY by SDK-internal registration
-                paths (e.g. Nexus ``@app.handler()``); consumer code MUST NOT
-                pass this. Genuine consumer instance-API usage still warns.
+            _internal: Keyword-only internal flag — when True, suppresses the
+                consumer-facing instance-API advisory. Set ONLY by SDK-internal
+                registration paths (e.g. Nexus ``@app.handler()``); consumer
+                code MUST NOT pass this. Keyword-only (after ``*``) so a
+                positional True cannot accidentally suppress the warning.
+                Genuine consumer instance-API usage still warns.
 
         Returns:
             Node ID

--- a/src/kailash/workflow/builder.py
+++ b/src/kailash/workflow/builder.py
@@ -363,21 +363,34 @@ class WorkflowBuilder:
         logger.info(f"Added node '{node_id}' of type '{node_class.__name__}'")
         return node_id
 
-    def _add_node_instance(self, node_instance: "Node", node_id: str | None) -> str:
-        """Handle instance pattern: add_node(node_instance, 'node_id')"""
+    def _add_node_instance(
+        self, node_instance: "Node", node_id: str | None, _internal: bool = False
+    ) -> str:
+        """Handle instance pattern: add_node(node_instance, 'node_id').
+
+        ``_internal`` suppresses the consumer-facing instance-API advisory.
+        It is set ONLY by SDK-internal registration paths (e.g. Nexus's
+        ``@app.handler()`` decorator, which wraps a user function in a
+        ``HandlerNode`` and registers it via this method). For those paths the
+        consumer wrote ZERO instance ``add_node`` calls — the advisory would be
+        a false positive, scaling to hundreds of spurious warnings per process
+        for correct decorator use (issue #1071 Gap B). Genuine consumer
+        instance-API misuse never sets ``_internal`` and still warns.
+        """
         import warnings
 
         # Generate ID if not provided
         if node_id is None:
             node_id = f"node_{uuid.uuid4().hex[:8]}"
 
-        warnings.warn(
-            f"Instance-based API usage detected. Consider using preferred pattern:\n"
-            f"  CURRENT: add_node(<instance>, '{node_id}')\n"
-            f"  PREFERRED: add_node('{node_instance.__class__.__name__}', '{node_id}', {{'param': value}})",
-            UserWarning,
-            stacklevel=3,
-        )
+        if not _internal:
+            warnings.warn(
+                f"Instance-based API usage detected. Consider using preferred pattern:\n"
+                f"  CURRENT: add_node(<instance>, '{node_id}')\n"
+                f"  PREFERRED: add_node('{node_instance.__class__.__name__}', '{node_id}', {{'param': value}})",
+                UserWarning,
+                stacklevel=3,
+            )
 
         # Store the instance
         self.nodes[node_id] = {
@@ -491,7 +504,12 @@ class WorkflowBuilder:
 
         return False
 
-    def add_node_instance(self, node_instance: Any, node_id: str | None = None) -> str:
+    def add_node_instance(
+        self,
+        node_instance: Any,
+        node_id: str | None = None,
+        _internal: bool = False,
+    ) -> str:
         """
         Add a node instance to the workflow.
 
@@ -500,6 +518,10 @@ class WorkflowBuilder:
         Args:
             node_instance: Pre-configured node instance
             node_id: Unique identifier for this node (auto-generated if not provided)
+            _internal: Internal flag — when True, suppresses the consumer-facing
+                instance-API advisory. Set ONLY by SDK-internal registration
+                paths (e.g. Nexus ``@app.handler()``); consumer code MUST NOT
+                pass this. Genuine consumer instance-API usage still warns.
 
         Returns:
             Node ID
@@ -507,7 +529,7 @@ class WorkflowBuilder:
         Raises:
             WorkflowValidationError: If node_id is already used or instance is invalid
         """
-        return self._add_node_instance(node_instance, node_id)
+        return self._add_node_instance(node_instance, node_id, _internal=_internal)
 
     def add_node_type(
         self,


### PR DESCRIPTION
## Summary

Fixes two API-discipline gaps reported in #1071 on the latest published releases.

**Gap A — `kaizen.api` hard-removed without a deprecation cycle.** `from kaizen.api import Agent` raised `ModuleNotFoundError` on every consumer upgrade. Restored as a PEP 562 `__getattr__` shim that re-exports the 15 historical symbols, each emitting `DeprecationWarning` naming the new import path. CHANGELOG migration table documents every renamed symbol. Per `zero-tolerance.md` Rule 6a (Remove Fully).

**Gap B — `@app.handler()` emitted the SDK's own instance-API advisory.** The decorator's internal `make_handler_workflow` builds the workflow via `WorkflowBuilder.add_node_instance(...)`, which warned the consumer about instance-API misuse — once per registered handler, hundreds per process for correct decorator use. Root-cause fix: threaded a keyword-only `_internal=True` flag from the decorator-internal registration; consumer instance-API misuse never sets it and STILL warns.

**Security-reviewer surfaced fix-immediately item (commit `cfc731b75`):** made `_internal` keyword-only (after `*`) on both `_add_node_instance` and `add_node_instance`. Without this, a misguided caller could write `builder.add_node_instance(node, "id", True)` and suppress the warning positionally. The underscore prefix is convention; the `*` is structural Python-signature enforcement. Regression test asserts `TypeError` on the positional form.

## Test plan

- [x] `from kaizen.api import Agent` resolves via shim emitting `DeprecationWarning` naming `from kaizen import Agent`
- [x] CHANGELOG documents the `kaizen.api` → `kaizen` migration with full symbol table
- [x] `@app.handler()` registration emits zero `Instance-based API usage detected` warnings
- [x] Genuine consumer `add_node_instance(<instance>, "id")` (without `_internal`) STILL warns
- [x] Positional `add_node_instance(node, "id", True)` raises `TypeError` (keyword-only enforcement)
- [x] Tier-2 regression tests in `packages/kailash-kaizen/tests/regression/` + `packages/kailash-nexus/tests/regression/`, no mocking, **24 passed**
- [x] 318 existing nexus/kaizen/builder/handler tests pass, no regressions
- [x] Pre-commit (Black, isort, Ruff, type-annotations, debug-statements, eval-usage, doc-style, Tier-1 unit tests) — **all gates pass** on the changed files
- [x] Code review (reviewer) — APPROVE-WITH-FIXES, all optional fixes addressed
- [x] Security review (security-reviewer) — APPROVE pending branch-read; verified inline (PEP 562 closed allow-list, no eval/exec, `_internal` keyword-only with safe default, only one call site sets True)

## Related issues

Fixes #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)