### PR TITLE
chore(analyze): #1091 — 2.22.0 split-version incident does not reproduce

### DIFF
--- a/workspaces/issue-1091-split-version/01-analysis/01-incident-verification.md
+++ b/workspaces/issue-1091-split-version/01-analysis/01-incident-verification.md
@@ -1,0 +1,53 @@
+# Issue #1091 — Verification of the "kailash 2.22.0 PyPI≠source" Incident
+
+/ analyze, 2026-05-18. Acceptance criterion 1 of #1091: "verify the 2.22.0
+PyPI≠source incident — the `.session-notes` claim is the lead, not yet
+independently confirmed; confirm the actual mismatch before authoring the
+rule."
+
+## Verdict: the incident does NOT reproduce. No split-version mismatch exists.
+
+## Evidence (live runtime checks, not documentation)
+
+| Surface                                       | Check                                               | Result                                                             |
+| --------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------ |
+| Git tag `v2.22.0` → `src/kailash/__init__.py` | `git show v2.22.0:...`                              | `__version__ = "2.22.0"`                                           |
+| Git tag `v2.22.0` → `pyproject.toml`          | `git show v2.22.0:...`                              | `version = "2.22.0"`                                               |
+| PyPI `kailash==2.22.0` wheel — dist metadata  | `importlib.metadata.version` in clean venv          | `2.22.0`                                                           |
+| PyPI `kailash==2.22.0` — runtime import       | `import kailash; kailash.__version__` in clean venv | `'2.22.0'`                                                         |
+| `2.22.1` release commit `abaea66a3`           | `git show`                                          | bumped `__init__.py` AND `pyproject.toml` atomically in one commit |
+| `v2.22.0..v2.22.1` history                    | `git log --oneline`                                 | no version-anchor-only commit; no mid-release split state          |
+
+Every kailash version anchor for 2.22.0 and 2.22.1 — git tag, source
+`__init__.py`, `pyproject.toml`, PyPI wheel metadata, and the installed
+package's runtime `__version__` — is consistent. There is no PyPI-vs-source
+mismatch.
+
+## What 2.22.1 actually was
+
+`abaea66a3` "release: kailash 2.22.0 → 2.22.1 + kailash-dataflow 2.9.18 →
+2.9.19" was a normal patch release carrying the #1083 follow-up
+(`TransactionScope.execute_raw` write-protection, commit `ea2d9ad84`). Not a
+version-mismatch fix. The prior session's `.session-notes` "split-version
+trap LIVE" line was a lead that does not survive verification — exactly the
+contingency #1091's own acceptance criterion 1 anticipated.
+
+## Disposition (per verify-resource-existence.md MUST-3)
+
+The existence check returns NEGATIVE. The rule #1091 proposed (post-publish
+PyPI-vs-source `__version__` verification for every release) targets an
+incident that does not exist.
+
+Residual hypothetical: `deployment.md` § TestPyPI Validation runs a
+post-install `__version__` check only for TestPyPI on major/minor releases —
+production PyPI and patch releases have no post-publish version check. This
+is a defense-in-depth gap, but no incident proves it ever bit anyone, and
+`zero-tolerance.md` Rule 5 already mandates atomic version-anchor updates
+(which `abaea66a3` demonstrably honored).
+
+Authoring a new rule with a disproven Origin violates `rule-authoring.md`
+Rule 6 (Origin must cite a real motivating incident) and `spec-accuracy.md`
+(no phantom citations). Recommendation: close #1091 — motivating evidence
+disproven; existing coverage (zero-tolerance Rule 5 + the TestPyPI check)
+adequately spans the space. User gate required per `value-prioritization.md`
+MUST-4 (#1091 carries a user-directed value-anchor).

--- a/workspaces/issue-1091-split-version/journal/0001-DISCOVERY-2220-split-version-incident-does-not-reproduce.md
+++ b/workspaces/issue-1091-split-version/journal/0001-DISCOVERY-2220-split-version-incident-does-not-reproduce.md
@@ -1,0 +1,78 @@
+---
+type: DISCOVERY
+date: 2026-05-18
+created_at: 2026-05-18T00:00:00Z
+author: agent
+session_id: analyze-1091
+session_turn: 1
+project: issue-1091-split-version
+topic: The kailash 2.22.0 PyPI-vs-source split-version incident does not reproduce
+phase: analyze
+tags:
+  [
+    analyze,
+    deployment,
+    version-consistency,
+    verify-resource-existence,
+    incident-disproven,
+  ]
+---
+
+# DISCOVERY — the 2.22.0 "split-version trap" does not reproduce
+
+## What was checked
+
+Issue #1091 was filed (2026-05-18) to codify a `deployment.md` rule for
+post-publish PyPI-vs-source `__version__` verification. Its motivating
+evidence was a prior session's `.session-notes` line: "hit the split-version
+trap LIVE (kailash 2.22.0 PyPI≠source)". #1091's acceptance criterion 1
+explicitly flagged this as an unconfirmed lead.
+
+`/analyze` ran the verification (see `01-analysis/01-incident-verification.md`).
+
+## Finding
+
+Every kailash 2.22.0 / 2.22.1 version anchor is consistent:
+
+- git tag `v2.22.0` — `__init__.py` and `pyproject.toml` both `2.22.0`
+- PyPI `kailash==2.22.0` — clean-venv `import kailash; __version__` → `'2.22.0'`; dist metadata → `2.22.0`
+- `2.22.1` release commit `abaea66a3` bumped both anchors atomically
+
+There is no PyPI-vs-source mismatch. The `.session-notes` lead did not
+survive a live runtime check.
+
+## Why this is the institutional lesson
+
+This is a textbook `verify-resource-existence.md` MUST-2 case: a session-notes
+claim (operator memory) described an INTENT/recollection, not runtime state.
+The one-command live check (`pip install kailash==2.22.0` in a clean venv +
+`import`) disproved it in under a minute. The codify candidate that would
+have been authored on faith — a `deployment.md` rule with a fabricated Origin
+— was blocked by running the existence check FIRST, exactly as #1091's own
+acceptance criterion 1 mandated.
+
+## Disposition
+
+Per `verify-resource-existence.md` MUST-3 (existence check negative → default
+is delete-or-stub, not provision) and `rule-authoring.md` Rule 6 (Origin must
+cite a real incident): recommend closing #1091. The residual hypothetical
+(no post-publish check on production PyPI / patch releases) is already spanned
+by `zero-tolerance.md` Rule 5 + `deployment.md` § TestPyPI Validation. Closure
+needs a user gate per `value-prioritization.md` MUST-4 — #1091 carries a
+user-directed value-anchor.
+
+## For Discussion
+
+1. Counterfactual: if `/analyze` had skipped the clean-venv check and trusted
+   the `.session-notes` lead, a `deployment.md` rule would have shipped with
+   an Origin line citing an incident that never happened — how many other
+   `.session-notes` "LIVE evidence" leads across the forest ledger are
+   similarly unverified?
+2. The prior session genuinely believed it hit a split-version trap. What did
+   it actually observe — a transient working-tree state during 2.22.1 release
+   prep (pyproject bumped, `__init__.py` not yet)? If so, that is normal
+   release-prep mid-state, not an incident — should `/wrapup` distinguish
+   "observed a transient" from "hit a bug" when writing evidence lines?
+3. Is the residual gap (no post-publish `__version__` check on production
+   PyPI patch releases) worth a rule on its own merits, or does authoring it
+   without an incident violate the "don't design for hypotheticals" discipline?


### PR DESCRIPTION
## Summary
- `/analyze` of #1091 ran the live verification its acceptance criterion 1 required
- Every `kailash` 2.22.0/2.22.1 version anchor is consistent — git tag `v2.22.0`, PyPI wheel runtime `__version__` (clean-venv import), dist metadata, and the atomic bump in release commit `abaea66a3`
- The prior session's `.session-notes` "split-version trap LIVE" line does not survive a runtime check
- Recommendation (user-gated): close #1091 — motivating incident disproven; `zero-tolerance.md` Rule 5 + the existing TestPyPI `__version__` check already span the space

## Test plan
- [x] Clean-venv `pip install kailash==2.22.0` → `import kailash; __version__` = `'2.22.0'`
- [x] `git show v2.22.0:` both version anchors = `2.22.0`
- [x] Pre-commit green

## Related issues
Refs #1091