### PR TITLE
fix(rag): correct 13 WorkflowNode constructors to canonical keyword form (F8 A2)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
@@ -93,7 +93,7 @@ class AgenticRAGNode(WorkflowNode):
         self.max_reasoning_steps = max_reasoning_steps
         self.planning_strategy = planning_strategy
         self.verification_enabled = verification_enabled
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create agentic RAG workflow"""
@@ -752,7 +752,7 @@ class ReasoningRAGNode(WorkflowNode):
     ):
         self.reasoning_depth = reasoning_depth
         self.strategy = strategy
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create reasoning RAG workflow"""

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/conversational.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/conversational.py
@@ -111,7 +111,7 @@ class ConversationalRAGNode(WorkflowNode):
         self.topic_tracking = topic_tracking
         # In-memory session storage (use persistent storage in production)
         self.sessions = {}
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create conversational RAG workflow"""

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/evaluation.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/evaluation.py
@@ -102,7 +102,7 @@ class RAGEvaluationNode(WorkflowNode):
         ]
         self.use_reference_answers = use_reference_answers
         self.llm_judge_model = llm_judge_model
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create RAG evaluation workflow"""

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
@@ -99,7 +99,7 @@ class FederatedRAGNode(WorkflowNode):
         self.min_participating_nodes = min_participating_nodes
         self.timeout_per_node = timeout_per_node
         self.enable_caching = enable_caching
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create federated RAG workflow"""

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
@@ -103,7 +103,7 @@ class GraphRAGNode(WorkflowNode):
         self.max_hops = max_hops
         self.community_algorithm = community_algorithm
         self.use_global_summary = use_global_summary
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create knowledge graph RAG workflow"""

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/multimodal.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/multimodal.py
@@ -91,7 +91,7 @@ class MultimodalRAGNode(WorkflowNode):
         self.image_encoder = image_encoder
         self.enable_ocr = enable_ocr
         self.fusion_strategy = fusion_strategy
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create multimodal RAG workflow"""

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/optimized.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/optimized.py
@@ -85,7 +85,7 @@ class CacheOptimizedRAGNode(WorkflowNode):
     ):
         self.cache_ttl = cache_ttl
         self.similarity_threshold = similarity_threshold
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create cache-optimized RAG workflow"""
@@ -326,7 +326,7 @@ class AsyncParallelRAGNode(WorkflowNode):
 
     def __init__(self, name: str = "async_parallel_rag", strategies: List[str] = None):
         self.strategies = strategies or ["semantic", "sparse", "hybrid"]
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create async parallel RAG workflow"""
@@ -534,7 +534,7 @@ class StreamingRAGNode(WorkflowNode):
 
     def __init__(self, name: str = "streaming_rag", chunk_size: int = 100):
         self.chunk_size = chunk_size
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create streaming RAG workflow"""
@@ -720,7 +720,7 @@ class BatchOptimizedRAGNode(WorkflowNode):
 
     def __init__(self, name: str = "batch_optimized_rag", batch_size: int = 32):
         self.batch_size = batch_size
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create batch-optimized RAG workflow"""

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/privacy.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/privacy.py
@@ -93,7 +93,7 @@ class PrivacyPreservingRAGNode(WorkflowNode):
         self.redact_pii = redact_pii
         self.anonymize_queries = anonymize_queries
         self.audit_logging = audit_logging
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create privacy-preserving RAG workflow"""

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/realtime.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/realtime.py
@@ -93,7 +93,7 @@ class RealtimeRAGNode(WorkflowNode):
         self.max_buffer_size = max_buffer_size
         self.document_buffer = deque(maxlen=max_buffer_size)
         self.last_update = datetime.now()
-        super().__init__(name, self._create_workflow())
+        super().__init__(workflow=self._create_workflow(), name=name)
 
     def _create_workflow(self) -> WorkflowNode:
         """Create real-time RAG workflow"""

