### PR TITLE
chore(release): kailash v2.25.1 — slim-core install budget (#1154) + CHANGELOG correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.25.1] - 2026-05-23
+
+### Fixed
+
+- **Slim-core install budget — lazy-import `filelock` in `trust/_locking.py` (#1154)** — `kailash.trust._locking::file_lock()` is now the sole filelock consumer and lazy-imports `from filelock import FileLock, Timeout` inside the function body. This breaks the `kailash.delegate.types → kailash.trust._locking → filelock` eager-import chain that the 2.24.1 hotfix worked around by promoting `filelock>=3.0` into slim-core `[project.dependencies]`. With #1154 landed, `filelock>=3.0` is removed from slim-core and returned to the `[trust]` extra. `pip install kailash` (bare) no longer pulls filelock; `pip install kailash[trust]` continues to install it as before. `validate_id` is still the canonical path-traversal guard (`trust-plane-security.md` Rule 2). 3 regression tests pin the invariants: (a) `from kailash.trust._locking import validate_id` does not load filelock into `sys.modules`; (b) `import kailash.delegate.types` does not load filelock; (c) `file_lock(...)` still works end-to-end when filelock is installed.
+
+### Documentation
+
+- **CHANGELOG correction for v2.25.0** — the 2.25.0 entry has three inaccuracies in its prose (the shipped code IS correct; only the release notes mis-described it). For accurate reference:
+  - `PrincipalKind` is a `typing.Literal["sovereign", "service_account", "delegate"]` type alias — NOT a `Python Enum`.
+  - The valid `principal_kind` values are `"sovereign"`, `"service_account"`, `"delegate"` — NOT `"human"`, `"agent"`, `"service"`.
+  - H1 grantee-registry enforcement raises the **pre-existing** `DispatchCascadeViolationError` — no new `UnregisteredGranteeError` class was added. The H1 wave added `TenantScopedCascade.grantees` (property) and `TenantScopedCascade.register_root_grantee()` (method); the error class itself was already part of the public surface in 2.24.0.
+
+### Notes
+
+This is a structural follow-up patch closing #1154 (queued from 2.24.1 hotfix). The slim-core size budget is restored to its pre-2.24.0 baseline. No public API changes; all 2.25.0 functionality (PrincipalKind discrimination, grantee-registry enforcement, audit-chain E2E tests) ships unchanged.
+
 ## [2.25.0] - 2026-05-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.25.0"
+version = "2.25.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}
@@ -30,23 +30,18 @@ dependencies = [
     # composition primitive (added in 2.24.0). Everything else is
     # opt-in via extras. See `pip install kailash[server,db-postgres,...]`.
     #
-    # Audit reference: issue #890 (pre-Delegate slim-core baseline) +
-    # 2.24.1 hotfix (added filelock for delegate.types → trust._locking →
-    # filelock eager chain — `kailash.trust._locking::validate_id` is
-    # the canonical path-traversal guard mandated by
-    # `trust-plane-security.md` Rule 2, so refactoring delegate.types
-    # to bypass _locking is BLOCKED). Every dep below has at least one
-    # module-scope import in that closure.
+    # Audit reference: issue #890 (pre-Delegate slim-core baseline).
+    # 2.25.1 (#1154) restored the pre-2.24.0 slim-core size by lazy-importing
+    # `filelock` inside `kailash.trust._locking.file_lock()`. The delegate
+    # path now reaches `_locking` for `validate_id` only — no eager filelock.
+    # `filelock` lives in the `[trust]` extra (pyproject.toml § trust below).
+    # Every dep below has at least one module-scope import in the slim-core
+    # closure.
     # ─────────────────────────────────────────────────────────────
     "jsonschema>=4.24.0",   # workflow/contracts.py:21 (Draft7Validator)
     "pydantic>=2.6",        # nodes/base.py:37, workflow/graph.py:12 (BaseModel)
     "pyyaml>=6.0",          # workflow/graph.py:11 (workflow serialization)
     "click>=8.0",           # backs `[project.scripts] kailash = ...` console entry
-    "filelock>=3.0",        # trust/_locking.py:38 (FileLock, Timeout) — eagerly
-                            # imported by kailash.delegate.types via
-                            # `from kailash.trust._locking import validate_id`
-                            # (2.24.0+). Duplicates declaration in [trust] extra
-                            # so `pip install kailash` resolves delegate cleanly.
 ]
 
 [project.optional-dependencies]

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.25.0"
+__version__ = "2.25.1"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/trust/_locking.py
+++ b/src/kailash/trust/_locking.py
@@ -35,8 +35,13 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator
 
-from filelock import FileLock, Timeout
-
+# NOTE: `filelock` is intentionally NOT imported at module scope. It lives in
+# the `[trust]` optional extra (pyproject.toml) and `file_lock()` is the only
+# consumer; importing it lazily inside the function body keeps `kailash.delegate`
+# slim-core installable without `filelock`. See issue #1154 + 2.25.1 release.
+# `validate_id` is the canonical path-traversal guard (`trust-plane-security.md`
+# Rule 2) reached from `kailash.delegate.types`; that import path MUST NOT
+# touch `filelock` at module load.
 from kailash.trust.exceptions import TrustError
 
 logger = logging.getLogger(__name__)
@@ -76,7 +81,18 @@ def file_lock(
         lock_path: Path to the lock file (created if absent)
         timeout: Maximum seconds to wait for the lock. 0 means block
             forever. Raises LockTimeoutError if exceeded.
+
+    Raises:
+        ImportError: If `filelock` is not installed. Install the trust extra:
+            `pip install kailash[trust]`. (Lazy-imported per issue #1154 so
+            slim-core delegate consumers do not pay for filelock.)
     """
+    # Lazy import — see module docstring + issue #1154. The slim-core delegate
+    # path reaches this module via `validate_id` only; importing `filelock` here
+    # (function-scope) ensures `from kailash.trust._locking import validate_id`
+    # does not eagerly load `filelock` on a bare `pip install kailash`.
+    from filelock import FileLock, Timeout
+
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     lock = FileLock(str(lock_path), timeout=timeout if timeout > 0 else -1)
     try:

--- a/tests/regression/test_issue_1154_slim_core_no_eager_filelock.py
+++ b/tests/regression/test_issue_1154_slim_core_no_eager_filelock.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: issue #1154 — slim-core delegate path must not eagerly import filelock.
+
+2.24.1 (hotfix) promoted `filelock>=3.0` from the `[trust]` extra into slim-core
+to make `pip install kailash` work — because `kailash.delegate.types` imports
+`validate_id` from `kailash.trust._locking`, which had a module-scope
+`from filelock import FileLock, Timeout`.
+
+2.25.1 (#1154) lazy-imported filelock inside `_locking.file_lock()` so the
+slim-core delegate path no longer touches filelock. This test pins the
+invariant: the `_locking` module loads cleanly without filelock, AND a fresh
+Python process importing `validate_id` does not load filelock.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_validate_id_does_not_eager_import_filelock() -> None:
+    """Subprocess: importing validate_id MUST NOT load filelock in sys.modules.
+
+    A subprocess is required because pytest's process may have already imported
+    filelock via other test paths. The clean subprocess proves the slim-core
+    invariant: a fresh interpreter that only imports the delegate-reachable
+    surface MUST see no `filelock` in `sys.modules`.
+    """
+    code = (
+        "import sys\n"
+        "from kailash.trust._locking import validate_id\n"
+        "validate_id('test-id-123')\n"
+        "assert 'filelock' not in sys.modules, (\n"
+        "    'filelock leaked into sys.modules after importing validate_id; '\n"
+        "    'lazy-import in trust/_locking.py::file_lock broke — see #1154'\n"
+        ")\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"slim-core delegate path eagerly imports filelock\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_delegate_types_does_not_eager_import_filelock() -> None:
+    """End-to-end: importing kailash.delegate.types MUST NOT load filelock.
+
+    This is the exact failure mode 2.24.1 hotfixed:
+    `import kailash.delegate` → ModuleNotFoundError: filelock (on clean install
+    without [trust] extra). Lazy-import #1154 restored slim-core installability.
+    """
+    code = (
+        "import sys\n"
+        "import kailash.delegate.types  # noqa: F401\n"
+        "assert 'filelock' not in sys.modules, (\n"
+        "    'kailash.delegate.types eagerly loads filelock; '\n"
+        "    'slim-core install budget regressed — see #1154'\n"
+        ")\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"kailash.delegate.types eagerly imports filelock\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_file_lock_still_works_when_filelock_available() -> None:
+    """Sanity: file_lock() still works after the lazy-import refactor.
+
+    Same-process test (filelock is installed in the dev env) — verifies the
+    in-body import resolves and the context manager acquires/releases.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from kailash.trust._locking import file_lock
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lock_path = Path(tmpdir) / "test.lock"
+        with file_lock(lock_path, timeout=5.0):
+            pass  # context entered + exited cleanly
+        # lock file was created
+        assert lock_path.exists()


### PR DESCRIPTION
## Summary

Patch release closing #1154 (queued from the 2.24.1 hotfix). Restores the pre-2.24.0 slim-core install budget by lazy-importing `filelock` inside `trust/_locking.py::file_lock()`. Also corrects 3 inaccuracies in the v2.25.0 CHANGELOG prose (shipped code is correct; only release notes were wrong).

## Scope

| Change | Files |
|--------|-------|
| Lazy-import filelock | `src/kailash/trust/_locking.py` |
| Return filelock to `[trust]` extra | `pyproject.toml` |
| Pin invariants | `tests/regression/test_issue_1154_slim_core_no_eager_filelock.py` (3 tests, all passing) |
| Version bump 2.25.0 → 2.25.1 | `pyproject.toml`, `src/kailash/__init__.py` |
| CHANGELOG: #1154 entry + 2.25.0 corrections | `CHANGELOG.md` |

## CHANGELOG correction note (re: v2.25.0)

The v2.25.0 entry mis-described shipped behavior in three ways. The CODE shipped in 2.25.0 IS correct; only the release notes prose was wrong:

| Claimed in v2.25.0 notes | Actual shipped |
|---|---|
| `PrincipalKind` is an `Enum` | `typing.Literal["sovereign","service_account","delegate"]` type alias |
| Variant values `human/agent/service` | `sovereign/service_account/delegate` |
| New exception `UnregisteredGranteeError` | Pre-existing `DispatchCascadeViolationError` is what H1 raises; no new exception class shipped |

Per `git.md` § Commit-message claim accuracy: this PR pushes the follow-up correction (no amend of v2.25.0). The corrected language ships in the v2.25.1 CHANGELOG entry's "Documentation" section.

## Test plan

- [x] 3 regression tests pass locally (`tests/regression/test_issue_1154_*`)
- [x] `release/v2.25.1` branch convention triggers PR-gate auto-skip
- [ ] CI green (Build Documentation expected)
- [ ] Admin-merge with `--admin --merge --delete-branch`
- [ ] Lightweight tag `v2.25.1` push triggers `publish-pypi.yml`
- [ ] Clean-venv install verification:
  - `pip install kailash==2.25.1` resolves WITHOUT pulling filelock
  - `pip install kailash[trust]==2.25.1` resolves WITH filelock
  - `from kailash.delegate import PrincipalKind` works on slim-core install

## Related issues

Closes #1154 (slim-core install budget). v2.25.0 functionality (PrincipalKind discrimination, grantee-registry enforcement, audit-chain E2E tests) ships unchanged — only the prose corrections + filelock dependency relocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>