### PR TITLE
docs(deploy): record kailash-dataflow 2.11.1 (#1252)

### DIFF
--- a/deploy/deployments/2026-06-03-dataflow-v2.11.1-1252-pg-regression.md
+++ b/deploy/deployments/2026-06-03-dataflow-v2.11.1-1252-pg-regression.md
@@ -1,0 +1,70 @@
+# Deployment — kailash-dataflow 2.11.1 (#1252 bulk isolation + #1249 PostgreSQL `list` regression)
+
+**Date:** 2026-06-03
+**Package:** `kailash-dataflow` `2.11.0 → 2.11.1` (patch — completes 2.11.0's multi-tenant security work)
+**Issues:** #1252 (HIGH, bulk isolation) closed by merge; PostgreSQL `list` regression in 2.11.0 (#1249 follow-up) fixed.
+
+## What shipped
+
+### 1. PostgreSQL multi-tenant `list` regression (introduced in 2.11.0)
+
+The 2.11.0 tenant-injection on SELECT/UPDATE/DELETE hardcoded a `?` placeholder
+and did NOT renumber PostgreSQL `$N` placeholders. A multi-tenant `express.list`
+emits a trailing `LIMIT $1 OFFSET $2`, so the injected `WHERE tenant_id = ?` left
+`$1` (LIMIT) bound to the tenant string → `argument of LIMIT must be type bigint,
+not type text`. SQLite (all-`?`, positional) hid it.
+
+Fix: dialect-placeholder-aware injection (`QueryInterceptor._detect_placeholder_style`
+
+- `_renumber_dollar_placeholders`). `$N` queries inject a `$N` tenant placeholder
+  and renumber all existing `$N`; `?`/`%s` keep positional insertion (byte-identical).
+
+**Why it shipped:** the `*_postgres.py` regression tests aborted on a non-existent
+harness method (`clean_database`) and never exercised the Postgres path. Now
+self-contained; a multi-tenant `list`-with-`LIMIT` cross-read test guards it.
+
+### 2. Bulk-path tenant isolation (#1252)
+
+`bulk_create`/`bulk_update`/`bulk_delete`/`bulk_upsert`/`upsert` read the bound
+tenant from a stale legacy dict (`_tenant_context`, only set by the unused
+`set_tenant_context()`) instead of the `tenant_context.switch()` contextvar — so
+bulk writes stored `tenant_id = NULL` and bulk update/delete had no tenant filter.
+All four now resolve via `get_current_tenant_id()`, stamp `tenant_id` on bulk rows,
+AND the bound tenant predicate into update/delete WHERE clauses, and fail closed.
+
+## Release mechanics
+
+- PR #1255 → admin-merge → `main` `f350d960e` (#1252 auto-closed).
+- Tag `dataflow-v2.11.1` (single tag push) → `publish-pypi.yml` run `26880521128` SUCCESS.
+- TestPyPI skipped per the standing minor/patch exception (prior 2.11.0 full-ship authorization carries to the patch).
+- Full PR-gate CI: 12 substantive checks SUCCESS (Python 3.11–3.14 matrix, DataFlow Tier-1, PACT, CodeQL). Zero failures.
+
+## Verification (published wheel)
+
+```
+uv pip install --refresh "kailash-dataflow==2.11.1"   # attempt 2 (uv index cache lag)
+dataflow.__version__ == "2.11.1"
+# Direct dialect-injection unit check on the PUBLISHED wheel (the exact 2.11.0 bug):
+inject_tenant_conditions('SELECT * FROM "t" ORDER BY "id" DESC LIMIT $1 OFFSET $2', [100,0])
+  -> 'SELECT * FROM "t" WHERE tenant_id = $1 ORDER BY "id" DESC LIMIT $2 OFFSET $3', ['acme',100,0]
+  -> DIALECT-RENUMBER CORRECT: True   (2.11.0 produced 'WHERE tenant_id = ? ... LIMIT $1' -> crash)
+```
+
+Pre-release: end-to-end against real PostgreSQL (port 5434) — create/read/list/
+count/update/delete + all bulk ops isolate, store non-NULL tenant_id, fail closed
+with no bound tenant. SQLite #1249 (24) + #1252 (10) + tenancy = 94 passed.
+
+## Sibling drift
+
+None — all other framework packages AT-PARITY with PyPI at release-time.
+
+## Notes
+
+- The local Postgres test DB (port 5434) accumulated ~167 leftover test tables
+  across the session's direct-Postgres verification runs, causing auto-migrate DDL
+  failures in the final clean-venv behavioral run; the dialect fix itself was
+  verified directly on the published wheel (above) and on real Postgres pre-release.
+- The Postgres integration test tier does NOT run in CI (`test-with-infrastructure.yml`
+  validates infra but invokes no pytest); the pre-existing
+  `test_bulk_upsert_delegation_integration.py` fixture failures are local-only,
+  pre-existing, and unrelated to this change.


### PR DESCRIPTION
Deployment record for kailash-dataflow 2.11.1 — bulk-path tenant isolation (#1252) + the 2.11.0 PostgreSQL multi-tenant list regression fix. Docs-only; published + verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)