### PR TITLE
feat(tooling): add tools/sweep-redteam.py for /sweep Sweep 5 (#1129)

### DIFF
--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -83,6 +83,12 @@ done
 # `<!-- sweep-redteam:v1:OK specs=N symbols=M orphans=O coverage_gaps=C stubs=S -->`
 # into the sweep report so readers (and any future enforcement hook)
 # can verify the mandated step actually ran.
+
+# BUILD-mode invocation (run from repo root; emits JSONL findings + sentinel):
+python3 tools/sweep-redteam.py --json --all          # every spec across every workspace
+python3 tools/sweep-redteam.py --json specs/foo.md   # single spec scope
+# Capture the trailing sentinel line into the sweep report verbatim; it is the
+# grep-able evidence the mandated symbol/Tier-2/stub verification actually ran.
 ```
 
 Categorize findings:

--- a/tests/regression/test_sweep_redteam_cli.py
+++ b/tests/regression/test_sweep_redteam_cli.py
@@ -1,0 +1,95 @@
+"""End-to-end CLI regression for `tools/sweep-redteam.py` (#1129).
+
+Per `.claude/rules/testing.md` § "End-to-End Pipeline Regression Above Unit
++ Integration": the unit tests exercise the tool's verification primitives
+in isolation; this regression test executes the literal CLI invocation the
+operator (and Sweep 5 in `.claude/commands/sweep.md`) runs, and asserts the
+sentinel byte-equality of its output. Lifts the manual walk receipt from
+PR #1175's body into a permanent CI gate.
+
+Per `.claude/rules/user-flow-validation.md` MUST-2: the receipt is the
+literal command output. This test re-runs that command on every CI build,
+so the walk receipt cannot decay.
+
+Tier-2 placement: invokes a subprocess against the real tool + real repo
+state. NO mocking (per testing.md § 3-Tier Testing).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TOOL = REPO_ROOT / "tools" / "sweep-redteam.py"
+SENTINEL_PATTERN = re.compile(
+    r"^<!-- sweep-redteam:v1:(OK|N/A) "
+    r"(specs=\d+ symbols=\d+ orphans=\d+ coverage_gaps=\d+ stubs=\d+|"
+    r"reason=orchestration-mode no_specs=(true|false) no_tool=(true|false))"
+    r" -->$",
+    re.MULTILINE,
+)
+
+
+@pytest.mark.regression
+def test_sweep_redteam_cli_all_against_this_repo() -> None:
+    """Walk receipt: `python tools/sweep-redteam.py --json --all` against this repo.
+
+    Asserts the sentinel byte-shape matches the documented contract in
+    `.claude/commands/sweep.md:83`. Exit code 0 when no findings; the tool
+    MAY emit findings (exit 1) without failing this test — the assertion
+    is on the sentinel shape, not on a green-only state.
+    """
+    assert TOOL.is_file(), f"tool missing: {TOOL}"
+    result = subprocess.run(
+        [sys.executable, str(TOOL), "--json", "--all"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode in (0, 1), (
+        f"unexpected exit {result.returncode}\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    match = SENTINEL_PATTERN.search(result.stdout)
+    assert match is not None, (
+        "sentinel not found in stdout; documented shape is "
+        "`<!-- sweep-redteam:v1:OK specs=N symbols=M orphans=O coverage_gaps=C stubs=S -->`"
+        f"\nstdout:\n{result.stdout}"
+    )
+
+
+@pytest.mark.regression
+def test_sweep_redteam_cli_rejects_path_outside_root(tmp_path: Path) -> None:
+    """Defense-in-depth: --json arg pointing outside the repo MUST refuse.
+
+    Per R1 security review (#1175 R1-security-01): the tool runs against
+    operator workspaces; an argv-influenced invocation passing
+    `--json /tmp/foo.md` MUST refuse with a typed error rather than
+    silently reading a path outside the repo root.
+    """
+    # Create a file outside REPO_ROOT (tmp_path is in $TMPDIR, not under repo).
+    outside_spec = tmp_path / "foo.md"
+    outside_spec.write_text("MUST `Some.Symbol` exists\n", encoding="utf-8")
+    assert not str(outside_spec).startswith(
+        str(REPO_ROOT)
+    ), "tmp_path unexpectedly under REPO_ROOT; the test premise is invalid"
+    result = subprocess.run(
+        [sys.executable, str(TOOL), "--json", str(outside_spec)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 2, (
+        f"expected parser.error exit 2; got {result.returncode}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert (
+        "escapes repo root" in result.stderr
+    ), f"expected 'escapes repo root' guard message; got:\n{result.stderr}"

--- a/tests/unit/tools/test_sweep_redteam.py
+++ b/tests/unit/tools/test_sweep_redteam.py
@@ -1,0 +1,337 @@
+"""Tier-1 unit tests for tools/sweep-redteam.py (#1129).
+
+Each test sets up a temporary fixture tree (specs/ + source files +
+tests/integration/) that emulates the production repo layout the tool
+walks, then asserts the JSONL findings + sentinel + exit code.
+
+The tool resolves ROOT via Path(__file__).resolve().parent.parent at
+import time (binding ROOT to the kailash-py checkout). For Tier-1
+isolation we monkeypatch the module-level ROOT to point at a tmp_path
+fixture tree per `rules/testing.md` Tier-1 (mocking allowed, <1s).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# --- Module import --------------------------------------------------------
+# The tool ships with a hyphen in its filename; load it explicitly so the
+# tests can drive its public functions without renaming the script.
+
+_TOOL_PATH = Path(__file__).resolve().parents[3] / "tools" / "sweep-redteam.py"
+
+
+def _load_tool_module():
+    spec = importlib.util.spec_from_file_location("sweep_redteam", _TOOL_PATH)
+    assert spec is not None and spec.loader is not None, _TOOL_PATH
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sweep_redteam"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sweep_redteam = _load_tool_module()
+
+
+# --- Fixture builders ------------------------------------------------------
+
+
+def _build_workspace_tree(
+    root: Path,
+    *,
+    spec_body: str = "",
+    source_files: dict[str, str] | None = None,
+    integration_tests: dict[str, str] | None = None,
+    workspace_name: str = "ws1",
+    spec_filename: str = "spec.md",
+) -> Path:
+    """Build a fixture tree at root that emulates the real repo layout.
+
+    Returns the spec file's path. The caller monkeypatches the tool's
+    ROOT to `root` so candidate_source_files / has_tier2_coverage scan
+    the fixture tree instead of the live checkout.
+    """
+    ws_specs = root / "workspaces" / workspace_name / "specs"
+    ws_specs.mkdir(parents=True, exist_ok=True)
+    spec_path = ws_specs / spec_filename
+    spec_path.write_text(spec_body, encoding="utf-8")
+
+    if source_files:
+        for rel, content in source_files.items():
+            target = root / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+
+    tests_integration = root / "tests" / "integration"
+    tests_integration.mkdir(parents=True, exist_ok=True)
+    if integration_tests:
+        for rel, content in integration_tests.items():
+            target = tests_integration / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+
+    return spec_path
+
+
+def _run_tool(monkeypatch, root: Path) -> tuple[int, list[dict], str]:
+    """Run the tool against `root`; return (exit_code, findings, sentinel).
+
+    Captures stdout via an in-memory buffer; parses every JSONL line as
+    a finding except the final HTML-comment sentinel.
+    """
+    monkeypatch.setattr(sweep_redteam, "ROOT", root)
+    specs = list(sweep_redteam.iter_spec_files(None))
+    buf = io.StringIO()
+    exit_code = sweep_redteam.run(specs, buf)
+    lines = [ln for ln in buf.getvalue().splitlines() if ln]
+    assert lines, "tool emitted no output (sentinel always required)"
+    sentinel = lines[-1]
+    assert sentinel.startswith("<!-- sweep-redteam:v1:OK ") and sentinel.endswith(
+        " -->"
+    ), f"sentinel malformed: {sentinel!r}"
+    findings = [json.loads(ln) for ln in lines[:-1]]
+    return exit_code, findings, sentinel
+
+
+def _parse_sentinel(sentinel: str) -> dict[str, int]:
+    """Extract specs=N symbols=M orphans=O coverage_gaps=C stubs=S."""
+    inner = sentinel.removeprefix("<!-- sweep-redteam:v1:OK ").removesuffix(" -->")
+    return {k: int(v) for k, v in (kv.split("=") for kv in inner.split())}
+
+
+# --- Test cases (mapped to issue #1129 acceptance criteria) ---------------
+
+
+def test_empty_specs_directory_emits_zero_sentinel(tmp_path, monkeypatch):
+    """Case 1: no spec files → sentinel reports zeros across every axis;
+    exit 0 because nothing was scanned.
+
+    Confirms the tool emits the sentinel even when there's no work — the
+    Sweep 5 protocol depends on the sentinel always being grep-able in
+    the report.
+    """
+    # Build an empty workspace structure (no spec file written).
+    (tmp_path / "workspaces" / "ws1" / "specs").mkdir(parents=True)
+    monkeypatch.setattr(sweep_redteam, "ROOT", tmp_path)
+
+    specs = list(sweep_redteam.iter_spec_files(None))
+    assert specs == [], "empty specs dir should yield no spec files"
+
+    buf = io.StringIO()
+    exit_code = sweep_redteam.run(specs, buf)
+    sentinel = buf.getvalue().strip()
+
+    assert exit_code == 0
+    parsed = _parse_sentinel(sentinel)
+    assert parsed == {
+        "specs": 0,
+        "symbols": 0,
+        "orphans": 0,
+        "coverage_gaps": 0,
+        "stubs": 0,
+    }
+
+
+def test_all_passing_spec_emits_no_findings(tmp_path, monkeypatch):
+    """Case 2: spec promises symbol; source has it; Tier-2 test imports it.
+
+    Expects: zero findings, sentinel reports symbols=1 with all gaps at 0,
+    exit code 0.
+    """
+    spec_body = (
+        "# Spec\n"
+        "## API\n"
+        "The runtime MUST use `myapp.api.Engine` for orchestration.\n"
+    )
+    source = (
+        "class Engine:\n"
+        '    """Real implementation."""\n'
+        "    def run(self):\n"
+        "        return 42\n"
+    )
+    integration_test = (
+        "from myapp.api import Engine\n"
+        "\n"
+        "def test_engine_runs():\n"
+        "    assert Engine().run() == 42\n"
+    )
+    _build_workspace_tree(
+        tmp_path,
+        spec_body=spec_body,
+        source_files={"src/myapp/api.py": source},
+        integration_tests={"test_engine.py": integration_test},
+    )
+
+    exit_code, findings, sentinel = _run_tool(monkeypatch, tmp_path)
+
+    assert findings == [], f"unexpected findings: {findings}"
+    parsed = _parse_sentinel(sentinel)
+    assert parsed["specs"] == 1
+    assert parsed["symbols"] == 1
+    assert parsed["orphans"] == 0
+    assert parsed["coverage_gaps"] == 0
+    assert parsed["stubs"] == 0
+    assert exit_code == 0
+
+
+def test_orphan_when_source_missing(tmp_path, monkeypatch):
+    """Case 3: spec promises symbol; source file missing entirely.
+
+    Expects: one `orphan` finding citing the unresolved symbol; sentinel
+    reports orphans=1; exit code 1.
+    """
+    spec_body = (
+        "# Spec\n"
+        "Implementations MUST provide `myapp.missing.Vanished` for the gateway.\n"
+    )
+    # NO source files written at all; tests/integration left empty.
+    _build_workspace_tree(tmp_path, spec_body=spec_body)
+
+    exit_code, findings, sentinel = _run_tool(monkeypatch, tmp_path)
+
+    assert exit_code == 1
+    assert len(findings) == 1, findings
+    finding = findings[0]
+    assert finding["category"] == "orphan"
+    assert finding["symbol"] == "myapp.missing.Vanished"
+    assert finding["source"] is None
+    assert "no candidate source files" in finding["evidence"]
+    parsed = _parse_sentinel(sentinel)
+    assert parsed["orphans"] == 1
+    assert parsed["coverage_gaps"] == 0
+    assert parsed["stubs"] == 0
+
+
+def test_coverage_gap_when_no_tier2_import(tmp_path, monkeypatch):
+    """Case 4: spec promises symbol; source present; no Tier-2 import.
+
+    Expects: one `coverage_gap` finding; sentinel reports coverage_gaps=1;
+    exit code 1. The source-presence check passes (no orphan); the stub
+    check passes (real body); only the Tier-2 grep returns empty.
+    """
+    spec_body = "# Spec\n" "Every request MUST route through `myapp.gateway.Router`.\n"
+    source = (
+        "class Router:\n"
+        "    def dispatch(self, request):\n"
+        "        return self._handlers[request.path](request)\n"
+        "    def __init__(self):\n"
+        "        self._handlers = {}\n"
+    )
+    _build_workspace_tree(
+        tmp_path,
+        spec_body=spec_body,
+        source_files={"src/myapp/gateway.py": source},
+        # No integration_tests — directory exists but contains no imports.
+        integration_tests={},
+    )
+
+    exit_code, findings, sentinel = _run_tool(monkeypatch, tmp_path)
+
+    assert exit_code == 1
+    assert len(findings) == 1, findings
+    finding = findings[0]
+    assert finding["category"] == "coverage_gap"
+    assert finding["symbol"] == "myapp.gateway.Router"
+    assert finding["source"] is not None
+    assert "src/myapp/gateway.py" in finding["source"]
+    assert "tests/integration" in finding["evidence"]
+    parsed = _parse_sentinel(sentinel)
+    assert parsed["orphans"] == 0
+    assert parsed["coverage_gaps"] == 1
+    assert parsed["stubs"] == 0
+
+
+def test_stub_when_body_raises_not_implemented(tmp_path, monkeypatch):
+    """Case 5: spec promises symbol; source present; body is a stub.
+
+    Body shape: `raise NotImplementedError(...)` as the sole statement.
+    Expects: one `stub` finding (and one `coverage_gap` because the
+    fixture also leaves Tier-2 empty — confirming the categories compose
+    independently). Sentinel reports stubs=1 + coverage_gaps=1; exit 1.
+    """
+    spec_body = "# Spec\n" "The cache layer MUST implement `myapp.cache.LRU.evict`.\n"
+    source = (
+        "class LRU:\n"
+        "    def evict(self, key):\n"
+        '        raise NotImplementedError("TODO in next sprint")\n'
+    )
+    _build_workspace_tree(
+        tmp_path,
+        spec_body=spec_body,
+        source_files={"src/myapp/cache.py": source},
+    )
+
+    exit_code, findings, sentinel = _run_tool(monkeypatch, tmp_path)
+
+    assert exit_code == 1
+    categories = sorted(f["category"] for f in findings)
+    assert categories == ["coverage_gap", "stub"], findings
+
+    stub_finding = next(f for f in findings if f["category"] == "stub")
+    assert stub_finding["symbol"] == "myapp.cache.LRU.evict"
+    assert "NotImplementedError" in stub_finding["evidence"]
+
+    parsed = _parse_sentinel(sentinel)
+    assert parsed["stubs"] == 1
+    assert parsed["coverage_gaps"] == 1
+    assert parsed["orphans"] == 0
+
+
+# --- MUST-symbol extraction sanity checks (documented heuristic) ----------
+
+
+def test_extract_symbols_requires_must_token(tmp_path):
+    """Backticked symbols on non-MUST lines are NOT extracted.
+
+    The heuristic deliberately requires the literal `MUST` token on the
+    SAME line as the backticked identifier; this prevents incidental
+    `Module.Name` mentions in prose from polluting the audit. Test the
+    contract documented in the tool's module docstring.
+    """
+    spec = tmp_path / "doc.md"
+    spec.write_text(
+        "# Notes\n"
+        "Reference: `myapp.unused.Symbol` is described elsewhere.\n"
+        "Implementations MUST provide `myapp.real.Symbol` everywhere.\n",
+        encoding="utf-8",
+    )
+    syms = sweep_redteam.extract_symbols(spec)
+    names = [s.name for s in syms]
+    assert names == ["myapp.real.Symbol"], names
+
+
+def test_extract_symbols_deduplicates_repeats(tmp_path):
+    """Same symbol mentioned twice yields one entry (first-seen wins)."""
+    spec = tmp_path / "doc.md"
+    spec.write_text(
+        "## §1\nMUST use `myapp.api.Engine` on line 2.\n"
+        "## §2\nMUST also use `myapp.api.Engine` on line 4.\n",
+        encoding="utf-8",
+    )
+    syms = sweep_redteam.extract_symbols(spec)
+    assert len(syms) == 1
+    assert syms[0].spec_line == 2, "first-seen line wins for dedup"
+
+
+def test_sentinel_field_shape_matches_spec(tmp_path, monkeypatch):
+    """Sentinel verbatim matches the documented shape in commands/sweep.md.
+
+    `<!-- sweep-redteam:v1:OK specs=N symbols=M orphans=O coverage_gaps=C stubs=S -->`
+    """
+    # Empty workspaces produces a stable sentinel — easy structural check.
+    (tmp_path / "workspaces" / "ws1" / "specs").mkdir(parents=True)
+    monkeypatch.setattr(sweep_redteam, "ROOT", tmp_path)
+    buf = io.StringIO()
+    sweep_redteam.run([], buf)
+    sentinel = buf.getvalue().strip()
+    expected = (
+        "<!-- sweep-redteam:v1:OK specs=0 symbols=0 "
+        "orphans=0 coverage_gaps=0 stubs=0 -->"
+    )
+    assert sentinel == expected

--- a/tools/sweep-redteam.py
+++ b/tools/sweep-redteam.py
@@ -76,7 +76,7 @@ import ast
 import json
 import re
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Iterator
 
@@ -316,8 +316,24 @@ def verify_symbol(symbol: SpecSymbol) -> list[Finding]:
     """
     # File-line ref shape — verify file exists and has ≥ that many lines
     if ":" in symbol.name and not symbol.name.split(".")[0].isidentifier():
-        path_str, line_str = symbol.name.rsplit(":", 1)
-        target = ROOT / path_str
+        path_str, _line_str = symbol.name.rsplit(":", 1)
+        target = (ROOT / path_str).resolve()
+        # Defense-in-depth: refuse path-collapse escapes even though the
+        # backtick-filerule regex bounds path chars. Per R1 security review
+        # LOW finding (R1-security-09).
+        try:
+            target.relative_to(ROOT.resolve())
+        except ValueError:
+            return [
+                Finding(
+                    category="orphan",
+                    symbol=symbol.name,
+                    spec=str(symbol.spec_path.relative_to(ROOT)),
+                    spec_line=symbol.spec_line,
+                    source=None,
+                    evidence=f"file-line ref escapes repo root: {path_str}",
+                )
+            ]
         if not target.is_file():
             return [
                 Finding(
@@ -539,9 +555,18 @@ def main(argv: list[str] | None = None) -> int:
         scope = Path(args.spec)
         if not scope.is_absolute():
             scope = ROOT / scope
-        if not scope.exists():
+        # Defense-in-depth: refuse paths outside ROOT even when the operator
+        # supplied an absolute path. Bounds the blast radius of an attacker
+        # who can influence argv (CI invocation with attacker-influenced
+        # parameters). Per R1 security review LOW finding (R1-security-01).
+        resolved = scope.resolve()
+        try:
+            resolved.relative_to(ROOT.resolve())
+        except ValueError:
+            parser.error(f"spec path escapes repo root: {scope}")
+        if not resolved.exists():
             parser.error(f"spec path does not exist: {scope}")
-        specs = list(iter_spec_files(scope))
+        specs = list(iter_spec_files(resolved))
 
     return run(specs, sys.stdout)
 

--- a/tools/sweep-redteam.py
+++ b/tools/sweep-redteam.py
@@ -238,8 +238,12 @@ def candidate_source_files(symbol: str) -> list[Path]:
     return deduped
 
 
-def find_symbol_in_ast(tree: ast.AST, tail_name: str) -> ast.AST | None:
-    """Walk an AST for a class/function/assignment matching tail_name."""
+def find_symbol_in_ast(tree: ast.AST, tail_name: str) -> ast.stmt | None:
+    """Walk an AST for a class/function/assignment matching tail_name.
+
+    Returns the matching statement node (ast.stmt) so callers can rely
+    on .lineno / .end_lineno being present.
+    """
     for node in ast.walk(tree):
         if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
             if node.name == tail_name:
@@ -251,7 +255,7 @@ def find_symbol_in_ast(tree: ast.AST, tail_name: str) -> ast.AST | None:
     return None
 
 
-def is_stub_body(node: ast.AST, source: str) -> tuple[bool, str]:
+def is_stub_body(node: ast.stmt, source: str) -> tuple[bool, str]:
     """Detect stub body: NotImplementedError raise, bare pass, or TODO comment.
 
     Returns (is_stub, evidence). Only applies to function/method definitions —
@@ -344,7 +348,7 @@ def verify_symbol(symbol: SpecSymbol) -> list[Finding]:
             )
         ]
 
-    found_at: tuple[Path, ast.AST, str] | None = None
+    found_at: tuple[Path, ast.stmt, str] | None = None
     for cand in candidates:
         try:
             src = cand.read_text(encoding="utf-8")

--- a/tools/sweep-redteam.py
+++ b/tools/sweep-redteam.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Sweep 5 redteam tool — per-spec MUST-symbol verification (#1129).
+
+Implements the `/sweep` Sweep 5 protocol from
+`.claude/commands/sweep.md` and `.claude/skills/spec-compliance/SKILL.md`:
+walk every `workspaces/*/specs/**/*.md`, extract MUST-clause symbols,
+verify they exist in source via AST parsing, verify Tier 2 wiring tests
+import them, and detect stub bodies (NotImplementedError / TODO / bare pass).
+
+Per `.claude/rules/probe-driven-verification.md` MUST-3: where structural
+verification is possible, use AST/grep/exit-code — NOT lexical regex over
+assistant prose. The MUST-symbol extraction here scans STRUCTURED markers
+in spec markdown (backticked identifiers next to "MUST" keywords); the
+verification is AST-walked Python source. Both halves are structural.
+
+# Invocation
+
+    tools/sweep-redteam.py --json specs/<file>.md   # one spec
+    tools/sweep-redteam.py --json --all             # every workspace spec
+
+# Output
+
+JSONL findings on stdout, one per line, followed by a sentinel comment.
+Findings have the shape:
+
+    {"category": "orphan|coverage_gap|stub|drift",
+     "symbol": "Module.Symbol",
+     "spec": "workspaces/<ws>/specs/<file>.md",
+     "spec_line": <int>,
+     "source": "<file:line>" | null,
+     "evidence": "<command + output>"}
+
+Sentinel (always emitted on stdout as the final line, on success or finding):
+
+    <!-- sweep-redteam:v1:OK specs=N symbols=M orphans=O coverage_gaps=C stubs=S -->
+
+Exit codes: 0 = no orphans/coverage_gaps/stubs; 1 = ≥1 finding (operator
+decides disposition).
+
+# MUST-symbol extraction heuristic
+
+A spec MUST symbol is extracted from any line containing `MUST` (case-
+sensitive) AND a backticked identifier of the shape:
+
+  * `Module.Symbol` or `Module.submodule.Symbol` (dotted path) — searched
+    for via AST in `packages/<pkg>/src/<module>.py` AND `src/<module>.py`.
+  * `path/to/file.py:NNN` (file-line ref) — line ref alone is verified by
+    file existence + line count.
+
+The heuristic is conservative — false negatives (missed symbols) are
+acceptable; false positives (spurious MUST citations) are not. The
+canonical entry shape is `MUST ... \`Module.Symbol\` ...` per the
+spec-compliance SKILL example tables.
+
+# Verification per symbol
+
+1. Source presence — AST-parse the candidate source file(s) and walk for
+   `ast.ClassDef` / `ast.FunctionDef` / `ast.AsyncFunctionDef` /
+   `ast.Assign(targets=[Name(...)])` matching the symbol's tail name.
+2. Tier 2 coverage — grep `tests/integration/**/*.py` for an `import` or
+   `from <module>` line referencing the module path. Missing = coverage_gap.
+3. Stub body — AST-walk the matching def's body: if a single `Raise` of
+   `NotImplementedError`, OR a single bare `Pass`, OR an inline `TODO` /
+   `FIXME` comment in the body source → stub finding.
+
+Drift detection (category 4) is out of scope for this v1 — the spec text
+that says "X" and source that does "Y" requires semantic comparison
+beyond AST shape; the tool emits the symbol presence/absence axis and
+defers drift to the human reviewer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Regex over STRUCTURED markdown markers (not semantic prose) — extracts a
+# backticked identifier from any line containing the literal "MUST" token.
+# Per probe-driven-verification.md MUST-3: structural lex over structured
+# markers is acceptable; this is NOT regex-over-semantic-claims.
+_MUST_LINE = re.compile(r"\bMUST\b")
+_BACKTICK_SYMBOL = re.compile(r"`([A-Z][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+)`")
+_BACKTICK_FILELINE = re.compile(r"`([A-Za-z0-9_./-]+\.py):(\d+)`")
+
+# Stub heuristics (AST-walked, not source-grepped)
+_STUB_COMMENT = re.compile(r"#\s*(TODO|FIXME|HACK|XXX)\b")
+
+
+@dataclass(frozen=True)
+class SpecSymbol:
+    """One MUST symbol mention extracted from a spec file."""
+
+    name: str  # dotted symbol path, e.g. "kailash.foo.Bar"
+    spec_path: Path  # absolute path to the spec file
+    spec_line: int  # 1-based line number where the mention appeared
+
+
+@dataclass
+class Finding:
+    category: str  # "orphan" | "coverage_gap" | "stub" | "drift"
+    symbol: str
+    spec: str
+    spec_line: int
+    source: str | None
+    evidence: str
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "category": self.category,
+                "symbol": self.symbol,
+                "spec": self.spec,
+                "spec_line": self.spec_line,
+                "source": self.source,
+                "evidence": self.evidence,
+            },
+            sort_keys=True,
+        )
+
+
+@dataclass
+class Sentinel:
+    specs: int = 0
+    symbols: int = 0
+    orphans: int = 0
+    coverage_gaps: int = 0
+    stubs: int = 0
+
+    def render(self) -> str:
+        return (
+            "<!-- sweep-redteam:v1:OK "
+            f"specs={self.specs} symbols={self.symbols} "
+            f"orphans={self.orphans} coverage_gaps={self.coverage_gaps} "
+            f"stubs={self.stubs} -->"
+        )
+
+
+# --- Spec extraction --------------------------------------------------------
+
+
+def extract_symbols(spec_path: Path) -> list[SpecSymbol]:
+    """Walk a spec file; extract MUST-tagged backticked symbols + file refs.
+
+    Returns a deduplicated list (preserves first-seen order). Conservative
+    extractor — only emits symbols matching the canonical shape.
+    """
+    text = spec_path.read_text(encoding="utf-8")
+    seen: dict[str, SpecSymbol] = {}
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if not _MUST_LINE.search(line):
+            continue
+        for m in _BACKTICK_SYMBOL.finditer(line):
+            name = m.group(1)
+            if name not in seen:
+                seen[name] = SpecSymbol(
+                    name=name, spec_path=spec_path, spec_line=line_no
+                )
+        for m in _BACKTICK_FILELINE.finditer(line):
+            ref = f"{m.group(1)}:{m.group(2)}"
+            if ref not in seen:
+                seen[ref] = SpecSymbol(name=ref, spec_path=spec_path, spec_line=line_no)
+    return list(seen.values())
+
+
+# --- Source verification ----------------------------------------------------
+
+
+def candidate_source_files(symbol: str) -> list[Path]:
+    """Map a dotted symbol path to likely source files.
+
+    "kailash.foo.bar.Baz" → tries (in order):
+      * src/kailash/foo/bar.py
+      * src/kailash/foo/bar/__init__.py
+      * packages/*/src/kailash/foo/bar.py
+      * packages/*/src/kailash_foo/bar.py (sub-package convention)
+
+    Returns ALL candidate paths that exist on disk. The tool does NOT
+    guess one — every candidate is parsed; first hit wins for evidence.
+    """
+    parts = symbol.split(".")
+    if len(parts) < 2:
+        return []
+    module_parts = parts[:-1]
+    candidates: list[Path] = []
+
+    # Try src/<module>.py and src/<module>/__init__.py
+    base = ROOT / "src" / Path(*module_parts)
+    candidates.append(base.with_suffix(".py"))
+    candidates.append(base / "__init__.py")
+
+    # Try packages/*/src/<module>.py
+    pkg_dir = ROOT / "packages"
+    if pkg_dir.is_dir():
+        for pkg in pkg_dir.iterdir():
+            if not pkg.is_dir():
+                continue
+            pkg_src = pkg / "src"
+            if not pkg_src.is_dir():
+                continue
+            candidates.append(pkg_src / Path(*module_parts).with_suffix(".py"))
+            candidates.append(pkg_src / Path(*module_parts) / "__init__.py")
+            # sub-package convention: "kailash_align" instead of "kailash.align"
+            if len(module_parts) >= 2 and module_parts[0] == "kailash":
+                alt_first = f"kailash_{module_parts[1]}"
+                alt_parts = [alt_first, *module_parts[2:]]
+                if alt_parts:
+                    candidates.append(pkg_src / Path(*alt_parts).with_suffix(".py"))
+                    candidates.append(pkg_src / Path(*alt_parts) / "__init__.py")
+
+    return [c for c in candidates if c.is_file()]
+
+
+def find_symbol_in_ast(tree: ast.AST, tail_name: str) -> ast.AST | None:
+    """Walk an AST for a class/function/assignment matching tail_name."""
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name == tail_name:
+                return node
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == tail_name:
+                    return node
+    return None
+
+
+def is_stub_body(node: ast.AST, source: str) -> tuple[bool, str]:
+    """Detect stub body: NotImplementedError raise, bare pass, or TODO comment.
+
+    Returns (is_stub, evidence). Only applies to function/method definitions —
+    classes and assignments cannot have stub bodies in this sense.
+    """
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return False, ""
+
+    body = node.body
+    # Strip leading docstring per Python convention
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+
+    if not body:
+        return False, ""
+
+    # Single statement bodies — the canonical stub shapes
+    if len(body) == 1:
+        stmt = body[0]
+        # raise NotImplementedError or raise NotImplementedError(...)
+        if isinstance(stmt, ast.Raise) and stmt.exc is not None:
+            exc = stmt.exc
+            name = None
+            if isinstance(exc, ast.Name):
+                name = exc.id
+            elif isinstance(exc, ast.Call) and isinstance(exc.func, ast.Name):
+                name = exc.func.id
+            if name == "NotImplementedError":
+                return True, f"raise NotImplementedError at line {stmt.lineno}"
+        # bare pass (as sole non-docstring body)
+        if isinstance(stmt, ast.Pass):
+            return True, f"bare pass at line {stmt.lineno}"
+
+    # TODO/FIXME comment inside the body source (lexically present in the
+    # function source range — still structural since we slice by line numbers)
+    try:
+        src_lines = source.splitlines()
+        body_src = "\n".join(src_lines[node.lineno - 1 : node.end_lineno])
+        m = _STUB_COMMENT.search(body_src)
+        if m:
+            return True, f"{m.group(1)} comment in body"
+    except (AttributeError, IndexError):
+        pass
+
+    return False, ""
+
+
+def verify_symbol(symbol: SpecSymbol) -> list[Finding]:
+    """Run the three checks for a SpecSymbol; emit findings for each gap.
+
+    Order: source-presence → stub-body → coverage. A missing source halts
+    the chain (no point checking stub/coverage on an orphan).
+    """
+    # File-line ref shape — verify file exists and has ≥ that many lines
+    if ":" in symbol.name and not symbol.name.split(".")[0].isidentifier():
+        path_str, line_str = symbol.name.rsplit(":", 1)
+        target = ROOT / path_str
+        if not target.is_file():
+            return [
+                Finding(
+                    category="orphan",
+                    symbol=symbol.name,
+                    spec=str(symbol.spec_path.relative_to(ROOT)),
+                    spec_line=symbol.spec_line,
+                    source=None,
+                    evidence=f"file not found: {path_str}",
+                )
+            ]
+        # Existence is enough — line refs do not get coverage/stub checks
+        return []
+
+    findings: list[Finding] = []
+    tail = symbol.name.split(".")[-1]
+    candidates = candidate_source_files(symbol.name)
+
+    if not candidates:
+        return [
+            Finding(
+                category="orphan",
+                symbol=symbol.name,
+                spec=str(symbol.spec_path.relative_to(ROOT)),
+                spec_line=symbol.spec_line,
+                source=None,
+                evidence="no candidate source files exist for module path",
+            )
+        ]
+
+    found_at: tuple[Path, ast.AST, str] | None = None
+    for cand in candidates:
+        try:
+            src = cand.read_text(encoding="utf-8")
+            tree = ast.parse(src, filename=str(cand))
+        except (OSError, SyntaxError):
+            continue
+        node = find_symbol_in_ast(tree, tail)
+        if node is not None:
+            found_at = (cand, node, src)
+            break
+
+    if found_at is None:
+        return [
+            Finding(
+                category="orphan",
+                symbol=symbol.name,
+                spec=str(symbol.spec_path.relative_to(ROOT)),
+                spec_line=symbol.spec_line,
+                source=None,
+                evidence=(
+                    f"ast.walk found no ClassDef/FunctionDef/Assign named "
+                    f"{tail!r} in {len(candidates)} candidate file(s)"
+                ),
+            )
+        ]
+
+    src_path, src_node, src_text = found_at
+    src_rel = str(src_path.relative_to(ROOT))
+    src_loc = f"{src_rel}:{src_node.lineno}"
+
+    # Stub-body check
+    is_stub, stub_evidence = is_stub_body(src_node, src_text)
+    if is_stub:
+        findings.append(
+            Finding(
+                category="stub",
+                symbol=symbol.name,
+                spec=str(symbol.spec_path.relative_to(ROOT)),
+                spec_line=symbol.spec_line,
+                source=src_loc,
+                evidence=stub_evidence,
+            )
+        )
+
+    # Tier-2 coverage check — grep tests/integration/ for module import
+    if not has_tier2_coverage(symbol.name):
+        findings.append(
+            Finding(
+                category="coverage_gap",
+                symbol=symbol.name,
+                spec=str(symbol.spec_path.relative_to(ROOT)),
+                spec_line=symbol.spec_line,
+                source=src_loc,
+                evidence=(
+                    f"no tests/integration/**/*.py file imports module "
+                    f"{'.'.join(symbol.name.split('.')[:-1])}"
+                ),
+            )
+        )
+
+    return findings
+
+
+def has_tier2_coverage(symbol_name: str) -> bool:
+    """Return True if any tests/integration/**/*.py imports the module."""
+    module_path = ".".join(symbol_name.split(".")[:-1])
+    if not module_path:
+        return False
+    tests_root = ROOT / "tests" / "integration"
+    if not tests_root.is_dir():
+        return False
+    # Build the structural import-line patterns:
+    #   "from <module>" / "import <module>"
+    # Use plain substring search per-file — fast, deterministic, scans bytes.
+    import_needle_from = f"from {module_path}".encode()
+    import_needle_imp = f"import {module_path}".encode()
+    for path in tests_root.rglob("*.py"):
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        if import_needle_from in data or import_needle_imp in data:
+            return True
+        # Also accept the parent module (sub-pkg convention shifts the path)
+        parent = ".".join(module_path.split(".")[:-1])
+        if parent:
+            if (
+                f"from {parent}".encode() in data
+                and module_path.split(".")[-1].encode() in data
+            ):
+                return True
+    return False
+
+
+# --- Orchestration ----------------------------------------------------------
+
+
+def iter_spec_files(scope: Path | None = None) -> Iterator[Path]:
+    """Yield spec files. With scope=None, walks all workspaces/*/specs/."""
+    if scope is not None:
+        if scope.is_file():
+            yield scope
+        elif scope.is_dir():
+            yield from sorted(scope.rglob("*.md"))
+        return
+    ws_root = ROOT / "workspaces"
+    if not ws_root.is_dir():
+        return
+    for ws in sorted(ws_root.iterdir()):
+        if not ws.is_dir():
+            continue
+        specs_dir = ws / "specs"
+        if not specs_dir.is_dir():
+            continue
+        yield from sorted(specs_dir.rglob("*.md"))
+
+
+def run(spec_paths: Iterable[Path], out) -> int:
+    """Run verification over the given specs; emit JSONL + sentinel.
+
+    Returns process exit code: 0 if no orphans/coverage_gaps/stubs, else 1.
+    """
+    sentinel = Sentinel()
+    for spec in spec_paths:
+        sentinel.specs += 1
+        symbols = extract_symbols(spec)
+        sentinel.symbols += len(symbols)
+        for sym in symbols:
+            for finding in verify_symbol(sym):
+                out.write(finding.to_json() + "\n")
+                if finding.category == "orphan":
+                    sentinel.orphans += 1
+                elif finding.category == "coverage_gap":
+                    sentinel.coverage_gaps += 1
+                elif finding.category == "stub":
+                    sentinel.stubs += 1
+    out.write(sentinel.render() + "\n")
+    has_finding = sentinel.orphans + sentinel.coverage_gaps + sentinel.stubs > 0
+    return 1 if has_finding else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sweep 5 redteam tool — extract MUST-tagged symbols from "
+            "workspaces/*/specs/**/*.md and verify presence + Tier 2 "
+            "coverage + stub-free body via AST."
+        ),
+        epilog=(
+            "Heuristic: MUST-symbol = a backticked identifier of shape "
+            "`Module.Symbol` or `path/to/file.py:NNN` on any line "
+            "containing the literal token MUST. Conservative — misses "
+            "are acceptable; spurious matches are not. See "
+            "tools/sweep-redteam.py module docstring + "
+            ".claude/skills/spec-compliance/SKILL.md."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit JSONL findings to stdout, one per line, with a sentinel "
+            "comment as the final line. This is the only supported output "
+            "format in v1."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--all",
+        action="store_true",
+        help="Verify every workspaces/*/specs/**/*.md file.",
+    )
+    group.add_argument(
+        "spec",
+        nargs="?",
+        help="A specific spec file or directory under workspaces/*/specs/.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.json:
+        # v1 only supports --json; reject anything else explicitly so the
+        # next reader knows the format is intentional, not under-implemented.
+        parser.error("--json is required (the only supported output format in v1)")
+
+    if args.all:
+        specs = list(iter_spec_files(None))
+    else:
+        scope = Path(args.spec)
+        if not scope.is_absolute():
+            scope = ROOT / scope
+        if not scope.exists():
+            parser.error(f"spec path does not exist: {scope}")
+        specs = list(iter_spec_files(scope))
+
+    return run(specs, sys.stdout)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sweep-redteam.py
+++ b/tools/sweep-redteam.py
@@ -49,8 +49,8 @@ sensitive) AND a backticked identifier of the shape:
 
 The heuristic is conservative — false negatives (missed symbols) are
 acceptable; false positives (spurious MUST citations) are not. The
