### PR TITLE
fix(kaizen-rag): query_processing defects + kaizen 2.24.3 (F25 Shard E + D close-out)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -33,18 +33,31 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ### Fixed (Shard D — `kaizen.nodes.rag.workflows`)
 
-- **`AdvancedRAGWorkflowNode` accepts a `text` input.** The advanced
-  workflow node's inner graph previously had an unwired chunker input,
-  so the workflow could not be executed by users following the public
-  surface contract. The chunker's `text` parameter now flows through the
-  workflow facade so `node.execute(text="document body...")` succeeds.
-  Mirrors the 2.24.2 fix for `SimpleRAGWorkflowNode`.
-- **`AdaptiveRAGWorkflowNode` accepts a `text` input.** Same class of
-  defect as above — the adaptive variant of the workflow node had the
-  same unwired chunker input. Now executable end-to-end.
-- **`RAGPipelineWorkflowNode` accepts a `text` input.** Same class of
-  defect — the pipeline variant's inner graph also required `text` that
-  nothing supplied. Now executable end-to-end.
+- **`AdvancedRAGWorkflowNode` now exposes a public `documents` parameter
+  (required, `list`-typed).** Previously the facade auto-derived
+  `quality_analyzer_documents` from the inner-graph node ID, forcing
+  callers to know the inner-graph layout. `node.execute(documents=[...])`
+  now works directly. Same defect class as the 2.24.2 fix for
+  `SimpleRAGWorkflowNode`, applied at the WorkflowNode-facade
+  `input_mapping` layer.
+- **`AdaptiveRAGWorkflowNode` now exposes public `documents` (required,
+  `list`-typed) + `query` (optional `str`, default `""`) parameters.**
+  Previously these leaked as `document_preprocessor_documents` /
+  `document_preprocessor_query`. Same defect class as above.
+- **`RAGPipelineWorkflowNode` now exposes public `documents` (required,
+  `list`-typed) + `query` (optional `str`, default `""`) + `strategy`
+  (optional `str`, default = `self.default_strategy`) parameters.**
+  Previously these leaked as `config_processor_documents` /
+  `config_processor_query` / `config_processor_strategy`.
+- **`RAGPipelineWorkflowNode` no longer crashes at the entry node on
+  first invocation.** The `config_processor` PythonCodeNode codegen
+  referenced an undefined `**kwargs` dict (PythonCodeNode binds explicit
+  inputs as locals, not a kwargs dict), so every invocation raised
+  `NameError: name 'kwargs' is not defined` at the entry node. The
+  codegen now constructs the processed_config dict directly from the
+  bound input parameters, with `RAGConfig` values safely embedded
+  (numeric coercion + `repr()` for string literals — no untrusted-value
+  interpolation surface).
 
 ### Notes
 

--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.24.3] — 2026-05-28 — RAG query_processing + workflows defect close-out (F25 Shards D + E)
+
+### Fixed (Shard E — `kaizen.nodes.rag.query_processing`)
+
+- **`AdaptiveQueryProcessorNode` now executes end-to-end (CRITICAL).** The
+  adaptive workflow embeds `QueryIntentClassifierNode` as a node-type
+  string and wires `intent_analyzer.routing_decision` →
+  `adaptive_processor.routing_decision`. Pre-fix the classifier's `run()`
+  returned a flat classification dict WITHOUT the `routing_decision`
+  field — that field existed only as the strategy_mapper output of the
+  classifier's own inner workflow, which is NOT exercised when the node
+  is composed as a single Node inside another workflow. Every end-to-end
+  call to the adaptive workflow crashed at codegen with
+  `NameError: name 'routing_decision' is not defined`. The fix returns
+  `routing_decision` from `QueryIntentClassifierNode.run()` as part of
+  the documented public contract, so the deterministic `run()` path and
+  the LLM-driven inner-workflow path both expose the same field shape.
+  Surfaced by the F25 RAG audit.
+- **`QueryDecompositionNode` resolver + LLM prompt aligned on
+  `depends_on`.** The dependency_resolver PythonCodeNode and the
+  `query_decomposer` LLM `system_prompt` now both use `depends_on` as the
+  per-sub-question dependency-list field name. This matches the broader
+  kaizen RAG convention used by `MultiHopQueryPlannerNode`'s hop_planner.
+  The change prevents future LLM outputs trained on the kaizen
+  `system_prompt` patterns from silently producing an empty dependency
+  graph through field-name drift.
+
+### Fixed (Shard D — `kaizen.nodes.rag.workflows`)
+
+- **`AdvancedRAGWorkflowNode` accepts a `text` input.** The advanced
+  workflow node's inner graph previously had an unwired chunker input,
+  so the workflow could not be executed by users following the public
+  surface contract. The chunker's `text` parameter now flows through the
+  workflow facade so `node.execute(text="document body...")` succeeds.
+  Mirrors the 2.24.2 fix for `SimpleRAGWorkflowNode`.
+- **`AdaptiveRAGWorkflowNode` accepts a `text` input.** Same class of
+  defect as above — the adaptive variant of the workflow node had the
+  same unwired chunker input. Now executable end-to-end.
+- **`RAGPipelineWorkflowNode` accepts a `text` input.** Same class of
+  defect — the pipeline variant's inner graph also required `text` that
+  nothing supplied. Now executable end-to-end.
+
+### Notes
+
+- Both Shard D (`workflows.py`) and Shard E (`query_processing.py`)
+  landed in the same release. Downstream nodes (`embedder` / `vector_db`)
+  in the workflow-node variants still require real embedding-provider +
+  vector-store configuration to complete the full pipeline end-to-end;
+  that broader inner-graph wiring is tracked as a separate scope.
+
 ## [2.24.2] — 2026-05-28 — `SimpleRAGWorkflowNode` runnable end-to-end (F25)
 
 ### Fixed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.24.2"
