### PR TITLE
chore(release): kailash v2.28.0 + kailash-nexus v2.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.28.0] - 2026-05-28
+
+### Fixed
+
+- **`delegate` audit-chain sign/verify contract is now satisfiable (HIGH, #1182)** — `AuditChainEngine.emit_event`'s prior signature contract was structurally unsatisfiable, blocking `DelegateRuntime.execute()` end-to-end under any real (non-`NullVerifier`) verifier. The sign-site signed the payload alone while the verify-site verified against the full pre-signature dict (`sequence` + `previous_hash` + `event_type` + `event_payload` + `signer_delegate_id` + `signed_at`), and the engine assigns `sequence` / `previous_hash` / `signed_at` AFTER receiving the signature — so no caller could ever produce a matching signature; `AuditChainSignatureError` raised at `sequence=0`. The `NullVerifier` masked the bug. The fix introduces a single shared `content_signing_bytes(event_type, event_payload, signer_delegate_id)` helper routed through `canonical_json_dumps`; both sign-sites (`runtime._emit_phase_audit`, `runtime`'s `with_posture` rotation emit, `dispatch` audit-event emit) AND the engine verify-site now produce the identical byte-string via this single helper. `AuditChainEntry` gains `to_content_signing_bytes()` delegating to it; `to_signing_bytes()` is unchanged (the cross-SDK full-entry canonical-shape contract + conformance vectors still depend on it). **Tamper-evidence is preserved, not weakened:** authorship (Ed25519 over `event_type` + `event_payload` + `signer_delegate_id`, defeating cross-signer substitution) and ordering (hash-chain via `previous_hash` = SHA-256 of prior entry's full canonical dict including sequence + prior signature, anchored by the substrate `AuditAnchor`) remain orthogonal defenses; excluding engine-assigned fields from the signature does not open a tamper hole because those fields were never the signature's job. Regression coverage: `tests/regression/` modules tagged `test_issue_1182_*` (real Ed25519, no mocking, no `NullVerifier`) — sign/verify byte-equality, `emit_event` accepts a content-pre-image signature, `DelegateRuntime.execute()` reaches `COMPLETED` under `Ed25519Verifier` with a real no-op connector, hash-chain detects payload/sequence tampering; payload-only signature (pre-fix behavior) is rejected.
+
+- **Async durable resume short-circuits completed nodes (HIGH, #1185)** — `AsyncLocalRuntime._execute_node_async` / `_execute_sync_node_async` previously invoked `node.execute_async()` / `execute()` unconditionally, so resuming a durable workflow with the same `idempotency_key` re-executed every node already completed and checkpointed on the prior run — firing side effects twice and breaking the "exactly once on resume" guarantee the sync `LocalRuntime` already honors. The fix adds `_w1_resume_short_circuit`, the async sibling of the sync gate: it reads the W1 `ExecutionTracker` that `execute_workflow_async` rehydrates from the prior checkpoint blob onto `context._w1_execution_tracker`; when a node is already completed it feeds the cached output into the per-run `AsyncExecutionTracker` via `record_result` (so dependents receive the restored output through the same `node_outputs` path a fresh execution populates), re-records completion into the W1 tracker (idempotent, keeps the checkpoint consistent), and returns `True` so the caller skips `execute_async` and the re-save/re-dispatch. Wired at the top of both per-node entry points. Reuses the inherited `LocalRuntime` checkpoint machinery (same `ExecutionTracker.is_completed` / `get_output` / `record_completion`) — no parallel notion of "completed". The sync runtime path is unchanged.
+
+### Changed
+
+- **CI: `python-no-eval` pre-commit hook now excludes 18 false-positive paths (#972 → PR #1190)** — extends the `python-no-eval` regex hook's exclude list to clear 18 documented false-positive matches across `src/kailash/`, `packages/kailash-dataflow/`, and tests. The hook continues to flag genuine `eval()` / `exec()` usage on user input per `rules/security.md` § "No eval() on user input"; this commit narrows the regex scope to test scaffolding that calls `model_validator(...)` / `eval_metric=...` / `.evaluate(...)` (none of which are the dangerous `eval` builtin). No behavior change at runtime; pre-commit CI is now clean across all repository paths.
+
+- **DataFlow test helper rename — eliminate shadowed inner-function on `pyright` (#1131 → PR #1193)** — `tests/integration/dataflow/test_mcp_integration.py` renamed an inner helper that shadowed a module-scope identifier, restoring `pyright --level error` to zero diagnostics across the dataflow integration suite. No production source change.
+
+- **Codify proposal landing — three pending sessions appended atomically (#1189)** — `.claude/.proposals/latest.yaml` codify-cycle proposal landing per `rules/artifact-flow.md` § "Append, Never Overwrite Unprocessed Proposals". Internal artifact-flow only; no consumer-visible API change.
+
+### Migration
+
+- No breaking changes. `pip install --upgrade kailash` from 2.27.x → 2.28.0 is drop-in. The audit-chain contract fix in #1182 changes signed-bytes content, but the prior contract was structurally unsatisfiable under real verifiers — no working downstream caller can have depended on it. The async durable resume fix in #1185 is purely additive: behavior changes only when the same `idempotency_key` is replayed against an already-completed node, which previously double-fired and now correctly short-circuits.
+
+### Notes
+
+- Six PRs land in this release: #1189 (codify proposal), #1190 (CI `python-no-eval` exclude), #1191 (#1185 async durable resume fix), #1192 (#1182 delegate audit-chain fix), #1193 (#1131 pyright rename), #1194 (#1012 nexus instance-API warning — shipped via `kailash-nexus 2.6.4`).
+- Companion `kailash-nexus 2.6.4` release ships the #1012 nexus instance-API `UserWarning` elimination (`@app.handler` registration no longer pollutes startup logs).
+- Framework SDK pins in `packages/kailash-{dataflow,nexus,kaizen}/pyproject.toml` advanced to `kailash>=2.28.0`. Existing framework wheels on PyPI keep their prior pins (admit 2.28.0 via minor backward-compat); the new pins ship with the next respective framework release.
+
 ## [2.27.0] - 2026-05-27
 
 ### Added

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # MySQL / SQLite / Mongo / Redis drivers move behind their per-DB
     # extras since their imports are function-local.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.23.0",
+    "kailash>=2.28.0",
     "sqlalchemy>=2.0.0",   # decorators.py + multi_tenancy + model_registry
     "asyncpg>=0.28.0",     # migrations/* (17 files, module-scope) — PG canonical async driver
     "click>=8.0.0",        # CLI: dataflow.cli.{validate,analyze,generate,perf,commands}

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # are either lazy-loaded or scoped to optional subsystems and now
     # live behind extras.
     # ─────────────────────────────────────────────────────────────
-    "kailash>=2.23.0",
+    "kailash>=2.28.0",
     "kailash-mcp>=0.2.4",       # core/base_agent.py:32 module-scope MCPClient
     "pydantic>=2.0.0",          # llm/deployment.py + auth modules
     "typing-extensions>=4.5.0", # core/schema_factory.py

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Nexus Changelog
 
+## [2.6.4] — 2026-05-28 — eliminate `@app.handler` instance-API UserWarning (#1012)
+
+Patch release fixing a startup-log noise issue that fired N `UserWarning("Instance-based API usage detected...")` lines on `@app.handler` registration. No public API change; the warning is now correctly scoped to genuine consumer misuse only.
+
+### Fixed
+
+- **`@app.handler` registration no longer emits `UserWarning` (#1012 → PR #1194)** — `make_handler_workflow` in `src/kailash/nodes/handler.py` builds a `HandlerNode` instance and registers it via `builder.add_node_instance()`. Pre-fix, the call omitted `_internal=True`, causing the workflow builder to emit a `UserWarning("Instance-based API usage detected...")` for every `@app.handler` registration — N handlers = N warnings polluting startup logs and pytest output. Fix: pass `_internal=True` to `add_node_instance()` at `src/kailash/nodes/handler.py:295`. The `_internal` flag narrows the advisory to genuine consumer misuse only. Consumers calling `add_node_instance` directly without `_internal=True` still receive the warning — the flag does NOT suppress the warning globally. Why not `warnings.filterwarnings`: suppression hides genuine consumer misuse elsewhere in the codebase, defeating the purpose of the advisory. Why not string-based `add_node("HandlerNode", id, config)`: `HandlerNode` wraps a Python callable that cannot be expressed as a JSON-serialisable config dict; instance-based registration is the only structurally correct path here. Regression test (4 cases): single `@app.handler` emits zero instance-API warnings; N `@app.handler` registrations emit zero instance-API warnings; handler with optional params emits no warning; direct consumer `add_node_instance` (without `_internal=True`) still warns.
+
+### Dependencies
+
+- `kailash>=2.28.0` (was `kailash>=2.16.0`) — pins the floor to the companion `kailash 2.28.0` release that ships the #1182 audit-chain fix + #1185 async durable resume fix.
+
+### Notes
+
+- The Nexus diff is `src/kailash/nodes/handler.py:295` + new regression test + `pyproject.toml` version + `src/nexus/__init__.py::__version__` + this CHANGELOG entry. No behavior change to the Nexus public API; consumer startup logs are now clean of the spurious instance-API advisory.
+- Companion `kailash 2.28.0` release ships #1182 (delegate audit-chain HIGH) and #1185 (async durable resume HIGH).
+
 ## [2.6.3] — 2026-05-09 — slim-core decoupling + PyPI install resolvability (#890)
 
 Patch release shipping the kailash-nexus side of the kailash 2.18.0 slim-core decoupling. No behavior change to the Nexus public API; only the dependency manifest is updated so `pip install kailash-nexus` resolves cleanly against the published kailash 2.18.0 wheel.

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.6.3"
+version = "2.6.4"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -36,7 +36,7 @@ dependencies = [
     # Tag-push CI installs `kailash` from PyPI before the new release is
     # published, so `kailash[server]` would silently drop the extra.
     # Direct declaration is dialect-stable across the release boundary.
-    "kailash>=2.16.0",
+    "kailash>=2.28.0",
     # Server middleware stack (matches kailash[server] contents).
     "fastapi>=0.104.0",
     "starlette>=0.36.0",

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -102,7 +102,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.6.3"
+__version__ = "2.6.4"
 __all__ = [
     # Core
     "Nexus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.27.0"
+version = "2.28.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.27.0"
+__version__ = "2.28.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

- **kailash 2.27.0 → 2.28.0** (MINOR): closes #1182 (HIGH delegate audit-chain) + #1185 (HIGH async durable resume) + #972/#1131/#1189/#1194 chore tail.
- **kailash-nexus 2.6.3 → 2.6.4** (PATCH): closes #1012 (eliminate `@app.handler` UserWarning).
- Framework SDK pins (dataflow, nexus, kaizen) advanced to `kailash>=2.28.0`.

This release-prep PR uses the `release/v*` branch convention to auto-skip the PR-gate matrix per `rules/git.md`.

## What ships in 2.28.0 (core kailash)

### HIGH fixes (the reason for this release)

- **#1182 — delegate audit-chain sign/verify contract is now satisfiable.** `AuditChainEngine.emit_event`'s prior signature contract was structurally unsatisfiable, blocking `DelegateRuntime.execute()` end-to-end under any real (non-`NullVerifier`) verifier. The sign-site signed the payload alone while the verify-site verified against the full pre-signature dict (`sequence` + `previous_hash` + ...), and the engine assigns those fields AFTER receiving the signature — so no caller could produce a matching signature. `NullVerifier` masked the bug. The fix introduces a single shared `content_signing_bytes(event_type, event_payload, signer_delegate_id)` helper routed through `canonical_json_dumps`; both sign-sites AND the engine verify-site produce the identical byte-string via this single helper. **Tamper-evidence preserved**, not weakened: authorship (Ed25519 over event content) and ordering (hash-chain) remain orthogonal defenses; excluding engine-assigned fields from the signature does not open a tamper hole because those fields were never the signature's job — they belong to the hash-chain.

- **#1185 — async durable resume short-circuits completed nodes.** `AsyncLocalRuntime` previously re-executed every node already completed and checkpointed on the prior run when resuming with the same `idempotency_key`, firing side effects twice and breaking the "exactly once on resume" guarantee the sync `LocalRuntime` already honors. The fix adds `_w1_resume_short_circuit`, the async sibling of the sync gate, wired at the top of both per-node entry points.

### Chore tail

- #972 → #1190: CI `python-no-eval` pre-commit hook excludes 18 documented false-positive paths.
- #1131 → #1193: DataFlow test helper rename eliminating shadowed inner-function pyright flag.
- #1189: Codify proposal landing — three pending sessions appended atomically.
- #1194: nexus instance-API warning (shipped via `kailash-nexus 2.6.4`).

## What ships in kailash-nexus 2.6.4

- **#1012 — eliminate `@app.handler` UserWarning.** `make_handler_workflow` now passes `_internal=True` to `add_node_instance()`, narrowing the instance-API advisory to genuine consumer misuse only. N handlers no longer = N startup-log warnings. Direct consumer `add_node_instance` without `_internal=True` still warns — the flag does NOT suppress globally.

## Release scope enumeration (per `rules/build-repo-release-discipline.md` MUST-3)

All 9 packages at PyPI parity at session start. No silent sibling drift. Only core kailash + kailash-nexus have unreleased commits since their last tag.

| Package | main → target | Status |
|---|---|---|
| `kailash` | 2.27.0 → **2.28.0** | RELEASING (MINOR) |
| `kailash-nexus` | 2.6.3 → **2.6.4** | RELEASING (PATCH) |
| `kailash-dataflow` | 2.10.0 | No release (test-rename only); kailash pin → >=2.28.0 |
| `kailash-kaizen` | 2.24.1 | No release (zero changes); kailash pin → >=2.28.0 |
| `kailash-mcp`, `-ml`, `-align`, `-pact`, `kaizen-agents` | parity | No release needed |

## Bump-type rationale

- **Core MINOR**: #1182 adds a new public method (`AuditChainEntry.to_content_signing_bytes`) AND materially changes the audit-chain signed-bytes contract. Strict semver per the project's "adheres to Semantic Versioning" declaration → MINOR. Prior contract was structurally unsatisfiable, so no working downstream caller can have depended on it; the public-surface addition itself is the semver trigger.
- **Nexus PATCH**: pure bug fix, no API surface change.

## Pre-flight gates

- Version anchors consistent (`pyproject.toml` ↔ `__init__.py::__version__`) for both core and nexus.
- `pre-commit run` on staged files: 14/14 hooks PASSED including Tier 1 unit tests, `no-eval`, `no-untracked-TODO-NNN`, type annotations, doc-style.
- Underlying merged PRs (#1182 / #1185 / #1194) each passed their own matrix CI (Python 3.11–3.14) before merging to main.

## TestPyPI disposition

**SKIPPED for both packages** — release-prep diff is metadata-only (pyproject + `__init__.py` + CHANGELOG + framework pin updates). No source code touched in this PR; all source changes were tested as part of the underlying merged PRs. Per `rules/deployment.md` exception clause, explicit human approval recorded in-session.

## Test plan

After admin-merge:
- [ ] Tag `v2.28.0` (lightweight, NOT annotated, per `deploy/deployment-config.md`) → triggers `publish-pypi.yml`
- [ ] Tag `nexus-v2.6.4` (lightweight) — push SEPARATELY with ≥1s pause per `rules/deployment.md` MUST: Multi-Package Release Tags Pushed Individually
- [ ] Verify PyPI publish CI run succeeds on `esperie-linux-arm` self-hosted runner
- [ ] Clean-venv install check per `build-repo-release-discipline.md` MUST-2: `uv pip install --refresh "kailash==2.28.0"` + import smoke; same for `kailash-nexus==2.6.4`
- [ ] PyPI cache lag retry loop (≤3× with 60s between, per the rule's documented protocol)

## Related issues

Closes #1182 · Closes #1185 · Closes #1012 · Closes #972 · Closes #1131
Companion to F23 release-readiness item in `SWEEP-2026-05-28.md` (untracked under F3 hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)