### PR TITLE
feat(delegate): H1 grantee-registry enforcement on TenantScopedCascade (#1146)

### DIFF
--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -184,18 +184,25 @@ class DispatchCascadeViolationError(ValueError):
     Surfaces when the bound :class:`DelegateIdentity` is not a known
     grantee of the bound :class:`TenantScopedCascade`. Distinct from
     :class:`CascadeTenantViolationError` (Invariant 2 runtime tenant
-    mismatch) — this error is the BIND-time check that the principal
-    was actually granted by the cascade.
+    mismatch) — this error is the cascade-grantee check that the
+    principal was actually granted by the cascade.
 
-    Note: the current :class:`TenantScopedCascade` does NOT yet expose
-    a persistent grantee registry (S3 emits one
-    :class:`~kailash.delegate.trust.GrantMoment` per ``cascade_child``
-    call but does not retain the grantee set). The construction-time
-    check here is structural — the identity's ``delegate_id`` is held
-    on the DispatchSurface and the cascade's tenant is cross-checked.
-    A future enhancement (S7+) will surface a grantee registry; this
-    error class is the stable typed surface that registry will plumb
-    into.
+    #1146 H1 — PR #1144 holistic /redteam HIGH finding H1 surfaced that
+    :class:`DispatchSurface.__init__` previously did NOT validate that the
+    supplied ``identity`` was actually granted by ``trust_cascade``. Any
+    caller with ANY :class:`DelegateIdentity` and a tenant-matching
+    cascade could construct a DispatchSurface that audited as that
+    identity — collapsing the cascade-as-authorization invariant.
+
+    The closure: :class:`~kailash.delegate.trust.TenantScopedCascade` now
+    carries a grantee registry (via :attr:`grantees` /
+    :meth:`register_root_grantee` / auto-registration on success in
+    :meth:`cascade_child`). :class:`DispatchSurface.__init__` raises this
+    error when ``identity.delegate_id not in trust_cascade.grantees`` at
+    bind, and :meth:`DispatchSurface.dispatch` re-validates the same
+    invariant at every dispatch-time entry for defense-in-depth (R2
+    composition, against the same ``object.__setattr__`` bypass surface
+    the §10 G1 principal-kind re-check defends).
     """
 
 
@@ -797,9 +804,12 @@ class DispatchSurface:
     Raises:
         DispatchEnvelopeViolationError: connector requires a capability
             the role does not grant, OR role is in a lifecycle that
-            refuses dispatch (RETIRED, SUSPENDED).
-        DispatchCascadeViolationError: the envelope's tenant binding is
-            inconsistent with the cascade's tenant.
+            refuses dispatch (RETIRED, SUSPENDED), OR identity's
+            ``principal_kind`` is not in the role's
+            ``permitted_principal_kinds`` (#1143 §10 G1).
+        DispatchCascadeViolationError: identity's ``delegate_id`` is not
+            in the trust_cascade's grantee registry (#1146 H1
+            cascade-as-authorization gate).
         TypeError: any argument fails its type check.
     """
 
@@ -924,6 +934,59 @@ class DispatchSurface:
                 f"{role.display_name!r} permitted_principal_kinds "
                 f"{sorted(role.permitted_principal_kinds)!r} "
                 "(#1143 §10 G1 — service-account vs sovereign separation)"
+            )
+
+        # #1146 H1 — grantee-registry gate. The bound identity's
+        # ``delegate_id`` MUST be in the cascade's grantee registry. The
+        # registry is populated by
+        # :meth:`TenantScopedCascade.register_root_grantee` (root seed) or
+        # by :meth:`TenantScopedCascade.cascade_child` on success.
+        # Identity NOT in the registry collapses the cascade-as-
+        # authorization invariant (PR #1144 holistic /redteam HIGH H1):
+        # any caller with ANY DelegateIdentity could otherwise construct
+        # a DispatchSurface that audited as that identity.
+        #
+        # Ordering: AFTER principal_kind (structurally more fundamental —
+        # wrong-kind identity should not even be considered for grantee
+        # lookup) and BEFORE capability (the cascade gate is more
+        # fundamental than the connector's capability requirements; an
+        # ungranted identity has no business being capability-checked).
+        #
+        # Defense-in-depth: the same check re-fires at every
+        # :meth:`dispatch` start per the F5 / R2 composition pattern,
+        # in case the cascade's grantee set is mutated (legitimately or
+        # via ``object.__setattr__`` bypass) between bind and dispatch.
+        if identity.delegate_id not in trust_cascade.grantees:
+            # Hash the identity for log-aggregator safety per
+            # observability.md MUST Rule 8 (schema-revealing field names
+            # MUST be DEBUG or hashed). The raw delegate_id remains on
+            # the bound DispatchSurface for in-process debugging; the
+            # error message carries only the 8-char SHA-256 prefix.
+            identity_hash = hashlib.sha256(
+                str(identity.delegate_id).encode("utf-8")
+            ).hexdigest()[:8]
+            logger.debug(
+                "dispatch.cascade_violation",
+                extra={
+                    "axis": "ungranted_identity",
+                    "connector_id": connector.connector_id,
+                    "delegate_id": str(identity.delegate_id),
+                    "cascade_tenant": (
+                        trust_cascade.tenant.tenant_id
+                        if not trust_cascade.tenant.is_global
+                        else "<global>"
+                    ),
+                    "grantee_count": len(trust_cascade.grantees),
+                },
+            )
+            raise DispatchCascadeViolationError(
+                f"DispatchSurface refuses bind: identity "
+                f"[delegate_id_hash={identity_hash}] is not a registered "
+                "grantee of the supplied trust_cascade "
+                "(#1146 H1 — cascade-as-authorization gate; identities "
+                "MUST be registered via TenantScopedCascade."
+                "register_root_grantee or admitted via cascade_child "
+                "before they can construct a DispatchSurface)"
             )
 
         # Invariant 3 — capability gating. Connector's required
@@ -1120,6 +1183,29 @@ class DispatchSurface:
                 f"permitted_principal_kinds {sorted(current_permitted)!r}; "
                 "invocation refused (#1143 §10 G1 — principal-kind "
                 "discriminator runtime re-check)"
