### PR TITLE
test(rag): F8 B3 — behavioral coverage of the 3 agentic RAG nodes

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
@@ -11,9 +11,7 @@ Implements RAG with autonomous agent capabilities:
 Based on ReAct, Toolformer, and agent research from 2024.
 """
 
-import json
 import logging
-from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
 from kailash.nodes.base import Node, NodeParameter, register_node

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
@@ -22,6 +22,7 @@ from kailash.nodes.code.python import PythonCodeNode
 from kailash.nodes.data.sql import SQLDatabaseNode
 from kailash.nodes.logic.workflow import WorkflowNode
 from kailash.workflow.builder import WorkflowBuilder
+from kailash.workflow.graph import Workflow
 
 from ..ai.llm_agent import LLMAgentNode
 
@@ -95,7 +96,7 @@ class AgenticRAGNode(WorkflowNode):
         self.verification_enabled = verification_enabled
         super().__init__(workflow=self._create_workflow(), name=name)
 
-    def _create_workflow(self) -> WorkflowNode:
+    def _create_workflow(self) -> Workflow:
         """Create agentic RAG workflow"""
         builder = WorkflowBuilder()
 
@@ -181,8 +182,12 @@ def execute_tool(action_string, documents, context):
         search_results = []
 
         for doc in documents[:50]:  # Limit for performance
-            content = doc.get("content", "").lower()
-            title = doc.get("title", "").lower()
+            if not isinstance(doc, dict):
+                continue  # skip malformed non-dict document elements
+            # `.get("content", "")` only defaults a MISSING key; a present
+            # key with a None value would still yield None, so coerce.
+            content = (doc.get("content") or "").lower()
+            title = (doc.get("title") or "").lower()
 
             # Score based on word overlap
             doc_words = set(content.split())
@@ -443,11 +448,14 @@ Return JSON:
             )
 
         # Result synthesizer
+        # NB: this code template is an f-string because the metadata block
+        # interpolates the constructor config (planning_strategy / max steps).
+        # Literal Python braces inside the sandboxed code are doubled ({{ }}).
         synthesizer_id = builder.add_node(
             "PythonCodeNode",
             node_id="result_synthesizer",
             config={
-                "code": """
+                "code": f"""
 # Synthesize final results
 reasoning_state = reasoning_state
 verification = verification if "verification" in locals() else None
@@ -470,7 +478,7 @@ if verification and verification.get("response"):
             verification_data = json.loads(verification_data)
         except Exception:
             # Fallback for invalid JSON (sandboxed - no logging available)
-            verification_data = {"confidence": 0.8}
+            verification_data = {{"confidence": 0.8}}
 
     verification_confidence = verification_data.get("confidence", 0.8)
     final_confidence = (base_confidence + confidence_boost) * verification_confidence
@@ -480,16 +488,16 @@ else:
 # Build reasoning trace
 reasoning_trace = []
 for step in reasoning_state["steps"]:
-    trace_entry = {
+    trace_entry = {{
         "step": step["step_number"],
         "thought": step["thought"],
         "action": step["action"],
         "observation": step["observation"]
-    }
+    }}
     reasoning_trace.append(trace_entry)
 
-result = {
-    "agentic_rag_result": {
+result = {{
+    "agentic_rag_result": {{
         "query": query,
         "answer": reasoning_state["final_answer"],
         "reasoning_trace": reasoning_trace,
@@ -497,13 +505,13 @@ result = {
         "confidence": final_confidence,
         "total_steps": len(reasoning_state["steps"]),
         "verification": verification.get("response") if verification else None,
-        "metadata": {
+        "metadata": {{
             "planning_strategy": "{self.planning_strategy}",
             "max_steps": {self.max_reasoning_steps},
             "completed_successfully": reasoning_state["completed"]
-        }
-    }
-}
+        }}
+    }}
+}}
 """
             },
         )
@@ -673,7 +681,9 @@ class ToolAugmentedRAGNode(Node):
         """Detect which tools are needed for the query"""
         required = []
 
