### PR TITLE
chore(coc): land /sync-to-build delivery — effortLevel xhigh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "description": "Kailash COC Claude (Python) - Claude Code hooks configuration",
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1"


### PR DESCRIPTION
## Summary

SessionStart hook flagged uncommitted `.claude/settings.json` drift (`effortLevel` high→xhigh + dropped trailing newline). Per the 2026-05-02 ESCALATED directive — "ALWAYS get the updated coc artifacts INTO MAIN BRANCH" — COC artifact drift lands on main before other session work.

- Restored the dropped trailing newline (zero-tolerance: clean artifact).
- Diff is a single load-bearing line: `effortLevel` high → xhigh.

## Related issues

None — COC artifact landing per `rules/coc-sync-landing.md` MUST-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)