### PR TITLE
release: kailash-kaizen 2.24.4 + kaizen-agents 0.9.8 (#855)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
 
 ## [Unreleased]
 
+## [2.24.4] — 2026-06-01 — DataFlowMemoryBackend warm-tier persistence (#855)
+
+### Fixed
+
+- **`DataFlowMemoryBackend` warm-tier persistence no longer raises on its own documented schema (#855)** — the `MemoryEntryModel` schema named a field `tags`, which collides with the core SDK's reserved `NodeMetadata.tags` (typed `set[str]`). `store()` passed `tags=json.dumps([...])` (a JSON string) to `MemoryEntryModelCreateNode`, and CreateNode metadata validation rejected it (`WorkflowValidationError: NodeMetadata.tags Input should be a valid set`), so warm-tier persistence raised on first store and had never worked for its own documented schema. Renamed the DataFlow column `tags` → `tag_list` at all four sites (docstring schema, `store()` write key, `store_many()` write key, and the `_record_to_entry()` read-back with a legacy `tags` fallback for pre-rename rows). The in-memory `MemoryEntry.tags` attribute is unchanged; only the persisted column name changes. Verified end-to-end against real SQLite: `store()`→`get()` round-trips content AND tags.
+
 ## [2.24.3] — 2026-05-28 — RAG query_processing + workflows defect close-out (F25 Shards D + E)
 
 ### Fixed (Shard E — `kaizen.nodes.rag.query_processing`)
@@ -76,7 +82,7 @@ All notable changes to the Kaizen AI Agent Framework will be documented in this 
   `semantic_chunker` required a `text` input that nothing supplied, so
   every call to `runtime.execute(...)` raised
   `WorkflowValidationError: Node 'semantic_chunker' missing required
-  inputs: ['text']`. The fix wires the chunker's `text` parameter
+inputs: ['text']`. The fix wires the chunker's `text` parameter
   through the workflow facade so users can now invoke
   `node.execute(text="document body...")` and the inner chunker
   receives the input as expected. Surfaced by the F25 RAG audit.

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.24.3"
+version = "2.24.4"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.24.3"
+__version__ = "2.24.4"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.8] — 2026-06-01 — persistent/learning memory shortcut repair + pyright drift (#855)
+
+### Fixed
+
+- **`Agent(memory="persistent")` and `Agent(memory="learning")` no longer crash (#855)** — the shortcut factories passed `storage_path=`/`enable_*=` kwargs that `HierarchicalMemory.__init__` (`hot_size, warm_backend, cold_backend, ...`) never accepted, so both shortcuts raised `TypeError: unexpected keyword argument 'storage_path'` on every call and were unusable. Both factories now build a real warm-tier-backed `HierarchicalMemory`: a `_safe_sqlite_dsn()` helper emits DataFlow's required 4-slash absolute SQLite DSN (the 3-slash form fails `unable to open database file`) and rejects `?`/`#`/null bytes; a `_build_dataflow_warm_backend()` helper registers `MemoryEntryModel` with the `tag_list` column (not the reserved `NodeMetadata.tags`) and returns a `DataFlowMemoryBackend`, degrading to hot-tier-only with a logged warning when DataFlow is unavailable (never a silent drop). Verified end-to-end: `store()`→`get()` round-trips content AND tags.
+- **pyright type-drift in `patterns/state_manager.py` and `journey/core.py` (#855)** — bound `DataFlow`/`AsyncLocalRuntime`/`WorkflowBuilder` in a `TYPE_CHECKING` block (previously "possibly unbound" from the lazy `try/except ImportError`); guaranteed an async-capable `self.runtime` via a graceful fallback to an owned `AsyncLocalRuntime` when a sync runtime is supplied; imported `Pipeline` unconditionally for type-checking (the prior `Pipeline = None` on ImportError broke every `Pipeline` annotation); switched to the canonical `Signature.with_guidelines()`. Reduces the three files from 19 errors / 14 warnings to 0/0.
+
 ## [0.9.7] — 2026-05-09 — slim core: orphan deletes + httpx/openai consolidation (#890)
 
 Patch release shipping kaizen-agents' slice of the kailash 2.18.0 / #890 slim-core decoupling. **No public-API behavior change** — three deps audited as orphans (zero imports across `src/kaizen_agents/`) are deleted, and the dep ordering is cleaned up. Users see no difference in installed packages from the `kailash-kaizen` + `openai` transitive set.

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.9.7"
+version = "0.9.8"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate


### PR DESCRIPTION
Metadata-only release prep (version + CHANGELOG; no source changes) for the
already-merged #855 fixes that landed without same-PR version bumps.

| Package | Bump | Ships |
|---|---|---|
| kailash-kaizen | 2.24.3 → 2.24.4 | DataFlowMemoryBackend `tags`→`tag_list` warm-tier fix (#1219) |
| kaizen-agents | 0.9.7 → 0.9.8 | persistent/learning memory shortcut crash repair + pyright drift (#1220) |

`release/v*` branch → auto-skips the PR-gate matrix (metadata-only).

## Related issues
Refs #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)