### PR TITLE
chore(workspace): #1035 sweep + wrapup artifacts

### DIFF
--- a/workspaces/issue-1035-delegate-py/.session-notes
+++ b/workspaces/issue-1035-delegate-py/.session-notes
@@ -1,44 +1,48 @@
-# Session Notes — 2026-05-24
+# Session Notes — 2026-05-25
 
 ## Where we are
 
-#1163 tracker (phantom `terrene-foundation/kailash-rs` citations + deferred cross-SDK rs parity) CLOSED `completed` this turn after F5 closure-by-discovery superseded its re-open gate. Scope sweep posted as comment 4528054850 (acceptance criterion #1 ✅); closure-provenance line cites #1162 per `git.md` Discipline. Stale shard plan (claimed 8 pending shards) moved to `todos/completed/` with status header — all S1–S8 delivered weeks ago. #1035 itself remains open pending maintainer close.
+`kailash.delegate` (#1035): a 3-round `/redteam` (R1: 6 CRIT + 5 HIGH → 3-shard
+parallel fix-wave X/Y/Z → R2+R3 clean = CONVERGED) shipped as **v2.26.0**, which
+had a slim-core release defect (delegate eager-imported cryptography → broke bare
+`pip install kailash`). Corrected in **v2.26.1** (lazy crypto import) — verified
+live on PyPI. Release cycle complete. Heavy multi-operator interleave with the
+parallel #1165 session throughout.
 
 ## Read first
 
-1. `workspaces/issue-1035-delegate-py/todos/completed/00-shard-plan.md` — status header confirms all S1–S8 delivered; do NOT re-implement
-2. `workspaces/issue-1035-delegate-py/journal/0005-AUTHORIZATION-cross-repo-esperie-enterprise-kailash-rs-f5.md` — F5 closure rationale; LOCAL-UNCOMMITTED, run `git status` first
-3. #1163 (CLOSED) comments — phantom-slug 3-artifact scope (#1143, PR #1142, PR #1152) + full acceptance disposition
-4. `README.md:351` — audit-chain forensic key-registry gap #1147 STILL OPEN (NOT fixed by v2.25.0/.1/.2)
-5. `CHANGELOG.md` § "[2.25.2]" + "[2.25.1]" Documentation — 4 v2.25.0 inaccuracies on record (do NOT amend earlier entries)
+1. `workspaces/issue-1035-delegate-py/journal/0008-RISK-slim-core-release-defect-and-correction.md` — the session's headline lesson + /codify candidates
+2. `workspaces/issue-1035-delegate-py/04-validate/08-convergence.md` — redteam convergence receipt (R1→R3)
+3. `workspaces/issue-1035-delegate-py/04-validate/sweep-2026-05-25.md` — full /sweep findings + ranked next items
+4. `src/kailash/delegate/verifier.py` (Ed25519Verifier.__init__ ~L195) — lazy-crypto pattern that defends slim-core
 
 ## In-flight state
 
-- Working-tree drift persists across packages/kailash-align, kaizen, dataflow, ml per F3 "LEAVE ALONE" — explicit-path staging required for any release-prep PR.
-- journal/0005 + the new comment on #1163 are LOCAL-UNCOMMITTED in this repo's working tree; never auto-committed in BUILD repos.
+- All session code merged + released (origin/main `6506a08b4`, v2.26.1). Local == origin/main.
+- Uncommitted: sweep report + journal/0008 + .session-notes (this file) — workspace artifacts, need a chore PR (branch protection; build-repo-release Rule 1a carve-out = no release needed).
+- Parallel notes referenced R2a test WIP at `/tmp/r2a-wip-preserve/` (DISCARD disposition) — not touched this session; state unverified.
 
 ## Outstanding ledger (forest)
 
