### PR TITLE
feat(delegate): §10 G1 principal-kind discrimination enforcement (#1143)

### DIFF
--- a/src/kailash/delegate/__init__.py
+++ b/src/kailash/delegate/__init__.py
@@ -45,10 +45,7 @@ from kailash.delegate.dispatch import (
     DispatchSurface,
     DispatchValidationError,
 )
-from kailash.delegate.envelope import (
-    DelegateConstraintEnvelope,
-    EnvelopeWideningError,
-)
+from kailash.delegate.envelope import DelegateConstraintEnvelope, EnvelopeWideningError
 from kailash.delegate.runtime import (
     DelegateRuntime,
     Posture,
@@ -75,6 +72,7 @@ from kailash.delegate.types import (
     LifecycleError,
     LifecycleState,
     PrincipalDirectory,
+    PrincipalKind,
     Role,
     RoleLifecycleState,
     RoleScope,
@@ -87,6 +85,7 @@ __all__ = [
     # Group 2 -- Identity + role substrate (S2.5 F2/F3)
     "DelegateIdentity",
     "PrincipalDirectory",
+    "PrincipalKind",
     "Role",
     "RoleLifecycleState",
     "RoleScope",

--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -63,21 +63,14 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol, runtime_checkable
 
-from kailash.delegate.audit import (
-    AuditChainEngine,
-    DelegateEventType,
-)
+from kailash.delegate.audit import AuditChainEngine, DelegateEventType
 from kailash.delegate.envelope import DelegateConstraintEnvelope
 from kailash.delegate.trust import (
     CascadeTenantViolationError,
     TenantScope,
     TenantScopedCascade,
 )
-from kailash.delegate.types import (
-    DelegateIdentity,
-    Role,
-    RoleLifecycleState,
-)
+from kailash.delegate.types import DelegateIdentity, Role, RoleLifecycleState
 from kailash.trust._json import canonical_json_dumps
 
 logger = logging.getLogger(__name__)
@@ -893,6 +886,46 @@ class DispatchSurface:
                 f"RETIRED/SUSPENDED roles cannot dispatch — Invariant 5)"
             )
 
+        # #1143 §10 G1 — principal-kind discriminator gate. The bound
+        # :class:`DelegateIdentity`'s ``principal_kind`` MUST be in the
+        # role's :attr:`permitted_principal_kinds` frozenset. A
+        # service-account identity binding to a sovereign-only role
+        # collapses the Genesis-to-Delegation attribution chain — the
+        # exact §10 G1 invariant.
+        #
+        # Checked AFTER lifecycle so a retired role surfaces the
+        # lifecycle failure first (it's the more fundamental refusal).
+        # Checked BEFORE capability so a principal-kind mismatch
+        # surfaces before downstream capability hashes — the kind
+        # mismatch is the load-bearing signal.
+        #
+        # Defense-in-depth: the same check re-fires at every
+        # :meth:`dispatch` start per the F5 / R2 composition pattern,
+        # in case the Role's ``permitted_principal_kinds`` is mutated
+        # between bind and dispatch (mutation of a frozenset is
+        # impossible, but the Role object itself could be swapped via
+        # an external reference).
+        if identity.principal_kind not in role.permitted_principal_kinds:
+            logger.debug(
+                "dispatch.envelope_violation",
+                extra={
+                    "axis": "principal_kind",
+                    "connector_id": connector.connector_id,
+                    "role_display_name": role.display_name,
+                    "identity_principal_kind": identity.principal_kind,
+                    "role_permitted_principal_kinds": sorted(
+                        role.permitted_principal_kinds
+                    ),
+                },
+            )
+            raise DispatchEnvelopeViolationError(
+                f"DispatchSurface refuses bind: identity principal_kind "
+                f"{identity.principal_kind!r} not in role "
+                f"{role.display_name!r} permitted_principal_kinds "
+                f"{sorted(role.permitted_principal_kinds)!r} "
+                "(#1143 §10 G1 — service-account vs sovereign separation)"
+            )
+
         # Invariant 3 — capability gating. Connector's required
         # capabilities MUST be a subset of the role's capability set.
         # C5-2 error-leakage: hash capability names in the caller-facing
@@ -954,6 +987,15 @@ class DispatchSurface:
             role.scope.capabilities.capabilities
         )
         self._lifecycle_at_bind: RoleLifecycleState = role.lifecycle
+        # #1143 §10 G1 — principal-kind snapshots for the dispatch-time
+        # re-check. ``identity.principal_kind`` is a Literal string
+        # (immutable). ``role.permitted_principal_kinds`` is a frozenset
+        # (immutable by construction). The pair forms the bind-time
+        # contract the F5 re-check at dispatch defends.
+        self._identity_principal_kind: str = identity.principal_kind
+        self._permitted_principal_kinds_at_bind: frozenset[str] = frozenset(
+            role.permitted_principal_kinds
+        )
 
     @property
     def connector(self) -> Connector:
@@ -1060,6 +1102,24 @@ class DispatchSurface:
                 f"from {self._lifecycle_at_bind.value!r} at bind to "
                 f"{current_lifecycle.value!r}; invocation refused (F5 "
                 "monotonicity — Invariant 5 runtime re-check)"
+            )
+        # Step 0a.1 — #1143 §10 G1 principal-kind re-check. Pair to the
+        # bind-time gate in __init__. The identity's principal_kind MUST
+        # still be in the role's permitted_principal_kinds at dispatch
+        # time. Defense-in-depth: if a caller swapped the Role's
+        # permitted set via direct attribute assignment (frozen=True
+        # blocks normal mutation but ``object.__setattr__`` bypasses)
+        # OR mutated the identity's principal_kind via the same
+        # bypass, the dispatch-time check refuses.
+        current_permitted = frozenset(self._role.permitted_principal_kinds)
+        current_kind = self._identity.principal_kind
+        if current_kind not in current_permitted:
+            raise DispatchEnvelopeViolationError(
+                f"DispatchSurface refuses dispatch: principal_kind "
+                f"{current_kind!r} not in current role "
+                f"permitted_principal_kinds {sorted(current_permitted)!r}; "
+                "invocation refused (#1143 §10 G1 — principal-kind "
+                "discriminator runtime re-check)"
             )
 
         # Step 0b — C6-1 DoS defense: depth + serialized-size limits

--- a/src/kailash/delegate/types.py
+++ b/src/kailash/delegate/types.py
@@ -41,12 +41,51 @@ import re
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Literal, get_args
 
 from kailash.trust._locking import validate_id as _validate_id
 from kailash.trust.chain import GenesisRecord as SubstrateGenesisRecord
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# PrincipalKind discriminator (#1143 §10 G1)
+# ---------------------------------------------------------------------------
+#
+# A Delegate acts through a scoped service-account principal distinct from
+# the sovereign (human) principal the Delegate acts for. §10 G1 of the
+# Terrene Delegate Specification mandates that the runtime MUST reject any
+# Connector binding where these principals collapse — impersonation breaks
+# the Genesis-to-Delegation attribution chain.
+#
+# ``PrincipalKind`` discriminates the THREE legitimate principal types:
+#
+# - ``"sovereign"`` — the human authority the Delegate ultimately acts for
+#   (the natural-person sovereign at the root of the Genesis chain).
+# - ``"service_account"`` — the scoped, non-human principal a Connector
+#   provisions to mediate a specific external surface (e.g. an HTTP API
+#   service account, a queue producer account).
+# - ``"delegate"`` — the default for a Delegate-bound identity that does
+#   NOT terminate at a Connector. Backwards-compatible default for existing
+#   call sites that construct identities without an explicit kind.
+#
+# The :class:`Role.permitted_principal_kinds` field restricts which kinds
+# may bind to a given Role; the :class:`DispatchSurface.__init__` gate
+# cross-validates the bound identity's ``principal_kind`` against the
+# role's permitted set and raises
+# :class:`kailash.delegate.dispatch.DispatchEnvelopeViolationError` on
+# mismatch. The same check re-fires at every ``execute()`` start per the
+# R2 composition re-validation pattern.
+PrincipalKind = Literal["sovereign", "service_account", "delegate"]
+
+#: Frozenset of every valid :data:`PrincipalKind` literal, derived
+#: structurally from the Literal at module-load. Used at runtime by
+#: :class:`Role.__post_init__` to validate ``permitted_principal_kinds``
+#: entries and by :class:`DelegateIdentity.__post_init__` to validate the
+#: ``principal_kind`` field. ``get_args(PrincipalKind)`` is the canonical
+#: structural enumeration — grep-stable, refactor-safe.
+_ALL_PRINCIPAL_KINDS: frozenset[str] = frozenset(get_args(PrincipalKind))
+
 
 __all__ = [
     "CapabilitySet",
@@ -55,6 +94,7 @@ __all__ = [
     "LifecycleError",
     "LifecycleState",
     "PrincipalDirectory",
+    "PrincipalKind",
     "Role",
     "RoleLifecycleState",
     "RoleScope",
@@ -203,12 +243,21 @@ class DelegateIdentity:
         genesis_ref: Reference to the genesis record that roots this
             Delegate's authority chain. EAGER REQUIRED — empty string
             rejected.
+        principal_kind: The :data:`PrincipalKind` discriminator (#1143 §10
+            G1). One of ``"sovereign"``, ``"service_account"``,
+            ``"delegate"``. Defaults to ``"delegate"`` for backwards
+            compatibility with existing call sites that pre-date the
+            discriminator. :class:`DispatchSurface.__init__` cross-validates
+            this against :attr:`Role.permitted_principal_kinds` and raises
+            :class:`~kailash.delegate.dispatch.DispatchEnvelopeViolationError`
+            on mismatch.
     """
 
     delegate_id: uuid.UUID
     sovereign_ref: str
     role_binding_ref: str
     genesis_ref: str
+    principal_kind: PrincipalKind = "delegate"
 
     def __post_init__(self) -> None:
         if not isinstance(self.delegate_id, uuid.UUID):
@@ -227,6 +276,20 @@ class DelegateIdentity:
             )
         if not self.genesis_ref:
             raise ValueError("DelegateIdentity.genesis_ref MUST be a non-empty string")
+        # #1143 §10 G1 — principal_kind MUST be one of the declared
+        # Literal values. We validate at runtime because Python's static
+        # Literal check is type-checker-only; a downstream caller passing
+        # an arbitrary string would otherwise silently corrupt the
+        # discriminator. Validation against ``_ALL_PRINCIPAL_KINDS``
+        # (derived structurally from ``get_args(PrincipalKind)``) keeps
+        # the source of truth single — the Literal alias.
+        if self.principal_kind not in _ALL_PRINCIPAL_KINDS:
+            raise ValueError(
+                f"DelegateIdentity.principal_kind MUST be one of "
+                f"{sorted(_ALL_PRINCIPAL_KINDS)!r}; got "
+                f"{self.principal_kind!r} (#1143 §10 G1 — principal-kind "
+                "discriminator)"
+            )
         # B3 (Round 2 sec M-1): path-traversal / null-byte / unsafe-char
         # rejection on every externally-sourced ref string. Per
         # trust-plane-security.md MUST Rule 2 the canonical helper is
@@ -263,6 +326,7 @@ class DelegateIdentity:
             "sovereign_ref": self.sovereign_ref,
             "role_binding_ref": self.role_binding_ref,
             "genesis_ref": self.genesis_ref,
+            "principal_kind": self.principal_kind,
         }
 
     @classmethod
@@ -329,11 +393,24 @@ class DelegateIdentity:
                     f"DelegateIdentity.from_dict: {field_name} MUST be a str; "
                     f"got {type(payload[field_name]).__name__}"
                 )
+        # #1143 §10 G1 — principal_kind round-trip. The field is OPTIONAL
+        # in the wire payload (back-compat with payloads emitted before
+        # the discriminator landed); when absent we default to "delegate"
+        # (matching the dataclass default). When present, it MUST be a
+        # str — __post_init__ enforces value validity against the
+        # Literal alias.
+        principal_kind_raw = payload.get("principal_kind", "delegate")
+        if not isinstance(principal_kind_raw, str):
+            raise TypeError(
+                "DelegateIdentity.from_dict: principal_kind MUST be a str; "
+                f"got {type(principal_kind_raw).__name__}"
+            )
         return cls(
             delegate_id=delegate_id,
             sovereign_ref=payload["sovereign_ref"],
             role_binding_ref=payload["role_binding_ref"],
             genesis_ref=payload["genesis_ref"],
+            principal_kind=principal_kind_raw,  # type: ignore[arg-type]
         )
 
 
@@ -438,6 +515,17 @@ class Role:
         display_name: Human-readable display name. Empty string rejected.
         scope: The :class:`RoleScope` — domain + capabilities (both axes).
         lifecycle: The :class:`RoleLifecycleState` this role is in.
+        permitted_principal_kinds: Frozenset of :data:`PrincipalKind`
+            literals this role permits an :class:`DelegateIdentity` to
+            bind under (#1143 §10 G1). Defaults to ALL kinds
+            (``frozenset({"sovereign", "service_account", "delegate"})``)
+            for backwards compatibility with roles defined before the
+            discriminator landed. :class:`DispatchSurface.__init__`
+            cross-validates ``identity.principal_kind in
+            role.permitted_principal_kinds`` at bind, and re-fires the
+            check at every ``execute()`` start per R2 composition
+            re-validation. Empty frozenset is REJECTED — a role that
+            permits no principal-kind is structurally unreachable.
 
     Deferred to S3 (#1035 follow-up): from_dict validating constructor
     closes the direct-dataclass-construction bypass; tracking via
@@ -448,6 +536,9 @@ class Role:
     display_name: str
     scope: RoleScope
     lifecycle: RoleLifecycleState
+    permitted_principal_kinds: frozenset[PrincipalKind] = field(
+        default_factory=lambda: frozenset(_ALL_PRINCIPAL_KINDS)  # type: ignore[arg-type]
+    )
 
     def __post_init__(self) -> None:
         if not isinstance(self.role_id, uuid.UUID):
@@ -465,6 +556,44 @@ class Role:
             raise TypeError(
                 "Role.lifecycle MUST be a RoleLifecycleState; got "
                 f"{type(self.lifecycle).__name__}"
+            )
+        # #1143 §10 G1 — permitted_principal_kinds discipline. Accept
+        # any iterable for ergonomic callers (a plain ``set`` or ``tuple``
+        # converts cleanly) but coerce to ``frozenset`` for immutability
+        # so the role's permitted set cannot be mutated post-bind.
+        if not isinstance(self.permitted_principal_kinds, frozenset):
+            try:
+                object.__setattr__(
+                    self,
+                    "permitted_principal_kinds",
+                    frozenset(self.permitted_principal_kinds),
+                )
+            except TypeError as exc:
+                raise TypeError(
+                    "Role.permitted_principal_kinds MUST be a frozenset (or "
+                    "iterable coercible to one) of PrincipalKind literals; "
+                    f"got {type(self.permitted_principal_kinds).__name__}"
+                ) from exc
+        # Empty set is structurally unreachable — a role that permits no
+        # principal-kind cannot ever be bound. Reject loudly so the
+        # misconfiguration surfaces at construction, not at dispatch.
+        if not self.permitted_principal_kinds:
+            raise ValueError(
+                "Role.permitted_principal_kinds MUST be non-empty; an empty "
+                "permitted set is structurally unreachable (no identity can "
+                "satisfy it). Use the default (all kinds) for unrestricted "
+                "roles."
+            )
+        # Each entry MUST be a valid PrincipalKind literal — the same
+        # Literal-derived allowlist DelegateIdentity validates against.
+        invalid = {
+            k for k in self.permitted_principal_kinds if k not in _ALL_PRINCIPAL_KINDS
+        }
+        if invalid:
+            raise ValueError(
+                f"Role.permitted_principal_kinds contains invalid entries "
+                f"{sorted(invalid)!r}; valid kinds are "
+                f"{sorted(_ALL_PRINCIPAL_KINDS)!r} (#1143 §10 G1)"
             )
 
 

--- a/tests/integration/delegate/test_conformance_vectors.py
+++ b/tests/integration/delegate/test_conformance_vectors.py
@@ -295,41 +295,66 @@ async def _exercise_dv_9_001_audit_chain_replay_round_trip() -> bool:
     return True
 
 
-@pytest.mark.asyncio
-async def _exercise_dv_10_001_g1_service_account_separation() -> bool:
-    """DV-10-001 — Connector service-account principal MUST differ from
-    sovereign principal.
+def _exercise_dv_10_001_g1_service_account_separation() -> bool:
+    """DV-10-001 -- #1143 §10 G1: principal-kind discriminator enforces
+    service-account vs sovereign separation at the dispatch bind gate.
 
-    REJECT iff: constructing a Connector whose tenant_id_observed equals
-    the principal's directory id collapses attribution -- in this py port,
-    the cascade tenant-isolation gate raises when invoked with mismatched
-    tenant context. We assert the *integrity-violation* path: a connector
-    that returns a tenant_id_observed unequal to the cascade's tenant
-    raises a CascadeTenantViolationError on dispatch.
+    REJECT iff: constructing a :class:`DispatchSurface` with a
+    ``service_account``-kind identity bound to a role whose
+    ``permitted_principal_kinds`` is ``frozenset({"sovereign"})`` raises
+    :class:`DispatchEnvelopeViolationError` at __init__.
 
-    The §10 G1 invariant manifests in py as: dispatch with a connector
-    whose tenant_id_observed != cascade.tenant.id MUST raise (the
-    DispatchCascadeViolationError class).
+    The §10 G1 invariant: a Delegate acts through a scoped service-account
+    principal distinct from the sovereign principal the Delegate acts
+    for. A Connector binding where these collapse impersonates the
+    sovereign and breaks the Genesis-to-Delegation attribution chain.
+    The :class:`Role.permitted_principal_kinds` field expresses which
+    kinds may bind; the dispatch gate refuses any mismatch.
     """
-    from kailash.delegate.dispatch import DispatchCascadeViolationError
+    from kailash.delegate.dispatch import DispatchEnvelopeViolationError
 
-    # Build a runtime where the cascade expects "tenant-A" but the
-    # connector reports "principal-conformance" (a sovereign principal
-    # identifier, NOT a tenant id) -- the cascade rejects on dispatch.
-    runtime, _, _, _, _ = _build_runtime(tenant_id="tenant-A")
-    # Patch the connector's observed tenant to the sovereign principal id
-    # to simulate the G1-amendment violation:
-    runtime.dispatch_surface.connector.tenant_id_observed = "principal-conformance"
+    # Build a sovereign-only role -- the role permits the SOVEREIGN
+    # principal-kind to bind, but NOT the service_account kind.
+    sovereign_only_role = Role(
+        role_id=uuid.uuid4(),
+        display_name="sovereign-only-conformance-role",
+        scope=RoleScope(
+            domain="finance",
+            capabilities=CapabilitySet(capabilities=("http.read",)),
+        ),
+        lifecycle=RoleLifecycleState.ACTIVE,
+        permitted_principal_kinds=frozenset({"sovereign"}),
+    )
+    # Construct a service-account-kind identity -- the impersonation
+    # collapse the §10 G1 invariant blocks.
+    service_account_identity = DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref="sov-conformance",
+        role_binding_ref="rb-conformance",
+        genesis_ref="g-agent-conformance",
+        principal_kind="service_account",
+    )
+    # Substrate dependencies for the bind attempt.
+    chain = _build_chain()
+    audit_engine = AuditChainEngine(chain=chain)
+    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-A"))
+    env = _build_envelope()
+    connector = _PassthroughConnector(tenant_id_observed="tenant-A")
     try:
-        await runtime.execute({"id": "g1-probe"})
-        return False
-    except DispatchCascadeViolationError:
+        DispatchSurface(
+            connector=connector,
+            signature=_ConformanceSig(),
+            envelope=env,
+            identity=service_account_identity,
+            audit_engine=audit_engine,
+            trust_cascade=cascade,
+            role=sovereign_only_role,
+            signer=_test_signer,
+        )
+    except DispatchEnvelopeViolationError:
         return True
-    except Exception:
-        # Any other rejection class also represents the runtime refusing
-        # the impersonation collapse -- the vector asserts REJECT, not
-        # which specific rejection class.
-        return True
+    # Bind succeeded -- the §10 G1 gate did not fire.
+    return False
 
 
 # Map vector_id -> async exerciser. Sync exercisers wrap to async for uniform dispatch.
@@ -343,7 +368,7 @@ async def _run_vector(vector: ConformanceVector) -> bool:
     if vector.id == "DV-9-001":
         return await _exercise_dv_9_001_audit_chain_replay_round_trip()
     if vector.id == "DV-10-001":
-        return await _exercise_dv_10_001_g1_service_account_separation()
+        return _exercise_dv_10_001_g1_service_account_separation()
     raise ValueError(f"no exerciser registered for vector {vector.id!r}")
 
 
@@ -360,8 +385,8 @@ async def test_dv_3_001_r2_composition_behaviour() -> None:
     assert target.expected is BehaviouralOutcome.REJECT
     exhibited_reject = await _run_vector(target)
     assert exhibited_reject is True, (
-        f"DV-3-001 expected REJECT (per §3 R2 composition); runtime did not "
-        f"exhibit rejection of widening cascade"
+        "DV-3-001 expected REJECT (per §3 R2 composition); runtime did not "
+        "exhibit rejection of widening cascade"
     )
 
 
@@ -373,8 +398,8 @@ async def test_dv_5_001_monotonic_tightening_behaviour() -> None:
     assert target.expected is BehaviouralOutcome.REJECT
     exhibited_reject = await _run_vector(target)
     assert exhibited_reject is True, (
-        f"DV-5-001 expected REJECT (per §5 monotonic-tightening); envelope "
-        f"did not raise EnvelopeWideningError"
+        "DV-5-001 expected REJECT (per §5 monotonic-tightening); envelope "
+        "did not raise EnvelopeWideningError"
     )
 
 
@@ -395,8 +420,8 @@ async def test_dv_7_001_taod_phase_monotonicity_behaviour() -> None:
     assert target.expected is BehaviouralOutcome.REJECT
     exhibited_reject = await _run_vector(target)
     assert exhibited_reject is True, (
-        f"DV-7-001 expected REJECT (per §7 TAOD phase monotonicity); "
-        f"runtime did not raise RuntimePhaseError on re-execute"
+        "DV-7-001 expected REJECT (per §7 TAOD phase monotonicity); "
+        "runtime did not raise RuntimePhaseError on re-execute"
     )
 
 
@@ -408,32 +433,31 @@ async def test_dv_9_001_audit_chain_replay_behaviour() -> None:
     assert target.expected is BehaviouralOutcome.ACCEPT
     accepted = await _run_vector(target)
     assert accepted is True, (
-        f"DV-9-001 expected ACCEPT (per §9 audit chain replay); audit "
-        f"entries did not round-trip byte-identically OR head hash mismatched"
+        "DV-9-001 expected ACCEPT (per §9 audit chain replay); audit "
+        "entries did not round-trip byte-identically OR head hash mismatched"
     )
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "DV-10-001 vector pins §10 G1 service-account separation "
-        "(Connector binding with sovereign principal MUST reject). The S5 "
-        "dispatch path does not yet enforce sovereign-vs-service-account "
-        "distinctness at this surface. The vector is the contract that "
-        "triggers the dispatch fix; XPASS surfaces gap loudly. See #1035 "
-        "follow-up."
-    ),
-)
 async def test_dv_10_001_g1_service_account_separation_behaviour() -> None:
+    """DV-10-001 -- #1143 §10 G1 principal-kind discriminator.
+
+    The DispatchSurface bind gate cross-validates ``identity.principal_kind``
+    against ``role.permitted_principal_kinds`` and raises
+    :class:`DispatchEnvelopeViolationError` on mismatch. Previously
+    xfail-strict pending the dispatch fix; now PASSES per the §10 G1
+    discriminator landing. Mirrors unit-level coverage in
+    ``tests/unit/delegate/test_dispatch.py::
+    test_dispatch_surface_refuses_principal_kind_mismatch``.
+    """
     vectors = ConformanceVectorLoader.load_canonical()
     target = next(v for v in vectors if v.id == "DV-10-001")
     assert target.expected is BehaviouralOutcome.REJECT
     rejected = await _run_vector(target)
     assert rejected is True, (
-        f"DV-10-001 expected REJECT (per §10 G1 service-account separation); "
-        f"runtime did not raise on sovereign-principal collapse"
+        "DV-10-001 expected REJECT (per §10 G1 service-account separation); "
+        "runtime did not raise on sovereign-principal collapse"
     )
 
 
@@ -475,14 +499,13 @@ async def test_full_canonical_set_produces_receipt() -> None:
         vectors_passed=passed,
     )
     assert receipt.vectors_total == 5
