### PR TITLE
feat(delegate): S1 workspace fences for kailash.delegate (#1035)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,22 @@ repos:
         pass_filenames: true
         stages: [pre-commit, manual]
 
+  # kailash.delegate architectural fences (#1035): Apache-2.0 substrate
+  # purity + conformance zero-engine-deps. Runs whenever the delegate
+  # package or the lint script itself changes. Pure-stdlib script; no
+  # external dependencies; resolves the venv via find-venv-python.sh
+  # for worktree compatibility (same pattern as spec-drift-gate above).
+  - repo: local
+    hooks:
+      - id: kailash-delegate-fences
+        name: kailash.delegate Apache-2.0 + zero-engine-deps fences (#1035)
+        description: "Enforce kailash.delegate has zero proprietary dependencies."
+        entry: scripts/development/find-venv-python.sh tools/lint-delegate-fences.py
+        language: system
+        files: ^(src/kailash/delegate/|tools/lint-delegate-fences\.py)
+        pass_filenames: false
+        stages: [pre-commit, manual]
+
   # No untracked TODO-NNN markers in production source (issue #781).
   # See .claude/rules/zero-tolerance.md Rule 2 + Rule 6 — every TODO-NNN
   # marker MUST either carry a tracker link (tracked: gh#NNN) or be

--- a/src/kailash/delegate/__init__.py
+++ b/src/kailash/delegate/__init__.py
@@ -1,0 +1,18 @@
+"""kailash.delegate -- Apache 2.0 OSS Delegate composition primitive.
+
+The audit-grade composition surface ``(Connector x Signature x ConstraintEnvelope
+x Executor)`` under EATP audit per Terrene Delegate Specification v0.
+
+DISAMBIGUATION: NOT ``kaizen_agents.delegate.Delegate`` (LLM execution facade).
+The kaizen-agents Delegate is one possible ``executor=`` argument here.
+
+Cross-implementation conformance: shares vendored conformance vectors with the
+proprietary kailash-rs implementation; ``receipts_agree(rs, py)`` is the
+cross-language verification gate.
+
+Per #1035: this package MUST have zero proprietary dependencies. The
+``tools/lint-delegate-fences.py`` lint enforces this fence.
+"""
+
+# Public surface populated by subsequent shards (S2..S8).
+__all__: list[str] = []

--- a/src/kailash/delegate/__init__.py
+++ b/src/kailash/delegate/__init__.py
@@ -1,3 +1,5 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
 """kailash.delegate -- Apache 2.0 OSS Delegate composition primitive.
 
 The audit-grade composition surface ``(Connector x Signature x ConstraintEnvelope

--- a/src/kailash/delegate/conformance/__init__.py
+++ b/src/kailash/delegate/conformance/__init__.py
@@ -1,3 +1,5 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
 """kailash.delegate.conformance -- shared conformance vectors with kailash-rs.
 
 Per #1035 F1 invariant: this subpackage MUST have ZERO engine dependencies.

--- a/src/kailash/delegate/conformance/__init__.py
+++ b/src/kailash/delegate/conformance/__init__.py
@@ -1,0 +1,8 @@
+"""kailash.delegate.conformance -- shared conformance vectors with kailash-rs.
+
+Per #1035 F1 invariant: this subpackage MUST have ZERO engine dependencies.
+The lint at ``tools/lint-delegate-fences.py`` enforces this; vectors load
+from JSON fixtures and validate via dataclass schemas only.
+"""
+
+__all__: list[str] = []

--- a/tests/unit/delegate/test_package_shell.py
+++ b/tests/unit/delegate/test_package_shell.py
@@ -17,8 +17,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LINT_SCRIPT = REPO_ROOT / "tools" / "lint-delegate-fences.py"
 DELEGATE_PKG = REPO_ROOT / "src" / "kailash" / "delegate"
@@ -59,9 +57,7 @@ def test_lint_script_exit_zero_on_clean_tree() -> None:
     )
 
 
-def test_lint_script_detects_proprietary_import(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> None:
+def test_lint_script_detects_proprietary_import() -> None:
     """Plant a temp file with a forbidden import; lint MUST exit 1."""
     forbidden = DELEGATE_PKG / "_s1_fence_probe.py"
     assert not forbidden.exists(), (
@@ -91,9 +87,7 @@ def test_lint_script_detects_proprietary_import(
         forbidden.unlink(missing_ok=True)
 
 
-def test_lint_script_detects_conformance_engine_import(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> None:
+def test_lint_script_detects_conformance_engine_import() -> None:
     """Plant a temp file in conformance/ that imports an engine module.
 
     Fence B says conformance/ may not import kailash.delegate.{runtime,

--- a/tests/unit/delegate/test_package_shell.py
+++ b/tests/unit/delegate/test_package_shell.py
@@ -1,0 +1,121 @@
+"""Tier-1 tests for the kailash.delegate package shell (S1, #1035).
+
+Covers:
+
+* package + conformance subpackage import cleanly with empty public surface,
+* the fence lint exits 0 against the committed tree,
+* the fence lint detects a Fence A violation introduced via a temp file.
+
+Subsequent shards (S2..S8) will populate the public surface; these tests
+remain stable because they assert the Apache-2.0 substrate + lint contract,
+not specific symbols.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LINT_SCRIPT = REPO_ROOT / "tools" / "lint-delegate-fences.py"
+DELEGATE_PKG = REPO_ROOT / "src" / "kailash" / "delegate"
+
+
+def test_kailash_delegate_imports_cleanly() -> None:
+    import kailash.delegate as pkg
+
+    assert pkg.__all__ == [], (
+        "S1 ships an empty public surface; later shards populate __all__. "
+        f"Got: {pkg.__all__!r}"
+    )
+
+
+def test_kailash_delegate_conformance_imports_cleanly() -> None:
+    import kailash.delegate.conformance as conformance
+
+    assert conformance.__all__ == [], (
+        "Conformance subpackage public surface is empty in S1. "
+        f"Got: {conformance.__all__!r}"
+    )
+
+
+def test_lint_script_exists_and_is_executable() -> None:
+    assert LINT_SCRIPT.is_file(), f"lint script missing at {LINT_SCRIPT}"
+
+
+def test_lint_script_exit_zero_on_clean_tree() -> None:
+    result = subprocess.run(
+        [sys.executable, str(LINT_SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"lint-delegate-fences.py failed on the committed tree.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_lint_script_detects_proprietary_import(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Plant a temp file with a forbidden import; lint MUST exit 1."""
+    forbidden = DELEGATE_PKG / "_s1_fence_probe.py"
+    assert not forbidden.exists(), (
+        "Probe path already exists — refusing to overwrite. "
+        "Delete the file and rerun."
+    )
+    forbidden.write_text(
+        '"""Temporary fence-violation probe (S1 test). Auto-deleted."""\n'
+        "from kailash_rs import foo  # noqa: F401  -- Fence A probe\n"
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, str(LINT_SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 1, (
+            "lint-delegate-fences.py should exit 1 on a proprietary import; "
+            f"got exit={result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert (
+            "Fence A violation" in result.stderr
+        ), f"expected 'Fence A violation' in stderr; got: {result.stderr}"
+        assert "kailash_rs" in result.stderr
+    finally:
+        forbidden.unlink(missing_ok=True)
+
+
+def test_lint_script_detects_conformance_engine_import(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Plant a temp file in conformance/ that imports an engine module.
+
+    Fence B says conformance/ may not import kailash.delegate.{runtime,
+    dispatch,trust,audit,posture}. Probe with a stub import — does not
+    require the engine module to exist; the lint reads via AST.
+    """
+    forbidden = DELEGATE_PKG / "conformance" / "_s1_fence_probe.py"
+    assert not forbidden.exists()
+    forbidden.write_text(
+        '"""Temporary Fence B probe. Auto-deleted."""\n'
+        "from kailash.delegate.runtime import Engine  # noqa: F401\n"
+    )
+    try:
+        result = subprocess.run(
+            [sys.executable, str(LINT_SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        assert result.returncode == 1
+        assert (
+            "Fence B violation" in result.stderr
+        ), f"expected 'Fence B violation' in stderr; got: {result.stderr}"
+    finally:
+        forbidden.unlink(missing_ok=True)

--- a/tools/lint-delegate-fences.py
+++ b/tools/lint-delegate-fences.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Enforce kailash.delegate architectural fences (#1035).
+
+Two fences:
+
+* **Fence A (Apache-2.0 substrate purity):** No module under
+  ``src/kailash/delegate/**`` may import ``kailash_rs``,
+  ``kailash.commercial``, ``kailash.proprietary``, or any name starting
+  with ``_rs_``. Per #1035 acceptance criterion: the package MUST stand
+  alone in the OSS SDK with zero proprietary dependency.
+
+* **Fence B (conformance zero-engine-deps):** Modules under
+  ``src/kailash/delegate/conformance/**`` may not import any of the
+  delegate engine modules (``runtime``, ``dispatch``, ``trust``,
+  ``audit``, ``posture``). Conformance loads vectors from JSON via
+  dataclasses + stdlib only so it can co-execute with kailash-rs.
+
+Uses ``ast.parse`` rather than regex so import aliases, parenthesized
+``from X import (a, b)`` blocks, and multi-line imports all resolve
+correctly. Exit 0 = clean; exit 1 = at least one fence violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PKG_ROOT = ROOT / "src" / "kailash" / "delegate"
+CONFORMANCE_ROOT = PKG_ROOT / "conformance"
+
+# Fence A — modules NO file under src/kailash/delegate/ may import.
+PROPRIETARY_PREFIXES = (
+    "kailash_rs",
+    "kailash.commercial",
+    "kailash.proprietary",
+)
+PROPRIETARY_LEAF_PREFIX = "_rs_"
+
+# Fence B — engine modules conformance/ may NOT import.
+ENGINE_MODULES = frozenset(
+    {
+        "kailash.delegate.runtime",
+        "kailash.delegate.dispatch",
+        "kailash.delegate.trust",
+        "kailash.delegate.audit",
+        "kailash.delegate.posture",
+    }
+)
+
+
+def _is_proprietary(module: str) -> bool:
+    """True if ``module`` matches a Fence A forbidden prefix."""
+    if module.startswith(PROPRIETARY_PREFIXES):
+        return True
+    # _rs_-prefixed leaf segment (e.g. ``kailash._rs_bridge``).
+    return any(part.startswith(PROPRIETARY_LEAF_PREFIX) for part in module.split("."))
+
+
+def _collect_imports(tree: ast.AST) -> list[tuple[str, int]]:
+    """Return ``(module_name, lineno)`` for every import in ``tree``."""
+    imports: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append((alias.name, node.lineno))
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imports.append((node.module, node.lineno))
+    return imports
+
+
+def _check_file(path: Path) -> list[str]:
+    """Return list of violation messages for ``path`` (empty = clean)."""
+    rel = path.relative_to(ROOT)
+    in_conformance = CONFORMANCE_ROOT in path.parents or path == CONFORMANCE_ROOT
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:  # surface as fence violation; do not silently skip.
+        return [f"{rel}:{exc.lineno}: SyntaxError parsing for fence check: {exc.msg}"]
+    violations: list[str] = []
+    for module, lineno in _collect_imports(tree):
+        if _is_proprietary(module):
+            violations.append(
+                f"{rel}:{lineno}: Fence A violation — import of proprietary "
+                f"module '{module}' (kailash.delegate must stay Apache-2.0 pure)"
+            )
+        if in_conformance and module in ENGINE_MODULES:
+            violations.append(
+                f"{rel}:{lineno}: Fence B violation — conformance/ imported engine "
+                f"module '{module}' (conformance must remain zero-engine-deps)"
+            )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0] if __doc__ else ""
+    )
+    parser.add_argument(
+        "--check", action="store_true", default=True, help="Default; kept for parity."
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="List each scanned file."
+    )
+    args = parser.parse_args(argv)
+
+    if not PKG_ROOT.is_dir():
+        print(
+            f"lint-delegate-fences: package root not found: {PKG_ROOT}", file=sys.stderr
+        )
+        return 1
+
+    files = sorted(PKG_ROOT.rglob("*.py"))
+    all_violations: list[str] = []
+    for path in files:
+        if args.verbose:
+            print(f"  scanning {path.relative_to(ROOT)}", file=sys.stderr)
+        all_violations.extend(_check_file(path))
+
+    if all_violations:
+        print("kailash.delegate fence violations:", file=sys.stderr)
+        for v in all_violations:
+            print(f"  {v}", file=sys.stderr)
+        print(
+            f"\n{len(all_violations)} violation(s) across {len(files)} file(s). "
+            "See #1035 + tools/lint-delegate-fences.py docstring.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.verbose:
+        print(
+            f"lint-delegate-fences: clean ({len(files)} files scanned)", file=sys.stderr
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Shard S1 of an 8-shard plan to implement the \`kailash.delegate\` Apache-2.0 OSS composition primitive (Connector × Signature × ConstraintEnvelope × Executor) per #1035. This shard lands ONLY the workspace fences + empty package scaffold. Public API surface stays empty (\`__all__ = []\`) — S2 populates types/envelope at integration time.

## What this shard does

* **Package shell.** \`src/kailash/delegate/__init__.py\` + \`src/kailash/delegate/conformance/__init__.py\` ship with empty \`__all__\` lists and load-bearing docstrings that declare the Apache-2.0 substrate purity invariant (Fence A) + the conformance zero-engine-deps invariant (Fence B). The kailash package's existing src/ auto-discovery picks them up; no \`pyproject.toml\` change needed.

* **Architectural lint.** \`tools/lint-delegate-fences.py\` (~141 LOC, pure stdlib, \`ast.parse\`-based) walks the delegate package and enforces:
  * **Fence A — Apache-2.0 substrate purity.** No file under \`src/kailash/delegate/\` may import \`kailash_rs\`, \`kailash.commercial\`, \`kailash.proprietary\`, or any \`_rs_\`-prefixed module.
  * **Fence B — conformance zero-engine-deps.** No file under \`src/kailash/delegate/conformance/\` may import any of the delegate engine modules (\`runtime\`, \`dispatch\`, \`trust\`, \`audit\`, \`posture\`). Conformance loads JSON vectors via dataclasses + stdlib only so it can co-execute with kailash-rs.

* **Pre-commit hook.** New \`kailash-delegate-fences\` local hook in \`.pre-commit-config.yaml\` runs the lint whenever \`src/kailash/delegate/**\` or \`tools/lint-delegate-fences.py\` changes. Resolves the venv via \`scripts/development/find-venv-python.sh\` so worktrees inherit the main checkout's \`.venv\` (same pattern as the existing \`spec-drift-gate\` hook).

* **Tier-1 tests.** \`tests/unit/delegate/test_package_shell.py\` — 6 tests covering: (a)+(b) package + conformance subpackage import cleanly with empty \`__all__\`; (c) lint script exists + is executable; (d) lint exits 0 on the committed tree; (e) lint detects a Fence A violation when a temp file with \`from kailash_rs import foo\` is planted inside the package; (f) lint detects a Fence B violation when a temp file with \`from kailash.delegate.runtime import Engine\` is planted inside \`conformance/\`. Probes are auto-cleaned in \`finally\`.

## Value anchor (#1035 verbatim)

> from kailash.delegate import ... works in the OSS SDK with zero proprietary dependency.

Fence A is the structural enforcement of this acceptance criterion at the lint layer — the lint exits 1 the moment any proprietary-import edge appears, and the pre-commit hook surfaces it at the commit boundary rather than in PR review.

## Coordination with S2

S2 (parallel worktree \`delegate-s2\`) implements \`types.py\` + \`envelope.py\` + their tests in the same \`src/kailash/delegate/\` package. S1 owns ONLY \`__init__.py\` (this PR), \`conformance/__init__.py\`, the lint script, the pre-commit entry, and \`tests/unit/delegate/{__init__,test_package_shell}.py\`. After both shards merge, the orchestrator adds S2 re-exports to \`__init__.py::__all__\`.

## Plan reference

Workspace plan: \`workspaces/issue-1035-delegate-py/todos/active/00-shard-plan.md\` (S1 row). Architecture: sibling \`02-plans/01-architecture.md\`.

## Test plan

- [x] \`pytest tests/unit/delegate/\` — all 6 tests pass (run via main-checkout \`.venv\`)
- [x] \`tools/lint-delegate-fences.py\` exits 0 on the committed tree
- [x] \`mypy\` clean on the 3 new source files (\`--follow-imports=silent\`); pre-existing kailash-wide errors are out of S1 scope per \`zero-tolerance.md\` Rule 1c
- [x] Fence A probe verified — lint exits 1 + emits \"Fence A violation\" on planted \`kailash_rs\` import
- [x] Fence B probe verified — lint exits 1 + emits \"Fence B violation\" on planted engine-module import inside \`conformance/\`
- [ ] CI green on PR (the pre-commit hook will fire on this branch; per-CI sequence will be the first end-to-end exercise of the new hook entry)

## Related issues

Tracks #1035.