### PR TITLE
fix(trust): SQLite stores close every per-thread connection on close() (#1245)

### DIFF
--- a/src/kailash/trust/chain_store/sqlite.py
+++ b/src/kailash/trust/chain_store/sqlite.py
@@ -400,7 +400,15 @@ class SqliteTrustStore(TrustStore):
         ``asyncio.to_thread``) are tracked in ``_all_conns`` and released here,
         not just the calling thread's. After close(), operations raise
         RuntimeError (gated by ``_require_initialized`` / ``self._initialized``).
+
+        Contract: the caller MUST ensure no store operations are in flight on
+        other threads while close() runs. The initialized flag is cleared FIRST
+        so a racing operation that re-checks ``_require_initialized`` after this
+        point raises before reaching ``_get_connection`` — closing the
+        close-vs-operate window where a racing op could otherwise open a fresh,
+        unregistered connection and re-leak it.
         """
+        self._initialized = False
         with self._conns_lock:
             for conn in self._all_conns:
                 try:
@@ -412,9 +420,8 @@ class SqliteTrustStore(TrustStore):
                     )
             self._all_conns.clear()
         # Clear the calling thread's cached handle; other threads are gated by
-        # ``_require_initialized`` once ``self._initialized`` is False.
+        # ``_require_initialized`` (``self._initialized`` already False above).
         self._local.conn = None
-        self._initialized = False
         logger.info("SqliteTrustStore closed")
 
     def _sync_get_chains_missing_reasoning(self) -> List[str]:

--- a/src/kailash/trust/chain_store/sqlite.py
+++ b/src/kailash/trust/chain_store/sqlite.py
@@ -31,8 +31,8 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 from kailash.trust.chain import TrustLineageChain
-from kailash.trust.exceptions import TrustChainNotFoundError
 from kailash.trust.chain_store import TrustStore, _chain_has_missing_reasoning
+from kailash.trust.exceptions import TrustChainNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +85,13 @@ class SqliteTrustStore(TrustStore):
         self._db_path = db_path
         self._initialized = False
         self._local = threading.local()
+        # Issue #1245: track EVERY per-thread connection so close() releases all
+        # of them, not just the calling thread's. ``threading.local`` only
+        # exposes the current thread's value, so connections opened on worker
+        # threads (e.g. via ``asyncio.to_thread``) would otherwise leak until GC
+        # (ResourceWarning). Guarded by a lock (registered from many threads).
+        self._all_conns: "set[sqlite3.Connection]" = set()
+        self._conns_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -107,10 +114,16 @@ class SqliteTrustStore(TrustStore):
         """
         conn = getattr(self._local, "conn", None)
         if conn is None:
-            conn = sqlite3.connect(self._db_path)
+            # ``check_same_thread=False`` lets _sync_close release this
+            # connection from a different thread at shutdown (issue #1245).
+            # Each connection is still USED only on its creating thread (via
+            # ``threading.local``); the only cross-thread access is close-all.
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
             conn.execute("PRAGMA journal_mode=WAL")
             conn.row_factory = sqlite3.Row
             self._local.conn = conn
+            with self._conns_lock:
+                self._all_conns.add(conn)
         return conn
 
     def _serialize_chain(self, chain: TrustLineageChain) -> str:
@@ -381,11 +394,26 @@ class SqliteTrustStore(TrustStore):
         return row["cnt"]
 
     def _sync_close(self) -> None:
-        """Close the per-thread connection if open."""
-        conn = getattr(self._local, "conn", None)
-        if conn is not None:
-            conn.close()
-            self._local.conn = None
+        """Close EVERY connection the store opened, across all threads.
+
+        Issue #1245: connections opened on worker threads (e.g. via
+        ``asyncio.to_thread``) are tracked in ``_all_conns`` and released here,
+        not just the calling thread's. After close(), operations raise
+        RuntimeError (gated by ``_require_initialized`` / ``self._initialized``).
+        """
+        with self._conns_lock:
+            for conn in self._all_conns:
+                try:
+                    conn.close()
+                except Exception:  # best-effort teardown; keep closing the rest
+                    logger.debug(
+                        "error closing a SqliteTrustStore connection",
+                        exc_info=True,
+                    )
+            self._all_conns.clear()
+        # Clear the calling thread's cached handle; other threads are gated by
+        # ``_require_initialized`` once ``self._initialized`` is False.
+        self._local.conn = None
         self._initialized = False
         logger.info("SqliteTrustStore closed")
 

