### PR TITLE
test(rag): F8 B6 — advanced RAG node coverage + A-S2 hybrid-workflow implementation

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
@@ -22,12 +22,26 @@ from kailash.workflow.builder import WorkflowBuilder
 
 from ..ai.llm_agent import LLMAgentNode
 
+# Side-effect import: registers DenseRetrievalNode / SparseRetrievalNode with
+# the Kailash NodeRegistry. create_hybrid_rag_workflow() looks these up by
+# string name at WorkflowBuilder.build() time, so the registration MUST have
+# run first regardless of rag-package import order.
+from . import similarity as _similarity  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 
-# Simple RAGConfig fallback to avoid circular import
+# Local RAGConfig to avoid a circular import with rag.strategies (which imports
+# nothing from this module, but advanced.py is imported very early in
+# rag/__init__.py). The field set is the subset the advanced nodes consume.
 class RAGConfig:
-    """Simple RAG configuration"""
+    """RAG configuration for the advanced techniques in this module.
+
+    ``retrieval_k`` is the only field that influences the hybrid workflow
+    built by :func:`create_hybrid_rag_workflow` (it caps the fused result
+    count); the remaining fields are carried for callers that pass a richer
+    config dict and inspect it downstream.
+    """
 
     def __init__(self, **kwargs):
         self.chunk_size = kwargs.get("chunk_size", 1000)
@@ -36,13 +50,162 @@ class RAGConfig:
         self.retrieval_k = kwargs.get("retrieval_k", 5)
 
 
-def create_hybrid_rag_workflow(config):
-    """Simple fallback workflow creator"""
-    # In a real implementation, this would create a proper workflow
-    # For now, return a simple mock workflow
-    from ...workflow.graph import Workflow
+def create_hybrid_rag_workflow(config: RAGConfig) -> WorkflowNode:
+    """Build a genuine hybrid-RAG retrieval workflow.
 
-    return Workflow(name="hybrid_rag_fallback", nodes=[], connections=[])
+    Hybrid RAG = dense (embedding-similarity) retrieval combined with sparse
+    (keyword / BM25-style) retrieval, fused with Reciprocal Rank Fusion (RRF).
+    This is the shared base workflow consumed by every advanced RAG node in
+    this module (``SelfCorrectingRAGNode``, ``RAGFusionNode``, ``HyDENode``,
+    ``StepBackRAGNode``) via ``self.base_rag_workflow.run(documents=...,
+    query=..., operation="retrieve")``.
+
+    Graph shape (4 nodes)::
+
+        source ──documents/query──┬──> dense  ──results──┐
+                                  └──> sparse ──results──┴──> fuse
+
+    - ``source`` (``PythonCodeNode``) — entry node; receives ``documents`` and
+      ``query`` via the WorkflowNode ``input_mapping`` and fans them out.
+    - ``dense`` (``DenseRetrievalNode``) — embedding-similarity retrieval; with
+      no LLM key configured it runs its deterministic keyword-overlap fallback.
+    - ``sparse`` (``SparseRetrievalNode``) — keyword / term-frequency retrieval.
+    - ``fuse`` (``PythonCodeNode``) — Reciprocal Rank Fusion over the dense and
+      sparse result lists; emits ``results`` / ``scores`` / ``metadata``.
+
+    The returned :class:`WorkflowNode` exposes the consumed contract: a
+    ``.run(documents=..., query=..., operation="retrieve")`` call returns a
+    dict with top-level ``results`` (fused document list), ``scores`` (fused
+    RRF scores), and ``metadata`` keys.
+
+    Args:
+        config: RAG configuration. ``config.retrieval_k`` caps the fused
+            result count.
+
+    Returns:
+        A ``WorkflowNode`` wrapping the hybrid dense+sparse+fusion workflow.
+    """
+    retrieval_k = int(getattr(config, "retrieval_k", 5) or 5)
+
+    builder = WorkflowBuilder()
+
+    # Entry node: holds documents + query, fans them out to both retrievers.
+    source_id = builder.add_node(
+        "PythonCodeNode",
+        node_id="source",
+        config={"code": 'result = {"documents": documents, "query": query}'},
+    )
+
+    # Dense retrieval (embedding similarity; deterministic fallback when no key).
+    dense_id = builder.add_node(
+        "DenseRetrievalNode",
+        node_id="dense",
+        config={},
+    )
+
+    # Sparse retrieval (keyword / term-frequency).
+    sparse_id = builder.add_node(
+        "SparseRetrievalNode",
+        node_id="sparse",
+        config={},
+    )
+
+    # Reciprocal Rank Fusion of the dense and sparse result lists.
+    fuse_id = builder.add_node(
+        "PythonCodeNode",
+        node_id="fuse",
+        config={
+            "code": f"""
+def _reciprocal_rank_fusion(doc_lists, k=60, top_k={retrieval_k}):
+    fused_scores = {{}}
+    doc_info = {{}}
+    for documents in doc_lists:
+        for rank, doc in enumerate(documents or []):
+            if not isinstance(doc, dict):
+                continue
+            doc_id = doc.get("id") or str(hash((doc.get("content") or "")[:50]))
+            fused_scores[doc_id] = fused_scores.get(doc_id, 0.0) + 1.0 / (k + rank + 1)
+            doc_info[doc_id] = doc
+    ordered = sorted(fused_scores.items(), key=lambda x: x[1], reverse=True)
+    docs = [doc_info[d] for d, _ in ordered[:top_k]]
+    scores_out = [s for _, s in ordered[:top_k]]
+    return docs, scores_out
+
+
+# dense_result / sparse_result are the `results` output lists of the
+# DenseRetrievalNode / SparseRetrievalNode (a list of document dicts).
+_dense = dense_result if isinstance(dense_result, list) else []
+_sparse = sparse_result if isinstance(sparse_result, list) else []
+_docs, _scores = _reciprocal_rank_fusion([_dense, _sparse])
+results = _docs
+scores = _scores
+# `results`, `scores`, `metadata` are surfaced as separate node outputs so
+# the WorkflowNode output_mapping can flatten them to the top level of the
+# consumed contract.
+metadata = {{
+    "fusion_method": "rrf",
+    "retrieval_modes": ["dense", "sparse"],
+    "retrieval_k": {retrieval_k},
+    "dense_count": len(_dense),
+    "sparse_count": len(_sparse),
+}}
+"""
+        },
+    )
+
+    # Fan documents + query from the source node to both retrievers.
+    builder.add_connection(source_id, "result.documents", dense_id, "documents")
+    builder.add_connection(source_id, "result.query", dense_id, "query")
+    builder.add_connection(source_id, "result.documents", sparse_id, "documents")
+    builder.add_connection(source_id, "result.query", sparse_id, "query")
+
+    # Feed both retrieval result lists into the fusion node.
+    builder.add_connection(dense_id, "results", fuse_id, "dense_result")
+    builder.add_connection(sparse_id, "results", fuse_id, "sparse_result")
+
+    workflow = builder.build(name="hybrid_rag_workflow")
+
+    return WorkflowNode(
+        workflow=workflow,
+        name="hybrid_rag_node",
+        description="Hybrid RAG combining dense and sparse retrieval with RRF fusion",
+        input_mapping={
+            "documents": {"node": "source", "parameter": "documents"},
+            "query": {"node": "source", "parameter": "query"},
+        },
+        output_mapping={
+            "results": {"node": "fuse", "output": "results"},
+            "scores": {"node": "fuse", "output": "scores"},
+            "metadata": {"node": "fuse", "output": "metadata"},
+        },
+    )
+
+
+def _doc_content(doc: Any) -> str:
+    """Return a document's text content as a string, never raising.
+
+    ``doc.get("content", "")`` returns ``None`` when the key is present with a
+    ``None`` value (the ``""`` default fires ONLY for a missing key); a
+    following slice / ``.lower()`` would then raise. This helper collapses a
+    missing key, a ``None`` value, and a non-dict element to ``""``.
+    """
+    if not isinstance(doc, dict):
+        return ""
+    return doc.get("content") or ""
+
+
+def _doc_dedup_key(doc: Any) -> str:
+    """Return a stable dedup key for a document dict.
+
+    Prefers an explicit ``id``; falls back to the first 50 chars of content.
+    Safe against present-but-None ``content`` and non-dict elements.
+    """
+    if not isinstance(doc, dict):
+        return _doc_content(doc)[:50]
+    doc_id = doc.get("id")
+    if doc_id:
+        return str(doc_id)
+    return _doc_content(doc)[:50]
 
 
 @register_node()
@@ -69,6 +232,10 @@ class SelfCorrectingRAGNode(Node):
             confidence_threshold=confidence_threshold,
             verification_model=verification_model,
         )
+        # kailash.nodes.base.Node stores constructor kwargs in self.config and
+        # does NOT set self.name; _initialize_components() references self.name
+        # when building the verifier LLMAgentNode, so bind it explicitly here.
+        self.name = name
         self.max_corrections = max_corrections
         self.confidence_threshold = confidence_threshold
         self.verification_model = verification_model
@@ -270,11 +437,15 @@ Respond with JSON only:
         if not retrieved_docs:
             return "No relevant documents found to answer the query."
 
