### PR TITLE
chore(release): kailash-kaizen 2.24.0 — F8 R1 kaizen.nodes.rag provably correct + F9 cleanup

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,95 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.24.0] — 2026-05-20 — kaizen.nodes.rag provably correct + F9 cleanup (F8 R1)
+
+### Added
+
+- **Behavioral coverage of every preserved RAG class** (F8 B1–B10). 643+ new
+  tests + 5 spec sections (`specs/kaizen-rag.md` is now the authoritative
+  domain truth for the 58 RAG class definitions: 55 `@register_node`
+  classes + 2 `RAGConfig` dataclasses + `RAGWorkflowRegistry`). The brief's
+  "provably correct, not merely importable" criterion is now closed —
+  every class has at least one behavioral test in the unit, integration,
+  or regression tier.
+- **`RAGStrategyRouterNode` / `RAGQualityAnalyzerNode` /
+  `RAGPerformanceMonitorNode` / `RAGWorkflowRegistry`** all gain Tier-1
+  unit + Tier-2a integration coverage (B10). The smoke-test
+  zero-`xfail` invariant added in B9c is preserved.
+
+### Fixed
+
+- **`RAGStrategyRouterNode.run()` no longer raises `AttributeError`**
+  (F8 B10). The class accessed `self.name` but the kailash `Node` base
+  stores name on `self.metadata.name`; every call raised AttributeError
+  on the LLMAgentNode init. Routes through `self.metadata.name` now.
+- **`pii_detector` codegen** — F9 #1112: dob regex uses non-capturing
+  groups so `re.findall` returns full-match strings (not tuples that
+  crashed `.encode()`); F9 #1113: function returns its dict on the
+  `redact=True` branch (was bound to a function-scope local never
+  returned); F9 #1114: codegen now binds `result =
+detect_and_redact_pii(text, ...)` at module scope so PythonCodeNode
+  reads the redaction dict (the function was defined but never called).
+- **`ConversationalRAGNode.create_session` session_id** — F9 #1116:
+  now sourced from `secrets.token_hex(16)` (128-bit CSPRNG). The prior
+  `sha256(f"{user_or_anon}_{datetime}")[:16]` form admitted ~10⁶
+  brute-force ops within a 1-second window on the anonymous flow.
+- **`RAGEvaluationNode` codegen** — F9 #1117/#1118:
+  `test_executor`, `context_evaluator`, and `metric_aggregator` all
+  return their dicts AND invoke their inner functions at module scope.
+  `metric_aggregator` now imports the `datetime` class inside the
+  function body (a module-scope `from datetime import datetime` is
+  shadowed by PythonCodeNode's `datetime` module injection; the bare
+  `datetime.now()` against the module raised `AttributeError`).
+- **`RealtimeRAGNode.start_monitoring`** — F9 #1121: retains the
+  monitoring task on `self._monitor_task`; `stop_monitoring()` is now
+  async and cancels + awaits the retained task (the prior
+  fire-and-forget made the task GC-eligible and left the loop
+  uncancellable from outside).
+- **`RealtimeStreamingRAGNode` `processing_time` unit** — F9 #1122:
+  reported in SECONDS (the prior `chunk_idx * chunk_interval` form left
+  consumers off-by-1000× from the asyncio.sleep call's seconds-based
+  semantics; `chunk_interval` is canonically milliseconds).
+- **`RAGQualityAnalyzerNode.run()` `expected_results` kwarg** — wired
+  through into `quality_analysis["expected_result_count"]` /
+  `expected_recall_ratio`; the documented kwarg was previously accepted
+  but silently dropped (Rule 3c — documented kwargs without consumption
+  is a silent-fallback variant).
+
+### Changed (env-models compliance)
+
+- **All 36 hardcoded `"gpt-4"` model defaults across 9 rag modules
+  replaced with env-loaded `_DEFAULT_LLM_MODEL`** (F9 #1126). Mirrors
+  the `router.py:22-24` precedent landed in F8 B10:
+  ```python
+  _DEFAULT_LLM_MODEL = os.environ.get(
+      "OPENAI_PROD_MODEL", os.environ.get("DEFAULT_LLM_MODEL")
+  )
+  ```
+  Affected modules: `advanced`, `agentic`, `conversational`, `evaluation`,
+  `graph`, `multimodal`, `query_processing`, `similarity`, `workflows`.
+  **Behavior change**: existing callers relying on the `"gpt-4"` default
+  now get the env-resolved value (or `None` when neither env var is set
+  — env-models-compliant). Set `OPENAI_PROD_MODEL` in `.env` to restore
+  prior behavior.
+- **`kailash.middleware.mcp.enhanced_server.MCPToolNode` /
+  `MCPResourceNode`** (F8 A1-core) — constructors now use the canonical
+  keyword `super().__init__(name=name, **config)` form. The prior
+  `super().__init__(name)` positional form raised `TypeError` on every
+  construction (Node base is keyword-only). External subclasses calling
+  the constructor positionally MUST migrate to keyword form.
+
+### Migration
+
+- **`StreamingRAGNode` collision** (still active from 2.23.0): the
+  realtime variant is `RealtimeStreamingRAGNode`; `optimized` keeps
+  `StreamingRAGNode`. No change in 2.24.0.
+- **Env-models migration**: if your dev/prod environment relied on the
+  baked-in `"gpt-4"` default and does not set `OPENAI_PROD_MODEL` or
+  `DEFAULT_LLM_MODEL`, set one of them in `.env`. The `model` config
+  block on each LLM-using node now resolves to `None` when neither is
+  set, which propagates to the LLMAgentNode constructor.
+
 ## [2.23.1] — 2026-05-19 — complete the `[rag]` extra (#891 follow-up)
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.23.1"
+version = "2.24.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.23.1"
+__version__ = "2.24.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

F8 R1 — kaizen 2.24.0 minor release. Closes the brief's *"provably correct, not merely importable"* criterion for `kaizen.nodes.rag` (resurrected in 2.23.0).

| Shard | Coverage | PRs |
| --- | --- | --- |
| A1 / A1-core / A2 / A3 | Constructor canonical form + xfail closure | merged prior to this branch |
| B1–B9c | Behavioral coverage of 51 registered classes | merged (B7→#1110, B8→merged, B9a→#1111, B9b→#1115, B9c→#1119) |
| B10 | router (3) + RAGWorkflowRegistry + 58/55/56 reconciliation | #1124 |
| F9 cleanup | 11 codegen + crypto + env-models defects | #1127 |
| **R1** | Version bump + CHANGELOG + clean-venv verify | **this PR** |

## Verification

- [x] 851 passing tests across `tests/unit/rag/`, `tests/integration/rag/`, `tests/regression/` (including the 10 new F9 regression tests + the 6 B10 regression tests)
- [x] Smoke set's zero-xfail invariant (B9c) holds
- [x] Pyright clean across all touched files
- [x] **Clean-venv install verified**: `kailash-kaizen-2.24.0` wheel installs into a fresh venv with `[rag]` extra; `import kaizen.nodes.rag` clean; B10 classes construct; F9 #1116 session_id is 32-char CSPRNG; F9 #1126 `_DEFAULT_LLM_MODEL` resolves from env across 9 modules.
- [x] **Cross-SDK parity**: A1-core's MCP node constructor fix is Python-specific (positional-vs-keyword super-call form); not portable to Rust trait constructors or Prism. No rs/prism parity obligation.

## Release-prep branch

This PR uses the `release/v2.24.0` branch per `rules/git.md` § "Release-Prep PRs MUST Use `release/v*` Branch Convention". The PR-gate matrix auto-skips on `release/v*` per the workflow `if: !startsWith(github.head_ref, 'release/')` guard, saving ~120 min × CI matrix size on this metadata-only diff.

## Migration

- **`StreamingRAGNode` collision** (active since 2.23.0): realtime variant is `RealtimeStreamingRAGNode`; `optimized` keeps `StreamingRAGNode`. Unchanged in 2.24.0.
- **Env-models behavior change** (F9 #1126): hardcoded `"gpt-4"` defaults replaced with env-loaded `_DEFAULT_LLM_MODEL = os.environ.get("OPENAI_PROD_MODEL", os.environ.get("DEFAULT_LLM_MODEL"))`. Set one of these env vars in `.env` to restore the prior baked-in default; otherwise the LLMAgentNode `model` config resolves to `None` (env-models-compliant per `rules/env-models.md`).
- **MCP node constructor form** (F8 A1-core): `MCPToolNode` / `MCPResourceNode` now use the canonical keyword `super().__init__(name=name, **config)` form. External subclasses calling the constructor positionally MUST migrate to keyword form.

## Related

Closes the F8 workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)