### PR TITLE
fix(dataflow): normalize PEP 604 union field types consistently (#1228 / F34)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.10.3] — 2026-06-01 — PEP 604 union field-type normalization parity (#1228 / F34)
+
+### Fixed
+
+- **`ModelRegistry._normalize_field_type` normalizes PEP 604 `X | None` unions identically to the `typing` spelling (#1228 follow-up, F34)** — the type-string normalizer (used for schema storage + change-detection) returned the alias name (`"Optional"` / `"Union"`) for `typing.Optional[int]` / `Union[int, str]` but fell to the `str()` fallback (`"int | None"` / `"int | str"`) for the PEP 604 `types.UnionType` spelling, because a `types.UnionType` has no `__name__` or `__origin__`. A model author switching annotation style (`Optional[int]` → `int | None`) would then see a spurious field-type change in schema comparison. The normalizer now detects `types.UnionType` and mirrors typing's naming exactly: a 2-arg `X | None` → `"Optional"`, every other union → `"Union"`. Tier-1: 5 added parity tests in `tests/unit/core/test_issue_1228_pep604_union_introspection.py`.
+
 ## [2.10.2] — 2026-06-01 — PEP 604 `T | None` recognized across type-introspection paths (#1228)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.10.2"
+version = "2.10.3"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.10.2"
+__version__ = "2.10.3"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/model_registry.py
+++ b/packages/kailash-dataflow/src/dataflow/core/model_registry.py
@@ -11,11 +11,12 @@ import hashlib
 import json
 import logging
 import threading
+import types
 import uuid
 import warnings
 from contextlib import contextmanager
 from datetime import UTC, datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, get_args
 
 try:
     from kailash.nodes.data.sql import SQLDatabaseNode
@@ -1228,6 +1229,20 @@ class ModelRegistry:
                 return origin.__name__
             else:
                 return f"{origin.__module__}.{origin.__name__}"
+        elif isinstance(field_type, types.UnionType):
+            # PEP 604 ``X | Y`` unions (e.g. ``int | None``) have no ``__name__``
+            # / ``__origin__``, so without this branch they fall to the
+            # ``str(field_type)`` fallback ("int | None") — diverging from the
+            # ``typing.Optional[int]`` / ``Union[int, None]`` spelling, which
+            # normalizes to "Optional" (or "Union") via the ``__name__`` branch
+            # above. Mirror that naming EXACTLY so a field declared ``int | None``
+            # normalizes identically to ``Optional[int]`` and a spelling switch
+            # is not seen as a schema change (issue #1228 / F34). typing names a
+            # 2-arg ``Union[X, None]`` "Optional" and every other union "Union".
+            args = get_args(field_type)
+            if len(args) == 2 and type(None) in args:
+                return "Optional"
+            return "Union"
         else:
             # Fallback to string representation
             return str(field_type)

--- a/packages/kailash-dataflow/tests/unit/core/test_issue_1228_pep604_union_introspection.py
+++ b/packages/kailash-dataflow/tests/unit/core/test_issue_1228_pep604_union_introspection.py
@@ -144,3 +144,47 @@ class TestTypeProcessorIssue1228:
         assert tp._resolved_types["x"] == (int | str)
         # Pass-through: a str value against int|str is returned unchanged.
         assert tp.validate_field("x", "hello") == "hello"
+
+
+@pytest.mark.unit
+class TestModelRegistryNormalizeFieldTypeIssue1228:
+    """ModelRegistry._normalize_field_type normalizes PEP 604 unions consistently.
+
+    Sibling of the #1228 introspection sweep (F34): the type-string normalizer used
+    for schema storage / change-detection returned the alias ``__name__`` ("Optional"
+    / "Union") for the ``typing`` spelling but fell to ``str(field_type)``
+    ("int | None") for the PEP 604 spelling. A user switching annotation style would
+    then see a spurious schema-type change. The fix mirrors typing's naming exactly
+    for ``types.UnionType``: a 2-arg ``X | None`` -> "Optional", every other union ->
+    "Union".
+    """
+
+    from typing import Union
+
+    def _norm(self, t):
+        from dataflow.core.model_registry import ModelRegistry
+
+        return ModelRegistry._normalize_field_type(object(), t)
+
+    def test_pep604_optional_matches_typing_optional(self):
+        assert self._norm(int | None) == self._norm(Optional[int]) == "Optional"
+
+    def test_pep604_optional_list_matches_typing(self):
+        assert self._norm(list | None) == self._norm(Optional[list]) == "Optional"
+
+    def test_pep604_multiarg_union_matches_typing_union(self):
+        from typing import Union
+
+        assert self._norm(int | str) == self._norm(Union[int, str]) == "Union"
+
+    def test_pep604_union_with_none_is_union_not_optional(self):
+        # typing names only the 2-arg Union[X, None] "Optional"; a 3-arg union
+        # (even with None) is "Union" — mirror that exactly.
+        from typing import Union
+
+        assert (
+            self._norm(int | str | None) == self._norm(Union[int, str, None]) == "Union"
+        )
+
+    def test_plain_type_unchanged(self):
+        assert self._norm(int) == "int"


### PR DESCRIPTION
## Summary

Follow-up to #1228 (forest item **F34**, surfaced by the #1228 reviewer). `ModelRegistry._normalize_field_type` — the type→string normalizer used for schema storage + change-detection — returned the alias name (`"Optional"` / `"Union"`) for the `typing` spelling but fell to `str(field_type)` (`"int | None"`) for the PEP 604 `types.UnionType` spelling (which has neither `__name__` nor `__origin__`). A model author switching annotation style (`Optional[int]` → `int | None`) would see a **spurious field-type change** in schema comparison.

**Fix:** detect `types.UnionType` and mirror typing's naming exactly — 2-arg `X | None` → `"Optional"`, every other union → `"Union"`.

Verified parity:

| typing | PEP 604 | normalized |
|---|---|---|
| `Optional[int]` | `int \| None` | `"Optional"` |
| `Optional[list]` | `list \| None` | `"Optional"` |
| `Union[int, str]` | `int \| str` | `"Union"` |
| `Union[int, str, None]` | `int \| str \| None` | `"Union"` |

Bumps kailash-dataflow → **2.10.3**.

## Tests
5 parity tests added to `tests/unit/core/test_issue_1228_pep604_union_introspection.py` (17 total). No existing test asserted the old `str()` fallback output.

## Security
N/A by inspection — pure type-string normalization (`isinstance` + `get_args` + return literal); no I/O, injection surface, or secrets.

## Related issues
Follow-up to #1228 (F34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)