### PR TITLE
chore(dataflow-tests): rename shadowing inner-function (#1131)

### DIFF
--- a/packages/kailash-dataflow/tests/unit/features/test_mcp_integration.py
+++ b/packages/kailash-dataflow/tests/unit/features/test_mcp_integration.py
@@ -46,14 +46,13 @@ def _make_product(
     depends_on: List[str] | None = None,
 ) -> ProductRegistration:
     """Create a minimal ProductRegistration for testing."""
-    if fn is None:
 
-        async def fn(ctx: Any) -> dict:
-            return {}
+    async def default_fn(ctx: Any) -> dict:
+        return {}
 
     return ProductRegistration(
         name=name,
-        fn=fn,
+        fn=fn if fn is not None else default_fn,
         mode=ProductMode(mode),
         depends_on=depends_on or [],
         staleness=StalenessPolicy(),


### PR DESCRIPTION
## Summary
`_make_product` helper had inner `async def fn(...)` shadowing the `fn: Any = None` parameter (Pyright `reportRedeclaration`). Defined `default_fn` unconditionally at function scope; select via `fn=fn if fn is not None else default_fn`. No production-code changes; test-helper rename only.

## Bonus
The fix also removes the conditional scope-leak the original `if fn is None: async def fn` pattern carried (rebound name was only visible if the branch ran).

## Test plan
- [x] `pytest --collect-only` reports 15 tests (unchanged)
- [x] No `reportRedeclaration` on the helper anymore (other ★ findings on the file are pre-existing unused-arg INFOs)

Fixes #1131