### PR TITLE
fix(kaizen-agents): repair persistent/learning memory shortcuts + pyright drift (#855)

### DIFF
--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -61,6 +61,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 markers = [
+    "unit: fast isolated unit tests (Tier 1)",
     "integration: integration tests against real infrastructure (Tier 2)",
     "regression: regression tests pinning a fixed bug (NEVER delete)",
 ]

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -60,6 +60,10 @@ exclude = ["tests*"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
+markers = [
+    "integration: integration tests against real infrastructure (Tier 2)",
+    "regression: regression tests pinning a fixed bug (NEVER delete)",
+]
 
 [tool.black]
 line-length = 88

--- a/packages/kaizen-agents/src/kaizen_agents/api/shortcuts.py
+++ b/packages/kaizen-agents/src/kaizen_agents/api/shortcuts.py
@@ -10,6 +10,7 @@ Shortcut Categories:
 - Tool access shortcuts: "none", "read_only", "constrained", "full"
 """
 
+import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Union
 
@@ -17,6 +18,8 @@ from kaizen_agents.api.types import MemoryDepth, ToolAccess
 
 if TYPE_CHECKING:
     from kaizen_agents.api.types import ExecutionMode
+
+logger = logging.getLogger(__name__)
 
 # Type aliases for lazy loading
 MemoryProviderType = Any  # Will be MemoryProvider when imported
@@ -41,31 +44,107 @@ def _create_session_memory(**kwargs) -> "MemoryProviderType":
     return BufferMemoryAdapter(max_turns=max_turns)
 
 
+def _safe_sqlite_dsn(memory_path: str) -> str:
+    """Build a DataFlow-safe 4-slash absolute SQLite DSN from a filesystem path.
+
+    DataFlow requires the 4-slash absolute form (``sqlite:////abs/path``); the
+    3-slash form (``sqlite:///rel/path``) is parsed as a *relative* path and
+    fails with ``DDLFailedError: unable to open database file`` (issue #855).
+
+    ``memory_path`` is treated as a directory (a ``memory.db`` file is created
+    inside it) unless it already ends in ``.db``, in which case it is the file.
+
+    Raises:
+        ValueError: if the path contains ``?``, ``#``, or a null byte, which
+            would corrupt the SQLite connection URI.
+    """
+    from pathlib import Path
+
+    if any(c in memory_path for c in ("?", "#", "\x00")):
+        raise ValueError(
+            f"Invalid memory_path {memory_path!r}: must not contain '?', '#', "
+            "or null bytes (these corrupt the SQLite connection URI)."
+        )
+
+    p = Path(memory_path).expanduser()
+    if p.suffix == ".db":
+        db_file = p.resolve()
+        db_file.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        p.mkdir(parents=True, exist_ok=True)
+        db_file = (p / "memory.db").resolve()
+
+    # 4-slash absolute form: "sqlite:////" + absolute-path-without-leading-slash.
+    return "sqlite:////" + str(db_file).lstrip("/")
+
+
+def _build_dataflow_warm_backend(memory_path: str) -> "MemoryProviderType":
+    """Build a DataFlow-backed warm-tier memory backend for the given path.
+
+    Registers ``MemoryEntryModel`` with a ``tag_list`` column — NOT ``tags``,
+    which collides with the core SDK's reserved ``NodeMetadata.tags`` (``set[str]``)
+    and fails CreateNode validation (issue #855) — then returns a
+    ``DataFlowMemoryBackend``.
+
+    Returns ``None`` (the caller falls back to a hot-tier-only provider) when
+    DataFlow is not installed, so ``store()`` never silently drops writes nor
+    raises on a missing optional dependency.
+    """
+    try:
+        from dataflow import DataFlow
+
+        from kaizen.memory.providers.dataflow_backend import DataFlowMemoryBackend
+    except ImportError:
+        logger.warning(
+            "kaizen_agents.memory: DataFlow is not installed; persistent/learning "
+            "memory degrades to hot-tier-only (no cross-session persistence). "
+            "Install with: pip install kailash-dataflow kailash"
+        )
+        return None
+
+    db = DataFlow(database_url=_safe_sqlite_dsn(memory_path))
+
+    @db.model
+    class MemoryEntryModel:
+        id: str
+        session_id: str
+        content: str
+        role: str
+        timestamp: str
+        source: str
+        importance: float
+        # Column is "tag_list" not "tags" — see issue #855 (reserved-name collision).
+        tag_list: str
+        metadata: str
+        embedding: str = ""
+
+    return DataFlowMemoryBackend(db, model_name="MemoryEntryModel")
+
+
 def _create_persistent_memory(**kwargs) -> "MemoryProviderType":
-    """Create a persistent memory provider with database backend."""
+    """Create a persistent memory provider with a DataFlow warm-tier backend.
+
+    The warm tier persists entries across sessions; when DataFlow is unavailable
+    the provider degrades to hot-tier-only (a logged warning, not a silent drop).
+    """
     from kaizen.memory.providers.hierarchical import HierarchicalMemory
 
-    path = kwargs.get("memory_path", "./data/memory")
-    return HierarchicalMemory(
-        storage_path=path,
-        enable_hot_tier=True,
-        enable_warm_tier=True,
-        enable_cold_tier=False,  # Cold tier for learning only
-    )
+    memory_path = kwargs.get("memory_path", "./data/memory")
+    return HierarchicalMemory(warm_backend=_build_dataflow_warm_backend(memory_path))
 
 
 def _create_learning_memory(**kwargs) -> "MemoryProviderType":
-    """Create a learning memory provider with pattern detection."""
+    """Create a learning memory provider with a DataFlow warm-tier backend.
+
+    Wired identically to ``persistent`` today: ``HierarchicalMemory`` does not
+    yet implement a cold/summarization tier, so learning shares the warm-backed
+    configuration rather than advertising a cold tier that would silently drop
+    writes (issue #855). Cold-tier learning is tracked as follow-up work.
+    """
     from kaizen.memory.providers.hierarchical import HierarchicalMemory
 
-    path = kwargs.get("memory_path", "./data/memory")
-    return HierarchicalMemory(
-        storage_path=path,
-        enable_hot_tier=True,
-        enable_warm_tier=True,
-        enable_cold_tier=True,  # Enable cold tier for long-term learning
-        enable_summarization=True,
-    )
+    memory_path = kwargs.get("memory_path", "./data/memory")
+    return HierarchicalMemory(warm_backend=_build_dataflow_warm_backend(memory_path))
 
 
 # Memory shortcut registry

--- a/packages/kaizen-agents/src/kaizen_agents/api/shortcuts.py
+++ b/packages/kaizen-agents/src/kaizen_agents/api/shortcuts.py
@@ -74,8 +74,10 @@ def _safe_sqlite_dsn(memory_path: str) -> str:
         p.mkdir(parents=True, exist_ok=True)
         db_file = (p / "memory.db").resolve()
 
-    # 4-slash absolute form: "sqlite:////" + absolute-path-without-leading-slash.
-    return "sqlite:////" + str(db_file).lstrip("/")
+    # 4-slash absolute form: "sqlite:////" + absolute-path with its single
+    # leading slash removed. removeprefix (not lstrip) strips exactly one slash
+    # so a path that resolves with a leading "//" is not silently collapsed.
+    return "sqlite:////" + str(db_file).removeprefix("/")
 
 
 def _build_dataflow_warm_backend(memory_path: str) -> "MemoryProviderType":

--- a/packages/kaizen-agents/src/kaizen_agents/journey/core.py
+++ b/packages/kaizen-agents/src/kaizen_agents/journey/core.py
@@ -50,10 +50,11 @@ if TYPE_CHECKING:
     from kaizen.core.base_agent import BaseAgent
     from kaizen.signatures.core import Signature
 
-    try:
-        from kaizen_agents.patterns.pipeline import Pipeline
-    except ImportError:
-        Pipeline = None  # type: ignore[assignment, misc]
+    # Imported unconditionally here (type-checking only — never executed at
+    # runtime). The runtime import stays lazy in ``_build_pipeline``. A
+    # try/except that rebinds ``Pipeline = None`` would turn it into a value and
+    # break every ``Pipeline`` type annotation below (reportInvalidTypeForm).
+    from kaizen_agents.patterns.pipeline import Pipeline
 
 from kaizen_agents.journey.behaviors import ReturnBehavior
 
@@ -293,19 +294,11 @@ class Pathway(metaclass=PathwayMeta):
         if self._signature_instance is None and self._signature is not None:
             sig = self._signature()
 
-            # Merge pathway guidelines with signature guidelines (REQ-INT-001)
+            # Merge pathway guidelines with signature guidelines (REQ-INT-001).
+            # Signature.with_guidelines() is the canonical merge API
+            # (kaizen.signatures.core) and returns a new Signature.
             if self._guidelines:
-                if hasattr(sig, "with_guidelines"):
-                    # Use the signature's with_guidelines method for proper merging
-                    sig = sig.with_guidelines(self._guidelines)
-                else:
-                    # Fallback: manually merge guidelines if method not available
-                    existing_guidelines = getattr(sig, "_guidelines", [])
-                    if hasattr(sig, "__class__") and hasattr(
-                        sig.__class__, "__guidelines__"
-                    ):
-                        existing_guidelines = list(sig.__class__.__guidelines__)
-                    sig._guidelines = existing_guidelines + list(self._guidelines)
+                sig = sig.with_guidelines(self._guidelines)
 
             self._signature_instance = sig
         return self._signature_instance
@@ -442,9 +435,13 @@ class Pathway(metaclass=PathwayMeta):
                     if field_name in context.accumulated_context:
                         inputs[field_name] = context.accumulated_context[field_name]
 
-            # Execute pipeline
-            if hasattr(pipeline, "execute"):
-                result = await pipeline.execute(inputs)
+            # Execute pipeline. The canonical Pipeline exposes a synchronous
+            # run(); some adapters may also offer an async execute() — prefer it
+            # when present (resolved dynamically so the static Pipeline type,
+            # which declares only run(), does not flag the optional method).
+            execute = getattr(pipeline, "execute", None)
+            if callable(execute):
+                result = await execute(inputs)
             elif hasattr(pipeline, "run"):
                 # Synchronous pipeline - wrap in dict if needed
                 result = pipeline.run(**inputs)

--- a/packages/kaizen-agents/src/kaizen_agents/patterns/state_manager.py
+++ b/packages/kaizen-agents/src/kaizen_agents/patterns/state_manager.py
@@ -55,8 +55,17 @@ import json
 import logging
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    # Bind the optional-dependency symbols for static analysis only; the
+    # runtime imports below stay behind try/except so a missing dependency
+    # raises a clear ImportError at __init__ rather than at module import.
+    from dataflow import DataFlow
+
+    from kailash.runtime import AsyncLocalRuntime
+    from kailash.workflow.builder import WorkflowBuilder
 
 
 def _mask_connection_string(connection_string: str) -> str:
@@ -221,10 +230,29 @@ class OrchestrationStateManager:
         # This ensures errors are caught at initialization time, not first use
         self._validate_connection()
 
-        # Initialize AsyncLocalRuntime for async workflow execution
+        # Initialize an async-capable runtime for async workflow execution.
+        # State operations call ``execute_workflow_async``; a sync runtime
+        # (e.g. a LocalRuntime acquired from a pool) lacks that method, so when
+        # one is supplied we warn and fall back to an owned AsyncLocalRuntime
+        # rather than rejecting it (callers passing a sync runtime keep working).
+        self.runtime: "AsyncLocalRuntime"
         if runtime is not None:
-            self.runtime = runtime.acquire()
-            self._owns_runtime = False
+            acquired = runtime.acquire()
+            if hasattr(acquired, "execute_workflow_async"):
+                self.runtime = cast("AsyncLocalRuntime", acquired)
+                self._owns_runtime = False
+            else:
+                logger.warning(
+                    "OrchestrationStateManager: provided runtime %s lacks "
+                    "execute_workflow_async; falling back to an owned "
+                    "AsyncLocalRuntime for async state operations.",
+                    type(acquired).__name__,
+                )
+                self.runtime = AsyncLocalRuntime(
+                    debug=False,
+                    connection_validation="warn",
+                )
+                self._owns_runtime = True
         else:
             self.runtime = AsyncLocalRuntime(
                 debug=False,
@@ -1026,9 +1054,12 @@ class OrchestrationStateManager:
 
     def close(self):
         """Release runtime reference."""
-        if hasattr(self, "runtime") and self.runtime is not None:
+        if getattr(self, "runtime", None) is not None:
             self.runtime.release()
-            self.runtime = None
+            # Drop the attribute (rather than assigning None) so the declared
+            # non-optional ``runtime: AsyncLocalRuntime`` type holds; the
+            # hasattr/getattr guards in close()/__del__ tolerate its absence.
+            del self.runtime
 
     def __del__(self):
         if getattr(self, "runtime", None) is not None:

--- a/packages/kaizen-agents/tests/regression/test_issue_855_memory_shortcuts.py
+++ b/packages/kaizen-agents/tests/regression/test_issue_855_memory_shortcuts.py
@@ -27,7 +27,30 @@ from __future__ import annotations
 import pytest
 
 from kaizen.memory.providers.types import MemoryEntry
-from kaizen_agents.api.shortcuts import resolve_memory_shortcut
+from kaizen_agents.api.shortcuts import _safe_sqlite_dsn, resolve_memory_shortcut
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("bad", ["x?mode=ro", "x#frag", "x\x00y"])
+def test_safe_sqlite_dsn_rejects_uri_metacharacters(tmp_path, bad):
+    """?, #, and null bytes must be rejected (they corrupt the SQLite URI, #855).
+
+    Pins the security invariant so a future refactor that drops the validation —
+    or a switch to SQLite ``file:`` URI mode where ``?mode=ro`` would be honored —
+    fails loudly instead of silently re-opening URI parameter injection.
+    """
+    with pytest.raises(ValueError, match="must not contain"):
+        _safe_sqlite_dsn(str(tmp_path / bad))
+
+
+@pytest.mark.regression
+def test_safe_sqlite_dsn_emits_4slash_absolute_form(tmp_path):
+    """Output is the 4-slash absolute DSN DataFlow requires, free of ?/# (#855)."""
+    dsn = _safe_sqlite_dsn(str(tmp_path / "mem"))
+    assert dsn.startswith("sqlite:////")
+    assert "?" not in dsn and "#" not in dsn
+    # Exactly four leading slashes after the scheme (absolute path, not relative).
+    assert dsn[len("sqlite://") :].startswith("//")
 
 
 @pytest.mark.regression

--- a/packages/kaizen-agents/tests/regression/test_issue_855_memory_shortcuts.py
+++ b/packages/kaizen-agents/tests/regression/test_issue_855_memory_shortcuts.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for issue #855 — persistent/learning memory shortcuts.
+
+Issue #855 had two coupled defects:
+
+1. **Crash (confirmed user-facing):** ``Agent(memory="persistent")`` and
+   ``Agent(memory="learning")`` raised
+   ``TypeError: unexpected keyword argument 'storage_path'`` because the shortcut
+   factories passed ``storage_path=`` / ``enable_*=`` kwargs that
+   ``HierarchicalMemory.__init__`` does not accept.
+
+2. **Warm-tier persistence:** the DataFlow warm backend stored the tag list in a
+   column named ``tags``, which collides with the core SDK's reserved
+   ``NodeMetadata.tags`` (``set[str]``) and failed CreateNode validation. The
+   column was renamed to ``tag_list``.
+
+``test_memory_shortcut_constructs_without_crash`` pins defect (1) and runs in any
+environment (the crash was about kwargs, independent of DataFlow). The warm-tier
+round-trip pins defect (2) and requires DataFlow (skipped when unavailable, since
+``kaizen-agents`` does not declare ``kailash-dataflow`` as a hard dependency — the
+warm tier is an optional capability that degrades to hot-tier-only with a warning).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kaizen.memory.providers.types import MemoryEntry
+from kaizen_agents.api.shortcuts import resolve_memory_shortcut
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("shortcut", ["persistent", "learning"])
+def test_memory_shortcut_constructs_without_crash(tmp_path, shortcut):
+    """resolve_memory_shortcut('persistent'|'learning') must not raise (#855).
+
+    Before the fix this raised ``TypeError`` on the unsupported ``storage_path``
+    kwarg, so ``Agent(memory="persistent"|"learning")`` was unusable.
+    """
+    provider = resolve_memory_shortcut(shortcut, memory_path=str(tmp_path / shortcut))
+    assert type(provider).__name__ == "HierarchicalMemory"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.parametrize("shortcut", ["persistent", "learning"])
+async def test_memory_shortcut_roundtrips_through_warm_tier(tmp_path, shortcut):
+    """A stored entry reads back with content AND tags via the warm tier (#855).
+
+    Pins the ``tag_list`` rename: the tag column persists as ``tag_list`` (not the
+    reserved ``NodeMetadata.tags``), so a regression to the colliding name would
+    fail this round-trip loudly. Requires DataFlow (the real warm-tier backend).
+    """
+    pytest.importorskip(
+        "dataflow", reason="warm-tier round-trip requires kailash-dataflow"
+    )
+
+    provider = resolve_memory_shortcut(shortcut, memory_path=str(tmp_path / shortcut))
+    assert provider.has_warm_tier is True, "DataFlow present but warm tier not wired"
+
+    entry = MemoryEntry(
+        content="remember this across sessions",
+        session_id="s-855",
+        importance=0.2,  # low importance -> demoted to the warm tier
+        tags=["alpha", "beta"],
+    )
+    entry_id = await provider.store(entry)
+
+    retrieved = await provider.get(entry_id)
+    assert retrieved is not None, "entry did not persist to the warm tier"
+    assert retrieved.content == "remember this across sessions"
+    assert retrieved.tags == ["alpha", "beta"], "tags must round-trip via tag_list"
+    assert await provider.count() >= 1


### PR DESCRIPTION
## Summary

Closes the kaizen-agents half of #855 (the warm-tier `tags`→`tag_list` rename
landed separately in #1219). Three clusters across three files; pyright now
reports **0 errors / 0 warnings** on all three (was **19 errors, 14 warnings**).

### Cluster A — `api/shortcuts.py` (confirmed user crash)
`Agent(memory="persistent")` and `Agent(memory="learning")` raised
`TypeError: unexpected keyword argument 'storage_path'` — the factories passed
`storage_path=`/`enable_*=` kwargs that `HierarchicalMemory.__init__`
(`hot_size, warm_backend, cold_backend, ...`) never accepted. The shortcuts were
unusable. Rewrote both factories to build a real warm-tier-backed
`HierarchicalMemory`: `_safe_sqlite_dsn()` emits DataFlow's required 4-slash
absolute DSN (the 3-slash form fails `unable to open database file`) and rejects
`?`/`#`/null bytes; `_build_dataflow_warm_backend()` registers `MemoryEntryModel`
with the `tag_list` column (not the reserved `NodeMetadata.tags`) and returns a
`DataFlowMemoryBackend`, degrading to hot-tier-only **with a logged warning**
when DataFlow is absent (never a silent drop).

### Cluster B — `patterns/state_manager.py`
`DataFlow`/`AsyncLocalRuntime`/`WorkflowBuilder` were "possibly unbound" (lazy
`try/except ImportError`) — bound them in a `TYPE_CHECKING` block. `self.runtime`
unioned `LocalRuntime` (no `execute_workflow_async`) and `AsyncLocalRuntime`;
guarantee an async-capable runtime by falling back to an owned
`AsyncLocalRuntime` (logged warning) when a sync runtime is supplied — graceful,
not eager-reject.

### Cluster C — `journey/core.py`
The `TYPE_CHECKING` block rebound `Pipeline = None` on ImportError, turning it
into a value and breaking every `Pipeline` type annotation — import it
unconditionally (type-checking only; runtime import stays lazy). Use the
canonical `Signature.with_guidelines()` instead of poking private
`_guidelines`/`__guidelines__`. Resolve `pipeline.execute` via `getattr`.

## User-flow walk receipts

`resolve_memory_shortcut("persistent"|"learning")` — the previously-crashing path:
```
resolve persistent -> HierarchicalMemory | has_warm_tier: True
resolve learning   -> HierarchicalMemory | has_warm_tier: True
stored id: 53057ad9 | count: 1
retrieved: ('remember me', ['x', 'y'])
WALK: PASS
```
No crash; warm tier wired; store→get round-trips content AND tags.

## Tests
- New `tests/regression/test_issue_855_memory_shortcuts.py` (4 cases: crash
  regression is env-independent; warm-tier round-trip `importorskip`s dataflow).
- 345 targeted unit tests pass (incl. `test_local_runtime_default` /
  `test_explicit_local_runtime` — the runtime-fallback change preserves them).
- `pytest --collect-only` exit 0 across the package (3363 collected).

## Pre-existing finding (NOT in this PR's scope)
`tests/unit/orchestration/test_parallel_pipeline.py` has pre-existing failures
(`TypeError: argument of type 'BaseAgentConfig' is not iterable` at
`src/kailash/nodes/base.py:303`) — verified identical on the pre-session commit
`7a077147f`. Different bug class (core-SDK node-config capture), wide blast
radius; tracked separately rather than folded into this kaizen-agents PR.

## Related issues
Refs #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)