### PR TITLE
fix(rag): repair 38 kaizen.nodes.rag Node constructors to canonical keyword form (F8 A1)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
@@ -63,15 +63,48 @@ class SelfCorrectingRAGNode(Node):
         confidence_threshold: float = 0.8,
         verification_model: str = "gpt-4",
     ):
+        super().__init__(
+            name=name,
+            max_corrections=max_corrections,
+            confidence_threshold=confidence_threshold,
+            verification_model=verification_model,
+        )
         self.max_corrections = max_corrections
         self.confidence_threshold = confidence_threshold
         self.verification_model = verification_model
         self.base_rag_workflow = None
         self.verifier_agent = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="self_correcting_rag",
+                description="Node instance name",
+            ),
+            "max_corrections": NodeParameter(
+                name="max_corrections",
+                type=int,
+                required=False,
+                default=2,
+                description="Maximum self-correction attempts",
+            ),
+            "confidence_threshold": NodeParameter(
+                name="confidence_threshold",
+                type=float,
+                required=False,
+                default=0.8,
+                description="Minimum confidence to accept a result",
+            ),
+            "verification_model": NodeParameter(
+                name="verification_model",
+                type=str,
+                required=False,
+                default="gpt-4",
+                description="Model used to verify result quality",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -473,15 +506,48 @@ class RAGFusionNode(Node):
         fusion_method: str = "rrf",
         query_generator_model: str = "gpt-4",
     ):
+        super().__init__(
+            name=name,
+            num_query_variations=num_query_variations,
+            fusion_method=fusion_method,
+            query_generator_model=query_generator_model,
+        )
         self.num_query_variations = num_query_variations
         self.fusion_method = fusion_method
         self.query_generator_model = query_generator_model
         self.query_generator = None
         self.base_rag_workflow = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="rag_fusion",
+                description="Node instance name",
+            ),
+            "num_query_variations": NodeParameter(
+                name="num_query_variations",
+                type=int,
+                required=False,
+                default=3,
+                description="Number of query variations to generate",
+            ),
+            "fusion_method": NodeParameter(
+                name="fusion_method",
+                type=str,
+                required=False,
+                default="rrf",
+                description="Fusion algorithm (rrf, weighted, distribution)",
+            ),
+            "query_generator_model": NodeParameter(
+                name="query_generator_model",
+                type=str,
+                required=False,
+                default="gpt-4",
+                description="Model used to generate query variations",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -945,15 +1011,48 @@ class HyDENode(Node):
         use_multiple_hypotheses: bool = True,
         num_hypotheses: int = 2,
     ):
+        super().__init__(
+            name=name,
+            hypothesis_model=hypothesis_model,
+            use_multiple_hypotheses=use_multiple_hypotheses,
+            num_hypotheses=num_hypotheses,
+        )
         self.hypothesis_model = hypothesis_model
         self.use_multiple_hypotheses = use_multiple_hypotheses
         self.num_hypotheses = num_hypotheses
         self.hypothesis_generator = None
         self.base_rag_workflow = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="hyde_rag",
