### PR TITLE
chore(release): kailash v2.25.2 — CHANGELOG correction for v2.25.0 forensic-key-registry claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.25.2] - 2026-05-23
+
+### Documentation
+
+- **CHANGELOG correction for v2.25.0 (continued, 4th inaccuracy) — audit-chain forensic key-registry gap NOT closed in 2.25.0** — the v2.25.1 entry corrected three inaccuracies in the v2.25.0 prose; a fourth was missed. The v2.25.0 entry (lines 37 + 45) claims "the audit-chain forensic gap was the only deferred item that flipped status this release (PR #1155)" and "With 2.25.0, the audit-chain forensic key-registry gap (previously deferred) is closed." Both statements are **incorrect**:
+  - PR #1146 closed the H1 **grantee** registry gap (`TenantScopedCascade.__grantees` + `register_root_grantee()`), not the audit-chain forensic key registry. The two gaps are distinct.
+  - The audit-chain forensic key-registry gap remains **open**, tracked at [issue #1147](https://github.com/terrene-foundation/kailash-py/issues/1147). `README.md` § "Delegate composition primitive — Pre-Pledge v0" correctly discloses this: `AuditChainEntry` stores per-event Ed25519 signatures, but the primitive does NOT bind signer keys to a public-key registry, fingerprint, or key-rotation epoch. Out-of-band identity-to-key binding is required; operators MUST provide their own attestation surface.
+  - Per `git.md` no-amend rule, the v2.25.0 prose is preserved in git history; this entry corrects the public-facing disclosure record. The v2.25.1 corrections for `PrincipalKind`-type, valid-values, and `UnregisteredGranteeError` stand.
+
+### Notes
+
+This is a structural follow-up patch correcting the public-facing release-notes record for v2.25.0. No code changes; no public API changes; no behavior change. All v2.25.0 functionality (`PrincipalKind` discrimination, grantee-registry enforcement, audit-chain E2E tests) ships unchanged from v2.25.1.
+
 ## [2.25.1] - 2026-05-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.25.1"
+version = "2.25.2"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.25.1"
+__version__ = "2.25.2"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

CHANGELOG-only patch release correcting a 4th inaccuracy in v2.25.0's prose that v2.25.1's Documentation correction round missed.

**Background:** v2.25.1 corrected three inaccuracies in v2.25.0's CHANGELOG prose:
1. \`PrincipalKind\` is \`typing.Literal\`, not \`Enum\`
2. Valid values are \`sovereign\`/\`service_account\`/\`delegate\`, not \`human\`/\`agent\`/\`service\`
3. H1 enforcement uses pre-existing \`DispatchCascadeViolationError\`, not a new \`UnregisteredGranteeError\` class

**Fourth inaccuracy (this PR):** v2.25.0 lines 37 + 45 claim \"the audit-chain forensic gap was the only deferred item that flipped status this release\" and \"With 2.25.0, the audit-chain forensic key-registry gap (previously deferred) is closed.\" Both are wrong:

- PR #1146 closed the H1 **grantee** registry gap (\`TenantScopedCascade.__grantees\`), NOT the audit-chain forensic key registry.
- The audit-chain forensic key-registry gap remains **open**, tracked at #1147. \`README.md:351\` correctly discloses this.
- The two gaps are distinct subsystems.

## Surfaced By

\`/redteam\` Round 1 (pact-specialist) — cross-agent disagreement resolved by construction:
- \`README.md:351\` (live source): gap OPEN, \"primitive does NOT bind signer keys to a public-key registry... [issue #1147]\"
- \`CHANGELOG.md:37,45\` (v2.25.0 prose): gap CLOSED
- \`audit.py\` grep: zero \`key_registry\`/\`attestation\` surface

## Why a Release Cut

\`build-repo-release-discipline.md\` §1a — CHANGELOG.md is EXCLUDED from the docs-only carve-out; any \`CHANGELOG.md\` change requires \`/release\`.

\`git.md\` no-amend rule: the v2.25.0 and v2.25.1 entries are immutable git history; the correction lives in v2.25.2's Documentation section as the 4th bullet.

## Scope

- \`CHANGELOG.md\` — adds v2.25.2 entry with 4th correction bullet
- \`pyproject.toml\` — version 2.25.1 → 2.25.2
- \`src/kailash/__init__.py\` — \`__version__\` 2.25.1 → 2.25.2

No code change. No behavior change. No public API change. All v2.25.0 functionality ships unchanged from v2.25.1.

## Test plan

- [x] Pre-commit hooks pass (Black, isort, Ruff, type annotations, ...)
- [x] PR-gate matrix auto-skipped (release/v\* branch convention per \`git.md\`)
- [ ] Admin-merge after CI green / path-filter auto-skip
- [ ] Tag \`v2.25.2\` push + publish-pypi.yml workflow success
- [ ] Clean-venv install: \`uv pip install kailash==2.25.2\` + \`import kailash; assert kailash.__version__ == \"2.25.2\"\`
- [ ] /redteam Round 2 closure-parity: HIGH finding from Round 1 resolved

## Related

- Builds on v2.25.1 PR #1160 (3 prior CHANGELOG corrections, slim-core install budget fix #1154)
- Documents but does NOT close #1147 (audit-chain forensic key registry — remains open per README disclosure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)