### PR TITLE
fix(delegate): R1 reconciliation + workspace receipt durability (post-#1164 recovery)

### DIFF
--- a/src/kailash/delegate/audit.py
+++ b/src/kailash/delegate/audit.py
@@ -26,12 +26,17 @@ provide for the Delegate runtime:
   :class:`AuditChainSignatureError`,
   :class:`CrossAnchorIntegrityError`.
 
-Cross-SDK byte-canonical fixtures emitted by either implementation MUST
-verify under the other via
-:func:`kailash.trust._json.canonical_json_dumps` (already byte-equal to
-rs serde_json per the S2 primitive survey). The acceptance criterion
-*"Cross-language audit-chain verification test green (py-emitted chain
-verifies under rs verifier)"* from #1035 is anchored on this surface.
+Cross-SDK design intent: chains emitted by either implementation are
+serialized via :func:`kailash.trust._json.canonical_json_dumps` so that
+the byte representation is stable and verifier-checkable. Cross-impl
+AGREEMENT is currently verified through the shared conformance-vector
+receipts (``tests/fixtures/delegate-conformance/canonical.json`` +
+``receipts_agree``), NOT through a live rs-verifier round-trip — there is
+no rs byte-vector pinned in this repo yet (see cross-sdk-inspection.md
+Rule 4: byte-equality to rs is an UNVERIFIED design goal until ≥3 rs-emitted
+vectors are vendored here). The #1035 acceptance criterion *"Cross-language
+audit-chain verification test green"* is satisfied by the conformance-receipt
+mechanism; a true byte-for-byte rs round-trip is tracked as future work.
 """
 
 from __future__ import annotations

--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -71,40 +71,13 @@ from kailash.delegate.trust import (
     TenantScopedCascade,
 )
 from kailash.delegate.types import DelegateIdentity, Role, RoleLifecycleState
+
+# kailash.delegate.verifier is a guaranteed in-tree sibling module (the
+# canonical Verifier Protocol + NullVerifier fail-closed default +
+# Ed25519Verifier). The Verifier contract is narrow:
+# verify(message: bytes, signature: bytes, signer_delegate_id: str) -> bool.
+from kailash.delegate.verifier import NullVerifier, Verifier
 from kailash.trust._json import canonical_json_dumps
-
-# Shard Y owns kailash.delegate.verifier — this import resolves at runtime
-# after merge. For in-worktree development, the import is conditional and
-# a NullVerifier sentinel is provided locally. The Verifier Protocol is a
-# narrow contract: verify(message: bytes, signature: bytes, signer_id: str)
-# -> bool. See workspace plan §C1 (signature verification wiring).
-try:
-    from kailash.delegate.verifier import (  # type: ignore[import-not-found]
-        NullVerifier,
-        Verifier,
-    )
-except ImportError:  # pragma: no cover (Shard Y not yet merged)
-    # In-worktree fallback for Shard X development. Defines the minimal
-    # Protocol surface Shard X needs to wire signature verification into
-    # dispatch. Replaced by the canonical Shard Y impl at merge time.
-
-    @runtime_checkable
-    class Verifier(Protocol):  # type: ignore[no-redef]
-        """Signature-verification protocol — Shard Y owns the canonical impl."""
-
-        def verify(
-            self, message: bytes, signature: bytes, signer_delegate_id: str
-        ) -> bool:  # pragma: no cover (Protocol)
-            ...
-
-    class NullVerifier:  # type: ignore[no-redef]
-        """Fail-closed default verifier — refuses every signature."""
-
-        def verify(
-            self, message: bytes, signature: bytes, signer_delegate_id: str
-        ) -> bool:
-            return False
-
 
 logger = logging.getLogger(__name__)
 
@@ -1973,17 +1946,25 @@ class DispatchSurface:
                     f"injected signer MUST return str; got "
                     f"{type(signature_hex).__name__}"
                 )
-            # Surface-shape sanity check: the audit engine's
-            # _validate_hex requires 128 lowercase-hex chars (Ed25519).
-            # A signer that returns less than 32 chars is structurally
-            # not a real signature; raise before the engine boundary so
-            # the error attribution is unambiguous (signer fault vs.
-            # engine fault).
-            if len(signature_hex) < 32:
+            # Surface-shape sanity check: mirror the audit engine's
+            # _validate_hex contract EXACTLY (128 lowercase-hex chars,
+            # Ed25519) at the signer boundary so the error attribution is
+            # unambiguous (signer fault vs. engine fault). A laxer check
+            # here (e.g. len < 32) would let a 64-char non-signature pass
+            # the dispatch boundary and fail later at the engine, mis-
+            # attributing a signer fault to the engine.
+            if len(signature_hex) != 128 or not all(
+                c in "0123456789abcdef" for c in signature_hex
+            ):
                 raise DispatchSignerError(
-                    f"injected signer returned a signature shorter than "
-                    "32 characters; production signatures are 128-char "
-                    f"lowercase hex (Ed25519); got {len(signature_hex)} chars"
+                    "injected signer MUST return a 128-char lowercase-hex "
+                    "Ed25519 signature; got "
+                    f"{len(signature_hex)} chars"
+                    + (
+                        " (non-hex or uppercase characters present)"
+                        if len(signature_hex) == 128
+                        else ""
+                    )
                 )
 
             # F-17 C1 cryptographic signature verification: the hex-shape

--- a/src/kailash/delegate/envelope.py
+++ b/src/kailash/delegate/envelope.py
@@ -93,11 +93,15 @@ class DelegateConstraintEnvelope:
         envelope: ConstraintEnvelope,
         genesis: DelegateGenesisRecord,
     ) -> "DelegateConstraintEnvelope":
-        """Construct from a genesis-seeded envelope (the only widening path).
+        """Construct from a genesis-seeded envelope (genesis-bound inception constructor).
 
-        This is the SOLE constructor that may set a fresh underlying
-        ``ConstraintEnvelope``. Once constructed, the envelope can only be
-        further tightened via :meth:`tighten_with`.
+        This is the genesis-anchored constructor: it binds a fresh underlying
+        ``ConstraintEnvelope`` to a :class:`DelegateGenesisRecord`. The bare
+        ``__init__`` and :meth:`from_dict` also accept a fresh inner envelope
+        (in-process trust + cross-SDK ingest respectively). What is invariant
+        across ALL three constructors: once constructed, the envelope can only
+        be further tightened via :meth:`tighten_with` (widening raises
+        ``EnvelopeWideningError``).
         """
         if not isinstance(envelope, ConstraintEnvelope):
             raise TypeError(

--- a/src/kailash/delegate/runtime.py
+++ b/src/kailash/delegate/runtime.py
@@ -78,7 +78,7 @@ from kailash.delegate.audit import AuditChainEngine, DelegateEventType
 from kailash.delegate.dispatch import DispatchResult, DispatchSurface
 from kailash.delegate.envelope import DelegateConstraintEnvelope
 from kailash.delegate.trust import TenantScope, TenantScopedCascade
-from kailash.delegate.types import DelegateIdentity
+from kailash.delegate.types import DelegateIdentity, LifecycleState
 from kailash.trust._json import canonical_json_dumps
 
 logger = logging.getLogger(__name__)
@@ -901,15 +901,16 @@ class DelegateRuntime:
             identity mismatch).
         TypeError: any argument fails its isinstance check.
 
