### PR TITLE
chore(deploy): record kailash 2.29.0 (#1209)

### DIFF
--- a/deploy/deployments/2026-06-02-v2.29.0-issue-1209-action-envelope-observed-at.md
+++ b/deploy/deployments/2026-06-02-v2.29.0-issue-1209-action-envelope-observed-at.md
@@ -1,0 +1,69 @@
+# Deployment Record — kailash 2.29.0 (#1209)
+
+**Date:** 2026-06-02
+**Package:** kailash (Core SDK) — single-package release
+**Tag:** `v2.29.0`
+**GitHub Release:** kailash 2.29.0 (created 2026-06-02T02:01:15Z)
+
+## What shipped
+
+`delegate.SignedActionEnvelope` now exposes `observed_at` as a first-class
+`datetime` field, symmetric with `AttestedReadReceipt.observed_at` (#1209).
+
+Before this release, a write envelope's signed timestamp was committed inside
+`canonical_bytes` (cryptographically sound) but not exposed as a field — so
+verifying a write envelope required the caller to supply `observed_at`
+out-of-band; it could not be re-derived from the envelope the way the read
+path re-derives it from `receipt.observed_at`. The field is now first-class
+(placed before the defaulted `payload`), so a write envelope is independently
+verifiable from the envelope object alone: the verifier reconstructs
+`canonical_bytes` from `envelope.observed_at` + `envelope.payload` with no
+out-of-band timestamp.
+
+## Breaking change
+
+`SignedActionEnvelope` constructor now requires `observed_at` (no default,
+symmetric with `AttestedReadReceipt`; a default would let an envelope ship
+without the committed timestamp, defeating verifiability). Scoped to the
+`delegate` module (new in 2.26.0); no other public surface affected.
+Migration (CHANGELOG): add `observed_at=datetime.now(timezone.utc)` —
+matching the timestamp committed into `canonical_bytes` — to each
+`SignedActionEnvelope(...)` call.
+
+## PRs
+
+- **#1237** — `feat(delegate): expose observed_at on SignedActionEnvelope (#1209)` — code + regression test + 3 in-repo connector construction-site updates. Reviewer APPROVE (zero findings, all mechanical sweeps pass); security-reviewer APPROVE (TOCTOU handled by design — field advisory, signature authoritative, tamper fails closed). Full PR-gate matrix green (Python 3.11–3.14, PACT, DataFlow Tier 1, CodeQL, infra).
+- **#1238** — `release: kailash 2.29.0 (#1209)` — version anchors + CHANGELOG on `release/v2.29.0` (PR-gate matrix auto-skipped per convention; Build Documentation green).
+
+## Release scope verification
+
+All 8 sibling packages confirmed at PyPI parity at release time — kailash core
+was the only release this cycle:
+
+| Package          | main = PyPI |
+| ---------------- | ----------- |
+| kailash-dataflow | 2.10.3      |
+| kailash-nexus    | 2.9.0       |
+| kailash-kaizen   | 2.24.5      |
+| kailash-mcp      | 0.2.14      |
+| kailash-ml       | 1.7.4       |
+| kailash-align    | 0.7.1       |
+| kailash-pact     | 0.12.0      |
+| kaizen-agents    | 0.9.8       |
+
+## Gate trail
+
+- **TestPyPI validation** (minor-release gate per deployment.md): run 26793694870 — Build + Publish to TestPyPI success. Clean-venv install (`--index-strategy unsafe-best-match`) verified version 2.29.0 + `observed_at` first-class + symmetric with `AttestedReadReceipt`.
+- **Production PyPI publish**: run 26793759811 (tag-triggered) — Build + Publish to PyPI + Create GitHub Release success.
+- **Clean-venv install gate** (build-repo-release-discipline Rule 2): `uv pip install kailash==2.29.0` from production PyPI succeeded on retry-2 (cache lag); `import kailash` → `2.29.0`; `observed_at` present on `SignedActionEnvelope`. ALL CHECKS PASS.
+
+## Cross-SDK (cross-sdk-inspection.md)
+
+The Rust SDK (`esperie-enterprise/kailash-rs`) should be inspected for the same
+write-envelope `observed_at` exposure asymmetry. Filing requires a per-issue
+user-authorized cross-repo grant (the public `terrene-foundation/kailash-rs`
+does not exist). **Surfaced for the maintainer — not actioned this session.**
+
+## Issue
+
+Fixes #1209 (CLOSED / COMPLETED, auto-closed by #1237 merge).


### PR DESCRIPTION
Deployment record for **kailash 2.29.0** — `delegate.SignedActionEnvelope.observed_at` first-class field (#1209).

Captures: feature PR #1237 + release-prep PR #1238, the TestPyPI → prod-PyPI gate trail, the 8-package sibling-parity table (kailash core was the only release), clean-venv install verification, and the cross-SDK inspection note (rs filing needs a user-authorized grant).

Released + verified live on PyPI this session. Docs-only record; no consumer-visible artifact change.

## Related issues
Refs #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)