### PR TITLE
test(rag): F8 B5 — behavioral coverage of the 3 federated RAG nodes

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
@@ -1201,8 +1201,17 @@ class CrossSiloRAGNode(Node):
                 governed_results.append(silo_result)
                 continue
 
-            # Apply governance based on agreement
+            # Apply governance based on agreement. ``dict.copy()`` is shallow —
+            # the nested ``results`` list would stay shared with silo_result,
+            # so the in-place content mutation below would silently govern the
+            # pre-governance record too. Rebuild ``results`` with independent
+            # per-result dicts so silo_results stays a true pre-governance
+            # record and governed_results is the only mutated structure.
             governed_silo_result = silo_result.copy()
+            governed_silo_result["results"] = [
+                dict(r) if isinstance(r, dict) else r
+                for r in silo_result.get("results", [])
+            ]
 
             if silo_result["silo"] != requester:
                 # Apply restrictions for other silos

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
@@ -319,7 +319,15 @@ def aggregate_federated_results(federated_responses):
 
         # Add results with node information
         for result in node_response["results"]:
+            # A node's results list is data from a federated peer — a non-dict
+            # element has no .copy(); a present-but-None content reaches a
+            # [:50] slice and a str-keyed group. Guard once at intake so every
+            # downstream aggregation strategy sees only well-formed dicts.
+            if not isinstance(result, dict):
+                continue
             result_with_node = result.copy()
+            if result_with_node.get("content") is None:
+                result_with_node["content"] = ""
             result_with_node["source_node"] = node_id
             result_with_node["node_weight"] = weight
             all_results.append(result_with_node)
@@ -437,8 +445,13 @@ def coordinate_caching(aggregated_results, distribution_plan):
 
     for result in aggregated_results["results"][:5]:  # Top 5 results
         if result["score"] > 0.8 and result.get("node_agreement", 0) > 0.5:
+            # A present-but-None content bypasses an upstream "" default and
+            # reaches .encode() — coerce before hashing.
+            content_hash = hashlib.sha256(
+                (result.get("content") or "").encode()
+            ).hexdigest()[:16]
             cache_candidates.append({
-                "content_hash": hashlib.sha256(result["content"].encode()).hexdigest()[:16],
+                "content_hash": content_hash,
                 "result": result,
                 "cache_priority": result["score"] * result.get("node_agreement", 1),
                 "ttl": 3600  # 1 hour
@@ -695,8 +708,10 @@ class EdgeRAGNode(Node):
 
     def run(self, **kwargs) -> Dict[str, Any]:
         """Execute edge-optimized RAG"""
-        query = kwargs.get("query", "")
-        local_data = kwargs.get("local_data", [])
+        # ``.get(key, default)`` only applies the default to a MISSING key; an
+        # explicit ``query=None`` returns ``None`` and ``None.encode()`` raises.
+        query = kwargs.get("query") or ""
+        local_data = kwargs.get("local_data") or []
         sync_with_cloud = kwargs.get("sync_with_cloud", False)
 
         # Check cache first
@@ -758,7 +773,11 @@ class EdgeRAGNode(Node):
         max_docs = 50 if self.power_mode == "low_power" else 200
 
         for doc in local_data[:max_docs]:
-            content = doc.get("content", "").lower()
+            # local_data is arbitrary user input — a non-dict element has no
+            # ``.get``; a present-but-None ``content`` bypasses the "" default.
+            if not isinstance(doc, dict):
+                continue
+            content = (doc.get("content") or "").lower()
             doc_words = set(content.split())
 
             # Quick scoring
@@ -785,14 +804,18 @@ class EdgeRAGNode(Node):
         elif self.model_size == "small":
             # Slightly better response
             if results:
-                top_content = results[0]["document"].get("content", "")[:100]
+                # A present-but-None ``content`` bypasses the "" default and
+                # ``None[:100]`` raises — coerce before slicing.
+                top_content = (results[0]["document"].get("content") or "")[:100]
                 response = f"Based on local data: {top_content}..."
             else:
                 response = "No relevant local data found. Consider syncing with cloud."
         else:  # medium
             # Best edge response
             if results:
-                contents = [r["document"].get("content", "")[:200] for r in results[:2]]
+                contents = [
+                    (r["document"].get("content") or "")[:200] for r in results[:2]
+                ]
                 response = f"Local analysis for '{query}': " + " ".join(contents)
             else:
                 response = f"No local matches for '{query}'. Cloud sync recommended."
@@ -988,10 +1011,13 @@ class CrossSiloRAGNode(Node):
 
     def run(self, **kwargs) -> Dict[str, Any]:
         """Execute cross-silo federated RAG"""
-        query = kwargs.get("query", "")
-        requester_org = kwargs.get("requester_org", "")
-        access_permissions = kwargs.get("access_permissions", [])
-        purpose = kwargs.get("purpose", "analysis")
+        # ``.get(key, default)`` only applies the default to a MISSING key; an
+        # explicit ``query=None`` reaches ``query.encode()`` in the audit-trail
+        # hash, and ``access_permissions=None`` reaches ``perm in None``.
+        query = kwargs.get("query") or ""
+        requester_org = kwargs.get("requester_org") or ""
+        access_permissions = kwargs.get("access_permissions") or []
+        purpose = kwargs.get("purpose") or "analysis"
 
         # Validate access
         access_valid = self._validate_cross_silo_access(

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
@@ -11,15 +11,13 @@ Implements RAG across distributed data sources without centralization:
 Based on federated learning and distributed systems research.
 """
 
-import asyncio
 import hashlib
 import json
 import logging
 import random
 import re
-from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional
 
 from kailash.nodes.api.rest import (  # noqa: F401  (registers "RESTClientNode" for builder.add_node)
     RESTClientNode,
@@ -1043,9 +1041,7 @@ class CrossSiloRAGNode(Node):
             }
 
         # Execute query across silos
-        silo_results = self._execute_cross_silo_query(
-            query, requester_org, access_permissions
-        )
+        silo_results = self._execute_cross_silo_query(query, requester_org)
 
         # Apply data governance rules
         governed_results = self._apply_governance(
@@ -1124,9 +1120,16 @@ class CrossSiloRAGNode(Node):
         return {"granted": True, "reason": "Access approved"}
 
     def _execute_cross_silo_query(
-        self, query: str, requester: str, permissions: List[str]
+        self, query: str, requester: str
     ) -> List[Dict[str, Any]]:
-        """Execute query across organizational silos"""
+        """Execute query across organizational silos.
+
+        The caller's permission list is validated upstream by
+        ``_validate_cross_silo_access`` before this runs; per-silo
+        ``access_level`` here is an organization-relationship decision
+        (own silo → full, peer silo → the data-sharing agreement), not a
+        re-check of the already-gated permission list.
+        """
         silo_results = []
 
         for silo in self.silos:
@@ -1260,14 +1263,19 @@ class CrossSiloRAGNode(Node):
             "data_flow": [],
         }
 
-        # Track data flow
+        # Track data flow. The governance markers are read from
+        # governed_results (the actual post-governance output returned to the
+        # requester) so the audit records what governance produced, not the
+        # pre-governance silo response.
+        governed_by_silo = {gr["silo"]: gr for gr in governed_results}
         for silo_result in silo_results:
+            governed = governed_by_silo.get(silo_result["silo"], silo_result)
             flow = {
                 "silo": silo_result["silo"],
                 "data_shared": silo_result["participated"],
                 "access_level": silo_result.get("access_level", "none"),
                 "governance_applied": any(
-                    r.get("governance_applied") for r in silo_result.get("results", [])
+                    r.get("governance_applied") for r in governed.get("results", [])
                 ),
             }
             audit["data_flow"].append(flow)
@@ -1286,11 +1294,37 @@ class CrossSiloRAGNode(Node):
     def _generate_compliance_report(
         self, requester: str, permissions: List[str], results: List[Dict]
     ) -> Dict[str, Any]:
-        """Generate compliance report"""
+        """Generate a compliance report derived from the actual request.
+
+        The verdict reflects the real ``requester``, the ``permissions`` that
+        were granted, and the governed ``results`` that crossed the boundary —
+        it is NOT a fixed "compliant" stamp. ``data_minimization`` is True only
+        when every peer silo's result actually carries a governance marker;
+        ``compliance_status`` degrades to "non_compliant" when a peer silo's
+        data crossed without governance applied.
+        """
+        # A peer silo is any participating silo other than the requester's own.
+        peer_results = [
+            r for r in results if r.get("participated") and r.get("silo") != requester
+        ]
+        # Every peer silo's content must carry a governance marker.
+        ungoverned_peers = [
+            r
+            for r in peer_results
+            if not all(item.get("governance_applied") for item in r.get("results", []))
+        ]
+        data_minimization = len(ungoverned_peers) == 0
+
         return {
-            "compliance_status": "compliant",
+            "compliance_status": (
+                "compliant" if data_minimization else "non_compliant"
+            ),
             "regulations_checked": ["GDPR", "CCPA", "Industry Standards"],
-            "data_minimization": True,
+            "requester": requester,
+            "permissions_granted": list(permissions),
+            "peer_silos_governed": len(peer_results) - len(ungoverned_peers),
+            "peer_silos_total": len(peer_results),
+            "data_minimization": data_minimization,
             "purpose_limitation": True,
             "access_controls": "enforced",
             "audit_trail": "maintained",

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
@@ -21,10 +21,15 @@ from collections import defaultdict
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from kailash.nodes.api.rest import RESTClientNode
+from kailash.nodes.api.rest import (  # noqa: F401  (registers "RESTClientNode" for builder.add_node)
+    RESTClientNode,
+)
 from kailash.nodes.base import Node, NodeParameter, register_node
-from kailash.nodes.code.python import PythonCodeNode
+from kailash.nodes.code.python import (  # noqa: F401  (registers "PythonCodeNode" for builder.add_node)
+    PythonCodeNode,
+)
 from kailash.nodes.logic.workflow import WorkflowNode
+from kailash.workflow import Workflow
 from kailash.workflow.builder import WorkflowBuilder
 
 logger = logging.getLogger(__name__)
@@ -88,7 +93,7 @@ class FederatedRAGNode(WorkflowNode):
     def __init__(
         self,
         name: str = "federated_rag",
-        federation_nodes: List[str] = None,
+        federation_nodes: Optional[List[str]] = None,
         aggregation_strategy: str = "weighted_average",
         min_participating_nodes: int = 2,
         timeout_per_node: float = 5.0,
@@ -101,9 +106,12 @@ class FederatedRAGNode(WorkflowNode):
         self.enable_caching = enable_caching
         super().__init__(workflow=self._create_workflow(), name=name)
 
-    def _create_workflow(self) -> WorkflowNode:
+    def _create_workflow(self) -> Workflow:
         """Create federated RAG workflow"""
         builder = WorkflowBuilder()
+        # Assigned only when caching is enabled; pre-bind so the later
+        # ``if self.enable_caching`` connection block has a defined name.
+        cache_coordinator_id: Optional[str] = None
 
         # Query distributor
         query_distributor_id = builder.add_node(
@@ -557,6 +565,9 @@ def format_federated_results(aggregated_results, federated_responses, cache_coor
         )
 
         if self.enable_caching:
+            # cache_coordinator_id is assigned in the matching enable_caching
+            # block above; narrow it from Optional[str] for the connections.
+            assert cache_coordinator_id is not None
             builder.add_connection(
                 result_aggregator_id,
                 "aggregated_results",
@@ -933,10 +944,10 @@ class CrossSiloRAGNode(Node):
     def __init__(
         self,
         name: str = "cross_silo_rag",
-        silos: List[str] = None,
+        silos: Optional[List[str]] = None,
         data_sharing_agreement: str = "minimal",
         audit_mode: str = "standard",
-        governance_rules: Dict[str, Any] = None,
+        governance_rules: Optional[Dict[str, Any]] = None,
     ):
         resolved_silos = silos or []
         resolved_governance_rules = governance_rules or {}

--- a/packages/kailash-kaizen/tests/integration/rag/test_federated_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_federated_nodes.py
@@ -390,8 +390,14 @@ class TestCrossSiloRAGNodeRun:
         assert meta["participating_silos"] >= 1
         assert meta["data_sharing_level"] == "minimal"
 
-    def test_run_compliance_report_marks_compliant(self):
-        """The compliance report is generated on the access-granted path."""
+    def test_run_compliance_report_reflects_real_request(self):
+        """The compliance report is derived from the actual request inputs.
+
+        The report echoes the real requester and the granted permissions, and
+        the verdict reflects per-peer governance state — it is NOT a fixed
+        "compliant" stamp. A single-silo request has zero peer silos, so
+        data-minimization holds vacuously.
+        """
         random.seed(0)
         result = CrossSiloRAGNode(silos=["org_a"]).run(
             query="trend",
@@ -401,6 +407,53 @@ class TestCrossSiloRAGNodeRun:
         report = result["compliance_report"]
         assert report["compliance_status"] == "compliant"
         assert report["data_minimization"] is True
+        # The report echoes the real request, not hardcoded values.
+        assert report["requester"] == "org_a"
+        assert report["permissions_granted"] == ["read_aggregated"]
+        # Single-silo request: the requester's own silo is not a peer.
+        assert report["peer_silos_total"] == 0
+
+    def test_run_compliance_report_counts_governed_peer_silos(self):
+        """With a peer silo present, the report counts how many were governed.
+
+        Under the default 'minimal' agreement, the peer silo's content is
+        governed (truncated + restricted-marker), so peer_silos_governed
+        equals peer_silos_total and the verdict is compliant.
+        """
+        random.seed(0)
+        result = CrossSiloRAGNode(silos=["org_a", "org_b"]).run(
+            query="trend",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        report = result["compliance_report"]
+        # seed 0 — org_b participates as a governed peer.
+        assert report["peer_silos_total"] >= 1
+        assert report["peer_silos_governed"] == report["peer_silos_total"]
+        assert report["compliance_status"] == "compliant"
+        assert report["data_minimization"] is True
+
+    def test_run_audit_trail_reflects_governed_results(self):
+        """The audit-trail data_flow records the governed peer-silo output.
+
+        The audit reads governance markers from governed_results (the actual
+        post-governance output) — a peer silo under the 'minimal' agreement is
+        recorded as governance_applied=True; the requester's own silo, which
+        is not governed, as False.
+        """
+        random.seed(0)
+        result = CrossSiloRAGNode(silos=["org_a", "org_b"]).run(
+            query="trend",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        flows = {f["silo"]: f for f in result["audit_trail"]["data_flow"]}
+        # The requester's own silo is full-access, not governed.
+        assert flows["org_a"]["governance_applied"] is False
+        assert flows["org_a"]["access_level"] == "full"
+        # seed 0 — org_b participates and is governed.
+        if flows["org_b"]["data_shared"]:
+            assert flows["org_b"]["governance_applied"] is True
 
 
 # ==========================================================================

--- a/packages/kailash-kaizen/tests/integration/rag/test_federated_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_federated_nodes.py
@@ -1,0 +1,566 @@
+"""Tier-2a integration coverage for ``kaizen.nodes.rag.federated``.
+
+F8 shard B5. The 3 federated RAG nodes ship a deterministic *simulated*
+federated path — ``federated.py`` marks the executor explicitly as "simulated
+- would use actual network calls". There is no container and no LLM key on the
+shipped default path: the federated aggregation, the cross-silo governance,
+and the edge retrieval are all real deterministic compute. NO mocking
+(``@patch`` / ``MagicMock`` / ``unittest.mock`` are BLOCKED in Tier 2 per the
+3-tier testing rule). There is nothing to mock — the deterministic compute IS
+the path under test.
+
+``FederatedRAGNode`` is a ``WorkflowNode``; its ``_create_workflow()`` builds a
+sub-workflow whose ``PythonCodeNode`` ``code=`` templates carry the
+distribution / aggregation / formatting logic. End-to-end runtime execution of
+that graph is a documented scope boundary (see the shard summary's WorkflowNode
+finding). This file covers what is exercisable with the ``[rag]`` extra alone:
+the codegen templates exercised DIRECTLY via ``exec`` against well-formed and
+malformed input (the B1 codegen-regression pattern), plus the
+random-seed-pinned cross-silo / edge ``run()`` paths.
+
+The **no-data-leak verification** (the B5 value-anchor) lives in
+``TestFederatedNoDataLeakBoundary`` — it asserts, with a unique sentinel
+string, exactly what does and does not cross the federated boundary.
+
+Assertions are structural: result keys, score ranges/ordering, list lengths,
+typed-error raises, sentinel presence/absence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from datetime import datetime
+
+import pytest
+
+from kaizen.nodes.rag.federated import CrossSiloRAGNode, EdgeRAGNode, FederatedRAGNode
+
+pytestmark = pytest.mark.integration
+
+
+# ==========================================================================
+# Codegen-template helper — exercise FederatedRAGNode's code= templates.
+#
+# The FederatedRAGNode codegen functions build a local ``result`` dict as
+# their FINAL statement but never ``return`` it — the function output is
+# unreachable to a direct caller (a WorkflowNode codegen finding, reported in
+# the shard summary). To exercise the logic behaviorally, this helper appends
+# ``\n    return result`` so the final ``result`` local is returned. The code=
+# string is read off the built workflow via ``get_node(id).code`` — the
+# canonical accessor: ``WorkflowBuilder.build()`` consumes the ``code`` config
+# kwarg into the PythonCodeNode's ``.code`` attribute and the rebuilt
+# NodeInstance ``.config`` is empty.
+# ==========================================================================
+
+
+def _exec_codegen_fn(workflow, node_id, fn_name, extra_ns=None):
+    """exec a FederatedRAGNode codegen template and return its function."""
+    code = workflow.get_node(node_id).code
+    namespace: dict = {
+        "datetime": datetime,
+        "hashlib": hashlib,
+        "random": random,
+    }
+    if extra_ns:
+        namespace.update(extra_ns)
+    exec(code + "\n    return result\n", namespace)
+    return namespace[fn_name]
+
+
+def _sample_federated_responses(*, none_content=False, non_dict_result=False):
+    """Build a well-formed federated_responses dict for the aggregator.
+
+    none_content / non_dict_result inject the two malformed-input shapes the
+    aggregator's result-intake loop must survive.
+    """
+    h_a_results: list = [{"content": "clinical protocol A", "score": 0.9}]
+    if none_content:
+        h_a_results = [{"content": None, "score": 0.9}]
+    if non_dict_result:
+        h_a_results = ["bare-string", {"content": "clinical protocol A", "score": 0.9}]
+    return {
+        "query_id": "q1",
+        "node_responses": [
+            {
+                "node_id": "hospital_a",
+                "results": h_a_results,
+                "metadata": {
+                    "response_time": 1.0,
+                    "result_count": len(h_a_results),
+                    "cache_hit": False,
+                },
+            },
+            {
+                "node_id": "hospital_b",
+                "results": [{"content": "clinical protocol B", "score": 0.8}],
+                "metadata": {
+                    "response_time": 1.5,
+                    "result_count": 1,
+                    "cache_hit": False,
+                },
+            },
+        ],
+        "failed_nodes": [],
+        "statistics": {
+            "total_nodes": 2,
+            "successful_nodes": 2,
+            "failed_nodes": 0,
+            "minimum_requirement_met": True,
+            "avg_response_time": 1.25,
+        },
+    }
+
+
+# ==========================================================================
+# FederatedRAGNode codegen templates — query_distributor + federated_executor
+# ==========================================================================
+
+
+class TestFederatedRAGCodegenDistribution:
+    """Behavioral coverage of the distribution-side codegen templates."""
+
+    def test_query_distributor_builds_one_target_per_endpoint(self):
+        """The distributor builds a per-endpoint target-node entry."""
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "query_distributor",
+            "distribute_query",
+        )
+        result = fn(
+            "treatment protocols",
+            {"hospital_a": "https://a.api", "hospital_b": "https://b.api"},
+            {},
+        )
+        assert result["ready_for_distribution"] is True
+        plan = result["distribution_plan"]
+        assert len(plan["target_nodes"]) == 2
+        assert plan["federation_metadata"]["total_nodes"] == 2
+
+    def test_query_distributor_empty_endpoints_yields_no_targets(self):
+        """No endpoints → an empty target-node list, no crash."""
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "query_distributor",
+            "distribute_query",
+        )
+        result = fn("query", {}, {})
+        assert result["distribution_plan"]["target_nodes"] == []
+
+    def test_federated_executor_produces_per_node_responses(self):
+        """The simulated executor produces a response per target node."""
+        random.seed(7)
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "federated_executor",
+            "execute_federated_queries",
+        )
+        plan = {
+            "query_id": "q1",
+            "target_nodes": [
+                {"node_id": "hospital_a", "endpoint": "u", "timeout": 5},
+                {"node_id": "research_lab", "endpoint": "u", "timeout": 5},
+            ],
+        }
+        result = fn(plan)
+        stats = result["federated_responses"]["statistics"]
+        # seed 7 — both simulated nodes succeed (10% failure rate not hit).
+        assert stats["total_nodes"] == 2
+        assert stats["successful_nodes"] + stats["failed_nodes"] == 2
+
+    def test_federated_executor_empty_targets_reports_zero_avg(self):
+        """An empty target list yields a zero avg_response_time, no ZeroDiv."""
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "federated_executor",
+            "execute_federated_queries",
+        )
+        result = fn({"query_id": "q1", "target_nodes": []})
+        assert result["federated_responses"]["statistics"]["avg_response_time"] == 0
+
+
+# ==========================================================================
+# FederatedRAGNode codegen templates — result_aggregator
+# ==========================================================================
+
+
+class TestFederatedRAGCodegenAggregator:
+    """Behavioral coverage of the result_aggregator codegen template."""
+
+    def test_aggregator_weighted_average_produces_scored_results(self):
+        """The weighted_average strategy aggregates per-node results."""
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "result_aggregator",
+            "aggregate_federated_results",
+        )
+        out = fn(_sample_federated_responses())["aggregated_results"]
+        assert out["total_raw_results"] == 2
+        assert out["aggregation_metadata"]["strategy"] == "weighted_average"
+        # Results are sorted by score, descending.
+        scores = [r["score"] for r in out["results"]]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_aggregator_voting_strategy_counts_votes(self):
+        """The voting strategy ranks results by accumulated votes."""
+        fn = _exec_codegen_fn(
+            FederatedRAGNode(
+                aggregation_strategy="voting"
+            )._create_workflow(),  # type: ignore[attr-defined]
+            "result_aggregator",
+            "aggregate_federated_results",
+        )
+        out = fn(_sample_federated_responses())["aggregated_results"]
+        assert out["aggregation_metadata"]["strategy"] == "voting"
+        for result in out["results"]:
+            assert result["metadata"]["aggregation_method"] == "voting"
+
+    def test_aggregator_below_minimum_returns_error(self):
+        """When fewer than min nodes responded, an error block is returned."""
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "result_aggregator",
+            "aggregate_federated_results",
+        )
+        responses = _sample_federated_responses()
+        responses["statistics"]["minimum_requirement_met"] = False
+        responses["statistics"]["successful_nodes"] = 1
+        out = fn(responses)["aggregated_results"]
+        assert out["error"] == "Insufficient nodes responded"
+
+    def test_aggregator_none_content_result_does_not_crash(self):
+        """A present-but-None content must not crash the [:50] grouping key.
+
+        Pre-fix the aggregator did ``result["content"][:50]`` — a None content
+        raised ``TypeError: 'NoneType' object is not subscriptable``. See
+        tests/regression/test_issue_f8b5_federated_defects.py.
+        """
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "result_aggregator",
+            "aggregate_federated_results",
+        )
+        out = fn(_sample_federated_responses(none_content=True))["aggregated_results"]
+        assert out["total_raw_results"] == 2
+
+    def test_aggregator_non_dict_result_element_is_skipped(self):
+        """A non-dict element in a node's results list is skipped, not crashed.
+
+        Pre-fix the aggregator did ``result.copy()`` on every element — a bare
+        string raised ``AttributeError: 'str' object has no attribute 'copy'``.
+        """
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "result_aggregator",
+            "aggregate_federated_results",
+        )
+        out = fn(_sample_federated_responses(non_dict_result=True))[
+            "aggregated_results"
+        ]
+        # The bare string is skipped; only the two dict results are aggregated.
+        assert out["total_raw_results"] == 2
+
+
+# ==========================================================================
+# FederatedRAGNode codegen templates — cache_coordinator + result_formatter
+# ==========================================================================
+
+
+class TestFederatedRAGCodegenFormatting:
+    """Behavioral coverage of the cache + formatting codegen templates."""
+
+    def test_cache_coordinator_identifies_high_value_candidates(self):
+        """The coordinator caches high-score, high-agreement results."""
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "cache_coordinator",
+            "coordinate_caching",
+        )
+        aggregated = {
+            "results": [
+                {"content": "high value", "score": 0.95, "node_agreement": 0.9},
+                {"content": "low value", "score": 0.4, "node_agreement": 0.2},
+            ]
+        }
+        out = fn(aggregated, {"query_id": "q1"})["cache_coordination"]
+        # Only the high-score / high-agreement result qualifies.
+        assert out["candidates_identified"] == 1
+
+    def test_cache_coordinator_none_content_does_not_crash(self):
+        """A present-but-None content must not crash the content_hash encode.
+
+        Pre-fix ``hashlib.sha256(result["content"].encode())`` raised
+        ``AttributeError: 'NoneType' object has no attribute 'encode'``.
+        """
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "cache_coordinator",
+            "coordinate_caching",
+        )
+        aggregated = {
+            "results": [{"content": None, "score": 0.95, "node_agreement": 0.9}]
+        }
+        out = fn(aggregated, {"query_id": "q1"})["cache_coordination"]
+        assert out["candidates_identified"] == 1
+
+    def test_result_formatter_builds_node_contribution_summary(self):
+        """The formatter builds the final federated-RAG output structure."""
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "result_formatter",
+            "format_federated_results",
+        )
+        aggregated = {
+            "results": [{"content": "c", "score": 0.9}],
+            "aggregation_metadata": {
+                "strategy": "weighted_average",
+                "node_weights": {"hospital_a": 1.0},
+                "participating_nodes": ["hospital_a"],
+            },
+            "total_raw_results": 1,
+            "federation_health": {"result_diversity": 0.5},
+        }
+        federated_responses = {
+            "node_responses": [
+                {
+                    "node_id": "hospital_a",
+                    "status": "success",
+                    "metadata": {"result_count": 1, "response_time": 1.0},
+                }
+            ],
+            "failed_nodes": [],
+            "statistics": {
+                "minimum_requirement_met": True,
+                "avg_response_time": 1.0,
+                "successful_nodes": 1,
+                "total_nodes": 1,
+            },
+        }
+        out = fn(aggregated, federated_responses)["federated_rag_output"]
+        assert set(out.keys()) >= {
+            "federated_results",
+            "node_contributions",
+            "aggregation_metadata",
+            "federation_health",
+            "performance_metrics",
+        }
+        assert "hospital_a" in out["node_contributions"]
+
+
+# ==========================================================================
+# EdgeRAGNode + CrossSiloRAGNode run() — seed-pinned deterministic paths
+# ==========================================================================
+
+
+class TestEdgeRAGNodeRun:
+    """EdgeRAGNode.run() against real deterministic edge-retrieval compute."""
+
+    def test_run_resource_usage_reports_model_size(self):
+        """resource_usage carries the configured model-size profile."""
+        result = EdgeRAGNode(model_size="tiny").run(
+            query="anomaly", local_data=[{"content": "anomaly detected"}]
+        )
+        assert result["resource_usage"]["model_size"] == "tiny"
+        assert result["resource_usage"]["estimated_cpu_ms"] == 50
+
+    def test_run_sync_requested_sets_high_priority(self):
+        """sync_with_cloud=True forces a high-priority sync recommendation."""
+        result = EdgeRAGNode().run(
+            query="q",
+            local_data=[{"content": f"q match {i}"} for i in range(20)],
+            sync_with_cloud=True,
+        )
+        rec = result["sync_recommendations"]
+        assert rec["should_sync"] is True
+        assert "User requested sync" in rec["reasons"]
+
+
+class TestCrossSiloRAGNodeRun:
+    """CrossSiloRAGNode.run() against real deterministic governance compute."""
+
+    def test_run_participating_silos_counted_in_metadata(self):
+        """federation_metadata counts the silos that participated."""
+        random.seed(0)
+        result = CrossSiloRAGNode(silos=["org_a", "org_b"]).run(
+            query="trend",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        meta = result["federation_metadata"]
+        assert meta["participating_silos"] >= 1
+        assert meta["data_sharing_level"] == "minimal"
+
+    def test_run_compliance_report_marks_compliant(self):
+        """The compliance report is generated on the access-granted path."""
+        random.seed(0)
+        result = CrossSiloRAGNode(silos=["org_a"]).run(
+            query="trend",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        report = result["compliance_report"]
+        assert report["compliance_status"] == "compliant"
+        assert report["data_minimization"] is True
+
+
+# ==========================================================================
+# No-data-leak boundary verification — the B5 value-anchor
+# ==========================================================================
+
+
+class TestFederatedNoDataLeakBoundary:
+    """Behavioral verification of what crosses the federated boundary.
+
+    The federated RAG nodes advertise data locality: ``FederatedRAGNode`` —
+    "Data never leaves source organizations"; ``CrossSiloRAGNode`` — "RAG
+    across organizational boundaries with strict data governance". These tests
+    pin a unique sentinel into the data a peer silo would hold and assert
+    exactly what does and does not cross the boundary in the node OUTPUT.
+
+    The honest characterization of the shipped contract:
+
+    * ``EdgeRAGNode`` is local-only by construction — there is NO federated
+      boundary; its output legitimately contains the local document text
+      because nothing is shared with any peer.
+    * ``FederatedRAGNode`` ingests only a ``query`` and ``node_endpoints`` — it
+      has NO document-corpus input, so no raw local document can leak; the
+      simulated executor generates its own per-node content.
+    * ``CrossSiloRAGNode`` IS the real cross-organization boundary. The
+      requester's own silo returns full content (its own data); EVERY OTHER
+      silo's content is governed before it crosses — ``minimal`` truncates and
+      stamps "[Details restricted ...]"; ``standard`` anonymizes (organization
+      names, numeric and ALLCAPS identifiers redacted).
+    """
+
+    _SENTINEL = "ZQXJSENTINEL9981"
+
+    def test_federated_rag_node_takes_no_document_corpus_input(self):
+        """FederatedRAGNode's parameter contract has no document-corpus input.
+
+        The structural guarantee behind "data never leaves source orgs": the
+        node cannot leak a raw local document because no raw document is ever
+        passed to it — only a query and per-node endpoints.
+        """
+        node = FederatedRAGNode()
+        # The WorkflowNode wraps a sub-workflow whose entry codegen
+        # (query_distributor) reads only ``query`` and ``node_endpoints``.
+        distributor_code = (
+            node._create_workflow()
+            .get_node("query_distributor")  # type: ignore[attr-defined]
+            .code
+        )
+        assert "def distribute_query(query, node_endpoints, federation_config)" in (
+            distributor_code
+        )
+        # No corpus / documents parameter anywhere in the distribution entry.
+        assert "documents" not in distributor_code
+
+    def test_federated_aggregate_carries_only_peer_supplied_content(self):
+        """The aggregate crossing the boundary carries scores + aggregates.
+
+        The aggregator's output is per-result content + score + metadata
+        (source nodes, weights, agreement) — it does NOT fabricate or attach
+        any caller-supplied raw local corpus, because the node never received
+        one. This pins the aggregate's shape so a future refactor that adds a
+        raw-corpus passthrough fails loudly.
+        """
+        fn = _exec_codegen_fn(
+            FederatedRAGNode()._create_workflow(),  # type: ignore[attr-defined]
+            "result_aggregator",
+            "aggregate_federated_results",
+        )
+        out = fn(_sample_federated_responses())["aggregated_results"]
+        for result in out["results"]:
+            assert set(result.keys()) <= {
+                "content",
+                "score",
+                "metadata",
+                "node_agreement",
+            }
+        # The aggregation metadata exposes only counts / weights / node ids.
+        assert set(out["aggregation_metadata"].keys()) == {
+            "strategy",
+            "node_weights",
+            "participating_nodes",
+        }
+
+    def test_cross_silo_requester_own_silo_keeps_full_content(self):
+        """The requester's OWN silo content is NOT governed — it is their data.
+
+        This is the boundary's correct asymmetry: an organization sees its own
+        data in full; only OTHER organizations' data is restricted.
+        """
+        random.seed(0)
+        result = CrossSiloRAGNode(
+            silos=["org_a", "org_b"], data_sharing_agreement="minimal"
+        ).run(
+            query=f"analysis {self._SENTINEL}",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        own = next(
+            s
+            for s in result["silo_results"]
+            if s.get("silo") == "org_a" and s.get("participated")
+        )
+        assert own["access_level"] == "full"
+        # The own-silo result is not stamped with a governance marker.
+        assert own["results"][0].get("governance_applied") is None
+
+    def test_cross_silo_minimal_agreement_restricts_other_silo_content(self):
+        """Under 'minimal', a peer silo's content crosses only as a summary.
+
+        The OTHER silo's content is truncated and stamped with an explicit
+        "[Details restricted ...]" marker — the raw detail does not cross.
+        """
+        random.seed(0)
+        result = CrossSiloRAGNode(
+            silos=["org_a", "org_b"], data_sharing_agreement="minimal"
+        ).run(
+            query="analysis",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        other = next(
+            (
+                s
+                for s in result["silo_results"]
+                if s.get("silo") == "org_b" and s.get("participated")
+            ),
+            None,
+        )
+        # seed 0 — org_b participates; if a future seed change drops it, the
+        # next assertion's None-guard makes the skip explicit rather than silent.
+        assert other is not None, "expected org_b to participate at seed 0"
+        governed = other["results"][0]
+        assert governed["governance_applied"] == "minimal_sharing"
+        assert "[Details restricted" in governed["content"]
+
+    def test_cross_silo_standard_agreement_anonymizes_other_silo_content(self):
+        """Under 'standard', a peer silo's content is anonymized before it
+        crosses: the organization name and numeric / ALLCAPS identifiers in the
+        sentinel-bearing query are redacted out of the peer's result."""
+        random.seed(0)
+        result = CrossSiloRAGNode(
+            silos=["org_a", "org_b"], data_sharing_agreement="standard"
+        ).run(
+            query="PATIENT 12345 trend",
+            requester_org="org_a",
+            access_permissions=["read_aggregated", "read_anonymized"],
+        )
+        other = next(
+            (
+                s
+                for s in result["silo_results"]
+                if s.get("silo") == "org_b" and s.get("participated")
+            ),
+            None,
+        )
+        assert other is not None, "expected org_b to participate at seed 0"
+        governed = other["results"][0]
+        assert governed["governance_applied"] == "anonymized"
+        # The peer's own org name and the raw identifiers are redacted.
+        assert "org_b" not in governed["content"]
+        assert "12345" not in governed["content"]
+        assert "PATIENT" not in governed["content"]
+        assert "[Organization]" in governed["content"]

--- a/packages/kailash-kaizen/tests/integration/rag/test_federated_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_federated_nodes.py
@@ -444,11 +444,10 @@ class TestFederatedNoDataLeakBoundary:
         node = FederatedRAGNode()
         # The WorkflowNode wraps a sub-workflow whose entry codegen
         # (query_distributor) reads only ``query`` and ``node_endpoints``.
-        distributor_code = (
-            node._create_workflow()
-            .get_node("query_distributor")  # type: ignore[attr-defined]
-            .code
-        )
+        # _create_workflow is a private helper; @register_node type-erases the
+        # class to Node so the checker cannot see it.
+        workflow = node._create_workflow()  # type: ignore[attr-defined]
+        distributor_code = workflow.get_node("query_distributor").code
         assert "def distribute_query(query, node_endpoints, federation_config)" in (
             distributor_code
         )

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b5_federated_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b5_federated_defects.py
@@ -1,0 +1,333 @@
+"""Regression: latent ``kaizen.nodes.rag.federated`` crashes on malformed input.
+
+F8 shard B5 surfaced nine crash sites across the three federated RAG node
+classes via behavioral coverage — six in ``run()`` paths, three in the
+``FederatedRAGNode`` ``_create_workflow()`` codegen templates. Per the
+B1-B4 two-path lesson, both the ``run()`` paths and the ``code=`` codegen
+templates were grepped for each pattern and fixed in the same shard.
+
+Defect 1 — EdgeRAGNode.run() None-query crash.
+  ``run()`` did ``kwargs.get("query", "")`` then ``query.encode()`` for the
+  cache key. The ``""`` default applies ONLY to a MISSING key; an explicit
+  ``query=None`` returned ``None`` and ``.encode()`` raised AttributeError.
+  Fix: ``kwargs.get("query") or ""``.
+
+Defect 2 — EdgeRAGNode._edge_optimized_retrieval None-content crash.
+  ``doc.get("content", "").lower()`` — a present-but-None content bypassed
+  the "" default and ``.lower()`` raised AttributeError.
+  Fix: ``(doc.get("content") or "").lower()``.
+
+Defect 3 — EdgeRAGNode._edge_optimized_retrieval non-dict element crash.
+  The retrieval loop iterated ``local_data`` calling ``doc.get(...)``. A
+  non-dict element (local_data is arbitrary user input) raised AttributeError
+  ('str' object has no attribute 'get').
+  Fix: ``isinstance(doc, dict)`` skip.
+
+Defect 4 — EdgeRAGNode._generate_edge_response None-content slice crash.
+  The 'small'/'medium' model branches did
+  ``results[0]["document"].get("content", "")[:100]`` — a present-but-None
+  content bypassed the default and ``None[:100]`` raised TypeError.
+  Fix: ``(... .get("content") or "")[:N]``.
+
+Defect 5 — CrossSiloRAGNode.run() None-query crash.
+  ``run()`` did ``kwargs.get("query", "")`` then the audit trail hashed
+  ``query.encode()``. An explicit ``query=None`` raised AttributeError.
+  Fix: ``kwargs.get("query") or ""``.
+
+Defect 6 — CrossSiloRAGNode.run() None-access_permissions crash.
+  ``run()`` did ``kwargs.get("access_permissions", [])`` then
+  ``_validate_cross_silo_access`` did ``all(perm in permissions ...)``. An
+  explicit ``access_permissions=None`` raised TypeError ('NoneType' is not
+  iterable).
+  Fix: ``kwargs.get("access_permissions") or []``.
+
+Defect 7 — result_aggregator codegen None-content crash.
+  The aggregator's weighted_average grouping did ``result["content"][:50]``
+  as a dict key. A present-but-None content raised TypeError ('NoneType' is
+  not subscriptable).
+  Fix: coerce a None content to "" at the result-intake loop.
+
+Defect 8 — result_aggregator codegen non-dict result-element crash.
+  The aggregator's intake loop did ``result.copy()`` on every element of a
+  node's results list. A non-dict element (results are peer-supplied data)
+  raised AttributeError ('str' object has no attribute 'copy').
+  Fix: ``isinstance(result, dict)`` skip at the intake loop.
+
+Defect 9 — cache_coordinator codegen None-content crash.
+  ``hashlib.sha256(result["content"].encode())`` raised AttributeError on a
+  present-but-None content.
+  Fix: ``(result.get("content") or "").encode()``.
+
+Defects 1-6 are ``run()``-path defects; defects 7-9 are
+``_create_workflow()`` codegen-template defects.
+
+All tests are behavioral — they call ``run()`` or exec the real rendered
+codegen template against malformed input and assert success / typed outputs,
+not source-grep.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from datetime import datetime
+
+import pytest
+
+from kaizen.nodes.rag.federated import CrossSiloRAGNode, EdgeRAGNode, FederatedRAGNode
+
+pytestmark = pytest.mark.regression
+
+
+_EDGE_KEYS = {"results", "resource_usage", "sync_recommendations", "edge_metadata"}
+_CROSS_SILO_DENIED_KEY = "error"
+
+
+def _exec_codegen_fn(node_id, fn_name, extra_ns=None):
+    """exec a FederatedRAGNode codegen template and return its function.
+
+    The codegen functions build a local ``result`` dict but never ``return``
+    it; this helper appends ``return result`` so the function logic is
+    behaviorally observable. The code= string is read off the built workflow
+    via ``get_node(id).code`` — ``WorkflowBuilder.build()`` consumes the
+    ``code`` config kwarg into the PythonCodeNode's ``.code`` attribute.
+    """
+    workflow = FederatedRAGNode()._create_workflow()  # type: ignore[attr-defined]
+    code = workflow.get_node(node_id).code
+    namespace: dict = {
+        "datetime": datetime,
+        "hashlib": hashlib,
+        "random": random,
+    }
+    if extra_ns:
+        namespace.update(extra_ns)
+    exec(code + "\n    return result\n", namespace)
+    return namespace[fn_name]
+
+
+# --------------------------------------------------------------------------
+# Defect 1 — EdgeRAGNode.run() None query
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_edge_none_query_does_not_crash():
+    """Defect 1: ``query=None`` must not raise AttributeError.
+
+    Pre-fix ``query.encode()`` for the cache key raised 'NoneType' object has
+    no attribute 'encode' — the kwargs.get default applies only to MISSING
+    keys.
+    """
+    result = EdgeRAGNode().run(query=None, local_data=[{"content": "x"}])
+    assert set(result.keys()) == _EDGE_KEYS
+
+
+def test_issue_f8b5_edge_missing_query_kwarg_does_not_crash():
+    """Defect 1 sibling: an absent query kwarg defaults to '' cleanly."""
+    result = EdgeRAGNode().run(local_data=[{"content": "x"}])
+    assert set(result.keys()) == _EDGE_KEYS
+
+
+# --------------------------------------------------------------------------
+# Defect 2 — EdgeRAGNode._edge_optimized_retrieval None content
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_edge_none_content_does_not_crash():
+    """Defect 2: a present-but-None document content must not crash retrieval.
+
+    Pre-fix ``doc.get("content", "").lower()`` raised 'NoneType' object has no
+    attribute 'lower'.
+    """
+    result = EdgeRAGNode().run(query="q", local_data=[{"content": None}])
+    assert set(result.keys()) == _EDGE_KEYS
+
+
+# --------------------------------------------------------------------------
+# Defect 3 — EdgeRAGNode._edge_optimized_retrieval non-dict element
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_edge_non_dict_document_element_is_skipped():
+    """Defect 3: a non-dict local_data element must be skipped, not crashed on.
+
+    Pre-fix ``doc.get(...)`` raised 'str' object has no attribute 'get'.
+    local_data is arbitrary user input.
+    """
+    result = EdgeRAGNode().run(
+        query="valve", local_data=["bare-string", {"content": "valve log"}, 99]
+    )
+    assert result["edge_metadata"]["local_data_size"] == 3
+
+
+def test_issue_f8b5_edge_all_non_dict_documents_does_not_crash():
+    """Defect 3 edge: an all-non-dict local_data yields a zero-score result."""
+    result = EdgeRAGNode().run(query="q", local_data=[1, 2, 3])
+    assert result["results"][0]["score"] == 0
+
+
+# --------------------------------------------------------------------------
+# Defect 4 — EdgeRAGNode._generate_edge_response None-content slice
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_edge_small_model_none_content_does_not_crash():
+    """Defect 4: a present-but-None content must not crash the 'small' model's
+    ``[:100]`` content slice.
+
+    Pre-fix this raised TypeError ('NoneType' object is not subscriptable).
+    The retrieval scoring matches the second doc; the top result's document
+    has the None content the response builder then slices.
+    """
+    result = EdgeRAGNode(model_size="small").run(
+        query="sensor data",
+        local_data=[{"content": None}, {"content": "sensor data reading"}],
+    )
+    assert set(result.keys()) == _EDGE_KEYS
+
+
+def test_issue_f8b5_edge_medium_model_none_content_does_not_crash():
+    """Defect 4 sibling: the 'medium' model's ``[:200]`` slice list
+    comprehension must also survive a present-but-None content."""
+    result = EdgeRAGNode(model_size="medium").run(
+        query="sensor data",
+        local_data=[{"content": None}, {"content": "sensor data reading"}],
+    )
+    assert set(result.keys()) == _EDGE_KEYS
+
+
+# --------------------------------------------------------------------------
+# Defect 5 — CrossSiloRAGNode.run() None query
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_cross_silo_none_query_does_not_crash():
+    """Defect 5: ``query=None`` must not crash the audit-trail query.encode().
+
+    Pre-fix the audit hash ``hashlib.sha256(query.encode())`` raised
+    'NoneType' object has no attribute 'encode'.
+    """
+    result = CrossSiloRAGNode(silos=["org_a"]).run(
+        query=None,
+        requester_org="org_a",
+        access_permissions=["read_aggregated"],
+    )
+    # Access is granted (org_a in federation, adequate permissions) — the
+    # structured success result is returned, audit hash computed over "".
+    assert "silo_results" in result
+
+
+# --------------------------------------------------------------------------
+# Defect 6 — CrossSiloRAGNode.run() None access_permissions
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_cross_silo_none_access_permissions_does_not_crash():
+    """Defect 6: ``access_permissions=None`` must not crash ``perm in None``.
+
+    Pre-fix ``_validate_cross_silo_access`` did
+    ``all(perm in permissions for perm in required)`` — a None permissions
+    raised TypeError (argument of type 'NoneType' is not iterable).
+    """
+    result = CrossSiloRAGNode(silos=["org_a"]).run(
+        query="q", requester_org="org_a", access_permissions=None
+    )
+    # None coerces to [] — the required read_aggregated permission is absent,
+    # so access is correctly denied (not crashed).
+    assert result[_CROSS_SILO_DENIED_KEY] == "Access denied"
+    assert result["reason"] == "Insufficient permissions"
+
+
+def test_issue_f8b5_cross_silo_missing_access_permissions_kwarg_does_not_crash():
+    """Defect 6 sibling: an absent access_permissions kwarg defaults to []."""
+    result = CrossSiloRAGNode(silos=["org_a"]).run(query="q", requester_org="org_a")
+    assert result[_CROSS_SILO_DENIED_KEY] == "Access denied"
+
+
+# --------------------------------------------------------------------------
+# Defect 7 — result_aggregator codegen None content
+# --------------------------------------------------------------------------
+
+
+def _aggregator_responses(*, none_content=False, non_dict_result=False):
+    """Build a federated_responses dict for the result_aggregator codegen."""
+    h_a: list = [{"content": "protocol A", "score": 0.9}]
+    if none_content:
+        h_a = [{"content": None, "score": 0.9}]
+    if non_dict_result:
+        h_a = ["bare-string", {"content": "protocol A", "score": 0.9}]
+    return {
+        "query_id": "q1",
+        "node_responses": [
+            {
+                "node_id": "hospital_a",
+                "results": h_a,
+                "metadata": {
+                    "response_time": 1.0,
+                    "result_count": len(h_a),
+                    "cache_hit": False,
+                },
+            },
+            {
+                "node_id": "hospital_b",
+                "results": [{"content": "protocol B", "score": 0.8}],
+                "metadata": {
+                    "response_time": 1.5,
+                    "result_count": 1,
+                    "cache_hit": False,
+                },
+            },
+        ],
+        "failed_nodes": [],
+        "statistics": {
+            "total_nodes": 2,
+            "successful_nodes": 2,
+            "failed_nodes": 0,
+            "minimum_requirement_met": True,
+            "avg_response_time": 1.25,
+        },
+    }
+
+
+def test_issue_f8b5_aggregator_none_content_does_not_crash():
+    """Defect 7: a present-but-None content must not crash the [:50] key.
+
+    Pre-fix ``content_key = result["content"][:50]`` raised TypeError
+    ('NoneType' object is not subscriptable).
+    """
+    fn = _exec_codegen_fn("result_aggregator", "aggregate_federated_results")
+    out = fn(_aggregator_responses(none_content=True))
+    assert out["aggregated_results"]["total_raw_results"] == 2
+
+
+# --------------------------------------------------------------------------
+# Defect 8 — result_aggregator codegen non-dict result element
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_aggregator_non_dict_result_element_is_skipped():
+    """Defect 8: a non-dict element in a node's results list must be skipped.
+
+    Pre-fix ``result.copy()`` raised AttributeError ('str' object has no
+    attribute 'copy'). A node's results list is peer-supplied data.
+    """
+    fn = _exec_codegen_fn("result_aggregator", "aggregate_federated_results")
+    out = fn(_aggregator_responses(non_dict_result=True))
+    # The bare string is skipped; the two dict results aggregate cleanly.
+    assert out["aggregated_results"]["total_raw_results"] == 2
+
+
+# --------------------------------------------------------------------------
+# Defect 9 — cache_coordinator codegen None content
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_cache_coordinator_none_content_does_not_crash():
+    """Defect 9: a present-but-None content must not crash the content_hash.
+
+    Pre-fix ``hashlib.sha256(result["content"].encode())`` raised
+    AttributeError ('NoneType' object has no attribute 'encode').
+    """
+    fn = _exec_codegen_fn("cache_coordinator", "coordinate_caching")
+    aggregated = {"results": [{"content": None, "score": 0.95, "node_agreement": 0.9}]}
+    out = fn(aggregated, {"query_id": "q1"})
+    assert out["cache_coordination"]["candidates_identified"] == 1

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b5_federated_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b5_federated_defects.py
@@ -372,3 +372,54 @@ def test_issue_f8b5_compliance_report_reflects_real_request_not_hardcoded():
     assert report_a["permissions_granted"] == ["read_aggregated"]
     # The two reports are NOT byte-identical (the pre-fix hardcoded dict was).
     assert report_a != report_b
+
+
+# --------------------------------------------------------------------------
+# Defect 11 — _apply_governance shallow-copied, mutating the input record
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_apply_governance_does_not_mutate_input_record():
+    """Defect 11: _apply_governance must not mutate its silo_results input.
+
+    Pre-fix ``governed_silo_result = silo_result.copy()`` was a SHALLOW copy:
+    the nested ``results`` list stayed shared between the pre-governance
+    record and the governed copy, so the in-place ``result["content"] =
+    self._minimize_content(...)`` mutation silently governed the input too.
+    The pre-governance ``silo_results`` is meant to be a true raw record
+    (read by ``_generate_audit_trail`` as the "what each silo actually
+    returned" side of the data-flow); a shared reference made it a lie.
+
+    Post-fix the governed copy rebuilds ``results`` with independent
+    per-result dicts, so the input record stays raw and un-marked.
+    """
+    node = CrossSiloRAGNode(silos=["org_a", "org_b"], data_sharing_agreement="minimal")
+    raw_content = "Detailed raw data from org_b: confidential protocol specifics"
+    silo_results = [
+        {
+            "silo": "org_b",
+            "participated": True,
+            "access_level": "minimal",
+            "results": [{"content": raw_content, "score": 0.7}],
+        }
+    ]
+    # _apply_governance is a private helper; @register_node type-erases the
+    # class to Node so the checker cannot see it.
+    governed = node._apply_governance(  # type: ignore[attr-defined]
+        silo_results, "org_a", "minimal"
+    )
+
+    # The input record is untouched — raw content preserved, no marker.
+    input_result = silo_results[0]["results"][0]
+    assert input_result["content"] == raw_content
+    assert "governance_applied" not in input_result
+
+    # The governed output IS restricted and carries the governance marker.
+    governed_result = governed[0]["results"][0]
+    assert governed_result["content"] != raw_content
+    assert "[Details restricted" in governed_result["content"]
+    assert governed_result["governance_applied"] == "minimal_sharing"
+
+    # The two results lists are independent objects, not a shared reference.
+    assert silo_results[0]["results"] is not governed[0]["results"]
+    assert input_result is not governed_result

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b5_federated_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b5_federated_defects.py
@@ -331,3 +331,44 @@ def test_issue_f8b5_cache_coordinator_none_content_does_not_crash():
     aggregated = {"results": [{"content": None, "score": 0.95, "node_agreement": 0.9}]}
     out = fn(aggregated, {"query_id": "q1"})
     assert out["cache_coordination"]["candidates_identified"] == 1
+
+
+# --------------------------------------------------------------------------
+# Defect 10 — CrossSiloRAGNode._generate_compliance_report ignored its inputs
+# --------------------------------------------------------------------------
+
+
+def test_issue_f8b5_compliance_report_reflects_real_request_not_hardcoded():
+    """Defect 10: the compliance report must reflect the actual request.
+
+    Pre-fix ``_generate_compliance_report`` returned a fixed
+    ``{"compliance_status": "compliant", ...}`` dict regardless of the
+    requester, the granted permissions, or the governed results — a
+    zero-tolerance Rule 2 fake-data smell (a compliance verdict that ignores
+    its inputs). Post-fix the report echoes the real requester / permissions
+    and the verdict is derived from per-peer governance state.
+
+    Two distinct requests must produce distinguishable reports — a hardcoded
+    report would be byte-identical.
+    """
+    random.seed(0)
+    r_a = CrossSiloRAGNode(silos=["org_a", "org_b"]).run(
+        query="trend",
+        requester_org="org_a",
+        access_permissions=["read_aggregated"],
+    )
+    random.seed(0)
+    r_b = CrossSiloRAGNode(silos=["org_a", "org_b"]).run(
+        query="trend",
+        requester_org="org_b",
+        access_permissions=["read_aggregated"],
+    )
+    report_a = r_a["compliance_report"]
+    report_b = r_b["compliance_report"]
+    # The report carries the real requester — a hardcoded report could not.
+    assert report_a["requester"] == "org_a"
+    assert report_b["requester"] == "org_b"
+    # The granted permissions are echoed from the real input.
+    assert report_a["permissions_granted"] == ["read_aggregated"]
+    # The two reports are NOT byte-identical (the pre-fix hardcoded dict was).
+    assert report_a != report_b

--- a/packages/kailash-kaizen/tests/unit/rag/test_federated_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_federated_nodes.py
@@ -1,0 +1,365 @@
+"""Tier-1 unit coverage for the 3 ``kaizen.nodes.rag.federated`` nodes.
+
+F8 shard B5. The value-anchor (verbatim from the workstream brief): "the RAG
+capability the user chose to preserve is provably correct, not merely
+importable" — and for federated RAG specifically the **no-data-leak claim**:
+the nodes advertise that raw documents stay local and only aggregates cross
+the boundary.
+
+``EdgeRAGNode`` and ``CrossSiloRAGNode`` are ``kailash.nodes.base.Node``
+subclasses with a direct ``run()``. Their default code path is deterministic
+simulated compute — ``federated.py`` marks the federated executor explicitly
+as "simulated - would use actual network calls". There is NO LLM key and NO
+network call on the shipped default path; ``run()`` computes its result with
+deterministic keyword / governance logic. These tests exercise that real path:
+no mocking of the aggregation / governance core (there is nothing to mock).
+
+``FederatedRAGNode`` is a ``WorkflowNode``; its ``run()`` executes a
+sub-workflow built by ``_create_workflow()``. Tier-1 covers its construction
+and the graph SHAPE (node count, parameter contract, conditional cache node);
+the ``code=`` PythonCodeNode templates are exercised directly in the Tier-2a
+file.
+
+One test per documented behavior; assertions are structural (output keys,
+score ranges/ordering, list lengths, typed raises).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.nodes.rag.federated import CrossSiloRAGNode, EdgeRAGNode, FederatedRAGNode
+
+pytestmark = pytest.mark.unit
+
+
+# ==========================================================================
+# EdgeRAGNode
+# ==========================================================================
+
+# The top-level keys EdgeRAGNode.run() always returns.
+_EDGE_KEYS = {"results", "resource_usage", "sync_recommendations", "edge_metadata"}
+
+
+class TestEdgeRAGNode:
+    """run() golden path + documented edge cases for EdgeRAGNode."""
+
+    def test_get_parameters_declares_query_and_local_data_required(self):
+        """query and local_data are the two required run-time inputs."""
+        params = EdgeRAGNode().get_parameters()
+        assert params["query"].required is True
+        assert params["local_data"].required is True
+        assert params["sync_with_cloud"].required is False
+
+    def test_run_golden_path_returns_documented_keys(self):
+        """run() returns the four documented top-level keys."""
+        result = EdgeRAGNode().run(
+            query="sensor anomaly",
+            local_data=[{"content": "sensor anomaly detected near valve"}],
+        )
+        assert set(result.keys()) == _EDGE_KEYS
+        assert result["edge_metadata"]["local_data_size"] == 1
+
+    def test_run_keyword_match_scores_relevant_document(self):
+        """A document sharing query words scores above zero and is retrieved."""
+        result = EdgeRAGNode(model_size="tiny").run(
+            query="valve pressure",
+            local_data=[
+                {"content": "valve pressure exceeded threshold"},
+                {"content": "completely unrelated text"},
+            ],
+        )
+        # tiny model reports the count of matched results in the answer text.
+        assert "Found 1 relevant results" in result["results"][0]["content"]
+        assert result["results"][0]["score"] > 0
+
+    def test_run_small_model_summarizes_top_document(self):
+        """The 'small' model echoes the top document's content in the answer."""
+        result = EdgeRAGNode(model_size="small").run(
+            query="valve pressure",
+            local_data=[{"content": "valve pressure exceeded threshold"}],
+        )
+        assert "Based on local data" in result["results"][0]["content"]
+
+    def test_run_no_matching_documents_returns_zero_score(self):
+        """A query matching no document yields a zero-score fallback result."""
+        result = EdgeRAGNode().run(
+            query="quantum tunnelling",
+            local_data=[{"content": "valve pressure log"}],
+        )
+        assert result["results"][0]["score"] == 0
+
+    def test_run_empty_local_data_returns_zero_score_result(self):
+        """An empty corpus yields exactly one zero-score fallback result."""
+        result = EdgeRAGNode().run(query="anything", local_data=[])
+        assert len(result["results"]) == 1
+        assert result["results"][0]["score"] == 0
+
+    def test_run_caches_result_and_returns_it_on_repeat_query(self):
+        """A repeated identical query returns the cached result object."""
+        node = EdgeRAGNode()
+        first = node.run(query="q", local_data=[{"content": "q match"}])
+        second = node.run(query="q", local_data=[{"content": "different text"}])
+        # The second call is a cache hit — same object, local_data ignored.
+        assert first is second
+
+    def test_run_performance_power_mode_bypasses_cache(self):
+        """power_mode='performance' skips the cache read on every call."""
+        node = EdgeRAGNode(power_mode="performance")
+        first = node.run(query="q", local_data=[{"content": "q"}])
+        second = node.run(query="q", local_data=[{"content": "q"}])
+        assert first is not second
+
+    def test_run_small_local_corpus_recommends_cloud_sync(self):
+        """Fewer than 10 local documents triggers a high-priority sync rec."""
+        result = EdgeRAGNode().run(query="q", local_data=[{"content": "q"}])
+        rec = result["sync_recommendations"]
+        assert rec["should_sync"] is True
+        assert rec["sync_priority"] == "high"
+        assert "Insufficient local data" in rec["reasons"]
+
+    # ---- documented edge cases ------------------------------------------
+
+    def test_run_missing_query_kwarg_defaults_cleanly(self):
+        """An absent query kwarg defaults to '' without crashing."""
+        result = EdgeRAGNode().run(local_data=[{"content": "x"}])
+        assert set(result.keys()) == _EDGE_KEYS
+
+    def test_run_missing_local_data_kwarg_defaults_to_empty(self):
+        """An absent local_data kwarg defaults to [] without crashing."""
+        result = EdgeRAGNode().run(query="anything")
+        assert result["edge_metadata"]["local_data_size"] == 0
+
+    def test_run_none_query_does_not_crash(self):
+        """An explicit query=None must not crash query.encode() / .lower()."""
+        result = EdgeRAGNode().run(query=None, local_data=[{"content": "x"}])
+        assert set(result.keys()) == _EDGE_KEYS
+
+    def test_run_none_content_document_does_not_crash(self):
+        """A document with content present-but-None must not crash retrieval."""
+        result = EdgeRAGNode().run(query="q", local_data=[{"content": None}])
+        assert set(result.keys()) == _EDGE_KEYS
+
+    def test_run_non_dict_document_element_is_skipped(self):
+        """A non-dict local_data element is skipped, not crashed on."""
+        result = EdgeRAGNode().run(
+            query="valve", local_data=["bare-string", {"content": "valve log"}]
+        )
+        assert result["edge_metadata"]["local_data_size"] == 2
+
+    def test_run_unicode_query_is_handled(self):
+        """A unicode query is handled by the keyword-matching path."""
+        result = EdgeRAGNode().run(
+            query="温度センサー", local_data=[{"content": "温度センサー alarm"}]
+        )
+        assert set(result.keys()) == _EDGE_KEYS
+
+
+# ==========================================================================
+# CrossSiloRAGNode
+# ==========================================================================
+
+# The top-level keys CrossSiloRAGNode.run() returns on the access-granted path.
+_CROSS_SILO_KEYS = {
+    "silo_results",
+    "audit_trail",
+    "compliance_report",
+    "federation_metadata",
+}
+
+
+class TestCrossSiloRAGNode:
+    """run() golden path + access-control + governance edge cases."""
+
+    def test_get_parameters_declares_required_inputs(self):
+        """query, requester_org and access_permissions are required."""
+        params = CrossSiloRAGNode().get_parameters()
+        assert params["query"].required is True
+        assert params["requester_org"].required is True
+        assert params["access_permissions"].required is True
+        assert params["purpose"].required is False
+
+    def test_run_granted_access_returns_documented_keys(self):
+        """An in-federation requester with adequate permissions gets results."""
+        result = CrossSiloRAGNode(silos=["org_a", "org_b"]).run(
+            query="industry trend analysis",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        assert set(result.keys()) == _CROSS_SILO_KEYS
+        assert result["federation_metadata"]["governance_applied"] is True
+
+    def test_run_non_federation_requester_is_denied(self):
+        """A requester outside the silo set is denied with a typed reason."""
+        result = CrossSiloRAGNode(silos=["org_a"]).run(
+            query="q",
+            requester_org="outsider",
+            access_permissions=["read_aggregated"],
+        )
+        assert result["error"] == "Access denied"
+        assert result["reason"] == "Organization not part of federation"
+
+    def test_run_insufficient_permissions_is_denied(self):
+        """A 'standard' agreement needs read_anonymized; absent → denied."""
+        result = CrossSiloRAGNode(
+            silos=["org_a"], data_sharing_agreement="standard"
+        ).run(
+            query="q",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        assert result["error"] == "Access denied"
+        assert result["reason"] == "Insufficient permissions"
+
+    def test_run_disallowed_purpose_is_denied(self):
+        """A purpose outside the governance allow-list is denied."""
+        result = CrossSiloRAGNode(silos=["org_a"]).run(
+            query="q",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+            purpose="exfiltration",
+        )
+        assert result["error"] == "Access denied"
+        assert "not allowed" in result["reason"]
+
+    def test_run_minimal_audit_mode_omits_full_trail(self):
+        """audit_mode='minimal' returns the deferred-audit sentinel string."""
+        result = CrossSiloRAGNode(silos=["org_a"], audit_mode="minimal").run(
+            query="q",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        assert result["audit_trail"] == "Audit available on request"
+
+    def test_run_standard_audit_mode_returns_structured_trail(self):
+        """The default audit mode returns a structured audit-trail dict."""
+        result = CrossSiloRAGNode(silos=["org_a"]).run(
+            query="q",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        audit = result["audit_trail"]
+        assert isinstance(audit, dict)
+        assert set(audit.keys()) >= {
+            "timestamp",
+            "query_hash",
+            "requester",
+            "federation_activity",
+            "data_flow",
+        }
+
+    # ---- documented edge cases ------------------------------------------
+
+    def test_run_missing_access_permissions_kwarg_denies_cleanly(self):
+        """An absent access_permissions kwarg defaults to [] → denied."""
+        result = CrossSiloRAGNode(silos=["org_a"]).run(query="q", requester_org="org_a")
+        assert result["error"] == "Access denied"
+
+    def test_run_none_access_permissions_denies_cleanly(self):
+        """An explicit access_permissions=None must not crash `perm in None`."""
+        result = CrossSiloRAGNode(silos=["org_a"]).run(
+            query="q", requester_org="org_a", access_permissions=None
+        )
+        assert result["error"] == "Access denied"
+
+    def test_run_none_query_does_not_crash_audit_hash(self):
+        """An explicit query=None must not crash the audit-trail query.encode()."""
+        result = CrossSiloRAGNode(silos=["org_a"]).run(
+            query=None,
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        assert set(result.keys()) == _CROSS_SILO_KEYS
+
+    def test_run_empty_silos_yields_no_participating_silos(self):
+        """An empty silo set denies the requester (not in federation)."""
+        result = CrossSiloRAGNode(silos=[]).run(
+            query="q",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        assert result["error"] == "Access denied"
+
+    def test_run_unicode_query_is_handled(self):
+        """A unicode query flows through the access + governance path."""
+        result = CrossSiloRAGNode(silos=["org_a"]).run(
+            query="産業動向の分析",
+            requester_org="org_a",
+            access_permissions=["read_aggregated"],
+        )
+        assert set(result.keys()) == _CROSS_SILO_KEYS
+
+
+# ==========================================================================
+# FederatedRAGNode — WorkflowNode construction + graph shape
+# ==========================================================================
+
+
+class TestFederatedRAGNode:
+    """Construction + the shape of the workflow ``_create_workflow()`` builds.
+
+    FederatedRAGNode is a WorkflowNode; the codegen ``code=`` templates are
+    exercised behaviorally in the Tier-2a integration file. Tier-1 covers the
+    construction contract and the conditional graph shape.
+    """
+
+    def test_constructs_with_defaults(self):
+        """The node constructs with documented default configuration."""
+        node = FederatedRAGNode()
+        assert node.aggregation_strategy == "weighted_average"
+        assert node.min_participating_nodes == 2
+        assert node.federation_nodes == []
+        assert node.enable_caching is True
+
+    def test_constructor_config_overrides_apply(self):
+        """Constructor kwargs override the federation configuration."""
+        node = FederatedRAGNode(
+            federation_nodes=["hospital_a", "hospital_b", "research_lab"],
+            aggregation_strategy="voting",
+            min_participating_nodes=3,
+            enable_caching=False,
+        )
+        assert node.federation_nodes == ["hospital_a", "hospital_b", "research_lab"]
+        assert node.aggregation_strategy == "voting"
+        assert node.min_participating_nodes == 3
+        assert node.enable_caching is False
+
+    def test_workflow_has_five_nodes_when_caching_enabled(self):
+        """With caching on, the workflow has the cache_coordinator node."""
+        # _create_workflow is a private helper; type-erased by @register_node.
+        workflow = FederatedRAGNode()._create_workflow()  # type: ignore[attr-defined]
+        assert set(workflow.nodes) == {
+            "query_distributor",
+            "federated_executor",
+            "result_aggregator",
+            "cache_coordinator",
+            "result_formatter",
+        }
+
+    def test_workflow_omits_cache_coordinator_when_caching_disabled(self):
+        """With caching off, the cache_coordinator node is not built."""
+        workflow = FederatedRAGNode(
+            enable_caching=False
+        )._create_workflow()  # type: ignore[attr-defined]
+        assert set(workflow.nodes) == {
+            "query_distributor",
+            "federated_executor",
+            "result_aggregator",
+            "result_formatter",
+        }
+
+    def test_min_participating_nodes_interpolated_into_executor_codegen(self):
+        """min_participating_nodes is interpolated into the executor template."""
+        workflow = FederatedRAGNode(
+            min_participating_nodes=4
+        )._create_workflow()  # type: ignore[attr-defined]
+        code = workflow.get_node("federated_executor").code
+        assert "successful_nodes >= 4" in code
+
+    def test_aggregation_strategy_interpolated_into_aggregator_codegen(self):
+        """aggregation_strategy is interpolated into the aggregator template."""
+        workflow = FederatedRAGNode(
+            aggregation_strategy="voting"
+        )._create_workflow()  # type: ignore[attr-defined]
+        code = workflow.get_node("result_aggregator").code
+        assert '"voting" == "voting"' in code

--- a/packages/kailash-kaizen/tests/unit/rag/test_federated_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_federated_nodes.py
@@ -304,12 +304,17 @@ class TestFederatedRAGNode:
     """
 
     def test_constructs_with_defaults(self):
-        """The node constructs with documented default configuration."""
+        """The node constructs with documented default configuration.
+
+        Instance attrs are accessed directly; the @register_node decorator
+        type-erases the class to Node so the checker cannot see them —
+        ``# type: ignore[attr-defined]`` per the established rag-test pattern.
+        """
         node = FederatedRAGNode()
-        assert node.aggregation_strategy == "weighted_average"
-        assert node.min_participating_nodes == 2
-        assert node.federation_nodes == []
-        assert node.enable_caching is True
+        assert node.aggregation_strategy == "weighted_average"  # type: ignore[attr-defined]
+        assert node.min_participating_nodes == 2  # type: ignore[attr-defined]
+        assert node.federation_nodes == []  # type: ignore[attr-defined]
+        assert node.enable_caching is True  # type: ignore[attr-defined]
 
     def test_constructor_config_overrides_apply(self):
         """Constructor kwargs override the federation configuration."""
@@ -319,10 +324,10 @@ class TestFederatedRAGNode:
             min_participating_nodes=3,
             enable_caching=False,
         )
-        assert node.federation_nodes == ["hospital_a", "hospital_b", "research_lab"]
-        assert node.aggregation_strategy == "voting"
-        assert node.min_participating_nodes == 3
-        assert node.enable_caching is False
+        assert node.federation_nodes == ["hospital_a", "hospital_b", "research_lab"]  # type: ignore[attr-defined]
+        assert node.aggregation_strategy == "voting"  # type: ignore[attr-defined]
+        assert node.min_participating_nodes == 3  # type: ignore[attr-defined]
+        assert node.enable_caching is False  # type: ignore[attr-defined]
 
     def test_workflow_has_five_nodes_when_caching_enabled(self):
         """With caching on, the workflow has the cache_coordinator node."""

--- a/specs/kaizen-rag.md
+++ b/specs/kaizen-rag.md
@@ -452,3 +452,132 @@ against a query on a deterministic rule-based scoring path.
   end-to-end, which the `[rag]` extra does not carry; the `PythonCodeNode`
   `code` templates are deterministic and exercised directly in the
   integration tests.
+
+## Federated RAG
+
+`kaizen/nodes/rag/federated.py` defines three nodes for retrieval across
+distributed data sources without centralization: `EdgeRAGNode`,
+`CrossSiloRAGNode`, and `FederatedRAGNode`. `EdgeRAGNode` and
+`CrossSiloRAGNode` are `kailash.nodes.base.Node` subclasses with a direct
+`run()`; `FederatedRAGNode` is a `kailash.nodes.logic.workflow.WorkflowNode`.
+None of the three requires an LLM key or a network call on its shipped default
+path — `federated.py` marks the federated executor explicitly as "simulated -
+would use actual network calls". The federated aggregation, the cross-silo
+governance, and the edge retrieval are all deterministic compute, and that
+deterministic path IS the shipped default.
+
+### `EdgeRAGNode`
+
+Resource-constrained RAG over a local document corpus. `get_parameters()`
+declares `query` (str, required) and `local_data` (list, required), plus
+`sync_with_cloud` (bool, optional) and the constructor profile parameters
+(`model_size`, `max_cache_size_mb`, `update_strategy`, `power_mode`).
+
+`run()` returns a dict with four keys: `results`, `resource_usage`,
+`sync_recommendations`, and `edge_metadata`. `_edge_optimized_retrieval`
+keyword-matches the query words against each document's `content` and returns
+the top five scored documents; `_generate_edge_response` builds an answer
+whose detail scales with `model_size` (`tiny` reports a match count, `small`
+echoes the top document, `medium` joins the top two). A repeated identical
+query returns the cached result object unless `power_mode` is `"performance"`,
+which bypasses the cache. `sync_recommendations` flags `should_sync` when the
+local corpus has fewer than ten documents, when the cache nears capacity, or
+when `sync_with_cloud` was requested.
+
+`local_data` is arbitrary user input: a non-dict element is skipped, and a
+present-but-`None` `content` is coerced to an empty string in both
+`_edge_optimized_retrieval` and the `_generate_edge_response` content slices.
+A `None` or missing `query` is coerced to an empty string before the cache-key
+`hashlib.sha256(...).encode()`.
+
+### `CrossSiloRAGNode`
+
+RAG across organizational silos with data-governance enforcement.
+`get_parameters()` declares `query`, `requester_org`, and `access_permissions`
+(all required), plus `purpose` (optional) and the constructor parameters
+(`silos`, `data_sharing_agreement`, `audit_mode`, `governance_rules`).
+
+`run()` first calls `_validate_cross_silo_access`: the requester must be a
+member of `silos`, must hold the permissions the `data_sharing_agreement` tier
+requires (`minimal` → `read_aggregated`; `standard` adds `read_anonymized`;
+`full` adds `read_samples`), and must state a `purpose` in the governance
+allow-list. A failed check returns `{"error": "Access denied", "reason": ...,
+"required_permissions": ...}`. On the granted path `run()` returns
+`silo_results`, `audit_trail`, `compliance_report`, and `federation_metadata`.
+
+`_execute_cross_silo_query` produces a per-silo result. `_apply_governance` is
+the cross-organization data boundary: the requester's OWN silo keeps `full`
+content; for every OTHER silo, a `minimal` agreement calls `_minimize_content`
+(truncates to the first twenty words and appends "[Details restricted by data
+sharing agreement]") and a `standard` agreement calls `_anonymize_content`
+(replaces each silo name with `[Organization]` and redacts numeric and
+all-caps identifiers). The governed result carries a `governance_applied`
+marker (`"minimal_sharing"` or `"anonymized"`); the requester's own result
+carries none. `audit_mode="minimal"` returns the string "Audit available on
+request" in place of the structured `audit_trail` dict.
+
+A `None` or missing `query` is coerced to an empty string before the
+audit-trail `query.encode()` hash; a `None` or missing `access_permissions` is
+coerced to an empty list before the membership check.
+
+### `FederatedRAGNode`
+
+Federated RAG as a `WorkflowNode`. The constructor accepts `federation_nodes`,
+`aggregation_strategy` (`"weighted_average"`, `"voting"`, or simple merge),
+`min_participating_nodes`, `timeout_per_node`, and `enable_caching`; the values
+are stored as instance attributes and interpolated into the generated
+workflow. `run()` is inherited from `WorkflowNode` and executes the sub-workflow
+built by `_create_workflow()`.
+
+`_create_workflow()` returns a `kailash.workflow.Workflow` built by
+`WorkflowBuilder`. With `enable_caching=True` the workflow has five
+`PythonCodeNode` steps — `query_distributor`, `federated_executor`,
+`result_aggregator`, `cache_coordinator`, and `result_formatter`; with
+`enable_caching=False` the `cache_coordinator` node is omitted.
+`min_participating_nodes` is interpolated into the `federated_executor`
+template's quorum check and `aggregation_strategy` into the `result_aggregator`
+template's strategy branch.
+
+Each step carries a `code` template (read off a built workflow node via
+`workflow.get_node(node_id).code`). `query_distributor` builds one
+target-node entry per endpoint. `federated_executor` is the simulated
+federated path — it generates a per-node response with deterministic
+`random`-seeded content and a quorum statistic. `result_aggregator` combines
+the per-node results under the configured strategy; its result-intake loop
+skips a non-dict peer result and coerces a present-but-`None` `content` to an
+empty string before the grouping key, so every downstream strategy sees only
+well-formed dicts. `cache_coordinator` selects high-score, high-agreement
+results and coerces a `None` `content` to an empty string before the
+`content_hash`. `result_formatter` builds the final `federated_rag_output`.
+
+### What crosses the federated boundary
+
+The federated RAG nodes advertise data locality — `FederatedRAGNode`'s
+docstring states "Data never leaves source organizations" and
+`CrossSiloRAGNode`'s states "strict data governance". The shipped contract,
+precisely:
+
+- `FederatedRAGNode` has no document-corpus input. Its workflow entry point
+  (`query_distributor`, `def distribute_query(query, node_endpoints,
+  federation_config)`) reads only a query and per-node endpoints — there is no
+  raw local document for the node to leak. The aggregate produced by
+  `result_aggregator` carries per-result `content`, `score`, and `metadata`
+  (source-node ids, weights, agreement) plus an `aggregation_metadata` block of
+  `strategy`, `node_weights`, and `participating_nodes` — counts and scores,
+  not a caller-supplied raw corpus.
+- `CrossSiloRAGNode` is the real cross-organization boundary. The requester's
+  own silo returns full content (its own data); every other silo's content is
+  governed before it crosses — truncated and stamped under `minimal`,
+  anonymized under `standard`.
+- `EdgeRAGNode` is local-only by construction: there is no federated boundary,
+  and its output legitimately contains the local document text because nothing
+  is shared with any peer.
+
+### Codegen-template runtime boundary
+
+The `FederatedRAGNode` `_create_workflow()` codegen functions build a local
+`result` dict as their final statement but do not `return` it; the integration
+tests exercise each template by exec-ing the rendered function with an appended
+`return result`. End-to-end runtime execution of the assembled sub-workflow is
+not covered by the `[rag]` extra alone — the `PythonCodeNode` `code` templates
+are deterministic and are covered directly.


### PR DESCRIPTION
## Summary

Shard **B5** of workstream F8 (`kaizen.nodes.rag` resurrection) — behavioral
coverage of the `federated` module (FederatedRAG; the no-data-leak claim).

- **70 new behavioral tests** — Tier-1 unit + Tier-2a integration (real
  compute / loopback HTTP, **no mocking**) + regression — across
  `EdgeRAGNode`, `CrossSiloRAGNode`, `FederatedRAGNode`.
- **No-data-leak verification** — `CrossSiloRAGNode` is the real cross-org
  boundary; sentinel-string tests confirm the requester's own silo keeps full
  content while every peer silo is governed before crossing (`minimal`
  truncates + restricts, `standard` anonymizes). `FederatedRAGNode` has no
  document-corpus input — only query+endpoints cross. `EdgeRAGNode` is
  local-only. The aggregate does NOT leak raw per-node documents.
- **10 latent defects found & fixed** (both `run()` and `code=` codegen
  templates checked):
  - 9 `content: None` / non-dict / `None`-input crash-class defects across
    `EdgeRAGNode.run()`, `CrossSiloRAGNode.run()`, and 2 codegen templates.
  - **`_generate_compliance_report` was a `zero-tolerance` Rule 2 fake-data
    violation** — it returned a hardcoded `{"compliance_status": "compliant"}`
    ignoring requester/permissions/results. Replaced with real logic deriving
    compliance from per-peer governance state (can now return
    `non_compliant`); `_generate_audit_trail` now records the actual
    governed results, not a fragile shared reference.
  - Regression: `test_issue_f8b5_federated_defects.py`.
- **Pyright** — `federated.py` + new test files 0 errors / 0 warnings / 0
  informations (type fixes, unused-import + dead-param cleanup;
  `RESTClientNode`/`PythonCodeNode` retained as `# noqa: F401` registration
  imports).
- **Spec** — appended `## Federated RAG` to `specs/kaizen-rag.md`.

## Test plan

- [x] 70 B5 tests pass; full rag suite green
- [x] Tier-2a real compute / loopback HTTP, zero `@patch`/`MagicMock`
- [x] `pre-commit run --files` clean; Pyright 0/0/0 on `federated.py` + new tests

## Related issues

Part of F8 (`kaizen.nodes.rag` behavioral coverage). No standalone issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)