### PR TITLE
fix(trust): canonical signing encoders reject NaN/Infinity + non-string keys (#1243)

### DIFF
--- a/src/kailash/trust/_json.py
+++ b/src/kailash/trust/_json.py
@@ -82,7 +82,9 @@ def _reject_nan_inf(constant: str) -> None:
     )
 
 
-def _reject_non_string_keys(obj: Any, path: str = "$") -> None:
+def _reject_non_string_keys(
+    obj: Any, path: str = "$", _seen: set[int] | None = None
+) -> None:
     """Reject non-string object keys before canonical serialization.
 
     ``json.dumps`` silently coerces ``int`` / ``float`` / ``bool`` / ``None``
@@ -94,22 +96,46 @@ def _reject_non_string_keys(obj: Any, path: str = "$") -> None:
     failure surfaces at the signing site rather than as a verification
     mismatch on another implementation.
 
+    Cyclic structures are rejected with ``ValueError`` (mirroring
+    ``json.dumps``'s own ``ValueError("Circular reference detected")``) via a
+    markers set added on container entry and discarded on exit. This preserves
+    the call sites' ``except (TypeError, ValueError)`` exception taxonomy
+    rather than letting the pure-Python recursion raise an uncaught
+    ``RecursionError`` (a ``RuntimeError`` subclass) before ``json.dumps`` runs.
+    Shared (DAG) substructures are NOT rejected — only true cycles, exactly
+    like ``json.dumps``.
+
     Raises:
-        ValueError: If any object key (at any nesting depth) is not a ``str``.
+        ValueError: If any object key (at any nesting depth) is not a ``str``,
+            or if ``obj`` contains a circular reference.
     """
-    if isinstance(obj, dict):
-        for key, value in obj.items():
-            if not isinstance(key, str):
-                raise ValueError(
-                    f"non-string object key {key!r} ({type(key).__name__}) at "
-                    f"{path} — canonical JSON requires string keys (RFC 8259 "
-                    f"object members); coercing would break round-trip symmetry "
-                    f"with canonical_json_loads"
-                )
-            _reject_non_string_keys(value, f"{path}.{key}")
-    elif isinstance(obj, (list, tuple)):
-        for index, value in enumerate(obj):
-            _reject_non_string_keys(value, f"{path}[{index}]")
+    if _seen is None:
+        _seen = set()
+    if isinstance(obj, (dict, list, tuple)):
+        obj_id = id(obj)
+        if obj_id in _seen:
+            raise ValueError(
+                f"Circular reference detected at {path} — canonical JSON "
+                f"cannot serialize cyclic structures"
+            )
+        _seen.add(obj_id)
+        try:
+            if isinstance(obj, dict):
+                for key, value in obj.items():
+                    if not isinstance(key, str):
+                        raise ValueError(
+                            f"non-string object key {key!r} "
+                            f"({type(key).__name__}) at {path} — canonical JSON "
+                            f"requires string keys (RFC 8259 object members); "
+                            f"coercing would break round-trip symmetry with "
+                            f"canonical_json_loads"
+                        )
+                    _reject_non_string_keys(value, f"{path}.{key}", _seen)
+            else:  # list / tuple
+                for index, value in enumerate(obj):
+                    _reject_non_string_keys(value, f"{path}[{index}]", _seen)
+        finally:
+            _seen.discard(obj_id)
 
 
 def canonical_json_dumps(obj: Any) -> str:

--- a/src/kailash/trust/_json.py
+++ b/src/kailash/trust/_json.py
@@ -48,20 +48,6 @@ def _make_duplicate_checker(path: str = "") -> Any:
     return check_duplicates
 
 
