### PR TITLE
release(891): pin kailash-dataflow/kaizen to kailash>=2.23.0

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [2.10.0] — 2026-05-19 — node-registry collision fix (#891)
 
+**Requires `kailash>=2.23.0`** — generated CRUD-node registration now passes
+`NodeRegistry.register(..., allow_override=True)`, an argument introduced in
+kailash 2.23.0.
+
 ### Changed
 
 - **`HybridSearchNode` renamed to `PgVectorHybridSearchNode` (#891)** — the

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.22.1",
+    "kailash>=2.23.0",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # are either lazy-loaded or scoped to optional subsystems and now
     # live behind extras.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.16.0",
+    "kailash>=2.23.0",
     "kailash-mcp>=0.2.4",       # core/base_agent.py:32 module-scope MCPClient
     "pydantic>=2.0.0",          # llm/deployment.py + auth modules
     "typing-extensions>=4.5.0", # core/schema_factory.py


### PR DESCRIPTION
## Summary

Metadata-only follow-up to #1094. Bumps the framework `kailash>=` pins to
`>=2.23.0`:

- **kailash-dataflow** — 2.10.0 calls `NodeRegistry.register(..., allow_override=True)`,
  an argument introduced in kailash 2.23.0. Without this pin,
  `pip install kailash-dataflow==2.10.0` against an older kailash raises
  `TypeError` on the first `@db.model` decoration. (Was `>=2.22.1`.)
- **kailash-kaizen** — moved to `>=2.23.0` in lockstep per release discipline
  (when core bumps, all frameworks pin to the new SDK). (Was `>=2.16.0`.)

`release/v*` branch — diff is metadata-only (two pyproject pins + one CHANGELOG
note), so the PR-gate matrix auto-skips.

## Test plan

- [x] Diff is strictly `pyproject.toml` pin + CHANGELOG (no src/test changes)
- [ ] Path-filter auto-skip confirms metadata-only

## Related issues

Refs #891