### PR TITLE
fix(trust): document + pin non-ASCII byte-vectors for the two canonical JSON encoders (#1258)

### DIFF
--- a/src/kailash/trust/_json.py
+++ b/src/kailash/trust/_json.py
@@ -11,6 +11,14 @@ output.
 
 Used by all cross-SDK deserialization paths to ensure both Python and Rust
 parsers reach the same conclusion on every input.
+
+Encoder note: ``canonical_json_dumps`` is the ``kailash.delegate.*`` canonical
+encoder and emits **raw UTF-8** (``ensure_ascii=False``). It is distinct from
+the trust-plane SIGNING encoder
+``kailash.trust.signing.crypto.serialize_for_signing``, which emits
+**ASCII-escaped** ``\\uXXXX`` (``ensure_ascii=True``). The divergence is
+per-subsystem and intentional — see ``canonical_json_dumps`` below and issue
+#1258.
 """
 
 from __future__ import annotations
@@ -158,6 +166,43 @@ def canonical_json_dumps(obj: Any) -> str:
     both of which carry 64-bit+ integers losslessly; common signing payloads
     (e.g. nanosecond timestamps) depend on this. JS-consumer ``2**53`` safety
     is out of scope (issue #1243 acceptance criterion 3).
+
+    Canonical contract (cross-SDK, SPEC-09 S8.2 — ``kailash.delegate.*``):
+
+    * ``ensure_ascii=False`` — non-ASCII code points are emitted as **raw
+      UTF-8 bytes**, NOT ``\\uXXXX`` escapes (``{"name":"漢字"}`` →
+      ``{"name":"漢字"}``, not ``{"name":"\\u6f22\\u5b57"}``). This matches
+      Rust ``serde_json``'s default ``to_string`` output, which does not
+      escape non-ASCII, so the delegate cross-SDK signing pre-image is
+      byte-identical on both SDKs.
+    * ``sort_keys=True`` + ``separators=(",", ":")`` — keys sorted by Unicode
+      code point at every level (equivalent to Rust ``BTreeMap<String>`` /
+      UTF-8 byte order, which agree for valid UTF-8), no inter-token
+      whitespace.
+    * **No Unicode normalization.** ``"é"`` (NFC, U+00E9) and ``"é"`` (NFD,
+      U+0065 U+0301) are DISTINCT signing pre-images — the encoder preserves
+      the input's code points verbatim, exactly as ``serde_json`` does.
+      Callers requiring NFC/NFD equivalence MUST normalize upstream.
+
+    Sibling encoder — divergence is intentional (issue #1258). The trust-plane
+    SIGNING family (``kailash.trust.signing.crypto.serialize_for_signing`` plus
+    the selective-disclosure / PACT-audit signers) uses the OPPOSITE
+    ``ensure_ascii=True`` (``\\uXXXX``-escaped, ASCII-only) because its Rust
+    counterpart and the pinned fixture ``tests/test-vectors/trust-plane-canonical.json``
+    (issue #959) escape non-ASCII. The two families NEVER cross-mix: no delegate
+    code path calls a signing encoder, and no signing path calls
+    ``canonical_json_dumps``. Note the signing family is NOT one byte-identical
+    encoder — ``serialize_for_signing`` carries a typed-scalar whitelist
+    (Decimal/UUID/datetime/bytes/Enum/dataclass) while the selective-disclosure
+    and PACT-audit signers use their own ``json.dumps(..., ensure_ascii=True,
+    sort_keys=True)`` call sites (``default=str``, no whitelist), so they diverge
+    byte-for-byte on typed-scalar inputs; what is uniform across the signing
+    family, and OPPOSITE to delegate, is ``ensure_ascii=True``. Each family
+    matches a different Rust serde contract, so
+    unifying them is a breaking cross-SDK signing-format migration requiring
+    coordinated Rust-side regeneration — NOT a casual edit (issue #1258).
+    Byte-vectors for this encoder are pinned in
+    ``tests/test-vectors/delegate-canonical.json``.
 
     Args:
         obj: Python object to serialize.

--- a/src/kailash/trust/signing/crypto.py
+++ b/src/kailash/trust/signing/crypto.py
@@ -237,6 +237,33 @@ def serialize_for_signing(obj: Any) -> str:
     trust-plane fail-closed-on-NaN posture (a ``NaN`` in a signed payload is
     already unverifiable — see ``trust-plane-security`` Rule 3).
 
+    Canonical contract (cross-SDK — trust-plane signing family):
+
+    * ``ensure_ascii=True`` — this is the ``json.dumps`` default; the call
+      below passes no override, so non-ASCII code points are emitted as
+      ``\\uXXXX`` escape sequences, producing ASCII-only output
+      (``{"name":"漢字"}`` → ``{"name":"\\u6f22\\u5b57"}``). This is
+      LOAD-BEARING: it matches the pinned cross-SDK fixture
+      ``tests/test-vectors/trust-plane-canonical.json`` (issue #959, vendored
+      to kailash-rs per ``cross-sdk-inspection.md`` Rule 4a), whose Rust
+      counterpart escapes non-ASCII for byte-stable signing pre-images.
+      Changing it to ``ensure_ascii=False`` would invalidate every existing
+      trust-plane signature AND the fixture.
+    * ``sort_keys=True`` + ``separators=(",", ":")`` — keys sorted, no
+      whitespace. The ``convert()`` whitelist below maps typed scalars
+      (Decimal / UUID / datetime / bytes / Enum / dataclass) to canonical
+      JSON forms (issue #959).
+    * **No Unicode normalization** — NFC (``"é"`` U+00E9) and NFD
+      (``"é"``) inputs are DISTINCT pre-images; their escapes differ
+      (``\\u00e9`` vs ``e\\u0301``). Normalize upstream if equivalence matters.
+
+    Sibling encoder — divergence is intentional (issue #1258). The delegate
+    cross-SDK path (``kailash.trust._json.canonical_json_dumps``) uses the
+    OPPOSITE ``ensure_ascii=False`` (raw UTF-8) to match ``serde_json``'s
+    default ``to_string``. The two families never cross-mix. Whether to unify
+    the two contracts is a breaking cross-SDK signing-format migration tracked
+    in issue #1258 — NOT a casual edit.
+
     Args:
         obj: Object to serialize (dataclass, dict, or primitive)
 

--- a/src/kailash/trust/signing/crypto.py
+++ b/src/kailash/trust/signing/crypto.py
@@ -253,8 +253,8 @@ def serialize_for_signing(obj: Any) -> str:
       whitespace. The ``convert()`` whitelist below maps typed scalars
       (Decimal / UUID / datetime / bytes / Enum / dataclass) to canonical
       JSON forms (issue #959).
-    * **No Unicode normalization** — NFC (``"é"`` U+00E9) and NFD
-      (``"é"``) inputs are DISTINCT pre-images; their escapes differ
+    * **No Unicode normalization** — NFC (composed, U+00E9) and NFD
+      (decomposed, U+0065 U+0301) inputs are DISTINCT pre-images; their escapes differ
       (``\\u00e9`` vs ``e\\u0301``). Normalize upstream if equivalence matters.
 
     Sibling encoder — divergence is intentional (issue #1258). The delegate

--- a/tests/regression/test_issue_1258_canonical_encoder_parity.py
+++ b/tests/regression/test_issue_1258_canonical_encoder_parity.py
@@ -91,7 +91,7 @@ class TestDelegateCanonicalFixtureParity:
             f"cross-SDK delegate fixture missing at {_DELEGATE_FIXTURE_PATH}; "
             "this fixture is the cross-SDK byte contract per issue #1258"
         )
-        return json.loads(_DELEGATE_FIXTURE_PATH.read_text())
+        return json.loads(_DELEGATE_FIXTURE_PATH.read_text(encoding="utf-8"))
 
     def test_fixture_loads_with_required_floor(self, fixture: dict) -> None:
         assert fixture["contract"] == "delegate-canonical-bytes"

--- a/tests/regression/test_issue_1258_canonical_encoder_parity.py
+++ b/tests/regression/test_issue_1258_canonical_encoder_parity.py
@@ -1,0 +1,183 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #1258 - the two trust-layer canonical-JSON encoders.
+
+The trust layer ships TWO canonical-JSON encoders, each matching a DIFFERENT
+Rust ``serde`` byte contract for a DIFFERENT subsystem:
+
+* ``kailash.trust._json.canonical_json_dumps`` -- ``kailash.delegate.*``
+  (SPEC-09 S8.2). ``ensure_ascii=False`` -> RAW UTF-8 output, matching
+  ``serde_json``'s default ``to_string``.
+* ``kailash.trust.signing.crypto.serialize_for_signing`` -- trust-plane
+  signing (Ed25519 / W3C-VC / multi-sig / PACT envelopes). ``ensure_ascii=True``
+  (``json.dumps`` default) -> ASCII-escaped ``\\uXXXX`` output, matching the
+  pinned cross-SDK fixture ``tests/test-vectors/trust-plane-canonical.json``
+  (issue #959).
+
+The two NEVER cross-mix and the divergence is INTENTIONAL -- unifying them
+would be a breaking cross-SDK signing-format migration requiring coordinated
+Rust-side regeneration (issue #1258 acceptance criterion 3; disposition: do
+NOT unify).
+
+This module pins:
+
+1. The delegate encoder's non-ASCII byte-vectors via the vendored fixture
+   ``tests/test-vectors/delegate-canonical.json`` (the #959 fixture already
+   pins the signing encoder; #1258 extended it with V8/V9/V10).
+2. The two-encoder divergence contract (agree on ASCII, diverge on non-ASCII).
+3. The no-Unicode-normalization invariant (NFC != NFD) for BOTH encoders.
+4. The ASCII-only-output contract: signing encoder output is ASCII-only;
+   delegate encoder output is raw UTF-8 for non-ASCII.
+
+These are BEHAVIORAL pins (call the function, assert the bytes) -- not
+source-greps -- per ``rules/testing.md`` "Behavioral Regression Tests Over
+Source-Grep". The NFC/NFD ``é`` pair is built via ``unicodedata.normalize`` so the two
+forms are byte-distinct BY CONSTRUCTION; astral code points use ``\\U``
+escapes. This prevents an editor or formatter from silently collapsing the
+NFC-vs-NFD distinction these tests assert.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+from kailash.trust._json import canonical_json_dumps
+from kailash.trust.signing.crypto import serialize_for_signing
+
+_DELEGATE_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "test-vectors"
+    / "delegate-canonical.json"
+)
+
+# Non-ASCII building blocks. The NFC/NFD pair is constructed via
+# unicodedata.normalize so the two forms are byte-distinct BY CONSTRUCTION
+# (a raw "é" literal pair risks an editor/formatter normalizing both to one
+# form, silently defeating the NFC-vs-NFD distinction these tests assert);
+# astral code points use explicit \U escapes.
+_BMP_CJK = "漢字"  # CJK two-char string
+_NFC_E_ACUTE = unicodedata.normalize("NFC", "é")  # -> U+00E9 (1 code point)
+_NFD_E_ACUTE = unicodedata.normalize("NFD", "é")  # -> U+0065 U+0301 (2 code points)
+_ASTRAL_EMOJI = "\U0001f389"  # party popper
+_ASTRAL_KEY = "\U0001d11e"  # musical symbol G clef
+
+
+def _sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Cross-SDK fixture parity for the delegate encoder (mirror of the #959
+# TestCrossSDKFixtureParity for serialize_for_signing).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestDelegateCanonicalFixtureParity:
+    """Iterate ``tests/test-vectors/delegate-canonical.json`` and assert every
+    vector's pinned RAW-UTF-8 canonical bytes / SHA-256 reproduce via
+    ``canonical_json_dumps``. The sibling kailash-rs ``serde_json`` path
+    consumes the same file per ``cross-sdk-inspection.md`` Rule 4a."""
+
+    @pytest.fixture(scope="class")
+    def fixture(self) -> dict:
+        assert _DELEGATE_FIXTURE_PATH.exists(), (
+            f"cross-SDK delegate fixture missing at {_DELEGATE_FIXTURE_PATH}; "
+            "this fixture is the cross-SDK byte contract per issue #1258"
+        )
+        return json.loads(_DELEGATE_FIXTURE_PATH.read_text())
+
+    def test_fixture_loads_with_required_floor(self, fixture: dict) -> None:
+        assert fixture["contract"] == "delegate-canonical-bytes"
+        # >=3 non-ASCII byte-vectors + sentinel per cross-sdk-inspection.md Rule 4.
+        assert len(fixture["vectors"]) >= 6
+
+    def test_every_vector_canonical_json_byte_equal(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            actual = canonical_json_dumps(v["input_repr"])
+            assert actual == v["expected_canonical_json"], (
+                f"vector {v['name']}: canonical-bytes divergence - "
+                f"got {actual!r}, expected {v['expected_canonical_json']!r}"
+            )
+
+    def test_every_vector_sha256_matches(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            actual = _sha256_hex(canonical_json_dumps(v["input_repr"]))
+            assert actual == v["expected_sha256"], (
+                f"vector {v['name']}: SHA-256 divergence - "
+                f"got {actual}, expected {v['expected_sha256']}"
+            )
+
+    def test_nfc_and_nfd_vectors_are_byte_distinct(self, fixture: dict) -> None:
+        """The encoder does NOT Unicode-normalize: the NFC and NFD vectors MUST
+        pin DIFFERENT canonical bytes / SHA-256 (else a future normalization
+        refactor would silently change every existing signing pre-image)."""
+        by_name = {v["name"]: v for v in fixture["vectors"]}
+        nfc = by_name["D3_unicode_nfc_composed_raw"]
+        nfd = by_name["D4_unicode_nfd_decomposed_raw"]
+        assert nfc["expected_canonical_json"] != nfd["expected_canonical_json"]
+        assert nfc["expected_sha256"] != nfd["expected_sha256"]
+
+
+# ---------------------------------------------------------------------------
+# Two-encoder divergence contract - the heart of #1258.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+class TestTwoEncoderDivergenceContract:
+    """The delegate (raw-UTF-8) and signing (ASCII-escaped) encoders AGREE on
+    pure-ASCII payloads and DIVERGE on every non-ASCII payload. This is the
+    intentional, documented per-subsystem split (#1258)."""
+
+    _ASCII_PAYLOAD = {"agent": "a1", "action": "approve", "cost": 42}
+    _NON_ASCII_PAYLOADS = [
+        {"name": _BMP_CJK},  # BMP CJK
+        {"name": _NFC_E_ACUTE},  # NFC composed (U+00E9)
+        {"name": _NFD_E_ACUTE},  # NFD decomposed (e + U+0301)
+        {"flag": _ASTRAL_EMOJI},  # astral emoji
+        {_ASTRAL_KEY: "clef"},  # astral object KEY
+    ]
+
+    def test_ascii_payload_encoders_agree(self) -> None:
+        assert canonical_json_dumps(self._ASCII_PAYLOAD) == serialize_for_signing(
+            self._ASCII_PAYLOAD
+        )
+
+    @pytest.mark.parametrize("payload", _NON_ASCII_PAYLOADS)
+    def test_non_ascii_payload_encoders_diverge(self, payload: dict) -> None:
+        delegate = canonical_json_dumps(payload)
+        signing = serialize_for_signing(payload)
+        assert delegate != signing, (
+            f"encoders MUST diverge on non-ASCII {payload!r}: "
+            f"delegate={delegate!r} signing={signing!r}"
+        )
+
+    @pytest.mark.parametrize("payload", _NON_ASCII_PAYLOADS)
+    def test_signing_output_is_ascii_only_delegate_is_raw(self, payload: dict) -> None:
+        """``serialize_for_signing`` (ensure_ascii=True) MUST emit ASCII-only
+        bytes; ``canonical_json_dumps`` (ensure_ascii=False) MUST emit raw
+        non-ASCII for the same input. This is the load-bearing behavioral
+        signature of the two contracts (not a source-grep)."""
+        assert serialize_for_signing(payload).isascii(), (
+            "serialize_for_signing MUST be ASCII-only (ensure_ascii=True) for "
+            "cross-SDK signing byte parity"
+        )
+        assert not canonical_json_dumps(payload).isascii(), (
+            "canonical_json_dumps MUST emit raw UTF-8 (ensure_ascii=False) for "
+            "non-ASCII, matching serde_json's default to_string"
+        )
+
+    def test_both_encoders_preserve_nfc_nfd_distinction(self) -> None:
+        """Neither encoder Unicode-normalizes: NFC (U+00E9) and NFD
+        (U+0065 U+0301) are distinct pre-images on BOTH encoders."""
+        nfc = {"name": _NFC_E_ACUTE}
+        nfd = {"name": _NFD_E_ACUTE}
+        assert canonical_json_dumps(nfc) != canonical_json_dumps(nfd)
+        assert serialize_for_signing(nfc) != serialize_for_signing(nfd)

--- a/tests/regression/test_issue_959_trust_canonical_bytes.py
+++ b/tests/regression/test_issue_959_trust_canonical_bytes.py
@@ -415,7 +415,7 @@ class TestVerifyIntegrityRaisesOnMismatchInStrictMode:
             len(candidates) == 1
         ), f"decision file MUST exist after record; found {candidates!r}"
         decision_file = candidates[0]
-        data = json.loads(decision_file.read_text())
+        data = json.loads(decision_file.read_text(encoding="utf-8"))
         data["decision"] = "tampered!"  # break the stored hash
         decision_file.write_text(json.dumps(data))
         return project, decision_id
@@ -457,7 +457,7 @@ class TestCrossSDKFixtureParity:
             f"cross-SDK trust-plane fixture missing at {_FIXTURE_PATH}; "
             "this fixture is the cross-SDK byte contract per issue #959"
         )
