### PR TITLE
fix(kaizen-rag): wire downstream unwired-inputs in 3 WorkflowNode subclasses (F25 Shard D)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/workflows.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/workflows.py
@@ -97,6 +97,18 @@ class AdvancedRAGWorkflowNode(WorkflowNode):
 
     Multi-stage RAG pipeline with quality checks, multiple retrieval strategies,
     and result validation. Includes monitoring and performance optimization.
+
+    Inputs
+    ------
+    documents : list
+        Document list to analyze + route through the quality-driven RAG
+        strategy. Routed to the inner-graph ``quality_analyzer`` via
+        ``input_mapping`` (see __init__).
+
+    The mapping makes the workflow self-sufficient at the public API
+    surface: callers invoke ``node.execute(documents=[...])`` and the
+    inner-graph quality analyzer receives ``documents`` without the
+    caller having to know inner-graph node IDs.
     """
 
     def __init__(
@@ -107,10 +119,27 @@ class AdvancedRAGWorkflowNode(WorkflowNode):
         # Build advanced workflow
         workflow = self._create_advanced_workflow()
 
+        # ``input_mapping`` routes the public ``documents`` parameter to the
+        # inner-graph ``quality_analyzer`` node's ``documents`` parameter.
+        # Without this mapping the facade auto-derives ``quality_analyzer_
+        # documents`` (node_id + ``_`` + param_name) — users would have to
+        # know the inner-graph node ID to invoke the workflow. Per F25 Shard D
+        # (same defect class as SimpleRAGWorkflowNode F25 Shard C): the entry
+        # parameter MUST be exposed via the WorkflowNode facade so users
+        # don't have to learn inner-graph node IDs to invoke the workflow.
         super().__init__(
             workflow=workflow,
             name=name,
             description="Advanced RAG with quality checks and multi-stage processing",
+            input_mapping={
+                "documents": {
+                    "node": "quality_analyzer",
+                    "parameter": "documents",
+                    "type": list,
+                    "required": True,
+                    "description": "Documents to analyze + route through quality-driven RAG strategy",
+                }
+            },
         )
 
     def _create_advanced_workflow(self):
@@ -262,6 +291,21 @@ class AdaptiveRAGWorkflowNode(WorkflowNode):
 
     AI-driven strategy selection that uses LLM to analyze documents and queries
     to automatically choose the optimal RAG approach for each use case.
+
+    Inputs
+    ------
+    documents : list
+        Document list to analyze for adaptive strategy selection. Routed
+        to the inner-graph ``document_preprocessor`` via ``input_mapping``.
+    query : str, optional
+        Query text passed alongside ``documents`` for LLM-driven strategy
+        selection. Defaults to ``""`` (matches preprocessor codegen
+        default). Also routed via ``input_mapping``.
+
+    The mapping makes the workflow self-sufficient at the public API
+    surface: callers invoke ``node.execute(documents=[...], query="...")``
+    and the inner-graph preprocessor receives both without the caller
+    having to know inner-graph node IDs.
     """
 
     def __init__(
@@ -276,10 +320,34 @@ class AdaptiveRAGWorkflowNode(WorkflowNode):
         # Build adaptive workflow
         workflow = self._create_adaptive_workflow()
 
+        # ``input_mapping`` routes the public ``documents`` + ``query``
+        # parameters to the inner-graph ``document_preprocessor`` node's
+        # ``documents`` / ``query`` parameters. Without this mapping the
+        # facade auto-derives ``document_preprocessor_documents`` /
+        # ``document_preprocessor_query`` — users would have to know the
+        # inner-graph node ID to invoke the workflow. Per F25 Shard D
+        # (same defect class as SimpleRAGWorkflowNode F25 Shard C).
         super().__init__(
             workflow=workflow,
             name=name,
             description="AI-driven adaptive RAG with intelligent strategy selection",
+            input_mapping={
+                "documents": {
+                    "node": "document_preprocessor",
+                    "parameter": "documents",
+                    "type": list,
+                    "required": True,
+                    "description": "Documents to analyze for adaptive strategy selection",
+                },
+                "query": {
+                    "node": "document_preprocessor",
+                    "parameter": "query",
+                    "type": str,
+                    "required": False,
+                    "default": "",
+                    "description": "Query text for LLM-driven strategy selection",
+                },
+            },
         )
 
     def _create_adaptive_workflow(self):
@@ -517,6 +585,24 @@ class RAGPipelineWorkflowNode(WorkflowNode):
 
     Flexible RAG workflow that can be configured for different use cases
     without code changes. Supports all strategies and custom configurations.
+
+    Inputs
+    ------
+    documents : list
+        Document list to process through the configurable RAG pipeline.
+        Routed to the inner-graph ``config_processor`` via ``input_mapping``.
+    query : str, optional
+        Query text for retrieval. Defaults to ``""`` (matches the
+        processor codegen default). Routed via ``input_mapping``.
+    strategy : str, optional
+        Strategy selection (``semantic`` / ``statistical`` / ``hybrid`` /
+        ``hierarchical``). Defaults to the class's ``default_strategy``
+        argument. Routed via ``input_mapping``.
+
+    The mapping makes the workflow self-sufficient at the public API
+    surface: callers invoke ``node.execute(documents=[...])`` and the
+    inner-graph processor receives the inputs without the caller having
+    to know inner-graph node IDs.
     """
 
     def __init__(
@@ -531,37 +617,86 @@ class RAGPipelineWorkflowNode(WorkflowNode):
         # Build configurable workflow
         workflow = self._create_configurable_workflow()
 
+        # ``input_mapping`` routes the public ``documents`` + ``query`` +
+        # ``strategy`` parameters to the inner-graph ``config_processor``
+        # node's ``documents`` / ``query`` / ``strategy`` parameters.
+        # Without this mapping the facade auto-derives ``config_processor_
+        # documents`` / ``config_processor_query`` / ``config_processor_
+        # strategy`` — users would have to know the inner-graph node ID to
+        # invoke the workflow. Per F25 Shard D (same defect class as
+        # SimpleRAGWorkflowNode F25 Shard C).
         super().__init__(
             workflow=workflow,
             name=name,
             description=f"Configurable RAG pipeline with {default_strategy} as default strategy",
+            input_mapping={
+                "documents": {
+                    "node": "config_processor",
+                    "parameter": "documents",
+                    "type": list,
+                    "required": True,
+                    "description": "Documents to process through the configurable RAG pipeline",
+                },
+                "query": {
+                    "node": "config_processor",
+                    "parameter": "query",
+                    "type": str,
+                    "required": False,
+                    "default": "",
+                    "description": "Query text for retrieval",
+                },
+                "strategy": {
+                    "node": "config_processor",
+                    "parameter": "strategy",
+                    "type": str,
+                    "required": False,
+                    "default": default_strategy,
+                    "description": "Strategy selection: semantic / statistical / hybrid / hierarchical",
+                },
+            },
         )
 
     def _create_configurable_workflow(self):
         """Create configurable RAG workflow"""
         builder = WorkflowBuilder()
 
-        # Configuration processor
+        # Configuration processor.
+        #
+        # F25 Shard D sibling-sweep fix (autonomous-execution.md MUST Rule 4
+        # — same-bug-class fix surfaced during the entry-wiring sweep):
+        # the prior codegen ended with ``result = process_config(documents,
+        # **kwargs)`` but ``kwargs`` is NOT defined in the PythonCodeNode
+        # exec scope (PythonCodeNode binds explicit input parameters as
+        # locals — ``documents``, ``query``, ``strategy`` — not a kwargs
+        # dict). Every invocation raised ``NameError: name 'kwargs' is
+        # not defined`` at the entry node.
+        #
+        # The fix constructs the config dict directly without the wrapper
+        # function + undefined ``**kwargs`` unpacking. The default values
+        # (chunk_size / overlap / embedding_model / retrieval_k) are
+        # interpolated from ``self.rag_config`` at workflow-build time,
+        # matching the original codegen's behavior when no override is
+        # supplied. PythonCodeNode does not expose a kwargs dict, so the
+        # original codegen's "user can override chunk_size at runtime"
+        # contract was never reachable through this PythonCodeNode anyway
+        # — the override path is via ``config: RAGConfig`` at construction
+        # time, which IS preserved.
         config_processor_id = builder.add_node(
             "PythonCodeNode",
             node_id="config_processor",
             config={
                 "code": f"""
-def process_config(documents, query="", strategy="{self.default_strategy}", **kwargs):
-    # Merge user config with defaults
-    processed_config = {{
-        "strategy": strategy,
-        "documents": documents,
-        "query": query,
-        "chunk_size": kwargs.get("chunk_size", {self.rag_config.chunk_size}),
-        "chunk_overlap": kwargs.get("chunk_overlap", {self.rag_config.chunk_overlap}),
-        "embedding_model": kwargs.get("embedding_model", "{self.rag_config.embedding_model}"),
-        "retrieval_k": kwargs.get("retrieval_k", {self.rag_config.retrieval_k})
-    }}
+processed_config = {{
+    "strategy": strategy if strategy else "{self.default_strategy}",
+    "documents": documents,
+    "query": query if query else "",
+    "chunk_size": {self.rag_config.chunk_size},
+    "chunk_overlap": {self.rag_config.chunk_overlap},
+    "embedding_model": "{self.rag_config.embedding_model}",
+    "retrieval_k": {self.rag_config.retrieval_k},
+}}
 
-    return processed_config
-
-result = process_config(documents, **kwargs)
+result = processed_config
 """
             },
         )

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/workflows.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/workflows.py
@@ -681,19 +681,49 @@ class RAGPipelineWorkflowNode(WorkflowNode):
         # contract was never reachable through this PythonCodeNode anyway
         # — the override path is via ``config: RAGConfig`` at construction
         # time, which IS preserved.
+        # Security round-1 (H1, M2): RAGConfig values + default_strategy
+        # are interpolated into a PythonCodeNode `code` string at workflow
+        # build time. To prevent code injection if RAGConfig is ever
+        # constructed from untrusted bytes (e.g. a Nexus endpoint that
+        # accepts RAGConfig kwargs), every interpolated value is forced
+        # through a typed coercion + `repr()` (which emits a syntactically
+        # safe Python literal — any embedded quotes / backslashes are
+        # escaped, control characters are encoded, and arbitrary
+        # subclass-`__str__`-override attacks are neutralized because the
+        # repr is computed on the coerced value).
+        #
+        # Strategy enum validation (M2): `default_strategy` MUST be one of
+        # the SwitchNode's declared cases. An unknown strategy would silently
+        # fall through to no case match — converting that into a typed
+        # ValueError surfaces misuse at construction instead of producing a
+        # confusing empty workflow output at runtime.
+        _ALLOWED_STRATEGIES = ("semantic", "statistical", "hybrid", "hierarchical")
+        if self.default_strategy not in _ALLOWED_STRATEGIES:
+            raise ValueError(
+                f"RAGPipelineWorkflowNode.default_strategy={self.default_strategy!r} "
+                f"is not in the allowed set {_ALLOWED_STRATEGIES}; "
+                f"SwitchNode would never dispatch to a matching case."
+            )
+
+        _default_strategy_lit = repr(self.default_strategy)
+        _chunk_size_lit = repr(int(self.rag_config.chunk_size))
+        _chunk_overlap_lit = repr(int(self.rag_config.chunk_overlap))
+        _embedding_model_lit = repr(str(self.rag_config.embedding_model))
+        _retrieval_k_lit = repr(int(self.rag_config.retrieval_k))
+
         config_processor_id = builder.add_node(
             "PythonCodeNode",
             node_id="config_processor",
             config={
                 "code": f"""
 processed_config = {{
-    "strategy": strategy if strategy else "{self.default_strategy}",
+    "strategy": strategy if strategy else {_default_strategy_lit},
     "documents": documents,
     "query": query if query else "",
-    "chunk_size": {self.rag_config.chunk_size},
-    "chunk_overlap": {self.rag_config.chunk_overlap},
-    "embedding_model": "{self.rag_config.embedding_model}",
-    "retrieval_k": {self.rag_config.retrieval_k},
+    "chunk_size": {_chunk_size_lit},
+    "chunk_overlap": {_chunk_overlap_lit},
+    "embedding_model": {_embedding_model_lit},
+    "retrieval_k": {_retrieval_k_lit},
 }}
 
 result = processed_config

--- a/packages/kailash-kaizen/tests/integration/rag/test_workflows_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_workflows_nodes.py
@@ -348,3 +348,214 @@ class TestSimpleRAGWorkflowEntryWiring:
             assert (
                 "semantic_chunker" not in msg or "text" not in msg
             ), f"chunker.text still unwired post-fix: {msg!r}"
+
+
+# ==========================================================================
+# Advanced / Adaptive / RAGPipeline WorkflowNode entry-wiring contracts
+# (F25 Shard D — sibling sweep against SimpleRAG's entry-wiring fix)
+# ==========================================================================
+#
+# F25 audit (`workspaces/kaizen-rag-node-coverage/04-validate/05-audit-gap-2026-05-28.md`
+# § 7) flagged that the SimpleRAGWorkflowNode entry-wiring fix has sibling
+# defects in the other three documented public WorkflowNode pipelines —
+# their facade ``get_parameters()`` does NOT surface the user-visible
+# entry inputs (``documents``, ``query``, ``strategy``) and instead leaks
+# the inner-graph-node-id-prefixed auto-derived names
+# (``quality_analyzer_documents``, ``document_preprocessor_documents``,
+# ``config_processor_documents``). Same defect class as the SimpleRAG
+# ``chunker.text`` un-wired entry — closed identically via
+# ``input_mapping`` on the WorkflowNode super-init.
+#
+# Per the F25 value-anchor (briefs/00-brief.md line 9-18, archived source
+# `workspaces/_archive/kaizen-rag-resurrection-superseded-2026-05-26/
+# kaizen-rag-resurrection/briefs/00-brief.md` § "Out of scope"): "the RAG
+# capability the user chose to preserve is provably correct, not merely
+# importable." A public Quick Start WorkflowNode whose facade hides the
+# user-visible parameter behind an auto-derived inner-graph name is
+# importable but NOT invocable without spelunking the inner graph —
+# exactly the failure mode the anchor closes.
+
+
+class TestAdvancedRAGWorkflowEntryWiring:
+    """``AdvancedRAGWorkflowNode`` exposes ``documents`` on the facade.
+
+    The inner graph's entry node is ``quality_analyzer`` (PythonCodeNode);
+    it requires ``documents``. Without ``input_mapping`` the facade
+    auto-derives ``quality_analyzer_documents`` — callers MUST know the
+    inner-graph node id to invoke the workflow.
+    """
+
+    def test_advanced_pipeline_facade_surfaces_documents_parameter(self):
+        node = AdvancedRAGWorkflowNode()
+        params = node.get_parameters()
+        assert (
+            "documents" in params
+        ), f"documents parameter missing from facade; got {list(params.keys())}"
+        documents_param = params["documents"]
+        assert (
+            documents_param.required is True
+        ), "documents MUST be a required parameter"
+        assert (
+            documents_param.type is list
+        ), "documents MUST be typed as list (per QualityAnalyzer codegen contract)"
+
+    def test_advanced_pipeline_routes_documents_to_quality_analyzer(self):
+        """Inner-graph ``quality_analyzer`` receives ``documents`` at runtime.
+
+        Pre-fix: ``runtime.execute(wf, parameters={'quality_analyzer':
+        {'documents': ...}})`` worked via the auto-derived path BUT the
+        facade exposed no clean ``documents`` parameter. Post-fix: the
+        facade's ``documents`` routes through ``input_mapping`` and any
+        runtime failure (if any) is DOWNSTREAM of ``quality_analyzer``
+        (e.g. ``doc_vector_db`` missing required configuration —
+        documented in F25 audit as an out-of-shard concern in
+        ``strategies.py``-owned sub-workflows).
+        """
+        wf = _wf(AdvancedRAGWorkflowNode())
+        runtime = LocalRuntime()
+        try:
+            runtime.execute(wf, parameters={"quality_analyzer": {"documents": _CORPUS}})
+        except Exception as exc:  # noqa: BLE001 — see assertion below
+            msg = str(exc)
+            assert (
+                "quality_analyzer" not in msg or "documents" not in msg
+            ), f"quality_analyzer.documents still unwired post-fix: {msg!r}"
+
+
+class TestAdaptiveRAGWorkflowEntryWiring:
+    """``AdaptiveRAGWorkflowNode`` exposes ``documents`` + ``query`` on the facade.
+
+    The inner graph's entry node is ``document_preprocessor`` (PythonCodeNode);
+    it requires ``documents`` and accepts an optional ``query``. Without
+    ``input_mapping`` the facade auto-derives
+    ``document_preprocessor_documents`` / ``document_preprocessor_query``.
+    """
+
+    def test_adaptive_pipeline_facade_surfaces_documents_parameter(self):
+        node = AdaptiveRAGWorkflowNode()
+        params = node.get_parameters()
+        assert (
+            "documents" in params
+        ), f"documents parameter missing from facade; got {list(params.keys())}"
+        assert params["documents"].required is True
+        assert params["documents"].type is list
+
+    def test_adaptive_pipeline_facade_surfaces_query_parameter(self):
+        """``query`` is exposed as an optional public parameter (default '').
+
+        The preprocessor codegen accepts ``query`` with a default of ``""``;
+        the facade MUST mirror that (required=False, default='') so callers
+        can invoke ``node.execute(documents=...)`` without supplying a query
+        AND can override it without learning the inner-graph node ID.
+        """
+        node = AdaptiveRAGWorkflowNode()
+        params = node.get_parameters()
+        assert (
+            "query" in params
+        ), f"query parameter missing from facade; got {list(params.keys())}"
+        assert params["query"].required is False
+        assert params["query"].type is str
+
+    def test_adaptive_pipeline_routes_documents_to_preprocessor(self):
+        wf = _wf(AdaptiveRAGWorkflowNode())
+        runtime = LocalRuntime()
+        try:
+            runtime.execute(
+                wf,
+                parameters={
+                    "document_preprocessor": {
+                        "documents": _CORPUS,
+                        "query": "test query",
+                    }
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — see assertion below
+            msg = str(exc)
+            assert (
+                "document_preprocessor" not in msg or "documents" not in msg
+            ), f"document_preprocessor.documents still unwired post-fix: {msg!r}"
+
+
+class TestRAGPipelineWorkflowEntryWiring:
+    """``RAGPipelineWorkflowNode`` exposes ``documents``/``query``/``strategy``.
+
+    The inner graph's entry node is ``config_processor`` (PythonCodeNode);
+    it requires ``documents`` and accepts optional ``query`` + ``strategy``.
+    """
+
+    def test_pipeline_facade_surfaces_documents_parameter(self):
+        node = RAGPipelineWorkflowNode()
+        params = node.get_parameters()
+        assert (
+            "documents" in params
+        ), f"documents parameter missing from facade; got {list(params.keys())}"
+        assert params["documents"].required is True
+        assert params["documents"].type is list
+
+    def test_pipeline_facade_surfaces_query_and_strategy_parameters(self):
+        """``query`` (default '') and ``strategy`` (default from class config).
+
+        Without ``input_mapping`` the facade would surface
+        ``config_processor_query`` / ``config_processor_strategy`` —
+        leaking the inner-graph node ID and forcing callers to know it.
+        """
+        node = RAGPipelineWorkflowNode()
+        params = node.get_parameters()
+        assert "query" in params, f"query missing; got {list(params.keys())}"
+        assert "strategy" in params, f"strategy missing; got {list(params.keys())}"
+        assert params["query"].required is False
+        assert params["query"].type is str
+        assert params["strategy"].required is False
+        assert params["strategy"].type is str
+
+    def test_pipeline_routes_documents_to_config_processor(self):
+        wf = _wf(RAGPipelineWorkflowNode())
+        runtime = LocalRuntime()
+        try:
+            runtime.execute(
+                wf,
+                parameters={"config_processor": {"documents": _CORPUS}},
+            )
+        except Exception as exc:  # noqa: BLE001 — see assertion below
+            msg = str(exc)
+            assert (
+                "config_processor" not in msg or "documents" not in msg
+            ), f"config_processor.documents still unwired post-fix: {msg!r}"
+
+    def test_pipeline_config_processor_codegen_runs_without_kwargs_nameerror(self):
+        """The ``config_processor`` codegen body MUST execute without ``NameError``.
+
+        Defect (separate bug class from the input-mapping defect, surfaced
+        during sibling-sweep work — fix applied in same PR per
+        ``rules/autonomous-execution.md`` MUST Rule 4):
+
+        Pre-fix line 564 of ``workflows.py`` reads:
+
+            result = process_config(documents, **kwargs)
+
+        ``kwargs`` is not defined in the PythonCodeNode exec scope —
+        PythonCodeNode binds explicit input parameters as locals
+        (``documents``, ``query``, ``strategy``), NOT a ``kwargs`` dict.
+        Result: a ``NameError: name 'kwargs' is not defined`` at first
+        runtime invocation of the pipeline.
+
+        Post-fix: codegen body is rewritten to construct the config dict
+        directly without the wrapper function + undefined ``**kwargs``
+        unpacking, eliminating the NameError.
+        """
+        wf = _wf(RAGPipelineWorkflowNode())
+        runtime = LocalRuntime()
+        try:
+            runtime.execute(
+                wf,
+                parameters={"config_processor": {"documents": _CORPUS}},
+            )
+        except Exception as exc:  # noqa: BLE001 — see assertion below
+            msg = str(exc)
+            # Defect is closed iff the message does NOT contain the
+            # NameError signature for the undefined ``kwargs`` symbol.
+            # Downstream failures (dispatcher routing, VectorDatabaseNode
+            # unwired config in sub-workflows) are out of shard scope.
+            assert (
+                "kwargs" not in msg or "NameError" not in msg
+            ), f"config_processor codegen still references undefined kwargs: {msg!r}"


### PR DESCRIPTION
## Summary

F25 Shard D — closes 3 entry-wiring defects + 1 sibling-sweep codegen bug in the documented public RAG WorkflowNode pipelines at `packages/kailash-kaizen/src/kaizen/nodes/rag/workflows.py`. Same defect class as F25 Shard C's `SimpleRAGWorkflowNode` fix (PR #1196).

## Defects fixed

**D1 — `AdvancedRAGWorkflowNode` (workflows.py:93)**
- Symptom: facade `get_parameters()` exposes auto-derived `quality_analyzer_documents` instead of clean `documents`. Users must spelunk the inner graph to invoke.
- Fix: `input_mapping={"documents": {"node": "quality_analyzer", "parameter": "documents", "type": list, "required": True, ...}}` on super-init.

**D2 — `AdaptiveRAGWorkflowNode` (workflows.py:271)**
- Symptom: facade exposes auto-derived `document_preprocessor_documents` and `document_preprocessor_query`; neither public parameter visible.
- Fix: `input_mapping={"documents": {...}, "query": {...}}` — documents `list`+required, query `str`+optional with default `""` (matches preprocessor codegen default).

**D3a — `RAGPipelineWorkflowNode` (workflows.py:534, facade)**
- Symptom: facade exposes auto-derived `config_processor_documents` / `_query` / `_strategy`; none visible.
- Fix: `input_mapping={"documents": {...}, "query": {...}, "strategy": {...}}` — documents `list`+required, query `str`+optional default `""`, strategy `str`+optional default = `self.default_strategy`.

**D3b — `RAGPipelineWorkflowNode` config_processor codegen NameError (workflows.py:564, separate bug class)**
- Symptom (surfaced during sibling-sweep per `rules/autonomous-execution.md` MUST Rule 4): codegen ends with `result = process_config(documents, **kwargs)` but `kwargs` is NOT defined in PythonCodeNode exec scope (PythonCodeNode binds explicit parameters as locals, not a kwargs dict). Every invocation `NameError`s at the entry node.
- Fix: rewrite codegen to construct the config dict directly without the wrapper function + undefined `**kwargs` unpacking. Default values (chunk_size, chunk_overlap, embedding_model, retrieval_k) interpolated from `self.rag_config` at build time, matching prior behavior. The override path via `config: RAGConfig` at construction is preserved; PythonCodeNode never exposed a kwargs dict so the "runtime override of chunk_size" contract was structurally unreachable through this node anyway.

## Test pass/fail summary

- Defect-witness tests (commit `0b68ed313`): 6 assertions FAIL pre-fix, PASS post-fix.
- Inner-graph routing tests (commit `0b68ed313`): 3 assertions PASS continuously.
- `test_workflows_nodes.py` (integration): 34/34 green post-fix.
- `test_workflows_nodes.py` (unit) + `test_issue_f8b7_workflow_defects.py` (regression): 72/72 green.
- Aggregate: 106/106 across the kaizen-rag test scope.

All tests use real `LocalRuntime` + real `WorkflowBuilder` + real chunker / switch / python-code nodes — NO mocking per `rules/testing.md` Tier 2/3.

## Sibling-sweep findings

Per `rules/autonomous-execution.md` MUST Rule 4, I enumerated all `WorkflowNode` subclasses across the full `packages/kailash-kaizen/src/kaizen/nodes/rag/` tree (13 additional classes across 11 files: realtime / agentic / graph / multimodal / evaluation / federated / optimized / privacy / conversational). **None of the 13 uses `input_mapping`** — every facade auto-derives inner-graph-node-id-prefixed parameter names, exactly the same defect class as the 3 fixed here.

Per Rule 4 bounding clause: "If the surfaced gap exceeds ≤500 LOC load-bearing / ≤5–10 invariants / ≤3–4 call-graph hops, filing the follow-up issue IS the correct disposition — the gap is a new shard, not a continuation of the current one." Sizing the 13-class sweep: ~30 LOC per class × 13 = ~390 LOC tests + ~13 × 2-3 fix LOC = ~430 LOC total, **but** invariant count (each class has 1-3 entry parameters that must be precisely identified + named) = 13–39 invariants, exceeding the ≤5–10 ceiling.

Recommendation: Shard E2 (follow-up shard) — sweep the 13 sibling WorkflowNode subclasses with the same `input_mapping` pattern. Value-anchor: same F25 audit value clause ("provably correct, not merely importable"). Requires user gate per `rules/value-prioritization.md` MUST-4 (no auto-creation of follow-up GH issues per `rules/upstream-issue-hygiene.md` MUST-1).

## Coordination

Per `rules/agents.md` MUST § Parallel-Worktree Package Ownership Coordination — version bump (kaizen 2.24.2 → 2.24.3) + combined CHANGELOG entry owned by parallel sibling Shard E on branch `fix/kaizen-rag-query-processing-defects`. This PR intentionally does NOT touch `packages/kailash-kaizen/pyproject.toml`, `packages/kailash-kaizen/src/kaizen/__init__.py`, or `packages/kailash-kaizen/CHANGELOG.md`. The combined CHANGELOG entry under Shard E's PR will mention both shards' fixes.

## Related issues

F25 workstream (kaizen-rag-node-coverage). Audit: `workspaces/kaizen-rag-node-coverage/04-validate/05-audit-gap-2026-05-28.md` § 7 named the defect class.