### PR TITLE
fix(delegate): re-export 11 S2 symbols from kailash.delegate.__init__ (#1035)

### DIFF
--- a/src/kailash/delegate/__init__.py
+++ b/src/kailash/delegate/__init__.py
@@ -9,12 +9,45 @@ DISAMBIGUATION: NOT ``kaizen_agents.delegate.Delegate`` (LLM execution facade).
 The kaizen-agents Delegate is one possible ``executor=`` argument here.
 
 Cross-implementation conformance: shares vendored conformance vectors with the
-proprietary kailash-rs implementation; ``receipts_agree(rs, py)`` is the
+kailash-rs implementation; ``receipts_agree(rs, py)`` is the
 cross-language verification gate.
 
 Per #1035: this package MUST have zero proprietary dependencies. The
 ``tools/lint-delegate-fences.py`` lint enforces this fence.
 """
 
-# Public surface populated by subsequent shards (S2..S8).
-__all__: list[str] = []
+# Public surface -- S2 types substrate. Later shards (S3-S8) extend this list
+# via parallel-shard merges per orphan-detection.md Rule 6a.
+from kailash.delegate.envelope import (
+    DelegateConstraintEnvelope,
+    EnvelopeWideningError,
+)
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateGenesisRecord,
+    DelegateIdentity,
+    LifecycleError,
+    LifecycleState,
+    PrincipalDirectory,
+    Role,
+    RoleLifecycleState,
+    RoleScope,
+)
+
+__all__ = [
+    # Group 1 -- Envelope (S2.5 F1/F7)
+    "DelegateConstraintEnvelope",
+    "EnvelopeWideningError",
+    # Group 2 -- Identity + role substrate (S2.5 F2/F3)
+    "DelegateIdentity",
+    "PrincipalDirectory",
+    "Role",
+    "RoleLifecycleState",
+    "RoleScope",
+    "CapabilitySet",
+    # Group 3 -- Lifecycle state machine (S2 -> S2.5)
+    "LifecycleState",
+    "LifecycleError",
+    # Group 4 -- Genesis composition (S2.5 F4)
+    "DelegateGenesisRecord",
+]

--- a/tests/unit/delegate/test_package_shell.py
+++ b/tests/unit/delegate/test_package_shell.py
@@ -23,12 +23,21 @@ DELEGATE_PKG = REPO_ROOT / "src" / "kailash" / "delegate"
 
 
 def test_kailash_delegate_imports_cleanly() -> None:
+    """Public surface count is the structural defense per orphan-detection.md
+    Rule 6a (Merge-Time ``__all__`` Reconciliation). When S3+ shards land new
+    symbols this count MUST move in lockstep -- a silent drop is the failure
+    mode this assertion catches."""
     import kailash.delegate as pkg
 
-    assert pkg.__all__ == [], (
-        "S1 ships an empty public surface; later shards populate __all__. "
-        f"Got: {pkg.__all__!r}"
+    assert len(pkg.__all__) == 11, (
+        "kailash.delegate.__all__ count drifted; S2 ships 11 symbols. "
+        "If a later shard added a symbol, update this count in the same commit "
+        f"per orphan-detection.md Rule 6a. Got: {pkg.__all__!r}"
     )
+    # Every entry MUST resolve to a real attribute on the package (eager-
+    # import contract from orphan-detection.md Rule 6).
+    for name in pkg.__all__:
+        assert hasattr(pkg, name), f"__all__ entry {name!r} not on package"
 
 
 def test_kailash_delegate_conformance_imports_cleanly() -> None:


### PR DESCRIPTION
## Summary

Wave 1 PR #1133 (S2 type substrate) shipped to main with the orchestrator \`__init__.py\` reconciliation commit missing — main shipped with \`__all__: list[str] = []\` while \`types.py\` + \`envelope.py\` export 11 public symbols. **Result: every \`from kailash.delegate import DelegateIdentity\` (or any of the 11 symbols) raises ImportError despite the symbols existing.**

This is the \`orphan-detection.md\` MUST Rule 6 failure mode in real form. Per \`autonomous-execution.md\` MUST Rule 4 (same-bug-class, within shard budget, fix-immediately) this is the follow-up.

## Root cause

The orchestrator integration commit that was supposed to land alongside #1133's merge was dropped by pre-commit auto-stash (the [INFO] Restored changes from /Users/.../.cache/pre-commit/patch... line). This commit uses \`git -c core.hooksPath=/dev/null\` per [\`git.md\` § Discipline](https://github.com/terrene-foundation/kailash-py/blob/main/.claude/rules/git.md) workaround. Hooks pass standalone — verified.

## Changes

- \`src/kailash/delegate/__init__.py\`: 11 eager imports + grouped \`__all__\` (4 groups per S2.5 reshape ordering)
- \`tests/unit/delegate/test_package_shell.py\`: \`test_kailash_delegate_imports_cleanly\` now asserts \`len(__all__) == 11\` + every entry resolves via \`hasattr\` (the structural defense per [\`orphan-detection.md\` Rule 6a](https://github.com/terrene-foundation/kailash-py/blob/main/.claude/rules/orphan-detection.md) count-dependent test pattern)

## Public surface (11 symbols)

| Group | Symbols |
| --- | --- |
| Envelope (S2.5 F1/F7) | \`DelegateConstraintEnvelope\`, \`EnvelopeWideningError\` |
| Identity + role substrate (S2.5 F2/F3) | \`DelegateIdentity\`, \`PrincipalDirectory\`, \`Role\`, \`RoleLifecycleState\`, \`RoleScope\`, \`CapabilitySet\` |
| Lifecycle state machine | \`LifecycleState\`, \`LifecycleError\` |
| Genesis composition (S2.5 F4) | \`DelegateGenesisRecord\` |

## Test plan

- [x] 82/82 delegate tests passing locally
- [x] mypy clean
- [x] \`from kailash.delegate import <each of 11 symbols>\` resolves at runtime (verified: \`count=11\` printed for every symbol)
- [x] Pre-commit hooks pass standalone

## Related issues

Follow-up to #1132 + #1133. Related to #1035 (Delegate composition primitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)