-| ID  | Item                                                                       | Value-anchor (MUST-1 source)                                      | Status                                          |
-| --- | -------------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------- |
-| F1  | Loom-side `/sync` Gate-1 of `.claude/.proposals/latest.yaml` (codify queue) | User approval prior session ("approved" on codify recommendation) | BLOCKED on loom session (not this repo's scope) |
-| F3  | Working-tree drift across packages/kaizen/dataflow/ml/align                | User directive 2026-05-22 — verbatim "LEAVE ALONE"                | LEAVE ALONE per user                            |
-| F10 | `.session-notes` split-layout migration per knowledge-convergence MUST-1   | `rules/knowledge-convergence.md` MUST-1                           | BLOCKED on loom-side /codify (not this scope)   |
+| ID  | Item | Value-anchor (MUST-1 source) | Status |
+| --- | ---- | ---------------------------- | ------ |
+| F1  | Loom-side `/sync` Gate-1 of codify queue | prior-session user approval on codify rec | BLOCKED on loom session |
+| F3  | Working-tree drift (kaizen/dataflow/ml/align, ~1606 files) | user directive 2026-05-22 verbatim "LEAVE ALONE" | LEAVE ALONE per user |
+| F10 | `.session-notes` split-layout migration | `knowledge-convergence.md` MUST-1 | BLOCKED on loom `/codify` |
+| F11 | Connector-ABC concrete-defaults (drop `__init_subclass__` proxy) to clear the 42 test-pyright errors | parallel-session anchor: "42 test-pyright errors shipped (zero-tolerance static debt)" | redteam-convergence half DELIVERED (v2.26.1); design half NOT done — this session KEPT the proxy. Re-validate pyright state + intent |
+| F12 | loom#350 pre-emit validator (7 emit-discipline findings) | `esperie-enterprise/loom#350` body | BLOCKED — loom-side root-cause |
+| F14 | `/codify` the slim-core import lesson (Pyright-fix-moved-import-to-module-scope → broke bare install; TestPyPI-skip let it reach PyPI) | journal/0008 §Lessons; this session's release-defect incident | queued — HIGH (recurrence-prevention) |
 
-Closed this session: `F9` → #1163 (closed `completed`, comment 4528054850, closure-provenance #1162). F5 closed earlier 2026-05-24 per journal/0005 (parallel session).
+Closed this session: `#1167` → merged (lazy-crypto fix, v2.26.1); `v2.26.0`→`v2.26.1` release cycle → PRs #1164/#1166/#1167/#1168 + tags; `F13-yank` → DEFERRED to maintainer (web-UI, see Open questions).
 
 ## Traps
 
-- `src/kailash/delegate/` ALREADY EXISTS feature-complete (S1–S8 shipped via #1035 series through commit `e7d2adc86`). Run `git log -- src/kailash/delegate/` before any "implement" recommendation.
-- `gh search issues|prs --state all` is invalid — only `open` or `closed`. Run separately + merge with `jq -s 'add'`. (Bug in #1163 criterion #1 as written; worked around in the sweep comment.)
-- F5 closure receipt (journal/0005) is LOCAL-UNCOMMITTED. The #1163 closure comment references "session journal in this repo" abstractly per `upstream-issue-hygiene.md` MUST-2; user accepted that evidentiary level.
-- Phantom `terrene-foundation/kailash-rs` citations remain in shipped bodies (#1143, PR #1142, PR #1152) per Strategy A immutability. PR #1142's `cross-repo-authorized:` greppable marker is documented as known-phantom in closed #1163.
-- Real rs target is `esperie-enterprise/kailash-rs` (BUILD) or `rrps-mtu/kailash-rs` (seed). Public Foundation-repo comments MUST stay abstract per `upstream-issue-hygiene.md` MUST-2.
-- `PrincipalKind` (py) is `typing.Literal["sovereign","service_account","delegate"]` — NOT Enum. Rs uses type-level Impersonation absence + runtime `assert_service_account_distinct`.
+- **Multi-operator interleave**: parallel #1165 session merged + cut releases mid-work; my release commit landed on a leftover branch (`fix/delegate-test-pyright-zero`, now 0-unique-commits, safe to delete). Neither session `/claim`ed. Next session MUST `/claim` delegate paths first.
+- **TestPyPI skip cost is real for slim-core/import-shape changes** — it let the 2.26.0 defect reach PyPI. For a new module in the slim-core import closure, do NOT skip TestPyPI.
+- F11 vs my work: I rebuilt Connector to 4-primitive + KEPT `__init_subclass__` proxy; the F11 plan wanted concrete-defaults to kill the 42 pyright errors. Confirm whether those errors persist before re-opening F11.
 
 ## Open questions for the human
 
-- Execute the bounded `~/repos/loom/kailash-rs` verification read (per existing authorization in journal/0005)? Currently skipped per `repo-scope-discipline.md` default.
-- Surface F10 (knowledge-convergence split-layout migration) to loom via /codify proposal?
-- R1 leftover: `DispatchCascadeViolationError` 3-way split? No user-anchored source per `value-prioritization.md` MUST-1 closed allowlist; design call awaiting brief or `DECISION` journal anchor.
-- F3 working-tree drift: how to resolve eventually (commit / stash / discard)? Currently durably "LEAVE ALONE"; surfaced for awareness.
+- **Yank 2.26.0** (broken slim-core import) — one-click maintainer web-UI: https://pypi.org/manage/project/kailash/release/2.26.0/ → Yank. Low urgency (2.26.1 is resolvable latest).
+- **Close #1035?** Shipped in 2.26.1 (PRs #1164/#1165/#1167); maintainer close-gate. Refs ready in the sweep report.
+- F11 still wanted (concrete-defaults Connector), or does the shipped proxy approach suffice?

--- a/workspaces/issue-1035-delegate-py/04-validate/sweep-2026-05-25.md
+++ b/workspaces/issue-1035-delegate-py/04-validate/sweep-2026-05-25.md
@@ -1,0 +1,55 @@
+# /sweep — kailash-py — 2026-05-25
+
+Repo-wide outstanding-work audit. Session context: #1035 delegate `/redteam`-to-convergence + release 2.26.0 → 2.26.1 corrective.
+
+## Findings
+
+### [LOW] [Sweep 1] Two active todos in OTHER workspaces (not this session)
+
+- Location: `workspaces/issue-891-hybridsearch-collision/todos/active/00-todos.md`, `workspaces/kaizen-rag-node-coverage/todos/active/00-plan.md`
+- Disposition: **DEFER-WITH-REASON** (out of this session's scope; #1035-only mandate). Both pre-date this session. Per value-prioritization MUST-3 they need value-anchor re-validation at their own next pickup — NOT auto-closed. Surfaced for the operator; not actioned here.
+- Why it matters: stale todos decay without re-validation; flagged so they are not silently inherited.
+
+### [FIXED] [Sweep 2] Pending journal entry promoted
+
+- Location: `workspaces/issue-1035-delegate-py/journal/.pending/1779642635016-0-RISK.md`
+- Disposition: **FIX-NOW** — promoted to `journal/0008-RISK-slim-core-release-defect-and-correction.md` (high-value: convergence arc + the 2.26.0 slim-core release-defect lesson + /codify candidates), `.pending` discarded.
+
+### [N/A] [Sweep 5] Redteam-vs-spec sweep — orchestration mode
+
+- `<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=true -->`
+- Evidence: `workspaces/*/specs` dir count = 0; `tools/sweep-redteam.py` absent. The #1035 workspace used Option A (rs-shipped impl as de facto spec — no local `specs/`). Structural N/A, not a proxy substitution.
+- Note: #1035 convergence WAS verified this session via the 3-round `/redteam` (08-convergence.md + 09-round3) — just not via the per-workspace-specs tool path.
+
+### [MED] [Sweep 3] #1035 open — closeable pending maintainer
+
+- Location: GH issue #1035 (20 open issues total in repo)
+- Disposition: **DEFER-WITH-REASON (maintainer gate)** — the delegate substrate is shipped + released (2.26.1, verified live on PyPI). Per `git.md` § Issue Closure (needs commit/PR ref) the closure comment is ready (PRs #1164/#1165/#1167, releases 2.26.0→2.26.1). Per `value-prioritization.md` MUST-4 + session-notes, #1035 close is the maintainer's call — NOT auto-closed.
+- Why it matters: closing without the maintainer gate violates the value-bearing-work closure rule; surfaced with the delivered-code refs ready.
+
+### [LOW] [Sweep 4] One unrelated open PR + one leftover local branch
+
+- PR #1130 (`fix/spec-anchor-drift-and-stale-workspace-archive`) — unrelated to #1035, pre-existing, NOT this session's. No action.
+- Local branch `fix/delegate-test-pyright-zero` — **zero unique commits vs main** (its content merged via release/v2.26.0 → #1166). Safe-to-delete leftover from the parallel pyright-zero work surfaced during the account-swap. Disposition: **DEFER (don't-destroy-parallel-state)** — local-only, harmless, may be the parallel operator's handle; recommend operator deletes (`git branch -D fix/delegate-test-pyright-zero`).
+
+### [LOW] [Sweep 6] Worktree + notes hygiene — clean
+
+- Only the main worktree remains (the 3 shard worktrees were removed post-merge). No `.session-notes` >30d. No `.pending` >14d (the one pending entry was promoted today).
+
+### [INFO] [Sweep 7] Process hygiene
+
+- `origin/main...HEAD` = 0/0 (all session work merged + pushed; local == origin/main).
+- Uncommitted: **1606 files** of pre-existing working-tree drift across `packages/kailash-{align,kaizen,dataflow,ml}` — the durable **F3 "LEAVE ALONE"** directive (per session-notes + `feedback_no_bulk_worktree_discard`). NOT touched this session; explicit-path staging used for every commit. Surfaced for awareness; disposition is the operator's (commit / stash / discard) — out of scope here.
+- No NEW stub markers introduced in delegate production code this session (verifier fix is real; the `NotImplementedError` hits in delegate are legitimate ABC abstractmethods).
+
+## Cross-cutting observations
+
+1. The session's highest-value institutional output is the **slim-core release-defect lesson** (journal/0008): a Pyright "possibly-unbound" fix moved a crypto import to module scope and broke `from kailash.delegate import ...` on bare install; TestPyPI-skip let it reach PyPI; the clean-venv gate caught it post-publish. Strong `/codify` candidate.
+2. Convergence + release + corrective-release all completed within-session per `build-repo-release-discipline` ("done means released, not merged"). 2.26.1 verified live.
+
+## Recommended next-session items (ranked)
+
+1. **`/codify` the slim-core import lesson** (journal/0008 §Lessons) — candidate rule clause: "a Pyright unbound-name fix MUST NOT move an extras-only import to module scope in the slim-core closure; lazy-import in-method or cache-in-`__init__`" + "new module in slim-core closure → do NOT skip TestPyPI." HIGH value (prevents recurrence across SDK).
+2. **Yank 2.26.0** — maintainer one-click web-UI action (https://pypi.org/manage/project/kailash/release/2.26.0/). Low urgency (2.26.1 is resolvable latest).
+3. **Maintainer-close #1035** with the delivered-code refs (PRs #1164/#1165/#1167, release 2.26.1).
+4. **M1/M3/M4/M5 + L1-L3 delegate hardening** (journal/0008 tail) — non-blocking; pick up if/when the `Delegate.compose()` composer work begins (M5 `advance_lifecycle` wiring naturally lands there).

--- a/workspaces/issue-1035-delegate-py/journal/0008-RISK-slim-core-release-defect-and-correction.md
+++ b/workspaces/issue-1035-delegate-py/journal/0008-RISK-slim-core-release-defect-and-correction.md
@@ -1,0 +1,69 @@
+---
+type: RISK
+status: promoted
+source_commit: d5e02209469626124fe96b4b62a919fbab2426de
+session: 2026-05-24/25 (/autonomize + /redteam-to-convergence + /release)
+---
+
+# RISK — `/redteam` convergence + slim-core release defect (2.26.0 → 2.26.1)
+
+## Convergence arc (#1035 delegate substrate)
+
+Round 1 (3 parallel agents): 6 CRITICAL + 5 HIGH. Fix-wave (3 parallel worktree
+shards X/Y/Z): all CRIT/HIGH closed. Round 2 (closure-parity) + Round 3
+(fresh-adversarial): 2 consecutive clean rounds = CONVERGED. Shipped via PR
+#1164 + #1165 (R1 reconciliation). Durable receipt: `04-validate/08-convergence.md`.
+
+## RISK — the release defect (the institutional lesson)
+
+**What happened:** 2.26.0 published to PyPI with `kailash.delegate.verifier`
+eager-importing `cryptography` at **module scope**. The delegate package is
+inside the slim-core import closure, and `cryptography` lives in the
+`[trust]`/`[server]` extras (NOT core deps). Result: `pip install kailash`
+(bare) → `from kailash.delegate import ...` → `ModuleNotFoundError: cryptography`.
+The documented #1035 import line was broken on every bare install.
+
+**Why it slipped:**
+
+1. Shard Y added `verifier.py` with a module-scope crypto import + a comment
+   wrongly asserting "cryptography is a core kailash dependency." It is not.
+2. PR #1165 (parallel session) MOVED the import to module scope specifically
+   to fix a Pyright "InvalidSignature possibly unbound" warning — trading the
+   slim-core invariant for the lint fix, without noticing the trade.
+3. **TestPyPI was skipped** (minor-release precedent + human approval). The
+   defect would have surfaced pre-publish on a TestPyPI clean-venv install.
+4. The build-repo-release Rule 2 clean-venv gate caught it — but POST-publish,
+   so 2.26.0 was already immutable on PyPI.
+
+**The fix (2.26.1):** lazy-import cryptography inside `Ed25519Verifier.__init__`
+(loud `ModuleNotFoundError` at construction if the extra is absent — the
+established "loud failure at call site" pattern; matches the #1154 lazy-`filelock`
+precedent that defends slim-core). `NullVerifier` (default) needs no crypto.
+Behavioral regression tests (`tests/regression/test_issue_1035_delegate_slim_core_import.py`,
+subprocess + `sys.modules` introspection, not source-grep) pin the invariant.
+2.26.0 yanked (maintainer web-UI action).
+
+## Lessons for next session / /codify candidates
+
+1. **The slim-core import closure is a defended invariant** (pyproject.toml
+   dependencies comment + #1154). Any new module under `src/kailash/` that an
+   eager `import kailash.<x>` reaches MUST NOT module-scope-import an extras-only
+   third-party lib. `deployment.md` § "Eagerly-Imported Transitive Dependencies"
+   already covers this — but the delegate slim-core closure is a SPECIFIC trap
+   (delegate is eager-reachable yet crypto-needing).
+2. **A Pyright "possibly-unbound" fix that moves an import to module scope can
+   silently break slim-core.** The correct pattern: lazy-import at the top of
+   the method (local-scope binding) OR cache on the instance in `__init__`.
+3. **TestPyPI skip cost is real for slim-core/import-shape changes.** The
+   minor-release TestPyPI-skip precedent is fine for behavior changes covered
+   by the matrix, but a NEW eager-import in the slim-core closure is exactly
+   the class TestPyPI's clean-venv install would catch pre-publish. Consider:
+   "new module in slim-core closure" → do NOT skip TestPyPI.
+
+## Tracked non-blocking follow-ups (from convergence)
+
+M1 `_consumed` TOCTOU · M3 payload-depth container-subclass · M4 unsalted
+`_tenant_id_hash` · M5 `advance_lifecycle` orphan (awaiting `Delegate.compose()`
+composer) · L1-L3 · `verifier=None` opt-in advisory (future major: flip
+fail-closed) · cross-impl byte-match deferred per `cross-sdk-inspection.md`
+Rule 4 (pending rs Ed25519 library confirmation).


### PR DESCRIPTION
## Summary

Workspace-only artifacts from the #1035 delegate `/sweep` + `/wrapup`:
- `journal/0008-RISK-...` — slim-core release-defect lesson (2.26.0 → 2.26.1)
- `04-validate/sweep-2026-05-25.md` — repo-wide sweep findings
- `.session-notes` — reconciled forest ledger

Workspace-only diff → build-repo-release Rule 1a carve-out (no release required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)