--- a/packages/kailash-kaizen/tests/regression/test_rag_resurrection_import_smoke.py
+++ b/packages/kailash-kaizen/tests/regression/test_rag_resurrection_import_smoke.py
@@ -129,9 +129,20 @@ def test_rag_coexists_with_broader_kaizen_node_surface():
 # Each entry below names one representative class per code module AND the
 # constructor kwargs to build it. `Node`-subclass entries are A1 scope (fixed:
 # canonical super().__init__(name=name, **config) keyword form) and asserted
-# live. `WorkflowNode`-subclass entries are A2 scope (super().__init__(name,
-# self._create_workflow()) — still broken until A2) and marked skip so this
-# file is green now; A2 un-skips them.
+# live.
+#
+# A2 corrected the 13 `WorkflowNode`-subclass constructor *forms*: positional
+# super().__init__(name, self._create_workflow()) — which landed `name` in the
+# `workflow` slot of WorkflowNode.__init__(workflow, **kwargs) and left the
+# real workflow with no positional slot, a TypeError on EVERY construction —
+# became canonical keyword super().__init__(workflow=self._create_workflow(),
+# name=name). The constructor form is now correct for all 17 WorkflowNode
+# subclasses, but 6 still cannot fully construct because their
+# _create_workflow() bodies reference unregistered node types or hit a
+# NameError — that is A3 scope, not A2, and those 6 are marked
+# xfail(strict=True) below so A3 un-marks them. `workflows.py`'s 4 classes
+# were already constructor-canonical (never A2 scope) but are A3-blocked on
+# the unregistered 'SemanticChunkerNode' all the same.
 # ---------------------------------------------------------------------------
 
 # (module, class_name, ctor_kwargs) — representative Node-subclass per module.
@@ -152,9 +163,101 @@ RAG_NODE_REPRESENTATIVES = [
     ("strategies", "SemanticRAGNode", {"name": "smoke_semantic_rag"}),
 ]
 