-def _walk_and_check(obj: Any, path: str = "$") -> Any:
-    """Recursively check for duplicate keys in nested objects.
-
-    The ``object_pairs_hook`` only detects duplicates at the level it is
-    called. For nested objects, we need to parse with the hook to catch
-    all levels. Since ``json.loads`` with ``object_pairs_hook`` applies
-    the hook at every nesting level, a single parse call handles all
-    depths.
-    """
-    # The hook is applied by json.loads at every object level, so
-    # recursive checking is handled by the parser itself.
-    return obj
-
-
 def canonical_json_loads(text: str) -> Any:
     """Parse JSON with strict mode and duplicate key rejection.
 
@@ -96,6 +82,36 @@ def _reject_nan_inf(constant: str) -> None:
     )
 
 
+def _reject_non_string_keys(obj: Any, path: str = "$") -> None:
+    """Reject non-string object keys before canonical serialization.
+
+    ``json.dumps`` silently coerces ``int`` / ``float`` / ``bool`` / ``None``
+    object keys to strings (``{1: "a"}`` -> ``'{"1":"a"}'``). The canonical
+    wire form assumes string keys (RFC 8259 object members), and
+    ``canonical_json_loads`` always yields string keys — so silent coercion
+    breaks round-trip symmetry between the encode/decode pair. We reject
+    non-string keys at the producer boundary instead, recursively, so the
+    failure surfaces at the signing site rather than as a verification
+    mismatch on another implementation.
+
+    Raises:
+        ValueError: If any object key (at any nesting depth) is not a ``str``.
+    """
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"non-string object key {key!r} ({type(key).__name__}) at "
+                    f"{path} — canonical JSON requires string keys (RFC 8259 "
+                    f"object members); coercing would break round-trip symmetry "
+                    f"with canonical_json_loads"
+                )
+            _reject_non_string_keys(value, f"{path}.{key}")
+    elif isinstance(obj, (list, tuple)):
+        for index, value in enumerate(obj):
+            _reject_non_string_keys(value, f"{path}[{index}]")
+
+
 def canonical_json_dumps(obj: Any) -> str:
     """Serialize to canonical JSON with sorted keys and no extra whitespace.
 
@@ -103,10 +119,35 @@ def canonical_json_dumps(obj: Any) -> str:
     nesting level, and no trailing whitespace or newlines are emitted.
     This matches the canonical encoder order required by SPEC-09 S8.2.
 
