### PR TITLE
fix(dataflow): bulk-path tenant isolation + PostgreSQL multi-tenant list regression (#1252)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [2.11.1] — 2026-06-03 — Multi-tenant PostgreSQL `list` regression fix + bulk-path tenant isolation (#1249 follow-up / #1252)
+
+### Security / Fixed
+
+- **PostgreSQL multi-tenant `list` regression fixed (#1249 follow-up, introduced in 2.11.0).** The 2.11.0 tenant-injection on the SELECT/UPDATE/DELETE path hardcoded a `?` placeholder and did not renumber PostgreSQL `$N` placeholders, so a multi-tenant `express.list` (which emits a trailing `LIMIT $1 OFFSET $2`) bound the tenant string to `$1`/`LIMIT` and raised `argument of LIMIT must be type bigint, not type text`. The injection is now **dialect-placeholder-aware**: for `$N` queries the tenant predicate uses a `$N` placeholder and all existing `$N` are renumbered consistently (`... WHERE tenant_id = $1 ... LIMIT $2 OFFSET $3`); `?` (SQLite) and `%s` (psycopg/MySQL) keep positional insertion (byte-identical output). Affected only multi-tenant PostgreSQL `list`; create/read/count/update/delete were unaffected. The `*_postgres.py` regression tests were made self-contained (they previously aborted on a non-existent harness method and never exercised the path — the gap that let the regression ship); a multi-tenant `list`-with-`LIMIT` cross-read test now guards it.
+
+- **Multi-tenant bulk/upsert paths now enforce tenant isolation (#1252).** `bulk_create` / `bulk_update` / `bulk_delete` / `bulk_upsert` / `upsert` (the `db.bulk` subsystem) read the bound tenant from a stale legacy dict (`_tenant_context`, only set by the unused `set_tenant_context()` API) instead of the `tenant_context.switch()` contextvar — so under multi-tenancy every bulk write stored `tenant_id = NULL` (rows invisible to all tenants) and bulk update/delete ran with no tenant filter (latent cross-tenant write/delete). All four paths now resolve the tenant from `get_current_tenant_id()`, stamp `tenant_id` on bulk-created rows, AND the bound tenant predicate into bulk update/delete WHERE clauses (dialect-correct `?`/`$N`/`%s`), and **fail closed** (raise) when multi-tenant mode is on but no tenant is bound — never writing a NULL-tenant row or running an unscoped mutation. Single-tenant projects are unaffected.
+
+### Tests
+
+- New `tests/regression/test_issue_1252_bulk_tenant_isolation.py` (10 SQLite Tier-2: bulk cross-read isolation, non-NULL tenant_id, update/delete tenant-scoping, upsert round-trip + isolation, fail-closed on each op, single-tenant-unchanged) + a `_postgres.py` variant. New dialect-renumber unit tests + a PostgreSQL multi-tenant `list` regression test added to the #1249 suites. Verified end-to-end against real PostgreSQL.
+
 ## [2.11.0] — 2026-06-03 — Multi-tenant `express` cross-tenant leak fixed; fail-closed isolation (#1249)
 
 ### Security

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.11.0"
+version = "2.11.1"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.11.0"
+__version__ = "2.11.1"
 
 __all__ = [
     "DataFlow",

--- a/packages/kailash-dataflow/src/dataflow/features/bulk.py
+++ b/packages/kailash-dataflow/src/dataflow/features/bulk.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from kailash.utils.url_credentials import mask_url
 
+from ..core.tenant_context import get_current_tenant_id
 from ..nodes.bulk_result_processor import BulkCreateResultProcessor
 
 
@@ -17,6 +18,90 @@ class BulkOperations:
 
     def __init__(self, dataflow_instance):
         self.dataflow = dataflow_instance
+
+    def _is_multi_tenant(self) -> bool:
+        """True iff this DataFlow instance is configured multi-tenant."""
+        return bool(
+            getattr(
+                getattr(getattr(self.dataflow, "config", None), "security", None),
+                "multi_tenant",
+                False,
+            )
+        )
+
+    def _model_has_tenant_field(self, model_name: str) -> bool:
+        """True iff the model carries a ``tenant_id`` field (a tenant table)."""
+        try:
+            return "tenant_id" in self.dataflow.get_model_fields(model_name)
+        except Exception:
+            return False
+
+    def _resolve_bulk_tenant(self, model_name: str) -> Optional[str]:
+        """Resolve the bound tenant for a bulk op, fail-closed under multi-tenant.
+
+        Issue #1252 — the bulk subsystem builds its own SQL and previously read
+        the bound tenant from the stale ``self.dataflow._tenant_context`` dict
+        (only ever populated by the unused ``set_tenant_context()`` legacy API),
+        which is empty ``{}`` under ``tenant_context.switch()``. That made every
+        bulk write persist ``tenant_id=NULL`` (rows invisible to all tenants) and
+        left bulk_update / bulk_delete unscoped (latent cross-tenant write/delete).
+
+        This reads the SAME contextvar source the single-record path uses
+        (``get_current_tenant_id()``) and FAILS CLOSED — mirroring the #1249
+        ``_apply_tenant_isolation`` guard in ``core/nodes.py`` — per
+        ``tenant-isolation.md`` MUST-2 + ``zero-tolerance.md`` Rule 3.
+
+        Returns:
+            The bound tenant id when the model is a tenant table under
+            multi_tenant. ``None`` when the model is NOT a tenant table OR the
+            instance is single-tenant (caller injects nothing in that case).
+
+        Raises:
+            RuntimeError: when the model is a tenant table under multi_tenant but
+            no tenant is bound to the current context — refusing to write a
+            NULL-tenant row or run an unscoped UPDATE/DELETE.
+        """
+        if not self._is_multi_tenant():
+            return None
+        if not self._model_has_tenant_field(model_name):
+            return None
+        tenant_id = get_current_tenant_id()
+        if not tenant_id:
+            raise RuntimeError(
+                f"Tenant isolation failed for {model_name}: multi_tenant=True but "
+                f"no tenant is bound to the current context. Bind one via "
+                f"db.tenant_context.switch(tenant_id) before this bulk operation. "
+                f"Refusing to execute an unscoped query (potential cross-tenant leak)."
+            )
+        return tenant_id
+
+    def _tenant_where_predicate(
+        self, database_type: str, params_offset: int, tenant_id: str
+    ) -> tuple:
+        """Build the ``tenant_id = <bound>`` SQL fragment for a WHERE clause.
+
+        Returns a dialect-correct placeholder fragment (NO leading ``AND``/``WHERE``
+        — the caller composes that) plus the single bound parameter. The tenant
+        value is always a BOUND parameter, never string-interpolated, per
+        ``security.md`` § Parameterized Queries.
+
+        Args:
+            database_type: 'postgresql' | 'mysql' | 'sqlite'.
+            params_offset: count of params already bound BEFORE this predicate
+                (drives PostgreSQL ``$N`` numbering).
+            tenant_id: the bound tenant id to compare against.
+
+        Returns:
+            tuple: (fragment: str, params: list) e.g. ``("tenant_id = $3", [tid])``.
+        """
+        db_lower = database_type.lower()
+        if db_lower == "postgresql":
+            fragment = f"tenant_id = ${params_offset + 1}"
+        elif db_lower == "mysql":
+            fragment = "tenant_id = %s"
+        else:  # sqlite
+            fragment = "tenant_id = ?"
+        return fragment, [tenant_id]
 
     def _serialize_params_for_sql(self, params: list, model_name: str) -> list:
         """Serialize dict/list parameters to JSON for SQL binding.
@@ -275,11 +360,15 @@ class BulkOperations:
                 "success": True,
             }
 
-        # Apply tenant context if multi-tenant
-        if self.dataflow.config.security.multi_tenant and self.dataflow._tenant_context:
-            tenant_id = self.dataflow._tenant_context.get("tenant_id")
+        # Issue #1252 — stamp tenant_id from the contextvar source (the one
+        # tenant_context.switch() actually sets), NOT the stale legacy
+        # self.dataflow._tenant_context dict. Fails closed under multi_tenant
+        # with no bound tenant; returns None (no stamp) for single-tenant or
+        # non-tenant models. See _resolve_bulk_tenant.
+        bound_tenant = self._resolve_bulk_tenant(model_name)
+        if bound_tenant is not None:
             for record in data:
-                record["tenant_id"] = tenant_id
+                record["tenant_id"] = bound_tenant
 
         # Auto-convert ISO datetime strings to datetime objects for each record
         from ..core.nodes import convert_datetime_fields
@@ -496,6 +585,16 @@ class BulkOperations:
         if is_filter_based:
             # Filter-based bulk update - perform actual database operation
             logger.warning("BULK_UPDATE: Processing filter-based update")
+
+            # Issue #1252 — resolve the bound tenant up front, OUTSIDE the try so
+            # the fail-closed RuntimeError PROPAGATES (raises) rather than being
+            # swallowed into an error dict by the broad `except Exception` below.
+            # Mirrors the #1249 _apply_tenant_isolation raise in core/nodes.py.
+            # None for single-tenant or non-tenant models. The tenant predicate is
+            # AND-ed into the WHERE below so it can never be dropped (latent
+            # cross-tenant write protection). See _resolve_bulk_tenant.
+            bound_tenant = self._resolve_bulk_tenant(model_name)
+
             try:
                 # Auto-convert ISO datetime strings to datetime objects in update_values
                 from ..core.nodes import convert_datetime_fields
@@ -565,6 +664,21 @@ class BulkOperations:
                 )
                 params.extend(where_params)
 
+                # Issue #1252 — AND the tenant predicate into the WHERE so a
+                # filter that would otherwise match another tenant's rows can
+                # only touch the bound tenant's rows. The tenant value is a
+                # BOUND parameter. An empty user filter yields no WHERE keyword,
+                # so add one when the tenant predicate is the only condition.
+                if bound_tenant is not None:
+                    tenant_fragment, tenant_params = self._tenant_where_predicate(
+                        database_type, params_offset=len(params), tenant_id=bound_tenant
+                    )
+                    if where_clause:
+                        where_clause = f"{where_clause} AND {tenant_fragment}"
+                    else:
+                        where_clause = f"WHERE {tenant_fragment}"
+                    params.extend(tenant_params)
+
                 query = f"UPDATE {table_name} {set_clause} {where_clause}"
                 logger.warning(
                     f"BULK_UPDATE: Executing query='{query}' with params={params}"
@@ -629,6 +743,12 @@ class BulkOperations:
         elif data is not None:
             # Data-based bulk update - update records by id
             logger.warning("BULK_UPDATE: Processing data-based update")
+
+            # Issue #1252 — resolve the bound tenant; AND-ed into each per-record
+            # WHERE id = ? below so tenant A cannot update tenant B's row by
+            # supplying its id. Fails closed under multi_tenant with no bound
+            # tenant. See _resolve_bulk_tenant.
+            bound_tenant = self._resolve_bulk_tenant(model_name)
 
             # Handle empty data list (valid - update 0 records)
             if len(data) == 0:
@@ -732,6 +852,19 @@ class BulkOperations:
                         else:  # sqlite
                             where_clause = "WHERE id = ?"
                         params.append(record["id"])
+
+                        # Issue #1252 — AND the tenant predicate so the per-id
+                        # UPDATE can only touch the bound tenant's row.
+                        if bound_tenant is not None:
+                            tenant_fragment, tenant_params = (
+                                self._tenant_where_predicate(
+                                    database_type,
+                                    params_offset=len(params),
+                                    tenant_id=bound_tenant,
+                                )
+                            )
+                            where_clause = f"{where_clause} AND {tenant_fragment}"
+                            params.extend(tenant_params)
 
                         query = f"UPDATE {table_name} {set_clause} {where_clause}"
 
@@ -844,6 +977,16 @@ class BulkOperations:
         if filter_criteria is not None:
             # Filter-based bulk delete - perform actual database operation
             logger.warning("BULK_DELETE: Processing filter-based delete")
+
+            # Issue #1252 — resolve the bound tenant up front, OUTSIDE the try so
+            # the fail-closed RuntimeError PROPAGATES (raises) rather than being
+            # swallowed into an error dict by the broad `except Exception` below.
+            # Mirrors the #1249 _apply_tenant_isolation raise in core/nodes.py.
+            # None for single-tenant or non-tenant models. AND-ed into the WHERE
+            # below so a filter cannot delete another tenant's rows (latent
+            # cross-tenant delete protection). See _resolve_bulk_tenant.
+            bound_tenant = self._resolve_bulk_tenant(model_name)
+
             try:
                 # Get database connection and execute DELETE
                 connection_string = self.dataflow.config.database.get_connection_url(
@@ -866,6 +1009,21 @@ class BulkOperations:
                 where_clause, params = self._build_where_clause(
                     filter_criteria, database_type, params_offset=0
                 )
+
+                # Issue #1252 — AND the tenant predicate into the WHERE so a
+                # filter can only delete the bound tenant's rows. Applied BEFORE
+                # the COUNT pre-check + the DELETE so both see the scoped WHERE.
+                # An empty user filter yields no WHERE keyword, so add one when
+                # the tenant predicate is the only condition.
+                if bound_tenant is not None:
+                    tenant_fragment, tenant_params = self._tenant_where_predicate(
+                        database_type, params_offset=len(params), tenant_id=bound_tenant
+                    )
+                    if where_clause:
+                        where_clause = f"{where_clause} AND {tenant_fragment}"
+                    else:
+                        where_clause = f"WHERE {tenant_fragment}"
+                    params.extend(tenant_params)
 
                 # Execute using cached AsyncSQLDatabaseNode
                 # FIX: Use cached node instead of creating fresh instance
@@ -1022,11 +1180,16 @@ class BulkOperations:
                     "All records must have an 'id' for upsert operations.",
                 }
 
-        # Apply tenant context if multi-tenant
-        if self.dataflow.config.security.multi_tenant and self.dataflow._tenant_context:
-            tenant_id = self.dataflow._tenant_context.get("tenant_id")
+        # Issue #1252 — stamp tenant_id from the contextvar source (the one
+        # tenant_context.switch() actually sets), NOT the stale legacy
+        # self.dataflow._tenant_context dict. Fails closed under multi_tenant
+        # with no bound tenant. tenant_id rides in the column list, so the
+        # ON CONFLICT (id) target stays valid (id is the PK; tenant_id is just
+        # another INSERT/EXCLUDED column). See _resolve_bulk_tenant.
+        bound_tenant = self._resolve_bulk_tenant(model_name)
+        if bound_tenant is not None:
             for record in data:
-                record["tenant_id"] = tenant_id
+                record["tenant_id"] = bound_tenant
 
         # Auto-convert ISO datetime strings to datetime objects for each record
         from ..core.nodes import convert_datetime_fields

--- a/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
+++ b/packages/kailash-dataflow/src/dataflow/tenancy/interceptor.py
@@ -835,6 +835,16 @@ class QueryInterceptor:
         modified_query = query
         modified_params = params.copy()
 
+        # Issue #1249 (Postgres regression): detect the placeholder style of the
+        # INCOMING query so the injected tenant predicate uses the SAME dialect.
+        # The prior code hardcoded ``?``; on PostgreSQL (``$N``) that mixed
+        # dialects AND failed to renumber the existing ``$N`` placeholders, so
+        # ``LIMIT $1`` silently bound to the tenant string (``argument of LIMIT
+        # must be type bigint, not type text``). For ``$N`` we emit a sentinel
+        # token and renumber the whole query left-to-right after insertion.
+        style = self._detect_placeholder_style(modified_query)
+        tenant_ph = self._tenant_placeholder_for_style(style)
+
         # Issue #1249: build the tenant-column reference once. When a genuine
         # alias / explicit table qualifier is needed (multi-table / JOIN
         # queries) we qualify; for a single-table SELECT we emit the bare
@@ -846,18 +856,18 @@ class QueryInterceptor:
 
         # Add tenant conditions to WHERE clause.
         # Issue #1249: the tenant VALUE is inserted into ``modified_params`` at
-        # the index matching the injected ``?``'s position among all
+        # the index matching the injected placeholder's position among all
         # placeholders — NOT appended — so positional drivers bind it correctly.
         if "WHERE" in modified_query.upper():
             # Add AND condition
             for table in tenant_tables:
                 tenant_condition = self._build_tenant_condition(
-                    modified_query, table, qualify=has_join
+                    modified_query, table, qualify=has_join, placeholder=tenant_ph
                 )
                 where_match = re.search(r"WHERE\s+", modified_query, re.IGNORECASE)
-                # Char index where the injected tenant ``?`` lands: just after
-                # ``WHERE `` (the condition is "<col> = ?"). Placeholders before
-                # this index = the tenant param's positional index.
+                # Char index where the injected tenant placeholder lands: just
+                # after ``WHERE `` (the condition is "<col> = <ph>"). Placeholders
+                # before this index = the tenant param's positional index.
                 insert_char = where_match.end()
                 param_idx = self._count_placeholders_before(modified_query, insert_char)
                 modified_query = (
@@ -872,15 +882,15 @@ class QueryInterceptor:
             # Add WHERE clause
             for table in tenant_tables:
                 tenant_condition = self._build_tenant_condition(
-                    modified_query, table, qualify=has_join
+                    modified_query, table, qualify=has_join, placeholder=tenant_ph
                 )
 
                 # Insert before ORDER BY, GROUP BY, or HAVING if present
                 insertion_point = self._find_insertion_point(modified_query)
                 if insertion_point:
-                    # The injected ``?`` lands at ``insertion_point`` (before
-                    # ORDER BY/GROUP BY/HAVING/LIMIT). Count placeholders before
-                    # that char index for the param insertion index.
+                    # The injected placeholder lands at ``insertion_point``
+                    # (before ORDER BY/GROUP BY/HAVING/LIMIT). Count placeholders
+                    # before that char index for the param insertion index.
                     param_idx = self._count_placeholders_before(
                         modified_query, insertion_point
                     )
@@ -891,45 +901,141 @@ class QueryInterceptor:
                     )
                     modified_params.insert(param_idx, self.tenant_id)
                 else:
-                    # WHERE clause appended at the very end → tenant ``?`` is the
-                    # last placeholder; append is correct here.
+                    # WHERE clause appended at the very end → tenant placeholder
+                    # is the last placeholder; append is correct here.
                     modified_query += f" WHERE {tenant_condition}"
                     modified_params.append(self.tenant_id)
                 break  # Only add one WHERE clause
 
+        # Issue #1249 (Postgres): renumber ``$N`` placeholders left-to-right so
+        # the textual ordinals match the (already-correctly-ordered) params list
+        # and the tenant sentinel token becomes a real ``$N``. No-op for ``?`` /
+        # ``%s`` (positional, bind by appearance order).
+        if style == "dollar":
+            modified_query = self._renumber_dollar_placeholders(modified_query)
+
         return modified_query, modified_params
 
-    def _build_tenant_condition(self, query: str, table: str, qualify: bool) -> str:
-        """Build the ``<col> = ?`` tenant predicate for a SELECT table.
+    def _build_tenant_condition(
+        self, query: str, table: str, qualify: bool, placeholder: str = "?"
+    ) -> str:
+        """Build the ``<col> = <placeholder>`` tenant predicate for a SELECT table.
 
         When ``qualify`` (multi-table / JOIN) the column is prefixed with the
         table alias (or the verbatim table token from the query) so the predicate
         is unambiguous. For a single-table SELECT the bare column is returned to
         avoid a quoted-vs-unquoted qualifier mismatch (issue #1249).
+
+        ``placeholder`` is the dialect-correct placeholder text for the bound
+        tenant value (issue #1249 Postgres regression): ``?`` for SQLite/generic,
+        ``%s`` for psycopg/MySQL, or the ``$N`` sentinel token for PostgreSQL
+        (renumbered downstream). It MUST match the placeholder style of the
+        incoming query so the injected predicate does not mix dialects.
         """
         if not qualify:
-            return f"{self.tenant_column} = ?"
+            return f"{self.tenant_column} = {placeholder}"
         table_alias = self._get_table_alias(query, table)
-        return f"{table_alias}.{self.tenant_column} = ?"
+        return f"{table_alias}.{self.tenant_column} = {placeholder}"
 
     # Placeholder forms across dialects: ``?`` (SQLite / generic),
     # ``$N`` (PostgreSQL), ``%s`` (MySQL / psycopg).
     _PLACEHOLDER_RE = re.compile(r"\?|\$\d+|%s")
+    # Sentinel for the to-be-inserted tenant placeholder. It is NOT a real
+    # placeholder of any dialect, so ``_PLACEHOLDER_RE`` does not match it and a
+    # ``$N`` renumber pass skips over it; the final render step replaces it with
+    # the dialect-correct placeholder. Chosen to be SQL-illegal so any failure
+    # to replace it surfaces loudly at execution rather than binding silently.
+    _TENANT_PLACEHOLDER_TOKEN = "\x00TENANT_PH\x00"
 
     def _count_placeholders_before(self, query: str, char_index: int) -> int:
         """Count bound-parameter placeholders before ``char_index`` in ``query``.
 
-        Issue #1249: the tenant ``?`` is inserted into the WHERE clause at a
-        specific character position, but positional drivers (SQLite, asyncpg)
+        Issue #1249: the tenant placeholder is inserted into the WHERE clause at
+        a specific character position, but positional drivers (SQLite, asyncpg)
         bind parameters by ORDER OF APPEARANCE. The tenant VALUE must therefore
         be inserted into the params list at the index equal to the number of
-        placeholders that precede the injected ``?`` — NOT appended at the end.
-        Appending shifts every trailing placeholder (e.g. ``LIMIT ?``,
+        placeholders that precede the injected placeholder — NOT appended at the
+        end. Appending shifts every trailing placeholder (e.g. ``LIMIT ?``,
         ``OFFSET ?``) onto the wrong value and the tenant filter binds against a
         LIMIT integer, silently matching zero rows (the read-returns-nothing
         symptom) or, worse, the wrong tenant.
         """
         return len(self._PLACEHOLDER_RE.findall(query[:char_index]))
+
+    @classmethod
+    def _detect_placeholder_style(cls, query: str) -> str:
+        """Detect the dialect placeholder style of ``query``.
+
+        Issue #1249 (Postgres regression): the tenant predicate injected into a
+        SELECT/UPDATE/DELETE MUST use the SAME placeholder style as the incoming
+        query, and ``$N`` placeholders must be renumbered after insertion. The
+        ``_apply_tenant_isolation`` caller in ``core/nodes.py`` does NOT pass a
+        ``database_type``, so the style is read off the query itself (the query
+        already carries dialect-specific placeholders from the SQL builder).
+
+        Returns one of:
+            ``"dollar"``  — PostgreSQL / asyncpg ``$1, $2, ...`` (ordinal).
+            ``"percent"`` — psycopg / MySQL ``%s`` (positional).
+            ``"qmark"``   — SQLite / generic ``?`` (positional). Also the default
+                            when the query carries no placeholders at all.
+        """
+        if re.search(r"\$\d+", query):
+            return "dollar"
+        if "%s" in query:
+            return "percent"
+        return "qmark"
+
+    @classmethod
+    def _tenant_placeholder_for_style(cls, style: str) -> str:
+        """Return the literal placeholder text for a tenant predicate.
+
+        For ``dollar`` we emit the sentinel token so a downstream renumber pass
+        (``_renumber_dollar_placeholders``) assigns the correct ``$N`` once the
+        full query is assembled. For ``percent`` / ``qmark`` the placeholder is
+        positional, so the literal text is final.
+        """
+        if style == "dollar":
+            return cls._TENANT_PLACEHOLDER_TOKEN
+        if style == "percent":
+            return "%s"
+        return "?"
+
+    @classmethod
+    def _renumber_dollar_placeholders(cls, query: str) -> str:
+        """Renumber every ``$N`` placeholder in left-to-right appearance order.
+
+        Issue #1249 (Postgres regression): inserting a tenant predicate into a
+        ``$N`` query shifts the positional index of every placeholder AFTER the
+        insertion point, but the textual ``$N`` numbers do not move on their own.
+        After the predicate is inserted (using the sentinel token for the tenant
+        placeholder, and the params list already ``.insert()``-ed at the correct
+        index), this pass walks the query left-to-right and re-assigns ``$1,
+        $2, ...`` to BOTH the sentinel token AND every existing ``$N`` in order
+        of appearance — guaranteeing the rendered ``$N`` sequence matches the
+        positional order of the params list.
+
+        Example (tenant inserted at index 0):
+            ``SELECT * FROM t WHERE <TOKEN> AND id = $1 LIMIT $2 OFFSET $3``
+            → ``SELECT * FROM t WHERE $1 AND id = $2 LIMIT $3 OFFSET $4``
+
+        Only the ``$N`` style needs this pass; ``?`` / ``%s`` are positional and
+        bind purely by appearance order, so textual renumbering is a no-op for
+        them (handled by the caller skipping this pass).
+        """
+        counter = {"n": 0}
+
+        # A single regex alternation matches either the tenant sentinel token or
+        # an existing ``$N`` placeholder, in one left-to-right pass, so the
+        # ordinal assignment respects the true appearance order of ALL bound
+        # placeholders (tenant + originals interleaved).
+        token = re.escape(cls._TENANT_PLACEHOLDER_TOKEN)
+        pattern = re.compile(rf"{token}|\$\d+")
+
+        def _assign(_match: "re.Match[str]") -> str:
+            counter["n"] += 1
+            return f"${counter['n']}"
+
+        return pattern.sub(_assign, query)
 
     def _inject_insert_conditions(
         self, query: str, params: List[Any], parsed: ParsedQuery
@@ -981,9 +1087,22 @@ class QueryInterceptor:
                 # inject_tenant_conditions checks params, not just the query,
                 # to confirm the tenant value was actually bound.
             else:
-                # Tenant column absent — append it plus a bound ``?`` placeholder.
+                # Tenant column absent — append it plus a bound placeholder.
+                # Issue #1249 (Postgres): the appended placeholder MUST match the
+                # incoming dialect. The tenant column is the LAST value, so for
+                # ``$N`` it is ``$<count+1>`` (one past the existing max); for
+                # ``?`` / ``%s`` it is positional. Appending is correct here (no
+                # renumber needed) because the tenant value is the final param.
+                style = self._detect_placeholder_style(modified_query)
+                if style == "dollar":
+                    existing = len(self._PLACEHOLDER_RE.findall(values))
+                    value_ph = f"${existing + 1}"
+                elif style == "percent":
+                    value_ph = "%s"
+                else:
+                    value_ph = "?"
                 new_columns = f"{columns}, {self.tenant_column}"
-                new_values = f"{values}, ?"
+                new_values = f"{values}, {value_ph}"
                 modified_query = re.sub(
                     rf"INSERT\s+INTO\s+{_IDENT}\s*\([^)]+\)\s*VALUES\s*\([^)]+\)",
                     f"INSERT INTO {table_token} ({new_columns}) VALUES ({new_values})",
@@ -1006,10 +1125,12 @@ class QueryInterceptor:
         modified_query = query
         modified_params = params.copy()
         # Issue #1249: insert the tenant VALUE at the placeholder-position of the
-        # injected ``?`` (after the SET-clause placeholders) rather than
-        # appending; positional drivers bind by order of appearance.
+        # injected placeholder (after the SET-clause placeholders) rather than
+        # appending; positional drivers bind by order of appearance. The
+        # predicate placeholder is rendered dialect-correctly (``$N`` renumbered)
+        # by _inject_where_predicate.
         modified_query, modified_params = self._inject_where_predicate(
-            modified_query, modified_params, f"{self.tenant_column} = ?"
+            modified_query, modified_params
         )
         return modified_query, modified_params
 
@@ -1025,23 +1146,33 @@ class QueryInterceptor:
         modified_params = params.copy()
         # Issue #1249: position-aware tenant param insertion (see UPDATE above).
         modified_query, modified_params = self._inject_where_predicate(
-            modified_query, modified_params, f"{self.tenant_column} = ?"
+            modified_query, modified_params
         )
         return modified_query, modified_params
 
     def _inject_where_predicate(
-        self, query: str, params: List[Any], predicate: str
+        self, query: str, params: List[Any]
     ) -> Tuple[str, List[Any]]:
-        """Inject a single-``?`` WHERE predicate with correct param positioning.
+        """Inject a single tenant WHERE predicate with correct param positioning.
 
-        Shared by UPDATE / DELETE. ``predicate`` MUST contain exactly one ``?``
-        placeholder (the tenant column). The bound tenant VALUE
-        (``self.tenant_id``) is inserted into ``params`` at the index matching
-        the injected ``?``'s position among all placeholders in the resulting
-        query — never appended blindly (issue #1249 param-ordering bug).
+        Shared by UPDATE / DELETE. The predicate ``<tenant_column> = <ph>`` is
+        built with a dialect-correct placeholder (issue #1249 Postgres
+        regression): ``?`` for SQLite/generic, ``%s`` for psycopg/MySQL, or a
+        ``$N`` sentinel for PostgreSQL renumbered left-to-right after insertion.
+        The bound tenant VALUE (``self.tenant_id``) is inserted into ``params``
+        at the index matching the injected placeholder's position among all
+        placeholders — never appended blindly (issue #1249 param-ordering bug).
         """
         modified_query = query
         modified_params = list(params)
+
+        # Issue #1249 (Postgres): detect the incoming dialect placeholder style
+        # and render the tenant predicate to match. The prior hardcoded ``?``
+        # mixed dialects on PostgreSQL (``$N``) and left existing ``$N``
+        # unrenumbered after the insertion shifted positions.
+        style = self._detect_placeholder_style(modified_query)
+        tenant_ph = self._tenant_placeholder_for_style(style)
+        predicate = f"{self.tenant_column} = {tenant_ph}"
 
         if "WHERE" in modified_query.upper():
             where_match = re.search(r"WHERE\s+", modified_query, re.IGNORECASE)
@@ -1056,10 +1187,16 @@ class QueryInterceptor:
         else:
             # No existing WHERE. For UPDATE/DELETE the WHERE goes at the end of
             # the statement, after any SET-clause placeholders, so the tenant
-            # ``?`` is the last placeholder → append is correct. (DataFlow does
-            # not emit trailing LIMIT on UPDATE/DELETE.)
+            # placeholder is the last placeholder → append is correct. (DataFlow
+            # does not emit trailing LIMIT on UPDATE/DELETE.)
             modified_query += f" WHERE {predicate}"
             modified_params.append(self.tenant_id)
+
+        # Issue #1249 (Postgres): renumber ``$N`` left-to-right so the sentinel
+        # token becomes a real ``$N`` and existing placeholders shift to match
+        # the params list order. No-op for ``?`` / ``%s``.
+        if style == "dollar":
+            modified_query = self._renumber_dollar_placeholders(modified_query)
 
         return modified_query, modified_params
 

--- a/packages/kailash-dataflow/tests/integration/bulk_operations/test_bulk_upsert_delegation_integration.py
+++ b/packages/kailash-dataflow/tests/integration/bulk_operations/test_bulk_upsert_delegation_integration.py
@@ -8,9 +8,9 @@ NO MOCKING - Uses real PostgreSQL on port 5434 via IntegrationTestSuite.
 """
 
 import pytest
-from dataflow import DataFlow
-
 from kailash.nodes.data.async_sql import AsyncSQLDatabaseNode
+
+from dataflow import DataFlow
 from tests.infrastructure.test_harness import IntegrationTestSuite
 
 
@@ -387,39 +387,44 @@ class TestBulkUpsertDelegationIntegration:
             score: int
             tenant_id: str
 
+        # Issue #1252: the bound tenant comes from the _current_tenant ContextVar
+        # set by tenant_context.switch() (read via get_current_tenant_id()), NOT
+        # the legacy db._tenant_context dict. Register the tenants and switch into
+        # each — the bulk subsystem stamps tenant_id from the bound context.
+        db.tenant_context.register_tenant("tenant_001", "T1")
+        db.tenant_context.register_tenant("tenant_002", "T2")
+
         # Upsert for tenant 1
-        db._tenant_context = {"tenant_id": "tenant_001"}
-        result1 = await db.bulk.bulk_upsert(
-            model_name="TestUpsertDelegation",
-            data=[
-                {
-                    "email": "shared@example.com",
-                    "name": "Tenant 1 User",
-                    "status": "active",
-                    "score": 100,
-                },
-            ],
-            conflict_resolution="update",
-            conflict_columns=["email", "tenant_id"],
-        )
+        with db.tenant_context.switch("tenant_001"):
+            result1 = await db.bulk.bulk_upsert(
+                model_name="TestUpsertDelegation",
+                data=[
+                    {
+                        "email": "shared@example.com",
+                        "name": "Tenant 1 User",
+                        "status": "active",
+                        "score": 100,
+                    },
+                ],
+                conflict_resolution="update",
+            )
 
         assert result1["success"] is True
 
         # Upsert for tenant 2 (same email, different tenant)
-        db._tenant_context = {"tenant_id": "tenant_002"}
-        result2 = await db.bulk.bulk_upsert(
-            model_name="TestUpsertDelegation",
-            data=[
-                {
-                    "email": "shared@example.com",
-                    "name": "Tenant 2 User",
-                    "status": "active",
-                    "score": 200,
-                },
-            ],
-            conflict_resolution="update",
-            conflict_columns=["email", "tenant_id"],
-        )
+        with db.tenant_context.switch("tenant_002"):
+            result2 = await db.bulk.bulk_upsert(
+                model_name="TestUpsertDelegation",
+                data=[
+                    {
+                        "email": "shared@example.com",
+                        "name": "Tenant 2 User",
+                        "status": "active",
+                        "score": 200,
+                    },
+                ],
+                conflict_resolution="update",
+            )
 
         assert result2["success"] is True
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_1249_tenant_isolation_leak.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1249_tenant_isolation_leak.py
@@ -272,6 +272,115 @@ def test_select_injection_binds_tenant_param_at_correct_position():
 
 @pytest.mark.regression
 @pytest.mark.unit
+def test_select_injection_renumbers_dollar_placeholders_postgres():
+    """Postgres ``$N``: tenant predicate is ``$N`` and existing $N renumber.
+
+    Regression for the #1249 follow-up (2.11.0 → 2.11.1). The injector hardcoded
+    ``?`` and did NOT renumber the trailing ``$N`` placeholders. DataFlow's
+    ``list`` emits ``... LIMIT $1 OFFSET $2``; injecting ``WHERE tenant_id = ?``
+    produced ``WHERE tenant_id = ? ... LIMIT $1 OFFSET $2`` with params
+    ``['acme', 100, 0]`` — on Postgres ``$1`` bound the tenant STRING to LIMIT
+    (``argument of LIMIT must be type bigint, not type text``). The fix renders
+    ``$1`` for the tenant predicate and shifts ``LIMIT $2 OFFSET $3``.
+    """
+    interceptor = QueryInterceptor(tenant_id="acme", tenant_tables=["feats"])
+    q = 'SELECT * FROM "feats" ORDER BY "id" DESC LIMIT $1 OFFSET $2'
+    mq, mp = interceptor.inject_tenant_conditions(q, [100, 0])
+    assert mq == (
+        'SELECT * FROM "feats" WHERE tenant_id = $1 ORDER BY "id" DESC '
+        "LIMIT $2 OFFSET $3"
+    ), f"placeholder renumber wrong: {mq}"
+    assert mp == ["acme", 100, 0], f"param ordering wrong: {mp}"
+    # No literal ``?`` may leak into a Postgres ($N) query (mixed-dialect bug).
+    assert "?" not in mq, f"mixed-dialect placeholder leaked: {mq}"
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_select_where_injection_renumbers_dollar_placeholders_postgres():
+    """Postgres ``$N`` SELECT WITH existing WHERE: AND-ed predicate renumbers.
+
+    ``SELECT ... WHERE active = $1 LIMIT $2 OFFSET $3`` → the tenant predicate is
+    inserted at position 0 (``$1``) and every existing placeholder shifts +1.
+    """
+    interceptor = QueryInterceptor(tenant_id="acme", tenant_tables=["feats"])
+    q = 'SELECT * FROM "feats" WHERE "active" = $1 ORDER BY "id" LIMIT $2 OFFSET $3'
+    mq, mp = interceptor.inject_tenant_conditions(q, [True, 50, 0])
+    assert mq == (
+        'SELECT * FROM "feats" WHERE tenant_id = $1 AND "active" = $2 '
+        'ORDER BY "id" LIMIT $3 OFFSET $4'
+    ), f"placeholder renumber wrong: {mq}"
+    assert mp == ["acme", True, 50, 0], f"param ordering wrong: {mp}"
+    assert "?" not in mq, f"mixed-dialect placeholder leaked: {mq}"
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_update_delete_injection_renumbers_dollar_placeholders_postgres():
+    """Postgres ``$N`` UPDATE / DELETE: tenant predicate renumbers correctly.
+
+    UPDATE: ``SET score=$1 WHERE id=$2`` → tenant inserted before ``id`` as
+    ``$2`` (after the SET placeholder), ``id`` shifts to ``$3``.
+    DELETE: ``WHERE id=$1`` → tenant ``$1``, ``id`` shifts to ``$2``.
+    """
+    it_u = QueryInterceptor(tenant_id="acme", tenant_tables=["feats"])
+    uq, up = it_u.inject_tenant_conditions(
+        'UPDATE "feats" SET "score" = $1 WHERE "id" = $2', [10, 42]
+    )
+    assert uq == (
+        'UPDATE "feats" SET "score" = $1 WHERE tenant_id = $2 AND "id" = $3'
+    ), f"update renumber wrong: {uq}"
+    assert up == [10, "acme", 42], f"update param ordering wrong: {up}"
+    assert "?" not in uq
+
+    it_d = QueryInterceptor(tenant_id="acme", tenant_tables=["feats"])
+    dq, dp = it_d.inject_tenant_conditions('DELETE FROM "feats" WHERE "id" = $1', [42])
+    assert dq == (
+        'DELETE FROM "feats" WHERE tenant_id = $1 AND "id" = $2'
+    ), f"delete renumber wrong: {dq}"
+    assert dp == ["acme", 42], f"delete param ordering wrong: {dp}"
+    assert "?" not in dq
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_select_injection_preserves_percent_placeholders_mysql():
+    """psycopg/MySQL ``%s``: tenant predicate uses ``%s``, no ``$N`` / ``?`` leak.
+
+    ``%s`` is positional, so no renumber is needed — but the injected tenant
+    placeholder MUST be ``%s`` (not the hardcoded ``?``) so the driver does not
+    see a mixed-dialect query.
+    """
+    interceptor = QueryInterceptor(tenant_id="acme", tenant_tables=["feats"])
+    q = 'SELECT * FROM "feats" ORDER BY "id" LIMIT %s OFFSET %s'
+    mq, mp = interceptor.inject_tenant_conditions(q, [100, 0])
+    assert mq == (
+        'SELECT * FROM "feats" WHERE tenant_id = %s ORDER BY "id" ' "LIMIT %s OFFSET %s"
+    ), f"percent placeholder wrong: {mq}"
+    assert mp == ["acme", 100, 0], f"param ordering wrong: {mp}"
+    assert "?" not in mq and "$" not in mq, f"mixed-dialect placeholder leaked: {mq}"
+
+
+@pytest.mark.regression
+@pytest.mark.unit
+def test_select_injection_qmark_unchanged_sqlite():
+    """SQLite ``?``: behavior is byte-identical to the pre-fix path (no regress).
+
+    The pre-#1249-follow-up SELECT injector hardcoded ``?`` and was correct for
+    SQLite. The dialect-aware fix MUST preserve that exact output for ``?``.
+    """
+    interceptor = QueryInterceptor(tenant_id="A", tenant_tables=["feats"])
+    q = 'SELECT * FROM "feats" ORDER BY "id" DESC LIMIT ? OFFSET ?'
+    mq, mp = interceptor.inject_tenant_conditions(q, [100, 0])
+    assert mq == (
+        'SELECT * FROM "feats" WHERE tenant_id = ? ORDER BY "id" DESC '
+        "LIMIT ? OFFSET ?"
+    ), f"sqlite ? path regressed: {mq}"
+    assert mp == ["A", 100, 0], f"param ordering wrong: {mp}"
+
+
+@pytest.mark.regression
+@pytest.mark.unit
 def test_insert_injection_does_not_duplicate_existing_tenant_column():
     """When tenant_id is already a column, bind its value — do not append.
 

--- a/packages/kailash-dataflow/tests/regression/test_issue_1249_tenant_isolation_leak_postgres.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1249_tenant_isolation_leak_postgres.py
@@ -12,6 +12,8 @@ PostgreSQL. This test confirms isolation holds on PostgreSQL's quoted-identifier
 SQL (``INSERT INTO "feats" ...`` + ``$1, $2`` placeholders + ``RETURNING``).
 """
 
+import uuid
+
 import pytest
 
 from dataflow import DataFlow
@@ -33,43 +35,134 @@ async def test_suite():
 async def test_express_multi_tenant_isolation_no_cross_tenant_leak_postgres(test_suite):
     """Two tenants create rows on PostgreSQL; each reads back ONLY its own."""
     db_url = test_suite.config.url
-    await test_suite.clean_database()
+
+    suffix = uuid.uuid4().hex[:8]
+    model_name = f"Feat1249{suffix}"
+    table = f"{model_name.lower()}s"
 
     db = DataFlow(db_url, auto_migrate=True, multi_tenant=True)
 
-    @db.model
-    class Feat1249:
-        entity_id: str
-        score: int
+    Feat = type(model_name, (), {"__annotations__": {"entity_id": str, "score": int}})
+    db.model(Feat)
 
-    await db.initialize()
+    try:
+        await db.initialize()
 
-    db.tenant_context.register_tenant("acme", "A")
-    db.tenant_context.register_tenant("globex", "G")
+        db.tenant_context.register_tenant("acme", "A")
+        db.tenant_context.register_tenant("globex", "G")
 
-    with db.tenant_context.switch("acme"):
-        await db.express.create("Feat1249", {"entity_id": "e1", "score": 10})
-    with db.tenant_context.switch("globex"):
-        await db.express.create("Feat1249", {"entity_id": "e1", "score": 99})
+        with db.tenant_context.switch("acme"):
+            await db.express.create(model_name, {"entity_id": "e1", "score": 10})
+        with db.tenant_context.switch("globex"):
+            await db.express.create(model_name, {"entity_id": "e1", "score": 99})
 
-    with db.tenant_context.switch("acme"):
-        acme_rows = await db.express.list("Feat1249", {})
-    with db.tenant_context.switch("globex"):
-        globex_rows = await db.express.list("Feat1249", {})
+        with db.tenant_context.switch("acme"):
+            acme_rows = await db.express.list(model_name, {})
+        with db.tenant_context.switch("globex"):
+            globex_rows = await db.express.list(model_name, {})
 
-    acme_scores = sorted(r.get("score") for r in acme_rows)
-    globex_scores = sorted(r.get("score") for r in globex_rows)
+        acme_scores = sorted(r.get("score") for r in acme_rows)
+        globex_scores = sorted(r.get("score") for r in globex_rows)
 
-    assert acme_scores == [10], f"cross-tenant leak (postgres): acme saw {acme_scores}"
-    assert globex_scores == [
-        99
-    ], f"cross-tenant leak (postgres): globex saw {globex_scores}"
+        assert acme_scores == [
+            10
+        ], f"cross-tenant leak (postgres): acme saw {acme_scores}"
+        assert globex_scores == [
+            99
+        ], f"cross-tenant leak (postgres): globex saw {globex_scores}"
 
-    # Raw-row assertion: tenant_id persisted non-NULL per row (defect #2).
-    async with test_suite.get_connection() as conn:
-        rows = await conn.fetch(
-            "SELECT entity_id, score, tenant_id FROM feat1249s ORDER BY id"
-        )
-    tenants = {r["tenant_id"] for r in rows}
-    assert None not in tenants, f"tenant_id stored NULL on postgres: {rows}"
-    assert tenants == {"acme", "globex"}, f"wrong tenant_id values: {rows}"
+        # Raw-row assertion: tenant_id persisted non-NULL per row (defect #2).
+        async with test_suite.get_connection() as conn:
+            rows = await conn.fetch(
+                f'SELECT entity_id, score, tenant_id FROM "{table}" ORDER BY id'
+            )
+        tenants = {r["tenant_id"] for r in rows}
+        assert None not in tenants, f"tenant_id stored NULL on postgres: {rows}"
+        assert tenants == {"acme", "globex"}, f"wrong tenant_id values: {rows}"
+    finally:
+        async with test_suite.get_connection() as conn:
+            await conn.execute(f'DROP TABLE IF EXISTS "{table}" CASCADE')
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.postgresql
+async def test_express_multi_tenant_list_with_limit_isolates_postgres(test_suite):
+    """Multi-tenant ``list`` (default LIMIT/OFFSET) isolates on PostgreSQL.
+
+    Regression for the #1249 follow-up (2.11.0 → 2.11.1): the SELECT-condition
+    injector hardcoded a ``?`` placeholder for the tenant predicate and did NOT
+    renumber the existing ``$N`` placeholders. DataFlow's ``list`` emits a
+    trailing ``LIMIT $1 OFFSET $2``; injecting ``WHERE tenant_id = ?`` produced
+    ``... WHERE tenant_id = ? ORDER BY id DESC LIMIT $1 OFFSET $2`` with params
+    ``['acme', 100, 0]`` — on PostgreSQL ``$1`` bound to the tenant STRING and
+    asyncpg raised ``argument of LIMIT must be type bigint, not type text``.
+    SQLite (all-``?``, positional) hid the defect because positional binding
+    happened to line up.
+
+    Pre-fix this test ERRORS at the first ``list`` (LIMIT type error). Post-fix
+    the injected predicate is ``$1`` and the existing placeholders renumber to
+    ``LIMIT $2 OFFSET $3``, so each tenant's list returns ONLY its own rows.
+    This is the exact path that shipped broken in 2.11.0 — covered here because
+    the pre-fix suite never exercised a multi-tenant Postgres ``list`` with the
+    default LIMIT.
+    """
+    db_url = test_suite.config.url
+
+    # Unique model/table per run (shared test DB); DROPped in finally.
+    suffix = uuid.uuid4().hex[:8]
+    model_name = f"Feat1249Limit{suffix}"
+    table = f"{model_name.lower()}s"
+
+    db = DataFlow(db_url, auto_migrate=True, multi_tenant=True)
+
+    Feat = type(model_name, (), {"__annotations__": {"entity_id": str, "score": int}})
+    db.model(Feat)
+
+    try:
+        await db.initialize()
+
+        db.tenant_context.register_tenant("acme", "A")
+        db.tenant_context.register_tenant("globex", "G")
+
+        # Multiple rows per tenant so the LIMIT (default) is genuinely exercised.
+        with db.tenant_context.switch("acme"):
+            for i in range(3):
+                await db.express.create(model_name, {"entity_id": f"a{i}", "score": i})
+        with db.tenant_context.switch("globex"):
+            for i in range(3):
+                await db.express.create(
+                    model_name, {"entity_id": f"g{i}", "score": 100 + i}
+                )
+
+        # list() with the framework default LIMIT — the trailing ``LIMIT $N
+        # OFFSET $N`` path that bound the tenant string to LIMIT pre-fix.
+        with db.tenant_context.switch("acme"):
+            acme_rows = await db.express.list(model_name, {})
+        with db.tenant_context.switch("globex"):
+            globex_rows = await db.express.list(model_name, {})
+
+        acme_scores = sorted(r.get("score") for r in acme_rows)
+        globex_scores = sorted(r.get("score") for r in globex_rows)
+
+        assert acme_scores == [0, 1, 2], f"list leak/wrong (acme, pg): {acme_scores}"
+        assert globex_scores == [
+            100,
+            101,
+            102,
+        ], f"list leak/wrong (globex, pg): {globex_scores}"
+
+        # Explicit non-default LIMIT/OFFSET also stays tenant-scoped (renumber
+        # holds when MORE trailing $N placeholders precede the injection point).
+        with db.tenant_context.switch("acme"):
+            acme_limited = await db.express.list(model_name, {}, limit=2, offset=0)
+        assert (
+            len(acme_limited) == 2
+        ), f"explicit LIMIT broke isolation/paging: {acme_limited}"
+        assert all(
+            r.get("score") in (0, 1, 2) for r in acme_limited
+        ), f"explicit-LIMIT list leaked globex rows: {acme_limited}"
+    finally:
+        async with test_suite.get_connection() as conn:
+            await conn.execute(f'DROP TABLE IF EXISTS "{table}" CASCADE')

--- a/packages/kailash-dataflow/tests/regression/test_issue_1252_bulk_tenant_isolation.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1252_bulk_tenant_isolation.py
@@ -1,0 +1,369 @@
+"""Regression tests for issue #1252 — DataFlow bulk + upsert cross-tenant leak.
+
+Issue #1252 (follow-up to #1249): in multi-tenant mode, DataFlow's BULK write
+paths (``bulk_create`` / ``bulk_update`` / ``bulk_delete`` / ``bulk_upsert``)
+provided NO tenant isolation. The bulk subsystem (``dataflow.features.bulk``,
+reached via the node dispatch at ``nodes.py`` and ``db.bulk.*``) builds its own
+SQL and does NOT route through ``_apply_tenant_isolation`` / ``QueryInterceptor``
+(the single-record enforcement point #1249 fixed). It HAD inline tenant handling
+but read the WRONG source:
+
+- ``tenant_context.switch(t)`` sets the ``_current_tenant`` ContextVar, read by
+  ``get_current_tenant_id()`` — the source the single-record path uses.
+- The bulk subsystem read ``self.dataflow._tenant_context.get("tenant_id")`` — a
+  SEPARATE legacy dict only populated by the unused ``set_tenant_context()``
+  API. Under ``switch()`` that dict stays empty ``{}`` → ``tenant_id`` was never
+  set → every bulk write persisted ``tenant_id = NULL`` (rows invisible to all
+  tenants), AND bulk_update / bulk_delete ran with NO ``tenant_id`` in the WHERE
+  (latent cross-tenant write/delete).
+
+The fix reads ``get_current_tenant_id()`` in all four bulk ops, stamps
+``tenant_id`` on create/upsert records, AND-s a bound ``tenant_id`` predicate
+into the WHERE for update/delete, and FAILS CLOSED (raises) when no tenant is
+bound under ``multi_tenant=True`` — mirroring the #1249 ``_apply_tenant_isolation``
+guard per ``tenant-isolation.md`` MUST-2 + ``zero-tolerance.md`` Rule 3.
+Single-tenant DataFlow (``multi_tenant=False``) keeps current behavior.
+
+These are permanent regression tests — NEVER delete (``rules/testing.md``
+Regression). The bulk subsystem methods are async (``db.bulk.*``), the exact
+path the node dispatch routes to.
+"""
+
+import sqlite3
+import tempfile
+
+import pytest
+
+from dataflow import DataFlow
+
+# ---------------------------------------------------------------------------
+# Tier-2: end-to-end bulk isolation through the real bulk subsystem (SQLite)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mt_db():
+    """Multi-tenant DataFlow over file-backed SQLite + Feat model.
+
+    Yields ``(db, tmpdir)`` and closes the DataFlow on teardown so the runner
+    does not accumulate ``ResourceWarning: Unclosed LocalRuntime`` per
+    ``rules/testing.md`` (fixtures yield + cleanup, never return).
+    """
+    tmpdir = tempfile.mkdtemp()
+    db = DataFlow(
+        f"sqlite:///{tmpdir}/mt.db",
+        auto_migrate=True,
+        multi_tenant=True,
+    )
+
+    @db.model
+    class Feat:
+        entity_id: str
+        score: int
+
+    db._ensure_connected()
+    db.tenant_context.register_tenant("acme", "A")
+    db.tenant_context.register_tenant("globex", "G")
+    try:
+        yield db, tmpdir
+    finally:
+        db.close()
+
+
+def _raw(tmpdir):
+    con = sqlite3.connect(f"{tmpdir}/mt.db")
+    try:
+        return con.execute(
+            "SELECT entity_id, score, tenant_id FROM feats ORDER BY tenant_id, score"
+        ).fetchall()
+    finally:
+        con.close()
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_create_isolation_no_cross_tenant_leak(mt_db):
+    """Two tenants bulk_create rows; each reads back ONLY its own rows.
+
+    This is the core #1252 leak: pre-fix every bulk_create row stored
+    ``tenant_id = NULL`` so each tenant's filtered read returned nothing.
+    """
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_create(
+            "Feat", [{"entity_id": "a1", "score": 1}, {"entity_id": "a2", "score": 2}]
+        )
+    with db.tenant_context.switch("globex"):
+        await db.bulk.bulk_create(
+            "Feat",
+            [{"entity_id": "g1", "score": 100}, {"entity_id": "g2", "score": 200}],
+        )
+
+    with db.tenant_context.switch("acme"):
+        acme_scores = sorted(r.get("score") for r in db.express_sync.list("Feat", {}))
+    with db.tenant_context.switch("globex"):
+        globex_scores = sorted(r.get("score") for r in db.express_sync.list("Feat", {}))
+
+    assert acme_scores == [1, 2], f"cross-tenant leak: acme saw {acme_scores}"
+    assert globex_scores == [100, 200], f"cross-tenant leak: globex saw {globex_scores}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_create_persists_non_null_tenant_id(mt_db):
+    """Every multi-tenant bulk_create row MUST persist a non-NULL tenant_id.
+
+    Pre-fix the stale-dict read left tenant_id=None on every bulk_create row.
+    """
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_create("Feat", [{"entity_id": "a", "score": 1}])
+    with db.tenant_context.switch("globex"):
+        await db.bulk.bulk_create("Feat", [{"entity_id": "g", "score": 2}])
+
+    rows = _raw(tmpdir)
+    assert all(r[2] is not None for r in rows), f"tenant_id stored as NULL: {rows}"
+    assert {r[2] for r in rows} == {"acme", "globex"}, f"wrong tenant_id values: {rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_update_is_tenant_scoped(mt_db):
+    """A filter-based bulk_update MUST only touch the bound tenant's rows.
+
+    acme runs ``bulk_update`` with an EMPTY filter (update-all). Pre-fix this
+    ran ``UPDATE feats SET score = 0`` with NO tenant predicate and would have
+    zeroed globex's rows too (latent cross-tenant write).
+    """
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_create(
+            "Feat", [{"entity_id": "a1", "score": 10}, {"entity_id": "a2", "score": 20}]
+        )
+    with db.tenant_context.switch("globex"):
+        await db.bulk.bulk_create(
+            "Feat",
+            [{"entity_id": "g1", "score": 100}, {"entity_id": "g2", "score": 200}],
+        )
+
+    # acme attempts to set ALL rows score=0 (empty filter, confirmed).
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_update(
+            "Feat", filter_criteria={}, update_values={"score": 0}, confirmed=True
+        )
+
+    rows = _raw(tmpdir)
+    acme_scores = sorted(r[1] for r in rows if r[2] == "acme")
+    globex_scores = sorted(r[1] for r in rows if r[2] == "globex")
+    assert acme_scores == [0, 0], f"same-tenant bulk_update failed: {rows}"
+    assert globex_scores == [
+        100,
+        200,
+    ], f"cross-tenant bulk_update leaked into globex: {rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_delete_is_tenant_scoped(mt_db):
+    """A filter-based bulk_delete MUST only delete the bound tenant's rows.
+
+    acme runs ``bulk_delete`` with an EMPTY filter (delete-all). Pre-fix this
+    ran ``DELETE FROM feats`` with NO tenant predicate and would have deleted
+    globex's rows too (latent cross-tenant delete).
+    """
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_create(
+            "Feat", [{"entity_id": "a1", "score": 10}, {"entity_id": "a2", "score": 20}]
+        )
+    with db.tenant_context.switch("globex"):
+        await db.bulk.bulk_create(
+            "Feat",
+            [{"entity_id": "g1", "score": 100}, {"entity_id": "g2", "score": 200}],
+        )
+
+    # acme attempts to delete ALL rows (empty filter, confirmed).
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_delete("Feat", filter_criteria={}, confirmed=True)
+
+    rows = _raw(tmpdir)
+    assert not any(r[2] == "acme" for r in rows), f"acme rows not deleted: {rows}"
+    globex_scores = sorted(r[1] for r in rows if r[2] == "globex")
+    assert globex_scores == [
+        100,
+        200,
+    ], f"cross-tenant bulk_delete removed globex's rows: {rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_upsert_round_trips_under_tenant_and_isolates(mt_db):
+    """bulk_upsert round-trips under a tenant (conflict on the id PK) AND
+    cannot touch another tenant's rows.
+
+    Pre-fix the stale-dict read left tenant_id=NULL on every upserted row. The
+    ON CONFLICT (id) target stays valid because ``id`` is the PK and
+    ``tenant_id`` rides in the column list as just another INSERT/EXCLUDED
+    column. acme updates its own row by id and inserts a fresh one; globex's
+    rows are untouched.
+    """
+    db, tmpdir = mt_db
+
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_create("Feat", [{"entity_id": "a1", "score": 1}])
+        acme_id = db.express_sync.list("Feat", {})[0]["id"]
+    with db.tenant_context.switch("globex"):
+        await db.bulk.bulk_create("Feat", [{"entity_id": "g1", "score": 100}])
+
+    # acme upserts: update its existing row (by id) + insert a new one.
+    with db.tenant_context.switch("acme"):
+        result = await db.bulk.bulk_upsert(
+            "Feat",
+            [
+                {"id": acme_id, "entity_id": "a1", "score": 999},
+                {"id": acme_id + 1000, "entity_id": "a2", "score": 5},
+            ],
+            conflict_resolution="update",
+        )
+    assert result.get("success") is True, f"bulk_upsert failed: {result}"
+
+    rows = _raw(tmpdir)
+    # acme's row updated to 999, tenant intact.
+    acme_rows = {r[0]: (r[1], r[2]) for r in rows if r[2] == "acme"}
+    assert acme_rows.get("a1") == (999, "acme"), f"upsert round-trip failed: {rows}"
+    assert acme_rows.get("a2") == (5, "acme"), f"upsert insert failed: {rows}"
+    # globex untouched.
+    globex_scores = sorted(r[1] for r in rows if r[2] == "globex")
+    assert globex_scores == [100], f"bulk_upsert leaked into globex: {rows}"
+    # No NULL tenant rows.
+    assert all(
+        r[2] is not None for r in rows
+    ), f"bulk_upsert stored NULL tenant: {rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_create_without_bound_tenant_fails_closed(mt_db):
+    """bulk_create under multi_tenant=True with NO bound tenant MUST raise AND
+    MUST NOT persist a tenant_id=NULL row.
+
+    Mirrors the #1249 fail-closed guard at the bulk subsystem layer per
+    tenant-isolation.md MUST-2 + zero-tolerance.md Rule 3.
+    """
+    db, tmpdir = mt_db
+
+    with pytest.raises(RuntimeError, match="no tenant is bound"):
+        await db.bulk.bulk_create("Feat", [{"entity_id": "orphan", "score": 1}])
+
+    rows = _raw(tmpdir)
+    assert rows == [], f"fail-open: a row was persisted with no bound tenant: {rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_update_without_bound_tenant_fails_closed(mt_db):
+    """bulk_update under multi_tenant=True with NO bound tenant MUST raise AND
+    MUST NOT run an unscoped UPDATE.
+    """
+    db, tmpdir = mt_db
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_create("Feat", [{"entity_id": "a", "score": 10}])
+
+    with pytest.raises(RuntimeError, match="no tenant is bound"):
+        await db.bulk.bulk_update(
+            "Feat", filter_criteria={}, update_values={"score": 0}, confirmed=True
+        )
+
+    # The bound acme row is untouched (no unscoped UPDATE ran).
+    rows = _raw(tmpdir)
+    assert [r[1] for r in rows] == [10], f"unscoped UPDATE ran: {rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_delete_without_bound_tenant_fails_closed(mt_db):
+    """bulk_delete under multi_tenant=True with NO bound tenant MUST raise AND
+    MUST NOT run an unscoped DELETE.
+    """
+    db, tmpdir = mt_db
+    with db.tenant_context.switch("acme"):
+        await db.bulk.bulk_create("Feat", [{"entity_id": "a", "score": 10}])
+
+    with pytest.raises(RuntimeError, match="no tenant is bound"):
+        await db.bulk.bulk_delete("Feat", filter_criteria={}, confirmed=True)
+
+    rows = _raw(tmpdir)
+    assert len(rows) == 1, f"unscoped DELETE ran: {rows}"
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_bulk_upsert_without_bound_tenant_fails_closed(mt_db):
+    """bulk_upsert under multi_tenant=True with NO bound tenant MUST raise AND
+    MUST NOT persist a tenant_id=NULL row.
+    """
+    db, tmpdir = mt_db
+
+    with pytest.raises(RuntimeError, match="no tenant is bound"):
+        await db.bulk.bulk_upsert("Feat", [{"id": 1, "entity_id": "x", "score": 5}])
+
+    rows = _raw(tmpdir)
+    assert rows == [], f"fail-open: a row was persisted with no bound tenant: {rows}"
+
+
+# ---------------------------------------------------------------------------
+# Single-tenant (multi_tenant=False) keeps current behavior — no stamping,
+# no fail-closed, no tenant_id column.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.sqlite
+async def test_single_tenant_bulk_ops_unchanged():
+    """A single-tenant DataFlow performs every bulk op without a bound tenant
+    and without a tenant_id column — the fix MUST NOT change this behavior.
+    """
+    tmpdir = tempfile.mkdtemp()
+    db = DataFlow(f"sqlite:///{tmpdir}/st.db", auto_migrate=True)  # single-tenant
+
+    @db.model
+    class Item:
+        name: str
+        qty: int
+
+    db._ensure_connected()
+    try:
+        con = sqlite3.connect(f"{tmpdir}/st.db")
+        cols = [c[1] for c in con.execute("PRAGMA table_info(items)").fetchall()]
+        con.close()
+        assert "tenant_id" not in cols, f"single-tenant model grew tenant_id: {cols}"
+
+        r = await db.bulk.bulk_create(
+            "Item", [{"name": "a", "qty": 1}, {"name": "b", "qty": 2}]
+        )
+        assert r.get("success") is True
+        r2 = await db.bulk.bulk_update(
+            "Item", filter_criteria={"name": "a"}, update_values={"qty": 99}
+        )
+        assert r2.get("success") is True
+        r3 = await db.bulk.bulk_delete("Item", filter_criteria={"name": "b"})
+        assert r3.get("success") is True
+
+        rows = sorted((x["name"], x["qty"]) for x in db.express_sync.list("Item", {}))
+        assert rows == [("a", 99)], f"single-tenant bulk ops misbehaved: {rows}"
+    finally:
+        db.close()

--- a/packages/kailash-dataflow/tests/regression/test_issue_1252_bulk_tenant_isolation_postgres.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1252_bulk_tenant_isolation_postgres.py
@@ -1,0 +1,206 @@
+"""PostgreSQL variant of the issue #1252 bulk cross-tenant isolation regression.
+
+Mirrors the core leak assertion from
+``test_issue_1252_bulk_tenant_isolation.py`` against a REAL PostgreSQL backend
+(shared infra on port 5434 via ``IntegrationTestSuite``). Marked
+``requires_postgres`` so it is skipped in the default no-infra run and exercised
+in CI where the shared database is available.
+
+The leak (#1252) was backend-agnostic — it lived in the bulk subsystem's
+stale-dict tenant source (``self.dataflow._tenant_context``), which is empty
+under ``tenant_context.switch()`` on every backend. This test confirms isolation
+holds on PostgreSQL's quoted-identifier SQL (``INSERT INTO "feats" ...`` +
+``$N`` placeholders + ``ON CONFLICT (id) ... RETURNING``) for bulk_create,
+bulk_update (filter-scoped), bulk_delete (filter-scoped), and bulk_upsert.
+
+Each test uses a UNIQUE model/table name (shared DB) and DROPs it in a finally
+block — the harness here has no ``clean_database()`` helper, so the prior
+``await test_suite.clean_database()`` aborted these tests before they ever
+exercised the Postgres bulk SQL (the coverage gap that let the #1249 follow-up
+ship a Postgres-only ``list`` regression on 2.11.0).
+"""
+
+import uuid
+
+import pytest
+
+from dataflow import DataFlow
+from tests.infrastructure.test_harness import IntegrationTestSuite
+
+
+@pytest.fixture
+async def test_suite():
+    """Real PostgreSQL integration suite (shared infra, port 5434)."""
+    suite = IntegrationTestSuite()
+    async with suite.session():
+        yield suite
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.postgresql
+async def test_bulk_isolation_no_cross_tenant_leak_postgres(test_suite):
+    """Two tenants exercise all four bulk ops on PostgreSQL; isolation holds."""
+    db_url = test_suite.config.url
+
+    suffix = uuid.uuid4().hex[:8]
+    model_name = f"Feat1252{suffix}"
+    table = f"{model_name.lower()}s"
+
+    db = DataFlow(db_url, auto_migrate=True, multi_tenant=True)
+
+    Feat = type(model_name, (), {"__annotations__": {"entity_id": str, "score": int}})
+    db.model(Feat)
+
+    try:
+        await db.initialize()
+
+        db.tenant_context.register_tenant("acme", "A")
+        db.tenant_context.register_tenant("globex", "G")
+
+        # bulk_create — non-NULL tenant_id + cross-read isolation.
+        with db.tenant_context.switch("acme"):
+            await db.bulk.bulk_create(
+                model_name,
+                [{"entity_id": "a1", "score": 1}, {"entity_id": "a2", "score": 2}],
+            )
+        with db.tenant_context.switch("globex"):
+            await db.bulk.bulk_create(
+                model_name,
+                [
+                    {"entity_id": "g1", "score": 100},
+                    {"entity_id": "g2", "score": 200},
+                ],
+            )
+
+        # express.list AFTER bulk_create — the Postgres ``list`` path (trailing
+        # ``LIMIT $N OFFSET $N``) that bound the tenant string to LIMIT pre-#1249
+        # follow-up. Isolation here proves the bulk-written rows are readable
+        # tenant-scoped on Postgres (the placeholder-renumber path).
+        with db.tenant_context.switch("acme"):
+            acme_scores = sorted(
+                r.get("score") for r in await db.express.list(model_name, {})
+            )
+        with db.tenant_context.switch("globex"):
+            globex_scores = sorted(
+                r.get("score") for r in await db.express.list(model_name, {})
+            )
+        assert acme_scores == [
+            1,
+            2,
+        ], f"cross-tenant leak (pg list): acme saw {acme_scores}"
+        assert globex_scores == [
+            100,
+            200,
+        ], f"cross-tenant leak (pg list): globex saw {globex_scores}"
+
+        async with test_suite.get_connection() as conn:
+            rows = await conn.fetch(f'SELECT tenant_id FROM "{table}"')
+        tenants = {r["tenant_id"] for r in rows}
+        assert None not in tenants, f"tenant_id stored NULL on postgres: {tenants}"
+        assert tenants == {"acme", "globex"}, f"wrong tenant_id values: {tenants}"
+
+        # bulk_update — empty filter (update-all) MUST only touch acme's rows.
+        with db.tenant_context.switch("acme"):
+            await db.bulk.bulk_update(
+                model_name,
+                filter_criteria={},
+                update_values={"score": 0},
+                confirmed=True,
+            )
+        async with test_suite.get_connection() as conn:
+            globex_after = sorted(
+                r["score"]
+                for r in await conn.fetch(
+                    f"SELECT score FROM \"{table}\" WHERE tenant_id = 'globex'"
+                )
+            )
+        assert globex_after == [
+            100,
+            200,
+        ], f"cross-tenant bulk_update leaked into globex (pg): {globex_after}"
+
+        # bulk_upsert — round-trips under acme on the id PK; globex untouched.
+        with db.tenant_context.switch("acme"):
+            acme_rows = await db.express.list(model_name, {})
+            acme_id = acme_rows[0]["id"]
+            result = await db.bulk.bulk_upsert(
+                model_name,
+                [{"id": acme_id, "entity_id": "a1", "score": 999}],
+                conflict_resolution="update",
+            )
+        assert result.get("success") is True, f"bulk_upsert failed (pg): {result}"
+        async with test_suite.get_connection() as conn:
+            upserted = await conn.fetchrow(
+                f'SELECT score, tenant_id FROM "{table}" WHERE id = $1', acme_id
+            )
+            globex_after = sorted(
+                r["score"]
+                for r in await conn.fetch(
+                    f"SELECT score FROM \"{table}\" WHERE tenant_id = 'globex'"
+                )
+            )
+        assert (
+            upserted["score"] == 999 and upserted["tenant_id"] == "acme"
+        ), f"bulk_upsert round-trip failed (pg): {dict(upserted)}"
+        assert globex_after == [
+            100,
+            200,
+        ], f"bulk_upsert leaked into globex (pg): {globex_after}"
+
+        # bulk_delete — empty filter (delete-all) MUST only delete acme's rows.
+        with db.tenant_context.switch("acme"):
+            await db.bulk.bulk_delete(model_name, filter_criteria={}, confirmed=True)
+        async with test_suite.get_connection() as conn:
+            remaining = await conn.fetch(f'SELECT tenant_id FROM "{table}"')
+        remaining_tenants = {r["tenant_id"] for r in remaining}
+        assert (
+            "acme" not in remaining_tenants
+        ), f"acme rows not deleted (pg): {remaining_tenants}"
+        assert remaining_tenants == {
+            "globex"
+        }, f"bulk_delete leaked into globex (pg): {remaining_tenants}"
+    finally:
+        async with test_suite.get_connection() as conn:
+            await conn.execute(f'DROP TABLE IF EXISTS "{table}" CASCADE')
+
+
+@pytest.mark.regression
+@pytest.mark.integration
+@pytest.mark.requires_postgres
+@pytest.mark.postgresql
+async def test_bulk_create_without_bound_tenant_fails_closed_postgres(test_suite):
+    """bulk_create under multi_tenant=True with NO bound tenant fails closed on PG."""
+    db_url = test_suite.config.url
+
+    suffix = uuid.uuid4().hex[:8]
+    model_name = f"Feat1252Fc{suffix}"
+    table = f"{model_name.lower()}s"
+
+    db = DataFlow(db_url, auto_migrate=True, multi_tenant=True)
+
+    Feat = type(model_name, (), {"__annotations__": {"entity_id": str, "score": int}})
+    db.model(Feat)
+
+    try:
+        await db.initialize()
+        db.tenant_context.register_tenant("acme", "A")
+
+        with pytest.raises(RuntimeError, match="no tenant is bound"):
+            await db.bulk.bulk_create(model_name, [{"entity_id": "orphan", "score": 1}])
+
+        # Fail-open check: NO row may exist with no bound tenant. The fail-closed
+        # raise fires before any INSERT, so the table may legitimately not exist
+        # (nothing was ever written) — that is ALSO a pass (zero rows persisted).
+        async with test_suite.get_connection() as conn:
+            exists = await conn.fetchval(
+                "SELECT to_regclass($1) IS NOT NULL", f"public.{table}"
+            )
+            rows = await conn.fetch(f'SELECT * FROM "{table}"') if exists else []
+        assert (
+            rows == []
+        ), f"fail-open: a row was persisted with no bound tenant (pg): {rows}"
+    finally:
+        async with test_suite.get_connection() as conn:
+            await conn.execute(f'DROP TABLE IF EXISTS "{table}" CASCADE')

--- a/packages/kailash-dataflow/tests/unit/features/test_bulk_upsert_delegation.py
+++ b/packages/kailash-dataflow/tests/unit/features/test_bulk_upsert_delegation.py
@@ -85,14 +85,29 @@ class TestBulkUpsertDelegation:
 
     @pytest.mark.asyncio
     async def test_bulk_upsert_tenant_context_applied(self, mock_dataflow):
-        """Test that tenant context is applied when multi-tenant is enabled."""
+        """Test that the BOUND tenant is stamped when multi-tenant is enabled.
+
+        Issue #1252: the tenant source is the ``_current_tenant`` ContextVar set
+        by ``tenant_context.switch()`` and read via ``get_current_tenant_id()``,
+        NOT the legacy ``self.dataflow._tenant_context`` dict (which is only
+        populated by the unused ``set_tenant_context()`` API and stays empty
+        under ``switch()``). This test pins the corrected source: it patches
+        ``get_current_tenant_id`` to model a bound tenant and asserts the
+        records are stamped from THAT source. The model is a tenant table
+        (``tenant_id`` in its fields), so stamping applies.
+        """
+        from dataflow.features import bulk as bulk_mod
         from dataflow.features.bulk import BulkOperations
 
-        # Enable multi-tenant mode
+        # Enable multi-tenant mode. The legacy dict is intentionally left empty
+        # to prove the fix no longer reads it.
         mock_dataflow.config.security.multi_tenant = True
-        mock_dataflow._tenant_context = {"tenant_id": "tenant_123"}
+        mock_dataflow._tenant_context = {}
         mock_dataflow._models = {"User": {"table_name": "test_users"}}
-        mock_dataflow.get_model_fields = MagicMock(return_value={})
+        # Tenant table = has a tenant_id field.
+        mock_dataflow.get_model_fields = MagicMock(
+            return_value={"tenant_id": {"type": str}}
+        )
 
         bulk_ops = BulkOperations(mock_dataflow)
 
@@ -108,18 +123,52 @@ class TestBulkUpsertDelegation:
             {"id": 2, "email": "test2@example.com", "name": "Test 2"},
         ]
 
-        await bulk_ops.bulk_upsert(
-            model_name="User",
-            data=test_data,
-            conflict_resolution="update",
-        )
+        # Model a bound tenant via the contextvar source (the #1249/#1252 source).
+        with patch.object(bulk_mod, "get_current_tenant_id", return_value="tenant_123"):
+            await bulk_ops.bulk_upsert(
+                model_name="User",
+                data=test_data,
+                conflict_resolution="update",
+            )
 
-        # Verify tenant_id was added to each record
+        # Verify the BOUND tenant_id was stamped on each record.
         for record in test_data:
             assert record.get("tenant_id") == "tenant_123"
 
         # Verify SQL node was called
         mock_sql_node.async_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_bulk_upsert_fails_closed_without_bound_tenant(self, mock_dataflow):
+        """Issue #1252: multi-tenant upsert on a tenant table with NO bound
+        tenant MUST raise — not stamp NULL and execute (fail-open)."""
+        from dataflow.features import bulk as bulk_mod
+        from dataflow.features.bulk import BulkOperations
+
+        mock_dataflow.config.security.multi_tenant = True
+        mock_dataflow._tenant_context = {}
+        mock_dataflow._models = {"User": {"table_name": "test_users"}}
+        mock_dataflow.get_model_fields = MagicMock(
+            return_value={"tenant_id": {"type": str}}
+        )
+        mock_sql_node = AsyncMock()
+        mock_sql_node.async_run = AsyncMock(return_value={"rows_affected": 0})
+        mock_dataflow._get_or_create_async_sql_node = MagicMock(
+            return_value=mock_sql_node
+        )
+
+        bulk_ops = BulkOperations(mock_dataflow)
+
+        with patch.object(bulk_mod, "get_current_tenant_id", return_value=None):
+            with pytest.raises(RuntimeError, match="no tenant is bound"):
+                await bulk_ops.bulk_upsert(
+                    model_name="User",
+                    data=[{"id": 1, "email": "x@e.com", "name": "X"}],
+                    conflict_resolution="update",
+                )
+
+        # No SQL executed — fail-closed before any write.
+        mock_sql_node.async_run.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_bulk_upsert_delegates_to_node(self, mock_dataflow):


### PR DESCRIPTION
## Summary

Two fixes completing the 2.11.0 multi-tenant security work, bundled as **kailash-dataflow 2.11.1**.

### 1. PostgreSQL multi-tenant `list` regression (introduced in 2.11.0, #1249 follow-up)
The 2.11.0 tenant-injection on SELECT/UPDATE/DELETE hardcoded a `?` placeholder and did **not** renumber PostgreSQL `$N` placeholders. A multi-tenant `express.list` emits a trailing `LIMIT $1 OFFSET $2`, so the injected `WHERE tenant_id = ?` left `$1` (LIMIT) bound to the tenant string → `argument of LIMIT must be type bigint, not type text`. SQLite (all-`?`, positional) hid it.

**Fix:** the injection is now dialect-placeholder-aware — `$N` queries inject a `$N` tenant placeholder and renumber all existing `$N` (`… WHERE tenant_id = $1 … LIMIT $2 OFFSET $3`); `?`/`%s` keep positional insertion (byte-identical output, no SQLite regression). Affected only multi-tenant PostgreSQL `list`; create/read/count/update/delete were unaffected.

**Why it shipped:** the `*_postgres.py` regression tests aborted on a non-existent harness method (`clean_database`) and never actually exercised the Postgres path. They're now self-contained (unique tables + `try/finally` DROP), and a multi-tenant `list`-with-`LIMIT` cross-read test guards the regression (FAILS pre-fix, PASSES post-fix — verified).

### 2. Bulk-path tenant isolation (#1252)
`bulk_create` / `bulk_update` / `bulk_delete` / `bulk_upsert` / `upsert` read the bound tenant from a stale legacy dict (`_tenant_context`, only set by the unused `set_tenant_context()` API) instead of the `tenant_context.switch()` contextvar — so under multi-tenancy every bulk write stored `tenant_id = NULL` (rows invisible to all tenants) and bulk update/delete ran with **no** tenant filter (latent cross-tenant write/delete). All four paths now resolve via `get_current_tenant_id()`, stamp `tenant_id` on bulk rows, AND the bound tenant predicate into update/delete WHERE clauses (dialect-correct `?`/`$N`/`%s`), and **fail closed** when `multi_tenant=True` with no bound tenant. Single-tenant unaffected.

## Verification (SQLite + real PostgreSQL on 5434)

- SQLite #1249 (24, +5 dialect-renumber unit tests) + #1252 (10) + tenancy suite: **94 passed**, 0 failures.
- PostgreSQL (`-m requires_postgres`): #1249 list-with-LIMIT + #1252 bulk isolation tests **pass**; direct end-to-end run — create/read/**list**/count/update/delete + all bulk ops isolate (tenant A never sees/touches B), store non-NULL tenant_id, and fail closed with no bound tenant.

## Tests

- New `tests/regression/test_issue_1252_bulk_tenant_isolation.py` (10 SQLite Tier-2) + `_postgres.py` variant.
- New dialect-renumber unit tests + a PostgreSQL multi-tenant `list` regression test added to the #1249 suites; `*_postgres.py` harness made self-contained.

## Related issues

Fixes #1252 — completes multi-tenant isolation begun in #1249 (2.11.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