-# Modules whose only node classes are WorkflowNode subclasses — A2 scope.
-# Listed for completeness; their instantiation is skip-marked below.
-RAG_WORKFLOWNODE_ONLY_MODULES = ["optimized", "workflows"]
+# (module, class_name, ctor_kwargs) — every WorkflowNode subclass in the rag
+# package. A2 corrected the 13 fixed classes' constructor *form*: positional
+# super().__init__(name, self._create_workflow()) — which landed `name` in the
+# `workflow` slot of WorkflowNode.__init__(workflow, **kwargs) and left the real
+# workflow with no positional slot, a TypeError on EVERY construction — became
+# canonical keyword super().__init__(workflow=self._create_workflow(), name=name).
+#
+# The constructor *form* is now correct for all 17, but 6 classes still cannot
+# FULLY construct because their _create_workflow() bodies reference unregistered
+# node types or hit a NameError — that is A3 scope, not A2. Those 6 are marked
+# xfail(strict=True): the moment A3 fixes the _create_workflow() bodies they
+# XPASS, the strict marker turns the unexpected pass into a FAILURE, and the A3
+# session is forced to remove the marks. The marker IS the A3 tracking hook —
+# skip would be silent, dropping the param would hide the gap.
+#
+# The 4 workflows.py classes were already constructor-canonical (multi-line
+# keyword super().__init__(workflow=, name=, description=)) and were never A2
+# scope — but they are A3-blocked on the unregistered 'SemanticChunkerNode' all
+# the same, so they carry the same xfail marker. Each class takes a defaulted
+# `name` plus defaulted config.
+_A3_CACHE_NODE = (
+    "A3 (R3): _create_workflow references unregistered node type 'CacheNode'"
+)
+_A3_SEMANTIC_CHUNKER = (
+    "A3 (R3): _create_workflow references unregistered node type 'SemanticChunkerNode'"
+)
+_A3_PII_NAMEERROR = (
+    "A3 (R4 LEAK, A0-tabled): privacy.py _create_workflow raises NameError 'pii_type'"
+)
+
+RAG_WORKFLOWNODE_SUBCLASSES = [
+    # 13 A2-fixed classes (positional super().__init__ → keyword form).
+    pytest.param("realtime", "RealtimeRAGNode", {"name": "smoke_realtime_rag"}),
+    pytest.param("agentic", "AgenticRAGNode", {"name": "smoke_agentic_rag"}),
+    pytest.param("agentic", "ReasoningRAGNode", {"name": "smoke_reasoning_rag"}),
+    pytest.param("evaluation", "RAGEvaluationNode", {"name": "smoke_rag_evaluation"}),
+    pytest.param("graph", "GraphRAGNode", {"name": "smoke_graph_rag"}),
+    pytest.param("multimodal", "MultimodalRAGNode", {"name": "smoke_multimodal_rag"}),
+    pytest.param("federated", "FederatedRAGNode", {"name": "smoke_federated_rag"}),
+    pytest.param(
+        "conversational",
+        "ConversationalRAGNode",
+        {"name": "smoke_conversational_rag"},
+    ),
+    pytest.param(
+        "optimized",
+        "CacheOptimizedRAGNode",
+        {"name": "smoke_cache_optimized_rag"},
+        marks=pytest.mark.xfail(strict=True, reason=_A3_CACHE_NODE),
+    ),
+    pytest.param(
+        "optimized", "AsyncParallelRAGNode", {"name": "smoke_async_parallel_rag"}
+    ),
+    pytest.param("optimized", "StreamingRAGNode", {"name": "smoke_streaming_rag"}),
+    pytest.param(
+        "optimized", "BatchOptimizedRAGNode", {"name": "smoke_batch_optimized_rag"}
+    ),
+    pytest.param(
+        "privacy",
+        "PrivacyPreservingRAGNode",
+        {"name": "smoke_privacy_rag"},
+        marks=pytest.mark.xfail(strict=True, reason=_A3_PII_NAMEERROR),
+    ),
+    # 4 workflows.py classes — already constructor-canonical, never A2 scope,
+    # but A3-blocked on the unregistered 'SemanticChunkerNode' node type.
+    pytest.param(
+        "workflows",
+        "SimpleRAGWorkflowNode",
+        {"name": "smoke_simple_rag_workflow"},
+        marks=pytest.mark.xfail(strict=True, reason=_A3_SEMANTIC_CHUNKER),
+    ),
+    pytest.param(
+        "workflows",
+        "AdvancedRAGWorkflowNode",
+        {"name": "smoke_advanced_rag_workflow"},
+        marks=pytest.mark.xfail(strict=True, reason=_A3_SEMANTIC_CHUNKER),
+    ),
+    pytest.param(
+        "workflows",
+        "AdaptiveRAGWorkflowNode",
+        {"name": "smoke_adaptive_rag_workflow"},
+        marks=pytest.mark.xfail(strict=True, reason=_A3_SEMANTIC_CHUNKER),
+    ),
+    pytest.param(
+        "workflows",
+        "RAGPipelineWorkflowNode",
+        {"name": "smoke_rag_pipeline_workflow"},
+        marks=pytest.mark.xfail(strict=True, reason=_A3_SEMANTIC_CHUNKER),
+    ),
+]
+
+# Stable test ids: (module.class_name) per param, mirroring RAG_NODE_REPRESENTATIVES.
+_RAG_WORKFLOWNODE_IDS = [
+    f"{p.values[0]}.{p.values[1]}" for p in RAG_WORKFLOWNODE_SUBCLASSES
+]
 
 
 @pytest.mark.regression
@@ -179,14 +282,32 @@ def test_representative_rag_node_constructs(mod, cls_name, ctor_kwargs):
 
 
 @pytest.mark.regression
