### PR TITLE
chore(release): kailash v2.24.0 — kailash.delegate composition primitive pre-pledge v0 (#1035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.0] - 2026-05-22
+
+### Added
+
+- **`kailash.delegate` composition primitive — pre-pledge v0 (#1035)** — new public top-level module shipping the (Connector × Signature × ConstraintEnvelope × Executor) composition substrate under EATP audit. 8-shard build (S1-S8 over PRs #1130-#1144 + L1 cleanup #1145):
+  - **S1 fences** — module + `kailash.delegate` namespace, Apache-2.0 license declaration, zero-engine-deps pre-commit fence (#1130).
+  - **S2 + S2.5 canonical types** — substrate dataclasses, F5 type-state monotonic envelope (#1136 + #1131).
+  - **S3 trust cascade** — `TenantScopedCascade`, `GrantMoment`, signed cascade chain (#1137).
+  - **S4 audit chain** — `AuditChainEngine`, `WitnessedCrossAnchor`, signed audit row emission (#1137).
+  - **S5 dispatch + Connector ABC** — `Connector` abstract base, `DispatchSurface`, `DispatchResult`, capability snapshot at construction, strict-type guard, 32-depth + 1MiB payload limits (#1138).
+  - **S6 runtime spine** — `DelegateRuntime`, `TAODState`/`TAODTransition` (Think-Act-Observe-Decide lifecycle), `Posture` enum (L1-L5 + HALT) with rank ladder, `R2Composition` validator with `is`-identity checks, `RuntimeExecutionResult` with lossy `to_dict`/`from_dict` (commits `bdc89a9b4`, `5fcf935db`, `e9626a223` for S6 R1 audit-emit-before-state-advance + no-recurse `_advance_to_failed_no_audit` helper).
+  - **S7 conformance schema** — `ConformanceVector`, `ConformanceVectorLoader.load_canonical()` with SHA-256 integrity check, `ConformanceVectorIntegrityError` tamper detection, `ConformanceReceipt` with `to_dict`/`from_dict`, `receipts_agree(rs, py)` cross-impl comparator with timestamp-exclusion, `assert_receipts_agree()`. 5 canonical vectors at `tests/fixtures/delegate-conformance/canonical.json` (DV-3-001, DV-5-001, DV-7-001, DV-9-001, DV-10-001). DV-5-001 + DV-10-001 vendored byte-for-byte from `terrene-foundation/kailash-rs` per cross-SDK fixture-vendoring discipline. §7 TAOD phase monotonicity enforced at runtime via `self._consumed` guard + try/finally (commit `d4ad6a9b3`).
+  - **S8 E2E + cross-impl receipts + pre-pledge README** — 8 end-to-end flows (Flow A happy path, B posture HALT, C tenant violation, C2 surface invariant, D signer failure no-recurse, E §7 single-shot, F ConformanceVectorLoader, G receipts_agree_dict identity); 3 Tier-2 cross-impl tests; README § "Delegate composition primitive — Pre-Pledge v0" disclosure enumerating 8 enforced invariants + 3 deferred items + 3 non-promises + how-to-verify + status.
+- **Holistic post-multi-wave /redteam** across all 8 shards on main caught 1 L1 (workspace-path-leakage scrub in module docstrings, PR #1145) + 5 cross-shard follow-ups filed as #1146-#1150 — none blocking v2.24.0.
+
+### Pre-Pledge v0 status
+
+`kailash.delegate` is shipped at pre-pledge v0 per the README disclosure section. Users may rely on the 8 enforced invariants (signed audit chain, capability snapshot at construction, posture ladder, single-shot §7 phase monotonicity, etc.) at this version. Three items remain explicitly deferred to a future minor: cross-SDK byte-determinism conformance for vectors DV-3/DV-7/DV-9 (py-leads at v2.24.0; rs leadership pending). Three explicit non-promises: no implicit retries, no shadow audit chains, no posture auto-upgrade. See README § "Delegate composition primitive — Pre-Pledge v0" for the full disclosure.
+
+### Notes
+
+This release ships a brand-new public top-level module (`kailash.delegate`), warranting SemVer minor. No breaking changes to existing public surfaces. The 6 holistic-/redteam follow-up issues (#1143, #1146-#1150) are tracked separately and will close as their respective fixes land in v2.24.x patches.
+
 ## [2.23.0] - 2026-05-19
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.23.0"
+version = "2.24.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.23.0"
+__version__ = "2.24.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Cuts **v2.24.0** of the `kailash` core package. **Minor bump** (not patch) — this release ships a brand-new public top-level module: `kailash.delegate` (~47 public symbols across 9 export groups).

Atomic version bumps per `zero-tolerance.md` Rule 5:
- `pyproject.toml`: `2.23.0` → `2.24.0`
- `src/kailash/__init__.py`: `2.23.0` → `2.24.0`

CHANGELOG populated with the full Delegate arc summary (S1-S8 across PRs #1130-#1144 + L1 cleanup #1145 + holistic /redteam follow-ups #1146-#1150).

This is a **release-prep PR** — diff is strictly metadata-only (pyproject.toml + `__init__.py` + CHANGELOG.md). Branch named `release/v2.24.0` per `git.md` Release-Prep convention, which auto-skips the PR-gate matrix (path filter `if: !startsWith(github.head_ref, 'release/')`).

**Sibling-package drift check** per `build-repo-release-discipline.md` MUST-3: only `kailash` core has drift (`2.24.0 > 2.23.0`); all 7 sibling packages (dataflow, nexus, kaizen, mcp, ml, align, pact) are already in sync with PyPI. Single-package release.

## What ships

`kailash.delegate` composition primitive — pre-pledge v0:

- 8-shard build delivering (Connector × Signature × ConstraintEnvelope × Executor) under EATP audit
- TAOD lifecycle state machine (Think-Act-Observe-Decide) with `Posture` ladder (L1-L5 + HALT)
- `R2Composition` validator with `is`-identity checks; `DelegateRuntime` spine
- Signed audit chain via `AuditChainEngine` + `WitnessedCrossAnchor`
- Tenant-scoped cascade via `TenantScopedCascade` + `GrantMoment`
- `ConformanceVector` schema + `ConformanceVectorLoader` (SHA-256 integrity); `receipts_agree(rs, py)` cross-impl comparator
- 5 canonical conformance vectors at `tests/fixtures/delegate-conformance/canonical.json` (DV-3/5/7/9/10); DV-5 + DV-10 vendored byte-for-byte from `terrene-foundation/kailash-rs` per cross-SDK fixture-vendoring discipline
- 8 E2E flows + 3 Tier-2 cross-impl receipt tests
- README § "Delegate composition primitive — Pre-Pledge v0" disclosure: 8 enforced invariants + 3 deferred items + 3 non-promises + how-to-verify + status

## Pre-pledge v0 framing

Users may rely on the 8 enforced invariants. Three items remain explicitly deferred to a future minor (cross-SDK byte-determinism conformance for vectors DV-3/DV-7/DV-9, py-leads at v2.24.0). Three explicit non-promises: no implicit retries, no shadow audit chains, no posture auto-upgrade.

## Test plan

- [x] `pyproject.toml::version` matches `src/kailash/__init__.py::__version__` (both `2.24.0`)
- [x] CHANGELOG.md has `## [2.24.0] - 2026-05-22` section with Delegate arc summary
- [x] Pre-commit clean on all 3 release files (black/isort/ruff/whitespace/EOF/TOML/YAML)
- [x] Runtime `import kailash; kailash.__version__ == "2.24.0"`
- [x] Sibling-package drift check: only `kailash` core needs release
- [ ] PR-gate matrix auto-skipped (release/v* branch convention)
- [ ] Admin-merge per owner workflow (`gh pr merge --admin --merge --delete-branch`)
- [ ] Tag `v2.24.0` push triggers `publish-pypi.yml`
- [ ] PyPI publish succeeds; `pypi.org/pypi/kailash/json` returns `2.24.0`
- [ ] Clean-venv install verification: `uv pip install kailash==2.24.0` + `from kailash import delegate`

## Related issues

Refs #1035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)