+                description="Node instance name",
+            ),
+            "hypothesis_model": NodeParameter(
+                name="hypothesis_model",
+                type=str,
+                required=False,
+                default="gpt-4",
+                description="LLM used to generate hypothetical documents",
+            ),
+            "use_multiple_hypotheses": NodeParameter(
+                name="use_multiple_hypotheses",
+                type=bool,
+                required=False,
+                default=True,
+                description="Generate multiple hypotheses per query",
+            ),
+            "num_hypotheses": NodeParameter(
+                name="num_hypotheses",
+                type=int,
+                required=False,
+                default=2,
+                description="Number of hypotheses to generate",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -1271,13 +1370,27 @@ class StepBackRAGNode(Node):
     """
 
     def __init__(self, name: str = "step_back_rag", abstraction_model: str = "gpt-4"):
+        super().__init__(name=name, abstraction_model=abstraction_model)
         self.abstraction_model = abstraction_model
         self.abstraction_generator = None
         self.base_rag_workflow = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="step_back_rag",
+                description="Node instance name",
+            ),
+            "abstraction_model": NodeParameter(
+                name="abstraction_model",
+                type=str,
+                required=False,
+                default="gpt-4",
+                description="LLM used to generate abstract queries",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
@@ -587,12 +587,38 @@ class ToolAugmentedRAGNode(Node):
         tool_registry: Dict[str, Callable] = None,
         auto_detect_tools: bool = True,
     ):
-        self.tool_registry = tool_registry or {}
+        resolved_registry = tool_registry or {}
+        super().__init__(
+            name=name,
+            tool_registry=resolved_registry,
+            auto_detect_tools=auto_detect_tools,
+        )
+        self.tool_registry = resolved_registry
         self.auto_detect_tools = auto_detect_tools
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="tool_augmented_rag",
+                description="Node instance name",
+            ),
+            "tool_registry": NodeParameter(
+                name="tool_registry",
+                type=dict,
+                required=False,
+                default=None,
+                description="Mapping of tool name to callable",
+            ),
+            "auto_detect_tools": NodeParameter(
+                name="auto_detect_tools",
+                type=bool,
+                required=False,
+                default=True,
+                description="Automatically detect which tools to invoke",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/conversational.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/conversational.py
@@ -686,7 +686,18 @@ class ConversationMemoryNode(Node):
         retention_policy: str = "adaptive",
         max_memories_per_user: int = 1000,
     ):
-        self.memory_types = memory_types or ["episodic", "semantic", "preferences"]
+        resolved_memory_types = memory_types or [
+            "episodic",
+            "semantic",
+            "preferences",
+        ]
+        super().__init__(
+            name=name,
+            memory_types=resolved_memory_types,
+            retention_policy=retention_policy,
+            max_memories_per_user=max_memories_per_user,
+        )
+        self.memory_types = resolved_memory_types
         self.retention_policy = retention_policy
         self.max_memories_per_user = max_memories_per_user
         # In-memory storage (use persistent DB in production)
@@ -697,10 +708,37 @@ class ConversationMemoryNode(Node):
                 "preferences": {},
             }
         )
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="conversation_memory",
+                description="Node instance name",
+            ),
+            "memory_types": NodeParameter(
+                name="memory_types",
+                type=list,
+                required=False,
+                default=None,
+                description="Memory categories (episodic, semantic, preferences)",
+            ),
+            "retention_policy": NodeParameter(
+                name="retention_policy",
+                type=str,
+                required=False,
+                default="adaptive",
+                description="Memory retention strategy",
+            ),
+            "max_memories_per_user": NodeParameter(
+                name="max_memories_per_user",
+                type=int,
+                required=False,
+                default=1000,
+                description="Per-user episodic memory cap",
+            ),
             "operation": NodeParameter(
                 name="operation",
                 type=str,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/evaluation.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/evaluation.py
@@ -485,12 +485,39 @@ class RAGBenchmarkNode(Node):
         workload_sizes: List[int] = None,
         concurrent_users: List[int] = None,
     ):
-        self.workload_sizes = workload_sizes or [10, 100, 1000]
-        self.concurrent_users = concurrent_users or [1, 5, 10]
-        super().__init__(name)
+        resolved_workload_sizes = workload_sizes or [10, 100, 1000]
+        resolved_concurrent_users = concurrent_users or [1, 5, 10]
+        super().__init__(
+            name=name,
+            workload_sizes=resolved_workload_sizes,
+            concurrent_users=resolved_concurrent_users,
+        )
+        self.workload_sizes = resolved_workload_sizes
+        self.concurrent_users = resolved_concurrent_users
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="rag_benchmark",
+                description="Node instance name",
+            ),
+            "workload_sizes": NodeParameter(
+                name="workload_sizes",
+                type=list,
+                required=False,
+                default=None,
+                description="Document-count workloads to benchmark",
+            ),
+            "concurrent_users": NodeParameter(
+                name="concurrent_users",
+                type=list,
+                required=False,
+                default=None,
+                description="Concurrency levels to benchmark",
+            ),
             "rag_systems": NodeParameter(
                 name="rag_systems",
                 type=dict,
@@ -697,12 +724,42 @@ class TestDatasetGeneratorNode(Node):
         categories: List[str] = None,
         include_adversarial: bool = True,
     ):
-        self.categories = categories or ["factual", "analytical", "comparative"]
+        resolved_categories = categories or [
+            "factual",
+            "analytical",
+            "comparative",
+        ]
+        super().__init__(
+            name=name,
+            categories=resolved_categories,
+            include_adversarial=include_adversarial,
+        )
+        self.categories = resolved_categories
         self.include_adversarial = include_adversarial
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="test_dataset_generator",
+                description="Node instance name",
+            ),
+            "categories": NodeParameter(
+                name="categories",
+                type=list,
+                required=False,
+                default=None,
+                description="Question categories to generate",
+            ),
+            "include_adversarial": NodeParameter(
+                name="include_adversarial",
+                type=bool,
+                required=False,
+                default=True,
+                description="Include adversarial test cases",
+            ),
             "num_samples": NodeParameter(
                 name="num_samples",
                 type=int,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
@@ -624,16 +624,57 @@ class EdgeRAGNode(Node):
         update_strategy: str = "incremental",
         power_mode: str = "balanced",
     ):
+        super().__init__(
+            name=name,
+            model_size=model_size,
+            max_cache_size_mb=max_cache_size_mb,
+            update_strategy=update_strategy,
+            power_mode=power_mode,
+        )
         self.model_size = model_size
         self.max_cache_size_mb = max_cache_size_mb
         self.update_strategy = update_strategy
         self.power_mode = power_mode
         self.cache = {}
         self.cache_size_bytes = 0
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="edge_rag",
+                description="Node instance name",
+            ),
+            "model_size": NodeParameter(
+                name="model_size",
+                type=str,
+                required=False,
+                default="small",
+                description="Edge model size profile",
+            ),
+            "max_cache_size_mb": NodeParameter(
+                name="max_cache_size_mb",
+                type=int,
+                required=False,
+                default=100,
+                description="Maximum local cache size in MB",
+            ),
+            "update_strategy": NodeParameter(
+                name="update_strategy",
+                type=str,
+                required=False,
+                default="incremental",
+                description="Edge index update strategy",
+            ),
+            "power_mode": NodeParameter(
+                name="power_mode",
+                type=str,
+                required=False,
+                default="balanced",
+                description="Edge power/performance profile",
+            ),
             "query": NodeParameter(
                 name="query", type=str, required=True, description="Query to process"
             ),
@@ -874,14 +915,57 @@ class CrossSiloRAGNode(Node):
         audit_mode: str = "standard",
         governance_rules: Dict[str, Any] = None,
     ):
-        self.silos = silos or []
+        resolved_silos = silos or []
+        resolved_governance_rules = governance_rules or {}
+        super().__init__(
+            name=name,
+            silos=resolved_silos,
+            data_sharing_agreement=data_sharing_agreement,
+            audit_mode=audit_mode,
+            governance_rules=resolved_governance_rules,
+        )
+        self.silos = resolved_silos
         self.data_sharing_agreement = data_sharing_agreement
         self.audit_mode = audit_mode
-        self.governance_rules = governance_rules or {}
-        super().__init__(name)
+        self.governance_rules = resolved_governance_rules
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="cross_silo_rag",
+                description="Node instance name",
+            ),
+            "silos": NodeParameter(
+                name="silos",
+                type=list,
+                required=False,
+                default=None,
+                description="Participating data silos",
+            ),
+            "data_sharing_agreement": NodeParameter(
+                name="data_sharing_agreement",
+                type=str,
+                required=False,
+                default="minimal",
+                description="Cross-silo data sharing agreement level",
+            ),
+            "audit_mode": NodeParameter(
+                name="audit_mode",
+                type=str,
+                required=False,
+                default="standard",
+                description="Audit logging mode",
+            ),
+            "governance_rules": NodeParameter(
+                name="governance_rules",
+                type=dict,
+                required=False,
+                default=None,
+                description="Cross-silo governance ruleset",
+            ),
             "query": NodeParameter(
                 name="query", type=str, required=True, description="Cross-silo query"
             ),

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
@@ -499,14 +499,55 @@ class GraphBuilderNode(Node):
         track_temporal: bool = False,
         confidence_scoring: bool = True,
     ):
+        super().__init__(
+            name=name,
+            merge_similar_entities=merge_similar_entities,
+            similarity_threshold=similarity_threshold,
+            track_temporal=track_temporal,
+            confidence_scoring=confidence_scoring,
+        )
         self.merge_similar_entities = merge_similar_entities
         self.similarity_threshold = similarity_threshold
         self.track_temporal = track_temporal
         self.confidence_scoring = confidence_scoring
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="graph_builder",
+                description="Node instance name",
+            ),
+            "merge_similar_entities": NodeParameter(
+                name="merge_similar_entities",
+                type=bool,
+                required=False,
+                default=True,
+                description="Merge entities above the similarity threshold",
+            ),
+            "similarity_threshold": NodeParameter(
+                name="similarity_threshold",
+                type=float,
+                required=False,
+                default=0.85,
+                description="Entity-merge similarity threshold",
+            ),
+            "track_temporal": NodeParameter(
+                name="track_temporal",
+                type=bool,
+                required=False,
+                default=False,
+                description="Track temporal relationships between entities",
+            ),
+            "confidence_scoring": NodeParameter(
+                name="confidence_scoring",
+                type=bool,
+                required=False,
+                default=True,
+                description="Attach confidence scores to extracted edges",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -621,10 +662,17 @@ class GraphQueryNode(Node):
     """
 
     def __init__(self, name: str = "graph_query"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="graph_query",
+                description="Node instance name",
+            ),
             "graph": NodeParameter(
                 name="graph",
                 type=dict,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/multimodal.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/multimodal.py
@@ -470,12 +470,37 @@ class VisualQuestionAnsweringNode(Node):
         model: str = "blip2-base",
         enable_captioning: bool = True,
     ):
+        super().__init__(
+            name=name,
+            model=model,
+            enable_captioning=enable_captioning,
+        )
         self.model = model
         self.enable_captioning = enable_captioning
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="vqa_node",
+                description="Node instance name",
+            ),
+            "model": NodeParameter(
+                name="model",
+                type=str,
+                required=False,
+                default="blip2-base",
+                description="Vision-language model for VQA",
+            ),
+            "enable_captioning": NodeParameter(
+                name="enable_captioning",
+                type=bool,
+                required=False,
+                default=True,
+                description="Generate an image caption alongside the answer",
+            ),
             "image_path": NodeParameter(
                 name="image_path",
                 type=str,
@@ -592,12 +617,37 @@ class ImageTextMatchingNode(Node):
         matching_model: str = "clip",
         bidirectional: bool = True,
     ):