+version = "2.24.3"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.24.2"
+__version__ = "2.24.3"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
@@ -824,6 +824,32 @@ class QueryIntentClassifierNode(Node):
             else:
                 strategy = "hybrid"
 
+            # F25 Shard E: `routing_decision` is part of the documented public
+            # contract for QueryIntentClassifierNode — both the strategy_mapper
+            # PythonCodeNode inside _create_workflow() (line ~931) AND any
+            # downstream composer (e.g. AdaptiveQueryProcessorNode) consume
+            # this field on the same shape. Returning it from run() keeps the
+            # contract symmetric: the deterministic run() path and the
+            # LLM-driven inner-workflow path both expose `routing_decision`.
+            # Without this field, composing this node as a single Node inside
+            # another workflow raises NameError at codegen time.
+            routing_decision = {
+                "intent_analysis": {
+                    "query_type": query_type,
+                    "domain": domain,
+                    "complexity": complexity,
+                    "requirements": requirements,
+                    "suggested_strategy": strategy,
+                },
+                "recommended_strategy": strategy,
+                "alternative_strategies": ["hybrid", "semantic", "hierarchical"],
+                "confidence": 0.8,
+                "reasoning": (
+                    f"Query type '{query_type}' with '{complexity}' complexity "
+                    f"suggests '{strategy}' strategy"
+                ),
+            }
+
             return {
                 "query_type": query_type,
                 "domain": domain,
@@ -831,16 +857,31 @@ class QueryIntentClassifierNode(Node):
                 "requirements": requirements,
                 "recommended_strategy": strategy,
                 "confidence": 0.8,
+                "routing_decision": routing_decision,
             }
 
         except Exception as e:
             logger.error(f"Query intent classification failed: {e}")
+            fallback_routing = {
+                "intent_analysis": {
+                    "query_type": "factual",
+                    "domain": "general",
+                    "complexity": "simple",
+                    "requirements": [],
+                    "suggested_strategy": "hybrid",
+                },
+                "recommended_strategy": "hybrid",
+                "alternative_strategies": ["hybrid", "semantic", "hierarchical"],
+                "confidence": 0.0,
+                "reasoning": f"Classification failed: {e}; defaulted to hybrid",
+            }
             return {
                 "query_type": "factual",
                 "domain": "general",
                 "complexity": "simple",
                 "requirements": [],
                 "recommended_strategy": "hybrid",
+                "routing_decision": fallback_routing,
                 "error": str(e),
             }
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
@@ -362,7 +362,8 @@ class QueryDecompositionNode(Node):
                 For each sub-question, indicate:
                 1. The question itself
                 2. Its type (factual, analytical, comparative, etc.)
-                3. Dependencies on other sub-questions
+                3. Dependencies on other sub-questions (use the `depends_on` field;
+                   list the integer indices of preceding sub-questions this one depends on)
                 4. How it contributes to the main question
 
                 Return as JSON: {
@@ -370,7 +371,7 @@ class QueryDecompositionNode(Node):
                         {
                             "question": "...",
                             "type": "...",
-                            "dependencies": [],
+                            "depends_on": [],
                             "contribution": "..."
                         }
                     ],
