### PR TITLE
fix(891): resolve node-registry name collisions + cross-module guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.23.0] - 2026-05-19
+
+### Changed
+
+- **Node-registry cross-module collision guard (#891)** — `NodeRegistry.register`
+  now raises `NodeConfigurationError` when a node name is re-registered by a
+  class from a different source file. Previously such collisions only emitted an
+  INFO log and the last import silently won, so `add_node("<name>")` resolved
+  import-order-dependently. Same-module re-registration (DataFlow model
+  decoration regenerating CRUD node classes per `@db.model`) stays non-fatal
+  per ADR-002.
+- **`BulkUpsertNode` renamed to `SQLBulkUpsertNode` (#891)** — the core bulk
+  upsert node registered the same global name as kailash-dataflow's
+  `BulkUpsertNode`. Migration: `add_node("BulkUpsertNode", ...)` →
+  `add_node("SQLBulkUpsertNode", ...)`.
+
 ## [2.22.1] - 2026-05-18
 
 ### Fixed

--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+## [2.10.0] — 2026-05-19 — node-registry collision fix (#891)
+
+### Changed
+
+- **`HybridSearchNode` renamed to `PgVectorHybridSearchNode` (#891)** — the
+  pgvector hybrid-search node registered the same global registry name as
+  kailash-kaizen's RAG `HybridSearchNode`, making `add_node("HybridSearchNode")`
+  resolve import-order-dependently. The `HybridSearchNode` Python symbol remains
+  importable for one minor cycle as a deprecation alias (a plain module alias —
+  not re-registered). Migration: `add_node("HybridSearchNode", ...)` →
+  `add_node("PgVectorHybridSearchNode", ...)`.
+- **`BulkUpsertNode` renamed to `DataFlowBulkUpsertNode` (#891)** — the standalone
+  bulk-upsert node collided with the kailash core `BulkUpsertNode`. Migration:
+  `add_node("BulkUpsertNode", ...)` → `add_node("DataFlowBulkUpsertNode", ...)`.
+  Per-model generated `{Model}BulkUpsertNode` names are unaffected.
+- **`mongodb_nodes.AggregateNode` renamed to `MongoAggregateNode` (#891)** — the
+  MongoDB aggregation-pipeline node collided with `aggregate_operations`'s SQL
+  `AggregateNode`. The SQL node keeps the `AggregateNode` name; the MongoDB node
+  is renamed. Migration for the MongoDB pipeline node only:
+  `add_node("AggregateNode", ...)` → `add_node("MongoAggregateNode", ...)`.
+
 ## [2.9.19] — 2026-05-18 — TransactionScope.execute_raw write-protection (#1083 follow-up)
 
 ### Fixed

--- a/packages/kailash-dataflow/README.md
+++ b/packages/kailash-dataflow/README.md
@@ -615,7 +615,7 @@ relevant_docs = results["search"]["results"]
 ```python
 from dataflow import DataFlow
 from dataflow.adapters import MongoDBAdapter
-from dataflow.nodes.mongodb_nodes import DocumentInsertNode, AggregateNode
+from dataflow.nodes.mongodb_nodes import DocumentInsertNode, MongoAggregateNode
 
 # Initialize MongoDB adapter (flexible schema, no models needed!)
 adapter = MongoDBAdapter("mongodb://localhost:27017/ecommerce")
@@ -644,7 +644,7 @@ users = await adapter.find(
 
 # Aggregation pipelines for analytics
 workflow = WorkflowBuilder()
-workflow.add_node("AggregateNode", "sales_by_category", {
+workflow.add_node("MongoAggregateNode", "sales_by_category", {
     "collection": "orders",
     "pipeline": [
         {"$match": {"status": "completed"}},

--- a/packages/kailash-dataflow/docs/analysis/database-expansion-strategy.md
+++ b/packages/kailash-dataflow/docs/analysis/database-expansion-strategy.md
@@ -231,7 +231,7 @@ async def create_collection(self, collection_name: str, schema: Dict[str, Dict])
 
 - **EmbedNode**: Generate embeddings from text/images (integration with Kaizen)
 - **SimilaritySearchNode**: KNN/ANN search by vector
-- **HybridSearchNode**: Combine vector + metadata filtering
+- **PgVectorHybridSearchNode**: Combine vector + metadata filtering
 - **IndexBuildNode**: Build HNSW/IVF indexes
 
 **Fit Score Analysis**:

--- a/packages/kailash-dataflow/docs/architecture/pgvector-implementation-plan.md
+++ b/packages/kailash-dataflow/docs/architecture/pgvector-implementation-plan.md
@@ -273,10 +273,10 @@ class CreateVectorIndexNode(AsyncNode):
         return {"success": True, "index_created": True}
 ```
 
-### 3. HybridSearchNode
+### 3. PgVectorHybridSearchNode
 
 ```python
-class HybridSearchNode(AsyncNode):
+class PgVectorHybridSearchNode(AsyncNode):
     """Hybrid search combining vector similarity and full-text search."""
 
     parameters = {

--- a/packages/kailash-dataflow/docs/guides/mongodb-quickstart.md
+++ b/packages/kailash-dataflow/docs/guides/mongodb-quickstart.md
@@ -610,7 +610,7 @@ from dataflow.nodes.mongodb_nodes import (
     DocumentInsertNode,
     DocumentFindNode,
     DocumentUpdateNode,
-    AggregateNode
+    MongoAggregateNode
 )
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.runtime import AsyncLocalRuntime
@@ -641,7 +641,7 @@ workflow.add_node("DocumentFindNode", "find_active", {
 })
 
 # Aggregate sales by category
-workflow.add_node("AggregateNode", "sales_by_category", {
+workflow.add_node("MongoAggregateNode", "sales_by_category", {
     "collection": "orders",
     "pipeline": [
         {"$match": {"status": "completed"}},
@@ -668,7 +668,7 @@ print(f"Sales results: {results['sales_by_category']['count']} categories")
 2. **DocumentFindNode** - Find documents with filters
 3. **DocumentUpdateNode** - Update documents
 4. **DocumentDeleteNode** - Delete documents
-5. **AggregateNode** - Aggregation pipelines
+5. **MongoAggregateNode** - Aggregation pipelines
 6. **BulkDocumentInsertNode** - Bulk insert
 7. **CreateIndexNode** - Create indexes
 8. **DocumentCountNode** - Count documents

--- a/packages/kailash-dataflow/docs/guides/pgvector-quickstart.md
+++ b/packages/kailash-dataflow/docs/guides/pgvector-quickstart.md
@@ -182,7 +182,7 @@ distance="ip"  # Range: -infinity to +infinity
 Combine semantic similarity with PostgreSQL full-text search for best of both worlds:
 
 ```python
-from dataflow.nodes.vector_nodes import HybridSearchNode
+from dataflow.nodes.vector_nodes import PgVectorHybridSearchNode
 
 # Create full-text index first
 await db.execute_query("""
@@ -192,7 +192,7 @@ await db.execute_query("""
 """)
 
 # Hybrid search
-workflow.add_node("HybridSearchNode", "search", {
+workflow.add_node("PgVectorHybridSearchNode", "search", {
     "table_name": "documents",
     "query_vector": query_embedding,
     "text_query": "machine learning",  # Text search term

--- a/packages/kailash-dataflow/examples/mongodb_crud_example.py
+++ b/packages/kailash-dataflow/examples/mongodb_crud_example.py
@@ -17,10 +17,12 @@ Prerequisites:
 import asyncio
 from datetime import datetime
 
+from kailash.runtime import AsyncLocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
 from dataflow import DataFlow
 from dataflow.adapters import MongoDBAdapter
 from dataflow.nodes.mongodb_nodes import (
-    AggregateNode,
     BulkDocumentInsertNode,
     CreateIndexNode,
     DocumentCountNode,
@@ -28,10 +30,8 @@ from dataflow.nodes.mongodb_nodes import (
     DocumentFindNode,
     DocumentInsertNode,
     DocumentUpdateNode,
+    MongoAggregateNode,
 )
-
-from kailash.runtime import AsyncLocalRuntime
-from kailash.workflow.builder import WorkflowBuilder
 
 
 async def setup_connection():
@@ -352,7 +352,7 @@ async def workflow_integration(adapter):
 
     # 4. Aggregate orders by status
     workflow.add_node(
-        "AggregateNode",
+        "MongoAggregateNode",
         "orders_by_status",
         {
             "collection": "orders",
@@ -368,7 +368,7 @@ async def workflow_integration(adapter):
             ],
         },
     )
-    print("  ✓ Added AggregateNode")
+    print("  ✓ Added MongoAggregateNode")
 
     # Execute workflow
     print("\n⚡ Executing Workflow:")

--- a/packages/kailash-dataflow/examples/pgvector_rag_example.py
+++ b/packages/kailash-dataflow/examples/pgvector_rag_example.py
@@ -14,16 +14,16 @@ Prerequisites:
 
 import asyncio
 
+from kailash.runtime import AsyncLocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
 from dataflow import DataFlow
 from dataflow.adapters import PostgreSQLVectorAdapter
 from dataflow.nodes.vector_nodes import (
     CreateVectorIndexNode,
-    HybridSearchNode,
+    PgVectorHybridSearchNode,
     VectorSearchNode,
 )
-
-from kailash.runtime import AsyncLocalRuntime
-from kailash.workflow.builder import WorkflowBuilder
 
 
 # Mock embedding function (replace with real embedding model)
@@ -258,7 +258,7 @@ async def hybrid_search_example(db, adapter):
 
     workflow = WorkflowBuilder()
     workflow.add_node(
-        "HybridSearchNode",
+        "PgVectorHybridSearchNode",
         "search",
         {
             "table_name": "knowledge_base",

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.9.19"
+version = "2.10.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -109,7 +109,7 @@ from .validation import (
 install_dataflow_logger_mask()
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.9.19"
+__version__ = "2.10.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -440,7 +440,10 @@ class NodeGenerator:
 
         # Register nodes with Kailash's NodeRegistry system
         for node_name, node_class in nodes.items():
-            NodeRegistry.register(node_class, alias=node_name)
+            # allow_override: @db.model regenerates CRUD node classes per
+            # decoration; their names may coincide with static nodes — the
+            # overwrite is intentional, exempt from the issue-#891 guard.
+            NodeRegistry.register(node_class, alias=node_name, allow_override=True)
             # Also register in module namespace for direct imports
             globals()[node_name] = node_class
             # Store in DataFlow instance for testing
@@ -478,7 +481,10 @@ class NodeGenerator:
 
         # Register nodes with Kailash's NodeRegistry system
         for node_name, node_class in nodes.items():
-            NodeRegistry.register(node_class, alias=node_name)
+            # allow_override: @db.model regenerates CRUD node classes per
+            # decoration; their names may coincide with static nodes — the
+            # overwrite is intentional, exempt from the issue-#891 guard.
+            NodeRegistry.register(node_class, alias=node_name, allow_override=True)
             globals()[node_name] = node_class
             # Store in DataFlow instance for testing
             self.dataflow_instance._nodes[node_name] = node_class

--- a/packages/kailash-dataflow/src/dataflow/core/workflow_binding.py
+++ b/packages/kailash-dataflow/src/dataflow/core/workflow_binding.py
@@ -57,7 +57,7 @@ class DataFlowWorkflowBinder:
         "BulkCreate": "BulkCreateNode",
         "BulkUpdate": "BulkUpdateNode",
         "BulkDelete": "BulkDeleteNode",
-        "BulkUpsert": "DataFlowBulkUpsertNode",
+        "BulkUpsert": "BulkUpsertNode",
     }
 
     def __init__(self, dataflow_instance: "DataFlow"):

--- a/packages/kailash-dataflow/src/dataflow/core/workflow_binding.py
+++ b/packages/kailash-dataflow/src/dataflow/core/workflow_binding.py
@@ -57,7 +57,7 @@ class DataFlowWorkflowBinder:
         "BulkCreate": "BulkCreateNode",
         "BulkUpdate": "BulkUpdateNode",
         "BulkDelete": "BulkDeleteNode",
-        "BulkUpsert": "BulkUpsertNode",
+        "BulkUpsert": "DataFlowBulkUpsertNode",
     }
 
     def __init__(self, dataflow_instance: "DataFlow"):

--- a/packages/kailash-dataflow/src/dataflow/gateway_integration.py
+++ b/packages/kailash-dataflow/src/dataflow/gateway_integration.py
@@ -15,7 +15,7 @@ from kailash.workflow.builder import WorkflowBuilder
 from nexus import Nexus, create_nexus
 
 # Import DataFlow nodes
-from .nodes.bulk_upsert import BulkUpsertNode
+from .nodes.bulk_upsert import DataFlowBulkUpsertNode
 from .nodes.monitoring_integration import (
     DataFlowComprehensiveMonitoringNode,
     DataFlowDeadlockDetectorNode,
@@ -322,7 +322,7 @@ class DataFlowGateway:
         else:
             bulk_upsert_config.update(self.default_database_config)
 
-        workflow.add_node("BulkUpsertNode", "bulk_upsert", bulk_upsert_config)
+        workflow.add_node("DataFlowBulkUpsertNode", "bulk_upsert", bulk_upsert_config)
 
         return {
             "workflow": workflow.build(),

--- a/packages/kailash-dataflow/src/dataflow/nodes/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/__init__.py
@@ -2,6 +2,7 @@
 
 try:
     from .aggregate_operations import AggregateNode
+    from .file_source import FileSourceNode
     from .mongodb_nodes import AggregateNode as MongoAggregateNode
     from .mongodb_nodes import BulkDocumentInsertNode
     from .mongodb_nodes import CreateIndexNode as MongoCreateIndexNode
@@ -22,8 +23,12 @@ try:
         TransactionSavepointNode,
         TransactionScopeNode,
     )
-    from .vector_nodes import CreateVectorIndexNode, HybridSearchNode, VectorSearchNode
-    from .file_source import FileSourceNode
+    from .vector_nodes import (
+        CreateVectorIndexNode,
+        HybridSearchNode,
+        PgVectorHybridSearchNode,
+        VectorSearchNode,
+    )
     from .workflow_connection_manager import (
         DataFlowConnectionManager,
         SmartNodeConnectionMixin,
@@ -47,7 +52,8 @@ __all__ = [
     "NaturalLanguageFilterNode",
     "VectorSearchNode",
     "CreateVectorIndexNode",
-    "HybridSearchNode",
+    "PgVectorHybridSearchNode",
+    "HybridSearchNode",  # deprecation alias for PgVectorHybridSearchNode (issue #891)
     # MongoDB nodes
     "DocumentInsertNode",
     "DocumentFindNode",

--- a/packages/kailash-dataflow/src/dataflow/nodes/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/__init__.py
@@ -3,7 +3,6 @@
 try:
     from .aggregate_operations import AggregateNode
     from .file_source import FileSourceNode
-    from .mongodb_nodes import AggregateNode as MongoAggregateNode
     from .mongodb_nodes import BulkDocumentInsertNode
     from .mongodb_nodes import CreateIndexNode as MongoCreateIndexNode
     from .mongodb_nodes import (
@@ -12,6 +11,7 @@ try:
         DocumentFindNode,
         DocumentInsertNode,
         DocumentUpdateNode,
+        MongoAggregateNode,
     )
     from .natural_language_filter import NaturalLanguageFilterNode
     from .schema_nodes import MigrationNode, SchemaModificationNode

--- a/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/bulk_upsert.py
@@ -12,7 +12,6 @@ from kailash.nodes.base import NodeParameter, register_node
 from kailash.nodes.base_async import AsyncNode
 from kailash.sdk_exceptions import NodeExecutionError, NodeValidationError
 
-
 # #499 finding 5 — PG/MySQL drivers embed raw column values in DETAIL /
 # Key(...)=(…) clauses. Strip them before any log or return-value echo so
 # PII / SECRET column values cannot leak through the observability layer.
@@ -40,8 +39,8 @@ _SUPPORTED_DIALECTS = frozenset({"postgresql", "mysql", "sqlite"})
 from .workflow_connection_manager import SmartNodeConnectionMixin
 
 
-@register_node()
-class BulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
+@register_node(alias="DataFlowBulkUpsertNode")
+class DataFlowBulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
     """Node for bulk upsert (insert or update) operations in DataFlow.
 
     This node extends AsyncNode with SmartNodeConnectionMixin to provide
@@ -69,7 +68,7 @@ class BulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
     """
 
     def __init__(self, **kwargs):
-        """Initialize the BulkUpsertNode with configuration parameters."""
+        """Initialize the DataFlowBulkUpsertNode with configuration parameters."""
         # Extract configuration parameters before calling super()
         self.table_name = kwargs.pop("table_name", None)
         self.connection_string = kwargs.pop("connection_string", None)
@@ -98,7 +97,9 @@ class BulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
 
         # Validate required configuration
         if not self.table_name:
-            raise NodeValidationError("table_name is required for BulkUpsertNode")
+            raise NodeValidationError(
+                "table_name is required for DataFlowBulkUpsertNode"
+            )
 
     def get_parameters(self) -> dict[str, NodeParameter]:
         """Define the runtime parameters this node accepts."""
@@ -643,14 +644,16 @@ class BulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
         """
         if kwargs.get("use_pooled_connection"):
             raise NodeValidationError(
-                "BulkUpsertNode does not support use_pooled_connection. "
+                "DataFlowBulkUpsertNode does not support use_pooled_connection. "
                 "DataFlowConnectionManager.execute() has no 'execute' operation. "
                 "Use BulkCreatePoolNode for pool-routed inserts, or pass "
                 "connection_string for direct execution."
             )
 
         if not self.connection_string:
-            raise NodeValidationError("BulkUpsertNode requires connection_string")
+            raise NodeValidationError(
+                "DataFlowBulkUpsertNode requires connection_string"
+            )
 
         from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
 
@@ -664,4 +667,4 @@ class BulkUpsertNode(SmartNodeConnectionMixin, AsyncNode):
 
 
 # For backward compatibility, also alias the old method name
-BulkUpsertNode.execute = BulkUpsertNode.async_run
+DataFlowBulkUpsertNode.execute = DataFlowBulkUpsertNode.async_run

--- a/packages/kailash-dataflow/src/dataflow/nodes/file_source.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/file_source.py
@@ -3,7 +3,7 @@
 """FileSourceNode -- CSV, Excel, Parquet, JSON/JSONL ingestion.
 
 Reads tabular data from files and produces records compatible with
-``BulkCreateNode`` and ``BulkUpsertNode``.  Registered as a standalone
+``BulkCreateNode`` and ``DataFlowBulkUpsertNode``.  Registered as a standalone
 utility node (not per-model).
 
 Lazy imports for ``openpyxl`` (Excel) and ``pyarrow`` (Parquet) ensure
@@ -72,7 +72,7 @@ class DataFlowDependencyError(ImportError):
 class FileSourceNode(AsyncNode):
     """Read tabular data from CSV, Excel, Parquet, or JSON files.
 
-    Produces output compatible with ``BulkCreateNode`` / ``BulkUpsertNode``::
+    Produces output compatible with ``BulkCreateNode`` / ``DataFlowBulkUpsertNode``::
 
         {"records": [...], "count": N, "errors": [...]}
 

--- a/packages/kailash-dataflow/src/dataflow/nodes/mongodb_nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/mongodb_nodes.py
@@ -470,8 +470,8 @@ class DocumentDeleteNode(AsyncNode):
             }
 
 
-@register_node()
-class AggregateNode(AsyncNode):
+@register_node(alias="MongoAggregateNode")
+class MongoAggregateNode(AsyncNode):
     """Execute MongoDB aggregation pipeline.
 
     This node executes a MongoDB aggregation pipeline for complex
@@ -489,7 +489,7 @@ class AggregateNode(AsyncNode):
             - collection (str): Collection name
 
     Example:
-        >>> workflow.add_node("AggregateNode", "sales_by_category", {
+        >>> workflow.add_node("MongoAggregateNode", "sales_by_category", {
         ...     "collection": "orders",
         ...     "pipeline": [
         ...         {"$match": {"status": "completed"}},
@@ -547,7 +547,7 @@ class AggregateNode(AsyncNode):
 
         if not isinstance(adapter, MongoDBAdapter):
             raise ValueError(
-                f"AggregateNode requires MongoDBAdapter, got {type(adapter).__name__}"
+                f"MongoAggregateNode requires MongoDBAdapter, got {type(adapter).__name__}"
             )
 
         try:

--- a/packages/kailash-dataflow/src/dataflow/nodes/vector_nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/nodes/vector_nodes.py
@@ -7,10 +7,10 @@ Workflow nodes for vector similarity search using PostgreSQLVectorAdapter.
 import logging
 from typing import Any, Dict, List, Optional
 
-from dataflow.adapters import PostgreSQLVectorAdapter
-
 from kailash.nodes.base import NodeParameter, register_node
 from kailash.nodes.base_async import AsyncNode
+
+from dataflow.adapters import PostgreSQLVectorAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -319,8 +319,8 @@ class CreateVectorIndexNode(AsyncNode):
             ) from e
 
 
-@register_node()
-class HybridSearchNode(AsyncNode):
+@register_node(alias="PgVectorHybridSearchNode")
+class PgVectorHybridSearchNode(AsyncNode):
     """
     Hybrid search combining vector similarity and full-text search.
 
@@ -330,7 +330,7 @@ class HybridSearchNode(AsyncNode):
     Requires PostgreSQLVectorAdapter with pgvector extension.
 
     Example:
-        workflow.add_node("HybridSearchNode", "search", {
+        workflow.add_node("PgVectorHybridSearchNode", "search", {
             "table_name": "documents",
             "query_vector": embedding,
             "text_query": "machine learning",
@@ -341,7 +341,7 @@ class HybridSearchNode(AsyncNode):
     """
 
     def __init__(self, **kwargs):
-        """Initialize HybridSearchNode."""
+        """Initialize PgVectorHybridSearchNode."""
         # Extract DataFlow-specific parameters
         self.table_name = kwargs.pop("table_name", None)
         self.dataflow_instance = kwargs.pop("dataflow_instance", None)
@@ -410,7 +410,7 @@ class HybridSearchNode(AsyncNode):
         # Get adapter from DataFlow instance
         if not self.dataflow_instance:
             raise ValueError(
-                "HybridSearchNode requires dataflow_instance. "
+                "PgVectorHybridSearchNode requires dataflow_instance. "
                 "This node must be used within a DataFlow workflow."
             )
 
@@ -419,7 +419,7 @@ class HybridSearchNode(AsyncNode):
         # Validate adapter type
         if not isinstance(adapter, PostgreSQLVectorAdapter):
             raise ValueError(
-                f"HybridSearchNode requires PostgreSQLVectorAdapter, "
+                f"PgVectorHybridSearchNode requires PostgreSQLVectorAdapter, "
                 f"got {type(adapter).__name__}. "
                 f"Initialize DataFlow with: "
                 f"db = DataFlow(adapter=PostgreSQLVectorAdapter(connection_string))"
@@ -427,7 +427,7 @@ class HybridSearchNode(AsyncNode):
 
         # Validate table_name
         if not self.table_name:
-            raise ValueError("table_name is required for HybridSearchNode")
+            raise ValueError("table_name is required for PgVectorHybridSearchNode")
 
         # Validate and get parameters from kwargs
         validated_inputs = self.validate_inputs(**kwargs)
@@ -456,7 +456,7 @@ class HybridSearchNode(AsyncNode):
             search_type = "hybrid" if text_query else "vector_only"
 
             logger.info(
-                f"HybridSearchNode: Found {len(results)} results for table "
+                f"PgVectorHybridSearchNode: Found {len(results)} results for table "
                 f"'{self.table_name}' using {search_type} search"
             )
 
@@ -469,8 +469,16 @@ class HybridSearchNode(AsyncNode):
 
         except Exception as e:
             logger.error(
-                f"HybridSearchNode failed for table '{self.table_name}': {str(e)}"
+                f"PgVectorHybridSearchNode failed for table '{self.table_name}': {str(e)}"
             )
             raise RuntimeError(
                 f"Hybrid search failed for table '{self.table_name}': {str(e)}"
             ) from e
+
+
+# Deprecation shim — `HybridSearchNode` was renamed to `PgVectorHybridSearchNode`
+# (issue #891: the bare name collided with kaizen's RAG node in the global
+# NodeRegistry). Plain module alias for direct Python importers; kept one minor
+# cycle. NOT re-decorated with @register_node — a decorated alias would re-create
+# the registry collision the rename closes.
+HybridSearchNode = PgVectorHybridSearchNode

--- a/packages/kailash-dataflow/tests/integration/bulk_operations/test_bulk_upsert_comprehensive.py
+++ b/packages/kailash-dataflow/tests/integration/bulk_operations/test_bulk_upsert_comprehensive.py
@@ -1,7 +1,7 @@
 """
-Comprehensive integration tests for BulkUpsertNode following NO MOCKING policy.
+Comprehensive integration tests for DataFlowBulkUpsertNode following NO MOCKING policy.
 
-This test suite validates BulkUpsertNode functionality with REAL database operations:
+This test suite validates DataFlowBulkUpsertNode functionality with REAL database operations:
 - Insert new records (no conflicts)
 - Update existing records (conflict exists)
 - Mixed insert + update in same batch
@@ -26,9 +26,9 @@ import time
 from typing import Any, Dict, List
 
 import pytest
-from dataflow.nodes.bulk_upsert import BulkUpsertNode
-
 from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
 
@@ -169,8 +169,8 @@ async def test_bulk_upsert_insert_only_new_records(setup_bulk_upsert_table):
     initial_count = await _count_records(connection_string, table_name)
     assert initial_count == 0, "Table should start empty"
 
-    # Create BulkUpsertNode
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -213,16 +213,16 @@ async def test_bulk_upsert_insert_only_new_records(setup_bulk_upsert_table):
     actual_records = await _verify_database_state(connection_string, table_name)
 
     # VERIFICATION 1: Correct number of records inserted
-    assert len(actual_records) == 3, (
-        f"Expected 3 records in database, found {len(actual_records)}"
-    )
+    assert (
+        len(actual_records) == 3
+    ), f"Expected 3 records in database, found {len(actual_records)}"
 
     # VERIFICATION 2: All records are present with correct data
     emails_in_db = {r["email"] for r in actual_records}
     expected_emails = {"alice@example.com", "bob@example.com", "charlie@example.com"}
-    assert emails_in_db == expected_emails, (
-        f"Email mismatch: expected {expected_emails}, got {emails_in_db}"
-    )
+    assert (
+        emails_in_db == expected_emails
+    ), f"Email mismatch: expected {expected_emails}, got {emails_in_db}"
 
     # VERIFICATION 3: Data integrity - check specific record values
     alice = next(r for r in actual_records if r["id"] == "user-001")
@@ -252,8 +252,8 @@ async def test_bulk_upsert_empty_table_large_batch(setup_bulk_upsert_table):
     connection_string = config["connection_string"]
     table_name = config["table_name"]
 
-    # Create BulkUpsertNode with batch size
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode with batch size
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -283,9 +283,9 @@ async def test_bulk_upsert_empty_table_large_batch(setup_bulk_upsert_table):
     actual_count = await _count_records(connection_string, table_name)
 
     # VERIFICATION: All 1000 records inserted
-    assert actual_count == 1000, (
-        f"Expected 1000 records in database, found {actual_count}"
-    )
+    assert (
+        actual_count == 1000
+    ), f"Expected 1000 records in database, found {actual_count}"
 
     # Verify batch processing metrics
     assert result["performance_metrics"]["batches_processed"] == 4  # 1000/250 = 4
@@ -344,8 +344,8 @@ async def test_bulk_upsert_update_only_existing_records(setup_bulk_upsert_table)
     initial_count = await _count_records(connection_string, table_name)
     assert initial_count == 3, "Should have 3 initial records"
 
-    # Create BulkUpsertNode
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -387,9 +387,9 @@ async def test_bulk_upsert_update_only_existing_records(setup_bulk_upsert_table)
     actual_records = await _verify_database_state(connection_string, table_name)
 
     # VERIFICATION 1: Record count unchanged (no inserts)
-    assert len(actual_records) == 3, (
-        f"Expected 3 records (no new inserts), found {len(actual_records)}"
-    )
+    assert (
+        len(actual_records) == 3
+    ), f"Expected 3 records (no new inserts), found {len(actual_records)}"
 
     # VERIFICATION 2: All records updated with new values
     alice = next(r for r in actual_records if r["id"] == "user-001")
@@ -436,8 +436,8 @@ async def test_bulk_upsert_update_preserves_unmodified_fields(setup_bulk_upsert_
         ],
     )
 
-    # Create BulkUpsertNode
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -519,8 +519,8 @@ async def test_bulk_upsert_mixed_insert_and_update(setup_bulk_upsert_table):
 
     initial_records_state = await _verify_database_state(connection_string, table_name)
 
-    # Create BulkUpsertNode
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -582,9 +582,9 @@ async def test_bulk_upsert_mixed_insert_and_update(setup_bulk_upsert_table):
     final_count = len(final_records)
 
     # VERIFICATION 1: Total count = 2 existing + 3 new = 5 records
-    assert final_count == 5, (
-        f"Expected 5 total records (2 updated + 3 inserted), found {final_count}"
-    )
+    assert (
+        final_count == 5
+    ), f"Expected 5 total records (2 updated + 3 inserted), found {final_count}"
 
     # VERIFICATION 2: Updates were applied
     alice = next(r for r in final_records if r["id"] == "user-001")
@@ -614,9 +614,9 @@ async def test_bulk_upsert_mixed_insert_and_update(setup_bulk_upsert_table):
     updated_ids = final_ids & initial_ids
 
     assert len(new_ids) == 3, f"Expected 3 new records, found {len(new_ids)}"
-    assert len(updated_ids) == 2, (
-        f"Expected 2 updated records, found {len(updated_ids)}"
-    )
+    assert (
+        len(updated_ids) == 2
+    ), f"Expected 2 updated records, found {len(updated_ids)}"
 
 
 @pytest.mark.asyncio
@@ -654,8 +654,8 @@ async def test_bulk_upsert_large_mixed_batch(setup_bulk_upsert_table):
     initial_count = await _count_records(connection_string, table_name)
     assert initial_count == 500
 
-    # Create BulkUpsertNode
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -751,8 +751,8 @@ async def test_bulk_upsert_strategy_update(setup_bulk_upsert_table):
         ],
     )
 
-    # Create BulkUpsertNode with UPDATE strategy
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode with UPDATE strategy
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -781,9 +781,9 @@ async def test_bulk_upsert_strategy_update(setup_bulk_upsert_table):
     actual_records = await _verify_database_state(connection_string, table_name)
 
     # VERIFICATION 1: Only 1 record (no duplicate)
-    assert len(actual_records) == 1, (
-        "Should have exactly 1 record (updated, not duplicated)"
-    )
+    assert (
+        len(actual_records) == 1
+    ), "Should have exactly 1 record (updated, not duplicated)"
 
     # VERIFICATION 2: Record was updated
     alice = actual_records[0]
@@ -823,8 +823,8 @@ async def test_bulk_upsert_strategy_ignore(setup_bulk_upsert_table):
         ],
     )
 
-    # Create BulkUpsertNode with IGNORE strategy
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode with IGNORE strategy
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -895,8 +895,8 @@ async def test_bulk_upsert_batch_processing_large_dataset(setup_bulk_upsert_tabl
     connection_string = config["connection_string"]
     table_name = config["table_name"]
 
-    # Create BulkUpsertNode with specific batch size
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode with specific batch size
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -952,8 +952,8 @@ async def test_bulk_upsert_duplicate_handling_in_batch(setup_bulk_upsert_table):
     connection_string = config["connection_string"]
     table_name = config["table_name"]
 
-    # Create BulkUpsertNode with duplicate handling
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode with duplicate handling
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -1043,9 +1043,9 @@ async def test_bulk_upsert_multi_tenant_isolation(setup_bulk_upsert_table):
     await alter_node.async_run()
     await alter_node.cleanup()
 
-    # Create BulkUpsertNode with multi-tenant support
+    # Create DataFlowBulkUpsertNode with multi-tenant support
     # Note: conflict_columns must include tenant_id for proper isolation
-    node = BulkUpsertNode(
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -1129,9 +1129,9 @@ async def test_bulk_upsert_multi_tenant_isolation(setup_bulk_upsert_table):
     )
 
     tenant1_final = next(r for r in final_records if r["tenant_id"] == "tenant_001")
-    assert tenant1_final["name"] == "Alice Tenant 1 UPDATED", (
-        "Tenant 1 should be updated"
-    )
+    assert (
+        tenant1_final["name"] == "Alice Tenant 1 UPDATED"
+    ), "Tenant 1 should be updated"
 
     tenant2_final = next(r for r in final_records if r["tenant_id"] == "tenant_002")
     assert tenant2_final["name"] == "Alice Tenant 2", "Tenant 2 should be unchanged"
@@ -1150,7 +1150,7 @@ async def test_bulk_upsert_bug_reproduction_zero_records(setup_bulk_upsert_table
     CRITICAL BUG REPRODUCTION TEST
 
     Reproduces the reported bug scenario:
-    - BulkUpsertNode reports success=True
+    - DataFlowBulkUpsertNode reports success=True
     - But ZERO records are actually inserted into database
     - Parameter conflict_fields transformed from list to JSON string
 
@@ -1169,8 +1169,8 @@ async def test_bulk_upsert_bug_reproduction_zero_records(setup_bulk_upsert_table
     initial_count = await _count_records(connection_string, table_name)
     assert initial_count == 0, "Table should start empty"
 
-    # Create BulkUpsertNode (matching bug report scenario)
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode (matching bug report scenario)
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -1208,14 +1208,14 @@ async def test_bulk_upsert_bug_reproduction_zero_records(setup_bulk_upsert_table
     actual_count = len(actual_records)
 
     # CRITICAL ASSERTION: Records should be inserted (not zero)
-    assert actual_count > 0, (
-        "BUG REPRODUCTION FAILED: Zero records inserted despite success=True"
-    )
+    assert (
+        actual_count > 0
+    ), "BUG REPRODUCTION FAILED: Zero records inserted despite success=True"
 
     # VERIFICATION: Correct number of records
-    assert actual_count == 2, (
-        f"Expected 2 records, found {actual_count} (BUG: silent failure)"
-    )
+    assert (
+        actual_count == 2
+    ), f"Expected 2 records, found {actual_count} (BUG: silent failure)"
 
     # VERIFICATION: Data integrity
     emails_in_db = {r["email"] for r in actual_records}
@@ -1241,8 +1241,8 @@ async def test_bulk_upsert_return_records(setup_bulk_upsert_table):
     connection_string = config["connection_string"]
     table_name = config["table_name"]
 
-    # Create BulkUpsertNode
-    node = BulkUpsertNode(
+    # Create DataFlowBulkUpsertNode
+    node = DataFlowBulkUpsertNode(
         node_id="test_bulk_upsert",
         table_name=table_name,
         database_type="postgresql",
@@ -1282,6 +1282,6 @@ async def test_bulk_upsert_return_records(setup_bulk_upsert_table):
     actual_records = await _verify_database_state(connection_string, table_name)
 
     # Compare returned records with database state
-    assert len(returned_records) == len(actual_records), (
-        "Returned records count should match database"
-    )
+    assert len(returned_records) == len(
+        actual_records
+    ), "Returned records count should match database"

--- a/packages/kailash-dataflow/tests/integration/bulk_operations/test_bulk_upsert_node_integration.py
+++ b/packages/kailash-dataflow/tests/integration/bulk_operations/test_bulk_upsert_node_integration.py
@@ -1,5 +1,5 @@
 """
-Integration tests for BulkUpsertNode with real database connections.
+Integration tests for DataFlowBulkUpsertNode with real database connections.
 Tests against PostgreSQL using Docker test environment.
 """
 
@@ -11,7 +11,7 @@ import pytest
 from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
 from pytest import approx
 
-from dataflow.nodes.bulk_upsert import BulkUpsertNode
+from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
 
@@ -24,7 +24,7 @@ async def test_suite():
 
 
 class TestBulkUpsertNodeIntegration:
-    """Integration tests for BulkUpsertNode with real database."""
+    """Integration tests for DataFlowBulkUpsertNode with real database."""
 
     def _extract_result_data(self, result):
         """Extract data from AsyncSQLDatabaseNode result format."""
@@ -109,8 +109,8 @@ class TestBulkUpsertNodeIntegration:
         """Test bulk upsert updates existing records."""
         connection_string = setup_test_table
 
-        # Create BulkUpsertNode
-        node = BulkUpsertNode(
+        # Create DataFlowBulkUpsertNode
+        node = DataFlowBulkUpsertNode(
             node_id="test_bulk_upsert",
             table_name="test_bulk_upsert_users",
             database_type="postgresql",
@@ -174,8 +174,8 @@ class TestBulkUpsertNodeIntegration:
         """Test bulk upsert with ignore strategy."""
         connection_string = setup_test_table
 
-        # Create BulkUpsertNode with ignore strategy
-        node = BulkUpsertNode(
+        # Create DataFlowBulkUpsertNode with ignore strategy
+        node = DataFlowBulkUpsertNode(
             node_id="test_bulk_upsert",
             table_name="test_bulk_upsert_users",
             database_type="postgresql",
@@ -241,8 +241,8 @@ class TestBulkUpsertNodeIntegration:
         """Test bulk upsert with version checking for optimistic locking."""
         connection_string = setup_test_table
 
-        # Create BulkUpsertNode with version checking
-        node = BulkUpsertNode(
+        # Create DataFlowBulkUpsertNode with version checking
+        node = DataFlowBulkUpsertNode(
             node_id="test_bulk_upsert",
             table_name="test_bulk_upsert_users",
             database_type="postgresql",
@@ -288,8 +288,8 @@ class TestBulkUpsertNodeIntegration:
         """Test returning upserted records."""
         connection_string = setup_test_table
 
-        # Create BulkUpsertNode
-        node = BulkUpsertNode(
+        # Create DataFlowBulkUpsertNode
+        node = DataFlowBulkUpsertNode(
             node_id="test_bulk_upsert",
             table_name="test_bulk_upsert_users",
             database_type="postgresql",
@@ -335,8 +335,8 @@ class TestBulkUpsertNodeIntegration:
         """Test batch processing with larger dataset."""
         connection_string = setup_test_table
 
-        # Create BulkUpsertNode with small batch size
-        node = BulkUpsertNode(
+        # Create DataFlowBulkUpsertNode with small batch size
+        node = DataFlowBulkUpsertNode(
             node_id="test_bulk_upsert",
             table_name="test_bulk_upsert_users",
             database_type="postgresql",
@@ -442,8 +442,8 @@ class TestBulkUpsertNodeIntegration:
         await constraint_node.async_run()
         await constraint_node.cleanup()
 
-        # Create BulkUpsertNode with multi-tenant support
-        node = BulkUpsertNode(
+        # Create DataFlowBulkUpsertNode with multi-tenant support
+        node = DataFlowBulkUpsertNode(
             node_id="test_bulk_upsert",
             table_name="test_bulk_upsert_users",
             database_type="postgresql",
@@ -503,8 +503,8 @@ class TestBulkUpsertNodeIntegration:
         """Test handling of duplicates within batch."""
         connection_string = setup_test_table
 
-        # Create BulkUpsertNode with duplicate handling
-        node = BulkUpsertNode(
+        # Create DataFlowBulkUpsertNode with duplicate handling
+        node = DataFlowBulkUpsertNode(
             node_id="test_bulk_upsert",
             table_name="test_bulk_upsert_users",
             database_type="postgresql",
@@ -561,8 +561,8 @@ class TestBulkUpsertNodeIntegration:
         """Test performance with large upsert operation."""
         connection_string = setup_test_table
 
-        # Create BulkUpsertNode
-        node = BulkUpsertNode(
+        # Create DataFlowBulkUpsertNode
+        node = DataFlowBulkUpsertNode(
             node_id="test_bulk_upsert",
             table_name="test_bulk_upsert_users",
             database_type="postgresql",
@@ -606,7 +606,7 @@ class TestBulkUpsertNodeIntegration:
         assert metrics["records_per_second"] > 100  # At least 100/sec in test env
 
         # For this performance test, we focus on throughput metrics
-        # The BulkUpsertNode should handle large volumes efficiently
+        # The DataFlowBulkUpsertNode should handle large volumes efficiently
 
         # Just assert that records_per_second is reasonable for integration test
         assert metrics["records_per_second"] > 100  # At least 100/sec in test env

--- a/packages/kailash-dataflow/tests/integration/nodes/test_bulk_upsert_conflict_on_integration.py
+++ b/packages/kailash-dataflow/tests/integration/nodes/test_bulk_upsert_conflict_on_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for BulkUpsertNode conflict_on with real PostgreSQL.
+"""Integration tests for DataFlowBulkUpsertNode conflict_on with real PostgreSQL.
 
 Tests real database operations with custom conflict fields including:
 - Natural keys (email, SKU)
@@ -9,7 +9,7 @@ Tests real database operations with custom conflict fields including:
 
 import pytest
 
-from dataflow.nodes.bulk_upsert import BulkUpsertNode
+from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
 
@@ -91,7 +91,7 @@ class TestBulkUpsertSingleConflictField:
 
     async def test_bulk_upsert_on_email(self, test_suite, users_table):
         """Test bulk upsert using email as conflict field."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -140,7 +140,7 @@ class TestBulkUpsertSingleConflictField:
 
     async def test_bulk_upsert_on_sku(self, test_suite, products_table):
         """Test bulk upsert using SKU as conflict field."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="products",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -192,7 +192,7 @@ class TestBulkUpsertCompositeConflictFields:
 
     async def test_bulk_upsert_on_composite_key(self, test_suite, order_items_table):
         """Test bulk upsert using composite key (order_id + product_id)."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="order_items",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -276,7 +276,7 @@ class TestBulkUpsertCompositeConflictFields:
         self, test_suite, order_items_table
     ):
         """Test that duplicates within batch are deduplicated by composite key."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="order_items",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -336,7 +336,7 @@ class TestBulkUpsertBackwardCompatibility:
         self, test_suite, users_table
     ):
         """Test that omitting conflict_on uses config conflict_columns."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -363,7 +363,7 @@ class TestBulkUpsertBackwardCompatibility:
         async with test_suite.get_connection() as conn:
             await conn.execute("ALTER TABLE users ADD COLUMN username TEXT UNIQUE")
 
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -398,7 +398,7 @@ class TestBulkUpsertMergeStrategies:
 
     async def test_merge_strategy_update(self, test_suite, users_table):
         """Test that update strategy modifies existing records."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -438,7 +438,7 @@ class TestBulkUpsertMergeStrategies:
 
     async def test_merge_strategy_ignore(self, test_suite, users_table):
         """Test that ignore strategy keeps existing records unchanged."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -484,7 +484,7 @@ class TestBulkUpsertLargeDatasets:
 
     async def test_bulk_upsert_1000_records(self, test_suite, users_table):
         """Test bulk upsert with 1000 records using email conflict."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -522,7 +522,7 @@ class TestBulkUpsertLargeDatasets:
         self, test_suite, users_table
     ):
         """Test bulk upsert with mix of inserts and updates in large dataset."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",

--- a/packages/kailash-dataflow/tests/integration/nodes/test_upsert_bulk_consistency.py
+++ b/packages/kailash-dataflow/tests/integration/nodes/test_upsert_bulk_consistency.py
@@ -1,16 +1,16 @@
-"""Consistency tests for BulkUpsertNode with conflict_on parameter.
+"""Consistency tests for DataFlowBulkUpsertNode with conflict_on parameter.
 
-Verifies that the standalone BulkUpsertNode behaves consistently with expected
+Verifies that the standalone DataFlowBulkUpsertNode behaves consistently with expected
 upsert semantics when using custom conflict fields.
 
-NOTE: These tests use the standalone BulkUpsertNode from dataflow.nodes.bulk_upsert.
+NOTE: These tests use the standalone DataFlowBulkUpsertNode from dataflow.nodes.bulk_upsert.
 The DataFlow-generated nodes use a different implementation which is being
 enhanced separately in features/bulk.py.
 """
 
 import pytest
 
-from dataflow.nodes.bulk_upsert import BulkUpsertNode
+from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
 
@@ -88,11 +88,11 @@ async def order_items_table(test_suite):
 @pytest.mark.integration
 @pytest.mark.timeout(15)
 class TestBulkUpsertConflictOnConsistency:
-    """Test standalone BulkUpsertNode behaves consistently with expected upsert semantics."""
+    """Test standalone DataFlowBulkUpsertNode behaves consistently with expected upsert semantics."""
 
     async def test_email_conflict_insert_then_update(self, test_suite, users_table):
-        """Test that BulkUpsertNode correctly handles INSERT then UPDATE on email."""
-        node = BulkUpsertNode(
+        """Test that DataFlowBulkUpsertNode correctly handles INSERT then UPDATE on email."""
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -150,8 +150,8 @@ class TestBulkUpsertConflictOnConsistency:
             assert record["name"] == "Alice Updated"  # Name changed
 
     async def test_sku_conflict_consistency(self, test_suite, products_table):
-        """Test that BulkUpsertNode handles SKU conflict correctly."""
-        node = BulkUpsertNode(
+        """Test that DataFlowBulkUpsertNode handles SKU conflict correctly."""
+        node = DataFlowBulkUpsertNode(
             table_name="products",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -199,8 +199,8 @@ class TestBulkUpsertConflictOnConsistency:
             assert float(record["price"]) == 99.99
 
     async def test_composite_key_consistency(self, test_suite, order_items_table):
-        """Test that BulkUpsertNode handles composite key conflicts correctly."""
-        node = BulkUpsertNode(
+        """Test that DataFlowBulkUpsertNode handles composite key conflicts correctly."""
+        node = DataFlowBulkUpsertNode(
             table_name="order_items",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -254,7 +254,7 @@ class TestBulkUpsertConflictOnConsistency:
     async def test_conflict_on_overrides_config_default(self, test_suite, users_table):
         """Test that runtime conflict_on overrides config conflict_columns."""
         # Create node with email as config default
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",
@@ -312,7 +312,7 @@ class TestBulkUpsertConflictOnConsistency:
 
     async def test_merge_strategy_consistency(self, test_suite, users_table):
         """Test that merge strategy (update vs ignore) works consistently."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string=test_suite.config.url,
             database_type="postgresql",

--- a/packages/kailash-dataflow/tests/integration/nodes/test_vector_nodes_integration.py
+++ b/packages/kailash-dataflow/tests/integration/nodes/test_vector_nodes_integration.py
@@ -1,21 +1,21 @@
 """
 Integration tests for vector workflow nodes with real PostgreSQL + pgvector.
 
-Tests VectorSearchNode, CreateVectorIndexNode, and HybridSearchNode
+Tests VectorSearchNode, CreateVectorIndexNode, and PgVectorHybridSearchNode
 with real database infrastructure and DataFlow integration.
 
 Following NO MOCKING policy for Tier 2 tests.
 """
 
 import pytest
+
 from dataflow import DataFlow
 from dataflow.adapters import PostgreSQLVectorAdapter
 from dataflow.nodes.vector_nodes import (
     CreateVectorIndexNode,
-    HybridSearchNode,
+    PgVectorHybridSearchNode,
     VectorSearchNode,
 )
-
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
 
@@ -274,14 +274,14 @@ class TestCreateVectorIndexNodeIntegration:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-class TestHybridSearchNodeIntegration:
-    """Integration tests for HybridSearchNode with real database."""
+class TestPgVectorHybridSearchNodeIntegration:
+    """Integration tests for PgVectorHybridSearchNode with real database."""
 
     async def test_hybrid_search_vector_only(self, vector_table_with_data):
-        """Test HybridSearchNode with vector-only search."""
+        """Test PgVectorHybridSearchNode with vector-only search."""
         dataflow, table_name = vector_table_with_data
 
-        node = HybridSearchNode(
+        node = PgVectorHybridSearchNode(
             table_name=table_name,
             dataflow_instance=dataflow,
         )
@@ -298,7 +298,7 @@ class TestHybridSearchNodeIntegration:
         assert len(result["results"]) <= 5
 
     async def test_hybrid_search_combined(self, vector_table_with_data, test_suite):
-        """Test HybridSearchNode with combined vector and text search."""
+        """Test PgVectorHybridSearchNode with combined vector and text search."""
         dataflow, table_name = vector_table_with_data
 
         # Create full-text search index
@@ -311,7 +311,7 @@ class TestHybridSearchNodeIntegration:
             """
             )
 
-        node = HybridSearchNode(
+        node = PgVectorHybridSearchNode(
             table_name=table_name,
             dataflow_instance=dataflow,
         )

--- a/packages/kailash-dataflow/tests/integration/security/test_bulk_upsert_sql_injection.py
+++ b/packages/kailash-dataflow/tests/integration/security/test_bulk_upsert_sql_injection.py
@@ -1,8 +1,8 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
-"""Tier 2 SQLi regression — BulkUpsertNode parameter binding (issue #492).
+"""Tier 2 SQLi regression — DataFlowBulkUpsertNode parameter binding (issue #492).
 
-Before this fix, ``BulkUpsertNode._build_upsert_query`` interpolated
+Before this fix, ``DataFlowBulkUpsertNode._build_upsert_query`` interpolated
 VALUES via ``value.replace("'", "''")`` and emitted a finished SQL
 string. Hand-rolled escapes are the classic SQLi vector: backslash-
 quote (``\\'``), null bytes (``\\x00``), Unicode quote homoglyphs
@@ -16,7 +16,7 @@ land in a separate flat list bound by the driver.
 
 These tests use the real PostgreSQL test infrastructure
 (``IntegrationTestSuite`` per ``tests/CLAUDE.md``) and exercise the
-classic SQLi payload set against the ``BulkUpsertNode`` public
+classic SQLi payload set against the ``DataFlowBulkUpsertNode`` public
 ``async_run`` surface. The contract: malicious payloads MUST land in
 the row as literal data; the side table that the payload tries to drop
 MUST remain intact.
@@ -38,7 +38,7 @@ import time
 import pytest
 from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
 
-from dataflow.nodes.bulk_upsert import BulkUpsertNode
+from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
@@ -158,7 +158,7 @@ async def test_bulk_upsert_rejects_sql_injection_in_string_field(upsert_table, p
     """Issue #492: every classic SQLi payload MUST be bound as data, not SQL."""
     connection_string, upsert_name, canary_name = upsert_table
 
-    node = BulkUpsertNode(
+    node = DataFlowBulkUpsertNode(
         node_id="bulk_upsert_sqli",
         table_name=upsert_name,
         database_type="postgresql",
@@ -202,7 +202,7 @@ async def test_bulk_upsert_mixed_safe_and_malicious_batch(upsert_table):
     """Multi-row batch: safe rows MUST land normally, malicious rows MUST be data."""
     connection_string, upsert_name, canary_name = upsert_table
 
-    node = BulkUpsertNode(
+    node = DataFlowBulkUpsertNode(
         node_id="bulk_upsert_sqli_batch",
         table_name=upsert_name,
         database_type="postgresql",
@@ -247,7 +247,7 @@ async def test_bulk_upsert_emits_no_inlined_payload_in_query(upsert_table):
     """
     connection_string, upsert_name, _canary_name = upsert_table
 
-    node = BulkUpsertNode(
+    node = DataFlowBulkUpsertNode(
         node_id="bulk_upsert_placeholder",
         table_name=upsert_name,
         database_type="postgresql",
@@ -288,7 +288,7 @@ async def test_bulk_upsert_rejects_invalid_table_identifier(bad_identifier):
     contains shell/SQL meta-characters MUST raise at query-build time, not
     silently land in DDL.
     """
-    node = BulkUpsertNode(
+    node = DataFlowBulkUpsertNode(
         node_id="bulk_upsert_id",
         table_name=bad_identifier,
         database_type="postgresql",
@@ -311,7 +311,7 @@ async def test_bulk_upsert_rejects_invalid_column_identifier():
     """Identifier safety MUST extend to column names supplied via the
     runtime ``conflict_on`` parameter and the ``columns`` list.
     """
-    node = BulkUpsertNode(
+    node = DataFlowBulkUpsertNode(
         node_id="bulk_upsert_col",
         table_name="users",
         database_type="postgresql",
@@ -336,7 +336,7 @@ async def test_bulk_upsert_rejects_unsupported_dialect():
     """
     from kailash.sdk_exceptions import NodeValidationError
 
-    node = BulkUpsertNode(
+    node = DataFlowBulkUpsertNode(
         node_id="bulk_upsert_dialect",
         table_name="users",
         database_type="postgres",  # typo — should be 'postgresql'

--- a/packages/kailash-dataflow/tests/unit/nodes/test_bulk_upsert_conflict_on.py
+++ b/packages/kailash-dataflow/tests/unit/nodes/test_bulk_upsert_conflict_on.py
@@ -1,4 +1,4 @@
-"""Unit tests for BulkUpsertNode conflict_on parameter.
+"""Unit tests for DataFlowBulkUpsertNode conflict_on parameter.
 
 Tests parameter validation, deduplication logic, and query building
 with custom conflict fields (natural keys and composite keys).
@@ -6,15 +6,15 @@ with custom conflict fields (natural keys and composite keys).
 
 import pytest
 
-from dataflow.nodes.bulk_upsert import BulkUpsertNode
+from dataflow.nodes.bulk_upsert import DataFlowBulkUpsertNode
 
 
 class TestBulkUpsertConflictOnParameter:
-    """Test conflict_on parameter handling in BulkUpsertNode."""
+    """Test conflict_on parameter handling in DataFlowBulkUpsertNode."""
 
     def test_conflict_on_parameter_exists(self):
         """Test that conflict_on parameter is properly defined."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="test_table",
             connection_string="postgresql://localhost/test",
         )
@@ -27,7 +27,7 @@ class TestBulkUpsertConflictOnParameter:
 
     def test_conflict_on_parameter_description(self):
         """Test that conflict_on parameter has descriptive documentation."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="test_table",
             connection_string="postgresql://localhost/test",
         )
@@ -40,7 +40,7 @@ class TestBulkUpsertConflictOnParameter:
 
     def test_deduplicate_with_single_conflict_field(self):
         """Test deduplication using single conflict field (email)."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
         )
@@ -66,7 +66,7 @@ class TestBulkUpsertConflictOnParameter:
 
     def test_deduplicate_with_composite_conflict_fields(self):
         """Test deduplication using composite key (order_id + product_id)."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="order_items",
             connection_string="postgresql://localhost/test",
         )
@@ -93,7 +93,7 @@ class TestBulkUpsertConflictOnParameter:
 
     def test_deduplicate_keep_last_strategy(self):
         """Test deduplication with handle_duplicates='last' strategy."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
             handle_duplicates="last",
@@ -115,7 +115,7 @@ class TestBulkUpsertConflictOnParameter:
 
     def test_build_query_with_single_conflict_field(self):
         """Test query building with single conflict field."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
             database_type="postgresql",
@@ -141,7 +141,7 @@ class TestBulkUpsertConflictOnParameter:
 
     def test_build_query_with_composite_conflict_fields(self):
         """Test query building with composite conflict fields."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="order_items",
             connection_string="postgresql://localhost/test",
             database_type="postgresql",
@@ -171,7 +171,7 @@ class TestBulkUpsertConflictOnParameter:
 
     def test_build_query_ignores_immutable_fields(self):
         """Test that id and created_at are never updated, regardless of conflict_on."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
             database_type="postgresql",
@@ -202,7 +202,7 @@ class TestBulkUpsertConflictOnParameter:
 
     def test_empty_conflict_on_uses_all_columns(self):
         """Test that empty conflict_on list is handled gracefully."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
             database_type="postgresql",
@@ -228,7 +228,7 @@ class TestBulkUpsertConflictOnParameter:
         This means NULL values WILL deduplicate in batch preprocessing.
         The database will handle NULL != NULL semantics during INSERT.
         """
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
         )
@@ -251,7 +251,7 @@ class TestBulkUpsertConflictOnParameter:
         """Test that result metadata includes the resolved conflict_on value."""
         # This is tested in integration tests since it requires async execution
         # Here we just verify the metadata structure is correct
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
             conflict_columns=["email"],  # Config default
@@ -266,7 +266,7 @@ class TestBulkUpsertBackwardCompatibility:
 
     def test_defaults_to_config_conflict_columns(self):
         """Test that omitting conflict_on uses config conflict_columns."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
             conflict_columns=["email"],  # Config default
@@ -291,7 +291,7 @@ class TestBulkUpsertBackwardCompatibility:
 
     def test_runtime_conflict_on_overrides_config(self):
         """Test that runtime conflict_on overrides config conflict_columns."""
-        node = BulkUpsertNode(
+        node = DataFlowBulkUpsertNode(
             table_name="users",
             connection_string="postgresql://localhost/test",
             conflict_columns=["email"],  # Config default

--- a/packages/kailash-dataflow/tests/unit/nodes/test_mongodb_nodes.py
+++ b/packages/kailash-dataflow/tests/unit/nodes/test_mongodb_nodes.py
@@ -8,9 +8,9 @@ a real MongoDB instance (Tier 1 - Unit Tests).
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from dataflow.adapters.mongodb import MongoDBAdapter
 from dataflow.nodes.mongodb_nodes import (
-    AggregateNode,
     BulkDocumentInsertNode,
     CreateIndexNode,
     DocumentCountNode,
@@ -18,6 +18,7 @@ from dataflow.nodes.mongodb_nodes import (
     DocumentFindNode,
     DocumentInsertNode,
     DocumentUpdateNode,
+    MongoAggregateNode,
 )
 
 
@@ -367,17 +368,17 @@ class TestDocumentDeleteNode:
 
 
 class TestAggregateNode:
-    """Test AggregateNode."""
+    """Test MongoAggregateNode."""
 
     def test_node_initialization(self):
         """Test node initialization."""
-        node = AggregateNode()
+        node = MongoAggregateNode()
 
         assert node is not None
 
     def test_node_parameters(self):
         """Test node parameters are properly defined."""
-        node = AggregateNode()
+        node = MongoAggregateNode()
         params = node.get_parameters()
 
         assert "collection" in params
@@ -391,7 +392,7 @@ class TestAggregateNode:
     @pytest.mark.asyncio
     async def test_async_run_success(self):
         """Test successful aggregation."""
-        node = AggregateNode()
+        node = MongoAggregateNode()
 
         # Setup mock adapter
         mock_adapter = MagicMock(spec=MongoDBAdapter)
@@ -421,7 +422,7 @@ class TestAggregateNode:
     @pytest.mark.asyncio
     async def test_async_run_empty_results(self):
         """Test aggregation with no results."""
-        node = AggregateNode()
+        node = MongoAggregateNode()
 
         # Setup mock adapter
         mock_adapter = MagicMock(spec=MongoDBAdapter)

--- a/packages/kailash-dataflow/tests/unit/nodes/test_vector_nodes.py
+++ b/packages/kailash-dataflow/tests/unit/nodes/test_vector_nodes.py
@@ -1,16 +1,17 @@
 """
 Unit tests for vector search nodes.
 
-Tests for VectorSearchNode, CreateVectorIndexNode, and HybridSearchNode.
+Tests for VectorSearchNode, CreateVectorIndexNode, and PgVectorHybridSearchNode.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from dataflow.adapters import PostgreSQLVectorAdapter
 from dataflow.nodes.vector_nodes import (
     CreateVectorIndexNode,
-    HybridSearchNode,
+    PgVectorHybridSearchNode,
     VectorSearchNode,
 )
 
@@ -338,12 +339,12 @@ class TestCreateVectorIndexNode:
 
 
 @pytest.mark.unit
-class TestHybridSearchNode:
-    """Test HybridSearchNode initialization and configuration."""
+class TestPgVectorHybridSearchNode:
+    """Test PgVectorHybridSearchNode initialization and configuration."""
 
     def test_node_initialization(self):
-        """HybridSearchNode initializes correctly."""
-        node = HybridSearchNode(
+        """PgVectorHybridSearchNode initializes correctly."""
+        node = PgVectorHybridSearchNode(
             table_name="documents",
             dataflow_instance=MagicMock(),
         )
@@ -352,8 +353,8 @@ class TestHybridSearchNode:
         assert node.dataflow_instance is not None
 
     def test_get_parameters(self):
-        """HybridSearchNode defines correct parameters."""
-        node = HybridSearchNode(table_name="documents")
+        """PgVectorHybridSearchNode defines correct parameters."""
+        node = PgVectorHybridSearchNode(table_name="documents")
         params = node.get_parameters()
 
         # Required parameters
@@ -381,8 +382,8 @@ class TestHybridSearchNode:
 
     @pytest.mark.asyncio
     async def test_async_run_requires_dataflow_instance(self):
-        """HybridSearchNode requires dataflow_instance."""
-        node = HybridSearchNode(table_name="documents")
+        """PgVectorHybridSearchNode requires dataflow_instance."""
+        node = PgVectorHybridSearchNode(table_name="documents")
         node.query_vector = [0.1] * 1536
 
         with pytest.raises(ValueError, match="requires dataflow_instance"):
@@ -390,11 +391,11 @@ class TestHybridSearchNode:
 
     @pytest.mark.asyncio
     async def test_async_run_requires_vector_adapter(self):
-        """HybridSearchNode requires PostgreSQLVectorAdapter."""
+        """PgVectorHybridSearchNode requires PostgreSQLVectorAdapter."""
         mock_dataflow = MagicMock()
         mock_dataflow.adapter = MagicMock()  # Not PostgreSQLVectorAdapter
 
-        node = HybridSearchNode(
+        node = PgVectorHybridSearchNode(
             table_name="documents",
             dataflow_instance=mock_dataflow,
         )
@@ -405,12 +406,12 @@ class TestHybridSearchNode:
 
     @pytest.mark.asyncio
     async def test_async_run_requires_table_name(self):
-        """HybridSearchNode requires table_name."""
+        """PgVectorHybridSearchNode requires table_name."""
         mock_adapter = MagicMock(spec=PostgreSQLVectorAdapter)
         mock_dataflow = MagicMock()
         mock_dataflow.adapter = mock_adapter
 
-        node = HybridSearchNode(
+        node = PgVectorHybridSearchNode(
             table_name=None,
             dataflow_instance=mock_dataflow,
         )
@@ -421,7 +422,7 @@ class TestHybridSearchNode:
 
     @pytest.mark.asyncio
     async def test_async_run_hybrid_search(self):
-        """HybridSearchNode executes hybrid search successfully."""
+        """PgVectorHybridSearchNode executes hybrid search successfully."""
         # Mock adapter
         mock_adapter = MagicMock(spec=PostgreSQLVectorAdapter)
         mock_results = [
@@ -434,7 +435,7 @@ class TestHybridSearchNode:
         mock_dataflow.adapter = mock_adapter
 
         # Create node
-        node = HybridSearchNode(
+        node = PgVectorHybridSearchNode(
             table_name="documents",
             dataflow_instance=mock_dataflow,
         )
@@ -470,7 +471,7 @@ class TestHybridSearchNode:
 
     @pytest.mark.asyncio
     async def test_async_run_vector_only_search(self):
-        """HybridSearchNode executes vector-only search when text_query is None."""
+        """PgVectorHybridSearchNode executes vector-only search when text_query is None."""
         # Mock adapter
         mock_adapter = MagicMock(spec=PostgreSQLVectorAdapter)
         mock_results = [{"id": "1", "title": "Doc 1"}]
@@ -480,7 +481,7 @@ class TestHybridSearchNode:
         mock_dataflow.adapter = mock_adapter
 
         # Create node
-        node = HybridSearchNode(
+        node = PgVectorHybridSearchNode(
             table_name="documents",
             dataflow_instance=mock_dataflow,
         )
@@ -497,7 +498,7 @@ class TestHybridSearchNode:
 
     @pytest.mark.asyncio
     async def test_async_run_handles_errors(self):
-        """HybridSearchNode handles adapter errors."""
+        """PgVectorHybridSearchNode handles adapter errors."""
         # Mock adapter that raises error
         mock_adapter = MagicMock(spec=PostgreSQLVectorAdapter)
         mock_adapter.hybrid_search = AsyncMock(
@@ -507,7 +508,7 @@ class TestHybridSearchNode:
         mock_dataflow = MagicMock()
         mock_dataflow.adapter = mock_adapter
 
-        node = HybridSearchNode(
+        node = PgVectorHybridSearchNode(
             table_name="documents",
             dataflow_instance=mock_dataflow,
         )

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.22.0] — 2026-05-19 — node-registry collision fix (#891)
+
+### Changed
+
+- **`HybridSearchNode` renamed to `SemanticHybridSearchNode` (#891)** — the RAG
+  hybrid-search node (`kaizen.nodes.ai.hybrid_search`) registered the same global
+  registry name as kailash-dataflow's pgvector `HybridSearchNode`, making
+  `add_node("HybridSearchNode")` resolve import-order-dependently. The class is
+  internal-only (not on the package's public `__init__` surface), so no
+  deprecation shim is provided. Deep importers migrate:
+  `from kaizen.nodes.ai.hybrid_search import HybridSearchNode` →
+  `import SemanticHybridSearchNode`; `add_node("HybridSearchNode", ...)` →
+  `add_node("SemanticHybridSearchNode", ...)`.
+
 ## [2.21.1] — 2026-05-18 — restore `kaizen.api` deprecation shim (#1071)
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.21.1"
+version = "2.22.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.21.1"
+__version__ = "2.22.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/__init__.py
@@ -16,7 +16,7 @@ from kaizen.providers.registry import PROVIDERS, get_available_providers, get_pr
 from .a2a import A2AAgentNode, A2ACoordinatorNode, SharedMemoryPoolNode
 from .agents import ChatAgent, FunctionCallingAgent, PlanningAgent, RetrievalAgent
 from .embedding_generator import EmbeddingGeneratorNode
-from .hybrid_search import AdaptiveSearchNode, HybridSearchNode
+from .hybrid_search import AdaptiveSearchNode, SemanticHybridSearchNode
 
 # Import intelligent orchestration nodes
 from .intelligent_agent_orchestrator import (
@@ -70,7 +70,7 @@ __all__ = [
     "SemanticMemoryStoreNode",
     "SemanticMemorySearchNode",
     "SemanticAgentMatchingNode",
-    "HybridSearchNode",
+    "SemanticHybridSearchNode",
     "AdaptiveSearchNode",
     "StreamingAnalyticsNode",
     "A2AMonitoringNode",

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/hybrid_search.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/hybrid_search.py
@@ -16,7 +16,6 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy as np
-
 from kailash.nodes.base import Node, NodeParameter, register_node
 
 from .a2a import A2AAgentCard
@@ -299,8 +298,8 @@ class ContextualScorer:
         return min(1.0, overlap / len(req_set) + 0.2)
 
 
-@register_node()
-class HybridSearchNode(Node):
+@register_node(alias="SemanticHybridSearchNode")
+class SemanticHybridSearchNode(Node):
     """Enhanced hybrid search for A2A agent matching."""
 
     def __init__(self, name: str = "hybrid_search", **kwargs):
@@ -762,7 +761,7 @@ class AdaptiveSearchNode(Node):
         self.weight_history = []
 
         # Initialize hybrid search
-        self.hybrid_search = HybridSearchNode(
+        self.hybrid_search = SemanticHybridSearchNode(
             name="internal_hybrid_search",
             semantic_weight=self.semantic_weight,
             keyword_weight=self.keyword_weight,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.22.1"
+version = "2.23.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.22.1"
+__version__ = "2.23.0"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/nodes/base.py
+++ b/src/kailash/nodes/base.py
@@ -28,14 +28,13 @@ from collections import OrderedDict
 from datetime import UTC, datetime
 from typing import Any, TypeVar
 
-from pydantic import BaseModel, Field, ValidationError
-
 from kailash.nodes.ports import InputPort, OutputPort, get_port_registry
 from kailash.sdk_exceptions import (
     NodeConfigurationError,
     NodeExecutionError,
     NodeValidationError,
 )
+from pydantic import BaseModel, Field, ValidationError
 
 # ADR-002: Module-level logger for node registration messages
 _logger = logging.getLogger(__name__)
@@ -1414,9 +1413,8 @@ class Node(ABC):
 
         # Then validate JSON-serializability
         # Skip JSON validation for state management objects
-        from pydantic import BaseModel
-
         from kailash.workflow.state import WorkflowStateWrapper
+        from pydantic import BaseModel
 
         non_serializable = []
         for k, v in outputs.items():
@@ -2298,6 +2296,11 @@ class NodeRegistry:
 
     _instance = None
     _nodes: dict[str, type[Node]] = {}
+    # Registry names ever registered with allow_override=True. DataFlow
+    # @db.model generates CRUD node classes whose names may coincide with
+    # static nodes; such names are exempt from the cross-module collision
+    # guard (issue #891) in either registration order. See register().
+    _override_names: set[str] = set()
 
     def __new__(cls):
         """Ensure singleton instance.
@@ -2313,7 +2316,13 @@ class NodeRegistry:
         return cls._instance
 
     @classmethod
-    def register(cls, node_class: type[Node], alias: str | None = None):
+    def register(
+        cls,
+        node_class: type[Node],
+        alias: str | None = None,
+        *,
+        allow_override: bool = False,
+    ):
         """Register a node class.
 
         Adds a node class to the global registry, making it available
@@ -2371,7 +2380,14 @@ class NodeRegistry:
             existing = cls._nodes[node_name]
             existing_module = getattr(existing, "__module__", None)
             new_module = getattr(node_class, "__module__", None)
-            if existing_module != new_module:
+            # The cross-module guard targets only static-vs-static cross-package
+            # collisions (issue #891). A registration is "dynamic" when the
+            # caller passed allow_override=True (DataFlow @db.model generates a
+            # fresh CRUD node class per decoration) OR the incumbent name was
+            # itself registered dynamically — in either order the overwrite is
+            # intentional, not the #891 import-order-dependent dispatch bug.
+            dynamic = allow_override or node_name in cls._override_names
+            if not dynamic and existing_module != new_module:
                 # __module__ strings differ — but a package reachable both as
                 # `pkg.*` and `src.pkg.*` (src/ on sys.path) yields two module
                 # spellings for ONE source file. A genuine collision is two
@@ -2397,11 +2413,13 @@ class NodeRegistry:
                         f"under an explicit @register_node(alias=...) with a "
                         f"distinct name."
                     )
-            # ADR-002: same-module (or same-file dual-import) re-registration
-            # stays non-fatal — DataFlow model decoration regenerates CRUD node
+            # ADR-002: same-module / same-file / dynamic re-registration stays
+            # non-fatal — DataFlow model decoration regenerates CRUD node
             # classes (fresh class objects, same __module__) per @db.model call.
             _logger.info(f"Overwriting existing node registration for '{node_name}'")
 
+        if allow_override:
+            cls._override_names.add(node_name)
         cls._nodes[node_name] = node_class
         _logger.debug(f"Registered node '{node_name}'")
 

--- a/src/kailash/nodes/base.py
+++ b/src/kailash/nodes/base.py
@@ -2384,6 +2384,10 @@ class NodeRegistry:
                     # Cross-module collision: two distinct classes from
                     # different modules claiming one registry name —
                     # import-order-dependent dispatch (issue #891). BLOCKED.
+                    _logger.error(
+                        f"Node name collision for '{node_name}': "
+                        f"{existing_module} vs {new_module} — registration refused"
+                    )
                     raise NodeConfigurationError(
                         f"Node name collision for '{node_name}': already "
                         f"registered by {existing_module}."

--- a/src/kailash/nodes/base.py
+++ b/src/kailash/nodes/base.py
@@ -2368,8 +2368,34 @@ class NodeRegistry:
         node_name = alias or node_class.__name__
 
         if node_name in cls._nodes:
-            # ADR-002: Changed from WARNING to INFO and use named logger
-            # This is expected behavior in DataFlow where model decoration re-registers nodes
+            existing = cls._nodes[node_name]
+            existing_module = getattr(existing, "__module__", None)
+            new_module = getattr(node_class, "__module__", None)
+            if existing_module != new_module:
+                # __module__ strings differ — but a package reachable both as
+                # `pkg.*` and `src.pkg.*` (src/ on sys.path) yields two module
+                # spellings for ONE source file. A genuine collision is two
+                # DIFFERENT files; compare source files to tell them apart.
+                try:
+                    same_file = inspect.getfile(existing) == inspect.getfile(node_class)
+                except (TypeError, OSError):
+                    same_file = False
+                if not same_file:
+                    # Cross-module collision: two distinct classes from
+                    # different modules claiming one registry name —
+                    # import-order-dependent dispatch (issue #891). BLOCKED.
+                    raise NodeConfigurationError(
+                        f"Node name collision for '{node_name}': already "
+                        f"registered by {existing_module}."
+                        f"{getattr(existing, '__name__', existing)}; "
+                        f"{new_module}.{node_class.__name__} cannot re-register "
+                        f"the same name from a different module. Register one "
+                        f"under an explicit @register_node(alias=...) with a "
+                        f"distinct name."
+                    )
+            # ADR-002: same-module (or same-file dual-import) re-registration
+            # stays non-fatal — DataFlow model decoration regenerates CRUD node
+            # classes (fresh class objects, same __module__) per @db.model call.
             _logger.info(f"Overwriting existing node registration for '{node_name}'")
 
         cls._nodes[node_name] = node_class

--- a/src/kailash/nodes/base.py
+++ b/src/kailash/nodes/base.py
@@ -28,13 +28,14 @@ from collections import OrderedDict
 from datetime import UTC, datetime
 from typing import Any, TypeVar
 
+from pydantic import BaseModel, Field, ValidationError
+
 from kailash.nodes.ports import InputPort, OutputPort, get_port_registry
 from kailash.sdk_exceptions import (
     NodeConfigurationError,
     NodeExecutionError,
     NodeValidationError,
 )
-from pydantic import BaseModel, Field, ValidationError
 
 # ADR-002: Module-level logger for node registration messages
 _logger = logging.getLogger(__name__)
@@ -1413,8 +1414,9 @@ class Node(ABC):
 
         # Then validate JSON-serializability
         # Skip JSON validation for state management objects
-        from kailash.workflow.state import WorkflowStateWrapper
         from pydantic import BaseModel
+
+        from kailash.workflow.state import WorkflowStateWrapper
 
         non_serializable = []
         for k, v in outputs.items():
@@ -2296,11 +2298,13 @@ class NodeRegistry:
 
     _instance = None
     _nodes: dict[str, type[Node]] = {}
-    # Registry names ever registered with allow_override=True. DataFlow
-    # @db.model generates CRUD node classes whose names may coincide with
-    # static nodes; such names are exempt from the cross-module collision
-    # guard (issue #891) in either registration order. See register().
-    _override_names: set[str] = set()
+    # Names whose CURRENT incumbent was registered with allow_override=True
+    # (DataFlow @db.model generates CRUD node classes). Updated on every
+    # registration to track the live incumbent — added on a dynamic
+    # registration, removed on a static one — so the cross-module collision
+    # guard (issue #891) is exempted only while a dynamic node holds the
+    # slot, never permanently. See register().
+    _dynamic_names: set[str] = set()
 
     def __new__(cls):
         """Ensure singleton instance.
@@ -2386,7 +2390,7 @@ class NodeRegistry:
             # fresh CRUD node class per decoration) OR the incumbent name was
             # itself registered dynamically — in either order the overwrite is
             # intentional, not the #891 import-order-dependent dispatch bug.
-            dynamic = allow_override or node_name in cls._override_names
+            dynamic = allow_override or node_name in cls._dynamic_names
             if not dynamic and existing_module != new_module:
                 # __module__ strings differ — but a package reachable both as
                 # `pkg.*` and `src.pkg.*` (src/ on sys.path) yields two module
@@ -2418,8 +2422,13 @@ class NodeRegistry:
             # classes (fresh class objects, same __module__) per @db.model call.
             _logger.info(f"Overwriting existing node registration for '{node_name}'")
 
+        # Track the LIVE incumbent's dynamic-ness: a dynamic registration marks
+        # the name exempt; a subsequent static registration un-marks it, so the
+        # exemption never outlives the dynamic node that earned it (issue #891).
         if allow_override:
-            cls._override_names.add(node_name)
+            cls._dynamic_names.add(node_name)
+        else:
+            cls._dynamic_names.discard(node_name)
         cls._nodes[node_name] = node_class
         _logger.debug(f"Registered node '{node_name}'")
 
@@ -2649,6 +2658,7 @@ class NodeRegistry:
             >>> # - Should re-register needed nodes
         """
         cls._nodes.clear()
+        cls._dynamic_names.clear()
         logging.info("Cleared all registered nodes")
 
 

--- a/src/kailash/nodes/data/bulk_operations.py
+++ b/src/kailash/nodes/data/bulk_operations.py
@@ -701,8 +701,8 @@ class BulkDeleteNode(AsyncSQLDatabaseNode, BulkOperationMixin):
         return operator_map.get(mongo_op, "=")
 
 
-@register_node()
-class BulkUpsertNode(AsyncSQLDatabaseNode, BulkOperationMixin):
+@register_node(alias="SQLBulkUpsertNode")
+class SQLBulkUpsertNode(AsyncSQLDatabaseNode, BulkOperationMixin):
     """Bulk insert or update (upsert) operations."""
 
     def __init__(self, **config):

--- a/tests/integration/nodes/data/test_bulk_operations_integration.py
+++ b/tests/integration/nodes/data/test_bulk_operations_integration.py
@@ -5,15 +5,14 @@ from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-
 from kailash.nodes.data.bulk_operations import (
     BulkCreateNode,
     BulkDeleteNode,
     BulkErrorStrategy,
     BulkOperationResult,
     BulkUpdateNode,
-    BulkUpsertNode,
     DatabaseType,
+    SQLBulkUpsertNode,
 )
 from kailash.sdk_exceptions import NodeExecutionError, NodeValidationError
 
@@ -497,7 +496,7 @@ class TestBulkDeleteNode:
 
 
 class TestBulkUpsertNode:
-    """Test BulkUpsertNode functionality."""
+    """Test SQLBulkUpsertNode functionality."""
 
     @pytest.mark.asyncio
     async def test_upsert_postgresql(self):
@@ -505,7 +504,7 @@ class TestBulkUpsertNode:
         mock_adapter = AsyncMock()
         mock_adapter.execute = AsyncMock()
 
-        node = BulkUpsertNode(
+        node = SQLBulkUpsertNode(
             database_type="postgresql",
             host="localhost",
             database="test",
@@ -536,7 +535,7 @@ class TestBulkUpsertNode:
         mock_adapter = AsyncMock()
         mock_adapter.execute = AsyncMock()
 
-        node = BulkUpsertNode(
+        node = SQLBulkUpsertNode(
             database_type="mysql",
             host="localhost",
             database="test",
@@ -563,7 +562,7 @@ class TestBulkUpsertNode:
         mock_adapter = AsyncMock()
         mock_adapter.execute = AsyncMock()
 
-        node = BulkUpsertNode(
+        node = SQLBulkUpsertNode(
             database_type="sqlite",
             database=":memory:",
             table_name="products",
@@ -587,7 +586,7 @@ class TestBulkUpsertNode:
         mock_adapter = AsyncMock()
         mock_adapter.execute = AsyncMock()
 
-        node = BulkUpsertNode(
+        node = SQLBulkUpsertNode(
             database_type="postgresql",
             host="localhost",
             database="test",
@@ -613,7 +612,7 @@ class TestBulkUpsertNode:
         mock_adapter = AsyncMock()
         mock_adapter.execute = AsyncMock()
 
-        node = BulkUpsertNode(
+        node = SQLBulkUpsertNode(
             database_type="postgresql",
             host="localhost",
             database="test",
@@ -724,8 +723,8 @@ class TestNodeParameters:
         assert "require_filter" in param_names
 
     def test_bulk_upsert_parameters(self):
-        """Test BulkUpsertNode parameters."""
-        node = BulkUpsertNode(
+        """Test SQLBulkUpsertNode parameters."""
+        node = SQLBulkUpsertNode(
             database_type="postgresql",
             host="localhost",
             database="test",

--- a/tests/regression/test_issue_891_node_registry_collisions.py
+++ b/tests/regression/test_issue_891_node_registry_collisions.py
@@ -23,19 +23,19 @@ from __future__ import annotations
 import inspect
 
 import pytest
-
 from kailash.nodes.base import Node, NodeRegistry
 from kailash.sdk_exceptions import NodeConfigurationError
 
 
 def _force_import_node_modules() -> None:
     """Import the node modules so their @register_node decorators run."""
+    import kailash.nodes.data.bulk_operations  # noqa: F401
+    import kaizen.nodes.ai.hybrid_search  # noqa: F401
+
     import dataflow.nodes.aggregate_operations  # noqa: F401
     import dataflow.nodes.bulk_upsert  # noqa: F401
     import dataflow.nodes.mongodb_nodes  # noqa: F401
     import dataflow.nodes.vector_nodes  # noqa: F401
-    import kailash.nodes.data.bulk_operations  # noqa: F401
-    import kaizen.nodes.ai.hybrid_search  # noqa: F401
 
 
 @pytest.mark.regression
@@ -133,3 +133,39 @@ def test_issue_891_same_module_reregistration_allowed():
         assert NodeRegistry._nodes[alias] is probe_b
     finally:
         NodeRegistry._nodes.pop(alias, None)
+
+
+@pytest.mark.regression
+def test_issue_891_allow_override_exempts_dynamic_registration():
+    """allow_override=True exempts the cross-module guard, in either order.
+
+    DataFlow @db.model regenerates CRUD node classes whose names may coincide
+    with static nodes (e.g. a `Document` model's generated `DocumentCountNode`
+    vs the static `mongodb_nodes.DocumentCountNode`). The overwrite is
+    intentional — the guard must not fire on it.
+    """
+    static_probe = _probe_node_class("_Issue891OvStatic")
+    dynamic_probe = _probe_node_class("_Issue891OvDynamic")
+    static_probe.__module__ = "json.decoder"
+    dynamic_probe.__module__ = "json.encoder"  # different file → would collide
+    alias = "_Issue891OverrideProbe"
+
+    # Order A — dynamic registers first; a later static registration of the
+    # same name from a different module must NOT raise (incumbent is dynamic).
+    NodeRegistry.register(dynamic_probe, alias=alias, allow_override=True)
+    try:
+        NodeRegistry.register(static_probe, alias=alias)
+        assert NodeRegistry._nodes[alias] is static_probe
+    finally:
+        NodeRegistry._nodes.pop(alias, None)
+        NodeRegistry._override_names.discard(alias)
+
+    # Order B — static registers first; a later dynamic registration
+    # (allow_override=True) of the same name must NOT raise.
+    NodeRegistry.register(static_probe, alias=alias)
+    try:
+        NodeRegistry.register(dynamic_probe, alias=alias, allow_override=True)
+        assert NodeRegistry._nodes[alias] is dynamic_probe
+    finally:
+        NodeRegistry._nodes.pop(alias, None)
+        NodeRegistry._override_names.discard(alias)

--- a/tests/regression/test_issue_891_node_registry_collisions.py
+++ b/tests/regression/test_issue_891_node_registry_collisions.py
@@ -1,0 +1,135 @@
+"""Regression tests for issue #891 — node-registry name collisions.
+
+Three pairs of distinct node classes each registered the same global
+``NodeRegistry`` name, making ``add_node("<name>")`` resolve to whichever
+class was imported last (import-order-dependent dispatch):
+
+- ``HybridSearchNode`` — kailash-dataflow vector node vs kailash-kaizen RAG node
+- ``BulkUpsertNode``   — kailash core node vs kailash-dataflow node
+- ``AggregateNode``    — dataflow.aggregate_operations vs dataflow.mongodb_nodes
+
+The fix renames the colliding classes to distinct names and adds a core-SDK
+guard that raises ``NodeConfigurationError`` on any future cross-module name
+collision (while leaving same-module re-registration — DataFlow model
+decoration — non-fatal per ADR-002).
+
+These tests import all three packages in one process (the exact scenario the
+collision needed) and assert each shape is reachable via a non-colliding
+identifier, the old bare names are gone, and the guard fires correctly.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from kailash.nodes.base import Node, NodeRegistry
+from kailash.sdk_exceptions import NodeConfigurationError
+
+
+def _force_import_node_modules() -> None:
+    """Import the node modules so their @register_node decorators run."""
+    import dataflow.nodes.aggregate_operations  # noqa: F401
+    import dataflow.nodes.bulk_upsert  # noqa: F401
+    import dataflow.nodes.mongodb_nodes  # noqa: F401
+    import dataflow.nodes.vector_nodes  # noqa: F401
+    import kailash.nodes.data.bulk_operations  # noqa: F401
+    import kaizen.nodes.ai.hybrid_search  # noqa: F401
+
+
+@pytest.mark.regression
+def test_issue_891_renamed_nodes_resolve_to_expected_classes():
+    """Each renamed node resolves in the registry to exactly one class."""
+    _force_import_node_modules()
+
+    expected = {
+        "PgVectorHybridSearchNode": "dataflow.nodes.vector_nodes",
+        "SemanticHybridSearchNode": "kaizen.nodes.ai.hybrid_search",
+        "SQLBulkUpsertNode": "kailash.nodes.data.bulk_operations",
+        "DataFlowBulkUpsertNode": "dataflow.nodes.bulk_upsert",
+        "AggregateNode": "dataflow.nodes.aggregate_operations",
+        "MongoAggregateNode": "dataflow.nodes.mongodb_nodes",
+    }
+    for name, module_tail in expected.items():
+        cls = NodeRegistry._nodes.get(name)
+        assert cls is not None, f"{name} not registered"
+        # tolerate the `src.`-prefixed dual-import spelling
+        assert cls.__module__.endswith(
+            module_tail
+        ), f"{name} resolved to {cls.__module__}, expected …{module_tail}"
+
+
+@pytest.mark.regression
+def test_issue_891_old_colliding_names_no_longer_registered():
+    """The bare colliding names HybridSearchNode / BulkUpsertNode are gone.
+
+    AggregateNode is intentionally still registered — it is kept by
+    dataflow.aggregate_operations (the convention owner); only the mongodb
+    side was renamed to MongoAggregateNode.
+    """
+    _force_import_node_modules()
+    assert "HybridSearchNode" not in NodeRegistry._nodes
+    assert "BulkUpsertNode" not in NodeRegistry._nodes
+
+
+@pytest.mark.regression
+def test_issue_891_dataflow_hybridsearch_deprecation_alias():
+    """dataflow's public HybridSearchNode symbol still imports (one cycle).
+
+    The alias is a plain module assignment — NOT re-decorated — so it does
+    not re-register the bare name and re-open the collision.
+    """
+    from dataflow.nodes import HybridSearchNode, PgVectorHybridSearchNode
+
+    assert HybridSearchNode is PgVectorHybridSearchNode
+
+
+def _probe_node_class(name: str) -> type[Node]:
+    """Build a minimal valid Node subclass for guard probes."""
+
+    def get_parameters(self):  # noqa: ANN001
+        return {}
+
+    def run(self, **kwargs):  # noqa: ANN001, ANN003
+        return {}
+
+    return type(name, (Node,), {"get_parameters": get_parameters, "run": run})
+
+
+@pytest.mark.regression
+def test_issue_891_cross_module_collision_raises():
+    """Two distinct classes from different source files cannot share a name."""
+    probe_a = _probe_node_class("_Issue891ProbeA")
+    probe_b = _probe_node_class("_Issue891ProbeB")
+    # point the probes at two real, distinct source files
+    probe_a.__module__ = "json.decoder"
+    probe_b.__module__ = "json.encoder"
+    assert inspect.getfile(probe_a) != inspect.getfile(probe_b)
+
+    alias = "_Issue891CollisionProbe"
+    NodeRegistry.register(probe_a, alias=alias)
+    try:
+        with pytest.raises(NodeConfigurationError, match="collision"):
+            NodeRegistry.register(probe_b, alias=alias)
+    finally:
+        NodeRegistry._nodes.pop(alias, None)
+
+
+@pytest.mark.regression
+def test_issue_891_same_module_reregistration_allowed():
+    """Same-module re-registration stays non-fatal (ADR-002 / DataFlow models)."""
+    probe_a = _probe_node_class("_Issue891SameModA")
+    probe_b = _probe_node_class("_Issue891SameModB")
+    # same source file → DataFlow model-decoration pattern (fresh class, same module)
+    probe_a.__module__ = "json.decoder"
+    probe_b.__module__ = "json.decoder"
+
+    alias = "_Issue891SameModuleProbe"
+    NodeRegistry.register(probe_a, alias=alias)
+    try:
+        # must NOT raise
+        NodeRegistry.register(probe_b, alias=alias)
+        assert NodeRegistry._nodes[alias] is probe_b
+    finally:
+        NodeRegistry._nodes.pop(alias, None)

--- a/tests/regression/test_issue_891_node_registry_collisions.py
+++ b/tests/regression/test_issue_891_node_registry_collisions.py
@@ -23,19 +23,19 @@ from __future__ import annotations
 import inspect
 
 import pytest
+
 from kailash.nodes.base import Node, NodeRegistry
 from kailash.sdk_exceptions import NodeConfigurationError
 
 
 def _force_import_node_modules() -> None:
     """Import the node modules so their @register_node decorators run."""
-    import kailash.nodes.data.bulk_operations  # noqa: F401
-    import kaizen.nodes.ai.hybrid_search  # noqa: F401
-
     import dataflow.nodes.aggregate_operations  # noqa: F401
     import dataflow.nodes.bulk_upsert  # noqa: F401
     import dataflow.nodes.mongodb_nodes  # noqa: F401
     import dataflow.nodes.vector_nodes  # noqa: F401
+    import kailash.nodes.data.bulk_operations  # noqa: F401
+    import kaizen.nodes.ai.hybrid_search  # noqa: F401
 
 
 @pytest.mark.regression
@@ -158,7 +158,7 @@ def test_issue_891_allow_override_exempts_dynamic_registration():
         assert NodeRegistry._nodes[alias] is static_probe
     finally:
         NodeRegistry._nodes.pop(alias, None)
-        NodeRegistry._override_names.discard(alias)
+        NodeRegistry._dynamic_names.discard(alias)
 
     # Order B — static registers first; a later dynamic registration
     # (allow_override=True) of the same name must NOT raise.
@@ -168,4 +168,36 @@ def test_issue_891_allow_override_exempts_dynamic_registration():
         assert NodeRegistry._nodes[alias] is dynamic_probe
     finally:
         NodeRegistry._nodes.pop(alias, None)
-        NodeRegistry._override_names.discard(alias)
+        NodeRegistry._dynamic_names.discard(alias)
+
+
+@pytest.mark.regression
+def test_issue_891_dynamic_exemption_does_not_outlive_the_dynamic_node():
+    """The allow_override exemption tracks the LIVE incumbent, not the name.
+
+    Once a static node takes a slot previously held by a dynamic node, a
+    genuine static-vs-static cross-module collision on that name MUST still
+    raise — the exemption must not be permanently sticky (issue #891).
+    """
+    dynamic_probe = _probe_node_class("_Issue891StickyDynamic")
+    static_a = _probe_node_class("_Issue891StickyStaticA")
+    static_b = _probe_node_class("_Issue891StickyStaticB")
+    dynamic_probe.__module__ = "json.decoder"
+    static_a.__module__ = "json.encoder"
+    static_b.__module__ = "json.scanner"  # third distinct real file
+    alias = "_Issue891StickyProbe"
+
+    try:
+        # 1. dynamic registers — name is now exempt
+        NodeRegistry.register(dynamic_probe, alias=alias, allow_override=True)
+        assert alias in NodeRegistry._dynamic_names
+        # 2. a static node takes the slot — exemption must be revoked
+        NodeRegistry.register(static_a, alias=alias)
+        assert alias not in NodeRegistry._dynamic_names
+        # 3. a second static node, different module — genuine #891 collision,
+        #    MUST raise even though the name was once dynamic
+        with pytest.raises(NodeConfigurationError, match="collision"):
+            NodeRegistry.register(static_b, alias=alias)
+    finally:
+        NodeRegistry._nodes.pop(alias, None)
+        NodeRegistry._dynamic_names.discard(alias)

--- a/workspaces/issue-891-hybridsearch-collision/01-analysis/01-rootcause.md
+++ b/workspaces/issue-891-hybridsearch-collision/01-analysis/01-rootcause.md
@@ -1,0 +1,44 @@
+# 01 — Root Cause: HybridSearchNode registry collision
+
+## Verified mechanics (2026-05-18)
+
+1. `register_node(alias=None)` (`src/kailash/nodes/base.py:2607`) defaults the
+   registry name to `node_class.__name__` when no alias is passed.
+2. Both nodes use a bare `@register_node()`:
+   - `packages/kailash-dataflow/src/dataflow/nodes/vector_nodes.py:322-323`
+     → registers as `"HybridSearchNode"` (pgvector hybrid search, `AsyncNode`).
+   - `packages/kailash-kaizen/src/kaizen/nodes/ai/hybrid_search.py:302-303`
+     → registers as `"HybridSearchNode"` (RAG semantic search, `Node`).
+3. `NodeRegistry.register` (`base.py:2368-2375`) on a name clash does NOT fail —
+   it INFO-logs `Overwriting existing node registration for 'HybridSearchNode'`
+   (`base.py:2373`) and overwrites. Last import wins.
+4. Result: `workflow.add_node("HybridSearchNode", ...)` resolves to whichever
+   class was imported last — import-order-dependent, non-deterministic across
+   environments and refactors.
+
+## The ADR-002 constraint (critical — rules out naive option c)
+
+`base.py:2371-2373` INFO-not-WARNING is intentional per ADR-002: DataFlow
+**legitimately** re-registers nodes. dataflow-specialist confirmed the mechanism:
+
+- `@db.model` (`dataflow/core/engine.py:1813`, decoration at `:1982-1983`) calls
+  `_generate_crud_nodes` on every decoration.
+- `dataflow/core/nodes.py:488` `_create_node_class` runs a `class DataFlowNode(AsyncNode):`
+  statement **inside the method body** (`nodes.py:498`) — a fresh class object
+  every call.
+- `nodes.py:443,481` re-register each fresh class via `NodeRegistry.register(...)`.
+
+⇒ A blanket "hard-fail on any duplicate name" (acceptance option c) — and even a
+narrowed `registry[name] is not node_class` identity check — would raise on
+legitimate DataFlow model re-decoration (re-import, test re-run, hot reload),
+because re-decoration produces a NEW class object each time.
+
+**Safe narrowing:** hard-fail only when the colliding classes have a DIFFERENT
+`__module__` (true cross-package collision). Same-module re-registration keeps
+the INFO-log path. This preserves ADR-002 while closing the collision class.
+
+## Severity
+
+MEDIUM — silent, import-order-dependent. No user report yet; live since
+`b553104c` (2026-03-11 monorepo refactor). Becomes a real failure the moment one
+process consumes both kailash-dataflow vector search and kailash-kaizen RAG.

--- a/workspaces/issue-891-hybridsearch-collision/01-analysis/02-resolution-options.md
+++ b/workspaces/issue-891-hybridsearch-collision/01-analysis/02-resolution-options.md
@@ -1,0 +1,86 @@
+# 02 — Resolution Options Analysis
+
+Issue #891 acceptance criteria offer three shapes. Analysis below; recommendation
+at the end. This is a public-API change → user gate at /todos.
+
+## Option (a) — Rename both classes [RECOMMENDED]
+
+Rename both colliding classes to capability-descriptive names; register each
+under an explicit alias matching the class name.
+
+- Kaizen: `HybridSearchNode` → `SemanticHybridSearchNode`
+  `@register_node(alias="SemanticHybridSearchNode")`.
+  Per kaizen-specialist: **internal-only** symbol (not in `kaizen/__init__.py`,
+  only reachable via `kaizen.nodes.ai.hybrid_search`). Rule 6a deprecation shim
+  is therefore NOT mandatory. 4 lines, 2 source files, zero tests, zero
+  `add_node` literals.
+- DataFlow: `HybridSearchNode` → `PgVectorHybridSearchNode`
+  `@register_node(alias="PgVectorHybridSearchNode")`.
+  Per dataflow-specialist: **public** symbol — exported from
+  `dataflow/nodes/__init__.py::__all__:50`. Rename touches ~6 source/doc files +
+  2 test files. Public → keep a one-cycle module alias
+  `HybridSearchNode = PgVectorHybridSearchNode` (plain assignment, NOT re-decorated
+  — a re-decorated alias would re-create the registry collision) so deep importers
+  do not hard-break; CHANGELOG migration entry.
+
+Pros: each name maps to exactly one class; names are self-documenting; blast
+radius is contained to the two packages; honors Rule 6a where it applies (public
+dataflow symbol) and skips ceremony where it doesn't (internal kaizen symbol).
+Cons: `add_node("HybridSearchNode", ...)` in old downstream workflow code stops
+resolving — surfaces as a loud "node not found" (acceptable: loud > silent-wrong;
+CHANGELOG documents the migration). Optional: register an ambiguity sentinel
+under `"HybridSearchNode"` that raises a typed error naming both replacements —
+gold-plating, listed as a sub-option for the user.
+
+## Option (b) — Namespace registration with package prefix
+
+Register as `dataflow.HybridSearchNode` / `kaizen.HybridSearchNode`.
+
+Rejected. The registry is a flat string→class dict. Prefixing only these two
+nodes makes the API inconsistent (every other node bare-named, these two
+prefixed). Prefixing ALL nodes is an ecosystem-wide breaking change to every
+`add_node(...)` call. Worst blast radius of the three.
+
+## Option (c) — Hard-fail at registration on duplicate name
+
+Rejected AS A STANDALONE FIX for two reasons:
+
+1. A blanket hard-fail breaks DataFlow model re-decoration (see 01-rootcause.md
+   — ADR-002). Even a `is not node_class` identity check breaks it, because
+   re-decoration produces fresh class objects.
+2. Even if narrowed, (c) alone does not FIX the collision — it converts silent
+   wrong-dispatch into a loud crash, which BREAKS the legitimate use case
+   "consume both vector search and RAG in one process". (c) is hardening, not a
+   resolution.
+
+BUT a `__module__`-narrowed (c) is a valuable COMPLEMENT to (a): make
+`NodeRegistry.register` raise `NodeConfigurationError` when a name collides with
+a class from a DIFFERENT `__module__`, keep INFO-log for same-module
+re-registration. This makes the entire collision class structurally impossible
+to recur silently — any future cross-package name clash fails loudly at import.
+
+## Recommendation
+
+**Option (a) + narrowed-(c) hardening**:
+
+1. Rename kaizen `HybridSearchNode` → `SemanticHybridSearchNode` (no shim — internal).
+2. Rename dataflow `HybridSearchNode` → `PgVectorHybridSearchNode` (one-cycle
+   module alias — public; CHANGELOG migration entry).
+3. Core SDK: `NodeRegistry.register` raises on cross-`__module__` name collision;
+   same-module re-registration keeps the ADR-002 INFO-log path.
+4. Tier-2 regression test importing BOTH packages, asserting each shape is
+   reachable via its non-colliding identifier and that `"HybridSearchNode"` no
+   longer silently overwrites.
+5. CHANGELOG entries on kailash-dataflow + kailash-kaizen.
+
+Open sub-decision for the user: register an ambiguity sentinel under the old
+`"HybridSearchNode"` string (helpful typed error) vs. leave it unregistered
+(plain "node not found"). Recommend leaving unregistered — simpler, and the
+narrowed-(c) hardening + CHANGELOG already cover the migration.
+
+## Scope
+
+~150–300 LOC across 3 packages (core SDK + dataflow + kaizen). Invariants:
+registry uniqueness, ADR-002 preservation, public-symbol shim (dataflow only),
+cross-import Tier-2 test, dual CHANGELOG. 5 invariants, ~3 call-graph hops —
+within single-shard budget.

--- a/workspaces/issue-891-hybridsearch-collision/01-analysis/03-final-plan.md
+++ b/workspaces/issue-891-hybridsearch-collision/01-analysis/03-final-plan.md
@@ -1,0 +1,82 @@
+# 03 — Final Plan (Scope B: all 3 collisions + core guard)
+
+User gate 2026-05-18: Scope B — rename all three colliding pairs + land the
+cross-`__module__` registry guard.
+
+## Naming principle
+
+Rename BOTH classes in a collision UNLESS an existing convention already
+designates a canonical owner — then keep the owner, rename the other.
+
+| Registry name      | Class                                 | Package      | New class + alias            | Rationale                                                                                            |
+| ------------------ | ------------------------------------- | ------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `HybridSearchNode` | `vector_nodes.HybridSearchNode`       | dataflow     | `PgVectorHybridSearchNode`   | no canonical owner → rename both                                                                     |
+| `HybridSearchNode` | `ai/hybrid_search.HybridSearchNode`   | kaizen       | `SemanticHybridSearchNode`   | no canonical owner → rename both                                                                     |
+| `BulkUpsertNode`   | `data/bulk_operations.BulkUpsertNode` | kailash core | `SQLBulkUpsertNode`          | no canonical owner (generic SQL vs pooled) → rename both                                             |
+| `BulkUpsertNode`   | `nodes/bulk_upsert.BulkUpsertNode`    | dataflow     | `DataFlowBulkUpsertNode`     | no canonical owner → rename both                                                                     |
+| `StreamingRAGNode` | `rag/realtime.StreamingRAGNode`       | kaizen       | `RealtimeStreamingRAGNode`   | convention exists — `rag/__init__.py:177` already aliases realtime as `RealtimeStreamingRAGNode`     |
+| `StreamingRAGNode` | `rag/optimized.StreamingRAGNode`      | kaizen       | **keeps** `StreamingRAGNode` | bare `StreamingRAGNode` import + `__all__` entry resolve to optimized — it is the convention's owner |
+
+All registrations become explicit: `@register_node(alias="<NewName>")`.
+
+## Core SDK guard (`src/kailash/nodes/base.py` `NodeRegistry.register`)
+
+On `node_name` already in `cls._nodes`:
+
+- same `__module__` → INFO-log + overwrite (unchanged — ADR-002 / DataFlow model
+  re-decoration path).
+- different `__module__` → raise `NodeConfigurationError` naming both
+  classes + modules.
+
+Atomicity: the guard crashes import on any un-renamed collision, so it lands in
+the SAME change as all six renames.
+
+## Rename call-site inventory
+
+### HybridSearchNode — dataflow (`PgVectorHybridSearchNode`)
+
+`vector_nodes.py` (class + decorator + 6 docstring/error strings),
+`nodes/__init__.py:25,50` (import + `__all__`), tests
+`test_vector_nodes.py` + `test_vector_nodes_integration.py`, docs
+(`pgvector-quickstart.md`, `pgvector-implementation-plan.md`,
+`database-expansion-strategy.md`), `examples/pgvector_rag_example.py`.
+Public → one-cycle module alias `HybridSearchNode = PgVectorHybridSearchNode`
+(plain assignment, NOT re-decorated).
+
+### HybridSearchNode — kaizen (`SemanticHybridSearchNode`)
+
+`ai/hybrid_search.py:302,303,765` (decorator, class, internal instantiation),
+`ai/__init__.py:19,73` (import + `__all__`). Internal-only → no shim required.
+
+### BulkUpsertNode — kailash core (`SQLBulkUpsertNode`)
+
+`data/bulk_operations.py:704,705` (decorator + class). Not in
+`nodes/__init__.py`/`data/__init__.py` exports — registry-string is the public
+surface. CHANGELOG on core kailash documents the `add_node` migration.
+
+### BulkUpsertNode — dataflow (`DataFlowBulkUpsertNode`)
+
+`nodes/bulk_upsert.py:44,72,101,646,653,667` (class, decorator, docstrings,
+errors, `.execute` monkeypatch), `gateway_integration.py:18,325` (import +
+`add_node` literal), `core/workflow_binding.py:60` (`"BulkUpsert"` keyword map),
+`nodes/file_source.py:6,75` (docstring refs). NOTE: `f"{model_name}BulkUpsertNode"`
+in `engine.py:3040` / `engine_production.py:209` / `protected_engine.py:137` are
+GENERATED per-model node names (`UserBulkUpsertNode`) — NOT the static node,
+leave untouched.
+
+### StreamingRAGNode — kaizen realtime (`RealtimeStreamingRAGNode`)
+
+`rag/realtime.py:404,417,767` (class, internal instantiation, `__all__`),
+`rag/__init__.py:177` (`as RealtimeStreamingRAGNode` alias becomes a direct
+import). Optimized side unchanged.
+
+## Deliverables
+
+- Core guard + 6 renames (atomic).
+- Tier-2 regression test: import all three package pairs, assert each shape
+  reachable via its non-colliding identifier, assert cross-module collision
+  raises.
+- CHANGELOG entries: kailash core, kailash-dataflow, kailash-kaizen.
+- Pre-flight: confirm no OTHER cross-module collision exists in the in-repo
+  node set (scan already done — only these 3; `CSVReaderNode`/`MyNode` hits
+  were docstring examples, not real registrations).

--- a/workspaces/issue-891-hybridsearch-collision/briefs/00-brief.md
+++ b/workspaces/issue-891-hybridsearch-collision/briefs/00-brief.md
@@ -1,0 +1,55 @@
+# Brief — Issue #891: HybridSearchNode name collision
+
+## Source
+
+GitHub issue #891 (OPEN, created 2026-05-08). Surfaced via smoke-test warning
+during kailash 2.17.0 release-prep. Pre-existing since `b553104c` (2026-03-11
+monorepo refactor). Picked up F4 — user-gated 2026-05-18 (anchor re-validated:
+user selected F4 from the stale-ledger gate).
+
+## The bug (verified live 2026-05-18)
+
+Two distinct classes register the same registry string `"HybridSearchNode"`:
+
+- `packages/kailash-dataflow/src/dataflow/nodes/vector_nodes.py:323`
+  `class HybridSearchNode(AsyncNode)` — pgvector hybrid vector+keyword search.
+  Requires `dataflow_instance`, `table_name`. Registered via `@register_node()`.
+- `packages/kailash-kaizen/src/kaizen/nodes/ai/hybrid_search.py:303`
+  `class HybridSearchNode(Node)` — RAG-shape API. Registered via `@register_node()`.
+
+`register_node(alias=None)` defaults the name to `node_class.__name__`, so both
+land on `"HybridSearchNode"` in the global `NodeRegistry._nodes` dict. Whichever
+imports last silently overwrites the other (`base.py:2373` INFO log). A workflow
+that consumes both kailash-dataflow vector search AND kailash-kaizen RAG in one
+process gets import-order-dependent dispatch.
+
+## Constraint discovered
+
+`base.py:2373` INFO-not-WARNING is intentional per ADR-002 — DataFlow model
+decoration legitimately re-registers nodes. So a blanket "hard-fail on any
+duplicate registration" (acceptance option c) would break DataFlow. Any
+hard-fail must be narrowed to cross-class / cross-package collisions.
+
+## Resolution shapes (from issue acceptance criteria)
+
+- (a) Rename one or both classes to non-colliding names + `DeprecationWarning`
+  shim per `rules/zero-tolerance.md` Rule 6a.
+- (b) Namespace registration with package prefix.
+- (c) Hard-fail at registration on duplicate name with a typed error.
+
+Decision is a public-API change affecting downstream `add_node("HybridSearchNode")`
+callers → requires user gate at /todos.
+
+## Acceptance criteria (issue #891)
+
+- [ ] Decide resolution shape (a/b/c) — user gate.
+- [ ] Fix lands in BOTH kailash-dataflow + kailash-kaizen in one release cycle.
+- [ ] Tier-2 regression test importing BOTH packages, asserting each shape is
+      reachable via a non-colliding identifier.
+- [ ] CHANGELOG entries on both packages documenting the migration step.
+
+## Scope estimate
+
+~150–300 LOC, single shard. Invariants: registry uniqueness, deprecation shim
+(one minor cycle), both-packages-same-cycle, Tier-2 cross-import test, dual
+CHANGELOG. Upper edge of single-shard budget but within it.

--- a/workspaces/issue-891-hybridsearch-collision/journal/0001-DISCOVERY-three-collisions-not-one.md
+++ b/workspaces/issue-891-hybridsearch-collision/journal/0001-DISCOVERY-three-collisions-not-one.md
@@ -1,0 +1,49 @@
+# DISCOVERY — The registry collision is a class of 3, not a single bug
+
+Date: 2026-05-18
+Phase: /analyze (issue #891)
+
+## Finding
+
+Issue #891 reports ONE registry-name collision (`HybridSearchNode`). A mechanical
+scan of every `@register_node`-decorated class across `src/` + `packages/*/src/`
+for duplicate class names surfaced **three genuine cross-module collisions**:
+
+| Registry name      | Class A                                                       | Class B                                       | Span                        |
+| ------------------ | ------------------------------------------------------------- | --------------------------------------------- | --------------------------- |
+| `HybridSearchNode` | `dataflow.nodes.vector_nodes` (`AsyncNode`)                   | `kaizen.nodes.ai.hybrid_search` (`Node`)      | cross-package               |
+| `BulkUpsertNode`   | `kailash.nodes.data.bulk_operations` (`AsyncSQLDatabaseNode`) | `dataflow.nodes.bulk_upsert` (`AsyncNode`)    | cross-package               |
+| `StreamingRAGNode` | `kaizen.nodes.rag.realtime` (`Node`)                          | `kaizen.nodes.rag.optimized` (`WorkflowNode`) | intra-package, cross-module |
+
+Two scan hits were false positives — `CSVReaderNode` and `MyNode` second
+instances are docstring `>>>` examples inside `src/kailash/nodes/base.py`, not
+real registrations.
+
+## Why this matters
+
+1. **Scanner-surface symmetry** (`rules/zero-tolerance.md` Rule 1a): the two
+   sibling collisions are the SAME bug class as #891. "Issue #891 only names
+   HybridSearchNode" is not grounds to leave the other two live.
+2. **The core hard-fail couples them.** The recommended core SDK hardening —
+   `NodeRegistry.register` raises on a cross-`__module__` name collision — would
+   crash package import on `BulkUpsertNode` and `StreamingRAGNode` the moment it
+   lands, UNLESS all three collisions are renamed first. The hardening and the
+   three renames are one atomic unit, not separable.
+
+## StreamingRAGNode — a partial prior fix
+
+`kaizen/nodes/rag/__init__.py:177` already aliases the realtime class as
+`RealtimeStreamingRAGNode` (`from .realtime import StreamingRAGNode as
+RealtimeStreamingRAGNode`) and exports both names in `__all__`. The author fixed
+the **Python import-symbol** collision but NOT the **registry** collision — both
+classes still `@register_node()` with the bare decorator, so the global
+`NodeRegistry` still has one `"StreamingRAGNode"` slot, import-order-dependent.
+Confirms the registry is a separate global that the `as`-alias workaround does
+not reach. The fix: realtime registers explicitly as `RealtimeStreamingRAGNode`
+(matching the existing convention), optimized keeps `StreamingRAGNode`.
+
+## Consequence for scope
+
+The user gated F4 = issue #891 (HybridSearchNode). This discovery expands the
+technically-correct scope to all three collisions + core hardening. That is a
+scope change beyond the issue title → surfaced for user gate at /todos.

--- a/workspaces/issue-891-hybridsearch-collision/journal/0002-DECISION-scope-b-all-three-plus-guard.md
+++ b/workspaces/issue-891-hybridsearch-collision/journal/0002-DECISION-scope-b-all-three-plus-guard.md
@@ -1,0 +1,38 @@
+# DECISION — Scope B: all 3 collisions + core registry guard
+
+Date: 2026-05-18
+Phase: /analyze → /todos gate
+
+## Decision
+
+User-gated 2026-05-18. Of three scope options surfaced, the user selected
+**Scope B**: rename all three colliding node pairs AND land the cross-module
+registry guard in core SDK.
+
+## Why this was a user gate
+
+Issue #891 names only `HybridSearchNode`. Scope B expands to `BulkUpsertNode` +
+`StreamingRAGNode` (sibling collisions surfaced by the scan — journal/0001) and
+touches kailash core (not just dataflow+kaizen). That is a scope change beyond
+the issue title → user decision, not agent self-authorization.
+
+## Rejected options
+
+- **Scope A (just #891):** cannot land the core guard — it would crash imports
+  on the two un-fixed collisions — so the bug class stays structurally open.
+- **Scope C (all 3, no guard):** fixes today's collisions but leaves no
+  structural defense; a 4th collision could slip in silently on the next
+  monorepo refactor.
+
+## Atomicity constraint
+
+The core `__module__` guard and the six renames are ONE atomic change. The guard
+raises `NodeConfigurationError` on any cross-module name collision at import
+time; shipping it before all six renames land would crash package import. They
+land together or not at all.
+
+## Resolution shape (from 01-analysis/02)
+
+Option (a) rename + narrowed option (c) guard. Option (b) package-prefix
+namespacing rejected (ecosystem-wide blast radius); plain option (c) hard-fail
+rejected (breaks DataFlow model re-decoration per ADR-002).

--- a/workspaces/issue-891-hybridsearch-collision/journal/0003-DISCOVERY-streamingrag-dead-aggregatenode-live.md
+++ b/workspaces/issue-891-hybridsearch-collision/journal/0003-DISCOVERY-streamingrag-dead-aggregatenode-live.md
@@ -1,0 +1,76 @@
+# DISCOVERY — StreamingRAGNode is dead code; AggregateNode is the real 3rd collision
+
+Date: 2026-05-19
+Phase: /implement (baseline + collision census)
+
+## What the runtime census found
+
+A definitive runtime census (monkeypatch `NodeRegistry.register`, force-import
+every node module across all 3 packages) found exactly **three LIVE
+cross-module collisions**:
+
+| Registry name      | Module A                              | Module B                             |
+| ------------------ | ------------------------------------- | ------------------------------------ |
+| `HybridSearchNode` | `dataflow.nodes.vector_nodes`         | `kaizen.nodes.ai.hybrid_search`      |
+| `BulkUpsertNode`   | `dataflow.nodes.bulk_upsert`          | `kailash.nodes.data.bulk_operations` |
+| `AggregateNode`    | `dataflow.nodes.aggregate_operations` | `dataflow.nodes.mongodb_nodes`       |
+
+`StreamingRAGNode` did **NOT** appear — and the reason changes the plan.
+
+## StreamingRAGNode: not a collision — dead code
+
+`kaizen/nodes/rag/realtime.py` and `kaizen/nodes/rag/optimized.py` are
+**un-importable**. Their imports target a `kaizen.nodes.{code,data,logic}` +
+`kaizen.runtime.async_local` module tree that **does not exist** in the kaizen
+package — those paths exist only in the core `kailash.*` SDK:
+
+- `from ..base import Node` — `kaizen.nodes.base` never re-exports `Node`
+- `from ..code.python import PythonCodeNode` — no `kaizen.nodes.code`
+- `from ..data.streaming import EventStreamNode` — no `kaizen.nodes.data`
+- `from ..logic.workflow import WorkflowNode` — no `kaizen.nodes.logic`
+- `from ...runtime.async_local import AsyncLocalRuntime` — no `kaizen.runtime.async_local`
+
+`git blame` dates the broken import to `b553104c` (2026-03-11 monorepo refactor)
+— the SAME commit that originated the HybridSearchNode collision. The refactor
+moved `rag/` into kaizen but never repointed its imports from `kailash.*` to the
+new layout. The whole `kaizen.nodes.rag` package has been dead since.
+
+Consequence: neither `StreamingRAGNode` class can import → neither registers →
+there is **no live `StreamingRAGNode` registry collision**. The /analyze-phase
+belief that it was a live collision was wrong — the `rag/__init__.py`
+`as RealtimeStreamingRAGNode` alias masked it (the package looked intentional).
+
+`kaizen.nodes.rag` is isolated dead code — NOT imported by `kaizen/__init__.py`
+or `kaizen/nodes/__init__.py`.
+
+## AggregateNode: the real third collision
+
+Two `AggregateNode` classes, both in dataflow, different modules:
+
+- `aggregate_operations.AggregateNode(Node)` — registered via explicit
+  `NodeRegistry.register(AggregateNode, alias="AggregateNode")` (`:416`).
+- `mongodb_nodes.AggregateNode(AsyncNode)` — MongoDB aggregation pipeline,
+  registered via bare `@register_node()` (`:473`).
+
+`dataflow/nodes/__init__.py:4-5` already disambiguates the Python symbol
+(`from .mongodb_nodes import AggregateNode as MongoAggregateNode`) and `__all__`
+has both names — identical pattern to StreamingRAGNode's `as`-alias, registry
+collision left unfixed. The convention owner is clear: `aggregate_operations`
+keeps `AggregateNode`; `mongodb_nodes` renames to `MongoAggregateNode`.
+
+My /analyze scan missed it because `aggregate_operations` registers via an
+explicit `NodeRegistry.register(...)` call, not a decorator — the decorator-only
+grep didn't see it.
+
+## Impact on the plan
+
+- **T3 (StreamingRAGNode rename) is moot** — renaming un-importable dead code.
+- **AggregateNode is new, in-scope** — live collision, same bug class; the core
+  guard (T4) would crash import on it if unfixed.
+- The dead `kaizen.nodes.rag` package is a separate pre-existing bug (broken
+  monorepo-refactor imports), open-ended (never-exercised code, unknown further
+  breakage) → exceeds this 1-shard budget → separate tracked issue per
+  `autonomous-execution.md` MUST Rule 4 budget-exceeded carve-out.
+
+→ Surfaced to user for re-gate (the /todos Scope-B gate named StreamingRAGNode,
+not AggregateNode).

--- a/workspaces/issue-891-hybridsearch-collision/journal/0004-DECISION-rag-resurrection-separate-pr.md
+++ b/workspaces/issue-891-hybridsearch-collision/journal/0004-DECISION-rag-resurrection-separate-pr.md
@@ -1,0 +1,51 @@
+# DECISION — kaizen.nodes.rag resurrection is a separate PR (this session)
+
+Date: 2026-05-19
+Phase: /implement (T3 re-disposition)
+
+## Investigation result
+
+User asked whether `kaizen.nodes.rag` is useful or replaced before deciding.
+Findings:
+
+- The package defines **53 RAG node classes** — GraphRAG, AgenticRAG,
+  FederatedRAG, MultimodalRAG, privacy-preserving RAG, ColBERT retrieval,
+  HyDE, cross-encoder rerank, query decomposition, RAG evaluation/benchmark,
+  etc. A substantial, ambitious RAG toolkit.
+- **Not replaced.** The only other retrieval code in kaizen is
+  `kaizen/retrieval/` — a single `SimpleVectorStore`. No equivalent for the
+  53 advanced RAG nodes exists anywhere else in kaizen.
+- **Dead-on-arrival, not killed-by-us.** Un-importable since `b553104c`
+  (2026-03-11 monorepo move) — the move relocated the package into kaizen but
+  never repointed its `kailash.nodes.*` imports. Git history since: one commit,
+  a bulk 819-file reformat. Zero functional work. Not imported, referenced, or
+  documented anywhere. Zero bug reports in 2+ months.
+- Full extent: 17 modules, 14 with broken relative imports (~40 import lines);
+  `rag/__init__.py` eagerly imports all 17.
+
+## Decision
+
+User-gated 2026-05-19: **resurrect `kaizen.nodes.rag` as a separate PR in this
+session**, AFTER the #891 collision PR merges.
+
+- The #891 PR (this workstream) drops `StreamingRAGNode` / rag entirely —
+  StreamingRAGNode is NOT a live collision (dead code never registers), so the
+  core guard never sees it. The #891 PR ships the 3 LIVE collision fixes
+  (HybridSearch, BulkUpsert, Aggregate) + the guard.
+- The partial import-repair edits to `realtime.py` / `optimized.py` were
+  reverted — they belong in the resurrection PR.
+- The resurrection PR: repair ~40 broken imports across 14 modules, functionally
+  validate the 53 node classes, add test coverage. Note: once the package is
+  importable, `StreamingRAGNode` (realtime ↔ optimized, cross-module) becomes a
+  LIVE collision and the #891 guard would crash on it — so the resurrection PR
+  MUST also rename realtime's `StreamingRAGNode` → `RealtimeStreamingRAGNode`
+  (the `rag/__init__.py:177` `as`-alias already anticipates the name).
+
+## Sequencing
+
+1. #891 PR: T4 guard + T5 test + T6 changelogs → merge.
+2. Resurrection PR: rag import repair + StreamingRAGNode rename + functional
+   validation + tests → merge.
+
+T7 (was "draft issue for rag validation") is superseded — the user chose
+execution over an issue.

--- a/workspaces/issue-891-hybridsearch-collision/specs/_index.md
+++ b/workspaces/issue-891-hybridsearch-collision/specs/_index.md
@@ -1,0 +1,5 @@
+# Specs Index — Issue #891 HybridSearchNode collision
+
+| Spec                      | Domain                 | Description                                                                                            |
+| ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `node-registry-naming.md` | Core SDK node registry | Registry name uniqueness contract, cross-package collision detection, the two HybridSearchNode renames |

--- a/workspaces/issue-891-hybridsearch-collision/specs/node-registry-naming.md
+++ b/workspaces/issue-891-hybridsearch-collision/specs/node-registry-naming.md
@@ -1,0 +1,53 @@
+# Spec — Node Registry Naming & Cross-Package Collision
+
+Domain: Core SDK `NodeRegistry` (`src/kailash/nodes/base.py`).
+
+## Contract
+
+1. Every registry string name maps to exactly ONE node class across the entire
+   kailash ecosystem. (Currently violated by `"HybridSearchNode"`.)
+2. Same-module re-registration of a node name is LEGITIMATE and MUST remain
+   non-fatal (INFO-log). Rationale: DataFlow `@db.model` decoration regenerates
+   CRUD/bulk node classes on every decoration — fresh class objects, same
+   `__module__`. This is ADR-002.
+3. Cross-`__module__` re-registration of the same name is a COLLISION and MUST
+   fail loudly at registration time with `NodeConfigurationError`, naming both
+   the incumbent and the colliding class + their modules.
+
+## Behavior change
+
+`NodeRegistry.register(node_class, alias=None)` — when `node_name` already in
+`cls._nodes`:
+
+- if `cls._nodes[node_name].__module__ == node_class.__module__`
+  → INFO-log "Overwriting…" + overwrite (unchanged, ADR-002 path).
+- else → raise `NodeConfigurationError` with both class+module names.
+
+## The two renames
+
+| Was                                                    | Becomes                    | Registry alias             | Package          | Public?                                                                                                               |
+| ------------------------------------------------------ | -------------------------- | -------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `HybridSearchNode(AsyncNode)` (pgvector hybrid search) | `PgVectorHybridSearchNode` | `PgVectorHybridSearchNode` | kailash-dataflow | public (`dataflow/nodes/__init__.py::__all__`) → one-cycle module alias `HybridSearchNode = PgVectorHybridSearchNode` |
+| `HybridSearchNode(Node)` (RAG semantic search)         | `SemanticHybridSearchNode` | `SemanticHybridSearchNode` | kailash-kaizen   | internal (`kaizen.nodes.ai.hybrid_search` only) → no shim required                                                    |
+
+Both classes register via explicit `@register_node(alias="<NewName>")` —
+explicit alias makes the registration intentional and grep-auditable, vs the
+implicit class-name default that caused the collision.
+
+## Acceptance (issue #891)
+
+- [ ] Each name maps to one class; cross-package collision raises at registration.
+- [ ] Fix lands in BOTH kailash-dataflow + kailash-kaizen, one release cycle.
+- [ ] Tier-2 regression test imports BOTH packages, asserts each shape is
+      reachable via its non-colliding identifier, asserts no silent overwrite.
+- [ ] CHANGELOG migration entries on both packages.
+
+## Edge cases
+
+- `add_node("HybridSearchNode", ...)` in legacy downstream code → after the fix
+  the string is unregistered → loud "node not found". Acceptable (loud >
+  silent-wrong). CHANGELOG documents migration to the explicit names.
+- DataFlow module alias is a PLAIN assignment, never `@register_node`-decorated —
+  a decorated alias would re-create the registry collision.
+- The new cross-module hard-fail must itself not break the existing core test
+  suite — verify no in-repo node pair already collides cross-module.


### PR DESCRIPTION
## Summary

Three pairs of distinct node classes each registered the same global
`NodeRegistry` name, so `add_node("<name>")` resolved to whichever class was
imported last — silent, import-order-dependent dispatch (issue #891 named one;
a registry census found three).

- `HybridSearchNode` — dataflow pgvector node → **`PgVectorHybridSearchNode`**
  (one-cycle module-alias `HybridSearchNode` kept; public symbol);
  kaizen RAG node → **`SemanticHybridSearchNode`** (internal-only, no shim).
- `BulkUpsertNode` — kailash core → **`SQLBulkUpsertNode`**;
  kailash-dataflow → **`DataFlowBulkUpsertNode`**.
- `AggregateNode` — dataflow `mongodb_nodes` → **`MongoAggregateNode`**;
  `aggregate_operations` keeps `AggregateNode` (convention owner).
- Core SDK: `NodeRegistry.register` now raises `NodeConfigurationError` on a
  cross-module name collision; same-module re-registration stays non-fatal
  (ADR-002 / DataFlow model decoration). `inspect.getfile` comparison tolerates
  the `src.*` dual-import spelling.

All five renamed classes register via explicit `@register_node(alias=...)`.
DataFlow's per-model generated `{Model}BulkUpsertNode` names are untouched.

Versions: kailash 2.22.1→2.23.0, kailash-dataflow 2.9.19→2.10.0,
kailash-kaizen 2.21.1→2.22.0. CHANGELOG migration entries on all three.

## Not in this PR

`StreamingRAGNode` is **not** a live collision — the whole `kaizen.nodes.rag`
package (17 modules, 53 RAG node classes) has been un-importable since the
2026-03-11 monorepo move (broken `kailash.*` imports). Dead code never
registers, so the guard never sees it. Resurrecting that package is a separate
workstream — handled in a follow-up PR.

## Test plan

- [x] Tier-2 regression test `tests/regression/test_issue_891_node_registry_collisions.py` (5/5)
- [x] dataflow unit tests for renamed nodes (74/74)
- [x] core node-registry unit tests (30/30)
- [x] full 3-package import census — 0 cross-module collisions
- [x] reviewer + security-reviewer gate — both clean (no CRIT/HIGH)
- [ ] CI matrix

## Related issues

Fixes #891