### PR TITLE
chore(release): kailash v2.26.1 — corrective patch for slim-core delegate import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.26.1] - 2026-05-25
+
+### Fixed
+
+- **`from kailash.delegate import ...` now works on a bare `pip install kailash`** — 2.26.0 shipped `kailash.delegate.verifier` with a module-scope `from cryptography...` import. Because the delegate package is inside the slim-core import closure and `cryptography` lives in the `[trust]`/`[server]` extras (NOT core dependencies), a bare install raised `ModuleNotFoundError: No module named 'cryptography'` on the documented #1035 import line. The cryptography import is now lazy inside `Ed25519Verifier.__init__` — `NullVerifier` (the default) needs no cryptography; `Ed25519Verifier` raises a clear `ModuleNotFoundError` at construction if the `[trust]`/`[server]` extra is absent (the established "loud failure at call site" pattern; matches the #1154 lazy-`filelock` precedent that defends slim-core). Behavioral regression tests (`tests/regression/test_issue_1035_delegate_slim_core_import.py`) assert the slim-core import invariant via subprocess + `sys.modules` introspection.
+
+### Notes
+
+- Corrective patch for 2.26.0 (yanked from PyPI). All 2.26.0 functionality is unchanged — only the cryptography import timing moved from module-scope to lazy. 489 delegate tests pass (487 + 2 new regression).
+
 ## [2.26.0] - 2026-05-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.26.0"
+version = "2.26.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.26.0"
+__version__ = "2.26.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Release-prep for **kailash 2.26.1** (corrective patch). Metadata-only diff (version bump + CHANGELOG) — the fix shipped via #1167.

## Why

2.26.0 (being yanked) eager-imported `cryptography` at module scope in `kailash.delegate.verifier`, breaking `from kailash.delegate import ...` on a bare `pip install kailash` (cryptography is a `[trust]`/`[server]` extra, not core). #1167 made the import lazy in `Ed25519Verifier.__init__`.

## Test plan

- [x] 489 delegate tests pass (487 + 2 new slim-core regression tests)
- [x] `import kailash.delegate` verified to NOT eager-load cryptography
- [ ] PR-gate auto-skip (release/* convention)
- [ ] Tag v2.26.1 → publish-pypi.yml → clean-venv install verify (the gate that caught 2.26.0)

## Related issues

#1035 follow-up. 2.26.0 yanked post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)