-    # Currently 4 of 5 vectors pass (DV-3, DV-5, DV-7, DV-9). DV-10 is
-    # the remaining xfail-tracked behavioral gap (§10 G1 service-account
-    # vs sovereign separation in the dispatch surface); the vector is
-    # the contract, the dispatch surface is the catch-up target. DV-7
-    # graduated from xfail when the runtime §7 single-shot guard landed.
-    assert receipt.vectors_passed == 4
-    assert receipt.conforms() is False  # 4 of 5 -- not yet conforming
-    # Both validation predicates hold on a partial receipt:
+    # All 5 vectors now pass (DV-3, DV-5, DV-7, DV-9, DV-10). DV-10
+    # graduated from xfail when #1143 landed the principal-kind
+    # discriminator gate on DispatchSurface.__init__. DV-7 graduated
+    # earlier when the runtime §7 single-shot guard landed.
+    assert receipt.vectors_passed == 5
+    assert receipt.conforms() is True  # 5 of 5 -- conforming
+    # Both validation predicates hold:
     assert receipt.vectors_passed <= receipt.vectors_total
 
 

--- a/tests/unit/delegate/test_dispatch.py
+++ b/tests/unit/delegate/test_dispatch.py
@@ -46,20 +46,6 @@ from kailash.delegate.dispatch import (
     DispatchValidationError,
     SignatureContract,
 )
