### PR TITLE
fix(from_brief): default-deny node allowlist closes brief→code-exec (#1125)

### DIFF
--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -131,9 +131,12 @@ __all__ = [
 # `from kailash.bootstrap import bootstrap` import would auto-register the
 # SUBMODULE as `kailash.bootstrap`, shadowing the callable on subsequent access.
 # Eagerly binding here makes `kailash.bootstrap` the CALLABLE (the explicit
-# attribute assignment wins over the submodule's auto-set), while
-# `kailash.bootstrap.bootstrap` (the dotted submodule form) is also still
-# reachable for users who prefer that import path.
+# attribute assignment wins over the submodule's auto-set). The supported
+# import paths are therefore `kailash.bootstrap(...)` (the callable) and
+# `from kailash.bootstrap import bootstrap` (resolves the submodule via
+# sys.modules). The dotted-attribute form `kailash.bootstrap.bootstrap` is
+# NOT reachable — `kailash.bootstrap` is the function after this bind, so
+# attribute access raises AttributeError.
 #
 # Safety check: the bootstrap module's top-level imports are pure-Python
 # (dataclasses, typing, logging, os) — NO kaizen at module-import time. Kaizen

--- a/src/kailash/_from_brief/confidence.py
+++ b/src/kailash/_from_brief/confidence.py
@@ -16,6 +16,8 @@ calibration baselines and is overridable per call.
 
 from __future__ import annotations
 
+import math
+
 from kailash._from_brief.exceptions import BriefInterpretationError
 
 __all__ = ["DEFAULT_CONFIDENCE_THRESHOLD", "check_confidence"]
@@ -50,10 +52,13 @@ def check_confidence(
     Returns:
         ``None`` when the value is at or above the threshold.
     """
-    if value < 0.0 or value > 1.0:
+    # IEEE-754 NaN comparisons are always False, so a NaN confidence
+    # would slip past both the range gate AND the threshold gate below;
+    # ``math.isfinite`` rejects NaN and ±inf as malformed (P5 threat).
+    if not math.isfinite(value) or value < 0.0 or value > 1.0:
         raise BriefInterpretationError(
-            f"interpretation_confidence={value!r} is outside the 0.0-1.0 "
-            f"range; the LLM emitted a malformed confidence score",
+            f"interpretation_confidence={value!r} is not a finite value in "
+            f"the 0.0-1.0 range; the LLM emitted a malformed confidence score",
             malformed=True,
         )
     if value < threshold:

--- a/src/kailash/_from_brief/validator.py
+++ b/src/kailash/_from_brief/validator.py
@@ -62,7 +62,11 @@ class BriefPlan(BaseModel):
     silently-ignored extra.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    # ``allow_inf_nan=False`` rejects NaN/±inf at Pydantic construction —
+    # defense-in-depth for the confidence gate (the LLM cannot smuggle a
+    # NaN confidence past the float field). ``check_confidence`` enforces
+    # the same floor with ``math.isfinite`` at the gate.
+    model_config = ConfigDict(extra="forbid", allow_inf_nan=False)
 
     interpretation_confidence: float
     """The LLM's self-rated 0.0-1.0 confidence in the plan."""

--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -122,11 +122,13 @@ def _check_payload_depth(obj: Any, current_depth: int = 0) -> None:
     frozenset, set, MappingView) cannot bypass the DoS defense. Strings,
     bytes, and bytearray are Sequences but their iteration yields
     characters/ints, which is meaningless for depth; exclude explicitly.
-    Sets are unordered iterables of hashable values; nested
-    Sets-of-Mappings/Sequences (or Sets-of-Sets) ARE reachable through
-    the canonical-JSON encoder once serialized as arrays, so they MUST
-    be walked as part of the same DoS-defense surface as Mapping +
-    Sequence.
+    Sets are unordered iterables of hashable values. A ``set`` cannot
+    directly contain a ``dict`` or ``list`` (unhashable), so a literal
+    Set-of-Mapping is not constructible; the constructible nested case is
+    ``frozenset``-of-``frozenset`` (and ABC-registered hashable
+    containers). The Set branch is walked so those nested-frozenset
+    payloads cannot bypass the depth bound — same DoS-defense surface as
+    Mapping + Sequence.
     """
     if current_depth > _MAX_PAYLOAD_DEPTH:
         raise DispatchValidationError(

--- a/src/kailash/delegate/runtime.py
+++ b/src/kailash/delegate/runtime.py
@@ -1062,6 +1062,17 @@ class DelegateRuntime:
         # call's audit chain segment writes against state the first
         # call is mid-mutating. Closes the M1 TOCTOU window surfaced by
         # the prior session's R1 security review.
+        #
+        # Scope caveat (R1 2026-05-27, MEDIUM): asyncio.Lock serializes
+        # concurrent execute() coroutines on ONE event loop — the
+        # documented and supported usage. It is NOT thread-safe, so it does
+        # not serialize two OS threads each running their own event loop
+        # against the SAME runtime instance. Sharing one DelegateRuntime
+        # across OS threads is outside the async contract (with_posture()
+        # returns a fresh runtime+lock per Invariant 5, so the natural
+        # pattern never shares instances cross-thread). If cross-thread
+        # sharing ever becomes supported, wrap acquisition in a
+        # threading.Lock; until then it is an undocumented-usage residual.
         self._consume_lock: asyncio.Lock = asyncio.Lock()
 
     @property

--- a/src/kailash/workflow/from_brief.py
+++ b/src/kailash/workflow/from_brief.py
@@ -11,7 +11,7 @@ The pipeline composes the foundation laid by :mod:`kailash._from_brief`::
     brief (prose)
       → scrub_brief()                # credential scrub (S1)
       → WorkflowPlanSignature        # LLM emits typed plan
-      → coerce_plan / validate_plan  # typed + confidence + allowlist (S1)
+      → coerce_plan / validate_plan  # schema + confidence + allowlist (S1)
       → WorkflowBuilder loop         # deterministic structural plumbing
       → WorkflowBuilder (returned)
 
@@ -69,18 +69,120 @@ __all__ = [
 ]
 
 
-# Code-execution nodes that MUST NOT be reachable from an LLM-generated
-# workflow. PythonCodeNode + AsyncPythonCodeNode both call exec() on
-# LLM-emitted code; a brief like "use PythonCodeNode with code that
-# imports os and runs os.system(...)" would realize attacker code if
-# the allowlist accepted those types. Per the SEC-1 finding at
-# workspaces/from-brief-1125/04-validate/round-02-security.md, this
-# denylist runs BEFORE the allowlist gate (i.e. these node types are
-# NEVER in the LLM's allowed surface, regardless of NodeRegistry state).
+# --------------------------------------------------------------------------- #
+# Node-type security model — DEFAULT-DENY positive allowlist (issue #1125 R2)  #
+# --------------------------------------------------------------------------- #
+#
+# The brief is UNTRUSTED input. `from_brief` realizes whatever node types the
+# LLM emits, so the node-type surface IS a code-execution boundary. The prior
+# model — "all registered nodes MINUS a denylist of code-exec nodes" — was
+# proven unsound (R2 2026-05-27): the dangerous set cannot be reliably
+# enumerated (e.g. PythonCodeNode execs via the CodeExecutor helper, invisible
+# to a class-scope scan; DataTransformer/Convergence nodes exec/eval config),
+# and every new code-running node added to the SDK would silently re-open the
+# bypass.
+#
+# `_SAFE_NODE_TYPES` inverts to DEFAULT-DENY (positive allowlist per
+# `rules/cc-artifacts.md` Rule 10): `from_brief` realizes ONLY these explicitly
+# vetted node types — data I/O, declarative transform/filter/sort, flow
+# control, DB/vector/streaming connectors — every one verified to take
+# DECLARATIVE config (field/operator/path), never config-supplied code or
+# expressions. A new SDK node is NOT brief-reachable until a human adds it here
+# AFTER review. The `tests/.../test_from_brief_safe_allowlist.py` inverse-
+# completeness test asserts no member is code-exec-capable, so a future
+# mis-curation is caught mechanically.
+#
+# Excluded by design (code execution or composition bypass): PythonCodeNode,
+# AsyncPythonCodeNode (exec), DataTransformer (exec config transformations),
+# ConvergenceCheckerNode, MultiCriteriaConvergenceNode (eval config
+# expression), WorkflowNode (nests an arbitrary sub-workflow that could embed
+# any of the above).
+_SAFE_NODE_TYPES: frozenset[str] = frozenset(
+    {
+        # Data readers / sources
+        "CSVReaderNode",
+        "JSONReaderNode",
+        "TextReaderNode",
+        "DocumentProcessorNode",
+        "DocumentSourceNode",
+        "DirectoryReaderNode",
+        "FileDiscoveryNode",
+        "QuerySourceNode",
+        # Data writers
+        "CSVWriterNode",
+        "JSONWriterNode",
+        "TextWriterNode",
+        # Declarative transforms (no config-code; field/operator/path config)
+        "FilterNode",
+        "Map",
+        "Sort",
+        "ChunkTextExtractorNode",
+        "ContextFormatterNode",
+        "ContextualCompressorNode",
+        "QueryTextWrapperNode",
+        "HierarchicalChunkerNode",
+        "SemanticChunkerNode",
+        "StatisticalChunkerNode",
+        "TextSplitterNode",
+        # Flow control
+        "MergeNode",
+        "AsyncMergeNode",
+        "SwitchNode",
+        "AsyncSwitchNode",
+        "SignalWaitNode",
+        # Database / cache / routing
+        "SQLDatabaseNode",
+        "AsyncSQLDatabaseNode",
+        "RedisNode",
+        "QueryRouterNode",
+        "OptimisticLockingNode",
+        "WorkflowConnectionPool",
+        # Vector / retrieval
+        "EmbeddingNode",
+        "VectorDatabaseNode",
+        "AsyncPostgreSQLVectorNode",
+        "HybridRetrieverNode",
+        "RelevanceScorerNode",
+        # Streaming / events
+        "EventGeneratorNode",
+        "EventStreamNode",
+        "KafkaConsumerNode",
+        "StreamPublisherNode",
+        "WebSocketNode",
+        # NOTE: SharePoint connectors (SharePointGraphReader/Writer) are
+        # EXCLUDED — `SharePointGraphReader` routes a config `device_code_callback`
+        # string to `importlib.import_module(...) + getattr + call` (a dynamic-
+        # import code-exec vector, #1125 R4 MEDIUM); the Writer shares that
+        # device-code-flow auth module. Both are denylisted below.
+    }
+)
+
+
+# Defense-in-depth FLOOR (secondary to the positive allowlist above). With the
+# default-deny allowlist, anything not in `_SAFE_NODE_TYPES` is already
+# rejected; this denylist is an UNCONDITIONAL floor at the realizer + the
+# caller-override path (`workflow_from_brief(allowed_node_types=...)`), so a
+# caller that supplies a custom allowlist still cannot re-admit a known
+# code-execution node. Enumerates the confirmed config-code-exec registered
+# nodes across all submodules (not only those `from_brief` warms), because the
+# NodeRegistry is process-global and these may be registered by other imports.
 _DANGEROUS_NODE_TYPES: frozenset[str] = frozenset(
     {
         "PythonCodeNode",
         "AsyncPythonCodeNode",
+        "DataTransformer",
+        "ConvergenceCheckerNode",
+        "MultiCriteriaConvergenceNode",
+        "BatchProcessorNode",
+        "CodeValidationNode",
+        "WorkflowValidationNode",
+        "ValidationTestSuiteExecutorNode",
+        "WorkflowNode",
+        # SharePoint connectors — dynamic-import code-exec vector via the
+        # config `device_code_callback` → `importlib.import_module` path
+        # (#1125 R4 MEDIUM); both share the device-code-flow auth module.
+        "SharePointGraphReader",
+        "SharePointGraphWriter",
     }
 )
 
@@ -182,9 +284,8 @@ def _signature_cls() -> type:
     if _SIGNATURE_CLS_CACHE is not None:
         return _SIGNATURE_CLS_CACHE
 
-    from kaizen.signatures import OutputField  # type: ignore[import-not-found]
-
     from kailash._from_brief.signatures import BriefPlanSignature
+    from kaizen.signatures import OutputField  # type: ignore[import-not-found]
 
     class WorkflowPlanSignature(BriefPlanSignature):
         """Kaizen Signature for Sg-Workflow plan emission.
@@ -277,56 +378,63 @@ if TYPE_CHECKING:
 # --------------------------------------------------------------------------- #
 
 
-def _registered_node_types() -> Set[str]:
-    """Return the set of registered Kailash node type names.
+def _safe_node_types() -> Set[str]:
+    """Return the DEFAULT-DENY safe node-type allowlist for `from_brief`.
 
-    Reads :meth:`kailash.nodes.base.NodeRegistry.list_nodes` at call
-    time so newly-registered node types are visible without a process
-    restart. This is the allowlist :func:`workflow_from_brief` passes
-    to :func:`validate_plan` per ``rules/agent-reasoning.md`` Rule 1
-    (the LLM may freely propose node types; the allowlist gate is the
-    structural check that rejects hallucinations).
+    Returns ``_SAFE_NODE_TYPES`` intersected with the nodes actually
+    registered in :class:`kailash.nodes.base.NodeRegistry` at call time —
+    so the allowlist never advertises a vetted node type whose submodule
+    is not installed, and never admits a node type that is not on the
+    explicit positive allowlist. This is the surface
+    :func:`workflow_from_brief` passes to the realizer per
+    ``rules/agent-reasoning.md`` Rule 1 (the LLM freely proposes node
+    types; this allowlist is the structural gate that rejects both
+    hallucinations AND any node type not vetted as safe).
+
+    DEFAULT-DENY (issue #1125 R2): a node type the LLM emits is realized
+    ONLY if it is BOTH registered AND in ``_SAFE_NODE_TYPES``. A new SDK
+    node is excluded until a human adds it to ``_SAFE_NODE_TYPES`` after
+    confirming it takes no config-supplied code (see the module-level
+    rationale + the inverse-completeness test).
 
     Returns:
-        A set of node type names registered at import time.
+        The safe node-type names that are registered in this process.
     """
     # Warm the common node-type submodules so the registry is populated
     # against the canonical Kailash node surface (data, logic, transform,
-    # code, AI). Wrapped in try/except per `rules/dependencies.md` —
-    # except branch is bounded to ImportError so non-import errors
-    # propagate loudly (NOT the silent-fallback anti-pattern).
-    try:
-        import kailash.nodes.data  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        import kailash.nodes.transform  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        import kailash.nodes.logic  # noqa: F401
-    except ImportError:
-        pass
-    try:
-        import kailash.nodes.code  # noqa: F401
-    except ImportError:
-        pass
-    # Note: `kailash.nodes.ai` is intentionally NOT warmed here — that
-    # submodule does not exist in the current SDK layout (verified via
-    # `ls src/kailash/nodes/ai`). Adding the import would create a static
-    # analyzer warning (pyright reportMissingImports). The allowlist still
-    # picks up any AI nodes registered through other warmed submodules.
+    # code). These are core `pip install kailash` submodules — a genuine
+    # ImportError here is a real breakage, NOT an expected-absent optional
+    # dep, so it is surfaced at WARN (per `rules/observability.md` Rule 5 +
+    # `rules/zero-tolerance.md` Rule 3) rather than silently swallowed. The
+    # guard is retained (a missing submodule must not crash the allowlist
+    # build) but the failure is now loud.
+    # (`kailash.nodes.ai` is intentionally absent — that submodule does not
+    # exist in the current SDK layout; warming it would raise a
+    # static-analyzer reportMissingImports.)
+    import importlib
+
+    for _submodule in (
+        "kailash.nodes.data",
+        "kailash.nodes.transform",
+        "kailash.nodes.logic",
+        "kailash.nodes.code",
+    ):
+        try:
+            importlib.import_module(_submodule)
+        except ImportError as exc:
+            logger.warning(
+                "workflow_from_brief.registry_warm_failed",
+                extra={"submodule": _submodule, "error": str(exc)},
+            )
 
     from kailash.nodes.base import NodeRegistry
 
-    # SEC-1 denylist: subtract dangerous code-execution nodes BEFORE
-    # returning. Per workspaces/from-brief-1125/04-validate/round-02-security.md
-    # finding SEC-1, PythonCodeNode + AsyncPythonCodeNode call exec() on
-    # LLM-emitted strings; gating them at the allowlist source ensures the
-    # augmented brief (`AVAILABLE NODE TYPES`) never enumerates them and the
-    # realizer's `validate_node_type` gate rejects them as unknown_value if
-    # the LLM hallucinates them anyway.
-    return set(NodeRegistry.list_nodes().keys()) - _DANGEROUS_NODE_TYPES
+    # DEFAULT-DENY: intersect the vetted positive allowlist with what is
+    # actually registered. Anything not in `_SAFE_NODE_TYPES` (including
+    # every code-execution node and any new/unvetted SDK node) is excluded
+    # by construction — there is no "all registered minus denylist" path
+    # that a newly-added dangerous node could slip through.
+    return set(_SAFE_NODE_TYPES) & set(NodeRegistry.list_nodes().keys())
 
 
 # --------------------------------------------------------------------------- #
@@ -489,26 +597,40 @@ def _coerce_connection_spec(raw: Dict[str, Any]) -> "ConnectionSpec":
     )
 
 
-def _realize(plan: Any) -> "WorkflowBuilder":
+def _realize(plan: Any, allowed_node_types: Set[str]) -> "WorkflowBuilder":
     """Realize a validated workflow plan into a WorkflowBuilder.
 
-    Pure structural plumbing per ``rules/agent-reasoning.md`` §
-    "Permitted Deterministic Logic" (exception 6, tool-result parsing).
-    The function does NOT inspect brief CONTENT — it only iterates the
-    LLM-validated plan and calls the framework's builder API.
+    Structural plumbing per ``rules/agent-reasoning.md`` § "Permitted
+    Deterministic Logic" (exception 6, tool-result parsing) — it does NOT
+    reason about brief CONTENT. It DOES enforce the node-type allowlist
+    and the SEC-1 code-execution denylist at the realization choke point:
+    ``validate_plan``'s top-level ``node_type`` gate is a structural no-op
+    for :class:`WorkflowPlan` because the per-node types live inside
+    ``plan.nodes[i]["node_type"]``, not at a top-level attribute. This
+    loop is therefore the boundary where an LLM-emitted ``node_type``
+    reaches ``builder.add_node``, so the allowlist + denylist MUST be
+    enforced here. The denylist is re-applied UNCONDITIONALLY (independent
+    of ``allowed_node_types``) so a caller-supplied allowlist cannot
+    re-admit a code-execution node.
 
     Args:
         plan: A :class:`WorkflowPlan` already validated by
-            :func:`validate_plan` (typed + confidence + allowlist).
+            :func:`validate_plan` (typed + confidence).
+        allowed_node_types: The registered-node allowlist (with the SEC-1
+            denylist already subtracted). Every realized ``node_type``
+            MUST be a member; ``_DANGEROUS_NODE_TYPES`` is additionally
+            enforced as an absolute floor regardless of this set.
 
     Returns:
         A :class:`~kailash.workflow.builder.WorkflowBuilder` populated
         with the plan's nodes and connections.
 
     Raises:
-        BriefInterpretationError: When a node spec or connection spec
-            is structurally malformed.
+        BriefInterpretationError: When a node spec or connection spec is
+            structurally malformed (``malformed=True``), or when a node
+            type is denylisted / not in the allowlist (``unknown_value``).
     """
+    from kailash._from_brief.allowlist import validate_node_type
     from kailash._from_brief.branching import realize_connections
     from kailash._from_brief.exceptions import BriefInterpretationError
     from kailash.workflow.builder import WorkflowBuilder
@@ -517,6 +639,21 @@ def _realize(plan: Any) -> "WorkflowBuilder":
     seen_ids: Set[str] = set()
     for raw_node in plan.nodes:
         spec = _coerce_node_spec(raw_node)
+        # SEC-1 denylist floor — enforced FIRST and unconditionally, so a
+        # custom allowed_node_types cannot re-admit a code-execution node
+        # (MEDIUM-2). PythonCodeNode/AsyncPythonCodeNode call exec() on
+        # LLM-emitted strings.
+        if spec["node_type"] in _DANGEROUS_NODE_TYPES:
+            raise BriefInterpretationError(
+                f"node_type={spec['node_type']!r} is denylisted because it "
+                f"executes arbitrary code (exec); a natural-language brief "
+                f"cannot realize it regardless of the allowlist",
+                unknown_value=spec["node_type"],
+            )
+        # Allowlist gate at the realization choke point — validate_plan's
+        # top-level node_type gate does not reach plan.nodes[i]["node_type"]
+        # (CRITICAL-1). Rejects hallucinated / prompt-injected node types.
+        validate_node_type(spec["node_type"], allowed_node_types)
         if spec["node_id"] in seen_ids:
             raise BriefInterpretationError(
                 f"plan contains duplicate node_id: {spec['node_id']!r}",
@@ -604,7 +741,13 @@ def workflow_from_brief(
     # Step 2 — derive model + allowlist.
     resolved_model = model if model is not None else get_default_llm_model()
     if allowed_node_types is None:
-        allowed_node_types = _registered_node_types()
+        allowed_node_types = _safe_node_types()
+    else:
+        # SEC-1: the denylist is a FLOOR, not a default. Subtract it even
+        # from a caller-supplied allowlist so a custom set cannot re-admit
+        # a code-execution node (MEDIUM-2). The realizer re-checks the
+        # denylist unconditionally too (defense in depth).
+        allowed_node_types = set(allowed_node_types) - _DANGEROUS_NODE_TYPES
 
     # Step 3 — augment the brief with the allowlist so the LLM has the
     # full vocabulary inline. The agent runs against a structured-output
@@ -648,8 +791,10 @@ def workflow_from_brief(
         confidence_threshold=confidence_threshold,
     )
 
-    # Step 6 — realize into a WorkflowBuilder.
-    builder = _realize(plan)
+    # Step 6 — realize into a WorkflowBuilder. The realizer enforces the
+    # node-type allowlist + SEC-1 denylist at the add_node choke point
+    # (validate_plan's top-level node_type gate does not reach plan.nodes).
+    builder = _realize(plan, allowed_node_types)
     logger.info(
         "workflow_from_brief.ok",
         extra={

--- a/tests/tier2_integration/runtime/mixins/test_cycle_execution_mixin.py
+++ b/tests/tier2_integration/runtime/mixins/test_cycle_execution_mixin.py
@@ -63,6 +63,8 @@ class TestCycleRuntime(BaseRuntime, CycleExecutionMixin):
     Note: GREEN phase - Now inherits CycleExecutionMixin for testing.
     """
 
+    __test__ = False  # helper runtime, not a pytest test class (Test* prefix)
+
     def __init__(self, enable_cycles=True, **kwargs):
         """Initialize test runtime with tracking capabilities."""
         # Filter out unknown kwargs to prevent super().__init__() errors

--- a/tests/tier2_integration/test_metadata_parameter_fix.py
+++ b/tests/tier2_integration/test_metadata_parameter_fix.py
@@ -30,6 +30,8 @@ from kailash.workflow.builder import WorkflowBuilder
 class TestNodeWithMetadataParam(Node):
     """Test node that uses 'metadata' as a parameter name."""
 
+    __test__ = False  # helper Node, not a pytest test class (Test* prefix)
+
     def get_parameters(self) -> dict[str, NodeParameter]:
         return {
             "id": NodeParameter(
@@ -56,6 +58,8 @@ class TestNodeWithMetadataParam(Node):
 class TestNodeWithoutMetadataParam(Node):
     """Test node that does NOT use 'metadata' as parameter."""
 
+    __test__ = False  # helper Node, not a pytest test class (Test* prefix)
+
     def get_parameters(self) -> dict[str, NodeParameter]:
         return {
             "id": NodeParameter(
@@ -69,6 +73,8 @@ class TestNodeWithoutMetadataParam(Node):
 
 class TestTypedNodeWithMetadataPort(TypedNode):
     """TypedNode with output port named 'metadata'."""
+
+    __test__ = False  # helper TypedNode, not a pytest test class (Test* prefix)
 
     # Input ports
     text_input = InputPort[str]("text_input", description="Text to process")

--- a/tests/unit/_from_brief/test_validator.py
+++ b/tests/unit/_from_brief/test_validator.py
@@ -72,6 +72,38 @@ class TestConfidenceGate:
             validate_plan(plan)
         assert excinfo.value.malformed is True
 
+    def test_nan_confidence_raises_malformed_at_gate(self):
+        """#1125 R1 MEDIUM-1: IEEE-754 NaN comparisons are always False, so
+        NaN slipped past both the range gate AND the threshold gate. The
+        gate MUST reject it via math.isfinite (P5 threat). Asserted at the
+        gate function because BriefPlan construction now rejects NaN earlier
+        (see test_nonfinite_confidence_rejected_at_plan_construction)."""
+        from kailash._from_brief.confidence import check_confidence
+
+        with pytest.raises(BriefInterpretationError) as excinfo:
+            check_confidence(float("nan"))
+        assert excinfo.value.malformed is True
+
+    def test_inf_confidence_raises_malformed_at_gate(self):
+        """#1125 R1 MEDIUM-1: +inf/-inf are non-finite and MUST be rejected
+        as malformed at the gate."""
+        from kailash._from_brief.confidence import check_confidence
+
+        for value in (float("inf"), float("-inf")):
+            with pytest.raises(BriefInterpretationError) as excinfo:
+                check_confidence(value)
+            assert excinfo.value.malformed is True
+
+    def test_nonfinite_confidence_rejected_at_plan_construction(self):
+        """#1125 R1 MEDIUM-1 (defense in depth): BriefPlan sets
+        allow_inf_nan=False so NaN/±inf are rejected by Pydantic before
+        validate_plan ever runs."""
+        from pydantic import ValidationError
+
+        for value in (float("nan"), float("inf"), float("-inf")):
+            with pytest.raises(ValidationError):
+                WorkflowLikePlan(interpretation_confidence=value)
+
 
 class TestAllowlistGate:
     def test_unknown_node_type_raises_with_name(self):

--- a/tests/unit/workflow/test_from_brief_realizer.py
+++ b/tests/unit/workflow/test_from_brief_realizer.py
@@ -239,24 +239,33 @@ def test_coerce_connection_spec_rejects_missing_target():
 
 
 def test_realize_single_node_builds_workflow():
-    """A single-node plan realizes into a buildable WorkflowBuilder."""
+    """A single-node plan realizes into a buildable WorkflowBuilder.
+
+    Uses a legitimate registered node (CSVReaderNode) — PythonCodeNode is
+    denylisted at realization (#1125 R1 CRITICAL-1) and can no longer be a
+    realizer fixture.
+    """
     from kailash.workflow.builder import WorkflowBuilder
-    from kailash.workflow.from_brief import _realize, _workflow_plan_cls
+    from kailash.workflow.from_brief import (
+        _realize,
+        _safe_node_types,
+        _workflow_plan_cls,
+    )
 
     plan_cls = _workflow_plan_cls()
     plan = plan_cls(
         nodes=[
             {
-                "node_type": "PythonCodeNode",
+                "node_type": "CSVReaderNode",
                 "node_id": "n1",
-                "config": {"code": "result = 42"},
+                "config": {},
             }
         ],
         connections=[],
         interpretation_confidence=0.9,
     )
 
-    builder = _realize(plan)
+    builder = _realize(plan, _safe_node_types())
     assert isinstance(builder, WorkflowBuilder)
     workflow = builder.build()
     assert "n1" in workflow.nodes
@@ -264,20 +273,24 @@ def test_realize_single_node_builds_workflow():
 
 def test_realize_two_nodes_with_connection_wires_them():
     """A two-node plan with one connection produces a wired workflow."""
-    from kailash.workflow.from_brief import _realize, _workflow_plan_cls
+    from kailash.workflow.from_brief import (
+        _realize,
+        _safe_node_types,
+        _workflow_plan_cls,
+    )
 
     plan_cls = _workflow_plan_cls()
     plan = plan_cls(
         nodes=[
             {
-                "node_type": "PythonCodeNode",
+                "node_type": "CSVReaderNode",
                 "node_id": "src",
-                "config": {"code": "result = [1, 2, 3]"},
+                "config": {},
             },
             {
-                "node_type": "PythonCodeNode",
+                "node_type": "CSVReaderNode",
                 "node_id": "dst",
-                "config": {"code": "result = sum(input)"},
+                "config": {},
             },
         ],
         connections=[
@@ -286,7 +299,7 @@ def test_realize_two_nodes_with_connection_wires_them():
         interpretation_confidence=0.9,
     )
 
-    builder = _realize(plan)
+    builder = _realize(plan, _safe_node_types())
     workflow = builder.build()
     assert len(workflow.nodes) == 2
     assert len(workflow.connections) == 1
@@ -294,20 +307,24 @@ def test_realize_two_nodes_with_connection_wires_them():
 
 def test_realize_duplicate_node_id_raises():
     """A plan with duplicate node_ids raises malformed=True."""
-    from kailash.workflow.from_brief import _realize, _workflow_plan_cls
+    from kailash.workflow.from_brief import (
+        _realize,
+        _safe_node_types,
+        _workflow_plan_cls,
+    )
 
     plan_cls = _workflow_plan_cls()
     plan = plan_cls(
         nodes=[
-            {"node_type": "PythonCodeNode", "node_id": "dup", "config": {}},
-            {"node_type": "PythonCodeNode", "node_id": "dup", "config": {}},
+            {"node_type": "CSVReaderNode", "node_id": "dup", "config": {}},
+            {"node_type": "CSVReaderNode", "node_id": "dup", "config": {}},
         ],
         connections=[],
         interpretation_confidence=0.9,
     )
 
     with pytest.raises(BriefInterpretationError) as exc_info:
-        _realize(plan)
+        _realize(plan, _safe_node_types())
     assert exc_info.value.malformed
     assert "dup" in str(exc_info.value)
 
@@ -317,39 +334,127 @@ def test_realize_duplicate_node_id_raises():
 # --------------------------------------------------------------------------- #
 
 
-def test_registered_node_types_returns_non_empty_set():
-    """`_registered_node_types()` returns the populated NodeRegistry,
-    minus the SEC-1 denylist of code-execution nodes.
-    """
-    from kailash.workflow.from_brief import _registered_node_types
+def test_safe_node_types_returns_curated_allowlist():
+    """#1125 R2: `_safe_node_types()` returns the DEFAULT-DENY positive
+    allowlist intersected with the registry — a non-empty set of vetted
+    safe nodes that includes common data-shaping nodes and excludes every
+    code-execution / composition node."""
+    from kailash.workflow.from_brief import _safe_node_types
 
-    types = _registered_node_types()
+    types = _safe_node_types()
     assert isinstance(types, set)
     assert len(types) > 0
-    # A canonical Kailash data-reader node is registered at import time.
-    assert "CSVReaderNode" in types
+    # Common safe nodes are present (useful brief surface).
+    for safe in ("CSVReaderNode", "JSONReaderNode", "FilterNode", "MergeNode"):
+        assert safe in types
+    # No code-execution / composition node is brief-reachable.
+    for danger in (
+        "PythonCodeNode",
+        "AsyncPythonCodeNode",
+        "DataTransformer",
+        "ConvergenceCheckerNode",
+        "MultiCriteriaConvergenceNode",
+        "WorkflowNode",
+    ):
+        assert danger not in types
 
 
 @pytest.mark.regression
-def test_workflow_from_brief_rejects_dangerous_code_execution_nodes():
-    """SEC-1 regression: PythonCodeNode + AsyncPythonCodeNode MUST be
-    rejected by the allowlist gate even though they are registered in
-    `NodeRegistry`. A brief that asks the LLM to emit a `PythonCodeNode`
-    with attacker-controlled `config.code` must NOT reach `builder.add_node`.
-    See workspaces/from-brief-1125/04-validate/round-02-security.md SEC-1.
+def test_default_deny_allowlist_excludes_code_exec_nodes():
+    """#1125 R2 CRITICAL-2: the safe allowlist is default-deny — only the
+    vetted `_SAFE_NODE_TYPES` are brief-reachable; the denylist FLOOR is
+    disjoint from it. (Behavioral enforcement asserted by the realizer
+    tests above; this pins the data-structure invariant.)
     """
     from kailash.workflow.from_brief import (
         _DANGEROUS_NODE_TYPES,
-        _registered_node_types,
+        _SAFE_NODE_TYPES,
+        _safe_node_types,
     )
 
-    allowed = _registered_node_types()
-    assert (
-        "PythonCodeNode" not in allowed
-    ), "SEC-1: PythonCodeNode MUST be in the denylist"
-    assert (
-        "AsyncPythonCodeNode" not in allowed
-    ), "SEC-1: AsyncPythonCodeNode MUST be in the denylist"
-    # Denylist constant itself MUST cover both names.
-    assert "PythonCodeNode" in _DANGEROUS_NODE_TYPES
-    assert "AsyncPythonCodeNode" in _DANGEROUS_NODE_TYPES
+    allowed = _safe_node_types()
+    # Default-deny: resolved allowlist is a subset of the vetted positive set.
+    assert allowed <= _SAFE_NODE_TYPES
+    # The defense-in-depth floor never overlaps the safe set.
+    assert _SAFE_NODE_TYPES.isdisjoint(_DANGEROUS_NODE_TYPES)
+    # Known code-exec nodes are in the floor (caller-override defense).
+    for danger in ("PythonCodeNode", "AsyncPythonCodeNode", "DataTransformer"):
+        assert danger in _DANGEROUS_NODE_TYPES
+        assert danger not in allowed
+
+
+def _workflow_plan_with(node_type: str):
+    """Build a WorkflowPlan whose single node is `node_type` (confidence 0.99)."""
+    import kailash.workflow.from_brief as fb
+    from kailash._from_brief.validator import coerce_plan
+
+    return coerce_plan(
+        {
+            "interpretation_confidence": 0.99,
+            "nodes": [{"node_type": node_type, "node_id": "n", "config": {}}],
+            "connections": [],
+        },
+        fb._workflow_plan_cls(),
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("dangerous", ["PythonCodeNode", "AsyncPythonCodeNode"])
+def test_realize_rejects_denylisted_code_execution_node(dangerous):
+    """SEC-1 / CRITICAL-1 (#1125 R1): a WorkflowPlan whose `plan.nodes`
+    contains a code-execution node MUST be rejected at realization — the
+    node type must NOT reach `builder.add_node`. Behavioral guard replacing
+    the prior constant-only assertion: `validate_plan`'s top-level node_type
+    gate is a no-op for WorkflowPlan (node types are nested in plan.nodes),
+    so `_realize` is the enforcement choke point.
+    """
+    from kailash._from_brief.exceptions import BriefInterpretationError
+    from kailash.workflow.from_brief import _realize, _safe_node_types
+
+    plan = _workflow_plan_with(dangerous)
+    with pytest.raises(BriefInterpretationError) as exc:
+        _realize(plan, _safe_node_types())
+    assert exc.value.unknown_value == dangerous
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("dangerous", ["PythonCodeNode", "AsyncPythonCodeNode"])
+def test_realize_denylist_is_a_floor_caller_override_cannot_readmit(dangerous):
+    """MEDIUM-2 (#1125 R1): a caller-supplied `allowed_node_types` that
+    includes a denylisted node MUST still be rejected — the denylist is an
+    absolute floor enforced unconditionally at realization.
+    """
+    from kailash._from_brief.exceptions import BriefInterpretationError
+    from kailash.workflow.from_brief import _realize
+
+    plan = _workflow_plan_with(dangerous)
+    with pytest.raises(BriefInterpretationError) as exc:
+        _realize(plan, {dangerous})  # caller tries to re-admit it
+    assert exc.value.unknown_value == dangerous
+
+
+@pytest.mark.regression
+def test_realize_rejects_hallucinated_unknown_node():
+    """CRITICAL-1 (#1125 R1): a node type not in the allowlist (LLM
+    hallucination or prompt injection) MUST be rejected at realization.
+    """
+    from kailash._from_brief.exceptions import BriefInterpretationError
+    from kailash.workflow.from_brief import _realize, _safe_node_types
+
+    plan = _workflow_plan_with("TotallyFakeInjectedNode")
+    with pytest.raises(BriefInterpretationError) as exc:
+        _realize(plan, _safe_node_types())
+    assert exc.value.unknown_value == "TotallyFakeInjectedNode"
+
+
+@pytest.mark.regression
+def test_realize_accepts_legitimate_registered_node():
+    """Positive control: a legitimate registered node realizes successfully
+    (the allowlist/denylist gate does not over-reject)."""
+    from kailash.workflow.from_brief import _realize, _safe_node_types
+
+    allowed = _safe_node_types()
+    assert "CSVReaderNode" in allowed
+    plan = _workflow_plan_with("CSVReaderNode")
+    builder = _realize(plan, allowed)
+    assert builder.build() is not None

--- a/tests/unit/workflow/test_from_brief_safe_allowlist.py
+++ b/tests/unit/workflow/test_from_brief_safe_allowlist.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Inverse-completeness guard for the from_brief default-deny safe allowlist.
+
+Issue #1125 R2 (CRITICAL-2): `from_brief` realizes only `_SAFE_NODE_TYPES`
+(default-deny positive allowlist). The security invariant is that NO member
+of that set can execute config-supplied code. The denylist model it replaced
+was proven unsound because the dangerous set cannot be reliably auto-derived;
+this test is the regression backstop that fires if a future edit adds a
+code-execution-capable node to the safe allowlist.
+
+The human review required to add a node to `_SAFE_NODE_TYPES` is the primary
+defense; these mechanical assertions are the structural net beneath it.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import textwrap
+
+import pytest
+
+
+def _warm_and_registry():
+    for mod in (
+        "kailash.nodes.data",
+        "kailash.nodes.transform",
+        "kailash.nodes.logic",
+        "kailash.nodes.code",
+    ):
+        importlib.import_module(mod)
+    from kailash.nodes.base import NodeRegistry
+
+    return NodeRegistry.list_nodes()
+
+
+def _source_calls_code_exec(cls) -> bool:
+    """True if `cls`'s OWN source calls a config-supplied code-load primitive:
+    - direct `exec`/`eval`/`compile` builtin call, or an attribute named
+      exec/eval;
+    - the `CodeExecutor` helper (PythonCodeNode's helper-delegation pattern a
+      plain builtin scan would miss);
+    - dynamic import `importlib.import_module(...)` / `__import__(...)` (the
+      #1125 R4 SharePointGraphReader `device_code_callback` vector — a config
+      string imported + getattr'd + called);
+    - unsafe deserialization `pickle.loads` / `marshal.loads` /
+      `dill.loads` / `cloudpickle.loads` / `yaml.load` (each can execute
+      arbitrary objects from config-supplied bytes).
+    """
+    try:
+        src = textwrap.dedent(inspect.getsource(cls))
+    except (OSError, TypeError):
+        return False
+    if "CodeExecutor" in src:
+        return True
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return False
+    _UNSAFE_LOADS = {"pickle", "marshal", "dill", "cloudpickle"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            if isinstance(fn, ast.Name) and fn.id in (
+                "exec",
+                "eval",
+                "compile",
+                "__import__",
+            ):
+                return True
+            if isinstance(fn, ast.Attribute):
+                if fn.attr in ("exec", "eval", "import_module"):
+                    return True
+                # <module>.loads — pickle/marshal/dill/cloudpickle deserialize
+                if (
+                    fn.attr == "loads"
+                    and isinstance(fn.value, ast.Name)
+                    and fn.value.id in _UNSAFE_LOADS
+                ):
+                    return True
+                # yaml.load (without SafeLoader) executes arbitrary tags
+                if (
+                    fn.attr == "load"
+                    and isinstance(fn.value, ast.Name)
+                    and fn.value.id == "yaml"
+                ):
+                    return True
+    return False
+
+
+def _class_calls_code_exec(cls) -> bool:
+    """True if `cls` OR any of its base classes (walking the MRO) calls
+    config-supplied code execution. Walking the MRO closes the
+    base-class/mixin inheritance gap (R3 security note): a node that inherits
+    an exec-capable `run`/`process` method from a base would otherwise pass an
+    own-source-only scan.
+
+    KNOWN ACCEPTED GAPS (mitigated by the human-curated allowlist + the
+    `_DANGEROUS_NODE_TYPES` floor + the disjointness test, NOT by this scan):
+    (1) a node execing via a helper named something other than `CodeExecutor`;
+    (2) dynamically-generated classes with no `inspect.getsource`; (3)
+    composition nodes (e.g. WorkflowNode) that nest an arbitrary sub-workflow
+    without any exec/eval in their own source — covered instead by the
+    denylist floor + `test_safe_allowlist_disjoint_from_denylist_floor`.
+    """
+    for klass in getattr(cls, "__mro__", (cls,)):
+        if klass is object:
+            continue
+        if _source_calls_code_exec(klass):
+            return True
+    return False
+
+
+def test_safe_allowlist_disjoint_from_denylist_floor():
+    """The positive allowlist and the defense-in-depth floor never overlap."""
+    from kailash.workflow.from_brief import _DANGEROUS_NODE_TYPES, _SAFE_NODE_TYPES
+
+    overlap = _SAFE_NODE_TYPES & _DANGEROUS_NODE_TYPES
+    assert overlap == set(), f"safe allowlist overlaps the denylist floor: {overlap}"
+
+
+def test_every_safe_node_is_registered():
+    """Every `_SAFE_NODE_TYPES` entry resolves to a real registered node
+    (typo / stale-name guard for the hand-curated frozenset)."""
+    from kailash.workflow.from_brief import _SAFE_NODE_TYPES
+
+    reg = _warm_and_registry()
+    missing = sorted(n for n in _SAFE_NODE_TYPES if n not in reg)
+    assert missing == [], f"safe allowlist names not in NodeRegistry: {missing}"
+
+
+def test_no_safe_node_executes_config_code():
+    """INVERSE-COMPLETENESS (the load-bearing guard): no node on the safe
+    allowlist may execute config-supplied code. Fires if a future edit adds
+    a code-exec-capable node to `_SAFE_NODE_TYPES`."""
+    from kailash.workflow.from_brief import _SAFE_NODE_TYPES
+
+    reg = _warm_and_registry()
+    offenders = sorted(
+        name
+        for name in _SAFE_NODE_TYPES
+        if name in reg and _class_calls_code_exec(reg[name])
+    )
+    assert offenders == [], (
+        f"safe-allowlisted nodes execute config code (denylist them + remove "
+        f"from _SAFE_NODE_TYPES): {offenders}"
+    )
+
+
+@pytest.mark.regression
+def test_known_code_exec_nodes_are_not_brief_reachable():
+    """#1125 R2 CRITICAL-2 regression: every confirmed config-code-exec node
+    is excluded from the resolved safe allowlist."""
+    from kailash.workflow.from_brief import _safe_node_types
+
+    allowed = _safe_node_types()
+    for danger in (
+        "PythonCodeNode",
+        "AsyncPythonCodeNode",
+        "DataTransformer",
+        "ConvergenceCheckerNode",
+        "MultiCriteriaConvergenceNode",
+        "WorkflowNode",
+    ):
+        assert danger not in allowed, f"{danger} is brief-reachable (CRITICAL-2)"


### PR DESCRIPTION
## Summary

Pre-release redteam (R1–R6) of the merged `from_brief` (#1125) + `delegate` (#1035) surface found — and this PR closes — an untrusted-brief → arbitrary-code-execution path on the `from_brief` workflow surface. Two compounding CRITICALs plus a dynamic-import MEDIUM, all confirmed by construction.

## Root cause

- **CRITICAL-1** — the node-type allowlist gate was a structural no-op: `validate_plan` inspected top-level `node_type`/`node_types`, but `WorkflowPlan` nests node types in `plan.nodes[i]`, so the gate iterated nothing and `_realize` called `builder.add_node` with zero enforcement.
- **CRITICAL-2** — the "all registered nodes − denylist" model was unsound: the dangerous set cannot be reliably enumerated (PythonCodeNode execs via a helper invisible to a class scan; DataTransformer / Convergence / validation nodes exec/eval config; the SharePoint reader dynamic-imports a config-named module). Every new code-running SDK node silently re-opened the bypass.

## Fix — default-deny

- `_SAFE_NODE_TYPES`: explicit positive allowlist of 43 vetted, config-declarative nodes (data I/O, filter/map/sort, flow control, DB/vector/streaming). A new SDK node is NOT brief-reachable until reviewed + added.
- `_realize` enforces the allowlist **plus** an unconditional `_DANGEROUS_NODE_TYPES` floor at the `add_node` choke point — a caller-supplied `allowed_node_types` cannot re-admit a code-exec node.
- Inverse-completeness test mechanically asserts no safe-listed node can reach `exec`/`eval`/`compile`/`CodeExecutor`/`import_module`/`__import__`/unsafe-deserialization across its MRO.
- Also closes: NaN/inf confidence-gate bypass (`math.isfinite` + `allow_inf_nan=False`); stale bootstrap dotted-path comment; delegate payload-depth docstring + M1 consume-lock thread-safety caveat. Plus tier2 `PytestCollectionWarning` hygiene.

## Verification

- By construction: PythonCodeNode / DataTransformer / Convergence / SharePoint / WorkflowNode rejected at realize; legitimate readers/writers/filters realize; caller-override cannot re-admit; unwarmed code-exec nodes blocked by default-deny.
- 928 tests pass under `-W error` (delegate + from_brief + bootstrap); collection 18192, exit 0.
- Redteam convergence: R5 (fresh re-derivation, minimal+full registry warm, 0 safe×code-load overlap) CONVERGED; R3 independently converged delegate + the default-deny model. Receipts in `workspaces/issue-1035-delegate-py/04-validate/`.

## Test plan

- [ ] CI matrix green
- [ ] Clean-venv install-verify on the 2.27.0 release (the slim-core import-shape change mandates a TestPyPI rehearsal)

## Related issues

Refs #1125, #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)