### PR TITLE
release: kailash-dataflow 2.11.2

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.11.2] — 2026-06-04 — SQLite datetime DeprecationWarning fix (#1250)
+
+### Fixed
+
+- **Explicit `sqlite3` datetime adapters registered — no more Python 3.12+ `DeprecationWarning` on SQLite datetime writes (#1250).** Storing a `datetime` through DataFlow's SQLite path (`aiosqlite` → stdlib `sqlite3`) emitted a `DeprecationWarning` because DataFlow relied on the stdlib `sqlite3` _default_ datetime adapter, deprecated as of Python 3.12 (and an error under `-W error::DeprecationWarning`, which blocked downstreams from enabling it). `dataflow.adapters.sqlite` now registers explicit datetime/date adapters at import that reproduce the deprecated default's output **byte-for-byte** so the stored wire format is unchanged for existing databases: `datetime` → `isoformat(" ")` (SPACE separator, e.g. `"2026-01-01 12:00:00"`), `date` → `isoformat()`. The registration is process-global + idempotent (sqlite3 adapters are module-level; aiosqlite shares the registry); last registration wins, so an app with its own datetime adapter is unaffected. Verified to cover naive, microsecond, and timezone-aware datetimes (tz-aware stores `"... 12:00:00+00:00"`, matching the legacy default).
+
 ## [2.11.1] — 2026-06-03 — Multi-tenant PostgreSQL `list` regression fix + bulk-path tenant isolation (#1249 follow-up / #1252)
 
 ### Security / Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.11.1"
+version = "2.11.2"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.11.1"
+__version__ = "2.11.2"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
Patch release for **#1250** (gate-reviewed + CI-green, merged in PR #1262): `dataflow.adapters.sqlite` registers explicit sqlite3 datetime/date adapters at import so DataFlow's SQLite path no longer emits the Python 3.12+ default-datetime-adapter `DeprecationWarning`. Adapters reproduce the legacy default byte-for-byte (datetime → `isoformat(" ")`, date → `isoformat()`) — stored wire format unchanged.

Metadata-only: version 2.11.1 → 2.11.2 + dataflow CHANGELOG.

Closes #1250