-        return json.loads(_FIXTURE_PATH.read_text())
+        return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
 
     def test_fixture_loads_with_required_floor(self, fixture: dict) -> None:
         assert fixture["contract"] == "trust-plane-canonical-bytes"

--- a/tests/regression/test_issue_959_trust_canonical_bytes.py
+++ b/tests/regression/test_issue_959_trust_canonical_bytes.py
@@ -198,7 +198,7 @@ class TestV5Uuid:
 
 
 # ---------------------------------------------------------------------------
-# Vector V6 — Unicode BMP (e.g. CJK) is preserved as-is (not escaped)
+# Vector V6 — Unicode BMP (e.g. CJK) is escaped to \uXXXX (ensure_ascii=True)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test-vectors/delegate-canonical.json
+++ b/tests/test-vectors/delegate-canonical.json
@@ -1,0 +1,75 @@
+{
+  "contract": "delegate-canonical-bytes",
+  "version": "1.0.0",
+  "spec_ref": "SPEC-09 S8.2",
+  "issue": "https://github.com/terrene-foundation/kailash-py/issues/1258",
+  "description": "Cross-SDK canonical-bytes byte-pin vectors for the delegate canonical JSON encoder (kailash.trust._json.canonical_json_dumps), used by kailash.delegate.* for SPEC-09 S8.2 cross-SDK parity. Both kailash-py and kailash-rs MUST produce byte-identical canonical_json and identical SHA-256 hex for every vector. This encoder uses ensure_ascii=False (RAW UTF-8 output, matching serde_json's default to_string) — the OPPOSITE of the trust-plane signing encoder serialize_for_signing (ensure_ascii=True / ASCII-escaped, see tests/test-vectors/trust-plane-canonical.json). The divergence is per-subsystem and intentional (issue #1258). canonical_json_dumps has no typed-scalar whitelist, so inputs are JSON-native only (str/int/float/bool/null/list/dict); non-ASCII is stored here as raw UTF-8 (both input_repr and expected_canonical_json) and the encoder re-emits it raw. The encoder performs NO Unicode normalization, so D3 (NFC, U+00E9) and D4 (NFD, U+0065 U+0301) are byte-distinct pre-images. Keys are sorted by Unicode code point (D7).",
+  "vectors": [
+    {
+      "name": "D1_ascii_payload",
+      "input_repr": {
+        "agent": "a1",
+        "action": "approve",
+        "cost": 42
+      },
+      "expected_canonical_json": "{\"action\":\"approve\",\"agent\":\"a1\",\"cost\":42}",
+      "expected_sha256": "3d8562fdd4e63efd07d9de2b3a96bc03f04a179b9b75efd4cd42280240760147"
+    },
+    {
+      "name": "D2_unicode_bmp_raw",
+      "input_repr": {
+        "name": "漢字"
+      },
+      "expected_canonical_json": "{\"name\":\"漢字\"}",
+      "expected_sha256": "3011f1db78cd11606ada35338c4593cadca0def5f3ba46d7d787dbf80a85cfe9"
+    },
+    {
+      "name": "D3_unicode_nfc_composed_raw",
+      "input_repr": {
+        "name": "é"
+      },
+      "expected_canonical_json": "{\"name\":\"é\"}",
+      "expected_sha256": "2f16b8477146a1b2ba7d6bb7cf7c9979c191cc2838a107dbf5f0d920b4cb3ba1"
+    },
+    {
+      "name": "D4_unicode_nfd_decomposed_raw",
+      "input_repr": {
+        "name": "é"
+      },
+      "expected_canonical_json": "{\"name\":\"é\"}",
+      "expected_sha256": "6a547588c4055916e090ed61467326046dd52810679d03bfb84d862a7123522e"
+    },
+    {
+      "name": "D5_astral_emoji_raw",
+      "input_repr": {
+        "flag": "🎉"
+      },
+      "expected_canonical_json": "{\"flag\":\"🎉\"}",
+      "expected_sha256": "62e45a342f42a856a076fab76195eff322cffc0840ebf48684473aed387aa137"
+    },
+    {
+      "name": "D6_astral_object_key_raw",
+      "input_repr": {
+        "𝄞": "clef"
+      },
+      "expected_canonical_json": "{\"𝄞\":\"clef\"}",
+      "expected_sha256": "31e42b0bfa4f3a741f9e5bd036dabdb87ee5a9058b966f8b477d5c148162bb52"
+    },
+    {
+      "name": "D7_mixed_sorted_nonascii_keys",
+      "input_repr": {
+        "é": 1,
+        "a": 2,
+        "漢": 3
+      },
+      "expected_canonical_json": "{\"a\":2,\"é\":1,\"漢\":3}",
+      "expected_sha256": "8b8f5c9bdea20447e35e527616160152fcde9366d366ec1c88d7e76394d743db"
+    },
+    {
+      "name": "EmptyDict_sentinel",
+      "input_repr": {},
+      "expected_canonical_json": "{}",
+      "expected_sha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    }
+  ]
+}

--- a/tests/test-vectors/trust-plane-canonical.json
+++ b/tests/test-vectors/trust-plane-canonical.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "spec_ref": "specs/trust-crypto.md §12.2",
   "issue": "https://github.com/terrene-foundation/kailash-py/issues/959",
-  "description": "Cross-SDK canonical-bytes byte-pin vectors for the trust-plane signing helper (kailash.trust.signing.crypto.serialize_for_signing). Both kailash-py and kailash-rs MUST produce byte-identical canonical_json and identical SHA-256 hex for every vector. Typed scalars are tagged ({\"$type\": ..., \"$value\": ...}) so the JSON file holds them losslessly. Each SDK's reifier turns tags back into the language's native object before feeding the serializer. Canonical bytes are ASCII-only (json ensure_ascii=True default) for byte-stable cross-SDK output.",
+  "description": "Cross-SDK canonical-bytes byte-pin vectors for the trust-plane signing helper (kailash.trust.signing.crypto.serialize_for_signing). Both kailash-py and kailash-rs MUST produce byte-identical canonical_json and identical SHA-256 hex for every vector. Typed scalars are tagged ({\"$type\": ..., \"$value\": ...}) so the JSON file holds them losslessly. Each SDK's reifier turns tags back into the language's native object before feeding the serializer. Canonical bytes are ASCII-only (json ensure_ascii=True default) for byte-stable cross-SDK output. Vectors V8-V10 (NFC-composed, NFD-decomposed, astral-plane object key) added per issue #1258 to pin the non-ASCII escape contract; the serializer performs NO Unicode normalization, so V8 (NFC) and V9 (NFD) are distinct pre-images.",
   "tag_schema": {
     "datetime": "ISO-8601 string with explicit tz; e.g. 2026-01-01T00:00:00+00:00",
     "date": "YYYY-MM-DD",
@@ -73,6 +73,30 @@
       },
       "expected_canonical_json": "{\"flag\":\"\\ud83c\\udf89\"}",
       "expected_sha256": "4ae22bd28ca5ffea28a6e299edefd66aff5cd192a58b7b05a425ad37a963f118"
+    },
+    {
+      "name": "V8_unicode_nfc_composed",
+      "input_repr": {
+        "name": "é"
+      },
+      "expected_canonical_json": "{\"name\":\"\\u00e9\"}",
+      "expected_sha256": "adad3fb0d32adb4fd93b9b1db248f1abe779f418b732b84c974df0110e8b26ab"
+    },
+    {
+      "name": "V9_unicode_nfd_decomposed",
+      "input_repr": {
+        "name": "é"
+      },
+      "expected_canonical_json": "{\"name\":\"e\\u0301\"}",
+      "expected_sha256": "e0615140b156e9bbdab823a0c444986bc6f7a9baac7d3515ae90ea96274c0f11"
+    },
+    {
+      "name": "V10_astral_plane_object_key",
+      "input_repr": {
+        "𝄞": "clef"
+      },
+      "expected_canonical_json": "{\"\\ud834\\udd1e\":\"clef\"}",
+      "expected_sha256": "1d775bdd399cd4d22312d79e8a65d1611a385d3f67e8064884e08a00b510d20b"
     },
     {
       "name": "EmptyDict_sentinel",

--- a/tests/unit/cross_sdk/test_canonical_json.py
+++ b/tests/unit/cross_sdk/test_canonical_json.py
@@ -162,3 +162,34 @@ def test_dumps_allows_large_integers():
     """
     assert canonical_json_dumps({"n": 2**53}) == '{"n":9007199254740992}'
     assert canonical_json_dumps({"n": 2**63 + 1}) == '{"n":9223372036854775809}'
+
+
+# ---------------------------------------------------------------------------
+# Issue #1258 — non-ASCII canonical contract: raw UTF-8 (ensure_ascii=False),
+# NO Unicode normalization. Byte-vectors are pinned cross-SDK in
+# tests/test-vectors/delegate-canonical.json (see
+# tests/regression/test_issue_1258_canonical_encoder_parity.py); these unit
+# tests document the behavior at the encoder's home module.
+# ---------------------------------------------------------------------------
+
+
+def test_dumps_emits_raw_utf8_not_ascii_escapes():
+    """``canonical_json_dumps`` uses ``ensure_ascii=False`` — non-ASCII code
+    points are emitted as raw UTF-8, NOT ``\\uXXXX`` escapes (matching Rust
+    ``serde_json``'s default ``to_string`` for the delegate cross-SDK path)."""
+    out = canonical_json_dumps({"name": "漢字"})  # 漢字
+    assert out == '{"name":"漢字"}'  # raw 漢字, not 漢字
+    assert not out.isascii()
+
+
+def test_dumps_does_not_unicode_normalize_nfc_vs_nfd():
+    """The encoder preserves the input's code points verbatim — NFC and NFD
+    are DISTINCT pre-images (no normalization). Constructed via
+    ``unicodedata.normalize`` so the two forms are byte-distinct by
+    construction regardless of source-file normalization."""
+    import unicodedata
+
+    nfc = unicodedata.normalize("NFC", "é")  # U+00E9
+    nfd = unicodedata.normalize("NFD", "é")  # U+0065 U+0301
+    assert nfc != nfd  # guard the test's own premise
+    assert canonical_json_dumps({"k": nfc}) != canonical_json_dumps({"k": nfd})

--- a/workspaces/issue-1258-canonical-encoder-parity/journal/0001-DECISION-do-not-unify-canonical-encoders.md
+++ b/workspaces/issue-1258-canonical-encoder-parity/journal/0001-DECISION-do-not-unify-canonical-encoders.md
@@ -235,3 +235,30 @@ state; divergence is visible and intentional; tests green. Deliverable walks.
 3. Should the long-term unification target (raw-UTF-8 / serde default) be
    captured as a tracked cross-SDK migration item now, or left dormant until a
    concrete driver (e.g. a JS consumer needing one canonical form) appears?
+
+## CI fix (2026-06-05) — Windows UnicodeDecodeError
+
+PR #1269's 4 windows-latest jobs failed: `test_conventions.py` (a trust
+source-convention scanner) raised `UnicodeDecodeError: 'charmap' codec can't
+decode byte 0x81` reading `crypto.py` with the locale codec (cp1252) on Windows.
+Root cause: my crypto.py docstring embedded a raw **decomposed** é
+(`e` + U+0301 = `0xCC 0x81`); `0x81` is undefined in cp1252.
+
+Fix (this fixup commit): ASCII-ify the crypto.py NFC/NFD docstring example
+(`"é"`/decomposed-`"é"` → "composed, U+00E9" / "decomposed, U+0065 U+0301") —
+also a doc improvement (invisible combining chars don't belong in a docstring).
+crypto.py + _json.py now carry ZERO cp1252-undefined bytes. Also hardened the
+two #1258 fixture loaders to `read_text(encoding="utf-8")`.
+
+### Follow-up (noted, not in this PR — pre-existing, out of #1258 scope)
+
+Three trust source-convention scanners read `*.py` source with the locale codec
+(no `encoding=`): `tests/trust/unit/test_conventions.py` (3 sites),
+`tests/trust/unit/test_sdk_conventions.py` (4), `tests/trust/test_dependency_direction.py`
+(1). A Python-source scanner MUST read UTF-8; on Windows they crash on ANY
+cp1252-undefined byte in scanned source (the codebase is full of non-ASCII
+docstrings). My crypto.py ASCII fix removes the immediate trigger, but the
+scanner fragility is latent. Recommended follow-up: add `encoding="utf-8"` to
+those source reads (also resolves pre-existing F541 lint surfaced in
+test_conventions.py). Reverted from this PR to keep #1258 scoped (per
+autonomous-execution Rule 4 shard-bound — separate concern, separate shard).

--- a/workspaces/issue-1258-canonical-encoder-parity/journal/0001-DECISION-do-not-unify-canonical-encoders.md
+++ b/workspaces/issue-1258-canonical-encoder-parity/journal/0001-DECISION-do-not-unify-canonical-encoders.md
@@ -1,0 +1,237 @@
+---
+type: DECISION
+date: 2026-06-05
+created_at: 2026-06-05T00:00:00Z
+author: agent
+project: kailash-py
+topic: "#1258 canonical-JSON encoder contracts: document + pin, do not unify"
+phase: implement
+tags: [trust, cross-sdk, canonical-json, signing, issue-1258]
+---
+
+# DECISION — #1258: document + pin the two canonical encoders; do NOT unify
+
+**Date:** 2026-06-05
+**Issue:** #1258 — trust: two canonical-JSON signing encoders diverge on `ensure_ascii`; `canonical_json_dumps` lacks pinned non-ASCII cross-SDK byte-vectors
+**Phase:** analyze → implement (pre-redteam)
+**Severity:** MEDIUM (latent cross-SDK byte-parity verification gap; no active break)
+
+## Context
+
+The trust layer ships **three** canonical-JSON encoders, each matching a
+DIFFERENT Rust `serde` byte contract for a DIFFERENT subsystem (verified by
+reading source + running both Python encoders against empirically-derived
+vectors):
+
+| Encoder                                              | `ensure_ascii`      | `sort_keys`            | Subsystem                                           | Rust counterpart                   |
+| ---------------------------------------------------- | ------------------- | ---------------------- | --------------------------------------------------- | ---------------------------------- |
+| `kailash.trust._json.canonical_json_dumps`           | `False` (raw UTF-8) | `True`                 | `kailash.delegate.*` (SPEC-09 S8.2)                 | `serde_json` default `to_string`   |
+| `kailash.trust.signing.crypto.serialize_for_signing` | `True` (escaped)    | `True`                 | trust-plane signing (Ed25519/W3C-VC/multi-sig/PACT) | ASCII-escaped serde (fixture #959) |
+| `pact.conformance.vectors.canonical_json_dumps`      | `False`             | `False` (struct order) | PACT conformance vectors                            | serde struct field-decl order      |
+
+The third (pact) encoder is OUT OF SCOPE for #1258 (separate package, separate
+cross-SDK contract — Rust struct field order). Cross-referenced here for
+completeness; not modified.
+
+## Brief-claim correction (per agents.md § brief verification)
+
+The issue body claims the fixture `tests/test-vectors/trust-plane-canonical.json`
+"pins `{"name":"漢字"}` → `{"name":"漢字"}`" (raw). **This is inaccurate.** The
+fixture's V6 vector actually pins `{"name":"漢字"}` (ASCII-escaped),
+which CORRECTLY matches `serialize_for_signing`'s `ensure_ascii=True`. Verified
+empirically: `serialize_for_signing({"name":"漢字"})` →
+`{"name":"漢字"}`, sha256 `0741d59c…` == fixture V6 expected_sha256.
+The fixture was internally consistent all along; only the issue's prose misread
+it. The real gap was (a) missing non-ASCII vectors for `canonical_json_dumps`
+and (b) undocumented per-subsystem divergence.
+
+## Decision (acceptance criterion 3: "decide whether to unify")
+
+**DO NOT unify the two contracts.** Disposition committed (per
+`value-prioritization.md` MUST-4 — no OR-escape-hatch):
+
+1. **Document** each encoder's canonical contract in its module docstring
+   (which subsystem, which `ensure_ascii`, which Rust counterpart, the
+   intentional divergence, and the no-Unicode-normalization invariant).
+2. **Pin** ≥3 non-ASCII byte-vectors for EACH encoder:
+   - signing: extended fixture with V8 (NFC composed), V9 (NFD decomposed),
+     V10 (astral-plane object key) — on top of existing V6/V7.
+   - delegate: NEW fixture `tests/test-vectors/delegate-canonical.json`
+     (8 vectors: ASCII, BMP, NFC, NFD, astral emoji, astral object key,
+     mixed-sort non-ASCII keys, empty-dict sentinel).
+3. **Do NOT unify** in kailash-py.
+
+### Why not unify
+
+Unification would be a **breaking cross-SDK signing-format migration**, NOT a
+casual edit, and either direction _breaks_ cross-SDK parity (the opposite of
+the issue's goal):
+
+- Changing `serialize_for_signing` → `ensure_ascii=False` invalidates every
+  existing trust-plane signature AND the pinned #959 fixture (vendored to
+  kailash-rs), AND breaks the ~10 signing callers (chain, key_manager,
+  multi_sig, timestamping, crl, rotation, w3c_vc) plus the sibling signers
+  (`selective_disclosure.py`, `pact/audit.py`) that _deliberately_ chose
+  `ensure_ascii=True`.
+- Changing `canonical_json_dumps` → `ensure_ascii=True` breaks delegate
+  cross-SDK parity with `serde_json`'s default raw-UTF-8 `to_string`.
+
+Each encoder matches an already-shipping, byte-pinned Rust counterpart.
+Unilateral change in kailash-py would desynchronize from kailash-rs. The
+verification gap (the actual #1258 defect) is closed by documentation + pinned
+vectors; the divergence itself is correct and intentional.
+
+### Long-term target (if ever unified)
+
+If a future coordinated cross-SDK migration unifies these, the target form
+should be raw-UTF-8 (`serde_json` default, the idiomatic Rust form). That is a
+breaking migration requiring (a) Rust-side coordination, (b) regeneration of
+all existing signatures + both fixtures, (c) a deprecation/migration cycle. It
+is genuinely blocked on kailash-rs coordination and is NOT this issue's scope.
+
+## Cross-SDK follow-up (per cross-sdk-inspection.md Rule 4a)
+
+`tests/test-vectors/delegate-canonical.json` is py-authored canonical; the
+sibling kailash-rs `serde_json` delegate path MUST vendor the same file
+byte-for-byte and assert reproduction. Filing the rs-side cross-issue is
+gated on user approval (`upstream-issue-hygiene.md` MUST-1) AND on the
+kailash-rs repo location being confirmed (see root `.session-notes` trap:
+`terrene-foundation/kailash-rs` does not currently resolve on GitHub).
+
+## Delivered (working-tree; BUILD-repo — commit gated on user)
+
+- `src/kailash/trust/_json.py` — `canonical_json_dumps` docstring + module note.
+- `src/kailash/trust/signing/crypto.py` — `serialize_for_signing` docstring.
+- `tests/test-vectors/trust-plane-canonical.json` — +V8/V9/V10 + description.
+- `tests/test-vectors/delegate-canonical.json` — NEW (8 vectors).
+- `tests/regression/test_issue_1258_canonical_encoder_parity.py` — NEW (16 tests).
+- `tests/regression/test_issue_959_trust_canonical_bytes.py` — fixed misleading
+  V6 section comment ("preserved as-is (not escaped)" → "escaped to \uXXXX").
+- `tests/unit/cross_sdk/test_canonical_json.py` — +2 non-ASCII unit tests.
+
+## Verification receipts
+
+- All vectors deterministically generated + cross-checked: existing 8 fixture
+  vectors reproduce 0-mismatch; new vectors' sha256 match empirical derivation.
+- `pytest tests/regression/test_issue_959_…  test_issue_1258_…  tests/unit/cross_sdk/`
+  → 70 passed; `tests/unit/cross_sdk/` → 78 passed.
+- `ruff check` clean; `ruff format --check` clean (4 files formatted); both
+  fixtures valid JSON (11 + 8 vectors).
+- pyright CLI (project venv v1.1.371) on `crypto.py`: 0 errors/warnings/info
+  (the harness-LSP "unreachable" hint on the `is_dataclass` branch is a
+  false positive — branch is a tested path).
+
+## Redteam R1 receipt (2026-06-05)
+
+Multi-agent redteam round, workflow run `wf_0ef55411-92a` (task `w6d8gr7cf`):
+3 parallel agents (reviewer, security-reviewer, general-purpose verifier) +
+adversarial verification of every MED+ finding.
+
+- **Verdict: CONVERGED.** overalls = [APPROVE, APPROVE, APPROVE]; 0 findings at
+  MED+; 0 confirmed-real after adversarial verification. Severity histogram:
+  2 LOW, 13 INFO.
+- The verifier independently re-derived every byte-vector in BOTH fixtures
+  (0 mismatches), confirmed the ASCII-agree / non-ASCII-diverge contract,
+  confirmed V8/V9 + D3/D4 NFC≠NFD byte-distinctness, confirmed the brief-claim
+  correction (V6 is escaped, not raw), and confirmed the pact encoder
+  characterization (ensure_ascii=False + sort_keys=False).
+- security-reviewer confirmed: no production signing/verification logic changed
+  (docstrings only); ensure_ascii=True LOAD-BEARING claim accurate; NFC/NFD
+  non-normalization is correct pre-image-stability posture; no secrets; the
+  do-not-unify decision preserves cross-SDK parity (no security gap).
+
+### LOW-1 (FIXED this session)
+
+reviewer flagged that the `canonical_json_dumps` docstring's "signing uses only
+`serialize_for_signing`" over-generalized — the selective-disclosure
+(`enforce/selective_disclosure.py`) and PACT-audit (`pact/audit.py`) signers
+share the `ensure_ascii=True` contract via their OWN `json.dumps(..., default=str)`
+call sites (no typed-scalar whitelist), so they diverge byte-for-byte from
+`serialize_for_signing` on typed-scalar inputs. Reworded the docstring to state
+the signing family is uniform on `ensure_ascii=True` but NOT one byte-identical
+encoder. Fixed in `src/kailash/trust/_json.py` this session.
+
+### LOW-2 → GATED FOLLOW-UP (NOT this shard; do NOT block #1258)
+
+The verifier found a **fourth** canonical encoder surface:
+`kailash_mcp.protocol.messages` exposes four `to_canonical_json` methods
+(`JsonRpcError`, `JsonRpcRequest`, `JsonRpcResponse`, `McpToolInfo`), all using
+`json.dumps(self.to_dict(), sort_keys=True, separators=(",",":"), ensure_ascii=False)`
+and documented as "byte-identical canonical JSON ... per EATP D6" / "byte-stable
+cross-SDK form" — yet with NO pinned non-ASCII byte-vectors
+(`cross-sdk-inspection.md` Rule 4 gap). Same bug class as #1258, but a DISTINCT
+package (kailash-mcp), DISTINCT spec surface (MCP JSON-RPC / EATP D6), DISTINCT
+Rust counterpart, and 4 message-type encoders to pin. Per `autonomous-execution.md`
+MUST Rule 4 (bounded by shard budget) this is a NEW shard, NOT a continuation —
+filing a follow-up issue is the correct disposition.
+
+**Recommended follow-up issue (DRAFT — filing gated on user approval per
+`upstream-issue-hygiene.md` MUST-1):** "mcp: pin non-ASCII cross-SDK byte-vectors
+for kailash_mcp.protocol.messages.*.to_canonical_json (EATP D6 byte-parity gap)"
+— pin ≥3 non-ASCII vectors (BMP / NFC / NFD / astral) per message type against
+kailash-rs serde_json output, mirroring the #1258 / #959 fixture pattern.
+
+## Redteam R2 receipt (2026-06-05) — convergence confirmed
+
+Focused confirming round (single reviewer agent `aee56c16e4e2d3f4b`) on the
+post-R1 LOW-1 docstring reword:
+
+- **Verdict: R2 CONVERGED — LOW-1 resolved, no new findings.**
+- Reviewer confirmed the reworded "Sibling encoder" paragraph is byte-accurate
+  to ground truth (signing family uniform on ensure_ascii=True but NOT one
+  byte-identical encoder); grep-verified `default=str` at the sibling signing
+  call sites (`selective_disclosure.py` 47/279/341/385, `pact/audit.py` 219/258)
+  AND `serialize_for_signing` count = 0 in both files.
+- Core delegate-vs-signing ensure_ascii contract + do-NOT-unify clause intact;
+  no stub introduced.
+- 127 regression + cross_sdk tests pass; `ruff check src/kailash/trust/_json.py`
+  clean.
+
+**Two consecutive clean rounds (R1 all-APPROVE/0-real, R2 LOW-1-resolved/0-new)
+= CONVERGENCE.**
+
+## User-flow walk receipt (2026-06-05)
+
+The user-facing path for this deliverable is: a developer (or CI) runs the
+test suite and reads the encoder docstrings to understand the canonical
+contract. Walked:
+
+```
+$ .venv/bin/python -m pytest tests/regression/test_issue_1258_canonical_encoder_parity.py \
+    tests/regression/test_issue_959_trust_canonical_bytes.py tests/unit/cross_sdk/ -q
+→ 127 passed
+$ .venv/bin/python -c "from kailash.trust._json import canonical_json_dumps; print(canonical_json_dumps({'name':'漢字'}))"
+→ {"name":"漢字"}          # raw UTF-8 (delegate contract)
+$ .venv/bin/python -c "from kailash.trust.signing.crypto import serialize_for_signing; print(serialize_for_signing({'name':'漢字'}))"
+→ {"name":"漢字"}  # ASCII-escaped (signing contract)
+```
+Disposition: both encoders behave exactly as the (now-documented) contracts
+state; divergence is visible and intentional; tests green. Deliverable walks.
+
+## Acceptance criteria (#1258) — final status
+
+- [x] Document each encoder's canonical contract in module docstrings — DONE
+      (`_json.py` canonical_json_dumps + module note; `crypto.py` serialize_for_signing).
+- [x] Pin ≥3 non-ASCII byte-vectors for EACH encoder — DONE (signing: V6/V7 +
+      new V8/V9/V10 = 5 non-ASCII; delegate: D2–D7 = 6 non-ASCII). Derived from
+      the canonicalization contract; rs-side live-verify is the gated cross-SDK
+      follow-up (the pinned bytes ARE the contract rs must match).
+- [x] Decide whether to unify — DONE (DECISION: do NOT unify; rationale above).
+
+## For Discussion
+
+1. (Counterfactual) If the kailash-rs repo becomes reachable, should the
+   delegate `delegate-canonical.json` vendoring + the MCP `to_canonical_json`
+   byte-pin follow-up be filed as ONE cross-SDK issue or two? The pact encoder
+   (3rd) and MCP encoders (4th) both lack pinned non-ASCII vectors — is a single
+   "audit every cross-SDK canonical encoder for byte-pins" sweep issue cleaner
+   than per-encoder issues?
+2. (Data-referencing) The decision rests on "each encoder matches a different
+   already-shipping Rust serde contract." We verified the Python side
+   empirically (0-mismatch byte-vectors) but the Rust counterparts are asserted
+   from the serde contract, not run. Is the do-not-unify decision safe to hold
+   WITHOUT a live kailash-rs reproduction, or does it need the rs-side vendor +
+   verify before the issue is truly closed?
+3. Should the long-term unification target (raw-UTF-8 / serde default) be
+   captured as a tracked cross-SDK migration item now, or left dormant until a
+   concrete driver (e.g. a JS consumer needing one canonical form) appears?


### PR DESCRIPTION
## Summary

Closes the latent cross-SDK byte-parity **verification** gap in #1258. The trust
layer ships two canonical-JSON encoders with **opposite** `ensure_ascii`
settings, each byte-aligned to a different Rust `serde` contract:

| Encoder | `ensure_ascii` | Subsystem | Rust counterpart |
| --- | --- | --- | --- |
| `kailash.trust._json.canonical_json_dumps` | `False` (raw UTF-8) | `kailash.delegate.*` (SPEC-09 S8.2) | `serde_json` default `to_string` |
| `kailash.trust.signing.crypto.serialize_for_signing` | `True` (ASCII-escaped) | trust-plane signing | ASCII-escaped (fixture #959) |

The divergence was undocumented and `canonical_json_dumps` had **zero** pinned
non-ASCII byte-vectors. The two encoders never cross-mix, so there is **no active
break** — only an unverified, undocumented contract.

## What changed

- **Document** each encoder's canonical contract + the no-Unicode-normalization
  invariant in their docstrings (`_json.py`, `signing/crypto.py`).
- **Pin** non-ASCII byte-vectors for **both** encoders:
  - signing: extend the #959 fixture with `V8` (NFC), `V9` (NFD), `V10`
    (astral-plane object key) — now 5 non-ASCII vectors.
  - delegate: new `tests/test-vectors/delegate-canonical.json` (8 vectors,
    6 non-ASCII).
  - new `tests/regression/test_issue_1258_canonical_encoder_parity.py`
    (16 behavioral tests) + 2 unit tests.
- **Decision: do NOT unify** (#1258 acceptance criterion 3). Each encoder matches
  a different already-shipping Rust contract; unifying in Python alone would
  *break* cross-SDK parity + invalidate existing signatures. Full rationale in
  the workspace journal `DECISION` entry.
- Fix a pre-existing misleading V6 comment in the #959 test.

**No production logic changed** (docstrings + test data only).

## Redteam — converged (2 rounds)

- R1: 3 parallel agents (reviewer + security-reviewer + independent byte-vector
  verifier) → all APPROVE, 0 MED+, 0 confirmed-real. Verifier independently
  re-derived every byte-vector (0 mismatches). security-reviewer confirmed no
  signing logic changed, no parity gap, no secrets.
- R2: confirmed the one LOW docstring-precision fix; no new findings.

## User-flow walk receipts

```
$ .venv/bin/python -m pytest tests/regression/test_issue_1258_canonical_encoder_parity.py \
    tests/regression/test_issue_959_trust_canonical_bytes.py tests/unit/cross_sdk/ -q
→ 127 passed

$ python -c "from kailash.trust._json import canonical_json_dumps as d; print(d({'name':'<CJK>'}))"
→ {"name":"<raw-UTF-8-CJK>"}      # delegate contract (ensure_ascii=False)
$ python -c "from kailash.trust.signing.crypto import serialize_for_signing as s; print(s({'name':'<CJK>'}))"
→ {"name":"漢字"}          # signing contract (ensure_ascii=True)
```
Both encoders behave exactly as the now-documented contracts state; divergence
is visible and intentional.

## Follow-up (not in this PR)

A **4th** canonical encoder (`kailash_mcp.protocol.messages.*.to_canonical_json`,
4 methods, `ensure_ascii=False`) has the same byte-pin gap — separate package /
spec / Rust counterpart, so a separate shard. Recommended follow-up issue drafted
in the journal `DECISION` entry (filing gated per upstream-issue-hygiene).

## Related issues

Fixes #1258
Follow-up from #1243 / #959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)