### PR TITLE
release: kailash 2.22.1 + kailash-dataflow 2.9.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.22.1] - 2026-05-18
+
+### Fixed
+
+- **`import kailash` failed on clean-venv install of 2.22.0 (CRITICAL)** — an `EventPublishNode` circular import surfaced on every fresh `pip install kailash==2.22.0`; resolved by an isort-driven split of the import block in `src/kailash/__init__.py`. No API change. Catch-up patch for a fix that landed on `main` after the 2.22.0 release tag (`build-repo-release-discipline.md` Rule 2 — clean-venv installability is the done gate).
+
 ## [2.22.0] - 2026-05-18
 
 ### Added

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [2.9.19] — 2026-05-18 — TransactionScope.execute_raw write-protection (#1083 follow-up)
+
+### Fixed
+
+- **`TransactionScope.execute_raw` write-protection bypass (HIGH, #1083 follow-up)** — `TransactionScope.execute_raw` (async) and `SyncTransactionScope.execute_raw` (sync) were the only DataFlow write surfaces not routed through `WriteProtectionEngine.check_operation` (spec invariant I1, `specs/dataflow-protection.md`). A caller with `read_only_mode=True` could mutate state via `async with db.transactions.begin() as tx: await tx.execute_raw("DELETE FROM ...")`. New `_classify_raw_sql_operation` + `_execute_raw_with_protection` helpers classify raw SQL by leading keyword (SELECT/WITH/SHOW/EXPLAIN → read; INSERT/UPDATE/DELETE/UPSERT → existing `OperationType`; DDL/unknown → `custom_query`, fail-closed) and call `check_operation` before connection dispatch. Same-bug-class with the #1050/#1058 enforcement chain. Surfaced by multi-agent `/redteam` against the #1083 closure.
+- **`auditor.log_violation` schema-name disclosure at WARN (observability Rule 8)** — the structured WARN log now emits an 8-char sha256 fingerprint of `model.field` instead of raw schema identifiers; raw values stay process-local in the audit `events` dict.
+
 ## [2.9.18] — 2026-05-18 — sanitizer set/tuple type-confusion fix (#1047)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.18"
+version = "2.9.19"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.21.2",
+    "kailash>=2.22.1",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.18"
+__version__ = "2.9.19"
 
 __all__ = [
     "DataFlow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.22.0"
+version = "2.22.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.22.0"
+__version__ = "2.22.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Coordinated patch release closing two unreleased split-version states (`zero-tolerance.md` Rule 5) found at `/release` scope detection:

- **kailash 2.22.1** — CRITICAL. PyPI `2.22.0` fails `import kailash` on every clean-venv install (EventPublishNode circular import). Fix `d9d9a597c` landed on main after the 2.22.0 tag; this is the catch-up patch.
- **kailash-dataflow 2.9.19** — HIGH. `TransactionScope.execute_raw` write-protection bypass (#1083 follow-up, PR #1088 `ea2d9ad84`) + observability Rule 8 schema-name hashing. Unreleased since 2.9.18 tag.

dataflow `kailash>=` pin advanced 2.21.2 → 2.22.1 (framework pin resolves vs local editable kailash). All 7 other framework packages AT PyPI parity — no sibling release.

## Test plan

- [x] Version consistency: pyproject + `__version__` match for both packages
- [x] Metadata-only diff → `release/v2.22.1` auto-skips PR-gate matrix
- [x] Underlying code already CI-verified: kailash-dataflow fix via PR #1088 (full matrix green); kailash fix `d9d9a597c` on main
- [ ] Post-merge: tag `v2.22.1` + `dataflow-v2.9.19` pushed individually → publish-pypi.yml → clean-venv install verify

## Related issues

Follow-up to #1083. Catch-up release for the 2.22.0 broken-import regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)