### PR TITLE
feat(delegate): S5 dispatch + Connector ABC (#1035)

### DIFF
--- a/src/kailash/delegate/__init__.py
+++ b/src/kailash/delegate/__init__.py
@@ -27,6 +27,15 @@ from kailash.delegate.audit import (
     DelegateEventType,
     WitnessedCrossAnchor,
 )
+from kailash.delegate.dispatch import (
+    Connector,
+    ConnectorInvocationResult,
+    DispatchCascadeViolationError,
+    DispatchEnvelopeViolationError,
+    DispatchResult,
+    DispatchSurface,
+    DispatchValidationError,
+)
 from kailash.delegate.envelope import (
     DelegateConstraintEnvelope,
     EnvelopeWideningError,
@@ -80,4 +89,12 @@ __all__ = [
     "AuditChainEmissionError",
     "AuditChainSignatureError",
     "CrossAnchorIntegrityError",
+    # Group 7 -- Dispatch + Connector (S5)
+    "Connector",
+    "ConnectorInvocationResult",
+    "DispatchSurface",
+    "DispatchResult",
+    "DispatchValidationError",
+    "DispatchEnvelopeViolationError",
+    "DispatchCascadeViolationError",
 ]

--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -55,7 +55,10 @@ instantiation via :class:`abc.ABC`.
 from __future__ import annotations
 
 import abc
+import hashlib
 import logging
+import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol, runtime_checkable
@@ -75,6 +78,7 @@ from kailash.delegate.types import (
     Role,
     RoleLifecycleState,
 )
+from kailash.trust._json import canonical_json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +88,39 @@ __all__ = [
     "DispatchCascadeViolationError",
     "DispatchEnvelopeViolationError",
     "DispatchResult",
+    "DispatchSignerError",
     "DispatchSurface",
     "DispatchValidationError",
     "SignatureContract",
 ]
+
+# ---------------------------------------------------------------------------
+# Payload-shape limits — Round-1 C6-1 DoS defense
+# ---------------------------------------------------------------------------
+# Deeply nested payloads trigger O(depth) recursion in canonical_json_dumps
+# and per-field type checks; oversize payloads block the dispatch hot path
+# while signing the audit envelope. Both limits are conservative defaults
+# (well above any legitimate signature payload) and refuse loudly via
+# DispatchValidationError so the caller learns at the boundary, not inside
+# the canonical-JSON encoder.
+_MAX_PAYLOAD_DEPTH = 32
+_MAX_PAYLOAD_SERIALIZED_BYTES = 1 * 1024 * 1024  # 1 MiB
+
+
+def _check_payload_depth(obj: Any, current_depth: int = 0) -> None:
+    """Recursive depth check used at dispatch entry (C6-1)."""
+    if current_depth > _MAX_PAYLOAD_DEPTH:
+        raise DispatchValidationError(
+            f"input_payload exceeds maximum nesting depth "
+            f"({_MAX_PAYLOAD_DEPTH}); refused to prevent DoS through "
+            "recursive canonical-JSON encoding"
+        )
+    if isinstance(obj, dict):
+        for v in obj.values():
+            _check_payload_depth(v, current_depth + 1)
+    elif isinstance(obj, (list, tuple)):
+        for v in obj:
+            _check_payload_depth(v, current_depth + 1)
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +139,25 @@ class DispatchValidationError(ValueError):
 
     ``ValueError``-derived per the S2.5 / S3 / S4 pattern — a signature
     contract violation is a caller fault, not a system fault.
+    """
+
+
+class DispatchSignerError(ValueError):
+    """Raised when the injected audit-signer fails or returns a malformed signature.
+
+    The :class:`DispatchSurface` requires a real signer at construction
+    (C2-1 zero-tolerance fix — placeholder ``"0" * 128`` is BLOCKED). When
+    the signer raises, the exception is re-wrapped with this typed surface
+    so callers distinguish signer faults from validation faults
+    (:class:`DispatchValidationError`) and envelope faults
+    (:class:`DispatchEnvelopeViolationError`).
+
+    Also raised when the signer's return value fails the surface-shape
+    check (non-string, too-short hex, non-hex characters). The audit
+    engine's own :func:`_validate_hex` is the canonical signature
+    validator (128-char lowercase hex for Ed25519); this class surfaces
+    the malformed-output failure BEFORE the audit-engine boundary so the
+    error attribution is unambiguous (signer fault vs. engine fault).
     """
 
 
@@ -210,6 +262,14 @@ class SignatureContract(Protocol):
 
 class Connector(abc.ABC):
     """Abstract external endpoint a Delegate invocation connects through.
+
+    Cross-impl parity: Mirrors rs ``DelegateConnector`` trait (S5
+    substrate). The :meth:`invoke` method signature is the byte-shape
+    contract for cross-SDK ``receipts_agree(rs, py)`` verification at
+    S7+ — both SDKs MUST produce byte-identical
+    :class:`ConnectorInvocationResult` payloads for identical input
+    under identical envelopes (per ``cross-sdk-inspection.md`` MUST-3
+    EATP D6 semantic-match).
 
     Subclasses provide the actual external behavior — HTTP request, MCP
     tool call, Kaizen Signature invocation, queue publish, etc. The ABC
@@ -356,6 +416,13 @@ class Connector(abc.ABC):
 class ConnectorInvocationResult:
     """The result of a single :meth:`Connector.invoke` call.
 
+    Cross-impl parity: Mirrors rs ``ConnectorInvocationResult`` struct.
+    The :meth:`to_dict` / :meth:`from_dict` round-trip is the wire-format
+    contract for cross-SDK receipt comparison — emits a JSON-serializable
+    dict whose keys match the rs serde representation byte-for-byte
+    (audit-event variants emitted as their string values per
+    :class:`DelegateEventType`).
+
     Frozen + slots per the S2/S3/S4 dataclass conventions. The
     DispatchSurface inspects every field of this result for the
     cross-validation invariants:
@@ -429,6 +496,58 @@ class ConnectorInvocationResult:
                 f"got {type(self.external_side_effect).__name__}"
             )
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-canonical dict (cross-SDK wire-format).
+
+        Cross-impl parity: the returned dict is the byte-shape contract
+        with the rs ``ConnectorInvocationResult`` serde encoding.
+        ``audit_events`` is emitted as a list of string sentinels (each
+        :class:`DelegateEventType` ``.value``) so the encoding is
+        portable across languages without depending on Python's enum
+        repr.
+        """
+        return {
+            "payload": dict(self.payload),
+            "audit_events": [e.value for e in self.audit_events],
+            "tenant_id_observed": self.tenant_id_observed,
+            "external_side_effect": self.external_side_effect,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ConnectorInvocationResult":
+        """Reconstruct from a :meth:`to_dict` payload.
+
+        Round-trip lossless: ``ConnectorInvocationResult.from_dict(r.to_dict())``
+        reconstructs an equal instance. Validates the
+        ``audit_events`` list-of-strings against the
+        :class:`DelegateEventType` enum at reconstruction time; unknown
+        variants raise ``ValueError`` from the enum constructor.
+        """
+        if not isinstance(data, dict):
+            raise TypeError(
+                "ConnectorInvocationResult.from_dict requires a dict; got "
+                f"{type(data).__name__}"
+            )
+        for required in ("payload", "audit_events", "external_side_effect"):
+            if required not in data:
+                raise ValueError(
+                    "ConnectorInvocationResult.from_dict missing required "
+                    f"field {required!r}"
+                )
+        events_raw = data["audit_events"]
+        if not isinstance(events_raw, (list, tuple)):
+            raise TypeError(
+                "ConnectorInvocationResult.from_dict 'audit_events' MUST be a "
+                f"list/tuple; got {type(events_raw).__name__}"
+            )
+        events = tuple(DelegateEventType(e) for e in events_raw)
+        return cls(
+            payload=dict(data["payload"]),
+            audit_events=events,
+            tenant_id_observed=data.get("tenant_id_observed"),
+            external_side_effect=data["external_side_effect"],
+        )
+
 
 # ---------------------------------------------------------------------------
 # DispatchResult — frozen dataclass returned by DispatchSurface.dispatch
@@ -438,6 +557,12 @@ class ConnectorInvocationResult:
 @dataclass(frozen=True, slots=True)
 class DispatchResult:
     """The chain-of-custody record of one dispatch invocation.
+
+    Cross-impl parity: Mirrors rs ``DispatchResult`` struct. The
+    :meth:`to_dict` / :meth:`from_dict` round-trip is the wire-format
+    contract for cross-SDK receipt comparison — ``executed_at`` is
+    emitted as ISO-8601 UTC, ``dispatch_id`` as a UUID string, the
+    audit-chain-entry hashes as a list of hex strings.
 
     Frozen + slots per conventions. Returned by
     :meth:`DispatchSurface.dispatch` on success — failure paths raise
@@ -459,6 +584,10 @@ class DispatchResult:
             the post-validation tenant for traceability.
         connector_id: The bound connector's ``connector_id`` for
             traceability against the connector subclass.
+        dispatch_id: Unique :class:`uuid.UUID` identifying this
+            dispatch invocation. Generated at construction by
+            :meth:`DispatchSurface.dispatch`; flows through cross-SDK
+            receipt correlation as the lookup key.
     """
 
     payload: dict[str, Any]
@@ -466,6 +595,7 @@ class DispatchResult:
     executed_at: datetime
     tenant_id: str
     connector_id: str
+    dispatch_id: uuid.UUID
 
     def __post_init__(self) -> None:
         if not isinstance(self.payload, dict):
@@ -504,6 +634,71 @@ class DispatchResult:
                 "DispatchResult.connector_id MUST be a non-empty str; got "
                 f"{self.connector_id!r}"
             )
+        if not isinstance(self.dispatch_id, uuid.UUID):
+            raise TypeError(
+                "DispatchResult.dispatch_id MUST be a uuid.UUID; got "
+                f"{type(self.dispatch_id).__name__}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-canonical dict (cross-SDK wire-format).
+
+        Cross-impl parity: the returned dict is the byte-shape contract
+        with the rs ``DispatchResult`` serde encoding. ``executed_at``
+        is ISO-8601 UTC; ``dispatch_id`` is the canonical UUID string;
+        ``audit_chain_entries`` is a list (not tuple) for JSON
+        compatibility.
+        """
+        return {
+            "payload": dict(self.payload),
+            "audit_chain_entries": list(self.audit_chain_entries),
+            "executed_at": self.executed_at.isoformat(),
+            "tenant_id": self.tenant_id,
+            "connector_id": self.connector_id,
+            "dispatch_id": str(self.dispatch_id),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DispatchResult":
+        """Reconstruct from a :meth:`to_dict` payload.
+
+        Round-trip lossless on all fields. ``executed_at`` is parsed
+        via :meth:`datetime.fromisoformat` (Python 3.11+ accepts the
+        full ISO-8601 surface); ``dispatch_id`` is parsed via
+        :class:`uuid.UUID`; ``audit_chain_entries`` is re-tupled.
+        """
+        if not isinstance(data, dict):
+            raise TypeError(
+                "DispatchResult.from_dict requires a dict; got "
+                f"{type(data).__name__}"
+            )
+        for required in (
+            "payload",
+            "audit_chain_entries",
+            "executed_at",
+            "tenant_id",
+            "connector_id",
+            "dispatch_id",
+        ):
+            if required not in data:
+                raise ValueError(
+                    "DispatchResult.from_dict missing required field " f"{required!r}"
+                )
+        executed_at_raw = data["executed_at"]
+        if not isinstance(executed_at_raw, str):
+            raise TypeError(
+                "DispatchResult.from_dict 'executed_at' MUST be an ISO-8601 "
+                f"str; got {type(executed_at_raw).__name__}"
+            )
+        executed_at = datetime.fromisoformat(executed_at_raw)
+        return cls(
+            payload=dict(data["payload"]),
+            audit_chain_entries=tuple(data["audit_chain_entries"]),
+            executed_at=executed_at,
+            tenant_id=data["tenant_id"],
+            connector_id=data["connector_id"],
+            dispatch_id=uuid.UUID(data["dispatch_id"]),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -524,6 +719,28 @@ _INVOCABLE_ROLE_LIFECYCLES: frozenset[RoleLifecycleState] = frozenset(
 
 class DispatchSurface:
     """Bind ``(Connector × Signature × Envelope × Identity)`` for dispatch.
+
+    Cross-impl parity: Mirrors rs ``DispatchSurface`` struct (S5
+    substrate). The bind-time gating contract (capability + lifecycle
+    snapshot at __init__; tenant cross-check at dispatch) is the
+    byte-shape contract for cross-SDK ``receipts_agree(rs, py)``
+    verification — both SDKs MUST refuse the same set of
+    (connector, signature, envelope, identity, role, cascade) tuples
+    by raising the same typed error class.
+
+    F5 Monotonicity Invariant
+    -------------------------
+    Capabilities AND lifecycle are snapshotted at bind. Runtime
+    tightening (capability revocation, lifecycle downgrade) is detected
+    at :meth:`dispatch` entry and FAILS CLOSED with
+    :class:`DispatchEnvelopeViolationError`. Runtime widening
+    (capability gain, lifecycle promotion) is IGNORED — the bind-time
+    set is the upper bound. The Role is held by reference, so mutations
+    on the underlying Role object after construction are reflected in
+    runtime checks; this guarantees a revoked capability or
+    state-transition to RETIRED/SUSPENDED between bind and dispatch
+    refuses the invocation rather than admitting it under the snapshot
+    of bind time.
 
     Construction is the bind-time gate; :meth:`dispatch` is the runtime
     invocation. The five invariants (top-of-module docstring) are split:
@@ -570,6 +787,19 @@ class DispatchSurface:
             set. A future S6+ change may collapse this into
             ``identity.role`` if/when the identity primitive grows that
             attribute.
+        signer: Callable producing the Ed25519 signature for each audit
+            event. Signature: ``signer(canonical_bytes) -> hex_str``
+            where ``canonical_bytes`` is the UTF-8 encoding of the
+            canonical-JSON of the audit payload AND the return value
+            is a 128-character lowercase-hex string (the audit-engine
+            contract). EAGER REQUIRED — Round-1 C2-1 zero-tolerance fix:
+            the prior ``"0" * 128`` placeholder is BLOCKED per
+            ``zero-tolerance.md`` Rule 2 "fake encryption" pattern.
+            Production deployments inject a real signer holding the
+            DispatchSurface's signing key; tests inject a deterministic
+            signer (e.g. ``lambda b: hashlib.sha256(b).hexdigest()``
+            doubled to 128 chars). The signer is called exactly once
+            per audit event emitted by the connector.
 
     Raises:
         DispatchEnvelopeViolationError: connector requires a capability
@@ -590,6 +820,7 @@ class DispatchSurface:
         audit_engine: AuditChainEngine,
         trust_cascade: TenantScopedCascade,
         role: Role,
+        signer: Callable[[bytes], str],
     ) -> None:
         # Type discipline at the boundary — defense-in-depth on top of
         # each composed type's own post_init.
@@ -622,6 +853,22 @@ class DispatchSurface:
             raise TypeError(
                 f"DispatchSurface.role MUST be a Role; got {type(role).__name__}"
             )
+        # C2-1 zero-tolerance fix: signer MUST be a real callable injected
+        # at construction. Passing None / a non-callable raises TypeError
+        # at bind time, preventing the prior ``"0" * 128`` placeholder
+        # ("fake encryption" pattern per zero-tolerance.md Rule 2) from
+        # ever reaching the dispatch hot path. The signer's runtime
+        # return-value surface is validated at every emission in
+        # :meth:`_signed_audit` so a malformed signer fails per-call,
+        # not silently for the lifetime of the DispatchSurface.
+        if not callable(signer):
+            raise TypeError(
+                "DispatchSurface.signer MUST be a callable producing "
+                "Ed25519 hex signatures; got "
+                f"{type(signer).__name__} (None / placeholder forms are "
+                "BLOCKED per zero-tolerance.md Rule 2 fake-encryption "
+                "fix C2-1)"
+            )
         # SignatureContract is a Protocol; runtime_checkable lets isinstance
         # verify the structural shape. Per zero-tolerance Rule 3a (typed
         # delegate guards), surface a typed error instead of an opaque
@@ -648,17 +895,33 @@ class DispatchSurface:
 
         # Invariant 3 — capability gating. Connector's required
         # capabilities MUST be a subset of the role's capability set.
-        # Direct frozenset.issubset() check; surface every missing
-        # capability for actionable error messages.
+        # C5-2 error-leakage: hash capability names in the caller-facing
+        # message so log-aggregator readers do not see the security
+        # vocabulary; full detail is structured-logged at DEBUG for
+        # operators investigating with full context.
         role_caps = frozenset(role.scope.capabilities.capabilities)
         missing = connector.requires_capabilities - role_caps
         if missing:
+            missing_hash = hashlib.sha256(
+                ",".join(sorted(missing)).encode("utf-8")
+            ).hexdigest()[:8]
+            logger.debug(
+                "dispatch.envelope_violation",
+                extra={
+                    "axis": "missing_capability",
+                    "connector_id": connector.connector_id,
+                    "required_capabilities": sorted(connector.requires_capabilities),
+                    "role_display_name": role.display_name,
+                    "granted_capabilities": sorted(role_caps),
+                    "missing": sorted(missing),
+                },
+            )
             raise DispatchEnvelopeViolationError(
                 f"DispatchSurface refuses bind: connector "
-                f"{connector.connector_id!r} requires capabilities "
-                f"{sorted(connector.requires_capabilities)!r} but role "
-                f"{role.display_name!r} grants only {sorted(role_caps)!r}; "
-                f"missing={sorted(missing)!r} (Invariant 3)"
+                f"{connector.connector_id!r} requires {len(missing)} "
+                f"capability/ies the role does not grant "
+                f"[missing_hash={missing_hash}] (Invariant 3 — see DEBUG "
+                "logs for detail)"
             )
 
         # Bind-time tenant consistency between cascade and identity. The
@@ -679,6 +942,18 @@ class DispatchSurface:
         self._audit_engine = audit_engine
         self._trust_cascade = trust_cascade
         self._role = role
+        self._signer = signer
+
+        # C4-1 F5 monotonicity snapshot: capture the bind-time
+        # capability set and lifecycle so :meth:`dispatch` can refuse
+        # invocations where the underlying Role drifted between bind
+        # and dispatch (revocation / state transition). frozenset
+        # captures by value; the lifecycle enum is immutable.
+        self._required_caps: frozenset[str] = frozenset(connector.requires_capabilities)
+        self._granted_caps_at_bind: frozenset[str] = frozenset(
+            role.scope.capabilities.capabilities
+        )
+        self._lifecycle_at_bind: RoleLifecycleState = role.lifecycle
 
     @property
     def connector(self) -> Connector:
@@ -764,11 +1039,74 @@ class DispatchSurface:
                 audit-visible (REASONING_SCRATCHPAD).
             Exception: connector-raised exceptions propagate verbatim.
         """
+        # Step 0a — C4-1 F5 monotonicity re-check. The role is held by
+        # reference; runtime tightening (capability revocation,
+        # lifecycle transition to RETIRED/SUSPENDED) MUST refuse the
+        # invocation rather than admit it under the bind-time snapshot.
+        # Widening is IGNORED — the bind-time set remains the upper bound.
+        current_caps = frozenset(self._role.scope.capabilities.capabilities)
+        if not self._required_caps.issubset(current_caps):
+            missing_now = self._required_caps - current_caps
+            raise DispatchEnvelopeViolationError(
+                f"DispatchSurface refuses dispatch: capability set drifted "
+                f"after bind; {len(missing_now)} required capability/ies "
+                "revoked between bind and dispatch (F5 monotonicity — "
+                "Invariant 3 runtime re-check)"
+            )
+        current_lifecycle = self._role.lifecycle
+        if current_lifecycle not in _INVOCABLE_ROLE_LIFECYCLES:
+            raise DispatchEnvelopeViolationError(
+                f"DispatchSurface refuses dispatch: role lifecycle drifted "
+                f"from {self._lifecycle_at_bind.value!r} at bind to "
+                f"{current_lifecycle.value!r}; invocation refused (F5 "
+                "monotonicity — Invariant 5 runtime re-check)"
+            )
+
+        # Step 0b — C6-1 DoS defense: depth + serialized-size limits
+        # BEFORE per-field type checks. canonical_json_dumps recurses on
+        # the payload during audit emission; deeply nested or oversize
+        # payloads are refused at the boundary.
+        if isinstance(input_payload, dict):
+            _check_payload_depth(input_payload)
+            try:
+                serialized_size = len(
+                    canonical_json_dumps(input_payload).encode("utf-8")
+                )
+            except (TypeError, ValueError) as exc:
+                # Non-JSON-serializable payloads surface as DispatchValidationError
+                # at the dispatch boundary so callers do not need to introspect
+                # canonical_json_dumps exception types.
+                raise DispatchValidationError(
+                    f"input_payload is not JSON-serializable for cross-SDK "
+                    f"canonical encoding: {exc}"
+                ) from exc
+            if serialized_size > _MAX_PAYLOAD_SERIALIZED_BYTES:
+                raise DispatchValidationError(
+                    f"input_payload exceeds maximum serialized size "
+                    f"({_MAX_PAYLOAD_SERIALIZED_BYTES} bytes); got "
+                    f"{serialized_size} bytes; refused to prevent DoS "
+                    "through unbounded audit-payload encoding"
+                )
+
         # Step 1 — input_payload validation against signature contract.
+        # C5-1 error-leakage fix: every DispatchValidationError surface
+        # carries a generic caller-facing message + correlation hash;
+        # full schema-revealing detail is structured-logged at DEBUG so
+        # log-aggregator readers (per observability.md MUST Rule 8) do
+        # not see schema names while operators investigating with debug
+        # logging retain full context.
         if not isinstance(input_payload, dict):
+            logger.debug(
+                "dispatch.validation_error",
+                extra={
+                    "axis": "payload_type",
+                    "signature_name": self._signature.name,
+                    "received_type": type(input_payload).__name__,
+                },
+            )
             raise DispatchValidationError(
-                f"DispatchSurface.dispatch input_payload MUST be a dict; got "
-                f"{type(input_payload).__name__}"
+                "input_payload type mismatch; expected dict (see DEBUG "
+                "logs for detail)"
             )
         # Closed-world schema: every key in input_payload MUST appear in
         # the signature's input_schema. Extra keys are rejected to close
@@ -778,26 +1116,78 @@ class DispatchSurface:
             self._signature.input_schema.keys()
         )
         if extra_keys:
+            extras_hash = self._field_hash(",".join(sorted(extra_keys)))
+            logger.debug(
+                "dispatch.validation_error",
+                extra={
+                    "axis": "undeclared_field",
+                    "signature_name": self._signature.name,
+                    "extra_keys": sorted(extra_keys),
+                    "declared_keys": sorted(self._signature.input_schema.keys()),
+                },
+            )
             raise DispatchValidationError(
-                f"DispatchSurface.dispatch input_payload has undeclared "
-                f"field(s) {sorted(extra_keys)!r}; signature "
-                f"{self._signature.name!r} declares only "
-                f"{sorted(self._signature.input_schema.keys())!r}"
+                f"input_payload has undeclared field(s) " f"[extras_hash={extras_hash}]"
             )
         for field_name, declared_type in self._signature.input_schema.items():
             if field_name not in input_payload:
+                field_hash = self._field_hash(field_name)
+                logger.debug(
+                    "dispatch.validation_error",
+                    extra={
+                        "axis": "missing_field",
+                        "signature_name": self._signature.name,
+                        "field_name": field_name,
+                    },
+                )
                 raise DispatchValidationError(
-                    f"DispatchSurface.dispatch input_payload missing required "
-                    f"field {field_name!r} declared by signature "
-                    f"{self._signature.name!r}"
+                    f"input_payload missing required field "
+                    f"[field_hash={field_hash}]"
                 )
             value = input_payload[field_name]
-            if not isinstance(value, declared_type):
+            # C6-2 strict type check: isinstance(True, int) is True in
+            # Python — reject bool for int-declared fields explicitly so
+            # the security.md sanitizer-contract Rule 2 (type-confusion
+            # raises, not coerces) holds at the dispatch boundary.
+            if declared_type is int and isinstance(value, bool):
+                field_hash = self._field_hash(field_name)
+                logger.debug(
+                    "dispatch.validation_error",
+                    extra={
+                        "axis": "bool_for_int_field",
+                        "signature_name": self._signature.name,
+                        "field_name": field_name,
+                        "received_type": "bool",
+                    },
+                )
                 raise DispatchValidationError(
-                    f"DispatchSurface.dispatch input_payload field "
-                    f"{field_name!r} declared as "
-                    f"{declared_type.__name__!r} received "
-                    f"{type(value).__name__!r}"
+                    f"input_payload field [field_hash={field_hash}] "
+                    f"declared int; bool BLOCKED (type coercion refused "
+                    "per security.md sanitizer Rule 2)"
+                )
+            # Allow numeric tower: int satisfies float field.
+            if (
+                declared_type is float
+                and isinstance(value, int)
+                and not isinstance(value, bool)
+            ):
+                pass  # accept int as float
+            elif not isinstance(value, declared_type):
+                field_hash = self._field_hash(field_name)
+                logger.debug(
+                    "dispatch.validation_error",
+                    extra={
+                        "axis": "type_mismatch",
+                        "signature_name": self._signature.name,
+                        "field_name": field_name,
+                        "declared_type": declared_type.__name__,
+                        "received_type": type(value).__name__,
+                    },
+                )
+                raise DispatchValidationError(
+                    f"input_payload field [field_hash={field_hash}] "
+                    f"failed schema validation (declared "
+                    f"{declared_type.__name__})"
                 )
 
         # Step 3 — invoke the connector. Connector exceptions propagate
@@ -813,6 +1203,19 @@ class DispatchSurface:
                 f"Connector {self._connector.connector_id!r} returned "
                 f"{type(result).__name__!r}; MUST return a "
                 "ConnectorInvocationResult instance"
+            )
+
+        # Step 3b — C2-3 side-effect-without-audit gate. zero-tolerance
+        # Rule 2 fake-dispatch class: a connector reporting an external
+        # mutation MUST emit at least one audit event documenting it.
+        # Mutation without provenance is BLOCKED because the audit trail
+        # is the only post-incident record of what actually changed.
+        if result.external_side_effect and not result.audit_events:
+            raise DispatchValidationError(
+                f"connector {self._connector.connector_id!r} reported "
+                "external_side_effect=True but emitted zero audit_events; "
+                "side-effects without audit trail are BLOCKED "
+                "(zero-tolerance.md Rule 2 fake-dispatch class)"
             )
 
         # Step 4 — cross-validate tenant isolation (Invariant 2).
@@ -848,17 +1251,42 @@ class DispatchSurface:
                 "signature_name": self._signature.name,
                 "external_side_effect": result.external_side_effect,
             }
-            # Use the per-emit-call default signed_at; signature is a
-            # placeholder Ed25519-shape hex value since the dispatch
-            # surface itself does not own signing keys — production
-            # deployments will inject a real signer in S6+. The
-            # placeholder is 128 zero-chars per the audit_engine
-            # signature validation contract.
+            # C2-1 zero-tolerance fix: call the injected signer with the
+            # canonical-bytes encoding of the audit payload. A signer
+            # fault re-raises as DispatchSignerError so the error
+            # taxonomy distinguishes signer faults from
+            # AuditChainEmissionError (signature surface-shape) and
+            # DispatchValidationError (input-shape).
+            canonical_bytes = canonical_json_dumps(payload).encode("utf-8")
+            try:
+                signature_hex = self._signer(canonical_bytes)
+            except Exception as exc:
+                raise DispatchSignerError(
+                    f"injected signer raised while signing audit event "
+                    f"{event_type.value!r}: {type(exc).__name__}: {exc}"
+                ) from exc
+            if not isinstance(signature_hex, str):
+                raise DispatchSignerError(
+                    f"injected signer MUST return str; got "
+                    f"{type(signature_hex).__name__}"
+                )
+            # Surface-shape sanity check: the audit engine's
+            # _validate_hex requires 128 lowercase-hex chars (Ed25519).
+            # A signer that returns less than 32 chars is structurally
+            # not a real signature; raise before the engine boundary so
+            # the error attribution is unambiguous (signer fault vs.
+            # engine fault).
+            if len(signature_hex) < 32:
+                raise DispatchSignerError(
+                    f"injected signer returned a signature shorter than "
+                    "32 characters; production signatures are 128-char "
+                    f"lowercase hex (Ed25519); got {len(signature_hex)} chars"
+                )
             entry = self._audit_engine.emit_event(
                 event_type=event_type.value,
                 payload=payload,
                 signer_identity=self._identity,
-                signature="0" * 128,
+                signature=signature_hex,
             )
             # Append the head_hash AFTER the emission so each entry's
             # hash captures the chain state at the moment of that
@@ -883,4 +1311,18 @@ class DispatchSurface:
             executed_at=datetime.now(timezone.utc),
             tenant_id=tenant_id_for_result,
             connector_id=self._connector.connector_id,
+            dispatch_id=uuid.uuid4(),
         )
+
+    @staticmethod
+    def _field_hash(field_name: str) -> str:
+        """C5-1 / C5-2 error-leakage helper.
+
+        Returns the first 8 chars of SHA-256(field_name) as a stable,
+        non-reversible correlation token. Used in
+        :class:`DispatchValidationError` messages so the caller can
+        cross-reference structured DEBUG logs without exposing schema
+        field names through log-aggregator surfaces (per
+        ``observability.md`` MUST Rule 8).
+        """
+        return hashlib.sha256(field_name.encode("utf-8")).hexdigest()[:8]

--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -1,0 +1,864 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportUnnecessaryIsInstance=false
+"""Connector ABC + Dispatch surface for ``kailash.delegate`` (S5 of #1035).
+
+Binds the existing Delegate primitives into the audit-grade composition
+``(Connector × Signature × ConstraintEnvelope × Executor)``. This is the
+surface a Delegate invocation actually flows through — the Connector is
+the external endpoint (HTTP, MCP tool, Kaizen Signature, custom adapter),
+the Signature defines the input/output contract, the ConstraintEnvelope
+carries the F5 monotonic-tightening invariant, and the
+:class:`DispatchSurface` is the bind-time composition that enforces every
+invariant at runtime.
+
+Invariants held by :class:`DispatchSurface` (within budget per
+``autonomous-execution.md`` MUST Rule 1 — five invariants total):
+
+1. **F5 type-state monotonic envelope** — the envelope passed at
+   construction is final; runtime composition is tightening-only via
+   :meth:`DelegateConstraintEnvelope.tighten_with` (which inherits the
+   S2.5 F1 widening-raise gate). The DispatchSurface MUST NOT loosen
+   the envelope between bind and invocation.
+2. **Tenant isolation** — the connector's observed tenant_id MUST equal
+   the cascade's bound tenant; mismatch raises
+   :class:`CascadeTenantViolationError` (re-using the
+   :mod:`kailash.delegate.trust` exception so cross-layer audits surface
+   one error class per tenant-boundary violation).
+3. **Capability gating** — the connector's declared
+   ``requires_capabilities`` frozenset MUST be a subset of the bound
+   role's :class:`CapabilitySet`. Checked at construction; raises
+   :class:`DispatchEnvelopeViolationError` on mismatch.
+4. **Audit emission only on audit-visible events** — :meth:`dispatch`
+   forwards every event in :attr:`ConnectorInvocationResult.audit_events`
+   to :meth:`AuditChainEngine.emit_event`; the engine's
+   ``_AUDIT_VISIBLE_EVENT_TYPES`` frozenset rejects any non-visible
+   variant. DispatchSurface does NOT re-implement the allowlist — it
+   lets :class:`AuditChainEmissionError` propagate (per C3
+   founder-ratified audit-visibility classifier).
+5. **Lifecycle state** — the bound :class:`Role` MUST be in an
+   invocable lifecycle. ``RoleLifecycleState.RETIRED`` and ``SUSPENDED``
+   refuse dispatch with :class:`DispatchEnvelopeViolationError`. Only
+   ``DRAFT`` and ``ACTIVE`` are invocable (DRAFT is permitted so test
+   harnesses can dispatch against pre-activation roles; runtime
+   deployments enforce ACTIVE-only via the surrounding deployment
+   policy).
+
+The Connector ABC itself is a pure abstract surface — subclasses
+provide the actual external endpoint behavior. The ABC enforces
+``async def invoke(...)`` as a coroutine, class-level
+``connector_id`` + ``connector_kind`` + ``requires_capabilities``
+metadata for the bind-time capability check, and refuses direct
+instantiation via :class:`abc.ABC`.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Protocol, runtime_checkable
+
+from kailash.delegate.audit import (
+    AuditChainEngine,
+    DelegateEventType,
+)
+from kailash.delegate.envelope import DelegateConstraintEnvelope
+from kailash.delegate.trust import (
+    CascadeTenantViolationError,
+    TenantScope,
+    TenantScopedCascade,
+)
+from kailash.delegate.types import (
+    DelegateIdentity,
+    Role,
+    RoleLifecycleState,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "Connector",
+    "ConnectorInvocationResult",
+    "DispatchCascadeViolationError",
+    "DispatchEnvelopeViolationError",
+    "DispatchResult",
+    "DispatchSurface",
+    "DispatchValidationError",
+    "SignatureContract",
+]
+
+
+# ---------------------------------------------------------------------------
+# Typed errors — distinct ValueError-derived classes per invariant axis
+# ---------------------------------------------------------------------------
+
+
+class DispatchValidationError(ValueError):
+    """Raised when ``input_payload`` violates the bound signature contract.
+
+    Surfaces type or shape mismatches between the actual ``input_payload``
+    and the bound :class:`SignatureContract.input_schema`. Distinct from
+    :class:`DispatchEnvelopeViolationError` (capability / tenant / lifecycle
+    gating, Invariants 3 + 5) and :class:`DispatchCascadeViolationError`
+    (trust cascade refuses the principal, Invariant 2).
+
+    ``ValueError``-derived per the S2.5 / S3 / S4 pattern — a signature
+    contract violation is a caller fault, not a system fault.
+    """
+
+
+class DispatchEnvelopeViolationError(ValueError):
+    """Raised when the envelope refuses the invocation at bind or dispatch.
+
+    Three sub-classes of violation surface here:
+
+    - **Capability missing** (Invariant 3): the connector's declared
+      ``requires_capabilities`` is not a subset of the bound role's
+      :class:`CapabilitySet`. Checked at construction so a misconfigured
+      DispatchSurface cannot even be built.
+    - **Tenant out of envelope scope**: the envelope's bound tenant is
+      not the cascade's tenant (cross-validation at construction). This
+      is a sibling of the runtime tenant-isolation check that uses
+      :class:`CascadeTenantViolationError` for the OBSERVED tenant;
+      this error covers the static binding-time mismatch.
+    - **Lifecycle state refuses dispatch** (Invariant 5): the bound
+      :class:`Role` is in :attr:`RoleLifecycleState.RETIRED` or
+      :attr:`RoleLifecycleState.SUSPENDED`. RETIRED is the closest
+      semantic to the spec's "REVOKED" (the existing
+      :mod:`kailash.delegate.types` enum does not declare REVOKED;
+      RETIRED is the canonical "no further bindings" state per
+      ``types.py`` :class:`RoleLifecycleState` docstring).
+    """
+
+
+class DispatchCascadeViolationError(ValueError):
+    """Raised when the trust cascade refuses the invocation.
+
+    Surfaces when the bound :class:`DelegateIdentity` is not a known
+    grantee of the bound :class:`TenantScopedCascade`. Distinct from
+    :class:`CascadeTenantViolationError` (Invariant 2 runtime tenant
+    mismatch) — this error is the BIND-time check that the principal
+    was actually granted by the cascade.
+
+    Note: the current :class:`TenantScopedCascade` does NOT yet expose
+    a persistent grantee registry (S3 emits one
+    :class:`~kailash.delegate.trust.GrantMoment` per ``cascade_child``
+    call but does not retain the grantee set). The construction-time
+    check here is structural — the identity's ``delegate_id`` is held
+    on the DispatchSurface and the cascade's tenant is cross-checked.
+    A future enhancement (S7+) will surface a grantee registry; this
+    error class is the stable typed surface that registry will plumb
+    into.
+    """
+
+
+# ---------------------------------------------------------------------------
+# SignatureContract — minimal Protocol the kailash.delegate package
+# does not yet expose a structured Signature primitive (Kaizen has one,
+# but Delegate is independent per Foundation Independence rules). We
+# declare a minimal Protocol so the dispatch surface has a typed binding
+# point. When a structured Delegate Signature primitive lands (S6+),
+# this Protocol becomes its conformance gate.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SignatureContract(Protocol):
+    """Minimal contract a Signature MUST satisfy to bind to DispatchSurface.
+
+    A signature names the connector's input/output schema. The schemas are
+    dict-shaped — keys are field names, values are the declared type (e.g.
+    ``{"user_id": str, "limit": int}``). DispatchSurface validates
+    ``input_payload`` against ``input_schema`` at dispatch time (Invariant
+    1, signature contract).
+
+    Per ``foundation-independence.md`` the Delegate spine does NOT couple
+    to Kaizen's Signature primitive; this Protocol is the structural
+    contract. A future structured Delegate Signature class (S6+) will
+    satisfy this Protocol; in the interim, any object exposing the three
+    attributes binds.
+
+    Attributes:
+        name: Identifier for the signature (e.g. ``"create_user"``).
+            Used in audit-event payloads + error messages.
+        input_schema: Mapping of input field name → declared type. The
+            ``DispatchSurface`` validates ``input_payload.keys()`` ⊆
+            ``input_schema.keys()`` and each value is instance-of the
+            declared type. Extra payload keys are rejected (closed-world
+            schema — per ``zero-tolerance.md`` Rule 3c, silently
+            dropping undocumented kwargs is BLOCKED; the equivalent here
+            is rejecting undeclared input fields rather than silently
+            forwarding them).
+        output_schema: Mapping of output field name → declared type. The
+            DispatchSurface does NOT enforce output_schema (the
+            connector owns its return shape); the field is held for
+            audit / observability + downstream consumers that re-derive
+            type-checks at the Signature layer.
+    """
+
+    name: str
+    input_schema: dict[str, type]
+    output_schema: dict[str, type]
+
+
+# ---------------------------------------------------------------------------
+# Connector ABC — pure abstract external-surface contract
+# ---------------------------------------------------------------------------
+
+
+class Connector(abc.ABC):
+    """Abstract external endpoint a Delegate invocation connects through.
+
+    Subclasses provide the actual external behavior — HTTP request, MCP
+    tool call, Kaizen Signature invocation, queue publish, etc. The ABC
+    defines exactly the surface :class:`DispatchSurface` needs:
+
+    - Class-level ``connector_id``, ``connector_kind``,
+      ``requires_capabilities`` metadata for bind-time gating.
+    - Async :meth:`invoke` returning a
+      :class:`ConnectorInvocationResult` carrying payload + audit events
+      + tenant observation + side-effect flag.
+
+    The ABC refuses direct instantiation via :class:`abc.ABC` + the
+    abstract :meth:`invoke`. Per ``orphan-detection.md`` MUST Rule 1,
+    this base class lives in the framework hot path:
+    :meth:`DispatchSurface.dispatch` calls ``await connector.invoke(...)``
+    directly — there is no facade orphan layer.
+
+    Subclass example::
+
+        class HttpConnector(Connector):
+            connector_id = "http-create-user"
+            connector_kind = "http"
+            requires_capabilities = frozenset({"http.write"})
+
+            async def invoke(
+                self,
+                input_payload,
+                *,
+                identity,
+                envelope,
+            ):
+                ...  # actual HTTP call
+                return ConnectorInvocationResult(
+                    payload={"user_id": "u-42"},
+                    audit_events=(DelegateEventType.EXTERNAL_SIDE_EFFECT,),
+                    tenant_id_observed=envelope.genesis_id,  # or actual tenant
+                    external_side_effect=True,
+                )
+    """
+
+    # Class-level metadata. Subclasses MUST override these — the bind
+    # check at DispatchSurface construction reads them. Defaults are
+    # intentionally empty / placeholder so a subclass that forgets to
+    # set them fails the bind check loudly rather than silently
+    # accepting the parent default.
+    connector_id: str = ""
+    connector_kind: str = ""
+    requires_capabilities: frozenset[str] = frozenset()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # Defense-in-depth: every concrete subclass MUST declare a
+        # non-empty connector_id at the class level so audit events
+        # carry a meaningful identifier. Empty string at the subclass
+        # level is BLOCKED (the ABC's empty default cannot satisfy this
+        # check).
+        if not cls.__abstractmethods__:
+            # Only enforce on concrete subclasses (abstract intermediate
+            # base classes may legitimately defer metadata to their own
+            # concrete subclasses).
+            if not isinstance(cls.connector_id, str) or not cls.connector_id:
+                raise TypeError(
+                    f"Connector subclass {cls.__name__!r} MUST declare a "
+                    f"non-empty class-level connector_id; got "
+                    f"{cls.connector_id!r}"
+                )
+            if not isinstance(cls.connector_kind, str) or not cls.connector_kind:
+                raise TypeError(
+                    f"Connector subclass {cls.__name__!r} MUST declare a "
+                    f"non-empty class-level connector_kind; got "
+                    f"{cls.connector_kind!r}"
+                )
+            if not isinstance(cls.requires_capabilities, frozenset):
+                raise TypeError(
+                    f"Connector subclass {cls.__name__!r} MUST declare "
+                    f"requires_capabilities as a frozenset; got "
+                    f"{type(cls.requires_capabilities).__name__}"
+                )
+
+    @abc.abstractmethod
+    async def invoke(
+        self,
+        input_payload: dict[str, Any],
+        *,
+        identity: DelegateIdentity,
+        envelope: DelegateConstraintEnvelope,
+    ) -> ConnectorInvocationResult:
+        """Invoke the external endpoint.
+
+        Subclasses MUST implement this as a coroutine returning a
+        :class:`ConnectorInvocationResult`. The DispatchSurface awaits
+        this directly; raising propagates to the caller (the DispatchSurface
+        does NOT swallow connector exceptions — per ``zero-tolerance.md``
+        Rule 3, silent error hiding is BLOCKED).
+
+        Args:
+            input_payload: The validated input payload (DispatchSurface
+                has already checked it against the bound
+                :attr:`SignatureContract.input_schema`).
+            identity: The bound :class:`DelegateIdentity`. Connectors may
+                use ``identity.delegate_id`` for audit correlation or
+                authn/authz checks against their own external surface.
+            envelope: The bound :class:`DelegateConstraintEnvelope`.
+                Connectors may inspect envelope constraints (budget
+                limits, model selection, etc.) to shape their request.
+
+        Returns:
+            A :class:`ConnectorInvocationResult` carrying the connector's
+            payload, the audit events the connector emitted, the
+            tenant_id the connector observed (for cross-validation), and
+            the external-side-effect flag.
+        """
+        raise NotImplementedError  # pragma: no cover (abstract)
+
+
+# ---------------------------------------------------------------------------
+# ConnectorInvocationResult — frozen dataclass returned by Connector.invoke
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorInvocationResult:
+    """The result of a single :meth:`Connector.invoke` call.
+
+    Frozen + slots per the S2/S3/S4 dataclass conventions. The
+    DispatchSurface inspects every field of this result for the
+    cross-validation invariants:
+
+    - ``audit_events`` flows into :meth:`AuditChainEngine.emit_event`
+      (Invariant 4 — audit-visible events only).
+    - ``tenant_id_observed`` cross-validates against the envelope's
+      tenant (Invariant 2 — tenant isolation).
+    - ``external_side_effect`` is a structural marker the DispatchSurface
+      surfaces in the returned :class:`DispatchResult`; it does NOT
+      itself gate audit emission (the connector's ``audit_events`` is
+      the explicit declaration of what to emit).
+
+    Attributes:
+        payload: The connector's return value (dict-shaped). The
+            DispatchSurface returns this verbatim on
+            :attr:`DispatchResult.payload`.
+        audit_events: Tuple of :class:`DelegateEventType` variants the
+            connector emitted during invocation. The DispatchSurface
+            forwards each to :meth:`AuditChainEngine.emit_event`;
+            non-audit-visible variants (e.g. ``REASONING_SCRATCHPAD``)
+            raise :class:`AuditChainEmissionError` from the engine's
+            own gate (the DispatchSurface does NOT re-check the
+            allowlist — single source of truth per
+            ``zero-tolerance.md`` Rule 4).
+        tenant_id_observed: The tenant the connector actually touched.
+            ``None`` is permitted ONLY when the envelope's bound
+            cascade is :class:`TenantScope.global_` (the explicit
+            unscoped variant); a non-None observed tenant on a
+            for_tenant-bound cascade with a mismatched id raises
+            :class:`CascadeTenantViolationError`.
+        external_side_effect: ``True`` iff the invocation produced an
+            externally-observable mutation (HTTP write, queue publish,
+            etc.). The DispatchSurface uses this flag for observability
+            but does NOT auto-emit an audit event — the connector
+            declares its events explicitly via ``audit_events``.
+    """
+
+    payload: dict[str, Any]
+    audit_events: tuple[DelegateEventType, ...]
+    tenant_id_observed: str | None
+    external_side_effect: bool
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.payload, dict):
+            raise TypeError(
+                "ConnectorInvocationResult.payload MUST be a dict; got "
+                f"{type(self.payload).__name__}"
+            )
+        if not isinstance(self.audit_events, tuple):
+            raise TypeError(
+                "ConnectorInvocationResult.audit_events MUST be a tuple; got "
+                f"{type(self.audit_events).__name__}"
+            )
+        for ev in self.audit_events:
+            if not isinstance(ev, DelegateEventType):
+                raise TypeError(
+                    "ConnectorInvocationResult.audit_events entries MUST be "
+                    f"DelegateEventType variants; got {type(ev).__name__}"
+                )
+        if self.tenant_id_observed is not None and not isinstance(
+            self.tenant_id_observed, str
+        ):
+            raise TypeError(
+                "ConnectorInvocationResult.tenant_id_observed MUST be str "
+                f"or None; got {type(self.tenant_id_observed).__name__}"
+            )
+        if not isinstance(self.external_side_effect, bool):
+            raise TypeError(
+                "ConnectorInvocationResult.external_side_effect MUST be bool; "
+                f"got {type(self.external_side_effect).__name__}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# DispatchResult — frozen dataclass returned by DispatchSurface.dispatch
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchResult:
+    """The chain-of-custody record of one dispatch invocation.
+
+    Frozen + slots per conventions. Returned by
+    :meth:`DispatchSurface.dispatch` on success — failure paths raise
+    typed errors before this is constructed.
+
+    Attributes:
+        payload: The connector's return value (verbatim from
+            :attr:`ConnectorInvocationResult.payload`).
+        audit_chain_entries: Tuple of entry hashes (SHA-256 hex) from
+            :meth:`AuditChainEngine.head_hash` after each event emission.
+            Empty tuple when the connector emitted no audit events. The
+            chain-of-custody invariant: dispatching a single
+            :class:`DispatchSurface.dispatch` call produces a contiguous
+            run of audit chain entries — consumers can replay the chain
+            from these hashes to verify the dispatch's audit trail.
+        executed_at: tz-aware UTC datetime of dispatch completion.
+        tenant_id: The validated tenant (cascade tenant, or empty string
+            for the explicit ``TenantScope.global_`` variant). Carries
+            the post-validation tenant for traceability.
+        connector_id: The bound connector's ``connector_id`` for
+            traceability against the connector subclass.
+    """
+
+    payload: dict[str, Any]
+    audit_chain_entries: tuple[str, ...]
+    executed_at: datetime
+    tenant_id: str
+    connector_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.payload, dict):
+            raise TypeError(
+                "DispatchResult.payload MUST be a dict; got "
+                f"{type(self.payload).__name__}"
+            )
+        if not isinstance(self.audit_chain_entries, tuple):
+            raise TypeError(
+                "DispatchResult.audit_chain_entries MUST be a tuple; got "
+                f"{type(self.audit_chain_entries).__name__}"
+            )
+        for h in self.audit_chain_entries:
+            if not isinstance(h, str):
+                raise TypeError(
+                    "DispatchResult.audit_chain_entries entries MUST be str; "
+                    f"got {type(h).__name__}"
+                )
+        if not isinstance(self.executed_at, datetime):
+            raise TypeError(
+                "DispatchResult.executed_at MUST be a datetime; got "
+                f"{type(self.executed_at).__name__}"
+            )
+        if self.executed_at.tzinfo is None:
+            raise ValueError(
+                "DispatchResult.executed_at MUST be timezone-aware (naive "
+                "datetimes break cross-SDK wire-format parity)"
+            )
+        if not isinstance(self.tenant_id, str):
+            raise TypeError(
+                f"DispatchResult.tenant_id MUST be a str; got "
+                f"{type(self.tenant_id).__name__}"
+            )
+        if not isinstance(self.connector_id, str) or not self.connector_id:
+            raise ValueError(
+                "DispatchResult.connector_id MUST be a non-empty str; got "
+                f"{self.connector_id!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# DispatchSurface — the (Connector × Signature × Envelope × Identity) bind
+# ---------------------------------------------------------------------------
+
+
+# RoleLifecycleStates that MAY invoke dispatch. DRAFT is permitted so
+# test harnesses can dispatch against pre-activation roles; runtime
+# deployments enforce ACTIVE-only via the surrounding deployment policy.
+# SUSPENDED and RETIRED refuse — SUSPENDED holds existing bindings but
+# permits no new operations; RETIRED is the spec's "REVOKED" semantic
+# (no further bindings ever).
+_INVOCABLE_ROLE_LIFECYCLES: frozenset[RoleLifecycleState] = frozenset(
+    {RoleLifecycleState.DRAFT, RoleLifecycleState.ACTIVE}
+)
+
+
+class DispatchSurface:
+    """Bind ``(Connector × Signature × Envelope × Identity)`` for dispatch.
+
+    Construction is the bind-time gate; :meth:`dispatch` is the runtime
+    invocation. The five invariants (top-of-module docstring) are split:
+
+    - Invariant 1 (F5 monotonic envelope) — held by the envelope itself
+      via :meth:`DelegateConstraintEnvelope.tighten_with`; DispatchSurface
+      holds the envelope by reference (frozen dataclass) so it cannot be
+      mutated post-bind.
+    - Invariant 3 (capability gating) — checked at construction.
+    - Invariant 5 (lifecycle state) — checked at construction.
+    - Invariant 2 (tenant isolation) — cross-checked at dispatch against
+      the connector's observed tenant.
+    - Invariant 4 (audit emission) — forwarded to
+      :class:`AuditChainEngine` whose own ``_AUDIT_VISIBLE_EVENT_TYPES``
+      frozenset is the single source of truth.
+
+    Per ``facade-manager-detection.md`` MUST Rule 3, the
+    :class:`AuditChainEngine` and :class:`TenantScopedCascade` are
+    explicit constructor dependencies — no global lookup, no
+    self-construction. Per ``orphan-detection.md`` MUST Rule 1, the
+    DispatchSurface IS the framework hot path that calls
+    ``connector.invoke()`` — there is no further indirection.
+
+    Args:
+        connector: A concrete :class:`Connector` subclass instance.
+        signature: An object satisfying :class:`SignatureContract`.
+        envelope: The :class:`DelegateConstraintEnvelope` bound for this
+            dispatch surface. Final at construction — runtime
+            ``tighten_with`` calls produce a NEW envelope; the
+            DispatchSurface's bound envelope does NOT change.
+        identity: The :class:`DelegateIdentity` of the principal
+            invoking this dispatch.
+        audit_engine: The :class:`AuditChainEngine` events flow to.
+            EAGER REQUIRED — DispatchSurface cannot be constructed
+            without a real engine.
+        trust_cascade: The :class:`TenantScopedCascade` whose tenant
+            cross-validates against the connector's observed tenant.
+            EAGER REQUIRED.
+        role: The :class:`Role` bound for the capability + lifecycle
+            check (Invariants 3 + 5). DelegateIdentity does NOT yet
+            carry a Role attribute (the existing identity primitive
+            holds a ``role_binding_ref`` string); the Role is passed
+            explicitly so the bind-time check has the actual capability
+            set. A future S6+ change may collapse this into
+            ``identity.role`` if/when the identity primitive grows that
+            attribute.
+
+    Raises:
+        DispatchEnvelopeViolationError: connector requires a capability
+            the role does not grant, OR role is in a lifecycle that
+            refuses dispatch (RETIRED, SUSPENDED).
+        DispatchCascadeViolationError: the envelope's tenant binding is
+            inconsistent with the cascade's tenant.
+        TypeError: any argument fails its type check.
+    """
+
+    def __init__(
+        self,
+        connector: Connector,
+        signature: SignatureContract,
+        envelope: DelegateConstraintEnvelope,
+        identity: DelegateIdentity,
+        *,
+        audit_engine: AuditChainEngine,
+        trust_cascade: TenantScopedCascade,
+        role: Role,
+    ) -> None:
+        # Type discipline at the boundary — defense-in-depth on top of
+        # each composed type's own post_init.
+        if not isinstance(connector, Connector):
+            raise TypeError(
+                "DispatchSurface.connector MUST be a Connector subclass "
+                f"instance; got {type(connector).__name__}"
+            )
+        if not isinstance(envelope, DelegateConstraintEnvelope):
+            raise TypeError(
+                "DispatchSurface.envelope MUST be a DelegateConstraintEnvelope; "
+                f"got {type(envelope).__name__}"
+            )
+        if not isinstance(identity, DelegateIdentity):
+            raise TypeError(
+                "DispatchSurface.identity MUST be a DelegateIdentity; got "
+                f"{type(identity).__name__}"
+            )
+        if not isinstance(audit_engine, AuditChainEngine):
+            raise TypeError(
+                "DispatchSurface.audit_engine MUST be an AuditChainEngine; got "
+                f"{type(audit_engine).__name__}"
+            )
+        if not isinstance(trust_cascade, TenantScopedCascade):
+            raise TypeError(
+                "DispatchSurface.trust_cascade MUST be a TenantScopedCascade; "
+                f"got {type(trust_cascade).__name__}"
+            )
+        if not isinstance(role, Role):
+            raise TypeError(
+                f"DispatchSurface.role MUST be a Role; got {type(role).__name__}"
+            )
+        # SignatureContract is a Protocol; runtime_checkable lets isinstance
+        # verify the structural shape. Per zero-tolerance Rule 3a (typed
+        # delegate guards), surface a typed error instead of an opaque
+        # AttributeError later.
+        if not isinstance(signature, SignatureContract):
+            raise TypeError(
+                "DispatchSurface.signature MUST satisfy SignatureContract "
+                "(name: str, input_schema: dict[str, type], "
+                "output_schema: dict[str, type]); got "
+                f"{type(signature).__name__}"
+            )
+
+        # Invariant 5 — lifecycle state. RETIRED + SUSPENDED refuse;
+        # DRAFT + ACTIVE allow. Checked BEFORE capability so a retired
+        # role surfaces the lifecycle failure rather than a downstream
+        # capability mismatch.
+        if role.lifecycle not in _INVOCABLE_ROLE_LIFECYCLES:
+            raise DispatchEnvelopeViolationError(
+                f"DispatchSurface refuses bind: role lifecycle "
+                f"{role.lifecycle.value!r} is not invocable "
+                f"(invocable={sorted(s.value for s in _INVOCABLE_ROLE_LIFECYCLES)}; "
+                f"RETIRED/SUSPENDED roles cannot dispatch — Invariant 5)"
+            )
+
+        # Invariant 3 — capability gating. Connector's required
+        # capabilities MUST be a subset of the role's capability set.
+        # Direct frozenset.issubset() check; surface every missing
+        # capability for actionable error messages.
+        role_caps = frozenset(role.scope.capabilities.capabilities)
+        missing = connector.requires_capabilities - role_caps
+        if missing:
+            raise DispatchEnvelopeViolationError(
+                f"DispatchSurface refuses bind: connector "
+                f"{connector.connector_id!r} requires capabilities "
+                f"{sorted(connector.requires_capabilities)!r} but role "
+                f"{role.display_name!r} grants only {sorted(role_caps)!r}; "
+                f"missing={sorted(missing)!r} (Invariant 3)"
+            )
+
+        # Bind-time tenant consistency between cascade and identity. The
+        # cascade is bound to a single tenant at construction; we hold
+        # the cascade by reference and re-validate the OBSERVED tenant
+        # at dispatch (Invariant 2 runtime check). The construction-time
+        # check here is structural — both cascade and identity exist
+        # and the cascade's tenant is captured.
+        # Note: identity does not yet carry a tenant_id (the genesis_ref
+        # string is the closest proxy); the cascade's tenant is the
+        # authoritative bind-time anchor. The runtime cross-check in
+        # dispatch() uses ConnectorInvocationResult.tenant_id_observed.
+
+        self._connector = connector
+        self._signature = signature
+        self._envelope = envelope
+        self._identity = identity
+        self._audit_engine = audit_engine
+        self._trust_cascade = trust_cascade
+        self._role = role
+
+    @property
+    def connector(self) -> Connector:
+        """Borrow the bound :class:`Connector` (read-only)."""
+        return self._connector
+
+    @property
+    def signature(self) -> SignatureContract:
+        """Borrow the bound :class:`SignatureContract` (read-only)."""
+        return self._signature
+
+    @property
+    def envelope(self) -> DelegateConstraintEnvelope:
+        """Borrow the bound :class:`DelegateConstraintEnvelope` (read-only).
+
+        The envelope is the F5 monotonic-tightening anchor — runtime
+        ``tighten_with`` calls produce a NEW envelope; this attribute
+        always returns the original bound envelope (the
+        DispatchSurface's contract — Invariant 1).
+        """
+        return self._envelope
+
+    @property
+    def identity(self) -> DelegateIdentity:
+        """Borrow the bound :class:`DelegateIdentity` (read-only)."""
+        return self._identity
+
+    @property
+    def role(self) -> Role:
+        """Borrow the bound :class:`Role` (read-only)."""
+        return self._role
+
+    @property
+    def audit_engine(self) -> AuditChainEngine:
+        """Borrow the bound :class:`AuditChainEngine` (read-only)."""
+        return self._audit_engine
+
+    @property
+    def trust_cascade(self) -> TenantScopedCascade:
+        """Borrow the bound :class:`TenantScopedCascade` (read-only)."""
+        return self._trust_cascade
+
+    async def dispatch(self, input_payload: dict[str, Any]) -> DispatchResult:
+        """Validate, invoke, cross-check, emit audit, return result.
+
+        Sequence (fail-closed at every step — typed error raises BEFORE
+        the next step runs):
+
+        1. Validate ``input_payload`` against
+           :attr:`SignatureContract.input_schema` (Invariant 1 signature
+           contract). Raises :class:`DispatchValidationError`.
+        2. (Bind-time invariants 3 + 5 already checked at __init__.)
+        3. Invoke ``await connector.invoke(input_payload, identity=...,
+           envelope=...)``. Connector exceptions propagate verbatim per
+           zero-tolerance Rule 3 (no silent error hiding).
+        4. Cross-validate ``result.tenant_id_observed`` against the
+           cascade's tenant (Invariant 2). Mismatch raises
+           :class:`CascadeTenantViolationError` (re-using trust.py's
+           exception so cross-layer audits surface one error class).
+        5. Forward every ``result.audit_events`` entry to
+           :meth:`AuditChainEngine.emit_event` (Invariant 4). The
+           engine's audit-visible allowlist raises
+           :class:`AuditChainEmissionError` for non-visible variants —
+           DispatchSurface does NOT re-check (single source of truth).
+        6. Construct + return :class:`DispatchResult`.
+
+        Args:
+            input_payload: The dict-shaped input. Keys MUST be a subset
+                of the bound signature's ``input_schema`` keys; values
+                MUST be instance-of the declared type. Extra keys are
+                rejected (closed-world schema — per zero-tolerance Rule
+                3c, silent kwargs drop is BLOCKED).
+
+        Returns:
+            A :class:`DispatchResult` carrying payload + audit chain
+            entry hashes + executed_at + tenant_id + connector_id.
+
+        Raises:
+            DispatchValidationError: input_payload violates the signature.
+            CascadeTenantViolationError: connector's observed tenant
+                does not match the cascade's tenant.
+            AuditChainEmissionError: an event in ``audit_events`` is not
+                audit-visible (REASONING_SCRATCHPAD).
+            Exception: connector-raised exceptions propagate verbatim.
+        """
+        # Step 1 — input_payload validation against signature contract.
+        if not isinstance(input_payload, dict):
+            raise DispatchValidationError(
+                f"DispatchSurface.dispatch input_payload MUST be a dict; got "
+                f"{type(input_payload).__name__}"
+            )
+        # Closed-world schema: every key in input_payload MUST appear in
+        # the signature's input_schema. Extra keys are rejected to close
+        # the silent-fallback failure mode where a typo'd kwarg silently
+        # never reaches the connector.
+        extra_keys = set(input_payload.keys()) - set(
+            self._signature.input_schema.keys()
+        )
+        if extra_keys:
+            raise DispatchValidationError(
+                f"DispatchSurface.dispatch input_payload has undeclared "
+                f"field(s) {sorted(extra_keys)!r}; signature "
+                f"{self._signature.name!r} declares only "
+                f"{sorted(self._signature.input_schema.keys())!r}"
+            )
+        for field_name, declared_type in self._signature.input_schema.items():
+            if field_name not in input_payload:
+                raise DispatchValidationError(
+                    f"DispatchSurface.dispatch input_payload missing required "
+                    f"field {field_name!r} declared by signature "
+                    f"{self._signature.name!r}"
+                )
+            value = input_payload[field_name]
+            if not isinstance(value, declared_type):
+                raise DispatchValidationError(
+                    f"DispatchSurface.dispatch input_payload field "
+                    f"{field_name!r} declared as "
+                    f"{declared_type.__name__!r} received "
+                    f"{type(value).__name__!r}"
+                )
+
+        # Step 3 — invoke the connector. Connector exceptions propagate
+        # verbatim; DispatchSurface MUST NOT swallow them per
+        # zero-tolerance Rule 3.
+        result = await self._connector.invoke(
+            input_payload,
+            identity=self._identity,
+            envelope=self._envelope,
+        )
+        if not isinstance(result, ConnectorInvocationResult):
+            raise DispatchValidationError(
+                f"Connector {self._connector.connector_id!r} returned "
+                f"{type(result).__name__!r}; MUST return a "
+                "ConnectorInvocationResult instance"
+            )
+
+        # Step 4 — cross-validate tenant isolation (Invariant 2).
+        cascade_tenant = self._trust_cascade.tenant
+        if cascade_tenant.is_global:
+            # Global cascade accepts any observed tenant (including None).
+            tenant_id_for_result = ""
+        else:
+            # for_tenant cascade — observed MUST match bound tenant.
+            expected_tenant = cascade_tenant.tenant_id
+            if result.tenant_id_observed != expected_tenant:
+                raise CascadeTenantViolationError(
+                    parent_tenant=expected_tenant,
+                    child_tenant=result.tenant_id_observed,
+                )
+            tenant_id_for_result = expected_tenant or ""
+
+        # Step 5 — emit audit events through the engine. The engine's
+        # _AUDIT_VISIBLE_EVENT_TYPES frozenset rejects non-visible
+        # variants; AuditChainEmissionError propagates verbatim per
+        # zero-tolerance Rule 4 (no re-implementation of the allowlist
+        # here — single source of truth in audit.py).
+        emitted_entry_hashes: list[str] = []
+        for event_type in result.audit_events:
+            # Build the audit event payload. The structured payload
+            # carries the dispatch context for downstream consumers
+            # (connector_id, signature.name, external_side_effect).
+            # Per observability.md MUST Rule 8 (schema-revealing field
+            # names) we keep payload keys generic, not schema-revealing.
+            payload: dict[str, Any] = {
+                "connector_id": self._connector.connector_id,
+                "connector_kind": self._connector.connector_kind,
+                "signature_name": self._signature.name,
+                "external_side_effect": result.external_side_effect,
+            }
+            # Use the per-emit-call default signed_at; signature is a
+            # placeholder Ed25519-shape hex value since the dispatch
+            # surface itself does not own signing keys — production
+            # deployments will inject a real signer in S6+. The
+            # placeholder is 128 zero-chars per the audit_engine
+            # signature validation contract.
+            entry = self._audit_engine.emit_event(
+                event_type=event_type.value,
+                payload=payload,
+                signer_identity=self._identity,
+                signature="0" * 128,
+            )
+            # Append the head_hash AFTER the emission so each entry's
+            # hash captures the chain state at the moment of that
+            # emission.
+            head = self._audit_engine.head_hash()
+            if head is not None:
+                emitted_entry_hashes.append(head)
+            else:  # pragma: no cover (defensive — engine always has a head after emit)
+                # If head_hash is None despite a successful emit, the
+                # engine has a contract regression; surface it loudly
+                # rather than silently dropping the entry.
+                raise RuntimeError(
+                    f"AuditChainEngine.head_hash returned None after "
+                    f"emit_event(sequence={entry.sequence}) — contract "
+                    "regression in AuditChainEngine"
+                )
+
+        # Step 6 — construct + return DispatchResult.
+        return DispatchResult(
+            payload=result.payload,
+            audit_chain_entries=tuple(emitted_entry_hashes),
+            executed_at=datetime.now(timezone.utc),
+            tenant_id=tenant_id_for_result,
+            connector_id=self._connector.connector_id,
+        )

--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -266,10 +266,32 @@ class Connector(abc.ABC):
         # carry a meaningful identifier. Empty string at the subclass
         # level is BLOCKED (the ABC's empty default cannot satisfy this
         # check).
-        if not cls.__abstractmethods__:
-            # Only enforce on concrete subclasses (abstract intermediate
-            # base classes may legitimately defer metadata to their own
-            # concrete subclasses).
+        #
+        # __init_subclass__ runs BEFORE ABCMeta computes
+        # __abstractmethods__ on the new class; use getattr with a
+        # default to handle both ordering paths. The subclass is
+        # "concrete" iff it overrode the abstract invoke method (so the
+        # abstract set, when populated, will be empty).
+        abstract_methods = getattr(cls, "__abstractmethods__", frozenset())
+        # Detect concrete subclasses: they MUST have overridden invoke
+        # such that it's no longer the ABC's abstract method.
+        invoke = cls.__dict__.get("invoke")
+        is_concrete = invoke is not None and not getattr(
+            invoke, "__isabstractmethod__", False
+        )
+        # Also concrete if abstract_methods is populated and empty
+        # (post-ABCMeta computation path).
+        if not is_concrete and abstract_methods == frozenset():
+            # Check whether invoke was inherited as abstract.
+            inherited_invoke = getattr(cls, "invoke", None)
+            if inherited_invoke is not None and not getattr(
+                inherited_invoke, "__isabstractmethod__", False
+            ):
+                is_concrete = True
+        if is_concrete:
+            # Concrete subclass — enforce metadata declaration. Abstract
+            # intermediate base classes may legitimately defer metadata
+            # to their own concrete subclasses.
             if not isinstance(cls.connector_id, str) or not cls.connector_id:
                 raise TypeError(
                     f"Connector subclass {cls.__name__!r} MUST declare a "

--- a/tests/integration/delegate/test_dispatch_wiring.py
+++ b/tests/integration/delegate/test_dispatch_wiring.py
@@ -35,10 +35,23 @@ end-to-end through the real substrate.
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from datetime import datetime, timezone
 
 import pytest
+
+
+def _test_signer(canonical_bytes: bytes) -> str:
+    """Deterministic 128-char hex signer for integration tests.
+
+    SHA-256 doubled to 128 chars satisfies the audit-engine's
+    _validate_hex(expected_len=128) contract while keeping the test
+    deterministic for cross-SDK byte-vector comparison.
+    """
+    h = hashlib.sha256(canonical_bytes).hexdigest()
+    return h + h
+
 
 from kailash.delegate.audit import (
     AuditChainEngine,
@@ -217,6 +230,7 @@ async def test_dispatch_end_to_end_wires_audit_and_tenant() -> None:
         audit_engine=audit_engine,
         trust_cascade=cascade,
         role=_build_role(),
+        signer=_test_signer,
     )
 
     # Pre-dispatch: chain is empty, no audit entries
@@ -281,6 +295,7 @@ async def test_dispatch_tenant_isolation_enforced_end_to_end() -> None:
         audit_engine=audit_engine,
         trust_cascade=cascade,
         role=_build_role(),
+        signer=_test_signer,
     )
 
     with pytest.raises(CascadeTenantViolationError):
@@ -329,6 +344,7 @@ async def test_dispatch_multiple_events_chain_correctly() -> None:
         audit_engine=audit_engine,
         trust_cascade=cascade,
         role=_build_role(),
+        signer=_test_signer,
     )
 
     result = await surface.dispatch({"user_id": "u-multi"})

--- a/tests/integration/delegate/test_dispatch_wiring.py
+++ b/tests/integration/delegate/test_dispatch_wiring.py
@@ -1,0 +1,351 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 integration test for ``DispatchSurface`` end-to-end wiring.
+
+S5 #1035 — Tier-2 wiring test per ``facade-manager-detection.md`` MUST
+Rule 1 ("Every Manager-Shape Class Has a Tier 2 Test"):
+``DispatchSurface`` is a Surface-shape coordinator that wires
+``(Connector × Signature × Envelope × Identity)`` into the
+``AuditChainEngine`` + ``TenantScopedCascade`` substrate.
+
+This test exercises the load-bearing wiring contract end-to-end:
+
+- A real ``TenantScopedCascade`` constrains tenant isolation.
+- A real ``AuditChainEngine`` (atop a real ``TrustLineageChain``)
+  receives the dispatched audit events.
+- A concrete ``MockConnector(Connector)`` subclass records every
+  argument it received from ``DispatchSurface`` AND emits real
+  ``ConnectorInvocationResult`` records that flow through the audit
+  emission path.
+
+**Tier classification:** the substrate ``TrustLineageChain`` is a real
+``@dataclass`` (not a ``typing.Protocol`` satisfier), so the
+"Protocol-Satisfying Deterministic Adapter" exception in
+``rules/testing.md`` does NOT apply to it. The ``MockConnector`` IS a
+Protocol-satisfying deterministic adapter for the abstract ``Connector``
+surface — it has deterministic output and satisfies the abstract
+``invoke`` contract. Per ``rules/testing.md`` § "Protocol Adapters", a
+deterministic adapter for an abstract protocol is NOT a mock; it is the
+test-side concrete subclass the abstract surface MUST permit.
+
+Pairs with the ``test_audit_chainengine_wiring.py`` pattern — same
+shape: import-path + facade-call shape + externally-observable assertion
+end-to-end through the real substrate.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.delegate.audit import (
+    AuditChainEngine,
+    DelegateEventType,
+)
+from kailash.delegate.dispatch import (
+    Connector,
+    ConnectorInvocationResult,
+    DispatchResult,
+    DispatchSurface,
+)
+from kailash.delegate.envelope import DelegateConstraintEnvelope
+from kailash.delegate.trust import (
+    CascadeTenantViolationError,
+    TenantScope,
+    TenantScopedCascade,
+)
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateGenesisRecord,
+    DelegateIdentity,
+    Role,
+    RoleLifecycleState,
+    RoleScope,
+)
+from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
+from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+
+# ---------------------------------------------------------------------------
+# Recording Connector — real Connector subclass for wiring observation
+# ---------------------------------------------------------------------------
+
+
+class RecordingMockConnector(Connector):
+    """Deterministic Connector subclass that records all invocation args.
+
+    Per ``rules/testing.md`` § "Protocol-Satisfying Deterministic
+    Adapters", this is a real subclass of the abstract :class:`Connector`
+    — NOT a mock. Its purpose: record every argument passed by
+    DispatchSurface so the integration test can assert the wiring
+    contract holds end-to-end.
+    """
+
+    connector_id = "wiring-conn-1"
+    connector_kind = "http"
+    requires_capabilities = frozenset({"http.read", "http.write"})
+
+    def __init__(self, *, tenant_id_observed: str | None = "tenant-wire") -> None:
+        self.tenant_id_observed = tenant_id_observed
+        self.invocations: list[dict] = []
+
+    async def invoke(
+        self,
+        input_payload,
+        *,
+        identity,
+        envelope,
+    ):
+        self.invocations.append(
+            {
+                "input_payload": dict(input_payload),
+                "identity_delegate_id": identity.delegate_id,
+                "identity_sovereign_ref": identity.sovereign_ref,
+                "envelope_genesis_id": envelope.genesis_id,
+            }
+        )
+        return ConnectorInvocationResult(
+            payload={"created": True, "received_user_id": input_payload["user_id"]},
+            audit_events=(DelegateEventType.EXTERNAL_SIDE_EFFECT,),
+            tenant_id_observed=self.tenant_id_observed,
+            external_side_effect=True,
+        )
+
+
+class WiringSignature:
+    """Minimal SignatureContract satisfier for the wiring test."""
+
+    name = "create_user_wiring"
+    input_schema = {"user_id": str}
+    output_schema = {"created": bool, "received_user_id": str}
+
+
+# ---------------------------------------------------------------------------
+# Substrate builders (real, no mocks)
+# ---------------------------------------------------------------------------
+
+
+def _build_chain(agent_id: str = "agent-wiring") -> TrustLineageChain:
+    return TrustLineageChain(
+        genesis=GenesisRecord(
+            id=f"g-{agent_id}",
+            agent_id=agent_id,
+            authority_id=f"auth-{agent_id}",
+            authority_type=AuthorityType.ORGANIZATION,
+            created_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            signature="a" * 128,
+        )
+    )
+
+
+def _build_identity() -> DelegateIdentity:
+    return DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref="sov-wiring",
+        role_binding_ref="rb-wiring",
+        genesis_ref="g-agent-wiring",
+    )
+
+
+def _build_envelope() -> DelegateConstraintEnvelope:
+    block = GenesisRecord(
+        id="g-env-wiring",
+        agent_id="agent-env-wiring",
+        authority_id="auth-env-wiring",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        signature="d" * 128,
+    )
+    genesis = DelegateGenesisRecord(
+        block=block, spec_version="1", capabilities=("read",)
+    )
+    return DelegateConstraintEnvelope.from_genesis(
+        ConstraintEnvelope(financial=FinancialConstraint(budget_limit=1000.0)),
+        genesis,
+    )
+
+
+def _build_role() -> Role:
+    return Role(
+        role_id=uuid.uuid4(),
+        display_name="wiring-test-role",
+        scope=RoleScope(
+            domain="finance",
+            capabilities=CapabilitySet(
+                capabilities=("http.read", "http.write", "extra.cap")
+            ),
+        ),
+        lifecycle=RoleLifecycleState.ACTIVE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier-2 wiring tests — every dependency is REAL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_dispatch_end_to_end_wires_audit_and_tenant() -> None:
+    """End-to-end: a successful dispatch produces a real audit entry on the
+    real TrustLineageChain AND the bound tenant survives cross-validation.
+
+    Wiring contract verified:
+    1. DispatchSurface.dispatch awaits Connector.invoke with the bound
+       identity + envelope (RecordingMockConnector records these).
+    2. ConnectorInvocationResult flows back; tenant observed matches
+       cascade's bound tenant (no CascadeTenantViolationError).
+    3. AuditChainEngine.emit_event lands a real AuditChainEntry on the
+       wrapped TrustLineageChain.audit_anchors (externally observable
+       via substrate state).
+    4. DispatchResult carries the audit_chain_entries head hash.
+    """
+    chain = _build_chain("agent-e2e")
+    audit_engine = AuditChainEngine(chain=chain)
+    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-wire"))
+    connector = RecordingMockConnector(tenant_id_observed="tenant-wire")
+    identity = _build_identity()
+    envelope = _build_envelope()
+
+    surface = DispatchSurface(
+        connector=connector,
+        signature=WiringSignature(),
+        envelope=envelope,
+        identity=identity,
+        audit_engine=audit_engine,
+        trust_cascade=cascade,
+        role=_build_role(),
+    )
+
+    # Pre-dispatch: chain is empty, no audit entries
+    assert len(audit_engine.entries) == 0
+    assert len(chain.audit_anchors) == 0
+    assert len(connector.invocations) == 0
+
+    # Dispatch
+    result = await surface.dispatch({"user_id": "user-42"})
+
+    # 1. DispatchResult shape
+    assert isinstance(result, DispatchResult)
+    assert result.payload == {"created": True, "received_user_id": "user-42"}
+    assert result.tenant_id == "tenant-wire"
+    assert result.connector_id == "wiring-conn-1"
+
+    # 2. Connector received the bound identity + envelope (wiring evidence)
+    assert len(connector.invocations) == 1
+    inv = connector.invocations[0]
+    assert inv["identity_delegate_id"] == identity.delegate_id
+    assert inv["identity_sovereign_ref"] == "sov-wiring"
+    assert inv["envelope_genesis_id"] == envelope.genesis_id
+    assert inv["input_payload"] == {"user_id": "user-42"}
+
+    # 3. AuditChainEngine wrote ONE entry through to the substrate chain
+    assert len(audit_engine.entries) == 1
+    assert len(chain.audit_anchors) == 1
+    entry = audit_engine.entries[0]
+    assert entry.event_type == "external_side_effect"
+    assert entry.event_payload["connector_id"] == "wiring-conn-1"
+    assert entry.event_payload["signature_name"] == "create_user_wiring"
+    assert entry.event_payload["external_side_effect"] is True
+    # Substrate anchor mirrors the engine entry
+    anchor = chain.audit_anchors[0]
+    assert anchor.action == "external_side_effect"
+    assert anchor.context["sequence"] == 0
+
+    # 4. DispatchResult.audit_chain_entries contains the head hash
+    assert len(result.audit_chain_entries) == 1
+    assert result.audit_chain_entries[0] == audit_engine.head_hash()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_dispatch_tenant_isolation_enforced_end_to_end() -> None:
+    """Tenant isolation (Invariant 2) fires end-to-end against real cascade.
+
+    Cascade bound to tenant-A; connector observes tenant-B → raises
+    CascadeTenantViolationError BEFORE any audit emission. No audit
+    entry lands on the substrate chain (fail-closed contract).
+    """
+    chain = _build_chain("agent-tenant-iso")
+    audit_engine = AuditChainEngine(chain=chain)
+    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-A"))
+    connector = RecordingMockConnector(tenant_id_observed="tenant-B")
+
+    surface = DispatchSurface(
+        connector=connector,
+        signature=WiringSignature(),
+        envelope=_build_envelope(),
+        identity=_build_identity(),
+        audit_engine=audit_engine,
+        trust_cascade=cascade,
+        role=_build_role(),
+    )
+
+    with pytest.raises(CascadeTenantViolationError):
+        await surface.dispatch({"user_id": "user-1"})
+
+    # Fail-closed: connector WAS invoked (the connector is the source of
+    # the observed tenant), but NO audit entry landed because the
+    # tenant cross-check fires BEFORE emission.
+    assert len(connector.invocations) == 1
+    assert len(audit_engine.entries) == 0
+    assert len(chain.audit_anchors) == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_dispatch_multiple_events_chain_correctly() -> None:
+    """Multiple audit events from one dispatch land sequentially with
+    correct previous_hash linkage on the real audit chain."""
+
+    class MultiEventConnector(Connector):
+        connector_id = "multi-event-conn"
+        connector_kind = "http"
+        requires_capabilities = frozenset({"http.read"})
+
+        async def invoke(self, input_payload, *, identity, envelope):
+            return ConnectorInvocationResult(
+                payload={"ok": True},
+                audit_events=(
+                    DelegateEventType.GRANT_CONSUMPTION,
+                    DelegateEventType.EXTERNAL_SIDE_EFFECT,
+                    DelegateEventType.CONSTRAINT_DECISION,
+                ),
+                tenant_id_observed="tenant-multi",
+                external_side_effect=True,
+            )
+
+    chain = _build_chain("agent-multi-event")
+    audit_engine = AuditChainEngine(chain=chain)
+    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-multi"))
+
+    surface = DispatchSurface(
+        connector=MultiEventConnector(),
+        signature=WiringSignature(),
+        envelope=_build_envelope(),
+        identity=_build_identity(),
+        audit_engine=audit_engine,
+        trust_cascade=cascade,
+        role=_build_role(),
+    )
+
+    result = await surface.dispatch({"user_id": "u-multi"})
+
+    # Three events emitted in declared order
+    assert len(audit_engine.entries) == 3
+    assert len(result.audit_chain_entries) == 3
+    assert audit_engine.entries[0].event_type == "grant_consumption"
+    assert audit_engine.entries[1].event_type == "external_side_effect"
+    assert audit_engine.entries[2].event_type == "constraint_decision"
+
+    # Sequence is monotonic, previous_hash chains correctly
+    assert audit_engine.entries[0].sequence == 0
+    assert audit_engine.entries[0].previous_hash == ""
+    assert audit_engine.entries[1].sequence == 1
+    assert audit_engine.entries[1].previous_hash != ""
+    assert audit_engine.entries[2].sequence == 2
+    assert (
+        audit_engine.entries[2].previous_hash != audit_engine.entries[1].previous_hash
+    )

--- a/tests/unit/delegate/test_dispatch.py
+++ b/tests/unit/delegate/test_dispatch.py
@@ -22,6 +22,7 @@ Connector surface.
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from dataclasses import FrozenInstanceError
 from datetime import datetime, timezone
@@ -39,10 +40,25 @@ from kailash.delegate.dispatch import (
     DispatchCascadeViolationError,
     DispatchEnvelopeViolationError,
     DispatchResult,
+    DispatchSignerError,
     DispatchSurface,
     DispatchValidationError,
     SignatureContract,
 )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic test signer — produces a 128-char lowercase hex string from
+# the canonical-bytes input. SHA-256 doubled to 128 chars satisfies the
+# audit-engine's _validate_hex(expected_len=128) contract.
+# ---------------------------------------------------------------------------
+
+
+def _test_signer(canonical_bytes: bytes) -> str:
+    h = hashlib.sha256(canonical_bytes).hexdigest()
+    return h + h  # 128-char lowercase hex
+
+
 from kailash.delegate.envelope import DelegateConstraintEnvelope
 from kailash.delegate.trust import (
     CascadeTenantViolationError,
@@ -318,6 +334,7 @@ def _make_surface(
     signature: SignatureContract | None = None,
     envelope: DelegateConstraintEnvelope | None = None,
     identity: DelegateIdentity | None = None,
+    signer=None,
 ) -> DispatchSurface:
     return DispatchSurface(
         connector=connector if connector is not None else MockConnector(),
@@ -327,6 +344,7 @@ def _make_surface(
         audit_engine=AuditChainEngine(chain=_build_chain()),
         trust_cascade=cascade if cascade is not None else _build_cascade(),
         role=role if role is not None else _build_role(),
+        signer=signer if signer is not None else _test_signer,
     )
 
 
@@ -363,9 +381,17 @@ def test_dispatch_surface_allows_draft_role_lifecycle() -> None:
 
 @pytest.mark.unit
 def test_dispatch_surface_refuses_missing_capability() -> None:
-    """Invariant 3 — connector requires capability role does not grant."""
+    """Invariant 3 — connector requires capability role does not grant.
+
+    C5-2 error-leakage fix: caller-facing message hashes the capability
+    names; full detail is structured-logged at DEBUG. Test matches on
+    the stable structural prefix ("refuses bind", "missing_hash=") and
+    NOT on the schema-revealing capability strings.
+    """
     role = _build_role(capabilities=("other.cap",))
-    with pytest.raises(DispatchEnvelopeViolationError, match="http.read"):
+    with pytest.raises(
+        DispatchEnvelopeViolationError, match=r"refuses bind.*missing_hash="
+    ):
         _make_surface(role=role)
 
 
@@ -389,9 +415,17 @@ def test_dispatch_surface_rejects_non_signature_object() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_dispatch_input_payload_type_mismatch_raises() -> None:
-    """Invariant 1 — declared str field receives int → DispatchValidationError."""
+    """Invariant 1 — declared str field receives int → DispatchValidationError.
+
+    C5-1 error-leakage fix: caller-facing message carries the field
+    hash, NOT the schema field name. The hash is stable
+    (sha256(field_name)[:8]) so log-aggregator correlation against
+    structured DEBUG logs is preserved.
+    """
     surface = _make_surface()
-    with pytest.raises(DispatchValidationError, match="user_id"):
+    with pytest.raises(
+        DispatchValidationError, match=r"field_hash=.*failed schema validation"
+    ):
         await surface.dispatch({"user_id": 42})  # type: ignore[dict-item]
 
 
@@ -416,7 +450,7 @@ async def test_dispatch_input_payload_missing_required_field_raises() -> None:
 @pytest.mark.asyncio
 async def test_dispatch_input_payload_non_dict_raises() -> None:
     surface = _make_surface()
-    with pytest.raises(DispatchValidationError, match="MUST be a dict"):
+    with pytest.raises(DispatchValidationError, match="type mismatch"):
         await surface.dispatch("not a dict")  # type: ignore[arg-type]
 
 
@@ -481,6 +515,7 @@ async def test_dispatch_audit_engine_round_trip() -> None:
         audit_engine=audit_engine,
         trust_cascade=_build_cascade(),
         role=_build_role(),
+        signer=_test_signer,
     )
     assert len(audit_engine.entries) == 0
     result = await surface.dispatch({"user_id": "u-1"})
@@ -525,6 +560,7 @@ async def test_dispatch_connector_invocation_carries_bound_identity_and_envelope
         audit_engine=AuditChainEngine(chain=_build_chain()),
         trust_cascade=_build_cascade(),
         role=_build_role(),
+        signer=_test_signer,
     )
     await surface.dispatch({"user_id": "u-1"})
     assert len(connector.invocations) == 1
@@ -594,6 +630,7 @@ def test_dispatch_result_is_frozen() -> None:
         executed_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
         tenant_id="t",
         connector_id="c",
+        dispatch_id=uuid.uuid4(),
     )
     with pytest.raises(FrozenInstanceError):
         r.payload = {}  # type: ignore[misc]
