### PR TITLE
release: kailash 2.29.0 (#1209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.29.0] - 2026-06-02
+
+### Added
+
+- **`delegate.SignedActionEnvelope` now exposes `observed_at` as a first-class field (#1209)** — a write envelope's signed timestamp was committed inside `canonical_bytes` (so verification was cryptographically sound) but was not exposed as a field, so verifying a write envelope required the caller to supply `observed_at` out-of-band; it could not be re-derived from the envelope the way the read path re-derives it from `AttestedReadReceipt.observed_at`. `SignedActionEnvelope` now carries `observed_at: datetime` (placed before the defaulted `payload` field), symmetric with `AttestedReadReceipt`, so a write envelope is independently verifiable from the envelope object alone — the verifier reconstructs `canonical_bytes` from `envelope.observed_at` + `envelope.payload` with no out-of-band timestamp. Regression: `tests/regression/test_issue_1209_action_envelope_observed_at.py` (structural symmetry with `AttestedReadReceipt`; verify-from-envelope-alone round-trip; tampered-`observed_at` fails re-derived verification; `observed_at` is required-no-default).
+
+### Changed
+
+- **BREAKING (`delegate` module, new in 2.26.0): `SignedActionEnvelope` constructor now requires `observed_at` (#1209)** — the new field is required (no default), symmetric with `AttestedReadReceipt`; a default would let an envelope ship without the committed timestamp, defeating independent verifiability. New-shape `Connector.write` implementations that construct `SignedActionEnvelope` directly MUST pass `observed_at`. **Migration:** add `observed_at=datetime.now(timezone.utc)` (or the action's actual observation time, matching the timestamp committed into `canonical_bytes`) to each `SignedActionEnvelope(...)` call. Scoped to the `delegate` module; no other public surface is affected.
+
 ## [2.28.4] - 2026-06-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.28.4"
+version = "2.29.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.28.4"
+__version__ = "2.29.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Cuts **kailash 2.29.0** carrying the #1209 delegate change (merged via #1237): `SignedActionEnvelope` exposes `observed_at` as a first-class field, symmetric with `AttestedReadReceipt` — write envelopes are now independently verifiable from the envelope object alone.

Metadata-only release-prep: version anchors (`pyproject.toml` + `src/kailash/__init__.py` → 2.29.0) + CHANGELOG. Branch is `release/v*` so the PR-gate matrix auto-skips.

## Release scope
All 8 sibling packages verified at PyPI parity (dataflow 2.10.3, nexus 2.9.0, kaizen 2.24.5, mcp 0.2.14, ml 1.7.4, align 0.7.1, pact 0.12.0, kaizen-agents 0.9.8). **kailash core is the only release this cycle.**

## Breaking change (delegate module, new in 2.26.0)
`SignedActionEnvelope` constructor now requires `observed_at`. Migration documented in CHANGELOG: add `observed_at=datetime.now(timezone.utc)` (matching the timestamp committed into `canonical_bytes`) to each `SignedActionEnvelope(...)` call. Scoped to `delegate`; no other public surface affected.

## Gate trail
- #1237 reviewed: reviewer APPROVE (zero findings, all mechanical sweeps pass) + security-reviewer APPROVE (TOCTOU handled by design — field advisory, signature authoritative).
- #1237 CI: all matrix jobs green (Python 3.11–3.14, PACT, DataFlow Tier 1, CodeQL, infra).
- TestPyPI validation + clean-venv install verification to follow the tag publish.

## Related issues
Fixes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)