### PR TITLE
fix(mcp): repair MCPToolNode/MCPResourceNode constructors, remove type:ignore (F8 A1-core)

### DIFF
--- a/src/kailash/middleware/mcp/enhanced_server.py
+++ b/src/kailash/middleware/mcp/enhanced_server.py
@@ -69,10 +69,23 @@ class MCPToolNode(Node):
         description: str = "",
         parameters_schema: Optional[Dict[str, Any]] = None,
     ):
-        super().__init__(name)  # type: ignore[call-arg]
-        self.tool_name = tool_name
-        self.description = description
-        self.parameters_schema = parameters_schema or {}
+        # Route construction config through the Node config-bag contract
+        # (kailash.nodes.base.Node.__init__(self, **kwargs) is keyword-only;
+        # name/description and node-specific keys flow into validated
+        # self.config). Canonical keyword super-call form.
+        super().__init__(
+            name=name,
+            description=description,
+            tool_name=tool_name,
+            parameters_schema=parameters_schema or {},
+        )
+        # Config-derived read attributes sourced from the validated config bag
+        # (preserves existing attribute-read call sites; config is the source
+        # of truth, fixing the prior bare-instance-attr stash).
+        self.tool_name = self.config["tool_name"]
+        self.description = self.config.get("description", description)
+        self.parameters_schema = self.config["parameters_schema"]
+        # Mutable runtime state (NOT configuration).
         self.execution_count = 0
         self.last_executed = None
 
@@ -122,19 +135,31 @@ class MCPResourceNode(Node):
         resource_type: str = "text",
         description: str = "",
     ):
-        super().__init__(name)  # type: ignore[call-arg]
-        self.resource_uri = resource_uri
-        self.resource_type = resource_type
-        self.description = description
+        # Route construction config through the Node config-bag contract
+        # (keyword-only Node.__init__). Canonical keyword super-call form.
+        super().__init__(
+            name=name,
+            description=description,
+            resource_uri=resource_uri,
+            resource_type=resource_type,
+        )
+        # Config-derived read attributes sourced from the validated config bag.
+        self.resource_uri = self.config["resource_uri"]
+        self.resource_type = self.config["resource_type"]
+        self.description = self.config.get("description", description)
+        # Mutable runtime state (NOT configuration).
         self.access_count = 0
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
+        # Read the default from the config bag, not a bare instance attr:
+        # Node.__init__ calls get_parameters() during super-init (before this
+        # subclass body resumes), so self.config is the only reliable source.
         return {
             "resource_uri": NodeParameter(
                 name="resource_uri",
                 type=str,
                 required=False,
-                default=self.resource_uri,
+                default=getattr(self, "config", {}).get("resource_uri", ""),
                 description="URI of the resource to access",
             )
         }

--- a/src/kailash/middleware/mcp/enhanced_server.py
+++ b/src/kailash/middleware/mcp/enhanced_server.py
@@ -101,8 +101,11 @@ class MCPToolNode(Node):
             description="Input data for the MCP tool",
         )
 
-        # Add schema-specific parameters
-        for param_name, param_info in self.parameters_schema.items():
+        # Add schema-specific parameters. Read from the validated config bag,
+        # not the bare instance attribute: Node.__init__ invokes get_parameters()
+        # during super-init (before the subclass body sets self.parameters_schema),
+        # so the bare-attr read would AttributeError on that first call.
+        for param_name, param_info in self.config.get("parameters_schema", {}).items():
             params[param_name] = NodeParameter(
                 name=param_name,
                 type=param_info.get("type", str),

--- a/tests/unit/mcp/test_server_enhanced.py
+++ b/tests/unit/mcp/test_server_enhanced.py
@@ -6,7 +6,6 @@ Tests for enhanced MCP server functionality without mocking external packages.
 from unittest.mock import Mock, patch
 
 import pytest
-
 from kailash_mcp.server import MCPServer
 
 
@@ -175,3 +174,35 @@ class TestMCPServerIntegration:
         assert hasattr(server, "_tool_registry")
         assert hasattr(server, "_resource_registry")
         assert hasattr(server, "_prompt_registry")
+
+
+@pytest.mark.regression
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "MCPToolNode does not implement the abstract Node.run method, so the "
+        "class is currently uninstantiable (TypeError on construction). "
+        "Implementing run is shard A3's scope. Once A3 lands, this xfail flips "
+        "to a hard failure (strict=True) — remove the marker and confirm the "
+        "MED-1 get_parameters() config-bag fix is reachable at runtime."
+    ),
+)
+def test_mcp_tool_node_get_parameters_reads_config_bag():
+    """MED-1: MCPToolNode.get_parameters() reads parameters_schema from the
+    validated config bag, not the bare instance attribute.
+
+    Node.__init__ invokes get_parameters() during super-init — before the
+    subclass body sets self.parameters_schema. A bare-attr read would raise
+    AttributeError on that first call; routing through self.config fixes it.
+    Constructing the node exercises that first get_parameters() call.
+    """
+    from kailash.middleware.mcp.enhanced_server import MCPToolNode
+
+    node = MCPToolNode(
+        name="t",
+        tool_name="x",
+        parameters_schema={"foo": {"type": str, "required": True}},
+    )
+    params = node.get_parameters()
+    assert "tool_input" in params
+    assert "foo" in params


### PR DESCRIPTION
## Summary

`src/kailash/middleware/mcp/enhanced_server.py` carried the identical
constructor-contract bug as the kaizen rag package: `MCPToolNode` and
`MCPResourceNode` called `super().__init__(name)` positionally against
`Node.__init__(self, **kwargs)`, with the violation suppressed by
`# type: ignore[call-arg]` rather than fixed.

This PR (shard A1-core of workstream F8) repairs both constructors to the
canonical keyword config-bag form, removes both `# type: ignore[call-arg]`
suppressions, and fixes `MCPToolNode.get_parameters()` to read the validated
config bag (it is invoked by `Node.__init__` during super-init, before the
subclass body sets the bare attribute).

## Known follow-up (shard A3)

Both classes implement `process()` rather than the abstract `Node.run` — a
distinct pre-existing defect (proven pre-session via `git show 0f906a1e0:`).
They remain non-instantiable until shard A3 reconciles `process`/`run`. The
new regression test is `xfail(strict=True)`-marked with that exact reason, so
A3 is forced to un-mark it and confirm runtime behavior.

## Test plan

- [x] `grep '# type: ignore[call-arg]'` = 0 in enhanced_server.py
- [x] `tests/unit/mcp/test_server_enhanced.py`: 11 passed, 1 xfailed
- [x] reviewer + security-reviewer: APPROVE-MERGE

## Related issues

Workstream F8 — `workspaces/kaizen-rag-node-coverage/`.