### PR TITLE
fix(delegate): align audit sign/verify on a content pre-image (#1182)

### DIFF
--- a/src/kailash/delegate/audit.py
+++ b/src/kailash/delegate/audit.py
@@ -67,7 +67,73 @@ __all__ = [
     "CrossAnchorIntegrityError",
     "DelegateEventType",
     "WitnessedCrossAnchor",
+    "content_signing_bytes",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Content-signing pre-image (#1182 root-cause fix)
+# ---------------------------------------------------------------------------
+
+
+def content_signing_bytes(
+    event_type: str,
+    event_payload: dict[str, Any],
+    signer_delegate_id: uuid.UUID,
+) -> bytes:
+    """Canonical UTF-8 bytes a delegate signs to attest event AUTHORSHIP.
+
+    This is the SINGLE source of the signed byte-string shared by both the
+    sign-site (a runtime / delegate with key access, BEFORE the engine has
+    assigned the chain-link fields) AND the verify-site
+    (:meth:`AuditChainEngine.emit_event`, which verifies against the SAME
+    bytes after constructing the entry). Both halves MUST call this helper
+    so the pre-image is byte-identical at both ends — the #1182 contract.
+
+    The pre-image deliberately covers ONLY the delegate-authored content:
+
+    - ``event_type`` — the kind of audit-visible event.
+    - ``event_payload`` — the event's domain-specific fields.
+    - ``signer_delegate_id`` — binds the signature to the signer, defeating
+      same-key cross-event substitution (an attacker cannot lift a valid
+      signature off one signer's event and replay it under another id).
+
+    It deliberately EXCLUDES the engine-assigned fields ``sequence`` /
+    ``previous_hash`` / ``signed_at``. Those are assigned by the engine
+    AFTER it receives the signature (the caller cannot know them at signing
+    time), so requiring the signature to cover them is structurally
+    unsatisfiable (#1182). Tamper-evidence of ordering — reorder / insert /
+    delete — is NOT carried by the signature; it is carried INDEPENDENTLY by
+    the substrate hash-chain: each emitted entry's ``previous_hash`` is the
+    SHA-256 of the prior entry's full canonical dict (which includes
+    ``sequence`` + ``previous_hash`` + the prior ``signature``), and the
+    substrate :class:`AuditAnchor` records that entry-hash + ``parent_anchor_id``
+    linkage. Mutating a committed entry's payload, sequence, or previous_hash
+    breaks the recomputed-hash linkage of every subsequent entry. Signature
+    attests authorship of content; hash-chain attests ordering. The two
+    layers are orthogonal and both load-bearing.
+
+    Mirrors the rs M4 substrate model where ``record(content) ->
+    AuditChainRecord`` signs the content and the ``eatp::ledger::LedgerEntry``
+    holds the ``prev_entry_hash`` / ``entry_hash`` linkage as-is (see
+    ``workspaces/issue-1035-delegate-py/01-analysis/02-kailash-rs-reference-extraction.md:55``).
+
+    Args:
+        event_type: One of :class:`DelegateEventType` string sentinels.
+        event_payload: The event's JSON-serializable payload dict.
+        signer_delegate_id: UUID of the signing :class:`DelegateIdentity`.
+
+    Returns:
+        Canonical UTF-8 bytes routed through
+        :func:`kailash.trust._json.canonical_json_dumps`.
+    """
+    return canonical_json_dumps(
+        {
+            "event_type": event_type,
+            "event_payload": event_payload,
+            "signer_delegate_id": str(signer_delegate_id),
+        }
+    ).encode("utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -279,8 +345,14 @@ class AuditChainEntry:
         signer_delegate_id: UUID of the :class:`DelegateIdentity`
             that signed this entry.
         signed_at: Tz-aware UTC datetime the signature was produced.
-        signature: 128-char lowercase-hex Ed25519 signature over
-            :meth:`to_signing_dict`'s canonical-JSON encoding.
+        signature: 128-char lowercase-hex Ed25519 signature over the
+            content pre-image produced by :meth:`to_content_signing_bytes`
+            (event_type + event_payload + signer_delegate_id). The signature
+            attests delegate authorship of the event content; it does NOT
+            cover the engine-assigned ``sequence`` / ``previous_hash`` /
+            ``signed_at`` fields (those are assigned after signing — #1182).
+            Ordering tamper-evidence is carried by the hash-chain, not the
+            signature.
     """
 
     sequence: int
@@ -374,15 +446,39 @@ class AuditChainEntry:
         return payload
 
     def to_signing_bytes(self) -> bytes:
-        """Canonical UTF-8 bytes a signer signed (signature EXCLUDED).
+        """Canonical UTF-8 bytes of the FULL pre-signature dict (signature EXCLUDED).
 
-        Convenience helper for :class:`kailash.delegate.verifier.Verifier`
-        callers — routes :meth:`to_signing_dict` through
-        :func:`canonical_json_dumps` and encodes to UTF-8 so the bytes
-        are byte-identical to what a signer would have signed. Cross-SDK
-        verifier parity depends on byte-equality of this representation.
+        Routes :meth:`to_signing_dict` (which includes the engine-assigned
+        ``sequence`` / ``previous_hash`` / ``signed_at`` fields) through
+        :func:`canonical_json_dumps`. This is the cross-SDK byte-canonical
+        FULL-entry representation pinned by the conformance receipts.
+
+        NOTE (#1182): this is NOT the byte-string the Ed25519 signature is
+        verified against. The signature attests delegate AUTHORSHIP of the
+        event CONTENT via :meth:`to_content_signing_bytes` — a pre-image that
+        excludes the engine-assigned fields, because the signer cannot know
+        them at signing time. Use :meth:`to_content_signing_bytes` for the
+        sign/verify byte-string; this method remains for the full-entry
+        canonical-shape contract (conformance vectors, cross-SDK parity).
         """
         return canonical_json_dumps(self.to_signing_dict()).encode("utf-8")
+
+    def to_content_signing_bytes(self) -> bytes:
+        """Canonical UTF-8 bytes the Ed25519 signature attests (#1182).
+
+        The delegate signs this content-only pre-image — ``event_type`` +
+        ``event_payload`` + ``signer_delegate_id`` — BEFORE the engine
+        assigns ``sequence`` / ``previous_hash`` / ``signed_at``. The engine
+        verifies the supplied signature against THESE bytes. Both halves
+        route through the module-level :func:`content_signing_bytes` helper,
+        guaranteeing the sign-site and verify-site agree byte-for-byte. See
+        :func:`content_signing_bytes` for the full security rationale (why
+        engine-assigned fields are excluded and how the hash-chain carries
+        ordering tamper-evidence independently of the signature).
+        """
+        return content_signing_bytes(
+            self.event_type, self.event_payload, self.signer_delegate_id
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -749,11 +845,18 @@ class AuditChainEngine:
             signer_identity: :class:`DelegateIdentity` that signed
                 the entry; ``delegate_id`` flows into
                 :attr:`AuditChainEntry.signer_delegate_id`.
-            signature: 128-char lowercase-hex Ed25519 signature
-                over :meth:`AuditChainEntry.to_signing_dict`'s
-                canonical-JSON. The engine does not compute the
-                signature itself — the caller (a delegate runtime
-                with key access) provides it.
+            signature: 128-char lowercase-hex Ed25519 signature over
+                the content pre-image (event_type + payload +
+                signer_delegate_id) produced by
+                :func:`content_signing_bytes` / the entry's
+                :meth:`AuditChainEntry.to_content_signing_bytes`. The
+                engine does not compute the signature itself — the caller
+                (a delegate runtime with key access) signs the SAME content
+                pre-image via :func:`content_signing_bytes` and passes the
+                hex here (#1182). The signature deliberately does NOT cover
+                the engine-assigned ``sequence`` / ``previous_hash`` /
+                ``signed_at`` fields (the caller cannot know them at signing
+                time); ordering tamper-evidence is the hash-chain's job.
             signed_at: Optional tz-aware datetime; defaults to
                 ``datetime.now(timezone.utc)`` at call time.
 
@@ -838,18 +941,29 @@ class AuditChainEngine:
                 signature=signature,
             )
 
-            # /redteam Round-1 C1 (CRITICAL) closure: cryptographically
-            # verify the signature against the entry's canonical signing
-            # bytes BEFORE appending. Prior shape-only hex validation
-            # let any 128-char hex string fall through (fake-encryption
-            # pattern per zero-tolerance.md Rule 2). The verifier is
-            # NullVerifier by default — so a runtime that doesn't wire
-            # an Ed25519Verifier rejects EVERY event, fail-closed.
-            # Inside the lock so concurrent emit_event calls cannot
-            # interleave a verify against a stale entry.
+            # /redteam Round-1 C1 (CRITICAL) closure + #1182 root-cause fix:
+            # cryptographically verify the signature against the entry's
+            # CONTENT-signing bytes BEFORE appending. Prior shape-only hex
+            # validation let any 128-char hex string fall through
+            # (fake-encryption pattern per zero-tolerance.md Rule 2). The
+            # verifier is NullVerifier by default — so a runtime that
+            # doesn't wire an Ed25519Verifier rejects EVERY event,
+            # fail-closed. Inside the lock so concurrent emit_event calls
+            # cannot interleave a verify against a stale entry.
+            #
+            # #1182: the verified byte-string is the CONTENT pre-image
+            # (event_type + event_payload + signer_delegate_id) via
+            # entry.to_content_signing_bytes(), NOT the full-entry
+            # to_signing_bytes(). The signer produced the signature BEFORE
+            # the engine assigned sequence / previous_hash / signed_at, so
+            # those engine-assigned fields cannot be in the signed pre-image
+            # — requiring them was structurally unsatisfiable (every caller
+            # raised AuditChainSignatureError at sequence=0). Ordering
+            # tamper-evidence stays with the hash-chain (previous_hash
+            # linkage + substrate entry-hash), independent of the signature.
             sig_bytes = bytes.fromhex(signature)
             if not self._verifier.verify(
-                entry.to_signing_bytes(),
+                entry.to_content_signing_bytes(),
                 sig_bytes,
                 str(signer_identity.delegate_id),
             ):
@@ -858,7 +972,8 @@ class AuditChainEngine:
                     f"failed for signer={signer_identity.delegate_id!r} at "
                     f"sequence={sequence} (verifier={type(self._verifier).__name__}). "
                     "Either the signature is invalid for the canonical "
-                    "to_signing_bytes() payload, the signer is not "
+                    "to_content_signing_bytes() payload (event_type + "
+                    "event_payload + signer_delegate_id), the signer is not "
                     "registered in the PrincipalDirectory, or the verifier "
                     "is the fail-closed NullVerifier (wire an Ed25519Verifier "
                     "with a populated directory)."

--- a/src/kailash/delegate/dispatch.py
+++ b/src/kailash/delegate/dispatch.py
@@ -63,7 +63,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Generic, NoReturn, Protocol, TypeVar, runtime_checkable
 
-from kailash.delegate.audit import AuditChainEngine, DelegateEventType
+from kailash.delegate.audit import (
+    AuditChainEngine,
+    DelegateEventType,
+    content_signing_bytes,
+)
 from kailash.delegate.envelope import DelegateConstraintEnvelope
 from kailash.delegate.trust import (
     CascadeTenantViolationError,
@@ -1847,12 +1851,24 @@ class DispatchSurface:
                 "external_side_effect": result.external_side_effect,
             }
             # C2-1 zero-tolerance fix: call the injected signer with the
-            # canonical-bytes encoding of the audit payload. A signer
+            # canonical-bytes encoding of the audit event. A signer
             # fault re-raises as DispatchSignerError so the error
             # taxonomy distinguishes signer faults from
             # AuditChainEmissionError (signature surface-shape) and
             # DispatchValidationError (input-shape).
-            canonical_bytes = canonical_json_dumps(payload).encode("utf-8")
+            #
+            # #1182: the signed (and verified) byte-string is the CONTENT
+            # pre-image — event_type + payload + signer_delegate_id — via
+            # content_signing_bytes, the SAME helper AuditChainEngine.
+            # emit_event verifies against. Pre-#1182 this signed the bare
+            # payload (canonical_json_dumps(payload)), which the engine's
+            # verify-site could never reproduce once it included the
+            # engine-assigned sequence/previous_hash/signed_at. The
+            # event_type is part of the pre-image, so it is rebuilt per
+            # iteration (each event_type in result.audit_events).
+            canonical_bytes = content_signing_bytes(
+                event_type.value, payload, self._identity.delegate_id
+            )
             try:
                 signature_hex = self._signer(canonical_bytes)
             except Exception as exc:

--- a/src/kailash/delegate/runtime.py
+++ b/src/kailash/delegate/runtime.py
@@ -75,12 +75,15 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Literal
 
-from kailash.delegate.audit import AuditChainEngine, DelegateEventType
+from kailash.delegate.audit import (
+    AuditChainEngine,
+    DelegateEventType,
+    content_signing_bytes,
+)
 from kailash.delegate.dispatch import DispatchResult, DispatchSurface
 from kailash.delegate.envelope import DelegateConstraintEnvelope
 from kailash.delegate.trust import TenantScope, TenantScopedCascade
 from kailash.delegate.types import DelegateIdentity, LifecycleState
-from kailash.trust._json import canonical_json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -1241,7 +1244,16 @@ class DelegateRuntime:
             "nonce_present": bool(human_acknowledged_nonce),
         }
         try:
-            canonical_bytes = canonical_json_dumps(rotation_payload).encode("utf-8")
+            # #1182: sign the content pre-image the engine verifies against
+            # (event_type + payload + signer_delegate_id), NOT the bare
+            # rotation_payload. Signing the payload alone produced a
+            # signature emit_event could never verify — same root cause as
+            # the _emit_phase_audit path.
+            canonical_bytes = content_signing_bytes(
+                DelegateEventType.POSTURE_OR_SOVEREIGN_HANDOVER.value,
+                rotation_payload,
+                self._identity.delegate_id,
+            )
             signature = self._signer(canonical_bytes)
             self._audit_engine.emit_event(
                 event_type=DelegateEventType.POSTURE_OR_SOVEREIGN_HANDOVER.value,
@@ -1707,8 +1719,14 @@ class DelegateRuntime:
 
         The event type per phase is fixed by
         :attr:`_PHASE_EVENT_TYPES`. The signature is computed via the
-        bound :attr:`_signer` over the canonical-JSON bytes of the
-        payload (mirrors the S5 dispatch path).
+        bound :attr:`_signer` over the CONTENT pre-image — event_type +
+        payload + signer_delegate_id — produced by
+        :func:`kailash.delegate.audit.content_signing_bytes`. The engine
+        verifies the supplied signature against the SAME pre-image (#1182);
+        signing the bare payload alone (the pre-#1182 behaviour) produced a
+        signature the engine could never verify, because emit_event verifies
+        against bytes the caller cannot reproduce — the engine-assigned
+        sequence / previous_hash / signed_at are unknown at signing time.
         """
         event_type = self._PHASE_EVENT_TYPES[phase]
         payload: dict[str, Any] = {
@@ -1717,7 +1735,12 @@ class DelegateRuntime:
         }
         if extra_payload:
             payload.update(extra_payload)
-        canonical_bytes = canonical_json_dumps(payload).encode("utf-8")
+        # #1182: sign the content pre-image the engine verifies against,
+        # NOT the bare payload. content_signing_bytes is the single shared
+        # source so sign-site and verify-site agree byte-for-byte.
+        canonical_bytes = content_signing_bytes(
+            event_type.value, payload, self._identity.delegate_id
+        )
         signature = self._signer(canonical_bytes)
         self._audit_engine.emit_event(
             event_type=event_type.value,

--- a/tests/e2e/delegate/test_delegate_e2e_flows.py
+++ b/tests/e2e/delegate/test_delegate_e2e_flows.py
@@ -67,6 +67,8 @@ import uuid
 from datetime import datetime, timezone
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from kailash.delegate.audit import AuditChainEngine, DelegateEventType
 from kailash.delegate.conformance.schema import (
@@ -94,10 +96,12 @@ from kailash.delegate.types import (
     CapabilitySet,
     DelegateGenesisRecord,
     DelegateIdentity,
+    PrincipalDirectory,
     Role,
     RoleLifecycleState,
     RoleScope,
 )
+from kailash.delegate.verifier import Ed25519Verifier
 from kailash.trust._json import canonical_json_dumps
 from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
 from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
@@ -109,16 +113,32 @@ from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
 # ---------------------------------------------------------------------------
 
 
-def _deterministic_signer(canonical_bytes: bytes) -> str:
-    """Deterministic 128-char hex signer for E2E flows (NOT a mock)."""
-    digest = hashlib.sha256(canonical_bytes).hexdigest()
-    return digest + digest
+def _make_ed25519_signer(priv: Ed25519PrivateKey):
+    """Real Ed25519 signer callable over whatever canonical bytes it is handed.
+
+    NOT a mock — a real cryptographic signer. The runtime / dispatch hand
+    this the #1182 content pre-image; the cascade hands it the grant-signing
+    bytes. A real Ed25519 signer signs ANY bytes correctly, so one signer
+    keyed to the stack identity satisfies every sign-site, and the wired
+    :class:`Ed25519Verifier` verifies each against the registered public key.
+    """
+
+    def signer(canonical_bytes: bytes) -> str:
+        return priv.sign(canonical_bytes).hex()
+
+    return signer
 
 
 class _CountingSigner:
-    """Signer that fails on the Nth call. Used for Flow D."""
+    """Real Ed25519 signer that RAISES on the Nth call. Used for Flow D.
 
-    def __init__(self, fail_on_call: int) -> None:
+    On every non-failing call it produces a REAL Ed25519 signature (so the
+    THINKING-phase audit entry actually verifies and lands), then raises a
+    RuntimeError on the configured call to exercise the signer-fault path.
+    """
+
+    def __init__(self, priv: Ed25519PrivateKey, fail_on_call: int) -> None:
+        self._priv = priv
         self.fail_on_call = fail_on_call
         self.calls = 0
 
@@ -126,8 +146,7 @@ class _CountingSigner:
         self.calls += 1
         if self.calls == self.fail_on_call:
             raise RuntimeError(f"signer fault on call {self.calls}")
-        digest = hashlib.sha256(canonical_bytes).hexdigest()
-        return digest + digest
+        return self._priv.sign(canonical_bytes).hex()
 
 
 def _build_chain(agent_id: str = "agent-e2e") -> TrustLineageChain:
@@ -150,6 +169,11 @@ def _build_identity() -> DelegateIdentity:
         role_binding_ref="rb-e2e",
         genesis_ref="g-agent-e2e",
     )
+
+
+def _build_keyed_identity() -> tuple[DelegateIdentity, Ed25519PrivateKey]:
+    """Build an identity + a real Ed25519 keypair for it (#1182 real-crypto e2e)."""
+    return _build_identity(), Ed25519PrivateKey.generate()
 
 
 def _build_envelope() -> DelegateConstraintEnvelope:
@@ -224,25 +248,68 @@ def _build_stack(
     posture: Posture = Posture.L5_DELEGATED,
     tenant_id: str = "tenant-e2e",
     connector_tenant_id: str | None = None,
-    signer=None,
+    signer_factory=None,
 ):
-    """Real-substrate stack — every dependency is a REAL primitive instance."""
+    """Real-substrate stack — every dependency is a REAL primitive instance.
+
+    #1182: wires a REAL :class:`Ed25519Verifier` (NOT NullVerifier) into both
+    the audit engine and the cascade, and a REAL Ed25519 signer keyed to the
+    stack identity. ``DelegateRuntime.execute()`` therefore exercises the
+    full sign→verify→append audit path under real cryptography — the exact
+    end-to-end path the #1182 contract mismatch was blocking. The signer is
+    keyed to the identity registered in the directory, so every audit emit's
+    content-pre-image signature verifies and the chain advances to COMPLETED.
+
+    ``signer_factory`` (Flow D) takes the stack's private key and returns a
+    custom signer callable (e.g. one that raises mid-execute); it shares the
+    SAME key so its non-failing calls still verify.
+    """
     chain = _build_chain()
-    audit_engine = AuditChainEngine(chain=chain)
-    cascade = TenantScopedCascade(tenant=TenantScope.for_tenant(tenant_id))
+    identity, priv = _build_keyed_identity()
+    pub_bytes = priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    directory = PrincipalDirectory(
+        identities=(identity,),
+        verification_keys={identity.delegate_id: pub_bytes},
+    )
+    # Same verifier CLASS on both audit engine and cascade — the runtime's
+    # R2 coherence gate requires type(audit.verifier) is type(cascade.verifier).
+    audit_engine = AuditChainEngine(
+        chain=chain, verifier=Ed25519Verifier(directory=directory)
+    )
+    cascade = TenantScopedCascade(
+        tenant=TenantScope.for_tenant(tenant_id),
+        verifier=Ed25519Verifier(directory=directory),
+    )
     envelope = _build_envelope()
-    identity = _build_identity()
     role = _build_role()
+    bound_signer = (
+        signer_factory(priv)
+        if signer_factory is not None
+        else _make_ed25519_signer(priv)
+    )
     # #1146 H1 — register the identity as a root grantee so the
-    # DispatchSurface bind-time grantee gate passes. Without this seed
-    # the cascade-as-authorization invariant refuses bind because the
-    # identity transited no cascade_child path (root identities are
-    # explicitly seeded by infrastructure at cascade-setup time).
-    cascade.register_root_grantee(identity)
+    # DispatchSurface bind-time grantee gate passes. With a real cascade
+    # verifier wired, the seed MUST carry a real grant_proof: the cascade
+    # verifies SHA-over {"delegate_id", "tenant"} against the registered key.
+    # The seed is signed with a SEPARATE plain real signer (NOT bound_signer)
+    # so a custom signer_factory's call-counting (Flow D) starts clean at the
+    # runtime's first emit — the build-time seed does not consume its budget.
+    seed_signer = _make_ed25519_signer(priv)
+    grant_proof = seed_signer(
+        canonical_json_dumps(
+            {
+                "delegate_id": str(identity.delegate_id),
+                "tenant": cascade.tenant.tenant_id,
+            }
+        ).encode("utf-8")
+    )
+    cascade.register_root_grantee(identity, grant_proof=grant_proof)
     connector = DeterministicConnector(
         tenant_id_observed=connector_tenant_id or tenant_id,
     )
-    bound_signer = signer if signer is not None else _deterministic_signer
     surface = DispatchSurface(
         connector=connector,
         signature=_Signature(),
@@ -465,9 +532,13 @@ async def test_e2e_flow_d_signer_failure_mid_execute_lands_failed_no_recurse() -
     attempting another signed audit emit (which would recurse into the
     same broken signer).
     """
-    failing_signer = _CountingSigner(fail_on_call=2)
+    # signer_factory receives the stack's real private key; the counting
+    # signer produces a REAL Ed25519 signature on call #1 (THINKING lands +
+    # verifies) and RAISES on call #2 (ACTING). The build-time grant_proof
+    # seed uses a SEPARATE signer (see _build_stack), so this counter starts
+    # clean at the runtime's first emit: #1 = THINKING, #2 = ACTING (raises).
     runtime, surface, audit_engine, chain, connector = _build_stack(
-        signer=failing_signer,
+        signer_factory=lambda priv: _CountingSigner(priv, fail_on_call=2),
     )
 
     result = await runtime.execute({"id": "flow-d-signer"})

--- a/tests/integration/delegate/test_signature_verification_wiring.py
+++ b/tests/integration/delegate/test_signature_verification_wiring.py
@@ -29,9 +29,9 @@ import pytest
 
 from kailash.delegate.audit import (
     AuditChainEngine,
-    AuditChainEntry,
     AuditChainSignatureError,
     DelegateEventType,
+    content_signing_bytes,
 )
 from kailash.delegate.trust import (
     CascadeSignatureError,
@@ -102,19 +102,18 @@ def test_audit_engine_with_ed25519_verifier_accepts_valid_signature() -> None:
         verifier=Ed25519Verifier(directory=directory),
     )
 
-    # Compute the canonical signing bytes for the entry we're about to
-    # emit, then sign them — same shape the verifier checks.
+    # #1182: sign the CONTENT pre-image the engine verifies against —
+    # event_type + payload + signer_delegate_id — NOT the full-entry
+    # to_signing_bytes() (which includes engine-assigned sequence /
+    # previous_hash / signed_at the caller cannot know at signing time).
     now = datetime(2026, 5, 24, 12, 0, 0, tzinfo=timezone.utc)
-    proto = AuditChainEntry(
-        sequence=0,
-        previous_hash="",
-        event_type=DelegateEventType.EXTERNAL_SIDE_EFFECT.value,
-        event_payload={"foo": "bar"},
-        signer_delegate_id=ident.delegate_id,
-        signed_at=now,
-        signature="ab" * 64,  # placeholder — engine ignores; uses real sig
+    sig_hex = signer(
+        content_signing_bytes(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT.value,
+            {"foo": "bar"},
+            ident.delegate_id,
+        )
     )
-    sig_hex = signer(proto.to_signing_bytes())
 
     entry = engine.emit_event(
         event_type=DelegateEventType.EXTERNAL_SIDE_EFFECT.value,
@@ -182,18 +181,16 @@ def test_audit_engine_with_ed25519_verifier_rejects_unknown_signer() -> None:
         genesis_ref="gen-stranger",
     )
     now = datetime(2026, 5, 24, 12, 0, 0, tzinfo=timezone.utc)
-    proto = AuditChainEntry(
-        sequence=0,
-        previous_hash="",
-        event_type=DelegateEventType.EXTERNAL_SIDE_EFFECT.value,
-        event_payload={"foo": "bar"},
-        signer_delegate_id=stranger.delegate_id,
-        signed_at=now,
-        signature="ab" * 64,
-    )
     # signer is keyed to a DIFFERENT identity — its signature is real but
-    # the directory has no key for `stranger`, so verification fails.
-    sig_hex = signer(proto.to_signing_bytes())
+    # the directory has no key for `stranger`, so verification fails. Sign
+    # the #1182 content pre-image (the bytes emit_event verifies against).
+    sig_hex = signer(
+        content_signing_bytes(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT.value,
+            {"foo": "bar"},
+            stranger.delegate_id,
+        )
+    )
 
     with pytest.raises(AuditChainSignatureError):
         engine.emit_event(

--- a/tests/regression/test_issue_1182_delegate_audit_signing_contract.py
+++ b/tests/regression/test_issue_1182_delegate_audit_signing_contract.py
@@ -1,0 +1,503 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for #1182 — delegate audit-chain sign/verify contract.
+
+Root cause (#1182): ``AuditChainEngine.emit_event``'s signature contract
+was structurally unsatisfiable. The runtime sign-site
+(``DelegateRuntime._emit_phase_audit``) signed the PAYLOAD ALONE, while the
+engine verify-site verified the signature against ``AuditChainEntry``'s
+FULL pre-signature dict (``to_signing_dict()`` → sequence + previous_hash +
+event_type + event_payload + signer_delegate_id + signed_at). The engine
+assigns ``sequence`` / ``previous_hash`` / ``signed_at`` AFTER it receives
+the signature, so the caller could NEVER produce a matching signature —
+``AuditChainSignatureError`` raised at sequence=0 under any real (non-Null)
+verifier. ``NullVerifier`` masked it (it rejects everything regardless).
+
+The fix (Design (a)): a single shared content pre-image —
+``content_signing_bytes(event_type, event_payload, signer_delegate_id)`` —
+is signed by the caller AND verified by the engine. The signature attests
+delegate AUTHORSHIP of the event CONTENT; it deliberately EXCLUDES the
+engine-assigned fields (the caller cannot know them at signing time).
+Ordering tamper-evidence (reorder / insert / delete) stays with the
+hash-chain: each entry's ``previous_hash`` is the SHA-256 of the prior
+entry's full canonical dict (which includes sequence + previous_hash +
+the prior signature), so mutating a committed entry breaks the recomputed
+linkage of every successor. Signature attests authorship; hash-chain
+attests ordering — orthogonal, both load-bearing.
+
+These tests use REAL Ed25519 cryptography end-to-end — NO mocking, NO
+NullVerifier — per the #1182 acceptance criteria + ``rules/testing.md``
+§ "Behavioral Regression Tests Over Source-Grep" and § Tier-2/Tier-3
+no-mocking.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from kailash.delegate.audit import (
+    AuditChainEngine,
+    AuditChainSignatureError,
+    DelegateEventType,
+    content_signing_bytes,
+)
+from kailash.delegate.dispatch import (
+    Connector,
+    ConnectorInvocationResult,
+    DispatchSurface,
+)
+from kailash.delegate.envelope import DelegateConstraintEnvelope
+from kailash.delegate.runtime import DelegateRuntime, Posture
+from kailash.delegate.trust import TenantScope, TenantScopedCascade
+from kailash.delegate.types import (
+    CapabilitySet,
+    DelegateGenesisRecord,
+    DelegateIdentity,
+    PrincipalDirectory,
+    Role,
+    RoleLifecycleState,
+    RoleScope,
+)
+from kailash.trust._json import canonical_json_dumps
+from kailash.trust.chain import AuthorityType, GenesisRecord, TrustLineageChain
+from kailash.trust.envelope import ConstraintEnvelope, FinancialConstraint
+
+# ---------------------------------------------------------------------------
+# Real-crypto helpers (NO mocks, NO NullVerifier)
+# ---------------------------------------------------------------------------
+
+
+def _make_keypair() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+def _pub_bytes(priv: Ed25519PrivateKey) -> bytes:
+    return priv.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+
+def _make_signer(priv: Ed25519PrivateKey):
+    """Real Ed25519 signer over whatever canonical bytes it is handed."""
+
+    def signer(canonical_bytes: bytes) -> str:
+        return priv.sign(canonical_bytes).hex()
+
+    return signer
+
+
+def _build_identity() -> DelegateIdentity:
+    return DelegateIdentity(
+        delegate_id=uuid.uuid4(),
+        sovereign_ref="sov-1182",
+        role_binding_ref="rb-1182",
+        genesis_ref="g-1182",
+    )
+
+
+def _build_chain(agent_id: str) -> TrustLineageChain:
+    return TrustLineageChain(
+        genesis=GenesisRecord(
+            id="g-1182",
+            agent_id=agent_id,
+            authority_id="auth-1182",
+            authority_type=AuthorityType.SYSTEM,
+            created_at=datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc),
+            signature="00" * 64,
+        )
+    )
+
+
+def _build_envelope() -> DelegateConstraintEnvelope:
+    block = GenesisRecord(
+        id="g-env-1182",
+        agent_id="agent-env-1182",
+        authority_id="auth-env-1182",
+        authority_type=AuthorityType.ORGANIZATION,
+        created_at=datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc),
+        signature="d" * 128,
+    )
+    genesis = DelegateGenesisRecord(
+        block=block, spec_version="1", capabilities=("read",)
+    )
+    return DelegateConstraintEnvelope.from_genesis(
+        ConstraintEnvelope(financial=FinancialConstraint(budget_limit=1000.0)),
+        genesis,
+    )
+
+
+def _build_role() -> Role:
+    return Role(
+        role_id=uuid.uuid4(),
+        display_name="1182-role",
+        scope=RoleScope(
+            domain="finance",
+            capabilities=CapabilitySet(capabilities=("noop.read",)),
+        ),
+        lifecycle=RoleLifecycleState.ACTIVE,
+    )
+
+
+class _NoOpConnector(Connector):
+    """Real Protocol-satisfying no-op connector (NOT a mock).
+
+    Returns a deterministic result with one audit-visible event so the
+    full ACTING-phase dispatch + audit-emit path runs under real crypto.
+    """
+
+    connector_id = "noop-1182"
+    connector_kind = "noop"
+    requires_capabilities = frozenset({"noop.read"})
+
+    def __init__(self, *, tenant_id_observed: str) -> None:
+        self.tenant_id_observed = tenant_id_observed
+        self.invocations: list[dict] = []
+
+    async def invoke(self, input_payload, *, identity, envelope):
+        self.invocations.append({"id": input_payload.get("id", "n/a")})
+        return ConnectorInvocationResult(
+            payload={"ok": True},
+            audit_events=(DelegateEventType.EXTERNAL_SIDE_EFFECT,),
+            tenant_id_observed=self.tenant_id_observed,
+            external_side_effect=True,
+        )
+
+
+class _Signature:
+    name = "noop-1182-sig"
+    input_schema = {"id": str}
+    output_schema = {"ok": bool}
+
+
+def _build_real_runtime(*, tenant_id: str = "tenant-1182"):
+    """Wire a full DelegateRuntime with a REAL Ed25519Verifier (no Null)."""
+    from kailash.delegate.verifier import Ed25519Verifier
+
+    priv = _make_keypair()
+    identity = _build_identity()
+    directory = PrincipalDirectory(
+        identities=(identity,),
+        verification_keys={identity.delegate_id: _pub_bytes(priv)},
+    )
+    chain = _build_chain(agent_id=str(identity.delegate_id))
+    audit_engine = AuditChainEngine(
+        chain=chain, verifier=Ed25519Verifier(directory=directory)
+    )
+    cascade = TenantScopedCascade(
+        tenant=TenantScope.for_tenant(tenant_id),
+        verifier=Ed25519Verifier(directory=directory),
+    )
+    signer = _make_signer(priv)
+    # Seed the root grantee with a real grant_proof (cascade verifies it).
+    grant_proof = signer(
+        canonical_json_dumps(
+            {"delegate_id": str(identity.delegate_id), "tenant": tenant_id}
+        ).encode("utf-8")
+    )
+    cascade.register_root_grantee(identity, grant_proof=grant_proof)
+    # R2 composition gate (Invariant 4) requires the SAME envelope + role
+    # object in the DispatchSurface AND the DelegateRuntime — build once.
+    envelope = _build_envelope()
+    role = _build_role()
+    surface = DispatchSurface(
+        connector=_NoOpConnector(tenant_id_observed=tenant_id),
+        signature=_Signature(),
+        envelope=envelope,
+        identity=identity,
+        audit_engine=audit_engine,
+        trust_cascade=cascade,
+        role=role,
+        signer=signer,
+    )
+    runtime = DelegateRuntime(
+        dispatch_surface=surface,
+        audit_engine=audit_engine,
+        cascade=cascade,
+        envelope=envelope,
+        identity=identity,
+        signer=signer,
+        posture=Posture.L5_DELEGATED,
+    )
+    return runtime, audit_engine, identity, priv
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — sign/verify byte-equality at the contract level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_issue_1182_sign_site_and_verify_site_share_identical_bytes() -> None:
+    """The bytes the runtime signs == the bytes emit_event verifies.
+
+    Before #1182 the runtime signed ``canonical_json_dumps(payload)`` while
+    the engine verified against ``entry.to_signing_bytes()`` (full dict with
+    engine-assigned fields). They could never be equal at sequence>0 OR even
+    at sequence=0 (the runtime omitted sequence/previous_hash/signed_at
+    entirely). The fix routes BOTH through ``content_signing_bytes``.
+    """
+    from kailash.delegate.audit import AuditChainEntry
+
+    did = uuid.uuid4()
+    event_type = DelegateEventType.EXTERNAL_SIDE_EFFECT.value
+    payload = {"run_id": str(uuid.uuid4()), "phase": "acting"}
+
+    # Sign-site bytes (what the runtime/dispatch produce via the helper).
+    sign_site_bytes = content_signing_bytes(event_type, payload, did)
+
+    # Verify-site bytes: build the entry the engine would build (with
+    # arbitrary engine-assigned fields) and ask for its content-signing
+    # bytes — they MUST equal the sign-site bytes regardless of sequence /
+    # previous_hash / signed_at.
+    entry = AuditChainEntry(
+        sequence=7,
+        previous_hash="ab" * 32,
+        event_type=event_type,
+        event_payload=payload,
+        signer_delegate_id=did,
+        signed_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+        signature="00" * 64,
+    )
+    verify_site_bytes = entry.to_content_signing_bytes()
+
+    assert sign_site_bytes == verify_site_bytes
+    # And the content pre-image must NOT contain the engine-assigned fields.
+    assert b"previous_hash" not in sign_site_bytes
+    assert b"sequence" not in sign_site_bytes
+    assert b"signed_at" not in sign_site_bytes
+    # It MUST bind event_type + payload + signer (authorship attestation).
+    assert b"event_type" in sign_site_bytes
+    assert b"event_payload" in sign_site_bytes
+    assert b"signer_delegate_id" in sign_site_bytes
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — the issue repro: emit_event with a runtime-path signature SUCCEEDS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_issue_1182_emit_event_accepts_runtime_path_signature() -> None:
+    """A signature over the content pre-image verifies under Ed25519Verifier.
+
+    This is the #1182 repro, corrected to sign what the runtime now signs:
+    the content pre-image. Pre-fix, NO caller could produce a matching
+    signature; emit_event raised AuditChainSignatureError at sequence=0.
+    """
+    from kailash.delegate.verifier import Ed25519Verifier
+
+    priv = _make_keypair()
+    did = uuid.uuid4()
+    ident = DelegateIdentity(
+        delegate_id=did,
+        sovereign_ref="s",
+        role_binding_ref="r",
+        genesis_ref="g",
+        principal_kind="delegate",
+    )
+    directory = PrincipalDirectory(
+        identities=(ident,),
+        verification_keys={did: _pub_bytes(priv)},
+    )
+    engine = AuditChainEngine(
+        chain=_build_chain(agent_id=str(did)),
+        verifier=Ed25519Verifier(directory),
+    )
+    payload = {"phase": "ingest", "delegate_id": str(did)}
+    signature = priv.sign(
+        content_signing_bytes(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT.value, payload, did
+        )
+    ).hex()
+
+    # Pre-fix: this raised AuditChainSignatureError at sequence=0.
+    entry = engine.emit_event(
+        DelegateEventType.EXTERNAL_SIDE_EFFECT.value, payload, ident, signature
+    )
+    assert entry.sequence == 0
+    assert len(engine.entries) == 1
+
+    # A second event advances the sequence + links the hash-chain.
+    payload2 = {"phase": "act"}
+    sig2 = priv.sign(
+        content_signing_bytes(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT.value, payload2, did
+        )
+    ).hex()
+    entry2 = engine.emit_event(
+        DelegateEventType.EXTERNAL_SIDE_EFFECT.value, payload2, ident, sig2
+    )
+    assert entry2.sequence == 1
+    assert entry2.previous_hash != ""  # hash-chain linked
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — end-to-end: DelegateRuntime.execute() completes under real crypto
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_issue_1182_delegate_runtime_execute_completes_under_ed25519() -> None:
+    """Full TAOD execute() reaches COMPLETED under a REAL Ed25519Verifier.
+
+    Pre-fix this landed FAILED at phase='thinking' with
+    AuditChainSignatureError (the first audit emit's signature could not be
+    verified). No mocking, no NullVerifier — real keypair + real connector.
+    """
+    runtime, audit_engine, _identity, _priv = _build_real_runtime()
+
+    result = await runtime.execute({"id": "issue-1182-e2e"})
+
+    assert result.taod_state.phase == "completed", (
+        f"execute() did not complete (phase={result.taod_state.phase!r}); "
+        f"#1182 sign/verify contract still broken"
+    )
+    assert result.dispatch_result is not None
+    # Every audit entry verified + landed (4 TAOD transitions + 1 dispatch).
+    assert len(audit_engine.entries) >= 4
+    # head_hash is set => the chain materialized.
+    assert audit_engine.head_hash() is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — tamper-evidence: mutating a committed entry breaks the hash-chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_issue_1182_hash_chain_detects_entry_tampering() -> None:
+    """The fix preserves ordering tamper-evidence via the hash-chain.
+
+    The signature no longer covers sequence/previous_hash, so we MUST prove
+    that reorder/insert/delete/mutation is still detectable INDEPENDENTLY —
+    through the previous_hash linkage. Mutating a committed entry's payload,
+    sequence, or previous_hash makes the recomputed predecessor-hash of the
+    NEXT entry diverge from the stored previous_hash.
+    """
+    from kailash.delegate.audit import AuditChainEntry
+
+    priv = _make_keypair()
+    did = uuid.uuid4()
+    ident = DelegateIdentity(
+        delegate_id=did,
+        sovereign_ref="s",
+        role_binding_ref="r",
+        genesis_ref="g",
+    )
+    from kailash.delegate.verifier import Ed25519Verifier
+
+    directory = PrincipalDirectory(
+        identities=(ident,),
+        verification_keys={did: _pub_bytes(priv)},
+    )
+    engine = AuditChainEngine(
+        chain=_build_chain(agent_id=str(did)),
+        verifier=Ed25519Verifier(directory),
+    )
+
+    def _emit(payload):
+        sig = priv.sign(
+            content_signing_bytes(
+                DelegateEventType.EXTERNAL_SIDE_EFFECT.value, payload, did
+            )
+        ).hex()
+        return engine.emit_event(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT.value, payload, ident, sig
+        )
+
+    e0 = _emit({"phase": "ingest"})
+    e1 = _emit({"phase": "act"})
+    e2 = _emit({"phase": "done"})
+
+    # The committed chain is internally consistent: each entry's
+    # previous_hash equals SHA-256 of the prior entry's full canonical dict.
+    import hashlib
+
+    def _entry_hash(entry: AuditChainEntry) -> str:
+        return hashlib.sha256(
+            canonical_json_dumps(entry.to_canonical_dict()).encode("utf-8")
+        ).hexdigest()
+
+    assert e0.previous_hash == ""  # genesis
+    assert e1.previous_hash == _entry_hash(e0)
+    assert e2.previous_hash == _entry_hash(e1)
+
+    # TAMPER: forge a replacement for e0 with a mutated payload but reuse
+    # its (sequence, previous_hash, signature). The signature still
+    # "verifies" the CONTENT in isolation only if re-signed — but the point
+    # is the HASH-CHAIN: e1.previous_hash was computed over the ORIGINAL e0.
+    tampered_e0 = AuditChainEntry(
+        sequence=e0.sequence,
+        previous_hash=e0.previous_hash,
+        event_type=e0.event_type,
+        event_payload={"phase": "INGEST-TAMPERED"},  # mutated content
+        signer_delegate_id=e0.signer_delegate_id,
+        signed_at=e0.signed_at,
+        signature=e0.signature,
+    )
+    # The successor's stored previous_hash no longer matches the recomputed
+    # hash of the tampered predecessor — ordering tamper detected.
+    assert e1.previous_hash != _entry_hash(tampered_e0)
+
+    # Sequence tampering is equally detectable: a re-sequenced entry hashes
+    # differently, breaking every downstream previous_hash linkage.
+    resequenced_e1 = AuditChainEntry(
+        sequence=99,  # mutated ordering
+        previous_hash=e1.previous_hash,
+        event_type=e1.event_type,
+        event_payload=e1.event_payload,
+        signer_delegate_id=e1.signer_delegate_id,
+        signed_at=e1.signed_at,
+        signature=e1.signature,
+    )
+    assert e2.previous_hash != _entry_hash(resequenced_e1)
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — a payload-only signature (the pre-#1182 sign-site) is REJECTED
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_issue_1182_payload_only_signature_is_rejected() -> None:
+    """Signing the bare payload (the pre-fix runtime behaviour) MUST fail.
+
+    Guards against a regression that re-introduces the payload-only sign
+    pre-image: the engine verifies the content pre-image (which includes
+    event_type + signer_delegate_id), so a signature over the bare payload
+    does not verify.
+    """
+    from kailash.delegate.verifier import Ed25519Verifier
+
+    priv = _make_keypair()
+    did = uuid.uuid4()
+    ident = DelegateIdentity(
+        delegate_id=did,
+        sovereign_ref="s",
+        role_binding_ref="r",
+        genesis_ref="g",
+    )
+    directory = PrincipalDirectory(
+        identities=(ident,),
+        verification_keys={did: _pub_bytes(priv)},
+    )
+    engine = AuditChainEngine(
+        chain=_build_chain(agent_id=str(did)),
+        verifier=Ed25519Verifier(directory),
+    )
+    payload = {"phase": "ingest"}
+    # Pre-#1182 sign-site: signature over the bare payload alone.
+    bad_sig = priv.sign(canonical_json_dumps(payload).encode("utf-8")).hex()
+
+    with pytest.raises(AuditChainSignatureError, match="content_signing_bytes"):
+        engine.emit_event(
+            DelegateEventType.EXTERNAL_SIDE_EFFECT.value, payload, ident, bad_sig
+        )
+    assert engine.entries == ()


### PR DESCRIPTION
## Summary
`AuditChainEngine.emit_event` verified the supplied signature against `to_signing_bytes()` (the full pre-signature dict including engine-assigned `sequence`/`previous_hash`/`signed_at`), while runtime sign-sites signed the payload alone. Since the engine assigns those fields *after* receiving the signature, no caller could produce a matching signature → `AuditChainSignatureError` at sequence=0, blocking `DelegateRuntime.execute()` under any real verifier (`NullVerifier` masked it).

Fix: a single shared `content_signing_bytes(event_type, event_payload, signer_delegate_id)` helper routed through `canonical_json_dumps`. Every sign-site (`runtime._emit_phase_audit`, the `with_posture` rotation emit, the `dispatch.py` audit-event emit) and the engine verify-site now produce the identical byte-string. `to_signing_bytes()` is left unchanged (cross-SDK conformance vectors depend on its full-entry shape).

## Tamper-evidence preserved (two orthogonal defenses)
- **Authorship** — the Ed25519 signature attests the delegate authored the event content (event_type + payload + signer_delegate_id); binding `signer_delegate_id` defeats cross-signer substitution.
- **Ordering** — reorder/insert/delete/mutation stays detectable via the hash-chain *independently* of the signature: each entry's `previous_hash` is SHA-256 over the prior entry's full canonical dict. Excluding engine-assigned fields from the signature opens no hole — they were never the signature's job.

## Test plan
- [x] 5 regression tests, real Ed25519, no mocking / no NullVerifier — `5 passed`
- [x] tamper test: mutating a committed entry's payload/sequence breaks the successor's `previous_hash` linkage
- [x] full delegate suite `531 passed, 1 skipped, 1 xfailed`
- [x] e2e rewired from fail-closed NullVerifier to real Ed25519Verifier (the masking path)
- [x] `kailash-delegate-fences` (#1035) + pre-commit pass

Fixes #1182

## Follow-up (user-routed, not filed — repo-scope)
kailash-rs delegate audit-chain should be checked for the equivalent sign/verify-site mismatch.