### PR TITLE
release: kailash 2.28.1 + kailash-nexus 2.7.0 (#937)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.28.1] - 2026-05-29
+
 ### Fixed
 
 - **Durable gateway no longer serves stale cached GETs (#937)** — the request deduplicator cached responses for ALL HTTP methods with a 1-hour TTL, so a second identical GET returned a stale body (e.g. a schedule still showing `enabled` after a disable). Deduplication is meaningful only for mutating methods (idempotent retry of POST/PUT/PATCH/DELETE); GET/HEAD/OPTIONS are safe reads that must reflect current state. Both `DurableWorkflowServer` and `DurableAPIGateway` now gate the dedup cache check + response store on a `_should_deduplicate(request)` predicate (`request.method not in {GET, HEAD, OPTIONS}`). Durability tracking (audit events, checkpoints) still applies to all methods — only the dedup cache is skipped for safe reads. Regression: `tests/regression/test_issue_937_safe_method_dedup.py`.

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Nexus Changelog
 
-## [Unreleased] — scheduler admin HTTP panel + typed-error wiring (#937)
+## [2.7.0] — 2026-05-29 — scheduler admin HTTP panel + typed-error wiring (#937)
 
 ### Added
 

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.6.4"
+version = "2.7.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -36,7 +36,7 @@ dependencies = [
     # Tag-push CI installs `kailash` from PyPI before the new release is
     # published, so `kailash[server]` would silently drop the extra.
     # Direct declaration is dialect-stable across the release boundary.
-    "kailash>=2.28.0",
+    "kailash>=2.28.1",
     # Server middleware stack (matches kailash[server] contents).
     "fastapi>=0.104.0",
     "starlette>=0.36.0",

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -102,7 +102,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.6.4"
+__version__ = "2.7.0"
 __all__ = [
     # Core
     "Nexus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.28.0"
+version = "2.28.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.28.0"
+__version__ = "2.28.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Metadata-only release-prep for the #937 work already merged to main (PR #1202).

- **kailash 2.28.0 → 2.28.1** (patch) — durable gateway safe-method dedup fix.
- **kailash-nexus 2.6.4 → 2.7.0** (minor) — `register_scheduler_admin` admin panel + NexusError→HTTP handler; `kailash>=2.28.1` pin.

CHANGELOG `[Unreleased]` entries finalized with date. Version anchors consistent (pyproject == `__version__` for both). F3-protected `uv.lock` + untracked files untouched (explicit-path staging).

Release-prep branch (`release/v*`) — auto-skips the PR-gate matrix per the branch convention. Both gates already passed on the code PR #1202 (reviewer + security-reviewer APPROVED, zero CRIT/HIGH/MED).

## Related issues

Refs #937