### PR TITLE
fix(core): F8 A3 — implement MCP Node.run + WorkflowNode.workflow property

### DIFF
--- a/packages/kailash-kaizen/tests/regression/test_rag_resurrection_import_smoke.py
+++ b/packages/kailash-kaizen/tests/regression/test_rag_resurrection_import_smoke.py
@@ -139,10 +139,13 @@ def test_rag_coexists_with_broader_kaizen_node_surface():
 # name=name). The constructor form is now correct for all 17 WorkflowNode
 # subclasses, but 6 still cannot fully construct because their
 # _create_workflow() bodies reference unregistered node types or hit a
-# NameError — that is A3 scope, not A2, and those 6 are marked
-# xfail(strict=True) below so A3 un-marks them. `workflows.py`'s 4 classes
-# were already constructor-canonical (never A2 scope) but are A3-blocked on
-# the unregistered 'SemanticChunkerNode' all the same.
+# NameError — that is A3-triage scope, not A2. A3 dispositioned all 6 (see
+# `workspaces/kaizen-rag-node-coverage/01-analysis/04-A3-triage.md`): the
+# rag-side `_create_workflow()` fixes are routed to the owning B-coverage
+# shards, and the owning B-shard un-marks its xfail when it lands the fix.
+# `workflows.py`'s 4 classes were already constructor-canonical (never A2
+# scope) but are A3-blocked on the unregistered 'SemanticChunkerNode' all
+# the same.
 # ---------------------------------------------------------------------------
 
 # (module, class_name, ctor_kwargs) — representative Node-subclass per module.
@@ -172,11 +175,13 @@ RAG_NODE_REPRESENTATIVES = [
 #
 # The constructor *form* is now correct for all 17, but 6 classes still cannot
 # FULLY construct because their _create_workflow() bodies reference unregistered
-# node types or hit a NameError — that is A3 scope, not A2. Those 6 are marked
-# xfail(strict=True): the moment A3 fixes the _create_workflow() bodies they
-# XPASS, the strict marker turns the unexpected pass into a FAILURE, and the A3
-# session is forced to remove the marks. The marker IS the A3 tracking hook —
-# skip would be silent, dropping the param would hide the gap.
+# node types or hit a NameError — that is A3-triage scope, not A2. Those 6 are
+# marked xfail(strict=True): the moment the owning B-coverage shard fixes the
+# _create_workflow() body they XPASS, the strict marker turns the unexpected
+# pass into a FAILURE, and that B-shard is forced to remove the mark. The
+# marker IS the cross-shard tracking hook (A3 dispositions, the B-shard fixes
+# + un-marks — see 04-A3-triage.md) — skip would be silent, dropping the
+# param would hide the gap.
 #
 # The 4 workflows.py classes were already constructor-canonical (multi-line
 # keyword super().__init__(workflow=, name=, description=)) and were never A2
@@ -299,9 +304,11 @@ def test_workflownode_subclass_constructs(mod, cls_name, ctor_kwargs):
     Constructor form is now correct for all 17, but 6 classes still cannot
     fully construct: their _create_workflow() bodies reference unregistered
     node types ('CacheNode', 'SemanticChunkerNode') or raise a NameError
-    ('pii_type'). Those are A3 scope and carry xfail(strict=True) — when A3
-    fixes the _create_workflow() bodies the params XPASS, the strict marker
-    fails the test, and A3 is forced to remove the marks.
+    ('pii_type'). A3-triage dispositioned all 6 (04-A3-triage.md) and routed
+    the rag-side fixes to the owning B-coverage shards; each carries
+    xfail(strict=True) — when the owning B-shard fixes the _create_workflow()
+    body the param XPASSes, the strict marker fails the test, and that
+    B-shard is forced to remove the mark.
 
     Same false-floor logic as the Node-subclass test above: a @register_node
     decorator runs the class body at import but never calls __init__, so only

--- a/src/kailash/middleware/mcp/enhanced_server.py
+++ b/src/kailash/middleware/mcp/enhanced_server.py
@@ -127,6 +127,18 @@ class MCPToolNode(Node):
             "executed_at": self.last_executed.isoformat(),
         }
 
