### PR TITLE
test(rag): F8 B2 — behavioral coverage of the 3 graph RAG nodes

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
@@ -10,18 +10,19 @@ Implements knowledge graph-based retrieval for complex reasoning:
 Based on Microsoft GraphRAG (2024) and knowledge graph research.
 """
 
-import json
 import logging
-from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional
 
 import networkx as nx
 from kailash.nodes.base import Node, NodeParameter, register_node
-from kailash.nodes.code.python import PythonCodeNode
+from kailash.nodes.code.python import (  # noqa: F401  registers "PythonCodeNode"
+    PythonCodeNode,
+)
 from kailash.nodes.logic.workflow import WorkflowNode
 from kailash.workflow.builder import WorkflowBuilder
+from kailash.workflow.graph import Workflow
 
-from ..ai.llm_agent import LLMAgentNode
+from ..ai.llm_agent import LLMAgentNode  # noqa: F401  registers "LLMAgentNode"
 
 logger = logging.getLogger(__name__)
 
@@ -82,8 +83,8 @@ class GraphRAGNode(WorkflowNode):
     def __init__(
         self,
         name: str = "graph_rag",
-        entity_types: List[str] = None,
-        relationship_types: List[str] = None,
+        entity_types: Optional[List[str]] = None,
+        relationship_types: Optional[List[str]] = None,
         max_hops: int = 2,
         community_algorithm: str = "louvain",
         use_global_summary: bool = True,
@@ -105,9 +106,12 @@ class GraphRAGNode(WorkflowNode):
         self.use_global_summary = use_global_summary
         super().__init__(workflow=self._create_workflow(), name=name)
 
-    def _create_workflow(self) -> WorkflowNode:
+    def _create_workflow(self) -> Workflow:
         """Create knowledge graph RAG workflow"""
         builder = WorkflowBuilder()
+        # Bound before the conditional so the use site below is provably bound
+        # whether or not the optional summary node is added.
+        summary_generator_id: Optional[str] = None
 
         # Entity extraction
         entity_extractor_id = builder.add_node(
@@ -438,6 +442,9 @@ result = {
         )
 
         if self.use_global_summary:
+            # The same guard bound summary_generator_id above; assert pins the
+            # invariant for the type checker.
+            assert summary_generator_id is not None
             builder.add_connection(
                 graph_builder_id, "graph_data", summary_generator_id, "graph_data"
             )

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
@@ -587,14 +587,19 @@ class GraphBuilderNode(Node):
 
         # Add sample graph building logic
         for doc in documents:
-            doc_id = doc.get("id", hash(doc.get("content", "")))
+            # Skip malformed (non-dict) entries rather than crashing on
+            # ``str.get`` — a document list may carry malformed elements.
+            if not isinstance(doc, dict):
+                continue
 
-            # Simplified entity extraction
-            # In production, would use proper NER
-            words = doc.get("content", "").split()
+            # ``doc.get("content", "")`` only defaults a MISSING key — a key
+            # present with value ``None`` returns ``None``. Coerce with
+            # ``or ""`` so the scoring path never calls a str method on None.
+            content = doc.get("content") or ""
+            doc_id = doc.get("id", hash(content))
 
             # Add some sample entities
-            if "transformer" in doc.get("content", "").lower():
+            if "transformer" in content.lower():
                 G.add_node("transformer", type="technology", documents={doc_id})
                 G.add_node("attention", type="concept", documents={doc_id})
                 G.add_edge("transformer", "attention", type="uses", confidence=0.9)
@@ -757,8 +762,14 @@ class GraphQueryNode(Node):
                 "avg_degree": (
                     sum(dict(G.degree()).values()) / len(G) if len(G) > 0 else 0
                 ),
+                # ``nx.average_clustering`` is undefined on a multigraph.
+                # ``GraphBuilderNode`` produces a ``MultiDiGraph`` whose
+                # node-link round-trip is also a multigraph, so collapse to a
+                # simple undirected ``Graph`` before computing clustering.
                 "clustering_coefficient": (
-                    nx.average_clustering(G.to_undirected()) if len(G) > 0 else 0
+                    nx.average_clustering(nx.Graph(G.to_undirected()))
+                    if len(G) > 0
+                    else 0
                 ),
             }
 

--- a/packages/kailash-kaizen/tests/integration/rag/test_graph_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_graph_nodes.py
@@ -1,0 +1,233 @@
+"""Tier-2a integration coverage for ``kaizen.nodes.rag.graph``.
+
+F8 shard B2. The 3 graph RAG nodes build and query real ``networkx`` knowledge
+graphs — ``networkx`` IS the real backend (no container, no LLM key for the
+deterministic ``run()`` paths). These tests exercise the nodes against real
+``networkx`` with NO mocking (``@patch`` / ``MagicMock`` / ``unittest.mock``
+are BLOCKED in Tier 2 per the 3-tier testing rule). Assertions are structural:
+real graph node/edge counts, query result shapes, path/centrality ordering,
+clustering values, and typed outputs.
+
+The value-anchor: "the RAG capability the user chose to preserve is provably
+correct, not merely importable." GraphRAG is the first user-named capability.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from kaizen.nodes.rag.graph import GraphBuilderNode, GraphQueryNode, GraphRAGNode
+
+pytestmark = pytest.mark.integration
+
+
+# Two documents, both carrying the "transformer" sentinel — GraphBuilderNode's
+# simplified extractor adds the transformer/attention subgraph per document.
+_DOCS = [
+    {"id": "paper-1", "content": "the transformer model and self-attention"},
+    {"id": "paper-2", "content": "a transformer architecture for sequences"},
+]
+
+
+# ===========================================================================
+# GraphBuilderNode — against real networkx
+# ===========================================================================
+class TestGraphBuilderIntegration:
+    def test_builds_real_networkx_multidigraph(self):
+        """The ``graph`` output deserializes into a genuine networkx
+        MultiDiGraph with the expected node/edge structure."""
+        result = GraphBuilderNode().run(documents=_DOCS)
+        G = nx.node_link_graph(result["graph"])
+        assert isinstance(G, nx.MultiDiGraph)
+        # Two transformer docs collapse to the same 2 named entity nodes.
+        assert set(G.nodes()) == {"transformer", "attention"}
+        # Each transformer doc adds its own "uses" edge — a MultiDiGraph keeps
+        # parallel edges, so 2 documents -> 2 edges.
+        assert G.number_of_edges() == 2
+        assert G.has_edge("transformer", "attention")
+
+    def test_node_attributes_preserved_through_serialization(self):
+        """Entity ``type`` attributes survive the node-link round-trip."""
+        result = GraphBuilderNode().run(documents=_DOCS)
+        G = nx.node_link_graph(result["graph"])
+        assert G.nodes["transformer"]["type"] == "technology"
+        assert G.nodes["attention"]["type"] == "concept"
+
+    def test_statistics_match_real_graph(self):
+        """``statistics`` reflects the real graph: density and component
+        count computed by networkx itself."""
+        result = GraphBuilderNode().run(documents=_DOCS)
+        G = nx.node_link_graph(result["graph"])
+        stats = result["statistics"]
+        assert stats["total_nodes"] == G.number_of_nodes()
+        assert stats["total_edges"] == G.number_of_edges()
+        assert stats["density"] == pytest.approx(nx.density(G))
+        assert stats["components"] == nx.number_weakly_connected_components(G)
+
+    def test_empty_corpus_builds_empty_real_graph(self):
+        result = GraphBuilderNode().run(documents=[])
+        G = nx.node_link_graph(result["graph"])
+        assert G.number_of_nodes() == 0
+        assert G.number_of_edges() == 0
+
+    def test_existing_graph_round_trips_through_real_networkx(self):
+        """An ``existing_graph`` is reconstructed by real networkx and
+        extended — the prior structure is preserved."""
+        base = GraphBuilderNode().run(documents=_DOCS[:1])["graph"]
+        result = GraphBuilderNode().run(documents=_DOCS[1:], existing_graph=base)
+        G = nx.node_link_graph(result["graph"])
+        assert set(G.nodes()) == {"transformer", "attention"}
+
+    def test_none_content_does_not_break_real_graph_build(self):
+        """A present-but-None content document is handled cleanly — the real
+        graph still builds from the well-formed sibling."""
+        result = GraphBuilderNode().run(
+            documents=[{"id": "n", "content": None}, *_DOCS]
+        )
+        G = nx.node_link_graph(result["graph"])
+        assert set(G.nodes()) == {"transformer", "attention"}
+
+
+# ===========================================================================
+# GraphQueryNode — against real networkx graphs
+# ===========================================================================
+def _real_graph() -> dict:
+    return GraphBuilderNode().run(documents=_DOCS)["graph"]
+
+
+class TestGraphQueryIntegration:
+    def test_path_query_traverses_real_graph(self):
+        """A ``path`` query runs ``nx.all_simple_paths`` over the real graph
+        and returns the genuine connection."""
+        result = GraphQueryNode().run(
+            graph=_real_graph(),
+            query_type="path",
+            query_params={
+                "source_entity": "transformer",
+                "target_entity": "attention",
+                "max_length": 4,
+            },
+        )
+        assert len(result["paths"]) >= 1
+        # Every returned path genuinely starts at source and ends at target.
+        for path in result["paths"]:
+            assert path["path"][0] == "transformer"
+            assert path["path"][-1] == "attention"
+            assert path["length"] == len(path["path"]) - 1
+
+    def test_pattern_query_returns_real_node_degree(self):
+        """A ``pattern`` query reports each node's real networkx degree."""
+        graph = _real_graph()
+        G = nx.node_link_graph(graph)
+        result = GraphQueryNode().run(
+            graph=graph,
+            query_type="pattern",
+            query_params={"pattern": {}},
+        )
+        by_entity = {m["entity"]: m for m in result["matches"]}
+        for name, match in by_entity.items():
+            assert match["degree"] == G.degree(name)
+
+    def test_pattern_query_type_filter_against_real_graph(self):
+        """Type-filtered ``pattern`` query returns only nodes whose real
+        attributes match."""
+        result = GraphQueryNode().run(
+            graph=_real_graph(),
+            query_type="pattern",
+            query_params={"pattern": {"node_type": "concept"}},
+        )
+        assert len(result["matches"]) == 1
+        assert result["matches"][0]["entity"] == "attention"
+
+    def test_aggregate_query_computes_real_statistics(self):
+        """The ``aggregate`` query computes node/edge counts, density,
+        average degree and clustering coefficient over the real multigraph —
+        and does not raise NetworkXNotImplemented."""
+        graph = _real_graph()
+        G = nx.node_link_graph(graph)
+        result = GraphQueryNode().run(
+            graph=graph, query_type="aggregate", query_params={}
+        )
+        agg = result["aggregations"]
+        assert agg["node_count"] == G.number_of_nodes()
+        assert agg["edge_count"] == G.number_of_edges()
+        assert agg["density"] == pytest.approx(nx.density(G))
+        # clustering coefficient is a real float in [0, 1].
+        assert 0.0 <= agg["clustering_coefficient"] <= 1.0
+
+    def test_aggregate_query_avg_degree_matches_networkx(self):
+        """Average degree from the ``aggregate`` query matches a direct
+        networkx degree computation."""
+        graph = _real_graph()
+        G = nx.node_link_graph(graph)
+        result = GraphQueryNode().run(
+            graph=graph, query_type="aggregate", query_params={}
+        )
+        expected = sum(dict(G.degree()).values()) / G.number_of_nodes()
+        assert result["aggregations"]["avg_degree"] == pytest.approx(expected)
+
+    def test_path_query_no_connection_returns_empty_paths(self):
+        """A ``path`` query for an absent endpoint returns an empty list —
+        real graph traversal, no crash."""
+        result = GraphQueryNode().run(
+            graph=_real_graph(),
+            query_type="path",
+            query_params={
+                "source_entity": "transformer",
+                "target_entity": "nonexistent-entity",
+            },
+        )
+        assert result["paths"] == []
+
+
+# ===========================================================================
+# GraphRAGNode — WorkflowNode construction + workflow-shape integration
+# ===========================================================================
+class TestGraphRAGNodeIntegration:
+    """``GraphRAGNode`` is a ``WorkflowNode``; its ``run()`` executes a
+    sub-workflow whose ``LLMAgentNode`` steps require an LLM key absent from
+    the ``[rag]`` extra. These tests verify the deterministic part: the
+    ``_create_workflow()`` builds a real, structurally-connected sub-workflow.
+    """
+
+    def test_create_workflow_builds_real_connected_workflow(self):
+        """``_create_workflow()`` returns a real built workflow whose nodes
+        are wired — the PythonCodeNode graph_builder/graph_retriever bodies
+        and the LLM nodes are all present and connected."""
+        # type: ignore[attr-defined] — the @register_node decorator erases the
+        # concrete subclass type to base Node, which does not declare the
+        # per-node _create_workflow helper. The method exists at runtime; the
+        # static erasure is a known Core SDK decorator gap (out of B2 scope).
+        wf = GraphRAGNode()._create_workflow()  # type: ignore[attr-defined]
+        # The full pipeline has 6 nodes when global summary is enabled.
+        assert len(wf.nodes) == 6
+        # The graph_builder PythonCodeNode carries a real code template.
+        builder_code = wf.nodes["graph_builder"].config["code"]
+        assert "build_knowledge_graph" in builder_code
+        assert "nx.MultiDiGraph" in builder_code
+
+    def test_create_workflow_retriever_code_carries_max_hops(self):
+        """``max_hops`` is interpolated into the real graph_retriever code
+        template the sub-workflow executes."""
+        wf = GraphRAGNode(max_hops=3)._create_workflow()  # type: ignore[attr-defined]
+        retriever_code = wf.nodes["graph_retriever"].config["code"]
+        assert "depth >= 3" in retriever_code
+
+    def test_create_workflow_summary_disabled_drops_node_and_connections(self):
+        """With ``use_global_summary=False`` the real workflow has 5 nodes and
+        no summary_generator wiring."""
+        wf = GraphRAGNode(use_global_summary=False)._create_workflow()  # type: ignore[attr-defined]
+        assert len(wf.nodes) == 5
+        assert "summary_generator" not in wf.nodes
+
+    def test_graph_rag_node_is_workflow_node(self):
+        """GraphRAGNode constructs as a real WorkflowNode with a built
+        sub-workflow attached."""
+        from kailash.nodes.logic.workflow import WorkflowNode
+
+        node = GraphRAGNode()
+        assert isinstance(node, WorkflowNode)
+        params = node.get_parameters()
+        assert isinstance(params, dict)
+        assert len(params) > 0

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b2_graph_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b2_graph_defects.py
@@ -1,0 +1,92 @@
+"""Regression: two latent ``kaizen.nodes.rag.graph`` run()-path defects.
+
+F8 shard B2 surfaced both defects via behavioral coverage of the graph RAG
+nodes. Both are ``run()``-path-only — the ``_create_workflow()`` codegen
+templates carry neither pattern (verified per the B1 two-path lesson).
+
+Defect 1 — None-content crash (same class as B1's similarity-node defect).
+  ``GraphBuilderNode.run()`` extracted document text via
+  ``doc.get("content", "")``. The ``""`` default applies ONLY to a MISSING
+  key; a document ``{"content": None}`` returned ``None`` and the subsequent
+  ``content.split()`` / ``content.lower()`` raised ``AttributeError``. A
+  non-dict document element also crashed on ``str.get``.
+  Fix: ``content = doc.get("content") or ""`` plus an ``isinstance(doc, dict)``
+  skip for malformed entries.
+
+Defect 2 — aggregate query multigraph crash.
+  ``GraphQueryNode.run()``'s ``aggregate`` query type computed
+  ``nx.average_clustering(G.to_undirected())``. ``GraphBuilderNode`` produces
+  a ``MultiDiGraph``; its node-link round-trip is also a multigraph, and
+  ``average_clustering`` raises ``NetworkXNotImplemented`` for multigraph
+  types. The documented ``aggregate`` query type never worked end-to-end.
+  Fix: ``nx.average_clustering(nx.Graph(G.to_undirected()))``.
+
+Behavioral tests: they call ``run()`` and assert success / typed outputs —
+not source-grep.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.nodes.rag.graph import GraphBuilderNode, GraphQueryNode
+
+pytestmark = pytest.mark.regression
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — GraphBuilderNode None-content / malformed-document crash
+# ---------------------------------------------------------------------------
+def test_graph_builder_none_content_does_not_crash():
+    """A document with ``content`` present-but-None must not crash run()."""
+    result = GraphBuilderNode().run(documents=[{"id": "n", "content": None}])
+    assert result["statistics"]["total_nodes"] == 0
+    assert result["build_metadata"]["documents_processed"] == 1
+
+
+def test_graph_builder_none_content_does_not_poison_sibling():
+    """A None-content doc must not block a well-formed transformer doc from
+    building its subgraph."""
+    result = GraphBuilderNode().run(
+        documents=[
+            {"id": "n", "content": None},
+            {"id": "good", "content": "the transformer model"},
+        ]
+    )
+    assert result["statistics"]["total_nodes"] == 2
+
+
+def test_graph_builder_malformed_non_dict_document_does_not_crash():
+    """A non-dict element in ``documents`` is skipped, not crashed on."""
+    result = GraphBuilderNode().run(
+        documents=["not a dict", {"id": "g", "content": "transformer here"}]
+    )
+    assert result["statistics"]["total_nodes"] == 2
+    assert result["build_metadata"]["documents_processed"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — GraphQueryNode aggregate-query multigraph crash
+# ---------------------------------------------------------------------------
+def test_graph_query_aggregate_does_not_crash_on_multigraph():
+    """The ``aggregate`` query type must compute the clustering coefficient
+    over a real GraphBuilderNode-produced MultiDiGraph without raising
+    NetworkXNotImplemented."""
+    graph = GraphBuilderNode().run(
+        documents=[{"id": "d1", "content": "transformer uses attention"}]
+    )["graph"]
+    result = GraphQueryNode().run(graph=graph, query_type="aggregate", query_params={})
+    agg = result["aggregations"]
+    assert agg["node_count"] == 2
+    assert agg["edge_count"] == 1
+    assert 0.0 <= agg["clustering_coefficient"] <= 1.0
+
+
+def test_graph_query_aggregate_empty_graph_returns_zeroed_stats():
+    """``aggregate`` over an empty graph returns zeroed stats — no
+    divide-by-zero, no clustering crash."""
+    empty = GraphBuilderNode().run(documents=[])["graph"]
+    result = GraphQueryNode().run(graph=empty, query_type="aggregate", query_params={})
+    agg = result["aggregations"]
+    assert agg["node_count"] == 0
+    assert agg["clustering_coefficient"] == 0

--- a/packages/kailash-kaizen/tests/unit/rag/test_graph_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_graph_nodes.py
@@ -318,34 +318,40 @@ class TestGraphRAGNode:
     graph SHAPE, not end-to-end execution."""
 
     def test_constructs_with_defaults(self):