-canonical entry shape is `MUST ... \`Module.Symbol\` ...` per the
-spec-compliance SKILL example tables.
+canonical entry shape is "MUST ... Module.Symbol ..." (the symbol
+wrapped in backticks) per the spec-compliance SKILL example tables.
 
 # Verification per symbol
 
@@ -87,7 +87,9 @@ ROOT = Path(__file__).resolve().parent.parent
 # Per probe-driven-verification.md MUST-3: structural lex over structured
 # markers is acceptable; this is NOT regex-over-semantic-claims.
 _MUST_LINE = re.compile(r"\bMUST\b")
-_BACKTICK_SYMBOL = re.compile(r"`([A-Z][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+)`")
+_BACKTICK_SYMBOL = re.compile(
+    r"`([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+)`"
+)
 _BACKTICK_FILELINE = re.compile(r"`([A-Za-z0-9_./-]+\.py):(\d+)`")
 
 # Stub heuristics (AST-walked, not source-grepped)
@@ -176,35 +178,46 @@ def extract_symbols(spec_path: Path) -> list[SpecSymbol]:
 def candidate_source_files(symbol: str) -> list[Path]:
     """Map a dotted symbol path to likely source files.
 
-    "kailash.foo.bar.Baz" → tries (in order):
-      * src/kailash/foo/bar.py
-      * src/kailash/foo/bar/__init__.py
-      * packages/*/src/kailash/foo/bar.py
-      * packages/*/src/kailash_foo/bar.py (sub-package convention)
+    "kailash.foo.bar.Baz" → tries (in order), every progressively-shorter
+    module-prefix because the symbol's last 1-N parts may be a
+    class.method.nested chain inside a single module file:
 
-    Returns ALL candidate paths that exist on disk. The tool does NOT
-    guess one — every candidate is parsed; first hit wins for evidence.
+      * src/kailash/foo/bar.py       (module = kailash.foo.bar, tail = Baz)
+      * src/kailash/foo/bar/__init__.py
+      * src/kailash/foo.py           (module = kailash.foo, tail = bar.Baz)
+      * src/kailash/foo/__init__.py
+      * packages/*/src/<module>.py   (mirrored for every prefix)
+      * packages/*/src/kailash_<sub>/<rest>.py (sub-package convention)
+
+    The tail-symbol AST walk in `find_symbol_in_ast` uses `parts[-1]`
+    only — so every candidate file is parsed and walked for the tail.
+    Returns ALL candidate paths that exist on disk in priority order
+    (longest module prefix first, shortest last). Deduplicated.
     """
     parts = symbol.split(".")
     if len(parts) < 2:
         return []
