### PR TITLE
feat(delegate): reconcile __init__.py __all__ for S3+S4 (#1035)

### DIFF
--- a/src/kailash/delegate/__init__.py
+++ b/src/kailash/delegate/__init__.py
@@ -18,9 +18,25 @@ Per #1035: this package MUST have zero proprietary dependencies. The
 
 # Public surface -- S2 types substrate. Later shards (S3-S8) extend this list
 # via parallel-shard merges per orphan-detection.md Rule 6a.
+from kailash.delegate.audit import (
+    AuditChainEmissionError,
+    AuditChainEngine,
+    AuditChainEntry,
+    AuditChainSignatureError,
+    CrossAnchorIntegrityError,
+    DelegateEventType,
+    WitnessedCrossAnchor,
+)
 from kailash.delegate.envelope import (
     DelegateConstraintEnvelope,
     EnvelopeWideningError,
+)
+from kailash.delegate.trust import (
+    CascadeScopeExpansionError,
+    CascadeTenantViolationError,
+    GrantMoment,
+    TenantScope,
+    TenantScopedCascade,
 )
 from kailash.delegate.types import (
     CapabilitySet,
@@ -50,4 +66,18 @@ __all__ = [
     "LifecycleError",
     # Group 4 -- Genesis composition (S2.5 F4)
     "DelegateGenesisRecord",
+    # Group 5 -- Trust cascade (S3 -- TenantScope, GrantMoment)
+    "TenantScope",
+    "TenantScopedCascade",
+    "GrantMoment",
+    "CascadeTenantViolationError",
+    "CascadeScopeExpansionError",
+    # Group 6 -- Audit chain (S4 -- AuditChainEngine, WitnessedCrossAnchor)
+    "AuditChainEngine",
+    "AuditChainEntry",
+    "WitnessedCrossAnchor",
+    "DelegateEventType",
+    "AuditChainEmissionError",
+    "AuditChainSignatureError",
+    "CrossAnchorIntegrityError",
 ]


### PR DESCRIPTION
## Summary

- `orphan-detection.md` MUST Rule 6a — parallel-shard `__all__` reconciliation after merging PR #1136 (S3 trust cascade) + PR #1135 (S4 audit chain) from divergent base SHAs
- Adds 12 new symbols across 2 new groups: trust cascade (S3) + audit chain (S4)
- All new symbols backed by eager module-scope imports (no `__getattr__` lazy resolution)

## What changed

**Group 5 — Trust cascade (S3):**
- `TenantScope`, `TenantScopedCascade`, `GrantMoment`
- `CascadeTenantViolationError`, `CascadeScopeExpansionError`

**Group 6 — Audit chain (S4):**
- `AuditChainEngine`, `AuditChainEntry`, `WitnessedCrossAnchor`
- `DelegateEventType`, `AuditChainEmissionError`, `AuditChainSignatureError`, `CrossAnchorIntegrityError`

## Why a separate PR

S3 + S4 landed in parallel worktrees from divergent base SHAs; both modified `src/kailash/delegate/__init__.py::__all__` independently. Git's 3-way merge picks one shard's edit arbitrarily, silently orphaning the other's exports. Per `orphan-detection.md` Rule 6a, the reconciliation MUST be an explicit commit that preserves invariants from both bases. This PR is that reconciliation.

## Test plan

- [x] `from kailash.delegate import *` resolves all 23 symbols at runtime
- [x] Each new entry in `__all__` has a matching module-scope eager import (Rule 6)
- [x] Group ordering canonical (HEAD shard's structure preserved, older base invariants additively merged)
- [x] Branch name `release/v*` auto-skips full PR-gate matrix per `git.md` release-prep convention (metadata-only diff)

## Related issues

Part of #1035 (Delegate composition primitive — Wave 2 closure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)