### PR TITLE
feat(delegate): S3 trust cascade — TenantScopedCascade + GrantMoment (#1035)

### DIFF
--- a/src/kailash/delegate/envelope.py
+++ b/src/kailash/delegate/envelope.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import Any
 
 from kailash.delegate.types import DelegateGenesisRecord
 from kailash.trust.envelope import ConstraintEnvelope
@@ -77,9 +78,11 @@ class DelegateConstraintEnvelope:
     on the resulting envelope chain back to the originating GenesisRecord
     without re-rooting.
 
-    Deferred to S3 (#1035 follow-up): from_dict validating constructor
-    closes the direct-dataclass-construction bypass per Round 1 sec H2;
-    tracking via workspace todos.
+    S3 (#1035) — the H2 deferral closes here: :meth:`from_dict` is the
+    audit-grade validating constructor that closes the direct-dataclass-
+    construction bypass. Cross-SDK ingest routes through :meth:`from_dict`;
+    the bare ``__init__`` and :meth:`from_genesis` continue to work for in-
+    process construction.
     """
 
     inner: ConstraintEnvelope
@@ -166,3 +169,67 @@ class DelegateConstraintEnvelope:
                 "indicates a regression in ConstraintEnvelope.intersect."
             )
         return DelegateConstraintEnvelope(inner=tightened, genesis_id=self.genesis_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical wire dict for cross-SDK round-trip (S3 H2).
+
+        Delegates the inner envelope serialization to the substrate's own
+        :meth:`ConstraintEnvelope.to_dict` (the canonical wire format
+        already shared across SDKs) and adds the spine-level
+        :attr:`genesis_id` alongside.
+
+        Pair with :meth:`from_dict` for round-trip; consumers serialize
+        via :func:`kailash.trust._json.canonical_json_dumps` for cross-SDK
+        byte parity.
+        """
+        return {
+            "inner": self.inner.to_dict(),
+            "genesis_id": self.genesis_id,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> DelegateConstraintEnvelope:
+        """Validating constructor from a wire dict (S3 H2 deferral closure).
+
+        Both required fields MUST be present; the inner dict is delegated
+        to the substrate's :meth:`ConstraintEnvelope.from_dict` (which
+        carries its own validation gates). Missing or wrong-typed fields
+        raise :class:`ValueError` / :class:`TypeError`.
+
+        This is the audit-grade ingest path; bare ``__init__`` and
+        :meth:`from_genesis` are the in-process paths. Cross-SDK ingest
+        MUST route through this constructor so the validating gate fires
+        on every externally-sourced envelope wrapper.
+        """
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "DelegateConstraintEnvelope.from_dict requires a dict; got "
+                f"{type(payload).__name__}"
+            )
+        missing = {"inner", "genesis_id"} - set(payload)
+        if missing:
+            raise ValueError(
+                f"DelegateConstraintEnvelope.from_dict missing required "
+                f"field(s): {sorted(missing)}"
+            )
+        inner_payload = payload["inner"]
+        if not isinstance(inner_payload, dict):
+            raise TypeError(
+                "DelegateConstraintEnvelope.from_dict: inner MUST be a "
+                f"dict; got {type(inner_payload).__name__}"
+            )
+        genesis_id = payload["genesis_id"]
+        if not isinstance(genesis_id, str):
+            raise TypeError(
+                "DelegateConstraintEnvelope.from_dict: genesis_id MUST be "
+                f"a str; got {type(genesis_id).__name__}"
+            )
+        if not genesis_id:
+            raise ValueError(
+                "DelegateConstraintEnvelope.from_dict: genesis_id MUST be "
+                "a non-empty string"
+            )
+        # Delegate inner envelope reconstruction to the substrate's own
+        # validating constructor; it owns the per-dimension contract.
+        inner = ConstraintEnvelope.from_dict(inner_payload)
+        return cls(inner=inner, genesis_id=genesis_id)

--- a/src/kailash/delegate/envelope.py
+++ b/src/kailash/delegate/envelope.py
@@ -189,17 +189,23 @@ class DelegateConstraintEnvelope:
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> DelegateConstraintEnvelope:
-        """Validating constructor from a wire dict (S3 H2 deferral closure).
+        """Construct from a JSON-native payload with field-presence
+        validation + inner-envelope delegation (S3 H2 deferral closure).
 
-        Both required fields MUST be present; the inner dict is delegated
-        to the substrate's :meth:`ConstraintEnvelope.from_dict` (which
-        carries its own validation gates). Missing or wrong-typed fields
-        raise :class:`ValueError` / :class:`TypeError`.
+        B4 (analyst H-3) — honest description of what this constructor does
+        relative to the bare ``__init__``:
 
-        This is the audit-grade ingest path; bare ``__init__`` and
-        :meth:`from_genesis` are the in-process paths. Cross-SDK ingest
-        MUST route through this constructor so the validating gate fires
-        on every externally-sourced envelope wrapper.
+        - The genesis_id non-emptiness invariant is checked here at the
+          field-presence layer. The inner :class:`ConstraintEnvelope`'s own
+          per-dimension contract is enforced by the substrate's
+          :meth:`ConstraintEnvelope.from_dict`.
+        - This classmethod adds field-presence checks that raise
+          :class:`ValueError` / :class:`TypeError` with a missing-field /
+          wrong-type message rather than ``KeyError``, plus the structural
+          guard that the inner payload is a dict.
+
+        Convenience loader for cross-SDK JSON ingest. Bare ``__init__`` and
+        :meth:`from_genesis` remain the in-process paths.
         """
         if not isinstance(payload, dict):
             raise TypeError(

--- a/src/kailash/delegate/trust.py
+++ b/src/kailash/delegate/trust.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 

--- a/src/kailash/delegate/trust.py
+++ b/src/kailash/delegate/trust.py
@@ -243,6 +243,62 @@ class TenantScope:
         """
         return self._is_global
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this :class:`TenantScope` to its canonical wire dict.
+
+        B2 (sec H-3): promoted from the private module-level
+        ``_tenant_to_dict`` helper to a public instance method per the EATP
+        SDK convention that every public dataclass exposes ``to_dict`` +
+        ``from_dict``. Cross-SDK ingest/emit paths route through this method
+        (and :meth:`from_dict`) instead of the now-removed private helper.
+
+        Cross-SDK wire format mirrors rs's tagged-union JSON: ``{"type":
+        "Global"}`` or ``{"type": "Tenant", "tenant_id": "..."}``. The
+        discriminator key is ``type`` for compatibility with rs serde's
+        default tagged-enum representation.
+
+        CROSS-SDK note (B6): rs ``cascade.rs::TenantScope`` does NOT yet
+        declare serde derives, so the rs wire format is UNDEFINED. When rs
+        adds serde, this wire format MUST be reconciled.
+        """
+        if self.is_global:
+            return {"type": "Global"}
+        return {"type": "Tenant", "tenant_id": self.tenant_id}
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> TenantScope:
+        """Deserialize a :class:`TenantScope` from its canonical wire dict.
+
+        B2 (sec H-3): promoted from the private module-level
+        ``_tenant_from_dict`` helper to a public classmethod per the EATP SDK
+        convention. Inverse of :meth:`to_dict`.
+
+        Raises:
+            TypeError: if ``payload`` is not a dict.
+            ValueError: on missing/unknown discriminator or missing /
+                non-string ``tenant_id`` for the Tenant variant.
+        """
+        if not isinstance(payload, dict):
+            raise TypeError(
+                f"TenantScope.from_dict requires a dict; got "
+                f"{type(payload).__name__}"
+            )
+        discriminator = payload.get("type")
+        if discriminator == "Global":
+            return cls.global_()
+        if discriminator == "Tenant":
+            tenant_id = payload.get("tenant_id")
+            if not isinstance(tenant_id, str):
+                raise ValueError(
+                    "TenantScope.from_dict payload type=Tenant requires a "
+                    "string tenant_id"
+                )
+            return cls.for_tenant(tenant_id)
+        raise ValueError(
+            f"TenantScope.from_dict: unknown discriminator: {discriminator!r} "
+            f"(expected 'Global' or 'Tenant')"
+        )
+
 
 # ---------------------------------------------------------------------------
 # TenantScopedCascade — the F1/F5/Option-A gate
@@ -524,7 +580,7 @@ class GrantMoment:
             "cascade_id": str(self.cascade_id),
             "parent_delegate_id": str(self.parent_delegate_id),
             "child_delegate_id": str(self.child_delegate_id),
-            "tenant": _tenant_to_dict(self.tenant),
+            "tenant": self.tenant.to_dict(),
             "granted_at": self.granted_at.isoformat(),
         }
 
@@ -541,40 +597,7 @@ class GrantMoment:
         return payload
 
 
-def _tenant_to_dict(tenant: TenantScope) -> dict[str, Any]:
-    """Serialize a :class:`TenantScope` to its canonical dict shape.
-
-    Cross-SDK wire format mirrors rs's tagged-union JSON: ``{"type":
-    "Global"}`` or ``{"type": "Tenant", "tenant_id": "..."}``. The
-    discriminator key is ``type`` for compatibility with rs serde's
-    default tagged-enum representation.
-    """
-    if tenant.is_global:
-        return {"type": "Global"}
-    return {"type": "Tenant", "tenant_id": tenant.tenant_id}
-
-
-def _tenant_from_dict(payload: dict[str, Any]) -> TenantScope:
-    """Deserialize a :class:`TenantScope` from its canonical dict shape.
-
-    Inverse of :func:`_tenant_to_dict`. Raises :class:`ValueError` on
-    unknown discriminator or missing ``tenant_id`` for the Tenant variant.
-    """
-    if not isinstance(payload, dict):
-        raise TypeError(
-            f"TenantScope payload MUST be a dict; got {type(payload).__name__}"
-        )
-    discriminator = payload.get("type")
-    if discriminator == "Global":
-        return TenantScope.global_()
-    if discriminator == "Tenant":
-        tenant_id = payload.get("tenant_id")
-        if not isinstance(tenant_id, str):
-            raise ValueError(
-                "TenantScope payload type=Tenant requires a string tenant_id"
-            )
-        return TenantScope.for_tenant(tenant_id)
-    raise ValueError(
-        f"unknown TenantScope discriminator: {discriminator!r} "
-        f"(expected 'Global' or 'Tenant')"
-    )
+# Note: B2 (sec H-3) — the prior module-level _tenant_to_dict /
+# _tenant_from_dict helpers were promoted to TenantScope.to_dict (instance
+# method) and TenantScope.from_dict (classmethod) above. The private helpers
+# were internal-only (no external callers), so promotion is API-additive.

--- a/src/kailash/delegate/trust.py
+++ b/src/kailash/delegate/trust.py
@@ -1,0 +1,558 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportUnnecessaryIsInstance=false
+"""Trust-cascade composition layer for ``kailash.delegate`` (S3 of #1035).
+
+Mirrors the kailash-rs ``kailash-delegate-trust`` crate's M3-01 + M3-02
+shipped surface (see ``workspaces/issue-1035-delegate-py/01-analysis/
+02-kailash-rs-reference-extraction.md`` § trust-cascade):
+
+- :class:`TenantScope` — typed 2-variant tagged union mirroring rs
+  ``TenantScope`` (``cascade.rs:101-149``). Either :class:`TenantScope.global_`
+  (no boundary) or :class:`TenantScope.for_tenant("id")`. The
+  ``Global``/``Tenant`` distinction is STRUCTURAL — "no isolation" is the
+  explicit ``Global`` variant, never an implicit ``None`` default that
+  silently disables the tenant boundary in a deployment that should have
+  been tenant-scoped (rs M-1 misconfiguration guard).
+- :class:`TenantScopedCascade` — the load-bearing cascade gate enforcing
+  fail-closed (1) tenant-first isolation (rs Option A RATIFIED), (2) F1
+  downward-only scope subset, (3) pairwise envelope tightening across
+  every PACT dimension via the existing
+  :meth:`kailash.delegate.envelope.DelegateConstraintEnvelope.tighten_with`
+  (which inherits the S2.5 F5 widening-raise gate). On success it emits a
+  :class:`GrantMoment` chain-of-custody record.
+- :class:`GrantMoment` — mirrors rs ``GrantMoment`` (``grant.rs:186-198``).
+  Frozen, tz-aware, hex-signature-validated, with ``to_canonical_dict()``
+  + ``to_signing_dict()`` (sign/verify split per S2.5 F7) suitable for
+  routing through :func:`kailash.trust._json.canonical_json_dumps` for
+  cross-SDK byte-canonical parity with rs reference fixtures.
+
+The cascade is fail-closed at EVERY step; an error in any step raises a
+typed error BEFORE the next step runs. Mirrors rs ``cascade_child``'s
+fixed-order check sequence at ``cascade.rs:276-313``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from kailash.delegate.envelope import DelegateConstraintEnvelope, EnvelopeWideningError
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateIdentity,
+    RoleScope,
+    _validate_hex,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CascadeScopeExpansionError",
+    "CascadeTenantViolationError",
+    "GrantMoment",
+    "TenantScope",
+    "TenantScopedCascade",
+]
+
+
+# ---------------------------------------------------------------------------
+# Typed errors (Option A RATIFIED + F1)
+# ---------------------------------------------------------------------------
+
+
+class CascadeTenantViolationError(ValueError):
+    """Raised when :meth:`TenantScopedCascade.cascade_child` crosses tenant.
+
+    Mirrors the rs ``TrustGateError::TenantIsolation`` variant (``error.rs:
+    51-65``). Tenant-first isolation per Option A RATIFIED: a Tenant-A
+    cascade cannot admit a Tenant-B child even when the scope subset +
+    envelope tightening would otherwise pass.
+
+    ``ValueError``-derived because the cross-tenant cascade is a contract
+    violation by the caller, not a system fault.
+    """
+
+    def __init__(
+        self,
+        parent_tenant: str | None,
+        child_tenant: str | None,
+    ) -> None:
+        self.parent_tenant = parent_tenant
+        self.child_tenant = child_tenant
+        super().__init__(
+            f"tenant isolation violated: parent tenant {parent_tenant!r} != "
+            f"child tenant {child_tenant!r} (Option A RATIFIED — a cross-"
+            f"tenant cascade is fail-closed regardless of scope/envelope "
+            f"tightening)"
+        )
+
+
+class CascadeScopeExpansionError(ValueError):
+    """Raised when a child's :class:`RoleScope` expands its parent's scope.
+
+    Mirrors the rs ``TrustGateError::CascadeWidening`` variant (``error.rs:
+    44-49``). F1 (ratified): the cascade is downward-only — a child scope
+    that is not a subset of its parent is rejected here.
+
+    Subset semantics:
+    - **Domain**: child MUST equal parent's domain (no cross-domain cascade).
+    - **Capabilities**: child :class:`CapabilitySet` MUST be a subset of
+      parent's (the intersection of parent ∩ child MUST equal child —
+      mirrors rs ``DelegationScope::is_subset_of`` operations check).
+
+    ``ValueError``-derived per the same caller-fault rationale as
+    :class:`CascadeTenantViolationError`.
+    """
+
+    def __init__(
+        self,
+        parent_domain: str,
+        child_domain: str,
+        added_capabilities: tuple[str, ...] = (),
+    ) -> None:
+        self.parent_domain = parent_domain
+        self.child_domain = child_domain
+        self.added_capabilities = added_capabilities
+        if parent_domain != child_domain:
+            msg = (
+                f"cascade scope expansion: child domain {child_domain!r} "
+                f"differs from parent domain {parent_domain!r} (F1 "
+                f"downward-only requires identical domain)"
+            )
+        else:
+            msg = (
+                f"cascade scope expansion: child added capabilities "
+                f"{sorted(added_capabilities)!r} not in parent's capability "
+                f"set (F1 downward-only requires subset; widening blocked)"
+            )
+        super().__init__(msg)
+
+
+# ---------------------------------------------------------------------------
+# TenantScope — typed 2-variant tagged union (M-1 misconfiguration guard)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TenantScope:
+    """The spine's tenant scope key (rs Option A RATIFIED).
+
+    Mirrors rs ``TenantScope`` (``cascade.rs:101-149``). A typed 2-variant
+    tagged union, NOT an ``Optional[str]``: "global / unscoped" is the
+    explicit :meth:`TenantScope.global_` variant, never an implicit
+    ``None``-default that silently disables the tenant boundary in a
+    deployment that should have been tenant-scoped (M-1 guard).
+
+    Construction MUST go through the classmethod factories
+    (:meth:`global_` or :meth:`for_tenant`) so the "Global vs Tenant"
+    choice is auditable at the call site.
+
+    Equality is structural — two scopes with the same ``tenant_id`` compare
+    equal; Global compares equal only to Global; Global never equals
+    ``Tenant("global")`` (the typed enum makes the distinction structural,
+    not stringly).
+    """
+
+    # Private discriminant: True = Global, False = Tenant
+    # Public callers MUST use the classmethods, never construct directly.
+    _is_global: bool
+    _tenant_id: str | None
+
+    def __post_init__(self) -> None:
+        # Defense-in-depth: the dataclass invariant is global xor tenant_id.
+        if self._is_global and self._tenant_id is not None:
+            raise ValueError(
+                "TenantScope: Global variant MUST NOT carry a tenant_id "
+                "(construct via TenantScope.global_() or .for_tenant(id))"
+            )
+        if not self._is_global and self._tenant_id is None:
+            raise ValueError(
+                "TenantScope: Tenant variant MUST carry a non-None tenant_id "
+                "(construct via TenantScope.for_tenant(id))"
+            )
+        if not self._is_global and self._tenant_id is not None and not self._tenant_id:
+            raise ValueError("TenantScope.for_tenant requires a non-empty tenant id")
+
+    @classmethod
+    def global_(cls) -> TenantScope:
+        """Return the explicit unscoped / global variant.
+
+        This is the DELIBERATE "no tenant boundary" choice — a tenant-scoped
+        deployment MUST NOT seed this. The classmethod name is ``global_``
+        (trailing underscore) because ``global`` is a Python keyword.
+        """
+        return cls(_is_global=True, _tenant_id=None)
+
+    @classmethod
+    def for_tenant(cls, tenant_id: str) -> TenantScope:
+        """Return a concrete tenant boundary keyed on ``tenant_id``.
+
+        A cascade bound to ``for_tenant("a")`` rejects a child claiming
+        ``for_tenant("b")`` (or ``global_()``) fail-closed via
+        :class:`CascadeTenantViolationError`.
+        """
+        if not isinstance(tenant_id, str):
+            raise TypeError(
+                "TenantScope.for_tenant requires a str tenant_id; got "
+                f"{type(tenant_id).__name__}"
+            )
+        return cls(_is_global=False, _tenant_id=tenant_id)
+
+    @property
+    def tenant_id(self) -> str | None:
+        """Borrow the tenant id (``None`` = unscoped / global).
+
+        Preserved verbatim from the rs accessor shape so cross-SDK consumers
+        of the M3-01 tenant scope-key surface keep their idioms.
+        """
+        return self._tenant_id
+
+    @property
+    def is_global(self) -> bool:
+        """``True`` iff this scope is the explicit unscoped / global variant.
+
+        A conformance helper for tenant-scoped deployments: ``assert not
+        scope.is_global`` makes a misconfigured global seed a loud test
+        failure rather than a silent contamination surface (M-1 guard).
+        """
+        return self._is_global
+
+
+# ---------------------------------------------------------------------------
+# TenantScopedCascade — the F1/F5/Option-A gate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TenantScopedCascade:
+    """A delegation cascade scoped to a single :class:`TenantScope`.
+
+    Mirrors rs ``TenantScopedCascade`` (``cascade.rs:196-335``). The cascade
+    is fail-closed at every step; each :meth:`cascade_child` call validates
+    the parent→child edge in fixed order:
+
+    1. **Tenant boundary** (Option A RATIFIED) — child tenant MUST equal
+       this cascade's tenant. Checked FIRST so a Tenant-A cascade cannot
+       even reach the scope/envelope checks for a Tenant-B child. Raises
+       :class:`CascadeTenantViolationError`.
+    2. **Scope subset** (F1 downward-only) — child :class:`RoleScope`'s
+       domain MUST equal parent's; child capabilities MUST be a subset of
+       parent's. Raises :class:`CascadeScopeExpansionError`.
+    3. **Envelope tightening** (F5) — delegates to the existing
+       :meth:`DelegateConstraintEnvelope.tighten_with`, which carries the
+       S2.5 pre-intersection widening check. Raises
+       :class:`EnvelopeWideningError` on any dimension widening.
+    4. **Emit GrantMoment** — on success, return a fully-formed
+       :class:`GrantMoment` chain-of-custody record.
+
+    The cascade is bound to a single tenant at construction; cascading a
+    cross-tenant child requires a NEW cascade for that tenant.
+    """
+
+    tenant: TenantScope
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.tenant, TenantScope):
+            raise TypeError(
+                "TenantScopedCascade.tenant MUST be a TenantScope; got "
+                f"{type(self.tenant).__name__}"
+            )
+
+    def cascade_child(
+        self,
+        parent_envelope: DelegateConstraintEnvelope,
+        child_envelope: DelegateConstraintEnvelope,
+        *,
+        parent_identity: DelegateIdentity,
+        child_identity: DelegateIdentity,
+        parent_scope: RoleScope,
+        child_scope: RoleScope,
+        child_tenant: TenantScope,
+        grant_proof: str,
+        granted_at: datetime | None = None,
+    ) -> GrantMoment:
+        """Validate one downward cascade edge and emit a :class:`GrantMoment`.
+
+        Steps 1-3 are fail-closed in the fixed order described in the class
+        docstring. On success (all three steps pass) step 4 emits the
+        chain-of-custody record.
+
+        Args:
+            parent_envelope: The parent's :class:`DelegateConstraintEnvelope`.
+                Carries the F5 envelope-tightening contract.
+            child_envelope: The child's raw
+                :class:`kailash.trust.envelope.ConstraintEnvelope` wrapped in
+                a :class:`DelegateConstraintEnvelope` (the wrapper carries
+                the genesis_id contract). The child's envelope MUST be at-
+                least-as-tight as the parent on every dimension.
+            parent_identity: Identity of the granting authority (used in the
+                emitted :class:`GrantMoment.parent_delegate_id`).
+            child_identity: Identity of the receiving delegate (used in the
+                emitted :class:`GrantMoment.child_delegate_id`).
+            parent_scope: Parent's :class:`RoleScope` (domain + capabilities).
+            child_scope: Child's :class:`RoleScope`; MUST be subset of parent.
+            child_tenant: The child's tenant scope. MUST equal
+                ``self.tenant`` (Option A RATIFIED).
+            grant_proof: Hex-encoded Ed25519 signature (128 lowercase hex
+                chars). Validated at the GrantMoment level.
+            granted_at: tz-aware UTC datetime; defaults to now() if None.
+
+        Returns:
+            A :class:`GrantMoment` recording WHO granted (parent) to WHOM
+            (child), under WHAT tenant, at WHEN, with the supplied
+            grant_proof signature.
+
+        Raises:
+            CascadeTenantViolationError: cross-tenant cascade attempt.
+            CascadeScopeExpansionError: child scope expands parent.
+            EnvelopeWideningError: child envelope widens parent on any dim.
+            TypeError: any argument fails its isinstance check.
+        """
+        # Type discipline at the boundary — defense-in-depth on top of
+        # the dataclass post_init in each composed type.
+        if not isinstance(parent_envelope, DelegateConstraintEnvelope):
+            raise TypeError(
+                "cascade_child.parent_envelope MUST be a "
+                f"DelegateConstraintEnvelope; got {type(parent_envelope).__name__}"
+            )
+        if not isinstance(child_envelope, DelegateConstraintEnvelope):
+            raise TypeError(
+                "cascade_child.child_envelope MUST be a "
+                f"DelegateConstraintEnvelope; got {type(child_envelope).__name__}"
+            )
+        if not isinstance(parent_identity, DelegateIdentity):
+            raise TypeError(
+                "cascade_child.parent_identity MUST be a DelegateIdentity; "
+                f"got {type(parent_identity).__name__}"
+            )
+        if not isinstance(child_identity, DelegateIdentity):
+            raise TypeError(
+                "cascade_child.child_identity MUST be a DelegateIdentity; "
+                f"got {type(child_identity).__name__}"
+            )
+        if not isinstance(parent_scope, RoleScope):
+            raise TypeError(
+                "cascade_child.parent_scope MUST be a RoleScope; got "
+                f"{type(parent_scope).__name__}"
+            )
+        if not isinstance(child_scope, RoleScope):
+            raise TypeError(
+                "cascade_child.child_scope MUST be a RoleScope; got "
+                f"{type(child_scope).__name__}"
+            )
+        if not isinstance(child_tenant, TenantScope):
+            raise TypeError(
+                "cascade_child.child_tenant MUST be a TenantScope; got "
+                f"{type(child_tenant).__name__}"
+            )
+
+        # Step 1 (Option A RATIFIED): tenant-first isolation, fail-closed
+        # BEFORE any scope/envelope work. The structural equality here
+        # implements the rs `child_tenant != &self.tenant` check.
+        if child_tenant != self.tenant:
+            raise CascadeTenantViolationError(
+                parent_tenant=self.tenant.tenant_id,
+                child_tenant=child_tenant.tenant_id,
+            )
+
+        # Step 2 (F1 downward-only): scope subset. Domain MUST equal; child
+        # capabilities MUST be a subset of parent's.
+        if parent_scope.domain != child_scope.domain:
+            raise CascadeScopeExpansionError(
+                parent_domain=parent_scope.domain,
+                child_domain=child_scope.domain,
+            )
+        added = _capability_diff(parent_scope.capabilities, child_scope.capabilities)
+        if added:
+            raise CascadeScopeExpansionError(
+                parent_domain=parent_scope.domain,
+                child_domain=child_scope.domain,
+                added_capabilities=added,
+            )
+
+        # Step 3 (F5): envelope tightening — delegated to the existing
+        # wrapper that already carries the pre-intersection widening check
+        # per S2.5 F1. Propagates EnvelopeWideningError verbatim.
+        _tightened = parent_envelope.tighten_with(child_envelope.inner)
+        # The tightened envelope is computed for side-effect (raises on
+        # widen); the emitted GrantMoment does NOT carry it because the
+        # canonical chain-of-custody record per rs grant.rs is identity +
+        # tenant + proof + timestamp — not the post-tightening envelope.
+        # The envelope contract is enforced by the raise above; downstream
+        # consumers requesting the tightened envelope MUST call tighten_with
+        # explicitly (S6 runtime spine will surface it).
+        del _tightened
+
+        # Step 4: emit the chain-of-custody GrantMoment.
+        return GrantMoment(
+            cascade_id=uuid.uuid4(),
+            parent_delegate_id=parent_identity.delegate_id,
+            child_delegate_id=child_identity.delegate_id,
+            tenant=self.tenant,
+            granted_at=(
+                granted_at if granted_at is not None else datetime.now(timezone.utc)
+            ),
+            grant_proof=grant_proof,
+        )
+
+
+def _capability_diff(parent: CapabilitySet, child: CapabilitySet) -> tuple[str, ...]:
+    """Return capabilities present in ``child`` but missing from ``parent``.
+
+    Order-stable: returns tokens in the order they appear in ``child``.
+    Empty result means ``child`` is a subset of ``parent``.
+    """
+    parent_set = set(parent.capabilities)
+    return tuple(c for c in child.capabilities if c not in parent_set)
+
+
+# ---------------------------------------------------------------------------
+# GrantMoment — chain-of-custody record (M3-02)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class GrantMoment:
+    """A signed Grant Moment recording one cascade edge.
+
+    Mirrors rs ``GrantMoment`` (``grant.rs:186-198``). Frozen, tz-aware,
+    Ed25519-hex-validated. The canonical chain-of-custody record on
+    success of :meth:`TenantScopedCascade.cascade_child` — records WHO
+    granted (parent), WHOM (child), under WHAT tenant, WHEN, with what
+    signature proof.
+
+    Cross-SDK byte-canonical fixtures emitted by py or rs are verified
+    via :func:`kailash.trust._json.canonical_json_dumps` on the dicts
+    returned by :meth:`to_canonical_dict` / :meth:`to_signing_dict`.
+
+    Args:
+        cascade_id: Unique per-cascade identifier (``uuid.UUID``).
+        parent_delegate_id: Granting authority's :attr:`DelegateIdentity.delegate_id`.
+        child_delegate_id: Receiving delegate's :attr:`DelegateIdentity.delegate_id`.
+        tenant: The :class:`TenantScope` this cascade edge is bound to
+            (same on parent + child by Option A — Step 1 enforces this).
+        granted_at: Timezone-aware UTC datetime. Naive datetimes rejected
+            (cross-SDK wire-format parity per S2.5 F6).
+        grant_proof: Hex-encoded Ed25519 signature, exactly 128 lowercase
+            hex chars. Validated via the substrate
+            :func:`kailash.delegate.types._validate_hex` helper.
+    """
+
+    cascade_id: uuid.UUID
+    parent_delegate_id: uuid.UUID
+    child_delegate_id: uuid.UUID
+    tenant: TenantScope
+    granted_at: datetime
+    grant_proof: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.cascade_id, uuid.UUID):
+            raise TypeError(
+                "GrantMoment.cascade_id MUST be a uuid.UUID; got "
+                f"{type(self.cascade_id).__name__}"
+            )
+        if not isinstance(self.parent_delegate_id, uuid.UUID):
+            raise TypeError(
+                "GrantMoment.parent_delegate_id MUST be a uuid.UUID; got "
+                f"{type(self.parent_delegate_id).__name__}"
+            )
+        if not isinstance(self.child_delegate_id, uuid.UUID):
+            raise TypeError(
+                "GrantMoment.child_delegate_id MUST be a uuid.UUID; got "
+                f"{type(self.child_delegate_id).__name__}"
+            )
+        if not isinstance(self.tenant, TenantScope):
+            raise TypeError(
+                "GrantMoment.tenant MUST be a TenantScope; got "
+                f"{type(self.tenant).__name__}"
+            )
+        if not isinstance(self.granted_at, datetime):
+            raise TypeError(
+                "GrantMoment.granted_at MUST be a datetime; got "
+                f"{type(self.granted_at).__name__}"
+            )
+        if self.granted_at.tzinfo is None:
+            raise ValueError(
+                "GrantMoment.granted_at MUST be timezone-aware (naive "
+                "datetimes break cross-SDK wire-format parity per S2.5 F6)"
+            )
+        # Ed25519 signature shape — 128 lowercase hex chars.
+        _validate_hex(
+            self.grant_proof,
+            expected_len=128,
+            field_name="GrantMoment.grant_proof (Ed25519)",
+        )
+
+    def to_signing_dict(self) -> dict[str, Any]:
+        """Return the pre-signature canonical dict (F7 — sign/verify split).
+
+        EXCLUDES :attr:`grant_proof`. Used by the signer/verifier to compute
+        or verify the signature over a deterministic byte payload. The
+        signature is computed over THIS dict's canonical-JSON encoding;
+        :meth:`to_canonical_dict` adds the signature for transport.
+
+        Mirrors the S2.5 :meth:`DelegateGenesisRecord.to_signing_dict`
+        shape; same convention for cross-SDK consumers.
+        """
+        return {
+            "cascade_id": str(self.cascade_id),
+            "parent_delegate_id": str(self.parent_delegate_id),
+            "child_delegate_id": str(self.child_delegate_id),
+            "tenant": _tenant_to_dict(self.tenant),
+            "granted_at": self.granted_at.isoformat(),
+        }
+
+    def to_canonical_dict(self) -> dict[str, Any]:
+        """Return the canonical-JSON-ready dict for cross-SDK byte parity.
+
+        Includes :attr:`grant_proof` (the Ed25519 signature). Routes through
+        :func:`kailash.trust._json.canonical_json_dumps` at the call site;
+        field NAMES and value TYPES MUST match the rs side exactly. Pairs
+        with :meth:`to_signing_dict` (F7 sign/verify split).
+        """
+        payload = self.to_signing_dict()
+        payload["grant_proof"] = self.grant_proof
+        return payload
+
+
+def _tenant_to_dict(tenant: TenantScope) -> dict[str, Any]:
+    """Serialize a :class:`TenantScope` to its canonical dict shape.
+
+    Cross-SDK wire format mirrors rs's tagged-union JSON: ``{"type":
+    "Global"}`` or ``{"type": "Tenant", "tenant_id": "..."}``. The
+    discriminator key is ``type`` for compatibility with rs serde's
+    default tagged-enum representation.
+    """
+    if tenant.is_global:
+        return {"type": "Global"}
+    return {"type": "Tenant", "tenant_id": tenant.tenant_id}
+
+
+def _tenant_from_dict(payload: dict[str, Any]) -> TenantScope:
+    """Deserialize a :class:`TenantScope` from its canonical dict shape.
+
+    Inverse of :func:`_tenant_to_dict`. Raises :class:`ValueError` on
+    unknown discriminator or missing ``tenant_id`` for the Tenant variant.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(
+            f"TenantScope payload MUST be a dict; got {type(payload).__name__}"
+        )
+    discriminator = payload.get("type")
+    if discriminator == "Global":
+        return TenantScope.global_()
+    if discriminator == "Tenant":
+        tenant_id = payload.get("tenant_id")
+        if not isinstance(tenant_id, str):
+            raise ValueError(
+                "TenantScope payload type=Tenant requires a string tenant_id"
+            )
+        return TenantScope.for_tenant(tenant_id)
+    raise ValueError(
+        f"unknown TenantScope discriminator: {discriminator!r} "
+        f"(expected 'Global' or 'Tenant')"
+    )

--- a/src/kailash/delegate/trust.py
+++ b/src/kailash/delegate/trust.py
@@ -455,15 +455,16 @@ class TenantScopedCascade:
         # Step 3 (F5): envelope tightening — delegated to the existing
         # wrapper that already carries the pre-intersection widening check
         # per S2.5 F1. Propagates EnvelopeWideningError verbatim.
-        _tightened = parent_envelope.tighten_with(child_envelope.inner)
-        # The tightened envelope is computed for side-effect (raises on
-        # widen); the emitted GrantMoment does NOT carry it because the
-        # canonical chain-of-custody record per rs grant.rs is identity +
-        # tenant + proof + timestamp — not the post-tightening envelope.
-        # The envelope contract is enforced by the raise above; downstream
-        # consumers requesting the tightened envelope MUST call tighten_with
-        # explicitly (S6 runtime spine will surface it).
-        del _tightened
+        #
+        # B3 (analyst H-1): the tightened envelope is now carried on the
+        # emitted GrantMoment instead of being discarded. Downstream
+        # consumers (S5/S6 runtime spine) MUST observe the post-tightening
+        # envelope as part of the chain-of-custody — recomputing it at
+        # every consumer doubled the tighten_with cost AND risked one site
+        # computing differently than another (silent drift). Carrying it
+        # on the GrantMoment keeps the cascade as the single source of
+        # truth for the F5 tightening result.
+        tightened = parent_envelope.tighten_with(child_envelope.inner)
 
         # Step 4: emit the chain-of-custody GrantMoment.
         return GrantMoment(
@@ -475,6 +476,7 @@ class TenantScopedCascade:
                 granted_at if granted_at is not None else datetime.now(timezone.utc)
             ),
             grant_proof=grant_proof,
+            tightened_envelope=tightened,
         )
 
 
@@ -518,6 +520,19 @@ class GrantMoment:
         grant_proof: Hex-encoded Ed25519 signature, exactly 128 lowercase
             hex chars. Validated via the substrate
             :func:`kailash.delegate.types._validate_hex` helper.
+        tightened_envelope: B3 (analyst H-1) — the post-cascade tightened
+            envelope produced by Step 3 (F5). Defaults to ``None`` when the
+            GrantMoment is constructed outside the cascade pipeline (e.g.
+            replayed from a wire-format payload that pre-dates the field).
+            S5/S6 runtime spine consumers observe the post-tightening
+            envelope from this attribute rather than re-calling
+            ``tighten_with`` at every site.
+
+    CROSS-SDK note (B7): py ``GrantMoment`` is a flat record; rs
+    ``GrantMoment::issue`` walks a ``DelegationChain`` substrate that py
+    does not yet expose. The py contract is structurally reduced — chain
+    composition lands in a separate workstream (see brief
+    ``workspaces/kailash-trust-chain-crypto-expansion/``).
     """
 
     cascade_id: uuid.UUID