+        super().__init__(
+            name=name,
+            matching_model=matching_model,
+            bidirectional=bidirectional,
+        )
         self.matching_model = matching_model
         self.bidirectional = bidirectional
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="image_text_matcher",
+                description="Node instance name",
+            ),
+            "matching_model": NodeParameter(
+                name="matching_model",
+                type=str,
+                required=False,
+                default="clip",
+                description="Image-text matching model",
+            ),
+            "bidirectional": NodeParameter(
+                name="bidirectional",
+                type=bool,
+                required=False,
+                default=True,
+                description="Match in both image->text and text->image directions",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=Union[str, dict],

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/privacy.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/privacy.py
@@ -635,13 +635,47 @@ class SecureMultiPartyRAGNode(Node):
         protocol: str = "secret_sharing",
         threshold: int = 2,
     ):
-        self.parties = parties or []
+        resolved_parties = parties or []
+        super().__init__(
+            name=name,
+            parties=resolved_parties,
+            protocol=protocol,
+            threshold=threshold,
+        )
+        self.parties = resolved_parties
         self.protocol = protocol
         self.threshold = threshold
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="secure_multiparty_rag",
+                description="Node instance name",
+            ),
+            "parties": NodeParameter(
+                name="parties",
+                type=list,
+                required=False,
+                default=None,
+                description="Participating parties in the MPC protocol",
+            ),
+            "protocol": NodeParameter(
+                name="protocol",
+                type=str,
+                required=False,
+                default="secret_sharing",
+                description="Secure multiparty computation protocol",
+            ),
+            "threshold": NodeParameter(
+                name="threshold",
+                type=int,
+                required=False,
+                default=2,
+                description="Minimum parties required to reconstruct",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
@@ -829,13 +863,47 @@ class ComplianceRAGNode(Node):
         default_retention_days: int = 30,
         require_explicit_consent: bool = True,
     ):
