### PR TITLE
fix(delegate): lazy-import cryptography in Ed25519Verifier — restore slim-core import

### DIFF
--- a/src/kailash/delegate/verifier.py
+++ b/src/kailash/delegate/verifier.py
@@ -48,12 +48,16 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-# cryptography is a core kailash dependency (the trust stack requires it).
-# Imported at module scope so `except InvalidSignature` always resolves —
-# importing inside the verify() try-block left the name unbound if the
-# import itself failed, masking the real error with a NameError.
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+# cryptography is NOT a core kailash dependency — it lives in the [trust] /
+# [server] extras (slim-core invariant; see pyproject.toml dependencies
+# comment + the #1154 lazy-filelock precedent). Module-scope import here
+# would break `from kailash.delegate import ...` on a bare `pip install
+# kailash`, since the delegate package is inside the slim-core import
+# closure. cryptography is imported lazily in Ed25519Verifier.__init__
+# (loud ImportError at construction if the extra is absent — the
+# established "loud failure at call site" pattern for extras-gated
+# capability), and the resolved symbols are cached on the instance so
+# verify() honours its NEVER-raises contract.
 
 if TYPE_CHECKING:  # pragma: no cover - typing-only
     from kailash.delegate.types import PrincipalDirectory
@@ -189,7 +193,29 @@ class Ed25519Verifier:
                 f"(facade-manager-detection.md MUST Rule 3: explicit "
                 f"framework dependency); got {type(directory).__name__}"
             )
+        # Lazy cryptography import — LOUD failure at construction if the
+        # [trust]/[server] extra is absent (slim-core invariant; bare
+        # `pip install kailash` does not ship cryptography). Resolving the
+        # symbols here (not at module scope) keeps `from kailash.delegate
+        # import ...` working on slim-core, and caching them on the
+        # instance lets verify() reference them while honouring its
+        # NEVER-raises contract. NullVerifier — the default — never
+        # constructs this class, so slim-core callers never hit the import.
+        try:
+            from cryptography.exceptions import InvalidSignature
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+                Ed25519PublicKey,
+            )
+        except ModuleNotFoundError as exc:  # pragma: no cover - extras-gated
+            raise ModuleNotFoundError(
+                "Ed25519Verifier requires the `cryptography` library, which "
+                "ships in the kailash [trust] / [server] extras. Install via "
+                "`pip install kailash[trust]` (or bind NullVerifier instead "
+                "for the fail-closed default). Underlying error: " + str(exc)
+            ) from exc
         self._directory = directory
+        self._Ed25519PublicKey = Ed25519PublicKey
+        self._InvalidSignature = InvalidSignature
 
     @property
     def directory(self) -> "PrincipalDirectory":
@@ -258,10 +284,10 @@ class Ed25519Verifier:
         # is raised on signature mismatch; any other exception (malformed key,
         # internal lib error) also falls closed.
         try:
-            public_key = Ed25519PublicKey.from_public_bytes(pk_bytes)
+            public_key = self._Ed25519PublicKey.from_public_bytes(pk_bytes)
             public_key.verify(bytes(signature), bytes(message))
             return True
-        except InvalidSignature:
+        except self._InvalidSignature:
             return False
         except Exception:  # pragma: no cover - catch-all for fail-closed
             # Per the Verifier protocol: NEVER raises. Any exception

--- a/tests/regression/test_issue_1035_delegate_slim_core_import.py
+++ b/tests/regression/test_issue_1035_delegate_slim_core_import.py
@@ -1,0 +1,71 @@
+"""Regression: `from kailash.delegate import ...` must work on slim-core.
+
+Issue #1035 follow-up — kailash 2.26.0 shipped `kailash.delegate.verifier`
+with a MODULE-SCOPE `from cryptography...` import. Because the delegate
+package is inside the slim-core import closure, a bare `pip install kailash`
+(which does NOT ship cryptography — it lives in the [trust]/[server] extras)
+raised `ModuleNotFoundError: No module named 'cryptography'` on the documented
+`from kailash.delegate import Delegate, ...` line.
+
+The fix moves the cryptography import to be lazy inside `Ed25519Verifier.__init__`
+(loud `ModuleNotFoundError` at construction if the extra is absent; the
+established "loud failure at call site" pattern for extras-gated capability).
+`NullVerifier` — the default — needs no cryptography.
+
+These are BEHAVIORAL regression tests (subprocess + sys.modules introspection),
+not source-grep, so they survive refactors per `rules/testing.md`.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.regression
+def test_delegate_import_does_not_eager_load_cryptography():
+    """`import kailash.delegate` MUST NOT pull cryptography into sys.modules.
+
+    This is the slim-core invariant: the delegate package is importable on a
+    bare `pip install kailash` where cryptography is absent. Asserting that
+    cryptography is NOT in sys.modules after the import proves the crypto
+    import is lazy (deferred to Ed25519Verifier construction), without
+    requiring a cryptography-free environment to run the test in.
+    """
+    code = (
+        "import sys; import kailash.delegate; "
+        "assert 'cryptography' not in sys.modules, "
+        "'kailash.delegate eager-loaded cryptography — slim-core broken'"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert (
+        result.returncode == 0
+    ), f"slim-core import invariant broken:\n{result.stderr}"
+
+
+@pytest.mark.regression
+def test_delegate_1035_import_line_resolves():
+    """The literal #1035 acceptance import line MUST resolve.
+
+    Run in a subprocess so the assertion exercises a fresh import of the
+    delegate package, not the already-imported test-session state.
+    """
+    code = (
+        "from kailash.delegate import ("
+        "Delegate, ConstraintEnvelope, PrincipalDirectory, "
+        "GenesisRecord, PostureState, AuditChain, Connector); "
+        "from kailash.delegate import Verifier, NullVerifier, Ed25519Verifier; "
+        "assert NullVerifier().verify(b'm', b's', 'x') is False"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert (
+        result.returncode == 0
+    ), f"#1035 delegate import line failed:\n{result.stderr}"


### PR DESCRIPTION
## Summary

**Corrective fix for a 2.26.0 release defect** caught by the build-repo-release Rule 2 clean-venv install gate.

kailash 2.26.0 shipped `kailash.delegate.verifier` with a **module-scope** `from cryptography...` import. The delegate package is inside the slim-core import closure, so a bare `pip install kailash` (cryptography lives in the `[trust]`/`[server]` extras, NOT core deps) raised `ModuleNotFoundError: No module named 'cryptography'` on the documented `from kailash.delegate import Delegate, ...` line.

## Fix

- Move the cryptography import into `Ed25519Verifier.__init__` — loud `ModuleNotFoundError` at construction if the extra is absent (the established "loud failure at call site" pattern; matches the #1154 lazy-filelock precedent that defends slim-core).
- `NullVerifier` (the default) needs no cryptography — slim-core callers are unaffected.
- `verify()` references the symbols cached on the instance, honouring its NEVER-raises contract.
- Corrected the false module comment that claimed "cryptography is a core kailash dependency."

## Test plan

- [x] 2 behavioral regression tests (`tests/regression/test_issue_1035_delegate_slim_core_import.py`) — subprocess + `sys.modules` introspection (not source-grep), asserting (a) `import kailash.delegate` does not eager-load cryptography, (b) the #1035 import line resolves
- [x] 487 delegate tests pass (no regression)
- [x] `import kailash.delegate` verified to NOT load cryptography into `sys.modules`
- [ ] Full matrix CI (this PR)

## Related issues

#1035 follow-up. Corrective release **2.26.1** follows this merge; **2.26.0 will be yanked** from PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)