### PR TITLE
fix(runtime): annotate __del__ _warnings param as ModuleType (#878)

### DIFF
--- a/src/kailash/runtime/async_local.py
+++ b/src/kailash/runtime/async_local.py
@@ -24,6 +24,7 @@ import weakref
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from types import ModuleType
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
 from kailash.nodes.base import Node
@@ -2068,7 +2069,7 @@ class AsyncLocalRuntime(LocalRuntime):
         self._workflow_signals.clear()
         self._cleanup_event_loop()
 
-    def __del__(self, _warnings=warnings) -> None:
+    def __del__(self, _warnings: ModuleType = warnings) -> None:
         """Emit ResourceWarning if runtime was not properly closed."""
         if getattr(self, "_ref_count", 0) > 0:
             _warnings.warn(

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -43,6 +43,7 @@ import time
 import warnings
 from collections import OrderedDict
 from datetime import UTC, datetime
+from types import ModuleType
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
 
 if TYPE_CHECKING:
@@ -2023,7 +2024,7 @@ class LocalRuntime(
         """Current reference count (for debugging/testing)."""
         return self._ref_count
 
-    def __del__(self, _warnings=warnings) -> None:
+    def __del__(self, _warnings: ModuleType = warnings) -> None:
         """Emit ResourceWarning if runtime was not properly closed."""
         if getattr(self, "_ref_count", 0) > 0:
             _warnings.warn(


### PR DESCRIPTION
## Summary

Resolves the last open finding of #878 — `AsyncLocalRuntime.__del__` pyright `reportIncompatibleMethodOverride` + the `super().__del__(_warnings=_warnings)` argument-type warning.

**Root cause:** the `_warnings=warnings` default makes pyright infer the param as the narrow module-singleton type `Module("warnings")`, irreconcilable across the override boundary.

**Fix:** annotate `_warnings: ModuleType = warnings` on both `LocalRuntime` and `AsyncLocalRuntime`. Broadens the inferred type to generic `ModuleType`; the `=warnings` default value is unchanged, so the interpreter-shutdown-safety idiom mandated by `rules/patterns.md` § "Async Resource Cleanup" stays intact. Annotations are runtime no-ops → behavior-preserving.

Deliberately **not** dropping the default param (the issue's other listed option) — that regresses the shutdown-safe finalizer (the `warnings` module global can be torn down at interpreter shutdown; the default-arg binding survives).

#878 AC#1 (LocalRuntime class-body attrs) + AC#3 (dialect.py) were already resolved on main; only AC#2 (`__del__` override) remained.

## User-flow walk receipts

```
$ .venv/bin/python -m pyright src/kailash/runtime/local.py src/kailash/runtime/async_local.py
0 errors, 0 warnings, 0 informations          # was: 1 error + 1 warning

$ .venv/bin/python -m pytest tests/unit/runtime/ -q
704 passed, 3 skipped in 7.01s

# behavior smoke: default-arg idiom preserved, construct+del clean
LocalRuntime.__del__ _warnings: default='warnings' annotation=<class 'module'>
AsyncLocalRuntime.__del__ _warnings: default='warnings' annotation=<class 'module'>
ok: imports, default-arg idiom preserved, construct+del clean
```

Diff: 4 insertions, 2 deletions across 2 files.

## Related issues

Closes #878 (AC#1/AC#3 already on main; this lands AC#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)