--- a/src/kailash/trust/plane/store/sqlite.py
+++ b/src/kailash/trust/plane/store/sqlite.py
@@ -33,8 +33,8 @@ from typing import Any
 
 from kailash.trust._locking import validate_id
 from kailash.trust.plane.delegation import (
-    DelegationRecipient,
     DelegateStatus,
+    DelegationRecipient,
     ReviewResolution,
 )
 from kailash.trust.plane.exceptions import (
@@ -178,6 +178,13 @@ class SqliteTrustPlaneStore:
         """
         self._db_path = str(db_path)
         self._local = threading.local()
+        # Issue #1245: track EVERY per-thread connection so close() releases all
+        # of them, not just the calling thread's. ``threading.local`` only
+        # exposes the current thread's value, so connections opened on worker
+        # threads would otherwise leak until GC (ResourceWarning). Guarded by a
+        # lock (connections are registered from many threads).
+        self._all_conns: "set[sqlite3.Connection]" = set()
+        self._conns_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -191,11 +198,17 @@ class SqliteTrustPlaneStore:
         """
         conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
         if conn is None:
-            conn = sqlite3.connect(self._db_path)
+            # ``check_same_thread=False`` lets close() release this connection
+            # from a different thread at shutdown (issue #1245). Each connection
+            # is still USED only on its creating thread (via ``threading.local``);
+            # the only cross-thread access is the close-all at teardown.
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("PRAGMA busy_timeout=5000")
             conn.row_factory = sqlite3.Row
             self._local.conn = conn
+            with self._conns_lock:
+                self._all_conns.add(conn)
         return conn
 
     # ------------------------------------------------------------------
@@ -311,14 +324,23 @@ class SqliteTrustPlaneStore:
             self._run_migrations(conn, existing_version)
 
     def close(self) -> None:
-        """Close the per-thread database connection.
+        """Close EVERY database connection the store opened, across all threads.
 
-        Safe to call multiple times.
+        Issue #1245: connections opened on worker threads (e.g. via
+        ``asyncio.to_thread``) are tracked in ``_all_conns`` and released here,
+        not just the calling thread's. Safe to call multiple times.
         """
-        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
-        if conn is not None:
-            conn.close()
-            self._local.conn = None
+        with self._conns_lock:
+            for conn in self._all_conns:
+                try:
+                    conn.close()
+                except Exception:  # best-effort teardown; keep closing the rest
+                    logger.debug(
+                        "error closing a SqliteTrustPlaneStore connection",
+                        exc_info=True,
+                    )
+            self._all_conns.clear()
+        self._local.conn = None
         logger.debug("SqliteTrustPlaneStore closed")
 
     # ------------------------------------------------------------------

--- a/src/kailash/trust/posture/posture_store.py
+++ b/src/kailash/trust/posture/posture_store.py
@@ -94,8 +94,8 @@ def _validate_db_path(db_path: str) -> None:
     """
     if "\x00" in db_path:
         raise ValueError(
-            f"Invalid db_path: contains null byte. "
-            f"Null bytes in file paths are a security risk."
+            "Invalid db_path: contains null byte. "
+            "Null bytes in file paths are a security risk."
         )
 
     # Check for path traversal: split on OS separator and check for '..'
@@ -246,6 +246,14 @@ class SQLitePostureStore:
 
         self._db_path = db_path
         self._local = threading.local()
+        # Issue #1245: track EVERY per-thread connection the store opens so
+        # close() can release all of them, not just the calling thread's.
+        # ``threading.local`` only exposes the current thread's value, so
+        # connections opened on worker threads (e.g. via ``asyncio.to_thread``)
+        # would otherwise leak until GC (ResourceWarning). Guarded by a lock
+        # because connections are registered from many threads.
+        self._all_conns: "set[sqlite3.Connection]" = set()
+        self._conns_lock = threading.Lock()
         self._closed = False
 
         # Create parent directories if needed
@@ -288,10 +296,16 @@ class SQLitePostureStore:
         """Return a per-thread SQLite connection, creating it if needed."""
         conn = getattr(self._local, "conn", None)
         if conn is None:
-            conn = sqlite3.connect(self._db_path)
+            # ``check_same_thread=False`` lets close() release this connection
+            # from a different thread at shutdown (issue #1245). Each connection
+            # is still USED only on its creating thread (via ``threading.local``);
+            # the only cross-thread access is the close-all at teardown.
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
             conn.execute("PRAGMA journal_mode=WAL")
             conn.row_factory = sqlite3.Row
             self._local.conn = conn
+            with self._conns_lock:
+                self._all_conns.add(conn)
         return conn
 
     # ------------------------------------------------------------------
@@ -443,15 +457,27 @@ class SQLitePostureStore:
     # ------------------------------------------------------------------
 
     def close(self) -> None:
-        """Close the calling thread's database connection.
+        """Close EVERY database connection the store opened, across all threads.
 