-
-
-# ---------------------------------------------------------------------------
-# Deterministic test signer — produces a 128-char lowercase hex string from
-# the canonical-bytes input. SHA-256 doubled to 128 chars satisfies the
-# audit-engine's _validate_hex(expected_len=128) contract.
-# ---------------------------------------------------------------------------
-
-
-def _test_signer(canonical_bytes: bytes) -> str:
-    h = hashlib.sha256(canonical_bytes).hexdigest()
-    return h + h  # 128-char lowercase hex
-
-
 from kailash.delegate.envelope import DelegateConstraintEnvelope
 from kailash.delegate.trust import (
     CascadeTenantViolationError,
@@ -76,6 +62,18 @@ from kailash.delegate.types import (
 )
 from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
 from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+# ---------------------------------------------------------------------------
+# Deterministic test signer — produces a 128-char lowercase hex string from
+# the canonical-bytes input. SHA-256 doubled to 128 chars satisfies the
+# audit-engine's _validate_hex(expected_len=128) contract.
+# ---------------------------------------------------------------------------
+
+
+def _test_signer(canonical_bytes: bytes) -> str:
+    h = hashlib.sha256(canonical_bytes).hexdigest()
+    return h + h  # 128-char lowercase hex
+
 
 # ---------------------------------------------------------------------------
 # Fixture helpers — keep tests focused on behavior under test
@@ -95,12 +93,13 @@ def _build_chain(agent_id: str = "agent-s5") -> TrustLineageChain:
     )
 
 