+        # type: ignore[attr-defined] on the constructor-attr reads below — the
+        # @register_node decorator erases the concrete GraphRAGNode type to
+        # base Node, which does not declare entity_types/max_hops/etc. The
+        # attributes exist at runtime (set in __init__); the static erasure is
+        # a known Core SDK decorator gap (out of B2 scope).
         node = GraphRAGNode()
-        assert node.entity_types == [
+        assert node.entity_types == [  # type: ignore[attr-defined]
             "person",
             "organization",
             "concept",
             "technology",
         ]
-        assert node.relationship_types == [
+        assert node.relationship_types == [  # type: ignore[attr-defined]
             "relates_to",
             "influences",
             "uses",
             "created_by",
         ]
-        assert node.max_hops == 2
-        assert node.community_algorithm == "louvain"
-        assert node.use_global_summary is True
+        assert node.max_hops == 2  # type: ignore[attr-defined]
+        assert node.community_algorithm == "louvain"  # type: ignore[attr-defined]
+        assert node.use_global_summary is True  # type: ignore[attr-defined]
 
     def test_constructs_with_custom_config(self):
+        # type: ignore[attr-defined] — see test_constructs_with_defaults.
         node = GraphRAGNode(
             entity_types=["gene", "protein"],
             relationship_types=["binds"],
             max_hops=5,
             use_global_summary=False,
         )
-        assert node.entity_types == ["gene", "protein"]
-        assert node.relationship_types == ["binds"]
-        assert node.max_hops == 5
-        assert node.use_global_summary is False
+        assert node.entity_types == ["gene", "protein"]  # type: ignore[attr-defined]
+        assert node.relationship_types == ["binds"]  # type: ignore[attr-defined]
+        assert node.max_hops == 5  # type: ignore[attr-defined]
+        assert node.use_global_summary is False  # type: ignore[attr-defined]
 
     def test_create_workflow_builds_expected_nodes_with_summary(self):
         """``_create_workflow()`` with ``use_global_summary=True`` builds the

--- a/packages/kailash-kaizen/tests/unit/rag/test_graph_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_graph_nodes.py
@@ -1,0 +1,399 @@
+"""Tier-1 unit coverage for the 3 ``kaizen.nodes.rag.graph`` nodes.
+
+F8 shard B2. The value-anchor (verbatim from the workstream brief): "the RAG
+capability the user chose to preserve is provably correct, not merely
+importable." GraphRAG is the first user-named capability.
+
+``graph.py`` ships three nodes:
+
+- ``GraphBuilderNode`` — builds a real ``networkx`` knowledge graph from
+  documents. ``run()`` is the direct, deterministic code path.
+- ``GraphQueryNode`` — queries a graph (path / pattern / aggregate query
+  types). ``run()`` is the direct, deterministic code path.
+- ``GraphRAGNode`` — a ``WorkflowNode``; its behavior is a sub-workflow built
+  by ``_create_workflow()``. Construction + workflow shape are covered here;
+  the LLM-backed sub-workflow nodes are not exercised (no LLM key in ``[rag]``).
+
+``networkx`` IS the shipped infrastructure — there is nothing to mock. These
+tests exercise the real graph-construction / query core. One test per
+documented behavior; assertions are structural (node/edge counts, query
+result shapes, score ordering, typed raises).
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from kaizen.nodes.rag.graph import GraphBuilderNode, GraphQueryNode, GraphRAGNode
+
+pytestmark = pytest.mark.unit
+
+
+# A document whose content contains the sentinel word "transformer" — the
+# GraphBuilderNode's simplified entity extraction adds the transformer/attention
+# subgraph for any such document (graph.py L598-601).
+_TRANSFORMER_DOC = {"id": "d1", "content": "the transformer architecture"}
+_PLAIN_DOC = {"id": "d2", "content": "a plain document with no entities"}
+
+
+# ===========================================================================
+# GraphBuilderNode
+# ===========================================================================
+class TestGraphBuilderNode:
+    """``GraphBuilderNode.run()`` — knowledge-graph construction."""
+
+    def test_get_parameters_declares_documents_required(self):
+        params = GraphBuilderNode().get_parameters()
+        assert params["documents"].required is True
+        assert params["documents"].type is list
+        # existing_graph / entity_types are optional update inputs.
+        assert params["existing_graph"].required is False
+        assert params["entity_types"].required is False
+
+    def test_golden_path_builds_transformer_subgraph(self):
+        """A transformer document yields the documented transformer/attention
+        subgraph: 2 entity nodes + 1 ``uses`` edge."""
+        result = GraphBuilderNode().run(documents=[_TRANSFORMER_DOC])
+        assert sorted(result.keys()) == [
+            "build_metadata",
+            "entity_map",
+            "graph",
+            "statistics",
+        ]
+        stats = result["statistics"]
+        assert stats["total_nodes"] == 2
+        assert stats["total_edges"] == 1
+        assert stats["components"] == 1
+        # The serialized graph round-trips into a real networkx MultiDiGraph.
+        G = nx.node_link_graph(result["graph"])
+        assert {n for n in G.nodes()} == {"transformer", "attention"}
+        assert G.has_edge("transformer", "attention")
+
+    def test_output_graph_is_node_link_serializable(self):
+        """``graph`` is a node-link dict — JSON-shaped, round-trippable."""
+        result = GraphBuilderNode().run(documents=[_TRANSFORMER_DOC])
+        graph = result["graph"]
+        assert isinstance(graph, dict)
+        assert graph["multigraph"] is True
+        assert graph["directed"] is True
+
+    def test_build_metadata_reflects_constructor_config(self):
+        node = GraphBuilderNode(merge_similar_entities=False, track_temporal=True)
+        result = node.run(documents=[_TRANSFORMER_DOC])
+        meta = result["build_metadata"]
+        assert meta["documents_processed"] == 1
+        assert meta["merge_applied"] is False
+        assert meta["temporal_tracking"] is True
+
+    def test_empty_documents_yields_empty_graph(self):
+        """Edge case: empty ``documents`` list — an empty graph, zero stats,
+        no crash."""
+        result = GraphBuilderNode().run(documents=[])
+        stats = result["statistics"]
+        assert stats["total_nodes"] == 0
+        assert stats["total_edges"] == 0
+        assert stats["density"] == 0
+        assert stats["components"] == 0
+        assert result["build_metadata"]["documents_processed"] == 0
+
+    def test_missing_documents_kwarg_defaults_to_empty(self):
+        """``run()`` with no ``documents`` kwarg degrades to an empty graph."""
+        result = GraphBuilderNode().run()
+        assert result["statistics"]["total_nodes"] == 0
+
+    def test_plain_document_adds_no_entities(self):
+        """A document without the transformer sentinel produces no nodes — the
+        simplified extractor only recognises the sentinel."""
+        result = GraphBuilderNode().run(documents=[_PLAIN_DOC])
+        assert result["statistics"]["total_nodes"] == 0
+
+    def test_multiple_transformer_docs_merge_into_one_subgraph(self):
+        """Two transformer documents share the same node ids — the graph has
+        2 nodes total, not 4 (nodes keyed by name)."""
+        result = GraphBuilderNode().run(
+            documents=[
+                {"id": "d1", "content": "transformer one"},
+                {"id": "d2", "content": "transformer two"},
+            ]
+        )
+        assert result["statistics"]["total_nodes"] == 2
+
+    def test_document_missing_content_key_does_not_crash(self):
+        """Edge case: a doc dict missing the ``content`` key entirely — the
+        ``""`` default applies, no entities, no crash."""
+        result = GraphBuilderNode().run(documents=[{"id": "no-content"}])
+        assert result["statistics"]["total_nodes"] == 0
+
+    def test_document_with_none_content_does_not_crash(self):
+        """Edge case (B1 None-content class): a doc with ``content`` present
+        but ``None``. The ``""`` default does NOT apply to a present-None key;
+        the scoring path must coerce None to ``""`` rather than crash."""
+        result = GraphBuilderNode().run(documents=[{"id": "n", "content": None}])
+        assert result["statistics"]["total_nodes"] == 0
+        assert result["build_metadata"]["documents_processed"] == 1
+
+    def test_none_content_mixed_with_good_doc(self):
+        """A None-content doc must not poison a well-formed sibling: the
+        transformer doc still builds its subgraph."""
+        result = GraphBuilderNode().run(
+            documents=[{"id": "n", "content": None}, _TRANSFORMER_DOC]
+        )
+        assert result["statistics"]["total_nodes"] == 2
+
+    def test_malformed_non_dict_document_does_not_crash(self):
+        """Edge case: a non-dict element in ``documents``. The node skips
+        malformed entries rather than crashing on ``str.get``."""
+        result = GraphBuilderNode().run(documents=["not a dict", _TRANSFORMER_DOC])
+        assert result["statistics"]["total_nodes"] == 2
+        assert result["build_metadata"]["documents_processed"] == 2
+
+    def test_unicode_content_does_not_crash(self):
+        """Unicode document content is handled — no entities here, but no
+        crash on non-ASCII text."""
+        result = GraphBuilderNode().run(
+            documents=[{"id": "u1", "content": "le café au lait — 日本語"}]
+        )
+        assert result["statistics"]["total_nodes"] == 0
+
+    def test_existing_graph_is_extended_not_replaced(self):
+        """When ``existing_graph`` is passed, the node updates it: a prior
+        graph plus a new transformer doc keeps the prior nodes."""
+        base = GraphBuilderNode().run(documents=[_TRANSFORMER_DOC])["graph"]
+        result = GraphBuilderNode().run(
+            documents=[{"id": "d3", "content": "another transformer"}],
+            existing_graph=base,
+        )
+        # Still 2 nodes (same entity names), graph reconstructed from base.
+        assert result["statistics"]["total_nodes"] == 2
+
+
+# ===========================================================================
+# GraphQueryNode
+# ===========================================================================
+def _build_graph() -> dict:
+    """A small real graph: transformer --uses--> attention."""
+    return GraphBuilderNode().run(documents=[_TRANSFORMER_DOC])["graph"]
+
+
+class TestGraphQueryNode:
+    """``GraphQueryNode.run()`` — path / pattern / aggregate query types."""
+
+    def test_get_parameters_declares_required_inputs(self):
+        params = GraphQueryNode().get_parameters()
+        assert params["graph"].required is True
+        assert params["query_type"].required is True
+        assert params["query_params"].required is True
+
+    def test_path_query_finds_connection(self):
+        """A ``path`` query between connected entities returns the path with
+        its length and edge list."""
+        result = GraphQueryNode().run(
+            graph=_build_graph(),
+            query_type="path",
+            query_params={
+                "source_entity": "transformer",
+                "target_entity": "attention",
+                "max_length": 3,
+            },
+        )
+        assert len(result["paths"]) == 1
+        path = result["paths"][0]
+        assert path["path"] == ["transformer", "attention"]
+        assert path["length"] == 1
+        assert path["edges"] == [("transformer", "attention")]
+
+    def test_path_query_missing_endpoint_returns_no_paths(self):
+        """A ``path`` query whose source/target is absent from the graph
+        returns an empty ``paths`` list — not a crash."""
+        result = GraphQueryNode().run(
+            graph=_build_graph(),
+            query_type="path",
+            query_params={
+                "source_entity": "nonexistent",
+                "target_entity": "attention",
+            },
+        )
+        assert result["paths"] == []
+
+    def test_pattern_query_filters_by_node_type(self):
+        """A ``pattern`` query with a ``node_type`` returns only matching
+        nodes, with attributes and degree."""
+        result = GraphQueryNode().run(
+            graph=_build_graph(),
+            query_type="pattern",
+            query_params={"pattern": {"node_type": "technology"}},
+        )
+        assert len(result["matches"]) == 1
+        match = result["matches"][0]
+        assert match["entity"] == "transformer"
+        assert match["attributes"]["type"] == "technology"
+        assert match["degree"] == 1
+
+    def test_pattern_query_no_type_returns_all_nodes(self):
+        """A ``pattern`` query with no ``node_type`` returns every node."""
+        result = GraphQueryNode().run(
+            graph=_build_graph(),
+            query_type="pattern",
+            query_params={"pattern": {}},
+        )
+        assert {m["entity"] for m in result["matches"]} == {
+            "transformer",
+            "attention",
+        }
+
+    def test_aggregate_query_returns_graph_statistics(self):
+        """An ``aggregate`` query returns node/edge counts, density, average
+        degree, and clustering coefficient over the real graph."""
+        result = GraphQueryNode().run(
+            graph=_build_graph(),
+            query_type="aggregate",
+            query_params={},
+        )
+        agg = result["aggregations"]
+        assert agg["node_count"] == 2
+        assert agg["edge_count"] == 1
+        assert 0.0 <= agg["density"] <= 1.0
+        assert agg["avg_degree"] >= 0.0
+        # clustering_coefficient must compute over the multigraph without
+        # raising NetworkXNotImplemented.
+        assert 0.0 <= agg["clustering_coefficient"] <= 1.0
+
+    def test_aggregate_query_on_empty_graph(self):
+        """``aggregate`` over an empty graph returns zeroed stats — no
+        divide-by-zero, no clustering crash."""
+        empty = GraphBuilderNode().run(documents=[])["graph"]
+        result = GraphQueryNode().run(
+            graph=empty, query_type="aggregate", query_params={}
+        )
+        agg = result["aggregations"]
+        assert agg["node_count"] == 0
+        assert agg["edge_count"] == 0
+        assert agg["avg_degree"] == 0
+        assert agg["clustering_coefficient"] == 0
+
+    def test_unknown_query_type_returns_empty_result_shape(self):
+        """An unrecognised ``query_type`` returns the base result shape with
+        empty matches/paths/aggregations — no crash, no exception."""
+        result = GraphQueryNode().run(
+            graph=_build_graph(),
+            query_type="nonsense",
+            query_params={},
+        )
+        assert result["matches"] == []
+        assert result["paths"] == []
+        assert result["aggregations"] == {}
+        assert result["query_type"] == "nonsense"
+
+    def test_path_query_default_max_length(self):
+        """``max_length`` defaults to 3 when omitted from query_params."""
+        result = GraphQueryNode().run(
+            graph=_build_graph(),
+            query_type="path",
+            query_params={
+                "source_entity": "transformer",
+                "target_entity": "attention",
+            },
+        )
+        assert len(result["paths"]) == 1
+
+    def test_query_result_echoes_query_params(self):
+        """The result echoes the query_type and query_params it was given."""
+        params = {"source_entity": "transformer", "target_entity": "attention"}
+        result = GraphQueryNode().run(
+            graph=_build_graph(), query_type="path", query_params=params
+        )
+        assert result["query_type"] == "path"
+        assert result["query_params"] == params
+
+
+# ===========================================================================
+# GraphRAGNode — WorkflowNode; construction + workflow-shape coverage
+# ===========================================================================
+class TestGraphRAGNode:
+    """``GraphRAGNode`` is a ``WorkflowNode``. Its ``run()`` executes a
+    sub-workflow built by ``_create_workflow()``. The sub-workflow's
+    ``LLMAgentNode`` steps need an LLM key (absent from ``[rag]``), so these
+    tests cover construction and the deterministic ``_create_workflow()``
+    graph SHAPE, not end-to-end execution."""
+
+    def test_constructs_with_defaults(self):
+        node = GraphRAGNode()
+        assert node.entity_types == [
+            "person",
+            "organization",
+            "concept",
+            "technology",
+        ]
+        assert node.relationship_types == [
+            "relates_to",
+            "influences",
+            "uses",
+            "created_by",
+        ]
+        assert node.max_hops == 2
+        assert node.community_algorithm == "louvain"
+        assert node.use_global_summary is True
+
+    def test_constructs_with_custom_config(self):
+        node = GraphRAGNode(
+            entity_types=["gene", "protein"],
+            relationship_types=["binds"],
+            max_hops=5,
+            use_global_summary=False,
+        )
+        assert node.entity_types == ["gene", "protein"]
+        assert node.relationship_types == ["binds"]
+        assert node.max_hops == 5
+        assert node.use_global_summary is False
+
+    def test_create_workflow_builds_expected_nodes_with_summary(self):
+        """``_create_workflow()`` with ``use_global_summary=True`` builds the
+        full 6-node graph RAG pipeline."""
+        # type: ignore[attr-defined] — the @register_node decorator erases the
+        # concrete subclass type to base Node, which does not declare the
+        # per-node _create_workflow helper. The method exists at runtime; the
+        # static erasure is a known Core SDK decorator gap (out of B2 scope).
+        wf = GraphRAGNode(use_global_summary=True)._create_workflow()  # type: ignore[attr-defined]
+        node_ids = set(wf.nodes.keys())
+        assert node_ids == {
+            "entity_extractor",
+            "graph_builder",
+            "query_processor",
+            "graph_retriever",
+            "summary_generator",
+            "result_synthesizer",
+        }
+
+    def test_create_workflow_omits_summary_node_when_disabled(self):
+        """With ``use_global_summary=False`` the ``summary_generator`` node is
+        absent — a 5-node pipeline."""
+        wf = GraphRAGNode(use_global_summary=False)._create_workflow()  # type: ignore[attr-defined]
+        node_ids = set(wf.nodes.keys())
+        assert "summary_generator" not in node_ids
+        assert len(node_ids) == 5
+
+    def test_create_workflow_entity_types_flow_into_extractor_prompt(self):
+        """Custom ``entity_types`` appear in the entity_extractor's system
+        prompt — the constructor config reaches the generated workflow."""
+        wf = GraphRAGNode(
+            entity_types=["gene", "protein"]
+        )._create_workflow()  # type: ignore[attr-defined]
+        prompt = wf.nodes["entity_extractor"].config["system_prompt"]
+        assert "gene" in prompt
+        assert "protein" in prompt
+
+    def test_create_workflow_max_hops_flows_into_retriever_code(self):
+        """``max_hops`` is interpolated into the graph_retriever code
+        template — the BFS depth bound reaches the generated code."""
+        wf = GraphRAGNode(max_hops=7)._create_workflow()  # type: ignore[attr-defined]
+        code = wf.nodes["graph_retriever"].config["code"]
+        assert "depth >= 7" in code
+
+    def test_get_parameters_exposes_workflow_inputs(self):
+        """As a WorkflowNode, GraphRAGNode exposes the sub-workflow's input
+        parameters via get_parameters()."""
+        params = GraphRAGNode().get_parameters()
+        assert isinstance(params, dict)
+        # The sub-workflow's leaf inputs are exposed as node parameters.
+        assert len(params) > 0

--- a/specs/kaizen-rag.md
+++ b/specs/kaizen-rag.md
@@ -186,3 +186,87 @@ each expose a private `_create_workflow(self) -> Workflow` method that builds a
 These helpers are not exercised by the `run()` default path; they are the
 workflow-composition surface for callers that want to run the retrieval logic
 through the Kailash runtime.
+
+## Graph RAG
+
+`kaizen/nodes/rag/graph.py` defines three knowledge-graph nodes. The toolkit
+ships `networkx` (via the `[rag]` extra) as the real graph backend — there is
+no separate graph database. `GraphBuilderNode` and `GraphQueryNode` compute
+their results entirely with deterministic `networkx` operations on the
+`run()` path. `GraphRAGNode` is a `kailash.nodes.logic.workflow.WorkflowNode`.
+
+### `GraphBuilderNode`
+
+Builds a knowledge graph from documents. `run(self, **kwargs) -> Dict[str, Any]`.
+
+- Inputs (`get_parameters()`): `documents` (`list`, required), `existing_graph`
+  (`dict`, optional — a prior graph to extend), `entity_types` (`list`,
+  optional), plus the constructor-config parameters `merge_similar_entities`,
+  `similarity_threshold`, `track_temporal`, `confidence_scoring`.
+- The graph is a `networkx.MultiDiGraph`. When `existing_graph` is supplied it
+  is reconstructed via `nx.node_link_graph` and extended; otherwise a fresh
+  graph is created.
+- Entity extraction is a simplified deterministic rule: a document whose
+  `content` contains the word `transformer` (case-insensitive) contributes a
+  `transformer` node (`type="technology"`) and an `attention` node
+  (`type="concept"`) joined by a `uses` edge. Documents without that word
+  contribute no nodes. Entity nodes are keyed by name, so multiple documents
+  naming the same entity collapse to one node.
+- A document may omit `content`, carry `content: None`, or be a non-dict
+  element of the `documents` list. None of these raises: a missing or `None`
+  content is coerced to an empty string, and a non-dict element is skipped.
+  `build_metadata["documents_processed"]` still counts every element of the
+  input list.
+- Returns: `graph` (a `nx.node_link_data` dict — JSON-shaped, round-trippable),
+  `entity_map` (a dict, currently empty), `statistics`
+  (`total_nodes`, `total_edges`, `density`, `components`, all computed by
+  `networkx`), and `build_metadata` (`documents_processed`, `merge_applied`,
+  `temporal_tracking`).
+
+### `GraphQueryNode`
+
+Queries a knowledge graph. `run(self, **kwargs) -> Dict[str, Any]`.
+
+- Inputs (`get_parameters()`): `graph` (`dict`, required — a node-link graph),
+  `query_type` (`str`, required), `query_params` (`dict`, required).
+- The result always carries `query_type`, `query_params`, `matches`, `paths`,
+  and `aggregations`. Three query types populate them:
+  - `path` — finds connections between `query_params["source_entity"]` and
+    `query_params["target_entity"]` (both lower-cased) via
+    `nx.all_simple_paths`, bounded by `max_length` (default 3), capped at 10
+    paths. Each path entry carries `path`, `length`, and `edges`. If either
+    endpoint is absent from the graph, `paths` is empty.
+  - `pattern` — returns nodes matching `query_params["pattern"]["node_type"]`
+    (or all nodes when no type is given), each with `entity`, `attributes`,
+    and `degree`; capped at 20 matches.
+  - `aggregate` — returns `node_count`, `edge_count`, `density`, `avg_degree`,
+    and `clustering_coefficient`. The clustering coefficient is computed over
+    `nx.Graph(G.to_undirected())` — the multigraph is collapsed to a simple
+    undirected graph because `nx.average_clustering` is undefined on a
+    multigraph. An empty graph yields zeroed statistics.
+- An unrecognised `query_type` returns the base result shape with empty
+  `matches`, `paths`, and `aggregations` — no exception.
+
+### `GraphRAGNode`
+
+`GraphRAGNode` is a `WorkflowNode`. Its `run()` (inherited from `WorkflowNode`)
+executes a sub-workflow built at construction time by
+`_create_workflow(self) -> Workflow`.
+
+- Constructor config: `entity_types` (default
+  `["person", "organization", "concept", "technology"]`), `relationship_types`
+  (default `["relates_to", "influences", "uses", "created_by"]`), `max_hops`
+  (default 2), `community_algorithm` (default `"louvain"`), and
+  `use_global_summary` (default `True`).
+- `_create_workflow()` builds a `WorkflowBuilder` graph. With
+  `use_global_summary=True` the workflow has six nodes — `entity_extractor`,
+  `graph_builder`, `query_processor`, `graph_retriever`, `summary_generator`,
+  `result_synthesizer`. With `use_global_summary=False` the `summary_generator`
+  node and its connections are omitted, leaving five nodes.
+- The constructor config flows into the generated workflow: `entity_types`
+  and `relationship_types` appear in the `entity_extractor` node's system
+  prompt, and `max_hops` is interpolated into the `graph_retriever` node's
+  `PythonCodeNode` code template as the BFS depth bound.
+- `entity_extractor`, `query_processor`, and `summary_generator` are
+  `LLMAgentNode` steps — executing the sub-workflow end-to-end requires an LLM
+  key, which the `[rag]` extra does not carry.


### PR DESCRIPTION
## Summary

Shard **B2** of workstream F8 (`kaizen.nodes.rag` resurrection) — behavioral
coverage of the `graph` module (GraphRAG, the first user-named capability).

- **52 new behavioral tests** — Tier-1 unit + Tier-2a integration (real
  `networkx`, **no mocking**) + 5 regression — across `GraphBuilderNode`,
  `GraphQueryNode`, `GraphRAGNode`. Structural assertions (node/edge counts,
  query results, ordering, typed raises).
- **2 latent defects found & fixed:**
  - `GraphBuilderNode.run()` crashed (`AttributeError`) on a document with
    `content: None` or a non-dict element — `doc.get("content", "")` returns
    `None` when the key is present-with-`None`. Fixed `doc.get("content") or ""`
    + `isinstance(doc, dict)` skip. (Same class as B1.)
  - `GraphQueryNode.run()`'s documented `aggregate` query type called
    `nx.average_clustering()` on a multigraph → `NetworkXNotImplemented`;
    `GraphBuilderNode` produces a `MultiDiGraph`, so `aggregate` never worked
    end-to-end. Fixed by collapsing via `nx.Graph(G.to_undirected())`.
  - Regression: `test_issue_f8b2_graph_defects.py` (5 behavioral tests).
- **Pyright** — 3 genuine type errors fixed in `graph.py` (implicit-Optional,
  wrong `_create_workflow` return type, possibly-unbound local) + unused-import
  cleanup. `graph.py` + new test files: 0 errors / 0 warnings. (`PythonCodeNode`/
  `LLMAgentNode` retained as `# noqa: F401` node-registration side-effect imports.)
- **Spec** — appended `## Graph RAG` to `specs/kaizen-rag.md` (code-first,
  citations grep-resolve).

## Test plan

- [x] 52 B2 tests pass; full rag suite (B1 + B2 + smoke) 107 passed
- [x] Tier-2a uses real networkx, zero `@patch`/`MagicMock`
- [x] `pre-commit run --files` clean; Pyright clean on `graph.py` + new tests

## Related issues

Part of F8 (`kaizen.nodes.rag` behavioral coverage). No standalone issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)