-@pytest.mark.parametrize("mod", RAG_WORKFLOWNODE_ONLY_MODULES)
-@pytest.mark.skip(reason="WorkflowNode constructors fixed in A2")
-def test_representative_workflownode_constructs(mod):
-    """A2 un-skips this: WorkflowNode-subclass modules construct.
+@pytest.mark.parametrize(
+    "mod, cls_name, ctor_kwargs",
+    RAG_WORKFLOWNODE_SUBCLASSES,
+    ids=_RAG_WORKFLOWNODE_IDS,
+)
+def test_workflownode_subclass_constructs(mod, cls_name, ctor_kwargs):
+    """Every WorkflowNode subclass in the rag package MUST construct.
 
-    `optimized` and `workflows` expose only WorkflowNode subclasses, whose
-    __init__ calls super().__init__(name, self._create_workflow()) — still
-    broken (A2 scope). Skip-marked so this file is green at A1; A2 removes the
-    skip and asserts construction of a representative WorkflowNode per module.
+    A2 corrected the 13 fixed classes' constructor form: positional
+    super().__init__(name, self._create_workflow()) — `name` landed in the
+    `workflow` slot of WorkflowNode.__init__(workflow, **kwargs), the real
+    workflow had no positional slot, TypeError on EVERY construction — became
+    canonical super().__init__(workflow=self._create_workflow(), name=name).
+
+    Constructor form is now correct for all 17, but 6 classes still cannot
+    fully construct: their _create_workflow() bodies reference unregistered
+    node types ('CacheNode', 'SemanticChunkerNode') or raise a NameError
+    ('pii_type'). Those are A3 scope and carry xfail(strict=True) — when A3
+    fixes the _create_workflow() bodies the params XPASS, the strict marker
+    fails the test, and A3 is forced to remove the marks.
+
+    Same false-floor logic as the Node-subclass test above: a @register_node
+    decorator runs the class body at import but never calls __init__, so only
+    an actual construction exercises super().__init__.
     """
-    importlib.import_module(f"kaizen.nodes.rag.{mod}")
+    module = importlib.import_module(f"kaizen.nodes.rag.{mod}")
+    cls = getattr(module, cls_name)
+    instance = cls(**ctor_kwargs)
+    assert instance is not None


### PR DESCRIPTION
## Summary

- Shard A2 of workstream F8 (behavioral coverage of the resurrected `kaizen.nodes.rag` package). Corrects the **13 `WorkflowNode`-subclass constructors** that called the base class positionally — `super().__init__(name, self._create_workflow())` — to the canonical keyword form `super().__init__(workflow=self._create_workflow(), name=name)`. `WorkflowNode.__init__(self, workflow=None, **kwargs)` has one positional slot; the old form put `name` into `workflow` and the real workflow into an un-capturable 2nd positional, raising `TypeError` on **every** construction.
- Hardens `test_rag_resurrection_import_smoke.py`: replaces the A1-era skipped placeholder with a parametrized constructor-floor test over all 17 rag `WorkflowNode` subclasses. 11 construct live; 6 are A3-blocked (their `_create_workflow()` bodies reference unregistered node types `CacheNode`/`SemanticChunkerNode` or hit a pre-existing `NameError`) and carry `xfail(strict=True)` so the A3 shard is forced to un-mark them.
- The canonical form is the minimal `workflow=`/`name=` — matching the already-correct `workflows.py` `WorkflowNode` precedent, not the plan's literal `**<cfg>` (a launch-time amendment per specs-authority Rule 5c; rationale in `workspaces/kaizen-rag-node-coverage/journal/0007`).

## Test plan

- [x] `grep` confirms 0 occurrences of the broken positional form, 13 of the canonical form across 9 rag modules
- [x] `test_rag_resurrection_import_smoke.py`: 45 passed, 6 xfailed, 0 failed, 0 XPASS
- [x] All 13 constructors: bare config-attr assignments remain before `super().__init__` (`_create_workflow()` reads them)
- [x] reviewer + security-reviewer gate: both APPROVE-MERGE

## Related issues

Workstream F8 / `/implement` cycle 2 — follows cycle 1 PRs #1098 (A1) + #1099 (A1-core). The 6 `xfail(strict=True)` markers track the next shard (A3 — R3 missing-node-type + R4 LEAK triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)