### PR TITLE
chore(deploy): record kailash-dataflow 2.10.3 (#1228 / F34)

### DIFF
--- a/deploy/deployments/2026-06-01-dataflow-v2.10.3-f34.md
+++ b/deploy/deployments/2026-06-01-dataflow-v2.10.3-f34.md
@@ -1,0 +1,56 @@
+# Deployment Record — kailash-dataflow 2.10.3 (2026-06-01)
+
+## Summary
+
+Single-package patch: **kailash-dataflow 2.10.3**. Closes forest item **F34** —
+the last PEP 604-vs-`typing` divergence in DataFlow type-introspection, surfaced
+by the #1228 reviewer. Follow-up to 2.10.2 (#1228).
+
+## What shipped
+
+`ModelRegistry._normalize_field_type` (the type→string normalizer for schema
+storage + change-detection) returned the alias name (`"Optional"` / `"Union"`)
+for the `typing` spelling but fell to `str(field_type)` (`"int | None"`) for the
+PEP 604 `types.UnionType` spelling — a `UnionType` has neither `__name__` nor
+`__origin__`, so it bypassed every branch above the `str()` fallback. A model
+author switching annotation style (`Optional[int]` → `int | None`) would see a
+spurious field-type change in schema comparison.
+
+Fix: new `elif isinstance(field_type, types.UnionType)` branch mirroring typing's
+naming EXACTLY — a 2-arg `X | None` → `"Optional"`, every other union → `"Union"`
+(typing names only the 2-arg `Union[X, None]` "Optional"; 3-arg `Union[X,Y,None]`
+is "Union"). The branch is placed after `hasattr(__origin__)` and before the
+`else` fallback; a `types.UnionType` can only reach it (no earlier branch catches
+it), so the existing typing-spelling path is unchanged.
+
+## Tests
+
+5 Tier-1 parity tests added to
+`tests/unit/core/test_issue_1228_pep604_union_introspection.py` (17 total). No
+existing test asserted the old `str()` fallback output.
+
+## Pipeline
+
+- PR: #1232 (branch `fix/f34-pep604-normalize-parity`, commit `f1c17adde`)
+- Merge: admin-merge (CI green — Python 3.11/3.12/3.13/3.14, DataFlow Tier-1, PACT, CodeQL, infrastructure; 18 checks pass)
+- Tag: `dataflow-v2.10.3` → publish-pypi.yml (success, OIDC trusted-publisher)
+- Gate review: reviewer (clean — no CRIT/HIGH/MED; one cosmetic LOW deferred: redundant test-only import). Security: N/A by inspection (pure type-string normalization — `isinstance` + `get_args` + literal return; no I/O, injection, or secrets).
+
+## Verification (clean-venv done-gate)
+
+```
+$ uv pip install "kailash-dataflow==2.10.3"   # clean venv, no editable
+$ python -c "import dataflow; print(dataflow.__version__)"  → 2.10.3
+  F34 parity: int|None == Optional[int] == "Optional"; int|str == Union[int,str] == "Union" — OK
+```
+
+PyPI: `kailash_dataflow-2.10.3-py3-none-any.whl` published.
+
+## Release scope
+
+Only kailash-dataflow needed release; all sibling packages at PyPI parity.
+
+## Cross-SDK
+
+N/A — PEP 604 `T | None` is Python-syntax-specific; no Rust analog (same
+disposition as #1228).


### PR DESCRIPTION
Deploy record for the kailash-dataflow 2.10.3 release (PEP 604 union field-type normalization parity, F34). Docs-only; build-repo-release Rule 1a carve-out — no /release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)