@@ -526,6 +541,7 @@ class GrantMoment:
     tenant: TenantScope
     granted_at: datetime
     grant_proof: str
+    tightened_envelope: DelegateConstraintEnvelope | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.cascade_id, uuid.UUID):
@@ -564,6 +580,14 @@ class GrantMoment:
             expected_len=128,
             field_name="GrantMoment.grant_proof (Ed25519)",
         )
+        if self.tightened_envelope is not None and not isinstance(
+            self.tightened_envelope, DelegateConstraintEnvelope
+        ):
+            raise TypeError(
+                "GrantMoment.tightened_envelope MUST be a "
+                "DelegateConstraintEnvelope or None; got "
+                f"{type(self.tightened_envelope).__name__}"
+            )
 
     def to_signing_dict(self) -> dict[str, Any]:
         """Return the pre-signature canonical dict (F7 — sign/verify split).
@@ -575,14 +599,32 @@ class GrantMoment:
 
         Mirrors the S2.5 :meth:`DelegateGenesisRecord.to_signing_dict`
         shape; same convention for cross-SDK consumers.
+
+        B5 (sec M-3) — cross-SDK byte-canonical contract: callers MUST route
+        the returned dict through
+        :func:`kailash.trust._json.canonical_json_dumps` for signing.
+        Direct ``json.dumps()`` (without ``sort_keys=True`` +
+        ``separators=(",", ":")``) breaks cross-SDK parity per
+        ``cross-sdk-inspection.md`` Rule 4 (helpers claiming byte-shape
+        parity with the sibling SDK MUST pin byte vectors). See
+        :meth:`to_signing_bytes` for a one-call convenience that returns
+        the canonical bytes directly.
         """
