### PR TITLE
fix(core): Node init-capture tolerates a non-dict self.config (v2.28.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.28.2] - 2026-06-01
+
+### Fixed
+
+- **Node init-param-capture no longer crashes on a typed `self.config`** — `Node.__init_with_capture` merged init params into `self.config` by iterating `name in self.config` and assigning `self.config[name]`, assuming the dict that `Node.__init__` creates. A `Node` subclass that deliberately replaces `self.config` with a typed config object (e.g. kaizen's `BaseAgentConfig`, as many `kaizen_agents` pattern nodes do) raised `TypeError: argument of type '<Config>' is not iterable` at construction, breaking ~93 `kaizen_agents` Pipeline orchestration tests. The capture is a dict-only convenience and now skips (rather than crashes) when `self.config` is not a mapping. Regression: `tests/regression/test_node_init_capture_non_dict_config.py`.
+
 ## [2.28.1] - 2026-05-29
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.28.1"
+version = "2.28.2"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.28.1"
+__version__ = "2.28.2"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/nodes/base.py
+++ b/src/kailash/nodes/base.py
@@ -299,6 +299,14 @@ class Node(ABC):
                 # raise. Don't mask the bug; just skip capture.
                 return
 
+            if not isinstance(self.config, dict):
+                # Param-capture merges init params into the dict that
+                # Node.__init__ creates. A subclass that deliberately replaces
+                # self.config with a typed config object (e.g. BaseAgentConfig)
+                # opts out of capture — skip rather than crash on the `in` /
+                # item-assignment operations below, which require a mapping.
+                return
+
             for name in param_names_to_capture:
                 if name in self.config:
                     # Subclass already forwarded this via **kwargs; preserve.

--- a/tests/regression/test_node_init_capture_non_dict_config.py
+++ b/tests/regression/test_node_init_capture_non_dict_config.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression: Node init-param-capture must tolerate a non-dict ``self.config``.
+
+A ``Node`` subclass may deliberately replace ``self.config`` (the dict
+``Node.__init__`` creates) with a typed config object — e.g. kaizen's
+``BaseAgentConfig``, which many ``kaizen_agents`` pattern nodes assign via
+``self.config = config or SomeConfig()``.
+
+The ``__init_with_capture`` wrapper merges init params into ``self.config`` for
+round-trip faithfulness, iterating ``name in self.config`` and assigning
+``self.config[name] = ...``. When ``self.config`` was a typed object rather than
+a mapping, that raised ``TypeError: argument of type '<Config>' is not iterable``
+at construction time, breaking ~93 ``kaizen_agents`` Pipeline orchestration
+tests. The capture is a dict-only convenience and MUST skip (not crash) when
+``self.config`` is not a mapping.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from kailash.nodes.base import Node, NodeParameter
+
+
+@dataclass
+class _TypedConfigStub:
+    """Stand-in for a typed config object (e.g. BaseAgentConfig) — not a dict."""
+
+    label: str = "x"
+
+
+class _NonDictConfigNode(Node):
+    """Node subclass that replaces self.config with a typed (non-dict) object."""
+
+    def __init__(self, label: str = "x", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        # Deliberately clobber the dict Node.__init__ created with a typed object,
+        # exactly as the kaizen_agents pattern nodes do with BaseAgentConfig.
+        self.config = _TypedConfigStub(label=label)
+
+    def get_parameters(self) -> dict[str, NodeParameter]:
+        return {}
+
+    def run(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+
+class _DictConfigNode(Node):
+    """Ordinary Node subclass that keeps the dict config Node.__init__ creates."""
+
+    def __init__(self, alpha: str = "a", **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    def get_parameters(self) -> dict[str, NodeParameter]:
+        return {}
+
+    def run(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+
+@pytest.mark.regression
+def test_node_init_capture_tolerates_non_dict_config() -> None:
+    """Constructing a Node whose self.config is a typed object must not raise."""
+    node = _NonDictConfigNode(label="hello")
+    assert isinstance(node.config, _TypedConfigStub)
+    assert node.config.label == "hello"
+
+
+@pytest.mark.regression
+def test_node_init_capture_preserves_dict_config_path() -> None:
+    """The normal dict-config capture path is unchanged (no regression)."""
+    node = _DictConfigNode(alpha="captured")
+    assert isinstance(node.config, dict)


### PR DESCRIPTION
## Summary

Fixes a pre-existing core-SDK crash discovered while validating #855:
`Node.__init_with_capture` (the init-param-capture wrapper that runs for every
`Node` subclass) iterated `name in self.config` and assigned `self.config[name]`,
assuming the dict that `Node.__init__` creates. A `Node` subclass that
deliberately replaces `self.config` with a **typed config object** — e.g.
kaizen's `BaseAgentConfig`, which many `kaizen_agents` pattern nodes assign via
`self.config = config or SomeConfig()` — raised
`TypeError: argument of type '<Config>' is not iterable` at construction.

This broke **~93** `kaizen_agents` Pipeline orchestration tests. The bug is
**pre-existing** (verified identical on `1b71db643`, before this work) and a
different class from #855; surfaced during #855 validation and fixed here on its
own branch.

## Fix
The capture is a dict-only round-trip-faithfulness convenience. It now **skips**
(matching the existing defensive-skip for a `None` config two lines above) when
`self.config` is not a mapping, rather than crashing. Normal dict-config nodes
are unaffected — the capture path runs exactly as before.

```python
if not isinstance(self.config, dict):
    # Subclass replaced self.config with a typed config object; opt out of
    # capture rather than crash on the `in` / item-assignment below.
    return
```

## Verification
- `kaizen_agents` orchestration suite: **22 failed / 93 errors → 231 passed**.
- Core node tests (base/config/capture): **46 pass, unchanged** — no regression
  to the normal dict-config capture path.
- New `tests/regression/test_node_init_capture_non_dict_config.py`: reproduces
  the exact `TypeError` **without** the fix (verified via stash) and **passes**
  with it; also pins the normal dict-config path.

## Related issues
Discovered during #855 validation (separate bug class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)