### PR TITLE
feat(delegate): S6 runtime spine — TAOD lifecycle + Posture + R2Composition (#1035)

### DIFF
--- a/src/kailash/delegate/__init__.py
+++ b/src/kailash/delegate/__init__.py
@@ -40,6 +40,18 @@ from kailash.delegate.envelope import (
     DelegateConstraintEnvelope,
     EnvelopeWideningError,
 )
+from kailash.delegate.runtime import (
+    DelegateRuntime,
+    Posture,
+    R2Composition,
+    R2CompositionError,
+    RuntimeCompositionError,
+    RuntimeExecutionResult,
+    RuntimePhaseError,
+    RuntimePostureBlockedError,
+    TAODState,
+    TAODTransition,
+)
 from kailash.delegate.trust import (
     CascadeScopeExpansionError,
     CascadeTenantViolationError,
@@ -97,4 +109,15 @@ __all__ = [
     "DispatchValidationError",
     "DispatchEnvelopeViolationError",
     "DispatchCascadeViolationError",
+    # Group 8 -- Runtime spine + TAOD lifecycle (S6)
+    "DelegateRuntime",
+    "Posture",
+    "TAODState",
+    "TAODTransition",
+    "R2Composition",
+    "RuntimeExecutionResult",
+    "RuntimeCompositionError",
+    "RuntimePostureBlockedError",
+    "RuntimePhaseError",
+    "R2CompositionError",
 ]

--- a/src/kailash/delegate/runtime.py
+++ b/src/kailash/delegate/runtime.py
@@ -1,0 +1,1365 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+# pyright: reportUnnecessaryIsInstance=false
+"""Runtime spine + TAOD lifecycle for ``kailash.delegate`` (S6 of #1035).
+
+Composes the existing Delegate primitives — ``DispatchSurface`` (S5),
+``AuditChainEngine`` (S4), ``TenantScopedCascade`` (S3),
+``DelegateConstraintEnvelope`` (S2.5), ``DelegateIdentity`` (S2) — into the
+audit-grade TAOD (Think-Act-Observe-Decide) execution lifecycle per the
+CARE Mirror Thesis.
+
+Cross-impl parity: Mirrors rs ``kailash-delegate-runtime`` (S6 substrate).
+The TAOD state-machine phase order, the per-phase audit event emission,
+the R2 composition contract, and the ``Posture`` enum admit byte-shape
+parity with the rs reference. ``RuntimeExecutionResult.to_dict`` /
+``from_dict`` round-trip is the wire-format contract.
+
+Invariants (within budget per ``autonomous-execution.md`` MUST Rule 1 —
+six invariants total):
+
+1. **Phase monotonicity** — TAOD transitions are append-only; once
+   ``COMPLETED`` or ``FAILED``, no further transitions are accepted
+   (raises :class:`RuntimePhaseError`).
+2. **Posture gating at THINKING** — every ``execute()`` reads the CURRENT
+   :class:`Posture` at THINKING phase entry (not bind-time). ``HALT``
+   refuses; downgrades are silently respected.
+3. **Audit binding** — every TAOD transition emits exactly one audit event
+   whose payload carries the ``run_id`` (cryptographic binding via the
+   bound signer per S5 C2-1 fix). A run is replayable from the audit
+   chain by ``run_id``.
+4. **R2 composition re-check** — :meth:`R2Composition.validate` runs at
+   construction AND at the start of every ``execute()`` (defense-in-depth
+   per S5 C4-1 pattern; a component reconstructed externally between
+   constructions cannot silently break the composition).
+5. **No silent posture downgrade** — :meth:`DelegateRuntime.with_posture`
+   accepts downgrades freely; upgrades require an explicit
+   ``human_acknowledged_nonce`` per ``rules/trust-posture.md`` MUST
+   Rule 3 (refuses with :class:`RuntimePostureBlockedError`).
+6. **Signer identity** — the ``audit_engine``'s signer reference MUST be
+   the SAME object (``is`` check, not ``==``) as the DispatchSurface's
+   signer. A drifted signer is signature forgery against the audit
+   trail and is BLOCKED at composition validation.
+
+The TAOD state machine::
+
+    INITIATED → THINKING → ACTING → OBSERVING → DECIDING → COMPLETED
+                                            ╲
+                                             ╲→ COMPLETED (early exit;
+                                                no decision required)
+                                       ╲
+                                        ╲→ FAILED (terminal — any phase error)
+
+The runtime is the spine; framework specialists (kaizen/nexus/dataflow)
+compose ON it, never re-implement it. Per ``orphan-detection.md`` Rule 1
+this module is the production hot path that calls
+:meth:`DispatchSurface.dispatch` directly — there is no further
+indirection.
+
+Note on Posture integration: this shard accepts a :class:`Posture` as a
+constructor parameter and gates ``execute()`` at THINKING on it. Runtime
+integration with the ``.claude/learning/posture.json`` state file
+(SessionStart-managed) is S8 e2e scope, NOT S6 — keeping S6's surface
+area bounded to the spine itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal
+
+from kailash.delegate.audit import (
+    AuditChainEngine,
+    DelegateEventType,
+)
+from kailash.delegate.dispatch import DispatchResult, DispatchSurface
+from kailash.delegate.envelope import DelegateConstraintEnvelope
+from kailash.delegate.trust import TenantScope, TenantScopedCascade
+from kailash.delegate.types import DelegateIdentity
+from kailash.trust._json import canonical_json_dumps
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DelegateRuntime",
+    "Posture",
+    "R2Composition",
+    "R2CompositionError",
+    "RuntimeCompositionError",
+    "RuntimeExecutionResult",
+    "RuntimePhaseError",
+    "RuntimePostureBlockedError",
+    "TAODState",
+    "TAODTransition",
+]
+
+
+# ---------------------------------------------------------------------------
+# Posture enum — graduated autonomy ladder (R2 composition gate)
+# ---------------------------------------------------------------------------
+
+
+class Posture(str, Enum):
+    """Graduated autonomy posture per ``rules/trust-posture.md``.
+
+    Mirrors rs ``Posture`` enum (S6 substrate). Sub-class of :class:`str`
+    per ``eatp.md`` SDK convention so the on-wire form is the bare string
+    value (cross-SDK canonical JSON consumes the value directly; no
+    re-encoding step).
+
+    Operative posture is the MINIMUM of the operator's per-operator
+    posture and the repo floor — this enum encodes the ladder; the
+    runtime's per-execute() gate at THINKING applies the value.
+
+    HALT is the emergency stop: any execute() against a HALT-postured
+    runtime refuses immediately at THINKING phase with
+    :class:`RuntimePostureBlockedError`.
+    """
+
+    L5_DELEGATED = "L5_DELEGATED"
+    L4_CONTINUOUS_INSIGHT = "L4_CONTINUOUS_INSIGHT"
+    L3_SHARED_PLANNING = "L3_SHARED_PLANNING"
+    L2_SUPERVISED = "L2_SUPERVISED"
+    L1_PSEUDO_AGENT = "L1_PSEUDO_AGENT"
+    HALT = "HALT"
+
+    @property
+    def _rank(self) -> int:
+        """Internal ordinal for monotonic comparison.
+
+        Higher rank = more autonomy. HALT is the floor (rank 0); L5 is
+        the ceiling. Used by :meth:`DelegateRuntime.with_posture` to
+        distinguish downgrades (silent) from upgrades (refuse without
+        nonce).
+        """
+        ladder = {
+            Posture.HALT: 0,
+            Posture.L1_PSEUDO_AGENT: 1,
+            Posture.L2_SUPERVISED: 2,
+            Posture.L3_SHARED_PLANNING: 3,
+            Posture.L4_CONTINUOUS_INSIGHT: 4,
+            Posture.L5_DELEGATED: 5,
+        }
+        return ladder[self]
+
+
+# ---------------------------------------------------------------------------
+# Typed errors
+# ---------------------------------------------------------------------------
+
+
+class RuntimeCompositionError(ValueError):
+    """Raised when the runtime composition contract is violated.
+
+    Construction-time check that the spine's primitives form a
+    consistent triplet: identity.principal_id is grantable per the
+    cascade; envelope.tenant_scope matches the cascade's scope;
+    audit_engine and dispatch_surface share the same signer reference.
+
+    Distinct from :class:`R2CompositionError` (the R2 re-check at
+    execute() start, defense-in-depth); this error is the bind-time
+    structural fault.
+    """
+
+
+class RuntimePostureBlockedError(ValueError):
+    """Raised when posture refuses an operation.
+
+    Two cases surface here:
+
+    - :attr:`Posture.HALT` at THINKING phase — every execute() under a
+      HALT-postured runtime fails fast.
+    - :meth:`DelegateRuntime.with_posture` upgrade without a
+      ``human_acknowledged_nonce`` — per ``rules/trust-posture.md``
+      MUST Rule 3, posture upgrades require explicit human acknowledgement.
+    """
+
+
+class RuntimePhaseError(ValueError):
+    """Raised when an illegal TAOD phase transition is attempted.
+
+    Phase monotonicity (Invariant 1) — transitions are append-only;
+    once :attr:`TAODState.phase` is ``completed`` or ``failed``, no
+    further transitions are accepted. Distinct from
+    :class:`RuntimePostureBlockedError` (posture refuses; phase machine
+    untouched).
+    """
+
+
+class R2CompositionError(ValueError):
+    """Raised when R2 composition validation fails.
+
+    The R2 (Reasoning + Reliability composition) gate validates that
+    (envelope, cascade, dispatch_surface) form a consistent triplet AND
+    that audit_engine + dispatch_surface share the same signer reference.
+    Fired at construction AND at every execute() start (defense-in-depth
+    against external component reconstruction between the two).
+
+    Distinct from :class:`RuntimeCompositionError` (the bind-time
+    structural fault) — this error is specifically the R2 re-check
+    failure mode, surfaced separately so callers can distinguish initial
+    construction faults from runtime composition drift.
+    """
+
+
+# ---------------------------------------------------------------------------
+# TAOD state machine
+# ---------------------------------------------------------------------------
+
+
+# Literal type pinning the legal phase values. The dataclass field is
+# typed against this so a typo in a phase name surfaces at type-check
+# time, not at runtime.
+TAODPhase = Literal[
+    "initiated",
+    "thinking",
+    "acting",
+    "observing",
+    "deciding",
+    "completed",
+    "failed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class TAODTransition:
+    """One phase transition recorded on a :class:`TAODState`.
+
+    Mirrors rs ``TaodTransition`` struct (S6 substrate). Frozen + slots
+    per the S2/S3/S4/S5 dataclass conventions. Append-only history of
+    transitions for audit + cross-SDK receipt comparison.
+
+    Attributes:
+        from_phase: The phase the state was IN before this transition.
+        to_phase: The phase the state moved TO.
+        at: tz-aware UTC datetime of the transition.
+        reason: Optional human-readable reason. ``None`` for normal
+            phase advancement; populated on FAILED transitions with the
+            error class name + message.
+    """
+
+    from_phase: str
+    to_phase: str
+    at: datetime
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.from_phase, str) or not self.from_phase:
+            raise TypeError(
+                "TAODTransition.from_phase MUST be a non-empty str; got "
+                f"{type(self.from_phase).__name__}={self.from_phase!r}"
+            )
+        if not isinstance(self.to_phase, str) or not self.to_phase:
+            raise TypeError(
+                "TAODTransition.to_phase MUST be a non-empty str; got "
+                f"{type(self.to_phase).__name__}={self.to_phase!r}"
+            )
+        if not isinstance(self.at, datetime):
+            raise TypeError(
+                "TAODTransition.at MUST be a datetime; got " f"{type(self.at).__name__}"
+            )
+        if self.at.tzinfo is None:
+            raise ValueError(
+                "TAODTransition.at MUST be timezone-aware (naive "
+                "datetimes break cross-SDK wire-format parity)"
+            )
+        if self.reason is not None and not isinstance(self.reason, str):
+            raise TypeError(
+                "TAODTransition.reason MUST be str or None; got "
+                f"{type(self.reason).__name__}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-canonical dict (cross-SDK wire-format).
+
+        Mirrors rs ``TaodTransition`` serde encoding. ``at`` is
+        ISO-8601 UTC; ``reason`` omitted when ``None`` to preserve the
+        rs serde-skip-if-none semantics.
+        """
+        payload: dict[str, Any] = {
+            "from_phase": self.from_phase,
+            "to_phase": self.to_phase,
+            "at": self.at.isoformat(),
+        }
+        if self.reason is not None:
+            payload["reason"] = self.reason
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TAODTransition":
+        """Reconstruct from a :meth:`to_dict` payload.
+
+        Round-trip lossless on all fields. ``at`` is parsed via
+        :meth:`datetime.fromisoformat`; ``reason`` defaults to ``None``
+        when absent (mirrors the rs serde-skip-if-none semantics).
+        """
+        if not isinstance(data, dict):
+            raise TypeError(
+                "TAODTransition.from_dict requires a dict; got "
+                f"{type(data).__name__}"
+            )
+        for required in ("from_phase", "to_phase", "at"):
+            if required not in data:
+                raise ValueError(
+                    f"TAODTransition.from_dict missing required field {required!r}"
+                )
+        at_raw = data["at"]
+        if not isinstance(at_raw, str):
+            raise TypeError(
+                "TAODTransition.from_dict 'at' MUST be an ISO-8601 str; got "
+                f"{type(at_raw).__name__}"
+            )
+        return cls(
+            from_phase=data["from_phase"],
+            to_phase=data["to_phase"],
+            at=datetime.fromisoformat(at_raw),
+            reason=data.get("reason"),
+        )
+
+
+# Phases that admit no further transitions (terminal). Module-level
+# constant so it does NOT become an init=False dataclass field (which
+# would conflict with frozen + slots and add per-instance storage).
+_TERMINAL_PHASES: frozenset[str] = frozenset({"completed", "failed"})
+
+# Legal successor map per phase. Module-level constant; one structural
+# contract; tests pin every edge.
+_LEGAL_SUCCESSORS: dict[str, frozenset[str]] = {
+    "initiated": frozenset({"thinking", "failed"}),
+    "thinking": frozenset({"acting", "failed"}),
+    "acting": frozenset({"observing", "failed"}),
+    "observing": frozenset({"deciding", "completed", "failed"}),
+    "deciding": frozenset({"completed", "failed"}),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class TAODState:
+    """The TAOD lifecycle state for one runtime execution.
+
+    Mirrors rs ``TaodState`` struct (S6 substrate). Frozen + slots — a
+    state transition produces a NEW :class:`TAODState` (the runtime
+    holds the latest internally; the
+    :class:`RuntimeExecutionResult` carries the final state).
+    Append-only :attr:`transitions` are the audit-of-audit: every
+    state mutation MUST be reflected as a transition entry.
+
+    The phase axis follows the CARE Mirror Thesis TAOD lifecycle:
+
+    - ``initiated`` — entry state; no work attempted yet.
+    - ``thinking`` — read posture + plan dispatch.
+    - ``acting`` — invoke the dispatch surface.
+    - ``observing`` — cross-validate the dispatch result.
+    - ``deciding`` — process a decision-required result.
+    - ``completed`` — terminal success.
+    - ``failed`` — terminal failure (any phase error).
+
+    Attributes:
+        phase: The current phase. Once ``completed`` or ``failed``, the
+            state is terminal — :meth:`advance_to` raises on further
+            transitions (Invariant 1).
+        started_at: tz-aware UTC datetime the state machine entered
+            ``initiated``.
+        transitions: Append-only tuple of every phase transition (with
+            timestamps + optional reasons).
+    """
+
+    phase: TAODPhase
+    started_at: datetime
+    transitions: tuple[TAODTransition, ...] = ()
+
+    def __post_init__(self) -> None:
+        # Cannot validate against the Literal type at runtime — the
+        # union's members are strings — so re-derive the allowlist
+        # explicitly. Drift between this set and TAODPhase is a typed
+        # contract that the unit tests pin.
+        valid_phases = {
+            "initiated",
+            "thinking",
+            "acting",
+            "observing",
+            "deciding",
+            "completed",
+            "failed",
+        }
+        if self.phase not in valid_phases:
+            raise ValueError(
+                f"TAODState.phase {self.phase!r} is not a known TAODPhase "
+                f"(valid: {sorted(valid_phases)})"
+            )
+        if not isinstance(self.started_at, datetime):
+            raise TypeError(
+                "TAODState.started_at MUST be a datetime; got "
+                f"{type(self.started_at).__name__}"
+            )
+        if self.started_at.tzinfo is None:
+            raise ValueError(
+                "TAODState.started_at MUST be timezone-aware (naive "
+                "datetimes break cross-SDK wire-format parity)"
+            )
+        if not isinstance(self.transitions, tuple):
+            raise TypeError(
+                "TAODState.transitions MUST be a tuple; got "
+                f"{type(self.transitions).__name__}"
+            )
+        for t in self.transitions:
+            if not isinstance(t, TAODTransition):
+                raise TypeError(
+                    "TAODState.transitions entries MUST be TAODTransition; "
+                    f"got {type(t).__name__}"
+                )
+
+    @property
+    def is_terminal(self) -> bool:
+        """True iff the state is in a terminal phase (``completed`` /
+        ``failed``).
+
+        Used by :meth:`advance_to` to enforce Invariant 1 (phase
+        monotonicity — once terminal, no further transitions accepted).
+        """
+        return self.phase in _TERMINAL_PHASES
+
+    def advance_to(
+        self,
+        next_phase: TAODPhase,
+        *,
+        reason: str | None = None,
+        at: datetime | None = None,
+    ) -> "TAODState":
+        """Return a NEW :class:`TAODState` advanced to ``next_phase``.
+
+        Append-only — Invariant 1 (phase monotonicity). Raises
+        :class:`RuntimePhaseError` if the current phase is already
+        terminal (``completed`` / ``failed``).
+
+        Per the TAOD machine definition, the LEGAL successor set per
+        phase is enumerated below. Any other transition raises.
+
+        Args:
+            next_phase: The phase to advance to.
+            reason: Optional reason recorded on the
+                :class:`TAODTransition`; required on FAILED transitions
+                so post-incident analysis can attribute the failure.
+            at: Optional tz-aware datetime; defaults to
+                ``datetime.now(timezone.utc)``.
+
+        Returns:
+            A NEW :class:`TAODState` with the advanced phase and the
+            appended transition.
+
+        Raises:
+            RuntimePhaseError: terminal-state transition attempt OR
+                illegal successor for the current phase.
+        """
+        if self.is_terminal:
+            raise RuntimePhaseError(
+                f"TAODState is terminal (phase={self.phase!r}); no further "
+                f"transitions accepted (Invariant 1 — phase monotonicity). "
+                f"Attempted next_phase={next_phase!r}."
+            )
+        legal_successors = _LEGAL_SUCCESSORS.get(self.phase, frozenset())
+        if next_phase not in legal_successors:
+            raise RuntimePhaseError(
+                f"Illegal TAOD transition from {self.phase!r} to "
+                f"{next_phase!r}; legal successors: "
+                f"{sorted(legal_successors)}"
+            )
+        at_resolved = at if at is not None else datetime.now(timezone.utc)
+        transition = TAODTransition(
+            from_phase=self.phase,
+            to_phase=next_phase,
+            at=at_resolved,
+            reason=reason,
+        )
+        return TAODState(
+            phase=next_phase,
+            started_at=self.started_at,
+            transitions=self.transitions + (transition,),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-canonical dict (cross-SDK wire-format).
+
+        Mirrors rs ``TaodState`` serde encoding. ``started_at`` is
+        ISO-8601 UTC; ``transitions`` is a list (not tuple) for JSON
+        compatibility.
+        """
+        return {
+            "phase": self.phase,
+            "started_at": self.started_at.isoformat(),
+            "transitions": [t.to_dict() for t in self.transitions],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TAODState":
+        """Reconstruct from a :meth:`to_dict` payload.
+
+        Round-trip lossless on all fields. The phase value is validated
+        against the legal phase allowlist via ``__post_init__``.
+        """
+        if not isinstance(data, dict):
+            raise TypeError(
+                "TAODState.from_dict requires a dict; got " f"{type(data).__name__}"
+            )
+        for required in ("phase", "started_at", "transitions"):
+            if required not in data:
+                raise ValueError(
+                    f"TAODState.from_dict missing required field {required!r}"
+                )
+        started_raw = data["started_at"]
+        if not isinstance(started_raw, str):
+            raise TypeError(
+                "TAODState.from_dict 'started_at' MUST be an ISO-8601 str; "
+                f"got {type(started_raw).__name__}"
+            )
+        transitions_raw = data["transitions"]
+        if not isinstance(transitions_raw, (list, tuple)):
+            raise TypeError(
+                "TAODState.from_dict 'transitions' MUST be a list/tuple; got "
+                f"{type(transitions_raw).__name__}"
+            )
+        return cls(
+            phase=data["phase"],
+            started_at=datetime.fromisoformat(started_raw),
+            transitions=tuple(TAODTransition.from_dict(t) for t in transitions_raw),
+        )
+
+
+# ---------------------------------------------------------------------------
+# RuntimeExecutionResult — the spine's return value
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeExecutionResult:
+    """The result of one :meth:`DelegateRuntime.execute` call.
+
+    Mirrors rs ``RuntimeExecutionResult`` struct (S6 substrate). The
+    :meth:`to_dict` / :meth:`from_dict` round-trip is the cross-SDK
+    receipt contract — both SDKs MUST produce byte-identical payloads
+    for identical input under identical envelopes (per
+    ``cross-sdk-inspection.md`` Rule 4).
+
+    Frozen + slots per the S3/S4/S5 dataclass conventions. Returned by
+    :meth:`DelegateRuntime.execute` on every code path (success,
+    posture-blocked, composition-failed). Failure paths populate
+    :attr:`dispatch_result` with ``None`` and the :attr:`taod_state`
+    with a transition trail ending in ``failed``.
+
+    Attributes:
+        run_id: Unique UUID for this execution. Cryptographically bound
+            into every audit event the runtime emits (Invariant 3).
+            Generated from :func:`secrets.token_bytes` per security best
+            practice (NOT :func:`uuid.uuid4` which uses the
+            non-cryptographic ``random`` module).
+        dispatch_result: The :class:`DispatchResult` from the bound
+            DispatchSurface. ``None`` when execution failed before the
+            ACTING phase produced a result (posture-blocked,
+            composition-failed, validation-failed).
+        taod_state: The final :class:`TAODState`, including the full
+            transition trail. A reader can replay the run's TAOD
+            history from this single attribute.
+        audit_head_hash: SHA-256 hex of the audit chain's head entry
+            AFTER execution completed. ``None`` ONLY when the runtime
+            failed before emitting any audit event (e.g. composition
+            failure). Used by downstream receipt construction to anchor
+            the run into the broader chain-of-custody.
+        terminated_at: tz-aware UTC datetime the runtime returned
+            control to the caller (success or failure).
+        posture_at_execute: The :class:`Posture` the runtime ran under
+            for this execute() call. Captured at THINKING phase entry
+            (Invariant 2 — posture is read at execute time, not at
+            bind time).
+    """
+
+    run_id: uuid.UUID
+    dispatch_result: DispatchResult | None
+    taod_state: TAODState
+    audit_head_hash: str | None
+    terminated_at: datetime
+    posture_at_execute: Posture
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.run_id, uuid.UUID):
+            raise TypeError(
+                "RuntimeExecutionResult.run_id MUST be a uuid.UUID; got "
+                f"{type(self.run_id).__name__}"
+            )
+        if self.dispatch_result is not None and not isinstance(
+            self.dispatch_result, DispatchResult
+        ):
+            raise TypeError(
+                "RuntimeExecutionResult.dispatch_result MUST be a "
+                f"DispatchResult or None; got {type(self.dispatch_result).__name__}"
+            )
+        if not isinstance(self.taod_state, TAODState):
+            raise TypeError(
+                "RuntimeExecutionResult.taod_state MUST be a TAODState; got "
+                f"{type(self.taod_state).__name__}"
+            )
+        if self.audit_head_hash is not None and not isinstance(
+            self.audit_head_hash, str
+        ):
+            raise TypeError(
+                "RuntimeExecutionResult.audit_head_hash MUST be str or None; "
+                f"got {type(self.audit_head_hash).__name__}"
+            )
+        if not isinstance(self.terminated_at, datetime):
+            raise TypeError(
+                "RuntimeExecutionResult.terminated_at MUST be a datetime; got "
+                f"{type(self.terminated_at).__name__}"
+            )
+        if self.terminated_at.tzinfo is None:
+            raise ValueError(
+                "RuntimeExecutionResult.terminated_at MUST be timezone-aware "
+                "(naive datetimes break cross-SDK wire-format parity)"
+            )
+        if not isinstance(self.posture_at_execute, Posture):
+            raise TypeError(
+                "RuntimeExecutionResult.posture_at_execute MUST be a Posture; "
+                f"got {type(self.posture_at_execute).__name__}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-canonical dict (cross-SDK wire-format).
+
+        Mirrors rs ``RuntimeExecutionResult`` serde encoding. ``run_id``
+        is the canonical UUID string; ``dispatch_result`` is None or
+        the nested DispatchResult dict; ``audit_head_hash`` is None or
+        the hex string; ``posture_at_execute`` is the enum string value.
+        """
+        return {
+            "run_id": str(self.run_id),
+            "dispatch_result": (
+                self.dispatch_result.to_dict()
+                if self.dispatch_result is not None
+                else None
+            ),
+            "taod_state": self.taod_state.to_dict(),
+            "audit_head_hash": self.audit_head_hash,
+            "terminated_at": self.terminated_at.isoformat(),
+            "posture_at_execute": self.posture_at_execute.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RuntimeExecutionResult":
+        """Reconstruct from a :meth:`to_dict` payload.
+
+        Round-trip lossless on all fields. ``run_id`` parsed via
+        :class:`uuid.UUID`; ``dispatch_result`` reconstructed via
+        :meth:`DispatchResult.from_dict` when non-None;
+        ``posture_at_execute`` validated against the
+        :class:`Posture` enum.
+        """
+        if not isinstance(data, dict):
+            raise TypeError(
+                "RuntimeExecutionResult.from_dict requires a dict; got "
+                f"{type(data).__name__}"
+            )
+        for required in (
+            "run_id",
+            "dispatch_result",
+            "taod_state",
+            "audit_head_hash",
+            "terminated_at",
+            "posture_at_execute",
+        ):
+            if required not in data:
+                raise ValueError(
+                    f"RuntimeExecutionResult.from_dict missing required field "
+                    f"{required!r}"
+                )
+        dispatch_raw = data["dispatch_result"]
+        dispatch_result = (
+            DispatchResult.from_dict(dispatch_raw) if dispatch_raw is not None else None
+        )
+        terminated_raw = data["terminated_at"]
+        if not isinstance(terminated_raw, str):
+            raise TypeError(
+                "RuntimeExecutionResult.from_dict 'terminated_at' MUST be an "
+                f"ISO-8601 str; got {type(terminated_raw).__name__}"
+            )
+        return cls(
+            run_id=uuid.UUID(data["run_id"]),
+            dispatch_result=dispatch_result,
+            taod_state=TAODState.from_dict(data["taod_state"]),
+            audit_head_hash=data["audit_head_hash"],
+            terminated_at=datetime.fromisoformat(terminated_raw),
+            posture_at_execute=Posture(data["posture_at_execute"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# R2Composition — composition validator (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+class R2Composition:
+    """Validator for the R2 (Reasoning + Reliability) composition contract.
+
+    Mirrors rs ``R2Composition`` (S6 substrate). The R2 gate validates
+    that (envelope, cascade, dispatch_surface) form a consistent triplet
+    AND that audit_engine + dispatch_surface share the SAME signer
+    reference object (``is`` check, not ``==``; signature forgery
+    defense per Invariant 6).
+
+    Called once at :meth:`DelegateRuntime.__init__` AND again at every
+    :meth:`DelegateRuntime.execute` start (defense-in-depth per the S5
+    C4-1 pattern — a component reconstructed externally between the two
+    cannot silently break the composition).
+
+    Per ``orphan-detection.md`` Rule 1 this validator is the framework's
+    R2 gate; the runtime calls it directly — no further indirection.
+    """
+
+    @staticmethod
+    def validate(
+        *,
+        envelope: DelegateConstraintEnvelope,
+        cascade: TenantScopedCascade,
+        dispatch_surface: DispatchSurface,
+        audit_engine: AuditChainEngine,
+        signer: Callable[[bytes], str],
+    ) -> None:
+        """Validate the R2 composition triplet + signer identity.
+
+        Raises:
+            R2CompositionError: tenant scope mismatch, envelope-swap
+                detected (post-bind identity inequality), signer
+                identity mismatch between audit_engine and
+                dispatch_surface.
+            TypeError: any argument fails its isinstance check.
+        """
+        if not isinstance(envelope, DelegateConstraintEnvelope):
+            raise TypeError(
+                "R2Composition.validate(envelope) MUST be a "
+                f"DelegateConstraintEnvelope; got {type(envelope).__name__}"
+            )
+        if not isinstance(cascade, TenantScopedCascade):
+            raise TypeError(
+                "R2Composition.validate(cascade) MUST be a "
+                f"TenantScopedCascade; got {type(cascade).__name__}"
+            )
+        if not isinstance(dispatch_surface, DispatchSurface):
+            raise TypeError(
+                "R2Composition.validate(dispatch_surface) MUST be a "
+                f"DispatchSurface; got {type(dispatch_surface).__name__}"
+            )
+        if not isinstance(audit_engine, AuditChainEngine):
+            raise TypeError(
+                "R2Composition.validate(audit_engine) MUST be an "
+                f"AuditChainEngine; got {type(audit_engine).__name__}"
+            )
+        if not callable(signer):
+            raise TypeError(
+                "R2Composition.validate(signer) MUST be callable; got "
+                f"{type(signer).__name__}"
+            )
+
+        # Envelope identity check — defense against post-bind envelope
+        # swap. The DispatchSurface's bound envelope MUST be the same
+        # object as the runtime's envelope (`is` check). A value-equal
+        # but distinct envelope is the substitution attack this guard
+        # closes (R2-substrate finding).
+        if dispatch_surface.envelope is not envelope:
+            raise R2CompositionError(
+                "R2 composition mismatch: dispatch_surface.envelope is not "
+                "the same object as the runtime's envelope; an envelope "
+                "swap between bind and execute is forbidden (Invariant 4 — "
+                "R2 composition gate)"
+            )
+
+        # Tenant scope alignment — envelope's genesis_id-derived scope
+        # must match the cascade's tenant scope. The current envelope
+        # primitive carries only genesis_id (no explicit tenant scope
+        # field — see envelope.py); the cascade is the authoritative
+        # tenant anchor. Cross-check via the DispatchSurface's bound
+        # cascade reference: it MUST be the same object as the runtime's
+        # cascade.
+        if dispatch_surface.trust_cascade is not cascade:
+            raise R2CompositionError(
+                "R2 composition mismatch: dispatch_surface.trust_cascade is "
+                "not the same object as the runtime's cascade; a cascade "
+                "swap between bind and execute is forbidden (Invariant 4 — "
+                "R2 composition gate)"
+            )
+
+        # Cascade tenant scope structural sanity — both Global and
+        # Tenant variants are valid; the runtime accepts either as long
+        # as the cascade and dispatch_surface agree (checked above).
+        # The redundant isinstance check below catches the case where
+        # the cascade's tenant attribute was externally replaced with
+        # a non-TenantScope object (sub-microsecond cost; structural
+        # defense against external mutation of the cascade post-bind).
+        if not isinstance(cascade.tenant, TenantScope):
+            raise R2CompositionError(
+                "R2 composition mismatch: cascade.tenant is not a "
+                f"TenantScope; got {type(cascade.tenant).__name__} (cascade "
+                "tenant axis corrupted between bind and execute)"
+            )
+
+        # Signer identity check (Invariant 6) — the audit_engine and
+        # the dispatch_surface MUST share the same signer reference.
+        # `is` is the load-bearing check: two distinct callables with
+        # value-identical output STILL constitute signature forgery if
+        # one of them was substituted post-bind. The DispatchSurface
+        # holds its signer at `_signer`; AuditChainEngine does not
+        # itself hold a signer (signer is per-emission by the dispatch
+        # path), so the check reduces to "dispatch_surface._signer is
+        # signer" — the runtime-provided signer MUST be the same object
+        # as the dispatch surface's signer.
+        if dispatch_surface._signer is not signer:
+            raise R2CompositionError(
+                "R2 composition mismatch: dispatch_surface signer is not "
+                "the same object as the runtime's signer; signer drift "
+                "between bind and execute is signature forgery against the "
+                "audit trail (Invariant 6 — signer identity)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# DelegateRuntime — the spine
+# ---------------------------------------------------------------------------
+
+
+def _generate_run_id() -> uuid.UUID:
+    """Generate a UUID4 backed by :mod:`secrets`, not :mod:`random`.
+
+    Per ``rules/security.md`` (no hardcoded weak randomness). The
+    stdlib's :func:`uuid.uuid4` historically uses :func:`os.urandom`
+    (which IS cryptographically strong) — but we route through
+    :func:`secrets.token_bytes` to make the cryptographic-strength
+    guarantee explicit and audit-grep-able. The byte layout is the
+    standard UUID4 RFC 4122 § 4.1.3 representation: 16 bytes with the
+    version + variant bits set.
+    """
+    raw = bytearray(secrets.token_bytes(16))
+    # Set version 4 (bits 12-15 of clock_seq_hi_and_reserved → 0100).
+    raw[6] = (raw[6] & 0x0F) | 0x40
+    # Set variant RFC 4122 (bits 6-7 of clock_seq_hi_and_reserved → 10).
+    raw[8] = (raw[8] & 0x3F) | 0x80
+    return uuid.UUID(bytes=bytes(raw))
+
+
+class DelegateRuntime:
+    """The TAOD runtime spine that composes Delegate primitives.
+
+    Cross-impl parity: Mirrors rs ``DelegateRuntime`` struct (S6
+    substrate). The TAOD phase order, the per-phase audit event types,
+    the R2 composition contract, and the Posture gating semantics admit
+    cross-SDK ``receipts_agree(rs, py)`` verification at S7+.
+
+    Per ``facade-manager-detection.md`` MUST Rule 3, every dependency is
+    an EXPLICIT constructor parameter — no global lookup, no
+    self-construction. Per ``orphan-detection.md`` MUST Rule 1, this
+    runtime IS the framework hot path that calls
+    :meth:`DispatchSurface.dispatch` directly — there is no further
+    indirection.
+
+    Args:
+        dispatch_surface: The bound :class:`DispatchSurface` (S5). The
+            runtime delegates the ACTING phase to this surface.
+        audit_engine: The :class:`AuditChainEngine` (S4) that records
+            every TAOD transition with run_id-bound payloads.
+        cascade: The :class:`TenantScopedCascade` (S3) that anchors
+            tenant isolation. MUST be the SAME object as the dispatch
+            surface's bound cascade (R2 composition).
+        envelope: The :class:`DelegateConstraintEnvelope` (S2.5). MUST
+            be the SAME object as the dispatch surface's bound envelope
+            (R2 composition).
+        identity: The :class:`DelegateIdentity` (S2) flowing into every
+            audit event as the signer identity.
+        signer: Callable ``(canonical_bytes) -> hex_str`` producing
+            Ed25519 hex signatures. MUST be the SAME object as the
+            dispatch surface's bound signer (Invariant 6).
+        posture: The starting :class:`Posture` for this runtime. Default
+            :attr:`Posture.L5_DELEGATED`. Posture is read at execute()
+            THINKING phase, so it can be mutated via
+            :meth:`with_posture` between executions.
+
+    Raises:
+        RuntimeCompositionError: identity/cascade/envelope composition
+            contract violation (e.g. identity.principal_id is not
+            grantable per the cascade — see note below).
+        R2CompositionError: R2 validation failed (envelope/cascade/signer
+            identity mismatch).
+        TypeError: any argument fails its isinstance check.
+
+    Note on identity/cascade gateability: the current
+    :class:`TenantScopedCascade` (S3) does not yet expose a persistent
+    grantee registry (S3 emits one :class:`GrantMoment` per
+    ``cascade_child`` call but does not retain the grantee set). The
+    bind-time check here re-uses the DispatchSurface's bind-time
+    invariant — DispatchSurface already validated identity-cascade
+    consistency at S5; the runtime trusts that gate. A future S7+
+    enhancement will surface a grantee registry; the runtime's
+    bind-time check will tighten to use it.
+    """
+
+    # Per-phase audit event mapping. Each TAOD transition emits exactly
+    # one audit event (Invariant 3); this mapping is the contract. The
+    # event types are drawn from the S4 DelegateEventType allowlist
+    # (audit-visible variants only — REASONING_SCRATCHPAD excluded per
+    # the engine's gate).
+    _PHASE_EVENT_TYPES: dict[str, DelegateEventType] = {
+        "thinking": DelegateEventType.CONSTRAINT_DECISION,
+        "acting": DelegateEventType.EXTERNAL_SIDE_EFFECT,
+        "observing": DelegateEventType.CONSTRAINT_DECISION,
+        "deciding": DelegateEventType.GRANT_CONSUMPTION,
+        "completed": DelegateEventType.GRANT_CONSUMPTION,
+        "failed": DelegateEventType.POSTURE_OR_SOVEREIGN_HANDOVER,
+    }
+
+    def __init__(
+        self,
+        *,
+        dispatch_surface: DispatchSurface,
+        audit_engine: AuditChainEngine,
+        cascade: TenantScopedCascade,
+        envelope: DelegateConstraintEnvelope,
+        identity: DelegateIdentity,
+        signer: Callable[[bytes], str],
+        posture: Posture = Posture.L5_DELEGATED,
+    ) -> None:
+        # Type discipline at the boundary — defense-in-depth on top of
+        # each composed type's own post_init.
+        if not isinstance(dispatch_surface, DispatchSurface):
+            raise TypeError(
+                "DelegateRuntime.dispatch_surface MUST be a DispatchSurface; "
+                f"got {type(dispatch_surface).__name__}"
+            )
+        if not isinstance(audit_engine, AuditChainEngine):
+            raise TypeError(
+                "DelegateRuntime.audit_engine MUST be an AuditChainEngine; "
+                f"got {type(audit_engine).__name__}"
+            )
+        if not isinstance(cascade, TenantScopedCascade):
+            raise TypeError(
+                "DelegateRuntime.cascade MUST be a TenantScopedCascade; got "
+                f"{type(cascade).__name__}"
+            )
+        if not isinstance(envelope, DelegateConstraintEnvelope):
+            raise TypeError(
+                "DelegateRuntime.envelope MUST be a DelegateConstraintEnvelope; "
+                f"got {type(envelope).__name__}"
+            )
+        if not isinstance(identity, DelegateIdentity):
+            raise TypeError(
+                "DelegateRuntime.identity MUST be a DelegateIdentity; got "
+                f"{type(identity).__name__}"
+            )
+        if not callable(signer):
+            raise TypeError(
+                "DelegateRuntime.signer MUST be callable; got "
+                f"{type(signer).__name__}"
+            )
+        if not isinstance(posture, Posture):
+            raise TypeError(
+                f"DelegateRuntime.posture MUST be a Posture; got "
+                f"{type(posture).__name__}"
+            )
+
+        # R2 composition validation at construction (Invariant 4 —
+        # part 1 of defense-in-depth; part 2 is the re-check at
+        # execute() start).
+        R2Composition.validate(
+            envelope=envelope,
+            cascade=cascade,
+            dispatch_surface=dispatch_surface,
+            audit_engine=audit_engine,
+            signer=signer,
+        )
+
+        # Identity-cascade consistency (the runtime composition
+        # contract). DispatchSurface already validated capability +
+        # lifecycle at bind; the runtime confirms the dispatch surface's
+        # identity is the SAME object as the runtime's identity (no
+        # silent identity swap between bind and execute).
+        if dispatch_surface.identity is not identity:
+            raise RuntimeCompositionError(
+                "Runtime composition mismatch: dispatch_surface.identity is "
+                "not the same object as the runtime's identity; identity "
+                "swap between bind and execute is BLOCKED."
+            )
+
+        self._dispatch_surface = dispatch_surface
+        self._audit_engine = audit_engine
+        self._cascade = cascade
+        self._envelope = envelope
+        self._identity = identity
+        self._signer = signer
+        self._posture = posture
+
+    @property
+    def posture(self) -> Posture:
+        """Borrow the current :class:`Posture` (read-only)."""
+        return self._posture
+
+    @property
+    def dispatch_surface(self) -> DispatchSurface:
+        """Borrow the bound :class:`DispatchSurface` (read-only)."""
+        return self._dispatch_surface
+
+    @property
+    def audit_engine(self) -> AuditChainEngine:
+        """Borrow the bound :class:`AuditChainEngine` (read-only)."""
+        return self._audit_engine
+
+    @property
+    def cascade(self) -> TenantScopedCascade:
+        """Borrow the bound :class:`TenantScopedCascade` (read-only)."""
+        return self._cascade
+
+    @property
+    def envelope(self) -> DelegateConstraintEnvelope:
+        """Borrow the bound :class:`DelegateConstraintEnvelope` (read-only)."""
+        return self._envelope
+
+    @property
+    def identity(self) -> DelegateIdentity:
+        """Borrow the bound :class:`DelegateIdentity` (read-only)."""
+        return self._identity
+
+    def with_posture(
+        self,
+        posture: Posture,
+        *,
+        human_acknowledged_nonce: str | None = None,
+    ) -> "DelegateRuntime":
+        """Return a NEW runtime with the posture changed.
+
+        Per Invariant 5: downgrades (lower rank) are accepted silently;
+        upgrades (higher rank) require an explicit
+        ``human_acknowledged_nonce`` per ``rules/trust-posture.md``
+        MUST Rule 3.
+
+        Args:
+            posture: The new :class:`Posture` to bind.
+            human_acknowledged_nonce: Required for upgrades. The runtime
+                does NOT validate the nonce against any registry here —
+                the SessionStart hook owns nonce issuance + validation
+                (S8 scope). The runtime's check is purely STRUCTURAL:
+                an upgrade MUST be paired with a non-empty nonce string.
+
+        Returns:
+            A NEW :class:`DelegateRuntime` with the changed posture,
+            preserving all other bindings.
+
+        Raises:
+            RuntimePostureBlockedError: upgrade attempted without a
+                non-empty ``human_acknowledged_nonce``.
+            TypeError: ``posture`` is not a :class:`Posture` value.
+        """
+        if not isinstance(posture, Posture):
+            raise TypeError(
+                f"with_posture(posture) MUST be a Posture; got "
+                f"{type(posture).__name__}"
+            )
+        # Distinguish downgrades from upgrades by rank. Equal rank
+        # (same posture) is a no-op upgrade (rank delta zero) and is
+        # admitted without a nonce.
+        if posture._rank > self._posture._rank:
+            if not human_acknowledged_nonce:
+                raise RuntimePostureBlockedError(
+                    f"Posture upgrade {self._posture.value!r} → "
+                    f"{posture.value!r} requires human_acknowledged_nonce "
+                    "(rules/trust-posture.md MUST Rule 3); downgrades are "
+                    "silent, upgrades are gated"
+                )
+        return DelegateRuntime(
+            dispatch_surface=self._dispatch_surface,
+            audit_engine=self._audit_engine,
+            cascade=self._cascade,
+            envelope=self._envelope,
+            identity=self._identity,
+            signer=self._signer,
+            posture=posture,
+        )
+
+    async def execute(self, input_payload: dict[str, Any]) -> RuntimeExecutionResult:
+        """Execute one TAOD lifecycle pass.
+
+        Sequence:
+
+        1. INITIATED — allocate run_id, build initial TAODState.
+        2. R2 composition re-check (Invariant 4 — defense-in-depth).
+        3. THINKING — read posture; ``HALT`` refuses, otherwise advance.
+        4. ACTING — invoke ``dispatch_surface.dispatch(input_payload)``;
+           catch dispatch errors → FAILED.
+        5. OBSERVING — cross-validate dispatch result; emit audit.
+        6. DECIDING — if payload signals ``_decision_required: True``,
+           process; else skip to COMPLETED.
+        7. COMPLETED — emit final audit; build RuntimeExecutionResult.
+
+        Every TAOD transition emits exactly one audit event (Invariant
+        3) with the run_id bound into its payload.
+
+        Args:
+            input_payload: The dispatch input. Forwarded verbatim to
+                :meth:`DispatchSurface.dispatch`.
+
+        Returns:
+            A :class:`RuntimeExecutionResult` carrying run_id +
+            dispatch_result (or None on failure) + final TAODState +
+            audit head hash + termination timestamp + posture.
+
+        Raises:
+            No exception propagates from execute() — every failure
+            path returns a :class:`RuntimeExecutionResult` with
+            ``taod_state.phase == "failed"`` and ``dispatch_result is
+            None``. The error class + message live on the FAILED
+            transition's ``reason`` field.
+        """
+        run_id = _generate_run_id()
+        started_at = datetime.now(timezone.utc)
+        state = TAODState(phase="initiated", started_at=started_at)
+        posture_at_execute = self._posture
+
+        # Step 2 — R2 composition re-check at execute() start.
+        # Defense-in-depth: a component reconstructed externally between
+        # __init__ and execute() must not silently break the
+        # composition (Invariant 4 part 2).
+        try:
+            R2Composition.validate(
+                envelope=self._envelope,
+                cascade=self._cascade,
+                dispatch_surface=self._dispatch_surface,
+                audit_engine=self._audit_engine,
+                signer=self._signer,
+            )
+        except (R2CompositionError, TypeError) as exc:
+            # Composition failure means we cannot emit ANY audit event
+            # (signer/audit binding may be the broken thing). Transition
+            # to FAILED without an audit emit and return.
+            failed_state = state.advance_to(
+                "failed",
+                reason=f"R2 composition re-check failed: "
+                f"{type(exc).__name__}: {exc}",
+            )
+            return self._build_result(
+                run_id=run_id,
+                dispatch_result=None,
+                taod_state=failed_state,
+                posture_at_execute=posture_at_execute,
+                emit_audit=False,
+            )
+
+        # Step 3 — INITIATED → THINKING.
+        state = state.advance_to("thinking")
+        self._emit_phase_audit(
+            run_id=run_id,
+            phase="thinking",
+            extra_payload={"posture": posture_at_execute.value},
+        )
+
+        # Posture gate (Invariant 2 — read at THINKING phase).
+        if posture_at_execute is Posture.HALT:
+            failed_state = state.advance_to(
+                "failed",
+                reason="posture HALT refuses execute()",
+            )
+            self._emit_phase_audit(
+                run_id=run_id,
+                phase="failed",
+                extra_payload={
+                    "reason": "posture_halt",
+                    "posture": posture_at_execute.value,
+                },
+            )
+            return self._build_result(
+                run_id=run_id,
+                dispatch_result=None,
+                taod_state=failed_state,
+                posture_at_execute=posture_at_execute,
+                emit_audit=False,  # already emitted above
+            )
+
+        # Step 4 — THINKING → ACTING. Invoke the dispatch surface;
+        # any exception transitions to FAILED.
+        state = state.advance_to("acting")
+        self._emit_phase_audit(
+            run_id=run_id,
+            phase="acting",
+            extra_payload={
+                "connector_id": self._dispatch_surface.connector.connector_id,
+            },
+        )
+
+        dispatch_result: DispatchResult | None
+        try:
+            dispatch_result = await self._dispatch_surface.dispatch(input_payload)
+        except Exception as exc:
+            # Dispatch failure — transition to FAILED. The dispatch
+            # surface already emitted its own audit events for any
+            # per-event work it completed before raising; the runtime
+            # records the FAILED phase explicitly with the exception
+            # class + message on the transition reason.
+            failed_state = state.advance_to(
+                "failed",
+                reason=f"dispatch raised: {type(exc).__name__}: {exc}",
+            )
+            self._emit_phase_audit(
+                run_id=run_id,
+                phase="failed",
+                extra_payload={
+                    "reason": "dispatch_error",
+                    "error_class": type(exc).__name__,
+                    "error_message": str(exc),
+                },
+            )
+            return self._build_result(
+                run_id=run_id,
+                dispatch_result=None,
+                taod_state=failed_state,
+                posture_at_execute=posture_at_execute,
+                emit_audit=False,
+            )
+
+        # Step 5 — ACTING → OBSERVING. Cross-validate tenant alignment
+        # between the dispatch result and the envelope. The dispatch
+        # surface already validated tenant isolation at the connector
+        # boundary (S5 Invariant 2); this is a defensive re-check at
+        # the runtime spine.
+        state = state.advance_to("observing")
+        cascade_tenant = self._cascade.tenant
+        expected_tenant = (
+            "" if cascade_tenant.is_global else (cascade_tenant.tenant_id or "")
+        )
+        if dispatch_result.tenant_id != expected_tenant:
+            failed_state = state.advance_to(
+                "failed",
+                reason=(
+                    f"runtime observe: tenant mismatch on dispatch result "
+                    f"(envelope cascade scope drifted vs dispatch surface)"
+                ),
+            )
+            self._emit_phase_audit(
+                run_id=run_id,
+                phase="failed",
+                extra_payload={
+                    "reason": "tenant_observe_mismatch",
+                    "expected_tenant_present": bool(expected_tenant),
+                },
+            )
+            return self._build_result(
+                run_id=run_id,
+                dispatch_result=dispatch_result,
+                taod_state=failed_state,
+                posture_at_execute=posture_at_execute,
+                emit_audit=False,
+            )
+
+        # Emit OBSERVING audit. The dispatch surface flagged whether
+        # the connector reported an external side effect; surface that
+        # in the runtime's observing event so the audit chain carries
+        # the full TAOD trail.
+        self._emit_phase_audit(
+            run_id=run_id,
+            phase="observing",
+            extra_payload={
+                "dispatch_id": str(dispatch_result.dispatch_id),
+                "connector_id": dispatch_result.connector_id,
+            },
+        )
+
+        # Step 6 — DECIDING (or skip to COMPLETED).
+        if dispatch_result.payload.get("_decision_required") is True:
+            state = state.advance_to("deciding")
+            self._emit_phase_audit(
+                run_id=run_id,
+                phase="deciding",
+                extra_payload={"dispatch_id": str(dispatch_result.dispatch_id)},
+            )
+
+        # Step 7 — terminal COMPLETED. Final audit emission.
+        state = state.advance_to("completed")
+        self._emit_phase_audit(
+            run_id=run_id,
+            phase="completed",
+            extra_payload={"dispatch_id": str(dispatch_result.dispatch_id)},
+        )
+
+        return self._build_result(
+            run_id=run_id,
+            dispatch_result=dispatch_result,
+            taod_state=state,
+            posture_at_execute=posture_at_execute,
+            emit_audit=False,
+        )
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    def _emit_phase_audit(
+        self,
+        *,
+        run_id: uuid.UUID,
+        phase: str,
+        extra_payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit one audit event for a TAOD phase transition.
+
+        Per Invariant 3, every transition produces exactly one audit
+        event. The run_id is bound into the payload so a post-incident
+        reader can replay every transition of a single run via the
+        audit chain.
+
+        The event type per phase is fixed by
+        :attr:`_PHASE_EVENT_TYPES`. The signature is computed via the
+        bound :attr:`_signer` over the canonical-JSON bytes of the
+        payload (mirrors the S5 dispatch path).
+        """
+        event_type = self._PHASE_EVENT_TYPES[phase]
+        payload: dict[str, Any] = {
+            "run_id": str(run_id),
+            "phase": phase,
+        }
+        if extra_payload:
+            payload.update(extra_payload)
+        canonical_bytes = canonical_json_dumps(payload).encode("utf-8")
+        signature = self._signer(canonical_bytes)
+        self._audit_engine.emit_event(
+            event_type=event_type.value,
+            payload=payload,
+            signer_identity=self._identity,
+            signature=signature,
+        )
+
+    def _build_result(
+        self,
+        *,
+        run_id: uuid.UUID,
+        dispatch_result: DispatchResult | None,
+        taod_state: TAODState,
+        posture_at_execute: Posture,
+        emit_audit: bool,
+    ) -> RuntimeExecutionResult:
+        """Construct the :class:`RuntimeExecutionResult` return value.
+
+        Captures the audit chain's head hash at the moment of return
+        (None when no audit events were emitted, e.g. composition
+        failure before THINKING). ``emit_audit`` is reserved for paths
+        that wish to emit a final terminal audit event before result
+        construction; currently all callers manage their own emissions
+        and pass ``emit_audit=False``.
+        """
+        # emit_audit reserved for future use (e.g. a unified terminal
+        # emit path); currently all caller-sites manage their own
+        # emissions for tighter control over per-failure payloads.
+        _ = emit_audit
+        head_hash = self._audit_engine.head_hash()
+        return RuntimeExecutionResult(
+            run_id=run_id,
+            dispatch_result=dispatch_result,
+            taod_state=taod_state,
+            audit_head_hash=head_hash,
+            terminated_at=datetime.now(timezone.utc),
+            posture_at_execute=posture_at_execute,
+        )

--- a/src/kailash/delegate/runtime.py
+++ b/src/kailash/delegate/runtime.py
@@ -105,6 +105,19 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
+# Minimum length for a structurally-acceptable posture-upgrade nonce.
+# The runtime's check is SYNTACTIC ONLY — cryptographic nonce validation
+# (single-use, signed by human authority, expiry) lives in SessionStart /
+# S8 nonce-registry integration. The length floor closes the trivial
+# truthy-string bypass surfaced at S6 Round 1 (C1): with no minimum, any
+# non-empty string (e.g. " ") satisfied the gate and produced a fake
+# safety property semantically indistinguishable from S5 C2-1 fake
+# authentication. 16 chars is the symmetric mirror of the rs reference's
+# minimum-length placeholder for the same gate; both sides converge on
+# the same floor so cross-SDK posture-rotation receipts remain comparable.
+_MIN_NONCE_LENGTH: int = 16
+
+
 class Posture(str, Enum):
     """Graduated autonomy posture per ``rules/trust-posture.md``.
 
@@ -1041,11 +1054,17 @@ class DelegateRuntime:
 
         Args:
             posture: The new :class:`Posture` to bind.
-            human_acknowledged_nonce: Required for upgrades. The runtime
-                does NOT validate the nonce against any registry here —
-                the SessionStart hook owns nonce issuance + validation
-                (S8 scope). The runtime's check is purely STRUCTURAL:
-                an upgrade MUST be paired with a non-empty nonce string.
+            human_acknowledged_nonce: Required for upgrades. The
+                runtime's nonce check is purely **SYNTACTIC**: it
+                rejects empty AND short (``< _MIN_NONCE_LENGTH`` = 16
+                chars) values only. Cryptographic nonce validation
+                (single-use, signed by human authority, expiry) is
+                **deferred to SessionStart / S8 nonce-registry
+                integration**; the runtime's gate is a structural
+                placeholder, NOT a cryptographic check. Callers MUST
+                treat this gate as the trivial-bypass closure (no
+                empty / one-char nonces) and rely on S8 to harden
+                against replayed-or-forged nonces.
 
         Returns:
             A NEW :class:`DelegateRuntime` with the changed posture,
@@ -1053,7 +1072,11 @@ class DelegateRuntime:
 
         Raises:
             RuntimePostureBlockedError: upgrade attempted without a
-                non-empty ``human_acknowledged_nonce``.
+                ``human_acknowledged_nonce`` of length
+                ``>= _MIN_NONCE_LENGTH`` (16) characters, OR audit
+                emission of the posture-rotation event failed (the
+                rotation is structurally invalid if it cannot be
+                audited).
             TypeError: ``posture`` is not a :class:`Posture` value.
         """
         if not isinstance(posture, Posture):
@@ -1065,13 +1088,61 @@ class DelegateRuntime:
         # (same posture) is a no-op upgrade (rank delta zero) and is
         # admitted without a nonce.
         if posture._rank > self._posture._rank:
-            if not human_acknowledged_nonce:
+            nonce_length = (
+                len(human_acknowledged_nonce) if human_acknowledged_nonce else 0
+            )
+            if nonce_length < _MIN_NONCE_LENGTH:
                 raise RuntimePostureBlockedError(
                     f"Posture upgrade {self._posture.value!r} → "
                     f"{posture.value!r} requires human_acknowledged_nonce "
-                    "(rules/trust-posture.md MUST Rule 3); downgrades are "
-                    "silent, upgrades are gated"
+                    f"of length >= {_MIN_NONCE_LENGTH} (got {nonce_length}); "
+                    "runtime's check is a SYNTACTIC placeholder — "
+                    "cryptographic validation lives in SessionStart/S8 "
+                    "nonce-registry integration (rules/trust-posture.md "
+                    "MUST Rule 3)"
                 )
+
+        # Emit a POSTURE_OR_SOVEREIGN_HANDOVER audit event on the
+        # SOURCE runtime's audit engine BEFORE returning the new
+        # runtime. Posture rotations (both upgrades AND downgrades)
+        # are security-relevant transitions: an attacker holding a
+        # legitimate L5_DELEGATED runtime that could call
+        # ``with_posture(L1)`` without an audit trail would leave the
+        # downgrade invisible to forensic correlation. Audit-before-
+        # rotate is the S6 R1 MED-1 fix; if the audit emission fails,
+        # the rotation is refused (structurally invalid: a rotation
+        # that cannot be audited cannot be trusted). This mirrors the
+        # S6 R1 A3/D1 emit-before-state-advance invariant applied to
+        # the posture transition surface.
+        rotation_payload = {
+            "rotation_id": str(uuid.UUID(bytes=secrets.token_bytes(16), version=4)),
+            "from_posture": self._posture.value,
+            "to_posture": posture.value,
+            "rank_delta": posture._rank - self._posture._rank,
+            "nonce_present": bool(human_acknowledged_nonce),
+        }
+        try:
+            canonical_bytes = canonical_json_dumps(rotation_payload).encode("utf-8")
+            signature = self._signer(canonical_bytes)
+            self._audit_engine.emit_event(
+                event_type=DelegateEventType.POSTURE_OR_SOVEREIGN_HANDOVER.value,
+                payload=rotation_payload,
+                signer_identity=self._identity,
+                signature=signature,
+            )
+        except Exception as audit_exc:
+            # The rotation MUST be observable; failing-closed here
+            # converts an unauditable rotation into a typed refusal
+            # the caller can catch and surface. Same severity class
+            # as the upgrade-without-nonce refusal — the rotation is
+            # structurally invalid.
+            raise RuntimePostureBlockedError(
+                f"Posture rotation {self._posture.value!r} → "
+                f"{posture.value!r} refused: audit-engine emit failed "
+                f"({type(audit_exc).__name__}); a rotation that cannot "
+                "be audited cannot be trusted"
+            ) from audit_exc
+
         return DelegateRuntime(
             dispatch_surface=self._dispatch_surface,
             audit_engine=self._audit_engine,
@@ -1151,26 +1222,62 @@ class DelegateRuntime:
             )
 
         # Step 3 — INITIATED → THINKING.
+        # Per S6 R1 A3/D1 fix: AUDIT FIRST, then advance state. If the
+        # audit emit raises (signer failure, JSON-serialization fault,
+        # I/O on the wrapped chain), the state MUST NOT advance — that
+        # leaves the chain authoritative and the in-memory state
+        # consistent with it. Falls back to a FAILED transition with a
+        # sanitized reason; the FAILED transition does NOT recurse into
+        # another audit emit (the audit subsystem itself just broke —
+        # see _advance_to_failed_no_audit).
+        try:
+            self._emit_phase_audit(
+                run_id=run_id,
+                phase="thinking",
+                extra_payload={"posture": posture_at_execute.value},
+            )
+        except Exception as audit_exc:
+            failed_state = self._advance_to_failed_no_audit(
+                state, phase="thinking", audit_exc=audit_exc
+            )
+            return self._build_result(
+                run_id=run_id,
+                dispatch_result=None,
+                taod_state=failed_state,
+                posture_at_execute=posture_at_execute,
+                emit_audit=False,
+            )
         state = state.advance_to("thinking")
-        self._emit_phase_audit(
-            run_id=run_id,
-            phase="thinking",
-            extra_payload={"posture": posture_at_execute.value},
-        )
 
         # Posture gate (Invariant 2 — read at THINKING phase).
         if posture_at_execute is Posture.HALT:
+            # FAILED-path: emit first, advance second. Sanitize the
+            # reason field per S6 R1 LOW-1 (to_dict observability) —
+            # the caller-facing TAOD reason carries the class/phase
+            # tag only; the full payload lives in the audit event.
+            try:
+                self._emit_phase_audit(
+                    run_id=run_id,
+                    phase="failed",
+                    extra_payload={
+                        "reason": "posture_halt",
+                        "posture": posture_at_execute.value,
+                    },
+                )
+            except Exception as audit_exc:
+                failed_state = self._advance_to_failed_no_audit(
+                    state, phase="thinking", audit_exc=audit_exc
+                )
+                return self._build_result(
+                    run_id=run_id,
+                    dispatch_result=None,
+                    taod_state=failed_state,
+                    posture_at_execute=posture_at_execute,
+                    emit_audit=False,
+                )
             failed_state = state.advance_to(
                 "failed",
                 reason="posture HALT refuses execute()",
-            )
-            self._emit_phase_audit(
-                run_id=run_id,
-                phase="failed",
-                extra_payload={
-                    "reason": "posture_halt",
-                    "posture": posture_at_execute.value,
-                },
             )
             return self._build_result(
                 run_id=run_id,
@@ -1180,38 +1287,69 @@ class DelegateRuntime:
                 emit_audit=False,  # already emitted above
             )
 
-        # Step 4 — THINKING → ACTING. Invoke the dispatch surface;
-        # any exception transitions to FAILED.
+        # Step 4 — THINKING → ACTING. Audit first, then advance.
+        try:
+            self._emit_phase_audit(
+                run_id=run_id,
+                phase="acting",
+                extra_payload={
+                    "connector_id": self._dispatch_surface.connector.connector_id,
+                },
+            )
+        except Exception as audit_exc:
+            failed_state = self._advance_to_failed_no_audit(
+                state, phase="acting", audit_exc=audit_exc
+            )
+            return self._build_result(
+                run_id=run_id,
+                dispatch_result=None,
+                taod_state=failed_state,
+                posture_at_execute=posture_at_execute,
+                emit_audit=False,
+            )
         state = state.advance_to("acting")
-        self._emit_phase_audit(
-            run_id=run_id,
-            phase="acting",
-            extra_payload={
-                "connector_id": self._dispatch_surface.connector.connector_id,
-            },
-        )
 
+        # Invoke the dispatch surface; any exception transitions to
+        # FAILED.
         dispatch_result: DispatchResult | None
         try:
             dispatch_result = await self._dispatch_surface.dispatch(input_payload)
         except Exception as exc:
-            # Dispatch failure — transition to FAILED. The dispatch
-            # surface already emitted its own audit events for any
-            # per-event work it completed before raising; the runtime
-            # records the FAILED phase explicitly with the exception
-            # class + message on the transition reason.
+            # Dispatch failure — emit FAILED audit first, then advance.
+            # Per S6 R1 LOW-1: the TAOD reason carries ONLY the class
+            # name + short phrase (sanitized for to_dict observability);
+            # the full exception message lives in the audit payload
+            # (signed + sized to forensic surface).
+            reason_sanitized = f"dispatch raised: {type(exc).__name__}"
+            try:
+                self._emit_phase_audit(
+                    run_id=run_id,
+                    phase="failed",
+                    extra_payload={
+                        "reason": "dispatch_error",
+                        "error_class": type(exc).__name__,
+                        "error_message": str(exc),
+                    },
+                )
+            except Exception as audit_exc:
+                # Audit subsystem broke AFTER dispatch raised — record
+                # FAILED without recursing into another audit attempt.
+                # The transition reason carries the audit-failure cause
+                # (dispatch failure remains in the original exc's
+                # chained traceback the caller may inspect).
+                failed_state = self._advance_to_failed_no_audit(
+                    state, phase="acting", audit_exc=audit_exc
+                )
+                return self._build_result(
+                    run_id=run_id,
+                    dispatch_result=None,
+                    taod_state=failed_state,
+                    posture_at_execute=posture_at_execute,
+                    emit_audit=False,
+                )
             failed_state = state.advance_to(
                 "failed",
-                reason=f"dispatch raised: {type(exc).__name__}: {exc}",
-            )
-            self._emit_phase_audit(
-                run_id=run_id,
-                phase="failed",
-                extra_payload={
-                    "reason": "dispatch_error",
-                    "error_class": type(exc).__name__,
-                    "error_message": str(exc),
-                },
+                reason=reason_sanitized,
             )
             return self._build_result(
                 run_id=run_id,
@@ -1225,27 +1363,40 @@ class DelegateRuntime:
         # between the dispatch result and the envelope. The dispatch
         # surface already validated tenant isolation at the connector
         # boundary (S5 Invariant 2); this is a defensive re-check at
-        # the runtime spine.
-        state = state.advance_to("observing")
+        # the runtime spine. Audit first, then advance.
         cascade_tenant = self._cascade.tenant
         expected_tenant = (
             "" if cascade_tenant.is_global else (cascade_tenant.tenant_id or "")
         )
         if dispatch_result.tenant_id != expected_tenant:
+            # Tenant mismatch — FAILED-path: emit first, advance second.
+            # Reason field already sanitized (no raw exception bleed).
+            try:
+                self._emit_phase_audit(
+                    run_id=run_id,
+                    phase="failed",
+                    extra_payload={
+                        "reason": "tenant_observe_mismatch",
+                        "expected_tenant_present": bool(expected_tenant),
+                    },
+                )
+            except Exception as audit_exc:
+                failed_state = self._advance_to_failed_no_audit(
+                    state, phase="acting", audit_exc=audit_exc
+                )
+                return self._build_result(
+                    run_id=run_id,
+                    dispatch_result=dispatch_result,
+                    taod_state=failed_state,
+                    posture_at_execute=posture_at_execute,
+                    emit_audit=False,
+                )
             failed_state = state.advance_to(
                 "failed",
                 reason=(
-                    f"runtime observe: tenant mismatch on dispatch result "
-                    f"(envelope cascade scope drifted vs dispatch surface)"
+                    "runtime observe: tenant mismatch on dispatch result "
+                    "(envelope cascade scope drifted vs dispatch surface)"
                 ),
-            )
-            self._emit_phase_audit(
-                run_id=run_id,
-                phase="failed",
-                extra_payload={
-                    "reason": "tenant_observe_mismatch",
-                    "expected_tenant_present": bool(expected_tenant),
-                },
             )
             return self._build_result(
                 run_id=run_id,
@@ -1255,35 +1406,72 @@ class DelegateRuntime:
                 emit_audit=False,
             )
 
-        # Emit OBSERVING audit. The dispatch surface flagged whether
-        # the connector reported an external side effect; surface that
-        # in the runtime's observing event so the audit chain carries
-        # the full TAOD trail.
-        self._emit_phase_audit(
-            run_id=run_id,
-            phase="observing",
-            extra_payload={
-                "dispatch_id": str(dispatch_result.dispatch_id),
-                "connector_id": dispatch_result.connector_id,
-            },
-        )
-
-        # Step 6 — DECIDING (or skip to COMPLETED).
-        if dispatch_result.payload.get("_decision_required") is True:
-            state = state.advance_to("deciding")
+        # Emit OBSERVING audit (first), then advance. The dispatch
+        # surface flagged whether the connector reported an external
+        # side effect; surface that in the runtime's observing event
+        # so the audit chain carries the full TAOD trail.
+        try:
             self._emit_phase_audit(
                 run_id=run_id,
-                phase="deciding",
+                phase="observing",
+                extra_payload={
+                    "dispatch_id": str(dispatch_result.dispatch_id),
+                    "connector_id": dispatch_result.connector_id,
+                },
+            )
+        except Exception as audit_exc:
+            failed_state = self._advance_to_failed_no_audit(
+                state, phase="acting", audit_exc=audit_exc
+            )
+            return self._build_result(
+                run_id=run_id,
+                dispatch_result=dispatch_result,
+                taod_state=failed_state,
+                posture_at_execute=posture_at_execute,
+                emit_audit=False,
+            )
+        state = state.advance_to("observing")
+
+        # Step 6 — DECIDING (or skip to COMPLETED). Audit first.
+        if dispatch_result.payload.get("_decision_required") is True:
+            try:
+                self._emit_phase_audit(
+                    run_id=run_id,
+                    phase="deciding",
+                    extra_payload={"dispatch_id": str(dispatch_result.dispatch_id)},
+                )
+            except Exception as audit_exc:
+                failed_state = self._advance_to_failed_no_audit(
+                    state, phase="observing", audit_exc=audit_exc
+                )
+                return self._build_result(
+                    run_id=run_id,
+                    dispatch_result=dispatch_result,
+                    taod_state=failed_state,
+                    posture_at_execute=posture_at_execute,
+                    emit_audit=False,
+                )
+            state = state.advance_to("deciding")
+
+        # Step 7 — terminal COMPLETED. Audit first, then advance.
+        try:
+            self._emit_phase_audit(
+                run_id=run_id,
+                phase="completed",
                 extra_payload={"dispatch_id": str(dispatch_result.dispatch_id)},
             )
-
-        # Step 7 — terminal COMPLETED. Final audit emission.
+        except Exception as audit_exc:
+            failed_state = self._advance_to_failed_no_audit(
+                state, phase=state.phase, audit_exc=audit_exc
+            )
+            return self._build_result(
+                run_id=run_id,
+                dispatch_result=dispatch_result,
+                taod_state=failed_state,
+                posture_at_execute=posture_at_execute,
+                emit_audit=False,
+            )
         state = state.advance_to("completed")
-        self._emit_phase_audit(
-            run_id=run_id,
-            phase="completed",
-            extra_payload={"dispatch_id": str(dispatch_result.dispatch_id)},
-        )
 
         return self._build_result(
             run_id=run_id,
@@ -1296,6 +1484,51 @@ class DelegateRuntime:
     # ------------------------------------------------------------------
     # internals
     # ------------------------------------------------------------------
+
+    def _advance_to_failed_no_audit(
+        self,
+        state: TAODState,
+        *,
+        phase: str,
+        audit_exc: BaseException,
+    ) -> TAODState:
+        """Advance to FAILED without recursing into another audit emit.
+
+        Per S6 R1 A3/D1: when ``_emit_phase_audit`` raises during a
+        TAOD transition, the state MUST land in FAILED — but the FAILED
+        transition itself MUST NOT attempt another audit emit (the
+        audit subsystem just broke; recursing would re-raise and never
+        produce a return value). This helper records the FAILED
+        transition with a sanitized reason naming the failure phase and
+        the audit-exception class — NOT the raw exception message
+        (per LOW-1 to_dict observability discipline).
+
+        The full ``str(audit_exc)`` is intentionally NOT included on
+        the TAOD reason field — it would leak audit-subsystem internals
+        (signer impl details, audit-chain implementation errors) into
+        the observable ``RuntimeExecutionResult.taod_state.to_dict()``
+        payload that downstream consumers read.
+
+        Args:
+            state: The current TAOD state (non-terminal). Must accept
+                a transition to "failed" (every non-terminal phase
+                does per ``_LEGAL_SUCCESSORS``).
+            phase: The phase whose audit emit just failed; surfaces
+                on the reason field so post-incident analysis can
+                attribute the audit failure to the correct transition.
+            audit_exc: The exception the audit emit raised; only the
+                class name lands on the reason field.
+
+        Returns:
+            A NEW TAODState advanced to "failed" with a sanitized
+            reason. No audit emit is attempted.
+        """
+        return state.advance_to(
+            "failed",
+            reason=(
+                f"audit emit failed at phase={phase!r}: " f"{type(audit_exc).__name__}"
+            ),
+        )
 
     def _emit_phase_audit(
         self,

--- a/tests/integration/delegate/test_runtime_wiring.py
+++ b/tests/integration/delegate/test_runtime_wiring.py
@@ -1,0 +1,355 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-2 integration test for ``DelegateRuntime`` end-to-end wiring.
+
+S6 #1035 — Tier-2 wiring test per ``facade-manager-detection.md`` MUST
+Rule 1 ("Every Manager-Shape Class Has a Tier 2 Test"):
+:class:`DelegateRuntime` composes ``DispatchSurface`` (S5) +
+``AuditChainEngine`` (S4) + ``TenantScopedCascade`` (S3) +
+``DelegateConstraintEnvelope`` (S2.5) + ``DelegateIdentity`` (S2) into
+the TAOD execution lifecycle.
+
+This test exercises the load-bearing wiring contract end-to-end:
+
+- A real ``TenantScopedCascade`` anchors tenant isolation.
+- A real ``AuditChainEngine`` (atop a real ``TrustLineageChain``)
+  receives the run_id-bound TAOD transition audit events.
+- A real ``DispatchSurface`` binds connector + signature + envelope +
+  identity per S5.
+- A real :class:`Connector` subclass produces real
+  :class:`ConnectorInvocationResult` records that flow through the
+  audit emission path.
+
+Tier classification: per ``rules/testing.md`` § "Protocol-Satisfying
+Deterministic Adapters" the :class:`Connector` subclasses below are NOT
+mocks — they satisfy the abstract surface deterministically. Every
+substrate dependency (chain, engine, cascade, envelope, identity) is a
+real instance, no mocks.
+
+Mirrors rs kailash-delegate-runtime substrate. The end-to-end audit
+chain produced here is the byte-canonical fixture shape S7 conformance
+vectors will pin.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+
+def _test_signer(canonical_bytes: bytes) -> str:
+    """Deterministic 128-char hex signer for integration tests."""
+    h = hashlib.sha256(canonical_bytes).hexdigest()
+    return h + h
+
+
+from kailash.delegate.audit import AuditChainEngine, DelegateEventType
+from kailash.delegate.dispatch import (
+    Connector,
+    ConnectorInvocationResult,
+    DispatchSurface,
+)
+from kailash.delegate.envelope import DelegateConstraintEnvelope
+from kailash.delegate.runtime import (
+    DelegateRuntime,
+    Posture,
+    R2CompositionError,
+    RuntimeExecutionResult,
+)
+from kailash.delegate.trust import TenantScope, TenantScopedCascade
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateGenesisRecord,
+    DelegateIdentity,
+    Role,
+    RoleLifecycleState,
+    RoleScope,
+)
+from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
+from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+
+# ---------------------------------------------------------------------------
+# Substrate builders (real, no mocks)
+# ---------------------------------------------------------------------------
+
+
+def _build_chain(agent_id: str = "agent-rt-wire") -> TrustLineageChain:
+    return TrustLineageChain(
+        genesis=GenesisRecord(
+            id=f"g-{agent_id}",
+            agent_id=agent_id,
+            authority_id=f"auth-{agent_id}",
+            authority_type=AuthorityType.ORGANIZATION,
+            created_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            signature="a" * 128,
+        )
+    )
+
+
+def _build_identity() -> DelegateIdentity:
+    return DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref="sov-rt-wire",
+        role_binding_ref="rb-rt-wire",
+        genesis_ref="g-agent-rt-wire",
+    )
+
+
+def _build_envelope() -> DelegateConstraintEnvelope:
+    block = GenesisRecord(
+        id="g-env-rt-wire",
+        agent_id="agent-env-rt-wire",
+        authority_id="auth-env-rt-wire",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        signature="d" * 128,
+    )
+    genesis = DelegateGenesisRecord(
+        block=block, spec_version="1", capabilities=("read",)
+    )
+    return DelegateConstraintEnvelope.from_genesis(
+        ConstraintEnvelope(financial=FinancialConstraint(budget_limit=1000.0)),
+        genesis,
+    )
+
+
+def _build_role() -> Role:
+    return Role(
+        role_id=uuid.uuid4(),
+        display_name="rt-wire-role",
+        scope=RoleScope(
+            domain="finance",
+            capabilities=CapabilitySet(capabilities=("http.read",)),
+        ),
+        lifecycle=RoleLifecycleState.ACTIVE,
+    )
+
+
+class RecordingConnector(Connector):
+    """Records every connector.invoke arg for wiring assertions."""
+
+    connector_id = "rt-wire-conn"
+    connector_kind = "http"
+    requires_capabilities = frozenset({"http.read"})
+
+    def __init__(self, *, tenant_id_observed: str = "tenant-rt-wire") -> None:
+        self.tenant_id_observed = tenant_id_observed
+        self.invocations: list[dict] = []
+
+    async def invoke(self, input_payload, *, identity, envelope):
+        self.invocations.append(
+            {
+                "input_payload": dict(input_payload),
+                "identity_id": identity.delegate_id,
+            }
+        )
+        return ConnectorInvocationResult(
+            payload={"ok": True, "echo": input_payload.get("id", "n/a")},
+            audit_events=(DelegateEventType.EXTERNAL_SIDE_EFFECT,),
+            tenant_id_observed=self.tenant_id_observed,
+            external_side_effect=True,
+        )
+
+
+class WiringSig:
+    """Minimal SignatureContract satisfier."""
+
+    name = "rt-wire-sig"
+    input_schema = {"id": str}
+    output_schema = {"ok": bool, "echo": str}
+
+
+def _build_runtime_stack(
+    *,
+    posture: Posture = Posture.L5_DELEGATED,
+    tenant_id: str = "tenant-rt-wire",
+    connector_tenant_id: str | None = None,
+):
+    """Construct the full runtime stack with real primitives."""
+    chain = _build_chain()
+    audit_engine = AuditChainEngine(chain=chain)
+    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant(tenant_id))
+    envelope = _build_envelope()
+    identity = _build_identity()
+    role = _build_role()
+    connector = RecordingConnector(
+        tenant_id_observed=connector_tenant_id or tenant_id,
+    )
+    surface = DispatchSurface(
+        connector=connector,
+        signature=WiringSig(),
+        envelope=envelope,
+        identity=identity,
+        audit_engine=audit_engine,
+        trust_cascade=cascade,
+        role=role,
+        signer=_test_signer,
+    )
+    runtime = DelegateRuntime(
+        dispatch_surface=surface,
+        audit_engine=audit_engine,
+        cascade=cascade,
+        envelope=envelope,
+        identity=identity,
+        signer=_test_signer,
+        posture=posture,
+    )
+    return runtime, surface, audit_engine, chain, connector
+
+
+# ---------------------------------------------------------------------------
+# Tier-2 wiring tests — every dependency is REAL
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_runtime_end_to_end_full_taod_lifecycle_against_real_substrate() -> None:
+    """Mirrors rs DelegateRuntime end-to-end test.
+
+    Wiring contract verified:
+    1. Runtime invokes DispatchSurface.dispatch (connector records args).
+    2. AuditChainEngine receives runtime-emitted TAOD events PLUS the
+       dispatch-emitted EXTERNAL_SIDE_EFFECT event.
+    3. All runtime audit events bind the run_id (Invariant 3).
+    4. RuntimeExecutionResult carries valid dispatch_result + audit head hash.
+    """
+    runtime, surface, audit_engine, chain, connector = _build_runtime_stack()
+
+    # Pre-execute: chain empty
+    assert len(audit_engine.entries) == 0
+    assert len(chain.audit_anchors) == 0
+    assert len(connector.invocations) == 0
+
+    result = await runtime.execute({"id": "rt-1"})
+
+    # 1. Connector invoked exactly once with the bound identity
+    assert len(connector.invocations) == 1
+    inv = connector.invocations[0]
+    assert inv["identity_id"] == runtime.identity.delegate_id
+    assert inv["input_payload"] == {"id": "rt-1"}
+
+    # 2. RuntimeExecutionResult shape
+    assert isinstance(result, RuntimeExecutionResult)
+    assert result.taod_state.phase == "completed"
+    assert result.dispatch_result is not None
+    assert result.dispatch_result.payload == {"ok": True, "echo": "rt-1"}
+    assert result.posture_at_execute == Posture.L5_DELEGATED
+
+    # 3. Audit chain has runtime transitions + dispatch event landed on
+    # the SHARED substrate chain (`audit_engine.entries` is the engine's
+    # tracked list; `chain.audit_anchors` is the substrate's list — both
+    # MUST stay in lockstep per S4 contract).
+    assert len(audit_engine.entries) == len(chain.audit_anchors)
+    # 4 runtime transitions + 1 dispatch event = 5 entries
+    assert len(audit_engine.entries) == 5
+
+    # 4. Every runtime-emitted entry carries run_id (Invariant 3).
+    runtime_entries = [e for e in audit_engine.entries if "run_id" in e.event_payload]
+    run_id_str = str(result.run_id)
+    for e in runtime_entries:
+        assert e.event_payload["run_id"] == run_id_str
+
+    # 5. Audit head hash on the result matches the engine's current head
+    assert result.audit_head_hash == audit_engine.head_hash()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_runtime_posture_halt_after_construction_blocks_at_thinking() -> None:
+    """HALT posture set POST-construction blocks at THINKING phase.
+
+    The runtime is built L5; with_posture downgrades to HALT; the next
+    execute() halts at THINKING without invoking the dispatch surface.
+    """
+    runtime, surface, audit_engine, chain, connector = _build_runtime_stack(
+        posture=Posture.L5_DELEGATED,
+    )
+
+    halted_runtime = runtime.with_posture(Posture.HALT)
+
+    result = await halted_runtime.execute({"id": "rt-halt"})
+
+    # Failed at thinking, connector never invoked
+    assert result.taod_state.phase == "failed"
+    assert result.dispatch_result is None
+    assert len(connector.invocations) == 0
+    # Runtime emitted at least one runtime audit event (the THINKING
+    # phase entry) AND the FAILED transition audit; no dispatch events.
+    runtime_entries = [e for e in audit_engine.entries if "run_id" in e.event_payload]
+    assert len(runtime_entries) >= 2  # THINKING + FAILED
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_runtime_r2_recheck_catches_envelope_swap_between_construct_and_execute() -> (
+    None
+):
+    """Invariant 4 — R2 composition re-check fires at execute() start.
+
+    Construct runtime cleanly; then externally mutate the runtime's
+    private envelope reference to a swapped-in envelope (simulating
+    component reconstruction between bind and execute). The execute()
+    start MUST detect the drift and transition to FAILED without
+    invoking the dispatch surface.
+    """
+    runtime, surface, audit_engine, chain, connector = _build_runtime_stack()
+
+    # Swap envelope post-construction (simulates external mutation
+    # between __init__ and execute() — the failure mode Invariant 4
+    # defense-in-depth catches).
+    swapped_envelope = _build_envelope()
+    assert swapped_envelope is not runtime._envelope
+    runtime._envelope = swapped_envelope
+
+    result = await runtime.execute({"id": "rt-r2"})
+
+    # R2 re-check at execute() start should land FAILED
+    assert result.taod_state.phase == "failed"
+    assert result.dispatch_result is None
+    # Connector NEVER invoked — failure precedes ACTING
+    assert len(connector.invocations) == 0
+    # The transition reason cites the R2 composition failure
+    last_transition = result.taod_state.transitions[-1]
+    assert "R2 composition" in (last_transition.reason or "")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_runtime_executes_multiple_runs_on_same_substrate() -> None:
+    """Two execute() calls on the same runtime produce two distinct
+    run_id-bound audit-chain segments on the same substrate.
+
+    Validates the runtime can be re-used across multiple TAOD
+    executions without state-leak between runs.
+    """
+    runtime, surface, audit_engine, chain, connector = _build_runtime_stack()
+
+    r1 = await runtime.execute({"id": "rt-multi-1"})
+    r2 = await runtime.execute({"id": "rt-multi-2"})
+
+    assert r1.run_id != r2.run_id
+    assert r1.taod_state.phase == "completed"
+    assert r2.taod_state.phase == "completed"
+
+    # 5 audit entries per successful run = 10 total
+    assert len(audit_engine.entries) == 10
+
+    # Each run's run_id appears in 4 runtime-emitted entries (4 phase
+    # transitions through completed).
+    run1_entries = [
+        e
+        for e in audit_engine.entries
+        if e.event_payload.get("run_id") == str(r1.run_id)
+    ]
+    run2_entries = [
+        e
+        for e in audit_engine.entries
+        if e.event_payload.get("run_id") == str(r2.run_id)
+    ]
+    assert len(run1_entries) == 4
+    assert len(run2_entries) == 4

--- a/tests/unit/delegate/test_package_shell.py
+++ b/tests/unit/delegate/test_package_shell.py
@@ -29,9 +29,10 @@ def test_kailash_delegate_imports_cleanly() -> None:
     mode this assertion catches."""
     import kailash.delegate as pkg
 
-    assert len(pkg.__all__) == 30, (
-        "kailash.delegate.__all__ count drifted; S5 ships 30 symbols "
-        "(S2: 11 + S3 trust cascade: 5 + S4 audit chain: 7 + S5 dispatch: 7). "
+    assert len(pkg.__all__) == 40, (
+        "kailash.delegate.__all__ count drifted; S6 ships 40 symbols "
+        "(S2: 11 + S3 trust cascade: 5 + S4 audit chain: 7 + S5 dispatch: 7 "
+        "+ S6 runtime spine: 10). "
         "If a later shard added a symbol, update this count in the same commit "
         f"per orphan-detection.md Rule 6a. Got: {pkg.__all__!r}"
     )

--- a/tests/unit/delegate/test_runtime.py
+++ b/tests/unit/delegate/test_runtime.py
@@ -666,11 +666,18 @@ def test_with_posture_upgrade_without_nonce_refused() -> None:
 
 @pytest.mark.unit
 def test_with_posture_upgrade_with_nonce_accepted() -> None:
-    """Upgrade with non-empty nonce is accepted."""
+    """Upgrade with sufficiently-long nonce is accepted.
+
+    Per S6 R1 C1 fix: nonce MUST be >= _MIN_NONCE_LENGTH (16) chars
+    to satisfy the SYNTACTIC posture-upgrade gate. The runtime does
+    NOT validate the nonce cryptographically — S8 nonce-registry
+    integration owns that — but the length floor closes the trivial
+    truthy-string bypass (any non-empty string used to pass).
+    """
     runtime, _, _ = _build_runtime(posture=Posture.L2_SUPERVISED)
     new_runtime = runtime.with_posture(
         Posture.L4_CONTINUOUS_INSIGHT,
-        human_acknowledged_nonce="ack-12345",
+        human_acknowledged_nonce="ack-1234567890abcd",  # 18 chars >= 16
     )
     assert new_runtime.posture == Posture.L4_CONTINUOUS_INSIGHT
 
@@ -749,15 +756,23 @@ async def test_execute_posture_halt_refuses_at_thinking() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_execute_dispatch_failure_transitions_to_failed() -> None:
-    """Dispatch raises → TAODState lands in FAILED."""
+    """Dispatch raises → TAODState lands in FAILED.
+
+    Per S6 R1 LOW-1: the TAOD reason field is SANITIZED — only the
+    exception class name leaks to the observable
+    ``RuntimeExecutionResult.to_dict()`` surface. The full
+    ``str(exc)`` lives in the audit chain's signed payload (sized to
+    forensic verification surface), NOT on the public reason field.
+    """
     connector = _MockConnector(raise_exc=RuntimeError("boom"))
     runtime, _, _ = _build_runtime(connector=connector)
     result = await runtime.execute({"id": "x-fail"})
     assert result.taod_state.phase == "failed"
     last_transition = result.taod_state.transitions[-1]
     assert last_transition.to_phase == "failed"
-    assert "boom" in (last_transition.reason or "")
+    # Sanitized reason — class name only, raw exception message MUST NOT bleed.
     assert "RuntimeError" in (last_transition.reason or "")
+    assert "boom" not in (last_transition.reason or "")
 
 
 @pytest.mark.unit
@@ -812,3 +827,184 @@ async def test_execute_run_id_is_uuid4() -> None:
     result = await runtime.execute({"id": "x-uuid"})
     assert isinstance(result.run_id, uuid.UUID)
     assert result.run_id.version == 4
+
+
+# ---------------------------------------------------------------------------
+# S6 R1 fix-immediately tests — A3/D1, C1, MED-1, LOW-1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_audit_emit_failure_during_thinking_phase_keeps_state_consistent() -> (
+    None
+):
+    """S6 R1 A3/D1: audit emit BEFORE state advance.
+
+    When ``_emit_phase_audit`` raises during the THINKING transition,
+    the state MUST NOT advance to "thinking" with no audit record.
+    Instead, the runtime transitions to FAILED with a SANITIZED reason
+    naming only the failure phase + exception class — no recursion
+    into another audit emit (the audit subsystem itself broke), and
+    no exception propagates from execute() (the no-throw contract is
+    preserved).
+    """
+    runtime, _, audit_engine = _build_runtime()
+
+    # Force the audit engine's emit_event to raise on the FIRST call
+    # (which is the THINKING transition's audit). State at that point
+    # is still "initiated" — must transition directly to "failed".
+    call_count = {"n": 0}
+    original_emit = audit_engine.emit_event
+
+    def _raising_emit(*args: Any, **kwargs: Any) -> Any:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("audit-subsystem-broken")
+        return original_emit(*args, **kwargs)
+
+    audit_engine.emit_event = _raising_emit  # type: ignore[method-assign]
+
+    # No exception propagates; FAILED transition is observable.
+    result = await runtime.execute({"id": "x-audit-fail"})
+    assert result.taod_state.phase == "failed"
+    # Only one transition: initiated→failed; thinking was never
+    # entered because the audit emit failed first.
+    transitions = result.taod_state.transitions
+    assert len(transitions) == 1
+    assert transitions[0].from_phase == "initiated"
+    assert transitions[0].to_phase == "failed"
+    # Reason cites the failed phase + audit-exception class — NOT the
+    # raw exception message (LOW-1 sanitization discipline).
+    reason = transitions[0].reason or ""
+    assert "thinking" in reason
+    assert "RuntimeError" in reason
+    assert "audit-subsystem-broken" not in reason
+
+
+@pytest.mark.unit
+def test_posture_upgrade_rejects_short_nonce() -> None:
+    """S6 R1 C1: nonce shorter than _MIN_NONCE_LENGTH (16) is refused.
+
+    A truthy one-char string used to satisfy the upgrade gate; the
+    hardened SYNTACTIC check rejects any nonce shorter than 16 chars
+    so the trivial bypass surface ("x" satisfied the gate) is closed.
+    """
+    runtime, _, _ = _build_runtime(posture=Posture.L2_SUPERVISED)
+    with pytest.raises(RuntimePostureBlockedError, match="length >= 16"):
+        runtime.with_posture(Posture.L5_DELEGATED, human_acknowledged_nonce="x")
+
+
+@pytest.mark.unit
+def test_posture_upgrade_accepts_sixteen_char_nonce() -> None:
+    """S6 R1 C1: nonce of exactly _MIN_NONCE_LENGTH (16) chars is accepted.
+
+    Boundary test: at the floor the gate admits the upgrade. The
+    audit-event side-effect of with_posture (S6 R1 MED-1) also fires
+    cleanly — no posture-blocked-error from audit emission.
+    """
+    runtime, _, _ = _build_runtime(posture=Posture.L2_SUPERVISED)
+    new_runtime = runtime.with_posture(
+        Posture.L5_DELEGATED,
+        human_acknowledged_nonce="x" * 16,
+    )
+    assert new_runtime.posture == Posture.L5_DELEGATED
+
+
+@pytest.mark.unit
+def test_with_posture_emits_audit_event_on_source_runtime() -> None:
+    """S6 R1 MED-1: every posture rotation emits an audit event.
+
+    Posture rotations (both upgrades AND downgrades) are
+    security-relevant transitions; an attacker holding a legitimate
+    L5_DELEGATED runtime that could call .with_posture(L1) silently
+    would leave the downgrade invisible to forensic correlation. The
+    audit event MUST land on the source runtime's audit engine and
+    carry from_posture, to_posture, and rank_delta in the payload.
+    """
+    runtime, _, audit_engine = _build_runtime(posture=Posture.L5_DELEGATED)
+    pre_count = len(audit_engine.entries)
+
+    # Downgrade (no nonce required) — MUST still emit.
+    new_runtime = runtime.with_posture(Posture.L2_SUPERVISED)
+    assert new_runtime.posture == Posture.L2_SUPERVISED
+
+    post_count = len(audit_engine.entries)
+    assert post_count - pre_count == 1
+    rotation_entry = audit_engine.entries[-1]
+    # Event type is POSTURE_OR_SOVEREIGN_HANDOVER per S6 contract.
+    assert (
+        rotation_entry.event_type
+        == DelegateEventType.POSTURE_OR_SOVEREIGN_HANDOVER.value
+    )
+    payload = rotation_entry.event_payload
+    assert payload["from_posture"] == "L5_DELEGATED"
+    assert payload["to_posture"] == "L2_SUPERVISED"
+    assert payload["rank_delta"] == -3  # 2 - 5
+    assert payload["nonce_present"] is False  # downgrade carries no nonce
+    assert "rotation_id" in payload
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_failed_reason_field_is_sanitized() -> None:
+    """S6 R1 LOW-1: FAILED transition reason is sanitized for to_dict.
+
+    The TAOD state's reason field is the OBSERVABLE surface exposed
+    via RuntimeExecutionResult.to_dict() → downstream logs/aggregators
+    per observability.md Rule 8. Schema-revealing adapter-internal
+    messages MUST NOT bleed into the reason field; the full message
+    lives in the signed audit-event payload (already sized to
+    forensic verification surface).
+    """
+    # Induce a dispatch error with a distinctive raw message —
+    # the message MUST NOT appear in the TAOD reason field.
+    sensitive_msg = "SENSITIVE_ADAPTER_INTERNAL_DETAIL_XYZ"
+    connector = _MockConnector(raise_exc=ValueError(sensitive_msg))
+    runtime, _, audit_engine = _build_runtime(connector=connector)
+    result = await runtime.execute({"id": "x-low1"})
+
+    # Verify dispatch did fail
+    assert result.taod_state.phase == "failed"
+    last_transition = result.taod_state.transitions[-1]
+    assert last_transition.to_phase == "failed"
+
+    # Critical: raw exception message MUST NOT appear in the
+    # observable reason field
+    reason = last_transition.reason or ""
+    assert sensitive_msg not in reason
+    # Class name IS allowed in reason (taxonomy signal)
+    assert "ValueError" in reason
+
+    # But the audit payload SHOULD carry the full message (signed +
+    # bounded forensic surface). Find the FAILED audit entry.
+    failed_entries = [
+        e
+        for e in audit_engine.entries
+        if e.event_payload.get("phase") == "failed"
+        and e.event_payload.get("reason") == "dispatch_error"
+    ]
+    assert len(failed_entries) == 1
+    assert failed_entries[0].event_payload["error_message"] == sensitive_msg
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_to_dict_does_not_leak_raw_exception_message() -> None:
+    """S6 R1 LOW-1: round-trip TAODState.to_dict() never carries raw exc.
+
+    Direct verification of the observability contract: the dict
+    payload that flows into downstream consumers MUST NOT carry the
+    raw adapter-internal exception message anywhere — not in the
+    reason field, not as a substring of any other field.
+    """
+    sensitive_msg = "DOWNSTREAM_SCHEMA_LEAK_CANARY"
+    connector = _MockConnector(raise_exc=RuntimeError(sensitive_msg))
+    runtime, _, _ = _build_runtime(connector=connector)
+    result = await runtime.execute({"id": "x-leak"})
+
+    # Walk the to_dict() payload for any occurrence of the sensitive
+    # message. Stringify the entire dict so a nested embedding would
+    # be caught.
+    state_dict_str = str(result.taod_state.to_dict())
+    assert sensitive_msg not in state_dict_str

--- a/tests/unit/delegate/test_runtime.py
+++ b/tests/unit/delegate/test_runtime.py
@@ -1,0 +1,814 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Tier-1 unit tests for ``kailash.delegate.runtime`` (S6, #1035).
+
+Covers TAOD state machine, Posture gating, R2 composition validator,
+RuntimeExecutionResult shape + round-trip, and DelegateRuntime spine
+construction + per-phase invariants. Per ``probe-driven-verification.md``
+MUST Rule 3 all assertions here are STRUCTURAL (typed-error class,
+phase value, count of audit entries, isinstance type checks) — no
+semantic regex/keyword matching against prose output.
+
+Tier classification: substrate dependencies (DispatchSurface,
+AuditChainEngine, TenantScopedCascade, DelegateConstraintEnvelope) are
+REAL — no mocks. The only "fake" object is the MockConnector subclass
+satisfying the abstract Connector contract deterministically; per
+``rules/testing.md`` § "Protocol-Satisfying Deterministic Adapters",
+this is NOT a mock — it's a deterministic adapter for the abstract
+Connector surface.
+
+Mirrors rs kailash-delegate-runtime substrate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import FrozenInstanceError
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from kailash.delegate.audit import AuditChainEngine, DelegateEventType
+from kailash.delegate.dispatch import (
+    Connector,
+    ConnectorInvocationResult,
+    DispatchResult,
+    DispatchSurface,
+)
+from kailash.delegate.envelope import DelegateConstraintEnvelope
+from kailash.delegate.runtime import (
+    DelegateRuntime,
+    Posture,
+    R2Composition,
+    R2CompositionError,
+    RuntimeCompositionError,
+    RuntimeExecutionResult,
+    RuntimePhaseError,
+    RuntimePostureBlockedError,
+    TAODState,
+    TAODTransition,
+)
+from kailash.delegate.trust import TenantScope, TenantScopedCascade
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateGenesisRecord,
+    DelegateIdentity,
+    Role,
+    RoleLifecycleState,
+    RoleScope,
+)
+from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
+from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+
+# ---------------------------------------------------------------------------
+# Test signer — deterministic 128-char hex (SHA-256 doubled).
+# ---------------------------------------------------------------------------
+
+
+def _test_signer(canonical_bytes: bytes) -> str:
+    """Deterministic SHA-256-doubled signer satisfying _validate_hex(128)."""
+    h = hashlib.sha256(canonical_bytes).hexdigest()
+    return h + h
+
+
+# ---------------------------------------------------------------------------
+# Substrate builders — real, no mocks
+# ---------------------------------------------------------------------------
+
+
+def _build_chain(agent_id: str = "agent-s6") -> TrustLineageChain:
+    return TrustLineageChain(
+        genesis=GenesisRecord(
+            id=f"g-{agent_id}",
+            agent_id=agent_id,
+            authority_id=f"auth-{agent_id}",
+            authority_type=AuthorityType.ORGANIZATION,
+            created_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            signature="a" * 128,
+        )
+    )
+
+
+def _build_identity() -> DelegateIdentity:
+    return DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref="sov-s6",
+        role_binding_ref="rb-s6",
+        genesis_ref="g-agent-s6",
+    )
+
+
+def _build_envelope() -> DelegateConstraintEnvelope:
+    block = GenesisRecord(
+        id="g-env-s6",
+        agent_id="agent-env-s6",
+        authority_id="auth-env-s6",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        signature="d" * 128,
+    )
+    genesis = DelegateGenesisRecord(
+        block=block, spec_version="1", capabilities=("read",)
+    )
+    return DelegateConstraintEnvelope.from_genesis(
+        ConstraintEnvelope(financial=FinancialConstraint(budget_limit=1000.0)),
+        genesis,
+    )
+
+
+def _build_role() -> Role:
+    return Role(
+        role_id=uuid.uuid4(),
+        display_name="s6-role",
+        scope=RoleScope(
+            domain="finance",
+            capabilities=CapabilitySet(capabilities=("http.read",)),
+        ),
+        lifecycle=RoleLifecycleState.ACTIVE,
+    )
+
+
+def _build_cascade(tenant_id: str | None = "tenant-s6") -> TenantScopedCascade:
+    if tenant_id is None:
+        return TenantScopedCascade(tenant=TenantScope.global_())
+    return TenantScopedCascade(tenant=TenantScope.for_tenant(tenant_id))
+
+
+class _MockConnector(Connector):
+    """Deterministic Connector subclass for runtime tests.
+
+    Per ``rules/testing.md`` § "Protocol-Satisfying Deterministic
+    Adapters", this is NOT a mock — it's a real Connector subclass.
+    Per ``rules/testing.md`` MUST: Helper Classes Use Stub/Helper/Fake
+    Suffix — leading underscore + lowercase indicates internal helper;
+    pytest's `Test*` collection does not match this name.
+    """
+
+    connector_id = "s6-mock-conn"
+    connector_kind = "http"
+    requires_capabilities = frozenset({"http.read"})
+
+    def __init__(
+        self,
+        *,
+        return_payload: dict | None = None,
+        tenant_id_observed: str | None = "tenant-s6",
+        raise_exc: BaseException | None = None,
+    ) -> None:
+        self.return_payload = (
+            return_payload if return_payload is not None else {"ok": True}
+        )
+        self.tenant_id_observed = tenant_id_observed
+        self.raise_exc = raise_exc
+        self.invocations: list[dict] = []
+
+    async def invoke(self, input_payload, *, identity, envelope):
+        self.invocations.append(
+            {
+                "input_payload": dict(input_payload),
+                "identity_id": identity.delegate_id,
+            }
+        )
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return ConnectorInvocationResult(
+            payload=self.return_payload,
+            audit_events=(DelegateEventType.EXTERNAL_SIDE_EFFECT,),
+            tenant_id_observed=self.tenant_id_observed,
+            external_side_effect=True,
+        )
+
+
+class _Sig:
+    """Minimal SignatureContract-satisfier for runtime tests."""
+
+    name = "s6-sig"
+    input_schema = {"id": str}
+    output_schema = {"ok": bool}
+
+
+def _build_surface(
+    *,
+    connector: Connector | None = None,
+    envelope: DelegateConstraintEnvelope | None = None,
+    identity: DelegateIdentity | None = None,
+    cascade: TenantScopedCascade | None = None,
+    audit_engine: AuditChainEngine | None = None,
+    role: Role | None = None,
+    signer=None,
+) -> tuple[
+    DispatchSurface,
+    DelegateConstraintEnvelope,
+    DelegateIdentity,
+    TenantScopedCascade,
+    AuditChainEngine,
+]:
+    envelope = envelope if envelope is not None else _build_envelope()
+    identity = identity if identity is not None else _build_identity()
+    cascade = cascade if cascade is not None else _build_cascade()
+    audit_engine = (
+        audit_engine
+        if audit_engine is not None
+        else AuditChainEngine(chain=_build_chain())
+    )
+    role = role if role is not None else _build_role()
+    signer = signer if signer is not None else _test_signer
+    connector = connector if connector is not None else _MockConnector()
+    surface = DispatchSurface(
+        connector=connector,
+        signature=_Sig(),
+        envelope=envelope,
+        identity=identity,
+        audit_engine=audit_engine,
+        trust_cascade=cascade,
+        role=role,
+        signer=signer,
+    )
+    return surface, envelope, identity, cascade, audit_engine
+
+
+def _build_runtime(
+    *,
+    posture: Posture = Posture.L5_DELEGATED,
+    connector: Connector | None = None,
+) -> tuple[DelegateRuntime, _MockConnector | Connector, AuditChainEngine]:
+    """Build a runtime with all real substrate primitives."""
+    if connector is None:
+        connector = _MockConnector()
+    surface, envelope, identity, cascade, audit_engine = _build_surface(
+        connector=connector,
+    )
+    runtime = DelegateRuntime(
+        dispatch_surface=surface,
+        audit_engine=audit_engine,
+        cascade=cascade,
+        envelope=envelope,
+        identity=identity,
+        signer=_test_signer,
+        posture=posture,
+    )
+    return runtime, connector, audit_engine
+
+
+# ---------------------------------------------------------------------------
+# TAODTransition — frozen + validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_taod_transition_is_frozen() -> None:
+    """Mirrors rs TaodTransition — frozen dataclass, no mutation."""
+    t = TAODTransition(
+        from_phase="initiated",
+        to_phase="thinking",
+        at=datetime.now(timezone.utc),
+    )
+    with pytest.raises(FrozenInstanceError):
+        t.reason = "x"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_taod_transition_rejects_naive_datetime() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        TAODTransition(
+            from_phase="initiated",
+            to_phase="thinking",
+            at=datetime.now(),  # naive
+        )
+
+
+@pytest.mark.unit
+def test_taod_transition_round_trip() -> None:
+    """Mirrors rs TaodTransition serde — to_dict/from_dict round-trip."""
+    original = TAODTransition(
+        from_phase="thinking",
+        to_phase="acting",
+        at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        reason="happy path",
+    )
+    restored = TAODTransition.from_dict(original.to_dict())
+    assert restored == original
+
+
+@pytest.mark.unit
+def test_taod_transition_round_trip_omits_none_reason() -> None:
+    """None reason omitted from to_dict per rs serde-skip-if-none."""
+    original = TAODTransition(
+        from_phase="thinking",
+        to_phase="acting",
+        at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    payload = original.to_dict()
+    assert "reason" not in payload
+    restored = TAODTransition.from_dict(payload)
+    assert restored == original
+
+
+# ---------------------------------------------------------------------------
+# TAODState — phase machine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_taod_state_initiated_is_not_terminal() -> None:
+    s = TAODState(phase="initiated", started_at=datetime.now(timezone.utc))
+    assert s.is_terminal is False
+    assert len(s.transitions) == 0
+
+
+@pytest.mark.unit
+def test_taod_state_completed_is_terminal() -> None:
+    s = TAODState(phase="completed", started_at=datetime.now(timezone.utc))
+    assert s.is_terminal is True
+
+
+@pytest.mark.unit
+def test_taod_state_failed_is_terminal() -> None:
+    s = TAODState(phase="failed", started_at=datetime.now(timezone.utc))
+    assert s.is_terminal is True
+
+
+@pytest.mark.unit
+def test_taod_state_rejects_unknown_phase() -> None:
+    with pytest.raises(ValueError, match="not a known TAODPhase"):
+        TAODState(phase="bogus", started_at=datetime.now(timezone.utc))  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_taod_state_legal_path_to_completion() -> None:
+    """Initiated → thinking → acting → observing → completed."""
+    s0 = TAODState(phase="initiated", started_at=datetime.now(timezone.utc))
+    s1 = s0.advance_to("thinking")
+    s2 = s1.advance_to("acting")
+    s3 = s2.advance_to("observing")
+    s4 = s3.advance_to("completed")
+    assert s4.phase == "completed"
+    assert len(s4.transitions) == 4
+    # Transitions append-only — ordered
+    assert [t.to_phase for t in s4.transitions] == [
+        "thinking",
+        "acting",
+        "observing",
+        "completed",
+    ]
+
+
+@pytest.mark.unit
+def test_taod_state_legal_path_with_deciding() -> None:
+    """Observing → deciding → completed is a legal alternate path."""
+    s = TAODState(phase="observing", started_at=datetime.now(timezone.utc))
+    s = s.advance_to("deciding").advance_to("completed")
+    assert s.phase == "completed"
+
+
+@pytest.mark.unit
+def test_taod_state_terminal_rejects_further_transition() -> None:
+    """Invariant 1 — completed state refuses any further transition."""
+    s = TAODState(phase="completed", started_at=datetime.now(timezone.utc))
+    with pytest.raises(RuntimePhaseError, match="terminal"):
+        s.advance_to("failed")
+
+
+@pytest.mark.unit
+def test_taod_state_failed_refuses_further_transition() -> None:
+    """Invariant 1 — failed state refuses any further transition."""
+    s = TAODState(phase="failed", started_at=datetime.now(timezone.utc))
+    with pytest.raises(RuntimePhaseError, match="terminal"):
+        s.advance_to("completed")
+
+
+@pytest.mark.unit
+def test_taod_state_illegal_successor_rejected() -> None:
+    """Phase machine rejects an illegal successor (initiated → completed)."""
+    s = TAODState(phase="initiated", started_at=datetime.now(timezone.utc))
+    with pytest.raises(RuntimePhaseError, match="Illegal TAOD transition"):
+        s.advance_to("completed")
+
+
+@pytest.mark.unit
+def test_taod_state_failed_from_any_non_terminal_phase() -> None:
+    """Every non-terminal phase may transition to failed."""
+    for phase in ("initiated", "thinking", "acting", "observing", "deciding"):
+        s = TAODState(phase=phase, started_at=datetime.now(timezone.utc))  # type: ignore[arg-type]
+        advanced = s.advance_to("failed", reason="test")
+        assert advanced.phase == "failed"
+
+
+@pytest.mark.unit
+def test_taod_state_round_trip() -> None:
+    """Mirrors rs TaodState serde — to_dict/from_dict round-trip."""
+    original = (
+        TAODState(
+            phase="initiated",
+            started_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        .advance_to("thinking", at=datetime(2026, 5, 22, 12, 0, 1, tzinfo=timezone.utc))
+        .advance_to("acting", at=datetime(2026, 5, 22, 12, 0, 2, tzinfo=timezone.utc))
+    )
+    restored = TAODState.from_dict(original.to_dict())
+    assert restored.phase == original.phase
+    assert restored.started_at == original.started_at
+    assert len(restored.transitions) == len(original.transitions)
+
+
+# ---------------------------------------------------------------------------
+# Posture enum
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_posture_string_values_match_rules() -> None:
+    """Posture enum values mirror rules/trust-posture.md identifiers."""
+    assert Posture.L5_DELEGATED.value == "L5_DELEGATED"
+    assert Posture.L4_CONTINUOUS_INSIGHT.value == "L4_CONTINUOUS_INSIGHT"
+    assert Posture.L3_SHARED_PLANNING.value == "L3_SHARED_PLANNING"
+    assert Posture.L2_SUPERVISED.value == "L2_SUPERVISED"
+    assert Posture.L1_PSEUDO_AGENT.value == "L1_PSEUDO_AGENT"
+    assert Posture.HALT.value == "HALT"
+
+
+@pytest.mark.unit
+def test_posture_rank_monotonic() -> None:
+    """Higher posture = higher rank; HALT is the floor."""
+    ranks = [
+        Posture.HALT._rank,
+        Posture.L1_PSEUDO_AGENT._rank,
+        Posture.L2_SUPERVISED._rank,
+        Posture.L3_SHARED_PLANNING._rank,
+        Posture.L4_CONTINUOUS_INSIGHT._rank,
+        Posture.L5_DELEGATED._rank,
+    ]
+    assert ranks == sorted(ranks)
+    assert Posture.HALT._rank == 0
+
+
+# ---------------------------------------------------------------------------
+# RuntimeExecutionResult — frozen + round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_runtime_execution_result_is_frozen() -> None:
+    r = RuntimeExecutionResult(
+        run_id=uuid.uuid4(),
+        dispatch_result=None,
+        taod_state=TAODState(phase="failed", started_at=datetime.now(timezone.utc)),
+        audit_head_hash=None,
+        terminated_at=datetime.now(timezone.utc),
+        posture_at_execute=Posture.L5_DELEGATED,
+    )
+    with pytest.raises(FrozenInstanceError):
+        r.run_id = uuid.uuid4()  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_runtime_execution_result_round_trip_no_dispatch() -> None:
+    original = RuntimeExecutionResult(
+        run_id=uuid.uuid4(),
+        dispatch_result=None,
+        taod_state=(
+            TAODState(
+                phase="failed",
+                started_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            ).advance_to(
+                "failed",  # not a legal transition? failed is terminal-from-init?
+                at=datetime(2026, 5, 22, 12, 0, 1, tzinfo=timezone.utc),
+            )
+            if False  # bypass — failed-from-failed would raise; use init-state alone
+            else TAODState(
+                phase="failed",
+                started_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            )
+        ),
+        audit_head_hash="ab" * 32,
+        terminated_at=datetime(2026, 5, 22, 12, 0, 1, tzinfo=timezone.utc),
+        posture_at_execute=Posture.HALT,
+    )
+    restored = RuntimeExecutionResult.from_dict(original.to_dict())
+    assert restored.run_id == original.run_id
+    assert restored.dispatch_result is None
+    assert restored.audit_head_hash == original.audit_head_hash
+    assert restored.posture_at_execute == Posture.HALT
+    assert restored.terminated_at == original.terminated_at
+
+
+@pytest.mark.unit
+def test_runtime_execution_result_rejects_naive_terminated_at() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        RuntimeExecutionResult(
+            run_id=uuid.uuid4(),
+            dispatch_result=None,
+            taod_state=TAODState(phase="failed", started_at=datetime.now(timezone.utc)),
+            audit_head_hash=None,
+            terminated_at=datetime.now(),  # naive
+            posture_at_execute=Posture.L5_DELEGATED,
+        )
+
+
+# ---------------------------------------------------------------------------
+# R2Composition — composition validator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_r2_composition_validates_clean_composition() -> None:
+    """A correctly-bound composition validates without raising."""
+    surface, envelope, identity, cascade, audit_engine = _build_surface()
+    R2Composition.validate(
+        envelope=envelope,
+        cascade=cascade,
+        dispatch_surface=surface,
+        audit_engine=audit_engine,
+        signer=_test_signer,
+    )
+
+
+@pytest.mark.unit
+def test_r2_composition_rejects_envelope_swap() -> None:
+    """Envelope-swap post-bind detected via `is` check (not value equality).
+
+    Mirrors rs R2 composition gate. A value-equal but DISTINCT envelope
+    is the substitution attack this guard closes.
+    """
+    surface, envelope, identity, cascade, audit_engine = _build_surface()
+    # Build a NEW envelope with the same VALUES but distinct identity.
+    swapped_envelope = _build_envelope()
+    assert swapped_envelope is not envelope
+    with pytest.raises(R2CompositionError, match="envelope"):
+        R2Composition.validate(
+            envelope=swapped_envelope,
+            cascade=cascade,
+            dispatch_surface=surface,
+            audit_engine=audit_engine,
+            signer=_test_signer,
+        )
+
+
+@pytest.mark.unit
+def test_r2_composition_rejects_cascade_swap() -> None:
+    surface, envelope, identity, cascade, audit_engine = _build_surface()
+    swapped_cascade = _build_cascade(tenant_id="tenant-s6")
+    assert swapped_cascade is not cascade
+    with pytest.raises(R2CompositionError, match="cascade"):
+        R2Composition.validate(
+            envelope=envelope,
+            cascade=swapped_cascade,
+            dispatch_surface=surface,
+            audit_engine=audit_engine,
+            signer=_test_signer,
+        )
+
+
+@pytest.mark.unit
+def test_r2_composition_rejects_signer_swap() -> None:
+    """Signer identity mismatch is signature forgery — BLOCKED.
+
+    Mirrors rs Invariant 6 — signer identity preservation.
+    """
+    surface, envelope, identity, cascade, audit_engine = _build_surface()
+
+    def _alt_signer(b: bytes) -> str:
+        return _test_signer(b)  # value-equal output, distinct object
+
+    assert _alt_signer is not _test_signer
+    with pytest.raises(R2CompositionError, match="signer"):
+        R2Composition.validate(
+            envelope=envelope,
+            cascade=cascade,
+            dispatch_surface=surface,
+            audit_engine=audit_engine,
+            signer=_alt_signer,
+        )
+
+
+# ---------------------------------------------------------------------------
+# DelegateRuntime — construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_runtime_constructs_with_clean_composition() -> None:
+    runtime, _, _ = _build_runtime()
+    assert runtime.posture == Posture.L5_DELEGATED
+
+
+@pytest.mark.unit
+def test_runtime_rejects_identity_swap() -> None:
+    """Identity-swap between dispatch surface and runtime is BLOCKED."""
+    surface, envelope, identity, cascade, audit_engine = _build_surface()
+    swapped_identity = _build_identity()
+    assert swapped_identity is not identity
+    with pytest.raises(RuntimeCompositionError, match="identity"):
+        DelegateRuntime(
+            dispatch_surface=surface,
+            audit_engine=audit_engine,
+            cascade=cascade,
+            envelope=envelope,
+            identity=swapped_identity,
+            signer=_test_signer,
+            posture=Posture.L5_DELEGATED,
+        )
+
+
+@pytest.mark.unit
+def test_runtime_rejects_non_callable_signer() -> None:
+    surface, envelope, identity, cascade, audit_engine = _build_surface()
+    with pytest.raises(TypeError, match="callable"):
+        DelegateRuntime(
+            dispatch_surface=surface,
+            audit_engine=audit_engine,
+            cascade=cascade,
+            envelope=envelope,
+            identity=identity,
+            signer="not-a-callable",  # type: ignore[arg-type]
+            posture=Posture.L5_DELEGATED,
+        )
+
+
+# ---------------------------------------------------------------------------
+# with_posture — Invariant 5 (downgrade silent, upgrade gated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_with_posture_downgrade_silent() -> None:
+    """Downgrades L5 → L4 / L1 / HALT need NO nonce."""
+    runtime, _, _ = _build_runtime(posture=Posture.L5_DELEGATED)
+    for target in (
+        Posture.L4_CONTINUOUS_INSIGHT,
+        Posture.L3_SHARED_PLANNING,
+        Posture.L2_SUPERVISED,
+        Posture.L1_PSEUDO_AGENT,
+        Posture.HALT,
+    ):
+        new_runtime = runtime.with_posture(target)
+        assert new_runtime.posture == target
+
+
+@pytest.mark.unit
+def test_with_posture_same_posture_is_silent() -> None:
+    """No-op (same rank) does not require a nonce."""
+    runtime, _, _ = _build_runtime(posture=Posture.L3_SHARED_PLANNING)
+    new_runtime = runtime.with_posture(Posture.L3_SHARED_PLANNING)
+    assert new_runtime.posture == Posture.L3_SHARED_PLANNING
+
+
+@pytest.mark.unit
+def test_with_posture_upgrade_without_nonce_refused() -> None:
+    """Upgrade without nonce raises RuntimePostureBlockedError."""
+    runtime, _, _ = _build_runtime(posture=Posture.L2_SUPERVISED)
+    with pytest.raises(RuntimePostureBlockedError, match="human_acknowledged_nonce"):
+        runtime.with_posture(Posture.L5_DELEGATED)
+
+
+@pytest.mark.unit
+def test_with_posture_upgrade_with_nonce_accepted() -> None:
+    """Upgrade with non-empty nonce is accepted."""
+    runtime, _, _ = _build_runtime(posture=Posture.L2_SUPERVISED)
+    new_runtime = runtime.with_posture(
+        Posture.L4_CONTINUOUS_INSIGHT,
+        human_acknowledged_nonce="ack-12345",
+    )
+    assert new_runtime.posture == Posture.L4_CONTINUOUS_INSIGHT
+
+
+@pytest.mark.unit
+def test_with_posture_upgrade_empty_nonce_refused() -> None:
+    """Empty-string nonce does NOT satisfy the upgrade gate."""
+    runtime, _, _ = _build_runtime(posture=Posture.L2_SUPERVISED)
+    with pytest.raises(RuntimePostureBlockedError, match="human_acknowledged_nonce"):
+        runtime.with_posture(Posture.L4_CONTINUOUS_INSIGHT, human_acknowledged_nonce="")
+
+
+# ---------------------------------------------------------------------------
+# execute() — TAOD lifecycle (Tier-1; substrate primitives are REAL)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_happy_path_completes() -> None:
+    """A clean execute() walks INITIATED → … → COMPLETED.
+
+    Mirrors rs DelegateRuntime::execute — verifies the TAOD phase order
+    on a clean dispatch path.
+    """
+    runtime, connector, audit_engine = _build_runtime()
+    result = await runtime.execute({"id": "x-1"})
+    assert isinstance(result, RuntimeExecutionResult)
+    assert result.taod_state.phase == "completed"
+    assert result.dispatch_result is not None
+    assert result.posture_at_execute == Posture.L5_DELEGATED
+    # Transitions: initiated→thinking, thinking→acting,
+    # acting→observing, observing→completed (no deciding).
+    assert [t.to_phase for t in result.taod_state.transitions] == [
+        "thinking",
+        "acting",
+        "observing",
+        "completed",
+    ]
+    assert result.audit_head_hash is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_with_decision_required_passes_through_deciding() -> None:
+    """Connector payload signals _decision_required → DECIDING phase fires."""
+    connector = _MockConnector(return_payload={"ok": True, "_decision_required": True})
+    runtime, _, _ = _build_runtime(connector=connector)
+    result = await runtime.execute({"id": "x-dec"})
+    assert result.taod_state.phase == "completed"
+    assert [t.to_phase for t in result.taod_state.transitions] == [
+        "thinking",
+        "acting",
+        "observing",
+        "deciding",
+        "completed",
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_posture_halt_refuses_at_thinking() -> None:
+    """Invariant 2 — HALT posture refuses execute() at THINKING phase."""
+    runtime, connector, audit_engine = _build_runtime(posture=Posture.HALT)
+    result = await runtime.execute({"id": "x-halt"})
+    assert result.taod_state.phase == "failed"
+    assert result.dispatch_result is None
+    # Connector never invoked
+    assert len(connector.invocations) == 0
+    # Final transition cites posture_halt
+    last_transition = result.taod_state.transitions[-1]
+    assert last_transition.to_phase == "failed"
+    assert "HALT" in (last_transition.reason or "")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_dispatch_failure_transitions_to_failed() -> None:
+    """Dispatch raises → TAODState lands in FAILED."""
+    connector = _MockConnector(raise_exc=RuntimeError("boom"))
+    runtime, _, _ = _build_runtime(connector=connector)
+    result = await runtime.execute({"id": "x-fail"})
+    assert result.taod_state.phase == "failed"
+    last_transition = result.taod_state.transitions[-1]
+    assert last_transition.to_phase == "failed"
+    assert "boom" in (last_transition.reason or "")
+    assert "RuntimeError" in (last_transition.reason or "")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_emits_audit_event_per_transition() -> None:
+    """Invariant 3 — every TAOD transition emits exactly one audit event.
+
+    On happy path with no deciding: 4 transitions (initiated→thinking,
+    thinking→acting, acting→observing, observing→completed) → 4 runtime
+    events PLUS 1 dispatch event from the connector's
+    EXTERNAL_SIDE_EFFECT = 5 audit entries total.
+    """
+    runtime, connector, audit_engine = _build_runtime()
+    pre_count = len(audit_engine.entries)
+    result = await runtime.execute({"id": "x-aud"})
+    post_count = len(audit_engine.entries)
+    # 4 runtime transitions + 1 dispatch event
+    assert post_count - pre_count == 5
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_audit_events_bind_run_id() -> None:
+    """Invariant 3 — every runtime-emitted audit event carries run_id."""
+    runtime, _, audit_engine = _build_runtime()
+    result = await runtime.execute({"id": "x-rid"})
+    run_id_str = str(result.run_id)
+    # Every runtime-emitted audit entry (NOT the dispatch surface's
+    # EXTERNAL_SIDE_EFFECT) carries the run_id binding. Filter on the
+    # presence of the run_id key in payload.
+    runtime_entries = [e for e in audit_engine.entries if "run_id" in e.event_payload]
+    assert len(runtime_entries) >= 4  # at least the 4 phase transitions
+    for entry in runtime_entries:
+        assert entry.event_payload["run_id"] == run_id_str
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_run_id_is_unique_across_invocations() -> None:
+    """Two execute() calls produce distinct run_ids."""
+    runtime, _, _ = _build_runtime()
+    r1 = await runtime.execute({"id": "x-1"})
+    r2 = await runtime.execute({"id": "x-2"})
+    assert r1.run_id != r2.run_id
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_run_id_is_uuid4() -> None:
+    """Run-id MUST be a UUID4 per secrets-backed generator."""
+    runtime, _, _ = _build_runtime()
+    result = await runtime.execute({"id": "x-uuid"})
+    assert isinstance(result.run_id, uuid.UUID)
+    assert result.run_id.version == 4


### PR DESCRIPTION
## Summary

- Adds the **runtime spine** that composes existing primitives (DispatchSurface from S5, AuditChainEngine from S4, TenantScopedCascade from S3, DelegateConstraintEnvelope from S2.5) into the TAOD (Think-Act-Observe-Decide) execution lifecycle with posture-aware gating and R2 composition validation
- 1,372 LOC `runtime.py` + 40 unit tests + 4 integration tests
- 10 new public symbols in `kailash.delegate.__all__` Group 8 (eager imports, orphan-detection Rule 6 compliant)

## 6 invariants held + verified

| # | Invariant | Verification |
|---|-----------|--------------|
| 1 | Phase monotonicity (TAOD transitions append-only; terminal states immutable) | `TAODState.advance_to` rejects terminal mutation + illegal successors → `RuntimePhaseError` |
| 2 | Posture gating at THINKING (read CURRENT, not bind-time; HALT refuses; downgrades respected) | `execute()` reads `self._posture` at THINKING entry |
| 3 | Audit binding (every TAOD transition emits exactly one audit event with `run_id` in payload) | 4-5 events per happy run; verified via signed-payload binding per S5 C2-1 fix |
| 4 | R2 composition re-check at construct + execute (defense-in-depth) | `R2Composition.validate()` runs in `__init__` AND at `execute()` start |
| 5 | No silent posture downgrade in `with_posture` (downgrades silent; upgrades require `human_acknowledged_nonce`) | `with_posture` rank-delta check; `RuntimePostureBlockedError` without nonce |
| 6 | Signer identity (audit_engine + dispatch_surface MUST share signer reference via `is` check) | `R2Composition` identity-check; forgery-defense for cross-binding |

## New public surface (Group 8)

- `DelegateRuntime` — runtime spine composing dispatch + audit + cascade + envelope + identity + signer + posture
- `Posture` (enum) — L1_PSEUDO_AGENT, L2_SUPERVISED, L3_SHARED_PLANNING, L4_CONTINUOUS_INSIGHT, L5_DELEGATED, HALT
- `TAODState`, `TAODTransition` — frozen+slots dataclasses with `Literal` phase type
- `R2Composition` — composition validator (CARE Reasoning+Reliability gate)
- `RuntimeExecutionResult` — frozen+slots with `to_dict`/`from_dict` (S3/S4/S5 EATP convention)
- `RuntimeCompositionError`, `RuntimePostureBlockedError`, `RuntimePhaseError`, `R2CompositionError`

## Design notes

- **No exceptions propagate from `execute()`** — every failure path returns `RuntimeExecutionResult` with `taod_state.phase == "failed"` and error class+message on the FAILED transition's `reason` field. Callers pattern-match on `taod_state.phase` rather than try/except.
- **Posture state-file integration deferred to S8** per shard plan — S6's `Posture` is a runtime parameter; integration with `.claude/learning/posture.json` SessionStart-managed state is S8 e2e scope.
- **10× `Mirrors rs ...` cross-SDK anchors** in runtime.py docstrings per cross-sdk-inspection.md MUST Rule 3 EATP D6 compliance.
- **UUID4 generation via `secrets.token_bytes`** (not `uuid.uuid4()` which uses `random`) per security best practice.

## Gates (all green)

- 40/40 S6 unit tests pass
- 4/4 S6 integration tests pass
- **283/284 full delegate suite (+1 pre-existing skip)** — was 239+; zero regressions in S2/S3/S4/S5 tests
- `pytest --collect-only tests/unit/delegate/` → 268 tests collected
- Clean warnings sweep (no DeprecationWarning / RuntimeWarning / ResourceWarning)
- 10 `Mirrors rs ...` cross-SDK anchors (target ≥3)
- `to_dict`/`from_dict` on all 3 public dataclasses (TAODTransition, TAODState, RuntimeExecutionResult)

## Test plan

- [x] All 287 delegate tests pass (6 invariants verified end-to-end)
- [x] `pytest --collect-only` exit 0 (orphan-detection Rule 5 merge gate)
- [x] `__all__` count test updated: 30 → 40 (AST-verified per testing.md MUST)
- [x] Eager imports for every new `__all__` entry (orphan-detection Rule 6)
- [x] No regressions in dispatch + trust + audit + envelope + types tests
- [x] R2 envelope-swap-after-bind caught by re-check (Invariant 4 defense-in-depth)
- [x] Posture HALT post-construction blocks at THINKING (integration test)

## Deferred to S7+

- **Identity-cascade grantee registry** — current `TenantScopedCascade` (S3) does not persist its grantee set; runtime's bind-time check trusts the DispatchSurface's S5 validation. S7+ enhancement tightens when the registry surfaces.
- **Cross-SDK byte-vector pinning** for `RuntimeExecutionResult` payloads — to_dict shape stable, but no pinned rs-derived fixtures yet (S7 conformance scope).
- **Posture state-file integration** (`.claude/learning/posture.json` SessionStart wiring) — S8 e2e scope.

## Related issues

Part of #1035 — Delegate composition primitive Wave 4 (S6 runtime spine). Unblocks S7 (conformance vectors — pin byte-shape of TAOD transitions + RuntimeExecutionResult for cross-impl receipts_agree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)