### PR TITLE
release: kailash 2.22.0 + kailash-kaizen 2.21.1 (Wave B: #1054 #1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.22.0] - 2026-05-18
+
+### Added
+
+- **`kailash.EventBus` domain-event primitive with pluggable backends (#1054)** — new public surface for in-process and broker-backed event publication. Exports: `EventBus`, `Subscription`, `DomainEvent`, `EventPublishNode`. Backends: `InMemoryEventBackend` (default, zero external dep) and `RedisStreamsEventBackend` (behind the existing `[redis]` optional extra). Backend selectable via constructor `backend=` arg or `KAILASH_EVENTBUS_BACKEND` env var (closed-list lookup, no arbitrary-import vector). `publish` + `subscribe` API supports `correlation_id` for trace propagation (auto-generated via `uuid.uuid4()` when omitted, round-trips to subscriber). `EventPublishNode` integrates publication into `WorkflowBuilder` steps. Type stub (`.pyi`) + `py.typed` marker shipped. Tier-2 round-trip suite at `tests/integration/events/test_eventbus_wiring.py` (16 passed + 1 documented xfail for live Redis). Fixes #1054.
+
+### Fixed
+
+- **`@app.handler()` decorator no longer emits the SDK's own instance-API advisory (#1071 Gap B)** — the decorator's internal `make_handler_workflow` registers via `WorkflowBuilder.add_node_instance`, which historically warned the consumer about instance-API misuse — once per registered handler, scaling to hundreds of spurious `UserWarning`s per process for correct decorator use. Added keyword-only `_internal: bool = False` flag to `_add_node_instance` and `add_node_instance`; `make_handler_workflow` passes `_internal=True`. Genuine consumer instance-API misuse never sets the flag and still warns. `_internal` is keyword-only (after `*`) so a positional `True` cannot accidentally suppress the warning. Fixes #1071 Gap B.
+
 ## [2.21.3] - 2026-05-18
 
 ### Fixed

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.21.1] — 2026-05-18 — restore `kaizen.api` deprecation shim (#1071)
+
 ### Fixed
 
 - **`kaizen.api` restored as a deprecation shim (#1071)** — the structural-split refactor (#75) relocated the unified Agent API from `kaizen.api` to `kaizen_agents.api` and removed `kaizen.api` outright with no deprecation cycle. `from kaizen.api import Agent` raised `ModuleNotFoundError` on every published release — a hard break for every downstream caller on first `pip install --upgrade`. `kaizen.api` is now restored as a PEP 562 deprecation shim: every public symbol that historically lived under `kaizen.api` resolves through it and emits a `DeprecationWarning` naming the new import path on attribute access. The shim will be removed in a future major release.

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.21.0"
+version = "2.21.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.21.0"
+__version__ = "2.21.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.21.3"
+version = "2.22.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -19,12 +19,18 @@ from kailash.workflow.builder import WorkflowBuilder
 # Import key components for easier access
 from kailash.workflow.graph import Connection, NodeInstance, Workflow
 
-# Eagerly register the EventBus workflow node. Imported here — AFTER the
-# runtime + WorkflowBuilder chain is fully initialized — to avoid the
-# circular import that occurs if it loads during kailash.nodes.__init__
-# (the node imports base_async -> runtime -> nodes.base_async). This
-# guarantees EventPublishNode resolves via NodeRegistry.get() on plain
-# `import kailash` for every install profile (issue #1054).
+# isort: split
+# Eagerly register the EventBus workflow node. MUST be imported AFTER the
+# runtime chain above so kailash.runtime.async_local -> kailash.nodes.base_async
+# is fully loaded first. Otherwise:
+#   EventPublishNode -> AsyncNode -> kailash.runtime.template_resolver
+#   -> kailash.runtime.__init__ -> async_local -> AsyncNode
+# triggers a partially-initialized-module ImportError on plain `import kailash`.
+# The `# isort: split` directive above is load-bearing: it tells isort to treat
+# this import as a separate sort block so the alphabetical-order pass does
+# NOT reorder it back before `runtime.local` (which would re-introduce the
+# circular import). Verified by `import kailash` + pre-commit Tier-1
+# collection (issue #1054).
 from kailash.nodes.events import EventPublishNode  # noqa: E402,F401
 
 

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -89,7 +89,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.21.3"
+__version__ = "2.22.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Wave B coordinated release — kailash 2.21.3 → **2.22.0** (minor: new EventBus public surface) + kailash-kaizen 2.21.0 → **2.21.1** (patch: restores kaizen.api deprecation shim). No sibling drift to sweep (all 8 BUILD-repo packages at PyPI parity before bump).

### Included PRs (already merged to main)
- **#1077** → Fixes #1071 (kaizen.api PEP 562 shim + @app.handler instance-API warning suppression + keyword-only `_internal` security fix)
- **#1078** → Fixes #1054 (kailash.EventBus + InMemory/RedisStreams backends + EventPublishNode WorkflowBuilder integration)

### Release-prep diff (metadata + CHANGELOG)
- `pyproject.toml` + `src/kailash/__init__.py` → kailash 2.22.0
- `packages/kailash-kaizen/pyproject.toml` + `packages/kailash-kaizen/src/kaizen/__init__.py` → kailash-kaizen 2.21.1
- `CHANGELOG.md` → 2.22.0 entry promoted with EventBus (Added) + @app.handler (Fixed) sections
- `packages/kailash-kaizen/CHANGELOG.md` → 2.21.1 entry promoted with kaizen.api migration table

### Additional fix in this branch (release-prep CI parity catch)
- **Circular import in `src/kailash/__init__.py`** (commit `d9d9a597c`) — the eager `EventPublishNode` registration introduced by #1054 triggered `EventPublishNode → AsyncNode → runtime → async_local → AsyncNode` on plain `import kailash`. Fix: reorder so `LocalRuntime`/`WorkflowBuilder` imports load the runtime chain first, and add `# isort: split` so isort does NOT revert the order on next pre-commit run. Caught at the release-prep pre-commit gate (`git.md` § Pre-FIRST-Push CI Parity); without it every clean-venv install of 2.22.0 would have `ImportError`'d — exactly the failure class `build-repo-release-discipline.md` Rule 2 prevents.

## Test plan

- [x] Pre-commit (Black, isort, Ruff, type-annotations, debug-statements, eval-usage, doc-style, **Tier-1 unit tests**) — green on all 7 changed files
- [x] `import kailash` resolves cleanly from clean Python interpreter; `from kailash import EventBus, EventPublishNode` works
- [x] Version anchors consistent: `pyproject.toml::version` == `__init__.py::__version__` (both packages, atomic per `zero-tolerance.md` Rule 5)
- [x] Sibling-drift enumeration before bump: all 8 packages at PyPI parity, no other releases needed
- [x] CI matrix runs (auto-skipped per `release/v*` branch convention in `git.md`, only release-prep gates apply)

## Release sequence (post-merge)

1. Admin-merge this PR
2. TestPyPI validation for kailash 2.22.0 (minor — `deployment.md` requires; kaizen 2.21.1 patch exempt with user approval)
3. Tag pushes **individually** per `ci-runners.md` Rule 8:
   - `git tag v2.22.0 && git push origin v2.22.0`
   - `sleep 1`
   - `git tag kaizen-v2.21.1 && git push origin kaizen-v2.21.1`
4. Watch `publish-pypi.yml` runs for both packages
5. Clean-venv verify both installs + import the new surface
6. Close #1071 + #1054 with merge SHA refs

## Related issues

Releases code for #1054 and #1071 (both merged via #1077 + #1078).

🤖 Generated with [Claude Code](https://claude.com/claude-code)