-    module_parts = parts[:-1]
+
     candidates: list[Path] = []
-
-    # Try src/<module>.py and src/<module>/__init__.py
-    base = ROOT / "src" / Path(*module_parts)
-    candidates.append(base.with_suffix(".py"))
-    candidates.append(base / "__init__.py")
-
-    # Try packages/*/src/<module>.py
     pkg_dir = ROOT / "packages"
+    pkg_srcs: list[Path] = []
     if pkg_dir.is_dir():
-        for pkg in pkg_dir.iterdir():
-            if not pkg.is_dir():
-                continue
-            pkg_src = pkg / "src"
-            if not pkg_src.is_dir():
-                continue
+        for pkg in sorted(pkg_dir.iterdir()):
+            if pkg.is_dir() and (pkg / "src").is_dir():
+                pkg_srcs.append(pkg / "src")
+
+    # Iterate module-prefix lengths from longest (parts[:-1]) down to 1,
+    # so the most-specific file is tried first. AST walk is cheap and
+    # first-hit semantics protect against name shadowing per
+    # find_symbol_in_ast's documented contract.
+    for prefix_len in range(len(parts) - 1, 0, -1):
+        module_parts = parts[:prefix_len]
+        # src/<module>.py and src/<module>/__init__.py
+        base = ROOT / "src" / Path(*module_parts)
+        candidates.append(base.with_suffix(".py"))
+        candidates.append(base / "__init__.py")
+        # packages/*/src/<module>.py
+        for pkg_src in pkg_srcs:
             candidates.append(pkg_src / Path(*module_parts).with_suffix(".py"))
             candidates.append(pkg_src / Path(*module_parts) / "__init__.py")
             # sub-package convention: "kailash_align" instead of "kailash.align"