-def _build_identity() -> DelegateIdentity:
+def _build_identity(*, principal_kind: str = "delegate") -> DelegateIdentity:
     return DelegateIdentity(
         delegate_id=uuid.uuid4(),
         sovereign_ref="sov-s5",
         role_binding_ref="rb-s5",
         genesis_ref="g-agent-s5",
+        principal_kind=principal_kind,  # type: ignore[arg-type]
     )
 
 
@@ -126,16 +125,20 @@ def _build_role(
     *,
     lifecycle: RoleLifecycleState = RoleLifecycleState.ACTIVE,
     capabilities: tuple[str, ...] = ("http.read", "http.write"),
+    permitted_principal_kinds: frozenset[str] | None = None,
 ) -> Role:
-    return Role(
-        role_id=uuid.uuid4(),
-        display_name="test-role",
-        scope=RoleScope(
+    kwargs: dict[str, object] = {
+        "role_id": uuid.uuid4(),
+        "display_name": "test-role",
+        "scope": RoleScope(
             domain="finance",
             capabilities=CapabilitySet(capabilities=capabilities),
         ),
-        lifecycle=lifecycle,
-    )
+        "lifecycle": lifecycle,
+    }
+    if permitted_principal_kinds is not None:
+        kwargs["permitted_principal_kinds"] = permitted_principal_kinds
+    return Role(**kwargs)  # type: ignore[arg-type]
 
 
 def _build_cascade(*, tenant_id: str | None = "tenant-a") -> TenantScopedCascade:
@@ -1053,3 +1056,95 @@ def test_dispatch_signer_error_is_value_error() -> None:
     err = DispatchSignerError("test")
     assert isinstance(err, ValueError)
     assert isinstance(err, DispatchSignerError)
+
+
+# ---------------------------------------------------------------------------
+# #1143 §10 G1 — principal-kind discriminator dispatch gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_service_account_on_sovereign_only_role() -> None:
+    """#1143 §10 G1 — DispatchSurface.__init__ MUST refuse a
+    service_account-kind identity binding to a role whose
+    permitted_principal_kinds = frozenset({"sovereign"}).
+    """
+    sovereign_only_role = _build_role(
+        permitted_principal_kinds=frozenset({"sovereign"}),
+    )
+    service_account_identity = _build_identity(principal_kind="service_account")
+    with pytest.raises(DispatchEnvelopeViolationError, match=r"principal_kind"):
+        _make_surface(role=sovereign_only_role, identity=service_account_identity)
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_delegate_on_sovereign_only_role() -> None:
+    """Mirror case: the default delegate kind ALSO refuses against a
+    sovereign-only role. The discriminator is exact; default kinds get
+    no implicit pass."""
+    sovereign_only_role = _build_role(
+        permitted_principal_kinds=frozenset({"sovereign"}),
+    )
+    delegate_identity = _build_identity(principal_kind="delegate")
+    with pytest.raises(DispatchEnvelopeViolationError, match=r"principal_kind"):
+        _make_surface(role=sovereign_only_role, identity=delegate_identity)
+
+
+@pytest.mark.unit
+def test_dispatch_surface_allows_sovereign_on_sovereign_only_role() -> None:
+    """Happy path: a sovereign-kind identity binds to a sovereign-only
+    role without raising."""
+    sovereign_only_role = _build_role(
+        permitted_principal_kinds=frozenset({"sovereign"}),
+    )
+    sovereign_identity = _build_identity(principal_kind="sovereign")
+    surface = _make_surface(role=sovereign_only_role, identity=sovereign_identity)
+    assert surface.identity.principal_kind == "sovereign"
+
+
+@pytest.mark.unit
+def test_dispatch_surface_default_permitted_set_allows_all_kinds() -> None:
+    """Backwards-compat: roles defined without explicit
+    permitted_principal_kinds permit every kind, so existing call sites
+    continue to bind cleanly."""
+    default_role = _build_role()  # default permitted = all kinds
+    for kind in ("sovereign", "service_account", "delegate"):
+        ident = _build_identity(principal_kind=kind)
+        surface = _make_surface(role=default_role, identity=ident)
+        assert surface.identity.principal_kind == kind
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_principal_kind_before_capability_check() -> None:
+    """Ordering: principal_kind mismatch fires BEFORE capability
+    mismatch. When a role has neither the right kind nor the right
+    capabilities, the kind error surfaces (the more fundamental refusal).
+    """
+    role = _build_role(
+        capabilities=("unrelated.cap",),  # connector requires http.read
+        permitted_principal_kinds=frozenset({"sovereign"}),
+    )
+    service_account_identity = _build_identity(principal_kind="service_account")
+    with pytest.raises(DispatchEnvelopeViolationError, match=r"principal_kind"):
+        _make_surface(role=role, identity=service_account_identity)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_principal_kind_re_check_at_dispatch_time() -> None:
+    """F5 / R2 defense-in-depth: the principal_kind check re-fires at
+    every dispatch() start. If the role's permitted set were swapped
+    after bind (object.__setattr__ bypass), the re-check refuses the
+    invocation.
+    """
+    # Bind with an all-kinds role (the default), then swap the role's
+    # permitted set to sovereign-only via object.__setattr__ to simulate
+    # post-bind tightening.
+    surface = _make_surface(
+        identity=_build_identity(principal_kind="service_account"),
+    )
+    object.__setattr__(
+        surface.role, "permitted_principal_kinds", frozenset({"sovereign"})
+    )
+    with pytest.raises(DispatchEnvelopeViolationError, match=r"principal_kind"):
+        await surface.dispatch({"user_id": "u-1"})

--- a/tests/unit/delegate/test_package_shell.py
+++ b/tests/unit/delegate/test_package_shell.py
@@ -29,10 +29,10 @@ def test_kailash_delegate_imports_cleanly() -> None:
     mode this assertion catches."""
     import kailash.delegate as pkg
 
-    assert len(pkg.__all__) == 47, (
-        "kailash.delegate.__all__ count drifted; S7 ships 47 symbols "
-        "(S2: 11 + S3 trust cascade: 5 + S4 audit chain: 7 + S5 dispatch: 7 "
-        "+ S6 runtime spine: 10 + S7 conformance schema: 7). "
+    assert len(pkg.__all__) == 48, (
+        "kailash.delegate.__all__ count drifted; #1143 ships 48 symbols "
+        "(S2: 12 [+PrincipalKind] + S3 trust cascade: 5 + S4 audit chain: 7 "
+        "+ S5 dispatch: 7 + S6 runtime spine: 10 + S7 conformance schema: 7). "
         "If a later shard added a symbol, update this count in the same commit "
         f"per orphan-detection.md Rule 6a. Got: {pkg.__all__!r}"
     )

--- a/tests/unit/delegate/test_types.py
+++ b/tests/unit/delegate/test_types.py
@@ -599,3 +599,129 @@ def test_principal_directory_frozen() -> None:
 def test_principal_directory_coerces_iterable_to_tuple() -> None:
     directory = PrincipalDirectory(identities=[_make_identity()])  # type: ignore[arg-type]
     assert isinstance(directory.identities, tuple)
+
+
+# ---------------------------------------------------------------------------
+# PrincipalKind discriminator (#1143 §10 G1)
+# ---------------------------------------------------------------------------
+
+
+def test_principal_kind_literal_values_are_three_canonical_kinds() -> None:
+    """The PrincipalKind Literal MUST be exactly the three §10 G1 kinds.
+
+    Structural invariant: if the Literal alias is widened or narrowed
+    (e.g. an "operator" kind sneaks in), this test fires and forces a
+    re-audit against the Terrene Delegate Specification §10 G1.
+    """
+    from typing import get_args
+
+    from kailash.delegate.types import PrincipalKind
+
+    assert set(get_args(PrincipalKind)) == {"sovereign", "service_account", "delegate"}
+
+
+def test_delegate_identity_default_principal_kind_is_delegate() -> None:
+    """Backwards-compat default: identities constructed without an
+    explicit principal_kind get "delegate". Existing call sites continue
+    to work without changes.
+    """
+    ident = _make_identity()
+    assert ident.principal_kind == "delegate"
+
+
+def test_delegate_identity_accepts_sovereign_kind() -> None:
+    ident = _make_identity(principal_kind="sovereign")
+    assert ident.principal_kind == "sovereign"
+
+
+def test_delegate_identity_accepts_service_account_kind() -> None:
+    ident = _make_identity(principal_kind="service_account")
+    assert ident.principal_kind == "service_account"
+
+
+def test_delegate_identity_rejects_invalid_principal_kind() -> None:
+    """Runtime validation against the Literal allowlist. A downstream
+    caller passing an arbitrary string MUST raise ValueError."""
+    with pytest.raises(ValueError, match="principal_kind"):
+        _make_identity(principal_kind="operator")  # not a canonical kind
+
+
+def test_delegate_identity_to_dict_includes_principal_kind() -> None:
+    ident = _make_identity(principal_kind="service_account")
+    payload = ident.to_dict()
+    assert payload["principal_kind"] == "service_account"
+
+
+def test_delegate_identity_from_dict_round_trips_principal_kind() -> None:
+    ident = _make_identity(principal_kind="sovereign")
+    rebuilt = DelegateIdentity.from_dict(ident.to_dict())
+    assert rebuilt.principal_kind == "sovereign"
+    assert rebuilt == ident
+
+
+def test_delegate_identity_from_dict_defaults_principal_kind_when_absent() -> None:
+    """Back-compat: payloads emitted BEFORE the discriminator landed
+    omit principal_kind. from_dict MUST default to "delegate"."""
+    payload = {
+        "delegate_id": str(uuid.uuid4()),
+        "sovereign_ref": "sov-1",
+        "role_binding_ref": "rb-1",
+        "genesis_ref": "g-1",
+        # No principal_kind key.
+    }
+    rebuilt = DelegateIdentity.from_dict(payload)
+    assert rebuilt.principal_kind == "delegate"
+
+
+def test_delegate_identity_from_dict_rejects_non_string_principal_kind() -> None:
+    payload = {
+        "delegate_id": str(uuid.uuid4()),
+        "sovereign_ref": "sov-1",
+        "role_binding_ref": "rb-1",
+        "genesis_ref": "g-1",
+        "principal_kind": 42,
+    }
+    with pytest.raises(TypeError, match="principal_kind"):
+        DelegateIdentity.from_dict(payload)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Role.permitted_principal_kinds (#1143 §10 G1)
+# ---------------------------------------------------------------------------
+
+
+def test_role_default_permitted_principal_kinds_is_all_kinds() -> None:
+    """Backwards-compat default: roles defined without an explicit
+    permitted_principal_kinds permit ALL kinds. Existing call sites
+    continue to work without changes."""
+    role = _make_role()
+    assert role.permitted_principal_kinds == frozenset(
+        {"sovereign", "service_account", "delegate"}
+    )
+
+
+def test_role_accepts_explicit_permitted_principal_kinds() -> None:
+    role = _make_role(permitted_principal_kinds=frozenset({"sovereign"}))
+    assert role.permitted_principal_kinds == frozenset({"sovereign"})
+
+
+def test_role_coerces_iterable_permitted_principal_kinds_to_frozenset() -> None:
+    """Ergonomic coercion: a plain set / tuple is accepted and frozen
+    at __post_init__ so the role's permitted set is immutable."""
+    role = _make_role(
+        permitted_principal_kinds={"sovereign", "service_account"},  # plain set
+    )
+    assert isinstance(role.permitted_principal_kinds, frozenset)
+    assert role.permitted_principal_kinds == frozenset({"sovereign", "service_account"})
+
+
+def test_role_rejects_empty_permitted_principal_kinds() -> None:
+    """An empty permitted set is structurally unreachable -- no identity
+    can satisfy it. Reject loudly at construction."""
+    with pytest.raises(ValueError, match="non-empty"):
+        _make_role(permitted_principal_kinds=frozenset())
+
+
+def test_role_rejects_invalid_permitted_principal_kinds() -> None:
+    with pytest.raises(ValueError, match="invalid entries"):
+        _make_role(permitted_principal_kinds=frozenset({"sovereign", "operator"}))


### PR DESCRIPTION
## Summary

Closes #1143 — PR #1144 holistic /redteam HIGH finding G1.

Adds the §10 G1 service-account vs sovereign principal type
discrimination the kailash.delegate primitive previously deferred:

- `PrincipalKind = Literal["sovereign", "service_account", "delegate"]` in `types.py`
- `DelegateIdentity.principal_kind` field (default `"delegate"` for backwards compat)
- `Role.permitted_principal_kinds: frozenset[PrincipalKind]` field (default: all kinds)
- `DispatchSurface.__init__` raises `DispatchEnvelopeViolationError` on mismatch
- F5 / R2 composition re-validates principal_kind at every `dispatch()` start
- DV-10-001 `xfail-strict` decorator REMOVED (test now passes natively per
  `orphan-detection.md` Rule 4a)
- Public `__all__` exports `PrincipalKind` per `orphan-detection.md` Rule 6
- Count-dependent `test_kailash_delegate_imports_cleanly` updated in the
  same commit per `orphan-detection.md` Rule 6a (47 → 48)

Conformance vector `canonical.json` hash UNCHANGED — the vector IS the
contract; #1143 closes the catch-up gap on the dispatch surface.

## Why this is structurally important

A Delegate acts through a scoped service-account principal distinct
from the sovereign (human) principal the Delegate acts for. A
Connector binding where these principals collapse impersonates the
sovereign and breaks the Genesis-to-Delegation attribution chain.

Before this PR, `DispatchSurface.__init__` had no principal-kind
discriminator: a Connector designed for a service-account principal
could be bound with a sovereign-principal identity (or vice versa)
and the dispatch surface would accept it. The audit chain would
record the side-effect, but attribution back to the originating
sovereign was structurally ambiguous.

After this PR, the discriminator is a first-class field on
`DelegateIdentity` (immutable on the frozen dataclass) and
`Role.permitted_principal_kinds` is the bind contract. The dispatch
gate refuses any mismatch with `DispatchEnvelopeViolationError`
before the surface is constructed. Defense-in-depth: the same check
re-fires at every `dispatch()` start, so a post-bind role swap via
`object.__setattr__` is also refused.

## Cross-SDK parity

kailash-rs `DelegateIdentity` needs the matching `principal_kind`
field per `cross-sdk-inspection.md` MUST Rule 1. This PR does NOT
file the rs issue (per `repo-scope-discipline.md` — pending user
authorization for cross-repo write).

## Test plan

- [x] `pytest tests/integration/delegate/test_conformance_vectors.py -xvs` — DV-10-001 passes natively
- [x] `pytest tests/unit/delegate/ -q` — 168 tests pass (new principal-kind unit tests + back-compat tests)
- [x] `pytest tests/e2e/delegate/ -q` — Flow A-G unchanged
- [x] `pytest --collect-only tests/` — 17,733 tests collect cleanly
- [x] Pre-commit hooks (black, isort, ruff, fences, Tier-1 unit gate) green
- [ ] Reviewer + security-reviewer convergence

## Related issues

Closes #1143
Refs #1035
Refs #1146 (sibling DispatchSurface.__init__ work — will rebase on this PR)