### PR TITLE
fix(dataflow): wire write-protection into TransactionScope.execute_raw (#1083 follow-up)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/protection.py
+++ b/packages/kailash-dataflow/src/dataflow/core/protection.py
@@ -5,6 +5,7 @@ Comprehensive write protection that integrates with Core SDK workflow execution.
 Provides multi-level protection: Global, Connection, Model, Operation, Field, and Runtime.
 """
 
+import hashlib
 import logging
 import re
 from abc import ABC, abstractmethod
@@ -212,7 +213,18 @@ class ProtectionAuditor:
     def log_violation(
         self, violation: ProtectionViolation, context: Optional[Dict[str, Any]] = None
     ):
-        """Log a protection violation."""
+        """Log a protection violation.
+
+        Per `rules/observability.md` Rule 8: schema-revealing field names
+        (model + field) bleed to log aggregators when emitted at WARN
+        because aggregators (Datadog/Splunk/CloudWatch) typically have a
+        wider audience than the production database — operators see
+        ``users.ssn`` schema even though VALUES never leak. The structured
+        WARN line therefore emits an 8-char sha256 fingerprint of
+        ``model.field`` instead of the raw names; the in-memory
+        ``events`` dict (process-local audit trail, not shipped to the
+        aggregator) keeps the raw value for forensic queries.
+        """
         event = {
             "timestamp": violation.timestamp,
             "message": str(violation),
@@ -224,7 +236,20 @@ class ProtectionAuditor:
             "context": context or {},
         }
         self.events.append(event)
-        logger.warning("protection.protection_violation", extra={"event": event})
+        # Compose a stable 8-char fingerprint of the schema identifier so
+        # the WARN line is grep-correlatable across events without
+        # exposing the raw schema name (observability.md Rule 8).
+        schema_identifier = f"{violation.model or ''}.{violation.field or ''}"
+        schema_hash = hashlib.sha256(schema_identifier.encode("utf-8")).hexdigest()[:8]
+        logger.warning(
+            "protection.protection_violation",
+            extra={
+                "operation": violation.operation.value,
+                "level": violation.level.value,
+                "schema_hash": schema_hash,
+                "connection": violation.connection,
+            },
+        )
 
     def log_allowed(
         self,

--- a/packages/kailash-dataflow/src/dataflow/features/transactions.py
+++ b/packages/kailash-dataflow/src/dataflow/features/transactions.py
@@ -38,6 +38,101 @@ _active_transaction: ContextVar[Optional[Any]] = ContextVar(
 _savepoint_depth: ContextVar[int] = ContextVar("_savepoint_depth", default=0)
 
 
+def _classify_raw_sql_operation(sql: str) -> str:
+    """Classify raw SQL into a `WriteProtectionEngine.check_operation` name.
+
+    Closes the same-bug-class gap surfaced by /redteam against the #1050
+    chain: `TransactionScope.execute_raw` and `SyncTransactionScope.
+    execute_raw` were the only DataFlow write surfaces not routed through
+    `check_operation` (spec invariant I1). Without this classifier a
+    caller with `read_only_mode=True` could `DELETE FROM users` through
+    `async with db.transactions.begin()`.
+
+    The classifier reads the leading SQL keyword and maps to an existing
+    operation name so the protection engine's `_operation_mapping` decides
+    BLOCK / AUDIT / WARN per its existing semantics (no new enum needed).
+
+    Mapping:
+    - `SELECT` / `WITH` / `SHOW` / `EXPLAIN` → "read" (READ tier — always
+      allowed under read_only_global / production_safe).
+    - `INSERT` → "create"; `UPDATE` → "update"; `DELETE` → "delete";
+      `UPSERT` (PostgreSQL `INSERT ... ON CONFLICT` is technically INSERT,
+      caught above) → "upsert".
+    - DDL (`CREATE` / `DROP` / `ALTER` / `TRUNCATE`) → falls through to
+      `custom_query` which the engine maps to `OperationType.CUSTOM_QUERY`
+      and BLOCKS under read_only_global / production_safe defaults.
+    - Anything unrecognized → "custom_query" (fail-closed in protected mode).
+    """
+    stripped = sql.lstrip()
+    if not stripped:
+        return "custom_query"
+    head = stripped[:8].upper().split()[0] if stripped else ""
+    if head in ("SELECT", "WITH", "SHOW", "EXPLAIN", "VALUES", "TABLE"):
+        return "read"
+    if head == "INSERT":
+        return "create"
+    if head == "UPDATE":
+        return "update"
+    if head == "DELETE":
+        return "delete"
+    if head == "UPSERT":  # MySQL UPSERT keyword if exposed
+        return "upsert"
+    # DDL + everything else falls through to CUSTOM_QUERY (engine BLOCKS
+    # under read_only_global / production_safe by default).
+    return "custom_query"
+
+
+async def _execute_raw_with_protection(
+    sql: str,
+    params: Optional[List[Any]],
+    *,
+    dataflow_instance: Optional[Any],
+    conn: Any,
+) -> Any:
+    """Run protection check then dispatch raw SQL on the pinned connection.
+
+    Single helper used by both `TransactionScope.execute_raw` (async) and
+    `SyncTransactionScope.execute_raw` (sync, via the BG loop). Pulls the
+    protection engine off the DataFlow instance the same way Express does
+    (`packages/kailash-dataflow/src/dataflow/features/express.py::
+    DataFlowExpress._check_protection_if_enabled`); on a non-protected
+    DataFlow the check is a no-op.
+    """
+    if dataflow_instance is not None:
+        protection_engine = getattr(dataflow_instance, "_protection_engine", None)
+        if protection_engine is not None:
+            connection_string = getattr(dataflow_instance, "database_url", None)
+            operation = _classify_raw_sql_operation(sql)
+            # context mirrors DataFlowExpress._check_protection_if_enabled —
+            # auditor accepts missing keys.
+            protection_engine.check_operation(
+                operation=operation,
+                model_name=None,
+                connection_string=connection_string,
+                context={"surface": "transactions.execute_raw"},
+            )
+    # asyncpg: connection.fetch / .execute take *params positional.
+    # aiosqlite: connection.execute takes a single tuple/list arg.
+    # Dispatch by connection type to bind correctly. asyncpg connections
+    # have a `fetch` method; aiosqlite connections do not.
+    is_asyncpg = hasattr(conn, "fetch") and hasattr(conn, "fetchrow")
+    sql_stripped = sql.lstrip()
+    is_select = (
+        sql_stripped[:6].upper() == "SELECT" or sql_stripped[:4].upper() == "WITH"
+    )
+    if is_asyncpg:
+        if params is None:
+            if is_select:
+                return await conn.fetch(sql)
+            return await conn.execute(sql)
+        if is_select:
+            return await conn.fetch(sql, *params)
+        return await conn.execute(sql, *params)
+    if params is None:
+        return await conn.execute(sql)
+    return await conn.execute(sql, params)
+
+
 class TransactionScope:
     """The yielded scope inside an ``async with db.transactions.begin()`` block.
 
@@ -56,7 +151,14 @@ class TransactionScope:
     (``txn["id"]``) — ``__getitem__`` maps the canonical attributes through.
     """
 
-    __slots__ = ("id", "isolation_level", "status", "type", "depth")
+    __slots__ = (
+        "id",
+        "isolation_level",
+        "status",
+        "type",
+        "depth",
+        "_dataflow_instance",
+    )
 
     def __init__(
         self,
@@ -66,12 +168,16 @@ class TransactionScope:
         status: str = "active",
         type: str = "transaction",
         depth: Optional[int] = None,
+        dataflow_instance: Optional[Any] = None,
     ) -> None:
         self.id = id
         self.isolation_level = isolation_level
         self.status = status
         self.type = type
         self.depth = depth
+        # Held so execute_raw can route through _protection_engine the same
+        # way DataFlowExpress does. See _execute_raw_with_protection.
+        self._dataflow_instance = dataflow_instance
 
     def __getitem__(self, key: str) -> Any:
         """Backward-compat dict-style access.
@@ -150,6 +256,12 @@ class TransactionScope:
         Raises:
             RuntimeError: When called outside the ``async with`` body —
                 the pinned connection only exists while the scope is active.
+            ProtectionViolation: When the DataFlow instance has write
+                protection enabled and the SQL is classified as a write
+                under the current protection level (spec invariant I1 —
+                single-check discipline extended to the raw-SQL surface,
+                closes the same-bug-class gap surfaced post-#1050 by the
+                multi-agent /redteam against the closure of #1083).
         """
         conn = _active_transaction.get()
         if conn is None:
@@ -159,31 +271,12 @@ class TransactionScope:
                 "`async with db.transactions.begin()` scope. "
                 "The pinned connection is only valid while the scope is active."
             )
-
-        # asyncpg: connection.fetch / .execute take *params positional.
-        # aiosqlite: connection.execute takes a single tuple/list arg.
-        # Dispatch by connection type to bind correctly. asyncpg connections
-        # have a `fetch` method; aiosqlite connections do not.
-        is_asyncpg = hasattr(conn, "fetch") and hasattr(conn, "fetchrow")
-
-        sql_stripped = sql.lstrip()
-        is_select = (
-            sql_stripped[:6].upper() == "SELECT" or sql_stripped[:4].upper() == "WITH"
+        return await _execute_raw_with_protection(
+            sql,
+            params,
+            dataflow_instance=self._dataflow_instance,
+            conn=conn,
         )
-
-        if is_asyncpg:
-            if params is None:
-                if is_select:
-                    return await conn.fetch(sql)
-                return await conn.execute(sql)
-            # asyncpg: positional unpacking
-            if is_select:
-                return await conn.fetch(sql, *params)
-            return await conn.execute(sql, *params)
-        # aiosqlite-style: single tuple param
-        if params is None:
-            return await conn.execute(sql)
-        return await conn.execute(sql, params)
 
 
 class TransactionManager:
@@ -308,6 +401,7 @@ class TransactionManager:
                 isolation_level=isolation_level,
                 status="active",
                 type="transaction",
+                dataflow_instance=self.dataflow,
             )
 
             yield scope
@@ -369,6 +463,7 @@ class TransactionManager:
                 status="active",
                 type="savepoint",
                 depth=depth,
+                dataflow_instance=self.dataflow,
             )
 
             yield scope
@@ -573,6 +668,7 @@ class SyncTransactionScope:
         "_status",
         "_type",
         "_depth",
+        "_dataflow_instance",
     )
 
     def __init__(
@@ -585,6 +681,7 @@ class SyncTransactionScope:
         status: str = "active",
         type: str = "transaction",
         depth: Optional[int] = None,
+        dataflow_instance: Optional[Any] = None,
     ) -> None:
         # ``conn`` is the pinned asyncpg/aiosqlite connection (NOT a pool)
         # bound to the manager's BG event loop. Set to ``_SCOPE_INACTIVE``
@@ -599,6 +696,9 @@ class SyncTransactionScope:
         self._status = status
         self._type = type
         self._depth = depth
+        # Held so execute_raw can route through _protection_engine the same
+        # way the async scope does. See _execute_raw_with_protection.
+        self._dataflow_instance = dataflow_instance
 
     # --- Metadata mirror of the async scope (read-only attribute proxies) ---
 
@@ -649,9 +749,22 @@ class SyncTransactionScope:
             rows (use ``dict(row)`` to materialize). For
             INSERT/UPDATE/DELETE on asyncpg: the command-tag string. For
             aiosqlite: the cursor object after ``execute()``.
+
+        Raises:
+            ProtectionViolation: When the DataFlow instance has write
+                protection enabled and the SQL is classified as a write
+                under the current protection level — same routing as
+                :meth:`TransactionScope.execute_raw`.
         """
         conn = self._guarded_conn()
-        return self._run_sync(_execute_raw_on_conn(conn, sql, params))
+        return self._run_sync(
+            _execute_raw_with_protection(
+                sql,
+                params,
+                dataflow_instance=self._dataflow_instance,
+                conn=conn,
+            )
+        )
 
     # --- Internal: typed guard for out-of-scope access ---
 
@@ -681,10 +794,11 @@ async def _execute_raw_on_conn(
 ) -> Any:
     """Execute a raw SQL statement on an asyncpg/aiosqlite connection.
 
-    Mirrors :meth:`TransactionScope.execute_raw`'s connection-type
-    dispatch — asyncpg takes positional ``*params``, aiosqlite takes a
-    single tuple/list. SELECT vs INSERT/UPDATE/DELETE chooses
-    ``fetch`` vs ``execute`` for asyncpg.
+    Connection-type dispatch only — does NOT route through the protection
+    engine. Prefer :func:`_execute_raw_with_protection` from the
+    `TransactionScope` / `SyncTransactionScope` entry points; this helper
+    remains for callers that have already done the protection check OR
+    are operating on a non-DataFlow-owned connection.
     """
     is_asyncpg = hasattr(conn, "fetch") and hasattr(conn, "fetchrow")
     sql_stripped = sql.lstrip()
@@ -902,6 +1016,7 @@ class SyncTransactionManager:
             isolation_level=isolation_level,
             status="active",
             type="transaction",
+            dataflow_instance=self._transactions.dataflow,
         )
 
         try:

--- a/packages/kailash-dataflow/tests/integration/test_issue_1083_followup_transactions_execute_raw_protection.py
+++ b/packages/kailash-dataflow/tests/integration/test_issue_1083_followup_transactions_execute_raw_protection.py
@@ -1,0 +1,254 @@
+"""Issue #1083 follow-up — `TransactionScope.execute_raw` write-protection
+enforcement (same-bug-class with #1050/#1058).
+
+Surfaced 2026-05-18 by the multi-agent /redteam Round 2 against the
+#1083 closure. R2 (pact-specialist pentest axis) found that
+`TransactionScope.execute_raw(sql, params)` was the 4th DataFlow write
+surface NOT routed through `WriteProtectionEngine.check_operation`
+(spec invariant I1). Without this fix a caller with `read_only_mode=True`
+could `DELETE FROM users WHERE id = $1` through
+`async with db.transactions.begin() as tx: await tx.execute_raw(...)`.
+
+The fix wires `TransactionScope.execute_raw` (async) and
+`SyncTransactionScope.execute_raw` (sync) through a shared helper
+`_execute_raw_with_protection` that classifies the raw SQL by leading
+keyword and calls `check_operation` BEFORE dispatching to the
+underlying connection. SELECT/WITH/SHOW/EXPLAIN route as "read"
+(always allowed under read-only); INSERT/UPDATE/DELETE/UPSERT route
+to their existing OperationType values; DDL falls through to
+CUSTOM_QUERY (BLOCKED under read_only_global / production_safe).
+
+Invariant pinned: every DataFlow mutation surface that takes raw SQL
+MUST route through `check_operation` before touching the connection
+(spec invariant I1 extended to the transactions surface).
+
+Tier-2 infrastructure (NO mocking — `rules/testing.md` § Tier 2):
+file-backed SQLite via `tempfile.mkdtemp()` + `sqlite:///<tmp>/test.db`
+per the migration-pool handshake constraint at
+`packages/kailash-dataflow/tests/CLAUDE.md`. The transactions surface
+is dialect-agnostic; SQLite alone proves the check fires before the
+underlying connection executes (the same fix code path runs on asyncpg).
+
+State-persistence verification: reads ARE allowed under read-only
+(spec invariant I7), so a read-back AFTER the block + AFTER releasing
+the transaction-scope confirms the row's pre-block value survived.
+"""
+
+import socket
+import tempfile
+from typing import Iterator
+
+import pytest
+
+from dataflow.core.protected_engine import ProtectedDataFlow
+from dataflow.core.protection import ProtectionViolation
+
+# PostgreSQL test infra — shared SDK Docker on port 5434 per
+# `packages/kailash-dataflow/tests/CLAUDE.md`. Async TransactionManager
+# requires asyncpg-backed connection_pool; SQLite is not supported on
+# that surface today, so async tests SKIP cleanly when PG is unreachable
+# (mirrors the dialect-skip pattern in test_issue_1050_*.py). Sync tests
+# use SyncTransactionManager which DOES own aiosqlite lifecycle and
+# runs against file-SQLite without PG.
+PG_URL = "postgresql://test_user:test_password@localhost:5434/kailash_test"
+
+
+def _pg_reachable() -> bool:
+    """Probe the shared SDK Docker PostgreSQL on port 5434."""
+    try:
+        with socket.create_connection(("localhost", 5434), timeout=1):
+            return True
+    except (OSError, socket.timeout):
+        return False
+
+
+_pg_available = _pg_reachable()
+
+
+@pytest.fixture
+def sqlite_url() -> Iterator[str]:
+    """file-backed SQLite URL — bare ``:memory:`` breaks DataFlow's
+    multi-connection migration handshake; see
+    ``packages/kailash-dataflow/tests/CLAUDE.md``.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="issue1083_followup_txn_raw_")
+    yield f"sqlite:///{tmpdir}/test.db"
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(30)
+@pytest.mark.skipif(
+    not _pg_available,
+    reason="async TransactionManager requires asyncpg pool; PG on port 5434 unreachable",
+)
+class TestTransactionsExecuteRawProtection:
+    """Issue #1083 follow-up — TransactionScope.execute_raw enforcement.
+
+    PG-only because async TransactionManager has no SQLite path today;
+    SyncTransactionManager (below) covers the same fix on aiosqlite.
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_execute_raw_blocks_delete_under_read_only(self):
+        """`tx.execute_raw("DELETE FROM ...")` MUST raise ProtectionViolation
+        under read-only AND the row MUST survive the block.
+        """
+        db = ProtectedDataFlow(database_url=PG_URL, enable_protection=True)
+
+        @db.model  # noqa: B903
+        class _DocAsync:
+            id: str
+            title: str
+
+        try:
+            await db.initialize()
+
+            seed = await db.express.create(
+                "_DocAsync", {"id": "seed-1", "title": "original"}
+            )
+            assert seed["id"] == "seed-1"
+
+            db.enable_read_only_mode("issue #1083 follow-up txn raw delete")
+
+            # The bypass surface: raw DELETE through transactions.
+            with pytest.raises(ProtectionViolation):
+                async with db.transactions.begin() as tx:
+                    await tx.execute_raw(
+                        "DELETE FROM _docasync WHERE id = ?", ["seed-1"]
+                    )
+
+            # READ is allowed under read-only (spec invariant I7) —
+            # read-back confirms the row survived the block.
+            row = await db.express.read("_DocAsync", "seed-1")
+            assert row is not None
+            assert row["title"] == "original"
+        finally:
+            await db.close_async()
+
+    @pytest.mark.asyncio
+    async def test_async_execute_raw_blocks_update_under_read_only(self):
+        """`tx.execute_raw("UPDATE ...")` MUST raise ProtectionViolation
+        under read-only AND the original value MUST survive.
+        """
+        db = ProtectedDataFlow(database_url=PG_URL, enable_protection=True)
+
+        @db.model  # noqa: B903
+        class _DocUpd:
+            id: str
+            title: str
+
+        try:
+            await db.initialize()
+            await db.express.create("_DocUpd", {"id": "seed-1", "title": "original"})
+
+            db.enable_read_only_mode("issue #1083 follow-up txn raw update")
+
+            with pytest.raises(ProtectionViolation):
+                async with db.transactions.begin() as tx:
+                    await tx.execute_raw(
+                        "UPDATE _docupd SET title = ? WHERE id = ?",
+                        ["MUTATED", "seed-1"],
+                    )
+
+            row = await db.express.read("_DocUpd", "seed-1")
+            assert row is not None
+            assert row["title"] == "original"
+        finally:
+            await db.close_async()
+
+    @pytest.mark.asyncio
+    async def test_async_execute_raw_allows_select_under_read_only(self):
+        """SELECT through `tx.execute_raw(...)` MUST be allowed under
+        read-only — the classifier maps SELECT to "read" which
+        WriteProtectionEngine permits (spec invariant I7).
+        """
+        db = ProtectedDataFlow(database_url=PG_URL, enable_protection=True)
+
+        @db.model  # noqa: B903
+        class _DocRead:
+            id: str
+            title: str
+
+        try:
+            await db.initialize()
+            await db.express.create("_DocRead", {"id": "seed-1", "title": "original"})
+
+            db.enable_read_only_mode("issue #1083 follow-up txn raw select")
+
+            # MUST NOT raise — proves SELECT routes through the
+            # classifier as "read" and not as a write.
+            async with db.transactions.begin() as tx:
+                rows = await tx.execute_raw(
+                    "SELECT id, title FROM _docread WHERE id = ?", ["seed-1"]
+                )
+            assert rows is not None
+        finally:
+            await db.close_async()
+
+    @pytest.mark.asyncio
+    async def test_async_execute_raw_works_when_protection_disabled(self):
+        """Sanity — the new protection wiring does NOT regress the
+        un-protected DataFlow path. Construction with
+        ``enable_protection=False`` lets every raw SQL through.
+        """
+        db = ProtectedDataFlow(database_url=PG_URL, enable_protection=False)
+
+        @db.model  # noqa: B903
+        class _DocOff:
+            id: str
+            title: str
+
+        try:
+            await db.initialize()
+            await db.express.create("_DocOff", {"id": "seed-1", "title": "original"})
+
+            async with db.transactions.begin() as tx:
+                await tx.execute_raw(
+                    "UPDATE _docoff SET title = ? WHERE id = ?",
+                    ["MUTATED", "seed-1"],
+                )
+
+            row = await db.express.read("_DocOff", "seed-1")
+            assert row is not None
+            assert row["title"] == "MUTATED"
+        finally:
+            await db.close_async()
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(30)
+class TestSyncTransactionsExecuteRawProtection:
+    """Issue #1083 follow-up — SyncTransactionScope.execute_raw enforcement.
+
+    Sync surface mirrors the async surface; the same
+    `_execute_raw_with_protection` helper enforces the contract via the
+    BG-loop event submitter.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sync_execute_raw_blocks_delete_under_read_only(self, sqlite_url):
+        """`tx.execute_raw("DELETE FROM ...")` through the sync scope MUST
+        raise ProtectionViolation under read-only.
+        """
+        db = ProtectedDataFlow(database_url=sqlite_url, enable_protection=True)
+
+        @db.model  # noqa: B903
+        class _DocSync:
+            id: str
+            title: str
+
+        try:
+            await db.initialize()
+            await db.express.create("_DocSync", {"id": "seed-1", "title": "original"})
+
+            db.enable_read_only_mode("issue #1083 follow-up txn raw sync delete")
+
+            with pytest.raises(ProtectionViolation):
+                with db.transactions_sync.begin() as tx:
+                    tx.execute_raw("DELETE FROM _docsync WHERE id = ?", ["seed-1"])
+
+            row = await db.express.read("_DocSync", "seed-1")
+            assert row is not None
+            assert row["title"] == "original"
+        finally:
+            await db.close_async()

--- a/specs/_index.md
+++ b/specs/_index.md
@@ -13,12 +13,13 @@ Domain truth for the Kailash platform. Each file is authoritative for its domain
 
 ## DataFlow
 
-| File                                       | Description                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------------ |
-| [dataflow-core.md](dataflow-core.md)       | DataFlow class, constructor, configuration, connection URL, engine, exceptions |
-| [dataflow-express.md](dataflow-express.md) | Express API (create/read/update/delete/list/count/bulk), Express Sync          |
-| [dataflow-models.md](dataflow-models.md)   | @db.model, field types, validation, classification, multi-tenant               |
-| [dataflow-cache.md](dataflow-cache.md)     | Cache layer, dialect, record ID coercion, transactions, pooling                |
+| File                                             | Description                                                                                                                                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [dataflow-core.md](dataflow-core.md)             | DataFlow class, constructor, configuration, connection URL, engine, exceptions                                                                         |
+| [dataflow-express.md](dataflow-express.md)       | Express API (create/read/update/delete/list/count/bulk), Express Sync                                                                                  |
+| [dataflow-models.md](dataflow-models.md)         | @db.model, field types, validation, classification, multi-tenant                                                                                       |
+| [dataflow-cache.md](dataflow-cache.md)           | Cache layer, dialect, record ID coercion, transactions, pooling                                                                                        |
+| [dataflow-protection.md](dataflow-protection.md) | ProtectedDataFlow write-protection invariants I1-I9, OperationType enum, check_operation routing, async-hot-path wiring (#1050/#1058 closure baseline) |
 
 ## Nexus
 


### PR DESCRIPTION
## Summary

`/redteam`-to-convergence against the #1083/#1084/#1085 closures surfaced a **HIGH** protection bypass: `TransactionScope.execute_raw` (async + sync) was the 4th DataFlow write surface NOT routed through `WriteProtectionEngine.check_operation` (spec invariant I1, `specs/dataflow-protection.md`). A caller with `read_only_mode=True` could mutate state via `async with db.transactions.begin() as tx: await tx.execute_raw("DELETE FROM ...")`. Same-bug-class with the #1050/#1058 chain just verified-closed; fixed in-cycle per `autonomous-execution.md` MUST-4.

## Changes

- **HIGH** — `transactions.py`: new `_classify_raw_sql_operation` + `_execute_raw_with_protection` helpers classify raw SQL by leading keyword (SELECT/WITH/SHOW/EXPLAIN → read; INSERT/UPDATE/DELETE/UPSERT → existing `OperationType`; DDL/unknown → `custom_query`, fail-closed) and call `check_operation` BEFORE connection dispatch. `dataflow_instance` plumbed to `TransactionScope` + `SyncTransactionScope` via `TransactionManager.begin` / `_savepoint` / `SyncTransactionManager.begin`.
- **Regression** — `tests/integration/test_issue_1083_followup_transactions_execute_raw_protection.py`: 5 tests (sync surface verified locally; async PG-only, skip-when-unavailable).
- Bundled same-shard (one /redteam-convergence cycle):
  - `protection.py`: `auditor.log_violation` WARN payload now emits an 8-char sha256 fingerprint of `model.field` instead of raw schema names (`observability.md` Rule 8); raw values stay process-local in the audit `events` dict.
  - `specs/_index.md`: add `dataflow-protection.md` row (`specs-authority.md` Rule 1 — spec was authoritative for I1-I9 but absent from the index).

## Test plan

- [x] Sync `execute_raw` blocks DELETE under read-only (passes locally, file-SQLite)
- [x] No regression: #1050 mutation matrix (8 surfaces) + workflow-runtime test still pass (file-sqlite)
- [ ] Async `execute_raw` blocks (4 tests, PG-only — CI on port 5434)
- [x] Pre-commit: spec-drift gate, Tier-1, doc-style — all green

## Related issues

Follow-up to #1083 (closed this session via S2/S3 verification). Same-bug-class with #1050 / #1058. 3-round multi-agent /redteam convergence: R1 0C/0H, R2 1H surfaced, R3 0/0/0/0 verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)