@@ -215,7 +228,14 @@ def candidate_source_files(symbol: str) -> list[Path]:
                     candidates.append(pkg_src / Path(*alt_parts).with_suffix(".py"))
                     candidates.append(pkg_src / Path(*alt_parts) / "__init__.py")
 
-    return [c for c in candidates if c.is_file()]
+    # Deduplicate while preserving priority order
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for c in candidates:
+        if c not in seen and c.is_file():
+            seen.add(c)
+            deduped.append(c)
+    return deduped
 
 
 def find_symbol_in_ast(tree: ast.AST, tail_name: str) -> ast.AST | None:


### PR DESCRIPTION
## Summary

Adds the `tools/sweep-redteam.py` audit tool that backs the `/sweep` Sweep 5 protocol. The tool walks `workspaces/*/specs/**/*.md`, extracts MUST-tagged backticked symbols, and verifies each via AST-walked source presence + Tier 2 integration-test import grep + stub-body detection.

## Related issues

Fixes #1129

## Acceptance criteria

- [x] `tools/sweep-redteam.py` exists with per-spec + `--all` invocation (`--json specs/<file>.md` and `--json --all`)
- [x] Emits sentinel matching documented field shape: `<!-- sweep-redteam:v1:OK specs=N symbols=M orphans=O coverage_gaps=C stubs=S -->`
- [x] `/sweep` Sweep 5 wired to invoke the tool (BUILD-mode invocation example added; pre-condition gate already correct)
- [x] Unit tests under `tests/unit/tools/test_sweep_redteam.py` covering: empty specs, all-passing spec, orphan finding, coverage_gap finding, stub finding (plus three contract tests for MUST-symbol extractor + sentinel shape)
- [~] **BUILD-mode pre-condition gate**: half-satisfied. `tools/sweep-redteam.py` IS present (`no_tool=false`); `workspaces/*/specs/` is NOT present in this repo (`no_specs=true` — only `workspaces/_archive/*/specs` exists). The orchestration-mode N/A sentinel fires per `commands/sweep.md:71`. See **User-flow walk receipt** below + **Recommendation** for disposition.

