### PR TITLE
release(kaizen): complete the [rag] extra (2.23.1)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.23.1] — 2026-05-19 — complete the `[rag]` extra (#891 follow-up)
+
+### Fixed
+
+- **`pip install "kailash-kaizen[rag]"` now imports `kaizen.nodes.rag`.**
+  2.23.0 resurrected the package but its `[rag]` extra declared only
+  `numpy`/`Pillow`; the resurrected import graph also needs `networkx`
+  (graph RAG — was undeclared anywhere) plus `requests` + `aiosqlite`
+  (pulled transitively via `kailash.nodes.api.rest` and the kailash data
+  path the rag modules import). `pip install "kailash-kaizen[rag]==2.23.0";
+import kaizen.nodes.rag` raised `ModuleNotFoundError: networkx`. The
+  `[rag]` extra is now the complete dependency set:
+  `numpy, Pillow, networkx, requests, aiosqlite`. **`kaizen.nodes.rag`
+  requires `pip install "kailash-kaizen[rag]"`** (its node-functional deps
+  are intentionally behind the extra per the issue #890 core-dep audit;
+  bare `import kaizen` is unaffected — the rag package is deep-import-only).
+
 ## [2.23.0] — 2026-05-19 — resurrect `kaizen.nodes.rag` (#891 follow-up)
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.23.0"
+version = "2.23.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -89,10 +89,16 @@ cache = [
     "redis>=5.0.0",
 ]
 
-# RAG / multimodal — numpy + Pillow for similarity, vision, hybrid search.
+# RAG / multimodal — the complete `import kaizen.nodes.rag` dependency set.
+# numpy/Pillow: similarity, vision, hybrid search. networkx: graph RAG.
+# requests + aiosqlite: pulled transitively via kailash.nodes.api.rest /
+# the kailash data path that the resurrected rag modules import.
 rag = [
     "numpy>=1.24.0",
     "Pillow>=10.0.0",
+    "networkx>=3.0",
+    "requests>=2.32",
+    "aiosqlite>=0.19.0",
 ]
 
 # Research validator — GitPython for repo introspection.

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.23.0"
+__version__ = "2.23.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

Metadata-only follow-up to #1096. `kaizen 2.23.0` resurrected
`kaizen.nodes.rag` but its `[rag]` extra declared only `numpy`/`Pillow`.
The clean-venv release gate caught that the resurrected import graph also
needs **`networkx`** (graph RAG — was declared *nowhere* in kaizen) plus
`requests` + `aiosqlite` (pulled transitively via `kailash.nodes.api.rest`
and the kailash data path the rag modules import). So
`pip install "kailash-kaizen[rag]==2.23.0"; import kaizen.nodes.rag`
raised `ModuleNotFoundError: networkx`.

`[rag]` extra is now the complete set: `numpy, Pillow, networkx, requests,
aiosqlite`. kaizen 2.23.0 → 2.23.1. `release/v*` branch — PR-gate matrix
auto-skips (diff is two pyproject lines + version + CHANGELOG).

## Verification

Established before this PR: with `numpy Pillow networkx requests aiosqlite`
present alongside `kailash-kaizen==2.23.0` from PyPI, all 16
`kaizen.nodes.rag` submodules import clean, every representative node
registers. This PR makes `kailash-kaizen[rag]` install exactly that set.
Post-publish: clean-venv `pip install "kailash-kaizen[rag]==2.23.1"` +
`import kaizen.nodes.rag` verification.

## Related issues

Refs #891