+    This encoder is symmetric with :func:`canonical_json_loads` on the value
+    domain it accepts: it rejects (raises) ``NaN`` / ``Infinity`` /
+    ``-Infinity`` (via ``allow_nan=False``) — which are not valid JSON per
+    RFC 8259 and which the paired decoder already refuses — and it rejects
+    non-string object keys rather than silently stringifying them. This
+    guarantees the encoder never produces signing pre-images that its own
+    decoder, Rust ``serde_json``, or any RFC-8259 verifier cannot read back.
+
+    Note: integers outside the JS-safe range (``±(2**53 - 1)``) are NOT
+    rejected. The canonical parity scope is Python and Rust (``serde_json``),
+    both of which carry 64-bit+ integers losslessly; common signing payloads
+    (e.g. nanosecond timestamps) depend on this. JS-consumer ``2**53`` safety
+    is out of scope (issue #1243 acceptance criterion 3).
+
     Args:
         obj: Python object to serialize.
 
     Returns:
         Canonical JSON string.
+
+    Raises:
+        ValueError: If ``obj`` contains ``NaN`` / ``Infinity`` / ``-Infinity``
+            float values, or any non-string object key.
     """
-    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    _reject_non_string_keys(obj)
+    return json.dumps(
+        obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )

--- a/src/kailash/trust/signing/crypto.py
+++ b/src/kailash/trust/signing/crypto.py
@@ -229,11 +229,23 @@ def serialize_for_signing(obj: Any) -> str:
     Converts dataclasses, dicts, and other types to a canonical JSON string
     that will produce the same output for equivalent inputs.
 
+    Non-finite floats (``NaN`` / ``Infinity`` / ``-Infinity``) are rejected
+    with ``ValueError`` (``allow_nan=False``): they are not valid JSON per
+    RFC 8259, so emitting them would produce signing pre-images that Rust
+    ``serde_json`` and other cross-SDK / W3C-VC verifiers cannot reconstruct,
+    silently breaking signature verification. This is consistent with the
+    trust-plane fail-closed-on-NaN posture (a ``NaN`` in a signed payload is
+    already unverifiable — see ``trust-plane-security`` Rule 3).
+
     Args:
         obj: Object to serialize (dataclass, dict, or primitive)
 
     Returns:
         Canonical JSON string
+
+    Raises:
+        ValueError: If ``obj`` contains a ``NaN`` / ``Infinity`` / ``-Infinity``
+            float value.
 
     Example:
         >>> serialize_for_signing({"b": 2, "a": 1})
@@ -284,7 +296,7 @@ def serialize_for_signing(obj: Any) -> str:
             return item
 
     converted = convert(obj)
-    return json.dumps(converted, separators=(",", ":"), sort_keys=True)
+    return json.dumps(converted, separators=(",", ":"), sort_keys=True, allow_nan=False)
 
 
 def hash_chain(data: Union[str, dict, bytes]) -> str:

--- a/tests/regression/test_issue_1243_canonical_json_dumps_allow_nan.py
+++ b/tests/regression/test_issue_1243_canonical_json_dumps_allow_nan.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for issue #1243.
+
+``kailash.trust._json.canonical_json_dumps`` emitted the non-JSON tokens
+``NaN`` / ``Infinity`` (it omitted ``allow_nan=False``) and silently
+stringified non-string object keys — producing canonical signing pre-images
+that its OWN paired decoder ``canonical_json_loads`` rejects, and that Rust
+``serde_json`` / JS verifiers cannot read back. The encode/decode pair was not
+round-trip-consistent within the same module.
+
+The fix makes the encoder reject the same value domain the decoder rejects.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from kailash.trust._json import canonical_json_dumps, canonical_json_loads
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    ("non_finite", "token"),
+    [
+        (float("nan"), "NaN"),
+        (float("inf"), "Infinity"),
+        (float("-inf"), "-Infinity"),
+    ],
+)
+def test_issue_1243_dumps_rejects_non_finite_symmetric_with_loads(non_finite, token):
+    """The encoder rejects exactly what the decoder rejects (NaN/Infinity).
+
+    Before the fix the encoder emitted ``'{"x":NaN}'`` while the decoder
+    raised ``ValueError`` on that same string — a round-trip break.
+    """
+    # Sanity: the parametrized value really is the non-finite float `token` names.
+    assert math.isnan(non_finite) or math.isinf(non_finite)
+
+    # Decoder rejects the literal form (the pre-fix encoder output).
+    with pytest.raises(ValueError):
+        canonical_json_loads(f'{{"x":{token}}}')
+
+    # Encoder MUST now reject the value too (the fix), rather than emit it.
+    with pytest.raises(ValueError):
+        canonical_json_dumps({"x": non_finite})
+
+
+@pytest.mark.regression
+def test_issue_1243_dumps_rejects_non_string_keys():
+    """Non-string object keys are rejected, not silently stringified.
+
+    ``{1: "a"}`` previously encoded to ``'{"1":"a"}'``; decoding that yields
+    ``{"1": "a"}`` (string key) != the original int-keyed dict — a round-trip
+    break the canonical signing path cannot tolerate.
+    """
+    for bad_key in (1, 3.14, True, None):
+        with pytest.raises(ValueError):
+            canonical_json_dumps({bad_key: "a"})
+
+
+@pytest.mark.regression
+def test_issue_1243_finite_payloads_round_trip_unchanged():
+    """Valid finite payloads still encode + decode byte-for-byte (no regression).
+
+    The fix must reject only the non-representable value domain; every legal
+    canonical payload — including large integers outside the JS-safe range —
+    must continue to round-trip.
+    """
+    obj = {
+        "agent": "a-1",
+        "nonce_ns": 1_780_000_000_000_000_001,  # > 2**53; Py<->Rust lossless
+        "scores": [1, 2.5, -3],
+        "nested": {"b": True, "c": None, "deep": {"z": "ok"}},
+    }
+    encoded = canonical_json_dumps(obj)
+    assert canonical_json_loads(encoded) == obj
+    # Deterministic sorted-key output preserved.
+    assert encoded == json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )

--- a/tests/regression/test_issue_1243_canonical_json_dumps_allow_nan.py
+++ b/tests/regression/test_issue_1243_canonical_json_dumps_allow_nan.py
@@ -83,3 +83,71 @@ def test_issue_1243_finite_payloads_round_trip_unchanged():
     assert encoded == json.dumps(
         obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False
     )
+
+
+@pytest.mark.regression
+def test_issue_1243_dumps_rejects_circular_reference_as_valueerror():
+    """Cyclic input raises ValueError (not RecursionError).
+
+    The producer-side key guard recurses before ``json.dumps``; a cyclic
+    structure must raise ``ValueError`` (caught by the signing call sites'
+    ``except (TypeError, ValueError)`` taxonomy at dispatch.py / audit.py),
+    NOT an uncaught ``RecursionError`` (a ``RuntimeError`` subclass) that
+    would escape those wrappers.
+    """
+    cyclic: dict = {"a": 1}
+    cyclic["self"] = cyclic
+    with pytest.raises(ValueError, match="[Cc]ircular"):
+        canonical_json_dumps(cyclic)
+
+
+@pytest.mark.regression
+def test_issue_1243_dumps_allows_shared_dag_substructure():
+    """A shared (non-cyclic) substructure is NOT a cycle and must encode.
+
+    The cycle guard tracks the ancestor path only (markers add-on-entry /
+    discard-on-exit), so the same dict referenced by two sibling keys is
+    accepted, exactly like ``json.dumps``.
+    """
+    shared = {"x": 1}
+    obj = {"a": shared, "b": shared}
+    assert canonical_json_dumps(obj) == '{"a":{"x":1},"b":{"x":1}}'
+
+
+# ---------------------------------------------------------------------------
+# Issue #1243 (HIGH-1, surfaced at security review): the LIVE Ed25519/HMAC
+# signing pre-image `serialize_for_signing` is a sibling canonical encoder
+# that had the identical `allow_nan` hole — on the more critical, cross-SDK
+# (Rust serde_json / W3C-VC) signing path. Same bug class, fixed in this PR.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("non_finite", [float("nan"), float("inf"), float("-inf")])
+def test_issue_1243_serialize_for_signing_rejects_non_finite(non_finite):
+    """The live signing pre-image rejects NaN/Infinity rather than emitting them.
+
+    Before the fix, ``serialize_for_signing({"x": float("nan")})`` returned the
+    non-JSON string ``'{"x":NaN}'`` into the Ed25519/HMAC-signed bytes — a
+    pre-image Rust ``serde_json`` and W3C-VC verifiers cannot reconstruct.
+    """
+    from kailash.trust.signing.crypto import serialize_for_signing
+
+    with pytest.raises(ValueError):
+        serialize_for_signing({"x": non_finite})
+
+
+@pytest.mark.regression
+def test_issue_1243_serialize_for_signing_finite_payload_unchanged():
+    """Finite signing payloads still serialize deterministically (no regression).
+
+    The fix must only reject the non-finite domain; the canonical sorted-key
+    output for legal payloads — including big-int nonces — is unchanged, so
+    existing signatures over finite payloads remain valid.
+    """
+    from kailash.trust.signing.crypto import serialize_for_signing
+
+    payload = {"b": 2, "a": 1, "nonce_ns": 1_780_000_000_000_000_001}
+    assert (
+        serialize_for_signing(payload) == '{"a":1,"b":2,"nonce_ns":1780000000000000001}'
+    )

--- a/tests/unit/cross_sdk/test_canonical_json.py
+++ b/tests/unit/cross_sdk/test_canonical_json.py
@@ -81,3 +81,84 @@ def test_strict_mode_rejects_control_characters():
     """
     with pytest.raises(json.JSONDecodeError):
         canonical_json_loads('{"key": "value\nwith newline"}')
+
+
+# ---------------------------------------------------------------------------
+# Issue #1243 — encoder/decoder round-trip symmetry.
+#
+# ``canonical_json_loads`` rejects NaN/Infinity (RFC 8259); the encoder MUST
+# reject the same values rather than emitting non-JSON tokens (``NaN``,
+# ``Infinity``) that its own paired decoder — and Rust ``serde_json`` — refuse.
+# It MUST also reject non-string object keys, which the wire form cannot carry
+# without silently stringifying them (breaking round-trip with the decoder,
+# whose output keys are always strings).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_dumps_rejects_non_finite_floats(bad):
+    """The encoder rejects NaN/Infinity/-Infinity, symmetric with the decoder.
+
+    Before the fix, ``canonical_json_dumps({"x": float("nan")})`` returned the
+    non-JSON string ``'{"x":NaN}'`` which ``canonical_json_loads`` then refused
+    to parse — the encode/decode pair was not round-trip-consistent.
+    """
+    with pytest.raises(ValueError):
+        canonical_json_dumps({"x": bad})
+
+
+def test_dumps_rejects_nested_non_finite_float():
+    """Non-finite floats nested inside arrays/objects are also rejected."""
+    with pytest.raises(ValueError):
+        canonical_json_dumps({"outer": {"vals": [1.0, float("inf")]}})
+
+
+def test_dumps_rejects_top_level_non_finite_float():
+    """A bare non-finite float (not wrapped in a container) is rejected."""
+    with pytest.raises(ValueError):
+        canonical_json_dumps(float("nan"))
+
+
+@pytest.mark.parametrize("key", [1, 2**53, 3.14, True, None])
+def test_dumps_rejects_non_string_object_key(key):
+    """Non-string object keys are rejected, not silently stringified.
+
+    ``json.dumps`` coerces int/float/bool/None keys to strings
+    (``{1: "a"}`` -> ``'{"1":"a"}'``); the canonical encoder MUST reject them
+    so the encode/decode pair round-trips (the decoder always yields string
+    keys).
+    """
+    with pytest.raises(ValueError):
+        canonical_json_dumps({key: "value"})
+
+
+def test_dumps_rejects_nested_non_string_object_key():
+    """Non-string keys nested below the top level are also rejected."""
+    with pytest.raises(ValueError):
+        canonical_json_dumps({"outer": {1: "value"}})
+
+
+def test_dumps_round_trip_symmetry_property():
+    """For every value the decoder rejects, the encoder rejects too.
+
+    This is the load-bearing invariant of issue #1243: the canonical
+    encode/decode pair must agree on the value domain. The encoder must never
+    produce bytes its own paired decoder cannot read back.
+    """
+    # NaN/Infinity: decoder rejects (parse_constant) -> encoder must reject.
+    for non_finite in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError):
+            canonical_json_dumps({"x": non_finite})
+
+
+def test_dumps_allows_large_integers():
+    """Integers beyond the JS-safe range are NOT rejected (Py<->Rust scope).
+
+    The canonical encoder's documented parity scope is Python and Rust
+    (``serde_json``), both of which carry 64-bit+ integers losslessly. Common
+    signing payloads (e.g. nanosecond timestamps ~1.78e18 > 2**53) rely on
+    this. JS-consumer 2**53 safety is explicitly out of scope per issue #1243
+    acceptance criterion 3 ("(Consider) ... when JS consumers are in scope").
+    """
+    assert canonical_json_dumps({"n": 2**53}) == '{"n":9007199254740992}'
+    assert canonical_json_dumps({"n": 2**63 + 1}) == '{"n":9223372036854775809}'


