### PR TITLE
chore(gitignore): ignore operator-local identity cache + journal-skip log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,10 @@ todos/
 .claude/settings.local.json
 **/.claude/learning/
 
+# Operator-local identity cache (multi-operator coordination substrate;
+# per-machine, mode 0600 — never committed)
+.claude/operator-id
+
 # Per-package proposal manifests are local-only; the canonical
 # proposal lives at root .claude/.proposals/latest.yaml.
 packages/*/.claude/.proposals/
@@ -203,6 +207,9 @@ output.txt
 
 # Pending journal entries (session-local; promoted to journal/ on /wrapup)
 **/journal/.pending/
+
+# Journal-skip log (transient; emitted by /journal hook on merge/no-match commits)
+**/.journal-skipped.log
 
 # Build/release artifacts
 test-release/


### PR DESCRIPTION
## Summary

- Add `.claude/operator-id` (multi-operator coordination identity cache, per-machine, mode 0600) to .gitignore — eliminates recurring SessionStart COC-drift false-positive
- Add `**/.journal-skipped.log` (transient log emitted by /journal hook on merge/no-match commits) — 5 such files already in working tree across workspaces

Both additions sit in the existing operator-local/transient class alongside `.claude/learning/`, `.claude/settings.local.json`, and `**/.claude/learning/`.

## User-flow walk receipt

Before edit:
$ git status --porcelain | head -1
?? .claude/operator-id

After edit:
$ git status --porcelain | grep operator-id
(no output — successfully ignored)

Disposition: SessionStart drift warning will no longer fire on this file across future sessions.

## Test plan

- [x] pre-commit run passed on commit (Tier 1 unit tests + structural checks green)
- [x] Walked the gitignore behavior — `.claude/operator-id` no longer surfaces in `git status`