### PR TITLE
fix(dataflow): enforce fail-closed multi-tenant express isolation (#1249)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+## [2.11.0] — 2026-06-03 — Multi-tenant `express` cross-tenant leak fixed; fail-closed isolation (#1249)
+
+### Security
+
+- **Multi-tenant `express` CRUD now enforces strict tenant isolation (#1249, CRITICAL).** With `multi_tenant=True`, `express(.sync)` provided NO isolation: writes stored `tenant_id = NULL` and reads returned every tenant's rows (a cross-tenant data leak). Four compounding defects in the tenant-injection enforcement point (`QueryInterceptor` / `_apply_tenant_isolation`) are fixed:
+  1. The SQL-syntax validator's `\w+` table-name regexes rejected quoted identifiers (`INSERT INTO "feats" …`), so every multi-tenant write fail-closed with a `RuntimeError`. The validator now accepts quoted/bracketed/backtick identifiers across all dialects.
+  2. The INSERT injection did not match quoted identifiers, so the tenant column/value was never bound (`tenant_id = NULL`). Injection is now identifier-normalized and binds the tenant value as a **bound parameter** at the correct position.
+  3. The SELECT/UPDATE/DELETE table matcher compared the parsed (quoted) table name against the unquoted declared tenant table; the mismatch left the query **unfiltered with no error** — the silent leak. Identifier normalization closes the mismatch, and the interceptor now **fails closed** (raises `TenantIsolationError`) when a declared tenant table cannot be matched or the injection is a no-op, rather than executing an unscoped query.
+  4. `tenant_isolation_strategy` was silently dropped as an unknown constructor parameter (DF-CFG-001) and its default `"schema"` was a no-op on SQLite. It is now an accepted, validated parameter; the default is `"row"` (the strategy DataFlow actually enforces on every backend); and a `"schema"`/`"database"` strategy on a backend that cannot deliver physical isolation **fails closed at startup** with a typed `DataFlowConfigurationError` instead of silently providing no isolation.
+
+### Changed (fail-closed — may surface previously-silent misconfigurations)
+
+- A tenant-isolated model written or read under `multi_tenant=True` with **no bound tenant** now raises (`RuntimeError`) instead of silently executing an unscoped query (which previously persisted a `tenant_id = NULL` row or returned all tenants' rows). Bind a tenant via `db.tenant_context.switch(tenant_id)` before the operation. DDL / auto-migration (which run with no bound tenant) are unaffected.
+- The default `SecurityConfig.tenant_isolation_strategy` changed `"schema"` → `"row"`. `"schema"` was a no-op on SQLite (no schemas); `"row"` is enforced on all backends.
+
+### Known limitation
+
+- The **bulk** and **upsert** write paths (`bulk_create`, `bulk_update`, `bulk_upsert`, `upsert`) are **not yet tenant-isolated** under `multi_tenant=True` — tracked in #1252. These paths do not disclose cross-tenant data, but `bulk_create` currently writes unscoped (`NULL`-tenant) rows. Use single-record `express` CRUD for tenant-isolated writes until #1252 lands.
+
+### Tests
+
+- Tier-2 regression suite `tests/regression/test_issue_1249_tenant_isolation_leak.py` (19 tests: cross-tenant read/write/delete isolation, non-NULL `tenant_id`, quoted-identifier validator, fail-closed no-tenant write, strategy validation) + a PostgreSQL-marked variant. Updated `tests/integration/tenancy/test_engine_tenancy_wiring.py` for the fail-closed enforcement point.
+
 ## [2.10.3] — 2026-06-01 — PEP 604 union field-type normalization parity (#1228 / F34)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.10.3"
+version = "2.11.0"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.10.3"
+__version__ = "2.11.0"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/core/config.py
+++ b/packages/kailash-dataflow/src/dataflow/core/config.py
@@ -568,7 +568,16 @@ class SecurityConfig:
 
     # Multi-tenancy
     multi_tenant: bool = False
-    tenant_isolation_strategy: str = "schema"  # schema, row, database
+    # Issue #1249: default changed from "schema" -> "row". DataFlow's tenant
+    # isolation is implemented as row-level tenant_id filtering (injected by
+    # QueryInterceptor on every DML path) and applies on EVERY backend. The
+    # prior "schema" default was a no-op on SQLite (which has no schemas),
+    # which silently left multi-tenant SQLite deployments with NO isolation —
+    # a cross-tenant leak. "row" is the only strategy that closes the leak on
+    # every backend. {"row", "schema", "database"} are the valid values;
+    # "schema"/"database" require physical-isolation backend support and are
+    # validated (fail-closed) at DataFlow startup.
+    tenant_isolation_strategy: str = "row"  # row, schema, database
 
     # Audit
     audit_enabled: bool = True

--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -132,6 +132,15 @@ class DataFlow(DataFlowEventMixin):
         pool_recycle: int = 3600,
         echo: bool = False,
         multi_tenant: bool = False,
+        # Issue #1249: tenant_isolation_strategy is now an ACCEPTED, VALIDATED
+        # constructor parameter (previously dropped as an unknown kwarg with a
+        # DF-CFG-001 warning). Accepts {"row", "schema", "database"}; defaults
+        # to "row" (the strategy DataFlow actually implements on every backend
+        # via SQL tenant_id injection). "schema"/"database" require backend
+        # support; on a backend that cannot provide that isolation (e.g.
+        # SQLite, which has no schemas) DataFlow FAILS CLOSED at startup rather
+        # than silently no-op'ing into a cross-tenant leak.
+        tenant_isolation_strategy: Optional[str] = None,
         encryption_key: Optional[str] = None,
         audit_logging: bool = False,
         cache_enabled: Optional[
@@ -319,6 +328,13 @@ class DataFlow(DataFlowEventMixin):
             ):
                 # Zero-config mode - use from_env
                 self.config = DataFlowConfig.from_env()
+                # Issue #1249: even in zero-config mode, honor an explicit
+                # tenant_isolation_strategy override so the value is never
+                # silently dropped.
+                if tenant_isolation_strategy is not None:
+                    self.config.security.tenant_isolation_strategy = (
+                        tenant_isolation_strategy
+                    )
             else:
                 # Create structured config from individual parameters
                 database_config = DatabaseConfig(
@@ -336,11 +352,20 @@ class DataFlow(DataFlowEventMixin):
                     slow_query_threshold=slow_query_threshold,
                 )
 
-                security_config = SecurityConfig(
+                # Issue #1249: tenant_isolation_strategy flows into
+                # SecurityConfig (default "row" — the only strategy DataFlow
+                # implements on every backend). None means "use the
+                # SecurityConfig default".
+                _security_kwargs = dict(
                     multi_tenant=multi_tenant,
                     encrypt_at_rest=encryption_key is not None,
                     audit_enabled=audit_logging,
                 )
+                if tenant_isolation_strategy is not None:
+                    _security_kwargs["tenant_isolation_strategy"] = (
+                        tenant_isolation_strategy
+                    )
+                security_config = SecurityConfig(**_security_kwargs)
 
                 # Prepare config parameters
                 # FIX: CACHE_INVALIDATION_BUG_REPORT.md - enable_caching is alias for cache_enabled
@@ -394,6 +419,12 @@ class DataFlow(DataFlowEventMixin):
                 logger.warning(
                     "engine.configuration_issues_detected", extra={"issues": issues}
                 )
+
+        # Issue #1249: validate the tenant isolation strategy at startup and
+        # fail CLOSED when the configured strategy cannot provide isolation on
+        # the active backend (e.g. "schema"/"database" on SQLite). A strategy
+        # that silently no-ops is a cross-tenant leak — refuse to start.
+        self._validate_tenant_isolation_strategy()
 
         # DF-CFG-001: Validate unknown kwargs to prevent silent configuration failures
         # This catches typos and removed parameters like 'skip_registry' early
@@ -7849,6 +7880,73 @@ class DataFlow(DataFlowEventMixin):
             "delete": self._generate_delete_sql(model_name, database_type),
             "bulk": self._generate_bulk_sql(model_name, database_type),
         }
+
+    # Issue #1249: valid tenant isolation strategies. "row" is implemented on
+    # every backend (QueryInterceptor SQL injection). "schema"/"database" denote
+    # PHYSICAL isolation (separate PostgreSQL schemas / separate databases) and
+    # require backend infrastructure DataFlow does not provision itself.
+    _VALID_TENANT_ISOLATION_STRATEGIES = frozenset({"row", "schema", "database"})
+
+    def _validate_tenant_isolation_strategy(self) -> None:
+        """Validate the configured tenant isolation strategy; fail closed.
+
+        Issue #1249. Two failure-closed conditions:
+
+        1. **Unknown strategy value** — any value outside
+           {"row", "schema", "database"} raises ``DataFlowConfigurationError``
+           rather than being silently ignored (the pre-fix DF-CFG-001 drop).
+
+        2. **Strategy unsupportable on the active backend** — "schema"/"database"
+           request PHYSICAL tenant isolation (separate PostgreSQL schemas /
+           separate databases). DataFlow implements ROW-level isolation (the
+           tenant_id column filter injected by ``QueryInterceptor``) on every
+           backend, but it does NOT provision physical schema/database
+           isolation. On SQLite there is no schema concept at all. Rather than
+           silently no-op a requested physical-isolation strategy into a
+           cross-tenant leak, DataFlow refuses to start and directs the operator
+           to ``tenant_isolation_strategy="row"`` (which IS delivered).
+
+        Row-level isolation is ALWAYS applied for tenant-id-bearing models
+        regardless of the configured strategy, so the leak is closed on every
+        backend; this validation only gates the physical-isolation strategies
+        DataFlow cannot honor.
+        """
+        from .config import SecurityConfig
+
+        security = getattr(self.config, "security", None)
+        if security is None:
+            return
+        strategy = getattr(security, "tenant_isolation_strategy", "row")
+
+        # (1) Unknown value — fail closed regardless of multi_tenant.
+        if strategy not in self._VALID_TENANT_ISOLATION_STRATEGIES:
+            from dataflow.exceptions import DataFlowConfigurationError
+
+            raise DataFlowConfigurationError(
+                f"Invalid tenant_isolation_strategy={strategy!r}. "
+                f"Valid strategies: {sorted(self._VALID_TENANT_ISOLATION_STRATEGIES)}. "
+                "Use 'row' for the row-level tenant_id filtering DataFlow "
+                "implements on every backend."
+            )
+
+        # (2) Physical-isolation strategy that DataFlow cannot deliver — fail
+        # closed only when multi-tenancy is actually enabled (otherwise the
+        # strategy is inert and harmless).
+        multi_tenant = getattr(security, "multi_tenant", False) is True
+        if multi_tenant and strategy in ("schema", "database"):
+            from dataflow.exceptions import DataFlowConfigurationError
+
+            backend = self._detect_database_type()
+            raise DataFlowConfigurationError(
+                f"tenant_isolation_strategy={strategy!r} requests PHYSICAL tenant "
+                f"isolation (separate {strategy}s) which DataFlow does not "
+                f"provision on the {backend!r} backend. Refusing to start rather "
+                "than silently provide NO isolation (cross-tenant data leak). "
+                "Set tenant_isolation_strategy='row' to use the row-level "
+                "tenant_id filtering DataFlow applies on every backend, or "
+                "provision the physical schema/database isolation externally and "
+                "manage it outside DataFlow."
+            )
 
     def _detect_database_type(self) -> str:
         """

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -730,20 +730,47 @@ class NodeGenerator:
 
                 _logger = logging.getLogger(__name__)
 
-                # Check for active tenant context
                 from .tenant_context import get_current_tenant_id
 
-                tenant_id = get_current_tenant_id()
-                if not tenant_id:
+                # DDL operations bypass tenant isolation (auto-migrate and schema
+                # bootstrap run with no tenant bound).
+                query_upper = query.strip().upper()
+                if query_upper.startswith(("CREATE ", "ALTER ", "DROP ")):
                     return query, params
 
-                # Check if this model has a tenant_id field (auto-detect tenant tables)
+                # Non-tenant models carry no tenant_id field — nothing to isolate.
                 if "tenant_id" not in self.model_fields:
                     return query, params
 
-                # DDL operations bypass tenant isolation
-                query_upper = query.strip().upper()
-                if query_upper.startswith(("CREATE ", "ALTER ", "DROP ")):
+                # Issue #1249 — FAIL CLOSED on a tenant-isolated model with no
+                # bound tenant under multi_tenant. The legacy ``return query,
+                # params`` here was a silent fail-OPEN: a write persisted a
+                # tenant_id=NULL row and a read returned every tenant's rows
+                # (the original cross-tenant leak class). Per tenant-isolation.md
+                # MUST-2 + zero-tolerance.md Rule 3, refuse rather than execute an
+                # unscoped statement. Single-tenant DataFlow (multi_tenant=False)
+                # keeps the pass-through — there is no tenant to scope by.
+                tenant_id = get_current_tenant_id()
+                if not tenant_id:
+                    multi_tenant = bool(
+                        getattr(
+                            getattr(
+                                getattr(self.dataflow_instance, "config", None),
+                                "security",
+                                None,
+                            ),
+                            "multi_tenant",
+                            False,
+                        )
+                    )
+                    if multi_tenant:
+                        raise RuntimeError(
+                            f"Tenant isolation failed for {self.model_name}: "
+                            f"multi_tenant=True but no tenant is bound to the current "
+                            f"context. Bind one via db.tenant_context.switch(tenant_id) "
+                            f"before this operation. Refusing to execute an unscoped "
+                            f"query (potential cross-tenant leak)."
+                        )
                     return query, params
 
                 # Get the table name for this model

--- a/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
+++ b/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
@@ -21,6 +21,47 @@ from .exceptions import CrossTenantAccessError, QueryParsingError, TenantIsolati
 logger = logging.getLogger(__name__)
 
 
+# Identifier fragment that matches an optionally-quoted SQL identifier across
+# the four dialect quoting styles DataFlow supports: bare (``feats``),
+# double-quoted (PostgreSQL / SQLite / ANSI ``"feats"``), backtick (MySQL
+# ```feats```) and bracket (SQL-Server ``[feats]``). The capture
+# group is the raw quoted-or-bare token; ``normalize_identifier`` strips the
+# wrapping quotes so matching and injection work regardless of dialect.
+#
+# Issue #1249: the prior validation / table-matching / injection regexes used a
+# bare ``\w+`` which silently failed to match quoted table names produced by
+# DataFlow's SQL builders (``INSERT INTO "feats" ...``). That mismatch
+# fail-closed the INSERT path AND fail-OPEN the SELECT path (no tenant filter
+# injected, no error raised). The shared ``_IDENT`` fragment closes the gap at
+# every site that matches or injects an identifier.
+_IDENT = r'(?:"[^"]+"|`[^`]+`|\[[^\]]+\]|\w+)'
+
+
+def normalize_identifier(name: str) -> str:
+    """Strip dialect quoting from a SQL identifier token.
+
+    ``"feats"`` -> ``feats``; ```feats``` -> ``feats``;
+    ``[feats]`` -> ``feats``; ``feats`` -> ``feats``. The returned value is the
+    canonical, unquoted identifier used for table-name comparison so the
+    interceptor matches regardless of how the SQL builder quoted the name.
+
+    Per ``dataflow-identifier-safety.md`` this is a NORMALIZE-for-comparison
+    helper (it never re-quotes or re-emits the value into SQL); the tenant_id
+    VALUE is always bound as a parameter, never interpolated.
+    """
+    if not isinstance(name, str):
+        return name
+    name = name.strip()
+    if len(name) >= 2:
+        if name[0] == '"' and name[-1] == '"':
+            return name[1:-1]
+        if name[0] == "`" and name[-1] == "`":
+            return name[1:-1]
+        if name[0] == "[" and name[-1] == "]":
+            return name[1:-1]
+    return name
+
+
 @dataclass
 class ParsedQuery:
     """Represents a parsed SQL query with extracted components."""
@@ -220,7 +261,39 @@ class QueryInterceptor:
                 table for table in parsed_query.tables if self.is_tenant_table(table)
             ]
 
+            # For INSERT the parser exposes the table via target_table (INSERT
+            # statements have no FROM clause, so .tables may be empty). Fold it
+            # in so the fail-closed guard below sees the genuine tenant table.
+            if (
+                parsed_query.query_type == "INSERT"
+                and parsed_query.target_table
+                and self.is_tenant_table(parsed_query.target_table)
+                and parsed_query.target_table not in tenant_tables_in_query
+            ):
+                tenant_tables_in_query.append(parsed_query.target_table)
+
             if not tenant_tables_in_query:
+                # Issue #1249 — FAIL CLOSED. When the caller constructed this
+                # interceptor with an EXPLICIT non-empty ``tenant_tables`` list,
+                # the caller is asserting "this query targets a tenant table".
+                # If no tenant table matched in the parsed query, the matcher
+                # silently failed (e.g. an identifier-quoting style the parser
+                # mis-handled). Returning the query unchanged here is the
+                # cross-tenant leak: the read executes with NO tenant filter.
+                # Raise instead so the nodes.py wrapper converts it to a loud
+                # RuntimeError rather than leaking. Per tenant-isolation.md
+                # MUST-2 + zero-tolerance.md Rule 3 (no silent fallback).
+                if self.tenant_tables:
+                    raise TenantIsolationError(
+                        "Tenant isolation could not be applied: query does not "
+                        "reference any of the declared tenant tables "
+                        f"{self.tenant_tables} after identifier normalization. "
+                        "Refusing to execute an unfiltered query "
+                        f"(query_type={parsed_query.query_type})."
+                    )
+                # No explicit tenant_tables declared → nothing the interceptor
+                # can scope; preserve the legacy pass-through (the caller did
+                # not assert this is a tenant table).
                 return query, params
 
             modified_query = query
@@ -253,11 +326,32 @@ class QueryInterceptor:
                     tenant_tables_in_query,
                 )
 
+            # Issue #1249 — FAIL CLOSED on no-op injection. If we identified a
+            # tenant table but the injection produced an identical query (the
+            # injection regex failed to match), the tenant filter was NOT
+            # applied. A SELECT/UPDATE/DELETE that runs without the WHERE clause
+            # leaks/over-mutates across tenants; an INSERT that runs without the
+            # tenant column stores tenant_id=NULL. Either way, refuse rather
+            # than execute an unscoped statement.
+            if modified_query == query and modified_params == params:
+                raise TenantIsolationError(
+                    "Tenant isolation injection produced no change for "
+                    f"{parsed_query.query_type} on tenant table(s) "
+                    f"{tenant_tables_in_query}. Refusing to execute an "
+                    "unfiltered query (possible identifier-quoting mismatch)."
+                )
+
             with self._lock:
                 self._query_stats["tenant_injections"] += 1
 
             return modified_query, modified_params
 
+        except TenantIsolationError:
+            # Already a typed fail-closed signal — re-raise without re-wrapping
+            # so the nodes.py wrapper surfaces the precise reason.
+            with self._lock:
+                self._query_stats["errors"] += 1
+            raise
         except Exception as e:
             with self._lock:
                 self._query_stats["errors"] += 1
@@ -271,11 +365,22 @@ class QueryInterceptor:
         # Remove alias if present
         table_name = table_name.split()[0] if " " in table_name else table_name
 
+        # Issue #1249: normalize quoted/bracketed identifiers on BOTH sides so a
+        # parsed quoted table name (``"feats"``) matches an unquoted
+        # tenant_tables entry (``feats``) and vice-versa. Without this the
+        # SELECT path returned the query UNCHANGED (no WHERE filter, no error) —
+        # the silent cross-tenant leak hole.
+        normalized = normalize_identifier(table_name)
+
         # If explicit lists are provided, use them
         if self.tenant_tables:
-            return table_name in self.tenant_tables
+            return any(
+                normalize_identifier(t) == normalized for t in self.tenant_tables
+            )
         if self.non_tenant_tables:
-            return table_name not in self.non_tenant_tables
+            return all(
+                normalize_identifier(t) != normalized for t in self.non_tenant_tables
+            )
 
         # Default: assume all tables are tenant tables unless explicitly marked otherwise
         return True
@@ -502,24 +607,41 @@ class QueryInterceptor:
         return "UNKNOWN"
 
     def _extract_tables(self, parsed) -> List[str]:
-        """Extract table names from parsed query."""
+        """Extract table names from parsed query.
+
+        Issue #1249: a quoted table name (``"feats"``) is tokenized by sqlparse
+        as ``Token.Literal.String.Symbol``, NOT ``Token.Name``. The prior
+        implementation only collected ``T.Name`` tokens, so the quoted table
+        produced by DataFlow's SQL builders was never added to ``tables`` — the
+        SELECT path then found no tenant table and (pre-fix) returned the query
+        UNCHANGED with no WHERE filter and no error: the silent cross-tenant
+        leak. We now collect both token types and normalize the result.
+        """
         tables = []
+
+        # A table identifier may appear as a bare Name or as a quoted
+        # String.Symbol ("feats" / `feats` / [feats]).
+        ident_ttypes = (T.Name, T.String.Symbol)
+
+        def _is_ident_token(token) -> bool:
+            return token.ttype in ident_ttypes
 
         def extract_from_token(token):
             if hasattr(token, "tokens"):
                 for subtoken in token.tokens:
                     extract_from_token(subtoken)
-            elif token.ttype is T.Name:
-                # This is a simplified extraction - in production would need more sophisticated parsing
-                tables.append(token.value)
+            elif _is_ident_token(token):
+                # This is a simplified extraction - in production would need more
+                # sophisticated parsing.
+                tables.append(normalize_identifier(token.value))
 
         # Look for FROM keyword and extract subsequent table names
         in_from_clause = False
         for token in parsed.tokens:
             if token.ttype is T.Keyword and token.value.upper() == "FROM":
                 in_from_clause = True
-            elif in_from_clause and token.ttype is T.Name:
-                tables.append(token.value)
+            elif in_from_clause and _is_ident_token(token):
+                tables.append(normalize_identifier(token.value))
                 in_from_clause = False
             elif hasattr(token, "tokens"):
                 extract_from_token(token)
@@ -657,14 +779,21 @@ class QueryInterceptor:
             # below as reading a potentially-unbound name.
             match = None
             if query_type == "INSERT":
-                match = re.search(r"INSERT\s+INTO\s+(\w+)", query_str, re.IGNORECASE)
+                match = re.search(
+                    rf"INSERT\s+INTO\s+({_IDENT})", query_str, re.IGNORECASE
+                )
             elif query_type == "UPDATE":
-                match = re.search(r"UPDATE\s+(\w+)", query_str, re.IGNORECASE)
+                match = re.search(rf"UPDATE\s+({_IDENT})", query_str, re.IGNORECASE)
             elif query_type == "DELETE":
-                match = re.search(r"DELETE\s+FROM\s+(\w+)", query_str, re.IGNORECASE)
+                match = re.search(
+                    rf"DELETE\s+FROM\s+({_IDENT})", query_str, re.IGNORECASE
+                )
 
             if match:
-                return match.group(1)
+                # Issue #1249: return the normalized (unquoted) identifier so the
+                # downstream is_tenant_table comparison matches the unquoted
+                # tenant_tables entries.
+                return normalize_identifier(match.group(1))
 
         return None
 
@@ -706,40 +835,101 @@ class QueryInterceptor:
         modified_query = query
         modified_params = params.copy()
 
-        # Add tenant conditions to WHERE clause
+        # Issue #1249: build the tenant-column reference once. When a genuine
+        # alias / explicit table qualifier is needed (multi-table / JOIN
+        # queries) we qualify; for a single-table SELECT we emit the bare
+        # column. Qualifying a single-table query with the NORMALIZED (unquoted)
+        # table name would produce ``feats.tenant_id`` against a ``"feats"``
+        # FROM clause — a qualifier-vs-FROM quoting mismatch. Bare column avoids
+        # that entirely and is unambiguous for the single-table case.
+        has_join = len(tenant_tables) > 1 or parsed.has_joins
+
+        # Add tenant conditions to WHERE clause.
+        # Issue #1249: the tenant VALUE is inserted into ``modified_params`` at
+        # the index matching the injected ``?``'s position among all
+        # placeholders — NOT appended — so positional drivers bind it correctly.
         if "WHERE" in modified_query.upper():
             # Add AND condition
             for table in tenant_tables:
-                table_alias = self._get_table_alias(modified_query, table)
-                tenant_condition = f"{table_alias}.{self.tenant_column} = ?"
-                modified_query = re.sub(
-                    r"WHERE\s+",
-                    f"WHERE {tenant_condition} AND ",
-                    modified_query,
-                    flags=re.IGNORECASE,
-                    count=1,
+                tenant_condition = self._build_tenant_condition(
+                    modified_query, table, qualify=has_join
                 )
-                modified_params.append(self.tenant_id)
+                where_match = re.search(r"WHERE\s+", modified_query, re.IGNORECASE)
+                # Char index where the injected tenant ``?`` lands: just after
+                # ``WHERE `` (the condition is "<col> = ?"). Placeholders before
+                # this index = the tenant param's positional index.
+                insert_char = where_match.end()
+                param_idx = self._count_placeholders_before(modified_query, insert_char)
+                modified_query = (
+                    modified_query[: where_match.end()]
+                    + f"{tenant_condition} AND "
+                    + modified_query[where_match.end() :]
+                )
+                modified_params.insert(param_idx, self.tenant_id)
+                if not has_join:
+                    break  # single table: one condition only
         else:
             # Add WHERE clause
             for table in tenant_tables:
-                table_alias = self._get_table_alias(modified_query, table)
-                tenant_condition = f"{table_alias}.{self.tenant_column} = ?"
+                tenant_condition = self._build_tenant_condition(
+                    modified_query, table, qualify=has_join
+                )
 
                 # Insert before ORDER BY, GROUP BY, or HAVING if present
                 insertion_point = self._find_insertion_point(modified_query)
                 if insertion_point:
+                    # The injected ``?`` lands at ``insertion_point`` (before
+                    # ORDER BY/GROUP BY/HAVING/LIMIT). Count placeholders before
+                    # that char index for the param insertion index.
+                    param_idx = self._count_placeholders_before(
+                        modified_query, insertion_point
+                    )
                     modified_query = (
                         modified_query[:insertion_point]
                         + f" WHERE {tenant_condition}"
                         + modified_query[insertion_point:]
                     )
+                    modified_params.insert(param_idx, self.tenant_id)
                 else:
+                    # WHERE clause appended at the very end → tenant ``?`` is the
+                    # last placeholder; append is correct here.
                     modified_query += f" WHERE {tenant_condition}"
-                modified_params.append(self.tenant_id)
+                    modified_params.append(self.tenant_id)
                 break  # Only add one WHERE clause
 
         return modified_query, modified_params
+
+    def _build_tenant_condition(self, query: str, table: str, qualify: bool) -> str:
+        """Build the ``<col> = ?`` tenant predicate for a SELECT table.
+
+        When ``qualify`` (multi-table / JOIN) the column is prefixed with the
+        table alias (or the verbatim table token from the query) so the predicate
+        is unambiguous. For a single-table SELECT the bare column is returned to
+        avoid a quoted-vs-unquoted qualifier mismatch (issue #1249).
+        """
+        if not qualify:
+            return f"{self.tenant_column} = ?"
+        table_alias = self._get_table_alias(query, table)
+        return f"{table_alias}.{self.tenant_column} = ?"
+
+    # Placeholder forms across dialects: ``?`` (SQLite / generic),
+    # ``$N`` (PostgreSQL), ``%s`` (MySQL / psycopg).
+    _PLACEHOLDER_RE = re.compile(r"\?|\$\d+|%s")
+
+    def _count_placeholders_before(self, query: str, char_index: int) -> int:
+        """Count bound-parameter placeholders before ``char_index`` in ``query``.
+
+        Issue #1249: the tenant ``?`` is inserted into the WHERE clause at a
+        specific character position, but positional drivers (SQLite, asyncpg)
+        bind parameters by ORDER OF APPEARANCE. The tenant VALUE must therefore
+        be inserted into the params list at the index equal to the number of
+        placeholders that precede the injected ``?`` — NOT appended at the end.
+        Appending shifts every trailing placeholder (e.g. ``LIMIT ?``,
+        ``OFFSET ?``) onto the wrong value and the tenant filter binds against a
+        LIMIT integer, silently matching zero rows (the read-returns-nothing
+        symptom) or, worse, the wrong tenant.
+        """
+        return len(self._PLACEHOLDER_RE.findall(query[:char_index]))
 
     def _inject_insert_conditions(
         self, query: str, params: List[Any], parsed: ParsedQuery
@@ -751,27 +941,57 @@ class QueryInterceptor:
         modified_query = query
         modified_params = params.copy()
 
-        # Add tenant_id to columns and values
+        # Issue #1249: ``_IDENT`` matches the quoted table name DataFlow emits
+        # (``INSERT INTO "feats" (...)``). The prior bare ``\w+`` did not match,
+        # so the tenant column/value was never injected and every multi-tenant
+        # write stored tenant_id=NULL. The tenant_id VALUE is always a bound
+        # parameter, never string-interpolated (security.md parameterized
+        # queries).
         insert_match = re.search(
-            r"INSERT\s+INTO\s+\w+\s*\(([^)]+)\)\s*VALUES\s*\(([^)]+)\)",
+            rf"INSERT\s+INTO\s+({_IDENT})\s*\(([^)]+)\)\s*VALUES\s*\(([^)]+)\)",
             modified_query,
             re.IGNORECASE,
         )
         if insert_match:
-            columns = insert_match.group(1)
-            values = insert_match.group(2)
+            table_token = insert_match.group(1)  # keep original quoting verbatim
+            columns = insert_match.group(2)
+            values = insert_match.group(3)
 
-            # Add tenant_id column
-            new_columns = f"{columns}, {self.tenant_column}"
-            new_values = f"{values}, ?"
+            # Parse the column list (preserving original quoting per element) so
+            # we can detect whether the tenant column is ALREADY present. In
+            # multi-tenant mode DataFlow auto-adds ``tenant_id`` to the model's
+            # field list, so the generated INSERT already carries a
+            # ``tenant_id`` column — but with the user-omitted value bound as
+            # NULL. Appending a SECOND ``tenant_id`` column (the pre-fix #1249
+            # behavior) produced a duplicate column; the DB kept the first
+            # (NULL) and the row stored tenant_id=NULL. We instead OVERWRITE the
+            # bound value at the existing tenant column's position.
+            col_tokens = [c.strip() for c in columns.split(",")]
+            normalized_cols = [normalize_identifier(c) for c in col_tokens]
+            tenant_col_norm = normalize_identifier(self.tenant_column)
 
-            modified_query = re.sub(
-                r"INSERT\s+INTO\s+\w+\s*\([^)]+\)\s*VALUES\s*\([^)]+\)",
-                f"INSERT INTO {parsed.target_table} ({new_columns}) VALUES ({new_values})",
-                modified_query,
-                flags=re.IGNORECASE,
-            )
-            modified_params.append(self.tenant_id)
+            if tenant_col_norm in normalized_cols:
+                # Tenant column already in the INSERT — bind the tenant_id VALUE
+                # at its position instead of appending a duplicate column.
+                tenant_idx = normalized_cols.index(tenant_col_norm)
+                if tenant_idx < len(modified_params):
+                    modified_params[tenant_idx] = self.tenant_id
+                # Query string is unchanged in this branch (column already
+                # present), so the no-op fail-closed guard in
+                # inject_tenant_conditions checks params, not just the query,
+                # to confirm the tenant value was actually bound.
+            else:
+                # Tenant column absent — append it plus a bound ``?`` placeholder.
+                new_columns = f"{columns}, {self.tenant_column}"
+                new_values = f"{values}, ?"
+                modified_query = re.sub(
+                    rf"INSERT\s+INTO\s+{_IDENT}\s*\([^)]+\)\s*VALUES\s*\([^)]+\)",
+                    f"INSERT INTO {table_token} ({new_columns}) VALUES ({new_values})",
+                    modified_query,
+                    flags=re.IGNORECASE,
+                    count=1,
+                )
+                modified_params.append(self.tenant_id)
 
         return modified_query, modified_params
 
@@ -785,25 +1005,12 @@ class QueryInterceptor:
         """Inject tenant conditions into UPDATE queries."""
         modified_query = query
         modified_params = params.copy()
-
-        # Add tenant condition to WHERE clause
-        if "WHERE" in modified_query.upper():
-            # Add AND condition
-            tenant_condition = f"{self.tenant_column} = ?"
-            modified_query = re.sub(
-                r"WHERE\s+",
-                f"WHERE {tenant_condition} AND ",
-                modified_query,
-                flags=re.IGNORECASE,
-                count=1,
-            )
-            modified_params.append(self.tenant_id)
-        else:
-            # Add WHERE clause
-            tenant_condition = f"{self.tenant_column} = ?"
-            modified_query += f" WHERE {tenant_condition}"
-            modified_params.append(self.tenant_id)
-
+        # Issue #1249: insert the tenant VALUE at the placeholder-position of the
+        # injected ``?`` (after the SET-clause placeholders) rather than
+        # appending; positional drivers bind by order of appearance.
+        modified_query, modified_params = self._inject_where_predicate(
+            modified_query, modified_params, f"{self.tenant_column} = ?"
+        )
         return modified_query, modified_params
 
     def _inject_delete_conditions(
@@ -816,23 +1023,42 @@ class QueryInterceptor:
         """Inject tenant conditions into DELETE queries."""
         modified_query = query
         modified_params = params.copy()
+        # Issue #1249: position-aware tenant param insertion (see UPDATE above).
+        modified_query, modified_params = self._inject_where_predicate(
+            modified_query, modified_params, f"{self.tenant_column} = ?"
+        )
+        return modified_query, modified_params
 
-        # Add tenant condition to WHERE clause
+    def _inject_where_predicate(
+        self, query: str, params: List[Any], predicate: str
+    ) -> Tuple[str, List[Any]]:
+        """Inject a single-``?`` WHERE predicate with correct param positioning.
+
+        Shared by UPDATE / DELETE. ``predicate`` MUST contain exactly one ``?``
+        placeholder (the tenant column). The bound tenant VALUE
+        (``self.tenant_id``) is inserted into ``params`` at the index matching
+        the injected ``?``'s position among all placeholders in the resulting
+        query — never appended blindly (issue #1249 param-ordering bug).
+        """
+        modified_query = query
+        modified_params = list(params)
+
         if "WHERE" in modified_query.upper():
-            # Add AND condition
-            tenant_condition = f"{self.tenant_column} = ?"
-            modified_query = re.sub(
-                r"WHERE\s+",
-                f"WHERE {tenant_condition} AND ",
-                modified_query,
-                flags=re.IGNORECASE,
-                count=1,
+            where_match = re.search(r"WHERE\s+", modified_query, re.IGNORECASE)
+            insert_char = where_match.end()
+            param_idx = self._count_placeholders_before(modified_query, insert_char)
+            modified_query = (
+                modified_query[: where_match.end()]
+                + f"{predicate} AND "
+                + modified_query[where_match.end() :]
             )
-            modified_params.append(self.tenant_id)
+            modified_params.insert(param_idx, self.tenant_id)
         else:
-            # Add WHERE clause
-            tenant_condition = f"{self.tenant_column} = ?"
-            modified_query += f" WHERE {tenant_condition}"
+            # No existing WHERE. For UPDATE/DELETE the WHERE goes at the end of
+            # the statement, after any SET-clause placeholders, so the tenant
+            # ``?`` is the last placeholder → append is correct. (DataFlow does
+            # not emit trailing LIMIT on UPDATE/DELETE.)
+            modified_query += f" WHERE {predicate}"
             modified_params.append(self.tenant_id)
 
         return modified_query, modified_params
@@ -982,23 +1208,26 @@ class QueryInterceptor:
                         "Malformed SQL: SELECT statement missing FROM clause"
                     )
 
-        # Check for proper table in INSERT statements
+        # Check for proper table in INSERT statements.
+        # Issue #1249: ``_IDENT`` accepts quoted identifiers ("feats" / `feats`
+        # / [feats]) — the prior bare ``\w+`` rejected DataFlow's quoted table
+        # names and fail-closed the INSERT path with "missing table name".
         if query_upper.startswith("INSERT"):
-            if not re.search(r"INSERT\s+INTO\s+\w+", query_upper):
+            if not re.search(rf"INSERT\s+INTO\s+{_IDENT}", query_upper):
                 raise QueryParsingError(
                     "Malformed SQL: INSERT statement missing table name"
                 )
 
         # Check for proper table in UPDATE statements
         if query_upper.startswith("UPDATE"):
-            if not re.search(r"UPDATE\s+\w+", query_upper):
+            if not re.search(rf"UPDATE\s+{_IDENT}", query_upper):
                 raise QueryParsingError(
                     "Malformed SQL: UPDATE statement missing table name"
                 )
 
         # Check for proper table in DELETE statements
         if query_upper.startswith("DELETE"):
-            if not re.search(r"DELETE\s+FROM\s+\w+", query_upper):
+            if not re.search(rf"DELETE\s+FROM\s+{_IDENT}", query_upper):
                 raise QueryParsingError(
                     "Malformed SQL: DELETE statement missing FROM clause"
                 )

--- a/packages/kailash-dataflow/tests/integration/tenancy/test_engine_tenancy_wiring.py
+++ b/packages/kailash-dataflow/tests/integration/tenancy/test_engine_tenancy_wiring.py
@@ -136,8 +136,16 @@ class TestGetTenantTables:
 class TestApplyTenantIsolation:
     """Tests that _apply_tenant_isolation on DataFlowNode works correctly."""
 
-    def test_no_tenant_context_passes_through(self, db):
-        """When no tenant context is active, queries pass through unchanged."""
+    def test_no_tenant_context_fails_closed_under_multi_tenant(self, db):
+        """Issue #1249: under multi_tenant=True, a tenant-isolated model queried
+        with NO bound tenant MUST fail closed — not pass through unscoped.
+
+        The legacy behavior here was a silent fail-OPEN: an unscoped SELECT
+        returned every tenant's rows and an unscoped INSERT persisted a
+        tenant_id=NULL row (the original cross-tenant leak class). Per
+        tenant-isolation.md MUST-2 + zero-tolerance.md Rule 3 the SQL
+        enforcement point must refuse rather than execute an unscoped query.
+        """
 
         @db.model
         class Item:
@@ -153,10 +161,29 @@ class TestApplyTenantIsolation:
         query = "SELECT * FROM items WHERE id = ?"
         params = ["item-1"]
 
-        # No tenant context active
-        result_query, result_params = node._apply_tenant_isolation(query, params)
-        assert result_query == query
-        assert result_params == params
+        # No tenant context active under multi_tenant=True -> fail closed.
+        with pytest.raises(RuntimeError, match="no tenant is bound"):
+            node._apply_tenant_isolation(query, params)
+
+    def test_ddl_passes_through_without_tenant_context(self, db):
+        """DDL (auto-migrate / schema bootstrap) runs with no bound tenant and
+        MUST still bypass tenant isolation — the fail-closed guard above applies
+        only to DML."""
+
+        @db.model
+        class Gadget:
+            id: str
+            tenant_id: str
+            name: str
+
+        node_class = db._nodes.get("GadgetCreateNode")
+        assert node_class is not None
+        node = node_class(node_id="test_ddl_no_tenant")
+
+        ddl = "CREATE TABLE gadgets (id TEXT, tenant_id TEXT, name TEXT)"
+        result_query, result_params = node._apply_tenant_isolation(ddl, [])
+        assert result_query == ddl
+        assert result_params == []
 
     def test_tenant_context_injects_conditions(self, db):
         """When tenant context is active, tenant conditions are injected into DML."""

--- a/packages/kailash-dataflow/tests/regression/test_issue_1249_tenant_isolation_leak.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1249_tenant_isolation_leak.py
@@ -1,0 +1,397 @@
+"""Regression tests for issue #1249 — DataFlow multi-tenant cross-tenant leak.
+
+Issue #1249: in multi-tenant mode, DataFlow's ``express`` CRUD provided NO
+tenant isolation. Four compounding defects produced a SILENT cross-tenant leak:
+
+1. The SQL-syntax validator's ``\\w+`` table-name regexes rejected quoted
+   identifiers (``INSERT INTO "feats" ...``), fail-closing the INSERT path.
+2. The INSERT injection regex did not match quoted identifiers, so the tenant
+   column/value was never bound and every write stored ``tenant_id = NULL``.
+3. The SELECT-path table matcher compared the parsed (quoted) table name
+   against the unquoted ``tenant_tables`` entry; the mismatch left
+   ``tenant_tables_in_query`` empty and the interceptor returned the query
+   UNCHANGED — no WHERE filter, no error: the silent leak.
+4. ``tenant_isolation_strategy`` was silently dropped as an unknown DataFlow
+   constructor parameter (DF-CFG-001), and its default ``"schema"`` is a no-op
+   on SQLite.
+
+These Tier-2 tests exercise the real express CRUD path against a real SQLite
+database (and a PostgreSQL-marked variant) and assert strict isolation. They are
+permanent regression tests — NEVER delete (``rules/testing.md`` Regression).
+"""
+
+import sqlite3
+import tempfile
+
+import pytest
+
+from dataflow import DataFlow
+from dataflow.exceptions import DataFlowConfigurationError
+from dataflow.tenancy.exceptions import TenantIsolationError
+from dataflow.tenancy.interceptor import QueryInterceptor, normalize_identifier
+
+# ---------------------------------------------------------------------------
+# Tier-2: end-to-end isolation through the real express CRUD path (SQLite)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mt_db():
+    """Multi-tenant DataFlow over file-backed SQLite + Feat model.
+
+    Yields ``(db, tmpdir)`` and closes the DataFlow on teardown so the runner
+    does not accumulate ``ResourceWarning: Unclosed LocalRuntime`` per
+    ``rules/testing.md`` (fixtures yield + cleanup, never return).
+    """
+    tmpdir = tempfile.mkdtemp()
+    db = DataFlow(
+        f"sqlite:///{tmpdir}/mt.db",
+        auto_migrate=True,
+        multi_tenant=True,
+    )
+
+    @db.model
+    class Feat:
+        entity_id: str
+        score: int
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("acme", "A")
+    db.tenant_context.register_tenant("globex", "G")
+    try:
+        yield db, tmpdir
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+def test_express_multi_tenant_isolation_no_cross_tenant_leak(mt_db):
+    """Two tenants create rows; each reads back ONLY its own rows.
+
+    This is the core #1249 leak: pre-fix, ``acme`` saw both tenants' rows.
+    """
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        db.express_sync.create("Feat", {"entity_id": "e1", "score": 10})
+    with db.tenant_context.switch("globex"):
+        db.express_sync.create("Feat", {"entity_id": "e1", "score": 99})
+
+    with db.tenant_context.switch("acme"):
+        acme_scores = sorted(r.get("score") for r in db.express_sync.list("Feat", {}))
+    with db.tenant_context.switch("globex"):
+        globex_scores = sorted(r.get("score") for r in db.express_sync.list("Feat", {}))
+
+    # The leak this regression test guards: acme MUST NOT see globex's row.
+    assert acme_scores == [10], f"cross-tenant leak: acme saw {acme_scores}"
+    assert globex_scores == [99], f"cross-tenant leak: globex saw {globex_scores}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+def test_express_multi_tenant_write_without_bound_tenant_fails_closed(mt_db):
+    """Issue #1249 (fail-closed write): a write under multi_tenant=True with NO
+    bound tenant MUST raise AND MUST NOT persist a tenant_id=NULL row.
+
+    Pre-fix the SQL enforcement point (``_apply_tenant_isolation``) returned the
+    INSERT unchanged when no tenant was bound, so an unscoped row was written
+    with ``tenant_id = NULL`` (invisible to every tenant's filtered read, a
+    latent fail-OPEN) before the API-layer error surfaced. Per
+    tenant-isolation.md MUST-2 + zero-tolerance.md Rule 3 the write must fail
+    closed with no side effect.
+    """
+    db, tmpdir = mt_db
+
+    # No db.tenant_context.switch(...) -> no bound tenant under multi_tenant.
+    with pytest.raises(RuntimeError, match="no tenant is bound"):
+        db.express_sync.create("Feat", {"entity_id": "orphan", "score": 1})
+
+    con = sqlite3.connect(f"{tmpdir}/mt.db")
+    try:
+        null_rows = con.execute(
+            "SELECT entity_id, tenant_id FROM feats WHERE tenant_id IS NULL"
+        ).fetchall()
+    finally:
+        con.close()
+    assert null_rows == [], f"fail-open: a NULL-tenant row was persisted: {null_rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+def test_express_multi_tenant_insert_persists_non_null_tenant_id(mt_db):
+    """Every multi-tenant INSERT MUST persist a non-NULL tenant_id (defect #2)."""
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        db.express_sync.create("Feat", {"entity_id": "a", "score": 1})
+    with db.tenant_context.switch("globex"):
+        db.express_sync.create("Feat", {"entity_id": "g", "score": 2})
+
+    con = sqlite3.connect(f"{tmpdir}/mt.db")
+    rows = con.execute(
+        "SELECT entity_id, score, tenant_id FROM feats ORDER BY id"
+    ).fetchall()
+    con.close()
+
+    # Pre-fix this returned tenant_id=None for every row.
+    assert all(r[2] is not None for r in rows), f"tenant_id stored as NULL: {rows}"
+    tenants = {r[2] for r in rows}
+    assert tenants == {"acme", "globex"}, f"wrong tenant_id values: {rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+def test_express_multi_tenant_update_is_tenant_scoped(mt_db):
+    """A tenant MUST NOT update another tenant's row even by primary key."""
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        db.express_sync.create("Feat", {"entity_id": "a", "score": 10})
+    with db.tenant_context.switch("globex"):
+        db.express_sync.create("Feat", {"entity_id": "g", "score": 99})
+
+    con = sqlite3.connect(f"{tmpdir}/mt.db")
+    rows = con.execute("SELECT id, tenant_id FROM feats ORDER BY id").fetchall()
+    con.close()
+    globex_id = next(r[0] for r in rows if r[1] == "globex")
+    acme_id = next(r[0] for r in rows if r[1] == "acme")
+
+    # acme attempts to overwrite globex's row by id — MUST be a no-op.
+    with db.tenant_context.switch("acme"):
+        db.express_sync.update("Feat", globex_id, {"score": 12345})
+
+    con = sqlite3.connect(f"{tmpdir}/mt.db")
+    globex_score = con.execute(
+        "SELECT score FROM feats WHERE id = ?", (globex_id,)
+    ).fetchone()[0]
+    con.close()
+    assert globex_score == 99, "cross-tenant UPDATE leaked into globex's row"
+
+    # Same-tenant update MUST still work.
+    with db.tenant_context.switch("acme"):
+        db.express_sync.update("Feat", acme_id, {"score": 777})
+    con = sqlite3.connect(f"{tmpdir}/mt.db")
+    acme_score = con.execute(
+        "SELECT score FROM feats WHERE id = ?", (acme_id,)
+    ).fetchone()[0]
+    con.close()
+    assert acme_score == 777, "same-tenant UPDATE failed"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+def test_express_multi_tenant_delete_is_tenant_scoped(mt_db):
+    """A tenant MUST NOT delete another tenant's row even by primary key."""
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        db.express_sync.create("Feat", {"entity_id": "a", "score": 10})
+    with db.tenant_context.switch("globex"):
+        db.express_sync.create("Feat", {"entity_id": "g", "score": 99})
+
+    con = sqlite3.connect(f"{tmpdir}/mt.db")
+    rows = con.execute("SELECT id, tenant_id FROM feats ORDER BY id").fetchall()
+    con.close()
+    globex_id = next(r[0] for r in rows if r[1] == "globex")
+
+    # acme attempts to delete globex's row — MUST be a no-op.
+    with db.tenant_context.switch("acme"):
+        db.express_sync.delete("Feat", globex_id)
+
+    con = sqlite3.connect(f"{tmpdir}/mt.db")
+    remaining = con.execute(
+        "SELECT COUNT(*) FROM feats WHERE id = ?", (globex_id,)
+    ).fetchone()[0]
+    con.close()
+    assert remaining == 1, "cross-tenant DELETE removed globex's row"
+
+
+# ---------------------------------------------------------------------------
+# Unit-tier: interceptor identifier-normalization + param-ordering regressions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_normalize_identifier_strips_all_dialect_quoting():
+    """normalize_identifier handles all four dialect quoting styles (defect #1-3)."""
+    assert normalize_identifier('"feats"') == "feats"  # ANSI / Postgres / SQLite
+    assert normalize_identifier("`feats`") == "feats"  # MySQL backtick
+    assert normalize_identifier("[feats]") == "feats"  # SQL-Server bracket
+    assert normalize_identifier("feats") == "feats"  # bare
+    assert normalize_identifier('  "feats"  ') == "feats"  # surrounding whitespace
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "query",
+    [
+        'INSERT INTO "feats" (entity_id, score) VALUES (?, ?)',  # ANSI quote
+        "INSERT INTO `feats` (entity_id, score) VALUES (?, ?)",  # MySQL
+        "INSERT INTO [feats] (entity_id, score) VALUES (?, ?)",  # SQL-Server
+        'UPDATE "feats" SET score = ? WHERE id = ?',
+        'DELETE FROM "feats" WHERE id = ?',
+    ],
+)
+def test_validator_accepts_quoted_identifiers(query):
+    """The validator's table-name check accepts quoted identifiers (defect #1).
+
+    Pre-fix the ``\\w+`` regex rejected ``"feats"`` and raised
+    "missing table name", fail-closing the write path.
+    """
+    interceptor = QueryInterceptor(tenant_id="A", tenant_tables=["feats"])
+    # parse_query runs _validate_sql_syntax; it MUST NOT raise on quoted tables.
+    parsed = interceptor.parse_query(query)
+    assert parsed.query_type in {"INSERT", "UPDATE", "DELETE"}
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_select_injection_binds_tenant_param_at_correct_position():
+    """Tenant param MUST be inserted at the placeholder position, not appended.
+
+    Defect: appending shifted the tenant value onto a trailing LIMIT/OFFSET
+    placeholder, so the filter bound ``tenant_id = <limit int>`` and matched
+    zero rows (the read-returns-nothing symptom).
+    """
+    interceptor = QueryInterceptor(tenant_id="A", tenant_tables=["feats"])
+    q = 'SELECT * FROM "feats" ORDER BY "id" DESC LIMIT ? OFFSET ?'
+    mq, mp = interceptor.inject_tenant_conditions(q, [100, 0])
+    assert "WHERE tenant_id = ?" in mq
+    # The tenant value 'A' MUST be the FIRST param (matching the WHERE ? that
+    # precedes LIMIT/OFFSET), NOT appended last.
+    assert mp == ["A", 100, 0], f"param ordering wrong: {mp}"
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_insert_injection_does_not_duplicate_existing_tenant_column():
+    """When tenant_id is already a column, bind its value — do not append.
+
+    In multi-tenant mode DataFlow auto-adds tenant_id to the INSERT column
+    list with a NULL value. The interceptor MUST overwrite that bound value
+    rather than append a duplicate column (which left tenant_id=NULL).
+    """
+    interceptor = QueryInterceptor(tenant_id="acme", tenant_tables=["feats"])
+    q = 'INSERT INTO "feats" ("entity_id", "score", "tenant_id") VALUES (?, ?, ?)'
+    mq, mp = interceptor.inject_tenant_conditions(q, ["e1", 10, None])
+    # No duplicate tenant_id column.
+    assert mq.count("tenant_id") == 1, f"duplicate tenant column: {mq}"
+    # The NULL bound for the auto-added tenant_id column is now the tenant value.
+    assert mp == ["e1", 10, "acme"], f"tenant value not bound: {mp}"
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_interceptor_fails_closed_when_no_tenant_table_matched():
+    """An explicit tenant_tables interceptor MUST raise — not pass through.
+
+    Closes the line-223 silent-leak hole: the caller asserted the query
+    targets a tenant table; if none matched, executing the query unfiltered
+    would leak. The interceptor raises TenantIsolationError instead.
+    Per tenant-isolation.md MUST-2 + zero-tolerance.md Rule 3.
+    """
+    interceptor = QueryInterceptor(tenant_id="A", tenant_tables=["feats"])
+    with pytest.raises(TenantIsolationError):
+        # 'other_table' is not in tenant_tables → no tenant table matched.
+        interceptor.inject_tenant_conditions(
+            'SELECT * FROM "other_table" WHERE x = ?', [1]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Defect #4: tenant_isolation_strategy accepted, validated, fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_tenant_isolation_strategy_row_accepted_no_unknown_param_warning():
+    """tenant_isolation_strategy='row' is accepted and stored (defect #4)."""
+    import warnings
+
+    tmpdir = tempfile.mkdtemp()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        db = DataFlow(
+            f"sqlite:///{tmpdir}/s.db",
+            auto_migrate=True,
+            multi_tenant=True,
+            tenant_isolation_strategy="row",
+        )
+        df_cfg = [str(w.message) for w in caught if "DF-CFG-001" in str(w.message)]
+    try:
+        assert db.config.security.tenant_isolation_strategy == "row"
+        # Pre-fix this emitted a DF-CFG-001 "unknown parameter" warning.
+        assert df_cfg == [], f"strategy treated as unknown kwarg: {df_cfg}"
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_tenant_isolation_strategy_default_is_row():
+    """Default strategy is 'row' (was 'schema', a SQLite no-op) — defect #4."""
+    tmpdir = tempfile.mkdtemp()
+    db = DataFlow(f"sqlite:///{tmpdir}/d.db", auto_migrate=True, multi_tenant=True)
+    try:
+        assert db.config.security.tenant_isolation_strategy == "row"
+    finally:
+        db.close()
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_tenant_isolation_strategy_invalid_value_fails_closed():
+    """An unknown strategy value MUST raise, not be silently ignored."""
+    tmpdir = tempfile.mkdtemp()
+    with pytest.raises(
+        DataFlowConfigurationError, match="Invalid tenant_isolation_strategy"
+    ):
+        DataFlow(
+            f"sqlite:///{tmpdir}/i.db",
+            multi_tenant=True,
+            tenant_isolation_strategy="bogus",
+        )
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_tenant_isolation_strategy_schema_on_sqlite_fails_closed():
+    """A strategy that cannot isolate on the backend MUST fail closed.
+
+    'schema'/'database' request PHYSICAL isolation DataFlow cannot provision on
+    SQLite. Rather than silently no-op into NO isolation (a cross-tenant leak),
+    DataFlow refuses to start.
+    """
+    tmpdir = tempfile.mkdtemp()
+    with pytest.raises(DataFlowConfigurationError, match="PHYSICAL tenant"):
+        DataFlow(
+            f"sqlite:///{tmpdir}/sc.db",
+            multi_tenant=True,
+            tenant_isolation_strategy="schema",
+        )
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_tenant_isolation_strategy_schema_inert_without_multitenant():
+    """A physical strategy is harmless (inert) when multi_tenant is off."""
+    tmpdir = tempfile.mkdtemp()
+    # Should NOT raise: no multi-tenancy → strategy is inert.
+    db = DataFlow(
+        f"sqlite:///{tmpdir}/in.db",
+        auto_migrate=True,
+        tenant_isolation_strategy="schema",
+    )
+    try:
+        assert db.config.security.tenant_isolation_strategy == "schema"
+    finally:
+        db.close()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1249_tenant_isolation_leak_postgres.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1249_tenant_isolation_leak_postgres.py
@@ -1,0 +1,75 @@
+"""PostgreSQL variant of the issue #1249 cross-tenant isolation regression.
+
+Mirrors the core leak assertion from
+``test_issue_1249_tenant_isolation_leak.py`` against a REAL PostgreSQL backend
+(shared infra on port 5434 via ``IntegrationTestSuite``). Marked
+``requires_postgres`` so it is skipped in the default no-infra run and exercised
+in CI where the shared database is available.
+
+The leak (#1249) was backend-agnostic — it lived in the SQL ``QueryInterceptor``
+identifier-normalization path, which runs identically for SQLite and
+PostgreSQL. This test confirms isolation holds on PostgreSQL's quoted-identifier
+SQL (``INSERT INTO "feats" ...`` + ``$1, $2`` placeholders + ``RETURNING``).
+"""
+
+import pytest
+
+from dataflow import DataFlow
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+
+@pytest.fixture
+async def test_suite():
+    """Real PostgreSQL integration suite (shared infra, port 5434)."""
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.postgresql
+async def test_express_multi_tenant_isolation_no_cross_tenant_leak_postgres(test_suite):
+    """Two tenants create rows on PostgreSQL; each reads back ONLY its own."""
+    db_url = test_suite.config.url
+    await test_suite.clean_database()
+
+    db = DataFlow(db_url, auto_migrate=True, multi_tenant=True)
+
+    @db.model
+    class Feat1249:
+        entity_id: str
+        score: int
+
+    await db.initialize()
+
+    db.tenant_context.register_tenant("acme", "A")
+    db.tenant_context.register_tenant("globex", "G")
+
+    with db.tenant_context.switch("acme"):
+        await db.express.create("Feat1249", {"entity_id": "e1", "score": 10})
+    with db.tenant_context.switch("globex"):
+        await db.express.create("Feat1249", {"entity_id": "e1", "score": 99})
+
+    with db.tenant_context.switch("acme"):
+        acme_rows = await db.express.list("Feat1249", {})
+    with db.tenant_context.switch("globex"):
+        globex_rows = await db.express.list("Feat1249", {})
+
+    acme_scores = sorted(r.get("score") for r in acme_rows)
+    globex_scores = sorted(r.get("score") for r in globex_rows)
+
+    assert acme_scores == [10], f"cross-tenant leak (postgres): acme saw {acme_scores}"
+    assert globex_scores == [
+        99
+    ], f"cross-tenant leak (postgres): globex saw {globex_scores}"
+
+    # Raw-row assertion: tenant_id persisted non-NULL per row (defect #2).
+    async with test_suite.get_connection() as conn:
+        rows = await conn.fetch(
+            "SELECT entity_id, score, tenant_id FROM feat1249s ORDER BY id"
+        )
+    tenants = {r["tenant_id"] for r in rows}
+    assert None not in tenants, f"tenant_id stored NULL on postgres: {rows}"
+    assert tenants == {"acme", "globex"}, f"wrong tenant_id values: {rows}"


### PR DESCRIPTION
## Summary

Multi-tenant `express` CRUD provided **NO** tenant isolation under `multi_tenant=True` (#1249, CRITICAL): writes stored `tenant_id = NULL` and reads returned every tenant's rows — a cross-tenant data leak. This fixes four compounding defects in the tenant-injection enforcement point (`QueryInterceptor` / `_apply_tenant_isolation`) and makes the path **fail-closed**.

### Root cause (4 defects, all verified live)
1. The SQL-syntax validator's `\w+` table-name regexes rejected quoted identifiers (`INSERT INTO "feats" …`) → every multi-tenant write fail-closed with a `RuntimeError` (the originally-filed symptom).
2. The INSERT injection did not match quoted identifiers → tenant value never bound → `tenant_id = NULL`.
3. The SELECT/UPDATE/DELETE table matcher compared the parsed (quoted) table name against the unquoted declared tenant table → mismatch → query returned **unfiltered, no error** (the silent leak).
4. `tenant_isolation_strategy` was silently dropped (DF-CFG-001) and its default `"schema"` is a no-op on SQLite.

### Fix
- **Identifier normalization** across the validator + INSERT/SELECT/UPDATE/DELETE injection (quoted/bracketed/backtick, all dialects); tenant value **bound as a parameter** at the correct position.
- **Fail-closed interceptor**: raises `TenantIsolationError` when a declared tenant table can't be matched after normalization, or when injection is a no-op — never returns an unscoped query.
- **Fail-closed no-bound-tenant DML**: a tenant-isolated model written/read under `multi_tenant=True` with no bound tenant now refuses (`RuntimeError`) instead of persisting a `NULL`-tenant row / returning all rows. DDL / auto-migrate still bypass.
- **Strategy validation**: `tenant_isolation_strategy` is accepted + validated; default `schema → row`; `schema`/`database` fail closed at startup on backends that can't deliver physical isolation.

## Security review

Adversarial red-team run in-session (independent reviewer sub-agents were server-rate-limited to 0 tokens; the audit was run directly with live attack scripts — the strongest channel). Verified isolation across read / read-by-PK / cross-tenant UPDATE / cross-tenant DELETE / filtered list / malicious-tenant-value injection / strategy fail-closed. The red-team **found and this PR fixes** an additional fail-open (no-bound-tenant write persisting a `NULL`-tenant row).

## User-flow walk receipts (scrubbed; synthetic tenants)

```
$ python repro.py   # multi_tenant=True, tenants acme + globex
acme create OK · globex create OK
acme reads scores: [10]            => ISOLATED (pre-fix: [10, 99])
RAW (entity_id, score, tenant_id): [('e1', 10, 'acme'), ('e1', 99, 'globex')]   # non-NULL
acme update(globex_id) -> globex unchanged [99]   # cross-tenant write blocked
acme delete(globex_id) -> globex unchanged [99]   # cross-tenant delete blocked
no-tenant create -> RuntimeError "no tenant is bound"; raw NULL-tenant rows: []  # fail-closed
strategy=schema|database|invalid -> DataFlowConfigurationError (fail-closed); row -> ok
```

## Tests

- `tests/regression/test_issue_1249_tenant_isolation_leak.py` — 19 Tier-2 tests (cross-tenant read/write/delete isolation, non-NULL tenant_id, fail-closed no-tenant write, quoted-identifier validator, strategy validation) + a PostgreSQL-marked variant.
- Updated `tests/integration/tenancy/test_engine_tenancy_wiring.py` for the fail-closed enforcement point. Full tenancy suite: 68 passed / 9 skipped (the 9 require Postgres infra; exercised by CI).

## Known limitation

The **bulk / upsert** write paths (`bulk_create`, `bulk_update`, `bulk_upsert`, `upsert`) are **not yet tenant-isolated** — they do not disclose cross-tenant data, but `bulk_create` currently writes unscoped (`NULL`-tenant) rows. Tracked in #1252. Use single-record `express` CRUD for tenant-isolated writes until then.

## Related issues

Fixes #1249
Known limitation tracked in #1252

🤖 Generated with [Claude Code](https://claude.com/claude-code)
