### PR TITLE
fix(dataflow): round-trip Optional[list]/Optional[dict] JSONB fields as Python list/dict (#1207)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.10.1] — 2026-06-01 — Optional[list]/Optional[dict] JSONB round-trip fix (#1207)
+
+### Fixed
+
+- **`db.express` round-trips `Optional[list]` / `Optional[dict]` JSONB fields as Python `list`/`dict`, not a JSON string (#1207)** — `express.create` and `express.read` returned a JSON-encoded `str` instead of the deserialized Python value for model fields declared `Optional[list]` / `Optional[dict]` (the idiomatic nullable-JSONB-column annotation). `_deserialize_json_fields` (`core/nodes.py`) checked `field_type in (dict, list)` against the raw annotation; for `Optional[list]` the annotation is `Union[list, None]` (or PEP 604 `list | None`, a `types.UnionType`), so the membership test was `False`, `json.loads` was skipped, and the raw string leaked to the caller. The fix adds `_unwrap_optional_type`, which collapses single-non-None-arg unions (`Optional[T]`, `Union[T, None]`, PEP 604 `T | None`) to the bare `T` before the membership check; routed through both `_deserialize_json_fields` (the read/create chokepoint covering all 13 call sites) AND `convert_datetime_fields` (the same `__origin__ is Union` blindness affected nullable `datetime | None` fields). Multi-arg unions and non-union annotations pass through unchanged. Regression: `tests/regression/test_issue_1207_optional_jsonb_roundtrip.py` (5 Tier-2 round-trips against real PostgreSQL with NON-EMPTY values) + `tests/unit/core/test_issue_1207_unwrap_optional_type.py` (15 Tier-1 helper unit tests).
+
 ## [2.10.0] — 2026-05-19 — node-registry collision fix (#891)
 
 **Requires `kailash>=2.23.0`** — generated CRUD-node registration now passes

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.10.0"
+version = "2.10.1"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -4,6 +4,7 @@ DataFlow Node Generation
 Dynamic node generation for database operations.
 """
 
+import types
 from typing import Any, Dict, List, Optional, Type, Union
 
 try:
@@ -165,6 +166,34 @@ def _normalize_id_type(type_annotation: Any) -> Any:
         return type_annotation
 
     return str  # fallback for unknown
+
+
+def _unwrap_optional_type(type_annotation: Any) -> Any:
+    """Unwrap ``Optional[T]`` / ``Union[T, None]`` / ``T | None`` to bare ``T``.
+
+    Covers BOTH union spellings (issue #1207):
+
+    1. ``typing.Optional[list]`` / ``typing.Union[list, None]`` —
+       ``typing.get_origin(x) is typing.Union``.
+    2. PEP 604 ``list | None`` (Python 3.10+) — produces a
+       ``types.UnionType`` whose ``typing.get_origin(x)`` returns
+       ``types.UnionType`` (NOT ``typing.Union``).
+
+    Only single-non-None-arg unions collapse (e.g. ``Optional[list]`` -> ``list``).
+    Multi-arg unions (``Union[list, dict]``) and non-union annotations are
+    returned unchanged so the downstream ``in (dict, list)`` membership check
+    behaves identically to a bare annotation.
+    """
+    import typing
+
+    origin = typing.get_origin(type_annotation)
+    if origin is typing.Union or origin is types.UnionType:
+        non_none = [
+            arg for arg in typing.get_args(type_annotation) if arg is not type(None)
+        ]
+        if len(non_none) == 1:
+            return non_none[0]
+    return type_annotation
 
 
 def convert_datetime_fields(data_dict: dict, model_fields: dict, logger) -> dict:
@@ -576,6 +605,13 @@ class NodeGenerator:
                     # Check if this field is a JSON field (dict or list type)
                     field_info = self.model_fields.get(field_name, {})
                     field_type = field_info.get("type")
+
+                    # Issue #1207: a field declared Optional[list]/Optional[dict]
+                    # (or PEP 604 ``list | None``) carries a Union annotation, NOT
+                    # the bare ``list``/``dict`` type, so the membership check below
+                    # was False and the raw JSON string leaked back to the caller.
+                    # Unwrap the Optional wrapper so JSONB round-trips deserialize.
+                    field_type = _unwrap_optional_type(field_type)
 
                     if field_type in (dict, list):
                         # Try to deserialize JSON string

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -234,12 +234,12 @@ def convert_datetime_fields(data_dict: dict, model_fields: dict, logger) -> dict
         else:
             field_type = field_info.get("type")
 
-        # Handle Optional[datetime] types
-        if hasattr(field_type, "__origin__"):
-            if field_type.__origin__ is typing.Union:
-                actual_types = [t for t in field_type.__args__ if t is not type(None)]
-                if actual_types and actual_types[0] == datetime:
-                    field_type = datetime
+        # Handle Optional[datetime] AND PEP 604 ``datetime | None`` (#1207
+        # sibling: the prior ``__origin__ is typing.Union`` check missed PEP 604
+        # unions — a ``types.UnionType`` has no ``__origin__`` — so nullable
+        # datetime fields declared ``datetime | None`` skipped parsing). Routing
+        # through the shared helper covers both union spellings.
+        field_type = _unwrap_optional_type(field_type)
 
         # If field is datetime type and value is string, try to parse it
         if field_type == datetime:

--- a/packages/kailash-dataflow/tests/regression/test_issue_1207_optional_jsonb_roundtrip.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1207_optional_jsonb_roundtrip.py
@@ -1,0 +1,183 @@
+"""Regression test for issue #1207: Optional[list]/Optional[dict] JSONB round-trip.
+
+`db.express.create`/`db.express.read` returned a JSON-encoded ``str`` instead of a
+Python ``list``/``dict`` for model fields declared ``Optional[list]`` /
+``Optional[dict]`` (JSONB columns). Plain ``list``/``dict`` fields worked; the
+``Optional[...]`` wrap was the trigger.
+
+Root cause: ``_deserialize_json_fields`` (dataflow/core/nodes.py) checked
+``field_type in (dict, list)`` against the raw declared annotation. For an
+``Optional[list]`` field the annotation is ``Union[list, None]`` (or PEP 604
+``list | None``, a ``types.UnionType``), NOT the bare ``list`` type — so the
+membership test was False, ``json.loads`` was skipped, and the JSON string leaked.
+
+These are Tier-2 integration tests (real PostgreSQL, NO mocking) exercising the
+full ``db.express`` create + read round-trip. CRITICAL per the issue: every
+assertion uses a NON-EMPTY value — an empty list/dict passes through the bug
+invisibly (``json.loads("[]") == []`` and the raw ``"[]"`` string also looks
+benign), so empty values cannot prove the fix.
+"""
+
+from typing import Optional
+
+import pytest
+
+from dataflow import DataFlow
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+
+@pytest.fixture
+async def test_suite():
+    """Create complete integration test suite with real PostgreSQL infrastructure."""
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_optional_list_nonempty_roundtrip_returns_python_list(test_suite):
+    """Optional[list] with a NON-EMPTY value round-trips back to a Python list."""
+    db = DataFlow(test_suite.config.url, auto_migrate=True)
+
+    @db.model
+    class Issue1207OptListDoc:
+        title: str
+        tags: Optional[list] = None  # Optional[list] JSONB column — the bug trigger
+
+    await db.initialize()
+
+    payload = ["alpha", "beta", "gamma"]  # NON-EMPTY — empty list hides the bug
+    created = await db.express.create(
+        "Issue1207OptListDoc", {"title": "doc-a", "tags": payload}
+    )
+
+    assert isinstance(
+        created["tags"], list
+    ), f"create() leaked {type(created['tags']).__name__}: {created['tags']!r}"
+    assert created["tags"] == payload
+
+    fetched = await db.express.read("Issue1207OptListDoc", created["id"])
+    assert isinstance(
+        fetched["tags"], list
+    ), f"read() leaked {type(fetched['tags']).__name__}: {fetched['tags']!r}"
+    assert fetched["tags"] == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_optional_dict_nonempty_roundtrip_returns_python_dict(test_suite):
+    """Optional[dict] with a NON-EMPTY value round-trips back to a Python dict."""
+    db = DataFlow(test_suite.config.url, auto_migrate=True)
+
+    @db.model
+    class Issue1207OptDictDoc:
+        title: str
+        meta: Optional[dict] = None  # Optional[dict] JSONB column — the bug trigger
+
+    await db.initialize()
+
+    payload = {"owner": "alice", "priority": 3, "nested": {"k": "v"}}  # NON-EMPTY
+    created = await db.express.create(
+        "Issue1207OptDictDoc", {"title": "doc-b", "meta": payload}
+    )
+
+    assert isinstance(
+        created["meta"], dict
+    ), f"create() leaked {type(created['meta']).__name__}: {created['meta']!r}"
+    assert created["meta"] == payload
+
+    fetched = await db.express.read("Issue1207OptDictDoc", created["id"])
+    assert isinstance(
+        fetched["meta"], dict
+    ), f"read() leaked {type(fetched['meta']).__name__}: {fetched['meta']!r}"
+    assert fetched["meta"] == payload
+    assert fetched["meta"]["nested"] == {"k": "v"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_optional_list_none_value_stays_none(test_suite):
+    """Optional[list] = None with a None value stays None (no crash, not "null")."""
+    db = DataFlow(test_suite.config.url, auto_migrate=True)
+
+    @db.model
+    class Issue1207OptListNoneDoc:
+        title: str
+        tags: Optional[list] = None
+
+    await db.initialize()
+
+    created = await db.express.create(
+        "Issue1207OptListNoneDoc", {"title": "doc-c", "tags": None}
+    )
+    assert created["tags"] is None, f"None leaked as {created['tags']!r}"
+
+    fetched = await db.express.read("Issue1207OptListNoneDoc", created["id"])
+    assert fetched["tags"] is None, f"None leaked as {fetched['tags']!r}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_pep604_list_or_none_nonempty_roundtrip_returns_python_list(test_suite):
+    """PEP 604 ``list | None`` (Python 3.10+) round-trips the same as Optional[list].
+
+    ``list | None`` produces a ``types.UnionType`` whose ``typing.get_origin``
+    returns ``types.UnionType`` (NOT ``typing.Union``), so the unwrap MUST handle
+    both spellings.
+    """
+    db = DataFlow(test_suite.config.url, auto_migrate=True)
+
+    @db.model
+    class Issue1207Pep604Doc:
+        title: str
+        labels: list | None = None  # PEP 604 union — distinct origin from Optional
+
+    await db.initialize()
+
+    payload = ["x", "y", "z"]  # NON-EMPTY
+    created = await db.express.create(
+        "Issue1207Pep604Doc", {"title": "doc-d", "labels": payload}
+    )
+    assert isinstance(
+        created["labels"], list
+    ), f"create() leaked {type(created['labels']).__name__}: {created['labels']!r}"
+    assert created["labels"] == payload
+
+    fetched = await db.express.read("Issue1207Pep604Doc", created["id"])
+    assert isinstance(
+        fetched["labels"], list
+    ), f"read() leaked {type(fetched['labels']).__name__}: {fetched['labels']!r}"
+    assert fetched["labels"] == payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+@pytest.mark.regression
+async def test_plain_list_dict_fields_unaffected(test_suite):
+    """No behavior change for plain (non-Optional) list/dict fields."""
+    db = DataFlow(test_suite.config.url, auto_migrate=True)
+
+    @db.model
+    class Issue1207PlainDoc:
+        title: str
+        tags: list  # plain list — must keep working exactly as before
+        meta: dict  # plain dict — must keep working exactly as before
+
+    await db.initialize()
+
+    tags = ["one", "two"]
+    meta = {"a": 1, "b": [2, 3]}
+    created = await db.express.create(
+        "Issue1207PlainDoc", {"title": "doc-e", "tags": tags, "meta": meta}
+    )
+    assert created["tags"] == tags and isinstance(created["tags"], list)
+    assert created["meta"] == meta and isinstance(created["meta"], dict)
+
+    fetched = await db.express.read("Issue1207PlainDoc", created["id"])
+    assert fetched["tags"] == tags and isinstance(fetched["tags"], list)
+    assert fetched["meta"] == meta and isinstance(fetched["meta"], dict)

--- a/packages/kailash-dataflow/tests/unit/core/test_issue_1207_unwrap_optional_type.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_issue_1207_unwrap_optional_type.py
@@ -1,0 +1,75 @@
+"""Tier-1 unit tests for the Optional/Union unwrap behind issue #1207.
+
+``_deserialize_json_fields`` skipped ``json.loads`` for ``Optional[list]`` /
+``Optional[dict]`` JSONB fields because the declared annotation is a Union, not
+the bare ``list``/``dict`` type, so the ``field_type in (dict, list)`` membership
+check was False. The fix routes the declared annotation through
+``_unwrap_optional_type`` before the membership check.
+
+These tests exercise that helper directly (no DB) and prove the unwrap collapses
+all four declaration forms the bug spec requires — ``Optional[list]``,
+``Optional[dict]``, ``typing.Union[..., None]``, and PEP 604 ``X | None`` — to
+the bare type the membership check expects, while leaving plain types,
+multi-arg unions, and non-union annotations unchanged. The full Tier-2 DB
+round-trip lives in tests/regression/test_issue_1207_optional_jsonb_roundtrip.py.
+"""
+
+from typing import Optional, Union
+
+import pytest
+
+from dataflow.core.nodes import _unwrap_optional_type
+
+
+@pytest.mark.unit
+class TestUnwrapOptionalTypeIssue1207:
+    """The membership check `field_type in (dict, list)` must see the bare type."""
+
+    def test_optional_list_unwraps_to_list(self):
+        assert _unwrap_optional_type(Optional[list]) is list
+        assert _unwrap_optional_type(Optional[list]) in (dict, list)
+
+    def test_optional_dict_unwraps_to_dict(self):
+        assert _unwrap_optional_type(Optional[dict]) is dict
+        assert _unwrap_optional_type(Optional[dict]) in (dict, list)
+
+    def test_typing_union_list_none_unwraps_to_list(self):
+        assert _unwrap_optional_type(Union[list, None]) is list
+
+    def test_typing_union_dict_none_unwraps_to_dict(self):
+        assert _unwrap_optional_type(Union[dict, None]) is dict
+
+    def test_pep604_list_or_none_unwraps_to_list(self):
+        # `list | None` produces a types.UnionType, NOT typing.Union — the unwrap
+        # MUST handle both origins (the second half of the #1207 fix).
+        assert _unwrap_optional_type(list | None) is list
+        assert _unwrap_optional_type(list | None) in (dict, list)
+
+    def test_pep604_dict_or_none_unwraps_to_dict(self):
+        assert _unwrap_optional_type(dict | None) is dict
+        assert _unwrap_optional_type(dict | None) in (dict, list)
+
+    def test_plain_list_passes_through_unchanged(self):
+        assert _unwrap_optional_type(list) is list
+
+    def test_plain_dict_passes_through_unchanged(self):
+        assert _unwrap_optional_type(dict) is dict
+
+    def test_non_json_type_unchanged_and_not_in_membership(self):
+        # A plain str field must NOT be treated as a JSON column.
+        assert _unwrap_optional_type(str) is str
+        assert _unwrap_optional_type(str) not in (dict, list)
+        assert _unwrap_optional_type(Optional[str]) is str
+        assert _unwrap_optional_type(Optional[str]) not in (dict, list)
+
+    def test_multi_arg_union_unchanged(self):
+        # Only single-non-None-arg unions collapse; a genuine multi-type union
+        # must pass through untouched so it does not spuriously match.
+        annotation = Union[list, dict]
+        assert _unwrap_optional_type(annotation) == annotation
+        assert _unwrap_optional_type(annotation) not in (dict, list)
+
+    def test_none_annotation_unchanged(self):
+        # field_info.get("type") returns None when type is absent — must not crash.
+        assert _unwrap_optional_type(None) is None
+        assert _unwrap_optional_type(None) not in (dict, list)

--- a/packages/kailash-dataflow/tests/unit/core/test_issue_1207_unwrap_optional_type.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_issue_1207_unwrap_optional_type.py
@@ -73,3 +73,59 @@ class TestUnwrapOptionalTypeIssue1207:
         # field_info.get("type") returns None when type is absent — must not crash.
         assert _unwrap_optional_type(None) is None
         assert _unwrap_optional_type(None) not in (dict, list)
+
+
+@pytest.mark.unit
+class TestConvertDatetimeFieldsOptionalIssue1207Sibling:
+    """#1207 sibling: convert_datetime_fields must parse nullable-datetime fields.
+
+    The datetime-parse path in convert_datetime_fields previously unwrapped only
+    the classic ``Optional[datetime]`` form (via ``field_type.__origin__ is
+    typing.Union``). A PEP 604 ``datetime | None`` is a ``types.UnionType`` with
+    NO ``__origin__`` attribute, so the unwrap was skipped and the ISO string was
+    returned unparsed. Routing through ``_unwrap_optional_type`` (same helper as
+    the JSONB fix) covers both spellings. Same bug class as #1207, fixed in the
+    same shard per autonomous-execution Rule 4.
+    """
+
+    @staticmethod
+    def _convert(field_type, iso_value="2024-01-01T12:00:00"):
+        import logging
+
+        from dataflow.core.nodes import convert_datetime_fields
+
+        out = convert_datetime_fields(
+            {"ts": iso_value},
+            {"ts": {"type": field_type}},
+            logging.getLogger("test_issue_1207_sibling"),
+        )
+        return out["ts"]
+
+    def test_classic_optional_datetime_parses(self):
+        import datetime as _dt
+        from typing import Optional
+
+        result = self._convert(Optional[_dt.datetime])
+        assert isinstance(
+            result, _dt.datetime
+        ), f"Optional[datetime] field left ISO string unparsed: {result!r}"
+
+    def test_pep604_datetime_or_none_parses(self):
+        # The sibling bug: `datetime | None` (types.UnionType, no __origin__).
+        import datetime as _dt
+
+        result = self._convert(_dt.datetime | None)
+        assert isinstance(
+            result, _dt.datetime
+        ), f"PEP 604 'datetime | None' field left ISO string unparsed: {result!r}"
+
+    def test_bare_datetime_still_parses(self):
+        import datetime as _dt
+
+        result = self._convert(_dt.datetime)
+        assert isinstance(result, _dt.datetime)
+
+    def test_non_datetime_field_untouched(self):
+        # A str field must NOT be coerced to datetime even with an ISO-ish value.
+        result = self._convert(str, iso_value="2024-01-01T12:00:00")
+        assert result == "2024-01-01T12:00:00"


### PR DESCRIPTION
## Summary

`db.express.create` / `db.express.read` returned a JSON-encoded `str` instead of
the deserialized Python `list`/`dict` for model fields declared `Optional[list]`
/ `Optional[dict]` (the idiomatic nullable-JSONB-column annotation). The DB write
path was correct (the column held a real JSONB array), but the read path leaked
the raw string — and a downstream `result["tags"][0]["label"]` then hit
`TypeError: string indices must be integers`.

Root cause: `_deserialize_json_fields` (`packages/kailash-dataflow/src/dataflow/core/nodes.py`)
checked `field_type in (dict, list)` against the raw declared annotation. For
`Optional[list]` the annotation is `Union[list, None]` (or PEP 604 `list | None`,
a `types.UnionType`) — NOT the bare `list` class — so the membership test was
`False`, `json.loads` was skipped, and the raw string was returned verbatim.

Fix: new helper `_unwrap_optional_type` collapses single-non-None-arg unions
(`Optional[T]`, `Union[T, None]`, PEP 604 `T | None`) to the bare `T` before the
membership check. Routed through:
- `_deserialize_json_fields` — the single read/create deserialization chokepoint
  (all 13 create/read/list/bulk call sites benefit from the one fix)
- `convert_datetime_fields` — the same `__origin__ is Union` blindness affected
  nullable `datetime | None` fields (proactively fixed in the same change)

Multi-arg unions (`Union[list, dict]`) and non-union annotations pass through
unchanged, so plain `list`/`dict` fields and `str` fields behave exactly as before.

## Related issues

Fixes #1207

## Verification (ground-truth, no mocking)

Tier-1 helper unit tests (run against the worktree's fixed dataflow src):

```
$ PYTHONPATH=packages/kailash-dataflow/src python -m pytest \
    packages/kailash-dataflow/tests/unit/core/test_issue_1207_unwrap_optional_type.py -q
15 passed
```

These exercise `_unwrap_optional_type` directly across all four declaration forms
(`Optional[list]`, `Optional[dict]`, `Union[T, None]`, PEP 604 `T | None`) plus
the pass-through cases (plain types, multi-arg unions, non-unions).

Tier-2 round-trip (`tests/regression/test_issue_1207_optional_jsonb_roundtrip.py`)
runs against real PostgreSQL in CI — 5 tests using NON-EMPTY values (per the issue:
empty list/dict hides the bug since `json.loads("[]") == []`), covering
`Optional[list]`, `Optional[dict]`, PEP 604 `list | None`, `None`-stays-`None`,
and plain-`list`/`dict`-unaffected.

## Convergence

Reviewer + security mechanical sweeps run inline (independent gate-review subagents
were infra-throttled this cycle):
- **Chokepoint + sibling-site sweep:** `_deserialize_json_fields` is the single
  JSON-field deserializer (13 call sites); no parallel deserializer bypasses the
  unwrap. Other PEP604-blind `__origin__ is Union` sites (`_normalize_type_annotation`,
  the BUG #514 is_optional detection, `type_processor.py:126`,
  `fk_aware_model_integration.py:407`) are a **distinct bug class** in separate
  subsystems (SQL-type inference / validation / FK migration) → tracked as a
  separate follow-up, not bundled here.
- **Version-safety:** `types.UnionType` + `get_origin`-on-PEP604 exist since 3.10;
  `requires-python = ">=3.11"` → no guard needed.
- **Security:** read-path deserialization only; does NOT weaken the str-field
  type-confusion guard on the write/sanitize path; `json.loads` runs on
  SDK-written DB data (no new attack surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)