-        # Simple response generation (can be enhanced with dedicated LLM)
+        # Simple response generation (can be enhanced with dedicated LLM).
+        # A present-but-None "content" (or a non-dict element) must not crash:
+        # doc.get("content", "") returns None when the key exists with value
+        # None — the "" default only fires for a MISSING key.
         context = "\n\n".join(
             [
-                f"Document {i + 1}: {doc.get('content', '')[:500]}..."
+                f"Document {i + 1}: {(doc.get('content') or '')[:500]}..."
                 for i, doc in enumerate(retrieved_docs[:3])
+                if isinstance(doc, dict)
             ]
         )
 
@@ -334,7 +505,10 @@ Assess the quality and provide improvement suggestions:
         """Format documents for verification prompt"""
         formatted = []
         for i, doc in enumerate(docs[:5]):  # Limit to 5 docs for prompt length
-            content = doc.get("content", "")[:300]  # Truncate for prompt
+            if not isinstance(doc, dict):
+                continue
+            # (doc.get("content") or "") guards a present-but-None content.
+            content = (doc.get("content") or "")[:300]  # Truncate for prompt
             formatted.append(f"Doc {i + 1}: {content}...")
         return "\n\n".join(formatted)
 
@@ -512,6 +686,9 @@ class RAGFusionNode(Node):
             fusion_method=fusion_method,
             query_generator_model=query_generator_model,
         )
+        # Node base class does not set self.name; _initialize_components()
+        # references it when naming the query-generator LLMAgentNode.
+        self.name = name
         self.num_query_variations = num_query_variations
         self.fusion_method = fusion_method
         self.query_generator_model = query_generator_model
@@ -635,7 +812,7 @@ class RAGFusionNode(Node):
                 "query_performances": query_performances,
                 "total_unique_documents": len(
                     set(
-                        doc.get("id", doc.get("content", "")[:50])
+                        _doc_dedup_key(doc)
                         for doc in fused_results.get("documents", [])
                     )
                 ),
@@ -803,7 +980,9 @@ Generate {self.num_query_variations} high-quality variations that will improve r
             documents = result.get("results", [])
 
             for rank, doc in enumerate(documents):
-                doc_id = doc.get("id", doc.get("content", "")[:50])  # Fallback ID
+                if not isinstance(doc, dict):
+                    continue
+                doc_id = _doc_dedup_key(doc)  # Fallback ID
 
                 # RRF score calculation
                 rrf_score = 1 / (k + rank + 1)
@@ -862,7 +1041,9 @@ Generate {self.num_query_variations} high-quality variations that will improve r
             scores = result.get("scores", [])
 
             for rank, (doc, score) in enumerate(zip(documents, scores)):
-                doc_id = doc.get("id", doc.get("content", "")[:50])
+                if not isinstance(doc, dict):
+                    continue
+                doc_id = _doc_dedup_key(doc)
 
                 weighted_score = score * weight
 
@@ -893,7 +1074,9 @@ Generate {self.num_query_variations} high-quality variations that will improve r
             scores = result.get("scores", [])
 
             for doc, score in zip(documents, scores):
-                doc_id = doc.get("id", doc.get("content", "")[:50])
+                if not isinstance(doc, dict):
+                    continue
+                doc_id = _doc_dedup_key(doc)
 
                 if doc_id not in seen_ids:
                     all_docs.append(doc)
@@ -919,8 +1102,9 @@ Generate {self.num_query_variations} high-quality variations that will improve r
         context = "\n\n".join(
             [
                 f"Source {i + 1} (RRF Score: {doc.get('fusion_metadata', {}).get('rrf_score', 0.0):.3f}): "
-                f"{doc.get('content', '')[:400]}..."
+                f"{_doc_content(doc)[:400]}..."
                 for i, doc in enumerate(top_docs)
+                if isinstance(doc, dict)
             ]
         )
 
@@ -1017,6 +1201,9 @@ class HyDENode(Node):
             use_multiple_hypotheses=use_multiple_hypotheses,
             num_hypotheses=num_hypotheses,
         )
+        # Node base class does not set self.name; _initialize_components()
+        # references it when naming the hypothesis-generator LLMAgentNode.
+        self.name = name
         self.hypothesis_model = hypothesis_model
         self.use_multiple_hypotheses = use_multiple_hypotheses
         self.num_hypotheses = num_hypotheses
@@ -1124,7 +1311,7 @@ class HyDENode(Node):
                 ),
                 "total_unique_docs": len(
                     set(
-                        doc.get("id", doc.get("content", "")[:50])
+                        _doc_dedup_key(doc)
                         for doc in combined_results.get("documents", [])
                     )
                 ),
@@ -1255,7 +1442,9 @@ Generate {self.num_hypotheses if self.use_multiple_hypotheses else 1} detailed h
             hypothesis_idx = result_info.get("hypothesis_index", 0)
 
             for doc, score in zip(documents, scores):
-                doc_id = doc.get("id", doc.get("content", "")[:50])
+                if not isinstance(doc, dict):
+                    continue
+                doc_id = _doc_dedup_key(doc)
 
                 # Track source hypothesis
                 if doc_id not in doc_sources:
@@ -1269,7 +1458,7 @@ Generate {self.num_hypotheses if self.use_multiple_hypotheses else 1} detailed h
 
         # Add source information to documents
         for doc in all_docs:
-            doc_id = doc.get("id", doc.get("content", "")[:50])
+            doc_id = _doc_dedup_key(doc)
             doc["hyde_sources"] = doc_sources.get(doc_id, [])
             doc["source_diversity"] = len(doc_sources.get(doc_id, []))
 
@@ -1301,8 +1490,9 @@ Generate {self.num_hypotheses if self.use_multiple_hypotheses else 1} detailed h
 
         context_parts = []
         for i, doc in enumerate(top_docs):