@@ -387,13 +388,18 @@ class QueryDecompositionNode(Node):
             config={
                 "code": """
 # Resolve dependencies and create execution order
+# F25 Shard E: the LLM system_prompt for query_decomposer advertises
+# `depends_on` as the per-sub-question dependency field (aligning with
+# MultiHopQueryPlannerNode's hop_planner convention). The resolver MUST
+# read the same key the prompt advertises — reading a different key
+# silently produces an empty dependency graph regardless of LLM output.
 decomposition = decomposition_result
 sub_questions = decomposition.get("sub_questions", [])
 
 # Build dependency graph
 dependency_graph = {}
 for i, sq in enumerate(sub_questions):
-    deps = sq.get("dependencies", [])
+    deps = sq.get("depends_on", [])
     dependency_graph[i] = deps
 
 # Topological sort for execution order

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
@@ -11,16 +11,25 @@ Implements sophisticated query enhancement techniques:
 All implementations use existing Kailash components and WorkflowBuilder patterns.
 """
 
-import json
 import logging
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union  # noqa: F401
 
 from kailash.nodes.base import Node, NodeParameter, register_node
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
 
-from ..ai.llm_agent import LLMAgentNode
+# Module-scope import retained as the monkeypatch target for the
+# integration test fixture `deterministic_llm` at
+# tests/integration/rag/test_query_processing_nodes.py — the fixture
+# uses `monkeypatch.setattr(<this module>, "LLMAgentNode", <stub>)` to
+# substitute a deterministic adapter. Runtime code references
+# "LLMAgentNode" only as a node-type string passed to
+# WorkflowBuilder.add_node; the class import itself is unused at runtime
+# but required for the test's setattr rebinding to land on this module's
+# namespace. The static-analyzer "unused import" finding is a known
+# false-positive for monkeypatch-target imports.
+from ..ai.llm_agent import LLMAgentNode  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -867,7 +876,17 @@ class QueryIntentClassifierNode(Node):
             }
 
         except Exception as e:
-            logger.error(f"Query intent classification failed: {e}")
+            # Security round-1 (M1): log the full exception detail to the
+            # framework logger (access-controlled), but do NOT echo str(e)
+            # into the runtime return dict. The dict flows back to Nexus
+            # channels / LLM prompts / public surfaces with broader read
+            # access than the framework log (rules/security.md § "No secrets
+            # in logs"); raw exception text may include filesystem paths,
+            # stack-trace fragments, or upstream-provider error bodies. The
+            # routing_decision contract surfaces a stable strategy fallback
+            # + a public error_class discriminator; full diagnostic stays in
+            # the logger.
+            logger.exception("Query intent classification failed")
             fallback_routing = {
                 "intent_analysis": {
                     "query_type": "factual",
@@ -879,7 +898,7 @@ class QueryIntentClassifierNode(Node):
                 "recommended_strategy": "hybrid",
                 "alternative_strategies": ["hybrid", "semantic", "hierarchical"],
                 "confidence": 0.0,
-                "reasoning": f"Classification failed: {e}; defaulted to hybrid",
+                "reasoning": "Classification failed; defaulted to hybrid",
             }
             return {
                 "query_type": "factual",
@@ -888,7 +907,7 @@ class QueryIntentClassifierNode(Node):
                 "requirements": [],
                 "recommended_strategy": "hybrid",
                 "routing_decision": fallback_routing,
-                "error": str(e),
+                "error_class": type(e).__name__,
             }
 
     def _create_workflow(self) -> Workflow:

--- a/packages/kailash-kaizen/tests/integration/rag/test_query_processing_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_query_processing_nodes.py
@@ -53,28 +53,23 @@ classes ship both a deterministic ``run()`` and an LLM-based
 via the deterministic substitute — they do NOT bless the deterministic
 ``run()`` fallback as the LLM-first authority.
 
-RUNTIME-DEFECT BOUNDARY (reported, NOT fixed in this shard — see the per-test
-findings inline): two SDK-side wiring/contract mismatches surfaced during
-end-to-end execution and are documented for the F25 owner:
+RUNTIME-DEFECT CLOSURE (F25 Shard E, 2026-05-28): the two wiring/contract
+mismatches the original Shard A documented are now FIXED in
+``packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py``:
 
-1. ``QueryDecompositionNode``'s dependency_resolver reads the
-   ``dependencies`` key from each sub_question, but the system_prompt
-   advertises ``depends_on`` as the field name. Cosmetic — the tests use
-   ``dependencies`` to match the resolver's actual contract.
+1. ``QueryDecompositionNode`` — the LLM ``system_prompt`` and the
+   dependency_resolver codegen are now aligned on the ``depends_on``
+   field name (matching ``MultiHopQueryPlannerNode``'s hop_planner
+   convention). The fixture below uses ``depends_on`` to match the
+   corrected contract.
 
-2. ``AdaptiveQueryProcessorNode._create_workflow`` wires
-   ``intent_analyzer.routing_decision`` → ``adaptive_processor.routing_decision``
-   but ``QueryIntentClassifierNode.run()`` returns a flat classification
-   dict with NO ``routing_decision`` field (that field exists only on the
-   inner strategy_mapper of the QueryIntentClassifierNode's own workflow,
-   which is NOT exercised when the node is composed as a single Node in
-   the adaptive workflow). End-to-end execution surfaces a NameError; the
-   test brackets the defect by exercising what RUNS (the intent_analyzer
-   half) and documenting the gap.
-
-Both findings are pre-existing SDK defects out-of-scope for this Tier-2
-coverage shard; the integration tests surface them clearly so the F25 owner
-has a precise reproducer.
+2. ``AdaptiveQueryProcessorNode`` — ``QueryIntentClassifierNode.run()``
+   now returns the ``routing_decision`` field as part of its public
+   contract, so composing the classifier as a Node inside the adaptive
+   workflow (and wiring ``intent_analyzer.routing_decision`` →
+   ``adaptive_processor.routing_decision``) succeeds end-to-end. The
+   ``AdaptiveQueryProcessorNodeIntegration`` end-to-end test asserts the
+   full ``adaptive_plan`` output.
 """
 
 from __future__ import annotations
@@ -678,69 +673,55 @@ class TestAdaptiveQueryProcessorNodeIntegration:
         assert type(analyzer).__name__ == "QueryIntentClassifierNode"
         assert type(processor).__name__ == "PythonCodeNode"
 
-    def test_create_workflow_intent_analyzer_executes_via_local_runtime(
+    def test_create_workflow_executes_end_to_end_via_local_runtime(
         self, deterministic_llm
     ):
-        """The intent_analyzer (a real QueryIntentClassifierNode) runs
-        end-to-end through LocalRuntime against the deterministic
-        ``query`` input.
+        """End-to-end LocalRuntime execution of the adaptive workflow.
 
-        RUNTIME-DEFECT BOUNDARY (reported, NOT fixed in this shard — see
-        the module-level finding below): the adaptive_processor's
-        PythonCodeNode references a `routing_decision` variable that the
-        graph wiring sources from `intent_analyzer.routing_decision`, but
-        the embedded ``QueryIntentClassifierNode.run()`` directly returns
-        a FLAT dict (query_type/domain/complexity/...) with NO
-        ``routing_decision`` field — that field is only produced by the
-        inner strategy_mapper of the QueryIntentClassifierNode's OWN
-        workflow, which is NOT exercised when the node is composed as a
-        single Node in the adaptive workflow. Result: the
-        adaptive_processor raises ``NameError: name 'routing_decision' is
-        not defined`` at the codegen body. This shard exercises what
-        currently RUNS — the intent_analyzer's real execution — and
-        documents the wiring gap for the F25 owner; fixing the wiring
-        exceeds the shard scope per the dispatch brief's "do not pad
-        scope" clause.
+        F25 Shard E fix: ``QueryIntentClassifierNode.run()`` now returns
+        the ``routing_decision`` field as part of its public contract
+        (alongside the flat classification dict). The adaptive_processor's
+        PythonCodeNode receives that field via the graph wiring
+        ``intent_analyzer.routing_decision`` →
+        ``adaptive_processor.routing_decision`` and uses it to compute
+        the processing plan.
 
-        FINDING (separate, for the F25 owner): ``AdaptiveQueryProcessorNode
-        ._create_workflow`` wires ``intent_analyzer.routing_decision`` →
-        ``adaptive_processor.routing_decision`` but
-        ``QueryIntentClassifierNode.run()`` returns a flat classification
-        dict with NO ``routing_decision`` field. The field exists only on
-        the inner strategy_mapper of the QueryIntentClassifierNode's own
-        workflow; embedding the node in another workflow bypasses that
-        inner mapper. Either (a) the adaptive workflow's intent_analyzer
-        edge should source ``recommended_strategy`` (which IS in the flat
-        output) and the codegen body should be updated, OR (b) the
-        adaptive workflow should embed the QueryIntentClassifierNode's
-        inner workflow (not the node itself) and pull the strategy_mapper
-        output. The runtime defect is bracketed by this test.
+        This test exercises the full composition: real
+        ``QueryIntentClassifierNode.run()`` produces routing_decision +
+        flat output; the wired edge passes routing_decision to the real
+        ``PythonCodeNode`` (adaptive_processor) which computes
+        processing_steps from the intent_analysis fields.
         """
         wf = _build(AdaptiveQueryProcessorNode(name="it_aqp_run"))
-        # Execute through LocalRuntime; the intent_analyzer node MUST
-        # produce its flat classification output even though the
-        # downstream adaptive_processor cannot consume it cleanly.
-        runtime = LocalRuntime()
-        # Use raise_on_error=False so the adaptive_processor's NameError
-        # does not abort the test — we are asserting what RUNS, not
-        # what's broken (the broken part is the documented finding).
-        try:
-            results, _ = runtime.execute(wf, parameters={"query": "Compare X vs Y"})
-        except Exception:
-            # Defensive: LocalRuntime may propagate or collect the error;
-            # if collected, results below; if raised, we still exercised
-            # the intent_analyzer and the runtime DID resolve the
-            # node-type strings — both gains the integration test exists
-            # to verify.
-            return
-        # If execution didn't raise, both nodes ran AND intent_analyzer
-        # output is well-formed.
+        results = _execute_workflow(wf, query="Compare X vs Y")
+
+        # Both nodes ran successfully; intent_analyzer is a real
+        # QueryIntentClassifierNode whose run() codepath produced the
+        # documented flat shape plus the routing_decision field.
         assert "intent_analyzer" in results
         ia_out = results["intent_analyzer"]
-        # The real QueryIntentClassifierNode.run() returns the documented
-        # flat shape; the deterministic substitute affects only the inner
-        # workflow which `run()` does NOT exercise.
         assert "query_type" in ia_out
+        assert "routing_decision" in ia_out, (
+            "QueryIntentClassifierNode.run() MUST return routing_decision "
+            "for composition compatibility (F25 Shard E fix)"
+        )
+        # routing_decision MUST carry the documented structure so
+        # downstream consumers (PythonCodeNode in adaptive_processor) can
+        # extract intent_analysis + recommended_strategy.
+        rd = ia_out["routing_decision"]
+        assert "intent_analysis" in rd
+        assert "recommended_strategy" in rd
+
+        # adaptive_processor ran end-to-end and produced the documented
+        # adaptive_plan output shape.
+        assert "adaptive_processor" in results
+        plan = results["adaptive_processor"]["result"]["adaptive_plan"]
+        assert plan["original_query"] == "Compare X vs Y"
+        assert "intent" in plan
+        assert "recommended_strategy" in plan
+        assert "processing_steps" in plan
+        # "rewrite" is always appended by the adaptive_processor codegen.
+        assert "rewrite" in plan["processing_steps"]
 
 
 # ==========================================================================

--- a/packages/kailash-kaizen/tests/integration/rag/test_query_processing_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_query_processing_nodes.py
@@ -141,23 +141,22 @@ class _DeterministicLLMAgent(Node):
         },
         # QueryDecompositionNode.query_decomposer → dependency_resolver expects
         # `decomposition_result` with `sub_questions[{...}]` +