+            )
+
+        # Step 0a.2 — #1146 H1 grantee-registry re-check. Pair to the
+        # bind-time gate in __init__. The cascade's grantee registry is
+        # mutable across the bind→dispatch boundary (additional
+        # cascade_child calls between bind and dispatch grow the set,
+        # which is fine — wider is permitted). What we defend against is
+        # the inverse: a caller that bypassed the bind-time gate by
+        # mutating the registry via object.__getattribute__ on the
+        # internal slot, OR a future revocation path that drops grantees.
+        # Defense-in-depth — the registry membership MUST hold at
+        # dispatch entry, not just at bind.
+        if self._identity.delegate_id not in self._trust_cascade.grantees:
+            identity_hash = hashlib.sha256(
+                str(self._identity.delegate_id).encode("utf-8")
+            ).hexdigest()[:8]
+            raise DispatchCascadeViolationError(
+                f"DispatchSurface refuses dispatch: identity "
+                f"[delegate_id_hash={identity_hash}] is no longer a "
+                "registered grantee of the trust_cascade "
+                "(#1146 H1 — cascade-as-authorization runtime re-check; "
+                "the cascade's grantee registry drifted between bind "
+                "and dispatch)"
             )
 
         # Step 0b — C6-1 DoS defense: depth + serialized-size limits

--- a/src/kailash/delegate/trust.py
+++ b/src/kailash/delegate/trust.py
@@ -304,7 +304,7 @@ class TenantScope:
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class TenantScopedCascade:
     """A delegation cascade scoped to a single :class:`TenantScope`.
 
@@ -323,11 +323,50 @@ class TenantScopedCascade:
        :meth:`DelegateConstraintEnvelope.tighten_with`, which carries the
        S2.5 pre-intersection widening check. Raises
        :class:`EnvelopeWideningError` on any dimension widening.
-    4. **Emit GrantMoment** — on success, return a fully-formed
-       :class:`GrantMoment` chain-of-custody record.
+    4. **Register child + emit GrantMoment** — on success, the child's
+       ``delegate_id`` is appended to the internal grantee registry AND a
+       fully-formed :class:`GrantMoment` chain-of-custody record is
+       returned.
 
     The cascade is bound to a single tenant at construction; cascading a
     cross-tenant child requires a NEW cascade for that tenant.
+
+    Grantee Registry (#1146 H1)
+    ---------------------------
+    The cascade carries an internal mutable set of authorized grantee
+    ``delegate_id``\\s exposed read-only via :attr:`grantees`. The registry
+    is populated by:
+
+    * :meth:`register_root_grantee` — explicit seeding of the root sovereign
+      who anchors the cascade; called by infrastructure at cascade-setup
+      time. The first identity authorized to dispatch under this cascade.
+    * :meth:`cascade_child` — on success (all 3 validation steps pass), both
+      ``parent_identity.delegate_id`` and ``child_identity.delegate_id`` are
+      registered as grantees BEFORE the :class:`GrantMoment` is emitted.
+
+    The registry is the structural anchor :class:`DispatchSurface` checks at
+    bind + dispatch time: a DispatchSurface constructed with an identity
+    whose ``delegate_id`` is not in ``cascade.grantees`` is refused with
+    :class:`DispatchCascadeViolationError`. This closes PR #1144 holistic
+    /redteam HIGH finding H1 — previously any caller with ANY
+    :class:`DelegateIdentity` and a tenant-matching cascade could construct
+    a DispatchSurface that audited as that identity; now only identities
+    that have actually transited the cascade (or been explicitly seeded as
+    the root grantee) are admissible.
+
+    The internal set is mutable BUT carried via ``object.__setattr__`` so
+    the frozen-dataclass shape (equality, hashability, serialization) is
+    preserved. The :attr:`grantees` property returns a frozenset snapshot
+    so external readers cannot mutate the registry through the public
+    surface.
+
+    Note: this dataclass uses ``frozen=True`` but NOT ``slots=True`` (the
+    sibling S2/S3 dataclasses use both). ``slots=True`` reserves only the
+    declared fields, blocking ``object.__setattr__`` of the ``_grantees``
+    slot in ``__post_init__``. Dropping ``slots=True`` preserves the
+    frozen-equality contract (the wire-format contract is unchanged — the
+    grantee registry is internal state, not serialized) while permitting
+    the internal mutable set the H1 closure requires.
     """
 
     tenant: TenantScope
@@ -338,6 +377,57 @@ class TenantScopedCascade:
                 "TenantScopedCascade.tenant MUST be a TenantScope; got "
                 f"{type(self.tenant).__name__}"
             )
