### PR TITLE
refactor(delegate): drop Connector __init_subclass__ proxy; concrete defaults (F11)

### DIFF
--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -61,7 +61,7 @@ import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Generic, Protocol, TypeVar, runtime_checkable
+from typing import Any, Generic, NoReturn, Protocol, TypeVar, runtime_checkable
 
 from kailash.delegate.audit import AuditChainEngine, DelegateEventType
 from kailash.delegate.envelope import DelegateConstraintEnvelope
@@ -457,25 +457,31 @@ class Connector(abc.ABC):
     primitives, plus class-level ``connector_id``/``connector_kind``/
     ``requires_capabilities`` metadata for bind-time gating.
 
-    **Backwards-compat (legacy invoke)**. The single :meth:`invoke`
-    method that pre-dated F-17 remains the dispatch hot path's entry
-    point for legacy Connector subclasses. Subclasses defining
-    ``invoke()`` but not the 6 new primitives are detected by
-    :meth:`__init_subclass__` and the 6 new abstracts are auto-installed
-    as default proxies routing through :meth:`invoke` (most commonly
-    via the ``write`` primitive). Per the issue plan §"Preserve
-    backwards-compat via legacy adapter", the 418-test suite continues
-    to pass while new connectors implement the full 4-primitive shape.
+    **Backwards-compat (legacy invoke)**. :meth:`invoke` is the sole
+    abstract method and the dispatch hot path's universal entry point —
+    :meth:`DispatchSurface.dispatch` always calls
+    ``await connector.invoke(...)``. The 6 newer members (3 accessors +
+    3 primitives) ship as **concrete defaults on this base class**: the
+    accessors raise a typed "not supported by a legacy connector" error,
+    and ``authenticate``/``write``/``read`` provide the legacy-adapter
+    behavior (trivial Principal; execute-and-synthesize-an-empty-signature
+    envelope/receipt). A subclass that implements only ``invoke()`` is
+    therefore fully concrete — it inherits the 6 defaults — with no
+    ``__init_subclass__`` runtime adaptation. Per the issue plan
+    §"Preserve backwards-compat via legacy adapter", the 418-test suite
+    continues to pass while new connectors implement the full
+    4-primitive shape.
 
-    New connectors SHOULD subclass :class:`Connector` directly and
-    implement all 6 new abstracts (the 3 accessors + 3 primitives).
-    Legacy connectors MAY subclass either :class:`Connector` (auto-
-    adapted via __init_subclass__) or :class:`LegacyInvokeConnector`
-    (explicit adapter wrapping a callable).
+    New connectors SHOULD subclass :class:`Connector`, implement
+    ``invoke()`` for the hot path, and OVERRIDE the 6 default members
+    (the 3 accessors + 3 primitives) with real implementations. Legacy
+    connectors MAY subclass either :class:`Connector` (inheriting the
+    defaults) or :class:`LegacyInvokeConnector` (explicit adapter
+    wrapping a callable).
 
-    The ABC refuses direct instantiation via :class:`abc.ABC` + the
-    abstract methods. Per ``orphan-detection.md`` MUST Rule 1, this
-    base class lives in the framework hot path:
+    The ABC refuses direct instantiation via :class:`abc.ABC` + the sole
+    abstract :meth:`invoke`. Per ``orphan-detection.md`` MUST Rule 1,
+    this base class lives in the framework hot path:
     :meth:`DispatchSurface.dispatch` calls ``await connector.invoke(...)``
     directly — there is no facade orphan layer.
 