-        return {
+        payload: dict[str, Any] = {
             "cascade_id": str(self.cascade_id),
             "parent_delegate_id": str(self.parent_delegate_id),
             "child_delegate_id": str(self.child_delegate_id),
             "tenant": self.tenant.to_dict(),
             "granted_at": self.granted_at.isoformat(),
         }
+        # B3 (analyst H-1): include the tightened envelope when present so
+        # cross-SDK byte-canonical fixtures reflect the post-cascade
+        # envelope state. None → omit the key entirely, preserving the
+        # pre-B3 wire format for GrantMoment instances constructed outside
+        # the cascade pipeline (e.g. replay paths that pre-date the field).
+        if self.tightened_envelope is not None:
+            payload["tightened_envelope"] = self.tightened_envelope.to_dict()
+        return payload
 
     def to_canonical_dict(self) -> dict[str, Any]:
         """Return the canonical-JSON-ready dict for cross-SDK byte parity.
@@ -595,6 +637,21 @@ class GrantMoment:
         payload = self.to_signing_dict()
         payload["grant_proof"] = self.grant_proof
         return payload
+
+    def to_signing_bytes(self) -> bytes:
+        """Return the canonical-JSON bytes ready for Ed25519 signing.
+
+        B5 (sec M-3) — convenience wrapper around
+        :meth:`to_signing_dict` + :func:`kailash.trust._json.canonical_json_dumps`.
+        Returning bytes directly closes the cross-SDK divergence trap where
+        a caller might use ``json.dumps()`` without canonical settings and
+        produce non-canonical bytes that break rs↔py verification.
+        """
+        # Lazy import to avoid a hot-path circular through trust._json if it
+        # ever grows a delegate dep; trust._json is otherwise foundational.
+        from kailash.trust._json import canonical_json_dumps
+
+        return canonical_json_dumps(self.to_signing_dict()).encode("utf-8")
 
 
 # Note: B2 (sec H-3) — the prior module-level _tenant_to_dict /

--- a/src/kailash/delegate/trust.py
+++ b/src/kailash/delegate/trust.py
@@ -34,6 +34,7 @@ fixed-order check sequence at ``cascade.rs:276-313``.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import uuid
 from dataclasses import dataclass, field
@@ -83,12 +84,33 @@ class CascadeTenantViolationError(ValueError):
     ) -> None:
         self.parent_tenant = parent_tenant
         self.child_tenant = child_tenant
+        # B1 (sec H-2): hash tenant IDs in the user-facing message per
+        # observability.md MUST Rule 8 (schema-revealing field names MUST be
+        # DEBUG or hashed). Raw tenant IDs remain on the exception
+        # attributes for in-process handling (tested), but the str(exc) form
+        # that may bleed into logs / cross-tenant error returns / aggregator
+        # surfaces carries only the 8-char SHA-256 prefix.
         super().__init__(
-            f"tenant isolation violated: parent tenant {parent_tenant!r} != "
-            f"child tenant {child_tenant!r} (Option A RATIFIED — a cross-"
-            f"tenant cascade is fail-closed regardless of scope/envelope "
-            f"tightening)"
+            f"tenant isolation violated: "
+            f"parent_tenant_hash={_tenant_id_hash(parent_tenant)} != "
+            f"child_tenant_hash={_tenant_id_hash(child_tenant)} (Option A "
+            f"RATIFIED — a cross-tenant cascade is fail-closed regardless of "
+            f"scope/envelope tightening)"
         )
+
+
+def _tenant_id_hash(tenant_id: str | None) -> str:
+    """Return a short SHA-256 prefix of a tenant id for log-safe display.
+
+    ``None`` returns the literal sentinel ``"<none>"`` (the Global variant has
+    no tenant id). Otherwise the first 8 hex chars of the SHA-256 digest of
+    the UTF-8 bytes — enough to disambiguate ~4×10^9 tenants in audit
+    correlation while not leaking the raw id into log aggregators (per
+    ``observability.md`` MUST Rule 8).
+    """
+    if tenant_id is None:
+        return "<none>"
+    return hashlib.sha256(tenant_id.encode("utf-8")).hexdigest()[:8]
 
 
 class CascadeScopeExpansionError(ValueError):

--- a/src/kailash/delegate/types.py
+++ b/src/kailash/delegate/types.py
@@ -267,16 +267,25 @@ class DelegateIdentity:
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> DelegateIdentity:
-        """Validating constructor from a wire dict (S3 H2 deferral closure).
+        """Construct from a JSON-native payload with type coercion + field-
+        presence validation (S3 H2 deferral closure).
 
-        Every required field MUST be present; types are coerced from JSON-
-        native (``str``) back to Python-native (``uuid.UUID``); every
-        post-init invariant fires after coercion. Missing or wrong-typed
-        fields raise :class:`ValueError` / :class:`TypeError`.
+        B4 (analyst H-3) — honest description of what this constructor does
+        relative to the bare ``__init__``:
 
-        This is the audit-grade ingest path; bare ``__init__`` is the in-
-        process path. Cross-SDK ingest MUST route through this constructor
-        so the validating gate fires on every externally-sourced identity.
+        - The underlying invariants (UUID format on ``delegate_id``,
+          non-emptiness of each ``*_ref``, path-traversal rejection via
+          ``kailash.trust._locking.validate_id``) are enforced by
+          ``__post_init__`` and ALSO fire on the bare ``__init__`` path.
+        - This classmethod adds two contributions on top: (1) JSON-native
+          ``str`` → Python-native ``uuid.UUID`` coercion for ``delegate_id``,
+          and (2) field-presence checks that raise :class:`ValueError` /
+          :class:`TypeError` with a missing-field / wrong-type message
+          rather than ``KeyError``.
+
+        Convenience loader for cross-SDK JSON ingest. Bare ``__init__``
+        remains the in-process path when callers already have UUIDs +
+        strings in hand.
         """
         if not isinstance(payload, dict):
             raise TypeError(

--- a/src/kailash/delegate/types.py
+++ b/src/kailash/delegate/types.py
@@ -188,9 +188,11 @@ class DelegateIdentity:
     in rs). A Delegate that cannot name its sovereign / role binding /
     genesis is not a valid identity.
 
-    Deferred to S3 (#1035 follow-up): from_dict validating constructor
-    closes the direct-dataclass-construction bypass; tracking via
-    workspace todos.
+    S3 (#1035) — the H2 deferral closes here: :meth:`from_dict` is the
+    audit-grade validating constructor that closes the direct-dataclass-
+    construction bypass. Cross-SDK ingest paths route through
+    :meth:`from_dict`; the bare ``__init__`` continues to work for in-
+    process construction.
 
     Args:
         delegate_id: Opaque Delegate identifier (``uuid.UUID``).
@@ -244,6 +246,86 @@ class DelegateIdentity:
             _validate_id(self.genesis_ref)
         except ValueError as exc:
             raise ValueError(f"DelegateIdentity.genesis_ref rejected: {exc}") from exc
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the canonical wire dict for cross-SDK round-trip (S3 H2).
+
+        Mirrors the EATP SDK convention: ``uuid.UUID`` serializes to its
+        string form; the three ``*_ref`` fields pass through verbatim
+        (already validated as non-empty + path-safe strings).
+
+        Pair with :meth:`from_dict` for round-trip; consumers serialize
+        via :func:`kailash.trust._json.canonical_json_dumps` for cross-SDK
+        byte parity.
+        """
+        return {
+            "delegate_id": str(self.delegate_id),
+            "sovereign_ref": self.sovereign_ref,
+            "role_binding_ref": self.role_binding_ref,
+            "genesis_ref": self.genesis_ref,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> DelegateIdentity:
+        """Validating constructor from a wire dict (S3 H2 deferral closure).
+
+        Every required field MUST be present; types are coerced from JSON-
+        native (``str``) back to Python-native (``uuid.UUID``); every
+        post-init invariant fires after coercion. Missing or wrong-typed
+        fields raise :class:`ValueError` / :class:`TypeError`.
+
+        This is the audit-grade ingest path; bare ``__init__`` is the in-
+        process path. Cross-SDK ingest MUST route through this constructor
+        so the validating gate fires on every externally-sourced identity.
+        """
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "DelegateIdentity.from_dict requires a dict; got "
+                f"{type(payload).__name__}"
+            )
+        missing = {
+            "delegate_id",
+            "sovereign_ref",
+            "role_binding_ref",
+            "genesis_ref",
+        } - set(payload)
+        if missing:
+            raise ValueError(
+                f"DelegateIdentity.from_dict missing required field(s): "
+                f"{sorted(missing)}"
+            )
+        raw_id = payload["delegate_id"]
+        if isinstance(raw_id, uuid.UUID):
+            delegate_id = raw_id
+        elif isinstance(raw_id, str):
+            try:
+                delegate_id = uuid.UUID(raw_id)
+            except (ValueError, AttributeError) as exc:
+                raise ValueError(
+                    f"DelegateIdentity.from_dict: delegate_id is not a "
+                    f"valid UUID string ({raw_id!r}); cross-SDK wire "
+                    f"format requires canonical UUID hex"
+                ) from exc
+        else:
+            raise TypeError(
+                "DelegateIdentity.from_dict: delegate_id MUST be a str or "
+                f"uuid.UUID; got {type(raw_id).__name__}"
+            )
+        # Coerce ref fields to str defensively — JSON natives are already
+        # str, but in-process callers may pass non-str by mistake; let the
+        # __post_init__ validate_id check do the path-traversal rejection.
+        for field_name in ("sovereign_ref", "role_binding_ref", "genesis_ref"):
+            if not isinstance(payload[field_name], str):
+                raise TypeError(
+                    f"DelegateIdentity.from_dict: {field_name} MUST be a str; "
+                    f"got {type(payload[field_name]).__name__}"
+                )
+        return cls(
+            delegate_id=delegate_id,
+            sovereign_ref=payload["sovereign_ref"],
+            role_binding_ref=payload["role_binding_ref"],
+            genesis_ref=payload["genesis_ref"],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/delegate/test_tenant_isolation.py
+++ b/tests/integration/delegate/test_tenant_isolation.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Integration test for S3 trust cascade exercised through TrustLineageChain.
+
+Per ``orphan-detection.md`` MUST Rule 2 and ``facade-manager-detection.md``:
+the cascade primitives (``TenantScopedCascade``, ``GrantMoment``) are wired
+end-to-end against the existing substrate :class:`TrustLineageChain` audit
+emission so an integration regression that orphans the cascade or breaks the
+audit-trail handoff fails here loudly.
+
+Tier classification follows the S2.5 ``test_genesis_chain_roundtrip.py``
+precedent (B5, Round 2 sec M-3): :class:`TrustLineageChain` is a plain
+``@dataclass`` (NOT a ``typing.Protocol`` satisfier), so the Tier-2
+"real-infrastructure" framing does not require Postgres at this layer — the
+chain object IS the infrastructure. Real-Postgres-backed
+``TrustChainStore`` persistence is the next-shard follow-up (S4 audit chain
++ S6 runtime spine wire the cascade against real PACT + real Postgres per
+#1035 acceptance criterion). This test exercises:
+
+1. End-to-end cascade success → :class:`GrantMoment` emission → audit
+   record committed to the substrate :class:`TrustLineageChain`.
+2. Cross-tenant cascade rejection: the chain MUST NOT receive an audit
+   record for a rejected cascade (fail-closed at the cascade gate).
+3. Scope-expansion cascade rejection: same audit-absence guarantee.
+4. Envelope-widening cascade rejection: same audit-absence guarantee.
+5. Chain hash advances after a successful cascade audit append: proves
+   the cascade-emitted GrantMoment composes the chain's tamper-evident
+   sequence — not a parallel side-channel.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.delegate.envelope import DelegateConstraintEnvelope, EnvelopeWideningError
+from kailash.delegate.trust import (
+    CascadeScopeExpansionError,
+    CascadeTenantViolationError,
+    GrantMoment,
+    TenantScope,
+    TenantScopedCascade,
+)
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateGenesisRecord,
+    DelegateIdentity,
+    RoleScope,
+)
+from kailash.trust.chain import (
+    AuthorityType,
+    DelegationRecord,
+    GenesisRecord,
+    TrustLineageChain,
+)
+from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+
+def _build_chain(*, genesis_id: str) -> TrustLineageChain:
+    """Build a real (in-memory) TrustLineageChain rooted at a substrate
+    GenesisRecord. Uses the same shape Wave 1 + S2.5 tests use."""
+    block = GenesisRecord(
+        id=genesis_id,
+        agent_id="agent-tier2",
+        authority_id="auth-tier2",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc),
+        signature="d" * 128,
+    )
+    return TrustLineageChain(genesis=block)
+
+
+def _envelope(budget: float, *, genesis_id: str) -> DelegateConstraintEnvelope:
+    block = GenesisRecord(
+        id=genesis_id,
+        agent_id="agent-env",
+        authority_id="auth-env",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc),
+        signature="d" * 128,
+    )
+    genesis = DelegateGenesisRecord(
+        block=block, spec_version="1", capabilities=("read",)
+    )
+    return DelegateConstraintEnvelope.from_genesis(
+        ConstraintEnvelope(financial=FinancialConstraint(budget_limit=budget)),
+        genesis,
+    )
+
+
+def _identity(suffix: str) -> DelegateIdentity:
+    return DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref=f"sov-{suffix}",
+        role_binding_ref=f"role-{suffix}",
+        genesis_ref=f"genesis-{suffix}",
+    )
+
+
+def _scope_finance() -> RoleScope:
+    return RoleScope(
+        domain="finance",
+        capabilities=CapabilitySet(capabilities=("read", "approve")),
+    )
+
+
+def _scope_finance_subset() -> RoleScope:
+    return RoleScope(
+        domain="finance",
+        capabilities=CapabilitySet(capabilities=("read",)),
+    )
+
+
+def _delegation_record_from_grant(
+    gm: GrantMoment,
+    *,
+    parent_identity: DelegateIdentity,
+    child_identity: DelegateIdentity,
+) -> DelegationRecord:
+    """Build a substrate DelegationRecord from a Delegate-layer GrantMoment.
+
+    The Delegate-layer GrantMoment carries the cascade-level proof; the
+    substrate chain records it as a DelegationRecord so the audit trail
+    composes the existing TrustLineageChain.delegations sequence."""
+    return DelegationRecord(
+        id=str(gm.cascade_id),
+        delegator_id=parent_identity.sovereign_ref,
+        delegatee_id=child_identity.sovereign_ref,
+        task_id=f"cascade-{gm.cascade_id}",
+        capabilities_delegated=["read"],
+        constraint_subset=[f"genesis:{parent_identity.genesis_ref}"],
+        delegated_at=gm.granted_at,
+        signature=gm.grant_proof,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Success path — cascade emits GrantMoment, audit appended to chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_cascade_success_appends_to_trust_lineage_chain() -> None:
+    """End-to-end success path: cascade emits GrantMoment → chain records it."""
+    chain = _build_chain(genesis_id="g-tier2-success-0001")
+    initial_hash = chain.hash()
+    initial_count = len(chain.delegations)
+
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope(100.0, genesis_id="g-parent")
+    child_env = _envelope(50.0, genesis_id="g-child")
+    parent = _identity("parent")
+    child = _identity("child")
+
+    gm = casc.cascade_child(
+        parent_env,
+        child_env,
+        parent_identity=parent,
+        child_identity=child,
+        parent_scope=_scope_finance(),
+        child_scope=_scope_finance_subset(),
+        child_tenant=TenantScope.for_tenant("tenant-a"),
+        grant_proof="b" * 128,
+    )
+
+    assert isinstance(gm, GrantMoment)
+    assert gm.parent_delegate_id == parent.delegate_id
+    assert gm.child_delegate_id == child.delegate_id
+    assert gm.tenant.tenant_id == "tenant-a"
+
+    # Wire the cascade-emitted moment through the substrate chain.
+    chain.delegations.append(
+        _delegation_record_from_grant(gm, parent_identity=parent, child_identity=child)
+    )
+
+    # State-persistence verification (per testing.md § State Persistence):
+    # read back the appended record and confirm chain hash advanced.
+    assert len(chain.delegations) == initial_count + 1
+    assert chain.delegations[-1].id == str(gm.cascade_id)
+    assert chain.delegations[-1].delegator_id == parent.sovereign_ref
+    assert chain.delegations[-1].delegatee_id == child.sovereign_ref
+    # Hash MUST change after appending — proves the cascade record composes
+    # the chain's tamper-evident sequence, not a parallel side-channel.
+    assert chain.hash() != initial_hash
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: cross-tenant cascade — chain MUST NOT receive an audit record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_cross_tenant_cascade_does_not_pollute_audit_chain() -> None:
+    """Cross-tenant cascade raises BEFORE any chain mutation — fail-closed.
+
+    The cascade gate's Step 1 fires before any audit work, so the
+    TrustLineageChain MUST be unchanged after the failed call."""
+    chain = _build_chain(genesis_id="g-tier2-crosstenant-0001")
+    initial_hash = chain.hash()
+    initial_count = len(chain.delegations)
+
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope(100.0, genesis_id="g-p")
+    child_env = _envelope(50.0, genesis_id="g-c")
+
+    with pytest.raises(CascadeTenantViolationError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity("parent"),
+            child_identity=_identity("child"),
+            parent_scope=_scope_finance(),
+            child_scope=_scope_finance_subset(),
+            child_tenant=TenantScope.for_tenant("tenant-b"),
+            grant_proof="a" * 128,
+        )
+
+    # Chain unmodified — fail-closed at the cascade gate.
+    assert len(chain.delegations) == initial_count
+    assert chain.hash() == initial_hash
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: scope-expansion cascade — same audit-absence guarantee
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_scope_expansion_cascade_does_not_pollute_audit_chain() -> None:
+    """Scope-expansion cascade raises BEFORE any chain mutation."""
+    chain = _build_chain(genesis_id="g-tier2-scope-0001")
+    initial_hash = chain.hash()
+    initial_count = len(chain.delegations)
+
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope(100.0, genesis_id="g-p")
+    child_env = _envelope(50.0, genesis_id="g-c")
+
+    with pytest.raises(CascadeScopeExpansionError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity("parent"),
+            child_identity=_identity("child"),
+            parent_scope=RoleScope(
+                domain="finance",
+                capabilities=CapabilitySet(capabilities=("read",)),
+            ),
+            # Child WIDENS — adds 'approve'
+            child_scope=RoleScope(
+                domain="finance",
+                capabilities=CapabilitySet(capabilities=("read", "approve")),
+            ),
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+
+    assert len(chain.delegations) == initial_count
+    assert chain.hash() == initial_hash
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: envelope-widening cascade — same audit-absence guarantee
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_envelope_widening_cascade_does_not_pollute_audit_chain() -> None:
+    """Envelope-widening cascade raises BEFORE any chain mutation.
+
+    EnvelopeWideningError is propagated from the existing S2.5
+    DelegateConstraintEnvelope.tighten_with's pre-intersection widening
+    check; the chain remains pristine."""
+    chain = _build_chain(genesis_id="g-tier2-env-0001")
+    initial_hash = chain.hash()
+    initial_count = len(chain.delegations)
+
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope(50.0, genesis_id="g-p")
+    child_env = _envelope(100.0, genesis_id="g-c")  # widens
+
+    with pytest.raises(EnvelopeWideningError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity("parent"),
+            child_identity=_identity("child"),
+            parent_scope=_scope_finance(),
+            child_scope=_scope_finance(),
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+
+    assert len(chain.delegations) == initial_count
+    assert chain.hash() == initial_hash
+
+
+# ---------------------------------------------------------------------------
+# Two successful cascades produce monotonically advancing chain hashes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_two_cascades_produce_monotonically_advancing_chain_hashes() -> None:
+    """Two successful cascade appends → three distinct chain hashes."""
+    chain = _build_chain(genesis_id="g-tier2-multi-0001")
+    h0 = chain.hash()
+
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope(100.0, genesis_id="g-p")
+    child_env = _envelope(50.0, genesis_id="g-c1")
+
+    parent = _identity("parent")
+    for i in range(2):
+        child = _identity(f"child-{i}")
+        gm = casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=parent,
+            child_identity=child,
+            parent_scope=_scope_finance(),
+            child_scope=_scope_finance_subset(),
+            child_tenant=TenantScope.for_tenant("tenant-a"),
+            grant_proof="b" * 128,
+        )
+        chain.delegations.append(
+            _delegation_record_from_grant(
+                gm, parent_identity=parent, child_identity=child
+            )
+        )
+
+    h2 = chain.hash()
+    # Two cascade-records → two distinct hash transitions.
+    assert len(chain.delegations) == 2
+    assert h2 != h0
+    # Unique cascade ids — proves each cascade emits a fresh moment.
+    assert chain.delegations[0].id != chain.delegations[1].id

--- a/tests/unit/delegate/test_trust_cascade.py
+++ b/tests/unit/delegate/test_trust_cascade.py
@@ -1,0 +1,645 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-1 tests for the S3 trust cascade (TenantScope + TenantScopedCascade +
+GrantMoment) per kailash-rs M3-01 + M3-02.
+
+Mirrors invariants surfaced in the kailash-rs reference extraction report at
+``workspaces/issue-1035-delegate-py/01-analysis/02-kailash-rs-reference-
+extraction.md`` § trust-cascade. The cascade is fail-closed at every step;
+each test exercises one step's typed-error gate or the success-path
+GrantMoment emission.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.delegate.envelope import DelegateConstraintEnvelope, EnvelopeWideningError
+from kailash.delegate.trust import (
+    CascadeScopeExpansionError,
+    CascadeTenantViolationError,
+    GrantMoment,
+    TenantScope,
+    TenantScopedCascade,
+)
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateGenesisRecord,
+    DelegateIdentity,
+    RoleScope,
+)
+from kailash.trust._json import canonical_json_dumps
+from kailash.trust.chain import AuthorityType
+from kailash.trust.chain import GenesisRecord as SubstrateGenesisRecord
+from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+# ---------------------------------------------------------------------------
+# Fixtures — minimal substrate + Delegate-layer constructs
+# ---------------------------------------------------------------------------
+
+
+def _identity(*, suffix: str = "1") -> DelegateIdentity:
+    return DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref=f"sov-{suffix}",
+        role_binding_ref=f"role-{suffix}",
+        genesis_ref=f"genesis-{suffix}",
+    )
+
+
+def _envelope_with_budget(
+    budget: float, *, genesis_id: str = "g-1"
+) -> DelegateConstraintEnvelope:
+    block = SubstrateGenesisRecord(
+        id=genesis_id,
+        agent_id="agent-1",
+        authority_id="auth-1",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc),
+        signature="d" * 128,
+    )
+    genesis = DelegateGenesisRecord(
+        block=block, spec_version="1", capabilities=("read",)
+    )
+    return DelegateConstraintEnvelope.from_genesis(
+        ConstraintEnvelope(financial=FinancialConstraint(budget_limit=budget)),
+        genesis,
+    )
+
+
+def _scope(
+    domain: str = "finance", caps: tuple[str, ...] = ("read", "approve")
+) -> RoleScope:
+    return RoleScope(domain=domain, capabilities=CapabilitySet(capabilities=caps))
+
+
+# ---------------------------------------------------------------------------
+# TenantScope — typed 2-variant union, M-1 misconfiguration guard
+# ---------------------------------------------------------------------------
+
+
+def test_tenant_scope_global_is_explicit_variant() -> None:
+    """Global is a named variant distinct from any tenant (rs M-1 guard)."""
+    g = TenantScope.global_()
+    assert g.is_global
+    assert g.tenant_id is None
+
+
+def test_tenant_scope_for_tenant_carries_id() -> None:
+    t = TenantScope.for_tenant("tenant-a")
+    assert not t.is_global
+    assert t.tenant_id == "tenant-a"
+
+
+def test_tenant_scope_global_not_equal_to_tenant_named_global() -> None:
+    """Global != Tenant('global') — the typed enum is structural, not stringly."""
+    assert TenantScope.global_() != TenantScope.for_tenant("global")
+
+
+def test_tenant_scope_for_tenant_rejects_non_str() -> None:
+    with pytest.raises(TypeError, match="str tenant_id"):
+        TenantScope.for_tenant(42)  # type: ignore[arg-type]
+
+
+def test_tenant_scope_for_tenant_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        TenantScope.for_tenant("")
+
+
+def test_tenant_scope_direct_construction_with_invalid_invariant_raises() -> None:
+    """Direct __init__ with mismatched discriminant fields raises (defense)."""
+    with pytest.raises(ValueError, match="Global variant MUST NOT carry"):
+        TenantScope(_is_global=True, _tenant_id="bad")
+    with pytest.raises(ValueError, match="Tenant variant MUST carry"):
+        TenantScope(_is_global=False, _tenant_id=None)
+
+
+def test_tenant_scope_is_frozen() -> None:
+    g = TenantScope.global_()
+    with pytest.raises(FrozenInstanceError):
+        g._is_global = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# GrantMoment — frozen, tz-aware, hex-validated
+# ---------------------------------------------------------------------------
+
+
+def _grant_moment(**overrides: object) -> GrantMoment:
+    defaults: dict[str, object] = {
+        "cascade_id": uuid.uuid4(),
+        "parent_delegate_id": uuid.uuid4(),
+        "child_delegate_id": uuid.uuid4(),
+        "tenant": TenantScope.for_tenant("tenant-a"),
+        "granted_at": datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc),
+        "grant_proof": "a" * 128,
+    }
+    defaults.update(overrides)
+    return GrantMoment(**defaults)  # type: ignore[arg-type]
+
+
+def test_grant_moment_constructs() -> None:
+    gm = _grant_moment()
+    assert isinstance(gm.cascade_id, uuid.UUID)
+    assert isinstance(gm.parent_delegate_id, uuid.UUID)
+    assert isinstance(gm.child_delegate_id, uuid.UUID)
+    assert gm.tenant.tenant_id == "tenant-a"
+    assert gm.granted_at.tzinfo is not None
+
+
+def test_grant_moment_is_frozen() -> None:
+    gm = _grant_moment()
+    with pytest.raises(FrozenInstanceError):
+        gm.grant_proof = "b" * 128  # type: ignore[misc]
+
+
+def test_grant_moment_rejects_naive_datetime() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        _grant_moment(granted_at=datetime(2026, 5, 21, 12, 0, 0))
+
+
+def test_grant_moment_rejects_non_uuid_ids() -> None:
+    with pytest.raises(TypeError, match="cascade_id MUST be a uuid.UUID"):
+        _grant_moment(cascade_id="not-a-uuid")
+    with pytest.raises(TypeError, match="parent_delegate_id MUST be a uuid.UUID"):
+        _grant_moment(parent_delegate_id="not-a-uuid")
+
+
+def test_grant_moment_rejects_non_tenant_scope() -> None:
+    with pytest.raises(TypeError, match="tenant MUST be a TenantScope"):
+        _grant_moment(tenant="tenant-a")
+
+
+def test_grant_moment_rejects_short_or_non_hex_signature() -> None:
+    with pytest.raises(ValueError, match="128 hex chars"):
+        _grant_moment(grant_proof="a" * 64)
+    with pytest.raises(ValueError, match="lowercase hex"):
+        _grant_moment(grant_proof="A" * 128)
+
+
+def test_grant_moment_to_signing_dict_excludes_grant_proof() -> None:
+    """F7 sign/verify split: to_signing_dict excludes the signature."""
+    gm = _grant_moment()
+    signing = gm.to_signing_dict()
+    assert "grant_proof" not in signing
+    assert "cascade_id" in signing
+    assert "parent_delegate_id" in signing
+    assert "child_delegate_id" in signing
+    assert "tenant" in signing
+    assert "granted_at" in signing
+
+
+def test_grant_moment_to_canonical_dict_includes_grant_proof() -> None:
+    """to_canonical_dict is the full transport shape (includes signature)."""
+    gm = _grant_moment()
+    canonical = gm.to_canonical_dict()
+    assert canonical["grant_proof"] == "a" * 128
+    # Everything in signing payload is also in canonical
+    for key in gm.to_signing_dict():
+        assert key in canonical
+
+
+def test_grant_moment_canonical_dict_byte_stable_across_constructions() -> None:
+    """Same inputs → byte-identical canonical-JSON output (cross-SDK contract)."""
+    cid = uuid.uuid4()
+    pid = uuid.uuid4()
+    chid = uuid.uuid4()
+    t = TenantScope.for_tenant("tenant-a")
+    when = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
+    proof = "a" * 128
+
+    gm1 = GrantMoment(
+        cascade_id=cid,
+        parent_delegate_id=pid,
+        child_delegate_id=chid,
+        tenant=t,
+        granted_at=when,
+        grant_proof=proof,
+    )
+    gm2 = GrantMoment(
+        cascade_id=cid,
+        parent_delegate_id=pid,
+        child_delegate_id=chid,
+        tenant=t,
+        granted_at=when,
+        grant_proof=proof,
+    )
+    assert canonical_json_dumps(gm1.to_canonical_dict()) == canonical_json_dumps(
+        gm2.to_canonical_dict()
+    )
+
+
+def test_grant_moment_tenant_serializes_as_tagged_union() -> None:
+    """Tenant variant: {"type": "Tenant", "tenant_id": "..."}."""
+    gm = _grant_moment(tenant=TenantScope.for_tenant("tenant-a"))
+    canonical = gm.to_canonical_dict()
+    assert canonical["tenant"] == {"type": "Tenant", "tenant_id": "tenant-a"}
+
+
+def test_grant_moment_global_tenant_serializes_as_tagged_union() -> None:
+    gm = _grant_moment(tenant=TenantScope.global_())
+    canonical = gm.to_canonical_dict()
+    assert canonical["tenant"] == {"type": "Global"}
+
+
+# ---------------------------------------------------------------------------
+# TenantScopedCascade — construction + type discipline
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_constructs_with_tenant() -> None:
+    c = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    assert c.tenant.tenant_id == "tenant-a"
+
+
+def test_cascade_rejects_non_tenant_scope() -> None:
+    with pytest.raises(TypeError, match="tenant MUST be a TenantScope"):
+        TenantScopedCascade(tenant="tenant-a")  # type: ignore[arg-type]
+
+
+def test_cascade_is_frozen() -> None:
+    c = TenantScopedCascade(tenant=TenantScope.global_())
+    with pytest.raises(FrozenInstanceError):
+        c.tenant = TenantScope.for_tenant("other")  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# cascade_child — Step 1 fail-closed: tenant boundary (Option A RATIFIED)
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_cross_tenant_child_raises_tenant_violation() -> None:
+    """Step 1: Tenant-A cascade cannot admit Tenant-B child, even with valid
+    scope + envelope tightening."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    scope = _scope()
+
+    with pytest.raises(CascadeTenantViolationError) as exc_info:
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=scope,
+            child_scope=scope,
+            child_tenant=TenantScope.for_tenant("tenant-b"),
+            grant_proof="a" * 128,
+        )
+    assert exc_info.value.parent_tenant == "tenant-a"
+    assert exc_info.value.child_tenant == "tenant-b"
+
+
+def test_cascade_global_to_tenant_raises_tenant_violation() -> None:
+    """Global cascade rejects a tenant-scoped child (no implicit upcast)."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    scope = _scope()
+    with pytest.raises(CascadeTenantViolationError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=scope,
+            child_scope=scope,
+            child_tenant=TenantScope.for_tenant("tenant-a"),
+            grant_proof="a" * 128,
+        )
+
+
+# ---------------------------------------------------------------------------
+# cascade_child — Step 2 fail-closed: scope subset (F1 downward-only)
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_cross_domain_child_raises_scope_expansion() -> None:
+    """F1: child domain MUST equal parent's domain — no cross-domain edge."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+
+    with pytest.raises(CascadeScopeExpansionError) as exc_info:
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=_scope(domain="finance"),
+            child_scope=_scope(domain="hr"),
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+    assert exc_info.value.parent_domain == "finance"
+    assert exc_info.value.child_domain == "hr"
+
+
+def test_cascade_capability_widening_raises_scope_expansion() -> None:
+    """F1: child capabilities MUST be a subset of parent's."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+
+    with pytest.raises(CascadeScopeExpansionError) as exc_info:
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=_scope(caps=("read",)),
+            # Child adds 'approve' — widening
+            child_scope=_scope(caps=("read", "approve")),
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+    assert "approve" in exc_info.value.added_capabilities
+
+
+def test_cascade_subset_capability_child_succeeds_step_2() -> None:
+    """Child with strictly-subset capabilities passes Step 2 (success-path
+    requires Steps 3+4 to also pass — see test_cascade_emits_grant_moment)."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+
+    gm = casc.cascade_child(
+        parent_env,
+        child_env,
+        parent_identity=_identity(suffix="parent"),
+        child_identity=_identity(suffix="child"),
+        parent_scope=_scope(caps=("read", "approve")),
+        child_scope=_scope(caps=("read",)),  # strict subset
+        child_tenant=TenantScope.global_(),
+        grant_proof="a" * 128,
+    )
+    assert isinstance(gm, GrantMoment)
+
+
+# ---------------------------------------------------------------------------
+# cascade_child — Step 3 fail-closed: envelope tightening (F5)
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_widening_envelope_propagates_envelope_widening_error() -> None:
+    """Step 3: child envelope that widens parent raises EnvelopeWideningError
+    (delegated to DelegateConstraintEnvelope.tighten_with's pre-intersection
+    widening check — F5)."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(50.0)
+    child_env = _envelope_with_budget(100.0)  # widens
+    scope = _scope()
+
+    with pytest.raises(EnvelopeWideningError, match="widen"):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=scope,
+            child_scope=scope,
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+
+
+# ---------------------------------------------------------------------------
+# cascade_child — Step 4 success-path: emit GrantMoment
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_emits_well_formed_grant_moment_on_success() -> None:
+    """All three checks pass → GrantMoment with parent+child identities
+    + tenant + tz-aware granted_at + signature."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    scope = _scope()
+    parent = _identity(suffix="parent")
+    child = _identity(suffix="child")
+    when = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
+
+    gm = casc.cascade_child(
+        parent_env,
+        child_env,
+        parent_identity=parent,
+        child_identity=child,
+        parent_scope=scope,
+        child_scope=scope,
+        child_tenant=TenantScope.for_tenant("tenant-a"),
+        grant_proof="b" * 128,
+        granted_at=when,
+    )
+    assert isinstance(gm, GrantMoment)
+    assert gm.parent_delegate_id == parent.delegate_id
+    assert gm.child_delegate_id == child.delegate_id
+    assert gm.tenant == TenantScope.for_tenant("tenant-a")
+    assert gm.granted_at == when
+    assert gm.grant_proof == "b" * 128
+
+
+def test_cascade_default_granted_at_is_tz_aware_utc_now() -> None:
+    """When granted_at is omitted, the cascade defaults to tz-aware utc now."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    scope = _scope()
+
+    gm = casc.cascade_child(
+        parent_env,
+        child_env,
+        parent_identity=_identity(suffix="parent"),
+        child_identity=_identity(suffix="child"),
+        parent_scope=scope,
+        child_scope=scope,
+        child_tenant=TenantScope.global_(),
+        grant_proof="a" * 128,
+    )
+    assert gm.granted_at.tzinfo is not None
+
+
+def test_cascade_step_order_tenant_check_runs_before_scope_check() -> None:
+    """Step ordering: tenant violation fires BEFORE scope-expansion check,
+    so a cross-tenant cascade with cross-domain scope raises
+    CascadeTenantViolationError, not CascadeScopeExpansionError."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+
+    with pytest.raises(CascadeTenantViolationError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=_scope(domain="finance"),
+            child_scope=_scope(domain="hr"),  # would raise scope error
+            child_tenant=TenantScope.for_tenant("tenant-b"),  # tenant fires first
+            grant_proof="a" * 128,
+        )
+
+
+def test_cascade_step_order_scope_check_runs_before_envelope_check() -> None:
+    """Step ordering: scope expansion fires BEFORE envelope widening check."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(50.0)
+    child_env = _envelope_with_budget(100.0)  # would widen
+
+    with pytest.raises(CascadeScopeExpansionError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=_scope(caps=("read",)),
+            child_scope=_scope(caps=("read", "approve")),  # widens scope
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Type discipline at the cascade boundary (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_rejects_non_envelope_types() -> None:
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    scope = _scope()
+    with pytest.raises(TypeError, match="parent_envelope MUST"):
+        casc.cascade_child(
+            "not-an-envelope",  # type: ignore[arg-type]
+            parent_env,
+            parent_identity=_identity(suffix="p"),
+            child_identity=_identity(suffix="c"),
+            parent_scope=scope,
+            child_scope=scope,
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+
+
+def test_cascade_rejects_non_identity_types() -> None:
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    env = _envelope_with_budget(100.0)
+    scope = _scope()
+    with pytest.raises(TypeError, match="parent_identity MUST"):
+        casc.cascade_child(
+            env,
+            env,
+            parent_identity="not-an-identity",  # type: ignore[arg-type]
+            child_identity=_identity(suffix="c"),
+            parent_scope=scope,
+            child_scope=scope,
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+
+
+# ---------------------------------------------------------------------------
+# from_dict — H2 deferral closure tests for identity + envelope
+# ---------------------------------------------------------------------------
+
+
+def test_delegate_identity_to_dict_from_dict_round_trip() -> None:
+    """to_dict → from_dict reconstructs identity equality."""
+    ident = DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref="sov-1",
+        role_binding_ref="role-1",
+        genesis_ref="genesis-1",
+    )
+    reconstructed = DelegateIdentity.from_dict(ident.to_dict())
+    assert reconstructed == ident
+
+
+def test_delegate_identity_from_dict_rejects_missing_field() -> None:
+    with pytest.raises(ValueError, match="missing required field"):
+        DelegateIdentity.from_dict(
+            {"delegate_id": str(uuid.uuid4()), "sovereign_ref": "sov-1"}
+        )
+
+
+def test_delegate_identity_from_dict_rejects_bad_uuid_string() -> None:
+    with pytest.raises(ValueError, match="not a valid UUID"):
+        DelegateIdentity.from_dict(
+            {
+                "delegate_id": "not-a-uuid",
+                "sovereign_ref": "sov-1",
+                "role_binding_ref": "role-1",
+                "genesis_ref": "genesis-1",
+            }
+        )
+
+
+def test_delegate_identity_from_dict_rejects_non_string_refs() -> None:
+    with pytest.raises(TypeError, match="MUST be a str"):
+        DelegateIdentity.from_dict(
+            {
+                "delegate_id": str(uuid.uuid4()),
+                "sovereign_ref": 123,  # type: ignore[dict-item]
+                "role_binding_ref": "role-1",
+                "genesis_ref": "genesis-1",
+            }
+        )
+
+
+def test_delegate_identity_from_dict_runs_post_init_validation() -> None:
+    """Path-traversal in a ref string is rejected via __post_init__ chain."""
+    with pytest.raises(ValueError, match="rejected"):
+        DelegateIdentity.from_dict(
+            {
+                "delegate_id": str(uuid.uuid4()),
+                "sovereign_ref": "../escape",  # validate_id rejects
+                "role_binding_ref": "role-1",
+                "genesis_ref": "genesis-1",
+            }
+        )
+
+
+def test_delegate_constraint_envelope_to_dict_from_dict_round_trip() -> None:
+    """to_dict → from_dict reconstructs envelope wrapper."""
+    env = _envelope_with_budget(75.0, genesis_id="g-roundtrip")
+    payload = env.to_dict()
+    reconstructed = DelegateConstraintEnvelope.from_dict(payload)
+    assert reconstructed.genesis_id == env.genesis_id
+    assert reconstructed.inner.financial is not None
+    assert reconstructed.inner.financial.budget_limit == 75.0
+
+
+def test_delegate_constraint_envelope_from_dict_rejects_missing_field() -> None:
+    with pytest.raises(ValueError, match="missing required field"):
+        DelegateConstraintEnvelope.from_dict({"inner": {}})
+
+
+def test_delegate_constraint_envelope_from_dict_rejects_empty_genesis_id() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        DelegateConstraintEnvelope.from_dict({"inner": {}, "genesis_id": ""})
+
+
+def test_delegate_constraint_envelope_from_dict_rejects_non_dict_inner() -> None:
+    with pytest.raises(TypeError, match="inner MUST be a"):
+        DelegateConstraintEnvelope.from_dict(
+            {"inner": "not-a-dict", "genesis_id": "g-1"}
+        )
+
+
+def test_delegate_identity_from_dict_accepts_uuid_object_directly() -> None:
+    """In-process callers may pass a uuid.UUID object directly; from_dict
+    accepts both string and UUID for the delegate_id slot."""
+    uid = uuid.uuid4()
+    reconstructed = DelegateIdentity.from_dict(
+        {
+            "delegate_id": uid,
+            "sovereign_ref": "sov-1",
+            "role_binding_ref": "role-1",
+            "genesis_ref": "genesis-1",
+        }
+    )
+    assert reconstructed.delegate_id == uid

--- a/tests/unit/delegate/test_trust_cascade.py
+++ b/tests/unit/delegate/test_trust_cascade.py
@@ -796,3 +796,124 @@ def test_grant_moment_to_signing_dict_uses_tenant_scope_to_dict() -> None:
     payload = gm.to_signing_dict()
     assert payload["tenant"] == scope.to_dict()
     assert payload["tenant"] == {"type": "Tenant", "tenant_id": "tenant-a"}
+
+
+# ---------------------------------------------------------------------------
+# GrantMoment.tightened_envelope — B3 (analyst H-1) cascade chain-of-custody
+# ---------------------------------------------------------------------------
+
+
+def test_grant_moment_carries_tightened_envelope_post_cascade() -> None:
+    """B3: cascade_child emits a GrantMoment whose tightened_envelope is the
+    actual post-tightening envelope, not None. Downstream consumers consume
+    this attribute rather than re-calling tighten_with."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    scope = _scope()
+
+    gm = casc.cascade_child(
+        parent_env,
+        child_env,
+        parent_identity=_identity(suffix="parent"),
+        child_identity=_identity(suffix="child"),
+        parent_scope=scope,
+        child_scope=scope,
+        child_tenant=TenantScope.global_(),
+        grant_proof="a" * 128,
+    )
+    assert gm.tightened_envelope is not None
+    assert isinstance(gm.tightened_envelope, DelegateConstraintEnvelope)
+    # The tightened envelope MUST equal the result of parent.tighten_with(child)
+    # — single source of truth. (Computed twice on this fixture; result should
+    # match byte-for-byte via canonical dict.)
+    expected = parent_env.tighten_with(child_env.inner)
+    assert gm.tightened_envelope.to_dict() == expected.to_dict()
+
+
+def test_grant_moment_to_canonical_dict_includes_tightened_envelope() -> None:
+    """B3: to_canonical_dict (and to_signing_dict) MUST include the
+    tightened_envelope key when present, so cross-SDK fixtures reflect the
+    post-cascade envelope state."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    scope = _scope()
+
+    gm = casc.cascade_child(
+        parent_env,
+        child_env,
+        parent_identity=_identity(suffix="parent"),
+        child_identity=_identity(suffix="child"),
+        parent_scope=scope,
+        child_scope=scope,
+        child_tenant=TenantScope.global_(),
+        grant_proof="a" * 128,
+    )
+    canonical = gm.to_canonical_dict()
+    assert "tightened_envelope" in canonical
+    assert canonical["tightened_envelope"] == gm.tightened_envelope.to_dict()
+    # Signing dict ALSO carries it (signed payload covers the envelope state).
+    signing = gm.to_signing_dict()
+    assert "tightened_envelope" in signing
+    # to_canonical_dict adds grant_proof on top; signing excludes it.
+    assert "grant_proof" not in signing
+    assert canonical["grant_proof"] == "a" * 128
+
+
+def test_grant_moment_omits_tightened_envelope_when_none() -> None:
+    """B3: direct GrantMoment construction without tightened_envelope (replay
+    paths, pre-B3 fixtures) MUST omit the key entirely — preserving the
+    pre-B3 wire format."""
+    gm = GrantMoment(
+        cascade_id=uuid.uuid4(),
+        parent_delegate_id=uuid.uuid4(),
+        child_delegate_id=uuid.uuid4(),
+        tenant=TenantScope.global_(),
+        granted_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        grant_proof="a" * 128,
+    )
+    assert gm.tightened_envelope is None
+    signing = gm.to_signing_dict()
+    assert "tightened_envelope" not in signing
+    canonical = gm.to_canonical_dict()
+    assert "tightened_envelope" not in canonical
+
+
+def test_grant_moment_rejects_non_envelope_tightened_envelope() -> None:
+    """Type discipline at the GrantMoment boundary — defense-in-depth."""
+    with pytest.raises(TypeError, match="tightened_envelope MUST be"):
+        GrantMoment(
+            cascade_id=uuid.uuid4(),
+            parent_delegate_id=uuid.uuid4(),
+            child_delegate_id=uuid.uuid4(),
+            tenant=TenantScope.global_(),
+            granted_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            grant_proof="a" * 128,
+            tightened_envelope="not-an-envelope",  # type: ignore[arg-type]
+        )
+
+
+# ---------------------------------------------------------------------------
+# GrantMoment.to_signing_bytes — B5 (sec M-3) cross-SDK byte-canonical helper
+# ---------------------------------------------------------------------------
+
+
+def test_grant_moment_to_signing_bytes_returns_canonical_json_bytes() -> None:
+    """B5: to_signing_bytes returns UTF-8 canonical-JSON bytes matching what
+    canonical_json_dumps would produce. Closes the trap where a caller uses
+    json.dumps() without sort_keys + separators and produces non-canonical
+    bytes that break cross-SDK rs↔py verification."""
+    gm = GrantMoment(
+        cascade_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        parent_delegate_id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        child_delegate_id=uuid.UUID("00000000-0000-0000-0000-000000000003"),
+        tenant=TenantScope.for_tenant("tenant-a"),
+        granted_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        grant_proof="a" * 128,
+    )
+    bytes_out = gm.to_signing_bytes()
+    assert isinstance(bytes_out, bytes)
+    # Round-trip via canonical_json_dumps yields the same bytes.
+    expected = canonical_json_dumps(gm.to_signing_dict()).encode("utf-8")
+    assert bytes_out == expected

--- a/tests/unit/delegate/test_trust_cascade.py
+++ b/tests/unit/delegate/test_trust_cascade.py
@@ -295,6 +295,71 @@ def test_cascade_cross_tenant_child_raises_tenant_violation() -> None:
     assert exc_info.value.child_tenant == "tenant-b"
 
 
+def test_cascade_tenant_violation_message_does_not_leak_raw_tenant_ids() -> None:
+    """B1 (sec H-2): str(exc) form MUST hash tenant IDs per observability.md
+    MUST Rule 8 (schema-revealing field names MUST be DEBUG or hashed).
+
+    Raw tenant IDs remain on the exception attributes (.parent_tenant /
+    .child_tenant) for in-process handling; the str(exc) form that may bleed
+    into logs / cross-tenant API error responses / aggregator surfaces carries
+    only the first 8 hex chars of the SHA-256 digest.
+    """
+    import hashlib
+
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    scope = _scope()
+
+    with pytest.raises(CascadeTenantViolationError) as exc_info:
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=scope,
+            child_scope=scope,
+            child_tenant=TenantScope.for_tenant("tenant-b"),
+            grant_proof="a" * 128,
+        )
+    msg = str(exc_info.value)
+    # Raw tenant strings MUST NOT appear in str(exc).
+    assert "tenant-a" not in msg
+    assert "tenant-b" not in msg
+    # The 8-char SHA-256 prefixes MUST appear in str(exc).
+    a_hash = hashlib.sha256(b"tenant-a").hexdigest()[:8]
+    b_hash = hashlib.sha256(b"tenant-b").hexdigest()[:8]
+    assert a_hash in msg
+    assert b_hash in msg
+    # Raw tenant IDs MUST still be accessible via the exception attributes
+    # (in-process handling — these never reach log aggregators by themselves).
+    assert exc_info.value.parent_tenant == "tenant-a"
+    assert exc_info.value.child_tenant == "tenant-b"
+
+
+def test_cascade_tenant_violation_message_handles_global_variant() -> None:
+    """B1 (sec H-2): Global variant (tenant_id=None) MUST render as the
+    literal sentinel ``<none>`` rather than hashing None."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    scope = _scope()
+    with pytest.raises(CascadeTenantViolationError) as exc_info:
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=scope,
+            child_scope=scope,
+            child_tenant=TenantScope.for_tenant("tenant-a"),
+            grant_proof="a" * 128,
+        )
+    msg = str(exc_info.value)
+    assert "parent_tenant_hash=<none>" in msg
+    assert "tenant-a" not in msg
+
+
 def test_cascade_global_to_tenant_raises_tenant_violation() -> None:
     """Global cascade rejects a tenant-scoped child (no implicit upcast)."""
     casc = TenantScopedCascade(tenant=TenantScope.global_())

--- a/tests/unit/delegate/test_trust_cascade.py
+++ b/tests/unit/delegate/test_trust_cascade.py
@@ -708,3 +708,91 @@ def test_delegate_identity_from_dict_accepts_uuid_object_directly() -> None:
         }
     )
     assert reconstructed.delegate_id == uid