## Design notes

Per `rules/probe-driven-verification.md` MUST-3: spec verification IS structural (AST walk + grep over imports), NOT lexical regex over assistant prose. The MUST-symbol extractor lexes structured markdown markers (backticked identifier on a line containing the literal token MUST) — that's structural-over-structured-markers per MUST-3, NOT regex-over-semantic-prose per MUST-1.

The candidate-source resolver walks progressively-shorter module prefixes so `myapp.cache.LRU.evict` resolves to `src/myapp/cache.py` with class `LRU` containing method `evict` — symbol paths don't have to terminate at a single-name tail.

Conservative extractor: false negatives (missed symbols) are acceptable; false positives (spurious MUST citations) are not. Tail-name AST walk uses first-hit semantics across candidates in priority order.

## Test plan

- [x] Tier-1 unit tests: 8 tests, all green in 0.48s (well under the <1s/test Tier-1 budget)
  - `test_empty_specs_directory_emits_zero_sentinel` — Case 1
  - `test_all_passing_spec_emits_no_findings` — Case 2
  - `test_orphan_when_source_missing` — Case 3
  - `test_coverage_gap_when_no_tier2_import` — Case 4
  - `test_stub_when_body_raises_not_implemented` — Case 5
  - `test_extract_symbols_requires_must_token` — extractor contract
  - `test_extract_symbols_deduplicates_repeats` — extractor contract
  - `test_sentinel_field_shape_matches_spec` — sentinel verbatim
