### PR TITLE
chore(release): kailash v2.24.1 — hotfix clean-venv install of delegate (#1035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.1] - 2026-05-22
+
+### Fixed
+
+- **`import kailash.delegate` failed on clean-venv install of 2.24.0 (CRITICAL)** — `kailash.delegate.types:46` eagerly imports `from kailash.trust._locking import validate_id` (the canonical path-traversal guard mandated by `trust-plane-security.md` Rule 2); `kailash.trust._locking:38` has a module-scope `from filelock import FileLock, Timeout`; `filelock` was declared only in the `[trust]` optional extra, not in core dependencies. Result: `pip install kailash==2.24.0` → `from kailash import delegate` → `ModuleNotFoundError: No module named 'filelock'`. Fixed by promoting `filelock>=3.0` to slim-core `[project.dependencies]` (duplicates the `[trust]` declaration so a bare install resolves delegate cleanly). Same failure class as `build-repo-release-discipline.md` Rule 2 "clean-venv installability is the done gate" + `deployment.md` "MUST: Eagerly-Imported Transitive Dependencies Are Declared By The Importing Package".
+
 ## [2.24.0] - 2026-05-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.24.0"
+version = "2.24.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}
@@ -26,18 +26,27 @@ dependencies = [
     # ─────────────────────────────────────────────────────────────
     # Slim core — only the deps required to `import kailash` and use
     # the workflow primitives (Workflow, WorkflowBuilder, LocalRuntime,
-    # Node, NodeMetadata, NodeParameter). Everything else is opt-in via
-    # extras. See `pip install kailash[server,db-postgres,...]`.
+    # Node, NodeMetadata, NodeParameter) PLUS the kailash.delegate
+    # composition primitive (added in 2.24.0). Everything else is
+    # opt-in via extras. See `pip install kailash[server,db-postgres,...]`.
     #
-    # Audit reference: issue #890. Confirmed by AST closure walk from
-    # `src/kailash/__init__.py` (only 4 eager modules: nodes/base.py,
-    # runtime/local.py, workflow/{builder,graph}.py). Every dep below
-    # has at least one module-scope import in that closure.
+    # Audit reference: issue #890 (pre-Delegate slim-core baseline) +
+    # 2.24.1 hotfix (added filelock for delegate.types → trust._locking →
+    # filelock eager chain — `kailash.trust._locking::validate_id` is
+    # the canonical path-traversal guard mandated by
+    # `trust-plane-security.md` Rule 2, so refactoring delegate.types
+    # to bypass _locking is BLOCKED). Every dep below has at least one
+    # module-scope import in that closure.
     # ─────────────────────────────────────────────────────────────
     "jsonschema>=4.24.0",   # workflow/contracts.py:21 (Draft7Validator)
     "pydantic>=2.6",        # nodes/base.py:37, workflow/graph.py:12 (BaseModel)
     "pyyaml>=6.0",          # workflow/graph.py:11 (workflow serialization)
     "click>=8.0",           # backs `[project.scripts] kailash = ...` console entry
+    "filelock>=3.0",        # trust/_locking.py:38 (FileLock, Timeout) — eagerly
+                            # imported by kailash.delegate.types via
+                            # `from kailash.trust._locking import validate_id`
+                            # (2.24.0+). Duplicates declaration in [trust] extra
+                            # so `pip install kailash` resolves delegate cleanly.
 ]
 
 [project.optional-dependencies]

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.24.0"
+__version__ = "2.24.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

**Hotfix for v2.24.0**: clean-venv `pip install kailash==2.24.0` followed by `from kailash import delegate` raised `ModuleNotFoundError: No module named 'filelock'`.

Promotes `filelock>=3.0` from the `[trust]` optional extra into slim-core `[project.dependencies]`.

## Root cause

The eager-import chain `kailash.delegate.types:46` → `kailash.trust._locking:38` → `from filelock import FileLock, Timeout` was added in v2.24.0 (S3 trust cascade + S6 runtime spine), but `filelock` was declared only in `[trust]`. Slim-core dev environments and CI install the `[dev]` extras (which include `[trust]`) so the failure was latent in main and only surfaced at PyPI clean-venv verification.

Failure class: `deployment.md` § "MUST: Eagerly-Imported Transitive Dependencies Are Declared By The Importing Package" + `build-repo-release-discipline.md` Rule 2 "clean-venv installability is the done gate".

## What this PR does

| File | Change |
| --- | --- |
| `pyproject.toml` | `version = "2.24.0"` → `"2.24.1"`; add `filelock>=3.0` to `[project.dependencies]` with audit comment explaining the eager chain |
| `src/kailash/__init__.py` | `__version__ = "2.24.0"` → `"2.24.1"` |
| `CHANGELOG.md` | `## [2.24.1] - 2026-05-22` entry documenting the failure mode + fix |

## Why slim-core (not refactor delegate.types)

`trust-plane-security.md` Rule 2 explicitly mandates `from kailash.trust._locking import validate_id` as the canonical path-traversal guard import — refactoring `delegate.types` to bypass `_locking` is BLOCKED by the security rule. The eager-chain fix is to honor the dep declaration.

Follow-up structural cleanup candidate: lazy-import `filelock` inside `_locking.py`'s functions that actually use it (only `file_lock`, `safe_read_json` need it; `validate_id` is a pure regex check). That refactor preserves the slim-core size budget but is out of scope for this hotfix per `build-repo-release-discipline.md` Rule 2 "fix the entire broken pattern in the hotfix".

## Test plan

- [x] `pyproject.toml::version == src/kailash/__init__.py::__version__ == "2.24.1"`
- [x] `filelock>=3.0` in `[project.dependencies]`
- [x] CHANGELOG `## [2.24.1] - 2026-05-22` section present
- [x] Pre-commit clean
- [x] Hotfix verified locally: `uv pip install filelock` in clean venv unblocks `from kailash import delegate`
- [ ] PR-gate matrix auto-skipped (release/v* branch convention)
- [ ] Admin-merge + tag `v2.24.1` push
- [ ] `publish-pypi.yml` succeeds
- [ ] Clean-venv `uv pip install kailash==2.24.1` + `from kailash import delegate` succeeds **without** also installing filelock manually

## Related issues

Refs #1035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)