+
+
+# ---------------------------------------------------------------------------
+# TenantScope.to_dict / from_dict — B2 (sec H-3) public-classmethod promotion
+# ---------------------------------------------------------------------------
+
+
+def test_tenant_scope_to_dict_global_variant() -> None:
+    """Global variant serializes to the tagged-union ``{"type": "Global"}``."""
+    assert TenantScope.global_().to_dict() == {"type": "Global"}
+
+
+def test_tenant_scope_to_dict_tenant_variant() -> None:
+    """Tenant variant serializes with the discriminator + tenant_id."""
+    assert TenantScope.for_tenant("tenant-a").to_dict() == {
+        "type": "Tenant",
+        "tenant_id": "tenant-a",
+    }
+
+
+def test_tenant_scope_from_dict_round_trip_global() -> None:
+    """Round-trip: TenantScope.from_dict(scope.to_dict()) == scope (Global)."""
+    scope = TenantScope.global_()
+    assert TenantScope.from_dict(scope.to_dict()) == scope
+
+
+def test_tenant_scope_from_dict_round_trip_tenant() -> None:
+    """Round-trip: TenantScope.from_dict(scope.to_dict()) == scope (Tenant)."""
+    scope = TenantScope.for_tenant("tenant-xyz")
+    assert TenantScope.from_dict(scope.to_dict()) == scope
+
+
+def test_tenant_scope_from_dict_rejects_non_dict() -> None:
+    """Non-dict payloads MUST raise TypeError."""
+    with pytest.raises(TypeError, match="requires a dict"):
+        TenantScope.from_dict("not-a-dict")  # type: ignore[arg-type]
+
+
+def test_tenant_scope_from_dict_rejects_missing_type() -> None:
+    """Missing discriminator MUST raise ValueError."""
+    with pytest.raises(ValueError, match="unknown discriminator"):
+        TenantScope.from_dict({"tenant_id": "tenant-a"})
+
+
+def test_tenant_scope_from_dict_rejects_unknown_type() -> None:
+    """Unknown discriminator MUST raise ValueError."""
+    with pytest.raises(ValueError, match="unknown discriminator"):
+        TenantScope.from_dict({"type": "Bogus"})
+
+
+def test_tenant_scope_from_dict_tenant_requires_tenant_id() -> None:
+    """type=Tenant payload without tenant_id MUST raise ValueError."""
+    with pytest.raises(ValueError, match="requires a string tenant_id"):
+        TenantScope.from_dict({"type": "Tenant"})
+
+
+def test_tenant_scope_from_dict_tenant_rejects_empty_tenant_id() -> None:
+    """type=Tenant payload with empty tenant_id MUST raise ValueError.
+
+    Inherits the for_tenant() invariant: empty tenant id rejected at
+    TenantScope construction.
+    """
+    with pytest.raises(ValueError, match="non-empty tenant id"):
+        TenantScope.from_dict({"type": "Tenant", "tenant_id": ""})
+
+
+def test_tenant_scope_from_dict_tenant_rejects_non_string_tenant_id() -> None:
+    """type=Tenant payload with non-string tenant_id MUST raise ValueError."""
+    with pytest.raises(ValueError, match="requires a string tenant_id"):
+        TenantScope.from_dict({"type": "Tenant", "tenant_id": 42})
+
+
+def test_grant_moment_to_signing_dict_uses_tenant_scope_to_dict() -> None:
+    """B2: GrantMoment.to_signing_dict routes through TenantScope.to_dict,
+    not the removed private _tenant_to_dict helper. Asserts the tenant
+    sub-dict matches the public method's output exactly."""
+    scope = TenantScope.for_tenant("tenant-a")
+    gm = GrantMoment(
+        cascade_id=uuid.uuid4(),
+        parent_delegate_id=uuid.uuid4(),
+        child_delegate_id=uuid.uuid4(),
+        tenant=scope,
+        granted_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        grant_proof="a" * 128,
+    )
+    payload = gm.to_signing_dict()
+    assert payload["tenant"] == scope.to_dict()
+    assert payload["tenant"] == {"type": "Tenant", "tenant_id": "tenant-a"}