- [x] `mypy tools/sweep-redteam.py` — clean (1 source file, 0 issues)
- [x] `python3 tools/sweep-redteam.py --json --all` — manual invocation against this repo

## User-flow walk receipt (per `rules/user-flow-validation.md` MUST-2)

Verbatim invocation against this repo's checkout:

\`\`\`
$ python3 tools/sweep-redteam.py --json --all
<!-- sweep-redteam:v1:OK specs=0 symbols=0 orphans=0 coverage_gaps=0 stubs=0 -->
$ echo \"exit: \$?\"
exit: 0
\`\`\`

Pre-condition gate evaluation (per `commands/sweep.md:69-74`):

\`\`\`
spec_count=0  (no workspaces/*/specs/ exists — only workspaces/_archive/*/specs)
tool_present=true
→ <!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->
\`\`\`

The tool runs cleanly; the gate fires N/A because no current workspace has materialized a `specs/` directory.

## Recommendation (per `rules/recommendation-quality.md` MUST-1)

The tool is feature-complete and tested. The BUILD-mode pre-condition gate's specs-dir half is not yet satisfied because no current workspace materializes `specs/`. Two options:

- **Option A — Land the tool as-is, leave specs materialization to operators** (recommended). The tool is operator-ready; future workspaces that materialize `briefs/` → `specs/` (per the standard CO workflow) will exercise it. Today's `/sweep` Sweep 5 logs the N/A sentinel; tomorrow's BUILD work with specs flips it to OK / findings. **Implications:** issue closes on tool delivery; no test workspace pollutes the repo; tomorrow's first real workspace exercises the tool end-to-end.
- **Option B — Add a fixture workspace + spec to make the gate immediately PASS.** Would require materializing `workspaces/<test-fixture>/specs/<file>.md` with a real (or representative) MUST symbol that resolves to real source. **Cons:** scope expansion beyond the issue body, and `rules/verify-resource-existence.md` MUST-3 default disposition is "delete-or-stub, not provision" when an existence check fails.

**Pros (A):** scope-tight, no synthetic fixtures in the repo, tool ships per acceptance criteria 1-4 verbatim. **Cons (A):** acceptance criterion 5 (\"BUILD-mode pre-condition gate PASSES\") is half-met until an operator materializes a workspace spec. I'd recommend A; if you'd rather B, say the word and I'll add a fixture workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)