### PR TITLE
chore(deps): refresh stale uv.lock to current editable versions

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1772,7 +1772,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.21.0"
+version = "2.28.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2097,7 +2097,7 @@ provides-extras = ["rlhf", "eval", "serve", "online", "rl-bridge", "all", "dev"]
 
 [[package]]
 name = "kailash-dataflow"
-version = "2.9.9"
+version = "2.10.3"
 source = { editable = "packages/kailash-dataflow" }
 dependencies = [
     { name = "asyncpg" },
@@ -2135,7 +2135,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'cloud'", specifier = ">=2.18" },
     { name = "httpx", marker = "extra == 'fabric'", specifier = ">=0.27" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
-    { name = "kailash", specifier = ">=2.18.0" },
+    { name = "kailash", specifier = ">=2.28.0" },
     { name = "kailash", extras = ["server"], marker = "extra == 'dev'" },
     { name = "kailash-dataflow", extras = ["fabric", "cloud", "excel", "parquet", "streaming"], marker = "extra == 'fabric-all'" },
     { name = "kailash-dataflow", extras = ["postgres-sync", "mysql", "sqlite", "mongo", "redis", "api", "security", "monitoring", "templates", "fabric-all"], marker = "extra == 'all'" },
@@ -2165,10 +2165,11 @@ provides-extras = ["postgres-sync", "mysql", "sqlite", "mongo", "redis", "api", 
 
 [[package]]
 name = "kailash-kaizen"
-version = "2.21.0"
+version = "2.24.5"
 source = { editable = "packages/kailash-kaizen" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiosqlite" },
     { name = "anyio" },
     { name = "cryptography" },
     { name = "httpx" },
@@ -2184,7 +2185,6 @@ cache = [
     { name = "redis" },
 ]
 db = [
-    { name = "aiosqlite" },
     { name = "asyncpg" },
 ]
 observability = [
@@ -2202,14 +2202,16 @@ providers-google = [
     { name = "google-genai" },
 ]
 rag = [
+    { name = "networkx" },
     { name = "numpy" },
     { name = "pillow" },
+    { name = "requests" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "aiosqlite", marker = "extra == 'db'", specifier = ">=0.19.0" },
+    { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "arxiv", marker = "extra == 'research'", specifier = ">=2.0" },
     { name = "asyncpg", marker = "extra == 'db'", specifier = ">=0.28.0" },
@@ -2230,9 +2232,10 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'providers-google'", specifier = ">=1.21.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12" },
-    { name = "kailash", specifier = ">=2.16.0" },
+    { name = "kailash", specifier = ">=2.28.0" },
     { name = "kailash-kaizen", extras = ["providers-azure", "providers-google", "providers-tokens", "providers-http", "server", "observability", "db", "cache", "rag", "research-validator"], marker = "extra == 'all'" },
     { name = "kailash-mcp", specifier = ">=0.2.4" },
+    { name = "networkx", marker = "extra == 'rag'", specifier = ">=3.0" },
     { name = "numpy", marker = "extra == 'rag'", specifier = ">=1.24.0" },
     { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'observability'", specifier = ">=1.20.0" },
@@ -2247,6 +2250,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "redis", marker = "extra == 'cache'", specifier = ">=5.0.0" },
     { name = "requests", marker = "extra == 'providers-http'", specifier = ">=2.32" },
+    { name = "requests", marker = "extra == 'rag'", specifier = ">=2.32" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "rouge-score", marker = "extra == 'evaluation'", specifier = ">=0.1.2" },
     { name = "rouge-score", marker = "extra == 'judges'", specifier = ">=0.1.2" },
@@ -2402,7 +2406,7 @@ provides-extras = ["dl", "dl-gpu", "rl", "rl-offline", "rl-envpool", "rl-distrib
 
 [[package]]
 name = "kailash-nexus"
-version = "2.6.3"
+version = "2.8.0"
 source = { editable = "packages/kailash-nexus" }
 dependencies = [
     { name = "aiofiles" },
@@ -2414,7 +2418,10 @@ dependencies = [
     { name = "httpx" },
     { name = "janus" },
     { name = "kailash" },
+    { name = "puremagic", version = "1.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "puremagic", version = "2.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pyjwt" },
+    { name = "python-multipart" },
     { name = "requests" },
     { name = "sqlalchemy" },
     { name = "starlette" },
@@ -2432,13 +2439,15 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "janus", specifier = ">=1.0" },
-    { name = "kailash", specifier = ">=2.16.0" },
+    { name = "kailash", specifier = ">=2.28.1" },
     { name = "prometheus-client", marker = "extra == 'metrics'", specifier = ">=0.20" },
+    { name = "puremagic", specifier = ">=1.0" },
     { name = "pyjwt", specifier = ">=2.8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-httpserver", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "requests", specifier = ">=2.28" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "starlette", specifier = ">=0.36.0" },
@@ -2487,7 +2496,7 @@ provides-extras = ["api", "execution", "dev", "all"]
 
 [[package]]
 name = "kaizen-agents"
-version = "0.9.7"
+version = "0.9.8"
 source = { editable = "packages/kaizen-agents" }
 dependencies = [
     { name = "httpx" },
@@ -4052,6 +4061,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/77/21b0ea2e1a73aa5fa9222b2a6b8ba325c43c3a8d54272839c991f2345656/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b", size = 3044737, upload-time = "2025-10-30T02:55:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/67/69/f36abe5f118c1dca6d3726ceae164b9356985805480731ac6712a63f24f0/psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d", size = 3347643, upload-time = "2025-10-10T11:13:53.499Z" },
     { url = "https://files.pythonhosted.org/packages/e1/36/9c0c326fe3a4227953dfb29f5d0c8ae3b8eb8c1cd2967aa569f50cb3c61f/psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316", size = 2803913, upload-time = "2025-10-10T11:13:57.058Z" },
+]
+
+[[package]]
+name = "puremagic"
+version = "1.30"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version < '3.12' and platform_machine != 's390x' and platform_machine != 'x86_64') or (python_full_version < '3.12' and platform_machine != 's390x' and sys_platform != 'darwin')",
+    "python_full_version < '3.12' and platform_machine == 's390x'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/7f/9998706bc516bdd664ccf929a1da6c6e5ee06e48f723ce45aae7cf3ff36e/puremagic-1.30.tar.gz", hash = "sha256:f9ff7ac157d54e9cf3bff1addfd97233548e75e685282d84ae11e7ffee1614c9", size = 314785, upload-time = "2025-07-04T18:48:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/ed/1e347d85d05b37a8b9a039ca832e5747e1e5248d0bd66042783ef48b4a37/puremagic-1.30-py3-none-any.whl", hash = "sha256:5eeeb2dd86f335b9cfe8e205346612197af3500c6872dffebf26929f56e9d3c1", size = 43304, upload-time = "2025-07-04T18:48:34.801Z" },
+]
+
+[[package]]
+name = "puremagic"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version >= '3.14' and platform_machine != 's390x' and platform_machine != 'x86_64') or (python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform != 'darwin')",
+    "python_full_version >= '3.14' and platform_machine == 's390x'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.13.*' and platform_machine != 's390x' and platform_machine != 'x86_64') or (python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'darwin')",
+    "python_full_version == '3.13.*' and platform_machine == 's390x'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "(python_full_version == '3.12.*' and platform_machine != 's390x' and platform_machine != 'x86_64') or (python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'darwin')",
+    "python_full_version == '3.12.*' and platform_machine == 's390x'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/74/ce5987ab9b8aec4ced06e2723ebb604205c9eb58abdad91453da93166380/puremagic-2.2.0.tar.gz", hash = "sha256:eb4bddf07c177c4b434554b92165b67449f5a51e152b976202d6254498810eef", size = 1189752, upload-time = "2026-04-08T01:39:55.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl", hash = "sha256:c4f7ed7307f056c787199acfda839555921be1df13abba61e8e6db0c787ae1d0", size = 71971, upload-time = "2026-04-08T01:39:54.169Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Regenerated the root \`uv.lock\` (\`uv lock\`) — the dev-only lockfile had lagged main since the last release cycle.

## Why
Editable pins were stale: kailash 2.21→2.28.3, kailash-dataflow 2.9.9→2.10.3, kailash-kaizen→2.24.5, kailash-nexus→2.8.0, kaizen-agents→0.9.8, plus dependency-graph additions (networkx, python-multipart, puremagic) from the merged release cycle. A stale lockfile makes a fresh \`uv sync\` resolve intermediate editable versions — harmless to PyPI consumers but confusing for dev setup.

## Scope
- `uv.lock` only (53 insertions / 10 deletions). No `pyproject.toml` / source / version-anchor changes.
- Regenerated deterministically from current `pyproject.toml` files; no PyPI-consumer impact.

## Related issues
None — standing working-tree drift cleanup (user-requested 2026-06-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)