### PR TITLE
fix(research): make GitPython import lazy in ResearchValidator

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/research/validator.py
+++ b/packages/kailash-kaizen/src/kaizen/research/validator.py
@@ -17,8 +17,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import git
-
 from .parser import ResearchPaper
 
 
@@ -122,6 +120,13 @@ class ResearchValidator:
 
     def _clone_repository(self, code_url: str, target_dir: str):
         """Clone code repository."""
+        try:
+            import git  # GitPython — optional `research-validator` extra
+        except ImportError as exc:
+            raise ImportError(
+                "Repository validation requires GitPython. Install the optional "
+                "extra: pip install 'kailash-kaizen[research-validator]'"
+            ) from exc
         try:
             git.Repo.clone_from(code_url, target_dir, depth=1)
         except Exception as e:

--- a/packages/kailash-kaizen/tests/regression/test_research_validator_lazy_git_import.py
+++ b/packages/kailash-kaizen/tests/regression/test_research_validator_lazy_git_import.py
@@ -1,0 +1,62 @@
+"""Regression: `kaizen.research` must not eagerly import GitPython.
+
+GitPython (`git`) is an OPTIONAL extra — `research-validator` in
+`packages/kailash-kaizen/pyproject.toml`. `kaizen/research/validator.py`
+previously did an unconditional module-scope `import git`, and
+`kaizen/research/__init__.py` eagerly imports `validator` — so importing
+anything under `kaizen.research` raised `ModuleNotFoundError: No module
+named 'git'` on every environment without the optional extra installed,
+including the kaizen regression-test collection gate (it blocked
+`pytest --collect-only` on `tests/regression/`).
+
+Fix: `import git` is now lazy — inside `ResearchValidator._clone_repository`,
+the single call site — with a clear install hint raised on `ImportError`.
+The module imports clean without the extra; the GitPython requirement
+surfaces (loudly, with a fix instruction) only when repository cloning runs.
+
+These tests run regardless of whether GitPython is installed: they assert
+the IMPORT graph does not pull `git` in, which holds either way.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+def _drop_from_sys_modules(*prefixes: str) -> None:
+    """Evict cached modules so the next import is exercised fresh."""
+    for name in list(sys.modules):
+        for prefix in prefixes:
+            if name == prefix or name.startswith(prefix + "."):
+                del sys.modules[name]
+                break
+
+
+@pytest.mark.regression
+def test_research_validator_module_imports_without_eager_git():
+    """Importing the validator module MUST NOT pull `git` into sys.modules."""
+    _drop_from_sys_modules("git", "kaizen.research.validator")
+
+    importlib.import_module("kaizen.research.validator")
+
+    assert "git" not in sys.modules, (
+        "kaizen.research.validator eagerly imported GitPython — `import git` "
+        "must stay lazy (inside ResearchValidator._clone_repository) so the "
+        "optional `research-validator` extra is not required to import it."
+    )
+
+
+@pytest.mark.regression
+def test_research_package_imports_without_eager_git():
+    """`import kaizen.research` eagerly imports validator — still no `git`."""
+    _drop_from_sys_modules("git", "kaizen.research")
+
+    importlib.import_module("kaizen.research")
+
+    assert "git" not in sys.modules, (
+        "import kaizen.research transitively eager-imported GitPython via "
+        "kaizen/research/__init__.py -> .validator -> import git."
+    )


### PR DESCRIPTION
## Summary

- `kaizen/research/validator.py` imported GitPython (`import git`) unconditionally at module scope, but GitPython is an **optional** extra (`research-validator`). `kaizen/research/__init__.py` eagerly imports `validator`, so importing anything under `kaizen.research` raised `ModuleNotFoundError: No module named 'git'` on any environment without the optional extra.
- This errored `test_issue_814_research_adapter_inputs_list.py` at collection and blocked `pytest --collect-only` on `packages/kailash-kaizen/tests/regression/` — surfaced by the F8 A2 gate review (MED-1).
- `git` is used at exactly one call site (`ResearchValidator._clone_repository`). The import is moved there as a lazy import with a clear install hint raised on `ImportError`. The module imports clean without the extra; the GitPython requirement surfaces loudly only when repository cloning runs.

## Test plan

- [x] New regression test `test_research_validator_lazy_git_import.py` (2 tests) — asserts importing `kaizen.research.validator` and `kaizen.research` does not pull `git` into `sys.modules`; passes regardless of whether GitPython is installed
- [x] `pytest --collect-only packages/kailash-kaizen/tests/regression/` — now clean (212 collected, 0 errors; was 208 collected + 1 error)
- [x] reviewer + security-reviewer gate

## Related issues

Follow-up to F8 A2 (PR #1100) — MED-1 surfaced by the A2 `/implement` gate review. Independent of the F8 workstream (different package subtree, `kaizen.research`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)