@@ -608,6 +645,7 @@ def test_dispatch_result_rejects_naive_datetime() -> None:
             executed_at=datetime(2026, 5, 22, 12, 0, 0),  # naive
             tenant_id="t",
             connector_id="c",
+            dispatch_id=uuid.uuid4(),
         )
 
 
@@ -620,6 +658,7 @@ def test_dispatch_result_rejects_empty_connector_id() -> None:
             executed_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
             tenant_id="t",
             connector_id="",
+            dispatch_id=uuid.uuid4(),
         )
 
 

--- a/tests/unit/delegate/test_dispatch.py
+++ b/tests/unit/delegate/test_dispatch.py
@@ -1,0 +1,643 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-1 unit tests for ``kailash.delegate.dispatch`` (S5, #1035).
+
+Covers the Connector ABC + DispatchSurface bind + dispatch surface.
+Per ``probe-driven-verification.md`` MUST Rule 3, all assertions here
+are STRUCTURAL (typed-error class raised, frozen-dataclass shape,
+isinstance type checks, audit-engine state-count) — no semantic
+regex / keyword matching against prose output. The bug class this
+shard exists to prevent (silent capability bypass, silent tenant
+crossing, silent audit-event drop) is structurally observable at the
+type / exception / counter level.
+
+Tier classification: substrate dependencies (TenantScopedCascade,
+AuditChainEngine, DelegateConstraintEnvelope) are REAL — no mocks.
+The only "fake" object is the MockConnector subclass that satisfies
+the Connector ABC contract deterministically; per
+``rules/testing.md`` § "Protocol-Satisfying Deterministic Adapters",
+this is NOT a mock — it's a deterministic adapter for the abstract
+Connector surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.delegate.audit import (
+    AuditChainEmissionError,
+    AuditChainEngine,
+    DelegateEventType,
+)
+from kailash.delegate.dispatch import (
+    Connector,
+    ConnectorInvocationResult,
+    DispatchCascadeViolationError,
+    DispatchEnvelopeViolationError,
+    DispatchResult,
+    DispatchSurface,
+    DispatchValidationError,
+    SignatureContract,
+)
+from kailash.delegate.envelope import DelegateConstraintEnvelope
+from kailash.delegate.trust import (
+    CascadeTenantViolationError,
+    TenantScope,
+    TenantScopedCascade,
+)
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateGenesisRecord,
+    DelegateIdentity,
+    Role,
+    RoleLifecycleState,
+    RoleScope,
+)
+from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
+from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — keep tests focused on behavior under test
+# ---------------------------------------------------------------------------
+
+
+def _build_chain(agent_id: str = "agent-s5") -> TrustLineageChain:
+    return TrustLineageChain(
+        genesis=GenesisRecord(
+            id=f"g-{agent_id}",
+            agent_id=agent_id,
+            authority_id=f"auth-{agent_id}",
+            authority_type=AuthorityType.ORGANIZATION,
+            created_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            signature="a" * 128,
+        )
+    )
+
+
+def _build_identity() -> DelegateIdentity:
+    return DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref="sov-s5",
+        role_binding_ref="rb-s5",
+        genesis_ref="g-agent-s5",
+    )
+
+
+def _build_envelope() -> DelegateConstraintEnvelope:
+    block = GenesisRecord(
+        id="g-env-s5",
+        agent_id="agent-env",
+        authority_id="auth-env",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        signature="d" * 128,
+    )
+    genesis = DelegateGenesisRecord(
+        block=block, spec_version="1", capabilities=("read",)
+    )
+    return DelegateConstraintEnvelope.from_genesis(
+        ConstraintEnvelope(financial=FinancialConstraint(budget_limit=1000.0)),
+        genesis,
+    )
+
+
+def _build_role(
+    *,
+    lifecycle: RoleLifecycleState = RoleLifecycleState.ACTIVE,
+    capabilities: tuple[str, ...] = ("http.read", "http.write"),
+) -> Role:
+    return Role(
+        role_id=uuid.uuid4(),
+        display_name="test-role",
+        scope=RoleScope(
+            domain="finance",
+            capabilities=CapabilitySet(capabilities=capabilities),
+        ),
+        lifecycle=lifecycle,
+    )
+
+
+def _build_cascade(*, tenant_id: str | None = "tenant-a") -> TenantScopedCascade:
+    if tenant_id is None:
+        return TenantScopedCascade(tenant=TenantScope.global_())
+    return TenantScopedCascade(tenant=TenantScope.for_tenant(tenant_id))
+
+
+# ---------------------------------------------------------------------------
+# A minimal SignatureContract-satisfying object
+# ---------------------------------------------------------------------------
+
+
+class FakeSignatureHelper:
+    """Deterministic SignatureContract-satisfier for tests.
+
+    Named *Helper not *Test per ``testing.md`` MUST: Helper Classes Use
+    Stub/Helper/Fake Suffix — pytest's ``Test*`` collection silently
+    drops ``__init__``-bearing helper classes.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str = "create_user",
+        input_schema: dict[str, type] | None = None,
+        output_schema: dict[str, type] | None = None,
+    ) -> None:
+        self.name = name
+        self.input_schema = (
+            input_schema if input_schema is not None else {"user_id": str}
+        )
+        self.output_schema = (
+            output_schema if output_schema is not None else {"created": bool}
+        )
+
+
+# ---------------------------------------------------------------------------
+# A minimal Connector-satisfying subclass that records all received args
+# ---------------------------------------------------------------------------
+
+
+class MockConnector(Connector):
+    """Deterministic Connector subclass for unit tests.
+
+    Per ``rules/testing.md`` § "Protocol-Satisfying Deterministic
+    Adapters", this is NOT a mock — it's a real Connector subclass
+    satisfying the abstract ``invoke`` contract deterministically.
+    Records all arguments passed to invoke() so tests can assert wiring.
+    """
+
+    connector_id = "mock-conn-1"
+    connector_kind = "http"
+    requires_capabilities = frozenset({"http.read"})
+
+    def __init__(
+        self,
+        *,
+        return_payload: dict | None = None,
+        tenant_id_observed: str | None = "tenant-a",
+        audit_events: tuple[DelegateEventType, ...] = (
+            DelegateEventType.EXTERNAL_SIDE_EFFECT,
+        ),
+        external_side_effect: bool = True,
+    ) -> None:
+        self.return_payload = (
+            return_payload if return_payload is not None else {"created": True}
+        )
+        self.tenant_id_observed = tenant_id_observed
+        self.audit_events = audit_events
+        self.external_side_effect = external_side_effect
+        self.invocations: list[dict] = []
+
+    async def invoke(
+        self,
+        input_payload,
+        *,
+        identity,
+        envelope,
+    ):
+        self.invocations.append(
+            {
+                "input_payload": input_payload,
+                "identity": identity,
+                "envelope": envelope,
+            }
+        )
+        return ConnectorInvocationResult(
+            payload=self.return_payload,
+            audit_events=self.audit_events,
+            tenant_id_observed=self.tenant_id_observed,
+            external_side_effect=self.external_side_effect,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Connector ABC — instantiation refusal + metadata validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_connector_abc_refuses_direct_instantiation() -> None:
+    """Connector is abc.ABC + @abstractmethod invoke — direct construct refused."""
+    with pytest.raises(TypeError, match="abstract"):
+        Connector()  # type: ignore[abstract]
+
+
+@pytest.mark.unit
+def test_connector_subclass_missing_connector_id_rejected() -> None:
+    """Concrete subclass MUST declare non-empty connector_id at class level."""
+    with pytest.raises(TypeError, match="connector_id"):
+
+        class BadConnector(Connector):
+            # connector_id intentionally not overridden (empty default)
+            connector_kind = "http"
+
+            async def invoke(self, input_payload, *, identity, envelope):
+                pass  # pragma: no cover
+
+
+@pytest.mark.unit
+def test_connector_subclass_missing_connector_kind_rejected() -> None:
+    """Concrete subclass MUST declare non-empty connector_kind at class level."""
+    with pytest.raises(TypeError, match="connector_kind"):
+
+        class BadConnector(Connector):
+            connector_id = "x"
+            # connector_kind intentionally not overridden
+
+            async def invoke(self, input_payload, *, identity, envelope):
+                pass  # pragma: no cover
+
+
+@pytest.mark.unit
+def test_connector_subclass_capabilities_must_be_frozenset() -> None:
+    """requires_capabilities MUST be a frozenset, not a list / set."""
+    with pytest.raises(TypeError, match="frozenset"):
+
+        class BadConnector(Connector):
+            connector_id = "x"
+            connector_kind = "http"
+            requires_capabilities = ["http.read"]  # type: ignore[assignment]
+
+            async def invoke(self, input_payload, *, identity, envelope):
+                pass  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# ConnectorInvocationResult — frozen + structural validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_connector_invocation_result_is_frozen() -> None:
+    r = ConnectorInvocationResult(
+        payload={"x": 1},
+        audit_events=(DelegateEventType.EXTERNAL_SIDE_EFFECT,),
+        tenant_id_observed="tenant-a",
+        external_side_effect=True,
+    )
+    with pytest.raises(FrozenInstanceError):
+        r.payload = {}  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_connector_invocation_result_rejects_non_dict_payload() -> None:
+    with pytest.raises(TypeError, match="payload MUST be a dict"):
+        ConnectorInvocationResult(
+            payload="not a dict",  # type: ignore[arg-type]
+            audit_events=(),
+            tenant_id_observed=None,
+            external_side_effect=False,
+        )
+
+
+@pytest.mark.unit
+def test_connector_invocation_result_rejects_non_event_tuple() -> None:
+    with pytest.raises(TypeError, match="DelegateEventType"):
+        ConnectorInvocationResult(
+            payload={},
+            audit_events=("not-an-event",),  # type: ignore[arg-type]
+            tenant_id_observed=None,
+            external_side_effect=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# DispatchSurface — bind-time invariants (3 + 5)
+# ---------------------------------------------------------------------------
+
+
+def _make_surface(
+    *,
+    role: Role | None = None,
+    cascade: TenantScopedCascade | None = None,
+    connector: Connector | None = None,
+    signature: SignatureContract | None = None,
+    envelope: DelegateConstraintEnvelope | None = None,
+    identity: DelegateIdentity | None = None,
+) -> DispatchSurface:
+    return DispatchSurface(
+        connector=connector if connector is not None else MockConnector(),
+        signature=signature if signature is not None else FakeSignatureHelper(),
+        envelope=envelope if envelope is not None else _build_envelope(),
+        identity=identity if identity is not None else _build_identity(),
+        audit_engine=AuditChainEngine(chain=_build_chain()),
+        trust_cascade=cascade if cascade is not None else _build_cascade(),
+        role=role if role is not None else _build_role(),
+    )
+
+
+@pytest.mark.unit
+def test_dispatch_surface_binds_when_invariants_hold() -> None:
+    surface = _make_surface()
+    assert surface.connector.connector_id == "mock-conn-1"
+    assert surface.role.lifecycle == RoleLifecycleState.ACTIVE
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_retired_role_lifecycle() -> None:
+    """Invariant 5 — RETIRED lifecycle refuses bind."""
+    role = _build_role(lifecycle=RoleLifecycleState.RETIRED)
+    with pytest.raises(DispatchEnvelopeViolationError, match="lifecycle"):
+        _make_surface(role=role)
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_suspended_role_lifecycle() -> None:
+    """Invariant 5 — SUSPENDED lifecycle refuses bind."""
+    role = _build_role(lifecycle=RoleLifecycleState.SUSPENDED)
+    with pytest.raises(DispatchEnvelopeViolationError, match="lifecycle"):
+        _make_surface(role=role)
+
+
+@pytest.mark.unit
+def test_dispatch_surface_allows_draft_role_lifecycle() -> None:
+    """Invariant 5 — DRAFT lifecycle binds (test/pre-activation use)."""
+    role = _build_role(lifecycle=RoleLifecycleState.DRAFT)
+    surface = _make_surface(role=role)
+    assert surface.role.lifecycle == RoleLifecycleState.DRAFT
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_missing_capability() -> None:
+    """Invariant 3 — connector requires capability role does not grant."""
+    role = _build_role(capabilities=("other.cap",))
+    with pytest.raises(DispatchEnvelopeViolationError, match="http.read"):
+        _make_surface(role=role)
+
+
+@pytest.mark.unit
+def test_dispatch_surface_rejects_non_signature_object() -> None:
+    """Invariant 1 — signature MUST satisfy SignatureContract protocol."""
+
+    class NotASignature:
+        # Missing input_schema / output_schema
+        name = "x"
+
+    with pytest.raises(TypeError, match="SignatureContract"):
+        _make_surface(signature=NotASignature())  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# DispatchSurface.dispatch — runtime invariants (1, 2, 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_input_payload_type_mismatch_raises() -> None:
+    """Invariant 1 — declared str field receives int → DispatchValidationError."""
+    surface = _make_surface()
+    with pytest.raises(DispatchValidationError, match="user_id"):
+        await surface.dispatch({"user_id": 42})  # type: ignore[dict-item]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_input_payload_extra_key_rejected() -> None:
+    """Closed-world schema — extra keys are rejected (Rule 3c parity)."""
+    surface = _make_surface()
+    with pytest.raises(DispatchValidationError, match="undeclared"):
+        await surface.dispatch({"user_id": "u-1", "extra": "x"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_input_payload_missing_required_field_raises() -> None:
+    surface = _make_surface()
+    with pytest.raises(DispatchValidationError, match="missing required"):
+        await surface.dispatch({})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_input_payload_non_dict_raises() -> None:
+    surface = _make_surface()
+    with pytest.raises(DispatchValidationError, match="MUST be a dict"):
+        await surface.dispatch("not a dict")  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_tenant_mismatch_raises_cascade_violation() -> None:
+    """Invariant 2 — connector observed tenant != cascade tenant."""
+    connector = MockConnector(tenant_id_observed="tenant-B")
+    cascade = _build_cascade(tenant_id="tenant-A")
+    surface = _make_surface(connector=connector, cascade=cascade)
+    with pytest.raises(CascadeTenantViolationError):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_global_cascade_accepts_any_observed_tenant() -> None:
+    """Global cascade accepts any observed tenant including None."""
+    connector = MockConnector(tenant_id_observed=None)
+    cascade = _build_cascade(tenant_id=None)  # global
+    surface = _make_surface(connector=connector, cascade=cascade)
+    result = await surface.dispatch({"user_id": "u-1"})
+    assert isinstance(result, DispatchResult)
+    assert result.tenant_id == ""
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_successful_returns_dispatch_result() -> None:
+    surface = _make_surface()
+    result = await surface.dispatch({"user_id": "u-42"})
+    assert isinstance(result, DispatchResult)
+    assert result.payload == {"created": True}
+    assert result.tenant_id == "tenant-a"
+    assert result.connector_id == "mock-conn-1"
+    assert result.executed_at.tzinfo is not None
+    # Invariant 4 — exactly one audit event was emitted → one entry hash.
+    assert len(result.audit_chain_entries) == 1
+    # Each hash is a 64-char lowercase hex SHA-256.
+    for h in result.audit_chain_entries:
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_audit_engine_round_trip() -> None:
+    """Round-trip: dispatch emits events → audit_engine.entries reflects them."""
+    chain = _build_chain("agent-roundtrip")
+    audit_engine = AuditChainEngine(chain=chain)
+    connector = MockConnector(
+        audit_events=(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT,
+            DelegateEventType.GRANT_CONSUMPTION,
+        ),
+    )
+    surface = DispatchSurface(
+        connector=connector,
+        signature=FakeSignatureHelper(),
+        envelope=_build_envelope(),
+        identity=_build_identity(),
+        audit_engine=audit_engine,
+        trust_cascade=_build_cascade(),
+        role=_build_role(),
+    )
+    assert len(audit_engine.entries) == 0
+    result = await surface.dispatch({"user_id": "u-1"})
+    # Both events emitted onto the chain.
+    assert len(audit_engine.entries) == 2
+    assert len(result.audit_chain_entries) == 2
+    # Audit chain entries are monotonic — sequence 0 then 1.
+    assert audit_engine.entries[0].sequence == 0
+    assert audit_engine.entries[1].sequence == 1
+    # Both entries carry the connector_id in their payload (wiring evidence).
+    for entry in audit_engine.entries:
+        assert entry.event_payload["connector_id"] == "mock-conn-1"
+        assert entry.event_payload["signature_name"] == "create_user"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_non_audit_visible_event_propagates_emission_error() -> None:
+    """Invariant 4 — REASONING_SCRATCHPAD is not audit-visible; engine refuses."""
+    connector = MockConnector(
+        audit_events=(DelegateEventType.REASONING_SCRATCHPAD,),
+    )
+    surface = _make_surface(connector=connector)
+    with pytest.raises(AuditChainEmissionError, match="audit-visible"):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_connector_invocation_carries_bound_identity_and_envelope() -> (
+    None
+):
+    """Connector.invoke receives the SAME identity + envelope bound at construction."""
+    identity = _build_identity()
+    envelope = _build_envelope()
+    connector = MockConnector()
+    surface = DispatchSurface(
+        connector=connector,
+        signature=FakeSignatureHelper(),
+        envelope=envelope,
+        identity=identity,
+        audit_engine=AuditChainEngine(chain=_build_chain()),
+        trust_cascade=_build_cascade(),
+        role=_build_role(),
+    )
+    await surface.dispatch({"user_id": "u-1"})
+    assert len(connector.invocations) == 1
+    inv = connector.invocations[0]
+    # Identity passed by reference — same delegate_id.
+    assert inv["identity"].delegate_id == identity.delegate_id
+    # Envelope passed by reference — same genesis_id.
+    assert inv["envelope"].genesis_id == envelope.genesis_id
+    # Input payload passed unchanged.
+    assert inv["input_payload"] == {"user_id": "u-1"}
+
+
+# ---------------------------------------------------------------------------
+# F5 monotonic envelope — Invariant 1 (envelope tightening, not widening)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_envelope_tightening_between_bind_and_invocation_ok() -> None:
+    """The bound envelope CAN be tightened to produce a NEW envelope; the
+    original bound envelope is NOT mutated (Invariant 1).
+
+    DispatchSurface holds the envelope by reference (frozen dataclass) so
+    the bound envelope is immutable. Tightening produces a NEW instance.
+    """
+    envelope = _build_envelope()
+    surface = _make_surface(envelope=envelope)
+    # Bound envelope identity preserved.
+    assert surface.envelope is envelope
+    # Tighten to a strictly stricter budget — produces a NEW envelope,
+    # does NOT mutate the surface's bound envelope.
+    tighter = ConstraintEnvelope(financial=FinancialConstraint(budget_limit=500.0))
+    new_envelope = envelope.tighten_with(tighter)
+    assert new_envelope is not envelope
+    # Surface still holds the ORIGINAL envelope (Invariant 1 — bind is final).
+    assert surface.envelope is envelope
+
+
+@pytest.mark.unit
+def test_envelope_widening_rejected_by_tighten_with() -> None:
+    """Widening (loosening) the envelope is rejected by tighten_with.
+
+    Invariant 1 transitively: the F5 widening-raise gate lives in the
+    DelegateConstraintEnvelope.tighten_with method; DispatchSurface
+    delegates to it. The widening attempt MUST raise EnvelopeWideningError
+    BEFORE any silent intersection.
+    """
+    from kailash.delegate.envelope import EnvelopeWideningError
+
+    envelope = _build_envelope()  # budget_limit=1000.0
+    # Attempt to widen to budget=2000 — loosens the financial dim.
+    looser = ConstraintEnvelope(financial=FinancialConstraint(budget_limit=2000.0))
+    with pytest.raises(EnvelopeWideningError):
+        envelope.tighten_with(looser)
+
+
+# ---------------------------------------------------------------------------
+# DispatchResult — frozen + structural validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dispatch_result_is_frozen() -> None:
+    r = DispatchResult(
+        payload={"x": 1},
+        audit_chain_entries=(),
+        executed_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        tenant_id="t",
+        connector_id="c",
+    )
+    with pytest.raises(FrozenInstanceError):
+        r.payload = {}  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_dispatch_result_rejects_naive_datetime() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        DispatchResult(
+            payload={},
+            audit_chain_entries=(),
+            executed_at=datetime(2026, 5, 22, 12, 0, 0),  # naive
+            tenant_id="t",
+            connector_id="c",
+        )
+
+
+@pytest.mark.unit
+def test_dispatch_result_rejects_empty_connector_id() -> None:
+    with pytest.raises(ValueError, match="connector_id"):
+        DispatchResult(
+            payload={},
+            audit_chain_entries=(),
+            executed_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            tenant_id="t",
+            connector_id="",
+        )
+
+
+# ---------------------------------------------------------------------------
+# DispatchCascadeViolationError — typed-error reachability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dispatch_cascade_violation_error_is_value_error() -> None:
+    """DispatchCascadeViolationError is the typed surface for grantee
+    refusal; it is a ValueError per the S2.5/S3/S4 convention.
+
+    The runtime grantee-registry check is deferred to S7+ (the current
+    TenantScopedCascade emits GrantMoment but does not retain the grantee
+    set); this test asserts the error class exists and is in the
+    correct base hierarchy so callers can catch it stably.
+    """
+    err = DispatchCascadeViolationError("test")
+    assert isinstance(err, ValueError)
+    assert isinstance(err, DispatchCascadeViolationError)

--- a/tests/unit/delegate/test_dispatch.py
+++ b/tests/unit/delegate/test_dispatch.py
@@ -26,6 +26,7 @@ import hashlib
 import uuid
 from dataclasses import FrozenInstanceError
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
@@ -680,3 +681,375 @@ def test_dispatch_cascade_violation_error_is_value_error() -> None:
     err = DispatchCascadeViolationError("test")
     assert isinstance(err, ValueError)
     assert isinstance(err, DispatchCascadeViolationError)
+
+
+# ---------------------------------------------------------------------------
+# Round 1 — C2-1 signer requirement (zero-tolerance fake-encryption fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dispatch_surface_rejects_non_callable_signer() -> None:
+    """C2-1: signer MUST be a callable; None/placeholder is BLOCKED."""
+    # Call DispatchSurface directly to bypass the test helper's signer default.
+    with pytest.raises(TypeError, match="signer MUST be a callable"):
+        DispatchSurface(
+            connector=MockConnector(),
+            signature=FakeSignatureHelper(),
+            envelope=_build_envelope(),
+            identity=_build_identity(),
+            audit_engine=AuditChainEngine(chain=_build_chain()),
+            trust_cascade=_build_cascade(),
+            role=_build_role(),
+            signer=None,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_invokes_injected_signer_per_event() -> None:
+    """C2-1: every audit-event emission MUST call the injected signer
+    exactly once with the canonical-bytes encoding of the payload."""
+    captured: list[bytes] = []
+
+    def recording_signer(canonical_bytes: bytes) -> str:
+        captured.append(canonical_bytes)
+        h = hashlib.sha256(canonical_bytes).hexdigest()
+        return h + h
+
+    connector = MockConnector(
+        audit_events=(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT,
+            DelegateEventType.GRANT_CONSUMPTION,
+        ),
+    )
+    surface = _make_surface(connector=connector, signer=recording_signer)
+    await surface.dispatch({"user_id": "u-1"})
+    # Signer called once per emitted event (2 in this case)
+    assert len(captured) == 2
+    # Each call received non-empty UTF-8 canonical bytes
+    for cb in captured:
+        assert isinstance(cb, bytes)
+        assert len(cb) > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_signer_fault_raises_dispatch_signer_error() -> None:
+    """C2-1: signer that raises MUST surface DispatchSignerError, not
+    leak the raw exception to the caller."""
+
+    def faulty_signer(_canonical_bytes: bytes) -> str:
+        raise RuntimeError("signing key unavailable")
+
+    surface = _make_surface(signer=faulty_signer)
+    with pytest.raises(DispatchSignerError, match="signing key unavailable"):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_signer_returns_non_str_raises() -> None:
+    """C2-1: signer return type MUST be str; surface-shape error."""
+
+    def bad_return_signer(_canonical_bytes: bytes) -> str:
+        return 12345  # type: ignore[return-value]
+
+    surface = _make_surface(signer=bad_return_signer)
+    with pytest.raises(DispatchSignerError, match="MUST return str"):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_signer_returns_short_signature_raises() -> None:
+    """C2-1: signer return value <32 chars is structurally invalid."""
+
+    def short_signer(_canonical_bytes: bytes) -> str:
+        return "0" * 16  # too short
+
+    surface = _make_surface(signer=short_signer)
+    with pytest.raises(DispatchSignerError, match="shorter than"):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+# ---------------------------------------------------------------------------
+# Round 1 — C2-3 side-effect-requires-audit gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_side_effect_without_audit_blocked() -> None:
+    """C2-3: external_side_effect=True with zero audit_events is BLOCKED
+    per zero-tolerance.md Rule 2 (fake-dispatch class)."""
+    connector = MockConnector(
+        audit_events=(),
+        external_side_effect=True,
+    )
+    surface = _make_surface(connector=connector)
+    with pytest.raises(DispatchValidationError, match="side-effects without audit"):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_no_side_effect_no_audit_is_ok() -> None:
+    """C2-3 negative case: a read-only connector with no audit events
+    and no side-effect is permitted (counterfactual to the gate)."""
+    connector = MockConnector(
+        audit_events=(),
+        external_side_effect=False,
+    )
+    surface = _make_surface(connector=connector)
+    result = await surface.dispatch({"user_id": "u-1"})
+    assert isinstance(result, DispatchResult)
+    assert result.audit_chain_entries == ()
+
+
+# ---------------------------------------------------------------------------
+# Round 1 — C4-1 F5 monotonicity runtime re-check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_capability_revocation_between_bind_and_dispatch_fails_closed() -> None:
+    """C4-1: capability revoked between bind and dispatch → fail-closed.
+
+    The Role object is mutated (its CapabilitySet replaced) after bind.
+    DispatchSurface's runtime check compares the bind-time required-caps
+    against the CURRENT role caps and raises
+    DispatchEnvelopeViolationError when a required cap is missing.
+    """
+    from kailash.delegate.types import CapabilitySet, RoleScope
+
+    role = _build_role(capabilities=("http.read", "http.write"))
+    surface = _make_surface(role=role)
+    # Revoke http.read AFTER bind. Role is frozen; bypass with
+    # object.__setattr__ (test-only — production code MUST NOT bypass
+    # frozen, real revocation replaces the Role instance upstream).
+    object.__setattr__(
+        role,
+        "scope",
+        RoleScope(
+            domain="finance",
+            capabilities=CapabilitySet(capabilities=("http.write",)),
+        ),
+    )
+    with pytest.raises(DispatchEnvelopeViolationError, match="capability set drifted"):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lifecycle_downgrade_to_retired_between_bind_and_dispatch_fails_closed() -> (
+    None
+):
+    """C4-1: role lifecycle transitions to RETIRED after bind → fail-closed."""
+    role = _build_role(lifecycle=RoleLifecycleState.ACTIVE)
+    surface = _make_surface(role=role)
+    # Transition to RETIRED AFTER bind (bypass frozen — test-only)
+    object.__setattr__(role, "lifecycle", RoleLifecycleState.RETIRED)
+    with pytest.raises(DispatchEnvelopeViolationError, match="lifecycle drifted"):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_capability_widening_between_bind_and_dispatch_ignored() -> None:
+    """C4-1: capability widening (gain) does NOT change behavior — bind
+    is the upper bound. A subset that still includes required caps
+    succeeds normally regardless of whether NEW unrelated caps were added.
+    """
+    from kailash.delegate.types import CapabilitySet, RoleScope
+
+    role = _build_role(capabilities=("http.read",))
+    surface = _make_surface(role=role)
+    # Widen the role AFTER bind — gain unrelated capability (bypass frozen)
+    object.__setattr__(
+        role,
+        "scope",
+        RoleScope(
+            domain="finance",
+            capabilities=CapabilitySet(
+                capabilities=("http.read", "http.write", "extra.cap")
+            ),
+        ),
+    )
+    # Dispatch succeeds: bind-time required cap (http.read) still present.
+    result = await surface.dispatch({"user_id": "u-1"})
+    assert isinstance(result, DispatchResult)
+
+
+# ---------------------------------------------------------------------------
+# Round 1 — C6-1 DoS depth + size limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_rejects_deeply_nested_payload() -> None:
+    """C6-1: payload exceeding maximum depth raises DispatchValidationError."""
+    # Build a 40-deep nested dict (limit is 32)
+    payload: dict[str, Any] = {"user_id": "u-1"}
+    inner: dict[str, Any] = payload
+    for _ in range(40):
+        inner["nested"] = {}
+        inner = inner["nested"]
+    # Use a signature accepting an extra dict field
+    sig = FakeSignatureHelper(input_schema={"user_id": str, "deep": dict})
+    payload = {"user_id": "u-1", "deep": payload["nested"]}
+    surface = _make_surface(signature=sig)
+    with pytest.raises(DispatchValidationError, match="exceeds maximum nesting depth"):
+        await surface.dispatch(payload)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_rejects_oversize_payload() -> None:
+    """C6-1: payload exceeding serialized-size limit raises validation."""
+    huge_str = "x" * (2 * 1024 * 1024)  # 2 MiB
+    sig = FakeSignatureHelper(input_schema={"user_id": str, "blob": str})
+    surface = _make_surface(signature=sig)
+    with pytest.raises(
+        DispatchValidationError, match="exceeds maximum serialized size"
+    ):
+        await surface.dispatch({"user_id": "u-1", "blob": huge_str})
+
+
+# ---------------------------------------------------------------------------
+# Round 1 — C6-2 strict type check (bool BLOCKED for int)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_rejects_bool_for_int_field() -> None:
+    """C6-2: isinstance(True, int) is True in Python; explicitly reject
+    bool for int-declared fields (security.md sanitizer Rule 2)."""
+    sig = FakeSignatureHelper(input_schema={"user_id": str, "count": int})
+    surface = _make_surface(signature=sig)
+    with pytest.raises(DispatchValidationError, match="bool BLOCKED"):
+        await surface.dispatch({"user_id": "u-1", "count": True})
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_accepts_int_for_float_field() -> None:
+    """C6-2 numeric-tower carve-out: int satisfies float-declared field."""
+    sig = FakeSignatureHelper(input_schema={"user_id": str, "ratio": float})
+    surface = _make_surface(signature=sig)
+    result = await surface.dispatch({"user_id": "u-1", "ratio": 42})
+    assert isinstance(result, DispatchResult)
+
+
+# ---------------------------------------------------------------------------
+# Round 1 closure-parity Row 3 — to_dict / from_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_connector_invocation_result_roundtrip() -> None:
+    """ConnectorInvocationResult.to_dict → from_dict is lossless."""
+    r = ConnectorInvocationResult(
+        payload={"created": True, "id": "u-42"},
+        audit_events=(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT,
+            DelegateEventType.GRANT_CONSUMPTION,
+        ),
+        tenant_id_observed="tenant-a",
+        external_side_effect=True,
+    )
+    d = r.to_dict()
+    # Wire-format shape: audit_events emitted as list of string values
+    assert isinstance(d["audit_events"], list)
+    assert d["audit_events"] == ["external_side_effect", "grant_consumption"]
+    assert d["tenant_id_observed"] == "tenant-a"
+    assert d["external_side_effect"] is True
+    # Round-trip reconstruction
+    r2 = ConnectorInvocationResult.from_dict(d)
+    assert r2 == r
+    assert r2.audit_events == r.audit_events
+    assert r2.payload == r.payload
+
+
+@pytest.mark.unit
+def test_connector_invocation_result_from_dict_rejects_missing_field() -> None:
+    with pytest.raises(ValueError, match="missing required field"):
+        ConnectorInvocationResult.from_dict({"payload": {}, "audit_events": []})
+
+
+@pytest.mark.unit
+def test_connector_invocation_result_from_dict_handles_none_tenant() -> None:
+    """Optional tenant_id_observed round-trips through None."""
+    r = ConnectorInvocationResult(
+        payload={},
+        audit_events=(),
+        tenant_id_observed=None,
+        external_side_effect=False,
+    )
+    r2 = ConnectorInvocationResult.from_dict(r.to_dict())
+    assert r2.tenant_id_observed is None
+
+
+@pytest.mark.unit
+def test_dispatch_result_roundtrip() -> None:
+    """DispatchResult.to_dict → from_dict is lossless on every field."""
+    did = uuid.uuid4()
+    r = DispatchResult(
+        payload={"created": True},
+        audit_chain_entries=("a" * 64, "b" * 64),
+        executed_at=datetime(2026, 5, 22, 12, 30, 0, tzinfo=timezone.utc),
+        tenant_id="tenant-wire",
+        connector_id="conn-1",
+        dispatch_id=did,
+    )
+    d = r.to_dict()
+    assert d["dispatch_id"] == str(did)
+    assert d["executed_at"] == "2026-05-22T12:30:00+00:00"
+    assert d["audit_chain_entries"] == ["a" * 64, "b" * 64]
+    r2 = DispatchResult.from_dict(d)
+    assert r2 == r
+    assert r2.dispatch_id == did
+    assert r2.executed_at == r.executed_at
+
+
+@pytest.mark.unit
+def test_dispatch_result_from_dict_rejects_missing_dispatch_id() -> None:
+    with pytest.raises(ValueError, match="dispatch_id"):
+        DispatchResult.from_dict(
+            {
+                "payload": {},
+                "audit_chain_entries": [],
+                "executed_at": "2026-05-22T12:00:00+00:00",
+                "tenant_id": "t",
+                "connector_id": "c",
+            }
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_result_dispatch_id_is_unique_per_call() -> None:
+    """Each dispatch() generates a fresh dispatch_id UUID."""
+    surface = _make_surface()
+    r1 = await surface.dispatch({"user_id": "u-1"})
+    r2 = await surface.dispatch({"user_id": "u-2"})
+    assert r1.dispatch_id != r2.dispatch_id
+    assert isinstance(r1.dispatch_id, uuid.UUID)
+    assert isinstance(r2.dispatch_id, uuid.UUID)
+
+
+# ---------------------------------------------------------------------------
+# Round 1 — DispatchSignerError typed-error reachability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dispatch_signer_error_is_value_error() -> None:
+    """DispatchSignerError MUST be a ValueError per the typed-error
+    convention; callers MAY catch ValueError as a base class."""
+    err = DispatchSignerError("test")
+    assert isinstance(err, ValueError)
+    assert isinstance(err, DispatchSignerError)

--- a/tests/unit/delegate/test_package_shell.py
+++ b/tests/unit/delegate/test_package_shell.py
@@ -29,8 +29,9 @@ def test_kailash_delegate_imports_cleanly() -> None:
     mode this assertion catches."""
     import kailash.delegate as pkg
 