### PR DESCRIPTION
## Value-anchor

Per issue #1035 acceptance criterion *"Pure-Python Delegate runs end-to-end vs a real PACT engine + real Postgres audit"* — the trust cascade is the load-bearing gate that makes the audit-grade argument compile. The S3 shard delivers:

- **TenantScopedCascade.cascade_child** — fail-closed in fixed step order (tenant boundary → scope subset → envelope tightening → GrantMoment emission).
- **TenantScope** — typed 2-variant tagged union (Global vs Tenant), NOT Optional[str], per rs M-1 misconfiguration guard.
- **GrantMoment** — chain-of-custody record with cross-SDK byte-canonical sign/verify split.
- **H2 from_dict closure** on DelegateIdentity + DelegateConstraintEnvelope (audit-grade ingest path).

Mirrors kailash-rs `kailash-delegate-trust` M3-01 + M3-02 shipped surface per `workspaces/issue-1035-delegate-py/01-analysis/02-kailash-rs-reference-extraction.md` § trust-cascade.

## Scope (S3 per todos/active/00-shard-plan.md)

| Surface | LOC | Tests |
|---|---|---|
| `src/kailash/delegate/trust.py` (new) | 558 (load-bearing logic ~180) | 30 Tier 1 |
| `src/kailash/delegate/types.py` (+88) | DelegateIdentity.to_dict/.from_dict | 6 Tier 1 |
| `src/kailash/delegate/envelope.py` (+73) | DelegateConstraintEnvelope.to_dict/.from_dict | 7 Tier 1 |
| `tests/integration/delegate/test_tenant_isolation.py` (new) | 339 | 5 Tier 2 |

