### PR TITLE
fix(runtime): propagate contextvars.Context across thread boundaries (#1200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.28.3] - 2026-06-01
+
+### Fixed
+
+- **Runtimes no longer drop `contextvars.Context` across their thread boundaries (#1200)** — `AsyncLocalRuntime`, `LocalRuntime`, `ParallelRuntime`, and `ParallelCyclicRuntime` dispatched sync node execution across a thread boundary (`loop.run_in_executor`, a raw `threading.Thread`, and `ThreadPoolExecutor.submit`) without propagating the caller's `contextvars.Context`. A `ContextVar` set before `execute()` / `execute_workflow_async()` was invisible inside a node's `run()` — the node saw the variable's default instead of the caller-set value, unlike the stdlib `asyncio.to_thread` convention. The fix snapshots `contextvars.copy_context()` in the caller frame and dispatches the thread-boundary callable through `ctx.run(...)` at all six affected sites (`async_local.py` ×2 `run_in_executor`, `local.py` raw `threading.Thread` + sync-in-async `ThreadPoolExecutor`, `parallel.py` `run_in_executor`, `parallel_cyclic.py` `submit`). Parallel paths use a fresh `ctx.copy()` per concurrent dispatch so a single `Context` is never entered concurrently. The distributed-worker path (`distributed.py`) is intentionally excluded: it reconstructs the workflow from a Redis-queued task in a separate process, so the original caller's context is already gone across the queue boundary. Regression: `tests/integration/runtime/test_contextvars_propagation.py` (8 tests — propagation across all five in-process dispatch paths + negative no-leak-when-unset cases).
+
 ## [2.28.2] - 2026-06-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.28.2"
+version = "2.28.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.28.2"
+__version__ = "2.28.3"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/runtime/async_local.py
+++ b/src/kailash/runtime/async_local.py
@@ -15,6 +15,7 @@ Key Features:
 """
 
 import asyncio
+import contextvars
 import hashlib
 import logging
 import os
@@ -1348,7 +1349,16 @@ class AsyncLocalRuntime(LocalRuntime):
             # Convert context back to inputs for sync execution
             return self._execute_sync_workflow_internal(workflow, context.variables)
 
-        result = await loop.run_in_executor(self.thread_pool, sync_execute)
+        # Propagate the caller's contextvars.Context across the thread-pool
+        # boundary. ``loop.run_in_executor`` does NOT copy the calling context
+        # (unlike ``asyncio.to_thread``), so a ContextVar set before
+        # ``execute_workflow_async`` would otherwise be invisible inside the
+        # sync node's ``run()``. Snapshot in THIS (caller) frame and run the
+        # dispatched callable through ``ctx.run(...)`` (#1200).
+        ctx = contextvars.copy_context()
+        result = await loop.run_in_executor(
+            self.thread_pool, lambda: ctx.run(sync_execute)
+        )
 
         # Wrap result in expected format
         return {
@@ -1805,7 +1815,13 @@ class AsyncLocalRuntime(LocalRuntime):
         def execute_sync():
             return node_instance.execute(**inputs)
 
-        return await loop.run_in_executor(self.thread_pool, execute_sync)
+        # Propagate the caller's contextvars.Context across the thread-pool
+        # boundary so a ContextVar set before execution is visible inside the
+        # sync node's ``run()`` (#1200). Snapshot in this (caller) frame.
+        ctx = contextvars.copy_context()
+        return await loop.run_in_executor(
+            self.thread_pool, lambda: ctx.run(execute_sync)
+        )
 
     async def _prepare_async_node_inputs(
         self,

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -4289,8 +4289,12 @@ class LocalRuntime(
                 )
 
             try:
+                # Propagate the caller's contextvars across the thread-pool
+                # boundary so a ContextVar set before execution is visible
+                # inside the node's run() on this sync-in-async path (#1200).
+                _caller_ctx = contextvars.copy_context()
                 with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future = executor.submit(asyncio.run, run_async())
+                    future = executor.submit(_caller_ctx.run, asyncio.run, run_async())
                     return future.result()
             except RuntimeError as thread_err:
                 # Python 3.13: asyncio.run() may fail in worker threads, or

--- a/src/kailash/runtime/local.py
+++ b/src/kailash/runtime/local.py
@@ -35,6 +35,7 @@ Examples:
 """
 
 import asyncio
+import contextvars
 import hashlib
 import json
 import logging
@@ -2183,6 +2184,15 @@ class LocalRuntime(
         result_container = []
         exception_container = []
 
+        # Propagate the caller's contextvars.Context across the raw thread
+        # boundary. A bare ``threading.Thread`` starts with an EMPTY context,
+        # so a ContextVar set before ``LocalRuntime.execute()`` (invoked from
+        # within a running event loop, routing through ``_execute_sync``) would
+        # otherwise be invisible inside the node's ``run()``. Snapshot in THIS
+        # (caller) frame and run the thread body through ``ctx.run(...)`` —
+        # mirroring stdlib ``asyncio.to_thread`` semantics (#1200).
+        _caller_ctx = contextvars.copy_context()
+
         def run_in_thread():
             """Run async execution in separate thread."""
             loop = None
@@ -2281,7 +2291,7 @@ class LocalRuntime(
                 if loop:
                     loop.close()
 
-        thread = threading.Thread(target=run_in_thread)
+        thread = threading.Thread(target=lambda: _caller_ctx.run(run_in_thread))
         thread.start()
         thread.join()
 

--- a/src/kailash/runtime/parallel.py
+++ b/src/kailash/runtime/parallel.py
@@ -5,6 +5,7 @@ specifically designed to run independent nodes concurrently for maximum performa
 """
 
 import asyncio
+import contextvars
 import logging
 import time
 from collections import deque
@@ -477,8 +478,15 @@ class ParallelRuntime:
 
                     async def execute_with_metrics():
                         with collector.collect(node_id=node_id) as context:
+                            # Propagate the caller's contextvars across the
+                            # thread-pool boundary so a ContextVar set before
+                            # execution is visible inside node.run() (#1200).
+                            ctx = contextvars.copy_context()
                             result = await loop.run_in_executor(
-                                None, lambda: node_instance.execute(**inputs)
+                                None,
+                                lambda: ctx.run(
+                                    lambda: node_instance.execute(**inputs)
+                                ),
                             )
                             return result, context.result()
 

--- a/src/kailash/runtime/parallel_cyclic.py
+++ b/src/kailash/runtime/parallel_cyclic.py
@@ -1,5 +1,6 @@
 """Enhanced parallel runtime with cyclic workflow support."""
 
+import contextvars
 import logging
 import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -278,6 +279,11 @@ class ParallelCyclicRuntime:
             # Execute groups sequentially, but nodes within groups in parallel
             results = {}
 
+            # Propagate the caller's contextvars across the thread-pool
+            # boundary so a ContextVar set before execution is visible inside
+            # each node's run() on the parallel-cyclic path (#1200).
+            caller_ctx = contextvars.copy_context()
+
             with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
                 for group_index, node_group in enumerate(execution_groups):
                     self.logger.info(
@@ -288,6 +294,7 @@ class ParallelCyclicRuntime:
                     future_to_node = {}
                     for node_id in node_group:
                         future = executor.submit(
+                            caller_ctx.copy().run,
                             self._execute_single_node,
                             workflow,
                             node_id,

--- a/tests/integration/runtime/test_contextvars_propagation.py
+++ b/tests/integration/runtime/test_contextvars_propagation.py
@@ -26,6 +26,8 @@ from kailash.nodes.base import Node, register_node
 from kailash.nodes.base_async import AsyncNode
 from kailash.runtime.async_local import AsyncLocalRuntime
 from kailash.runtime.local import LocalRuntime
+from kailash.runtime.parallel import ParallelRuntime
+from kailash.runtime.parallel_cyclic import ParallelCyclicRuntime
 from kailash.workflow.builder import WorkflowBuilder
 
 # A request-scoped ContextVar with a sentinel default. The bug surfaces when a
@@ -33,6 +35,19 @@ from kailash.workflow.builder import WorkflowBuilder
 _ctx_sentinel: contextvars.ContextVar[str] = contextvars.ContextVar(
     "issue_1200_sentinel", default="DEFAULT"
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ctx_sentinel():
+    """Reset the ContextVar to its default after each test.
+
+    SYNC tests share the main thread's contextvars.Context, so a ``set()`` in
+    one sync test leaks into the next (async tests are isolated per-task by
+    pytest-asyncio). This teardown restores the baseline so negative tests
+    observe the true default, not a sibling test's residue.
+    """
+    yield
+    _ctx_sentinel.set("DEFAULT")
 
 
 @register_node()
@@ -175,4 +190,80 @@ async def test_local_runtime_no_contextvar_set_sees_default():
     assert results["reader"]["seen"] == "DEFAULT", (
         "node observed an unexpected contextvar value via LocalRuntime when "
         f"the caller set nothing: got {results['reader']['seen']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sibling dispatch sites surfaced by the #1200 /redteam mechanical sweep.
+# The issue named 3 sites in AsyncLocalRuntime + LocalRuntime, but the SAME
+# bug class (node execution dispatched across a thread boundary without
+# copy_context) also lives in ParallelRuntime (loop.run_in_executor) and
+# ParallelCyclicRuntime (ThreadPoolExecutor.submit). A user running a PARALLEL
+# workflow — the common performance path — would still lose contextvars after
+# fixing only the 3 named sites. Same-bug-class, fixed in the same shard per
+# autonomous-execution.md Rule 4.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_parallel_runtime_propagates_contextvar():
+    """Sibling site: ParallelRuntime sync-node dispatch via loop.run_in_executor.
+
+    ParallelRuntime.execute dispatches each regular (sync) Node through
+    ``loop.run_in_executor(None, lambda: node_instance.execute(**inputs))``.
+    The node MUST observe the caller-set ContextVar value.
+    """
+    _ctx_sentinel.set("SET-BY-CALLER-PARALLEL")
+
+    builder = WorkflowBuilder()
+    builder.add_node("ReadContextVarNode", "reader", {})
+    workflow = builder.build()
+
+    runtime = ParallelRuntime()
+    results, _ = await runtime.execute(workflow)
+
+    assert results["reader"]["seen"] == "SET-BY-CALLER-PARALLEL", (
+        "contextvar lost across the ParallelRuntime executor thread hop: "
+        f"got {results['reader']['seen']!r}"
+    )
+
+
+@pytest.mark.integration
+def test_parallel_cyclic_runtime_propagates_contextvar():
+    """Sibling site: ParallelCyclicRuntime node dispatch via ThreadPoolExecutor.
+
+    Passing ``parallel_nodes`` routes the node through
+    ``executor.submit(caller_ctx.copy().run, self._execute_single_node, ...)``.
+    Each parallel worker runs an independent copy of the caller's context, so
+    the node MUST observe the caller-set ContextVar value.
+    """
+    _ctx_sentinel.set("SET-BY-CALLER-CYCLIC")
+
+    builder = WorkflowBuilder()
+    builder.add_node("ReadContextVarNode", "reader", {})
+    workflow = builder.build()
+
+    runtime = ParallelCyclicRuntime()
+    results, _ = runtime.execute(workflow, parallel_nodes={"reader"})
+
+    assert results["reader"]["seen"] == "SET-BY-CALLER-CYCLIC", (
+        "contextvar lost across the ParallelCyclicRuntime ThreadPoolExecutor "
+        f"submit hop: got {results['reader']['seen']!r}"
+    )
+
+
+@pytest.mark.integration
+def test_parallel_cyclic_runtime_no_contextvar_set_sees_default():
+    """Negative/regression: ParallelCyclicRuntime path unaffected when unset."""
+    builder = WorkflowBuilder()
+    builder.add_node("ReadContextVarNode", "reader", {})
+    workflow = builder.build()
+
+    runtime = ParallelCyclicRuntime()
+    results, _ = runtime.execute(workflow, parallel_nodes={"reader"})
+
+    assert results["reader"]["seen"] == "DEFAULT", (
+        "node observed an unexpected contextvar value via ParallelCyclicRuntime "
+        f"when the caller set nothing: got {results['reader']['seen']!r}"
     )

--- a/tests/integration/runtime/test_contextvars_propagation.py
+++ b/tests/integration/runtime/test_contextvars_propagation.py
@@ -1,0 +1,178 @@
+"""Regression tests for contextvars.Context propagation across thread boundaries.
+
+Issue #1200: AsyncLocalRuntime and LocalRuntime dropped the caller's
+contextvars.Context when dispatching node execution across a thread boundary.
+A ContextVar set by the caller before execute* was invisible inside a node's
+run() (it saw the default).
+
+There are three affected dispatch sites across two classes:
+  1. AsyncLocalRuntime._execute_sync_workflow      -> loop.run_in_executor
+  2. AsyncLocalRuntime._execute_sync_node_in_thread -> loop.run_in_executor
+  3. LocalRuntime._execute_sync                     -> raw threading.Thread
+
+The fix snapshots the caller's context with contextvars.copy_context() in the
+calling frame and runs the dispatched callable through ctx.run(...), mirroring
+stdlib asyncio.to_thread copy_context semantics.
+
+NO MOCKING — these exercise the real runtimes against real node execution.
+"""
+
+import asyncio
+import contextvars
+
+import pytest
+
+from kailash.nodes.base import Node, register_node
+from kailash.nodes.base_async import AsyncNode
+from kailash.runtime.async_local import AsyncLocalRuntime
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
+
+# A request-scoped ContextVar with a sentinel default. The bug surfaces when a
+# node observes the default instead of the value the caller set before execute*.
+_ctx_sentinel: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "issue_1200_sentinel", default="DEFAULT"
+)
+
+
+@register_node()
+class ReadContextVarNode(Node):
+    """Sync node that reports the value of the issue-1200 ContextVar.
+
+    A sync node so it is dispatched across the thread boundary the bug lives on
+    (async nodes run on the event-loop thread and never lose context).
+    """
+
+    def get_parameters(self):
+        return {}
+
+    def run(self, **kwargs):
+        return {"seen": _ctx_sentinel.get()}
+
+
+@register_node()
+class PassThroughAsyncNode(AsyncNode):
+    """Async node forcing the AsyncLocalRuntime mixed-async execution path.
+
+    Its presence alongside a sync node makes the runtime dispatch the sync node
+    via ``_execute_sync_node_in_thread`` (site 2) rather than the sync-only
+    workflow path (site 1). AsyncNode subclasses implement ``async_run()``.
+    """
+
+    def get_parameters(self):
+        return {}
+
+    async def async_run(self, **kwargs):
+        await asyncio.sleep(0)
+        return {"value": "async-ok"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_runtime_sync_only_workflow_propagates_contextvar():
+    """Site 1: sync-only workflow under AsyncLocalRuntime.
+
+    A sync-only workflow routes through ``_execute_sync_workflow`` ->
+    ``loop.run_in_executor``. The node MUST observe the caller-set value.
+    """
+    _ctx_sentinel.set("SET-BY-CALLER-A")
+
+    builder = WorkflowBuilder()
+    builder.add_node("ReadContextVarNode", "reader", {})
+    workflow = builder.build()
+
+    runtime = AsyncLocalRuntime()
+    results, _ = await runtime.execute_workflow_async(workflow, inputs={})
+
+    assert results["reader"]["seen"] == "SET-BY-CALLER-A", (
+        "contextvar lost across the AsyncLocalRuntime sync-only workflow "
+        f"thread hop: got {results['reader']['seen']!r}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_runtime_sync_node_in_mixed_workflow_propagates_contextvar():
+    """Site 2: sync node within a mixed async workflow under AsyncLocalRuntime.
+
+    The async node forces the mixed-async path so the sync node is dispatched
+    via ``_execute_sync_node_in_thread`` -> ``loop.run_in_executor``.
+    """
+    _ctx_sentinel.set("SET-BY-CALLER-B")
+
+    builder = WorkflowBuilder()
+    builder.add_node("PassThroughAsyncNode", "asyncer", {})
+    builder.add_node("ReadContextVarNode", "reader", {})
+    workflow = builder.build()
+
+    runtime = AsyncLocalRuntime()
+    results, _ = await runtime.execute_workflow_async(workflow, inputs={})
+
+    assert results["reader"]["seen"] == "SET-BY-CALLER-B", (
+        "contextvar lost across the AsyncLocalRuntime sync-node thread hop "
+        f"in a mixed async workflow: got {results['reader']['seen']!r}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_local_runtime_sync_execute_from_running_loop_propagates_contextvar():
+    """Site 3: sync ``LocalRuntime.execute()`` from inside a running loop.
+
+    Being inside this pytest-asyncio coroutine means a loop is already running,
+    so ``execute()`` dispatches to ``_execute_sync`` -> raw ``threading.Thread``
+    (which starts with an empty context). The node MUST still observe the
+    caller-set value.
+    """
+    _ctx_sentinel.set("SET-BY-CALLER-C")
+
+    builder = WorkflowBuilder()
+    builder.add_node("ReadContextVarNode", "reader", {})
+    workflow = builder.build()
+
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow)
+
+    assert results["reader"]["seen"] == "SET-BY-CALLER-C", (
+        "contextvar lost across the LocalRuntime raw-thread hop "
+        f"(sync execute from running loop): got {results['reader']['seen']!r}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_runtime_no_contextvar_set_sees_default():
+    """Negative/regression: a workflow that does NOT use contextvars is unaffected.
+
+    With no caller set(), the node sees the ContextVar's default — confirming
+    the copy_context() wrap introduces no behavior change for the common case.
+    """
+    # Deliberately do NOT call _ctx_sentinel.set() in this test's context.
+    builder = WorkflowBuilder()
+    builder.add_node("ReadContextVarNode", "reader", {})
+    workflow = builder.build()
+
+    runtime = AsyncLocalRuntime()
+    results, _ = await runtime.execute_workflow_async(workflow, inputs={})
+
+    assert results["reader"]["seen"] == "DEFAULT", (
+        "node observed an unexpected contextvar value when the caller set "
+        f"nothing: got {results['reader']['seen']!r}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_local_runtime_no_contextvar_set_sees_default():
+    """Negative/regression: LocalRuntime path is unaffected when no var is set."""
+    builder = WorkflowBuilder()
+    builder.add_node("ReadContextVarNode", "reader", {})
+    workflow = builder.build()
+
+    with LocalRuntime() as runtime:
+        results, _ = runtime.execute(workflow)
+
+    assert results["reader"]["seen"] == "DEFAULT", (
+        "node observed an unexpected contextvar value via LocalRuntime when "
+        f"the caller set nothing: got {results['reader']['seen']!r}"
+    )


### PR DESCRIPTION
## Summary

Core SDK runtimes dropped the caller's `contextvars.Context` when dispatching
sync node execution across a thread boundary, so a `ContextVar` set before
`execute()` / `execute_workflow_async()` was invisible inside a node's `run()`
(the node saw the variable's default). This breaks the stdlib `asyncio.to_thread`
convention that callers reasonably expect.

The fix snapshots `contextvars.copy_context()` in the **caller frame** and runs
the thread-boundary callable through `ctx.run(...)` at all six affected dispatch
sites:

- `async_local.py` — `_execute_sync_workflow` + `_execute_sync_node_in_thread` (`run_in_executor`)
- `local.py` — `_execute_sync` raw `threading.Thread` + the sync-in-async `ThreadPoolExecutor` path
- `parallel.py` — `execute_with_metrics` (`run_in_executor`)
- `parallel_cyclic.py` — `executor.submit` (uses a fresh `caller_ctx.copy()` per concurrent dispatch)

Parallel paths use a fresh `ctx.copy()` per concurrent task so a single `Context`
object is never entered concurrently (which would raise "cannot enter context:
already entered").

The distributed-worker path (`distributed.py:1380` dequeue I/O, `:1489`
queue-reconstructed workflow) is **intentionally excluded** — the workflow is
rebuilt from a Redis-queued task in a separate worker process, so the original
caller's context is already gone across the queue boundary; `copy_context()`
there would snapshot the meaningless worker context.

## Related issues

Fixes #1200

## Verification (ground-truth, no mocking)

Pre-fix repro on `main` (unfixed src) — bug reproduces:

```
$ python -c "<minimal LocalRuntime repro from #1200>"
seen = DEFAULT          # ← the bug: caller-set contextvar invisible in node.run()
```

Post-fix, same repro through the worktree src:

```
seen = SET-BY-CALLER    # ← fixed
```

Regression suite (`tests/integration/runtime/test_contextvars_propagation.py`,
run against the worktree's fixed src):

```
$ PYTHONPATH=src python -m pytest tests/integration/runtime/test_contextvars_propagation.py -q
........  8 passed
```

8 tests cover all five in-process dispatch paths (AsyncLocalRuntime sync-only,
AsyncLocalRuntime sync-node-in-mixed, LocalRuntime raw-thread, ParallelRuntime,
ParallelCyclicRuntime) — each asserts the contextvar is SEEN (not the default),
plus three negative cases asserting the default is preserved when no var is set
(no spurious injection). The positive cases fail pre-fix (`got 'DEFAULT'`).

## Convergence

Reviewer + security mechanical sweeps run inline (independent gate-review
subagents were infra-throttled this cycle):
- **Dispatch-site sweep:** every `run_in_executor` / `ThreadPoolExecutor` /
  `threading.Thread` / `.submit` site in `src/kailash/runtime/` is either fixed
  or justifiably excluded (distributed-worker, shutdown signal-handler,
  watchdog monitor thread — none carry a live caller context).
- **Concurrency safety:** parallel paths confirmed to use per-task `ctx.copy()`.
- **Security:** context propagation across the thread hop is the *intended*
  behavior — the caller's tenant/clearance/request context SHOULD reach
  `node.run()`; each `execute()` takes a fresh snapshot in the caller frame, so
  no cross-caller staleness and no cross-node contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)