### PR TITLE
docs(deploy): record kailash-ml 1.7.5+1.7.6 release (#1241)

### DIFF
--- a/deploy/deployment-config.md
+++ b/deploy/deployment-config.md
@@ -22,7 +22,7 @@
 | kailash-kaizen   | `kaizen-v*`        | 2.20.0          |
 | kailash-nexus    | `nexus-v*`         | 2.9.0           |
 | kailash-pact     | `pact-v*`          | 0.11.0          |
-| kailash-ml       | `ml-v*`            | 1.7.2           |
+| kailash-ml       | `ml-v*`            | 1.7.6           |
 | kailash-align    | `align-v*`         | 0.7.0           |
 | kailash-mcp      | `mcp-v*`           | 0.2.12          |
 | kaizen-agents    | `kaizen-agents-v*` | 0.9.5           |

--- a/deploy/deployments/2026-06-03-ml-v1.7.5-v1.7.6-1241-featurestore-getfeatures.md
+++ b/deploy/deployments/2026-06-03-ml-v1.7.5-v1.7.6-1241-featurestore-getfeatures.md
@@ -1,0 +1,53 @@
+# Deployment Record — kailash-ml 1.7.5 + 1.7.6 (#1241)
+
+**Date:** 2026-06-03
+**Package:** kailash-ml — single-package release (two patch versions same session)
+**Tags:** `ml-v1.7.5`, `ml-v1.7.6`
+**GitHub Releases:** kailash-ml 1.7.5 + 1.7.6
+**Issue:** Fixes #1241 (closed COMPLETED on PR #1244 merge). Unblocks #643 step-3 (2.0.0 cutover).
+
+## What shipped
+
+The canonical 1.x feature-retrieval surface, `kailash_ml.features.FeatureStore.get_features(...)`, **always raised** before this work and is now functional.
+
+### Root cause (deeper than the issue stated)
+
+`get_features` forwarded a declarative `FeatureSchema` to `dataflow.ml_feature_source`, but that binding duck-types on a FeatureGroup-shaped `.materialize()` the schema does not expose. The `FeatureGroup` class is M2-deferred per `ml-feature-store.md §11` — so the canonical surface was specced against a class its own spec says doesn't exist yet, and **every call raised `FeatureStoreError`**. The two specs (`ml-feature-store.md` vs `dataflow-ml-integration.md`) contradicted each other, and `dataflow-ml-integration.md` carried a **false "verified positive end-to-end (F-E2-23)"** claim (corrected in PR #1244).
+
+### Fix (PR #1244 → 1.7.5)
+
+An internal `SchemaFeatureGroup` read adapter wraps the schema and reads the backing DataFlow table named after the schema (`schema.name` == `@db.model` name, per spec §1.1 "thin bridge, owns no DDL"). No public-API signature change. Point-in-time correctness (§6.2 MUST-1) is framework-first with no raw SQL: DataFlow pushes the `timestamp_column <= point_in_time` window down via MongoDB `$lte`; polars computes the latest-row-per-entity as-of dedup. Multi-tenant binds `db.tenant_context.switch(...)` (DataFlow-native, fail-closed under both `schema` and `row` isolation strategies).
+
+### Follow-up fix (PR #1246 → 1.7.6)
+
+The **1.7.5 published-wheel end-to-end verification walk** (build-repo-release-discipline Rule 2 / user-flow-validation) caught a semantic bug the unit/integration/regression gates + two review rounds + full CI matrix all missed: `get_features(schema)` with **no** timestamp returned **every historical row** (duplicate entity rows) instead of one latest row per entity. The contract is "when timestamp is None the latest values are returned." The 1.7.5 dedup was gated on `point_in_time is not None`; 1.7.6 runs the latest-per-entity dedup whenever the schema declares a `timestamp_column` (both the as-of and the no-timestamp cases). The test gap (every prior test used one row per entity) was closed — happy-path + regression tests now use multiple observations per entity, and the new regression was verified to fail on the buggy guard.
+
+## Gate reviews
+
+- **PR #1244 (1.7.5):** reviewer R1 (2 MED — empty+entity_ids raise, null-ts shadow) → fixed → R2 **APPROVE**; security-reviewer R1 (1 LOW — tenant strategy) → fixed (context-binding) → R2 **APPROVE**.
+- **PR #1246 (1.7.6):** reviewer **APPROVE** (full ml collection 2534 tests clean); security-reviewer **APPROVE** (zero findings).
+
+## CI + install verification
+
+Full Python 3.10–3.14 matrix green on both PRs. Tags pushed individually. publish-pypi.yml runs `26862787770` (1.7.5) + `26863453469` (1.7.6) succeeded; TestPyPI skipped per patch-release exception with human authorization.
+
+Clean-venv install verified live (`uv pip install --refresh`, 1 retry for PyPI cache lag): `kailash_ml.__version__ == "1.7.6"`. Full end-to-end walk on the **published 1.7.6 wheel** against a real SQLite DataFlow — all 4 checks pass:
+
+1. no-timestamp → one row per entity, latest value (`u1=99`, height=3).
+2. point-in-time as-of 2026-02-01 → `u1=1` (not the later 99).
+3. `entity_ids=[u1,u3]` → narrowed.
+4. empty table → empty DataFrame, no raise.
+
+## Cross-SDK
+
+The kailash-rs `FeatureStore` is a `save`/`load` artifact store (no `get_features` / `FeatureGroup` / DataFlow-bridge), so the #1241 bug class is structurally impossible there. No cross-SDK issue filed (cross-repo READ authorized + journaled per `repo-scope-discipline.md`).
+
+## Sibling drift
+
+None — at release-time enumeration all 7 other framework packages were AT-PARITY with PyPI (kailash 2.29.0, kailash-dataflow 2.10.3, kailash-nexus 2.9.0, kailash-kaizen 2.24.5, kailash-mcp 0.2.14, kailash-align 0.7.1, kailash-pact 0.12.0).
+
+## Follow-up (not blocking)
+
+- The DataFlow multi-tenant **write** path errors on a simple model (`Tenant isolation failed ... Malformed SQL: INSERT statement missing table name`), which blocks a multi-tenant Tier-2 test for get_features. Separate DataFlow concern, distinct from #1241.
+- An aiosqlite `DeprecationWarning` (default datetime adapter, Python 3.12+) fires on any DataFlow+SQLite+datetime path — pre-existing DataFlow sqlite-adapter gap, not introduced here.
+- The polars-dedup as-of materialises the `<= T` candidate window in memory (cap 1,000,000) — correct for 1.x-scale; DB-side windowed as-of is M2.


### PR DESCRIPTION
Deployment record + config version bump (1.7.2→1.7.6) for the #1241 FeatureStore.get_features fix. Docs-only (deploy/** — build-repo-release-discipline §1a carve-out; no /release needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)