-    assert len(pkg.__all__) == 11, (
-        "kailash.delegate.__all__ count drifted; S2 ships 11 symbols. "
+    assert len(pkg.__all__) == 30, (
+        "kailash.delegate.__all__ count drifted; S5 ships 30 symbols "
+        "(S2: 11 + S3 trust cascade: 5 + S4 audit chain: 7 + S5 dispatch: 7). "
         "If a later shard added a symbol, update this count in the same commit "
         f"per orphan-detection.md Rule 6a. Got: {pkg.__all__!r}"
     )


### PR DESCRIPTION
## Summary

- Adds the **Connector ABC + DispatchSurface** that binds `(Connector × Signature × ConstraintEnvelope × Identity)` into the audit-grade executable composition surface
- Composes existing primitives: `DelegateConstraintEnvelope` (F5 type-state), `TenantScopedCascade` (S3), `AuditChainEngine` (S4), `DelegateIdentity` + `Role` (S2.5)
- 623 LOC dispatch.py + 478 LOC unit tests + 264 LOC integration tests
- 7 new public symbols added to `kailash.delegate.__all__` Group 7 (eager imports, orphan-detection Rule 6 compliant)

## 5 invariants held + verified

| # | Invariant | Test |
|---|-----------|------|
| 1 | F5 monotonic envelope (no widening between bind + invocation) | `test_envelope_tightening_between_bind_and_invocation_ok`, `test_envelope_widening_rejected_by_tighten_with` |
| 2 | Tenant isolation (fail-closed BEFORE audit emission) | `test_dispatch_tenant_mismatch_raises_cascade_violation`, `test_dispatch_tenant_isolation_enforced_end_to_end` |
| 3 | Capability gating at bind time | `test_dispatch_surface_refuses_missing_capability` |
| 4 | Audit emission allowlist (single source of truth = `_AUDIT_VISIBLE_EVENT_TYPES` frozenset in audit.py) | `test_dispatch_non_audit_visible_event_propagates_emission_error`, `test_dispatch_audit_engine_round_trip` |
| 5 | Lifecycle state (RETIRED + SUSPENDED refuse; DRAFT + ACTIVE allow) | `test_dispatch_surface_refuses_retired_role_lifecycle`, `test_dispatch_surface_refuses_suspended_role_lifecycle` |

## New public surface (Group 7)

- `Connector` (ABC) — `async invoke(input_payload, *, identity, envelope) -> ConnectorInvocationResult`
- `ConnectorInvocationResult` — `payload`, `audit_events`, `tenant_id_observed`, `external_side_effect`
- `DispatchSurface` — binds the 4-tuple; `async dispatch(input_payload) -> DispatchResult`
- `DispatchResult` — `payload`, `audit_chain_entries`, `executed_at`, `tenant_id`, `connector_id`
- `DispatchValidationError` (ValueError) — signature schema mismatch
- `DispatchEnvelopeViolationError` (ValueError) — capability missing, lifecycle dead, envelope refused
- `DispatchCascadeViolationError` (ValueError) — declared for stable typed surface; runtime grantee-registry check deferred to S7+ (TenantScopedCascade does not yet retain a grantee set — documented in dispatch.py docstring)

## Same-shard fix-immediately (autonomous-execution.md MUST Rule 4)

- `Connector.__init_subclass__` AttributeError: `__abstractmethods__` not yet set when ABC subclass hooks fire. Fixed via `getattr` + concrete-detection on `cls.__dict__["invoke"].__isabstractmethod__`. ~10 LOC, same bug class, landed in same shard.

## Gates (all green)

- 29/29 S5 unit tests pass
- 3/3 S5 integration tests pass
- 218/218 full delegate suite (+1 pre-existing skip) — zero regressions in S2/S3/S4 tests
- `pytest --collect-only tests/unit/delegate/` → exit 0, 207 tests collected

## Test plan

- [x] All 218 delegate tests pass (5 invariants verified end-to-end)
- [x] `pytest --collect-only` exit 0 (orphan-detection Rule 5 merge gate)
- [x] `__all__` count test updated: 23 → 30 (AST-verified per testing.md MUST)
- [x] Eager imports for every new `__all__` entry (orphan-detection Rule 6)
- [x] No regressions in trust + audit + envelope + types tests

## Related issues

Part of #1035 — Delegate composition primitive Wave 3 (S5 dispatch). Unblocks S6 (runtime spine — composes S5's DispatchSurface into TAOD lifecycle + R2 composition + posture wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)