-        self.regulations = regulations or ["gdpr", "ccpa"]
+        resolved_regulations = regulations or ["gdpr", "ccpa"]
+        super().__init__(
+            name=name,
+            regulations=resolved_regulations,
+            default_retention_days=default_retention_days,
+            require_explicit_consent=require_explicit_consent,
+        )
+        self.regulations = resolved_regulations
         self.default_retention_days = default_retention_days
         self.require_explicit_consent = require_explicit_consent
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="compliance_rag",
+                description="Node instance name",
+            ),
+            "regulations": NodeParameter(
+                name="regulations",
+                type=list,
+                required=False,
+                default=None,
+                description="Compliance regulations to enforce (gdpr, ccpa, ...)",
+            ),
+            "default_retention_days": NodeParameter(
+                name="default_retention_days",
+                type=int,
+                required=False,
+                default=30,
+                description="Default data retention period in days",
+            ),
+            "require_explicit_consent": NodeParameter(
+                name="require_explicit_consent",
+                type=bool,
+                required=False,
+                default=True,
+                description="Require explicit user consent before processing",
+            ),
             "query": NodeParameter(
                 name="query", type=str, required=True, description="Query to process"
             ),

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
@@ -79,16 +79,41 @@ class QueryExpansionNode(Node):
         expansion_method: str = "llm",
         num_expansions: int = 5,
     ):
+        super().__init__(
+            name=name,
+            expansion_method=expansion_method,
+            num_expansions=num_expansions,
+        )
         self.expansion_method = expansion_method
         self.num_expansions = num_expansions
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="query_expansion",
+                description="Node instance name",
+            ),
+            "expansion_method": NodeParameter(
+                name="expansion_method",
+                type=str,
+                required=False,
+                default="llm",
+                description="Algorithm (llm, wordnet, custom)",
+            ),
+            "num_expansions": NodeParameter(
+                name="num_expansions",
+                type=int,
+                required=False,
+                default=5,
+                description="Number of query variations to generate",
+            ),
             "query": NodeParameter(
                 name="query", type=str, required=True, description="Query to expand"
-            )
+            ),
         }
 
     def run(self, **kwargs) -> Dict[str, Any]:
@@ -254,17 +279,24 @@ class QueryDecompositionNode(Node):
     """
 
     def __init__(self, name: str = "query_decomposition"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="query_decomposition",
+                description="Node instance name",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
                 required=True,
                 description="Complex query to decompose",
-            )
+            ),
         }
 
     def run(self, **kwargs) -> Dict[str, Any]:
@@ -445,17 +477,24 @@ class QueryRewritingNode(Node):
     """
 
     def __init__(self, name: str = "query_rewriting"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="query_rewriting",
+                description="Node instance name",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
                 required=True,
                 description="Query to rewrite and improve",
-            )
+            ),
         }
 
     def run(self, **kwargs) -> Dict[str, Any]:
@@ -676,17 +715,24 @@ class QueryIntentClassifierNode(Node):
     """
 
     def __init__(self, name: str = "query_intent_classifier"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="query_intent_classifier",
+                description="Node instance name",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
                 required=True,
                 description="Query to classify intent for",
-            )
+            ),
         }
 
     def run(self, **kwargs) -> Dict[str, Any]:
@@ -942,17 +988,24 @@ class MultiHopQueryPlannerNode(Node):
     """
 
     def __init__(self, name: str = "multi_hop_planner"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="multi_hop_planner",
+                description="Node instance name",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
                 required=True,
                 description="Complex query requiring multi-hop planning",
-            )
+            ),
         }
 
     def run(self, **kwargs) -> Dict[str, Any]:
@@ -1199,17 +1252,24 @@ class AdaptiveQueryProcessorNode(Node):
     """
 
     def __init__(self, name: str = "adaptive_query_processor"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="adaptive_query_processor",
+                description="Node instance name",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
                 required=True,
                 description="Query to process adaptively",
-            )
+            ),
         }
 
     def run(self, **kwargs) -> Dict[str, Any]:

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/realtime.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/realtime.py
@@ -438,12 +438,37 @@ class RealtimeStreamingRAGNode(Node):
         chunk_size: int = 50,
         chunk_interval: int = 100,
     ):
+        super().__init__(
+            name=name,
+            chunk_size=chunk_size,
+            chunk_interval=chunk_interval,
+        )
         self.chunk_size = chunk_size
         self.chunk_interval = chunk_interval
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="streaming_rag",
+                description="Node instance name",
+            ),
+            "chunk_size": NodeParameter(
+                name="chunk_size",
+                type=int,
+                required=False,
+                default=50,
+                description="Tokens per streamed chunk",
+            ),
+            "chunk_interval": NodeParameter(
+                name="chunk_interval",
+                type=int,
+                required=False,
+                default=100,
+                description="Milliseconds between streamed chunks",
+            ),
             "query": NodeParameter(
                 name="query", type=str, required=True, description="Search query"
             ),
@@ -593,15 +618,40 @@ class IncrementalIndexNode(Node):
         index_type: str = "hybrid",
         merge_strategy: str = "immediate",
     ):
+        super().__init__(
+            name=name,
+            index_type=index_type,
+            merge_strategy=merge_strategy,
+        )
         self.index_type = index_type
         self.merge_strategy = merge_strategy
         self.index = {}
         self.document_store = {}
         self.update_log = deque(maxlen=1000)
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="incremental_index",
+                description="Node instance name",
+            ),
+            "index_type": NodeParameter(
+                name="index_type",
+                type=str,
+                required=False,
+                default="hybrid",
+                description="Type of index (inverted, vector, hybrid)",
+            ),
+            "merge_strategy": NodeParameter(
+                name="merge_strategy",
+                type=str,
+                required=False,
+                default="immediate",
+                description="How to merge incremental updates",
+            ),
             "operation": NodeParameter(
                 name="operation",
                 type=str,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/router.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/router.py
@@ -31,13 +31,38 @@ class RAGStrategyRouterNode(Node):
         llm_model: str = "gpt-4",
         provider: str = "openai",
     ):
+        super().__init__(
+            name=name,
+            llm_model=llm_model,
+            provider=provider,
+        )
         self.llm_model = llm_model
         self.provider = provider
         self.llm_agent = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="rag_strategy_router",
+                description="Node instance name",
+            ),
+            "llm_model": NodeParameter(
+                name="llm_model",
+                type=str,
+                required=False,
+                default="gpt-4",
+                description="LLM model for routing analysis",
+            ),
+            "provider": NodeParameter(
+                name="provider",
+                type=str,
+                required=False,
+                default="openai",
+                description="LLM provider for routing analysis",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -452,10 +477,17 @@ class RAGQualityAnalyzerNode(Node):
     """
 
     def __init__(self, name: str = "rag_quality_analyzer"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="rag_quality_analyzer",
+                description="Node instance name",
+            ),
             "rag_results": NodeParameter(
                 name="rag_results",
                 type=dict,
@@ -666,11 +698,18 @@ class RAGPerformanceMonitorNode(Node):
     """
 
     def __init__(self, name: str = "rag_performance_monitor"):
+        super().__init__(name=name)
         self.performance_history = []
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="rag_performance_monitor",
+                description="Node instance name",
+            ),
             "rag_results": NodeParameter(
                 name="rag_results",
                 type=dict,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/router.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/router.py
@@ -6,6 +6,7 @@ Includes LLM-powered strategy selection and performance monitoring.
 """
 
 import logging
+import os
 import time
 from typing import Any, Dict, List, Optional
 
@@ -14,6 +15,13 @@ from kailash.nodes.base import Node, NodeParameter, register_node
 from ..ai.llm_agent import LLMAgentNode
 
 logger = logging.getLogger(__name__)
+
+# Default routing model resolved from the environment (.env is the single
+# source of truth — never hardcode model names). May be None when unset;
+# that is env-models-compliant and acceptable as a default.
+_DEFAULT_LLM_MODEL = os.environ.get(
+    "OPENAI_PROD_MODEL", os.environ.get("DEFAULT_LLM_MODEL")
+)
 
 
 @register_node()
@@ -28,7 +36,7 @@ class RAGStrategyRouterNode(Node):
     def __init__(
         self,
         name: str = "rag_strategy_router",
-        llm_model: str = "gpt-4",
+        llm_model: Optional[str] = _DEFAULT_LLM_MODEL,
         provider: str = "openai",
     ):
         super().__init__(
@@ -53,7 +61,7 @@ class RAGStrategyRouterNode(Node):
                 name="llm_model",
                 type=str,
                 required=False,
-                default="gpt-4",
+                default=_DEFAULT_LLM_MODEL,
                 description="LLM model for routing analysis",
             ),
             "provider": NodeParameter(

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/similarity.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/similarity.py
@@ -75,14 +75,47 @@ class DenseRetrievalNode(Node):
         similarity_metric: str = "cosine",
         use_instruction_embeddings: bool = False,
     ):
+        super().__init__(
+            name=name,
+            embedding_model=embedding_model,
+            similarity_metric=similarity_metric,
+            use_instruction_embeddings=use_instruction_embeddings,
+        )
         self.embedding_model = embedding_model
         self.similarity_metric = similarity_metric
         self.use_instruction_embeddings = use_instruction_embeddings
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="dense_retrieval",
+                description="Node instance name",
+            ),
+            "embedding_model": NodeParameter(
+                name="embedding_model",
+                type=str,
+                required=False,
+                default="text-embedding-3-small",
+                description="Model for embeddings (OpenAI, Cohere, custom)",
+            ),
+            "similarity_metric": NodeParameter(
+                name="similarity_metric",
+                type=str,
+                required=False,
+                default="cosine",
+                description="Distance metric (cosine, euclidean, dot)",
+            ),
+            "use_instruction_embeddings": NodeParameter(
+                name="use_instruction_embeddings",
+                type=bool,
+                required=False,
+                default=False,
+                description="Prefix embeddings with retrieval instructions",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
@@ -211,15 +244,40 @@ class SparseRetrievalNode(Node):
         method: str = "bm25",
         use_query_expansion: bool = True,
     ):