-            content = doc.get("content", "")[:300]
-            source_info = doc.get("hyde_sources", [])
+            if not isinstance(doc, dict):
+                continue
+            content = _doc_content(doc)[:300]
             diversity = doc.get("source_diversity", 0)
 
             context_parts.append(
@@ -1371,6 +1561,9 @@ class StepBackRAGNode(Node):
 
     def __init__(self, name: str = "step_back_rag", abstraction_model: str = "gpt-4"):
         super().__init__(name=name, abstraction_model=abstraction_model)
+        # Node base class does not set self.name; _initialize_components()
+        # references it when naming the abstraction-generator LLMAgentNode.
+        self.name = name
         self.abstraction_model = abstraction_model
         self.abstraction_generator = None
         self.base_rag_workflow = None
@@ -1603,7 +1796,9 @@ Generate a broader, more abstract version that would help retrieve relevant back
         specific_scores = specific_results.get("scores", [])
 
         for doc, score in zip(specific_docs, specific_scores):
-            doc_id = doc.get("id", doc.get("content", "")[:50])
+            if not isinstance(doc, dict):
+                continue
+            doc_id = _doc_dedup_key(doc)
             weighted_score = score * specific_weight
 
             doc_with_metadata = doc.copy()
@@ -1622,7 +1817,9 @@ Generate a broader, more abstract version that would help retrieve relevant back
         abstract_scores = abstract_results.get("scores", [])
 
         for doc, score in zip(abstract_docs, abstract_scores):
-            doc_id = doc.get("id", doc.get("content", "")[:50])
+            if not isinstance(doc, dict):
+                continue
+            doc_id = _doc_dedup_key(doc)
 
             # Skip if already added from specific results
             if doc_id in doc_sources:
@@ -1671,16 +1868,19 @@ Generate a broader, more abstract version that would help retrieve relevant back
         if not documents:
             return f"No relevant documents found for query: {specific_query}"
 
-        # Separate background and specific information
+        # Separate background and specific information. isinstance(doc, dict)
+        # guards a non-dict element (documents is arbitrary upstream data).
         background_docs = [
             doc
             for doc in documents[:3]
-            if doc.get("step_back_metadata", {}).get("source_type") == "abstract"
+            if isinstance(doc, dict)
+            and doc.get("step_back_metadata", {}).get("source_type") == "abstract"
         ]
         specific_docs = [
             doc
             for doc in documents[:5]
-            if doc.get("step_back_metadata", {}).get("source_type") == "specific"
+            if isinstance(doc, dict)
+            and doc.get("step_back_metadata", {}).get("source_type") == "specific"
         ]
 
         # Build response with background context first
@@ -1689,13 +1889,13 @@ Generate a broader, more abstract version that would help retrieve relevant back
         if background_docs:
             response_parts.append("\nBackground Context:")
             for i, doc in enumerate(background_docs):
-                content = doc.get("content", "")[:250]
+                content = _doc_content(doc)[:250]
                 response_parts.append(f"Background {i + 1}: {content}...")
 
         if specific_docs:
             response_parts.append("\nSpecific Information:")
             for i, doc in enumerate(specific_docs):
-                content = doc.get("content", "")[:300]
+                content = _doc_content(doc)[:300]
                 response_parts.append(f"Specific {i + 1}: {content}...")
 
         response_parts.append(

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
@@ -239,8 +239,13 @@ class SelfCorrectingRAGNode(Node):
         self.max_corrections = max_corrections
         self.confidence_threshold = confidence_threshold
         self.verification_model = verification_model
-        self.base_rag_workflow = None
-        self.verifier_agent = None
+        # Lazily populated by _initialize_components(), which is the first
+        # statement of run(); typed as their concrete classes so the use
+        # sites in _perform_rag / _verify_result_quality do not each need a
+        # None-guard. The None initializer is the only place the Optional-ness
+        # is visible.
+        self.base_rag_workflow: WorkflowNode = None  # type: ignore[assignment]
+        self.verifier_agent: LLMAgentNode = None  # type: ignore[assignment]
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
@@ -692,8 +697,9 @@ class RAGFusionNode(Node):
         self.num_query_variations = num_query_variations
         self.fusion_method = fusion_method
         self.query_generator_model = query_generator_model
-        self.query_generator = None
-        self.base_rag_workflow = None
+        # Lazily populated by _initialize_components() before any use.
+        self.query_generator: LLMAgentNode = None  # type: ignore[assignment]
+        self.base_rag_workflow: WorkflowNode = None  # type: ignore[assignment]
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
@@ -1207,8 +1213,9 @@ class HyDENode(Node):
         self.hypothesis_model = hypothesis_model
         self.use_multiple_hypotheses = use_multiple_hypotheses
         self.num_hypotheses = num_hypotheses
-        self.hypothesis_generator = None
-        self.base_rag_workflow = None
+        # Lazily populated by _initialize_components() before any use.
+        self.hypothesis_generator: LLMAgentNode = None  # type: ignore[assignment]
+        self.base_rag_workflow: WorkflowNode = None  # type: ignore[assignment]
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
@@ -1565,8 +1572,9 @@ class StepBackRAGNode(Node):
         # references it when naming the abstraction-generator LLMAgentNode.
         self.name = name
         self.abstraction_model = abstraction_model
-        self.abstraction_generator = None
-        self.base_rag_workflow = None
+        # Lazily populated by _initialize_components() before any use.
+        self.abstraction_generator: LLMAgentNode = None  # type: ignore[assignment]
+        self.base_rag_workflow: WorkflowNode = None  # type: ignore[assignment]
 
     def get_parameters(self) -> Dict[str, NodeParameter]:
         return {
@@ -1716,6 +1724,9 @@ Generate a broader, more abstract version that would help retrieve relevant back
 
     def _parse_abstract_query(self, response: Dict) -> str:
         """Parse abstract query from LLM response"""
+        # Bind content before the try so the except branch (which returns it)
+        # cannot reference an unbound name if response.get(...) itself raises.
+        content: Any = ""
         try:
             content = response.get("content", "")
             if isinstance(content, list):

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
@@ -11,10 +11,9 @@ Implementation of cutting-edge RAG patterns including:
 All techniques use existing Kailash components and WorkflowBuilder patterns.
 """
 
-import asyncio
 import json
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List
 
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.nodes.logic.workflow import WorkflowNode
@@ -336,7 +335,7 @@ class SelfCorrectingRAGNode(Node):
 
             # If not final attempt, prepare for correction
             if attempt < self.max_corrections:
-                documents = self._refine_documents(query, documents, verification)
+                documents = self._refine_documents(documents, verification)
                 query = self._refine_query(query, verification)
 
         # Return best attempt if all corrections exhausted
@@ -565,19 +564,68 @@ Assess the quality and provide improvement suggestions:
         }
 
     def _refine_documents(
-        self, query: str, documents: List[Dict], verification: Dict
+        self, documents: List[Dict], verification: Dict
     ) -> List[Dict]:
-        """Refine document set based on verification feedback"""
+        """Refine the document set based on verification feedback.
+
+        Acts on BOTH halves of the verifier's feedback:
+
+        - ``suggestions`` — an explicit "filter" recommendation trims the set.
+        - ``issues`` — the specific problems the verifier identified. A
+          relevance / noise issue ("irrelevant", "off-topic", "noise",
+          "unrelated", "low quality") means the retrieved set is too broad, so
+          refinement tightens it. A coverage issue ("missing", "incomplete",
+          "insufficient", "too few", "not enough") means the set is too
+          narrow — trimming it would make the next attempt worse, so the full
+          set is preserved.
+
+        Honoring ``issues`` (not only ``suggestions``) is what makes the
+        self-correction loop respond to what the verifier actually found,
+        rather than only to the verifier's free-text advice strings.
+        """
         issues = verification.get("issues", [])
         suggestions = verification.get("suggestions", [])
 
-        # Simple refinement: filter documents if suggested
-        if any("filter" in suggestion.lower() for suggestion in suggestions):
-            # Keep top 80% of documents by relevance
+        issues_text = " ".join(str(i) for i in issues).lower()
+        relevance_issue = any(
+            term in issues_text
+            for term in (
+                "irrelevant",
+                "off-topic",
+                "off topic",
+                "noise",
+                "unrelated",
+                "low quality",
+            )
+        )
+        coverage_issue = any(
+            term in issues_text
+            for term in (
+                "missing",
+                "incomplete",
+                "insufficient",
+                "too few",
+                "not enough",
+                "lack",
+            )
+        )
+        filter_suggested = any(
+            "filter" in str(suggestion).lower() for suggestion in suggestions
+        )
+
+        # A coverage issue means the set is already too narrow — trimming it
+        # would worsen the next attempt, so preserve the full set even if a
+        # filter was loosely suggested.
+        if coverage_issue and not relevance_issue:
+            return documents
+
+        # A relevance/noise issue OR an explicit filter suggestion means the
+        # set is too broad — trim to the top 80% by retrieval rank.
+        if relevance_issue or filter_suggested:
             keep_count = max(1, int(len(documents) * 0.8))
             return documents[:keep_count]
 
-        # If no specific refinement suggested, return original
+        # No actionable feedback — return the set unchanged.
         return documents
 
     def _refine_query(self, query: str, verification: Dict) -> str:
@@ -1042,11 +1090,11 @@ Generate {self.num_query_variations} high-quality variations that will improve r
         doc_scores = {}
         doc_contents = {}
 
-        for query_idx, (result, weight) in enumerate(zip(all_results, weights)):
+        for result, weight in zip(all_results, weights):
             documents = result.get("results", [])
             scores = result.get("scores", [])
 
-            for rank, (doc, score) in enumerate(zip(documents, scores)):
+            for doc, score in zip(documents, scores):
                 if not isinstance(doc, dict):
                     continue
                 doc_id = _doc_dedup_key(doc)

--- a/packages/kailash-kaizen/tests/integration/rag/test_advanced_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_advanced_nodes.py
@@ -1,0 +1,244 @@
+"""Tier-2 integration coverage for ``kaizen.nodes.rag.advanced``.
+
+F8 shard B6. The 4 advanced RAG nodes (``SelfCorrectingRAGNode``,
+``RAGFusionNode``, ``HyDENode``, ``StepBackRAGNode``) all retrieve through the
+shared ``create_hybrid_rag_workflow`` base workflow — A-S2 of this shard
+replaced a shipped empty-``Workflow`` placeholder with a genuine hybrid-RAG
+``WorkflowNode`` (dense + sparse retrieval, RRF fusion).
+
+NO mocking (``@patch`` / ``MagicMock`` / ``unittest.mock`` are BLOCKED in
+Tier 2/3 per ``rules/testing.md``). These tests execute the real hybrid
+workflow end-to-end through a real in-process ``LocalRuntime`` — there is no
+container and no LLM key required: ``DenseRetrievalNode`` /
+``SparseRetrievalNode`` run their deterministic keyword-overlap fallback, and
+the fusion node is a real ``PythonCodeNode``. The retrieval / generation core
+is exercised, not mocked — that IS the no-mocking contract met via "real
+lightweight backend" (numpy ships with the ``[rag]`` extra).
+
+Assertions are structural: workflow graph shape, node ``code`` presence,
+end-to-end result keys/values, score ordering.
+"""
+
+from __future__ import annotations
+
+import pytest
+from kailash.nodes.logic.workflow import WorkflowNode
+
+from kaizen.nodes.rag.advanced import (
+    HyDENode,
+    RAGConfig,
+    RAGFusionNode,
+    SelfCorrectingRAGNode,
+    StepBackRAGNode,
+    create_hybrid_rag_workflow,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# Deterministic corpus: d1/d3 overlap the ML query terms, d2 is off-topic.
+_CORPUS = [
+    {"id": "d1", "content": "neural network optimization techniques and methods"},
+    {"id": "d2", "content": "italian pasta recipes with fresh tomato sauce"},
+    {"id": "d3", "content": "gradient descent algorithms for training neural networks"},
+    {"id": "d4", "content": "backpropagation and weight updates in deep learning"},
+]
+_QUERY = "how to optimize neural network training"
+
+
+# ==========================================================================
+# create_hybrid_rag_workflow — graph shape + real end-to-end execution
+# ==========================================================================
+
+
+class TestHybridRagWorkflowGraph:
+    """Assert the A-S2 workflow graph shape directly (no execution)."""
+
+    def test_workflow_node_count_and_ids(self):
+        """The hybrid graph is exactly source + dense + sparse + fuse."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        assert isinstance(wf, WorkflowNode)
+        nodes = wf._workflow.nodes  # type: ignore[union-attr]
+        assert set(nodes.keys()) == {"source", "dense", "sparse", "fuse"}
+
+    def test_workflow_has_six_connections(self):
+        """source fans to 2 retrievers (4 edges) + 2 edges into fuse = 6."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        connections = wf._workflow.connections  # type: ignore[union-attr]
+        assert len(connections) == 6
+
+    def test_fuse_node_carries_rrf_code(self):
+        """The fuse PythonCodeNode's code= template implements RRF."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        # the built PythonCodeNode instance exposes its template as .code
+        fuse = wf._workflow.get_node("fuse")  # type: ignore[union-attr]
+        code = fuse.code  # type: ignore[attr-defined]
+        assert "_reciprocal_rank_fusion" in code
+        # the codegen template carries the same isinstance guard as run() paths
+        assert "isinstance" in code
+
+    def test_input_and_output_mapping_present(self):
+        """The WorkflowNode maps documents/query in and results/scores out."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        # _input_mapping / _output_mapping are WorkflowNode internals not on
+        # the Node base type pyright resolves create_hybrid_rag_workflow to.
+        assert set(wf._input_mapping.keys()) == {"documents", "query"}  # type: ignore[attr-defined]
+        assert set(wf._output_mapping.keys()) == {  # type: ignore[attr-defined]
+            "results",
+            "scores",
+            "metadata",
+        }
+
+
+class TestHybridRagWorkflowExecution:
+    """Execute the A-S2 workflow end-to-end through a real LocalRuntime."""
+
+    def test_run_executes_and_returns_contract(self):
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        assert set(out.keys()) == {"results", "scores", "metadata"}
+
+    def test_run_fuses_dense_and_sparse(self):
+        """metadata records non-zero dense and sparse contributions."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        meta = out["metadata"]
+        assert meta["dense_count"] >= 1
+        assert meta["sparse_count"] >= 1
+
+    def test_run_scores_descending(self):
+        """Fused RRF scores are returned in descending order."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        assert out["scores"] == sorted(out["scores"], reverse=True)
+
+    def test_run_results_align_with_scores(self):
+        """results and scores are parallel lists of the same length."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        assert len(out["results"]) == len(out["scores"])
+
+    def test_run_prefers_on_topic_documents(self):
+        """The neural-network docs outrank the off-topic pasta doc."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        retrieved_ids = {d.get("id") for d in out["results"]}
+        # at least one ML doc retrieved; the pasta doc must not be the only hit
+        assert retrieved_ids & {"d1", "d3", "d4"}
+
+
+# ==========================================================================
+# The 4 advanced nodes — real end-to-end retrieval through the hybrid base
+# ==========================================================================
+
+
+class TestSelfCorrectingRAGEndToEnd:
+    def test_retrieves_real_documents(self):
+        """run() drives the real hybrid workflow and returns retrieved docs."""
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        # the hybrid retrieval populated the result with real documents
+        assert isinstance(result["retrieved_documents"], list)
+        assert result["final_response"]
+
+    def test_quality_assessment_present(self):
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        qa = result["quality_assessment"]
+        assert "confidence" in qa
+
+
+class TestRAGFusionEndToEnd:
+    def test_fuses_multi_query_retrieval(self):
+        """RAG-Fusion runs multiple queries through the real hybrid workflow."""
+        result = RAGFusionNode(num_query_variations=2).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        fused = result["fused_results"]
+        assert "documents" in fused
+        assert result["fusion_metadata"]["queries_processed"] >= 1
+
+    def test_fused_documents_are_real(self):
+        result = RAGFusionNode(num_query_variations=2).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        docs = result["fused_results"]["documents"]
+        assert all(isinstance(d, dict) for d in docs)
+
+
+class TestHyDEEndToEnd:
+    def test_retrieves_with_hypotheses(self):
+        """HyDE retrieves through the hybrid workflow using hypotheses."""
+        result = HyDENode(num_hypotheses=2).run(documents=_CORPUS, query=_QUERY)
+        assert result["hyde_metadata"]["num_hypotheses"] >= 1
+        assert "documents" in result["combined_retrieval"]
+
+    def test_final_answer_generated(self):
+        result = HyDENode(num_hypotheses=1).run(documents=_CORPUS, query=_QUERY)
+        assert isinstance(result["final_answer"], str)
+        assert result["final_answer"]
+
+
+class TestStepBackEndToEnd:
+    def test_dual_retrieval_specific_and_abstract(self):
+        """Step-Back retrieves for both the specific and abstract query."""
+        result = StepBackRAGNode().run(documents=_CORPUS, query=_QUERY)
+        meta = result["step_back_metadata"]
+        assert meta["specific_docs_count"] >= 0
+        assert meta["abstract_docs_count"] >= 0
+        assert "documents" in result["combined_results"]
+
+    def test_final_answer_generated(self):
+        result = StepBackRAGNode().run(documents=_CORPUS, query=_QUERY)
+        assert isinstance(result["final_answer"], str)
+        assert result["final_answer"]
+
+
+# ==========================================================================
+# Defect regression boundary — malformed corpus through real execution
+# ==========================================================================
+
+
+class TestMalformedCorpusEndToEnd:
+    """The content:None / non-dict crash class, exercised end-to-end.
+
+    B6 defect 2: helper methods crashed on present-but-None content and
+    non-dict elements. These tests drive the full run() path with a malformed
+    corpus through the real hybrid workflow — no crash, documented keys.
+    """
+
+    _BAD = [
+        {"id": "d1", "content": None},
+        {"id": "d2"},
+        "not-a-dict-element",
+        {"content": None},
+        {"id": "d5", "content": "real neural network content"},
+    ]
+
+    def test_self_correcting_survives_malformed_corpus(self):
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=self._BAD, query=_QUERY
+        )
+        assert "final_response" in result
+
+    def test_rag_fusion_survives_malformed_corpus(self):
+        result = RAGFusionNode(num_query_variations=1).run(
+            documents=self._BAD, query=_QUERY
+        )
+        assert "fused_results" in result
+
+    def test_hyde_survives_malformed_corpus(self):
+        result = HyDENode(num_hypotheses=1).run(documents=self._BAD, query=_QUERY)
+        assert "final_answer" in result
+
+    def test_step_back_survives_malformed_corpus(self):
+        result = StepBackRAGNode().run(documents=self._BAD, query=_QUERY)
+        assert "final_answer" in result
+
+    def test_hybrid_workflow_survives_malformed_corpus(self):
+        """The A-S2 workflow itself tolerates a malformed corpus."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=self._BAD, query=_QUERY, operation="retrieve")
+        assert set(out.keys()) == {"results", "scores", "metadata"}

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b6_advanced_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b6_advanced_defects.py
@@ -1,0 +1,214 @@
+"""Regression: latent ``kaizen.nodes.rag.advanced`` defects + the A-S2 stub.
+
+F8 shard B6 surfaced, via behavioral coverage of the 4 advanced RAG nodes:
+
+A-S2 — create_hybrid_rag_workflow shipped placeholder.
+  The function returned ``Workflow(name="hybrid_rag_fallback", nodes=[],
+  connections=[])`` and imported it from ``kaizen.workflow.graph`` — a module
+  that does not exist, so the placeholder ``ImportError``'d the moment any of
+  the 4 advanced nodes called it via ``_initialize_components()``. It is a
+  shipped ``zero-tolerance.md`` Rule 2 stub ("return a simple mock workflow").
+  Fix: a genuine hybrid-RAG WorkflowNode — dense (DenseRetrievalNode) + sparse
+  (SparseRetrievalNode) retrieval fused with Reciprocal Rank Fusion.
+
+Defect 1 — all 4 advanced nodes crashed on every run().
+  ``_initialize_components()`` builds an LLMAgentNode named ``f"{self.name}
+  ..."``. ``kailash.nodes.base.Node.__init__`` stores constructor kwargs in
+  ``self.config`` and never sets ``self.name``; the f-string raised
+  ``AttributeError: object has no attribute 'name'`` before any retrieval ran.
+  Since _initialize_components() is the FIRST statement of every run(), all
+  four nodes were fully broken. Fix: bind ``self.name`` in each __init__.
+
+Defect 2 — content:None / non-dict crash class (10 helper sites).
+  ``doc.get("content", "")`` returns ``None`` for a present-but-None key (the
+  ``""`` default fires ONLY for a MISSING key); a following slice / .lower()
+  then raised ``TypeError``. And ``doc.get("id", doc.get("content","")[:50])``
+  evaluates the slice default EAGERLY — it crashed even when ``id`` was
+  present. A non-dict element (documents is arbitrary upstream input) raised
+  ``AttributeError`` on ``.get`` / ``.copy``. Fix: ``_doc_content`` /
+  ``_doc_dedup_key`` helpers + ``isinstance(doc, dict)`` guards; the fuse
+  codegen template carries the same guards (the B1-B5 two-path lesson).
+
+These tests fail against the pre-B6 advanced.py and pass against the fix.
+Assertions are behavioral: call the function, assert it returns / does not
+raise — never source-grep.
+"""
+
+from __future__ import annotations
+
+import pytest
+from kailash.nodes.logic.workflow import WorkflowNode
+
+from kaizen.nodes.rag.advanced import (
+    HyDENode,
+    RAGConfig,
+    RAGFusionNode,
+    SelfCorrectingRAGNode,
+    StepBackRAGNode,
+    create_hybrid_rag_workflow,
+)
+
+pytestmark = pytest.mark.regression
+
+
+_CORPUS = [
+    {"id": "d1", "content": "neural network optimization"},
+    {"id": "d2", "content": "gradient descent for neural networks"},
+]
+# content:None (present-but-None), missing content, non-dict element.
+_MALFORMED = [
+    {"id": "d1", "content": None},
+    {"id": "d2"},
+    "not-a-dict-element",
+    {"content": None},
+]
+
+
+# ==========================================================================
+# A-S2 — create_hybrid_rag_workflow is a real workflow, not a placeholder
+# ==========================================================================
+
+
+class TestAS2HybridWorkflowImplemented:
+    def test_returns_workflow_node_not_empty_workflow(self):
+        """A-S2: the factory returns a real WorkflowNode (was empty Workflow)."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        assert isinstance(wf, WorkflowNode)
+
+    def test_workflow_is_not_empty(self):
+        """The pre-B6 placeholder shipped nodes=[]; the real one has 4 nodes."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        assert len(wf._workflow.nodes) == 4  # type: ignore[union-attr]
+
+    def test_workflow_runs_and_returns_consumed_contract(self):
+        """The pre-B6 placeholder ImportError'd; the real one executes."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query="optimize neural networks")
+        assert set(out.keys()) == {"results", "scores", "metadata"}
+
+
+# ==========================================================================
+# Defect 1 — self.name AttributeError on every advanced-node run()
+# ==========================================================================
+
+
+class TestDefect1NodeNameBound:
+    """All 4 nodes must expose self.name (referenced in _initialize_components)."""
+
+    @pytest.mark.parametrize(
+        "cls",
+        [SelfCorrectingRAGNode, RAGFusionNode, HyDENode, StepBackRAGNode],
+    )
+    def test_node_has_name_attribute(self, cls):
+        assert hasattr(cls(), "name")
+
+    @pytest.mark.parametrize(
+        "cls",
+        [SelfCorrectingRAGNode, RAGFusionNode, HyDENode, StepBackRAGNode],
+    )
+    def test_custom_name_is_bound(self, cls):
+        assert cls(name="custom_rag").name == "custom_rag"
+
+    def test_self_correcting_run_does_not_attributeerror(self):
+        """run() reached the verifier-naming f-string and would AttributeError."""
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=_CORPUS, query="optimize neural networks"
+        )
+        assert "final_response" in result
+
+    def test_rag_fusion_run_does_not_attributeerror(self):
+        result = RAGFusionNode(num_query_variations=1).run(
+            documents=_CORPUS, query="optimize neural networks"
+        )
+        assert "fused_results" in result
+
+    def test_hyde_run_does_not_attributeerror(self):
+        result = HyDENode(num_hypotheses=1).run(
+            documents=_CORPUS, query="optimize neural networks"
+        )
+        assert "final_answer" in result
+
+    def test_step_back_run_does_not_attributeerror(self):
+        result = StepBackRAGNode().run(
+            documents=_CORPUS, query="optimize neural networks"
+        )
+        assert "final_answer" in result
+
+
+# ==========================================================================
+# Defect 2 — content:None / non-dict crash class across 4 nodes' helpers
+# ==========================================================================
+
+
+class TestDefect2NoneContentAndNonDict:
+    """Malformed documents must not crash any advanced-node run() path."""
+
+    def test_self_correcting_run_survives_malformed_corpus(self):
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=_MALFORMED, query="optimize neural networks"
+        )
+        assert "final_response" in result
+
+    def test_rag_fusion_run_survives_malformed_corpus(self):
+        result = RAGFusionNode(num_query_variations=1).run(
+            documents=_MALFORMED, query="optimize neural networks"
+        )
+        assert "fused_results" in result
+
+    def test_hyde_run_survives_malformed_corpus(self):
+        result = HyDENode(num_hypotheses=1).run(
+            documents=_MALFORMED, query="optimize neural networks"
+        )
+        assert "final_answer" in result
+
+    def test_step_back_run_survives_malformed_corpus(self):
+        result = StepBackRAGNode().run(
+            documents=_MALFORMED, query="optimize neural networks"
+        )
+        assert "final_answer" in result
+
+    def test_self_correcting_generate_response_none_content(self):
+        """_generate_response: doc.get('content','')[:500] crashed on None."""
+        node = SelfCorrectingRAGNode()
+        out = node._generate_response("q", [{"id": "d1", "content": None}])  # type: ignore[attr-defined]
+        assert isinstance(out, str)
+
+    def test_rag_fusion_rrf_none_content_and_non_dict(self):
+        """_reciprocal_rank_fusion: eager id/content default + non-dict crash."""
+        node = RAGFusionNode()
+        bad = [{"id": "d1", "content": None}, "not-a-dict"]
+        out = node._reciprocal_rank_fusion([{"results": bad}])  # type: ignore[attr-defined]
+        assert "documents" in out
+
+    def test_hyde_combine_hypothesis_results_none_content(self):
+        """_combine_hypothesis_results: doc['hyde_sources']= crashed on non-dict."""
+        node = HyDENode()
+        bad = [{"id": "d1", "content": None}, "not-a-dict"]
+        out = node._combine_hypothesis_results(  # type: ignore[attr-defined]
+            [{"retrieval_result": {"results": bad, "scores": [1.0, 2.0]}}]
+        )
+        assert "documents" in out
+
+    def test_step_back_combine_results_non_dict(self):
+        """_combine_step_back_results: doc.copy() crashed on a non-dict element."""
+        node = StepBackRAGNode()
+        bad = [{"id": "d1", "content": None}, "not-a-dict"]
+        out = node._combine_step_back_results(  # type: ignore[attr-defined]
+            {"results": bad, "scores": [1.0, 2.0]},
+            {"results": [], "scores": []},
+            "specific",
+            "abstract",
+        )
+        assert "documents" in out
+
+    def test_hybrid_workflow_fuse_template_guards_non_dict(self):
+        """The fuse codegen template (second path) carries the isinstance guard.
+
+        B1-B5 lesson 2: a defect spanning a run()/helper path AND a code=
+        codegen template must be fixed on both. The fuse PythonCodeNode runs
+        RRF over retrieved docs; a malformed corpus reaching it must not crash
+        the workflow execution.
+        """
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_MALFORMED, query="optimize neural networks")
+        assert set(out.keys()) == {"results", "scores", "metadata"}

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b6_advanced_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b6_advanced_defects.py
@@ -212,3 +212,66 @@ class TestDefect2NoneContentAndNonDict:
         wf = create_hybrid_rag_workflow(RAGConfig())
         out = wf.run(documents=_MALFORMED, query="optimize neural networks")
         assert set(out.keys()) == {"results", "scores", "metadata"}
+
+
+# ==========================================================================
+# Substance — _refine_documents honors verification `issues`, not only
+# `suggestions`. The self-correction loop computed verification issues and
+# then discarded them; refinement now responds to what the verifier found.
+# ==========================================================================
+
+_TEN_DOCS = [{"id": f"d{i}", "content": f"document {i}"} for i in range(10)]
+
+
+class TestRefineDocumentsHonorsIssues:
+    """SelfCorrectingRAGNode._refine_documents acts on verification feedback."""
+
+    def test_relevance_issue_trims_document_set(self):
+        """A relevance/noise issue (no filter suggestion) trims the set.
+
+        Pre-B6: _refine_documents read only `suggestions`; a verification that
+        reported a relevance issue but gave no "filter" suggestion left the
+        document set unchanged — shallower self-correction than advertised.
+        """
+        node = SelfCorrectingRAGNode()
+        verification = {
+            "issues": ["several irrelevant documents were retrieved"],
+            "suggestions": [],  # no "filter" advice — only the issue drives it
+        }
+        refined = node._refine_documents(_TEN_DOCS, verification)  # type: ignore[attr-defined]
+        assert len(refined) < len(_TEN_DOCS)
+        assert len(refined) == 8  # top 80% by retrieval rank
+
+    def test_coverage_issue_preserves_full_set(self):
+        """A coverage issue means the set is too narrow — keep all docs."""
+        node = SelfCorrectingRAGNode()
+        verification = {
+            "issues": ["retrieved context is incomplete; key facts missing"],
+            "suggestions": ["filter the documents"],  # loose filter advice
+        }
+        refined = node._refine_documents(_TEN_DOCS, verification)  # type: ignore[attr-defined]
+        # a coverage issue overrides a loose filter suggestion — trimming a
+        # too-narrow set would make the next correction attempt worse
+        assert len(refined) == len(_TEN_DOCS)
+
+    def test_no_actionable_feedback_returns_unchanged(self):
+        node = SelfCorrectingRAGNode()
+        verification = {"issues": ["minor phrasing nitpick"], "suggestions": []}
+        refined = node._refine_documents(_TEN_DOCS, verification)  # type: ignore[attr-defined]
+        assert refined == _TEN_DOCS
+
+    def test_filter_suggestion_still_trims(self):
+        """An explicit filter suggestion still trims (suggestions path intact)."""
+        node = SelfCorrectingRAGNode()
+        verification = {"issues": [], "suggestions": ["filter low-quality docs"]}
+        refined = node._refine_documents(_TEN_DOCS, verification)  # type: ignore[attr-defined]
+        assert len(refined) == 8
+
+    def test_refine_documents_signature_has_no_query_param(self):
+        """The spurious unused `query` parameter was removed."""
+        import inspect
+
+        # @register_node erases the concrete type; the helper is real.
+        sig = inspect.signature(SelfCorrectingRAGNode._refine_documents)  # type: ignore[attr-defined]
+        params = [p for p in sig.parameters if p != "self"]
+        assert params == ["documents", "verification"]

--- a/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
@@ -1,0 +1,474 @@
+"""Tier-1 unit coverage for the 4 ``kaizen.nodes.rag.advanced`` nodes + RAGConfig.
+
+F8 shard B6. The value-anchor (verbatim from the workstream brief): "the RAG
+capability the user chose to preserve is provably correct, not merely
+importable" — HyDE is a user-named capability and self-correction is a
+substance claim, so these tests lock the *behavior* a user gets, not just the
+import.
+
+``SelfCorrectingRAGNode`` / ``RAGFusionNode`` / ``HyDENode`` /
+``StepBackRAGNode`` are ``kailash.nodes.base.Node`` subclasses with a direct
+``run()``. With NO LLM key configured (the realistic deployment of the
+resurrected ``[rag]`` toolkit, which declares no LLM dependency), each node's
+LLM-backed step degrades to a real rule-based fallback inside a
+``try/except`` block — the fallback IS a deterministic implementation, so the
+golden path here is the no-key path and there is nothing to mock.
+
+The shared base workflow every node retrieves through is the
+``create_hybrid_rag_workflow`` ``WorkflowNode`` (A-S2 of this shard): dense +
+sparse retrieval fused with Reciprocal Rank Fusion. ``DenseRetrievalNode`` and
+``SparseRetrievalNode`` run their deterministic keyword-overlap fallback with
+no key, so the whole pipeline produces real, assertable output offline.
+
+One test per documented behavior; assertions are structural (output keys,
+list lengths, score ordering, types, typed raises).
+"""
+
+from __future__ import annotations
+
+import pytest
+from kailash.nodes.logic.workflow import WorkflowNode
+
+from kaizen.nodes.rag.advanced import (
+    HyDENode,
+    RAGConfig,
+    RAGFusionNode,
+    SelfCorrectingRAGNode,
+    StepBackRAGNode,
+    create_hybrid_rag_workflow,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# A small deterministic corpus reused across the node tests. d1/d3 overlap the
+# query terms; d2 does not — keyword-overlap retrieval should rank d1/d3 above.
+_CORPUS = [
+    {"id": "d1", "content": "neural network optimization techniques and methods"},
+    {"id": "d2", "content": "italian pasta recipes with tomato sauce"},
+    {"id": "d3", "content": "gradient descent for training neural networks"},
+]
+_QUERY = "how to optimize neural networks"
+
+
+# ==========================================================================
+# RAGConfig — contract coverage
+# ==========================================================================
+
+
+class TestRAGConfig:
+    """Construction, defaults, and field types of the advanced-module config."""
+
+    def test_defaults(self):
+        """RAGConfig() applies the documented default values."""
+        cfg = RAGConfig()
+        assert cfg.chunk_size == 1000
+        assert cfg.chunk_overlap == 200
+        assert cfg.embedding_model == "text-embedding-3-small"
+        assert cfg.retrieval_k == 5
+
+    def test_field_types(self):
+        """Default field values have the expected types."""
+        cfg = RAGConfig()
+        assert isinstance(cfg.chunk_size, int)
+        assert isinstance(cfg.chunk_overlap, int)
+        assert isinstance(cfg.embedding_model, str)
+        assert isinstance(cfg.retrieval_k, int)
+
+    def test_kwargs_override_defaults(self):
+        """Each field is overridable via a constructor kwarg."""
+        cfg = RAGConfig(
+            chunk_size=512,
+            chunk_overlap=64,
+            embedding_model="custom-embed",
+            retrieval_k=10,
+        )
+        assert cfg.chunk_size == 512
+        assert cfg.chunk_overlap == 64
+        assert cfg.embedding_model == "custom-embed"
+        assert cfg.retrieval_k == 10
+
+    def test_unknown_kwarg_is_ignored_not_raised(self):
+        """An unrecognised kwarg does not raise (the **kwargs construction)."""
+        cfg = RAGConfig(unknown_field="x")
+        assert cfg.retrieval_k == 5  # documented default still applies
+
+
+# ==========================================================================
+# create_hybrid_rag_workflow — A-S2: the implemented base workflow
+# ==========================================================================
+
+
+class TestCreateHybridRagWorkflow:
+    """The hybrid-RAG workflow A-S2 implemented (replaced the placeholder)."""
+
+    def test_returns_workflow_node(self):
+        """The factory returns a real WorkflowNode, not an empty Workflow."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        assert isinstance(wf, WorkflowNode)
+
+    def test_workflow_graph_has_four_nodes(self):
+        """The hybrid graph is source + dense + sparse + fuse = 4 nodes."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        node_ids = set(wf._workflow.nodes.keys())  # type: ignore[union-attr]
+        assert node_ids == {"source", "dense", "sparse", "fuse"}
+
+    def test_workflow_is_not_empty(self):
+        """Regression guard against the shipped empty-nodes placeholder."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        assert len(wf._workflow.nodes) > 0  # type: ignore[union-attr]
+
+    def test_run_returns_results_scores_metadata(self):
+        """run() exposes the {results, scores, metadata} consumed contract."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        assert set(out.keys()) == {"results", "scores", "metadata"}
+        assert isinstance(out["results"], list)
+        assert isinstance(out["scores"], list)
+        assert isinstance(out["metadata"], dict)
+
+    def test_run_metadata_records_hybrid_modes(self):
+        """metadata names both dense and sparse retrieval modes."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        assert out["metadata"]["fusion_method"] == "rrf"
+        assert out["metadata"]["retrieval_modes"] == ["dense", "sparse"]
+
+    def test_run_retrieves_relevant_documents(self):
+        """The neural-network docs (d1/d3) are retrieved for the NN query."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        retrieved_ids = {d.get("id") for d in out["results"]}
+        assert "d1" in retrieved_ids or "d3" in retrieved_ids
+
+    def test_retrieval_k_caps_result_count(self):
+        """config.retrieval_k caps the fused result count."""
+        wf = create_hybrid_rag_workflow(RAGConfig(retrieval_k=1))
+        out = wf.run(documents=_CORPUS, query=_QUERY, operation="retrieve")
+        assert len(out["results"]) <= 1
+        assert out["metadata"]["retrieval_k"] == 1
+
+    def test_run_empty_documents_returns_empty_results(self):
+        """An empty corpus yields empty results, not a crash."""
+        wf = create_hybrid_rag_workflow(RAGConfig())
+        out = wf.run(documents=[], query=_QUERY, operation="retrieve")
+        assert out["results"] == []
+        assert out["scores"] == []
+
+
+# ==========================================================================
+# SelfCorrectingRAGNode
+# ==========================================================================
+
+_SCR_KEYS = {
+    "query",
+    "final_response",
+    "retrieved_documents",
+    "scores",
+    "quality_assessment",
+    "self_correction_metadata",
+    "status",
+}
+
+
+class TestSelfCorrectingRAGNode:
+    """run() golden path + edge cases for SelfCorrectingRAGNode."""
+
+    def test_get_parameters_declares_documents_and_query_required(self):
+        params = SelfCorrectingRAGNode().get_parameters()
+        assert params["documents"].required is True
+        assert params["query"].required is True
+        assert params["config"].required is False
+
+    def test_run_golden_path_returns_documented_keys(self):
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        assert set(result.keys()) == _SCR_KEYS
+
+    def test_run_status_is_corrected_or_best_effort(self):
+        """status is one of the two documented terminal values."""
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        assert result["status"] in {"corrected", "best_effort"}
+
+    def test_run_records_correction_history(self):
+        """self_correction_metadata records one attempt per correction round."""
+        result = SelfCorrectingRAGNode(max_corrections=1).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        meta = result["self_correction_metadata"]
+        assert meta["total_attempts"] >= 1
+        assert len(meta["correction_history"]) == meta["total_attempts"]
+
+    def test_run_empty_documents_does_not_crash(self):
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=[], query=_QUERY
+        )
+        assert set(result.keys()) == _SCR_KEYS
+
+    def test_run_missing_query_uses_empty_default(self):
+        """A missing query defaults to '' and does not crash."""
+        result = SelfCorrectingRAGNode(max_corrections=0).run(documents=_CORPUS)
+        assert set(result.keys()) == _SCR_KEYS
+
+    def test_run_malformed_documents_does_not_crash(self):
+        """content:None + non-dict elements are tolerated (B6 defect class)."""
+        bad = [{"id": "d1", "content": None}, "not-a-dict", {"content": None}]
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=bad, query=_QUERY
+        )
+        assert set(result.keys()) == _SCR_KEYS
+
+    def test_run_unicode_query(self):
+        result = SelfCorrectingRAGNode(max_corrections=0).run(
+            documents=_CORPUS, query="优化神经网络 αβγ"
+        )
+        assert set(result.keys()) == _SCR_KEYS
+
+    def test_generate_response_handles_none_content(self):
+        """_generate_response tolerates a present-but-None content value."""
+        node = SelfCorrectingRAGNode()
+        # @register_node erases the concrete type to Node; the private helper
+        # is genuinely defined on SelfCorrectingRAGNode.
+        out = node._generate_response("q", [{"id": "d1", "content": None}])  # type: ignore[attr-defined]
+        assert isinstance(out, str)
+
+    def test_generate_response_empty_docs(self):
+        node = SelfCorrectingRAGNode()
+        out = node._generate_response("q", [])  # type: ignore[attr-defined]
+        assert "No relevant documents" in out
+
+
+# ==========================================================================
+# RAGFusionNode
+# ==========================================================================
+
+_FUSION_KEYS = {
+    "original_query",
+    "query_variations",
+    "fused_results",
+    "final_response",
+    "fusion_metadata",
+}
+
+
+class TestRAGFusionNode:
+    """run() golden path + edge cases for RAGFusionNode."""
+
+    def test_get_parameters_declares_documents_and_query_required(self):
+        params = RAGFusionNode().get_parameters()
+        assert params["documents"].required is True
+        assert params["query"].required is True
+
+    def test_run_golden_path_returns_documented_keys(self):
+        result = RAGFusionNode(num_query_variations=2).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        assert set(result.keys()) == _FUSION_KEYS
+
+    def test_run_processes_original_plus_variations(self):
+        """fusion_metadata counts the original query plus its variations."""
+        result = RAGFusionNode(num_query_variations=2).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        meta = result["fusion_metadata"]
+        # original + up-to-num_query_variations fallback variations
+        assert meta["queries_processed"] >= 1
+        assert meta["fusion_method"] == "rrf"
+
+    def test_run_fallback_variations_when_no_llm(self):
+        """With no LLM key the rule-based fallback still yields variations."""
+        result = RAGFusionNode(num_query_variations=3).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        assert isinstance(result["query_variations"], list)
+
+    def test_run_empty_documents_does_not_crash(self):
+        result = RAGFusionNode(num_query_variations=1).run(documents=[], query=_QUERY)
+        assert set(result.keys()) == _FUSION_KEYS
+
+    def test_run_malformed_documents_does_not_crash(self):
+        bad = [{"id": "d1", "content": None}, "not-a-dict", {"content": None}]
+        result = RAGFusionNode(num_query_variations=1).run(documents=bad, query=_QUERY)
+        assert set(result.keys()) == _FUSION_KEYS
+
+    def test_reciprocal_rank_fusion_handles_malformed_docs(self):
+        """_reciprocal_rank_fusion tolerates None-content + non-dict docs."""
+        node = RAGFusionNode()
+        bad = [{"id": "d1", "content": None}, "not-a-dict"]
+        # @register_node erases the concrete type; the helper is real.
+        out = node._reciprocal_rank_fusion([{"results": bad}])  # type: ignore[attr-defined]
+        assert out["fusion_method"] == "rrf"
+
+    def test_reciprocal_rank_fusion_orders_by_score(self):
+        """Fused scores come out in descending order."""
+        node = RAGFusionNode()
+        r1 = {"results": [{"id": "a", "content": "x"}, {"id": "b", "content": "y"}]}
+        r2 = {"results": [{"id": "a", "content": "x"}]}
+        out = node._reciprocal_rank_fusion([r1, r2])  # type: ignore[attr-defined]
+        assert out["scores"] == sorted(out["scores"], reverse=True)
+
+    def test_run_unknown_fusion_method_falls_back_to_rrf(self):
+        """An unrecognised fusion method degrades to RRF, not a crash."""
+        result = RAGFusionNode(num_query_variations=1, fusion_method="bogus").run(
+            documents=_CORPUS, query=_QUERY
+        )
+        assert result["fused_results"]["fusion_method"] == "rrf"
+
+
+# ==========================================================================
+# HyDENode
+# ==========================================================================
+
+_HYDE_KEYS = {
+    "original_query",
+    "hypotheses_generated",
+    "hypothesis_results",
+    "combined_retrieval",
+    "final_answer",
+    "hyde_metadata",
+}
+
+
+class TestHyDENode:
+    """run() golden path + edge cases for HyDENode."""
+
+    def test_get_parameters_declares_documents_and_query_required(self):
+        params = HyDENode().get_parameters()
+        assert params["documents"].required is True
+        assert params["query"].required is True
+
+    def test_run_golden_path_returns_documented_keys(self):
+        result = HyDENode(num_hypotheses=2).run(documents=_CORPUS, query=_QUERY)
+        assert set(result.keys()) == _HYDE_KEYS
+
+    def test_run_generates_fallback_hypothesis_when_no_llm(self):
+        """With no LLM key the rule-based fallback yields >=1 hypothesis."""
+        result = HyDENode(num_hypotheses=2).run(documents=_CORPUS, query=_QUERY)
+        assert len(result["hypotheses_generated"]) >= 1
+        assert result["hyde_metadata"]["method"] == "HyDE"
+
+    def test_run_empty_documents_does_not_crash(self):
+        result = HyDENode(num_hypotheses=1).run(documents=[], query=_QUERY)
+        assert set(result.keys()) == _HYDE_KEYS
+
+    def test_run_malformed_documents_does_not_crash(self):
+        bad = [{"id": "d1", "content": None}, "not-a-dict", {"content": None}]
+        result = HyDENode(num_hypotheses=1).run(documents=bad, query=_QUERY)
+        assert set(result.keys()) == _HYDE_KEYS
+
+    def test_run_single_hypothesis_mode(self):
+        """use_multiple_hypotheses=False still produces a valid result."""
+        result = HyDENode(use_multiple_hypotheses=False, num_hypotheses=1).run(
+            documents=_CORPUS, query=_QUERY
+        )
+        assert set(result.keys()) == _HYDE_KEYS
+
+    def test_combine_hypothesis_results_handles_malformed_docs(self):
+        node = HyDENode()
+        bad = [{"id": "d1", "content": None}, "not-a-dict"]
+        # @register_node erases the concrete type; the helper is real.
+        out = node._combine_hypothesis_results(  # type: ignore[attr-defined]
+            [{"retrieval_result": {"results": bad, "scores": [1.0, 2.0]}}]
+        )
+        assert "documents" in out
+
+    def test_generate_final_answer_handles_malformed_docs(self):
+        node = HyDENode()
+        bad = [{"id": "d1", "content": None}, "not-a-dict"]
+        out = node._generate_final_answer("q", {"documents": bad}, ["h"])  # type: ignore[attr-defined]
+        assert isinstance(out, str)
+
+    def test_generate_final_answer_empty_docs(self):
+        node = HyDENode()
+        out = node._generate_final_answer("q", {"documents": []}, ["h"])  # type: ignore[attr-defined]
+        assert "No relevant documents" in out
+
+
+# ==========================================================================
+# StepBackRAGNode
+# ==========================================================================
+
+_STEPBACK_KEYS = {
+    "specific_query",
+    "abstract_query",
+    "specific_retrieval",
+    "abstract_retrieval",
+    "combined_results",
+    "final_answer",
+    "step_back_metadata",
+}
+
+
+class TestStepBackRAGNode:
+    """run() golden path + edge cases for StepBackRAGNode."""
+
+    def test_get_parameters_declares_documents_and_query_required(self):
+        params = StepBackRAGNode().get_parameters()
+        assert params["documents"].required is True
+        assert params["query"].required is True
+
+    def test_run_golden_path_returns_documented_keys(self):
+        result = StepBackRAGNode().run(documents=_CORPUS, query=_QUERY)
+        assert set(result.keys()) == _STEPBACK_KEYS
+
+    def test_run_generates_abstract_query(self):
+        """The step-back node produces a non-empty abstract query."""
+        result = StepBackRAGNode().run(documents=_CORPUS, query=_QUERY)
+        assert isinstance(result["abstract_query"], str)
+        assert result["abstract_query"]
+        assert result["step_back_metadata"]["method"] == "step_back_prompting"
+
+    def test_run_empty_documents_does_not_crash(self):
+        result = StepBackRAGNode().run(documents=[], query=_QUERY)
+        assert set(result.keys()) == _STEPBACK_KEYS
+
+    def test_run_malformed_documents_does_not_crash(self):
+        bad = [{"id": "d1", "content": None}, "not-a-dict", {"content": None}]
+        result = StepBackRAGNode().run(documents=bad, query=_QUERY)
+        assert set(result.keys()) == _STEPBACK_KEYS
+
+    def test_fallback_abstraction_for_how_query(self):
+        """The rule-based abstraction fallback handles a 'how' query."""
+        node = StepBackRAGNode()
+        # @register_node erases the concrete type; the helper is real.
+        out = node._generate_fallback_abstraction("how does X work?")  # type: ignore[attr-defined]
+        assert isinstance(out, str)
+        assert out
+
+    def test_combine_step_back_results_handles_malformed_docs(self):
+        node = StepBackRAGNode()
+        bad = [{"id": "d1", "content": None}, "not-a-dict"]
+        out = node._combine_step_back_results(  # type: ignore[attr-defined]
+            {"results": bad, "scores": [1.0, 2.0]},
+            {"results": [], "scores": []},
+            "specific",
+            "abstract",
+        )
+        assert "documents" in out
+
+    def test_generate_step_back_answer_handles_malformed_docs(self):
+        node = StepBackRAGNode()
+        docs = [
+            {
+                "id": "x",
+                "content": None,
+                "step_back_metadata": {"source_type": "specific"},
+            },
+            "not-a-dict",
+        ]
+        out = node._generate_step_back_answer("q", "a", {"documents": docs})  # type: ignore[attr-defined]
+        assert isinstance(out, str)
+
+    def test_generate_step_back_answer_empty_docs(self):
+        node = StepBackRAGNode()
+        out = node._generate_step_back_answer("q", "a", {"documents": []})  # type: ignore[attr-defined]
+        assert "No relevant documents" in out
+
+    def test_parse_abstract_query_handles_non_dict_response(self):
+        """_parse_abstract_query does not raise on a non-dict response."""
+        node = StepBackRAGNode()
+        out = node._parse_abstract_query("not-a-dict")  # type: ignore[arg-type]
+        assert isinstance(out, str)

--- a/specs/kaizen-rag.md
+++ b/specs/kaizen-rag.md
@@ -559,7 +559,7 @@ precisely:
 
 - `FederatedRAGNode` has no document-corpus input. Its workflow entry point
   (`query_distributor`, `def distribute_query(query, node_endpoints,
-  federation_config)`) reads only a query and per-node endpoints — there is no
+federation_config)`) reads only a query and per-node endpoints — there is no
   raw local document for the node to leak. The aggregate produced by
   `result_aggregator` carries per-result `content`, `score`, and `metadata`
   (source-node ids, weights, agreement) plus an `aggregation_metadata` block of
@@ -581,3 +581,92 @@ tests exercise each template by exec-ing the rendered function with an appended
 `return result`. End-to-end runtime execution of the assembled sub-workflow is
 not covered by the `[rag]` extra alone — the `PythonCodeNode` `code` templates
 are deterministic and are covered directly.
+
+## Advanced RAG
+
+`kaizen/nodes/rag/advanced.py` ships four advanced RAG techniques as
+`kailash.nodes.base.Node` subclasses with a direct `run()` —
+`SelfCorrectingRAGNode`, `RAGFusionNode`, `HyDENode`, `StepBackRAGNode` — plus
+the shared retrieval workflow `create_hybrid_rag_workflow` and the
+module-local `RAGConfig`.
+
+### `RAGConfig`
+
+`RAGConfig` is a `**kwargs`-based config class. Its four fields and defaults:
+`chunk_size` (1000), `chunk_overlap` (200), `embedding_model`
+(`"text-embedding-3-small"`), `retrieval_k` (5). An unrecognized kwarg is
+ignored, not raised. `retrieval_k` is the field that influences
+`create_hybrid_rag_workflow` — it caps the fused result count.
+
+### `create_hybrid_rag_workflow`
+
+`create_hybrid_rag_workflow(config: RAGConfig)` builds a genuine hybrid-RAG
+retrieval workflow and returns it wrapped in a `WorkflowNode`. Hybrid RAG
+combines dense (embedding-similarity) retrieval with sparse (keyword /
+term-frequency) retrieval and fuses the two with Reciprocal Rank Fusion (RRF).
+
+The workflow graph has four nodes:
+
+- `source` (`PythonCodeNode`) — entry node; receives `documents` and `query`
+  via the `WorkflowNode` `input_mapping` and fans them out.
+- `dense` (`DenseRetrievalNode`) — embedding-similarity retrieval. With no LLM
+  key configured it runs its deterministic keyword-overlap fallback.
+- `sparse` (`SparseRetrievalNode`) — keyword / term-frequency retrieval.
+- `fuse` (`PythonCodeNode`) — RRF over the dense and sparse result lists;
+  emits `results`, `scores`, and `metadata` as separate node outputs.
+
+The graph has six connections: `source` fans `documents` and `query` to both
+`dense` and `sparse` (four edges), and `dense` and `sparse` each feed their
+`results` output into `fuse` (two edges). The returned `WorkflowNode` carries
+an `input_mapping` (`documents`, `query` → `source`) and an `output_mapping`
+(`results`, `scores`, `metadata` ← `fuse`), so a `run(documents=...,
+query=..., operation="retrieve")` call returns a dict with top-level
+`results` (the fused document list), `scores` (the fused RRF scores), and
+`metadata` (`fusion_method`, `retrieval_modes`, `retrieval_k`, `dense_count`,
+`sparse_count`). The `fuse` codegen template skips a non-dict document and
+coerces a present-but-`None` `content` to an empty string before the dedup
+key, so a malformed corpus does not crash workflow execution.
+
+`advanced.py` imports `kaizen.nodes.rag.similarity` for the side effect of
+registering `DenseRetrievalNode` / `SparseRetrievalNode` with the Kailash
+`NodeRegistry`, which `WorkflowBuilder.build()` requires.
+
+### The four advanced node classes
+
+All four nodes declare `documents` (list) and `query` (str) as `required=True`
+run-time parameters and accept an optional `config` dict. Each `run()` first
+calls `_initialize_components()`, which builds the node's `LLMAgentNode`
+helper(s) and the shared `base_rag_workflow` via `create_hybrid_rag_workflow`.
+Every LLM-backed step (verification, query-variation generation, hypothesis
+generation, abstract-query generation) is wrapped in a `try/except` that falls
+back to a deterministic rule-based implementation — with no LLM key
+configured, the node still produces a real, contract-shaped output.
+
+The document-text helpers `_doc_content` and `_doc_dedup_key` are the
+module's shared guards against malformed documents: `_doc_content` collapses a
+missing key, a present-but-`None` `content`, and a non-dict element to `""`;
+`_doc_dedup_key` returns a stable dedup key (explicit `id`, else the first 50
+chars of content) and is safe against the same malformed inputs.
+
+- **`SelfCorrectingRAGNode`** — retrieves, verifies result quality, and
+  iteratively refines up to `max_corrections` times. `run()` returns `query`,
+  `final_response`, `retrieved_documents`, `scores`, `quality_assessment`,
+  `self_correction_metadata` (one `correction_history` entry per attempt), and
+  `status` (`"corrected"` if the confidence threshold was met, else
+  `"best_effort"`).
+- **`RAGFusionNode`** — generates query variations, retrieves for the original
+  query plus each variation, and fuses the result lists. `run()` returns
+  `original_query`, `query_variations`, `fused_results`, `final_response`, and
+  `fusion_metadata`. `_fuse_results` dispatches on `fusion_method` —
+  `_reciprocal_rank_fusion` (the default and the fallback for an unknown
+  method), `_weighted_fusion`, `_simple_concatenation`.
+- **`HyDENode`** — generates hypothetical answers, retrieves using each
+  hypothesis as the query, and combines the per-hypothesis results. `run()`
+  returns `original_query`, `hypotheses_generated`, `hypothesis_results`,
+  `combined_retrieval`, `final_answer`, and `hyde_metadata`.
+- **`StepBackRAGNode`** — generates an abstract step-back query, retrieves for
+  both the specific and the abstract query, and combines the two result sets
+  with specific results weighted 0.7 and abstract 0.3. `run()` returns
+  `specific_query`, `abstract_query`, `specific_retrieval`,
+  `abstract_retrieval`, `combined_results`, `final_answer`, and
+  `step_back_metadata`.


### PR DESCRIPTION
## Summary

Shard **B6** of workstream F8 (`kaizen.nodes.rag` resurrection) — behavioral
coverage of the `advanced` module (HyDE, self-correction, RAG-fusion,
step-back) **plus A-S2**: implementing the shipped placeholder.

- **A-S2** — `create_hybrid_rag_workflow` was a `zero-tolerance` Rule 2
  placeholder returning an empty `Workflow(nodes=[], connections=[])` and
  importing from a non-existent module (`ImportError` at call time). Replaced
  with a real hybrid-RAG `WorkflowNode` — a 4-node graph (`source` →
  `dense`+`sparse` → `fuse`) with Reciprocal Rank Fusion, `input_mapping`/
  `output_mapping` matching the `{results, scores, metadata}` contract its 4
  consumers expect.
- **101 new behavioral tests** — 50 Tier-1 unit + 22 Tier-2 integration (real
  numpy / real `LocalRuntime`, **no mocking**) + 29 regression — across
  `SelfCorrectingRAGNode`, `RAGFusionNode`, `HyDENode`, `StepBackRAGNode`,
  `RAGConfig`, and `create_hybrid_rag_workflow`.
- **3 defects found & fixed:**
  - **Defect 1 (major)** — all 4 advanced nodes crashed on *every* `run()`:
    `_initialize_components` referenced `self.name`, which `Node` never sets
    (kwargs land in `self.config`). The whole module was 100% runtime-broken.
    Fixed by binding `self.name` in each `__init__`.
  - **Defect 2** — `content: None` / non-dict crash class across 10 helper
    sites (incl. eager-slice-default `doc.get("id", doc.get("content","")[:50])`).
    Fixed via shared `_doc_content`/`_doc_dedup_key` helpers + `isinstance` guards.
  - **Defect 3** — `_refine_documents` (self-correction) extracted verification
    `issues` then discarded them — only loose `suggestion` strings drove
    refinement. Now honors `issues` (relevance issue → trim, coverage issue →
    preserve); 5 regression tests.
- **Pyright** — `advanced.py` + new test files 0 errors / 0 warnings / 0
  informations (justified registration imports excepted).
- **Spec** — appended `## Advanced RAG` to `specs/kaizen-rag.md`.

## Test plan

- [x] 101 B6 tests pass
- [x] Tier-2 real numpy / LocalRuntime, zero `@patch`/`MagicMock`
- [x] `pre-commit run --files` clean; Pyright 0/0/0 on `advanced.py` + new tests

## Related issues

Part of F8 (`kaizen.nodes.rag` behavioral coverage). No standalone issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)