### PR TITLE
fix(dataflow): register explicit sqlite datetime adapters (#1250)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/adapters/sqlite.py
+++ b/packages/kailash-dataflow/src/dataflow/adapters/sqlite.py
@@ -5,9 +5,11 @@ SQLite-specific database adapter implementation.
 """
 
 import asyncio
+import datetime as _datetime
 import logging
 import os
 import re
+import sqlite3 as _sqlite3
 import sys
 import traceback
 import warnings
@@ -25,6 +27,37 @@ from .dialect import DialectManager
 from .exceptions import ConnectionError, QueryError, TransactionError
 
 _sqlite_dialect = DialectManager.get_dialect("sqlite")
+
+
+def _register_sqlite_datetime_adapters() -> None:
+    """Register explicit sqlite3 ``datetime``/``date`` adapters (issue #1250).
+
+    Python 3.12 deprecated the stdlib ``sqlite3`` *default* datetime adapter;
+    binding a ``datetime`` through DataFlow's SQLite path
+    (``aiosqlite`` -> ``sqlite3``) therefore emits a ``DeprecationWarning``
+    (and an error under ``-W error::DeprecationWarning``). We register explicit
+    adapters that reproduce the legacy default's output **byte-for-byte** so no
+    warning fires AND the stored wire format is unchanged for existing
+    databases:
+
+    - ``datetime`` -> ``isoformat(" ")`` (SPACE separator, e.g.
+      ``"2026-01-01 12:00:00"``) — exactly what the deprecated default emitted.
+    - ``date`` -> ``isoformat()`` (e.g. ``"2026-01-01"``).
+
+    Process-global + idempotent (sqlite3 adapters are module-level, and
+    ``aiosqlite`` shares the same global registry). Last registration wins, so
+    an application that registers its own datetime adapter is unaffected.
+    """
+    # SPACE separator matches the deprecated stdlib default exactly; using the
+    # "T" separator (isoformat()) would silently change the stored format and
+    # break round-trips against pre-existing rows.
+    _sqlite3.register_adapter(_datetime.datetime, lambda val: val.isoformat(" "))
+    _sqlite3.register_adapter(_datetime.date, lambda val: val.isoformat())
+
+
+# Register on import so the adapters are active whenever DataFlow's SQLite
+# path is loaded (issue #1250).
+_register_sqlite_datetime_adapters()
 
 
 def _safe_identifier(name: str) -> str:

--- a/packages/kailash-dataflow/tests/regression/test_issue_1250_sqlite_datetime_deprecation.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1250_sqlite_datetime_deprecation.py
@@ -33,13 +33,19 @@ def test_issue_1250_sqlite_datetime_adapters_registered():
         warnings.simplefilter("error", DeprecationWarning)
         conn = sqlite3.connect(":memory:")
         try:
-            conn.execute("CREATE TABLE t (d TIMESTAMP, day DATE)")
+            conn.execute("CREATE TABLE t (d TIMESTAMP, day DATE, tz TIMESTAMP)")
             conn.execute(
-                "INSERT INTO t VALUES (?, ?)",
-                (_datetime.datetime(2026, 1, 1, 12, 0, 0), _datetime.date(2026, 1, 1)),
+                "INSERT INTO t VALUES (?, ?, ?)",
+                (
+                    _datetime.datetime(2026, 1, 1, 12, 0, 0),
+                    _datetime.date(2026, 1, 1),
+                    _datetime.datetime(
+                        2026, 1, 1, 12, 0, 0, tzinfo=_datetime.timezone.utc
+                    ),
+                ),
             )
             conn.commit()
-            row = conn.execute("SELECT d, day FROM t").fetchone()
+            row = conn.execute("SELECT d, day, tz FROM t").fetchone()
         finally:
             conn.close()
 
@@ -47,6 +53,9 @@ def test_issue_1250_sqlite_datetime_adapters_registered():
     # datetime uses a SPACE separator, NOT "T" — so existing rows still match.
     assert row[0] == "2026-01-01 12:00:00"
     assert row[1] == "2026-01-01"
+    # tz-aware: SPACE separator + offset, exactly as the legacy default emitted
+    # (the legacy adapter was literally ``isoformat(" ")``).
+    assert row[2] == "2026-01-01 12:00:00+00:00"
 
 
 @pytest.mark.regression

--- a/packages/kailash-dataflow/tests/regression/test_issue_1250_sqlite_datetime_deprecation.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_1250_sqlite_datetime_deprecation.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression test for issue #1250.
+
+Storing a ``datetime`` through DataFlow's SQLite path emitted a
+``DeprecationWarning`` from ``aiosqlite`` -> stdlib ``sqlite3`` because DataFlow
+relied on the ``sqlite3`` *default* datetime adapter, deprecated as of Python
+3.12. The fix registers explicit ISO-8601 ``datetime``/``date`` adapters at
+import of ``dataflow.adapters.sqlite`` so no warning is emitted on 3.12+.
+"""
+
+from __future__ import annotations
+
+import datetime as _datetime
+import sqlite3
+import warnings
+
+import pytest
+
+
+@pytest.mark.regression
+def test_issue_1250_sqlite_datetime_adapters_registered():
+    """Importing the DataFlow SQLite adapter registers explicit datetime adapters.
+
+    With the explicit adapter registered, binding a ``datetime`` through
+    ``sqlite3`` (which ``aiosqlite`` wraps) no longer triggers the deprecated
+    default-adapter path, so no ``DeprecationWarning`` fires.
+    """
+    import dataflow.adapters.sqlite  # noqa: F401 -- import triggers registration
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.execute("CREATE TABLE t (d TIMESTAMP, day DATE)")
+            conn.execute(
+                "INSERT INTO t VALUES (?, ?)",
+                (_datetime.datetime(2026, 1, 1, 12, 0, 0), _datetime.date(2026, 1, 1)),
+            )
+            conn.commit()
+            row = conn.execute("SELECT d, day FROM t").fetchone()
+        finally:
+            conn.close()
+
+    # Byte-for-byte identical to the deprecated stdlib default's output:
+    # datetime uses a SPACE separator, NOT "T" — so existing rows still match.
+    assert row[0] == "2026-01-01 12:00:00"
+    assert row[1] == "2026-01-01"
+
+
+@pytest.mark.regression
+def test_issue_1250_no_datetime_deprecation_warning_on_sqlite_express(tmp_path):
+    """A datetime round-trip through DataFlow's SQLite express path emits no
+    ``DeprecationWarning`` on Python 3.12+ (the issue's acceptance criterion)."""
+    from dataflow import DataFlow
+
+    db = DataFlow(f"sqlite:///{tmp_path}/d1250.sqlite", auto_migrate=True)
+
+    @db.model
+    class Event1250:
+        name: str
+        at: _datetime.datetime
+
+    db._ensure_connected()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        created = db.express_sync.create(
+            "Event1250",
+            {"name": "x", "at": _datetime.datetime(2026, 1, 1, 12, 0, 0)},
+        )
+
+    assert created["name"] == "x"
+
+    # The datetime survives the round-trip (stored + read back).
+    rows = db.express_sync.list("Event1250", {"name": "x"})
+    assert len(rows) == 1
+    assert "2026-01-01" in str(rows[0]["at"])


### PR DESCRIPTION
## Summary
Storing a `datetime` through DataFlow's SQLite path emitted a `DeprecationWarning` from `aiosqlite` → stdlib `sqlite3` because DataFlow relied on the `sqlite3` **default** datetime adapter, deprecated as of Python 3.12 (and an error under `-W error::DeprecationWarning`, which blocked downstreams from enabling it). Per `zero-tolerance.md` Rule 1, framework-emitted deprecation warnings are owned, not deferred.

## Fix
`dataflow.adapters.sqlite` registers explicit datetime/date adapters at import. They reproduce the deprecated default's output **byte-for-byte** so the stored wire format is unchanged for existing databases:
- `datetime` → `isoformat(" ")` — **SPACE** separator, e.g. `"2026-01-01 12:00:00"` (exactly what the deprecated default emitted).
- `date` → `isoformat()` — e.g. `"2026-01-01"`.

> Using the `"T"` separator (`isoformat()`) would silently change the stored format and break round-trips against pre-existing rows — so the space separator is **load-bearing** (verified empirically against the legacy default).

Process-global + idempotent (sqlite3 adapters are module-level; aiosqlite shares the registry); last registration wins, so an app with its own adapter is unaffected.

## User-flow walk receipt
```
>>> db.express_sync.create("W", {"name": "n", "at": datetime(2026,1,1,12,0,0)})
    under warnings.simplefilter("error", DeprecationWarning)
>>> created + listed OK; stored at = '2026-01-01 12:00:00'  (space format, == legacy)
```

## Tests
- Structural: importing `dataflow.adapters.sqlite` registers the adapters; binding a `datetime`/`date` through `sqlite3` under `-W error::DeprecationWarning` succeeds + stores the byte-for-byte legacy format.
- Tier-2: a datetime express round-trip under `simplefilter("error", DeprecationWarning)` succeeds (the issue's acceptance criterion).

## No regression (proven)
Main-vs-branch on the dataflow sqlite/datetime/express surface: **28 failed → 26 failed** (only this PR's 2 tests flip green) and **51 → 33 warnings** (18 datetime DeprecationWarnings eliminated). The 26 remaining failures are **pre-existing** (model-registry API, async-context DF-501, Postgres-auth, node-registry) — identical on `main`, structurally unrelated to datetime adapters.

## Related issues
Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)