-    Note on identity/cascade gateability: the current
-    :class:`TenantScopedCascade` (S3) does not yet expose a persistent
-    grantee registry (S3 emits one :class:`GrantMoment` per
-    ``cascade_child`` call but does not retain the grantee set). The
-    bind-time check here re-uses the DispatchSurface's bind-time
-    invariant — DispatchSurface already validated identity-cascade
-    consistency at S5; the runtime trusts that gate. A future S7+
-    enhancement will surface a grantee registry; the runtime's
-    bind-time check will tighten to use it.
+    Note on identity/cascade gateability: :class:`TenantScopedCascade`
+    exposes a persistent grantee registry (``cascade.grantees`` —
+    ``frozenset[UUID]``, populated by ``register_root_grantee`` and
+    ``cascade_child``; #1146 H1). :class:`DispatchSurface` enforces
+    ``identity.delegate_id in cascade.grantees`` at bind
+    (``dispatch.py`` bind path) and re-checks at dispatch
+    (``dispatch.py`` dispatch path). The runtime binds the same cascade
+    object through the R2 composition gate, so the DispatchSurface
+    grantee check IS the runtime's grantee gate by composition — no
+    parallel registry is maintained here.
     """
 
     # Per-phase audit event mapping. Each TAOD transition emits exactly
@@ -1036,8 +1037,6 @@ class DelegateRuntime:
         # axis is independent of the TAOD per-run axis: TAOD governs
         # one execute() invocation; lifecycle governs the Delegate's
         # lifetime. Both are append-only and monotonic.
-        from kailash.delegate.types import LifecycleState
-
         self._lifecycle_state: LifecycleState = LifecycleState.PROPOSED
         # §7 TAOD phase monotonicity — runtime is single-shot per receipt.
         # Once execute() returns (success OR failure), the runtime is
@@ -1084,7 +1083,7 @@ class DelegateRuntime:
     @property
     def lifecycle_state(
         self,
-    ) -> "LifecycleState":  # noqa: F821 - late-bound by import in __init__
+    ) -> LifecycleState:
         """Borrow the current :class:`LifecycleState` (#1035 H1/F-11).
 
         Returns the D3 lifecycle state — Proposed at construction; the
@@ -1094,9 +1093,7 @@ class DelegateRuntime:
         """
         return self._lifecycle_state
 
-    def advance_lifecycle(
-        self, target: "LifecycleState"  # noqa: F821 - late-bound by import in __init__
-    ) -> "LifecycleState":  # noqa: F821
+    def advance_lifecycle(self, target: LifecycleState) -> LifecycleState:
         """Advance to ``target`` lifecycle state iff legal (#1035 H1/F-11).
 
         Routes through :meth:`LifecycleState.advance_to` — the D3

--- a/src/kailash/delegate/verifier.py
+++ b/src/kailash/delegate/verifier.py
@@ -48,6 +48,13 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+# cryptography is a core kailash dependency (the trust stack requires it).
+# Imported at module scope so `except InvalidSignature` always resolves —
+# importing inside the verify() try-block left the name unbound if the
+# import itself failed, masking the real error with a NameError.
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
 if TYPE_CHECKING:  # pragma: no cover - typing-only
     from kailash.delegate.types import PrincipalDirectory
 
@@ -251,11 +258,6 @@ class Ed25519Verifier:
         # is raised on signature mismatch; any other exception (malformed key,
         # internal lib error) also falls closed.
         try:
-            from cryptography.exceptions import InvalidSignature
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import (
-                Ed25519PublicKey,
-            )
-
             public_key = Ed25519PublicKey.from_public_bytes(pk_bytes)
             public_key.verify(bytes(signature), bytes(message))
             return True

--- a/tests/unit/delegate/test_dispatch.py
+++ b/tests/unit/delegate/test_dispatch.py
@@ -781,13 +781,16 @@ async def test_dispatch_signer_returns_non_str_raises() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_dispatch_signer_returns_short_signature_raises() -> None:
-    """C2-1: signer return value <32 chars is structurally invalid."""
+    """C2-1: signer return value that is not exactly 128 lowercase-hex
+    chars is structurally invalid (mirrors the audit engine's _validate_hex
+    Ed25519 contract at the dispatch boundary for unambiguous attribution).
+    """
 
     def short_signer(_canonical_bytes: bytes) -> str:
-        return "0" * 16  # too short
+        return "0" * 16  # not 128 chars
 
     surface = _make_surface(signer=short_signer)
-    with pytest.raises(DispatchSignerError, match="shorter than"):
+    with pytest.raises(DispatchSignerError, match="128-char lowercase-hex"):
         await surface.dispatch({"user_id": "u-1"})
 
 

--- a/workspaces/issue-1035-delegate-py/.session-notes
+++ b/workspaces/issue-1035-delegate-py/.session-notes
@@ -1,0 +1,44 @@
+# Session Notes — 2026-05-24
+
+## Where we are
+
+#1163 tracker (phantom `terrene-foundation/kailash-rs` citations + deferred cross-SDK rs parity) CLOSED `completed` this turn after F5 closure-by-discovery superseded its re-open gate. Scope sweep posted as comment 4528054850 (acceptance criterion #1 ✅); closure-provenance line cites #1162 per `git.md` Discipline. Stale shard plan (claimed 8 pending shards) moved to `todos/completed/` with status header — all S1–S8 delivered weeks ago. #1035 itself remains open pending maintainer close.
+
+## Read first
+
+1. `workspaces/issue-1035-delegate-py/todos/completed/00-shard-plan.md` — status header confirms all S1–S8 delivered; do NOT re-implement
+2. `workspaces/issue-1035-delegate-py/journal/0005-AUTHORIZATION-cross-repo-esperie-enterprise-kailash-rs-f5.md` — F5 closure rationale; LOCAL-UNCOMMITTED, run `git status` first
+3. #1163 (CLOSED) comments — phantom-slug 3-artifact scope (#1143, PR #1142, PR #1152) + full acceptance disposition
+4. `README.md:351` — audit-chain forensic key-registry gap #1147 STILL OPEN (NOT fixed by v2.25.0/.1/.2)
+5. `CHANGELOG.md` § "[2.25.2]" + "[2.25.1]" Documentation — 4 v2.25.0 inaccuracies on record (do NOT amend earlier entries)
+
+## In-flight state
+
+- Working-tree drift persists across packages/kailash-align, kaizen, dataflow, ml per F3 "LEAVE ALONE" — explicit-path staging required for any release-prep PR.
+- journal/0005 + the new comment on #1163 are LOCAL-UNCOMMITTED in this repo's working tree; never auto-committed in BUILD repos.
+
+## Outstanding ledger (forest)
+
+| ID  | Item                                                                       | Value-anchor (MUST-1 source)                                      | Status                                          |
+| --- | -------------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- |
+| F1  | Loom-side `/sync` Gate-1 of `.claude/.proposals/latest.yaml` (codify queue) | User approval prior session ("approved" on codify recommendation) | BLOCKED on loom session (not this repo's scope) |
+| F3  | Working-tree drift across packages/kaizen/dataflow/ml/align                | User directive 2026-05-22 — verbatim "LEAVE ALONE"                | LEAVE ALONE per user                            |
+| F10 | `.session-notes` split-layout migration per knowledge-convergence MUST-1   | `rules/knowledge-convergence.md` MUST-1                           | BLOCKED on loom-side /codify (not this scope)   |
+
+Closed this session: `F9` → #1163 (closed `completed`, comment 4528054850, closure-provenance #1162). F5 closed earlier 2026-05-24 per journal/0005 (parallel session).
+
+## Traps
+
+- `src/kailash/delegate/` ALREADY EXISTS feature-complete (S1–S8 shipped via #1035 series through commit `e7d2adc86`). Run `git log -- src/kailash/delegate/` before any "implement" recommendation.
+- `gh search issues|prs --state all` is invalid — only `open` or `closed`. Run separately + merge with `jq -s 'add'`. (Bug in #1163 criterion #1 as written; worked around in the sweep comment.)
+- F5 closure receipt (journal/0005) is LOCAL-UNCOMMITTED. The #1163 closure comment references "session journal in this repo" abstractly per `upstream-issue-hygiene.md` MUST-2; user accepted that evidentiary level.
+- Phantom `terrene-foundation/kailash-rs` citations remain in shipped bodies (#1143, PR #1142, PR #1152) per Strategy A immutability. PR #1142's `cross-repo-authorized:` greppable marker is documented as known-phantom in closed #1163.
+- Real rs target is `esperie-enterprise/kailash-rs` (BUILD) or `rrps-mtu/kailash-rs` (seed). Public Foundation-repo comments MUST stay abstract per `upstream-issue-hygiene.md` MUST-2.
+- `PrincipalKind` (py) is `typing.Literal["sovereign","service_account","delegate"]` — NOT Enum. Rs uses type-level Impersonation absence + runtime `assert_service_account_distinct`.
+
+## Open questions for the human
+
+- Execute the bounded `~/repos/loom/kailash-rs` verification read (per existing authorization in journal/0005)? Currently skipped per `repo-scope-discipline.md` default.
+- Surface F10 (knowledge-convergence split-layout migration) to loom via /codify proposal?
+- R1 leftover: `DispatchCascadeViolationError` 3-way split? No user-anchored source per `value-prioritization.md` MUST-1 closed allowlist; design call awaiting brief or `DECISION` journal anchor.
+- F3 working-tree drift: how to resolve eventually (commit / stash / discard)? Currently durably "LEAVE ALONE"; surfaced for awareness.

--- a/workspaces/issue-1035-delegate-py/01-analysis/01-external-spec-extraction.md
+++ b/workspaces/issue-1035-delegate-py/01-analysis/01-external-spec-extraction.md
@@ -1,0 +1,456 @@
+# External Spec Extraction — Delegate Specification v0
+
+**Source:** `/Users/esperie/repos/dev/unicorn-focus/drafts/02-delegate-spec-v0-outline.md`
+**Source size:** 256 lines (~31 KB), authored by Dr. Jack Hong (Terrene Foundation), CC BY 4.0 pre-pledged
+**Source self-description (lines 3-4):**
+
+> "**Status:** Pre-draft scaffold. Not the spec. A structural skeleton for the founder to author against."
+
+**Critical framing finding — read this before everything else.**
+
+The external document is **not a normative specification**. It is a _section outline plus open-question list_ that Dr. Hong intends to author the actual spec against over a 6–8 week window (lines 4-5). The 15 sections each have an **Intent paragraph** (what the section will eventually settle) and an **Open questions** list (decisions the founder must make). The document explicitly states:
+
+- Line 3: "Pre-draft scaffold. Not the spec."
+- Line 247: "if a section can only be implemented one way, it is over-specified" — the discipline being asserted for the _future_ spec
+- Line 253: "The end-state I would target for v1.0: a 35–55 page document" — i.e. the current 11-page outline is not yet that document
+
+**Consequence for #1035 acceptance criteria.** The acceptance bar "py-emitted chain verifies under rs verifier" cannot be satisfied by reading record-shape mandates off this document, because the document does not define record shapes. What it DOES define is (a) the section structure both implementations must eventually conform to, (b) the substrate inheritances (EATP v2.2 audit, PACT 5-dimensional envelope, posture gradient `PSEUDO → TOOL → SUPERVISED → DELEGATING → AUTONOMOUS`), and (c) a set of recommendation candidates the author has pre-staked on individual open questions.
+
+The honest extraction below distinguishes three categories:
+
+1. **MANDATED** — text the outline asserts as a structural requirement (mostly inheritances from prior Terrene specs)
+2. **PROPOSED / RECOMMENDATION CANDIDATE** — text the outline pre-stakes a position on but flags as not-yet-final
+3. **OPEN** — open questions the author has explicitly deferred
+
+Any kailash-py implementation that picks Category-2 or invents Category-3 answers ahead of the founder MUST flag the decision as ahead-of-spec, because the kailash-rs implementation may pick differently and the two will not converge until v1.0 lands.
+
+---
+
+## 1. Section Map
+
+The outline numbers 15 sections. Issue #1035 names sections §3-§10. The outline's numbering DIFFERS from #1035's mapping — the outline's Section 3 is "Role Binding", Section 4 is "Genesis Record", etc. The mapping I infer from #1035's titles:
+
+| #1035 title     | Outline section                                       | Outline lines |
+| --------------- | ----------------------------------------------------- | ------------- |
+| §3 Identity     | Section 1 — Identity                                  | 42–53         |
+| §4 Genesis      | Section 4 — Genesis Record                            | 78–88         |
+| §5 Envelopes    | Section 5 — Constraint Envelopes                      | 90–100        |
+| §6 Posture      | Section 6 — Posture Gradient                          | 102–112       |
+| §7 Cascade      | Section 7 — Cascade & Sub-Delegation                  | 114–124       |
+| §8 Memory       | Section 8 — Memory and Institutional Knowledge        | 126–136       |
+| §9 Audit        | Section 9 — Audit Chain (EATP Provenance)             | 138–148       |
+| §10 Integration | Section 10 — Integration Surface (Enterprise Systems) | 150–171       |
+
+This re-numbering is itself a finding — #1035 may be using a working numbering that does not match the outline's section order. Implementations should track BOTH numbers in cross-references.
+
+### §3 Identity (outline Section 1, lines 42–53)
+
+**Intent (verbatim line 44):** define what a Delegate is — _"a named, role-bearing, cryptographically-rooted agent with explicit authority, an explicit constraint envelope, and an unbroken audit chain back to a human sovereign."_
+
+**Distinguishes from** (line 44): a chatbot (no role binding), an agentic framework (no audit chain), an Envoy (exterior orientation), a workflow (no posture gradient).
+
+**Load-bearing primitives the section names but does NOT settle:**
+
+- Identity key (open question 1, line 48): `(organization_id, role_id, version)` tuple _vs._ opaque UUID. **OPEN.**
+- Human-readable name (Q2, line 49): part of spec'd identity _vs._ UI-layer only. **OPEN.**
+- Voice/output style (Q3, line 50): part of identity _vs._ part of role-binding. **OPEN.**
+- Sovereign pointer (Q4, line 51): persisted on Delegate _vs._ reconstructed at audit time. **OPEN.**
+- Sovereign re-pointing mid-lifecycle (Q5, line 52): allowed _vs._ requires retire+re-instantiate. **OPEN.**
+
+### §4 Genesis (outline Section 4, lines 78–88)
+
+**Intent (line 80):** the immutable, signed artifact establishing a Delegate's authority and constraints at instantiation. Analogous to Envoy's Genesis Record. EATP v2.2 conformance.
+
+**Load-bearing primitives:**
+
+- Signing party (Q1, line 84): human sovereign personally / org signing authority (CISO) / countersigned. **OPEN.**
+- **PROPOSED required fields (Q2, line 85, "proposed"):** `delegate_id`, `role_binding`, `sovereign`, `instantiation_timestamp`, `initial_envelope`, `initial_posture`, `signature`. **PROPOSED — not settled.**
+- Optional fields candidate (line 85): expected lifetime, renewal cadence, succession plan.
+- On-chain anchoring (Q3, line 86): Sigstore / org HSM / Terrene witness / hybrid / org's own EATP ledger only. **OPEN.**
+- Cross-vendor portability (Q4, line 87): "should an Aegis-instantiated Delegate's Genesis Record be verifiable by a competing-vendor EATP verifier?" — _directly relevant to #1035's cross-language verification criterion._ **OPEN.**
+- Genesis Amendment mechanism (Q5, line 88): non-destructive correction _vs._ retirement + re-instantiation only. **OPEN.**
+
+### §5 Envelopes (outline Section 5, lines 90–100)
+
+**Intent (line 92):** apply PACT's 5-dimensional envelope (Financial, Operational, Temporal, Data Access, Communication) with enterprise-specific particulars. **MANDATES monotonic tightening** — envelope may only narrow within a single lifecycle, never widen. Widening requires a new Genesis Record (re-instantiation).
+
+**Load-bearing primitives:**
+
+- **The 5 PACT dimensions** (line 92, MANDATED inheritance): Financial / Operational / Temporal / Data Access / Communication.
+- **PROPOSED additional dimensions** (Q1, line 96): Jurisdictional (legal regimes), Counterparty (allowed external parties), Materiality (business-impact threshold). **PROPOSED — not settled.**
+- Financial envelope shape (Q2, line 97): per-transaction _vs._ per-period _vs._ both. **OPEN** (line 97 calls "both" the "safest default").
+- Data Access classification (Q3, line 98): import customer's existing taxonomy _vs._ re-define. **OPEN.**
+- Communication enumeration (Q4, line 99): allowed channels _vs._ counterparties _vs._ both. **OPEN.**
+- Monotonic tightening exceptions (Q5, line 100): "is the rule absolute?" — recommendation is child Delegate for temporary widening, NOT relaxation. **PROPOSED.**
+
+### §6 Posture (outline Section 6, lines 102–112)
+
+**Intent (line 104):** inherit Envoy's `PSEUDO → TOOL → SUPERVISED → DELEGATING → AUTONOMOUS` ladder, redefined for enterprise verbs. **MANDATES ratcheting** — posture advances only by explicit human grant, never implicit.
+
+**Load-bearing primitives:**
+
+- **5-state posture ladder** (line 104, MANDATED): `PSEUDO → TOOL → SUPERVISED → DELEGATING → AUTONOMOUS`.
+- PSEUDO semantics (Q1, line 108): "shadow mode" _vs._ "draft mode" — different operational shapes. **OPEN.**
+- **PROPOSED 6th state `RESTRICTED`** (Q2, line 109) between SUPERVISED and DELEGATING. **PROPOSED — not settled.**
+- Automatic downgrade triggers (Q3, line 110): anomaly detection / audit failure / envelope violation. **OPEN.**
+- **PROPOSED cascade-posture cap** (Q4, line 111, "Recommendation candidate"): "no higher than the parent." **PROPOSED.**
+- Posture granularity (Q5, line 112): per-Delegate _vs._ per-(Delegate, capability). **OPEN.**
+
+### §7 Cascade (outline Section 7, lines 114–124)
+
+**Intent (line 116):** how a Delegate creates and authorises sub-Delegates. References PACT's **D/T/R addressing** (Domain / Tenant / Role). **MANDATES authority/envelope tightening on cascade** — never relax. Every sub-Delegate's actions chain back through parent's Delegation Records to the originating Genesis Record.
+
+**Load-bearing primitives:**
+
+- **D/T/R cascade addressing** (line 116, MANDATED inheritance from PACT).
+- **MANDATED audit chain-through:** sub-Delegate actions chain back through parent to originating Genesis Record (line 116).
+- Maximum cascade depth (Q1, line 120): "no spec-level cap, but runtime implementations must support ≥ 5". **PROPOSED.**
+- Lateral cascade (Q2, line 121): peer Delegate at same posture _vs._ downward-only. **OPEN.**
+- Sync/async default (Q3, line 122). **OPEN.**
+- Sub-Delegate fate on parent retirement (Q4, line 123): cascade-retire / re-root / quarantine. **OPEN.**
+- **Tenant isolation under cascade (Q5, line 124):** "A Delegate in Tenant-A must not be able to cascade into Tenant-B even if both tenants are within the same Domain." This reads MANDATED, though phrased as an open question.
+
+### §8 Memory (outline Section 8, lines 126–136)
+
+**Intent (line 128):** three-tier memory model — (a) session-scoped working memory, (b) Delegate-lifecycle memory, (c) role-scoped institutional memory (outlives Delegate, passes to successor). The spec's answer to the founder's _succession / knowledge continuity_ forcing function.
+
+**Load-bearing primitives:**
+
+- **3-tier memory taxonomy** (line 128, structurally asserted): session / Delegate-lifecycle / role-scoped institutional.
+- Memory ownership on employee departure (Q1, line 132): retire+archive _vs._ pass to successor. **OPEN — depends on §3 role-binding decision.**
+- Memory storage location (Q2, line 133): inside Delegate (portability) _vs._ outside in role-scoped store (isolation, ownership clarity). **OPEN.**
+- Redaction protocol on customer termination (Q3, line 134). **OPEN.**
+- Schema source (Q4, line 135): import from Aegis or kailash-rs _vs._ minimal own contract. **OPEN.**
+- Reasoning-chain memory vs. audit-chain memory boundary (Q5, line 136): "the boundary is load-bearing for trust." **OPEN.**
+
+### §9 Audit (outline Section 9, lines 138–148)
+
+**Intent (line 140):** EATP v2.2 conformance. **MANDATES every action emits a signed record naming the Delegate, the originating Genesis Record, the envelope it operated under, the inputs consumed, the outputs produced, and (where applicable) the human grant that authorised the action class** (line 140).
+
+**Load-bearing primitives:**
+
+- **MANDATED EATP v2.2 conformance** (line 140) — the substrate.
+- **MANDATED minimum attestation surface per action** (line 140 enumeration): Delegate id, originating Genesis Record, envelope-under-which, inputs, outputs, authorising human grant.
+- Granularity (Q1, line 144): every model call _vs._ every external side-effect. **PROPOSED:** "side-effects mandatory, model calls optional but encouraged."
+- Latency budget (Q2, line 145): Envoy specifies ≤ 5ms structural / ≤ 50ms semantic-cached — _"does Delegate inherit this or specify its own?"_ **OPEN.**
+- Tamper-anchoring (Q3, line 146): Sigstore / org HSM / Terrene witness / "implementation choice". **OPEN.**
+- Regulator-access shape (Q4, line 147). **OPEN.**
+- Self-introspection (Q5, line 148): Delegate queries its own audit chain _vs._ external-auditor-only. **OPEN.**
+
+### §10 Integration (outline Section 10, lines 150–171)
+
+**Intent (line 152):** binding contract between Delegate and enterprise systems-of-record. **MANDATES four required primitives** (lines 154–158); **specifies three optional primitives** (lines 160–164).
+
+**Load-bearing primitives — MANDATED required (lines 155–158):**
+
+- SAML / OIDC authentication into target system
+- A signed action envelope around every write
+- An EATP-attested receipt of every read (for audit completeness on data-access decisions)
+- A revocation channel (instant human revocation of Delegate's access to a specific system)
+
+**Load-bearing primitives — optional (lines 161–164):**
+
+- Native API binding (vs. screen-scraping fallback)
+- Change-data-capture subscription
+- Bulk-operation envelope
+
+**Open questions:**
+
+- Connector catalog scope (Q1, line 167): part of spec _vs._ separate "Delegate Connector Catalog". **OPEN.**
+- Direct database access (Q2, line 168): forbidden _vs._ allowed under stricter envelope _vs._ allowed only at posture ≤ SUPERVISED. **OPEN.**
+- Credential model (Q3, line 169): impersonation _vs._ delegation _vs._ substitution. **PROPOSED:** "delegation by default, impersonation forbidden, substitution allowed for write-heavy systems."
+- Connector conformance test suite (Q4, line 170): "**Recommendation candidate: yes, mandatory at v1.0; Apache 2.0 published alongside the spec; pre-pledged to Terrene.**" **PROPOSED but strong.**
+- Bindingless-system fallback (Q5, line 171): browser-driven action with per-action attestation. **OPEN.**
+
+---
+
+## 2. Canonical Types
+
+**Finding — the outline does NOT define canonical types in the sense of dataclass-shaped record schemas.** It names artifacts by role and inherits structure from prior Terrene specs (EATP, PACT) without re-deriving fields. The complete inventory of _named_ artifacts in the outline:
+
+| Named artifact                        | Where named                                                                                                                                      | Field shape given?                                                                                                                                                                                     |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Delegate**                          | line 13 (definition), throughout                                                                                                                 | NO — described by behaviour, not by struct                                                                                                                                                             |
+| **Genesis Record**                    | line 80 (Sec 4 intent), and lines 78, 85, 87, 116, 140, 175, 216, 217                                                                            | PARTIAL — line 85 "proposed" enumeration: `delegate_id`, `role_binding`, `sovereign`, `instantiation_timestamp`, `initial_envelope`, `initial_posture`, `signature`                                    |
+| **Delegation Record**                 | lines 31, 80, 116                                                                                                                                | NO — inherited from EATP v2.2; not re-derived                                                                                                                                                          |
+| **Constraint Envelope** (PACT 5-dim)  | line 92 (Sec 5 intent), throughout                                                                                                               | PARTIAL — five dimensions named (Financial / Operational / Temporal / Data Access / Communication), proposed extensions (Jurisdictional, Counterparty, Materiality); per-dimension shape NOT specified |
+| **Posture** (state in 5-state ladder) | line 104 (Sec 6 intent)                                                                                                                          | PARTIAL — state values enumerated (`PSEUDO`, `TOOL`, `SUPERVISED`, `DELEGATING`, `AUTONOMOUS`); proposed `RESTRICTED`; transition rules NOT formalised                                                 |
+| **Role binding**                      | Section 3 (lines 67–76) — re-numbered, OUT OF #1035 scope                                                                                        | OPEN — Q4 (line 75) asks whether "Role" is a first-class spec object                                                                                                                                   |
+| **Grant Moment**                      | line 175 (Sec 11), line 178                                                                                                                      | NO — inherited from Envoy charter, not re-derived                                                                                                                                                      |
+| **Escalation event**                  | Q2 line 180 ("structured event with a category and a routing target")                                                                            | PARTIAL — categories named (envelope violation, anomaly, novel intent); fields not specified                                                                                                           |
+| **Audit Chain**                       | line 138 (Sec 9 title)                                                                                                                           | NO — inherited from EATP v2.2                                                                                                                                                                          |
+| **Delegate Posture Digest**           | line 181 ("Recommendation candidate")                                                                                                            | PROPOSED — not specified                                                                                                                                                                               |
+| **Lifecycle state**                   | line 56 (6 proposed states: `proposed → instantiated → posture-graded → active → retired → archived`) — Sec 2, OUT OF #1035 scope but referenced |
+
+**Types implementations need that the outline does NOT name:**
+
+- `Connector` — outline references "connector implementations" (lines 167, 170) but never defines the type
+- `Executor` — not named
+- `DelegateMessage` — outline references "inter-Delegate messaging surface" (Sec 12, line 191) but defers the messaging contract to "a minimal messaging contract is part of the Delegate spec; richer orchestration patterns are a sibling spec" (line 191). No type given.
+- `PrincipalDirectory` — not named
+- `AuditChain` — named but no struct given (line 138)
+- `LifecycleTransition` — not named; the issue body's reference to a Rust runtime crate using `LifecycleTransition` over the 6-state chain is a kailash-rs implementation choice, NOT a spec mandate
+- `PostureState` — implicit only
+
+**The composition surface `Delegate.compose(connectors=, directory=, signature=, envelope=, executor=, pact_engine=)` named in the issue body is NOT in the outline at all.** This is an issue-body invention (likely a kailash-rs reflection), not a spec-mandated API. See §6 below.
+
+---
+
+## 3. Invariants
+
+Tagged with section of origin. Categorised as MANDATED (asserted as structural requirement) or PROPOSED (recommendation candidate / "should").
+
+### MANDATED invariants
+
+| #    | Invariant                                                                                                                                                                            | Section                                     | Line |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- | ---- |
+| I-1  | Every Delegate is cryptographically rooted with an unbroken audit chain back to a human sovereign                                                                                    | Identity (Sec 1)                            | 44   |
+| I-2  | Constraint envelope monotonic tightening within a lifecycle — may narrow, never widen                                                                                                | Envelopes (Sec 5)                           | 92   |
+| I-3  | Envelope widening requires a new Genesis Record (re-instantiation)                                                                                                                   | Envelopes (Sec 5)                           | 92   |
+| I-4  | Posture is ratcheted — advances only by explicit human grant, never implicit                                                                                                         | Posture (Sec 6)                             | 104  |
+| I-5  | Authority and envelopes always tighten on cascade — never relax                                                                                                                      | Cascade (Sec 7)                             | 116  |
+| I-6  | Every sub-Delegate's actions chain back through parent's Delegation Records to originating Genesis Record                                                                            | Cascade (Sec 7)                             | 116  |
+| I-7  | Tenant isolation under cascade — a Delegate in Tenant-A MUST NOT cascade into Tenant-B even within the same Domain                                                                   | Cascade (Sec 7)                             | 124  |
+| I-8  | Every action emits a signed record naming: Delegate, originating Genesis Record, envelope-under-which, inputs consumed, outputs produced, authorising human grant (where applicable) | Audit (Sec 9)                               | 140  |
+| I-9  | EATP v2.2 conformance for the entire audit chain                                                                                                                                     | Audit (Sec 9)                               | 140  |
+| I-10 | Integration writes require a signed action envelope                                                                                                                                  | Integration (Sec 10)                        | 156  |
+| I-11 | Integration reads emit an EATP-attested receipt                                                                                                                                      | Integration (Sec 10)                        | 157  |
+| I-12 | Every integration MUST expose an instant human revocation channel                                                                                                                    | Integration (Sec 10)                        | 158  |
+| I-13 | Integration authentication MUST use SAML / OIDC into the target system                                                                                                               | Integration (Sec 10)                        | 155  |
+| I-14 | Two Delegates from different organizations interacting MUST present mutual attestation (this is where Delegate meets Envoy)                                                          | Multi-Delegate (Sec 12, OUT-OF-#1035-scope) | 194  |
+| I-15 | The Delegate spec MUST reference (not re-derive) PACT and EATP — "one paragraph and a citation — never a re-explanation"                                                             | Author's Note                               | 249  |
+
+### PROPOSED invariants ("Recommendation candidate" — author has pre-staked but not settled)
+
+| #    | Invariant                                                                                                                              | Section                         | Line |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ---- |
+| P-1  | Multi-role binding requires the INTERSECTION of role envelopes, never the union                                                        | Role Binding (Sec 3, OUT)       | 72   |
+| P-2  | Cascade depth: no spec-level cap, runtime implementations must support ≥ 5                                                             | Cascade (Sec 7)                 | 120  |
+| P-3  | Sub-Delegate's posture: no higher than parent                                                                                          | Posture (Sec 6)                 | 111  |
+| P-4  | Audit granularity: side-effects mandatory, model calls optional but encouraged                                                         | Audit (Sec 9)                   | 144  |
+| P-5  | Integration credential model: delegation by default, impersonation forbidden, substitution allowed for write-heavy systems             | Integration (Sec 10)            | 169  |
+| P-6  | Connector conformance test suite mandatory at v1.0, Apache 2.0, pre-pledged to Terrene                                                 | Integration (Sec 10)            | 170  |
+| P-7  | Backward compatibility: minor versions (v1.x) MUST accept records from any prior v1.x                                                  | Versioning (Sec 14, OUT)        | 215  |
+| P-8  | Deprecation cycle: feature deprecated in N MUST remain implementable in N+1, MAY be removed in N+2; runtimes MUST emit warnings in N+1 | Versioning (Sec 14, OUT)        | 218  |
+| P-9  | Emergent fleet behaviour monitoring: optional at v1.0, mandatory at v2.0                                                               | Multi-Delegate (Sec 12, OUT)    | 195  |
+| P-10 | Delegate portability across deployment tiers: portable; tier is runtime property, not identity                                         | Sovereignty (Sec 13, OUT)       | 203  |
+| P-11 | Grant Moments: expiring grants encouraged; permanent grants explicitly marked                                                          | Human Interaction (Sec 11, OUT) | 182  |
+| P-12 | Spec governance transfers from Integrum to Terrene at v1.0 stability                                                                   | Versioning (Sec 14, OUT)        | 219  |
+
+**Lifecycle state machine — proposed transitions** (Sec 2, line 56, OUT OF #1035 scope but referenced by #1035's issue body):
+
+> "Six proposed states: **proposed → instantiated → posture-graded → active → retired → archived**."
+
+The outline proposes this chain but explicitly asks open questions about whether `proposed` is a real state (Q1, line 60), whether `retired` is one-shot or has a wind-down period (Q3, line 62), and whether `archived` is runtime or storage (Q4, line 63). The state machine **edges are NOT formalised** beyond the arrow-chain in line 56. A Delegate forking (sub-state, parallel chain, e.g. a Compliance Delegate spawning GDPR-Audit-2026) is asked as open question 5 (line 64) — NOT settled.
+
+---
+
+## 4. Conformance Vectors
+
+**Finding — the outline does NOT enumerate canonical conformance vectors.** What it says about implementation agreement:
+
+1. **Conformance levels are mentioned but not defined** (Sec 14, line 211): "Conformance levels (Conforming / Partially Conforming / Non-Conforming) and the labelling discipline implementations must follow." The labels are named; the criteria are not.
+
+2. **Cross-vendor verification is an OPEN question** (Sec 4 Q4, line 87, verbatim):
+
+   > "What is the spec's stance on Genesis Record portability across runtime vendors? Should an Aegis-instantiated Delegate's Genesis Record be verifiable by a competing-vendor EATP verifier?"
+
+   This is precisely the kailash-py / kailash-rs interop question #1035 is asking — and the spec author has flagged it as not-yet-decided.
+
+3. **Conformance test vector set is planned but not authored** (Author's Note, line 253):
+
+   > "a separate conformance test vector set (Apache 2.0, pre-pledged to Terrene), accompanied by an Aegis reference-implementation conformance report"
+
+   The test vectors are an artifact of the _future_ v1.0 release, not part of the current outline.
+
+4. **Connector conformance test suite is also proposed-not-built** (Sec 10 Q4, line 170, "Recommendation candidate"): mandatory at v1.0.
+
+5. **Conformance report shape** (Author's Note, line 253): example phrasing — "Aegis v1.0 implements Delegate spec v1.0 at Conformance Level 2 [Sections 1–14, partial 15]; gaps listed; remediation timeline published". This is illustrative of the _form_ a conformance report would take, not a per-section vector.
+
+**Implication for #1035.** Until conformance vectors exist, kailash-py and kailash-rs cannot agree on "compatible" by running a shared test suite. They can only agree on (a) shared inheritances (EATP v2.2 record shapes, PACT 5-dim envelope grammar) — which are external substrate specs already in the Terrene ecosystem — and (b) on whatever convention the two teams negotiate ahead of the spec landing. The kailash-py team should treat the kailash-rs implementation as a _peer_, not as the conformance oracle.
+
+---
+
+## 5. Cross-Language Verification Surface
+
+#1035's acceptance criterion is "py-emitted chain verifies under rs verifier". The outline tells us:
+
+### What the outline says verification covers
+
+The audit chain (Sec 9) is the verification target. The mandated attestation surface (I-8 above, line 140) names six fields every action record carries:
+
+1. The Delegate (identity)
+2. The originating Genesis Record (root)
+3. The envelope it operated under (constraint snapshot at action time)
+4. The inputs it consumed
+5. The outputs it produced
+6. (Where applicable) the human grant that authorised the action class
+
+A "py-emitted chain" that "verifies under rs verifier" therefore needs cross-language agreement on:
+
+- **EATP v2.2 record framing** — signature scheme, canonicalisation, hash function. NOT defined in the outline; INHERITED from EATP spec.
+- **Genesis Record fields** — the proposed list at line 85 (`delegate_id`, `role_binding`, `sovereign`, `instantiation_timestamp`, `initial_envelope`, `initial_posture`, `signature`). PROPOSED, not settled.
+- **Envelope serialisation** — PACT 5-dim. NOT defined in the outline; INHERITED from PACT spec.
+- **Delegation Record framing** — NOT defined in the outline; INHERITED from EATP v2.2.
+- **Hash-chain anchoring scheme** — Sec 9 Q3 (line 146) explicitly OPEN: Sigstore / org HSM / Terrene witness / "implementation choice".
+
+### What the outline does NOT settle that verification needs
+
+- Canonical JSON / CBOR / protobuf encoding for records
+- Time encoding (RFC 3339? unix epoch? monotonic counter for ordering?)
+- Field ordering for hashing
+- Signature scheme (Ed25519? ECDSA P-256?)
+- Whether the audit chain is per-Delegate, per-tenant, or per-organisation
+- How the chain is anchored against tampering (Q3, line 146 OPEN)
+- Cross-vendor verifiability is itself OPEN (Sec 4 Q4, line 87)
+
+**Conclusion for #1035.** Cross-language verification cannot be implemented purely from this outline. It requires:
+
+(a) The actual EATP v2.2 and PACT spec texts (referenced but external to the outline); **AND**
+
+(b) A documented convention between kailash-py and kailash-rs on every Category-3 OPEN item above that affects byte-level record shape. This convention should be filed as part of #1035's analysis output and propagated to BOTH SDKs so neither drifts.
+
+The kailash-rs implementation (per the issue body) has presumably already made choices on these — those choices are NOT spec-derived, they are kailash-rs-derived. kailash-py either (i) mirrors them by reading the rs source, (ii) negotiates revisions with the rs team, or (iii) waits for the Dr. Hong v1.0 spec. Strategy (i) is fastest; strategy (ii) is safest cross-SDK; strategy (iii) defeats #1035's timeline.
+
+---
+
+## 6. Composition Surface
+
+**Finding — the API shape named in the issue body does NOT appear in the outline.**
+
+The issue body cites:
+
+```
+Delegate.compose(connectors=, directory=, signature=, envelope=, executor=, pact_engine=)
+await delegate.run()  # ingest → classify → trust → dispatch → audit
+```
+
+Searching the outline for these terms:
+
+- `compose` — NOT present
+- `connectors=` — `connector` plural appears at lines 27 ("specific connector implementations"), 167 ("connector implementations (SAP, M365, Salesforce, Workday, ServiceNow)"), 170 ("connector conformance test suite"). The PARAMETER NAME `connectors=` is not in the outline.
+- `directory=` (PrincipalDirectory) — NOT present
+- `signature=` (signing config) — `signature` appears in the proposed Genesis Record field list at line 85, but not as a composer parameter
+- `envelope=` — `envelope` is everywhere; not as a composer parameter
+- `executor=` — NOT present
+- `pact_engine=` — NOT present
+- `ingest → classify → trust → dispatch → audit` pipeline — NOT present in the outline
+
+**What the outline says about runtime surface (verbatim, line 247, Author's Note):**
+
+> "Resist the temptation to specify the runtime. Aegis is the reference runtime. The spec must not encode Aegis's internal architecture as if it were universal. The spec must define what every conforming runtime must do, not how Aegis does it. The discipline is: if a section can only be implemented one way, it is over-specified; if a section can be implemented in five reasonable ways, the spec is at the right altitude."
+
+**Implication.** The `Delegate.compose(...)` builder is a kailash-rs-shaped API, not a spec-mandated API. If kailash-py mirrors it, it does so as cross-SDK courtesy / parity, not as spec conformance. The outline's discipline (line 247) actively WARNS against any single runtime shape being treated as universal — so adopting the rs surface as the spec contract would violate the outline's own anti-over-specification rule.
+
+**Recommendation for kailash-py.** Adopt the rs composer shape if cross-SDK parity is the project goal, but flag it in the codebase as "convention with kailash-rs, not spec-derived" so future spec revisions don't break the parity claim silently.
+
+---
+
+## 7. Genesis / Lifecycle
+
+### Genesis Record (Section 4, lines 78–88)
+
+**MANDATED:**
+
+- The Genesis Record is **immutable, signed, established at instantiation** (line 80)
+- It establishes the Delegate's **authority and constraints** (line 80)
+- **Every subsequent Delegation Record cascades from it** (line 80)
+- **EATP v2.2 conformance** (line 80)
+
+**PROPOSED required fields** (line 85, the only field shape given anywhere in the outline):
+
+```
+delegate_id
+role_binding
+sovereign
+instantiation_timestamp
+initial_envelope
+initial_posture
+signature
+```
+
+The author qualifies this with "(proposed)" — it is not settled.
+
+**Optional field candidates** (line 85): expected lifetime, renewal cadence, succession plan.
+
+### Lifecycle (Section 2, lines 54–64)
+
+The outline proposes a 6-state chain (line 56, verbatim):
+
+> "Six proposed states: **proposed → instantiated → posture-graded → active → retired → archived**."
+
+**This matches the issue body's chain `Proposed → Instantiated → PostureGraded → Active → Retired → Archived` exactly** (casing differs). So the kailash-rs `LifecycleTransition` enum is faithful to the outline's PROPOSED chain.
+
+**However**, the outline flags FIVE open questions about this state machine (lines 60–64):
+
+1. Is `proposed` a real spec-level state, or pre-spec (procurement/RFP)?
+2. What is the minimum data set required to transition `instantiated` → `posture-graded`?
+3. Does `retired` immediately strip envelope+credentials, or is there a wind-down period for in-flight obligations?
+4. Is `archived` runtime (read-only audit) or storage (cold)?
+5. Can a Delegate fork (e.g. a Compliance Delegate spawning GDPR-Audit-2026)?
+
+The state machine **edges are NOT formalised** beyond the arrow chain. The outline does not enumerate allowed transitions (e.g. "can active → retired be re-opened? must instantiated → posture-graded happen before any work?"). These are exactly the edges a kailash-py implementation needs to settle to be cross-verifiable with kailash-rs.
+
+---
+
+## 8. Spec Ground Beyond #1035 Acceptance Criteria
+
+The outline covers 15 sections; #1035's scope explicitly names §3–§10 (mapping to outline Sections 1, 4–10). The following sections are in the outline but presumably outside #1035's first-pass scope. They are surfaced here because several of them carry MANDATED invariants kailash-py implementations will encounter at the boundary:
+
+### Section 2 — Lifecycle (lines 54–64)
+
+**Why it matters even though #1035 names §4 Genesis as the lifecycle proxy.** The 6-state chain (`proposed → instantiated → posture-graded → active → retired → archived`) is the temporal spine the outline says "every other section refers back to" (line 56). The issue body's `LifecycleTransition` enum implements this; #1035 work cannot ship without taking a position on the state machine edges.
+
+### Section 3 — Role Binding (lines 67–76)
+
+**Why it matters.** Section 8 Memory ownership (Q1, line 132) explicitly depends on the role-binding decision (Delegate bound to role? to human? to both?). And the Genesis Record's `role_binding` field (line 85) cannot be designed without the §3 answer. So §4 Genesis is downstream of §3 Role Binding even though #1035 only names §4.
+
+### Section 11 — Human Interaction (Grant Moments, lines 173–183)
+
+**Why it matters.** The MANDATED attestation surface in §9 Audit (line 140) names "the human grant that authorised the action class" as a record field. Without §11's Grant Moment shape, the audit record's grant reference field has no schema. PROPOSED time-bounded grants (P-11 above) imply the audit record needs to encode grant expiry.
+
+### Section 12 — Multi-Delegate Coordination (lines 185–195)
+
+**Why it matters.** I-14 above (Delegate-meets-Envoy mutual attestation, line 194) is a MANDATED cross-organization invariant. A kailash-py implementation that does not surface the messaging contract will not be able to interoperate with another organization's kailash-rs Delegate. The outline pre-stakes a position (line 191, "Recommendation candidate"): "a minimal messaging contract is part of the Delegate spec; richer orchestration patterns are a sibling spec."
+
+### Section 13 — Sovereignty and Deployment (lines 197–207)
+
+**Why it matters.** Four deployment tiers (public cloud / private cloud / on-prem / sovereign appliance). P-10 above mandates Delegate portability across tiers. If kailash-py is the OSS Python SDK and kailash-rs is proprietary, the portability invariant means a Delegate emitted by one MUST be loadable by the other after a tier migration.
+
+### Section 14 — Versioning (lines 209–219)
+
+**Why it matters.** P-7 (backward compat within minor) and P-8 (deprecation cycle) are PROPOSED but apply to both SDKs immediately. Spec capability advertisement in the Genesis Record (Q3, line 217) is OPEN — both SDKs likely need to add a `spec_version` field to Genesis Records before #1035 closes.
+
+### Section 15 — Open Licensing (lines 221–231)
+
+**Why it matters for kailash-py specifically.** kailash-py is Apache 2.0 OSS; kailash-rs is proprietary. Q4 (line 230, MANDATED-by-Apache-2.0): "May commercial implementations charge for runtime, certification, support? Yes." This explicitly permits the asymmetric licensing of the two SDKs. The trademark question (Q2, line 228) recommends "Delegate" the term stays untrademarked — so kailash-py can use the term freely.
+
+### Cross-cutting from the Author's Note (lines 235–253)
+
+- **Honesty discipline** (line 251, citing CLAUDE.md Directive 2): "The four production deployments (RRPS, TPC, HMI, RSAF) have implemented Delegate-shaped artifacts informally, before the spec existed. The spec must describe what _can be built_, not retroactively elevate what _has been built_ into more than it was." — Implication for kailash-py: do NOT extract canonical types from those production deployments and claim them as spec; flag any port as "pre-spec convention".
+
+- **One trust system with two orientations** (line 243): Envoy (exterior) + Delegate (interior) share EATP / PACT / posture / CARE. kailash-py's Delegate impl shares substrate with any Envoy impl; the spec author has been explicit that they are NOT separate trust systems with a bridge.
+
+- **The end-state v1.0 target** (line 253): "a 35–55 page document". The current outline is ~11 printed pages. The spec is roughly 25–40% complete by page count.
+
+---
+
+## Appendix — Citations Index
+
+All line numbers reference `/Users/esperie/repos/dev/unicorn-focus/drafts/02-delegate-spec-v0-outline.md`.
+
+| Topic                                         | Lines   |
+| --------------------------------------------- | ------- |
+| Status: pre-draft scaffold                    | 3–7     |
+| Purpose & Scope                               | 11–36   |
+| Delegate definition (1-sentence)              | 13, 44  |
+| Five PACT envelope dimensions                 | 92      |
+| Five posture states                           | 33, 104 |
+| Six lifecycle states                          | 56      |
+| Proposed Genesis Record fields                | 85      |
+| Mandated audit record contents                | 140     |
+| Mandated integration primitives               | 154–158 |
+| Mandated cross-org mutual attestation         | 194     |
+| Anti-over-specification discipline            | 247     |
+| Honesty discipline (vs retroactive elevation) | 251     |
+| v1.0 end-state target                         | 253     |

--- a/workspaces/issue-1035-delegate-py/01-analysis/02-kailash-rs-reference-extraction.md
+++ b/workspaces/issue-1035-delegate-py/01-analysis/02-kailash-rs-reference-extraction.md
@@ -1,0 +1,775 @@
+# Reference extraction — kailash-rs Delegate spine (for #1035 Python OSS mirror)
+
+**Date:** 2026-05-21
+**Cross-repo authorization:** `journal/0001-cross-repo-authorization-kailash-rs-check.md`
+**Scope:** read-only. No edits, no commits, no PRs against `terrene-foundation/kailash-rs` (remote: `esperie-enterprise/kailash-rs`).
+**Sources cited verbatim with absolute paths under `/Users/esperie/repos/loom/kailash-rs/`.**
+
+---
+
+## Top-line LOC inventory
+
+The six lib.rs files are crate-root re-export shells (~692 LOC total); the load-bearing implementation lives in submodules. Real per-crate LOC:
+
+| Crate                          | Total LOC (src/) | Lib.rs | Submodules                                                                                                                                    |
+| ------------------------------ | ---------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kailash-delegate-types`       | 1,446            | 322    | composition (204) · envelope (330) · role (202) · identity (126) · directory (62) · intent (66) · memory (48) · message (54) · lifecycle (32) |
+| `kailash-delegate-runtime`     | 6,473            | 145    | delegate (1,748) · composition (1,065) · posture (978) · memory (787) · lifecycle (684) · intent_role (612) · message (454)                   |
+| `kailash-delegate-trust`       | 1,664            | 58     | grant (742) · cascade (530) · envelope (178) · error (81) · access (75)                                                                       |
+| `kailash-delegate-dispatch`    | 1,276            | 83     | connector (267) · dispatch (265) · auth (264) · revocation (138) · receipt (135) · token (124)                                                |
+| `kailash-delegate-audit`       | 1,238            | 34     | anchor (718) · chain (486)                                                                                                                    |
+| `kailash-delegate-conformance` | 1,099            | 50     | vectors/mod (575) · receipt (349) · vectors/catalog (125)                                                                                     |
+| **TOTAL**                      | **13,196**       |        |                                                                                                                                               |
+
+The Rust delegate spine is feature-complete through M8-02 (E2E regression). Most mature: `kailash-delegate-runtime` and `kailash-delegate-trust` — every other crate exists in service of these two.
+
+---
+
+## Per-crate report
+
+### 1. `kailash-delegate-types` — substrate-composition wrappers + identity/role/lifecycle
+
+`<rs>/crates/kailash-delegate-types/src/lib.rs:1-29` declares the §249 "compose, do not re-derive" constraint. **The dependency edge on `eatp` + `kailash-governance` IS the structural composition gate**: every substrate primitive is held verbatim inside a wrapper, never re-skinned as a parallel serde-only type.
+
+#### Public surface (re-exports at `lib.rs:41-58`)
+
+```
+pub use composition::{AuditChainRecord, GenesisRecord, PostureState, Principal};
+pub use directory::PrincipalDirectory;
+pub use eatp::types::PostureLevel;  // D1: re-export of frozen substrate enum
+pub use envelope::{DelegateConstraintEnvelope, DelegateConstraintEnvelopeWire};
+pub use identity::{DelegateId, DelegateIdentity, DelegateIdentityMetadata};
+pub use intent::{InboundIntentEnvelope, IntentSource};
+pub use lifecycle::LifecycleState;
+pub use memory::{MemoryScope, MemoryStoreHandle};
+pub use message::DelegateMessage;
+pub use role::{CapabilitySet, Role, RoleBinding, RoleId, RoleLifecycleState, RoleScope, VoiceAttrs};
+```
+
+#### Composition wrappers (`composition.rs`)
+
+All four "compose, don't re-derive" anchors live here. Every wrapper holds the substrate value in a `pub` field (or accessor) — deleting it is a compile error, surfacing substrate drift loudly:
+
+- **`GenesisRecord`** (`composition.rs:51-88`) wraps `eatp::chain::GenesisBlock` + adds `spec_version: String` + `capabilities: Vec<String>`. `#[non_exhaustive]`. Signing remains the substrate's responsibility (`CareChain::sign()`).
+- **`PostureState`** (`composition.rs:105-135`) composes BOTH `PostureLevel` (frozen enum) AND `eatp::posture::PostureSystem` (transition state machine). Deliberately not `Clone`/`Serialize` because `PostureSystem` owns boxed transition hooks; exposed by reference.
+- **`AuditChainRecord`** (`composition.rs:147-171`) wraps `eatp::ledger::LedgerEntry` verbatim — the substrate's `prev_entry_hash`/`entry_hash` chain linkage is held as-is.
+- **`Principal`** (`composition.rs:187-204`) wraps `eatp::types::AgentId`. Explicit "composes, does not re-skin" doc constraint.
+
+#### F5 type-state — `DelegateConstraintEnvelope` (`envelope.rs:54-145`)
+
+**This is the load-bearing type-state pattern Python must mirror.** The Rust encoding closes four widening hatches that type-state alone is insufficient to close:
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(try_from = "DelegateConstraintEnvelopeWire")]
+pub struct DelegateConstraintEnvelope {
+    /// PRIVATE — closes the `Clone`+field-reconstruct hatch.
+    inner: ConstraintEnvelope,
+}
+```
+
+The four closed hatches (`envelope.rs:1-46`):
+
+1. **`Clone` + field-reconstruct** — closed by NOT deriving `Clone` and keeping `inner` private.
+2. **`serde::Deserialize`** — closed by `#[serde(try_from = ...)]`. Every deserialize routes through `DelegateConstraintEnvelopeWire { parent, child }` (`envelope.rs:130-145`), whose `TryFrom` runs the PUBLIC `kailash_governance::validate_tightening` check (parent → child). A wire payload that widens its declared parent fails to deserialize.
+3. **`Default`** — closed by NOT deriving `Default`.
+4. **`From` / builder** — closed by having NO public `From` impl and NO builder. The ONLY widening constructor is `DelegateConstraintEnvelope::genesis_seed(genesis: &GenesisRecord, envelope: ConstraintEnvelope) -> Self` (`envelope.rs:71-93`) — gated behind a `GenesisRecord`.
+
+`tighten(self, child) -> Result<Self, MonotonicTighteningError>` (`envelope.rs:109-112`) **consumes `self`** — a rejected widening consumes the parent envelope and returns the typed error; the caller cannot recover the parent to retry a widening. There is deliberately no `widen` counterpart.
+
+`proptest! prop_tighten_is_monotone_nonwidening` (`envelope.rs:289-328`) is the regression backstop: for any descending sequence of financial limits, every successive `tighten` succeeds; every reverse step is always rejected.
+
+#### Identity (`identity.rs`)
+
+- **`DelegateId`** (`identity.rs:25-49`) is a `pub struct DelegateId(pub Uuid)`. Opaque UUID newtype. **Deliberately NOT a `(organization_id, role_id, spec_version)` tuple** (A1): keying identity on that triple would re-root the Genesis chain every time any of those moves.
+- **`DelegateIdentityMetadata`** (`identity.rs:56-83`) carries the triple as INDEXED metadata, never identity key.
+- **`DelegateIdentity`** (`identity.rs:91-126`) carries `sovereign_ref: String` as an **EAGER REQUIRED** field (never `Option`). No `tier` field — tier is a runtime property (portability I1).
+
+#### Role (`role.rs`) — clusters B1/B2/B3/B4
+
+- **`RoleId`** (`role.rs:20-44`): `pub struct RoleId(pub Uuid)`.
+- **`RoleLifecycleState`** (`role.rs:50-61`): `Draft | Active | Suspended | Retired`. `#[non_exhaustive]`.
+- **`CapabilitySet`** (`role.rs:69-96`): wraps `Vec<eatp::types::Capability>`. **`intersect()` is the INTERSECTION; deliberately no `union()`** — accumulating roles must never widen capability (B1).
+- **`RoleScope`** (`role.rs:105-123`): `{ domain: kailash_governance::Address, capabilities: CapabilitySet }`. STRUCT with BOTH axes (B4). Composes the grammar-validated PACT D/T/R `Address` rather than a re-skinned string.
+- **`Role`** (`role.rs:126-154`), **`VoiceAttrs`** (`role.rs:160-177`), **`RoleBinding`** (`role.rs:187-201`).
+
+#### Lifecycle (`lifecycle.rs`)
+
+The D3 single linear chain — pure data, no logic here:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum LifecycleState {
+    Proposed, Instantiated, PostureGraded, Active, Retired, Archived,
+}
+```
+
+The guard logic lives in `kailash-delegate-runtime/src/lifecycle.rs::LifecycleTransition`.
+
+#### Memory / Message / Intent / Directory (small files)
+
+- **`MemoryScope`** (`memory.rs:18-25`): `Delegate | Role | Task`. `#[non_exhaustive]`.
+- **`MemoryStoreHandle`** (`memory.rs:36-48`): `{ role_ref: RoleId, scope: MemoryScope }`. **The store is owned by the role and lives OUTSIDE the Delegate; the Delegate holds only this handle** (C2).
+- **`DelegateMessage`** (`message.rs:22-54`): `{ from: Principal, to: Principal, payload: serde_json::Value, envelope_ref: String, audit_ref: String }`. Minimal attested envelope; routing is the sibling Mesh spec.
+- **`InboundIntentEnvelope`** (`intent.rs:38-66`): `{ originator: String, source: IntentSource, payload: Value, received_at: DateTime<Utc> }`. Net-new — no substrate equivalent. `IntentSource = Human | Agent | System`.
+- **`PrincipalDirectory`** (`directory.rs:21-62`): `BTreeMap<String, DelegateId>` (deterministic for audit-stable iteration). `register()` / `lookup()` / `len()` / `is_empty()`.
+
+---
+
+### 2. `kailash-delegate-trust` — envelope + cascade + grant moments
+
+`<rs>/crates/kailash-delegate-trust/src/lib.rs:1-58` is the trust-gate composition layer. The crate composes substrate from `eatp` and **`kailash-governance` (NOT `kailash-pact`)** — the M1-02 cargo-deny fence enforces this lighter dep.
+
+#### Public surface (`lib.rs:46-58`)
+
+```
+pub use access::check_pact_access;
+pub use cascade::{CascadeCacheKey, TenantScope, TenantScopedCascade};
+pub use envelope::effective_multi_role_envelope;
+pub use error::TrustGateError;
+pub use grant::{
+    GrantAuthorityEnvelope, GrantMoment, GrantMomentBroker, GrantSigner, GrantedAuthority,
+};
+```
+
+#### TenantScope (`cascade.rs:100-149`) — RATIFIED Option A
+
+Typed 2-variant enum, **NOT** `Option<String>` — "global / unscoped" is the EXPLICIT `Global` variant so a tenant-scoped deployment cannot accidentally seed unscoped:
+
+```rust
+pub enum TenantScope { Tenant(String), #[default] Global }
+```
+
+#### CascadeCacheKey (`cascade.rs:158-185`)
+
+`{ delegation_id: Uuid, tenant: TenantScope }`. Two cascades sharing a delegation id but differing in tenant scope are distinct keys — this is the structural realization of Option A.
+
+#### TenantScopedCascade (`cascade.rs:196-335`) — the load-bearing cascade primitive
+
+```rust
+pub struct TenantScopedCascade {
+    chain: DelegationChain,       // composed substrate (private, accessor only)
+    tenant: TenantScope,
+}
+```
+
+**`cascade_child()`** (`cascade.rs:276-313`) is the gold-standard cascade check — fixed fail-closed order across 3 layers:
+
+```rust
+pub fn cascade_child(
+    &self,
+    parent: &DelegationScope,
+    child: &DelegationScope,
+    parent_env: &ConstraintEnvelope,
+    child_env: &ConstraintEnvelope,
+    child_tenant: &TenantScope,
+) -> Result<(), TrustGateError> {
+    // (1) RATIFIED Option A: tenant boundary first, fail-closed.
+    if child_tenant != &self.tenant { return Err(TenantIsolation { .. }); }
+    // (2) F1 downward-only: substrate DelegationScope::is_subset_of (3 axes only).
+    if !child.is_subset_of(parent) { return Err(CascadeWidening { .. }); }
+    // (3) F5 envelope tightening across ALL 5 PACT dimensions:
+    //     the PUBLIC kailash_governance::validate_tightening.
+    kailash_governance::validate_tightening(parent_env, child_env)?;
+    Ok(())
+}
+```
+
+The envelope pair is REQUIRED (not optional) precisely so the F5 layer cannot be bypassed by passing `None`.
+
+**`trace_to_genesis()`** (`cascade.rs:328-334`) — composes the substrate `DelegationChain::trace_to_genesis`. Well-defined because the cascade is a tree (F1: no lateral edges).
+
+#### Grant Moments (`grant.rs:1-742` — 742 LOC, full H1 design)
+
+- **`GrantSigner`** (`grant.rs:99-127`): typed enum: `Human(HumanOrigin) | DelegatedAuthority(GrantedAuthority)`. The `DelegatedAuthority` arm carries a **mandatory** (non-`Option`) back-reference to the granting authority's delegation-chain position.
+- **`GrantedAuthority`** (`grant.rs:62-84`): `{ delegation_id: Uuid }` — mandatory by construction (private field, no constructor that omits it).
+- **`GrantAuthorityEnvelope`** (`grant.rs:135-178`): bounds a compromised grant key — `{ max_posture: PostureLevel, capability_classes: Vec<Capability>, max_grants_per_period: u32 }`.
+- **`GrantMoment`** (`grant.rs:186-198`): `{ grant_id, signer, capability, posture, issued_at }`. Only constructible through `GrantMoment::issue(…)` or `GrantMomentBroker::issue_grant(…)`, which already enforces the H1 amendments fail-closed (authority verified against the CURRENT delegation chain — a revoked authority fails CLOSED).
+
+The crate composes `eatp::human::{HoldQueue, HumanOrigin, PseudoAgent}` verbatim.
+
+---
+
+### 3. `kailash-delegate-runtime` — lifecycle + composition surface + posture
+
+The largest crate (6,473 LOC). Decomposed into ordered shards: R1 lifecycle (M6-01), R2 envelope+cascade (M6-02), R3 posture (M6-03), R4 memory+genesis+composition (M6-04a), M6-05 message-send.
+
+#### Public surface (`lib.rs:122-145`)
+
+```
+pub use composition::{CascadeWithPostureError, R2CompositionEngine};
+pub use delegate::{verify_genesis, Delegate, GenesisVerificationError, IntentRoleSeam, RehydrationProof};
+pub use lifecycle::{is_legal_transition, legal_next, LifecycleError, LifecycleTransition, SpawnError, TransitionError};
+pub use memory::{delegate_holds_handle_not_store, MemoryEntry, MemoryRegistry, MemoryResolveError, RepointError, RepointReceipt, RoleMemoryStore};
+pub use message::{resolve_disagreement, ConflictResolution, DisagreementOutcome, EnvelopeWinner, MessageSendError, SpecUpgrade, SpecUpgradeError};
+pub use posture::{enforce_posture_cap, DowngradeTrigger, PostureAdvanceError, PostureCapError, PostureRatchet, RestrictedProfile};
+```
+
+#### R1: Lifecycle state machine (`lifecycle.rs`)
+
+**`legal_next()`** (`lifecycle.rs:91-103`) is the authoritative legal-edge table:
+
+```rust
+pub fn legal_next(state: LifecycleState) -> Option<LifecycleState> {
+    match state {
+        Proposed => Some(Instantiated),
+        Instantiated => Some(PostureGraded),
+        PostureGraded => Some(Active),
+        Active => Some(Retired),
+        Retired => Some(Archived),
+        Archived => None,
+        _ => None,  // non_exhaustive future-state: fail-closed
+    }
+}
+```
+
+**`LifecycleTransition<L: KnowledgeLedger>`** (`lifecycle.rs:207-401`):
+
+- `new(delegate_id, audit: Arc<AuditChainEngine<L>>)` — seeds at `Proposed`.
+- `async fn transition(&mut self, to) -> Result<AuditChainRecord, TransitionError>`:
+  1. Legality check — illegal edges rejected BEFORE any audit event emitted.
+  2. Audit-attest — `audit.record(LedgerContent::Evidence(json!({...})))` is `async`.
+  3. Apply — only after audit succeeds. Audit failure leaves state unchanged.
+- `async fn spawn_sub_delegate(&self, child_tenant) -> Result<(LifecycleTransition, TenantScopedCascade), SpawnError>` (`lifecycle.rs:359-400`):
+  - Only legal when `state == Active` (otherwise `SpawnError::NotActive`).
+  - Produces a **CASCADE** (D3): fresh child `DelegationChain` + fresh `TrustKeyPair` + fresh `AuditChainEngine` + fresh `DelegateId`.
+  - **C3 ratified:** records ONE `delegate.subdelegate.spawned` evidence event on the **parent's** audit chain (opaque UUIDs only — no envelope/key/identity secret). Parent-chain append failure fails the spawn.
+
+`TransitionError = Illegal(LifecycleError) | Audit(EatpError)`.
+`SpawnError = NotActive { parent_state } | Audit(EatpError)`.
+`LifecycleError { from, to, expected: Option<LifecycleState> }` — carries the single legal successor.
+
+#### R2: Composition engine (`composition.rs`) — F5 surface
+
+`R2CompositionEngine` (`composition.rs:149-387`) is the runtime composition surface. **Deliberately NO Clone/Default/From/builder** — inherits F5 hatches from `DelegateConstraintEnvelope`:
+
+```rust
+pub struct R2CompositionEngine {
+    effective: DelegateConstraintEnvelope,  // PRIVATE — F5 type-state
+    tenant: TenantScope,                     // Option A
+}
+```
+
+**The only widening constructor:** `from_genesis(genesis: &GenesisRecord, baseline: ConstraintEnvelope, tenant: TenantScope) -> Self` (`composition.rs:175-184`).
+
+**`tighten_effective(self, child) -> Result<Self, MonotonicTighteningError>`** (`composition.rs:203-210`) — consumes `self` (inherits M2-02's no-recovery shape).
+
+**`cascade_child(&self, cascade, parent_scope, child_scope, child_env, child_tenant) -> Result<(), TrustGateError>`** (`composition.rs:246-267`) routes verbatim through `TenantScopedCascade::cascade_child` — the runtime never re-implements the check.
+
+**`cascade_child_with_posture(...)`** (`composition.rs:308-330`) adds R3's cross-Delegate posture cap as the final fail-closed step on the SAME edge.
+
+**Option A tenant threading:**
+
+- `cache_key(delegation_id: Uuid) -> CascadeCacheKey` (`composition.rs:343-345`)
+- `audit_tenant_label() -> Option<&str>` (`composition.rs:355-357`)
+- `metric_tenant_label() -> &str` — `"global"` for the explicit unscoped variant (`composition.rs:367-369`).
+
+The proptest `prop_cascade_never_widens_any_of_the_5_pact_dimensions` (`composition.rs:947-1063`) fences ALL 5 PACT dimensions including the subtle empty-set operational widening case.
+
+#### R3: Posture ratchet (`posture.rs`)
+
+Three load-bearing invariants (`posture.rs:38-54`):
+
+1. **advance-only-by-grant** — `PostureRatchet::advance_on_grant(&GrantMoment)` is the ONLY method that raises posture. No `set_posture`, no `raise_to`, no public mutable accessor.
+2. **fail-closed-downgrade** — `downgrade_on_violation` drops posture to `Pseudo` floor on envelope-violation or audit-failure. If the audit append recording the downgrade itself fails, posture STILL drops.
+3. **child ≤ parent** — `enforce_posture_cap(parent: PostureLevel, child: PostureLevel) -> Result<(), PostureCapError>` (`posture.rs:171-178`).
+
+`DowngradeTrigger = EnvelopeViolation(MonotonicTighteningError) | AuditFailure(EatpError)`.
+`PostureAdvanceError = NotAnAdvance { current, grant } | Audit(EatpError)`.
+
+D2: posture is a per-Delegate SCALAR — never a `BTreeMap<CapabilityId, PostureLevel>`. D1: no sixth posture level; `RestrictedProfile` is a NAMED ENVELOPE TEMPLATE.
+
+#### R4: Delegate composition surface (`delegate.rs` — 1,748 LOC)
+
+**`Delegate`** is the 5-factor wire-up: `PrincipalDirectory × TenantScopedCascade × R2CompositionEngine × AuditChainEngine × DispatchEngine/Connector`. Instantiated ONLY from a verified `GenesisRecord`.
+
+**`verify_genesis(genesis: &GenesisRecord, chain_owner: &TrustKeyPair) -> Result<RehydrationProof, GenesisVerificationError>`** (`delegate.rs:222-261`) — fixed fail-closed order:
+
+1. **Unrooted check** — `public_key_hex` MUST decode to 32-byte Ed25519 key.
+2. **Owner-key match** — declared owner key MUST equal supplied keypair's public key.
+3. **Chain integrity** — `CareChain::new(chain_owner).genesis(block).sign()?.verify_chain()?`.
+
+`GenesisVerificationError = Unrooted { detail } | OwnerKeyMismatch { declared, supplied } | ChainIntegrity(EatpError) | SpecVersionMismatch { proof, metadata }`.
+
+`RehydrationProof { verified_genesis_owner: String, spec_version: String }` — the token `Delegate::instantiate` requires as proof genesis was verified. Mintable ONLY by `verify_genesis`; existence IS the proof.
+
+Posture seeding (M6-04a, floor-only): every M6-04a-built Delegate seeds `PostureRatchet` at `PostureLevel::Pseudo` (L1, minimum autonomy). `Delegate::instantiate` never accepts a caller posture value — escalation at instantiation is structurally unrepresentable.
+
+#### M6-05: Message send + disagreement resolution (`message.rs`)
+
+- **`MessageSendError = EnvelopeExpired { expired_at, now } | Audit(EatpError)`** (`message.rs:81-104`).
+- **`ConflictResolution`** (`message.rs:130-137`): ratified 2-variant `StricterEnvelopeWins | EscalateToHuman`. `#[non_exhaustive]` for future arbiter arm; NO arbiter / NO runtime-configurable in v0 (F3).
+- **`EnvelopeWinner = First | Second | Equivalent`** (`message.rs:141-153`).
+- **`DisagreementOutcome = StricterWins { winner: EnvelopeWinner } | Escalate`** (`message.rs:161-172`).
+- **`resolve_disagreement(env_a, env_b)`** composes the PUBLIC `kailash_governance::validate_tightening` — "stricter envelope" is "the envelope that does not widen the other"; never a re-derived comparison.
+
+Spec upgrade (I3): `Delegate::apply_spec_upgrade` composes the M4 audit layer's own `requires_reroot` classification + `reroot_for_major_upgrade`.
+
+---
+
+### 4. `kailash-delegate-dispatch` — Connector trait + idempotent dispatch
+
+`<rs>/crates/kailash-delegate-dispatch/src/lib.rs:1-83` is the connector-facing binding contract. The crate **deliberately does NOT depend on `kaizen-agents` or `kailash-delegate-runtime`** — the M1-02 F3 resolved-graph CI fence enforces this. `-dispatch` stays connector-facing.
+
+#### Public surface (`lib.rs:68-83`)
+
+```
+pub use auth::{assert_service_account_distinct, ConnectorAuth, ImpersonationByCloneError, ServiceAccountRef};
+pub use connector::{Connector, ConnectorError, OptionalPrimitive};
+pub use dispatch::{DispatchDisposition, DispatchEngine, DispatchError, DispatchOutcome, IdempotencyKey};
+pub use kailash_delegate_types::Principal;
+pub use receipt::{record_read_receipt, record_write_envelope, AttestationError, AttestedReadReceipt, SignedActionEnvelope};
+pub use revocation::{RevocationChannel, DEFAULT_TOKEN_TTL};
+pub use token::{issue_test_token, OidcClaims, OidcVerifier, TokenError};
+```
+
+#### The `Connector` trait — `connector.rs:115-237`
+
+**This is the trait the issue body promises Python must mirror.** Actual signature (verbatim from `connector.rs:115-237`):
+
+```rust
+#[async_trait]
+pub trait Connector: Send + Sync {
+    // Inherent methods every implementor MUST provide:
+    fn revocation(&self) -> &RevocationChannel;
+    fn ledger(&self) -> &dyn KnowledgeLedger;
+    fn verifier(&self) -> &OidcVerifier;
+
+    // Required primitive 1 — SAML/OIDC auth (provided method; trait owns the sequencing):
+    async fn authenticate(
+        &self,
+        bearer_token: &str,
+        sovereign: &Principal,
+    ) -> Result<Principal, ConnectorError> {
+        let service_account = self.verifier().verify_to_principal(bearer_token)?;
+        assert_service_account_distinct(&service_account, sovereign)?;  // G1(a) clone check
+        Ok(service_account)
+    }
+
+    // Required primitive 2 — signed action envelope per write:
+    async fn write<F, Fut>(
+        &self,
+        actor: &Principal,
+        action: &str,
+        perform_write: F,
+    ) -> Result<SignedActionEnvelope, ConnectorError>
+    where F: FnOnce() -> Fut + Send,
+          Fut: Future<Output = Result<(), ConnectorError>> + Send,
+    {
+        if self.revocation().is_revoked(actor) { return Err(Revoked(...)); }
+        perform_write().await?;
+        let envelope = record_write_envelope(self.ledger(), actor, action).await?;
+        Ok(envelope)
+    }
+
+    // Required primitive 3 — EATP-attested receipt per read:
+    async fn read<T, F, Fut>(
+        &self,
+        reader: &Principal,
+        resource: &str,
+        perform_read: F,
+    ) -> Result<(T, AttestedReadReceipt), ConnectorError>
+    where T: Send,
+          F: FnOnce() -> Fut + Send,
+          Fut: Future<Output = Result<T, ConnectorError>> + Send,
+    {
+        if self.revocation().is_revoked(reader) { return Err(Revoked(...)); }
+        let value = perform_read().await?;
+        let receipt = record_read_receipt(self.ledger(), reader, resource).await?;
+        Ok((value, receipt))
+    }
+
+    fn optional_primitives(&self) -> &[OptionalPrimitive] { &[] }
+}
+```
+
+**Note the divergence from the #988 issue body's `pull / normalize / capabilities` sketch.** The shipped trait is `authenticate / write / read / revocation` — the §10 4-required-primitives outline (SAML/OIDC auth, signed action envelope per write, EATP-attested receipt per read, instant revocation channel). The original `pull / normalize / capabilities` proposal in #988 was the channel-data-fetch shape; what shipped is the trust/auth/audit shape. **Python's `Connector` ABC must mirror the shipped shape, not the issue-body sketch.**
+
+#### `OptionalPrimitive` (`connector.rs:78-104`)
+
+```rust
+#[non_exhaustive]
+pub enum OptionalPrimitive {
+    NativeApiBinding, ChangeDataCapture, BulkEnvelope, BrowserFallback,
+    // NO DirectDb variant — G2 compile-time guarantee
+}
+```
+
+The test `assert_no_direct_db_variant` (`connector.rs:255-266`) is an exhaustive match with no `_ =>` arm — adding `DirectDb` upstream breaks compilation. Python should mirror this with a closed `Enum` + a comparable structural assertion (e.g. a unit test enumerating exactly the allowed members against `set(OptionalPrimitive)`).
+
+#### `ConnectorAuth` (`auth.rs:87-117`) — G1 type-forbidden impersonation
+
+```rust
+#[non_exhaustive]
+pub enum ConnectorAuth {
+    ScopedDelegation { service_account_ref: ServiceAccountRef, role_ref: RoleId },
+    #[cfg(feature = "substitution")]
+    Substitution { delegate_account_ref: DelegateAccountRef },
+    // NO Impersonation variant — G1 compile-time guarantee
+}
+```
+
+Test `assert_no_impersonation_variant` (`auth.rs:218-230`) is the same exhaustive-match enforcement.
+
+**`assert_service_account_distinct(service_account: &Principal, sovereign: &Principal) -> Result<(), ImpersonationByCloneError>`** (`auth.rs:166-176`) — G1 amendment (a) runtime check: even with `Impersonation` type-removed, a connector could provision the service account as a clone of the human's credentials. Runtime check rejects equality.
+
+#### `OidcVerifier` (`token.rs:56-104`) — REAL bearer-token verification, no mock
+
+HS256 in v0 via `jsonwebtoken` crate. `OidcClaims { sub, exp, iss }`. `issue_test_token` (`token.rs:117-124`) is provided so the required-primitive integration test mints a REAL token (signed with the real key) and verifies it through the real verifier — Tier-2 no-mocking contract.
+
+#### `DispatchEngine<T>` (`dispatch.rs:79-148`) — net-new idempotent dispatch
+
+NOT a wrap of a substrate primitive — `kaizen_agents::GovernedSupervisor` provides retry-with-cap recovery, NOT exactly-once. This engine adds the dedup layer on top.
+
+```rust
+pub struct DispatchEngine<T> { cache: Mutex<HashMap<IdempotencyKey, T>> }
+
+impl<T: Clone> DispatchEngine<T> {
+    pub fn dispatch<F>(&self, key: &IdempotencyKey, action: F)
+        -> Result<DispatchOutcome<T>, DispatchError>
+    where F: FnOnce() -> Result<T, DispatchError>;
+}
+```
+
+- First dispatch: runs `action`, caches `Ok` value, returns `Executed`.
+- Subsequent dispatch with same key: returns cached value WITHOUT calling `action`, with `ReplayedCached`.
+- Failed action NOT cached — composes the supervisor's retry-with-cap.
+- Lock-poison-safe: recovers via `PoisonError::into_inner` rather than panicking.
+
+`DispatchDisposition = Executed | ReplayedCached`.
+`DispatchOutcome<T> { value: T, disposition: DispatchDisposition }`.
+
+#### Receipt (`receipt.rs:42-73`)
+
+```rust
+pub struct SignedActionEnvelope { actor: Principal, action: String, audit_entry: LedgerEntryId }
+pub struct AttestedReadReceipt { reader: Principal, resource: String, audit_entry: LedgerEntryId }
+```
+
+Both record into `LedgerContent::Evidence(json!({"agent_id": ..., "kind": "connector_write"|"connector_read", "action"|"resource": ...}))`.
+
+Residency posture (`receipt.rs:13-24`): identity/action recorded verbatim BY DESIGN — a redacted audit trail is not an audit trail. The audit ledger CONTENT is on-prem-resident by topology; only the M4 salted chain-head crosses the residency boundary.
+
+#### Revocation (`revocation.rs`)
+
+`RevocationChannel` + `DEFAULT_TOKEN_TTL`. Per-call introspection bounded by short token TTL (G1 amendment (b)).
+
+---
+
+### 5. `kailash-delegate-audit` — append-only hash chain over EATP ledger
+
+`<rs>/crates/kailash-delegate-audit/src/lib.rs:1-34` — composes substrate `eatp::ledger::KnowledgeLedger`. Does NOT re-implement hash chaining, hash computation, or tamper detection — those stay in the substrate.
+
+#### Public surface (`lib.rs:29-34`)
+
+```
+pub use anchor::{
+    classify_constraint_error, classify_constraint_outcome, validate_cross_tier_mode,
+    AuditVisibility, CrossAnchorError, CrossTierMode, DelegateEventKind, Salt, WitnessedCrossAnchor,
+};
+pub use chain::{AuditChainEngine, ChainId, ChainTier};
+```
+
+#### ChainTier + ChainId (`chain.rs:54-138`)
+
+```rust
+#[non_exhaustive]
+pub enum ChainTier { OnPrem, Cloud, Named(String) }
+
+#[non_exhaustive]
+pub struct ChainId {
+    pub spec_version: String,
+    pub tier: ChainTier,
+    pub succession_ref: Option<[u8; 32]>,  // I3 lineage link
+}
+
+impl ChainId {
+    pub fn major(&self) -> &str;
+    pub fn requires_reroot(&self, target_spec_version: &str) -> bool;  // major-component change
+}
+```
+
+#### AuditChainEngine (`chain.rs:158-332`)
+
+```rust
+pub struct AuditChainEngine<L: KnowledgeLedger = InMemoryLedger> {
+    chain_id: ChainId,
+    ledger: Arc<L>,
+}
+
+impl<L: KnowledgeLedger> AuditChainEngine<L> {
+    pub fn new(chain_id: ChainId) -> Self;  // InMemoryLedger default
+    pub fn with_ledger(chain_id: ChainId, ledger: Arc<L>) -> Self;
+    pub fn chain_id(&self) -> &ChainId;
+    pub fn ledger(&self) -> &Arc<L>;
+
+    pub async fn record(&self, content: LedgerContent) -> Result<AuditChainRecord, EatpError>;
+    pub async fn verify_integrity(&self) -> Result<(), EatpError>;
+    pub async fn head(&self) -> Result<Option<LedgerEntry>, EatpError>;
+    pub fn hashes_equal(a: &[u8; 32], b: &[u8; 32]) -> bool;  // constant-time, substrate fn
+    pub async fn reroot_for_major_upgrade(
+        &self,
+        target_spec_version: impl Into<String>,
+    ) -> Result<AuditChainEngine<InMemoryLedger>, EatpError>;
+}
+```
+
+**Emitted-chain wire format (what Python must produce in a form the Rust verifier can verify per #1035 acceptance criterion 7).** A `LedgerEntry` (from `eatp::ledger`) carries:
+
+- `entry_id: LedgerEntryId` (UUID)
+- `sequence: u64` (substrate-computed, gap-free)
+- `prev_entry_hash: Option<[u8; 32]>` (first entry: `None`)
+- `entry_hash: [u8; 32]` (SHA-256 over canonical-JSON input via `LedgerEntry::compute_hash`)
+- `content: LedgerContent` (an enum: `Evidence(serde_json::Value)`, `PolicyDecision(...)`, etc.)
+- `timestamp: DateTime<Utc>`
+
+The `content` for a Delegate-emitted event is `LedgerContent::Evidence(serde_json::Value)`. Example payloads observed in the Rust source:
+
+- Lifecycle transition (`lifecycle.rs:293-300`):
+  ```json
+  {
+    "event": "delegate.lifecycle.transition",
+    "delegate_id": "<uuid>",
+    "from": "Proposed",
+    "to": "Instantiated"
+  }
+  ```
+- Sub-delegate spawn (`lifecycle.rs:391-396`):
+  ```json
+  {
+    "event": "delegate.subdelegate.spawned",
+    "parent_id": "<uuid>",
+    "child_id": "<uuid>"
+  }
+  ```
+- Connector write/read (`dispatch/receipt.rs:90-94, 121-125`):
+  ```json
+  {"agent_id": "<id>", "kind": "connector_write", "action": "<string>"}
+  {"agent_id": "<id>", "kind": "connector_read", "resource": "<string>"}
+  ```
+
+**Cross-impl chain agreement** requires identical canonical-JSON shape for these payloads. Python must use the same field names, same value types, same key order semantics (substrate `LedgerEntry::compute_hash` uses canonical JSON — Python must use a canonical-JSON serializer compatible with the Rust substrate's hashing input).
+
+#### Cross-anchor (`anchor.rs:1-120` + 598 LOC of impl) — M4-02
+
+Net-new, no substrate primitive. Per-tier chains (default `CrossTierMode::PerTierWitnessed`) joined by a salted on-prem-head digest:
+
+1. On-prem chain head computed via substrate.
+2. Fresh 32-byte CSPRNG `Salt` (`ZeroizeOnDrop`).
+3. Publish `anchor_digest = SHA-256(salt || onprem_head_entry_hash)` to cloud — salt never leaves on-prem.
+4. Seam verification: cloud-side recomputes and constant-time-compares via `LedgerEntry::hashes_equal`.
+
+`CrossTierMode = PerTierWitnessed | SingleContinuous`. `SingleContinuous` is opt-in for same-residency only.
+`CrossAnchorError = SeamVerificationFailed | ContinuousAcrossResidencyBoundary { detail }`.
+
+---
+
+### 6. `kailash-delegate-conformance` — F1-fenced behavioural vectors + cross-impl receipts
+
+`<rs>/crates/kailash-delegate-conformance/src/lib.rs:1-50` — the **OSS-bound** crate. Apache-2.0 / Terrene-pledged mirror; one over-specified vector that encodes a proprietary engine internal permanently forces the engine open.
+
+**Structural defense:** `Cargo.toml` depends on NO `kailash-delegate-*` engine crate — an engine symbol cannot resolve. CI workflow `.github/workflows/rust.yml` "Delegate spine F1 fence" step asserts manifest stays engine-free AND greps `src/` for any `kailash_delegate_*` symbol.
+
+#### Public surface (`lib.rs:46-50`)
+
+```
+pub use receipt::{receipts_agree, ConformanceReceipt, ReceiptError};
+pub use vectors::{
+    delegate_spec_vectors, validate_vector_set, BehaviouralOutcome, ConformanceVector, SchemaError, SpecAnchor,
+};
+```
+
+#### Conformance vector format (`vectors/mod.rs`)
+
+**Format: Rust data, declared via Rust function** (`vectors/catalog.rs::delegate_spec_vectors`), serialized as **JSON** for cross-impl sharing. NOT checked-in JSON files — vectors are generated by calling the Rust function; the in-session feedback loop is `validate_vector_set(&vectors)`.
+
+The schema (`vectors/mod.rs:227-249`):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "ConformanceVectorWire")]
+#[non_exhaustive]
+pub struct ConformanceVector {
+    pub id: String,              // e.g. "DV-5-001" — cross-impl receipt addresses by this id
+    pub spec_anchor: SpecAnchor, // MANDATORY — F1 fence #1
+    pub given: String,           // plain spec language; NEVER a serialized engine struct
+    pub behaviour: String,       // plain spec language; the per-vector review reads this
+    pub expected: BehaviouralOutcome,  // CLOSED enum — F1 fences #2 + #3
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum BehaviouralOutcome { Accept, Reject, EscalateToHuman }
+
+pub struct SpecAnchor { section: String /* private; dotted-decimal; validated */ }
+```
+
+`SpecAnchor` is constructible ONLY through `SpecAnchor::new(section)` or `TryFrom<String>` (`serde(try_from)`). It validates dotted-decimal ASCII digits with interior single dots (no leading/trailing/doubled dot). Display renders WITH `§` glyph; storage WITHOUT.
+
+**Three structural fences** (`vectors/mod.rs:16-43`):
+
+1. Mandatory spec-§ anchor + validating deserialization (every vector reconstructed from JSON routes through `ConformanceVector::new`).
+2. Behavioural-only expected output (closed enum — cannot round-trip an engine struct).
+3. Value-allowlist enforced by the type system (an asserted value outside the published taxonomy is unrepresentable, not gate-rejected).
+
+`SchemaError = InvalidSpecAnchor { detail } | EmptyField { field, detail } | DuplicateId { id }`.
+
+`validate_vector_set(&[ConformanceVector]) -> Result<(), SchemaError>` — every vector valid AND all ids unique.
+
+**Authored vectors** (only 2 in M7-02 — `vectors/catalog.rs`):
+
+- `DV-5-001` (`SpecAnchor("5")`, expected `Reject`) — monotonic-tightening: a Delegation widening the Financial dimension MUST be rejected.
+- `DV-10-001` (`SpecAnchor("10")`, expected `Reject`) — G1 service-account / sovereign-principal separation: identical principal is impersonation; reject the binding.
+
+**For Python:** mirror by exporting `delegate_spec_vectors() -> list[ConformanceVector]` and serializing to JSON byte-identically. The JSON form a vector serializes to (from `vectors/mod.rs:412-419` round-trip test): `SpecAnchor` serializes as its bare section string `"7.3"` (not a struct).
+
+Example expected JSON for `DV-5-001`:
+
+```json
+{
+  "id": "DV-5-001",
+  "spec_anchor": "5",
+  "given": "Genesis Record G authorizes a Delegate, and a Delegation D from that Delegate widens the Financial dimension of its constraint envelope relative to G",
+  "behaviour": "the runtime MUST reject Delegation D -- a delegated constraint envelope may only tighten, never widen, a PACT dimension within a single lifecycle; widening requires a new Genesis Record",
+  "expected": "Reject"
+}
+```
+
+#### F4 cross-impl receipt protocol (`receipt.rs`)
+
+**This is the cross-SDK agreement primitive #1035 acceptance criterion 7 hinges on.**
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "ConformanceReceiptWire")]
+#[non_exhaustive]
+pub struct ConformanceReceipt {
+    pub implementation: String,       // "kailash-rs", "kailash-py"
+    pub vector_crate_version: String, // exact crate version pinned
+    pub commit_sha: String,           // commit SHA of the vector-set revision
+    pub vectors_total: usize,
+    pub vectors_passed: usize,        // MUST be ≤ vectors_total
+}
+
+impl ConformanceReceipt {
+    pub fn conforms(&self) -> bool {
+        self.vectors_total > 0 && self.vectors_passed == self.vectors_total
+    }
+}
+
+pub fn receipts_agree(a: &ConformanceReceipt, b: &ConformanceReceipt) -> bool {
+    a.implementation != b.implementation
+        && a.vector_crate_version == b.vector_crate_version
+        && a.commit_sha == b.commit_sha
+        && a.conforms()
+        && b.conforms()
+}
+```
+
+`ReceiptError = EmptyField { field, detail } | PassedExceedsTotal { passed, total }`.
+
+**Critical for Python:** the agreement protocol is COUNTS-ONLY by F1 design — never field-by-field engine diff. Python emits a `ConformanceReceipt { implementation: "kailash-py", vector_crate_version, commit_sha, vectors_total, vectors_passed }` after running the same vector set; Rust + Python receipts cross-reference via `receipts_agree`. The receipt is `serde`-serializable so each implementation persists it durably (journal entry / `observations.jsonl`) per `verify-resource-existence.md` MUST-4.
+
+---
+
+## Open/closed gap map — Python mirror translation patterns
+
+| Rust primitive                                                                                    | Encoding pattern                                                                          | Python OSS mirror translation                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `DelegateConstraintEnvelope` type-state (no Clone/Default/From; private inner; `serde(try_from)`) | Type-state via private field + consuming `tighten(self) -> Self` + `try_from` deserialize | `@dataclass(frozen=True, slots=True)` with **private `_inner`**, **no `__init__` taking the underlying envelope** (only classmethod `genesis_seed(cls, genesis, envelope)`); `tighten(self, child) -> "DelegateConstraintEnvelope"` raises `MonotonicTighteningError` and **returns a NEW instance** (Python can't "consume" but the frozen-dataclass + private-field combination closes the reconstruct hatch); pydantic `model_validator(mode="before")` or a `__post_init__` running the tightening check on deserialize. The "Wire" pair `{ parent, child }` becomes a Pydantic model whose `model_validator(mode="after")` calls `validate_tightening`. |
+| `LifecycleState` (`#[non_exhaustive]` enum)                                                       | Closed Rust enum + non_exhaustive future variants + wildcard fail-closed arm              | `class LifecycleState(StrEnum)` — `PROPOSED / INSTANTIATED / POSTURE_GRADED / ACTIVE / RETIRED / ARCHIVED`. Mirror `legal_next` as a module-level dict `\_LEGAL_NEXT: dict[LifecycleState, LifecycleState                                                                                                                                                                                                                                                                                                                                                                                                                                                    | None]`. Mirror the wildcard fail-closed default via a `.get(state)`(returns`None` for unknown variants, fail-closed).                                                                                                                                                                                                              |
+| `LifecycleTransition` (async; audit-before-apply)                                                 | Stateful struct + `Arc<AuditChainEngine>`                                                 | `class LifecycleTransition` with `_state: LifecycleState`, `_audit: AuditChainEngine`; `async def transition(self, to) -> AuditChainRecord` — same fixed order: legality → audit-attest → apply. Audit failure leaves state unchanged.                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `TenantScope = Tenant(String)                                                                     | Global`                                                                                   | Typed 2-variant enum with `#[default] Global`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `class TenantScope: ...` as a sealed dataclass union, or a `Literal["global"]                                                                                                                                                                                                                                                      | tuple[Literal["tenant"], str]`. Cleaner: dataclass hierarchy `TenantScope`→`TenantScopeTenant(tenant_id: str)`/`TenantScopeGlobal()`with`is_global()`/`tenant_id() -> str | None`accessors. **Must NOT use`Optional[str]`\*\* — typed structural distinction is the whole point (M-1 misconfig guard). |
+| `TenantScopedCascade.cascade_child` (3-layer fixed order)                                         | Borrow-based 5-arg fn                                                                     | `def cascade_child(self, parent_scope, child_scope, parent_env, child_env, child_tenant) -> None` — raises `TrustGateError` (one of `TenantIsolation`, `CascadeWidening`, `Tightening`). Envelope pair REQUIRED (no default-None).                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `R2CompositionEngine` (only widening constructor is `from_genesis`)                               | Private field + no public constructor except `from_genesis`                               | `class R2CompositionEngine`: `__init__` raises `NotImplementedError` (or is decorated `@final` private); the only public constructor is `@classmethod from_genesis(cls, genesis, baseline, tenant)`. `tighten_effective(self, child) -> "R2CompositionEngine"` returns a new instance (Python equivalent of consuming-self).                                                                                                                                                                                                                                                                                                                                 |
+| `PostureRatchet` (advance-only-by-grant; fail-closed downgrade)                                   | Stateful struct + scalar `PostureLevel` field                                             | `class PostureRatchet`: `_posture: PostureLevel`; **no `set_posture`, no `raise_to`**. The ONLY raising method is `async def advance_on_grant(self, grant: GrantMoment)`. `downgrade_on_violation(self, trigger)` drops to floor even on audit-record failure.                                                                                                                                                                                                                                                                                                                                                                                               |
+| `Connector` trait (default methods own sequencing)                                                | `#[async_trait]` with provided methods                                                    | `class Connector(abc.ABC)`: `@abstractmethod` properties `revocation`, `ledger`, `verifier`. **Non-abstract** `async def authenticate / write / read` — the ABC owns the sequencing (revocation check, attestation) so subclass authors cannot forget. Python can't fully replicate the trait's "compile-time-can't-skip-the-check" but the non-abstract concrete methods + private hooks pattern (`async def _perform_write` abstract, `async def write` final concrete that calls it) is the closest equivalent.                                                                                                                                           |
+| `OptionalPrimitive` (no `DirectDb` — compile-time guarantee)                                      | `#[non_exhaustive]` enum + exhaustive-match test                                          | `class OptionalPrimitive(Enum)`: `NATIVE_API_BINDING / CHANGE_DATA_CAPTURE / BULK_ENVELOPE / BROWSER_FALLBACK`. Mirror the compile-time guarantee with a unit test asserting `set(OptionalPrimitive) == {NATIVE_API_BINDING, CHANGE_DATA_CAPTURE, BULK_ENVELOPE, BROWSER_FALLBACK}` — adding `DIRECT_DB` fails the test. (Python loses the structural strength but gains the test-asserted invariant.)                                                                                                                                                                                                                                                       |
+| `ConnectorAuth` (no `Impersonation`)                                                              | Same enum + exhaustive-match                                                              | Same pattern: `class ConnectorAuth: ...` sealed union; unit test enumerates the exact allowed variants.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `assert_service_account_distinct`                                                                 | Runtime `Principal != Principal` check                                                    | `def assert_service_account_distinct(service_account: Principal, sovereign: Principal) -> None` — raises `ImpersonationByCloneError(principal: str)`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `OidcVerifier` (HS256, real `jsonwebtoken`)                                                       | `jsonwebtoken` crate                                                                      | `class OidcVerifier`: backed by `pyjwt` (or `python-jose`). `verify(token: str) -> OidcClaims`; `verify_to_principal(token: str) -> Principal`. Real verification, no mock — same Tier-2 contract as Rust.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `AuditChainEngine` (composes `KnowledgeLedger`)                                                   | Generic over `L: KnowledgeLedger`                                                         | `class AuditChainEngine[L: KnowledgeLedger]`: `async def record(content: LedgerContent) -> AuditChainRecord`; `async def verify_integrity() -> None`; `async def head() -> LedgerEntry                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | None`; `async def reroot_for_major_upgrade(target_spec_version) -> AuditChainEngine[InMemoryLedger]`. **Canonical-JSON serialization MUST byte-match the Rust substrate's hashing input** — use `json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=False)` and verify against a Rust-generated reference vector. |
+| `ConformanceVector` (validating constructor + `serde(try_from)`)                                  | Pydantic-like validating dataclass                                                        | `class ConformanceVector(BaseModel)` (pydantic v2): `model_validator(mode="after")` raises `SchemaError`. `SpecAnchor` as a custom Pydantic type with `field_validator` enforcing dotted-decimal. **Serialized form must match Rust byte-identically** (cross-impl JSON sharing).                                                                                                                                                                                                                                                                                                                                                                            |
+| `ConformanceReceipt` + `receipts_agree`                                                           | Counts-only F4 protocol                                                                   | Identical pydantic model + standalone `def receipts_agree(a, b) -> bool` with the EXACT same predicate (distinct implementations + same version + same SHA + both conform). This is the cross-impl agreement primitive #1035 acceptance criterion 7 hinges on.                                                                                                                                                                                                                                                                                                                                                                                               |
+| `delegate_spec_vectors() -> Vec<ConformanceVector>`                                               | Rust function building the vector list                                                    | `def delegate_spec_vectors() -> list[ConformanceVector]`. Build the SAME 2 vectors (DV-5-001, DV-10-001) with byte-identical `given`/`behaviour` prose. JSON-export must round-trip against the Rust JSON form.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+
+---
+
+## Rust shard ordering — what Python should mirror
+
+`git log --oneline -30 -- crates/kailash-delegate-*/` (from `<rs>`):
+
+```
+9a612dd1 feat(delegate): -runtime R1 lifecycle state machine (#988 M6-01)
+4efc3b85 fix(delegate): -runtime emit parent-chain sub-delegate-spawn audit event + align rustdoc (#988 M6-01, C3)
+78de99f3 feat(delegate): -runtime R2 envelope+cascade tightening — F5 co-shipment (#988 M6-02)
+4dccdef3 test(delegate): -runtime fence the operational PACT dimension in the F5 regression suite (#988 M6-02, MEDIUM-1)
+ff80207a feat(delegate): -runtime R3 posture ratchet + cross-Delegate cap (#988 M6-03)
+4b3a9491 docs(delegate): add `# Caller contract` security section to with_posture (#988 M6-03)
+d0ad005a feat(delegate): -runtime R4 memory + genesis-verify + composition surface (#988 M6-04a)
+ea4ba8a1 fix(delegate): close F5 posture-escalation + 4 gate findings (#988 M6-04a)
+07dd183d docs(delegate): correct two stale posture-rehydration doc refs (#988 M6-04a)
+d5e8ab80 fix(delegate): re-export RepointError at the crate root (#988 M6-04a)
+93bd9e35 feat(delegate): -runtime intent->role LLM step + F3/F6 quarantine (#988 M6-04b)
+92c3f17d fix(delegate): harden F3 fence against cargo-tree errors + doc candidate-ceiling (#988 M6-04b)
+923dfe59 feat(delegate): -runtime M6-05 message send path + disagreement resolution + spec upgrade (#988)
+f4a72a7a feat(delegate): -conformance M7-01 vector schema + F1 licensing fence (#988)
+22aad3cb fix(delegate): M7-01 gate-review fixes — validating vector deserialization + broadened F1 fence (#988)
+151fd6cb feat(delegate): -conformance M7-02 F4 cross-impl receipt protocol + first behavioural vectors (#988)
+98df7f01 fix(delegate): M7-02 gate fix — receipts_agree requires distinct implementations (#988)
+88cacd40 feat(delegate-spine): M8-02 add composed-Delegate E2E regression (#988)
+ccf17055 docs(delegate-spine): M8-02 release-prep disposition journal + nightly fmt (#988)
+```
+
+Earlier merged-via-PR commits (visible via `git log --all`):
+
+```
+c5202094 feat(delegate): -dispatch Connector trait + G1/G2 auth model (#988 M5-01)
+1a1e369a feat(delegate): -trust Grant Moments + GrantSigner (#988 M3-02)
+bde686c2 fix(delegate): -audit zeroize cross-anchor Salt + narrow serialize surface (#988 M4 M-3)
+fc12ab24 fix(delegate): -dispatch alg-confusion rejection tests + receipt residency doc (#988 M5 M-2/M-4)
+65081e36 fix(delegate): -trust enforce 5-dim envelope tightening on cascade edges + tenant-misconfig guard (#988 M3 H-1)
+730645c7 Merge pull request #1032 from esperie-enterprise/feat/delegate-spine-m3-trust
+61a36249 Merge pull request #1033 from esperie-enterprise/feat/delegate-spine-m4-audit
+```
+
+**Shard ordering pattern Python should mirror:**
+
+1. **M1** — workspace setup (Cargo manifest fences). For Python: pyproject.toml + package layout fences (the F1 conformance crate MUST NOT import any engine module).
+2. **M2-01** types (composition wrappers, identity, role, lifecycle, message, memory, intent, directory) before M2-02 envelope (the F5 type-state).
+3. **M3-01** trust cascade (`TenantScopedCascade::cascade_child` — tenant → scope → envelope) before **M3-02** grant moments.
+4. **M4** audit chain (lib + cross-anchor) — independently shardable; only depends on `-types`.
+5. **M5** dispatch — `Connector` trait + G1/G2 auth + idempotent dispatch; **independently shardable** (does not depend on `-runtime`).
+6. **M6-01** runtime lifecycle (composes -types + -audit).
+7. **M6-02** runtime R2 composition engine + F5 cascade (composes -trust + -types).
+8. **M6-03** posture ratchet + cross-Delegate posture cap.
+9. **M6-04a** memory + genesis-verify + composition surface (`Delegate::instantiate` + `verify_genesis`).
+10. **M6-04b** intent→role LLM step — **F3/F6 quarantined** behind a default-off feature gate. Python equivalent: an optional install extra (`pip install kailash-delegate[intent-role]`) that pulls `kailash-kaizen`.
+11. **M6-05** message send path + disagreement resolution + spec upgrade (composes M4 reroot primitive).
+12. **M7-01** conformance schema + F1 licensing fence (NO vectors yet — schema first, hard sequencing).
+13. **M7-02** first behavioural vectors + F4 cross-impl receipt protocol.
+14. **M8-02** composed-Delegate E2E regression.
+
+**Key shard discipline:** M7-01 ships the schema with ZERO vectors authored (the F1 fence lands before any vector can leak an engine internal). M7-02 then authors vectors against the frozen schema. Python MUST honor this two-step.
+
+---
+
+## Substrate dependencies — what Python needs to reproduce
+
+The Rust spine composes (never re-derives):
+
+- **`eatp`** — `chain::{CareChain, GenesisBlock}`, `keys::TrustKeyPair`, `delegation::{DelegationChain, DelegationScope, DelegationRecord}`, `constraints::ConstraintEnvelope`, `ledger::{KnowledgeLedger, InMemoryLedger, LedgerEntry, LedgerEntryId, LedgerContent}`, `human::{HoldQueue, HumanOrigin, PseudoAgent}`, `posture::PostureSystem`, `types::{AgentId, OrgId, Capability, ConstraintDimensions, TrustLevel, PostureLevel, Subject, SubjectType}`, `EatpError`.
+- **`kailash-governance`** — `Address` (D/T/R), `validate_tightening`, `compute_effective_envelope`, `can_access`, `MonotonicTighteningError`.
+
+**Python equivalents** must already exist in `kailash-py` (the EATP + governance substrate is shared across SDKs — this is the open-core/open-spec relationship the #988 issue body describes). The Python Delegate package should `from kailash.eatp import ...` / `from kailash.governance import ...` in the same composition pattern — and the F1 conformance package's `pyproject.toml` MUST NOT depend on any `kailash-delegate-*` module.
+
+---
+
+## 5-line summary
+
+1. **Per-crate LOC** (full src/, not just lib.rs): -types 1,446 · -runtime 6,473 · -trust 1,664 · -dispatch 1,276 · -audit 1,238 · -conformance 1,099. Total 13,196 LOC. lib.rs files are re-export shells (692 LOC); load-bearing impl lives in submodules.
+2. **Most mature**: `kailash-delegate-runtime` (the load-bearing composition surface) and `kailash-delegate-trust` (the cascade gate); every other crate exists in service of these two.
+3. **Canonical-type list** (the Python ABC/dataclass mirror set): `DelegateId`, `RoleId`, `DelegateIdentity`, `DelegateIdentityMetadata`, `Role`, `RoleBinding`, `RoleScope`, `CapabilitySet`, `VoiceAttrs`, `RoleLifecycleState`, `LifecycleState`, `GenesisRecord`, `PostureState`, `PostureLevel`, `AuditChainRecord`, `Principal`, `PrincipalDirectory`, `DelegateConstraintEnvelope` (F5 type-state), `DelegateMessage`, `InboundIntentEnvelope`, `IntentSource`, `MemoryScope`, `MemoryStoreHandle`, `TenantScope`, `CascadeCacheKey`, `TenantScopedCascade`, `GrantSigner`, `GrantedAuthority`, `GrantAuthorityEnvelope`, `GrantMoment`, `Connector` (ABC), `ConnectorAuth`, `ServiceAccountRef`, `OptionalPrimitive`, `OidcVerifier`, `OidcClaims`, `SignedActionEnvelope`, `AttestedReadReceipt`, `RevocationChannel`, `DispatchEngine`, `IdempotencyKey`, `DispatchOutcome`, `DispatchDisposition`, `ChainId`, `ChainTier`, `AuditChainEngine`, `WitnessedCrossAnchor`, `Salt`, `CrossTierMode`, `R2CompositionEngine`, `LifecycleTransition`, `PostureRatchet`, `RestrictedProfile`, `Delegate`, `RehydrationProof`, `IntentRoleSeam`, `ConflictResolution`, `DisagreementOutcome`, `EnvelopeWinner`, `ConformanceVector`, `SpecAnchor`, `BehaviouralOutcome`, `ConformanceReceipt`. Plus error families: `TrustGateError`, `LifecycleError`, `TransitionError`, `SpawnError`, `GenesisVerificationError`, `MessageSendError`, `SpecUpgradeError`, `PostureAdvanceError`, `PostureCapError`, `DowngradeTrigger`, `CascadeWithPostureError`, `ConnectorError`, `ImpersonationByCloneError`, `TokenError`, `DispatchError`, `AttestationError`, `MonotonicTighteningError`, `SchemaError`, `ReceiptError`, `CrossAnchorError`.
+4. **Conformance vector format**: Rust function `delegate_spec_vectors() -> Vec<ConformanceVector>` (in `-conformance/src/vectors/catalog.rs`), JSON-serializable via serde for cross-impl byte-identical sharing. Schema enforces: mandatory `SpecAnchor` (dotted-decimal), closed `BehaviouralOutcome` enum (`Accept|Reject|EscalateToHuman`), validating `try_from` deserialize. Currently 2 authored vectors: DV-5-001 (§5 monotonic tightening, Reject) + DV-10-001 (§10 G1 principal separation, Reject). Cross-impl agreement via `receipts_agree(rs_receipt, py_receipt) -> bool` — counts-only protocol that never inspects per-vector engine output (F1 design).
+5. **Rust shard ordering Python should mirror**: M1 (workspace fences) → M2 (-types: composition wrappers first, then F5 envelope type-state) → M3 (-trust: cascade first, then grant moments) → M4 (-audit: chain + cross-anchor) → M5 (-dispatch: Connector trait + G1/G2 + idempotent dispatch) → M6-01..04a (-runtime: lifecycle → R2 composition → R3 posture → R4 composition surface) → M6-04b (intent→role behind default-off feature gate) → M6-05 (message send + disagreement + spec upgrade) → M7-01 (-conformance: schema + F1 fence, ZERO vectors) → M7-02 (first behavioural vectors + F4 cross-impl receipt protocol) → M8-02 (composed-Delegate E2E regression). Key discipline: F1 schema before any vector; -conformance package MUST have zero engine deps.

--- a/workspaces/issue-1035-delegate-py/01-analysis/03-kailash-py-primitive-survey.md
+++ b/workspaces/issue-1035-delegate-py/01-analysis/03-kailash-py-primitive-survey.md
@@ -1,0 +1,392 @@
+# kailash-py Primitive Survey for Delegate Composition Surface (Issue #1035)
+
+**Date:** 2026-05-21
+**Scope:** kailash-py CWD only (per `rules/repo-scope-discipline.md` — no cross-repo reads)
+**Goal:** Enumerate primitives the Delegate composition surface (`Connector × Signature × Envelope × Executor`, per `#1035`) can REUSE vs. those that need fresh implementation. Drive the layout decision (`src/kailash/delegate/` vs `packages/kailash-delegate/`).
+**Frame:** The Delegate Spec v0 (issue #1035 body / `/Users/esperie/repos/dev/unicorn-focus/drafts/02-delegate-spec-v0-outline.md` per `01-external-spec-extraction.md`) describes a composition primitive whose call site looks like `Delegate.compose(connector=..., signature=..., envelope=..., executor=..., pact_engine=engine)`. The acceptance bar is "py-emitted EATP chain verifies under the rs verifier."
+
+---
+
+## TL;DR (one-paragraph)
+
+kailash-py has **deep, production-grade implementations** of every primitive the Delegate composition surface needs to compose with — except (a) the Delegate composition primitive itself, (b) a `kailash.delegate.Connector` ABC, and (c) the Delegate-specific conformance vector set. PACT engine, EATP audit chain (with cross-SDK byte-canonical JSON), `ConstraintEnvelope` (with monotonic `intersect()`), tenant scoping, and a conformance-vector pattern that is already cross-SDK-byte-equality-validated against kailash-rs all exist in shippable form. The kaizen-agents `Delegate` is a separately-named class (LLM execution facade) that does NOT occupy the issue #1035 composition surface; near-miss only.
+
+---
+
+## 1. PACT engine — composition target
+
+**Path:** `/Users/esperie/repos/loom/kailash-py/packages/kailash-pact/src/pact/engine.py`
+**Class:** `PactEngine` (file line 126; 1413 LOC total)
+**Public constructor signature** (`engine.py:151-162`):
+
+```python
+class PactEngine:
+    def __init__(
+        self,
+        org: str | Path | dict[str, Any],
+        *,
+        model: str | None = None,
+        budget_usd: float | None = None,
+        clearance: str = "restricted",
+        store_backend: str = "memory",
+        cost_model: Any | None = None,
+        on_held: HeldActionCallback | None = None,
+        enforcement_mode: EnforcementMode = EnforcementMode.ENFORCE,
+    ) -> None: ...
+```
+
+**What the Delegate's `pact_engine=engine` parameter gets:**
+
+- `engine.submit(objective, role, context)` (`engine.py:212`) — async governed execution entry point; lock-protected check-remaining → execute → record-cost (`engine.py:239`).
+- `engine.governance` property — read-only `_ReadOnlyGovernanceWrapper` (`engine.py:1366-1391`) per `rules/pact-governance.md` MUST Rule 1 (agents NEVER receive raw `GovernanceEngine`).
+- `engine.costs` property — `CostTracker` (`pact/costs.py`).
+- `engine.events` property — `EventBus(maxlen=10000)` (`engine.py:191`).
+- Default `GovernanceCallback` (`engine.py:85-122`) — per-node verification: HELD → `GovernanceHeldError`, BLOCKED → `PactError`, AUTO_APPROVED → proceed.
+
+**Lifecycle a Delegate would need:** construct once → wire as `pact_engine=` constructor arg on `Delegate.compose(...)` → Delegate calls `engine.governance.verify_action(role_address, action, context)` BEFORE every Connector pull; on AUTO_APPROVED, execute; on HELD/BLOCKED, surface verdict + halt.
+
+**Reuse verdict:** **REUSE AS-IS.** The Delegate's contract — "every execution step authorized by PACT" — is exactly what `PactEngine.submit()` already enforces. The Delegate wraps a lower-level loop and calls `engine.governance.verify_action()` per step, OR delegates the loop itself to `engine.submit()` if the work is single-objective.
+
+---
+
+## 2. EATP audit-chain primitive — cross-SDK contract owner
+
+**Wire format owner:** `/Users/esperie/repos/loom/kailash-py/src/kailash/trust/chain.py` (1443 LOC)
+
+**Core dataclasses** (per `chain.py` grep):
+
+| Class                     | Line | Has `to_dict` / `from_dict` |
+| ------------------------- | ---- | --------------------------- |
+| `GenesisRecord`           | 121  | yes (`@dataclass`)          |
+| `DelegationRecord`        | 222  | line 325 / 359              |
+| `AuditAnchor`             | 509  | line 575 / 605              |
+| `ChainConstraintEnvelope` | 442  | yes                         |
+| `CapabilityAttestation`   | 419  | yes                         |
+| `TrustLineageChain`       | 672  | line 997 / 1053             |
+| `LinkedHashChain`         | 1122 | line 1377 / 1398            |
+
+`TrustLineageChain.hash(previous_hash=None)` (`chain.py:701-755`) — produces the cross-SDK hash via `kailash.trust.signing.crypto.hash_trust_chain_state` (unsalted backward-compatible mode) OR `hash_trust_chain_state_salted` (linked-hash mode). Five canonical CARE constraint dimensions enumerated at `chain.py:33-35` (`financial, operational, temporal, data_access, communication`) — matches kailash-rs and `pact.config.ConstraintDimension`.
+
+**Canonical JSON encoder** (cross-SDK byte-equality):
+
+- `/Users/esperie/repos/loom/kailash-py/src/kailash/trust/_json.py:65` — `canonical_json_loads(text)` with `DuplicateKeyError`.
+- `/Users/esperie/repos/loom/kailash-py/src/kailash/trust/_json.py:99` — `canonical_json_dumps(obj)` deterministic sorted-key encoder.
+- Also re-implemented for cross-SDK shape parity in `/Users/esperie/repos/loom/kailash-py/packages/kailash-pact/src/pact/conformance/vectors.py:80` (`canonical_json_dumps`) with field-ordered separators `(",", ":")` matching `serde_json::to_string` exactly, insertion-order keys, `ensure_ascii=False`. The module's docstring at `vectors.py:21-37` is explicit: "The canonical JSON shape is a CROSS-SDK contract. It mirrors the Rust serde output."
+
+**Sync EATP emission protocol:** `/Users/esperie/repos/loom/kailash-py/src/kailash/trust/pact/eatp_emitter.py:28` — `PactEatpEmitter(Protocol)` with three methods (`emit_genesis`, `emit_delegation`, `emit_capability`) + `InMemoryPactEmitter` ref implementation (`eatp_emitter.py:53`). GovernanceEngine drives these per-event.
+
+**Already byte-canonical-verified against kailash-rs:** The PACT N4 / N5 conformance runner (`packages/kailash-pact/src/pact/conformance/runner.py:1-44`) explicitly states it is "the Python-side analog of the Rust `conformance_vectors.rs::all_vectors_load_and_pass` test" and asserts `event.canonical_json() == expected.canonical_json` byte-for-byte. The cross-SDK contract source-of-truth file cited at `vectors.py:36-37` is `kailash-rs/crates/kailash-pact/tests/conformance_vectors.rs`.
+
+**Reuse verdict:** **REUSE AS-IS.** The acceptance bar "py-emitted chain verifies under rs verifier" is already passing for the N4/N5 contract surface. Delegate's emitted EATP records (Genesis + Delegation + Capability + Audit) MUST flow through `chain.py` dataclasses and `_json.py::canonical_json_dumps` — NOT a fresh implementation. The conformance-vector pattern (see §8) is the structural defense that keeps the byte-equality contract green as the Delegate emits its own records.
+
+---
+
+## 3. Connector base / ABC — fresh authoring, but pattern templates exist
+
+**No `class.*Connector` base or ABC exists under `src/kailash/`.** The `nodes/api/` directory contains concrete protocol clients (`auth.py`, `http.py`, `rest.py`, `graphql.py`, `monitoring.py`, `rate_limiting.py`, `security.py`) but no abstract Connector base. Verified by `grep -rln "class.*Connector" /Users/esperie/repos/loom/kailash-py/src/kailash/` → zero hits.
+
+**Closest existing pattern — `StreamingChatAdapter`** at `/Users/esperie/repos/loom/kailash-py/packages/kaizen-agents/src/kaizen_agents/delegate/adapters/protocol.py:60`:
+
+```python
+@runtime_checkable
+class StreamingChatAdapter(Protocol):
+    """Protocol for LLM provider adapters."""
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        ...
+    ) -> AsyncGenerator[StreamEvent, None]: ...
+```
+
+Also: `RetryStrategy(ABC)` at `/packages/kailash-mcp/src/kailash_mcp/errors.py:272` (1 abstract method); `MCPServerBase(ABC)` at `/packages/kailash-mcp/src/kailash_mcp/server.py:100`; `ClientStore(ABC)` / `TokenStore(ABC)` at `/packages/kailash-mcp/src/kailash_mcp/auth/oauth.py:340, 400`. These are framework-internal ABCs, not general-purpose connector bases.
+
+**Recommendation:** Author a fresh `kailash.delegate.Connector` ABC that mirrors the rs trait (pull / normalize / capabilities). Use the `typing.Protocol` + `@runtime_checkable` pattern from `StreamingChatAdapter` for the duck-typed surface AND export an `abc.ABC` subclass with `@abstractmethod` decorators for the explicit-inheritance surface (per `rules/testing.md` § "Protocol-Satisfying Deterministic Adapters" exception — Protocol satisfaction is NOT a mock; canonical for test deterministic-adapters).
+
+**Reuse verdict:** **FRESH AUTHORING.** Pattern templates exist in `StreamingChatAdapter` (Protocol form) and `MCPServerBase` (ABC form). The Delegate Connector ABC should follow Protocol form for duck-typing flexibility + ABC subclass for default behavior inheritance.
+
+---
+
+## 4. Signature / Executor types — application-supplied, but overlap exists
+
+**Signature primitive (Kaizen-owned):** `/Users/esperie/repos/loom/kailash-py/packages/kailash-kaizen/src/kaizen/signatures/core.py`
+
+- `class InputField` (line 47) — field declaration
+- `class OutputField` (line 88) — field declaration
+- `class SignatureMeta(type)` (line 118) — metaclass
+- `class Signature(metaclass=SignatureMeta)` (line 249) — base class
+- `class SignatureParser` (line 642), `SignatureValidator` (line 863), `SignatureCompiler` (line 1015), `SignatureTemplate` (line 1735), `SignatureOptimizer` (line 1814)
+
+**Signature pattern example** (`kaizen/signatures/core.py`):
+
+```python
+class TriageSignature(Signature):
+    ticket: str = InputField(description="Support ticket content")
+    priority: str = OutputField(description="urgent, high, normal, low")
+```
+
+**Executor:** No single canonical `Executor` class exists. Closest surfaces: `LocalRuntime` / `AsyncLocalRuntime` (`src/kailash/runtime/local.py`), kaizen-agents `AgentLoop` (`delegate/loop.py`), and the application's own ReAct/multi-cycle loops. The issue #1035 spec text says Signature/Executor are **application-supplied** — the Delegate surface accepts them as opaque types and composes them.
+
+**Recommendation:** Use `typing.Protocol` (NOT inheritance) for `kailash.delegate.Signature` and `kailash.delegate.Executor` so application-supplied types can pass without being forced to import a Delegate-specific base. The Kaizen `Signature` and any other application-supplied callable that matches the Protocol shape can be passed unchanged.
+
+**Reuse verdict:** **PROTOCOL ACCEPTANCE, NO FRESH IMPL.** Kaizen's `Signature` exists and is fully featured (~2000 LOC of validation, compilation, optimization). Define Delegate's Signature/Executor as Protocols and Kaizen's Signature satisfies the surface by structural typing.
+
+---
+
+## 5. ConstraintEnvelope — REUSE the canonical SPEC-07 type
+
+**Path:** `/Users/esperie/repos/loom/kailash-py/src/kailash/trust/envelope.py` (1645 LOC)
+**Status:** Already canonical, already cross-SDK-aligned, already monotonic-tightening-enforced.
+
+**SPEC-07 ConstraintEnvelope** (`envelope.py:1-26`):
+
+> "Canonical ConstraintEnvelope — SINGLE source of truth for constraint envelopes. SPEC-07: ConstraintEnvelope Unification. This module defines the canonical `ConstraintEnvelope` type that replaces the three previously scattered implementations: 1. `kailash.trust.chain.ConstraintEnvelope` — EATP lineage chain (generic bag) 2. `kailash.trust.plane.models.ConstraintEnvelope` — TrustPlane 5-dimension type 3. `kailash.trust.pact.config.ConstraintEnvelopeConfig` — PACT governance config. The canonical type is a frozen dataclass superset with: Five constraint dimensions (financial, operational, temporal, data_access, communication), Gradient thresholds for verification gradient classification, Posture ceiling per ADR-010, Monotonic tightening via `intersect()`, Deterministic canonical JSON for cross-SDK compatibility, HMAC-SHA256 signing via `SecretRef`, NaN/Inf protection on all numeric fields."
+
+**Key Delegate-relevant surfaces:**
+
+- `ConstraintEnvelope.intersect(other)` (`envelope.py:838-865`) — **the tighten-only operator the issue body needs.** Commutative + associative. Per-dimension intersection: numeric `min()`, allow-lists set-intersection, block-lists set-union, booleans OR.
+- `ConstraintEnvelope.is_tighter_than(other)` (`envelope.py:867`) — predicate for verifying "child envelope is ≤ parent".
+- `ConstraintEnvelope.to_canonical_json()` (`envelope.py:1029`) — cross-SDK byte-canonical encoder.
+- `ConstraintEnvelope.envelope_hash()` (`envelope.py:806`) — SHA-256 of constraint content; tamper detection.
+- `sign_envelope(envelope, secret_ref)` (`envelope.py:1424`) / `verify_envelope(...)` (`envelope.py:1489`) — HMAC-SHA256 round-trip.
+- `from_plane_envelope(...)` / `to_plane_envelope(...)` — adapters for legacy plane callers.
+- Frozen dataclass — `rules/pact-governance.md` MUST Rule 6 and `rules/trust-plane-security.md` MUST Rule 4 enforced.
+
+**Already imported by kaizen-agents Delegate** (`packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py:63`):
+
+```python
+from kailash.trust.envelope import ConstraintEnvelope
+```
+
+The existing kaizen-agents `Delegate(... envelope: ConstraintEnvelope | None = None ...)` (`delegate.py:359`) already passes the canonical type to its `L3GovernedAgent` wrapper.
+
+**Reuse verdict:** **REUSE AS-IS.** The Delegate composition surface MUST import `from kailash.trust.envelope import ConstraintEnvelope`. The rs type-state "tighten-only never widen" maps to py's `intersect()` + `is_tighter_than()` predicate guard. No fresh frozen-dataclass needed.
+
+---
+
+## 6. Tenant isolation primitive — exists in dataflow/tenancy/, no general-purpose `TenantScopedCascade`
+
+**Closest match:** `/Users/esperie/repos/loom/kailash-py/packages/kailash-dataflow/src/dataflow/tenancy/`
+
+```
+tenancy/
+  __init__.py
+  exceptions.py
+  interceptor.py
+  security.py
+```
+
+This is DataFlow-coupled tenant isolation (query interceptor + tenant-aware security checks). It is NOT a free-standing primitive on the Trust Plane or PACT surface.
+
+**Other tenant references:**
+
+- `grep -rln "TenantContext\|tenant_id"` across `src/kailash/trust/` and `packages/kailash-pact/src/` shows tenant_id flows through audit records (`audit_store.py`), JWT auth context (`trust/auth/jwt.py`, `trust/auth/context.py`, `trust/auth/models.py`), and AWS SSO (`trust/auth/sso/azure.py`).
+- PACT engine has tenant_id touch points in `pact/engine.py` and `pact/ml/__init__.py`.
+
+**No `class TenantScopedCascade` analog exists** in the trust plane or PACT package. The rs side's `TenantScopedCascade` (per #1035 issue body context) does not have a 1:1 py equivalent.
+
+**Recommendation:** The Delegate's tenant isolation should be enforced at the PACT envelope layer — `ConstraintEnvelope` already carries `data_access` constraints that include tenant scope (per `envelope.py` `DataAccessConstraint`). For the cascade-style "every connector call carries tenant scope down to the audit record" pattern, author a **fresh thin wrapper** `kailash.delegate.TenantScope(tenant_id, envelope)` that (a) injects `tenant_id` into the audit context dict before every `pact_engine.governance.verify_action()` call, and (b) emits `tenant_id` in every EATP record per `chain.py` dataclass field. This is a ~30 LOC composition primitive, not a fresh subsystem.
+
+**Reuse verdict:** **MOSTLY FRESH AUTHORING (~30 LOC composition wrapper).** Underlying tenant tracking exists in DataFlow + audit_store + JWT auth context, but a Trust-Plane-level `TenantScopedCascade` does not.
+
+---
+
+## 7. Lifecycle state machine pattern — workflow has them, Delegate can mirror
+
+**State-machine patterns in kailash-py** (from `grep -l "class.*State\|StateMachine"` across `src/kailash/workflow/`):
+
+- `workflow/builder.py`
+- `workflow/cycle_state.py` — cycle execution state
+- `workflow/cyclic_runner.py` — cycle runner with state transitions
+- `workflow/edge_infrastructure.py`
+- `workflow/state.py` — workflow state base
+- `workflow/runner.py` — main runner
+- `nodes/transaction/saga_state_storage.py` — saga state persistence (canonical typed-state pattern)
+- `core/resilience/health_monitor.py` — health state transitions
+- `nodes/alerts/base.py` — alert lifecycle
+
+**Most relevant pattern: `kailash.trust.plane.delegation::DelegateStatus`** at `src/kailash/trust/plane/delegation.py:65`:
+
+```python
+class DelegateStatus(Enum):
+    ...  # typed enum-state transitions
+```
+
+And the kaizen-agents `Delegate` (`packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py:270`) uses a wrapper-stack composition (AgentLoop → L3GovernedAgent → MonitoredAgent) rather than a state machine.
+
+**EATP-side state machine:** `rules/eatp.md` "Monotonic escalation only: AUTO_APPROVED → FLAGGED → HELD → BLOCKED (never downgrade)". Same shape applies to Delegate execution states.
+
+**Recommendation:** Use `enum.Enum` (str-backed per `rules/eatp.md` SDK convention) for Delegate lifecycle states: `INIT → AUTHORIZED → EXECUTING → COMPLETED | BLOCKED | HELD | FAILED`. Mirror the monotonic-escalation rule. No new state-machine framework needed — Python's enum + a tiny transition guard table is the canonical pattern across kailash.
+
+**Reuse verdict:** **PATTERN REUSE.** No need to import a state-machine framework; enum + transition guard inside Delegate's loop matches kailash-wide convention.
+
+---
+
+## 8. Conformance-test infrastructure — PACT N4/N5 is the canonical template
+
+**Direct template:** `/Users/esperie/repos/loom/kailash-py/packages/kailash-pact/src/pact/conformance/`
+
+```
+conformance/
+  __init__.py
+  cli.py          # CLI runner
+  runner.py       # ConformanceRunner, RunnerReport, VectorOutcome, VectorStatus
+  vectors.py      # ConformanceVector schema + parse + canonical_json_dumps
+```
+
+**Why this is exactly the template Delegate needs:**
+
+1. **Cross-SDK byte-equality contract** — `runner.py:11-13` "It is deliberately framework-agnostic: it does NOT touch `GovernanceEngine` or any production governance hot path. Its sole responsibility is the cross-SDK byte-equality contract."
+2. **JSON vector format** — vectors live as `*.json` files; `load_vectors_from_dir(path)` (`vectors.py:64`) discovers + parses + sorts by `id`.
+3. **Failure mode is fail-LOUD** — malformed vector raises `ConformanceVectorError`; per-vector mismatch records expected + actual + SHA-256 fingerprints for cross-SDK diff (`runner.py:30-44`).
+4. **Already implements `cross-sdk-inspection.md` MUST Rule 4 + 4a** — pins byte vectors empirically derived from kailash-rs serde output; vendored canonical JSON files.
+
+**Secondary template:** `/Users/esperie/repos/loom/kailash-py/src/kailash/trust/plane/conformance/__init__.py`
+
+- `ConformanceLevel(Enum)` — COMPATIBLE / CONFORMANT / COMPLETE (`__init__.py:38`)
+- `ConformanceTest(@dataclass)` — single test with `RequirementLevel` (MUST / SHOULD / MAY) (`__init__.py:61`)
+- `ConformanceReport` (`__init__.py:86`)
+- `ConformanceSuite` (`__init__.py:215`) — drives a test set against an implementation
+- This is the **EATP TrustPlane suite** (RFC-2119-style requirements testing) — heavier than PACT's byte-canonical vectors.
+
+**Recommendation:** Use **PACT conformance/ as the template** for `kailash.delegate.conformance/`. Same module layout (`vectors.py`, `runner.py`, `cli.py`), same `canonical_json_dumps` byte-equality contract, same `VectorStatus.PASSED|FAILED|UNSUPPORTED` shape. Add Delegate-specific contract names (e.g. `D1` = Connector capabilities canonical, `D2` = audit-chain emission canonical, etc.). Vectors live as `*.json` files vendored from kailash-rs per `rules/cross-sdk-inspection.md` Rule 4a (sibling-canonical fixtures vendored, NOT re-authored).
+
+**Reuse verdict:** **PATTERN-CLONE FROM `pact/conformance/`.** Do NOT re-invent the conformance harness. The PACT cross-SDK byte-equality contract is the working reference; Delegate's contract is structurally identical (different fields, same byte-canonical-vs-vendored-vectors discipline).
+
+---
+
+## 9. Package layout decision — `src/kailash/delegate/` (per issue #1035, confirmed by convention)
+
+**Existing layout convention** (`ls /Users/esperie/repos/loom/kailash-py/src/kailash/` shows 40+ subpackages):
+
+```
+src/kailash/{access_control, adapters, analysis, api, channels, client, config,
+             core, database, db, diagnostics, edge, events, gateway,
+             infrastructure, integrations, manifest.py, middleware, migration,
+             ml, monitoring, nodes, observability, planning, resources, runtime,
+             security.py, servers, testing, tracking, trust, utils,
+             visualization, workflow}
+```
+
+**Versus `packages/` (separate-installable sub-packages):**
+
+```
+packages/{kailash-align, kailash-dataflow, kailash-kaizen, kailash-mcp,
+          kailash-ml, kailash-nexus, kailash-pact, kaizen-agents}
+```
+
+**The decision rule** (from `rules/framework-first.md` + `pyproject.toml` analysis):
+
+- `src/kailash/<sub>/` is for **first-class subsystems shipped with `pip install kailash`** — workflow runtime, trust plane, governance primitives, observability. These all live in the core `kailash` package (version `2.23.0` per `pyproject.toml`).
+- `packages/kailash-<X>/` is for **opinionated framework packages** with their own version cadence, optional extras, and standalone install (e.g. `pip install kailash-pact`).
+
+**Issue #1035 says `from kailash.delegate import ...`.** That import path REQUIRES `src/kailash/delegate/` — not `packages/kailash-delegate/`. Confirmed by the existing `src/kailash/trust/`, `src/kailash/workflow/`, `src/kailash/runtime/` subpackage convention (all shipped under the `kailash` top-level).
+
+**Recommendation:** **`src/kailash/delegate/` per #1035 issue body.** This places Delegate alongside `src/kailash/trust/` (envelope + chain), `src/kailash/runtime/` (executors), and `src/kailash/workflow/` (lifecycle) — exactly the primitives Delegate composes. A separate `packages/kailash-delegate/` would (a) break the documented import path, (b) require a new pypi name + version cadence, (c) duplicate the dependency on `kailash.trust` and `kailash-pact` that core `kailash` already carries. Per `rules/dependencies.md` § "Latest Versions Always" and `python-environment.md` § "Monorepo Sub-Packages MUST Be Installed Editable", the cost of a new sub-package is real; the benefit (separate version cadence) is not needed for a composition primitive that lives directly on top of trust+pact.
+
+**Reuse verdict:** **`src/kailash/delegate/` per #1035 issue body.** Single source of truth, no new sub-package.
+
+---
+
+## 10. No-existing-Delegate confirmation — kaizen-agents `Delegate` is a different concept (near-miss documented)
+
+**Grep results** (`grep -rn "class Delegate\|from kailash.delegate\|import kailash.delegate"`):
+
+| Hit                                                                 | Type                                           | Significance                                             |
+| ------------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `src/kailash/trust/plane/delegation.py:65`                          | `class DelegateStatus(Enum)`                   | Enum, not the composition surface                        |
+| `src/kailash/trust/export/siem.py:157`                              | `class DelegateEvent(SIEMEvent)`               | SIEM event subclass, not the composition surface         |
+| `packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py:270` | **`class Delegate:`**                          | **NEAR-MISS — different concept** (LLM execution facade) |
+| `packages/kaizen-agents/src/kaizen_agents/delegate/events.py:46`    | `class DelegateEvent:`                         | Event type for the kaizen-agents Delegate                |
+| `packages/kailash-mcp/.venv/.../pandas/.../test_constructors.py:60` | `class Delegate(PandasDelegate, PandasObject)` | Vendored pandas test — irrelevant                        |
+
+**Critical near-miss: `kaizen_agents.delegate.Delegate`** (`packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py:270`, 711 LOC):
+
+- **Purpose:** "Facade composing a wrapper stack for autonomous AI execution" (`delegate.py:271`). Composes `AgentLoop → [L3GovernedAgent] → [MonitoredAgent]`.
+- **Constructor takes** (`delegate.py:351-359`):
+  ```python
+  Delegate(
+      model: str,                              # LLM model name
+      signature: type[Signature] | None,        # Kaizen Signature class
+      tools: list | ToolRegistry,
+      system_prompt: str,
+      max_turns: int,
+      mcp_servers: list,
+      budget_usd: float | None,
+      envelope: ConstraintEnvelope | None,      # IMPORTS THE CANONICAL TYPE
+      ...
+  )
+  ```
+- **No `compose()` classmethod.** No `connector=`, no `pact_engine=`, no `executor=`. It is an LLM-execution facade, NOT the composition surface issue #1035 describes.
+
+**How they relate:** The kaizen-agents `Delegate` is one POSSIBLE Executor implementation that the new `kailash.delegate.Delegate.compose(... executor=kaizen_agents.Delegate(...) ...)` could wire. They sit at different layers:
+
+- `kailash.delegate.Delegate` (new, issue #1035) = composition primitive (Connector × Signature × Envelope × Executor × PactEngine)
+- `kaizen_agents.delegate.Delegate` (existing) = one specific Executor (LLM agent loop with wrapper stack)
+
+**Naming risk:** Both classes named `Delegate` will create import-path confusion. Two options:
+
+- (a) Rename the new one (e.g. `Composition`, `ComposedDelegate`, `DelegateComposition`) — breaks #1035's documented `from kailash.delegate import Delegate` import.
+- (b) Keep both names; document the disambiguation in `kailash/delegate/__init__.py` and update kaizen-agents docs to reference its Delegate as `kaizen_agents.Delegate`.
+
+**Recommendation:** Option (b). The two classes live in different packages (`kailash.delegate.Delegate` vs `kaizen_agents.Delegate`) so the import statement disambiguates. Per `rules/recommendation-quality.md` MUST-3 — cons: import-collision risk in user code that does `from kailash.delegate import Delegate` AND `from kaizen_agents import Delegate` in the same file. Mitigation: a one-line note in the SPEC v0 (when it lands) calling out the namespace split.
+
+**Reuse verdict:** **NO EXISTING IMPLEMENTATION OF THE ISSUE-#1035 COMPOSITION SURFACE.** Near-miss documented; namespace collision risk flagged for the spec.
+
+---
+
+## Cross-cutting reuse table
+
+| Delegate dependency               | kailash-py primitive                                                     | Path                                                                                         | Reuse?                                                                     |
+| --------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| PACT engine                       | `PactEngine`                                                             | `packages/kailash-pact/src/pact/engine.py:126`                                               | **Reuse as-is**                                                            |
+| EATP audit chain                  | `TrustLineageChain` + records                                            | `src/kailash/trust/chain.py:672`                                                             | **Reuse as-is**                                                            |
+| Cross-SDK canonical JSON          | `canonical_json_dumps`                                                   | `src/kailash/trust/_json.py:99` + `packages/kailash-pact/src/pact/conformance/vectors.py:80` | **Reuse as-is**                                                            |
+| EATP sync emitter                 | `PactEatpEmitter` Protocol                                               | `src/kailash/trust/pact/eatp_emitter.py:28`                                                  | **Reuse as-is**                                                            |
+| ConstraintEnvelope (tighten-only) | Canonical SPEC-07 `ConstraintEnvelope`                                   | `src/kailash/trust/envelope.py`                                                              | **Reuse as-is**                                                            |
+| Envelope `intersect()`            | `ConstraintEnvelope.intersect()`                                         | `src/kailash/trust/envelope.py:838`                                                          | **Reuse as-is**                                                            |
+| Envelope tightening predicate     | `ConstraintEnvelope.is_tighter_than()`                                   | `src/kailash/trust/envelope.py:867`                                                          | **Reuse as-is**                                                            |
+| Envelope HMAC sign/verify         | `sign_envelope` / `verify_envelope`                                      | `src/kailash/trust/envelope.py:1424, 1489`                                                   | **Reuse as-is**                                                            |
+| Connector ABC                     | none — fresh authoring                                                   | (new: `src/kailash/delegate/connector.py`)                                                   | **Fresh (~50 LOC; template from `StreamingChatAdapter` Protocol pattern)** |
+| Signature (application-supplied)  | Kaizen `Signature` (Protocol-satisfies)                                  | `packages/kailash-kaizen/src/kaizen/signatures/core.py:249`                                  | **Protocol acceptance**                                                    |
+| Executor (application-supplied)   | Application-defined; kaizen-agents Delegate, `LocalRuntime`, etc.        | (Protocol acceptance)                                                                        | **Protocol acceptance**                                                    |
+| Tenant scoping wrapper            | DataFlow `tenancy/` + audit/JWT tenant_id flow; no Trust-Plane primitive | `packages/kailash-dataflow/src/dataflow/tenancy/` + scattered                                | **Mostly fresh (~30 LOC wrapper)**                                         |
+| Lifecycle state machine           | enum + transition guard (kailash convention)                             | `src/kailash/trust/plane/delegation.py:65` `DelegateStatus` enum pattern                     | **Pattern reuse, no fresh framework**                                      |
+| Conformance suite                 | PACT N4/N5 conformance runner + vectors                                  | `packages/kailash-pact/src/pact/conformance/`                                                | **Pattern-clone (template)**                                               |
+| Layout: package home              | `src/kailash/delegate/`                                                  | (new)                                                                                        | **Per #1035 spec**                                                         |
+| `Delegate` class itself           | NONE                                                                     | (new)                                                                                        | **Fresh authoring**                                                        |
+
+---
+
+## Suggested fresh-authoring footprint (orientation only — not a plan)
+
+The Delegate composition surface authoring is bounded to roughly:
+
+1. `src/kailash/delegate/__init__.py` — public surface, `__all__` per `rules/orphan-detection.md` Rule 6
+2. `src/kailash/delegate/connector.py` — `Connector` ABC + Protocol (~50 LOC)
+3. `src/kailash/delegate/delegate.py` — `Delegate` + `Delegate.compose(...)` classmethod (~300-500 LOC, composition logic; no business logic — wires PactEngine + ConstraintEnvelope + Connector + Signature + Executor)
+4. `src/kailash/delegate/tenant.py` — `TenantScope` wrapper (~30 LOC)
+5. `src/kailash/delegate/state.py` — `DelegateState` enum + transition guard (~50 LOC)
+6. `src/kailash/delegate/conformance/{vectors.py, runner.py, cli.py}` — cloned from `pact/conformance/` (~400-600 LOC, mostly schema + runner; vectors live as JSON files vendored from kailash-rs)
+7. `tests/integration/test_delegate_wiring.py` per `rules/facade-manager-detection.md` Rule 2 — Tier 2 test exercising Delegate end-to-end through the framework facade
+8. `tests/regression/test_issue_1035_delegate_cross_sdk_byte_parity.py` per `rules/cross-sdk-inspection.md` Rule 4 — pin ≥3 byte vectors from kailash-rs
+
+Total: ~900-1200 LOC of new authoring, plus vendored conformance vectors from kailash-rs. Comfortably within one shard's per-session capacity budget per `rules/autonomous-execution.md` § Per-Session Capacity Budget if the conformance vectors are scoped as a separate shard (load-bearing logic is the composition layer + Connector ABC; conformance vectors are mostly boilerplate-stamping).
+
+---
+
+## Notes on framing for #1035 implementation
+
+- The `01-external-spec-extraction.md` (companion in this workspace) flagged that the source document is "Pre-draft scaffold. Not the spec." (`02-delegate-spec-v0-outline.md:3`). The kailash-py primitive landscape is therefore the harder constraint than the spec text: every Delegate decision MUST compose with the existing PACT/EATP/ConstraintEnvelope/conformance surface above, OR explicitly justify a fresh implementation that diverges.
+- Per `rules/cross-sdk-inspection.md` MUST Rule 3 (EATP D6 compliance) — implementation details may differ between py and rs, but **semantics MUST match**. The canonical JSON encoder + the N4/N5 conformance pattern is the structural defense that keeps this true.
+- Per `rules/orphan-detection.md` MUST Rule 1 — every public Delegate facade attribute MUST have a production call site in the framework's hot path within 5 commits. The Delegate is at risk of orphan-pattern (downstream consumers import it but the framework never invokes it on the data path) UNLESS it is wired into kaizen-agents' Delegate (Executor) and PACT's submit() path as the canonical composition entry.
+
+---
+
+## Survey complete
+
+Report file: `/Users/esperie/repos/loom/kailash-py/workspaces/issue-1035-delegate-py/01-analysis/03-kailash-py-primitive-survey.md`

--- a/workspaces/issue-1035-delegate-py/02-plans/00-RECOMMENDATION.md
+++ b/workspaces/issue-1035-delegate-py/02-plans/00-RECOMMENDATION.md
@@ -1,0 +1,55 @@
+# Recommendation — Cardinal decision before /todos approval
+
+## TL;DR
+
+**Recommend: Option A — treat the kailash-rs shipped Delegate runtime as the de facto spec for kailash-py interop.** Unblocks immediate /implement across 7 parallel-shard waves. Cardinal decision is yes/no on whether the rs-shipped implementation is the source-of-truth for kailash-py conformance.
+
+## The cardinal question
+
+The external **Delegate Specification v0** (Terrene, CC BY 4.0, at `~/repos/dev/unicorn-focus/drafts/02-delegate-spec-v0-outline.md`) — the document #1035 cites as authoritative — was confirmed by Agent 1 to be a **pre-draft scaffold, not a normative spec**:
+
+- ZERO formally-defined types (~11 named artifacts, only Genesis Record has a partial proposed field list).
+- NO conformance vectors enumerated.
+- Conformance levels (Conforming / Partially Conforming / Non-Conforming) named but criteria undefined.
+- Cross-vendor verifiability flagged as an OPEN question (§4 Q4).
+- The document itself states (line 247) "if a section can only be implemented one way, it is over-specified."
+
+Meanwhile **kailash-rs has shipped the runtime through M8-02 E2E** (13,196 LOC across 6 crates, per Agent 2), with conformance vectors defined as a Rust function `delegate_spec_vectors() -> Vec<ConformanceVector>`. The rs side is the de facto authority because it's the only place the contract is concretely defined.
+
+**The cardinal decision:**
+
+| Option                                                                                                                              | What it means in plain language                                                                                                                                                                                                                                        | Implication                                                                                                                                                                                                                                       |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A. Mirror rs as the de facto spec** (recommended)                                                                                 | Build kailash-py to match what rs actually does, verified via shared conformance vectors vendored from rs. The "spec" is whatever rs runs today; any spec-document ambiguity is resolved by reading rs source.                                                         | Unblocks 7 shards immediately. Cross-impl conformance well-defined. Strategic implication: the document spec never becomes source-of-truth — the open-source Python impl is forever a follower of the proprietary rs impl.                        |
+| **B. Pause until Delegate Spec v0 reaches normative status**                                                                        | Don't ship kailash-py Delegate until someone (Terrene Foundation) writes the actual normative spec. Today's "spec" is a sketch — building to a sketch is BLOCKED on `verify-resource-existence.md` MUST-2 (citing intent ≠ runtime).                                   | #1035 stays open indefinitely. Issue body's open-substrate argument for regulators / academics / community connectors continues to be a one-sided claim (rs has implementation, py does not). User must engage Terrene Foundation drafting cycle. |
+| **C. Hybrid — ship minimum surface satisfying #1035 acceptance criteria, mark as "exploration release" pending spec normalization** | Ship `from kailash.delegate import Delegate, ConstraintEnvelope, ...` with the rs-mirrored types + conformance vectors, but flag the package version as `0.x` and the README as "exploration release; API will change when Delegate Spec v0 reaches normative status." | Compromise between A and B — half the strategic concern of A (we publicly acknowledge the spec is unsettled) with most of A's throughput.                                                                                                         |
+
+### Pros of A (the recommendation)
+
+- **Unblocks 7 immediate shards** — the rs side already worked through 8 milestones (M1-M8); py mirrors the proven decomposition.
+- **Reuses ~80% of kailash-py's existing primitives** (per Agent 3): SPEC-07 `ConstraintEnvelope` (already canonical, with `intersect()` + `is_tighter_than()`), `TrustLineageChain` + EATP with cross-SDK `canonical_json_dumps`, `PactEngine`, `PactEatpEmitter` Protocol, the `pact/conformance/` pattern (already byte-canonical-validated against rs).
+- **Cross-impl conformance is concrete** — we vendor `delegate_spec_vectors()` from rs as checked-in JSON fixtures + run them in both impls; `receipts_agree(rs, py)` proves cross-language verification (#1035's acceptance criterion).
+- **Satisfies #1035's load-bearing argument** — regulator/academic/community connector author gets a runnable Apache-2.0 implementation today, not "wait for the spec to be drafted."
+- **Same M-numbered shard ordering as rs** (M1 fences → M2 types → M3 trust → M4 audit → M5 dispatch → M6 runtime → M7 conformance → M8 E2E) — keeps reasoning legible to future cross-impl audits.
+
+### Cons of A (real, not glossed)
+
+- **The "spec" is effectively "whatever rs does today"** — rs API drift mechanically becomes py API drift. Mitigation: the `receipts_agree(rs, py)` cross-impl check catches drift; vendored vectors are the pinning surface.
+- **Strategic precedent** — the Delegate Spec v0 document loses load-bearing status. Future Terrene Foundation drafting work has reduced authority because both impls predate it. This is a real institutional cost; the user should know.
+- **Python impl must keep pace with rs M-numbered shards** — when rs ships M9, py must ship M9 or fall behind on conformance vectors. Ongoing maintenance commitment (per `feedback_drive_to_completion.md`).
+- **Two `Delegate` classes — naming friction permanent.** `kaizen_agents.delegate.Delegate` (LLM-execution facade, 711 LOC, existing) ≠ `kailash.delegate.Delegate` (composition primitive, new). The new one CAN wire the old one as an `executor=` — but the namespace collision will confuse readers forever. Mitigation: explicit disambiguation paragraph in both classes' docstrings.
+- **#1035 issue body is partially stale**: it says `Connector` is `pull/normalize/capabilities`; rs ships `authenticate/write/read/revocation`. We MUST mirror the shipped shape and amend #1035's body (or close + re-file).
+
+### Why NOT B
+
+B is technically clean but operationally inert. The Terrene Foundation drafting cycle is calendar-bound (per `autonomous-execution.md` § "Does NOT apply to: human-authority gates"); waiting could be months. Meanwhile rs ships through M9, M10, M11 — by the time the spec normalizes, py is so far behind the cross-impl conformance argument is purely theoretical. The user opened #1035 because the open-substrate argument needs a real implementation, not a planned one.
+
+### Why NOT C (could be the right call if A's strategic cost is unacceptable)
+
+C is a compromise that buys back some institutional optionality. The downside is it ships a `0.x` "exploration" badge that downstream consumers may distrust — kaizen-agents, regulators, the academic Build #14 want a stable substrate, not an exploratory one. If the user wants C, the version label and README disclaimer become load-bearing artifacts and shard M1 must include the language drafting.
+
+## Approve Option A and proceed to /todos shard plan?
+
+(yes / no / pick B or C with rationale)
+
+Once approved, the next gate is `/todos` (structural human gate per `workspaces/CLAUDE.md` Phase 02) — I'll surface the 7-shard decomposition with each shard's value-anchor, mirroring rs M-numbered ordering. The decomposition is drafted at `02-plans/01-architecture.md` and `todos/active/00-shard-plan.md` already so the user can review concurrently with the cardinal decision.

--- a/workspaces/issue-1035-delegate-py/02-plans/01-architecture.md
+++ b/workspaces/issue-1035-delegate-py/02-plans/01-architecture.md
@@ -1,0 +1,104 @@
+# Architecture — kailash.delegate (Apache 2.0, #1035)
+
+**Assumes:** Option A from `00-RECOMMENDATION.md` approved (rs-shipped impl is de facto spec).
+
+## Goal
+
+Ship `from kailash.delegate import Delegate, ConstraintEnvelope, PrincipalDirectory, GenesisRecord, PostureState, AuditChain, Connector` as the Apache-2.0 OSS substrate satisfying #1035 acceptance criteria. Zero proprietary dependency. Cross-impl conformance to kailash-rs verified via vendored `delegate_spec_vectors()`.
+
+## Package layout
+
+Per Agent 3 + #1035 body, layout is `src/kailash/delegate/` (in-tree under `src/kailash/`), NOT `packages/kailash-delegate/`. Rationale: `src/kailash/trust/`, `src/kailash/workflow/`, `src/kailash/runtime/` are the established home for first-class composition primitives that ship under `kailash` versioning; `packages/kailash-*/` is for opinionated frameworks with separate version cadence (DataFlow, Nexus, Kaizen, ML, Align). Delegate is composition, not framework.
+
+```
+src/kailash/delegate/
+├── __init__.py              # public surface: re-export per #1035 import path
+├── types.py                 # canonical types (mirrors kailash-delegate-types)
+├── envelope.py              # DelegateConstraintEnvelope wrapping kailash.trust.envelope.ConstraintEnvelope
+├── trust.py                 # TenantScopedCascade + GrantMoment
+├── audit.py                 # AuditChainEngine wrapping kailash.trust.TrustLineageChain + WitnessedCrossAnchor
+├── dispatch.py              # Connector ABC + OptionalPrimitive + ConnectorAuth + dispatch engine
+├── runtime.py               # Delegate + Delegate.compose() + LifecycleTransition + R2CompositionEngine
+├── posture.py               # PostureState + PostureRatchet
+└── conformance/
+    ├── __init__.py
+    ├── vectors.py           # vendored from kailash-rs delegate_spec_vectors() — JSON fixtures
+    ├── runner.py            # ConformanceVector execution + receipt emission
+    ├── cli.py               # `python -m kailash.delegate.conformance` entry point
+    └── fixtures/            # checked-in JSON copies of DV-5-001, DV-10-001, etc.
+```
+
+## Reuse map (per Agent 3 survey)
+
+| Delegate primitive                     | kailash-py existing                                                                                                                                                                      | New code needed                                                                                                                                   |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ConstraintEnvelope`                   | `src/kailash/trust/envelope.py` SPEC-07 canonical — `intersect()`, `is_tighter_than()`, HMAC sign/verify, already imported by kaizen-agents                                              | Thin `DelegateConstraintEnvelope` wrapper enforcing type-state (monotonic tightening only)                                                        |
+| `AuditChain`                           | `src/kailash/trust/chain.py` `TrustLineageChain` + `src/kailash/trust/_json.py` `canonical_json_dumps` (cross-SDK) + `src/kailash/trust/pact/eatp_emitter.py` `PactEatpEmitter` Protocol | `AuditChainEngine` wrapper emitting Delegate-specific event shape rs verifier accepts                                                             |
+| `PactEngine`                           | `packages/kailash-pact/src/pact/engine.py:126`                                                                                                                                           | Wire as `pact_engine=` arg to `Delegate.compose()`                                                                                                |
+| Conformance pattern                    | `packages/kailash-pact/src/pact/conformance/` (vectors.py + runner.py + cli.py — already byte-canonical against rs)                                                                      | Clone 1:1 layout for `src/kailash/delegate/conformance/`                                                                                          |
+| `Connector` ABC                        | NONE                                                                                                                                                                                     | Fresh ~50 LOC ABC mirroring rs trait `authenticate/write/read/revocation` (NOT issue body's `pull/normalize/capabilities` — rs ship trumps issue) |
+| `Delegate.compose()`                   | NONE                                                                                                                                                                                     | Fresh ~300-400 LOC composition class + lifecycle state machine                                                                                    |
+| `TenantScopedCascade`                  | NONE (tenant primitives scattered across DataFlow + audit + JWT)                                                                                                                         | Fresh ~30 LOC `TenantScope` wrapper                                                                                                               |
+| `DelegateState` lifecycle enum         | NONE                                                                                                                                                                                     | Fresh ~50 LOC `Proposed → Instantiated → PostureGraded → Active → Retired → Archived`                                                             |
+| `PostureRatchet`                       | NONE                                                                                                                                                                                     | Fresh ~80 LOC monotonic-only posture transitions                                                                                                  |
+| `PrincipalDirectory` + `GenesisRecord` | NONE (PACT has signer registry — different shape)                                                                                                                                        | Fresh ~150 LOC per rs reference                                                                                                                   |
+| Conformance vectors                    | NONE                                                                                                                                                                                     | Vendor DV-5-001 + DV-10-001 from rs as JSON fixtures                                                                                              |
+
+## Invariants (mirrored from rs runtime lib.rs preamble)
+
+1. **D3 single linear lifecycle chain** — `Proposed → Instantiated → PostureGraded → Active → Retired → Archived`. No state-skipping. No backward edges. Archived terminal.
+2. **Every accepted transition emits one audit event** to `AuditChainEngine`.
+3. **Illegal lifecycle edge raises typed `LifecycleError`** BEFORE any audit is written.
+4. **`ConstraintEnvelope` widening BLOCKED** — only `Delegate.compose(envelope=)` at genesis time may set a fresh envelope; runtime composition is tighten-only.
+5. **Cascade child gets its own delegation + audit chain** — never a fork of parent's chain.
+6. **Tenant-first isolation** — `TenantScopedCascade.cascade_child` enforces `Option A RATIFIED` per rs M3-01.
+7. **F1 conformance package has ZERO engine dependencies** — `kailash.delegate.conformance` MUST NOT import the runtime engine. CI grep + manifest-empty-engine-deps fence.
+8. **Cross-impl agreement is counts-only** via `receipts_agree(rs, py) -> bool` — never field-by-field engine diff. Same vector version + both conformed = agree.
+
+## Naming disambiguation (load-bearing)
+
+`kaizen_agents.delegate.Delegate` (existing, 711 LOC, LLM-execution facade composing `AgentLoop → L3GovernedAgent → MonitoredAgent`) is a DIFFERENT CONCEPT from `kailash.delegate.Delegate` (new, composition primitive). The new class CAN wire the old one as an `executor=` argument. Both classes MUST carry explicit docstring disambiguation:
+
+```python
+# kailash/delegate/runtime.py
+class Delegate:
+    """Delegate composition primitive (Connector × Signature × Envelope × Executor).
+
+    DISAMBIGUATION: NOT kaizen_agents.delegate.Delegate (LLM execution facade).
+    This is the audit-grade composition surface under EATP audit per #1035.
+    The kaizen-agents Delegate is one possible `executor=` argument.
+    """
+```
+
+```python
+# packages/kaizen-agents/src/kaizen_agents/delegate/delegate.py
+class Delegate:
+    """LLM execution facade composing AgentLoop, L3GovernedAgent, MonitoredAgent.
+
+    DISAMBIGUATION: NOT kailash.delegate.Delegate (composition primitive).
+    This Delegate orchestrates LLM-level agent execution; the composition-primitive
+    Delegate at `from kailash.delegate import Delegate` is a higher-level
+    audit-grade surface that can use this class as its `executor=` argument.
+    """
+```
+
+## Cross-impl conformance contract
+
+Per Agent 2: `delegate_spec_vectors() -> Vec<ConformanceVector>` is the rs source. We vendor as checked-in JSON fixtures under `src/kailash/delegate/conformance/fixtures/`. Each fixture is byte-canonical-equal to rs `Vec<ConformanceVector>` JSON serialization. py runs the vectors through its own engine + emits `ConformanceReceipt`. `receipts_agree(rs_receipt, py_receipt)` is the cross-impl gate. Today 2 vectors: DV-5-001 (§5 monotonic tightening), DV-10-001 (§10 G1 principal separation). py inherits both at M7-02.
+
+Cross-impl drift surface: when rs adds DV-X-NNN, py CI MUST pull the new fixture in the next release window. Fence: a `vendored-vectors-currency` CI check comparing local fixture commit-SHA against rs upstream HEAD.
+
+## Test strategy
+
+Per `rules/testing.md` 3-tier with NO mocking at Tiers 2/3:
+
+- **Tier 1 (unit)** — pure-type tests (envelope.intersect symmetry, lifecycle edge enumeration, posture ratchet monotonicity).
+- **Tier 2 (integration)** — real PACT engine + real Postgres EATP audit chain (#1035 acceptance criterion: "Pure-Python Delegate runs end-to-end vs a real PACT engine + real Postgres audit (NO mocks at the boundary)").
+- **Tier 3 (E2E)** — conformance-vector replay via `python -m kailash.delegate.conformance` + cross-impl receipt comparison fixture.
+
+## CI fences
+
+- F1: conformance package has zero engine deps (grep + pyproject extras manifest check).
+- F2: vendored vectors byte-canonical against rs upstream (commit-SHA tracking).
+- F3: lifecycle edge enumeration exhaustive (no missing-state-coverage warning).
+- F4: receipt protocol round-trip — py-emitted receipt parseable by rs verifier shape contract.

--- a/workspaces/issue-1035-delegate-py/04-validate/R1-cross-check-stand-down.md
+++ b/workspaces/issue-1035-delegate-py/04-validate/R1-cross-check-stand-down.md
@@ -1,0 +1,78 @@
+# R1 Redteam Cross-Check (stand-down hand-off, 2026-05-24)
+
+**Status:** This session ran an independent R1 multi-agent redteam on shipped
+`src/kailash/delegate/` THEN stood down on user direction — the parallel
+`feat/1035-redteam-integration` line (verifier.py + Connector 4-primitive
+rebuild + naming aliases, ~3795 LOC) is the AUTHORITATIVE line for #1035
+convergence. This file preserves this session's R1 findings as a
+cross-reference input for the authoritative session. It is NOT a competing
+disposition.
+
+## Provenance
+
+- 3 parallel agents (reviewer + security-reviewer + general-purpose closure-parity), base SHA `6f22db92b` (main, pre-parallel-shards).
+- Surface reviewed: the SHIPPED `src/kailash/delegate/` at v2.25.2 — i.e. BEFORE the parallel session's verifier.py / Connector-rebuild work landed on feat/1035-redteam-integration.
+
+## Headline verdict (this session's calibration)
+
+**0 CRIT / 0 HIGH** on the shipped surface. 4 MED + 5 LOW, predominantly
+docstring-drift / cross-SDK overclaim class. 418 tests collected, 377 passed
+
+- 1 skip (unit), 0 Tier-2/3 mocks. All 6 #1035 acceptance criteria PASS as code.
+
+## Severity-calibration divergence vs the authoritative line (IMPORTANT)
+
+The authoritative session's Round 1 (analyst-led) classified the API-naming
+mismatch as **5 CRITICAL** and treated signature-verification absence as
+**C1 + H2** (→ built `verifier.py`). This session's calibration differs:
+
+- **API-naming mismatch:** this session rated **MINOR** (PASS-with-renamed-API
+  — README §357 already publishes shipped names; renaming post-v2.24.0 is a
+  breaking change). The authoritative line resolves it by ADDING ALIASES
+  (`Delegate = DelegateRuntime`, etc.) — a valid resolution this session did
+  not object to; merely a different disposition than "update #1035 body."
+- **Signature verification (C1/H2):** this session's security agent reviewed
+  the audit/crypto surface (canonical_json_dumps + 128-char hex validation +
+  monotonic sequence under emit lock) and did NOT flag missing signature
+  verification as CRIT/HIGH. The authoritative line treated it as CRITICAL and
+  built `verifier.py` (Ed25519Verifier). **If the authoritative C1/H2 finding
+  is correct, this session's security agent UNDER-classified** — the
+  authoritative verifier.py work is the safer disposition. Recorded here so the
+  divergence is auditable, not silently dropped.
+
+## This session's R1 findings (cross-reference)
+
+| Sev   | File:line                                                                      | Class                | Note for authoritative session                                                                                                         |
+| ----- | ------------------------------------------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| MED   | `runtime.py:907-915`                                                           | stale docstring      | claims grantee registry is "future S7+" — already shipped #1146/#1158. May already be touched by parallel runtime.py +82 diff; verify. |
+| MED   | `envelope.py:96`                                                               | misleading wording   | "only widening path" prose imprecise (bare `__init__` + `from_dict` also set fresh inner).                                             |
+| MED   | `audit.py:29-34`, `dispatch.py:501-507/644-650`, `conformance/schema.py:14-16` | cross-SDK overclaim  | byte-canonical-to-rs claims lack pinned rs vectors per cross-sdk-inspection.md Rule 4.                                                 |
+| MED   | `trust.py:428-463, 600-611`                                                    | cascade-as-authority | any cascade holder can register grantees; documented as #1147 territory; architectural (exceeds shard budget).                         |
+| LOW   | `runtime.py:1057-1112`                                                         | deferred nonce       | `human_acknowledged_nonce` syntactic-only; needs tracking-issue link per zero-tolerance Rule 1b.                                       |
+| LOW   | `dispatch.py:1425-1430`                                                        | signer attribution   | 32-char lower-bound vs strict 128; misroutes error attribution. (May be superseded by parallel verifier.py.)                           |
+| LOW   | `audit.py:213,234`                                                             | parity-but-blocked   | `REASONING_SCRATCHPAD` rejection path needs a Tier-2 test asserting it fires.                                                          |
+| LOW   | `trust.py:600-611`                                                             | defense-in-depth     | `cascade_child` registers parent idempotently w/o membership check; #1147 adjacent.                                                    |
+| MINOR | `__init__.py`                                                                  | API naming           | shipped vs #1035-body names — RESOLVED by authoritative line's aliases.                                                                |
+
+## loom#350 triangulation (this session, see journal/0007 for the authorization receipt)
+
+All 7 loom#350 emit-discipline findings reproduce on this repo's synced
+artifacts. NONE invalidate the delegate code disposition. Finding 2 (analyst
+declares Edit/Write/Task contradicting `rules/agents.md` read-only
+classification) is the systemic gap that BOTH redteam lines navigated:
+this session dispatched general-purpose for closure-parity (correct per rule);
+the authoritative line dispatched analyst (the agent file's wrong tools made
+that path available). Disposition: loom-source fix, fix-the-class via the
+#350 pre-emit validator.
+
+## Hand-off recommendation
+
+The authoritative line should:
+
+1. Verify the MED docstring-drift findings above weren't masked by its own
+   runtime.py/audit.py/trust.py diffs.
+2. Treat the C1/H2 verifier.py work as the correct (safer) disposition — this
+   session's 0-CRIT/HIGH calibration on the crypto surface was the more
+   permissive read.
+3. Pick ONE naming disposition (aliases — already chosen by authoritative line)
+   and update #1035 body OR keep aliases; do not do both half-way.

--- a/workspaces/issue-1035-delegate-py/briefs/00-brief.md
+++ b/workspaces/issue-1035-delegate-py/briefs/00-brief.md
@@ -1,0 +1,7 @@
+# Brief — Implement Delegate composition primitive in kailash-py (#1035)
+
+**User directive (verbatim, 2026-05-21):** "proceed, please /autonomize in parallel and /redteam to convergence. I'm puzzled, why wasn't Delegate built? its core in kaizen right? Please check kailash-rs (cross repo) and verify Delegate is built there too"
+
+**Issue:** terrene-foundation/kailash-py #1035 — `feat(delegate): open Delegate composition reference — kailash.delegate (Apache 2.0, Terrene-pledged substrate)`.
+
+**Cross-repo authorization:** journal/0001 covers the read-only sweep of `~/repos/loom/kailash-rs` (sibling Rust SDK).

--- a/workspaces/issue-1035-delegate-py/journal/0001-cross-repo-authorization-kailash-rs-check.md
+++ b/workspaces/issue-1035-delegate-py/journal/0001-cross-repo-authorization-kailash-rs-check.md
@@ -1,0 +1,12 @@
+# 0001 — Cross-Repo Authorization: Read-only check of kailash-rs Delegate status
+
+**Date:** 2026-05-21
+**Requester:** user (jack@researchroom.sg)
+**Verbatim instruction:** "Please check kailash-rs (cross repo) and verify Delegate is built there too"
+**Target repo:** terrene-foundation/kailash-rs (sibling SDK)
+**Action (bounded):** read-only — `gh issue list/view` for Delegate references, filesystem `ls`/`grep` against `~/repos/loom/kailash-rs/` checkout if present, to verify whether the Delegate composition primitive (Connector × Signature × Envelope × Executor, per Delegate Spec v0) is implemented in the Rust SDK.
+**Scope exclusions:** no writes, no PRs, no comments, no source edits, no issue creation against kailash-rs in this session.
+
+cross-repo-authorized: terrene-foundation/kailash-rs
+
+Per `rules/repo-scope-discipline.md` § User-Authorized Exception. Authorization is limited to this single read sweep; any subsequent cross-repo action (filing a paired issue, opening a PR) requires a fresh user gate.

--- a/workspaces/issue-1035-delegate-py/journal/0002-cross-repo-authorization-rs-conformance-vendoring.md
+++ b/workspaces/issue-1035-delegate-py/journal/0002-cross-repo-authorization-rs-conformance-vendoring.md
@@ -1,0 +1,78 @@
+# Cross-repo authorization — kailash-rs conformance fixture vendoring (S7)
+
+cross-repo-authorized: terrene-foundation/kailash-rs
+
+## Requester
+
+User (jack@researchroom.sg) via AskUserQuestion turn, 2026-05-22.
+
+## Target
+
+`terrene-foundation/kailash-rs` (resolver logical key: `build.rs`).
+
+## Bounded action
+
+READ-only operations on `terrene-foundation/kailash-rs` working tree to locate
+
+- copy conformance fixture files for the kailash.delegate composition primitive
+  (issue #1035). Specifically:
+
+* Locate conformance fixture files under `bindings/kailash-rs/test-vectors/`,
+  `specs/delegate-conformance/`, or equivalent directory containing JSON byte-
+  shape pin vectors for: TAOD transitions, DispatchResult, ConnectorInvocation
+  Result, AuditChainEntry, RuntimeExecutionResult round-trip.
+* Read those files (via `cat`, `Read`, or `grep` against the rs working tree).
+* Vendor (copy byte-for-byte) the canonical fixture files into kailash-py at
+  `tests/fixtures/delegate-conformance/` per `cross-sdk-inspection.md` Rule 4a
+  (Sibling-Canonical Fixtures MUST Be Vendored, Not Re-Authored).
+
+## Explicitly excluded
+
+- NO writes to kailash-rs working tree
+- NO `gh pr create` / `gh issue create` against kailash-rs
+- NO `gh issue comment` / `gh pr comment` against kailash-rs
+- NO incidental reads of kailash-rs source beyond the conformance fixtures
+  enumerated above
+- NO modifications to rs branches
+
+## Verbatim user instruction (AskUserQuestion 2026-05-22)
+
+> "Yes — READ-only on terrene-foundation/kailash-rs conformance fixtures
+> (Recommended)"
+>
+> Bounded action: READ-only. Target: terrene-foundation/kailash-rs. Scope:
+> locate + copy conformance fixture files (likely under
+> bindings/kailash-rs/test-vectors/ or specs/delegate-conformance/) for TAOD
+> transitions, Dispatch byte-shapes, RuntimeExecutionResult round-trip,
+> AuditChainEntry hashes. NO writes, NO PRs, NO comments on rs side. Journal
+> entry lands BEFORE first gh/cat/grep command per User-Authorized Exception
+> condition 4. Repo registered via bin/lib/loom-links.mjs::resolveRepo per
+> cross-repo.md MUST-1.
+
+## Five-condition compliance (repo-scope-discipline.md User-Authorized Exception)
+
+1. **User-initiated** ✅ — AskUserQuestion turn 2026-05-22 (not agent-suggested)
+2. **Explicit + specific** ✅ — named target repo + bounded READ action
+3. **Confirmed** ✅ — restated by agent + user answered selected option
+4. **Journaled before acting** ✅ — this file lands BEFORE first cross-repo
+   command (verified by grep `cross-repo-authorized: terrene-foundation/kailash-rs`
+   in `journal/.pending/` or committed journal entries pre-dating any rs read)
+5. **Scoped exactly** ✅ — only READ on the named repo; no scope creep
+
+## Receipt
+
+Journal entry committed to `workspaces/issue-1035-delegate-py/journal/` at
+`0002-cross-repo-authorization-rs-conformance-vendoring.md` BEFORE first
+cross-repo command. Greppable marker line above: `cross-repo-authorized:
+terrene-foundation/kailash-rs`.
+
+## Disposition for S7 worktree-isolated agent
+
+The agent operates in a worktree at `.claude/worktrees/delegate-s7`. The
+authorization extends to that agent for the bounded READ action only. The
+agent's prompt MUST include this journal entry by reference + the
+five-condition compliance reminder.
+
+## Timestamp
+
+2026-05-22 (session in progress).

--- a/workspaces/issue-1035-delegate-py/journal/0003-DECISION-s7-conformance-schema-alignment-with-rs.md
+++ b/workspaces/issue-1035-delegate-py/journal/0003-DECISION-s7-conformance-schema-alignment-with-rs.md
@@ -1,0 +1,196 @@
+---
+type: DECISION
+date: 2026-05-22
+created_at: 2026-05-22T00:00:00+00:00
+author: co-authored
+project: issue-1035-delegate-py
+topic: S7 conformance schema design — alignment with rs canonical schema + Fence B
+phase: implement
+tags: [s7, conformance, cross-sdk, fence-b, behavioural-only]
+---
+
+# S7 ConformanceVector schema — design alignment with kailash-rs canonical
+
+## Context
+
+S7 of issue #1035 (Delegate composition primitive) ships the conformance schema
+
+- first cross-SDK byte-shape vectors. The brief proposed:
+
+* `ConformanceVector(vector_id, category, inputs, expected_byte_hash, expected_payload, pinned_at, pinned_by_sdk)`
+* `receipts_agree(rs_result: RuntimeExecutionResult, py_result: RuntimeExecutionResult) -> ReceiptsAgreeReport`
+* 5 JSON-fixture vectors with SHA-256 hashes of canonical-JSON serializations
+
+Discovery of the kailash-rs canonical (`crates/kailash-delegate-conformance/`, READ-only
+per `repo-scope-discipline.md` User-Authorized Exception receipt at journal/0002)
+surfaced two structural constraints that force a re-design:
+
+## Discovery — rs canonical schema (READ-only inspection)
+
+The rs crate `kailash-delegate-conformance` (Cargo.toml `publish = false` +
+`LicenseRef-Proprietary`, with OSS-mirror plan documented in lib.rs) ships:
+
+1. **`ConformanceVector { id, spec_anchor: SpecAnchor, given, behaviour, expected: BehaviouralOutcome }`** —
+   behavioural-only assertions anchored to Delegate-spec § numbers.
+   `BehaviouralOutcome` is a CLOSED enum: `Accept | Reject | EscalateToHuman`.
+2. **`ConformanceReceipt { implementation, vector_crate_version, commit_sha, vectors_total, vectors_passed }`** —
+   counts-based cross-impl agreement record.
+3. **`receipts_agree(a, b) -> bool`** — verifies BOTH receipts name SAME
+   `(vector_crate_version, commit_sha)` AND both fully conformed AND impls
+   are DISTINCT. NEVER a field-by-field engine diff.
+4. **F1 fence** — the conformance crate depends on NO `kailash-delegate-*`
+   engine crate; an engine symbol structurally cannot resolve.
+5. **F4 protocol** — the spec deliberately AVOIDS field-by-field engine diff:
+   "Naively, 'agree' would mean diffing the two engines' outputs field-by-field —
+   but that re-introduces the F1 leak (an engine internal becomes the comparison key)."
+
+## Constraints This Imposes On S7
+
+### Constraint 1 — Fence B (`tools/lint-delegate-fences.py:42-51`)
+
+`conformance/` MUST NOT import `kailash.delegate.runtime`, `dispatch`, `trust`,
+`audit`, `posture`. The brief's `receipts_agree(rs: RuntimeExecutionResult,
+py: RuntimeExecutionResult)` signature would directly import
+`kailash.delegate.runtime.RuntimeExecutionResult` into `conformance/schema.py` —
+**this would fail the lint at first push.**
+
+### Constraint 2 — F1 Licensing Fence (rs spec)
+
+A vector that round-trips `RuntimeExecutionResult.to_dict()` bytes from kailash-py
+WITHOUT corresponding rs-side bytes would assert a Python-side engine internal as
+a cross-SDK contract. When rs gets its delegate runtime, its byte-shape MUST match
+the pinned vector — but right now rs has NO delegate runtime (only the
+conformance schema crate). Pinning RuntimeExecutionResult bytes today
+unilaterally locks rs into matching py's encoding before rs has authored its own.
+
+### Constraint 3 — cross-sdk-inspection.md Rule 4a (sibling-canonical vendoring)
+
+The rs `ConformanceVector` schema (behavioural-only) IS THE CANONICAL. Vendoring
+means kailash-py adopts the rs schema shape — not the brief's `byte_hash` shape.
+A parallel `byte_hash`-shaped py-side schema would be the exact "parallel
+hand-authored copy" Rule 4a blocks (sibling-canonical fixtures MUST be vendored,
+not re-authored).
+
+## Design Decision
+
+**Adopt the rs canonical schema shape AND add a public-surface dict-shape
+receipts-agree comparator that satisfies the brief's parity-verification intent
+without violating Fence B.**
+
+Specifically:
+
+### Layer 1 — Behavioural conformance (vendored from rs canonical)
+
+`src/kailash/delegate/conformance/schema.py` exports:
+
+- `SpecAnchor` — dotted-decimal Delegate-spec § anchor, validated by
+  `TryFrom<String>` equivalent in Python (`SpecAnchor.from_str`); raises
+  `SchemaError` on malformed input. Byte-identical wire shape with rs:
+  serializes as bare section string (e.g. `"7.3"`).
+- `BehaviouralOutcome(Enum)` — `ACCEPT | REJECT | ESCALATE_TO_HUMAN`. CLOSED
+  taxonomy. JSON-serializes as PascalCase (`Accept | Reject | EscalateToHuman`)
+  matching rs `serde` default.
+- `ConformanceVector` — frozen dataclass with `id`, `spec_anchor`, `given`,
+  `behaviour`, `expected`. Validates all required fields non-empty via `validate()`.
+- `validate_vector_set(vectors)` — checks unique IDs, all individually valid.
+- `ConformanceVectorLoader` — `load_canonical()` from
+  `tests/fixtures/delegate-conformance/canonical.json` (vendored byte-identical
+  from rs once rs ships the JSON form).
+
+### Layer 2 — Conformance receipt + receipts_agree (vendored from rs canonical)
+
+`ConformanceReceipt(implementation, vector_crate_version, commit_sha,
+vectors_total, vectors_passed)` + `receipts_agree(a, b) -> bool`. Counts-based,
+not engine-diff. Byte-identical wire shape with rs.
+
+### Layer 3 — Dict-shape comparator (Python-OSS-only extension; honors Fence B)
+
+`receipts_agree_dict(a: dict, b: dict, *, exclude_fields: frozenset[str] = ...)
+-> ReceiptsAgreeReport` operates on ALREADY-SERIALIZED `RuntimeExecutionResult.to_dict()`
+output. The dict input is JSON, not an engine class — `conformance/` can compare
+JSON shapes without importing engine modules.
+
+This satisfies the brief's `receipts_agree(rs, py)` intent: callers serialize
+their RuntimeExecutionResult via `.to_dict()` (a method on the engine), pass
+the dicts in, get a structured `ReceiptsAgreeReport` back. Engine internals
+NEVER cross the conformance boundary.
+
+`exclude_fields` defaults to `frozenset({"terminated_at", "executed_at"})` —
+observation-local fields not part of cross-impl contract.
+
+### Layer 4 — Canonical fixtures (Python-OSS-only first; rs catches up)
+
+`tests/fixtures/delegate-conformance/canonical.json` ships 5 behavioural vectors:
+
+- DV-3-001 (§3 R2 composition validation)
+- DV-5-001 (§5 monotonic tightening — mirrors rs catalog.rs vector)
+- DV-7-001 (§7 TAOD lifecycle phase monotonicity)
+- DV-9-001 (§9 audit chain emission)
+- DV-10-001 (§10 G1 service-account separation — mirrors rs catalog.rs vector)
+
+Each vector is byte-shape-compatible with rs `ConformanceVector` serde encoding.
+When rs ships its JSON vector loader, we vendor rs's canonical.json byte-for-byte
+per Rule 4a.
+
+## What Changes vs The Brief
+
+| Brief proposed                                  | Actually shipping                                           | Why                                          |
+| ----------------------------------------------- | ----------------------------------------------------------- | -------------------------------------------- |
+| `expected_byte_hash`-shape vectors              | Behavioural-outcome-shape vectors (rs canonical)            | Rule 4a sibling-canonical vendoring          |
+| `receipts_agree(RuntimeExecutionResult, ...)`   | `receipts_agree(ConformanceReceipt, ConformanceReceipt)`    | Fence B + rs F4 protocol                     |
+| `byte_hash` field on each vector                | `expected: BehaviouralOutcome` (closed enum)                | rs F1 fence (no engine internals in vectors) |
+| (not in brief)                                  | `receipts_agree_dict(dict, dict)` for runtime-result parity | Bridges brief's intent without Fence B viol  |
+| (not in brief)                                  | `validate_vector_set()` mirror of rs validator              | rs canonical mirror                          |
+| `pinned_by_sdk: Literal["py", "rs"]` provenance | NOT shipped (rs canonical doesn't carry this)               | Vendoring = byte-identical, no addenda       |
+
+## Invariants (5 — within shard budget)
+
+1. **Schema vendoring** — `ConformanceVector` / `SpecAnchor` / `BehaviouralOutcome`
+   / `ConformanceReceipt` / `receipts_agree` byte-shape-match rs.
+2. **Fence B preserved** — `conformance/schema.py` imports ZERO
+   `kailash.delegate.{runtime,dispatch,trust,audit,posture}` symbols.
+3. **Behavioural-only** — `BehaviouralOutcome` is a CLOSED enum; vectors cannot
+   smuggle engine internals.
+4. **Dict-shape parity contract** — `receipts_agree_dict` excludes timestamps
+   AND uses ordered comparison for `audit_chain_entries` + `transitions`.
+5. **Validating deserialization** — every vector deserialized from JSON routes
+   through the same validator as in-code construction (no smuggling malformed
+   anchors past the schema).
+
+## Consequences
+
+- S7 ships a behaviourally-correct, byte-shape-compatible-with-rs conformance
+  schema FIRST. rs catches up to ship its JSON vector loader; py vendors then.
+- The brief's `RuntimeExecutionResult` byte-comparison intent is preserved
+  via Layer-3 dict-comparator that engine-callers feed via `.to_dict()` on
+  the public API surface — Fence B intact.
+- The "first 5 vectors" deliverable lands as behavioural vectors (not byte
+  hashes); when rs ships byte-shape vectors of `RuntimeExecutionResult`,
+  those vendor in as a SECOND fixture file
+  (`tests/fixtures/delegate-conformance/runtime-byte-shapes.json`).
+
+## For Discussion
+
+1. (Counterfactual) Would shipping `byte_hash`-shape vectors today, then
+   "fixing" them when rs catches up, be cheaper? — No: doing so creates a
+   parallel hand-authored copy that drifts from rs canonical (Rule 4a
+   violation), and the "fix" later requires every downstream test
+   referencing the byte-hash shape to break + migrate.
+2. (Specific data) The rs `BehaviouralOutcome` enum is non_exhaustive in
+   Rust; should py's `BehaviouralOutcome` also be open-ended? — Python
+   enums are inherently extensible (subclassing); the closed-taxonomy
+   semantics live in `from_str` validation that raises on unknown variant.
+   Matches rs runtime behavior (deserializer rejects unknown variants).
+3. (Counterfactual) If rs never ships JSON vector loader, does py's
+   `canonical.json` become the de-facto canonical? — Yes; per Rule 4a's
+   "byte-identical" intent, py becomes canonical the moment it ships AND
+   rs vendors py's `canonical.json` when rs ships its loader. The direction
+   of canonicalness flips based on who lands first; the OSS mirror is the
+   long-term canonical reference per rs lib.rs commentary.
+
+## Receipt
+
+This entry lands at `workspaces/issue-1035-delegate-py/journal/0003-DECISION-s7-conformance-schema-alignment-with-rs.md`
+BEFORE any schema file is written. The companion journal/0002 records the
+cross-repo READ authorization; this entry records the design pivot from the
+brief's byte-shape intent to the rs canonical behavioural-only schema.

--- a/workspaces/issue-1035-delegate-py/journal/0004-AUTHORIZATION-cross-repo-rs-f5-upstream-issue-filings.md
+++ b/workspaces/issue-1035-delegate-py/journal/0004-AUTHORIZATION-cross-repo-rs-f5-upstream-issue-filings.md
@@ -1,0 +1,61 @@
+# 0004 — AUTHORIZATION — Cross-Repo F5 Upstream Issue Filings (kailash-rs)
+
+cross-repo-authorized: terrene-foundation/kailash-rs
+
+## Authorization receipt
+
+- **Requester:** session operator (resolved via `lib/operator-id.js`)
+- **Target repo:** `terrene-foundation/kailash-rs`
+- **Bounded action:** file two (2) upstream issues for cross-SDK semantic-parity gaps:
+  - Issue A: principal-kind taxonomy on `DelegateIdentity` / `Role` / `DispatchSurface`
+  - Issue B: grantee registry on `TenantScopedCascade` + dispatch identity-bind validation
+- **Timestamp:** 2026-05-24 (session window 02:30Z+)
+- **Authority chain:** `repo-scope-discipline.md` § User-Authorized Exception (5-condition test)
+
+## 5-Condition Test (each satisfied)
+
+1. **User-initiated** ✓ — verbatim user turn: "approved, pelase /autonomize in parallel and /redteam to convergence" (responding to recommendation that named target + bounded action explicitly)
+2. **Explicit + specific** ✓ — prior session message named target repo `terrene-foundation/kailash-rs` and bounded action (file 2 upstream issues for principal-kind taxonomy + grantee-registry parity)
+3. **Confirmed** ✓ — agent presented recommendation A naming target + action; user responded "approved" before any cross-repo command ran
+4. **Journaled before acting** ✓ — this entry; this line predates any `gh` invocation against `terrene-foundation/kailash-rs` in this session
+5. **Scoped exactly** ✓ — only the named action (2 upstream issue filings) against only the named repo; per-issue gate per `upstream-issue-hygiene.md` MUST-1 still applies before each submission; incidental reads against the rs repo are limited to (a) duplicate-issue existence check (`gh issue list`), (b) public-source verification of named symbols if needed for minimal-repro accuracy
+
+## Stacked discipline
+
+- **`upstream-issue-hygiene.md` MUST-1** — drafting permitted under this authorization; _submission_ of each issue requires its OWN per-issue gate (each draft body presented for explicit y/N approval)
+- **`upstream-issue-hygiene.md` MUST-2** — both issue bodies MUST be scrubbed of downstream-context tokens (no `/redteam` references, no kailash-py PR numbers, no workspace shard IDs, no internal rule file paths)
+- **`upstream-issue-hygiene.md` MUST-3** — 5-section shape only (Affected API / Minimal repro / Expected vs actual / Severity / Acceptance criteria)
+- **`verify-resource-existence.md` MUST-1** — duplicate-issue existence check against `terrene-foundation/kailash-rs` precedes drafting
+
+## Source surfacing context (LOCAL ONLY — does not leak into issue bodies)
+
+The semantic-divergence claims this authorization covers were surfaced via the kailash-py side of the cross-SDK parity contract:
+
+- principal-kind taxonomy: kailash-py issue surfaced + closed via local fix; the rs side remains uncovered (cross-SDK parity is the open work)
+- grantee registry: kailash-py issue surfaced + closed via local fix; the rs side `TenantScopedCascade` lacks the corresponding grantee tracking
+
+These surfacing details belong in THIS journal entry (local context); they MUST NOT appear in the upstream issue bodies per `upstream-issue-hygiene.md` MUST-2.
+
+## Closure criteria for this authorization
+
+- (a) two issue bodies drafted, redteam-converged, and presented for per-issue gates; or
+- (b) one filed + one declined by user at gate; or
+- (c) both declined by user at gate.
+
+Any outcome that proceeds beyond (a) authorization scope (e.g. filing a third issue, opening a PR, commenting on existing rs issues) requires a fresh user-initiated authorization with its own journal entry.
+
+## ⚠ AUTHORIZATION VOID — TARGET DOES NOT EXIST AS NAMED
+
+Per `verify-resource-existence.md` MUST-1 existence check (live `gh api`):
+
+| Repo                            | Exists | Accessibility          | Notes                                                                                                        |
+| ------------------------------- | ------ | ---------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `terrene-foundation/kailash-rs` | **NO** | 404                    | The org has NO `kailash-rs` repo. Authorization target does NOT exist.                                       |
+| `esperie-enterprise/kailash-rs` | YES    | private, gh can access | Described as canonical BUILD repo (esperie-enterprise is private org)                                        |
+| `rrps-mtu/kailash-rs`           | YES    | private, gh can access | "verbatim seed of esperie-enterprise/kailash-rs; upstream tracked via git remote, forking disabled upstream" |
+
+Per `repo-scope-discipline.md` User-Authorized Exception condition 2 ("Explicit + specific — names the target repo"), substituting one repo for another would self-extend authorization — BLOCKED. The session HALTS here for user re-authorization with the correct target named.
+
+This authorization (0004) is recorded as voided-at-existence-check. Filing actions did NOT proceed. The cross-repo-authorized marker at the top of this file remains for audit completeness, but no `gh issue create` has been issued.
+
+Outcome: surfaced to user for explicit re-authorization naming the correct target repo.

--- a/workspaces/issue-1035-delegate-py/journal/0005-AUTHORIZATION-cross-repo-esperie-enterprise-kailash-rs-f5.md
+++ b/workspaces/issue-1035-delegate-py/journal/0005-AUTHORIZATION-cross-repo-esperie-enterprise-kailash-rs-f5.md
@@ -1,0 +1,82 @@
+# 0005 — AUTHORIZATION — Cross-Repo F5 Upstream Issue Filings (esperie-enterprise/kailash-rs)
+
+cross-repo-authorized: esperie-enterprise/kailash-rs
+
+Supersedes: 0004 (voided — target `terrene-foundation/kailash-rs` does not exist per live `gh api` check)
+
+## Authorization receipt
+
+- **Requester:** session operator (resolved via `lib/operator-id.js`)
+- **Target repo:** `esperie-enterprise/kailash-rs` (verified existing + accessible + issues enabled via `gh api repos/esperie-enterprise/kailash-rs`)
+- **Bounded action:** file two (2) upstream issues for cross-SDK semantic-parity gaps:
+  - Issue A: principal-kind taxonomy on rust `DelegateIdentity` / `Role` / `DispatchSurface`
+  - Issue B: grantee registry on rust `TenantScopedCascade` + dispatch identity-bind validation
+- **Timestamp:** 2026-05-24 (session window post-12:30Z)
+- **Authority chain:** `repo-scope-discipline.md` § User-Authorized Exception (5-condition test)
+
+## 5-Condition Test (each satisfied)
+
+1. **User-initiated** ✓ — verbatim user turn: "approved" in response to a recommendation that explicitly named `esperie-enterprise/kailash-rs` as target + 2-issue bounded action
+2. **Explicit + specific** ✓ — prior session message recommended target `esperie-enterprise/kailash-rs` with rationale (canonical BUILD per its own description) vs `rrps-mtu/kailash-rs` (downstream seed with forking disabled); user approved the recommendation pick
+3. **Confirmed** ✓ — recommendation surfaced + named target + user responded "approved" before any cross-repo command ran against the new target
+4. **Journaled before acting** ✓ — this entry; this line predates any `gh` invocation against `esperie-enterprise/kailash-rs` in this session
+5. **Scoped exactly** ✓ — only 2 issue filings against the named repo; per-issue gate per `upstream-issue-hygiene.md` MUST-1 still applies before each submission; incidental reads against the rs repo are limited to (a) duplicate-issue existence check (`gh issue list`), (b) public-source verification of named rust symbols for minimal-repro accuracy
+
+## Stacked discipline
+
+- **`upstream-issue-hygiene.md` MUST-1** — drafting permitted; _submission_ of each issue requires its OWN per-issue gate
+- **`upstream-issue-hygiene.md` MUST-2** — scrub all downstream-context tokens from both bodies (no `/redteam` references, no kailash-py PR numbers, no workspace shard IDs, no internal rule file paths). Note: esperie-enterprise being private does NOT relax scrub — consumer-context tokens leak across org boundaries even in private repos
+- **`upstream-issue-hygiene.md` MUST-3** — 5-section shape only
+- **`verify-resource-existence.md` MUST-1** — duplicate-issue check + named-symbol verification against the rs source precede drafting
+
+## Notes on private-repo context
+
+`esperie-enterprise` is a private org. The user owns this org (per `esperie-enterprise/delegate-connectors-enterprise` description: "consumes the kailash-delegate-\* spine — esperie-enterprise/kailash-rs#988"). Filing in a private repo controlled by the user is structurally bounded — but cross-repo discipline still applies because each repo has its own conventions, protection rules, and maintainer ownership.
+
+## Closure criteria for this authorization
+
+Same as 0004: (a) two drafts redteam-converged + presented for per-issue gates; or (b) one filed + one declined; or (c) both declined. Any expansion (third issue, PR, comment) requires fresh authorization.
+
+## ⚠ FINDINGS — Both Py-Side Gaps Already Structurally Closed In Rs
+
+Per `verify-resource-existence.md` MUST-3, before drafting issues I verified the rs source state. Reads were limited to authorization condition 5 scope (existence + named-symbol verification).
+
+### Finding 1 — principal_kind taxonomy (py #1143 equivalent): **closure-by-design on rs**
+
+Read: `crates/kailash-delegate-dispatch/src/lib.rs`, `crates/kailash-delegate-types/src/composition.rs::Principal`.
+
+The rs side achieves the §10 G1 invariant ("a sovereign principal cannot bind a service-account role; dispatch MUST refuse with a typed error") via **type-level structural enforcement**, not a runtime `principal_kind` field:
+
+- `auth::ConnectorAuth::ScopedDelegation` is the v0 default
+- **`Impersonation` enum variant does not exist** — compile-time guarantee enforced by an exhaustive-match test (`auth::tests::assert_no_impersonation_variant`)
+- `auth::assert_service_account_distinct` is invoked inside `Connector::authenticate` (the principal≠sovereign check, ratified G1 amendment (a))
+- `auth::ConnectorAuth::Substitution` is gated behind a default-off `substitution` Cargo feature (ratified G1 amendment (b)), not "inert by convention"
+
+The py approach (runtime `principal_kind: Literal[...]` + `permitted_principal_kinds: frozenset[...]` + runtime cross-check) and the rs approach (type-forbidden Impersonation variant + runtime distinctness assertion at authenticate) achieve the same invariant. The rs approach is arguably MORE robust because impersonation is _unrepresentable in the type system_ rather than runtime-checked.
+
+**Disposition:** NO ISSUE NEEDED. Filing would propose downgrading the rs structural enforcement to match the py runtime check.
+
+### Finding 2 — grantee registry (py #1146 equivalent): **closure-by-design on rs (with specific runtime wiring question)**
+
+Read: `crates/kailash-delegate-trust/src/grant.rs`, `crates/kailash-delegate-trust/src/cascade.rs`, `crates/kailash-delegate-dispatch/src/dispatch.rs`.
+
+The rs grant model is substantially more sophisticated than py's `frozenset[uuid.UUID]`:
+
+- `GrantSigner::DelegatedAuthority` carries a **mandatory** (non-Option, private field) `GrantedAuthority` back-reference to the substrate `delegation_id`
+- `GrantMoment::issue` walks the **CURRENT** delegation chain at issuance time (ratified H1 amendment HIGH: current-chain verification — revoked CFO fails CLOSED)
+- `GrantAuthorityEnvelope` caps the authority's max posture / capability classes / per-period grant count (ratified H1 amendment HIGH: grant-authority itself is envelope-bounded)
+- `DelegationRecord::is_active()` (substrate) is the authority-of-record; the spine adds no parallel revocation cache
+- `TenantScopedCascade.cascade_child` validates BOTH `DelegationScope::is_subset_of` AND PACT 5-dim `validate_tightening`, fail-closed on widening on either layer
+- `TenantScope` is a typed 2-variant enum (Tenant/Global) — explicit "global / unscoped" at every construction site (M-1 misconfiguration guard)
+
+**The py issue was "TenantScopedCascade.grantees: frozenset[UUID]" + "DispatchSurface validates identity.delegate_id in cascade.grantees".** The rs side instead binds grantees via cryptographic walkable-to-genesis lineage (`GrantSigner::DelegatedAuthority(GrantedAuthority{delegation_id})`) + current-chain verification at grant issuance. There is no `cascade.grantees: frozenset` because the cascade IS the lineage; membership is proven by `trace_to_genesis()` walking the substrate `DelegationChain`.
+
+**Open sub-question** (would change disposition if answered "no"): does `DispatchEngine` (or its caller in `kailash-delegate-runtime` composition) verify at dispatch time that the authenticated `Principal` is reachable in the active `TenantScopedCascade`'s lineage? The dispatch.rs I read is the idempotency layer (exactly-once dedup); the principal-in-cascade verification, if wired, would be in the runtime composition or trust-engine. I did NOT read the composition layer end-to-end — that's beyond the authorization's "minimal-repro accuracy" scope and would require a more invasive cross-repo read.
+
+**Disposition (recommended):** NO ISSUE NEEDED in current scope. If the open sub-question turns out to be unwired, the right issue is much narrower than the py port — specifically "wire principal-in-cascade-lineage check at DispatchEngine dispatch site" — and would need fresh authorization with the corrected scope.
+
+### Net outcome
+
+Both authorizations (0004 + 0005) close as **outcome (c) — both declined** in the closure criteria, but on the substantive ground that the gaps don't exist as framed, NOT because the user declined at gate. The F5 forest-ledger row should reclassify from "BLOCKED on user authorization for cross-repo write" to "CLOSED-BY-DISCOVERY — rs achieves both invariants by design; cross-SDK parity is structurally maintained via different mechanisms (py: runtime field, rs: type-level + cryptographic lineage)".
+
+The session-notes premise ("cross-SDK rs parity gap" naming `kailash-rs DelegateIdentity.principal_kind` + `TenantScopedCascade.grantees`) was based on py-side terminology not yet verified against rs source.

--- a/workspaces/issue-1035-delegate-py/journal/0007-AUTHORIZATION-cross-repo-esperie-enterprise-loom-350-triangulation.md
+++ b/workspaces/issue-1035-delegate-py/journal/0007-AUTHORIZATION-cross-repo-esperie-enterprise-loom-350-triangulation.md
@@ -1,0 +1,36 @@
+# 0006 — AUTHORIZATION — Cross-Repo Triangulation Read (esperie-enterprise/loom#350)
+
+cross-repo-authorized: esperie-enterprise/loom
+
+## Authorization receipt
+
+- **Requester:** session operator (user turn 2026-05-24, message "see issue 350 for triage and updating your results, its filed by dce and they are holding 7 issues to triangulate with your triage" — clarified to mean issue filed in `esperie-enterprise/loom`)
+- **Target repo:** `esperie-enterprise/loom`
+- **Bounded action:** read `esperie-enterprise/loom#350` body + comments + the 7 sub-issues referenced by #350 (8 total issue reads). NO writes. NO incidental reads beyond those 8 issues.
+- **Timestamp:** 2026-05-24 (session window post-R1-redteam reconciliation)
+- **Authority chain:** `repo-scope-discipline.md` § User-Authorized Exception (5-condition test)
+
+## 5-Condition Test (each satisfied)
+
+1. **User-initiated** ✓ — verbatim user turn naming `loom` as target + `issue 350` as the bounded action + "7 issues to triangulate" as the scope
+2. **Explicit + specific** ✓ — `esperie-enterprise/loom` confirmed as the target (`git remote -v` against `~/repos/loom` resolves `git@github.com:esperie-enterprise/loom.git`); action is bounded read of #350 + 7 referenced sub-issues
+3. **Confirmed** ✓ — agent restated action + target to user via AskUserQuestion; user selected "Yes — read #350 + 7 sub-issues only" before any `gh` invocation against esperie-enterprise/loom proceeds
+4. **Journaled before acting** ✓ — this entry; this line predates any `gh` command in this session against the target repo for the purposes of #350 triangulation
+5. **Scoped exactly** ✓ — only `gh issue view 350` + `gh issue view <sub-N>` for the 7 referenced sub-issues against `esperie-enterprise/loom`. No PR reads, no source reads, no writes, no comments.
+
+## Purpose
+
+The 7-finding evidence cluster in #350 is filed under the title "loom emit lacks pre-emit validation against own rule corpus — 7-finding evidence cluster (2026-05-23)". The R1 multi-agent redteam against shipped `src/kailash/delegate/` returned 0 CRIT / 0 HIGH + several MED/LOW findings primarily in the docstring-drift / cross-SDK overclaim class. User's instruction is to triangulate the loom-side 7-finding cluster against our delegate-side R1 triage to surface:
+
+- loom findings that INVALIDATE one of our R1 dispositions (e.g., the rule loom's emit validation would have caught was our exact bug class)
+- loom findings that EXTEND our R1 coverage (e.g., a finding class we missed)
+- loom findings that are LOOM-SIDE ONLY (no triangulation relevant to kailash-py delegate)
+
+## Closure criteria for this authorization
+
+(a) #350 + 7 sub-issues read; triangulation matrix produced + surfaced to user; OR (b) target inaccessible (404 / permission denied) → authorization terminates immediately and is logged here. Any expansion (8th issue read, PR read, source read, write) requires fresh authorization.
+
+## Notes
+
+- Per `feedback_commit_workspaces_for_team.md` (memory 2026-05-24): this journal entry MUST be committed to the kailash-py git history for receipt durability. The chore PR landing `workspaces/issue-1035-delegate-py/` (task #9) carries this entry as part of its diff.
+- Per `upstream-issue-hygiene.md` MUST-2: no scrub concern arises because this is a READ, not a write. No downstream-context tokens leak.


### PR DESCRIPTION
## Summary

Recovers + lands R1 redteam reconciliation fixes that were bypassed when PR #1164 merged `feat/1035-redteam-integration` to main at an earlier branch tip (the fixes were committed locally after the remote push, so they never reached the merged history). All target production code already shipped via #1164; this PR adds the correctness fixes on top.

### Production fixes (`src/kailash/delegate/`, pyright-clean after)
- **verifier.py** — `InvalidSignature` was imported inside the `verify()` try-block but referenced in the `except` clause; an import failure would raise `NameError` and mask the real error. Hoisted `cryptography` imports to module scope (core dep). **Real bug fix.**
- **runtime.py** — hoisted `LifecycleState` to module scope (was late-bound in `__init__` with string annotations + `noqa: F821` that pyright flagged `reportUndefinedVariable`); dropped stale "future S7+ grantee registry" docstring (registry shipped #1146/#1158).
- **dispatch.py** — signer surface check was `len < 32` (accepted 32-127 char non-signatures, misrouting attribution to the engine); tightened to the exact 128-char lowercase-hex Ed25519 contract. Removed dead `try/except ImportError` verifier fallback (shard-y `verifier.py` is now an in-tree sibling) that produced duplicate `Verifier`/`NullVerifier` types pyright flagged incompatible.
- **envelope.py** — `from_genesis` docstring claimed "SOLE constructor"/"only widening path" (false; `__init__` + `from_dict` also set fresh inner). Reworded to the accurate cross-constructor tightening-only invariant.
- **audit.py** — cross-SDK byte-equality docstring overclaimed "already byte-equal to rs per S2 survey" with no pinned rs vector; reworded to honest design-intent + conformance-receipt-verified (`cross-sdk-inspection.md` Rule 4).
- **test_dispatch.py** — updated signer-too-short assertion to the tightened 128-char contract message.

### Workspace receipt durability (CRIT-1)
Commits `workspaces/issue-1035-delegate-py/` analysis/plans/briefs/journals that were untracked, including the cross-repo authorization receipts (journal 0005 for `esperie-enterprise/kailash-rs` F5, 0007 for `esperie-enterprise/loom#350` triangulation) — per `repo-scope-discipline.md` § User-Authorized Exception condition 4 + `verify-resource-existence.md` MUST-4, these MUST be git-durable.

## Verification
- `pyright src/kailash/delegate/` → 0 errors, 0 warnings
- `pytest tests/unit/delegate tests/integration/delegate` → 487 passed, 1 skipped

## Known follow-up (NOT in this PR)
- 42 pyright errors in delegate TEST files (`MockConnector` vs the rebuilt 4-primitive `Connector` ABC — runtime-concrete but pyright sees abstract). Systematic test-double reconciliation tracked separately.

## Related issues
Follow-up to #1035 / #1164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)