### PR TITLE
fix(kaizen): Gemini parts=None + parser subscripted-generic crashes (#1140, #1141)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.24.1] — 2026-05-25 — LLM-path crash fixes (#1140, #1141)
+
+### Fixed
+
+- **`GoogleGeminiProvider._extract_response` no longer crashes on `parts=None`
+  candidates (#1140).** Gemini returns candidates whose `.content` is populated
+  but `.content.parts` is `None` on SAFETY / MAX_TOKENS / tool-call-only
+  finishes. The guard now checks `.parts` before iterating, so these routine
+  production responses return a well-formed dict (empty content, empty
+  tool_calls) instead of raising `TypeError: 'NoneType' object is not
+iterable`. `finish_reason` still surfaces (`content_filter` / `length`) so
+  callers can detect the filter fired. The sibling `_format_tool_calls` path
+  carried the same None-deref and is fixed in the same change.
+- **`JSONOutputParser._convert_to_type` no longer silently corrupts results for
+  subscripted-generic OutputField types (#1141).** A `Signature` OutputField
+  typed `Optional[List[Dict]]` / `List[X]` / `Dict[K, V]` triggered
+  `TypeError: Subscripted generics cannot be used with class and instance
+checks` on Python 3.9+, which was swallowed and fell through to regex
+  key-value extraction — returning malformed strings while reporting success.
+  The parser now unwraps subscripted generics via `typing.get_origin` /
+  `get_args` before the `isinstance` check, so well-formed JSON parses into the
+  documented `list` / `dict` runtime shapes. Genuine malformed JSON still
+  surfaces as a parse failure.
+
 ## [2.24.0] — 2026-05-20 — kaizen.nodes.rag provably correct + F9 cleanup (F8 R1)
 
 ### Added

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.24.0"
+version = "2.24.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.24.0"
+__version__ = "2.24.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/execution/parser.py
+++ b/packages/kailash-kaizen/src/kaizen/execution/parser.py
@@ -8,6 +8,7 @@ into structured outputs that match signature specifications.
 import json
 import logging
 import re
+import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -143,6 +144,20 @@ class JSONOutputParser(OutputParser):
         field_def = signature.output_fields.get(field_name, {})
         expected_type = field_def.get("type", str)
 
+        # Unwrap subscripted generics (List[X], Dict[K, V], Optional[X],
+        # Union[...]) before any isinstance check. On Python 3.9+,
+        # `isinstance(value, typing.List[...])` raises
+        # `TypeError: Subscripted generics cannot be used with class and
+        # instance checks`. That TypeError previously propagated up to the
+        # JSON-parse caller's `except (json.JSONDecodeError, TypeError)` block,
+        # marking the entire well-formed JSON parse as failed and silently
+        # falling through to KeyValueOutputParser (issue #1141). Reducing the
+        # generic to its runtime origin (`list`, `dict`, `typing.Union`, ...)
+        # makes the membership check safe again.
+        origin = typing.get_origin(expected_type)
+        if origin is not None:
+            return self._convert_generic(value, origin, expected_type, field_name)
+
         # If value is already correct type, return it
         if isinstance(value, expected_type):
             return value
@@ -196,6 +211,103 @@ class JSONOutputParser(OutputParser):
                 return str(value)
             else:
                 return value
+
+    def _convert_generic(
+        self, value: Any, origin: Any, expected_type: Any, field_name: str
+    ) -> Any:
+        """
+        Handle a subscripted generic OutputField type safely.
+
+        `expected_type` is a subscripted generic such as ``List[Dict]``,
+        ``Dict[str, int]``, or ``Optional[List[X]]``. `origin` is its
+        ``typing.get_origin(...)`` result (``list``/``dict``/``typing.Union``/...).
+        These cannot be passed to ``isinstance`` directly, so we type-check
+        against the unwrapped runtime container class and return the value
+        as-is when it matches (complex types are returned as-is, matching the
+        existing ``else`` branch of ``_convert_to_type``).
+        """
+        # Optional[X] / Union[...] — origin is typing.Union.
+        if origin is typing.Union:
+            args = typing.get_args(expected_type)
+            non_none = [a for a in args if a is not type(None)]
+            if value is None:
+                # None is valid iff NoneType is part of the union (Optional[X]).
+                if type(None) in args:
+                    return None
+                # Union without None but value is None — return as-is; the
+                # caller (LLM JSON) did not supply a value to coerce.
+                return value
+            # Dispatch on the single non-None arm when unambiguous.
+            if len(non_none) == 1:
+                arm = non_none[0]
+                arm_origin = typing.get_origin(arm)
+                if arm_origin is not None:
+                    # e.g. Optional[List[Dict]] -> recurse on List[Dict].
+                    return self._convert_generic(value, arm_origin, arm, field_name)
+                # Plain class arm (e.g. Optional[str]) — re-dispatch through
+                # the normal scalar conversion path.
+                return self._convert_scalar(value, arm, field_name)
+            # Ambiguous union (multiple non-None arms) — return as-is.
+            return value
+
+        # Container generics (list, dict, tuple, set, frozenset): type-check
+        # against the unwrapped origin class and return as-is on match.
+        if origin in (list, dict, tuple, set, frozenset):
+            if isinstance(value, origin):
+                return value
+            # Mismatched runtime type for a declared container — return as-is
+            # (complex types are returned as-is per the existing contract).
+            return value
+
+        # Any other generic origin (e.g. typing.Literal, custom generics):
+        # return the value unchanged — these are complex types.
+        return value
+
+    def _convert_scalar(self, value: Any, expected_type: Any, field_name: str) -> Any:
+        """
+        Convert ``value`` to a plain (non-generic) class ``expected_type``.
+
+        Used by ``_convert_generic`` when an ``Optional[X]`` arm is a plain
+        class. Mirrors the scalar branches of ``_convert_to_type``.
+        """
+        try:
+            if isinstance(value, expected_type):
+                return value
+        except TypeError:
+            # expected_type is not a usable isinstance predicate; return as-is.
+            return value
+        # Delegate to the scalar conversion logic by temporarily treating
+        # expected_type as the field's type. Reuse _convert_to_type's coercion
+        # branches via a minimal inline path to avoid re-reading the signature.
+        try:
+            if expected_type == float:
+                if isinstance(value, str):
+                    cleaned = value.strip().lower()
+                    if cleaned in ["", "none", "null", "n/a"]:
+                        return 0.0
+                    number_match = re.search(r"[-+]?\d*\.?\d+", cleaned)
+                    return float(number_match.group()) if number_match else 0.0
+                return float(value)
+            elif expected_type == int:
+                if isinstance(value, str):
+                    cleaned = value.strip().lower()
+                    if cleaned in ["", "none", "null", "n/a"]:
+                        return 0
+                    number_match = re.search(r"[-+]?\d+", cleaned)
+                    return int(number_match.group()) if number_match else 0
+                return int(value)
+            elif expected_type == bool:
+                if isinstance(value, str):
+                    return value.lower() in ["true", "yes", "1", "y"]
+                return bool(value)
+            elif expected_type == str:
+                return str(value)
+            return value
+        except (ValueError, TypeError) as e:
+            logger.warning(
+                f"Type conversion failed for {field_name}: {e}, using fallback"
+            )
+            return value
 
 
 class KeyValueOutputParser(OutputParser):

--- a/packages/kailash-kaizen/src/kaizen/providers/llm/google.py
+++ b/packages/kailash-kaizen/src/kaizen/providers/llm/google.py
@@ -287,6 +287,8 @@ class GoogleGeminiProvider(UnifiedAIProvider):
         candidate = response.candidates[0]
         if not hasattr(candidate, "content") or not candidate.content:
             return tool_calls
+        if not candidate.content.parts:
+            return tool_calls
 
         for part in candidate.content.parts:
             if hasattr(part, "function_call") and part.function_call:
@@ -337,7 +339,11 @@ class GoogleGeminiProvider(UnifiedAIProvider):
 
     def _extract_response(self, response: Any, model: str) -> dict[str, Any]:
         content_text = ""
-        if response.candidates and response.candidates[0].content:
+        if (
+            response.candidates
+            and response.candidates[0].content
+            and response.candidates[0].content.parts
+        ):
             for part in response.candidates[0].content.parts:
                 if hasattr(part, "text") and part.text:
                     content_text += part.text

--- a/packages/kailash-kaizen/tests/regression/test_issue_1140_google_parts_none.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1140_google_parts_none.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for issue #1140.
+
+Gemini returns candidates whose ``.content`` is a populated proto but whose
+``.content.parts`` is ``None`` on ``finish_reason`` SAFETY, MAX_TOKENS, or
+tool-call-only finishes. The pre-fix guard in
+``GoogleGeminiProvider._extract_response`` checked ``.content`` (truthy) but
+then iterated ``.content.parts`` (None) -> ``TypeError: 'NoneType' object is
+not iterable``, which was caught and re-raised as a ``RuntimeError`` crashing
+every Kaizen agent consuming Gemini on routine safety-filtered /
+token-limited / tool-call responses.
+
+After the fix, a ``parts=None`` candidate yields a normal well-formed dict with
+empty ``content`` text and empty ``tool_calls`` list -- no exception.
+
+``_extract_response`` is a pure function over a response object: no network and
+no google-genai SDK are required. ``GoogleGeminiProvider()`` constructs without
+the SDK (the import is lazy, inside ``chat``/``is_available``), so we build a
+fake response with ``types.SimpleNamespace`` and call ``_extract_response``
+directly.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from kaizen.providers.llm.google import GoogleGeminiProvider
+
+
+def _make_parts_none_response(finish_reason: str) -> types.SimpleNamespace:
+    """Build a Gemini-shaped response whose candidate has content but no parts.
+
+    Mirrors the issue's minimal repro: ``candidates[0].content`` is a populated
+    proto object, but ``candidates[0].content.parts`` is ``None``.
+    """
+    content = types.SimpleNamespace(parts=None, role="model")
+    candidate = types.SimpleNamespace(content=content, finish_reason=finish_reason)
+    return types.SimpleNamespace(
+        candidates=[candidate],
+        usage_metadata=types.SimpleNamespace(
+            prompt_token_count=12,
+            candidates_token_count=0,
+            total_token_count=12,
+        ),
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("finish_reason", ["SAFETY", "MAX_TOKENS"])
+def test_issue_1140_parts_none_returns_well_formed_dict(finish_reason: str) -> None:
+    """parts=None on SAFETY/MAX_TOKENS finishes MUST NOT raise."""
+    provider = GoogleGeminiProvider()
+    response = _make_parts_none_response(finish_reason)
+
+    result = provider._extract_response(response, "gemini-2.0-flash")
+
+    # Returns the documented dict shape, no exception.
+    assert isinstance(result, dict)
+    # Empty content text (the actual key is "content", not "content_text").
+    assert result["content"] == ""
+    # tool_calls is a structurally-empty list, not None and not raising.
+    assert result["tool_calls"] == []
+    # Remaining documented keys still present and well-formed.
+    assert result["role"] == "assistant"
+    assert result["model"] == "gemini-2.0-flash"
+    assert isinstance(result["usage"], dict)
+    assert result["metadata"]["provider"] == "google_gemini"
+
+
+@pytest.mark.regression
+def test_issue_1140_parts_none_tool_call_path_does_not_raise() -> None:
+    """The tool-call assembly path (_format_tool_calls) MUST also tolerate
+    parts=None -- the same None-deref bug class lived there too (a candidate
+    with populated .content but .content.parts is None on a tool-call-only
+    finish iterated content.parts and raised TypeError)."""
+    provider = GoogleGeminiProvider()
+    response = _make_parts_none_response("STOP")
+
+    # _format_tool_calls is the sibling path; assert it returns [] not raises.
+    assert provider._format_tool_calls(response) == []
+
+    # And through the full extraction path as well.
+    result = provider._extract_response(response, "gemini-2.0-flash")
+    assert result["tool_calls"] == []

--- a/packages/kailash-kaizen/tests/regression/test_issue_1141_parser_subscripted_generics.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_1141_parser_subscripted_generics.py
@@ -1,0 +1,154 @@
+"""Regression test for issue #1141 — subscripted-generic OutputField parsing.
+
+Bug: ``JSONOutputParser._convert_to_type`` ran ``isinstance(value, expected_type)``
+where ``expected_type`` could be a subscripted generic declared on a
+``kaizen.signatures.Signature`` OutputField — ``typing.List[typing.Dict]``,
+``typing.Optional[typing.List[X]]``, ``typing.Dict[K, V]``. On Python 3.9+,
+``isinstance(value, typing.List[...])`` raises
+``TypeError: Subscripted generics cannot be used with class and instance checks``.
+
+That TypeError propagated up to the JSON-parse caller's
+``except (json.JSONDecodeError, TypeError)`` block, marking the ENTIRE
+well-formed JSON parse as failed. ``ResponseParser.parse_response`` then silently
+fell through to ``KeyValueOutputParser``, which regex-extracts the JSON-as-text
+and returns malformed string fragments. The agent appeared to "succeed" but
+returned garbage — a silent-corruption failure mode.
+
+These tests assert the runtime SHAPE of the parsed output (list / dict), not
+source strings, and exercise the real parser end-to-end. They are deterministic
+and offline (no network / DB).
+"""
+
+from typing import Dict, List, Optional
+
+import pytest
+
+from kaizen.execution.parser import JSONOutputParser, ResponseParser
+from kaizen.signatures import InputField, OutputField, Signature
+
+
+class OptionalListDictSignature(Signature):
+    """Signature whose output is Optional[List[Dict]] — the issue's repro shape."""
+
+    query: str = InputField(description="The user query")
+    items: Optional[List[Dict]] = OutputField(description="A list of dict records")
+
+
+class ListSignature(Signature):
+    """Signature whose output is List[str]."""
+
+    query: str = InputField(description="The user query")
+    tags: List[str] = OutputField(description="A list of string tags")
+
+
+class DictSignature(Signature):
+    """Signature whose output is Dict[str, int]."""
+
+    query: str = InputField(description="The user query")
+    counts: Dict[str, int] = OutputField(description="A mapping of name to count")
+
+
+@pytest.mark.regression
+def test_optional_list_dict_parses_to_list_runtime_shape():
+    """Optional[List[Dict]] OutputField parses well-formed JSON into a list.
+
+    Pre-fix this raised TypeError inside _convert_to_type and the whole parse
+    was marked failed, falling through to KeyValueOutputParser.
+    """
+    sig = OptionalListDictSignature()
+    parser = JSONOutputParser()
+
+    result = parser.parse(
+        '{"items": [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]}',
+        sig.outputs,
+        sig,
+    )
+
+    assert result.success is True
+    assert result.extraction_method == "json_parsing"
+    items = result.structured_output["items"]
+    assert isinstance(items, list)
+    assert items == [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+    assert all(isinstance(row, dict) for row in items)
+
+
+@pytest.mark.regression
+def test_optional_list_dict_accepts_none():
+    """Optional[List[Dict]] tolerates a JSON null (None) for the field."""
+    sig = OptionalListDictSignature()
+    parser = JSONOutputParser()
+
+    result = parser.parse('{"items": null}', sig.outputs, sig)
+
+    assert result.success is True
+    assert result.extraction_method == "json_parsing"
+    assert result.structured_output["items"] is None
+
+
+@pytest.mark.regression
+def test_list_str_parses_to_list_runtime_shape():
+    """List[str] OutputField parses well-formed JSON into a list of strings."""
+    sig = ListSignature()
+    parser = JSONOutputParser()
+
+    result = parser.parse('{"tags": ["alpha", "beta", "gamma"]}', sig.outputs, sig)
+
+    assert result.success is True
+    assert result.extraction_method == "json_parsing"
+    tags = result.structured_output["tags"]
+    assert isinstance(tags, list)
+    assert tags == ["alpha", "beta", "gamma"]
+
+
+@pytest.mark.regression
+def test_dict_kv_parses_to_dict_runtime_shape():
+    """Dict[str, int] OutputField parses well-formed JSON into a dict."""
+    sig = DictSignature()
+    parser = JSONOutputParser()
+
+    result = parser.parse('{"counts": {"a": 3, "b": 5}}', sig.outputs, sig)
+
+    assert result.success is True
+    assert result.extraction_method == "json_parsing"
+    counts = result.structured_output["counts"]
+    assert isinstance(counts, dict)
+    assert counts == {"a": 3, "b": 5}
+
+
+@pytest.mark.regression
+def test_response_parser_end_to_end_uses_json_not_keyvalue():
+    """Through the full ResponseParser, a subscripted-generic field on
+    well-formed JSON resolves via json_parsing — NOT a KeyValueOutputParser
+    fallthrough that would return malformed string fragments."""
+    sig = OptionalListDictSignature()
+    parser = ResponseParser()
+
+    raw = '{"items": [{"id": 1}, {"id": 2}]}'
+    out = parser.parse_response(raw, sig.outputs, sig)
+
+    # The full pipeline returns the parsed structured output. The decisive
+    # assertion is the runtime SHAPE: a real list of dicts, not a string blob
+    # that KeyValueOutputParser would have regex-extracted.
+    items = out["items"]
+    assert isinstance(items, list)
+    assert items == [{"id": 1}, {"id": 2}]
+
+
+@pytest.mark.regression
+def test_malformed_json_still_reports_parse_failure():
+    """A genuinely malformed JSON body still surfaces as a JSON parse failure.
+
+    The fix removes the SPURIOUS TypeError from subscripted generics; it must
+    NOT mask a real json.JSONDecodeError. The subscripted-generic field must
+    not silently return KeyValueOutputParser garbage when the JSON is broken.
+    """
+    sig = OptionalListDictSignature()
+    parser = JSONOutputParser()
+
+    # Unterminated object — a real json.JSONDecodeError.
+    result = parser.parse('{"items": [{"id": 1}, {"id": 2}', sig.outputs, sig)
+
+    assert result.success is False
+    assert result.extraction_method == "json_parsing"
+    assert result.errors
+    assert "JSON parsing failed" in result.errors[0]


### PR DESCRIPTION
## Summary

Two HIGH-severity production crashes in the Kaizen LLM path, fixed with root-cause changes + behavioral regression tests. Kaizen patch 2.24.0 → 2.24.1.

- **#1140 — `GoogleGeminiProvider._extract_response` crashed on `parts=None` candidates.** Gemini returns candidates whose `.content` is populated but `.content.parts` is `None` on SAFETY / MAX_TOKENS / tool-call-only finishes — routine production traffic. The guard now checks `.parts` before iterating; returns a well-formed dict (empty content + tool_calls) instead of raising `TypeError: 'NoneType' object is not iterable`. `finish_reason` still surfaces (`content_filter` / `length`) so callers detect the filter fired. The sibling `_format_tool_calls` path carried the same None-deref and is fixed in the same change.
- **#1141 — `JSONOutputParser._convert_to_type` silently corrupted results for subscripted-generic OutputField types.** A `Signature` OutputField typed `Optional[List[Dict]]` / `List[X]` / `Dict[K,V]` triggered `TypeError: Subscripted generics cannot be used with class and instance checks` on Python 3.9+, which was swallowed and fell through to regex key-value extraction — returning malformed strings while reporting success. The parser now unwraps subscripted generics via `typing.get_origin` / `get_args` before the `isinstance` check.

## Validation

- 9 behavioral regression tests (6 for #1141, 3 for #1140), all `@pytest.mark.regression`; both suites confirmed FAIL pre-fix, PASS post-fix.
- pyright-clean on both changed files (worktree 0/0 vs origin's prior debt).
- `pytest --collect-only` clean across the kaizen regression tree (372 tests).
- Red-team Round 1: reviewer + security-reviewer both CONVERGED, no CRIT/HIGH. Security-reviewer confirmed no information-hiding on the safety path (finish_reason preserved); no unbounded recursion in the new generic-unwrap helper.

## Test plan

- [x] Regression tests pass (9/9)
- [x] pyright clean on parser.py + google.py
- [x] collect-only clean
- [x] Red-team converged (reviewer + security-reviewer)

## Related issues

Closes #1140
Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)