### PR DESCRIPTION
## Summary

The canonical-JSON **signing** encoders omitted `allow_nan=False` and did no producer-side key validation, so they emitted the non-JSON tokens `NaN`/`Infinity` and silently stringified non-string object keys — producing signing pre-images that the paired decoder, Rust `serde_json`, and W3C-VC verifiers cannot read back, silently breaking cross-implementation verification.

This PR hardens **both** canonical signing encoders in the trust layer (they are separate subsystems — see below):

### 1. `kailash.trust._json.canonical_json_dumps` (delegate/SPEC-09 cross-SDK parity) — the issue's named target
- `allow_nan=False` → raises on `NaN`/`Infinity`/`-Infinity` (symmetric with `canonical_json_loads`).
- Recursive `_reject_non_string_keys` producer-side guard → raises on any non-string object key (RFC 8259), with `json.dumps`-style **cycle detection** (markers set) so a cyclic payload raises `ValueError` (caught by the call sites' `except (TypeError, ValueError)` taxonomy) rather than an uncaught `RecursionError`. Shared DAG substructures are accepted.
- Removed dead `_walk_and_check` no-op helper (zero-tolerance Rule 2).

### 2. `kailash.trust.signing.crypto.serialize_for_signing` (live Ed25519/HMAC pre-image) — surfaced at security review
- The actual trust-plane signing pre-image (sign/verify/hash_chain/hmac_sign, W3C-VC interop, multi-sig, rotation, PACT envelopes, reasoning traces) had the **identical** `allow_nan` hole on the more critical, cross-SDK path. Added `allow_nan=False`. Same bug class → fixed in-PR per `autonomous-execution.md` Rule 4.

**Verified the two encoders are separate subsystems that never cross-mix** (`grep`: `delegate/*` uses only `canonical_json_dumps`; `trust/signing,plane,pact,operations/*` use only `serialize_for_signing`) — so this is hardening, not a wire-format break. Only already-unverifiable NaN/Infinity payloads change behavior.

### Scoping decisions
- **Big integers** (`> 2**53`) intentionally NOT rejected — the parity scope is Python ↔ Rust (`serde_json`), both lossless on 64-bit+ ints (nanosecond-timestamp signing payloads). JS `2**53` safety is out of scope per issue criterion 3.
- **`ensure_ascii` divergence** between the two encoders (trust-plane = `True`, matching its `trust-plane-canonical.json` fixture; delegate = `False`) + missing non-ASCII cross-SDK byte-vectors for `canonical_json_dumps` → **separate follow-up #1258** (breaking wire-format migration; exceeds this shard).

## Review-driven changes (this PR)
- **code-reviewer (APPROVE):** flagged cyclic input → `RecursionError` escaping the call-site `except` taxonomy → fixed with cycle detection.
- **security-reviewer (REQUEST-CHANGES → addressed):** HIGH-1 `serialize_for_signing` `allow_nan` → fixed; HIGH-2 `ensure_ascii`/byte-vectors → verified not-a-break, dispositioned as follow-up #1258.

## User-flow walk receipt
```
>>> canonical_json_dumps({'x': float('nan')})   → ValueError: Out of range float values...
>>> canonical_json_dumps({1: 'a'})              → ValueError: non-string object key 1 (int)...
>>> serialize_for_signing({'x': float('inf')})  → ValueError (live signing pre-image now rejects)
>>> round-trip big-int nonce 1.78e18            → encoded+decoded unchanged, signatures unaffected
```

## Tests
- `tests/unit/cross_sdk/test_canonical_json.py` — reject-case unit tests.
- `tests/regression/test_issue_1243_canonical_json_dumps_allow_nan.py` — `@pytest.mark.regression` behavioral: NaN/Inf symmetry, non-string keys, **cyclic→ValueError**, **shared-DAG accepted**, `serialize_for_signing` NaN/Inf rejection + finite-unchanged.
- Full surface green: **6316 passed, 36 skipped** (trust signing + delegate + cross_sdk), incl. the cross-SDK byte-vector fixture.

## Related issues
Closes #1243
Follow-up: #1258 (ensure_ascii divergence + non-ASCII cross-SDK byte-vector pinning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)