### PR TITLE
fix(ml): get_features without a timestamp returns latest-per-entity (#1241)

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,13 @@
 # kailash-ml Changelog
 
+## [1.7.6] — 2026-06-03 — fix: get_features without a timestamp returns latest-per-entity (#1241 follow-up)
+
+Follow-up to 1.7.5. The 1.7.5 `SchemaFeatureGroup` adapter gated its latest-per-entity dedup on `point_in_time is not None`, so `get_features(schema)` with **no** timestamp returned **every historical row** (duplicate entities) instead of the latest row per entity. The `get_features` contract is "when timestamp is None the latest values are returned" — one feature vector per entity. Caught by the 1.7.5 published-wheel end-to-end verification walk (the unit/integration tests had used one row per entity, so the dedup gap was unobservable).
+
+### Fixed
+
+- **`get_features(schema)` (no timestamp) now returns the latest row per entity (#1241).** Dedup-to-latest now runs whenever the schema declares a `timestamp_column`, realising both halves of the contract: `point_in_time` given → as-of-T value (window-bounded then deduped, unchanged); `point_in_time` None → latest value per entity. Happy-path + regression tests strengthened to use multiple observations per entity (a guard the prior tests lacked).
+
 ## [1.7.5] — 2026-06-03 — fix: canonical FeatureStore.get_features now retrieves features (#1241)
 
 The canonical 1.x feature-retrieval surface, `FeatureStore.get_features(...)`, previously raised on **every** call and is now functional. This unblocks the 2.0.0 cutover (#643 step 3), which depends on a working canonical retrieval surface.

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "1.7.5"
+version = "1.7.6"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "1.7.5"
+__version__ = "1.7.6"

--- a/packages/kailash-ml/src/kailash_ml/features/_schema_feature_group.py
+++ b/packages/kailash-ml/src/kailash_ml/features/_schema_feature_group.py
@@ -138,15 +138,21 @@ class SchemaFeatureGroup:
 
         frame = pl.DataFrame(rows)
 
-        # As-of dedup: keep the latest row per entity. The window query already
-        # bounded timestamp <= point_in_time, so "latest per entity" within the
-        # fetched rows IS the point-in-time-correct value. `nulls_last=True`
-        # ensures a row with a NULL timestamp_column can never shadow a real
-        # timestamped row (descending sort otherwise places NULLs first, where
-        # `unique(keep="first")` would pick them).
+        # Latest-per-entity dedup: keep the most recent row per entity whenever
+        # the schema declares a timestamp column. This realises BOTH halves of
+        # the get_features contract (store.py docstring):
+        #   * point_in_time given → `_query_window` already bounded the rows to
+        #     timestamp <= T, so "latest per entity" within that window IS the
+        #     point-in-time-correct value (as-of T).
+        #   * point_in_time None → "the latest values are returned": one row per
+        #     entity, the most recent. Without this, the no-timestamp path would
+        #     return every historical row (duplicate entities) — wrong for a
+        #     feature-vector retrieval.
+        # `nulls_last=True` ensures a row with a NULL timestamp_column can never
+        # shadow a real timestamped row (a descending sort otherwise places
+        # NULLs first, where `unique(keep="first")` would pick them).
         if (
-            point_in_time is not None
-            and ts_col is not None
+            ts_col is not None
             and ts_col in frame.columns
             and entity_col in frame.columns
             and frame.height

--- a/packages/kailash-ml/tests/integration/test_feature_store_get_features_wiring.py
+++ b/packages/kailash-ml/tests/integration/test_feature_store_get_features_wiring.py
@@ -66,9 +66,15 @@ def _schema() -> FeatureSchema:
 
 async def test_get_features_happy_path_returns_dataframe(churn_db: DataFlow):
     db = churn_db
+    # u1 has TWO observations — no-timestamp get_features MUST return the latest
+    # (one feature vector per entity), not every historical row.
     db.express_sync.create(
         "UserChurn",
         {"entity_id": "u1", "event_time": datetime(2026, 1, 1), "login_count_7d": 3},
+    )
+    db.express_sync.create(
+        "UserChurn",
+        {"entity_id": "u1", "event_time": datetime(2026, 2, 1), "login_count_7d": 5},
     )
     db.express_sync.create(
         "UserChurn",
@@ -81,7 +87,12 @@ async def test_get_features_happy_path_returns_dataframe(churn_db: DataFlow):
     assert isinstance(out, pl.DataFrame)
     assert "entity_id" in out.columns
     assert "login_count_7d" in out.columns
-    assert set(out["entity_id"].to_list()) == {"u1", "u2"}
+    # One row per entity (latest), NOT every historical row.
+    assert out.height == 2
+    assert sorted(out["entity_id"].to_list()) == ["u1", "u2"]
+    by_entity = {r["entity_id"]: r["login_count_7d"] for r in out.to_dicts()}
+    assert by_entity["u1"] == 5, "u1 latest (Feb=5), not the Jan row"
+    assert by_entity["u2"] == 7
 
 
 async def test_get_features_point_in_time_returns_as_of_value(churn_db: DataFlow):

--- a/packages/kailash-ml/tests/regression/test_issue_1241_get_features_returns_dataframe.py
+++ b/packages/kailash-ml/tests/regression/test_issue_1241_get_features_returns_dataframe.py
@@ -84,6 +84,35 @@ async def test_issue_1241_get_features_point_in_time_is_correct(db: DataFlow):
     ], "as-of must return latest row <= T, not after T"
 
 
+async def test_issue_1241_no_timestamp_returns_latest_per_entity(db: DataFlow):
+    """1.7.6 regression: `get_features(schema)` with NO timestamp must return
+    the LATEST row per entity (one feature vector per entity), per the
+    get_features contract ("when timestamp is None the latest values are
+    returned"). The 1.7.5 adapter gated dedup on `point_in_time is not None`,
+    so the no-timestamp path returned every historical row — duplicate
+    entities. Caught by the published-wheel end-to-end walk.
+    """
+    # Two rows for e1 (Jan score=1, Mar score=9), one for e2.
+    db.express_sync.create(
+        "Churn", {"entity_id": "e1", "event_time": datetime(2026, 1, 1), "score": 1}
+    )
+    db.express_sync.create(
+        "Churn", {"entity_id": "e1", "event_time": datetime(2026, 3, 1), "score": 9}
+    )
+    db.express_sync.create(
+        "Churn", {"entity_id": "e2", "event_time": datetime(2026, 1, 1), "score": 7}
+    )
+    store = FeatureStore(db, default_tenant_id="_single")
+
+    out = await store.get_features(_schema())  # no timestamp → latest per entity
+
+    assert out.height == 2, "must be one row per entity, not every historical row"
+    assert sorted(out["entity_id"].to_list()) == ["e1", "e2"]
+    by_entity = {r["entity_id"]: r["score"] for r in out.to_dicts()}
+    assert by_entity["e1"] == 9, "e1 latest (Mar=9), not the Jan row"
+    assert by_entity["e2"] == 7
+
+
 async def test_issue_1241_empty_table_with_entity_ids_returns_empty(db: DataFlow):
     """MED-1 regression: an empty table + entity_ids filter must return an
     empty DataFrame, not raise. The adapter's empty return must carry the


### PR DESCRIPTION
## Summary

Follow-up to the #1241 fix (kailash-ml 1.7.5). The published-wheel end-to-end verification walk caught a semantic bug that the unit/integration/regression gates missed: `get_features(schema)` with **no** timestamp returned **every historical row** (duplicate entity rows) instead of the latest row per entity.

The `get_features` contract (store.py docstring) is *"when timestamp is None the latest values are returned"* — one feature vector per entity. The 1.7.5 adapter gated its latest-per-entity dedup on `point_in_time is not None`, so the no-timestamp "latest" path skipped dedup. A feature store that returns duplicate entity rows is broken for downstream ML.

### Fix
Dedup-to-latest now runs whenever the schema declares a `timestamp_column`, realising **both** halves of the contract:
- `point_in_time` given → window-bounded (`ts <= T` in `_query_window`) then deduped = as-of-T value (**unchanged**).
- `point_in_time` None → deduped to the latest value per entity.

### Why the gates missed it (test-gap closed)
Every happy-path test used **one** row per entity, so dedup-vs-no-dedup was unobservable. The published-wheel walk used two observations for `u1` and exposed it. Tests strengthened:
- Happy-path wiring test now uses 2 rows for `u1` (asserts latest=5, height=2).
- New regression `test_issue_1241_no_timestamp_returns_latest_per_entity` — **verified to fail on the buggy guard and pass with the fix** (genuine guard, not theatre).

## User-flow walk receipt (on the published 1.7.5 wheel)
```
$ get_features(schema)                       → entities ['u1','u1','u2']  ← BUG (u1 twice)
$ get_features(schema, timestamp=2026-02-01) → u1 as-of = [1]             ← correct
```
Post-fix: `get_features(schema)` → one row per entity, latest value.

## Tests
All 39 feature-store tests pass (unit + integration + regression). Version 1.7.5 → 1.7.6 (consistent across pyproject + _version.py); CHANGELOG entry added.

## Related issues
Refs #1241 (follow-up to the 1.7.5 fix; #1241 already closed). 1.7.5 is correct for the timestamp-given case + single-row-per-entity tables; 1.7.6 supersedes it for the no-timestamp multi-row case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)