-        query_lower = query.lower()
+        # `query` is declared required, but a caller may still pass it as
+        # None explicitly; coerce so tool detection never crashes.
+        query_lower = (query or "").lower()
 
         # Simple keyword detection (would use NER/classification in production)
         if any(
@@ -699,7 +709,10 @@ class ToolAugmentedRAGNode(Node):
         if tool_outputs:
             answer_parts.append("and computational tools:")
             for tool, output in tool_outputs.items():
-                if "error" not in output:
+                # Registered tools are arbitrary user callables with no
+                # return-shape contract; only dict outputs carry an "error"
+                # key, so a non-dict return is treated as a successful result.
+                if not isinstance(output, dict) or "error" not in output:
                     answer_parts.append(f"\n- {tool}: {output}")
 
         answer_parts.append(
@@ -754,7 +767,7 @@ class ReasoningRAGNode(WorkflowNode):
         self.strategy = strategy
         super().__init__(workflow=self._create_workflow(), name=name)
 
-    def _create_workflow(self) -> WorkflowNode:
+    def _create_workflow(self) -> Workflow:
         """Create reasoning RAG workflow"""
         builder = WorkflowBuilder()
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
@@ -14,17 +14,21 @@ Based on ReAct, Toolformer, and agent research from 2024.
 import json
 import logging
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
-from kailash.nodes.api.rest import RESTClientNode
 from kailash.nodes.base import Node, NodeParameter, register_node
-from kailash.nodes.code.python import PythonCodeNode
-from kailash.nodes.data.sql import SQLDatabaseNode
+
+# PythonCodeNode is imported for its @register_node side effect: the
+# sub-workflows below reference it by the string "PythonCodeNode", so its
+# class must be registered before _create_workflow() runs.
+from kailash.nodes.code.python import PythonCodeNode  # noqa: F401
 from kailash.nodes.logic.workflow import WorkflowNode
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
 
-from ..ai.llm_agent import LLMAgentNode
+# LLMAgentNode is imported for its @register_node side effect: the
+# sub-workflows reference it by the string "LLMAgentNode".
+from ..ai.llm_agent import LLMAgentNode  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +89,7 @@ class AgenticRAGNode(WorkflowNode):
     def __init__(
         self,
         name: str = "agentic_rag",
-        tools: List[str] = None,
+        tools: Optional[List[str]] = None,
         max_reasoning_steps: int = 5,
         planning_strategy: str = "react",
         verification_enabled: bool = True,
@@ -423,6 +427,7 @@ result = {{
         )
 
         # Verification agent (if enabled)
+        verifier_id: Optional[str] = None
         if self.verification_enabled:
             verifier_id = builder.add_node(
                 "LLMAgentNode",
@@ -541,6 +546,9 @@ result = {{
 
         # Verification (if enabled)
         if self.verification_enabled:
+            # verifier_id was assigned in the matching `if` block above; the
+            # assert documents that invariant and narrows the type for pyright.
+            assert verifier_id is not None
             builder.add_connection(
                 state_manager_id, "reasoning_state", verifier_id, "answer_to_verify"
             )
@@ -592,7 +600,7 @@ class ToolAugmentedRAGNode(Node):
     def __init__(
         self,
         name: str = "tool_augmented_rag",
-        tool_registry: Dict[str, Callable] = None,
+        tool_registry: Optional[Dict[str, Callable]] = None,
         auto_detect_tools: bool = True,
     ):
         resolved_registry = tool_registry or {}

--- a/packages/kailash-kaizen/tests/integration/rag/test_agentic_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_agentic_nodes.py
@@ -81,7 +81,7 @@ class TestToolAugmentedRAGIntegration:
         """A registered tool's real output is woven into the synthesized
         answer and lifts confidence to 0.9."""
 
-        def calculator(query, context):
+        def calculator(_query, _context):
             return {"tool": "calculator", "result": 168}
 
         result = ToolAugmentedRAGNode(tool_registry={"calculator": calculator}).run(
@@ -103,7 +103,7 @@ class TestToolAugmentedRAGIntegration:
         )
         endpoint = httpserver.url_for("/units")
 
-        def unit_converter(query, context):
+        def unit_converter(_query, _context):
             # Genuine outbound HTTP GET to the loopback server.
             with urllib.request.urlopen(endpoint, timeout=3) as resp:
                 return json.loads(resp.read().decode())
@@ -122,7 +122,7 @@ class TestToolAugmentedRAGIntegration:
         httpserver.expect_request("/broken").respond_with_data("boom", status=500)
         endpoint = httpserver.url_for("/broken")
 
-        def unit_converter(query, context):
+        def unit_converter(_query, _context):
             with urllib.request.urlopen(endpoint, timeout=3) as resp:
                 return json.loads(resp.read().decode())
 
@@ -242,7 +242,7 @@ class TestAgenticObservability:
         name — the observable contract for a tool failure
         (rules/observability.md Mandatory Log Points)."""
 
-        def boom(query, context):
+        def boom(_query, _context):
             raise RuntimeError("network down")
 
         with caplog.at_level(logging.ERROR, logger="kaizen.nodes.rag.agentic"):

--- a/packages/kailash-kaizen/tests/integration/rag/test_agentic_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_agentic_nodes.py
@@ -1,0 +1,256 @@
+"""Tier-2a integration coverage for ``kaizen.nodes.rag.agentic``.
+
+F8 shard B3. The 3 agentic RAG nodes are exercised here with NO mocking
+(``@patch`` / ``MagicMock`` / ``unittest.mock`` are BLOCKED in Tier 2 per the
+3-tier testing rule). The agentic path is the most defect-prone RAG path per
+the plan, so the integration tests assert end-to-end structural behavior.
+
+Real infrastructure used:
+
+- ``ToolAugmentedRAGNode``'s deterministic ``run()`` path needs no external
+  infra — tool detection is keyword-based and synthesis is rule-based. Its
+  default path makes NO network call, so the deterministic path is tested
+  directly.
+- One test stands up a real loopback HTTP server (``pytest_httpserver`` —
+  real ``http.server`` on ``127.0.0.1``, real infra, NOT a mock) and registers
+  a tool callable that performs a genuine REST call against it, proving the
+  ``tool_registry`` contract end-to-end with real network IO.
+- The ``AgenticRAGNode`` / ``ReasoningRAGNode`` ``WorkflowNode``s build real
+  sub-workflows via the real ``WorkflowBuilder``; their ``code=``
+  ``PythonCodeNode`` templates are executed directly against real input.
+
+Assertions are structural: output keys, score ranges, list lengths, real
+graph node counts, typed outputs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+import warnings
+
+import pytest
+
+from kaizen.nodes.rag.agentic import (
+    AgenticRAGNode,
+    ReasoningRAGNode,
+    ToolAugmentedRAGNode,
+)
+
+pytestmark = pytest.mark.integration
+
+
+_DOCS = [
+    {"id": "p1", "content": "the transformer model uses self-attention", "title": "T"},
+    {"id": "p2", "content": "recurrent networks process sequences in order"},
+]
+
+
+def _build(node):
+    """Build a WorkflowNode's sub-workflow, silencing cosmetic
+    PythonCodeNode line-count UserWarnings."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return node._create_workflow()
+
+
+# ===========================================================================
+# ToolAugmentedRAGNode — deterministic run() path, real (no-infra) execution
+# ===========================================================================
+class TestToolAugmentedRAGIntegration:
+    def test_end_to_end_run_returns_structural_output(self):
+        """A full ``run()`` over a real document set returns the documented
+        output shape with sane value ranges."""
+        result = ToolAugmentedRAGNode().run(
+            query="calculate the average length", documents=_DOCS
+        )
+        assert set(result.keys()) == {
+            "answer",
+            "tools_invoked",
+            "tool_outputs",
+            "confidence",
+        }
+        assert isinstance(result["answer"], str) and result["answer"]
+        assert "calculator" in result["tools_invoked"]
+        assert 0.0 <= result["confidence"] <= 1.0
+        # The synthesized answer reports the real document count.
+        assert "2 documents" in result["answer"]
+
+    def test_registered_tool_output_flows_into_answer(self):
+        """A registered tool's real output is woven into the synthesized
+        answer and lifts confidence to 0.9."""
+
+        def calculator(query, context):
+            return {"tool": "calculator", "result": 168}
+
+        result = ToolAugmentedRAGNode(tool_registry={"calculator": calculator}).run(
+            query="calculate the total", documents=_DOCS
+        )
+        assert result["tool_outputs"]["calculator"]["result"] == 168
+        assert result["confidence"] == 0.9
+        assert "calculator" in result["answer"]
+
+    def test_genuine_rest_tool_against_loopback_server(self, httpserver):
+        """A tool callable that makes a REAL REST call to a loopback HTTP
+        server resolves end-to-end. The server is real ``http.server`` on
+        127.0.0.1 — real infrastructure, not a mock.
+
+        This proves the ``tool_registry`` contract: tools are arbitrary
+        callables, including ones that perform genuine network IO."""
+        httpserver.expect_request("/units").respond_with_json(
+            {"converted": 42.0, "unit": "kg"}
+        )
+        endpoint = httpserver.url_for("/units")
+
+        def unit_converter(query, context):
+            # Genuine outbound HTTP GET to the loopback server.
+            with urllib.request.urlopen(endpoint, timeout=3) as resp:
+                return json.loads(resp.read().decode())
+
+        result = ToolAugmentedRAGNode(
+            tool_registry={"unit_converter": unit_converter}
+        ).run(query="convert these units", documents=_DOCS)
+
+        assert "unit_converter" in result["tools_invoked"]
+        assert result["tool_outputs"]["unit_converter"]["converted"] == 42.0
+        assert result["confidence"] == 0.9
+
+    def test_failing_rest_tool_is_captured_not_propagated(self, httpserver):
+        """When a REST tool hits a real 500 from the loopback server, the
+        node captures the failure as an error entry rather than crashing."""
+        httpserver.expect_request("/broken").respond_with_data("boom", status=500)
+        endpoint = httpserver.url_for("/broken")
+
+        def unit_converter(query, context):
+            with urllib.request.urlopen(endpoint, timeout=3) as resp:
+                return json.loads(resp.read().decode())
+
+        result = ToolAugmentedRAGNode(
+            tool_registry={"unit_converter": unit_converter}
+        ).run(query="convert the units", documents=[])
+        assert "error" in result["tool_outputs"]["unit_converter"]
+        # The node still produces a usable answer despite the tool failure.
+        assert isinstance(result["answer"], str) and result["answer"]
+
+
+# ===========================================================================
+# AgenticRAGNode — real WorkflowBuilder graph + real code= template execution
+# ===========================================================================
+class TestAgenticRAGIntegration:
+    def test_real_workflow_built_with_six_nodes(self):
+        """``_create_workflow()`` builds a real Workflow with six nodes when
+        verification is enabled."""
+        wf = _build(AgenticRAGNode(verification_enabled=True))
+        assert len(wf.nodes) == 6
+        # The workflow carries real connections between the nodes.
+        assert len(wf.connections) > 0
+
+    def test_tool_executor_template_runs_real_search(self):
+        """The tool_executor ``code=`` template executes a real keyword
+        search and ranks documents by overlap score."""
+        wf = _build(AgenticRAGNode())
+        code = wf.nodes["tool_executor"].config["code"]
+        ns = {
+            "reasoning_state": {"current_action": 'search("transformer attention")'},
+            "documents": [
+                {"id": "hit", "content": "the transformer uses attention heavily"},
+                {"id": "miss", "content": "completely unrelated text"},
+            ],
+        }
+        exec(code, ns)
+        tr = ns["result"]["tool_result"]
+        assert tr["tool"] == "search"
+        assert tr["count"] == 1
+        # The matching document scored above zero and ranks first.
+        assert tr["results"][0]["id"] == "hit"
+        assert tr["results"][0]["score"] > 0
+
+    def test_tool_executor_template_calculate_real_arithmetic(self):
+        """The tool_executor ``calculate`` action evaluates real arithmetic
+        via the AST-walked safe evaluator."""
+        wf = _build(AgenticRAGNode())
+        code = wf.nodes["tool_executor"].config["code"]
+        ns = {
+            "reasoning_state": {"current_action": "calculate((100 - 80) / 80 * 100)"},
+            "documents": [],
+        }
+        exec(code, ns)
+        assert ns["result"]["tool_result"]["result"] == pytest.approx(25.0)
+
+    def test_result_synthesizer_template_interpolates_real_config(self):
+        """The result_synthesizer template runs and the constructor config
+        is interpolated into the real metadata block."""
+        wf = _build(
+            AgenticRAGNode(planning_strategy="tree-of-thought", max_reasoning_steps=9)
+        )
+        code = wf.nodes["result_synthesizer"].config["code"]
+        ns = {
+            "reasoning_state": {
+                "steps": [
+                    {
+                        "step_number": 1,
+                        "thought": "t",
+                        "action": "search(x)",
+                        "observation": {"tool": "search"},
+                    }
+                ],
+                "final_answer": "the answer",
+                "completed": True,
+            },
+            "query": "compare revenue",
+        }
+        exec(code, ns)
+        out = ns["result"]["agentic_rag_result"]
+        assert out["answer"] == "the answer"
+        assert out["tools_used"] == ["search"]
+        assert out["metadata"]["planning_strategy"] == "tree-of-thought"
+        assert out["metadata"]["max_steps"] == 9
+        assert out["total_steps"] == 1
+
+
+# ===========================================================================
+# ReasoningRAGNode — real WorkflowBuilder graph
+# ===========================================================================
+class TestReasoningRAGIntegration:
+    def test_real_workflow_built_with_three_nodes(self):
+        """``_create_workflow()`` builds a real Workflow with three nodes and
+        real connections."""
+        wf = _build(ReasoningRAGNode())
+        assert set(wf.nodes) == {
+            "problem_decomposer",
+            "step_reasoner",
+            "logic_verifier",
+        }
+        assert len(wf.connections) > 0
+
+    def test_constructor_config_flows_into_real_prompt(self):
+        """The constructor strategy + depth land in the real decomposer
+        system prompt of the built workflow."""
+        wf = _build(ReasoningRAGNode(reasoning_depth=6, strategy="tree_of_thought"))
+        prompt = wf.nodes["problem_decomposer"].config["system_prompt"]
+        assert "Strategy: tree_of_thought" in prompt
+        assert "Max depth: 6" in prompt
+
+
+# ===========================================================================
+# Observability — fallback / error log assertions
+# ===========================================================================
+class TestAgenticObservability:
+    def test_failing_tool_emits_error_log(self, caplog):
+        """A registered tool that raises is logged at ERROR with the tool
+        name — the observable contract for a tool failure
+        (rules/observability.md Mandatory Log Points)."""
+
+        def boom(query, context):
+            raise RuntimeError("network down")
+
+        with caplog.at_level(logging.ERROR, logger="kaizen.nodes.rag.agentic"):
+            result = ToolAugmentedRAGNode(tool_registry={"calculator": boom}).run(
+                query="calculate the sum", documents=[]
+            )
+        assert "error" in result["tool_outputs"]["calculator"]
+        assert any(
+            "calculator" in r.message and r.levelno == logging.ERROR
+            for r in caplog.records
+        )

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b3_agentic_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b3_agentic_defects.py
@@ -161,7 +161,7 @@ def test_tool_augmented_non_dict_tool_output_does_not_crash():
     """A registered tool returning a non-dict value (here a bare int) must
     not crash answer synthesis — non-dict outputs have no error key and are
     treated as successful results."""
-    result = ToolAugmentedRAGNode(tool_registry={"calculator": lambda q, c: 42}).run(
+    result = ToolAugmentedRAGNode(tool_registry={"calculator": lambda _q, _c: 42}).run(
         query="calculate the sum", documents=[]
     )
     assert result["tool_outputs"]["calculator"] == 42
@@ -171,7 +171,7 @@ def test_tool_augmented_non_dict_tool_output_does_not_crash():
 def test_tool_augmented_non_dict_tool_output_string_return():
     """A tool returning a bare string is likewise tolerated."""
     result = ToolAugmentedRAGNode(
-        tool_registry={"calculator": lambda q, c: "computed: ok"}
+        tool_registry={"calculator": lambda _q, _c: "computed: ok"}
     ).run(query="calculate the average", documents=[])
     assert result["tool_outputs"]["calculator"] == "computed: ok"
     assert "computed: ok" in result["answer"]

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b3_agentic_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b3_agentic_defects.py
@@ -1,0 +1,177 @@
+"""Regression: four latent ``kaizen.nodes.rag.agentic`` defects.
+
+F8 shard B3 surfaced four crashes via behavioral coverage of the agentic RAG
+nodes. Each is fixed in ``agentic.py`` in the same shard.
+
+Defect 1 — tool_executor codegen None-content / non-dict crash.
+  The ``tool_executor`` ``code=`` template's ``search`` branch extracted
+  document text via ``doc.get("content", "").lower()``. The ``""`` default
+  applies ONLY to a MISSING key; a document ``{"content": None}`` returned
+  ``None`` and ``.lower()`` raised ``AttributeError``. A non-dict document
+  element also crashed on ``str.get``.
+  Fix: ``isinstance(doc, dict)`` skip + ``(doc.get("content") or "")``.
+
+Defect 2 — result_synthesizer codegen NameError.
+  The ``result_synthesizer`` ``code=`` block was a plain (non-f) string yet
+  embedded ``{self.planning_strategy}`` / ``{self.max_reasoning_steps}``
+  meant for interpolation. At ``PythonCodeNode`` sandbox runtime these
+  became invalid ``self.x`` references raising ``NameError`` — the agentic
+  result-synthesis step never produced its metadata block.
+  Fix: convert the block to an f-string with doubled literal braces,
+  matching the sibling ``state_manager`` template.
+
+Defect 3 — ToolAugmentedRAGNode None-query crash.
+  ``_detect_required_tools()`` called ``query.lower()``; an explicit
+  ``query=None`` raised ``AttributeError``.
+  Fix: ``(query or "").lower()``.
+
+Defect 4 — ToolAugmentedRAGNode non-dict tool-output crash.
+  ``_synthesize_with_tools()`` ran ``"error" not in output``; a registered
+  tool callable returning a non-dict value (tools are arbitrary user
+  callables with no return-shape contract) raised ``TypeError``.
+  Fix: ``not isinstance(output, dict) or "error" not in output``.
+
+Defects 1 + 2 are ``_create_workflow()`` codegen-template defects; defects
+3 + 4 are ``run()``-path defects. Per the B1 two-path lesson, both the
+``run()`` paths and the codegen templates were grepped for each pattern.
+
+All tests are behavioral — they call ``run()`` / exec the real codegen
+template and assert success / typed outputs, not source-grep.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from kaizen.nodes.rag.agentic import AgenticRAGNode, ToolAugmentedRAGNode
+
+pytestmark = pytest.mark.regression
+
+
+def _template(node, node_id):
+    """Return a built sub-workflow node's code= template, silencing the
+    cosmetic PythonCodeNode line-count UserWarnings."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return node._create_workflow().nodes[node_id].config["code"]
+
+
+# ---------------------------------------------------------------------------
+# Defect 1 — tool_executor codegen None-content / non-dict crash
+# ---------------------------------------------------------------------------
+def test_tool_executor_none_content_does_not_crash():
+    """The tool_executor search branch must tolerate a document whose
+    ``content`` key is present-but-None."""
+    code = _template(AgenticRAGNode(), "tool_executor")
+    ns = {
+        "reasoning_state": {"current_action": 'search("transformer")'},
+        "documents": [{"id": "n", "content": None}],
+    }
+    exec(code, ns)
+    assert ns["result"]["tool_result"]["tool"] == "search"
+    assert ns["result"]["tool_result"]["count"] == 0
+
+
+def test_tool_executor_none_title_does_not_crash():
+    """A present-but-None ``title`` must not crash the search branch."""
+    code = _template(AgenticRAGNode(), "tool_executor")
+    ns = {
+        "reasoning_state": {"current_action": 'search("transformer")'},
+        "documents": [{"id": "n", "content": "transformer model", "title": None}],
+    }
+    exec(code, ns)
+    assert ns["result"]["tool_result"]["count"] == 1
+
+
+def test_tool_executor_non_dict_document_is_skipped():
+    """A non-dict element in ``documents`` is skipped, not crashed on."""
+    code = _template(AgenticRAGNode(), "tool_executor")
+    ns = {
+        "reasoning_state": {"current_action": 'search("transformer")'},
+        "documents": ["not a dict", {"id": "g", "content": "transformer here"}],
+    }
+    exec(code, ns)
+    assert ns["result"]["tool_result"]["count"] == 1
+
+
+def test_tool_executor_none_content_does_not_poison_sibling():
+    """A None-content document must not block a well-formed sibling from
+    matching the search query."""
+    code = _template(AgenticRAGNode(), "tool_executor")
+    ns = {
+        "reasoning_state": {"current_action": 'search("transformer")'},
+        "documents": [
+            {"id": "bad", "content": None},
+            {"id": "good", "content": "the transformer model"},
+        ],
+    }
+    exec(code, ns)
+    assert ns["result"]["tool_result"]["count"] == 1
+    assert ns["result"]["tool_result"]["results"][0]["id"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# Defect 2 — result_synthesizer codegen NameError
+# ---------------------------------------------------------------------------
+def test_result_synthesizer_template_does_not_raise_nameerror():
+    """The result_synthesizer ``code=`` template must execute without a
+    NameError — it was once a plain string with literal {self.x}."""
+    code = _template(AgenticRAGNode(), "result_synthesizer")
+    ns = {
+        "reasoning_state": {"steps": [], "final_answer": "x", "completed": True},
+        "query": "q",
+    }
+    exec(code, ns)  # must not raise NameError: name 'self' is not defined
+    assert "agentic_rag_result" in ns["result"]
+
+
+def test_result_synthesizer_interpolates_constructor_config():
+    """The metadata block carries the real constructor config values, not
+    the literal placeholder strings."""
+    node = AgenticRAGNode(planning_strategy="tree-of-thought", max_reasoning_steps=11)
+    code = _template(node, "result_synthesizer")
+    ns = {
+        "reasoning_state": {"steps": [], "final_answer": "x", "completed": True},
+        "query": "q",
+    }
+    exec(code, ns)
+    meta = ns["result"]["agentic_rag_result"]["metadata"]
+    assert meta["planning_strategy"] == "tree-of-thought"
+    assert meta["max_steps"] == 11
+    # The literal placeholder must NOT survive into the output.
+    assert meta["planning_strategy"] != "{self.planning_strategy}"
+
+
+# ---------------------------------------------------------------------------
+# Defect 3 — ToolAugmentedRAGNode None-query crash
+# ---------------------------------------------------------------------------
+def test_tool_augmented_none_query_does_not_crash():
+    """An explicit ``query=None`` must not crash run()'s tool detection."""
+    result = ToolAugmentedRAGNode().run(query=None, documents=[])
+    assert result["tools_invoked"] == []
+    assert result["confidence"] == 0.7
+
+
+# ---------------------------------------------------------------------------
+# Defect 4 — ToolAugmentedRAGNode non-dict tool-output crash
+# ---------------------------------------------------------------------------
+def test_tool_augmented_non_dict_tool_output_does_not_crash():
+    """A registered tool returning a non-dict value (here a bare int) must
+    not crash answer synthesis — non-dict outputs have no error key and are
+    treated as successful results."""
+    result = ToolAugmentedRAGNode(tool_registry={"calculator": lambda q, c: 42}).run(
+        query="calculate the sum", documents=[]
+    )
+    assert result["tool_outputs"]["calculator"] == 42
+    assert "calculator" in result["answer"]
+
+
+def test_tool_augmented_non_dict_tool_output_string_return():
+    """A tool returning a bare string is likewise tolerated."""
+    result = ToolAugmentedRAGNode(
+        tool_registry={"calculator": lambda q, c: "computed: ok"}
+    ).run(query="calculate the average", documents=[])
+    assert result["tool_outputs"]["calculator"] == "computed: ok"
+    assert "computed: ok" in result["answer"]

--- a/packages/kailash-kaizen/tests/unit/rag/test_agentic_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_agentic_nodes.py
@@ -1,0 +1,288 @@
+"""Tier-1 unit coverage for the 3 ``kaizen.nodes.rag.agentic`` nodes.
+
+F8 shard B3. The value-anchor (verbatim from the workstream brief): "the RAG
+capability the user chose to preserve is provably correct, not merely
+importable." Agentic is the most defect-prone RAG path per the plan.
+
+``agentic.py`` ships three nodes:
+
+- ``ToolAugmentedRAGNode`` — a ``Node`` with a direct, deterministic ``run()``.
+  Detects required tools by keyword, invokes registered tool callables, and
+  synthesizes an answer. No LLM key needed — the synthesis is rule-based.
+- ``AgenticRAGNode`` — a ``WorkflowNode``; its behavior is a sub-workflow built
+  by ``_create_workflow()``. Construction + workflow shape + the ``code=``
+  ``PythonCodeNode`` templates are covered here. The LLM-backed sub-workflow
+  steps and end-to-end runtime are not exercised (no LLM key in ``[rag]``).
+- ``ReasoningRAGNode`` — a ``WorkflowNode``; same coverage shape as
+  ``AgenticRAGNode``.
+
+Assertions are structural (output keys, tool lists, confidence ranges, node
+counts, typed raises). One test per documented behavior. The ``code=``
+templates of the WorkflowNodes are exercised directly via ``exec`` against
+malformed input — the B1 codegen-regression pattern.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from kaizen.nodes.rag.agentic import (
+    AgenticRAGNode,
+    ReasoningRAGNode,
+    ToolAugmentedRAGNode,
+)
+
+pytestmark = pytest.mark.unit
+
+
+_DOCS = [
+    {"id": "d1", "content": "the transformer model and self-attention"},
+    {"id": "d2", "content": "a plain document about sequences", "title": "Seqs"},
+]
+
+
+def _build(node):
+    """Build a WorkflowNode's sub-workflow, silencing the cosmetic
+    PythonCodeNode 'exceeds recommended line count' UserWarnings."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return node._create_workflow()
+
+
+# ===========================================================================
+# ToolAugmentedRAGNode — direct run() path
+# ===========================================================================
+class TestToolAugmentedRAGNode:
+    """``ToolAugmentedRAGNode.run()`` — keyword tool detection + synthesis."""
+
+    def test_get_parameters_declares_query_required(self):
+        params = ToolAugmentedRAGNode().get_parameters()
+        assert params["query"].required is True
+        assert params["query"].type is str
+        assert params["documents"].required is False
+        assert params["tool_registry"].required is False
+        assert params["auto_detect_tools"].required is False
+
+    def test_golden_path_returns_documented_keys(self):
+        """``run()`` returns the four documented keys."""
+        result = ToolAugmentedRAGNode().run(query="summarize the docs", documents=_DOCS)
+        assert sorted(result.keys()) == [
+            "answer",
+            "confidence",
+            "tool_outputs",
+            "tools_invoked",
+        ]
+        assert isinstance(result["answer"], str)
+        assert isinstance(result["tools_invoked"], list)
+
+    def test_calculator_tool_detected_by_keyword(self):
+        """A query containing 'calculate' detects the calculator tool."""
+        result = ToolAugmentedRAGNode().run(query="calculate the sum", documents=[])
+        assert "calculator" in result["tools_invoked"]
+
+    def test_unit_converter_and_date_tools_detected(self):
+        """'convert' detects unit_converter; 'days' detects date_calculator."""
+        r1 = ToolAugmentedRAGNode().run(query="convert these units", documents=[])
+        assert "unit_converter" in r1["tools_invoked"]
+        r2 = ToolAugmentedRAGNode().run(query="how many days remain", documents=[])
+        assert "date_calculator" in r2["tools_invoked"]
+
+    def test_no_tool_keyword_yields_empty_tools_invoked(self):
+        """A query with no tool keyword invokes no tools."""
+        result = ToolAugmentedRAGNode().run(query="what is the topic", documents=_DOCS)
+        assert result["tools_invoked"] == []
+
+    def test_confidence_higher_when_tools_produce_output(self):
+        """Confidence is 0.9 when a registered tool produced output, else 0.7."""
+        registry = {"calculator": lambda q, c: {"value": 42}}
+        with_tool = ToolAugmentedRAGNode(tool_registry=registry).run(
+            query="calculate sum", documents=[]
+        )
+        assert with_tool["confidence"] == 0.9
+        no_tool = ToolAugmentedRAGNode().run(query="describe the docs", documents=[])
+        assert no_tool["confidence"] == 0.7
+
+    def test_unregistered_detected_tool_yields_no_output(self):
+        """A tool detected by keyword but absent from the registry simply
+        produces no tool output — it is still listed in tools_invoked."""
+        result = ToolAugmentedRAGNode(tool_registry={}).run(
+            query="calculate the total", documents=[]
+        )
+        assert "calculator" in result["tools_invoked"]
+        assert result["tool_outputs"] == {}
+        assert result["confidence"] == 0.7
+
+    def test_failing_tool_callable_is_captured_as_error(self):
+        """A registered tool that raises is captured as an {'error': ...}
+        entry rather than crashing run()."""
+
+        def boom(query, context):
+            raise RuntimeError("tool exploded")
+
+        result = ToolAugmentedRAGNode(tool_registry={"calculator": boom}).run(
+            query="calculate", documents=[]
+        )
+        assert "error" in result["tool_outputs"]["calculator"]
+        assert "tool exploded" in result["tool_outputs"]["calculator"]["error"]
+
+    # --- documented edge cases ------------------------------------------
+    def test_empty_query_and_documents_does_not_crash(self):
+        result = ToolAugmentedRAGNode().run(query="", documents=[])
+        assert result["tools_invoked"] == []
+        assert result["confidence"] == 0.7
+
+    def test_missing_documents_kwarg_defaults_to_empty(self):
+        """``documents`` is optional; omitting it defaults to []."""
+        result = ToolAugmentedRAGNode().run(query="calculate sum")
+        assert "0 documents" in result["answer"]
+
+    def test_malformed_documents_do_not_crash_run(self):
+        """Non-dict elements, {} and {"content": None} are tolerated —
+        synthesis only counts len(documents)."""
+        result = ToolAugmentedRAGNode().run(
+            query="describe", documents=["not a dict", {}, {"content": None}]
+        )
+        assert "3 documents" in result["answer"]
+
+    def test_unicode_query_is_preserved_in_answer(self):
+        result = ToolAugmentedRAGNode().run(query="résumé café 日本語", documents=[])
+        assert "résumé café 日本語" in result["answer"]
+
+
+# ===========================================================================
+# AgenticRAGNode — WorkflowNode construction + sub-workflow shape
+# ===========================================================================
+class TestAgenticRAGNode:
+    """``AgenticRAGNode`` is a ``WorkflowNode``; coverage is its construction
+    and the shape of the workflow ``_create_workflow()`` builds."""
+
+    def test_constructs_with_defaults(self):
+        node = AgenticRAGNode()
+        assert node.tools == ["search", "calculator", "database"]
+        assert node.max_reasoning_steps == 5
+        assert node.planning_strategy == "react"
+        assert node.verification_enabled is True
+
+    def test_constructor_config_overrides_apply(self):
+        node = AgenticRAGNode(
+            tools=["search"],
+            max_reasoning_steps=9,
+            planning_strategy="tree-of-thought",
+            verification_enabled=False,
+        )
+        assert node.tools == ["search"]
+        assert node.max_reasoning_steps == 9
+        assert node.planning_strategy == "tree-of-thought"
+        assert node.verification_enabled is False
+
+    def test_workflow_has_six_nodes_with_verification(self):
+        """With verification enabled the sub-workflow has six nodes."""
+        wf = _build(AgenticRAGNode(verification_enabled=True))
+        assert set(wf.nodes) == {
+            "planner_agent",
+            "react_agent",
+            "tool_executor",
+            "state_manager",
+            "verifier_agent",
+            "result_synthesizer",
+        }
+
+    def test_workflow_omits_verifier_when_disabled(self):
+        """With verification disabled the verifier_agent node is omitted —
+        five nodes remain."""
+        wf = _build(AgenticRAGNode(verification_enabled=False))
+        assert "verifier_agent" not in wf.nodes
+        assert len(wf.nodes) == 5
+
+    def test_max_reasoning_steps_interpolated_into_state_manager(self):
+        """``max_reasoning_steps`` flows into the state_manager code template."""
+        wf = _build(AgenticRAGNode(max_reasoning_steps=8))
+        code = wf.nodes["state_manager"].config["code"]
+        assert 'state["current_step"] >= 8' in code
+
+    def test_tools_interpolated_into_planner_prompt(self):
+        """The constructor ``tools`` list appears in the planner system prompt."""
+        wf = _build(AgenticRAGNode(tools=["search", "verify"]))
+        prompt = wf.nodes["planner_agent"].config["system_prompt"]
+        assert "search, verify" in prompt
+
+    # --- result_synthesizer code template (B1 codegen-regression pattern) -
+    def test_result_synthesizer_template_executes(self):
+        """The result_synthesizer ``code=`` template runs without NameError
+        and interpolates the constructor config into metadata.
+
+        Regression guard: the block was once a plain (non-f) string with
+        literal ``{self.planning_strategy}`` — invalid Python at runtime."""
+        wf = _build(AgenticRAGNode(planning_strategy="react", max_reasoning_steps=6))
+        code = wf.nodes["result_synthesizer"].config["code"]
+        ns = {
+            "reasoning_state": {"steps": [], "final_answer": "ans", "completed": True},
+            "query": "q",
+        }
+        exec(code, ns)
+        meta = ns["result"]["agentic_rag_result"]["metadata"]
+        assert meta["planning_strategy"] == "react"
+        assert meta["max_steps"] == 6
+        assert meta["completed_successfully"] is True
+
+    def test_tool_executor_template_search_over_documents(self):
+        """The tool_executor ``code=`` template runs a real keyword search
+        over documents when given a search action."""
+        wf = _build(AgenticRAGNode())
+        code = wf.nodes["tool_executor"].config["code"]
+        ns = {
+            "reasoning_state": {"current_action": 'search("transformer")'},
+            "documents": [{"id": "d", "content": "the transformer model"}],
+        }
+        exec(code, ns)
+        tr = ns["result"]["tool_result"]
+        assert tr["tool"] == "search"
+        assert tr["count"] == 1
+
+    def test_tool_executor_template_calculate_action(self):
+        """The tool_executor ``calculate`` action evaluates safe arithmetic."""
+        wf = _build(AgenticRAGNode())
+        code = wf.nodes["tool_executor"].config["code"]
+        ns = {
+            "reasoning_state": {"current_action": "calculate(2 + 3 * 4)"},
+            "documents": [],
+        }
+        exec(code, ns)
+        assert ns["result"]["tool_result"]["result"] == 14
+
+
+# ===========================================================================
+# ReasoningRAGNode — WorkflowNode construction + sub-workflow shape
+# ===========================================================================
+class TestReasoningRAGNode:
+    """``ReasoningRAGNode`` is a ``WorkflowNode``; coverage is its
+    construction and the shape of the workflow ``_create_workflow()`` builds."""
+
+    def test_constructs_with_defaults(self):
+        node = ReasoningRAGNode()
+        assert node.reasoning_depth == 3
+        assert node.strategy == "chain_of_thought"
+
+    def test_constructor_config_overrides_apply(self):
+        node = ReasoningRAGNode(reasoning_depth=5, strategy="tree_of_thought")
+        assert node.reasoning_depth == 5
+        assert node.strategy == "tree_of_thought"
+
+    def test_workflow_has_three_nodes(self):
+        """The reasoning sub-workflow always has three nodes."""
+        wf = _build(ReasoningRAGNode())
+        assert set(wf.nodes) == {
+            "problem_decomposer",
+            "step_reasoner",
+            "logic_verifier",
+        }
+
+    def test_strategy_and_depth_interpolated_into_decomposer_prompt(self):
+        """``strategy`` and ``reasoning_depth`` flow into the decomposer
+        system prompt."""
+        wf = _build(ReasoningRAGNode(reasoning_depth=4, strategy="tree_of_thought"))
+        prompt = wf.nodes["problem_decomposer"].config["system_prompt"]
+        assert "Strategy: tree_of_thought" in prompt
+        assert "Max depth: 4" in prompt

--- a/packages/kailash-kaizen/tests/unit/rag/test_agentic_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_agentic_nodes.py
@@ -96,7 +96,7 @@ class TestToolAugmentedRAGNode:
 
     def test_confidence_higher_when_tools_produce_output(self):
         """Confidence is 0.9 when a registered tool produced output, else 0.7."""
-        registry = {"calculator": lambda q, c: {"value": 42}}
+        registry = {"calculator": lambda _q, _c: {"value": 42}}
         with_tool = ToolAugmentedRAGNode(tool_registry=registry).run(
             query="calculate sum", documents=[]
         )
@@ -118,7 +118,7 @@ class TestToolAugmentedRAGNode:
         """A registered tool that raises is captured as an {'error': ...}
         entry rather than crashing run()."""
 
-        def boom(query, context):
+        def boom(_query, _context):
             raise RuntimeError("tool exploded")
 
         result = ToolAugmentedRAGNode(tool_registry={"calculator": boom}).run(

--- a/packages/kailash-kaizen/tests/unit/rag/test_agentic_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_agentic_nodes.py
@@ -159,11 +159,16 @@ class TestAgenticRAGNode:
     and the shape of the workflow ``_create_workflow()`` builds."""
 
     def test_constructs_with_defaults(self):
+        # The constructor resolves `tools or [...]` defaults onto instance
+        # attributes; node.config captures the *raw* kwarg (None for a default
+        # tools=), so the instance attrs are the canonical post-construction
+        # surface. The @register_node decorator erases the concrete type to
+        # the Node base, hence the targeted attr-defined ignores below.
         node = AgenticRAGNode()
-        assert node.tools == ["search", "calculator", "database"]
-        assert node.max_reasoning_steps == 5
-        assert node.planning_strategy == "react"
-        assert node.verification_enabled is True
+        assert node.tools == ["search", "calculator", "database"]  # type: ignore[attr-defined]
+        assert node.max_reasoning_steps == 5  # type: ignore[attr-defined]
+        assert node.planning_strategy == "react"  # type: ignore[attr-defined]
+        assert node.verification_enabled is True  # type: ignore[attr-defined]
 
     def test_constructor_config_overrides_apply(self):
         node = AgenticRAGNode(
@@ -172,10 +177,10 @@ class TestAgenticRAGNode:
             planning_strategy="tree-of-thought",
             verification_enabled=False,
         )
-        assert node.tools == ["search"]
-        assert node.max_reasoning_steps == 9
-        assert node.planning_strategy == "tree-of-thought"
-        assert node.verification_enabled is False
+        assert node.tools == ["search"]  # type: ignore[attr-defined]
+        assert node.max_reasoning_steps == 9  # type: ignore[attr-defined]
+        assert node.planning_strategy == "tree-of-thought"  # type: ignore[attr-defined]
+        assert node.verification_enabled is False  # type: ignore[attr-defined]
 
     def test_workflow_has_six_nodes_with_verification(self):
         """With verification enabled the sub-workflow has six nodes."""
@@ -261,14 +266,16 @@ class TestReasoningRAGNode:
     construction and the shape of the workflow ``_create_workflow()`` builds."""
 
     def test_constructs_with_defaults(self):
+        # Instance attrs are the canonical post-construction surface — see the
+        # AgenticRAGNode note above for the @register_node type-erasure.
         node = ReasoningRAGNode()
-        assert node.reasoning_depth == 3
-        assert node.strategy == "chain_of_thought"
+        assert node.reasoning_depth == 3  # type: ignore[attr-defined]
+        assert node.strategy == "chain_of_thought"  # type: ignore[attr-defined]
 
     def test_constructor_config_overrides_apply(self):
         node = ReasoningRAGNode(reasoning_depth=5, strategy="tree_of_thought")
-        assert node.reasoning_depth == 5
-        assert node.strategy == "tree_of_thought"
+        assert node.reasoning_depth == 5  # type: ignore[attr-defined]
+        assert node.strategy == "tree_of_thought"  # type: ignore[attr-defined]
 
     def test_workflow_has_three_nodes(self):
         """The reasoning sub-workflow always has three nodes."""

--- a/specs/kaizen-rag.md
+++ b/specs/kaizen-rag.md
@@ -270,3 +270,90 @@ executes a sub-workflow built at construction time by
 - `entity_extractor`, `query_processor`, and `summary_generator` are
   `LLMAgentNode` steps — executing the sub-workflow end-to-end requires an LLM
   key, which the `[rag]` extra does not carry.
+
+## Agentic RAG
+
+`kaizen/nodes/rag/agentic.py` defines three nodes that bring autonomous-agent
+patterns (tool use, ReAct-style reasoning loops, multi-step reasoning chains)
+to RAG. `ToolAugmentedRAGNode` is a direct `Node` with a deterministic
+`run()`; `AgenticRAGNode` and `ReasoningRAGNode` are `WorkflowNode`s whose
+behavior is a sub-workflow built at construction time.
+
+### `ToolAugmentedRAGNode`
+
+A `kailash.nodes.base.Node` with a direct `run(self, **kwargs) -> Dict[str, Any]`.
+It augments retrieval by invoking registered tool callables.
+
+- Constructor: `ToolAugmentedRAGNode(name, tool_registry, auto_detect_tools)`.
+  `tool_registry` is a `Dict[str, Callable]` mapping a tool name to a callable
+  invoked as `tool(query, context)`; it defaults to an empty dict.
+- Inputs (`get_parameters()`): `query` (`str`, required), `documents`
+  (`list`, optional), `context` (`dict`, optional), plus the three
+  constructor parameters.
+- `run()` calls `_detect_required_tools(query)` — a keyword scan that appends
+  `calculator` for a query containing `calculate`/`compute`/`sum`/`average`,
+  `unit_converter` for `convert`/`unit`/`measurement`, and `date_calculator`
+  for `date`/`days`/`weeks`/`months`. Each detected tool that is present in
+  `tool_registry` is invoked; a tool that raises is caught and recorded as
+  `{"error": str(e)}` in `tool_outputs`, and the failure is logged via
+  `logger.error` on the `kaizen.nodes.rag.agentic` logger.
+- `run()` returns `answer` (a synthesized string), `tools_invoked` (the list
+  of detected tool names), `tool_outputs` (the per-tool result dict), and
+  `confidence` (`0.9` when any tool produced output, else `0.7`).
+- A tool detected by keyword but absent from `tool_registry` is still listed
+  in `tools_invoked`; it simply contributes no `tool_outputs` entry.
+- Edge handling: a missing `documents` kwarg defaults to an empty list; a
+  `query` of `None` is coerced to an empty string before tool detection;
+  malformed documents (non-dict elements, `{}`, `{"content": None}`) are
+  tolerated — synthesis only counts `len(documents)`. A registered tool
+  returning a non-dict value (tools are arbitrary callables with no
+  return-shape contract) is treated as a successful result.
+
+### `AgenticRAGNode`
+
+`AgenticRAGNode` is a `WorkflowNode`. Its `run()` (inherited from
+`WorkflowNode`) executes a sub-workflow built at construction time by
+`_create_workflow(self) -> Workflow`.
+
+- Constructor config: `tools` (default `["search", "calculator",
+  "database"]`), `max_reasoning_steps` (default 5), `planning_strategy`
+  (default `"react"`), and `verification_enabled` (default `True`).
+- `_create_workflow()` builds a `WorkflowBuilder` graph. With
+  `verification_enabled=True` the workflow has six nodes — `planner_agent`,
+  `react_agent`, `tool_executor`, `state_manager`, `verifier_agent`,
+  `result_synthesizer`. With `verification_enabled=False` the
+  `verifier_agent` node and its connections are omitted, leaving five nodes.
+- `planner_agent`, `react_agent`, and `verifier_agent` are `LLMAgentNode`
+  steps; `tool_executor`, `state_manager`, and `result_synthesizer` are
+  `PythonCodeNode` steps carrying a `code` template.
+- The constructor config flows into the generated workflow: the `tools` list
+  appears in the `planner_agent` system prompt, `max_reasoning_steps` is
+  interpolated into the `state_manager` `code` template as the step bound and
+  into the `result_synthesizer` template's `metadata.max_steps`, and
+  `planning_strategy` is interpolated into the `result_synthesizer`
+  template's `metadata.planning_strategy`.
+- The `tool_executor` `code` template implements the `search`, `calculate`,
+  `database`, and `verify` tools. `search` scores documents by query-word
+  overlap; a document whose `content` or `title` is missing or `None` is
+  coerced to an empty string and a non-dict document element is skipped.
+  `calculate` evaluates arithmetic via an AST-walked safe evaluator (no
+  `eval`/`exec`).
+- The `LLMAgentNode` steps require an LLM key to execute end-to-end, which
+  the `[rag]` extra does not carry.
+
+### `ReasoningRAGNode`
+
+`ReasoningRAGNode` is a `WorkflowNode`. Its `run()` (inherited) executes a
+sub-workflow built at construction time by
+`_create_workflow(self) -> Workflow`.
+
+- Constructor config: `reasoning_depth` (default 3) and `strategy` (default
+  `"chain_of_thought"`).
+- `_create_workflow()` builds a `WorkflowBuilder` graph with three nodes —
+  `problem_decomposer`, `step_reasoner`, and `logic_verifier`, all
+  `LLMAgentNode` steps.
+- The constructor config flows into the generated workflow: `strategy` and
+  `reasoning_depth` are interpolated into the `problem_decomposer` system
+  prompt.
+- The `LLMAgentNode` steps require an LLM key to execute end-to-end, which
+  the `[rag]` extra does not carry.


### PR DESCRIPTION
## Summary

Shard **B3** of workstream F8 (`kaizen.nodes.rag` resurrection) — behavioral
coverage of the `agentic` module (AgenticRAG; the plan's most defect-prone path).

- **45 new behavioral tests** — 25 Tier-1 unit + 11 Tier-2a integration (real
  loopback HTTP for the REST tool, **no mocking**) + 9 regression — across
  `ToolAugmentedRAGNode`, `AgenticRAGNode`, `ReasoningRAGNode`.
- **4 latent defects found & fixed** (both `run()` and `code=` codegen
  templates checked per the B1 lesson):
  1. `tool_executor` codegen crashed on `{"content": None}` / non-dict docs —
     `isinstance(doc, dict)` skip + `(doc.get("content") or "")`.
  2. **`result_synthesizer` codegen `NameError`** (load-bearing) — the `code=`
     block embedded `{self.x}` references but was a plain string, not an
     f-string → invalid `self.x` at `PythonCodeNode` runtime. Converted to an
     f-string with doubled literal braces.
  3. `_detect_required_tools` crashed on explicit `query=None` — `(query or "")`.
  4. `_synthesize_with_tools` crashed when a tool returned a non-dict —
     `isinstance(output, dict)` guard.
  - Regression: `test_issue_f8b3_agentic_defects.py` (9 tests).
- **Pyright** — `agentic.py` + new test files 0 errors / 0 warnings (genuine
  type fixes: `Optional` annotations, possibly-unbound local, unused-import
  cleanup; `PythonCodeNode`/`LLMAgentNode` retained as `# noqa: F401`
  registration side-effect imports).
- **Spec** — appended `## Agentic RAG` to `specs/kaizen-rag.md`.

## Separate finding (NOT fixed — out of B3 scope)

The 2 `WorkflowNode` subclasses' sub-workflows do not execute end-to-end:
`AgenticRAGNode` builds **unmarked cycles** (`react_agent`↔`state_manager`↔
`tool_executor`) without `cycle=True`; `ReasoningRAGNode` wires invalid
`LLMAgentNode` params. Workflow-graph-wiring defects needing runtime redesign
+ an LLM key — a separate shard. Construction, `_create_workflow()` graph
shape, and the `code=` templates ARE covered here. (Recorded in workspace
journal 0010.)

## Test plan

- [x] 45 B3 tests pass; rag smoke stays green (45 passed, 6 xfail)
- [x] Tier-2a uses a real loopback HTTP server, zero `@patch`/`MagicMock`
- [x] `pre-commit run --files` clean; Pyright clean on `agentic.py` + new tests

## Related issues

Part of F8 (`kaizen.nodes.rag` behavioral coverage). No standalone issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)