### PR TITLE
fix(delegate): Connector default primitives raise typed guard (closes #1177 + #1178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (breaking, delegate substrate)
+
+- **`Connector.authenticate` / `.write` / `.read` default implementations now raise `NotImplementedError`** via `_legacy_unsupported(name)` instead of returning empty-crypto envelopes / `Principal(tenant_id=None)`. Closes GH #1177 (empty-crypto orphan defaults on write/read — downstream verifiers that did not explicitly check `len(signature) > 0` / `len(attestation) > 0` would treat the prior defaults as authenticated/attested) + GH #1178 (`Principal(tenant_id=None)` from the prior `authenticate` default silently slipped through tenant-scoped authorization checks in multi-tenant deployments). The inline defaults were a transitional convenience carried over from the pre-2.26.0 `__init_subclass__` proxy era and were never part of the documented audit-grade contract — `LegacyInvokeConnector` and direct legacy `invoke()`-only subclasses MUST use `.invoke()` for all dispatch; reaching for `.authenticate()` / `.write()` / `.read()` now gets a clear refusal rather than a silent unverifiable envelope. The 3 newer ACCESSOR defaults (`.revocation` / `.ledger` / `.auth_verifier`) already raised via `_legacy_unsupported` since 2.26.0; this change extends the same defense-in-depth pattern to the 3 primitives.
+
+### Migration
+
+- Connector subclasses that need `.authenticate()` / `.write()` / `.read()` MUST implement them explicitly (override with the real cryptographic exchange). The prior inline-default behavior (empty signature / empty attestation / `Principal(tenant_id=None)`) was security-defense-in-depth unsafe and is removed without a deprecation shim — the prior return values were structurally indistinguishable from a real authenticated/attested envelope at the type level, so a `DeprecationWarning` shim would have continued to ship the same defense-in-depth gap during the deprecation window. New-shape connectors that already override the 3 primitives are unaffected.
+- Consumers calling the 3 primitives on a `LegacyInvokeConnector` (or any subclass that does not override them) will now receive `NotImplementedError: Connector primitive 'write' not implemented by this legacy invoke()-only connector — use connector.invoke(...) or migrate the connector to the 4-primitive shape`. Route those call sites through `.invoke(...)`.
+
 ## [2.26.2] - 2026-05-25
 
 ### Fixed

--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -653,9 +653,14 @@ class Connector(abc.ABC):
 
     # ─── Default primitives (3) — mirror rs trait async fns ─────────────
     #
-    # Concrete defaults provide the legacy-adapter behavior so an
-    # invoke()-only connector is fully concrete. New-shape connectors
-    # OVERRIDE these with real cryptographic implementations.
+    # Concrete defaults raise via ``_legacy_unsupported``: legacy
+    # ``invoke()``-only connectors do NOT expose the rs-mirrored
+    # primitive surface, so a caller reaching for ``.authenticate()`` /
+    # ``.write()`` / ``.read()`` against a legacy connector gets a clear
+    # refusal rather than a silent empty-crypto envelope or
+    # ``Principal(tenant_id=None)`` (closes the defense-in-depth gaps
+    # from GH #1177 + #1178). New-shape connectors OVERRIDE these with
+    # real cryptographic implementations.
 
     async def authenticate(
         self,
@@ -664,17 +669,17 @@ class Connector(abc.ABC):
     ) -> Principal:
         """Authenticate the dispatch identity; return a :class:`Principal`.
 
-        Default (legacy invoke()-only connectors): returns a trivial
-        Principal scoped to the bound identity — legacy connectors
-        authenticated implicitly via ``invoke()``. New-shape connectors
-        override with a real authentication exchange (and may raise a
-        connector-defined exception on failure).
+        Default (legacy invoke()-only connectors): raises a typed
+        ``_legacy_unsupported`` guard — legacy connectors authenticated
+        implicitly via ``invoke()`` and do NOT expose a separate
+        authentication exchange. The prior default returned
+        ``Principal(tenant_id=None)`` which silently slipped through
+        tenant-scoped authorization checks in multi-tenant deployments
+        (GH #1178); refusing structurally is the defense-in-depth fix.
+        New-shape connectors override with a real authentication exchange
+        (and may raise a connector-defined exception on failure).
         """
-        return Principal(
-            delegate_id=str(identity.delegate_id),
-            tenant_id=None,
-            claims={},
-        )
+        _legacy_unsupported("authenticate")
 
     async def write(
         self,
@@ -685,28 +690,18 @@ class Connector(abc.ABC):
     ) -> SignedActionEnvelope:
         """Execute a write action under audit; return a signed action envelope.
 
-        Default (legacy invoke()-only connectors): executes the action and
-        synthesizes a :class:`SignedActionEnvelope` with an EMPTY signature
-        — legacy connectors did not produce cryptographic action
-        signatures, so new-shape callers receiving an empty-signature
-        envelope MUST treat it as unverifiable per F-17 dispatch wiring.
-        New-shape connectors override with a real signing exchange whose
-        signature is verifiable via the runtime's :class:`Verifier`.
+        Default (legacy invoke()-only connectors): raises a typed
+        ``_legacy_unsupported`` guard — legacy connectors do NOT produce
+        cryptographic action signatures. The prior default executed the
+        action and returned a :class:`SignedActionEnvelope` with an EMPTY
+        signature, which any downstream verifier that did not explicitly
+        check ``len(signature) > 0`` would treat as authenticated (GH
+        #1177); refusing structurally is the defense-in-depth fix.
+        Legacy connectors execute through ``invoke()`` only. New-shape
+        connectors override with a real signing exchange whose signature
+        is verifiable via the runtime's :class:`Verifier`.
         """
-        payload_obj = await action()
-        payload_dict: dict[str, Any]
-        if isinstance(payload_obj, dict):
-            payload_dict = payload_obj
-        else:
-            payload_dict = {"value": payload_obj}
-        canonical_bytes = canonical_json_dumps(payload_dict).encode("utf-8")
-        return SignedActionEnvelope(
-            action_id=uuid.uuid4(),
-            canonical_bytes=canonical_bytes,
-            signature=b"",  # legacy connector did not sign
-            signer_delegate_id=str(identity.delegate_id),
-            payload=payload_dict,
-        )
+        _legacy_unsupported("write")
 
     async def read(
         self,
@@ -717,55 +712,45 @@ class Connector(abc.ABC):
     ) -> tuple[T_Read, AttestedReadReceipt]:
         """Execute a read query under audit; return (payload, attested-receipt).
 
-        Default (legacy invoke()-only connectors): executes the query and
-        synthesizes an :class:`AttestedReadReceipt` with an EMPTY
-        attestation — legacy connectors did not produce cryptographic read
-        attestations. New-shape connectors override with a real attestation
-        exchange.
+        Default (legacy invoke()-only connectors): raises a typed
+        ``_legacy_unsupported`` guard — legacy connectors do NOT produce
+        cryptographic read attestations. The prior default executed the
+        query and returned an :class:`AttestedReadReceipt` with an EMPTY
+        attestation, which downstream consumers that did not explicitly
+        check ``len(attestation) > 0`` would treat as attested (GH
+        #1177); refusing structurally is the defense-in-depth fix.
+        New-shape connectors override with a real attestation exchange.
         """
-        value = await query()
-        canonical_bytes = canonical_json_dumps(
-            {
-                "value": (
-                    value
-                    if isinstance(
-                        value, (dict, list, str, int, float, bool, type(None))
-                    )
-                    else repr(value)
-                )
-            }
-        ).encode("utf-8")
-        receipt = AttestedReadReceipt(
-            read_id=uuid.uuid4(),
-            canonical_bytes=canonical_bytes,
-            attestation=b"",
-            attester_delegate_id=str(identity.delegate_id),
-            observed_at=datetime.now(timezone.utc),
-        )
-        return value, receipt
+        _legacy_unsupported("read")
 
 
 # ---------------------------------------------------------------------------
-# Typed guard for accessor surface unsupported by legacy connectors.
-# The 3 accessor defaults on Connector call this so a caller reaching for
-# ``connector.revocation`` against a legacy invoke()-only connector gets a
-# clear refusal rather than a silent AttributeError. The legacy default
-# behavior for the 3 primitives (authenticate / write / read) is inlined
-# directly into the Connector base class concrete defaults above — there is
-# no longer any __init_subclass__ proxy-installation machinery.
+# Typed guard for the 6 newer Connector members (3 accessors + 3 primitives)
+# unsupported by legacy invoke()-only connectors.
+# All 6 newer Connector members raise via _legacy_unsupported on their
+# concrete defaults — legacy ``invoke()``-only connectors do not expose any
+# of these surfaces; new-shape connectors override each with their real
+# implementation. The prior default behavior for the 3 primitives
+# (authenticate / write / read) inlined empty-crypto envelopes /
+# ``Principal(tenant_id=None)`` directly, which silently slipped through
+# downstream verifier + tenant-authorization checks (GH #1177 + #1178);
+# refusing structurally closes that defense-in-depth gap.
 # ---------------------------------------------------------------------------
 
 
 def _legacy_unsupported(name: str) -> NoReturn:
-    """Raise a typed refusal for a primitive a legacy connector does not expose.
+    """Raise a typed refusal for a member a legacy connector does not expose.
 
     Legacy ``invoke()``-only connectors do not expose the rs-mirrored
-    accessor surface; callers that reach for ``connector.revocation`` /
-    ``.ledger`` / ``.auth_verifier`` against a legacy connector get a clear
-    refusal rather than a silent AttributeError (per ``zero-tolerance.md``
-    Rule 3a typed-delegate guards). The ``NoReturn`` annotation lets the
-    accessor properties declare their real return types without a
-    fall-through-to-None type error.
+    accessor surface (``revocation`` / ``ledger`` / ``auth_verifier``)
+    OR the rs-mirrored primitive surface (``authenticate`` / ``write`` /
+    ``read``); callers that reach for any of those against a legacy
+    connector get a clear refusal rather than a silent
+    ``AttributeError`` (accessors) or silent empty-crypto envelope /
+    ``Principal(tenant_id=None)`` (primitives, per ``zero-tolerance.md``
+    Rule 3a typed-delegate guards + GH #1177 + #1178). The ``NoReturn``
+    annotation lets the accessor properties + primitive methods declare
+    their real return types without a fall-through-to-None type error.
     """
     raise NotImplementedError(
         f"Connector primitive {name!r} not implemented by this legacy "
@@ -786,10 +771,15 @@ class LegacyInvokeConnector(Connector):
     existing legacy connectors that ship as bare ``async def invoke(...)``
     callables (not as Connector subclasses) can wrap into the new Connector
     ABC via this adapter. The wrapped callable is invoked from the
-    :meth:`invoke` method; the 6 newer members (3 accessors + 3 primitives)
-    are satisfied by the concrete defaults inherited from
-    :class:`Connector` (accessors raise the typed legacy guard; the
-    primitives provide the legacy-adapter behavior).
+    :meth:`invoke` method; all 6 newer members (3 accessors + 3 primitives)
+    raise the typed ``_legacy_unsupported`` guard via the concrete defaults
+    inherited from :class:`Connector` — legacy adapters MUST use
+    ``.invoke()`` for all dispatch; consumers reaching for
+    ``.authenticate()`` / ``.write()`` / ``.read()`` / ``.revocation`` /
+    ``.ledger`` / ``.auth_verifier`` get a clear refusal rather than a
+    silent empty-crypto envelope or ``Principal(tenant_id=None)``
+    (closes the orphan-defaults defense-in-depth gap from GH #1177 +
+    #1178).
 
     The adapter is most useful for downstream consumers porting legacy
     connector callables to the new ABC without subclassing. New connectors

--- a/tests/unit/delegate/test_legacy_invoke_connector.py
+++ b/tests/unit/delegate/test_legacy_invoke_connector.py
@@ -181,15 +181,29 @@ async def test_legacy_invoke_connector_routes_invoke_through_callable() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 4. New-shape primitive surfaces work via auto-installed proxies
+# 4. The 6 newer surfaces (3 accessors + 3 primitives) refuse on legacy
+#    invoke()-only connectors via the typed _legacy_unsupported guard.
+#    Closes GH #1177 (empty-crypto orphan defaults on authenticate/write/
+#    read) + GH #1178 (Principal(tenant_id=None) multi-tenant footgun
+#    on authenticate). The prior default-behavior tests are rewritten to
+#    assert the typed refusal; the new acceptance tests below repro the
+#    issue bodies verbatim.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_legacy_invoke_connector_authenticate_proxy_returns_principal() -> None:
-    """Auto-installed authenticate() proxy returns a Principal scoped to the identity."""
-    from kailash.delegate.dispatch import Principal
+async def test_legacy_invoke_connector_authenticate_default_raises_unsupported() -> (
+    None
+):
+    """Default authenticate() on a legacy invoke()-only connector refuses with typed error.
+
+    Closes GH #1178 — the prior default returned
+    ``Principal(tenant_id=None)`` which silently slipped through
+    tenant-scoped authorization checks. The typed refusal is the
+    defense-in-depth fix; legacy connectors MUST authenticate
+    implicitly via ``invoke()``.
+    """
 
     async def _invoke(input_payload, *, identity, envelope):
         return ConnectorInvocationResult(
@@ -201,16 +215,21 @@ async def test_legacy_invoke_connector_authenticate_proxy_returns_principal() ->
 
     adapter = LegacyInvokeConnector(_invoke)
     identity = _build_identity()
-    p = await adapter.authenticate(identity, None)  # type: ignore[arg-type]
-    assert isinstance(p, Principal)
-    assert p.delegate_id == str(identity.delegate_id)
+    with pytest.raises(NotImplementedError, match="authenticate"):
+        await adapter.authenticate(identity, None)  # type: ignore[arg-type]
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_legacy_invoke_connector_write_proxy_synthesizes_envelope() -> None:
-    """Auto-installed write() proxy executes the action and synthesizes an envelope."""
-    from kailash.delegate.dispatch import SignedActionEnvelope
+async def test_legacy_invoke_connector_write_default_raises_unsupported() -> None:
+    """Default write() on a legacy invoke()-only connector refuses with typed error.
+
+    Closes GH #1177 (write half) — the prior default executed the
+    action and returned a ``SignedActionEnvelope`` with an EMPTY
+    signature that any verifier not explicitly length-checking would
+    treat as authenticated. The typed refusal is the defense-in-depth
+    fix; legacy connectors MUST dispatch through ``invoke()``.
+    """
 
     async def _invoke(input_payload, *, identity, envelope):
         return ConnectorInvocationResult(
@@ -226,14 +245,40 @@ async def test_legacy_invoke_connector_write_proxy_synthesizes_envelope() -> Non
     async def _action() -> dict:
         return {"written": True, "value": 42}
 
-    env = await adapter.write(
-        _action, identity=identity, envelope=None  # type: ignore[arg-type]
-    )
-    assert isinstance(env, SignedActionEnvelope)
-    assert env.payload == {"written": True, "value": 42}
-    # Legacy proxy produces empty signature — callers MUST treat as unverifiable
-    assert env.signature == b""
-    assert env.signer_delegate_id == str(identity.delegate_id)
+    with pytest.raises(NotImplementedError, match="write"):
+        await adapter.write(
+            _action, identity=identity, envelope=None  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_legacy_invoke_connector_read_default_raises_unsupported() -> None:
+    """Default read() on a legacy invoke()-only connector refuses with typed error.
+
+    Closes GH #1177 (read half) — the prior default executed the
+    query and returned an ``AttestedReadReceipt`` with an EMPTY
+    attestation. The typed refusal is the defense-in-depth fix.
+    """
+
+    async def _invoke(input_payload, *, identity, envelope):
+        return ConnectorInvocationResult(
+            payload={},
+            audit_events=(),
+            tenant_id_observed=None,
+            external_side_effect=False,
+        )
+
+    adapter = LegacyInvokeConnector(_invoke)
+    identity = _build_identity()
+
+    async def _query() -> str:
+        return "read-value"
+
+    with pytest.raises(NotImplementedError, match="read"):
+        await adapter.read(
+            _query, identity=identity, envelope=None  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.unit
@@ -255,3 +300,145 @@ def test_legacy_invoke_connector_accessor_raises_unsupported() -> None:
         _ = adapter.ledger
     with pytest.raises(NotImplementedError, match="auth_verifier"):
         _ = adapter.auth_verifier
+
+
+# ---------------------------------------------------------------------------
+# 5. Acceptance tests for GH #1177 + #1178 — verbatim repros from the
+#    issue bodies. A direct LegacyInvokeConnector subclass with its own
+#    invoke() must STILL refuse the 3 primitive surfaces (the bug was
+#    that the inline defaults handled them with empty-crypto / null
+#    tenant); a Connector subclass that OVERRIDES write/read/authenticate
+#    must continue to dispatch the override (the contract works for
+#    new-shape connectors).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_issue_1177_legacy_only_write_raises_unsupported() -> None:
+    """GH #1177 acceptance — legacy subclass with own invoke() refuses .write()."""
+
+    class LegacyOnly(LegacyInvokeConnector):
+        connector_id = "legacy"
+        connector_kind = "test"
+        requires_capabilities: frozenset[str] = frozenset()
+
+        async def invoke(self, action, *, identity=None, envelope=None):
+            return ConnectorInvocationResult(
+                payload={"ok": True},
+                audit_events=(),
+                tenant_id_observed=None,
+                external_side_effect=False,
+            )
+
+    # Direct construction (no wrapped callable) — exercise the subclass shape.
+    c = LegacyOnly.__new__(LegacyOnly)
+    identity = _build_identity()
+
+    async def _action() -> dict:
+        return {}
+
+    with pytest.raises(NotImplementedError, match="write"):
+        await c.write(_action, identity=identity, envelope=None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_issue_1177_legacy_only_read_raises_unsupported() -> None:
+    """GH #1177 acceptance — legacy subclass with own invoke() refuses .read()."""
+
+    class LegacyOnly(LegacyInvokeConnector):
+        connector_id = "legacy"
+        connector_kind = "test"
+        requires_capabilities: frozenset[str] = frozenset()
+
+        async def invoke(self, action, *, identity=None, envelope=None):
+            return ConnectorInvocationResult(
+                payload={"ok": True},
+                audit_events=(),
+                tenant_id_observed=None,
+                external_side_effect=False,
+            )
+
+    c = LegacyOnly.__new__(LegacyOnly)
+    identity = _build_identity()
+
+    async def _query() -> str:
+        return "v"
+
+    with pytest.raises(NotImplementedError, match="read"):
+        await c.read(_query, identity=identity, envelope=None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_issue_1178_legacy_only_authenticate_raises_unsupported() -> None:
+    """GH #1178 acceptance — legacy subclass with own invoke() refuses .authenticate().
+
+    The prior default returned ``Principal(tenant_id=None)``; the
+    refusal closes the multi-tenant footgun the issue called out.
+    """
+
+    class LegacyOnly(LegacyInvokeConnector):
+        connector_id = "legacy"
+        connector_kind = "test"
+        requires_capabilities: frozenset[str] = frozenset()
+
+        async def invoke(self, action, *, identity=None, envelope=None):
+            return ConnectorInvocationResult(
+                payload={"ok": True},
+                audit_events=(),
+                tenant_id_observed=None,
+                external_side_effect=False,
+            )
+
+    c = LegacyOnly.__new__(LegacyOnly)
+    identity = _build_identity()
+    with pytest.raises(NotImplementedError, match="authenticate"):
+        await c.authenticate(identity, None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_new_shape_subclass_override_returns_real_value() -> None:
+    """New-shape sanity — a Connector that OVERRIDES write returns the override.
+
+    The typed-refusal default is only the LEGACY behavior; new-shape
+    connectors that implement their own .write() continue to dispatch
+    the override (the contract still works for them).
+    """
+    from kailash.delegate.dispatch import Connector, SignedActionEnvelope
+
+    class NewShape(Connector):
+        connector_id = "new-shape"
+        connector_kind = "test"
+        requires_capabilities: frozenset[str] = frozenset()
+
+        async def invoke(self, input_payload, *, identity, envelope):
+            return ConnectorInvocationResult(
+                payload={},
+                audit_events=(),
+                tenant_id_observed=None,
+                external_side_effect=False,
+            )
+
+        async def write(self, action, *, identity, envelope):
+            payload = await action()
+            return SignedActionEnvelope(
+                action_id=uuid.uuid4(),
+                canonical_bytes=b"canon",
+                signature=b"real-sig-bytes",
+                signer_delegate_id=str(identity.delegate_id),
+                payload=payload if isinstance(payload, dict) else {"value": payload},
+            )
+
+    conn = NewShape()
+    identity = _build_identity()
+
+    async def _action() -> dict:
+        return {"written": True}
+
+    env = await conn.write(_action, identity=identity, envelope=None)  # type: ignore[arg-type]
+    assert isinstance(env, SignedActionEnvelope)
+    assert env.signature == b"real-sig-bytes"
+    assert env.payload == {"written": True}

--- a/tests/unit/delegate/test_legacy_invoke_connector.py
+++ b/tests/unit/delegate/test_legacy_invoke_connector.py
@@ -323,7 +323,7 @@ async def test_issue_1177_legacy_only_write_raises_unsupported() -> None:
         connector_kind = "test"
         requires_capabilities: frozenset[str] = frozenset()
 
-        async def invoke(self, action, *, identity=None, envelope=None):
+        async def invoke(self, input_payload, *, identity, envelope):
             return ConnectorInvocationResult(
                 payload={"ok": True},
                 audit_events=(),
@@ -352,7 +352,7 @@ async def test_issue_1177_legacy_only_read_raises_unsupported() -> None:
         connector_kind = "test"
         requires_capabilities: frozenset[str] = frozenset()
 
-        async def invoke(self, action, *, identity=None, envelope=None):
+        async def invoke(self, input_payload, *, identity, envelope):
             return ConnectorInvocationResult(
                 payload={"ok": True},
                 audit_events=(),
@@ -384,7 +384,7 @@ async def test_issue_1178_legacy_only_authenticate_raises_unsupported() -> None:
         connector_kind = "test"
         requires_capabilities: frozenset[str] = frozenset()
 
-        async def invoke(self, action, *, identity=None, envelope=None):
+        async def invoke(self, input_payload, *, identity, envelope):
             return ConnectorInvocationResult(
                 payload={"ok": True},
                 audit_events=(),


### PR DESCRIPTION
## Summary

- Flip `Connector.authenticate` / `.write` / `.read` default implementations from inline empty-crypto/`tenant_id=None` to `_legacy_unsupported(name)` raise — mirrors the existing 3 accessor defaults' pattern.
- Closes the defense-in-depth gap where legacy `invoke()`-only connectors emitted syntactically-valid but cryptographically-empty `SignedActionEnvelope` / `AttestedReadReceipt` / `Principal(tenant_id=None)` objects from defaults inherited via `LegacyInvokeConnector`.
- 2 existing tests asserting the bug behavior (`authenticate_proxy_returns_principal`, `write_proxy_synthesizes_envelope`) rewritten; 4 new acceptance tests added covering the verbatim #1177/#1178 issue-body repros + a new-shape override sanity test.

## Related issues

- Closes #1177 (empty-crypto `authenticate` / `write` / `read` orphan defaults)
- Closes #1178 (`Principal(tenant_id=None)` multi-tenant footgun)
- Substrate context: part of the `#1035` delegate substrate; R2 (`workspaces/issue-1035-delegate-py/04-validate/R2-convergence.md`) deferred these as orthogonal to the type-debt refactor (PR #1176) because folding them in would have broken the behavioral parity that made the option-(c) refactor safe.

## Breaking change disclosure

This removes the inline-default behavior on the 3 Connector primitives. External `Connector` subclasses (including those extending `LegacyInvokeConnector`) that called `.authenticate()` / `.write()` / `.read()` on an inherited-default basis will now raise `NotImplementedError`. The defaults were a transitional convenience carried from the pre-2.26.2 `__init_subclass__` proxy era and were never part of the documented contract. CHANGELOG `[Unreleased]` section documents the migration (override the 3 primitives explicitly OR route calls through `.invoke(...)`).

## Rule 6a (deprecation-cycle) tension — disclosed

Per `rules/zero-tolerance.md` Rule 6a, public-API removal normally requires a `DeprecationWarning` shim covering one minor cycle. This PR ships the typed-guard raise without a shim. Rationale (documented in commit `54541a582` body + CHANGELOG Migration section): the prior return values were structurally indistinguishable from a real authenticated/attested envelope at the type level, so a `DeprecationWarning` shim would continue to ship the EXACT failure mode #1177/#1178 flag during the deprecation window. The defense-in-depth security intent of both issues requires direct removal.

## Test plan

- [x] `pytest tests/unit/delegate/test_legacy_invoke_connector.py` — 15/15 pass (incl. 4 new acceptance tests for #1177/#1178)
- [x] `pytest tests/unit/delegate/` — 444 pass / 1 skipped
- [x] `pytest tests/integration/delegate/ -W error` — 492 pass / 1 skipped (no warnings)
- [x] `pyright src/kailash/delegate/dispatch.py tests/unit/delegate/test_legacy_invoke_connector.py` — 0 errors / 0 warnings / 0 informations
- [x] Same-bug-class sweep across `src/kailash/delegate/` + `packages/`: no production hot-path consumer relies on the prior inline-default behavior (unrelated `.authenticate()` matches in kailash-mcp / kailash-nexus / kailash-kaizen target `AuthProvider` / `dash_auth` surfaces, not `Connector`)