+        # #1146 H1 — internal mutable grantee registry. Frozen dataclass
+        # bypass via object.__setattr__ keeps the registry isolated from
+        # the frozen-shape contract (equality / hashability / wire format
+        # do not include the registry). The set is populated by
+        # register_root_grantee + cascade_child; external readers see a
+        # frozenset snapshot via the grantees property.
+        object.__setattr__(self, "_grantees", set())
+
+    @property
+    def grantees(self) -> frozenset[uuid.UUID]:
+        """Borrow the current grantee registry as a read-only frozenset.
+
+        #1146 H1 — the snapshot is frozen, so external code holding a
+        reference cannot mutate the registry. Each property access returns
+        a fresh frozenset reflecting the current registry state at call
+        time; subsequent :meth:`cascade_child` calls do NOT mutate prior
+        snapshots.
+
+        :class:`DispatchSurface.__init__` consumes this property to check
+        ``identity.delegate_id in cascade.grantees`` and raises
+        :class:`DispatchCascadeViolationError` on mismatch (the H1 gate).
+        """
+        # The slot is set in __post_init__; bypass __getattr__ via
+        # __getattribute__ on the slot name for symmetry with __setattr__.
+        return frozenset(object.__getattribute__(self, "_grantees"))
+
+    def register_root_grantee(self, identity: DelegateIdentity) -> None:
+        """Seed the registry with the root sovereign / origin identity.
+
+        #1146 H1 — the cascade's grantee registry is empty at construction;
+        an identity that anchors the cascade (the root sovereign in EATP
+        terms, the genesis delegate in #1035 terms) MUST be explicitly
+        registered before it can construct a :class:`DispatchSurface`
+        against this cascade.
+
+        Idempotent — calling with the same identity twice is a no-op.
+
+        Args:
+            identity: The :class:`DelegateIdentity` whose ``delegate_id``
+                anchors the cascade. Typed at the boundary so the registry
+                cannot accept stray strings / UUIDs.
+
+        Raises:
+            TypeError: if ``identity`` is not a :class:`DelegateIdentity`.
+        """
+        if not isinstance(identity, DelegateIdentity):
+            raise TypeError(
+                "TenantScopedCascade.register_root_grantee identity MUST "
+                f"be a DelegateIdentity; got {type(identity).__name__}"
+            )
+        object.__getattribute__(self, "_grantees").add(identity.delegate_id)
 
     def cascade_child(
         self,
@@ -465,7 +555,19 @@ class TenantScopedCascade:
         # truth for the F5 tightening result.
         tightened = parent_envelope.tighten_with(child_envelope.inner)
 
-        # Step 4: emit the chain-of-custody GrantMoment.
+        # Step 4 (#1146 H1): register BOTH parent and child as authorized
+        # grantees of this cascade. Registration happens AFTER all three
+        # validation gates pass — a cross-tenant or widening-scope or
+        # widening-envelope attempt does NOT pollute the registry. The
+        # parent is auto-registered idempotently to support multi-edge
+        # cascades that descend from the same root (the root sovereign is
+        # seeded once via register_root_grantee; subsequent grandchildren
+        # observe the parent already in the set).
+        _grantees = object.__getattribute__(self, "_grantees")
+        _grantees.add(parent_identity.delegate_id)
+        _grantees.add(child_identity.delegate_id)
+
+        # Step 5: emit the chain-of-custody GrantMoment.
         return GrantMoment(
             cascade_id=uuid.uuid4(),
             parent_delegate_id=parent_identity.delegate_id,

--- a/src/kailash/delegate/trust.py
+++ b/src/kailash/delegate/trust.py
@@ -351,22 +351,42 @@ class TenantScopedCascade:
     /redteam HIGH finding H1 — previously any caller with ANY
     :class:`DelegateIdentity` and a tenant-matching cascade could construct
     a DispatchSurface that audited as that identity; now only identities
-    that have actually transited the cascade (or been explicitly seeded as
-    the root grantee) are admissible.
+    that have been registered with this cascade (via
+    :meth:`register_root_grantee` or as a parent/child side-effect of a
+    successful :meth:`cascade_child` call) are admissible. Registration
+    is the structural gate; the cascade reference itself is the trust
+    authority for seeding (see trust-boundary note below + README #1147
+    disclosure for durable-attestation roadmap).
 
     The internal set is mutable BUT carried via ``object.__setattr__`` so
     the frozen-dataclass shape (equality, hashability, serialization) is
     preserved. The :attr:`grantees` property returns a frozenset snapshot
-    so external readers cannot mutate the registry through the public
-    surface.
+    suitable for read-only consumption (the snapshot itself cannot be
+    mutated to inject grantees back into the source).
+
+    **Trust boundary.** The cascade reference IS the trust authority. Any
+    caller holding a reference to this ``TenantScopedCascade`` is, by
+    construction, the operator who constructed it (or an heir of that
+    operator's authorization). Operators MUST scope cascade references
+    behind their own authorization gate — see README §"What the primitive
+    does NOT promise" → `issue #1147 <https://github.com/terrene-foundation/kailash-py/issues/1147>`_
+    for the durable-registry roadmap. The internal set is exposed under
+    Python's name-mangled attribute (``_TenantScopedCascade__grantees``)
+    rather than a single-underscore convention; the mangled form means
+    direct attribute access like ``cascade._grantees`` raises
+    ``AttributeError`` rather than silently leaking the mutable set.
+    Determined adversaries holding a cascade reference can still spell
+    the mangled form, but the spelling is loud and intentional — the
+    cascade reference is itself the authorization, so this matches the
+    documented trust boundary.
 
     Note: this dataclass uses ``frozen=True`` but NOT ``slots=True`` (the
     sibling S2/S3 dataclasses use both). ``slots=True`` reserves only the
-    declared fields, blocking ``object.__setattr__`` of the ``_grantees``
-    slot in ``__post_init__``. Dropping ``slots=True`` preserves the
-    frozen-equality contract (the wire-format contract is unchanged — the
-    grantee registry is internal state, not serialized) while permitting
-    the internal mutable set the H1 closure requires.
+    declared fields, blocking ``object.__setattr__`` of the internal
+    grantee slot in ``__post_init__``. Dropping ``slots=True`` preserves
+    the frozen-equality contract (the wire-format contract is unchanged —
+    the grantee registry is internal state, not serialized) while
+    permitting the internal mutable set the H1 closure requires.
     """
 
     tenant: TenantScope
@@ -383,7 +403,7 @@ class TenantScopedCascade:
         # do not include the registry). The set is populated by
         # register_root_grantee + cascade_child; external readers see a
         # frozenset snapshot via the grantees property.
-        object.__setattr__(self, "_grantees", set())
+        object.__setattr__(self, "_TenantScopedCascade__grantees", set())
 
     @property
     def grantees(self) -> frozenset[uuid.UUID]:
@@ -401,7 +421,9 @@ class TenantScopedCascade:
         """
         # The slot is set in __post_init__; bypass __getattr__ via
         # __getattribute__ on the slot name for symmetry with __setattr__.
-        return frozenset(object.__getattribute__(self, "_grantees"))
+        return frozenset(
+            object.__getattribute__(self, "_TenantScopedCascade__grantees")
+        )
 
     def register_root_grantee(self, identity: DelegateIdentity) -> None:
         """Seed the registry with the root sovereign / origin identity.
@@ -413,6 +435,15 @@ class TenantScopedCascade:
         against this cascade.
 
         Idempotent — calling with the same identity twice is a no-op.
+
+        **Trust boundary.** This method has no access-control gate by
+        design — any caller holding a reference to this cascade is
+        implicitly authorized to seed the registry. The cascade reference
+        IS the trust authority; the operator who constructed the cascade
+        owns its grantee policy. Production operators MUST scope cascade
+        references behind their own authorization layer (see README
+        §"What the primitive does NOT promise" + `issue #1147 <https://github.com/terrene-foundation/kailash-py/issues/1147>`_
+        for the durable-registry roadmap).
 
         Args:
             identity: The :class:`DelegateIdentity` whose ``delegate_id``
@@ -427,7 +458,9 @@ class TenantScopedCascade:
                 "TenantScopedCascade.register_root_grantee identity MUST "
                 f"be a DelegateIdentity; got {type(identity).__name__}"
             )
-        object.__getattribute__(self, "_grantees").add(identity.delegate_id)
+        object.__getattribute__(self, "_TenantScopedCascade__grantees").add(
+            identity.delegate_id
+        )
 
     def cascade_child(
         self,
@@ -563,7 +596,17 @@ class TenantScopedCascade:
         # cascades that descend from the same root (the root sovereign is
         # seeded once via register_root_grantee; subsequent grandchildren
         # observe the parent already in the set).
-        _grantees = object.__getattribute__(self, "_grantees")
+        #
+        # Trust-boundary note: cascade_child does NOT require parent_identity
+        # to be pre-registered as a grantee — the cascade reference itself
+        # is the trust authority (see class docstring + register_root_grantee).
+        # Combined with grant_proof being shape-only-validated today (#1147
+        # README disclosure documents this gap), cascade_child operates as a
+        # secondary seeding path equivalent to register_root_grantee; the H1
+        # closure structurally is "identity must be registered with this
+        # cascade", NOT "identity must have transited a signed-and-verified
+        # grant chain". Durable signed attestation is the #1147 roadmap.
+        _grantees = object.__getattribute__(self, "_TenantScopedCascade__grantees")
         _grantees.add(parent_identity.delegate_id)
         _grantees.add(child_identity.delegate_id)
 

--- a/tests/e2e/delegate/test_delegate_e2e_flows.py
+++ b/tests/e2e/delegate/test_delegate_e2e_flows.py
@@ -68,10 +68,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from kailash.delegate.audit import (
-    AuditChainEngine,
-    DelegateEventType,
-)
+from kailash.delegate.audit import AuditChainEngine, DelegateEventType
 from kailash.delegate.conformance.schema import (
     ConformanceVectorLoader,
     receipts_agree_dict,
@@ -103,7 +100,6 @@ from kailash.delegate.types import (
 )
 from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
 from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
-
 
 # ---------------------------------------------------------------------------
 # Real-substrate builders (no mocks). Protocol-satisfying connectors and
@@ -236,6 +232,12 @@ def _build_stack(
     envelope = _build_envelope()
     identity = _build_identity()
     role = _build_role()
+    # #1146 H1 — register the identity as a root grantee so the
+    # DispatchSurface bind-time grantee gate passes. Without this seed
+    # the cascade-as-authorization invariant refuses bind because the
+    # identity transited no cascade_child path (root identities are
+    # explicitly seeded by infrastructure at cascade-setup time).
+    cascade.register_root_grantee(identity)
     connector = DeterministicConnector(
         tenant_id_observed=connector_tenant_id or tenant_id,
     )

--- a/tests/integration/delegate/test_conformance_vectors.py
+++ b/tests/integration/delegate/test_conformance_vectors.py
@@ -176,6 +176,8 @@ def _build_runtime(
     env = envelope or _build_envelope()
     identity = _build_identity()
     role = _build_role()
+    # #1146 H1 — seed the cascade with the root grantee.
+    cascade.register_root_grantee(identity)
     connector = _PassthroughConnector(tenant_id_observed=tenant_id)
     surface = DispatchSurface(
         connector=connector,

--- a/tests/integration/delegate/test_dispatch_wiring.py
+++ b/tests/integration/delegate/test_dispatch_wiring.py
@@ -41,25 +41,11 @@ from datetime import datetime, timezone
 
 import pytest
 
-
-def _test_signer(canonical_bytes: bytes) -> str:
-    """Deterministic 128-char hex signer for integration tests.
-
-    SHA-256 doubled to 128 chars satisfies the audit-engine's
-    _validate_hex(expected_len=128) contract while keeping the test
-    deterministic for cross-SDK byte-vector comparison.
-    """
-    h = hashlib.sha256(canonical_bytes).hexdigest()
-    return h + h
-
-
-from kailash.delegate.audit import (
-    AuditChainEngine,
-    DelegateEventType,
-)
+from kailash.delegate.audit import AuditChainEngine, DelegateEventType
 from kailash.delegate.dispatch import (
     Connector,
     ConnectorInvocationResult,
+    DispatchCascadeViolationError,
     DispatchResult,
     DispatchSurface,
 )
@@ -79,6 +65,17 @@ from kailash.delegate.types import (
 )
 from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
 from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+
+def _test_signer(canonical_bytes: bytes) -> str:
+    """Deterministic 128-char hex signer for integration tests.
+
+    SHA-256 doubled to 128 chars satisfies the audit-engine's
+    _validate_hex(expected_len=128) contract while keeping the test
+    deterministic for cross-SDK byte-vector comparison.
+    """
+    h = hashlib.sha256(canonical_bytes).hexdigest()
+    return h + h
 
 
 # ---------------------------------------------------------------------------
@@ -221,6 +218,8 @@ async def test_dispatch_end_to_end_wires_audit_and_tenant() -> None:
     connector = RecordingMockConnector(tenant_id_observed="tenant-wire")
     identity = _build_identity()
     envelope = _build_envelope()
+    # #1146 H1 — seed the cascade with the root grantee.
+    cascade.register_root_grantee(identity)
 
     surface = DispatchSurface(
         connector=connector,
@@ -286,12 +285,15 @@ async def test_dispatch_tenant_isolation_enforced_end_to_end() -> None:
     audit_engine = AuditChainEngine(chain=chain)
     cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-A"))
     connector = RecordingMockConnector(tenant_id_observed="tenant-B")
+    identity = _build_identity()
+    # #1146 H1 — seed the cascade with the root grantee.
+    cascade.register_root_grantee(identity)
 
     surface = DispatchSurface(
         connector=connector,
         signature=WiringSignature(),
         envelope=_build_envelope(),
-        identity=_build_identity(),
+        identity=identity,
         audit_engine=audit_engine,
         trust_cascade=cascade,
         role=_build_role(),
@@ -335,12 +337,15 @@ async def test_dispatch_multiple_events_chain_correctly() -> None:
     chain = _build_chain("agent-multi-event")
     audit_engine = AuditChainEngine(chain=chain)
     cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-multi"))
+    identity = _build_identity()
+    # #1146 H1 — seed the cascade with the root grantee.
+    cascade.register_root_grantee(identity)
 
     surface = DispatchSurface(
         connector=MultiEventConnector(),
         signature=WiringSignature(),
         envelope=_build_envelope(),
-        identity=_build_identity(),
+        identity=identity,
         audit_engine=audit_engine,
         trust_cascade=cascade,
         role=_build_role(),
@@ -365,3 +370,70 @@ async def test_dispatch_multiple_events_chain_correctly() -> None:
     assert (
         audit_engine.entries[2].previous_hash != audit_engine.entries[1].previous_hash
     )
+
+
+# ---------------------------------------------------------------------------
+# #1146 H1 — grantee-registry cascade-as-authorization wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_dispatch_h1_grantee_gate_refuses_ungranted_identity_end_to_end() -> None:
+    """#1146 H1 — Tier-2 wiring: an ungranted identity is refused at bind
+    against a REAL TenantScopedCascade. No audit emission, no connector
+    invocation, no DispatchSurface instance leaks past the gate.
+
+    This closes PR #1144 holistic /redteam HIGH H1 end-to-end:
+    a caller with an arbitrary DelegateIdentity who acquires a
+    tenant-matching cascade reference CANNOT bind a DispatchSurface
+    that audits as that identity.
+    """
+    chain = _build_chain("agent-h1")
+    audit_engine = AuditChainEngine(chain=chain)
+    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-h1"))
+    # Identity is constructed but NEVER registered as a grantee — the
+    # exact failure mode the H1 finding describes.
+    ungranted_identity = _build_identity()
+    with pytest.raises(
+        DispatchCascadeViolationError, match=r"not a registered grantee"
+    ):
+        DispatchSurface(
+            connector=RecordingMockConnector(tenant_id_observed="tenant-h1"),
+            signature=WiringSignature(),
+            envelope=_build_envelope(),
+            identity=ungranted_identity,
+            audit_engine=audit_engine,
+            trust_cascade=cascade,
+            role=_build_role(),
+            signer=_test_signer,
+        )
+    # Fail-closed: no audit emission, no connector invocation, no
+    # substrate mutation.
+    assert len(audit_engine.entries) == 0
+    assert len(chain.audit_anchors) == 0
+    assert cascade.grantees == frozenset()
+
+
+@pytest.mark.integration
+def test_dispatch_h1_grantee_gate_admits_root_grantee_end_to_end() -> None:
+    """#1146 H1 — happy path: identity explicitly seeded via
+    register_root_grantee binds cleanly against a real cascade."""
+    chain = _build_chain("agent-h1-root")
+    audit_engine = AuditChainEngine(chain=chain)
+    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-h1"))
+    identity = _build_identity()
+    # Seed the grantee registry.
+    cascade.register_root_grantee(identity)
+    # Bind succeeds.
+    surface = DispatchSurface(
+        connector=RecordingMockConnector(tenant_id_observed="tenant-h1"),
+        signature=WiringSignature(),
+        envelope=_build_envelope(),
+        identity=identity,
+        audit_engine=audit_engine,
+        trust_cascade=cascade,
+        role=_build_role(),
+        signer=_test_signer,
+    )
+    assert surface.identity.delegate_id == identity.delegate_id
+    assert identity.delegate_id in cascade.grantees

--- a/tests/integration/delegate/test_receipts_agree_cross_impl.py
+++ b/tests/integration/delegate/test_receipts_agree_cross_impl.py
@@ -50,20 +50,14 @@ from datetime import datetime, timezone
 import pytest
 
 from kailash.delegate.audit import AuditChainEngine, DelegateEventType
-from kailash.delegate.conformance.schema import (
-    ReceiptsAgreeReport,
-    receipts_agree_dict,
-)
+from kailash.delegate.conformance.schema import ReceiptsAgreeReport, receipts_agree_dict
 from kailash.delegate.dispatch import (
     Connector,
     ConnectorInvocationResult,
     DispatchSurface,
 )
 from kailash.delegate.envelope import DelegateConstraintEnvelope
-from kailash.delegate.runtime import (
-    DelegateRuntime,
-    Posture,
-)
+from kailash.delegate.runtime import DelegateRuntime, Posture
 from kailash.delegate.trust import TenantScope, TenantScopedCascade
 from kailash.delegate.types import (
     CapabilitySet,
@@ -147,6 +141,8 @@ def _build_runtime() -> DelegateRuntime:
         ),
         lifecycle=RoleLifecycleState.ACTIVE,
     )
+    # #1146 H1 — seed the cascade with the root grantee.
+    cascade.register_root_grantee(identity)
     surface = DispatchSurface(
         connector=_DeterministicConnector(),
         signature=_Signature(),

--- a/tests/integration/delegate/test_runtime_wiring.py
+++ b/tests/integration/delegate/test_runtime_wiring.py
@@ -39,13 +39,6 @@ from datetime import datetime, timezone
 
 import pytest
 
-
-def _test_signer(canonical_bytes: bytes) -> str:
-    """Deterministic 128-char hex signer for integration tests."""
-    h = hashlib.sha256(canonical_bytes).hexdigest()
-    return h + h
-
-
 from kailash.delegate.audit import AuditChainEngine, DelegateEventType
 from kailash.delegate.dispatch import (
     Connector,
@@ -71,6 +64,12 @@ from kailash.delegate.types import (
 )
 from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
 from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+
+def _test_signer(canonical_bytes: bytes) -> str:
+    """Deterministic 128-char hex signer for integration tests."""
+    h = hashlib.sha256(canonical_bytes).hexdigest()
+    return h + h
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +176,9 @@ def _build_runtime_stack(
     envelope = _build_envelope()
     identity = _build_identity()
     role = _build_role()
+    # #1146 H1 — seed the cascade with the root grantee so DispatchSurface
+    # bind passes the grantee gate.
+    cascade.register_root_grantee(identity)
     connector = RecordingConnector(
         tenant_id_observed=connector_tenant_id or tenant_id,
     )

--- a/tests/unit/delegate/test_dispatch.py
+++ b/tests/unit/delegate/test_dispatch.py
@@ -339,14 +339,23 @@ def _make_surface(
     envelope: DelegateConstraintEnvelope | None = None,
     identity: DelegateIdentity | None = None,
     signer=None,
+    skip_grantee_registration: bool = False,
 ) -> DispatchSurface:
+    bound_cascade = cascade if cascade is not None else _build_cascade()
+    bound_identity = identity if identity is not None else _build_identity()
+    # #1146 H1 — register the identity as a root grantee BEFORE
+    # DispatchSurface construction so the bind-time grantee check passes.
+    # Tests that want to exercise the H1 refusal path pass
+    # skip_grantee_registration=True.
+    if not skip_grantee_registration:
+        bound_cascade.register_root_grantee(bound_identity)
     return DispatchSurface(
         connector=connector if connector is not None else MockConnector(),
         signature=signature if signature is not None else FakeSignatureHelper(),
         envelope=envelope if envelope is not None else _build_envelope(),
-        identity=identity if identity is not None else _build_identity(),
+        identity=bound_identity,
         audit_engine=AuditChainEngine(chain=_build_chain()),
-        trust_cascade=cascade if cascade is not None else _build_cascade(),
+        trust_cascade=bound_cascade,
         role=role if role is not None else _build_role(),
         signer=signer if signer is not None else _test_signer,
     )
@@ -511,13 +520,16 @@ async def test_dispatch_audit_engine_round_trip() -> None:
             DelegateEventType.GRANT_CONSUMPTION,
         ),
     )
+    cascade = _build_cascade()
+    identity = _build_identity()
+    cascade.register_root_grantee(identity)  # #1146 H1
     surface = DispatchSurface(
         connector=connector,
         signature=FakeSignatureHelper(),
         envelope=_build_envelope(),
-        identity=_build_identity(),
+        identity=identity,
         audit_engine=audit_engine,
-        trust_cascade=_build_cascade(),
+        trust_cascade=cascade,
         role=_build_role(),
         signer=_test_signer,
     )
@@ -556,13 +568,15 @@ async def test_dispatch_connector_invocation_carries_bound_identity_and_envelope
     identity = _build_identity()
     envelope = _build_envelope()
     connector = MockConnector()
+    cascade = _build_cascade()
+    cascade.register_root_grantee(identity)  # #1146 H1
     surface = DispatchSurface(
         connector=connector,
         signature=FakeSignatureHelper(),
         envelope=envelope,
         identity=identity,
         audit_engine=AuditChainEngine(chain=_build_chain()),
-        trust_cascade=_build_cascade(),
+        trust_cascade=cascade,
         role=_build_role(),
         signer=_test_signer,
     )
@@ -676,10 +690,11 @@ def test_dispatch_cascade_violation_error_is_value_error() -> None:
     """DispatchCascadeViolationError is the typed surface for grantee
     refusal; it is a ValueError per the S2.5/S3/S4 convention.
 
-    The runtime grantee-registry check is deferred to S7+ (the current
-    TenantScopedCascade emits GrantMoment but does not retain the grantee
-    set); this test asserts the error class exists and is in the
-    correct base hierarchy so callers can catch it stably.
+    #1146 H1 closure: the grantee-registry check IS wired (see the
+    DispatchSurface H1 tests below). This test pins the typed-error
+    hierarchy so downstream callers can catch on
+    DispatchCascadeViolationError without depending on its concrete
+    message shape.
     """
     err = DispatchCascadeViolationError("test")
     assert isinstance(err, ValueError)
@@ -1147,4 +1162,132 @@ async def test_dispatch_principal_kind_re_check_at_dispatch_time() -> None:
         surface.role, "permitted_principal_kinds", frozenset({"sovereign"})
     )
     with pytest.raises(DispatchEnvelopeViolationError, match=r"principal_kind"):
+        await surface.dispatch({"user_id": "u-1"})
+
+
+# ---------------------------------------------------------------------------
+# #1146 H1 — grantee-registry bind + dispatch gate (cascade-as-authorization)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_ungranted_identity_at_bind() -> None:
+    """#1146 H1 — DispatchSurface.__init__ MUST raise
+    DispatchCascadeViolationError when the bound identity's delegate_id
+    is not in the cascade's grantee registry.
+
+    PR #1144 holistic /redteam HIGH H1: previously any caller with ANY
+    DelegateIdentity and a tenant-matching cascade could construct a
+    DispatchSurface that audited as that identity. The grantee check
+    closes this — the identity MUST have transited cascade_child OR
+    been explicitly seeded via register_root_grantee.
+    """
+    with pytest.raises(
+        DispatchCascadeViolationError, match=r"not a registered grantee"
+    ):
+        _make_surface(skip_grantee_registration=True)
+
+
+@pytest.mark.unit
+def test_dispatch_surface_admits_root_grantee_at_bind() -> None:
+    """Identity explicitly registered via register_root_grantee binds
+    cleanly — the canonical bootstrap path."""
+    cascade = _build_cascade()
+    identity = _build_identity()
+    cascade.register_root_grantee(identity)
+    surface = DispatchSurface(
+        connector=MockConnector(),
+        signature=FakeSignatureHelper(),
+        envelope=_build_envelope(),
+        identity=identity,
+        audit_engine=AuditChainEngine(chain=_build_chain()),
+        trust_cascade=cascade,
+        role=_build_role(),
+        signer=_test_signer,
+    )
+    assert surface.identity.delegate_id == identity.delegate_id
+
+
+@pytest.mark.unit
+def test_dispatch_surface_admits_cascade_child_grantee_at_bind() -> None:
+    """An identity admitted as a child via cascade_child binds cleanly
+    — the canonical 'admit-via-cascade' path."""
+    cascade = _build_cascade()
+    parent = _build_identity()
+    child = _build_identity()
+    cascade.register_root_grantee(parent)
+    # Bring child into the registry via a successful cascade_child.
+    parent_env = _build_envelope()
+    cascade.cascade_child(
+        parent_env,
+        parent_env,  # same envelope = no widening
+        parent_identity=parent,
+        child_identity=child,
+        parent_scope=_build_role().scope,
+        child_scope=_build_role().scope,
+        child_tenant=cascade.tenant,
+        grant_proof="a" * 128,
+    )
+    # Now construct a DispatchSurface as the CHILD — admitted by cascade.
+    surface = DispatchSurface(
+        connector=MockConnector(),
+        signature=FakeSignatureHelper(),
+        envelope=parent_env,
+        identity=child,
+        audit_engine=AuditChainEngine(chain=_build_chain()),
+        trust_cascade=cascade,
+        role=_build_role(),
+        signer=_test_signer,
+    )
+    assert surface.identity.delegate_id == child.delegate_id
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_grantee_before_capability_check() -> None:
+    """Ordering: grantee gate fires BEFORE capability gate. When an
+    identity is both ungranted AND the role lacks required caps, the
+    grantee error surfaces (the more fundamental refusal — cascade
+    authorization precedes capability authorization)."""
+    role = _build_role(capabilities=("unrelated.cap",))  # connector wants http.read
+    with pytest.raises(
+        DispatchCascadeViolationError, match=r"not a registered grantee"
+    ):
+        _make_surface(role=role, skip_grantee_registration=True)
+
+
+@pytest.mark.unit
+def test_dispatch_surface_refuses_grantee_after_principal_kind_check() -> None:
+    """Ordering: principal_kind gate fires BEFORE grantee gate. A
+    wrong-kind identity surfaces principal_kind refusal even when also
+    ungranted (principal_kind is structurally more fundamental —
+    wrong-kind identity has no business being grantee-checked)."""
+    sovereign_only_role = _build_role(
+        permitted_principal_kinds=frozenset({"sovereign"}),
+    )
+    service_account_identity = _build_identity(principal_kind="service_account")
+    # Both gates would refuse; ordering says principal_kind wins.
+    with pytest.raises(DispatchEnvelopeViolationError, match=r"principal_kind"):
+        _make_surface(
+            role=sovereign_only_role,
+            identity=service_account_identity,
+            skip_grantee_registration=True,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_grantee_re_check_at_dispatch_time() -> None:
+    """F5 / R2 defense-in-depth: the grantee check re-fires at every
+    dispatch() start. If the cascade's grantee registry were mutated
+    after bind (object.__getattribute__ on the internal slot then
+    .clear()), the re-check refuses the invocation.
+    """
+    surface = _make_surface()
+    # Drain the registry via the internal slot bypass — simulating a
+    # post-bind registry mutation. Production code MUST NOT do this;
+    # the bypass exercises the defense-in-depth gate.
+    object.__getattribute__(surface.trust_cascade, "_grantees").clear()
+    with pytest.raises(
+        DispatchCascadeViolationError, match=r"no longer a registered grantee"
+    ):
         await surface.dispatch({"user_id": "u-1"})

--- a/tests/unit/delegate/test_dispatch.py
+++ b/tests/unit/delegate/test_dispatch.py
@@ -1279,15 +1279,50 @@ def test_dispatch_surface_refuses_grantee_after_principal_kind_check() -> None:
 async def test_dispatch_grantee_re_check_at_dispatch_time() -> None:
     """F5 / R2 defense-in-depth: the grantee check re-fires at every
     dispatch() start. If the cascade's grantee registry were mutated
-    after bind (object.__getattribute__ on the internal slot then
-    .clear()), the re-check refuses the invocation.
+    after bind (via Python's name-mangled internal slot
+    ``_TenantScopedCascade__grantees``), the re-check refuses the
+    invocation.
+
+    The internal slot is name-mangled (double-underscore at class
+    scope) so a single-underscore access like ``cascade._grantees``
+    raises ``AttributeError``. Reaching the mutable set requires
+    spelling the mangled form. Production code MUST NOT do this; this
+    test exercises the mangled form deliberately to simulate a
+    determined post-bind registry mutation and confirm the dispatch-time
+    re-check structurally guards against it.
     """
     surface = _make_surface()
-    # Drain the registry via the internal slot bypass — simulating a
-    # post-bind registry mutation. Production code MUST NOT do this;
-    # the bypass exercises the defense-in-depth gate.
-    object.__getattribute__(surface.trust_cascade, "_grantees").clear()
+    # Drain the registry via the name-mangled internal slot — simulating
+    # a post-bind registry mutation. The mangled form is the only path
+    # external code can reach the mutable set.
+    object.__getattribute__(
+        surface.trust_cascade, "_TenantScopedCascade__grantees"
+    ).clear()
     with pytest.raises(
         DispatchCascadeViolationError, match=r"no longer a registered grantee"
     ):
         await surface.dispatch({"user_id": "u-1"})
+
+
+@pytest.mark.unit
+def test_tenant_scoped_cascade_grantees_slot_is_name_mangled() -> None:
+    """Per security-reviewer F1: the grantee registry MUST NOT be reachable
+    via a single-underscore alias. The internal slot is name-mangled
+    (``_TenantScopedCascade__grantees``); ``cascade._grantees`` raises
+    ``AttributeError``. The mangled form is loud and intentional —
+    determined adversaries with a cascade reference can still spell it,
+    but the cascade reference IS itself the trust authority (see class
+    docstring + README #1147 disclosure for the durable-registry
+    roadmap).
+    """
+    from kailash.delegate.trust import TenantScope, TenantScopedCascade
+
+    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-test"))
+    # Underscore-prefix alias raises AttributeError — single-underscore
+    # convention is NOT the mutation surface.
+    with pytest.raises(AttributeError):
+        cascade._grantees  # noqa: B018
+    # The mangled form IS reachable (Python's name-mangling rule) —
+    # documented and intentional per the trust boundary.
+    mangled = object.__getattribute__(cascade, "_TenantScopedCascade__grantees")
+    assert mangled == set()

--- a/tests/unit/delegate/test_runtime.py
+++ b/tests/unit/delegate/test_runtime.py
@@ -62,7 +62,6 @@ from kailash.delegate.types import (
 from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
 from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
 
-
 # ---------------------------------------------------------------------------
 # Test signer — deterministic 128-char hex (SHA-256 doubled).
 # ---------------------------------------------------------------------------
@@ -209,6 +208,9 @@ def _build_surface(
     envelope = envelope if envelope is not None else _build_envelope()
     identity = identity if identity is not None else _build_identity()
     cascade = cascade if cascade is not None else _build_cascade()
+    # #1146 H1 — seed the cascade with the root grantee so DispatchSurface
+    # bind passes the grantee gate.
+    cascade.register_root_grantee(identity)
     audit_engine = (
         audit_engine
         if audit_engine is not None

--- a/tests/unit/delegate/test_trust_cascade.py
+++ b/tests/unit/delegate/test_trust_cascade.py
@@ -917,3 +917,172 @@ def test_grant_moment_to_signing_bytes_returns_canonical_json_bytes() -> None:
     # Round-trip via canonical_json_dumps yields the same bytes.
     expected = canonical_json_dumps(gm.to_signing_dict()).encode("utf-8")
     assert bytes_out == expected
+
+
+# ---------------------------------------------------------------------------
+# #1146 H1 — grantee registry on TenantScopedCascade
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_grantees_initially_empty() -> None:
+    """A freshly-constructed cascade has an empty grantee registry."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    assert casc.grantees == frozenset()
+
+
+def test_cascade_grantees_property_returns_frozenset_snapshot() -> None:
+    """The grantees property returns a frozenset snapshot — external
+    callers cannot mutate the registry through the public surface."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    grantees = casc.grantees
+    assert isinstance(grantees, frozenset)
+    # frozenset has no .add / .remove — the type system enforces immutability
+
+
+def test_register_root_grantee_seeds_registry() -> None:
+    """register_root_grantee adds the identity's delegate_id to the
+    grantees set — the canonical bootstrap path for the cascade."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    root = _identity(suffix="root")
+    casc.register_root_grantee(root)
+    assert root.delegate_id in casc.grantees
+    assert len(casc.grantees) == 1
+
+
+def test_register_root_grantee_is_idempotent() -> None:
+    """Re-registering the same identity is a no-op (idempotent set add)."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    root = _identity(suffix="root")
+    casc.register_root_grantee(root)
+    casc.register_root_grantee(root)  # second call — no-op
+    assert len(casc.grantees) == 1
+
+
+def test_register_root_grantee_rejects_non_identity() -> None:
+    """register_root_grantee MUST reject non-DelegateIdentity arguments
+    (typed at the boundary so the registry cannot accept stray UUIDs)."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    with pytest.raises(TypeError, match="DelegateIdentity"):
+        casc.register_root_grantee("not-an-identity")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="DelegateIdentity"):
+        casc.register_root_grantee(uuid.uuid4())  # type: ignore[arg-type]
+
+
+def test_cascade_child_registers_both_parent_and_child_on_success() -> None:
+    """On successful cascade_child, BOTH parent_identity and
+    child_identity are registered as grantees. The parent is registered
+    idempotently so multi-edge cascades descending from the same root
+    do not require manual re-registration at every hop."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    parent = _identity(suffix="parent")
+    child = _identity(suffix="child")
+    casc.cascade_child(
+        parent_env,
+        child_env,
+        parent_identity=parent,
+        child_identity=child,
+        parent_scope=_scope(),
+        child_scope=_scope(),
+        child_tenant=TenantScope.for_tenant("tenant-a"),
+        grant_proof="a" * 128,
+    )
+    assert parent.delegate_id in casc.grantees
+    assert child.delegate_id in casc.grantees
+    assert len(casc.grantees) == 2
+
+
+def test_cascade_child_does_not_register_on_tenant_violation() -> None:
+    """A cross-tenant cascade attempt MUST NOT pollute the registry —
+    fail-closed at Step 1 leaves the registry empty."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    with pytest.raises(CascadeTenantViolationError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=_scope(),
+            child_scope=_scope(),
+            child_tenant=TenantScope.for_tenant("tenant-b"),  # cross-tenant
+            grant_proof="a" * 128,
+        )
+    assert casc.grantees == frozenset()
+
+
+def test_cascade_child_does_not_register_on_scope_violation() -> None:
+    """Scope-expansion refusal at Step 2 leaves the registry empty —
+    no partial-registration on the failed-validation path."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(100.0)
+    child_env = _envelope_with_budget(50.0)
+    with pytest.raises(CascadeScopeExpansionError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=_scope(caps=("read",)),
+            child_scope=_scope(caps=("read", "approve")),  # widens
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+    assert casc.grantees == frozenset()
+
+
+def test_cascade_child_does_not_register_on_envelope_widening() -> None:
+    """Envelope widening refusal at Step 3 leaves the registry empty."""
+    casc = TenantScopedCascade(tenant=TenantScope.global_())
+    parent_env = _envelope_with_budget(50.0)
+    child_env = _envelope_with_budget(100.0)  # widens
+    with pytest.raises(EnvelopeWideningError):
+        casc.cascade_child(
+            parent_env,
+            child_env,
+            parent_identity=_identity(suffix="parent"),
+            child_identity=_identity(suffix="child"),
+            parent_scope=_scope(),
+            child_scope=_scope(),
+            child_tenant=TenantScope.global_(),
+            grant_proof="a" * 128,
+        )
+    assert casc.grantees == frozenset()
+
+
+def test_cascade_grantees_grow_across_multiple_cascade_child_calls() -> None:
+    """Multi-edge cascade: A → B → C registers A, B, and C as grantees
+    on the same cascade instance (the cascade-as-authorization anchor
+    across the full chain)."""
+    casc = TenantScopedCascade(tenant=TenantScope.for_tenant("tenant-a"))
+    parent_env = _envelope_with_budget(100.0)
+    mid_env = _envelope_with_budget(75.0)
+    leaf_env = _envelope_with_budget(50.0)
+    a = _identity(suffix="A")
+    b = _identity(suffix="B")
+    c = _identity(suffix="C")
+
+    casc.cascade_child(
+        parent_env,
+        mid_env,
+        parent_identity=a,
+        child_identity=b,
+        parent_scope=_scope(),
+        child_scope=_scope(),
+        child_tenant=TenantScope.for_tenant("tenant-a"),
+        grant_proof="a" * 128,
+    )
+    casc.cascade_child(
+        mid_env,
+        leaf_env,
+        parent_identity=b,
+        child_identity=c,
+        parent_scope=_scope(),
+        child_scope=_scope(),
+        child_tenant=TenantScope.for_tenant("tenant-a"),
+        grant_proof="b" * 128,
+    )
+    assert {a.delegate_id, b.delegate_id, c.delegate_id} <= casc.grantees
+    assert len(casc.grantees) == 3


### PR DESCRIPTION
## Summary
Closes #1146 — PR #1144 holistic /redteam HIGH finding H1.

Adds grantee-registry tracking to `TenantScopedCascade` so the previously
declared-but-unwired `DispatchCascadeViolationError` now fires when a
DispatchSurface is constructed with an identity that was never granted
under the supplied cascade:

- `TenantScopedCascade` gains a grantee registry (internal mutable set;
  exposed read-only via the `grantees` property as a frozenset snapshot).
- `cascade_child` auto-registers BOTH `parent_identity.delegate_id` and
  `child_identity.delegate_id` AFTER all 3 validation gates pass, BEFORE
  emitting the `GrantMoment`. Validation failures (cross-tenant, scope
  expansion, envelope widening) do NOT pollute the registry.
- `register_root_grantee(identity)` is the canonical bootstrap path for
  the root sovereign / origin identity; idempotent and type-disciplined.
- `DispatchSurface.__init__` raises `DispatchCascadeViolationError` if
  `identity.delegate_id not in trust_cascade.grantees`. Gate ordering:
  lifecycle → principal_kind → **grantee** → capability.
- R2 composition re-validates the grantee membership at every
  `DispatchSurface.dispatch()` start (defense-in-depth on top of the
  bind-time gate, mirroring the §10 G1 principal-kind re-check landed in
  PR #1157).
- Error messages hash the `delegate_id` (sha256 prefix) per
  `observability.md` MUST Rule 8 so only the 8-char prefix bleeds to log
  aggregators.
- `DispatchCascadeViolationError` was already exported in
  `kailash.delegate.__all__`; the docstring is updated to describe the
  H1 closure (previously deferred to S7+).

## Design choice (option C — internal mutable set + property snapshot)

`TenantScopedCascade` is `@dataclass(frozen=True)`; the grantee
registry is internal mutable state attached via `object.__setattr__`
in `__post_init__`. `slots=True` is dropped on this dataclass only
(sibling S2/S3 dataclasses retain `slots+frozen`) so the bypass works;
the serialization / equality / wire-format contract is unchanged because
the registry is internal state, not serialized. The `grantees` property
returns a frozenset snapshot so external readers cannot mutate the
registry through the public surface.

## Cross-SDK parity

kailash-rs `TenantScopedCascade` likely has the same gap per
`cross-sdk-inspection.md` MUST Rule 1. This PR does NOT file the rs
issue (per `repo-scope-discipline.md` — pending user authorization for
the cross-repo write).

## Test plan
- [x] `pytest tests/unit/delegate/` — 71 trust_cascade tests pass
  (including 10 new grantee tests); test_dispatch.py passes with 6 new
  H1 tests; test_runtime.py / test_types.py unaffected.
- [x] `pytest tests/integration/delegate/` — all wiring tests pass
  with 2 new end-to-end H1 wiring tests added.
- [x] `pytest tests/e2e/delegate/` — Flow A–G + #1149 / #1150 tests pass
  (`_build_stack()` updated to register the identity as root grantee).
- [x] DV-10-001 (PR #1157 §10 G1 conformance vector) still passes
  natively (principal_kind fires before grantee per gate ordering).
- [x] `pytest --collect-only tests/` — exit 0 (17751 tests collected).
- [ ] Reviewer + security-reviewer convergence.

## Related issues
Closes #1146
Refs #1035
Builds on #1143 (PR #1157) — joins the §10 G1 cross-validation gate order.