+    def run(self, **kwargs: Any) -> Dict[str, Any]:
+        """Bridge the Node ``run(**kwargs)`` contract to the MCP
+        ``process(inputs)`` convention.
+
+        ``kailash.nodes.base.Node.run`` is abstract and keyword-only; the MCP
+        server's per-tool execution convention is ``process(inputs: dict)``.
+        This adapter collects the Node-graph keyword call into the ``inputs``
+        dict ``process`` expects (carrying ``tool_input`` per
+        ``get_parameters()``) and returns the real ``process`` result.
+        """
+        return self.process(kwargs)
+
 
 class MCPResourceNode(Node):
     """Kailash node representing an MCP resource."""
@@ -177,6 +189,18 @@ class MCPResourceNode(Node):
             "resource_type": self.resource_type,
             "access_count": self.access_count,
         }
+
+    def run(self, **kwargs: Any) -> Dict[str, Any]:
+        """Bridge the Node ``run(**kwargs)`` contract to the MCP
+        ``process(inputs)`` convention.
+
+        ``kailash.nodes.base.Node.run`` is abstract and keyword-only; the MCP
+        server's per-resource execution convention is ``process(inputs: dict)``.
+        This adapter collects the Node-graph keyword call into the ``inputs``
+        dict ``process`` expects (carrying ``resource_uri`` per
+        ``get_parameters()``) and returns the real ``process`` result.
+        """
+        return self.process(kwargs)
 
 
 class MiddlewareMCPServer:

--- a/src/kailash/nodes/logic/workflow.py
+++ b/src/kailash/nodes/logic/workflow.py
@@ -127,6 +127,11 @@ class WorkflowNode(Node):
         if not self._workflow:
             self._load_workflow()
 
+    @property
+    def workflow(self) -> Workflow | None:
+        """The inner wrapped :class:`Workflow` (``None`` until loaded)."""
+        return self._workflow
+
     def _validate_config(self):
         """Override validation for WorkflowNode.
 

--- a/tests/integration/nodes/test_workflow_node.py
+++ b/tests/integration/nodes/test_workflow_node.py
@@ -20,12 +20,9 @@ def register_test_nodes():
     NodeRegistry.register(InputTestNode, "InputTestNode")
     NodeRegistry.register(ProcessorTestNode, "ProcessorTestNode")
     yield
-    # Clean up after tests
+    # Clean up after tests (pop with default never raises)
     for node_name in ["InputTestNode", "ProcessorTestNode"]:
-        try:
-            NodeRegistry._nodes.pop(node_name, None)
-        except:
-            pass
+        NodeRegistry._nodes.pop(node_name, None)
 
 
 # Removed @register_node() to prevent test pollution
@@ -372,3 +369,20 @@ class TestWorkflowNode:
         )
 
         assert results["results"]["processor"]["result"] == 70  # 10 * 7
+
+
+@pytest.mark.regression
+def test_workflow_node_workflow_property_returns_inner_workflow():
+    """WorkflowNode exposes the inner wrapped Workflow via a read-only
+    `.workflow` property.
+
+    Downstream code (kaizen.nodes.rag.workflows / strategies) accesses
+    `workflow_node.workflow`; before this fix WorkflowNode only stored
+    `self._workflow` with no public accessor, raising AttributeError.
+    """
+    inner = Workflow("wf-prop-001", "data_processing")
+    inner.add_node("input", InputTestNode(name="input"))
+
+    node = WorkflowNode(workflow=inner)
+
+    assert node.workflow is inner

--- a/tests/unit/mcp/test_server_enhanced.py
+++ b/tests/unit/mcp/test_server_enhanced.py
@@ -177,16 +177,6 @@ class TestMCPServerIntegration:
 
 
 @pytest.mark.regression
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "MCPToolNode does not implement the abstract Node.run method, so the "
-        "class is currently uninstantiable (TypeError on construction). "
-        "Implementing run is shard A3's scope. Once A3 lands, this xfail flips "
-        "to a hard failure (strict=True) — remove the marker and confirm the "
-        "MED-1 get_parameters() config-bag fix is reachable at runtime."
-    ),
-)
 def test_mcp_tool_node_get_parameters_reads_config_bag():
     """MED-1: MCPToolNode.get_parameters() reads parameters_schema from the
     validated config bag, not the bare instance attribute.
