### PR TITLE
fix(kaizen): DataFlowMemoryBackend tags->tag_list column rename (warm-tier persistence, #855)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/memory/providers/dataflow_backend.py
+++ b/packages/kailash-kaizen/src/kaizen/memory/providers/dataflow_backend.py
@@ -44,7 +44,10 @@ class DataFlowMemoryBackend:
             timestamp: str  # ISO format
             source: str
             importance: float
-            tags: str  # JSON array
+            tag_list: str  # JSON array. NOTE: NOT "tags" — a DataFlow model
+                           # field named "tags" collides with the core SDK's
+                           # reserved NodeMetadata.tags (set[str]) and fails
+                           # CreateNode validation (see issue #855).
             metadata: str  # JSON object
             embedding: Optional[str] = None  # JSON array
 
@@ -126,7 +129,9 @@ class DataFlowMemoryBackend:
                 "timestamp": entry.timestamp.isoformat(),
                 "source": entry.source.value,
                 "importance": entry.importance,
-                "tags": json.dumps(entry.tags),
+                # Column is "tag_list" not "tags" — see model-schema note above
+                # (the reserved NodeMetadata.tags collision, issue #855).
+                "tag_list": json.dumps(entry.tags),
                 "metadata": json.dumps(entry.metadata),
                 "embedding": json.dumps(entry.embedding) if entry.embedding else None,
             },
@@ -166,7 +171,8 @@ class DataFlowMemoryBackend:
                     "timestamp": entry.timestamp.isoformat(),
                     "source": entry.source.value,
                     "importance": entry.importance,
-                    "tags": json.dumps(entry.tags),
+                    # Column is "tag_list" not "tags" (issue #855 collision).
+                    "tag_list": json.dumps(entry.tags),
                     "metadata": json.dumps(entry.metadata),
                     "embedding": (
                         json.dumps(entry.embedding) if entry.embedding else None
@@ -442,8 +448,10 @@ class DataFlowMemoryBackend:
         Returns:
             MemoryEntry instance
         """
-        # Parse JSON fields
-        tags = record.get("tags", "[]")
+        # Parse JSON fields. Column is "tag_list" (renamed from "tags" to avoid
+        # the reserved NodeMetadata.tags set[str] collision — issue #855); fall
+        # back to legacy "tags" for any pre-rename rows.
+        tags = record.get("tag_list", record.get("tags", "[]"))
         if isinstance(tags, str):
             try:
                 tags = json.loads(tags)


### PR DESCRIPTION
## Summary

`DataFlowMemoryBackend`'s documented `MemoryEntryModel` schema named a field
**`tags`**, which collides with the core SDK's reserved `NodeMetadata.tags`
field (typed `set[str]`). `store()` passed `tags=json.dumps([...])` (a JSON
string) to `MemoryEntryModelCreateNode`, and CreateNode metadata validation
rejected it:

```
WorkflowValidationError: Invalid node metadata: NodeMetadata.tags
Input should be a valid set [input_value='[]', input_type=str]
```

As a result the warm-tier persistence path raised on the first `store()` and
had **never worked** for its own documented schema. There was no test that
constructed the backend, so this shipped broken.

## Fix

Rename the DataFlow column `tags` → `tag_list` at all four sites in
`dataflow_backend.py`:

- the docstring schema,
- `store()` write key,
- `store_many()` write key,
- `_record_to_entry()` read-back (with a legacy `"tags"` fallback for any
  pre-rename rows).

The in-memory `MemoryEntry.tags` attribute is unchanged — only the persisted
DataFlow column name changes. No public API change.

## Verification

End-to-end against real SQLite (4-slash absolute DSN), deterministic across
reruns:

- direct `backend.store(e)` → `backend.get(id)` round-trips both **content**
  and **tags** (`["a", "b"]`);
- `HierarchicalMemory` low-importance store persists to the warm tier and reads
  back.

Adds no new pyright diagnostics (the file's 15 pre-existing `reportOptionalCall`
errors on `main` are unchanged). Pre-commit (Black / isort / Ruff / Tier-1)
green.

## Scope note

This is the warm-tier persistence half of #855. The remaining #855 items
(kaizen-agents `shortcuts.py` memory-shortcut crash, `state_manager.py` and
`journey/core.py` pyright drift) are tracked separately and are not in this PR.

## Related issues

Refs #855