@@ -531,83 +537,24 @@ class Connector(abc.ABC):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        # F-17 backwards-compat adapter: if the subclass overrides
-        # ``invoke()`` but does NOT override the 6 new primitives
-        # (3 accessors + 3 primitive methods), auto-install default
-        # proxies that route through ``invoke()``. This preserves the
-        # 418-test legacy suite while keeping the abstract-method
-        # contract for new connectors implementing the full rs shape.
-        #
-        # Detection: look in cls.__dict__ for an explicitly-overridden
-        # ``invoke`` (not inherited as abstract). If present AND none of
-        # the new abstracts are overridden in cls.__dict__, install the
-        # default proxies as concrete methods on the subclass.
-        invoke_in_dict = cls.__dict__.get("invoke")
-        legacy_invoke_defined = invoke_in_dict is not None and not getattr(
-            invoke_in_dict, "__isabstractmethod__", False
-        )
-        if legacy_invoke_defined:
-            # Auto-install proxies for any of the 6 new primitives the
-            # subclass did NOT explicitly define. The proxies satisfy
-            # the @abstractmethod requirement so ABCMeta no longer
-            # blocks instantiation; the dispatch hot path still calls
-            # ``invoke()`` for legacy subclasses, so the proxies are
-            # primarily ABC-satisfaction shims with sensible defaults
-            # for callers that DO use the new surface against a legacy
-            # connector.
-            if "revocation" not in cls.__dict__:
-                cls.revocation = _LEGACY_REVOCATION_PROPERTY  # type: ignore[assignment]
-            if "ledger" not in cls.__dict__:
-                cls.ledger = _LEGACY_LEDGER_PROPERTY  # type: ignore[assignment]
-            if "auth_verifier" not in cls.__dict__:
-                cls.auth_verifier = _LEGACY_AUTH_VERIFIER_PROPERTY  # type: ignore[assignment]
-            if "authenticate" not in cls.__dict__:
-                cls.authenticate = _legacy_authenticate  # type: ignore[assignment]
-            if "write" not in cls.__dict__:
-                cls.write = _legacy_write  # type: ignore[assignment]
-            if "read" not in cls.__dict__:
-                cls.read = _legacy_read  # type: ignore[assignment]
-            # Re-compute __abstractmethods__ so ABCMeta sees the
-            # newly-installed proxies as concrete satisfactions of the
-            # abstract surface. ABCMeta populates __abstractmethods__
-            # AFTER __init_subclass__ in some Python versions; guard
-            # with getattr to handle both ordering paths.
-            current_abstracts = getattr(cls, "__abstractmethods__", frozenset())
-            if current_abstracts:
-                cls.__abstractmethods__ = frozenset(
-                    name
-                    for name in current_abstracts
-                    if name
-                    not in {
-                        "revocation",
-                        "ledger",
-                        "auth_verifier",
-                        "authenticate",
-                        "write",
-                        "read",
-                    }
-                )
-
-        # Defense-in-depth: every concrete subclass MUST declare a
-        # non-empty connector_id at the class level so audit events
-        # carry a meaningful identifier. Empty string at the subclass
-        # level is BLOCKED (the ABC's empty default cannot satisfy this
-        # check).
-        abstract_methods = getattr(cls, "__abstractmethods__", frozenset())
-        # Detect concrete subclasses: empty __abstractmethods__ AND
-        # either invoke is overridden OR all 6 new abstracts are.
-        is_concrete = abstract_methods == frozenset() and (
-            legacy_invoke_defined
-            or all(
-                name in cls.__dict__
-                or not getattr(getattr(cls, name, None), "__isabstractmethod__", False)
-                for name in ("authenticate", "write", "read")
-            )
+        # Concrete-defaults design: :meth:`invoke` is the sole abstract
+        # method; the 6 newer members (3 accessors + 3 primitives) ship
+        # as concrete defaults on this base class. A subclass is concrete
+        # exactly when it implements ``invoke()`` (overrides the abstract).
+        # No runtime proxy installation and no ``__abstractmethods__``
+        # mutation — ABCMeta resolves abstractness from the inherited
+        # concrete defaults, so pyright models legacy invoke()-only
+        # subclasses as concrete (no spurious reportAbstractUsage).
+        invoke_attr = getattr(cls, "invoke", None)
+        is_concrete = invoke_attr is not None and not getattr(
+            invoke_attr, "__isabstractmethod__", False
         )
         if is_concrete:
-            # Concrete subclass — enforce metadata declaration. Abstract
-            # intermediate base classes may legitimately defer metadata
-            # to their own concrete subclasses.
+            # Defense-in-depth: every concrete subclass MUST declare
+            # non-empty connector metadata so audit events carry a
+            # meaningful identifier. Abstract intermediate base classes
+            # (invoke still abstract) legitimately defer metadata to
+            # their own concrete subclasses.
             if not isinstance(cls.connector_id, str) or not cls.connector_id:
                 raise TypeError(
                     f"Connector subclass {cls.__name__!r} MUST declare a "
@@ -666,29 +613,35 @@ class Connector(abc.ABC):
         """
         raise NotImplementedError  # pragma: no cover (abstract)
 
-    # ─── Required accessors (3) — mirror rs trait inherent methods ──────
+    # ─── Default accessors (3) — mirror rs trait inherent methods ───────
+    #
+    # Concrete defaults: legacy invoke()-only connectors do not expose the
+    # rs-mirrored accessor surface, so accessing one raises a typed guard
+    # (per ``zero-tolerance.md`` Rule 3a) rather than a silent
+    # AttributeError. New-shape connectors OVERRIDE these with real
+    # ``@property`` accessors.
 
     @property
-    @abc.abstractmethod
     def revocation(self) -> RevocationChannel:
-        """The connector's revocation channel. Reachable for every dispatch."""
-        raise NotImplementedError  # pragma: no cover (abstract)
+        """The connector's revocation channel (default: unsupported by legacy connectors)."""
+        _legacy_unsupported("revocation")
 
     @property
-    @abc.abstractmethod
     def ledger(self) -> KnowledgeLedger:
-        """The connector's knowledge ledger (where dispatch reads/writes record)."""
-        raise NotImplementedError  # pragma: no cover (abstract)
+        """The connector's knowledge ledger (default: unsupported by legacy connectors)."""
+        _legacy_unsupported("ledger")
 
     @property
-    @abc.abstractmethod
     def auth_verifier(self) -> AuthVerifier:
-        """The connector's authentication verifier (OIDC/SAML/etc.)."""
-        raise NotImplementedError  # pragma: no cover (abstract)
+        """The connector's authentication verifier (default: unsupported by legacy connectors)."""
+        _legacy_unsupported("auth_verifier")
 
-    # ─── Required primitives (3) — mirror rs trait async fns ────────────
+    # ─── Default primitives (3) — mirror rs trait async fns ─────────────
+    #
+    # Concrete defaults provide the legacy-adapter behavior so an
+    # invoke()-only connector is fully concrete. New-shape connectors
+    # OVERRIDE these with real cryptographic implementations.
 
-    @abc.abstractmethod
     async def authenticate(
         self,
         identity: DelegateIdentity,
@@ -696,11 +649,18 @@ class Connector(abc.ABC):
     ) -> Principal:
         """Authenticate the dispatch identity; return a :class:`Principal`.
 
-        Raises a connector-defined exception if authentication fails.
+        Default (legacy invoke()-only connectors): returns a trivial
+        Principal scoped to the bound identity — legacy connectors
+        authenticated implicitly via ``invoke()``. New-shape connectors
+        override with a real authentication exchange (and may raise a
+        connector-defined exception on failure).
         """
-        raise NotImplementedError  # pragma: no cover (abstract)
+        return Principal(
+            delegate_id=str(identity.delegate_id),
+            tenant_id=None,
+            claims={},
+        )
 
-    @abc.abstractmethod
     async def write(
         self,
         action: Callable[[], Awaitable[Any]],
@@ -710,12 +670,29 @@ class Connector(abc.ABC):
     ) -> SignedActionEnvelope:
         """Execute a write action under audit; return a signed action envelope.
 
-        The signature on the envelope MUST be verifiable via the runtime's
-        :class:`Verifier`.
+        Default (legacy invoke()-only connectors): executes the action and
+        synthesizes a :class:`SignedActionEnvelope` with an EMPTY signature
+        — legacy connectors did not produce cryptographic action
+        signatures, so new-shape callers receiving an empty-signature
+        envelope MUST treat it as unverifiable per F-17 dispatch wiring.
+        New-shape connectors override with a real signing exchange whose
+        signature is verifiable via the runtime's :class:`Verifier`.
         """
-        raise NotImplementedError  # pragma: no cover (abstract)
+        payload_obj = await action()
+        payload_dict: dict[str, Any]
+        if isinstance(payload_obj, dict):
+            payload_dict = payload_obj
+        else:
+            payload_dict = {"value": payload_obj}
+        canonical_bytes = canonical_json_dumps(payload_dict).encode("utf-8")
+        return SignedActionEnvelope(
+            action_id=uuid.uuid4(),
+            canonical_bytes=canonical_bytes,
+            signature=b"",  # legacy connector did not sign
+            signer_delegate_id=str(identity.delegate_id),
+            payload=payload_dict,
+        )
 
-    @abc.abstractmethod
     async def read(
         self,
         query: Callable[[], Awaitable[T_Read]],
@@ -723,129 +700,63 @@ class Connector(abc.ABC):
         identity: DelegateIdentity,
         envelope: DelegateConstraintEnvelope,
     ) -> tuple[T_Read, AttestedReadReceipt]:
-        """Execute a read query under audit; return (payload, attested-receipt)."""
-        raise NotImplementedError  # pragma: no cover (abstract)
+        """Execute a read query under audit; return (payload, attested-receipt).
+
+        Default (legacy invoke()-only connectors): executes the query and
+        synthesizes an :class:`AttestedReadReceipt` with an EMPTY
+        attestation — legacy connectors did not produce cryptographic read
+        attestations. New-shape connectors override with a real attestation
+        exchange.
+        """
+        value = await query()
+        canonical_bytes = canonical_json_dumps(
+            {
+                "value": (
+                    value
+                    if isinstance(
+                        value, (dict, list, str, int, float, bool, type(None))
+                    )
+                    else repr(value)
+                )
+            }
+        ).encode("utf-8")
+        receipt = AttestedReadReceipt(
+            read_id=uuid.uuid4(),
+            canonical_bytes=canonical_bytes,
+            attestation=b"",
+            attester_delegate_id=str(identity.delegate_id),
+            observed_at=datetime.now(timezone.utc),
+        )
+        return value, receipt
 
 
 # ---------------------------------------------------------------------------
-# Legacy-adapter default proxies — installed by __init_subclass__ when a
-# subclass defines invoke() but not the 6 new primitives. Module-level
-# functions so __init_subclass__ can assign them as method descriptors.
+# Typed guard for accessor surface unsupported by legacy connectors.
+# The 3 accessor defaults on Connector call this so a caller reaching for
+# ``connector.revocation`` against a legacy invoke()-only connector gets a
+# clear refusal rather than a silent AttributeError. The legacy default
+# behavior for the 3 primitives (authenticate / write / read) is inlined
+# directly into the Connector base class concrete defaults above — there is
+# no longer any __init_subclass__ proxy-installation machinery.
 # ---------------------------------------------------------------------------
 
 
-def _legacy_unsupported(name: str) -> "Any":
-    """Return a sentinel that explains the new-shape primitive is unsupported.
+def _legacy_unsupported(name: str) -> NoReturn:
+    """Raise a typed refusal for a primitive a legacy connector does not expose.
 
     Legacy ``invoke()``-only connectors do not expose the rs-mirrored
-    primitive surface; callers that reach for ``connector.write(...)``
-    against a legacy connector get a clear refusal rather than a silent
-    AttributeError (per ``zero-tolerance.md`` Rule 3a typed-delegate guards).
+    accessor surface; callers that reach for ``connector.revocation`` /
+    ``.ledger`` / ``.auth_verifier`` against a legacy connector get a clear
+    refusal rather than a silent AttributeError (per ``zero-tolerance.md``
+    Rule 3a typed-delegate guards). The ``NoReturn`` annotation lets the
+    accessor properties declare their real return types without a
+    fall-through-to-None type error.
     """
     raise NotImplementedError(
         f"Connector primitive {name!r} not implemented by this legacy "
         f"invoke()-only connector — use connector.invoke(...) or migrate "
         f"the connector to the 4-primitive shape"
     )
-
-
-class _LegacyAccessor:
-    """Sentinel accessor: raises on access via __get__ descriptor protocol."""
-
-    def __init__(self, name: str) -> None:
-        self._name = name
-
-    def __get__(self, instance: Any, owner: type | None = None) -> Any:
-        if instance is None:
-            return self
-        _legacy_unsupported(self._name)
-
-
-_LEGACY_REVOCATION_PROPERTY = _LegacyAccessor("revocation")
-_LEGACY_LEDGER_PROPERTY = _LegacyAccessor("ledger")
-_LEGACY_AUTH_VERIFIER_PROPERTY = _LegacyAccessor("auth_verifier")
-
-
-async def _legacy_authenticate(
-    self: Any,
-    identity: DelegateIdentity,
-    envelope: DelegateConstraintEnvelope,
-) -> Principal:
-    """Default ``authenticate`` for legacy invoke()-only connectors.
-
-    Returns a trivial Principal scoped to the bound identity. Legacy
-    connectors authenticated implicitly via ``invoke()`` — this proxy
-    keeps that contract surface alive for new-shape callers.
-    """
-    return Principal(
-        delegate_id=str(identity.delegate_id),
-        tenant_id=None,
-        claims={},
-    )
-
-
-async def _legacy_write(
-    self: Any,
-    action: Callable[[], Awaitable[Any]],
-    *,
-    identity: DelegateIdentity,
-    envelope: DelegateConstraintEnvelope,
-) -> SignedActionEnvelope:
-    """Default ``write`` for legacy invoke()-only connectors.
-
-    Executes the action and returns a synthesized SignedActionEnvelope
-    with an EMPTY signature — legacy connectors did not produce
-    cryptographic action signatures. New-shape callers receiving an
-    empty-signature envelope from a legacy connector MUST treat it as
-    unverifiable per F-17 dispatch wiring.
-    """
-    payload_obj = await action()
-    payload_dict: dict[str, Any]
-    if isinstance(payload_obj, dict):
-        payload_dict = payload_obj
-    else:
-        payload_dict = {"value": payload_obj}
-    canonical_bytes = canonical_json_dumps(payload_dict).encode("utf-8")
-    return SignedActionEnvelope(
-        action_id=uuid.uuid4(),
-        canonical_bytes=canonical_bytes,
-        signature=b"",  # legacy connector did not sign
-        signer_delegate_id=str(identity.delegate_id),
-        payload=payload_dict,
-    )
-
-
-async def _legacy_read(
-    self: Any,
-    query: Callable[[], Awaitable[T_Read]],
-    *,
-    identity: DelegateIdentity,
-    envelope: DelegateConstraintEnvelope,
-) -> tuple[T_Read, AttestedReadReceipt]:
-    """Default ``read`` for legacy invoke()-only connectors.
-
-    Executes the query and returns the value plus a synthesized
-    :class:`AttestedReadReceipt` with an EMPTY attestation — legacy
-    connectors did not produce cryptographic read attestations.
-    """
-    value = await query()
-    canonical_bytes = canonical_json_dumps(
-        {
-            "value": (
-                value
-                if isinstance(value, (dict, list, str, int, float, bool, type(None)))
-                else repr(value)
-            )
-        }
-    ).encode("utf-8")
-    receipt = AttestedReadReceipt(
-        read_id=uuid.uuid4(),
-        canonical_bytes=canonical_bytes,
-        attestation=b"",
-        attester_delegate_id=str(identity.delegate_id),
-        observed_at=datetime.now(timezone.utc),
-    )
-    return value, receipt
 
 
 # ---------------------------------------------------------------------------
@@ -860,9 +771,10 @@ class LegacyInvokeConnector(Connector):
     existing legacy connectors that ship as bare ``async def invoke(...)``
     callables (not as Connector subclasses) can wrap into the new Connector
     ABC via this adapter. The wrapped callable is invoked from the
-    :meth:`invoke` method; the 6 new abstracts are auto-satisfied via the
-    same default proxies the ``__init_subclass__`` machinery installs for
-    direct Connector subclasses.
+    :meth:`invoke` method; the 6 newer members (3 accessors + 3 primitives)
+    are satisfied by the concrete defaults inherited from
+    :class:`Connector` (accessors raise the typed legacy guard; the
+    primitives provide the legacy-adapter behavior).
 
     The adapter is most useful for downstream consumers porting legacy
     connector callables to the new ABC without subclassing. New connectors

--- a/tests/unit/delegate/test_connector_abc_shape.py
+++ b/tests/unit/delegate/test_connector_abc_shape.py
@@ -1,6 +1,6 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
-"""Connector ABC shape — verify the 6 rs-mirrored abstract members (F-17).
+"""Connector ABC shape — verify the rs-mirrored member surface (F-17).
 
 Per ``workspaces/issue-1035-delegate-py/01-analysis/02-kailash-rs-reference-
 extraction.md:332-385`` (Round-1 F-17), the Python :class:`Connector` ABC
@@ -9,17 +9,26 @@ accessors (revocation/ledger/auth_verifier) + 3 required primitives
 (authenticate/write/read). The legacy ``invoke()`` method is preserved
 for backwards-compat.
 
+**Concrete-defaults design (option c).** ``invoke()`` is the sole
+``@abstractmethod``; the 6 newer members (3 accessors + 3 primitives)
+ship as concrete defaults on the base class (accessors raise a typed
+legacy guard; the primitives provide the legacy-adapter behavior).
+A subclass implementing only ``invoke()`` is therefore fully concrete
+by inheritance — there is no ``__init_subclass__`` runtime proxy
+installation and no ``__abstractmethods__`` mutation, so static type
+checkers model legacy invoke()-only subclasses as concrete (no spurious
+``reportAbstractUsage``).
+
 This file verifies the structural ABC contract:
 
 1. Connector is abc.ABC; direct instantiation refused.
-2. Connector.__abstractmethods__ contains all 7 abstracts (legacy invoke
-   + 3 accessors + 3 primitives).
-3. A subclass implementing only invoke() instantiates successfully via
-   the __init_subclass__ legacy-adapter auto-installation.
-4. A subclass implementing only invoke() exposes the 6 new primitive
-   surfaces (auto-installed proxies) without AttributeError.
-5. A subclass implementing all 6 new primitives directly (no invoke
-   override) also constructs successfully.
+2. Connector.__abstractmethods__ == {"invoke"} — the sole abstract member.
+3. The 6 newer members are concrete defaults (NOT abstract).
+4. A subclass implementing only invoke() instantiates successfully by
+   inheriting the concrete defaults.
+5. A subclass implementing only invoke() exposes the 6 new primitive
+   surfaces (accessors raise the typed guard; primitives run the default).
+6. A subclass implementing all 6 new primitives directly also constructs.
 """
 
 from __future__ import annotations
@@ -50,40 +59,36 @@ def test_connector_abc_refuses_direct_instantiation() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 2. __abstractmethods__ has the 7 expected members
+# 2. __abstractmethods__ == {"invoke"} — invoke is the SOLE abstract member
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 def test_connector_abc_has_expected_abstract_members() -> None:
-    """Connector.__abstractmethods__ MUST contain the 7 rs-mirrored abstracts.
+    """Connector.__abstractmethods__ MUST be exactly {"invoke"} (option c).
 
-    7 = 1 legacy (invoke) + 3 accessors (revocation, ledger, auth_verifier)
-    + 3 primitives (authenticate, write, read). Per F-17, the rs trait
-    shape is the byte-canonical contract; deviating from this set breaks
-    cross-SDK parity.
+    ``invoke()`` is the sole abstract member; the 6 newer rs-mirrored
+    members (3 accessors + 3 primitives) ship as concrete defaults on the
+    base class. Per F-17 the rs trait shape is still mirrored as the member
+    surface (see ``test_connector_abc_six_new_members_are_concrete``); only
+    the abstractness lives on ``invoke`` so legacy invoke()-only subclasses
+    are concrete by inheritance.
     """
-    expected = {
-        # legacy entry point (preserved for backwards-compat)
-        "invoke",
-        # 3 required accessors
-        "revocation",
-        "ledger",
-        "auth_verifier",
-        # 3 required primitives
-        "authenticate",
-        "write",
-        "read",
-    }
-    assert Connector.__abstractmethods__ == expected, (
-        f"Connector ABC drift: expected {sorted(expected)}, "
+    assert Connector.__abstractmethods__ == frozenset({"invoke"}), (
+        f"Connector ABC drift: expected {{'invoke'}}, "
         f"got {sorted(Connector.__abstractmethods__)}"
     )
 
 
 @pytest.mark.unit
-def test_connector_abc_six_new_members_distinct_from_invoke() -> None:
-    """The 6 new abstract members (3 accessors + 3 primitives) MUST be distinct from invoke."""
+def test_connector_abc_six_new_members_are_concrete() -> None:
+    """The 6 rs-mirrored members exist as CONCRETE defaults, distinct from invoke.
+
+    Option (c): the 3 accessors (revocation/ledger/auth_verifier) + 3
+    primitives (authenticate/write/read) are present on the base class but
+    are NOT abstract — a legacy invoke()-only subclass inherits them and is
+    fully concrete. ``invoke`` remains the sole abstract member.
+    """
     new_members = {
         "revocation",
         "ledger",
@@ -94,7 +99,17 @@ def test_connector_abc_six_new_members_distinct_from_invoke() -> None:
     }
     assert len(new_members) == 6
     assert "invoke" not in new_members
-    assert new_members <= Connector.__abstractmethods__
+    # Present on the base class …
+    assert new_members <= set(dir(Connector))
+    # … but NONE of them is abstract (only invoke is).
+    assert new_members.isdisjoint(Connector.__abstractmethods__)
+    for name in new_members:
+        member = inspect.getattr_static(Connector, name)
+        # Resolve property fget so the abstractness check sees the callable.
+        target = member.fget if isinstance(member, property) else member
+        assert not getattr(
+            target, "__isabstractmethod__", False
+        ), f"{name} MUST be a concrete default, not abstract"
 
 
 # ---------------------------------------------------------------------------
@@ -310,19 +325,25 @@ async def test_new_shape_authenticate_returns_principal() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 6. Subclass missing ALL primitives but ALSO missing invoke is fully abstract
+# 6. Subclass missing invoke() is abstract — instantiation refused
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_subclass_missing_invoke_and_primitives_is_abstract() -> None:
-    """Empty subclass (no overrides) MUST be abstract — instantiation refused."""
+def test_subclass_missing_invoke_is_abstract() -> None:
+    """Subclass not overriding invoke() MUST be abstract — instantiation refused.
+
+    Option (c): invoke is the sole abstract member, so a subclass that does
+    not implement it inherits exactly one unsatisfied abstract ({"invoke"})
+    and cannot be instantiated. The 6 newer members are concrete defaults
+    and never block instantiation.
+    """
 
     class _Empty(Connector):
         connector_id = "empty"
         connector_kind = "test"
 
-    # All 7 abstracts remain unsatisfied.
-    assert len(_Empty.__abstractmethods__) == 7
+    # invoke is the sole unsatisfied abstract.
+    assert _Empty.__abstractmethods__ == frozenset({"invoke"})
     with pytest.raises(TypeError, match="abstract"):
         _Empty()  # type: ignore[abstract]

--- a/tests/unit/delegate/test_dispatch.py
+++ b/tests/unit/delegate/test_dispatch.py
@@ -255,8 +255,10 @@ def test_connector_subclass_missing_connector_id_rejected() -> None:
             # connector_id intentionally not overridden (empty default)
             connector_kind = "http"
 
-            async def invoke(self, input_payload, *, identity, envelope):
-                pass  # pragma: no cover
+            async def invoke(
+                self, input_payload, *, identity, envelope
+            ) -> ConnectorInvocationResult:
+                raise NotImplementedError  # pragma: no cover
 
 
 @pytest.mark.unit
@@ -268,8 +270,10 @@ def test_connector_subclass_missing_connector_kind_rejected() -> None:
             connector_id = "x"
             # connector_kind intentionally not overridden
 
-            async def invoke(self, input_payload, *, identity, envelope):
-                pass  # pragma: no cover
+            async def invoke(
+                self, input_payload, *, identity, envelope
+            ) -> ConnectorInvocationResult:
+                raise NotImplementedError  # pragma: no cover
 
 
 @pytest.mark.unit
@@ -282,8 +286,10 @@ def test_connector_subclass_capabilities_must_be_frozenset() -> None:
             connector_kind = "http"
             requires_capabilities = ["http.read"]  # type: ignore[assignment]
 
-            async def invoke(self, input_payload, *, identity, envelope):
-                pass  # pragma: no cover
+            async def invoke(
+                self, input_payload, *, identity, envelope
+            ) -> ConnectorInvocationResult:
+                raise NotImplementedError  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace `Connector` ABC's `__init_subclass__` proxy (which installed runtime
`_legacy_authenticate`/`_legacy_write`/`_legacy_read` + 3 accessor proxies on
subclasses AND mutated `__abstractmethods__`) with concrete defaults on the
base class itself. `invoke()` remains the sole `@abstractmethod`.

**Net change:** −61 LOC (+209/−270 across `dispatch.py` + 2 tests).

## Why

The proxy was implicit — subclasses inherited behavior they never declared,
and mutating `__abstractmethods__` at metaclass time made abstractness
state-dependent on import order. Concrete defaults make the contract
explicit on the ABC: every method has a typed body or a typed guard, no
metaclass mutation.

## Empirical evidence (pyright)

Connector-ABC error class — fully eliminated:

- **Baseline (origin/main):** 41 errors, 5 warnings on `tests/unit/delegate/ + tests/integration/delegate/`
- **This PR:** 0 errors, 5 warnings (all 5 are pre-existing, unrelated to this refactor — see R2 receipt)

## R2 convergence receipt

3 parallel reviewer agents converged Round 1 — `workspaces/issue-1035-delegate-py/04-validate/R2-convergence.md`:
- 0 CRIT / 0 HIGH findings
- 2 MEDIUM pre-existing findings (empty-crypto primitive defaults; `authenticate` `tenant_id=None` footgun) flagged orthogonal — byte-parity with `origin/main`, explicitly out-of-scope per R2 receipt
- Recommended: track the 2 MEDIUMs as follow-up issues on the `#1035` substrate

## Test plan

- [x] 439 delegate unit tests pass + 1 skipped (`pytest .claude/worktrees/f11-connector-abc/tests/unit/delegate/`)
- [x] Pyright 41→0 errors on the delegate test surface
- [x] All pre-commit hooks green (Tier 1 unit tests, license fences, type-annotation guard, etc.)
- [ ] CI matrix (will run automatically)

## Related issues

Part of the `#1035` substrate (Connector ABC + delegate signature verification work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)