48 new tests; 130/130 delegate tests pass; 166/166 trust unit tests still green; mypy clean on all touched modules.

## Wave 1 integration notes

- Per the prompt's coordination note: `src/kailash/delegate/__init__.py` was NOT edited; the orchestrator handles post-merge `__all__` re-export integration per `orphan-detection.md` Rule 6a.
- Edited `types.py` and `envelope.py` only to add `to_dict`/`from_dict` (additive — closes the explicit S2.5b docstring deferral markers pointing to S3). All Wave 1 contracts preserved.

## Workspace cross-references

- `workspaces/issue-1035-delegate-py/02-plans/01-architecture.md` § "Reuse map" rows 5-6 + § "Invariants" rows 5-6.
- `workspaces/issue-1035-delegate-py/todos/active/00-shard-plan.md` § S3.
- `workspaces/issue-1035-delegate-py/01-analysis/02-kailash-rs-reference-extraction.md` § trust-cascade.

## Surfaced recommendation (not inlined per workspace discipline)

The canonical `kailash.trust._locking.validate_id` regex `^[a-zA-Z0-9_-]+$` rejects `:`-bearing identifiers. S3 does NOT introduce any new `:`-bearing surface (TenantScope uses raw string tenant_ids that bypass validate_id since they are audit-record keys, not substrate record paths). However, the broader workspace should consider whether PACT D/T/R-shaped tenant identifiers (`org:foo:bar`) need a separate `validate_tenant_id` helper supporting `:` while preserving path-traversal rejection. Surfacing here per `trust-plane-security.md` Multi-Site Kwarg Plumbing rule; not inlined as a one-off bypass.

## Deferred to subsequent shards

- `from_dict` for Role, RoleScope, CapabilitySet, PrincipalDirectory, DelegateGenesisRecord (the remaining Wave 1 types) — load-bearing identity + envelope surfaces are closed; remaining types are decorative dataclasses whose direct-construction bypass is lower risk. Per the prompt's "if budget tight" allowance.

## Related issues

Implements S3 of #1035 per the Wave 2 launch gate.

## Test plan

- [x] Tier 1: 43 new cascade + GrantMoment + from_dict tests pass
- [x] Tier 2: 5 integration scenarios exercise cascade through TrustLineageChain audit emission
- [x] Wave 1 regression: 82/82 prior delegate tests still pass
- [x] Trust substrate regression: 166/166 trust unit tests still pass
- [x] mypy clean on src/kailash/delegate/trust.py + types.py + envelope.py
- [ ] CI to be confirmed on PR