### PR TITLE
chore(deploy): record kailash-dataflow 2.10.2 (#1228, #753, #979)

### DIFF
--- a/deploy/deployments/2026-06-01-dataflow-v2.10.2-1228-753-979.md
+++ b/deploy/deployments/2026-06-01-dataflow-v2.10.2-1228-753-979.md
@@ -1,0 +1,86 @@
+# Deployment Record — kailash-dataflow 2.10.2 (2026-06-01)
+
+## Summary
+
+Single-package release: **kailash-dataflow 2.10.2**. PEP 604 `T | None` union
+recognition across DataFlow type-introspection paths (#1228, sibling of #1207),
+plus the async-first psycopg2 dependency-classification correction (#753) and a
+Tier-1 bare-runtime-import fix (#979).
+
+## What shipped
+
+### #1228 — PEP 604 `T | None` recognized across type-introspection (primary)
+
+Sibling of #1207. #1207 fixed only the JSONB read-path deserializer; the same
+two-spelling gap (`origin is Union` / `__origin__ is Union` without matching
+`types.UnionType`) lived in 9 other introspection sites across 5 modules. A
+PEP 604 `tags: list | None` field — `get_origin` → `types.UnionType`, no
+`__origin__` attribute — was silently mishandled (SQL-type inference, param
+generation, schema-nullable detection, validation optionality, type coercion).
+
+Fixed sites:
+
+- `core/nodes.py` — `_normalize_id_type`, `_normalize_type_annotation`, `is_optional` gate (#514)
+- `core/type_processor.py` — `validate_field` complex-union pass-through
+- `core/schema.py` — `_parse_field` nullable detection
+- `core/engine.py` — `_python_type_to_sql_type`
+- `validation/model_validator.py` — `validate_primary_key` Optional-id rejection + `validate_field_types` base-type unwrap
+- `migrations/fk_aware_model_integration.py` — `_is_nullable_field`
+
+The four `__origin__`-gated sites were converted to `get_origin`/`get_args`
+(a `types.UnionType` has no `__origin__`).
+
+### #753 — psycopg2 classified as async-first opt-in extra
+
+Verified (against import sites, not the test's stale claim): DataFlow is
+async-first — asyncpg is the baseline driver; psycopg2 is needed ONLY on the
+sync PostgreSQL DDL path (`SyncDDLExecutor`, opt-in via sync `create_tables()`).
+The #890 dependency-slimming audit correctly moved psycopg2-binary to the
+`postgres-sync` extra; the #753 regression test still asserted the pre-#890
+baseline placement and so failed on main. Corrected the test to guard the
+`postgres-sync` extra (+ a new inverse guard locking psycopg2-binary OUT of
+baseline). The `SyncDDLExecutor` ImportError and `pool_utils` probe warning now
+direct users to `pip install "kailash-dataflow[postgres-sync]"`.
+
+### #979 — Tier-1 bare-runtime-import fix
+
+`tests/unit/test_protection_system_critical_gaps.py` had a module-scope
+`from kailash.runtime.async_local import AsyncLocalRuntime` flagged by the
+Tier-1 no-bare-runtime-import guard. Moved function-local to its only use site.
+
+## Tests
+
+- Tier-1: `tests/unit/core/test_issue_1228_pep604_union_introspection.py` (12, one per fixed path)
+- Tier-2 (real PostgreSQL): `tests/regression/test_issue_1228_pep604_union_roundtrip.py` (2 — PEP 604 `@db.model` auto-migrate + round-trip + NULL)
+- #753: `tests/regression/test_issue_753_psycopg2_dep_declared.py` (4, extra-declaration + baseline-exclusion + import-chain skip-aware)
+
+## Pipeline
+
+- PR: #1230 (branch `fix/1228-pep604-union-introspection`, 2 atomic commits: `d66fb00` #1228, `fc8f4f81` #753/#979)
+- Merge: `578175040` (admin-merge, CI green — Python 3.11/3.12/3.13/3.14, DataFlow Tier-1, PACT, CodeQL, infrastructure all pass)
+- Tag: `dataflow-v2.10.2` → publish-pypi.yml run `26737401082` (success, OIDC trusted-publisher)
+- Gate reviews: reviewer (clean, no blocking); security-reviewer (APPROVED, zero findings)
+
+## Verification (clean-venv done-gate)
+
+```
+$ uv pip install "kailash-dataflow==2.10.2"   # clean venv, no editable
+$ python -c "import dataflow; print(dataflow.__version__)"  → 2.10.2
+  PEP604 T|None recognition (clean venv): OK — id-unwrap + schema-nullable
+  async-first baseline confirmed: asyncpg present, psycopg2 absent (opt-in via [postgres-sync])
+```
+
+PyPI: `kailash_dataflow-2.10.2-py3-none-any.whl` published. (`info.version`
+"latest" field showed cache-lag to 2.10.1 immediately post-publish; the
+`/2.10.2/json` endpoint + clean-install resolution are the authoritative
+confirmation — documented lag per build-repo-release-discipline.)
+
+## Release scope
+
+Only kailash-dataflow needed release; all sibling packages (kailash 2.28.3,
+nexus, kaizen, mcp, ml, align, pact) at PyPI parity — no sibling drift to sweep.
+
+## Cross-SDK
+
+#1228: N/A — PEP 604 `T | None` is Python-syntax-specific; Rust's `Option<T>`
+is a single nominal type with no two-spelling union-introspection analog.


### PR DESCRIPTION
Deploy record for the kailash-dataflow 2.10.2 release (PEP 604 type-introspection #1228 + psycopg2 async-first extra classification #753 + Tier-1 import-hygiene #979). Docs-only (deploy/**); build-repo-release Rule 1a carve-out — no /release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)