@@ -206,3 +196,48 @@ def test_mcp_tool_node_get_parameters_reads_config_bag():
     params = node.get_parameters()
     assert "tool_input" in params
     assert "foo" in params
+
+
+@pytest.mark.regression
+def test_mcp_tool_node_run_bridges_to_process():
+    """CLASS5: MCPToolNode.run(**kwargs) bridges the Node run(**kwargs)
+    contract to the MCP process(inputs) convention and returns the real
+    process payload.
+
+    Node.run is abstract; before shard A3, MCPToolNode was uninstantiable.
+    The run adapter collects its kwargs into the inputs dict and delegates
+    to process — proving the class is now concrete AND that run produces
+    process's output.
+    """
+    from kailash.middleware.mcp.enhanced_server import MCPToolNode
+
+    node = MCPToolNode(name="t", tool_name="x")
+    result = node.run(tool_input={"k": "v"})
+
+    assert isinstance(result, dict)
+    assert "tool_result" in result
+    assert "execution_count" in result
+    assert result["execution_count"] == 1
+    assert result["tool_result"] == "Executed MCP tool x"
+
+
+@pytest.mark.regression
+def test_mcp_resource_node_run_bridges_to_process():
+    """CLASS5: MCPResourceNode.run(**kwargs) bridges the Node run(**kwargs)
+    contract to the MCP process(inputs) convention and returns the real
+    process payload.
+
+    Node.run is abstract; before shard A3, MCPResourceNode was
+    uninstantiable. The run adapter collects its kwargs into the inputs
+    dict and delegates to process.
+    """
+    from kailash.middleware.mcp.enhanced_server import MCPResourceNode
+
+    node = MCPResourceNode(name="t", resource_uri="u")
+    result = node.run(resource_uri="u")
+
+    assert isinstance(result, dict)
+    assert "resource_content" in result
+    assert "access_count" in result
+    assert result["access_count"] == 1
+    assert result["resource_content"] == "Content from u"


### PR DESCRIPTION
## Summary

Shard **A3** of workstream F8 (`kaizen.nodes.rag` resurrection). A3 is the
R3/R4/CLASS5 triage shard; it fixes the two **kailash-core gaps** that block
the rag package and have no rag-side owner, and dispositions the rest to the
owning B-coverage shards (see `workspaces/kaizen-rag-node-coverage/01-analysis/04-A3-triage.md`).

- **CLASS5** — `MCPToolNode` / `MCPResourceNode` implemented `process()` but
  not the abstract `Node.run`, so both were uninstantiable. Added a
  `run(**kwargs)` adapter that bridges the Node-graph keyword contract to the
  MCP `process(inputs)` convention (`process` stays the per-tool override
  point). The `xfail(strict=True)` test `test_mcp_tool_node_get_parameters_reads_config_bag`
  is un-marked → real pass; a behavioral regression test locks `run()`.
- **`WorkflowNode.workflow`** — core `WorkflowNode` stored `_workflow` but
  exposed no public property; rag code reading `.workflow` hit `AttributeError`.
  Added a read-only `@property def workflow`.
- Corrected the rag smoke-test docstring: A3 dispositions, the owning
  B-shard un-marks its xfail (A2's prediction "A3 un-marks" was inaccurate).

R3 (chunker/cache registry imports + stale `add_connection(route=)`), R4
(privacy f-string escapes), and the ~40 pre-existing Pyright defects are
dispositioned to B-coverage shards in the triage doc — not in this PR.

## Test plan

- [x] `tests/unit/mcp/test_server_enhanced.py` — 154 passed, no xfail/xpass
- [x] `WorkflowNode.workflow` behavioral regression test passes
- [x] rag resurrection smoke — 45 passed, 6 xfailed (rag xfails correctly
      stay xfail; A3 routes rag fixes to B-shards)
- [x] `pre-commit run --all-files` clean
- [x] verified zero regressions: `test_error_workflow_execution_failure`
      fails identically on `main` `208bcf166` (pre-existing
      workflow-error-propagation bug, out of F8 scope — recorded in triage doc)

## Related issues

Part of F8 (`kaizen.nodes.rag` behavioral coverage). No standalone issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)