+        super().__init__(
+            name=name,
+            method=method,
+            use_query_expansion=use_query_expansion,
+        )
         self.method = method
         self.use_query_expansion = use_query_expansion
         self.k1 = 1.2  # BM25 parameter
         self.b = 0.75  # BM25 parameter
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="sparse_retrieval",
+                description="Node instance name",
+            ),
+            "method": NodeParameter(
+                name="method",
+                type=str,
+                required=False,
+                default="bm25",
+                description="Algorithm choice (bm25, tfidf, splade)",
+            ),
+            "use_query_expansion": NodeParameter(
+                name="use_query_expansion",
+                type=bool,
+                required=False,
+                default=True,
+                description="Generate related terms automatically",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
@@ -496,12 +554,26 @@ class ColBERTRetrievalNode(Node):
     def __init__(
         self, name: str = "colbert_retrieval", token_model: str = "bert-base-uncased"
     ):
+        super().__init__(name=name, token_model=token_model)
         self.token_model = token_model
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="colbert_retrieval",
+                description="Node instance name",
+            ),
+            "token_model": NodeParameter(
+                name="token_model",
+                type=str,
+                required=False,
+                default="bert-base-uncased",
+                description="BERT model for token embeddings",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
@@ -755,11 +827,18 @@ class MultiVectorRetrievalNode(Node):
     """
 
     def __init__(self, name: str = "multi_vector_retrieval"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="multi_vector_retrieval",
+                description="Node instance name",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
@@ -1057,12 +1136,26 @@ class CrossEncoderRerankNode(Node):
         name: str = "cross_encoder_rerank",
         rerank_model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
     ):
+        super().__init__(name=name, rerank_model=rerank_model)
         self.rerank_model = rerank_model
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="cross_encoder_rerank",
+                description="Node instance name",
+            ),
+            "rerank_model": NodeParameter(
+                name="rerank_model",
+                type=str,
+                required=False,
+                default="cross-encoder/ms-marco-MiniLM-L-6-v2",
+                description="Cross-encoder model for scoring",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,
@@ -1297,13 +1390,36 @@ class HybridFusionNode(Node):
         fusion_method: str = "rrf",
         weights: Optional[Dict[str, float]] = None,
     ):
+        # NOTE: get_parameters() references self.fusion_method for its default,
+        # and Node.__init__ calls get_parameters() — so this attr MUST be set
+        # before super(). The remaining attrs follow the canonical post-super
+        # config-bag order.
         self.fusion_method = fusion_method
-        self.weights = weights or {"dense": 0.7, "sparse": 0.3}
-        super().__init__(name)
+        resolved_weights = weights or {"dense": 0.7, "sparse": 0.3}
+        super().__init__(
+            name=name,
+            fusion_method=fusion_method,
+            weights=resolved_weights,
+        )
+        self.weights = resolved_weights
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="hybrid_fusion",
+                description="Node instance name",
+            ),
+            "weights": NodeParameter(
+                name="weights",
+                type=dict,
+                required=False,
+                default=None,
+                description="Importance weights per retriever",
+            ),
             "retrieval_results": NodeParameter(
                 name="retrieval_results",
                 type=list,
@@ -1585,11 +1701,18 @@ class PropositionBasedRetrievalNode(Node):
     """
 
     def __init__(self, name: str = "proposition_retrieval"):
-        super().__init__(name)
+        super().__init__(name=name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         """Get node parameters"""
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="proposition_retrieval",
+                description="Node instance name",
+            ),
             "query": NodeParameter(
                 name="query",
                 type=str,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/strategies.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/strategies.py
@@ -380,12 +380,28 @@ class SemanticRAGNode(Node):
     """
 
     def __init__(self, name: str = "semantic_rag", config: Optional[RAGConfig] = None):
-        self.config = config or RAGConfig()
+        super().__init__(name=name)
+        # Node-specific RAG configuration: stored under `rag_config`, NOT
+        # `self.config` — the base Node reserves `self.config` for its dict
+        # config-bag, and the __init_with_capture wrapper iterates it.
+        self.rag_config = config or RAGConfig()
         self.workflow_node = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="semantic_rag",
+                description="Node instance name",
+            ),
+            "config": NodeParameter(
+                name="config",
+                type=dict,
+                required=False,
+                description="RAG configuration parameters",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -409,7 +425,7 @@ class SemanticRAGNode(Node):
     def run(self, **kwargs) -> Dict[str, Any]:
         """Run semantic RAG using WorkflowNode"""
         if not self.workflow_node:
-            self.workflow_node = create_semantic_rag_workflow(self.config)
+            self.workflow_node = create_semantic_rag_workflow(self.rag_config)
 
         # Delegate to WorkflowNode
         return self.workflow_node.execute(**kwargs)
@@ -427,12 +443,26 @@ class StatisticalRAGNode(Node):
     def __init__(
         self, name: str = "statistical_rag", config: Optional[RAGConfig] = None
     ):
-        self.config = config or RAGConfig()
+        super().__init__(name=name)
+        # Node-specific RAG configuration under `rag_config` (see SemanticRAGNode).
+        self.rag_config = config or RAGConfig()
         self.workflow_node = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="statistical_rag",
+                description="Node instance name",
+            ),
+            "config": NodeParameter(
+                name="config",
+                type=dict,
+                required=False,
+                description="RAG configuration parameters",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -456,7 +486,7 @@ class StatisticalRAGNode(Node):
     def run(self, **kwargs) -> Dict[str, Any]:
         """Run statistical RAG using WorkflowNode"""
         if not self.workflow_node:
-            self.workflow_node = create_statistical_rag_workflow(self.config)
+            self.workflow_node = create_statistical_rag_workflow(self.rag_config)
 
         return self.workflow_node.execute(**kwargs)
 
@@ -476,13 +506,27 @@ class HybridRAGNode(Node):
         config: Optional[RAGConfig] = None,
         fusion_method: str = "rrf",
     ):
-        self.config = config or RAGConfig()
+        super().__init__(name=name, fusion_method=fusion_method)
+        # Node-specific RAG configuration under `rag_config` (see SemanticRAGNode).
+        self.rag_config = config or RAGConfig()
         self.fusion_method = fusion_method
         self.workflow_node = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="hybrid_rag",
+                description="Node instance name",
+            ),
+            "config": NodeParameter(
+                name="config",
+                type=dict,
+                required=False,
+                description="RAG configuration parameters",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -515,7 +559,9 @@ class HybridRAGNode(Node):
 
         if not self.workflow_node or fusion_method != self.fusion_method:
             self.fusion_method = fusion_method
-            self.workflow_node = create_hybrid_rag_workflow(self.config, fusion_method)
+            self.workflow_node = create_hybrid_rag_workflow(
+                self.rag_config, fusion_method
+            )
 
         return self.workflow_node.execute(**kwargs)
 
@@ -532,12 +578,26 @@ class HierarchicalRAGNode(Node):
     def __init__(
         self, name: str = "hierarchical_rag", config: Optional[RAGConfig] = None
     ):
-        self.config = config or RAGConfig()
+        super().__init__(name=name)
+        # Node-specific RAG configuration under `rag_config` (see SemanticRAGNode).
+        self.rag_config = config or RAGConfig()
         self.workflow_node = None
-        super().__init__(name)
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
+            "name": NodeParameter(
+                name="name",
+                type=str,
+                required=False,
+                default="hierarchical_rag",
+                description="Node instance name",
+            ),
+            "config": NodeParameter(
+                name="config",
+                type=dict,
+                required=False,
+                description="RAG configuration parameters",
+            ),
             "documents": NodeParameter(
                 name="documents",
                 type=list,
@@ -561,6 +621,6 @@ class HierarchicalRAGNode(Node):
     def run(self, **kwargs) -> Dict[str, Any]:
         """Run hierarchical RAG using WorkflowNode"""
         if not self.workflow_node:
-            self.workflow_node = create_hierarchical_rag_workflow(self.config)
+            self.workflow_node = create_hierarchical_rag_workflow(self.rag_config)
 
         return self.workflow_node.execute(**kwargs)

--- a/packages/kailash-kaizen/tests/regression/test_rag_resurrection_import_smoke.py
+++ b/packages/kailash-kaizen/tests/regression/test_rag_resurrection_import_smoke.py
@@ -113,3 +113,80 @@ def test_rag_coexists_with_broader_kaizen_node_surface():
     """
     import kaizen.nodes.ai  # noqa: F401  — large non-rag kaizen node package
     import kaizen.nodes.rag  # noqa: F401  — must not raise under the guard
+
+
+# ---------------------------------------------------------------------------
+# Constructor-floor coverage (F8 A1 / A2).
+#
+# The import-smoke tests above execute every class body + every @register_node
+# decorator at import — but a @register_node decorator does NOT call __init__.
+# A node whose __init__ calls super().__init__(name) positionally against the
+# kailash.nodes.base.Node keyword config-bag imports clean yet raises TypeError
+# on EVERY construction. That is the resurrection false-floor: "imports clean"
+# is necessary but not sufficient — the package was advertised as usable while
+# every node was un-constructable.
+#
+# Each entry below names one representative class per code module AND the
+# constructor kwargs to build it. `Node`-subclass entries are A1 scope (fixed:
+# canonical super().__init__(name=name, **config) keyword form) and asserted
+# live. `WorkflowNode`-subclass entries are A2 scope (super().__init__(name,
+# self._create_workflow()) — still broken until A2) and marked skip so this
+# file is green now; A2 un-skips them.
+# ---------------------------------------------------------------------------
+
+# (module, class_name, ctor_kwargs) — representative Node-subclass per module.
+RAG_NODE_REPRESENTATIVES = [
+    ("advanced", "SelfCorrectingRAGNode", {"name": "smoke_self_correcting"}),
+    ("agentic", "ToolAugmentedRAGNode", {"name": "smoke_tool_augmented"}),
+    ("conversational", "ConversationMemoryNode", {"name": "smoke_conv_memory"}),
+    ("evaluation", "RAGBenchmarkNode", {"name": "smoke_rag_benchmark"}),
+    ("federated", "EdgeRAGNode", {"name": "smoke_edge_rag"}),
+    ("graph", "GraphBuilderNode", {"name": "smoke_graph_builder"}),
+    ("multimodal", "VisualQuestionAnsweringNode", {"name": "smoke_vqa"}),
+    ("privacy", "SecureMultiPartyRAGNode", {"name": "smoke_secure_mpc"}),
+    ("query_processing", "QueryExpansionNode", {"name": "smoke_query_expansion"}),
+    ("realtime", "RealtimeStreamingRAGNode", {"name": "smoke_realtime_streaming"}),
+    ("registry", "RAGWorkflowRegistry", {}),
+    ("router", "RAGStrategyRouterNode", {"name": "smoke_rag_router"}),
+    ("similarity", "DenseRetrievalNode", {"name": "smoke_dense_retrieval"}),
+    ("strategies", "SemanticRAGNode", {"name": "smoke_semantic_rag"}),
+]
+
+# Modules whose only node classes are WorkflowNode subclasses — A2 scope.
+# Listed for completeness; their instantiation is skip-marked below.
+RAG_WORKFLOWNODE_ONLY_MODULES = ["optimized", "workflows"]
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "mod, cls_name, ctor_kwargs",
+    RAG_NODE_REPRESENTATIVES,
+    ids=[f"{m}.{c}" for m, c, _ in RAG_NODE_REPRESENTATIVES],
+)
+def test_representative_rag_node_constructs(mod, cls_name, ctor_kwargs):
+    """One representative Node-subclass per module MUST construct, no TypeError.
+
+    This is the line-per-module that catches the resurrection false-floor: a
+    @register_node decorator runs the class body at import but never calls
+    __init__. Only an actual construction exercises super().__init__ — a
+    positional super().__init__(name) against the keyword config-bag raises
+    TypeError here while the import-smoke tests above stay green.
+    """
+    module = importlib.import_module(f"kaizen.nodes.rag.{mod}")
+    cls = getattr(module, cls_name)
+    instance = cls(**ctor_kwargs)
+    assert instance is not None
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("mod", RAG_WORKFLOWNODE_ONLY_MODULES)
+@pytest.mark.skip(reason="WorkflowNode constructors fixed in A2")
+def test_representative_workflownode_constructs(mod):
+    """A2 un-skips this: WorkflowNode-subclass modules construct.
+
+    `optimized` and `workflows` expose only WorkflowNode subclasses, whose
+    __init__ calls super().__init__(name, self._create_workflow()) — still
+    broken (A2 scope). Skip-marked so this file is green at A1; A2 removes the
+    skip and asserts construction of a representative WorkflowNode per module.
+    """
+    importlib.import_module(f"kaizen.nodes.rag.{mod}")


### PR DESCRIPTION
## Summary

The resurrected `kaizen.nodes.rag` package (kaizen 2.23.0) imports + registers
but **0 of its node classes could be constructed** — every `Node`-subclass
called `super().__init__(name)` positionally against
`kailash.nodes.base.Node.__init__(self, **kwargs)` (keyword-only config-bag).
The resurrection's import-smoke gate was a false floor: `@register_node`
registers the class but never instantiates it.

This PR (shard A1 of workstream F8) repairs all 38 `super().__init__(name)`
sites across 13 rag modules to the canonical keyword form
`super().__init__(name=name, **<declared config>)`, declaring node config in
`get_parameters()` so it flows into the validated `self.config`. Also fixes a
latent `self.config`/`RAGConfig` attribute collision in strategies.py and
sources `router.py`'s `llm_model` default from the environment (no hardcoded
`gpt-4`, per `env-models.md`).

The import-smoke regression test is hardened to **instantiate** ≥1 node per
module — the one line per module that would have caught the false floor.

## Test plan

- [x] `grep super().__init__(name)` = 0 across all rag modules
- [x] `test_rag_resurrection_import_smoke.py`: 34 passed, 2 skipped (WorkflowNode modules → shard A2)
- [x] Per-module instantiation verified for all 13 modules
- [x] reviewer + security-reviewer: APPROVE-MERGE (0 introduced regressions; 40 Pyright diagnostics all proven pre-existing)

## Related issues

Workstream F8 — `workspaces/kaizen-rag-node-coverage/`. Follow-up to the
`kaizen.nodes.rag` resurrection (kaizen 2.23.0/2.23.1, PR #1096/#1097).