### PR TITLE
chore(coc): land Sweep 8 release-readiness fix

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -646,6 +646,51 @@ changes:
       realized through the gate) per self-referential-codify.md MUST-1
       + redteam-integration.md — NOT by averaging severities.
 
+  - type: command_update
+    artifact: sweep
+    files:
+      - .claude/commands/sweep.md
+    classification_suggestion: global
+    context: |
+      Sweep stale-tag false-positive fix (BUILD->loom, kailash-py 2026-05-30).
+      ADDS "Sweep 8: Release readiness (publishing repos only)"; bumps the
+      workflow count 7->8 and Closure step-1 count 1-7->1-8.
+
+      Root-cause: /sweep had NO mechanical release-readiness step (Sweep 4 is
+      "Open PRs and stale feature branches"). An agent improvised a release
+      check (SWEEP-2026-05-28.md "Sweep 4 / release-readiness") and hand-picked
+      a STALE diff base (v2.27.0) instead of the actual latest tag (v2.28.1),
+      re-flagging already-released fixes (#1182, #1185 — both ancestors of
+      v2.28.1) as "unreleased HIGH" on every sweep. That recurring false
+      positive is what made /sweep feel "neverending" to the operator.
+
+      Fix: Sweep 8 derives the diff base MECHANICALLY from
+      `git tag --sort=-version:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$'`
+      (plain vX.Y.Z stable tags only; the $-anchor excludes prerelease -rc1
+      and package-prefixed dataflow-v* tags so a future v2.29.0-rc1 cannot
+      sort above v2.29.0 and re-introduce the bug). Flags "unreleased" ONLY
+      when `git log "$LATEST"..HEAD -- src/ packages/*/src` is non-empty;
+      docs/.claude/workspace diffs do NOT ship. Verifies any named PR via
+      `git merge-base --is-ancestor <sha> "$LATEST"` before calling it
+      unreleased. Hand-picking a base tag is BLOCKED.
+
+      Self-referential gate (self-referential-codify.md Rule 1+2 — sweep.md is
+      named on the Commands allowlist): multi-agent redteam-with-tests ran in
+      parallel BEFORE this proposal. reviewer APPROVED (1 MED prerelease-sort,
+      fixed same-shard by the $-anchored regex; 2 LOW doc-grade). security-
+      reviewer APPROVED (0 CRIT/HIGH/MED; $LATEST quoted + read-only repo-local
+      => no injection; Sweeps 1-7 byte-unchanged; true-positive detection
+      preserved). cc-architect APPROVED (149 lines <= 150 cap; CLI-neutral;
+      structural fit). The line-141 "1-7"->"1-8" LOW (flagged by 2 agents)
+      fixed same-shard.
+
+      Loom Gate-1 classification suggestion: GLOBAL — the stale-tag bug class
+      is language-agnostic; every publishing BUILD repo (kailash-rs) shares the
+      failure mode. The bash is Python-anchored (pyproject.toml, src/,
+      packages/*/src); the "(publishing repos only)" guard + "no shippable
+      change" disposition degrade safely in non-Python/non-publishing repos.
+      loom may prefer a variant overlay for the rs lane's Cargo.toml anchors.
+
 deferred:
   - id: "issue-1086-candidate-3"
     summary: |

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -17,7 +17,7 @@ Autonomous — runs every sweep sequentially, accumulates findings into a single
 
 ## Workflow
 
-Run all 7 sweeps. Aggregate findings into a single report at the end with severity (CRIT / HIGH / MED / LOW), disposition, and pointer (file:line, PR#, issue#).
+Run all 8 sweeps. Aggregate findings into a single report at the end with severity (CRIT / HIGH / MED / LOW), disposition, and pointer (file:line, PR#, issue#).
 
 ### Sweep 1: Active todos across all workspaces
 
@@ -117,6 +117,21 @@ grep -rEn 'TODO|FIXME|HACK|XXX|NotImplementedError' \
 
 Surface: uncommitted changes, branch ahead/behind origin/main, new stub markers in production code (BLOCKED per `rules/zero-tolerance.md` Rule 2).
 
+### Sweep 8: Release readiness (publishing repos only)
+
+For repos that publish version anchors (`pyproject.toml` + `__init__.py`), determine what is GENUINELY unreleased. The diff base MUST be derived mechanically from the latest tag — hand-picking a base tag is BLOCKED. A stale base re-flags already-released fixes as "unreleased" on every sweep (the false-positive that makes sweeps feel neverending).
+
+```bash
+# plain vX.Y.Z stable tags ONLY — `$`-anchor excludes prerelease (-rc1) + package-
+# prefixed (dataflow-v*) tags; else a future v2.29.0-rc1 sorts above v2.29.0 (stale-base bug)
+LATEST=$(git tag --sort=-version:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+# shippable code ONLY (docs/.claude/workspace do NOT ship); `packages/*/src` is a repo-root glob
+git log --oneline "$LATEST"..HEAD -- src/ packages/*/src 2>/dev/null
+grep -m1 '^version' pyproject.toml   # anchor must match $LATEST unless mid-release
+```
+
+Flag "unreleased work" ONLY when the shippable-code diff above is non-empty. If the only diff since `$LATEST` is docs / `.claude/` / workspace files → record "no shippable change since `$LATEST`", NOT a release finding. Before naming any merged PR as unreleased, confirm it via `git merge-base --is-ancestor <sha> "$LATEST"` (ancestor = already released).
+
 ## Output
 
 Write findings to `workspaces/<project>/04-validate/sweep-<date>.md` (workspace context active) OR `SWEEP-<date>.md` at root. Each finding: `[SEVERITY] [Sweep N] <title>` + Location + Disposition + Evidence + Why-this-matters + Action-taken-if-FIX-NOW. End with cross-cutting observations and 2-5 ranked recommended next-session items.
@@ -125,7 +140,7 @@ Write findings to `workspaces/<project>/04-validate/sweep-<date>.md` (workspace 
 
 Before reporting `/sweep` complete:
 
-1. ALL Sweep 1-7 outputs accumulated
+1. ALL Sweep 1-8 outputs accumulated
 2. Trivial fixes applied inline (`rules/zero-tolerance.md` Rule 1); reclassified `FIXED` with commit SHA
 3. Non-trivial fixes filed as workspace todos OR GH issues with delivered-code references
 4. Report committed (`git add` + `git commit`)


### PR DESCRIPTION
## Summary

Lands the **Sweep 8 (release-readiness)** addition to `/sweep` plus its `latest.yaml` proposal entry — a COC artifact codified last session, committed to main first per `coc-sync-landing.md` MUST-1 so it survives the in-flight #1174 feature-branch work.

## Why

`/sweep` had no mechanical release-readiness step. An agent improvised one with a hand-picked stale diff base (`v2.27.0` vs actual latest `v2.28.1`), re-flagging already-released fixes (#1182, #1185) as "unreleased HIGH" every cycle — the false positive that made sweeps feel neverending. Sweep 8 derives the base mechanically from the latest stable tag (`$`-anchored `vX.Y.Z` regex, excluding `-rc` / package-prefixed tags) and flags only non-empty shippable-code diffs (`src/`, `packages/*/src`).

## Self-referential gate

Per `self-referential-codify.md` (sweep.md is on the Commands allowlist), a 3-agent redteam-with-tests ran last session BEFORE the proposal: reviewer APPROVED, security-reviewer APPROVED (0 CRIT/HIGH/MED), cc-architect APPROVED (149 ≤ 150 line cap). The `latest.yaml` entry carries the BUILD→loom hand-off for loom Gate-1 (global classification suggestion).

## Scope

Two `.claude/` files only — `commands/sweep.md` + an appended `.proposals/latest.yaml` entry. No code, no version change.

## Related issues

Follow-up of the 2026-05-30 `/sweep` stale-tag root-cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)