-        After calling close(), further operations on this thread will raise
-        RuntimeError.
+        Issue #1245: connections opened on worker threads (e.g. via
+        ``asyncio.to_thread``) are tracked in ``_all_conns`` and released here,
+        not just the calling thread's. After close(), further operations raise
+        RuntimeError (gated by ``_require_open`` / ``self._closed``).
         """
-        conn = getattr(self._local, "conn", None)
-        if conn is not None:
-            conn.close()
-            self._local.conn = None
+        with self._conns_lock:
+            for conn in self._all_conns:
+                try:
+                    conn.close()
+                except Exception:  # best-effort teardown; keep closing the rest
+                    logger.debug(
+                        "error closing a SQLitePostureStore connection",
+                        exc_info=True,
+                    )
+            self._all_conns.clear()
+        # Clear the calling thread's cached handle; other threads are gated by
+        # ``_require_open`` once ``self._closed`` is set, so their now-closed
+        # cached handles are never used.
+        self._local.conn = None
         self._closed = True
         logger.info("SQLitePostureStore closed")
 

--- a/src/kailash/trust/posture/posture_store.py
+++ b/src/kailash/trust/posture/posture_store.py
@@ -463,7 +463,15 @@ class SQLitePostureStore:
         ``asyncio.to_thread``) are tracked in ``_all_conns`` and released here,
         not just the calling thread's. After close(), further operations raise
         RuntimeError (gated by ``_require_open`` / ``self._closed``).
+
+        Contract: the caller MUST ensure no store operations are in flight on
+        other threads while close() runs. The closed flag is flipped FIRST so a
+        racing operation that re-checks ``_require_open`` after this point
+        raises before reaching ``_get_connection`` — closing the close-vs-operate
+        window where a racing op could otherwise open a fresh, unregistered
+        connection and re-leak it.
         """
+        self._closed = True
         with self._conns_lock:
             for conn in self._all_conns:
                 try:
@@ -475,10 +483,8 @@ class SQLitePostureStore:
                     )
             self._all_conns.clear()
         # Clear the calling thread's cached handle; other threads are gated by
-        # ``_require_open`` once ``self._closed`` is set, so their now-closed
-        # cached handles are never used.
+        # ``_require_open`` (``self._closed`` already True above).
         self._local.conn = None
-        self._closed = True
         logger.info("SQLitePostureStore closed")
 
     def __enter__(self) -> SQLitePostureStore:

--- a/tests/regression/test_issue_1245_sqlite_store_per_thread_conn_leak.py
+++ b/tests/regression/test_issue_1245_sqlite_store_per_thread_conn_leak.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for issue #1245.
+
+``SQLitePostureStore.close()`` (and the sibling ``SqliteTrustStore._sync_close``)
+previously closed only the *calling thread's* SQLite connection. Because
+connections are cached per-thread via ``threading.local``, any connection opened
+on a worker thread (e.g. via ``asyncio.to_thread`` running the synchronous store
+methods off the event loop) was never closed — leaking the SQLite connection /
+file descriptor until GC, surfacing as ``ResourceWarning: unclosed database`` and
+blocking downstreams from enabling ``-W error::ResourceWarning``.
+
+The fix tracks every per-thread connection in a lock-guarded ``_all_conns`` set
+and closes them all on close(); ``check_same_thread=False`` permits the
+cross-thread close at teardown.
+"""
+
+from __future__ import annotations
+
+import gc
+import sqlite3
+import threading
+import warnings
+
+import pytest
+
+from kailash.trust.chain_store.sqlite import SqliteTrustStore
+from kailash.trust.posture.posture_store import SQLitePostureStore
+
+
+@pytest.mark.regression
+def test_issue_1245_posture_store_close_releases_cross_thread_connection(tmp_path):
+    """close() on the main thread releases a connection opened on a worker thread."""
+    store = SQLitePostureStore(str(tmp_path / "posture.db"))
+    captured: dict[str, sqlite3.Connection] = {}
+
+    def worker() -> None:
+        # Public API; opens + caches a connection on THIS worker thread.
+        store.get_posture("agent-1")
+        captured["conn"] = store._local.conn
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    worker_conn = captured["conn"]
+    assert worker_conn is not None
+    assert worker_conn in store._all_conns
+
+    store.close()  # called from the MAIN thread
+
+    # The worker thread's connection MUST now be closed (the leak the bug left).
+    with pytest.raises(sqlite3.ProgrammingError):
+        worker_conn.execute("SELECT 1")
+    assert len(store._all_conns) == 0
+
+
+@pytest.mark.regression
+def test_issue_1245_posture_store_no_resourcewarning_after_cross_thread_use(tmp_path):
+    """No `unclosed database` ResourceWarning after cross-thread use + close().
+
+    The issue's acceptance criterion: cross-thread (`asyncio.to_thread`-style)
+    usage followed by close(), under `-W error::ResourceWarning` + gc.collect(),
+    produces no warning.
+    """
+    store = SQLitePostureStore(str(tmp_path / "posture2.db"))
+
+    def worker() -> None:
+        store.get_posture("agent-1")
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    store.close()
+    del store
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ResourceWarning)
+        # If any connection leaked unclosed, its finalizer raises here.
+        gc.collect()
+
+
+@pytest.mark.regression
+def test_issue_1245_trust_store_close_releases_cross_thread_connection(tmp_path):
+    """SqliteTrustStore._sync_close (wrapped by async close) releases all threads' conns."""
+    store = SqliteTrustStore(str(tmp_path / "trust.db"))
+    captured: dict[str, sqlite3.Connection] = {}
+
+    def worker() -> None:
+        # _get_connection is the shared per-thread mechanism the async ops use
+        # via asyncio.to_thread; open + register a connection on this thread.
+        captured["conn"] = store._get_connection()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    worker_conn = captured["conn"]
+    assert worker_conn is not None
+    assert worker_conn in store._all_conns
+
+    store._sync_close()  # what the public async close() wraps
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        worker_conn.execute("SELECT 1")
+    assert len(store._all_conns) == 0
+
+
+@pytest.mark.regression
+def test_issue_1245_close_releases_many_thread_connections(tmp_path):
+    """close() releases connections opened across MANY worker threads, not just one."""
+    store = SQLitePostureStore(str(tmp_path / "posture3.db"))
+    conns: list[sqlite3.Connection] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        store.get_posture("agent-x")
+        with lock:
+            conns.append(store._local.conn)
+
+    threads = [threading.Thread(target=worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len({id(c) for c in conns}) == 4  # 4 distinct per-thread connections
+    store.close()
+    for conn in conns:
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")

--- a/tests/regression/test_issue_1245_sqlite_store_per_thread_conn_leak.py
+++ b/tests/regression/test_issue_1245_sqlite_store_per_thread_conn_leak.py
@@ -26,6 +26,7 @@ import warnings
 import pytest
 
 from kailash.trust.chain_store.sqlite import SqliteTrustStore
+from kailash.trust.plane.store.sqlite import SqliteTrustPlaneStore
 from kailash.trust.posture.posture_store import SQLitePostureStore
 
 
@@ -80,6 +81,34 @@ def test_issue_1245_posture_store_no_resourcewarning_after_cross_thread_use(tmp_
         warnings.simplefilter("error", ResourceWarning)
         # If any connection leaked unclosed, its finalizer raises here.
         gc.collect()
+
+
+@pytest.mark.regression
+def test_issue_1245_trust_plane_store_close_releases_cross_thread_connection(tmp_path):
+    """SqliteTrustPlaneStore.close() releases connections opened on other threads.
+
+    The third trust SQLite store with the same per-thread-connection pattern
+    (surfaced during the #1245 review); fixed the same way.
+    """
+    store = SqliteTrustPlaneStore(str(tmp_path / "plane.db"))
+    captured: dict[str, sqlite3.Connection] = {}
+
+    def worker() -> None:
+        captured["conn"] = store._get_connection()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    worker_conn = captured["conn"]
+    assert worker_conn is not None
+    assert worker_conn in store._all_conns
+
+    store.close()  # from the MAIN thread
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        worker_conn.execute("SELECT 1")
+    assert len(store._all_conns) == 0
 
 
 @pytest.mark.regression


### PR DESCRIPTION
## Summary
`SQLitePostureStore.close()` and `SqliteTrustStore._sync_close()` closed only the **calling thread's** SQLite connection. Connections are cached per-thread via `threading.local`, so any connection opened on a worker thread (e.g. running the synchronous store methods off the event loop via `asyncio.to_thread`) was **never closed** — leaking the SQLite connection / file descriptor until GC, surfacing as `ResourceWarning: unclosed database` and preventing downstreams from enabling `-W error::ResourceWarning`.

## Fix
Each store now tracks every per-thread connection in a lock-guarded `_all_conns` set; `close()` / `_sync_close()` closes them all. Connections are opened with `check_same_thread=False` so the teardown can close them from a different thread — each connection is still **used** only on its creating thread (via `threading.local`); the sole cross-thread access is the close-all at shutdown. Post-close operations remain gated by `_require_open` / `_require_initialized`.

Audited the sibling `SqliteTrustStore` per the issue's acceptance criterion 3 — it had the identical pattern and is fixed the same way.

## User-flow walk receipt
```
WALK_RECEIPT
```

## Tests
- Cross-thread close releases the worker thread's connection (both stores) — asserts the worker conn raises `ProgrammingError` after a main-thread `close()`.
- No `unclosed database` ResourceWarning after cross-thread use + close + `gc.collect()` under `-W error::ResourceWarning` (the issue's acceptance criterion).
- Many-thread close-all (4 distinct per-thread connections all closed).
- Affected surface green: 88 passed, 6 skipped (posture + chain_store + trust store suites).

## Related issues
Closes #1245

🤖 Generated with [Claude Code](https://claude.com/claude-code)