-        # `composition_strategy`. The resolver's topological-sort key is
-        # `dependencies` (NOT `depends_on` — the system_prompt advertises
-        # the latter but the resolver reads the former; an SDK-side
-        # mismatch the test isolates from). Use `dependencies` so the
-        # resolver's dep graph reflects the actual contract.
+        # `composition_strategy`. F25 Shard E aligned the resolver + LLM
+        # prompt on `depends_on` (matching MultiHopQueryPlannerNode's
+        # hop_planner convention). The substitute output uses `depends_on`
+        # so the resolver's dep graph reflects the corrected contract.
         "query_decomposer": {
             "sub_questions": [
                 {
                     "question": "What is BERT?",
                     "type": "factual",
-                    "dependencies": [],
+                    "depends_on": [],
                     "contribution": "definition",
                 },
                 {
                     "question": "How does it work?",
                     "type": "analytical",
-                    "dependencies": [0],
+                    "depends_on": [0],
                     "contribution": "mechanism",
                 },
             ],


### PR DESCRIPTION
## Summary

F25 Shard E close-out — fixes 2 defects in `packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py` AND owns the combined `kailash-kaizen` 2.24.2 → 2.24.3 version bump + CHANGELOG on behalf of both Shard D (sibling PR on `fix/kaizen-rag-workflows-unwired-inputs`) and Shard E.

## Defects fixed (Shard E)

### Defect 1 (CRITICAL) — `AdaptiveQueryProcessorNode` end-to-end `NameError`

The adaptive workflow embeds `QueryIntentClassifierNode` via the `"QueryIntentClassifierNode"` node-type string and wires `intent_analyzer.routing_decision` → `adaptive_processor.routing_decision`. Pre-fix the classifier's `run()` returned a flat classification dict (`query_type`, `domain`, `complexity`, `requirements`, `recommended_strategy`, `confidence`) — but NO `routing_decision` field. That field existed only as the strategy_mapper output of the classifier's own inner workflow, which is NOT exercised when the node is composed as a single Node inside another workflow.

Result: every end-to-end execution of `AdaptiveQueryProcessorNode._create_workflow()` crashed at codegen with `NameError: name 'routing_decision' is not defined`. The class was importable but unusable.

**Root-cause fix path:** updated `QueryIntentClassifierNode.run()` to return `routing_decision` as part of the documented public contract — symmetric with the strategy_mapper output of the classifier's own inner workflow. Both paths now expose the same field shape; any composer wiring the `intent_analyzer.routing_decision` edge works regardless of whether the classifier is run directly or through its inner workflow.

Test: `TestAdaptiveQueryProcessorNodeIntegration::test_create_workflow_executes_end_to_end_via_local_runtime` converted from "documents broken" to "asserts end-to-end execution succeeds" — exercises the full composition and asserts the `adaptive_plan` output shape.

### Defect 2 — `QueryDecompositionNode` resolver + LLM prompt aligned on `depends_on`

The `dependency_resolver` PythonCodeNode and the `query_decomposer` LLM `system_prompt` now both use `depends_on` as the per-sub-question dependency-list field name — matching the broader kaizen RAG convention used by `MultiHopQueryPlannerNode`'s hop_planner. Test fixture in `test_query_processing_nodes.py` updated to match.

## Sibling — Shard D (separate PR)

Shard D PR: see `fix/kaizen-rag-workflows-unwired-inputs` — fixes 3 unwired-text-input defects in `AdvancedRAGWorkflowNode` / `AdaptiveRAGWorkflowNode` / `RAGPipelineWorkflowNode` (same class as the 2.24.2 `SimpleRAGWorkflowNode` fix). Shard D will be open at the same time as this PR.

## Version bump ownership

Per `rules/agents.md` § Parallel-Worktree Package Ownership Coordination, Shard E owns the `kailash-kaizen` 2.24.2 → 2.24.3 version bump + CHANGELOG entry on behalf of both shards. Shard D's PR does NOT touch `pyproject.toml` / `__init__.py` / CHANGELOG. The combined-release sequencing is documented in the CHANGELOG entry for 2.24.3.

## Test plan

- [x] `pytest packages/kailash-kaizen/tests/integration/rag/test_query_processing_nodes.py -v` — 24 passed
- [x] `pytest packages/kailash-kaizen/tests/unit/rag/test_query_processing_nodes.py` — 73 passed
- [x] Total: 97 tests, all green
- [x] Pre-commit hooks pass on all 3 commits

## Sibling-sweep findings

Per `rules/autonomous-execution.md` MUST-4 (same-class fix-immediately within shard budget): no additional same-class defects surfaced in `query_processing.py`. The only production defect documented in the F25 audit report § 7 was the `SimpleRAGWorkflowNode` `chunker.text` defect — already fixed in 2.24.2 — and the class of unwired-input defects in sibling workflow nodes is Shard D's scope.

## Related issues

F25 RAG audit — `workspaces/kaizen-rag-node-coverage/04-validate/05-audit-gap-2026-05-28.md` (Spot-check 8 + Test Files RUNTIME-DEFECT BOUNDARY).