### PR TITLE
refactor(dataflow): consolidate two-spelling Optional/Union detection (#772)

### DIFF
--- a/packages/kailash-dataflow/src/dataflow/core/engine.py
+++ b/packages/kailash-dataflow/src/dataflow/core/engine.py
@@ -11,7 +11,6 @@ import os
 import re
 import threading
 import time
-import types
 import warnings
 from copy import deepcopy
 from datetime import datetime
@@ -91,6 +90,9 @@ from .events import DataFlowEventMixin
 from .logging_config import mask_sensitive_values  # Phase 7: Sensitive value masking
 from .nodes import NodeGenerator
 from .schema_cache import create_schema_cache  # ADR-001: Schema cache integration
+from .type_introspection import (  # issue #772: shared union detection
+    union_non_none_args,
+)
 
 # Source name validation (used in Redis keys, cache keys, endpoint paths)
 _SOURCE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]{0,63}$")
@@ -5396,11 +5398,11 @@ class DataFlow(DataFlowEventMixin):
         """
         from typing import get_args, get_origin
 
-        # Handle Optional types (Union[type, None]). issue #1228: PEP 604 ``T | None``
-        # has origin types.UnionType and NO ``__origin__`` attribute, so route through
-        # get_origin/get_args to recognize both spellings.
-        _origin = get_origin(python_type)
-        if _origin is Union or _origin is types.UnionType:
+        # Handle Optional types (Union[type, None]). Two-spelling union detection
+        # (typing.Union AND PEP 604 ``T | None``) routes through the shared
+        # primitive (issue #772 / #1228); this caller keeps its own extraction
+        # policy -- only a 2-arg Optional[SomeType] collapses to the SQL type.
+        if union_non_none_args(python_type) is not None:
             args = get_args(python_type)
             if len(args) == 2 and type(None) in args:
                 # This is Optional[SomeType], extract the actual type

--- a/packages/kailash-dataflow/src/dataflow/core/model_registry.py
+++ b/packages/kailash-dataflow/src/dataflow/core/model_registry.py
@@ -11,12 +11,13 @@ import hashlib
 import json
 import logging
 import threading
-import types
 import uuid
 import warnings
 from contextlib import contextmanager
 from datetime import UTC, datetime
-from typing import Any, Dict, List, Optional, Tuple, get_args
+from typing import Any, Dict, List, Optional, Tuple
+
+from .type_introspection import union_non_none_args
 
 try:
     from kailash.nodes.data.sql import SQLDatabaseNode
@@ -1212,40 +1213,34 @@ class ModelRegistry:
         This prevents 'Unknown field type <class str>' warnings by converting
         Python type objects to their simple names.
         """
+        # Optional/Union in EITHER spelling -- typing ``Union[X, None]`` /
+        # ``Optional[X]`` AND PEP 604 ``X | Y`` -- normalizes identically: a
+        # 2-arg ``X | None`` names "Optional", every other union names "Union".
+        # Detection routes through the single ``union_non_none_args`` primitive
+        # (issue #772 consolidation) so a new union spelling is handled in ONE
+        # place, not re-inlined here. This also closes the #1228 / F34 spelling
+        # divergence structurally -- both spellings traverse the same branch.
+        non_none = union_non_none_args(field_type)
+        if non_none is not None:
+            return "Optional" if len(non_none) == 1 else "Union"
+
         if isinstance(field_type, type):
             # Handle built-in types
             if field_type.__module__ == "builtins":
                 return field_type.__name__
-            else:
-                # For non-builtin types, use module.name format
-                return f"{field_type.__module__}.{field_type.__name__}"
-        elif hasattr(field_type, "__name__"):
+            # For non-builtin types, use module.name format
+            return f"{field_type.__module__}.{field_type.__name__}"
+        if hasattr(field_type, "__name__"):
             # Handle other objects with __name__ attribute
             return field_type.__name__
-        elif hasattr(field_type, "__origin__"):
-            # Handle typing generics like List[str], Optional[int], etc.
+        if hasattr(field_type, "__origin__"):
+            # Handle non-union typing generics like List[str], Dict[K, V], etc.
             origin = field_type.__origin__
             if origin.__module__ == "builtins":
                 return origin.__name__
-            else:
-                return f"{origin.__module__}.{origin.__name__}"
-        elif isinstance(field_type, types.UnionType):
-            # PEP 604 ``X | Y`` unions (e.g. ``int | None``) have no ``__name__``
-            # / ``__origin__``, so without this branch they fall to the
-            # ``str(field_type)`` fallback ("int | None") — diverging from the
-            # ``typing.Optional[int]`` / ``Union[int, None]`` spelling, which
-            # normalizes to "Optional" (or "Union") via the ``__name__`` branch
-            # above. Mirror that naming EXACTLY so a field declared ``int | None``
-            # normalizes identically to ``Optional[int]`` and a spelling switch
-            # is not seen as a schema change (issue #1228 / F34). typing names a
-            # 2-arg ``Union[X, None]`` "Optional" and every other union "Union".
-            args = get_args(field_type)
-            if len(args) == 2 and type(None) in args:
-                return "Optional"
-            return "Union"
-        else:
-            # Fallback to string representation
-            return str(field_type)
+            return f"{origin.__module__}.{origin.__name__}"
+        # Fallback to string representation
+        return str(field_type)
 
     def _normalize_stored_field_type(self, field_type_str: str) -> str:
         """Normalize stored field types from old format to new format.

--- a/packages/kailash-dataflow/src/dataflow/core/nodes.py
+++ b/packages/kailash-dataflow/src/dataflow/core/nodes.py
@@ -4,8 +4,9 @@ DataFlow Node Generation
 Dynamic node generation for database operations.
 """
 
-import types
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
+
+from .type_introspection import strip_annotated, union_non_none_args
 
 try:
     from kailash.nodes.base import Node, NodeParameter, NodeRegistry
@@ -152,19 +153,16 @@ def _coerce_record_id(model_fields: Dict[str, Any], id_value: Any) -> Any:
 
 def _normalize_id_type(type_annotation: Any) -> Any:
     """Normalize a type annotation for ID coercion, stripping Optional/Union wrappers."""
-    import typing
+    # Strip a single Annotated[T, ...] layer first (issue #772 consolidation).
+    type_annotation = strip_annotated(type_annotation)
 
-    # Match BOTH union spellings (issue #1228, sibling of #1207): typing.Union /
-    # Optional[T] (get_origin -> typing.Union) AND PEP 604 ``T | None`` (get_origin
-    # -> types.UnionType; a UnionType has no ``__origin__`` attribute, so the prior
-    # getattr-based check silently missed it).
-    origin = typing.get_origin(type_annotation)
-    if origin is Union or origin is types.UnionType:
-        args = typing.get_args(type_annotation)
-        non_none_types = [arg for arg in args if arg is not type(None)]
+    # Two-spelling union detection (typing.Union / Optional[T] AND PEP 604
+    # ``T | None``) routes through the shared primitive (issue #772 / #1207 / #1228).
+    non_none_types = union_non_none_args(type_annotation)
+    if non_none_types is not None:
         if non_none_types:
             return _normalize_id_type(non_none_types[0])
-        return str  # fallback
+        return str  # all-None union edge -> fallback
 
     if isinstance(type_annotation, type):
         return type_annotation
@@ -187,16 +185,14 @@ def _unwrap_optional_type(type_annotation: Any) -> Any:
     Multi-arg unions (``Union[list, dict]``) and non-union annotations are
     returned unchanged so the downstream ``in (dict, list)`` membership check
     behaves identically to a bare annotation.
-    """
-    import typing
 
-    origin = typing.get_origin(type_annotation)
-    if origin is typing.Union or origin is types.UnionType:
-        non_none = [
-            arg for arg in typing.get_args(type_annotation) if arg is not type(None)
-        ]
-        if len(non_none) == 1:
-            return non_none[0]
+    Two-spelling detection routes through the shared primitive (issue #772 /
+    #1207); this caller keeps its collapse-only policy (single-non-None-arg
+    unions collapse; multi-arg and all-None unions return unchanged).
+    """
+    non_none = union_non_none_args(type_annotation)
+    if non_none is not None and len(non_none) == 1:
+        return non_none[0]
     return type_annotation
 
 
@@ -372,17 +368,22 @@ class NodeGenerator:
             A simple Python type (str, int, bool, list, dict, etc.)
             For Optional[T], returns the normalized inner type T
         """
-        # PEP 604 ``T | None`` (issue #1228, sibling of #1207): a types.UnionType
-        # has NO ``__origin__`` attribute, so the hasattr-gated block below skips it
-        # entirely. Normalize it through the same single-non-None-arg collapse the
-        # typing.Union branch applies, BEFORE the __origin__ check.
-        from typing import get_args as _get_args
-        from typing import get_origin as _get_origin
+        # Strip a single Annotated[T, ...] layer first (issue #772 consolidation):
+        # Annotated annotations now resolve to their wrapped type instead of
+        # falling through to the str fallback at the end of this method.
+        type_annotation = strip_annotated(type_annotation)
 
-        if _get_origin(type_annotation) is types.UnionType:
-            non_none_types = [
-                arg for arg in _get_args(type_annotation) if arg is not type(None)
-            ]
+        # Two-spelling union detection routes through the shared primitive
+        # (issue #772 / #1207 / #1228): typing.Union / Optional[T] AND PEP 604
+        # ``T | None``. This subsumes BOTH the prior standalone types.UnionType
+        # block AND the ``origin is Union`` branch inside the __origin__ check.
+        # Every non-empty union collapses to its first non-None arg (Optional,
+        # single-arg union, and multi-arg union all normalize to the first
+        # non-None member); an all-None union falls back to str. The Optional
+        # wrapper itself is detected SEPARATELY for required=False in parameter
+        # generation (see get_parameters); this method only returns the inner type.
+        non_none_types = union_non_none_args(type_annotation)
+        if non_none_types is not None:
             if non_none_types:
                 return self._normalize_type_annotation(non_none_types[0])
             return str
@@ -390,29 +391,9 @@ class NodeGenerator:
         # Handle typing constructs
         if hasattr(type_annotation, "__origin__"):
             origin = type_annotation.__origin__
-            args = getattr(type_annotation, "__args__", ())
-
-            # Handle Optional[T] -> Union[T, None]
-            if origin is Union:
-                # Check if this is Optional[T] (Union[T, None])
-                non_none_types = [arg for arg in args if arg is not type(None)]
-
-                if len(non_none_types) == 1 and type(None) in args:
-                    # This is Optional[T] - normalize the inner type
-                    # The Optional wrapper is detected separately in parameter generation
-                    return self._normalize_type_annotation(non_none_types[0])
-                elif len(non_none_types) == 1:
-                    # Union with single type (not Optional) - normalize it
-                    return self._normalize_type_annotation(non_none_types[0])
-                elif len(non_none_types) == 0:
-                    # Union[None] edge case - treat as Any
-                    return str
-                else:
-                    # Complex Union (not Optional) - keep first non-None type
-                    return self._normalize_type_annotation(non_none_types[0])
 
             # Handle List[T], Dict[K, V], etc. - return base container type
-            elif origin in (list, List):
+            if origin in (list, List):
                 return list
             elif origin in (dict, Dict):
                 return dict
@@ -1150,18 +1131,19 @@ class NodeGenerator:
                             # BUG #514 FIX: Store Optional info for validation
                             # We keep required=True to prevent Core SDK from dropping the parameter,
                             # but we'll handle None values specially in validate_inputs()
-                            from typing import get_args, get_origin
+                            from typing import get_args
 
                             is_optional = False
                             field_type = field_info["type"]
 
-                            # issue #1228: match typing.Union AND PEP 604 ``T | None``
-                            # (origin types.UnionType) so PEP 604 nullable fields are
-                            # detected as optional.
-                            _origin = get_origin(field_type)
-                            if _origin is Union or _origin is types.UnionType:
-                                args = get_args(field_type)
-                                if type(None) in args:
+                            # Two-spelling union detection routes through the shared
+                            # primitive (issue #772 / #1228: typing.Union AND PEP 604
+                            # ``T | None``). This is the SEPARATE Optional-detection
+                            # contract (required=False from Optional[T]); it keeps its
+                            # own policy -- a union is optional iff its args contained
+                            # NoneType -- distinct from the type-normalization sites.
+                            if union_non_none_args(field_type) is not None:
+                                if type(None) in get_args(field_type):
                                     is_optional = True
 
                             # ADR-002: Changed from WARNING to DEBUG - type normalization tracing

--- a/packages/kailash-dataflow/src/dataflow/core/schema.py
+++ b/packages/kailash-dataflow/src/dataflow/core/schema.py
@@ -7,7 +7,6 @@ This module was migrated from the old core/schema.py to maintain test compatibil
 
 import inspect
 import logging
-import types
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -24,6 +23,10 @@ from typing import (
     get_type_hints,
 )
 from uuid import UUID
+
+from .type_introspection import (  # issue #772: shared union detection
+    union_non_none_args,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -318,9 +321,11 @@ class SchemaParser:
         nullable = False
         actual_type = field_type
 
-        # issue #1228: match typing.Union AND PEP 604 ``T | None`` (a
-        # ``types.UnionType`` origin) so PEP 604 nullable fields parse as nullable.
-        if origin is Union or origin is types.UnionType:
+        # Two-spelling union detection (typing.Union AND PEP 604 ``T | None``)
+        # routes through the shared primitive (issue #772 / #1228); this caller
+        # keeps its own policy -- Optional[X] sets nullable + unwraps, other
+        # unions become JSON (dict).
+        if union_non_none_args(field_type) is not None:
             # Check if it's Optional (Union[X, None])
             if type(None) in args:
                 nullable = True

--- a/packages/kailash-dataflow/src/dataflow/core/type_introspection.py
+++ b/packages/kailash-dataflow/src/dataflow/core/type_introspection.py
@@ -1,0 +1,69 @@
+"""Single-site type-introspection primitives for DataFlow (issue #772).
+
+Several DataFlow helpers independently re-implemented the same two-spelling
+Optional/Union detection -- ``get_origin(a) is Union or get_origin(a) is
+types.UnionType`` -- to recognize BOTH the legacy ``typing.Optional[T]`` /
+``typing.Union[T, None]`` form AND the PEP 604 ``T | None`` form. Each copy had
+to be patched independently whenever a new type-form appeared. That maintenance
+tax fired twice: #1207 (the JSONB read-path deserializer) and #1228 (PEP 604
+``T | None`` across node generation, ID coercion, type processing, schema
+parsing, engine SQL mapping, model validation, and FK inference). Both
+incidents had to touch every copy.
+
+This module centralizes ONLY the detection + non-None extraction into one
+primitive (``union_non_none_args``) plus the Annotated-strip helper
+(``strip_annotated``). Each caller keeps its OWN post-detection policy --
+some recurse on the first non-None arg, some return multi-type unions as-is,
+some set a nullable flag. The shared primitive means the next union spelling
+is handled in exactly one place.
+
+ASCII-only docstrings throughout (Windows source-scanner constraint).
+"""
+
+import types
+import typing
+from typing import Any, Union, get_args, get_origin
+
+
+def union_non_none_args(annotation: Any) -> list | None:
+    """Two-spelling Optional/Union detection -- the SINGLE place a new union
+    spelling is handled (issue #772; #1207 / #1228 PEP 604 drift is the
+    evidence that motivated consolidating this detection).
+
+    Recognizes BOTH spellings of a union/optional in one predicate:
+
+    1. ``typing.Union[T, ...]`` / ``typing.Optional[T]`` -- ``get_origin``
+       returns ``typing.Union``.
+    2. PEP 604 ``T | None`` (Python 3.10+) -- ``get_origin`` returns
+       ``types.UnionType``.
+
+    Returns:
+        - the list of non-``None`` args if ``annotation`` is a union in either
+          spelling (``Optional[int]`` -> ``[int]``; ``str | int`` ->
+          ``[str, int]``; the all-``None`` edge -> ``[]``). The caller decides
+          what to do with a single arg vs multiple args vs an empty list.
+        - ``None`` if ``annotation`` is not a union at all (a bare type, a
+          parameterized container like ``list[str]``, etc.).
+
+    The ``None`` return is distinct from the ``[]`` return: ``None`` means
+    "not a union"; ``[]`` means "a union whose only member was ``NoneType``".
+    """
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        return [a for a in get_args(annotation) if a is not type(None)]
+    return None
+
+
+def strip_annotated(annotation: Any) -> Any:
+    """``Annotated[T, ...]`` -> ``T`` (single layer); pass through otherwise.
+
+    The next drift example the issue (#772) named explicitly was
+    ``typing.Annotated``. Verified on Python 3.12: ``get_origin(Annotated[int,
+    "x"]) is typing.Annotated`` and ``get_args(Annotated[int, "x"])[0]`` is the
+    wrapped type (``int``). A non-``Annotated`` annotation is returned
+    unchanged, so this is safe to call unconditionally before any further
+    introspection.
+    """
+    if get_origin(annotation) is typing.Annotated:
+        return get_args(annotation)[0]
+    return annotation

--- a/packages/kailash-dataflow/src/dataflow/core/type_processor.py
+++ b/packages/kailash-dataflow/src/dataflow/core/type_processor.py
@@ -5,11 +5,12 @@ forced type conversions. Validates field values against declared types.
 """
 
 import logging
-import types
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Dict, Optional, Union, get_args, get_origin
+from typing import Any, Dict, Optional, get_origin
 from uuid import UUID
+
+from .type_introspection import strip_annotated, union_non_none_args
 
 logger = logging.getLogger("dataflow.type_processor")
 
@@ -69,21 +70,23 @@ class TypeAwareFieldProcessor:
         if field_type is None:
             return None
 
-        origin = get_origin(field_type)
+        # Strip a single Annotated[T, ...] layer first so Annotated[int, "x"]
+        # resolves to int (issue #772 consolidation: Annotated handled in one
+        # place via strip_annotated, not falling through to the str fallback).
+        field_type = strip_annotated(field_type)
 
         # ``Optional[T]`` / ``Union[T, None]`` (legacy typing form) and PEP 604
-        # ``T | None`` (the ``X | Y`` syntax) both reach this branch. The
-        # legacy form returns ``Union`` from ``get_origin``; PEP 604 returns
-        # ``types.UnionType``. Match either.
-        if origin is Union or origin is types.UnionType:
-            args = get_args(field_type)
-            non_none_types = [t for t in args if t is not type(None)]
+        # ``T | None`` both reach this branch via the shared two-spelling
+        # detection in union_non_none_args (issue #772 / #1207 / #1228).
+        non_none_types = union_non_none_args(field_type)
+        if non_none_types is not None:
             if len(non_none_types) == 1:
                 # Recurse so Optional[list[str]] resolves through list[str] to list.
                 return self._resolve_type(non_none_types[0])
-            # Multi-type union, return as-is
+            # Multi-type union, return as-is.
             return field_type
 
+        origin = get_origin(field_type)
         if origin is not None:
             # Parameterized builtin generic — strip parameters so isinstance() can
             # use it. list[str] -> list, dict[str, Any] -> dict, tuple[int, ...] -> tuple.
@@ -123,9 +126,9 @@ class TypeAwareFieldProcessor:
             return value
 
         # Handle Union types that weren't simplified (multiple non-None types).
-        # issue #1228: match PEP 604 ``T | None`` (origin types.UnionType) too.
-        _origin = get_origin(expected_type)
-        if _origin is Union or _origin is types.UnionType:
+        # Two-spelling detection (typing.Union AND PEP 604 ``T | None``) routes
+        # through the shared primitive (issue #772 / #1228).
+        if union_non_none_args(expected_type) is not None:
             # For complex Union types, pass through
             return value
 

--- a/packages/kailash-dataflow/src/dataflow/migrations/fk_aware_model_integration.py
+++ b/packages/kailash-dataflow/src/dataflow/migrations/fk_aware_model_integration.py
@@ -40,26 +40,17 @@ import asyncio
 import inspect
 import logging
 import re
-import types
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    get_args,
-    get_origin,
-)
+from typing import Any, Dict, List, Optional, Set, Tuple, Type, get_args
 
 # DataFlow core imports
 from dataflow.core.engine import DataFlow
 from dataflow.core.model_registry import ModelRegistry
+from dataflow.core.type_introspection import (  # issue #772: shared union detection
+    union_non_none_args,
+)
 
 # from dataflow.core.schema_change import SchemaChange, ChangeType
 from dataflow.migrations.migration_engine import MigrationEngine
@@ -414,11 +405,10 @@ class FKAwareModelTracker:
 
     def _is_nullable_field(self, field_type: Type) -> bool:
         """Check if field is nullable based on type annotation."""
-        # Check for Optional[Type] or Union[Type, None]. issue #1228: PEP 604
-        # ``T | None`` has origin types.UnionType and NO ``__origin__`` attribute,
-        # so route through get_origin/get_args to recognize both spellings.
-        origin = get_origin(field_type)
-        if origin is Union or origin is types.UnionType:
+        # Two-spelling union detection (typing.Union AND PEP 604 ``T | None``)
+        # routes through the shared primitive (issue #772 / #1228); the policy
+        # here is distinct -- nullable iff the union args contain NoneType.
+        if union_non_none_args(field_type) is not None:
             return type(None) in get_args(field_type)
 
         # Default to nullable

--- a/packages/kailash-dataflow/src/dataflow/validation/model_validator.py
+++ b/packages/kailash-dataflow/src/dataflow/validation/model_validator.py
@@ -15,18 +15,11 @@ Integration: Called during @db.model() decorator when strict_mode enabled
 """
 
 import datetime
-import types
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Union,
-    get_args,
-    get_origin,
-    get_type_hints,
-)
+from typing import Any, Dict, List, Optional, get_args, get_origin, get_type_hints
 
+from dataflow.core.type_introspection import (  # issue #772: shared union detection
+    union_non_none_args,
+)
 from dataflow.validation.strict_mode import StrictModeConfig
 from dataflow.validation.validators import BaseValidator, ValidationError
 
@@ -158,10 +151,11 @@ def validate_primary_key(model_cls: type) -> ValidationResult:
     # Extract id field type
     id_type = type_hints["id"]
 
-    # Rule 4: Check if Optional/Union (id cannot be optional)
-    # issue #1228: match PEP 604 ``T | None`` (origin types.UnionType) too.
-    origin = get_origin(id_type)
-    if origin is Union or origin is types.UnionType:  # Optional is Union[T, None]
+    # Rule 4: Check if Optional/Union (id cannot be optional). Two-spelling
+    # union detection (typing.Union AND PEP 604 ``T | None``) routes through the
+    # shared primitive (issue #772 / #1228); the policy here is distinct -- an
+    # Optional id is rejected.
+    if union_non_none_args(id_type) is not None:  # Optional is Union[T, None]
         args = get_args(id_type)
         # Check if this is Optional (Union with None)
         if type(None) in args:
@@ -468,10 +462,11 @@ def validate_field_types(model_cls: type) -> List[ValidationResult]:
         if field_name in ("created_at", "updated_at"):
             continue
 
-        # Unwrap Optional/Union to get base type
-        # issue #1228: match PEP 604 ``T | None`` (origin types.UnionType) too.
-        origin = get_origin(field_type)
-        if origin is Union or origin is types.UnionType:  # Optional is Union[T, None]
+        # Unwrap Optional/Union to get base type. Two-spelling union detection
+        # (typing.Union AND PEP 604 ``T | None``) routes through the shared
+        # primitive (issue #772 / #1228); this caller keeps its own policy --
+        # the first non-None arg is the base type.
+        if union_non_none_args(field_type) is not None:  # Optional is Union[T, None]
             args = get_args(field_type)
             # Find non-None type
             base_type = None

--- a/packages/kailash-dataflow/tests/regression/test_issue_772_type_introspection_consolidation.py
+++ b/packages/kailash-dataflow/tests/regression/test_issue_772_type_introspection_consolidation.py
@@ -1,0 +1,261 @@
+"""Regression gate for #772 — consolidated two-spelling Optional/Union detection.
+
+#772 consolidated the two-spelling Optional/Union detection (``origin is Union
+or origin is types.UnionType``) that was independently re-implemented across
+DataFlow's type-introspection helpers into a SINGLE primitive,
+``union_non_none_args`` (plus ``strip_annotated``). #1207 and #1228 were the
+maintenance-tax incidents the consolidation prevents recurring.
+
+Two test classes:
+
+1. **Structural invariants** (``ast``/``grep`` based — this is the ONE
+   legitimately structural test per cross-sdk-inspection Rule 3a + refactor-
+   invariants.md): exactly ONE ``def union_non_none_args`` exists in the source
+   tree, AND no ``is types.UnionType`` literal survives OUTSIDE
+   ``type_introspection.py``. These fail loudly if a future change re-inlines
+   union detection at any caller.
+
+2. **Behavioral coverage** mirroring #768 (parameterized generics on
+   ``_resolve_type``), #1207 (``_unwrap_optional_type`` JSONB read path), and
+   #1228 (PEP 604 ``T | None`` across every routed helper) THROUGH the
+   consolidated path, so those fixes stay green.
+"""
+
+import ast
+from pathlib import Path
+from typing import Annotated, Any, Dict, List, Optional, Union
+
+import pytest
+
+from dataflow.core.nodes import NodeGenerator, _normalize_id_type, _unwrap_optional_type
+from dataflow.core.type_processor import TypeAwareFieldProcessor
+
+# packages/kailash-dataflow/src/dataflow  (this file is at .../tests/regression/)
+SRC_DATAFLOW = Path(__file__).resolve().parents[2] / "src" / "dataflow"
+INTROSPECTION_REL = "core/type_introspection.py"
+
+
+# --------------------------------------------------------------------------- #
+# 1. Structural invariants (AST / grep — the consolidation's signature lock)
+# --------------------------------------------------------------------------- #
+@pytest.mark.regression
+class TestIssue772StructuralInvariants:
+    """The two-spelling union detection exists in EXACTLY ONE place."""
+
+    def _py_files(self):
+        return sorted(SRC_DATAFLOW.rglob("*.py"))
+
+    def test_exactly_one_def_union_non_none_args(self):
+        """AST-enumerate every `def union_non_none_args` across the src tree."""
+        definitions = []
+        for path in self._py_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and node.name == "union_non_none_args"
+                ):
+                    definitions.append(
+                        f"{path.relative_to(SRC_DATAFLOW)}:{node.lineno}"
+                    )
+        assert len(definitions) == 1, (
+            "union_non_none_args must be defined EXACTLY once (the #772 "
+            f"consolidation invariant); found {len(definitions)}: {definitions}. "
+            "A second definition means a caller re-inlined union detection."
+        )
+        assert definitions[0].startswith("core/type_introspection.py"), (
+            f"the single union_non_none_args def must live in "
+            f"{INTROSPECTION_REL}; found at {definitions[0]}"
+        )
+
+    def test_no_uniontype_reference_survives_outside_introspection_module(self):
+        """No ``types.UnionType`` attribute reference survives in live code
+        outside type_introspection.py -- ``is types.UnionType``,
+        ``isinstance(x, types.UnionType)``, or ANY other form.
+
+        AST-based (matches every ``ast.Attribute`` whose attr is ``UnionType``)
+        so it catches the ``isinstance`` spelling the prior substring check
+        missed at ``model_registry.py`` (issue #772 follow-up), AND it ignores
+        docstring / comment prose (those parse as ``ast.Constant``, never
+        ``ast.Attribute``) without needing string-prefix special-casing.
+        """
+        offenders = []
+        for path in self._py_files():
+            rel = str(path.relative_to(SRC_DATAFLOW))
+            if rel == INTROSPECTION_REL:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Attribute) and node.attr == "UnionType":
+                    offenders.append(f"{rel}:{node.lineno}")
+        assert not offenders, (
+            "types.UnionType must NOT be referenced in live code outside "
+            f"{INTROSPECTION_REL} (the #772 single-detection-site invariant). "
+            f"Re-inlined/missed sites: {offenders}"
+        )
+
+    def test_routed_callers_import_the_shared_primitive(self):
+        """The routed callers import union_non_none_args (no orphan helper)."""
+        # The four primary + routed sibling modules MUST import the primitive.
+        routed = [
+            "core/type_processor.py",
+            "core/nodes.py",
+            "core/engine.py",
+            "core/schema.py",
+            "core/model_registry.py",
+            "validation/model_validator.py",
+            "migrations/fk_aware_model_integration.py",
+        ]
+        for rel in routed:
+            text = (SRC_DATAFLOW / rel).read_text(encoding="utf-8")
+            assert "union_non_none_args" in text, (
+                f"{rel} no longer references union_non_none_args; either the "
+                "import was dropped or the detection was re-inlined."
+            )
+
+
+# --------------------------------------------------------------------------- #
+# 2. Behavioral coverage through the consolidated path (#768 / #1207 / #1228)
+# --------------------------------------------------------------------------- #
+def _resolve(annotation: Any):
+    tp = TypeAwareFieldProcessor({"f": {"type": annotation, "required": False}}, "M")
+    return tp._resolved_types["f"]
+
+
+@pytest.fixture
+def gen():
+    import types as _types
+
+    return NodeGenerator(_types.SimpleNamespace())
+
+
+@pytest.mark.regression
+class TestIssue768ParameterizedGenericsResolveType:
+    """#768: parameterized generics resolve to their isinstance-usable origin."""
+
+    def test_list_str_resolves_to_list(self):
+        assert _resolve(list[str]) is list
+
+    def test_dict_str_any_resolves_to_dict(self):
+        assert _resolve(Dict[str, Any]) is dict
+
+    def test_typing_list_resolves_to_list(self):
+        assert _resolve(List[int]) is list
+
+    def test_optional_parameterized_resolves_through_to_origin(self):
+        # Optional[list[str]] -> list[str] -> list (recurse through the union).
+        assert _resolve(Optional[list[str]]) is list
+
+
+@pytest.mark.regression
+class TestIssue1207UnwrapOptionalThroughConsolidatedPath:
+    """#1207: _unwrap_optional_type handles both union spellings, collapse-only."""
+
+    def test_optional_list_collapses_to_list(self):
+        assert _unwrap_optional_type(Optional[list]) is list
+
+    def test_typing_union_list_none_collapses_to_list(self):
+        assert _unwrap_optional_type(Union[list, None]) is list
+
+    def test_pep604_list_or_none_collapses_to_list(self):
+        assert _unwrap_optional_type(list | None) is list
+
+    def test_optional_dict_collapses_to_dict(self):
+        assert _unwrap_optional_type(Optional[dict]) is dict
+
+    def test_multi_arg_union_returned_unchanged(self):
+        assert _unwrap_optional_type(Union[list, dict]) == Union[list, dict]
+
+    def test_plain_type_passes_through(self):
+        assert _unwrap_optional_type(str) is str
+
+
+@pytest.mark.regression
+class TestIssue1228Pep604ThroughConsolidatedPath:
+    """#1228: PEP 604 ``T | None`` treated identically to Optional[T]."""
+
+    def test_normalize_id_type_pep604_agrees_with_typing(self):
+        assert _normalize_id_type(int | None) is _normalize_id_type(Optional[int])
+
+    def test_normalize_type_annotation_pep604_agrees_with_typing(self, gen):
+        assert gen._normalize_type_annotation(
+            list | None
+        ) is gen._normalize_type_annotation(Optional[list])
+
+    def test_resolve_type_pep604_optional_resolves_to_inner(self):
+        assert _resolve(int | None) is int
+
+    def test_resolve_type_multi_arg_pep604_union_returned_as_is(self):
+        # _resolve_type's distinct policy: multi-type union returned unchanged.
+        assert _resolve(int | str) == (int | str)
+
+    def test_validate_field_passes_multi_arg_pep604_union_through(self):
+        tp = TypeAwareFieldProcessor({"x": {"type": int | str, "required": False}}, "M")
+        assert tp._resolved_types["x"] == (int | str)
+        assert tp.validate_field("x", "hello") == "hello"
+
+
+@pytest.mark.regression
+class TestIssue772AnnotatedStripAdd:
+    """#772 strict ADD: every routed normalize/resolve site now strips Annotated.
+
+    Pre-consolidation, Annotated[T, ...] fell through to the str fallback at
+    _normalize_type_annotation / _normalize_id_type and was returned unchanged
+    by _resolve_type's origin branch. Post-consolidation, strip_annotated runs
+    first at each site, so Annotated resolves to its wrapped type. This is the
+    consolidation's proof — a new type-form handled in ONE place.
+    """
+
+    def test_resolve_type_strips_annotated(self):
+        assert _resolve(Annotated[int, "x"]) is int
+
+    def test_normalize_type_annotation_strips_annotated(self, gen):
+        assert gen._normalize_type_annotation(Annotated[int, "x"]) is int
+
+    def test_normalize_id_type_strips_annotated(self):
+        assert _normalize_id_type(Annotated[int, "x"]) is int
+
+
+@pytest.mark.regression
+class TestIssue772ModelRegistryFieldNaming:
+    """#772 follow-up: ``model_registry._normalize_field_type`` was a 10th site
+    re-implementing two-spelling union detection via ``isinstance(_,
+    types.UnionType)`` -- missed by the original substring invariant (it has no
+    ``is types.UnionType`` literal). It now routes through ``union_non_none_args``;
+    BOTH union spellings name identically and the prior outputs are preserved
+    exactly. Behavior baseline (pre-refactor): Optional[int]/int|None -> "Optional",
+    str|int / Union[int,str,None] / int|str|None -> "Union", list[str] -> "list",
+    str -> "str".
+    """
+
+    @staticmethod
+    def _norm(annotation: Any) -> str:
+        from dataflow.core.model_registry import ModelRegistry
+
+        # _normalize_field_type uses only its argument, not instance state.
+        reg = object.__new__(ModelRegistry)
+        return reg._normalize_field_type(annotation)
+
+    def test_pep604_optional_names_optional(self):
+        assert self._norm(int | None) == "Optional"
+
+    def test_typing_optional_names_optional(self):
+        assert self._norm(Optional[int]) == "Optional"
+
+    def test_both_optional_spellings_agree(self):
+        assert self._norm(int | None) == self._norm(Optional[int]) == "Optional"
+
+    def test_pep604_multi_union_names_union(self):
+        assert self._norm(str | int) == "Union"
+
+    def test_typing_multi_union_with_none_names_union(self):
+        assert self._norm(Union[int, str, None]) == "Union"
+
+    def test_pep604_multi_union_with_none_names_union(self):
+        assert self._norm(int | str | None) == "Union"
+
+    def test_builtin_passes_through(self):
+        assert self._norm(str) == "str"
+
+    def test_parameterized_generic_names_origin(self):
+        assert self._norm(list[str]) == "list"

--- a/packages/kailash-dataflow/tests/unit/test_type_introspection.py
+++ b/packages/kailash-dataflow/tests/unit/test_type_introspection.py
@@ -1,0 +1,232 @@
+"""Tier-1 unit tests for the consolidated type-introspection primitives (#772).
+
+#772 consolidated the two-spelling Optional/Union detection that was previously
+re-implemented in four+ DataFlow helpers (the maintenance tax #1207 / #1228
+each paid) into a SINGLE primitive, ``union_non_none_args``, plus an Annotated
+strip helper, ``strip_annotated``. Each caller keeps its OWN post-detection
+policy; only the detection + non-None extraction is centralized.
+
+These tests cover (1) the two primitives directly, and (2) behavioral parity
+of all four routed helpers -- every test CALLS the helper and asserts its
+return (behavioral, never source-substring-grep; the AST/grep structural
+invariants live in tests/regression/test_issue_772_*). The Annotated-strip
+cases double as the consolidation's proof: every routed helper now strips a
+single Annotated[T, ...] layer where it previously fell through to ``str``.
+"""
+
+import types as _types
+from datetime import datetime
+from decimal import Decimal
+from typing import Annotated, Any, Dict, List, Optional, Union
+
+import pytest
+
+from dataflow.core.nodes import NodeGenerator, _normalize_id_type, _unwrap_optional_type
+from dataflow.core.type_introspection import strip_annotated, union_non_none_args
+from dataflow.core.type_processor import TypeAwareFieldProcessor
+
+
+# --------------------------------------------------------------------------- #
+# union_non_none_args
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+class TestUnionNonNoneArgs:
+    """The single two-spelling Optional/Union detection site (#772)."""
+
+    def test_optional_int_returns_int_list(self):
+        assert union_non_none_args(Optional[int]) == [int]
+
+    def test_typing_union_with_none_returns_int_list(self):
+        assert union_non_none_args(Union[int, None]) == [int]
+
+    def test_pep604_int_or_none_returns_int_list(self):
+        # PEP 604 ``T | None`` -> get_origin is types.UnionType (NOT typing.Union).
+        assert union_non_none_args(int | None) == [int]
+
+    def test_multi_type_union_returns_all_non_none_args(self):
+        # str | int (no None) -> caller decides; helper returns both.
+        assert union_non_none_args(str | int) == [str, int]
+
+    def test_typing_multi_type_union_returns_all_non_none_args(self):
+        assert union_non_none_args(Union[str, int]) == [str, int]
+
+    def test_parameterized_generic_is_not_a_union(self):
+        # list[str] origin is `list`, NOT a union -> None ("not a union").
+        assert union_non_none_args(list[str]) is None
+
+    def test_typing_list_is_not_a_union(self):
+        assert union_non_none_args(List[str]) is None
+
+    def test_bare_type_is_not_a_union(self):
+        assert union_non_none_args(int) is None
+
+    def test_optional_none_edge_collapses_to_nonetype_not_union(self):
+        # ``Optional[None]`` / ``Union[None]`` simplify to NoneType (a bare type),
+        # so they are NOT unions -> None. The ``[]`` empty-list return is reserved
+        # for any future spelling whose only member is NoneType.
+        assert union_non_none_args(Optional[None]) is None
+        assert union_non_none_args(Union[None]) is None
+
+    def test_none_return_distinct_from_empty_list(self):
+        # Contract: None == "not a union"; [] == "union whose only arg was None".
+        # A bare type yields None, never [].
+        assert union_non_none_args(str) is None
+
+
+# --------------------------------------------------------------------------- #
+# strip_annotated
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+class TestStripAnnotated:
+    """Single-layer Annotated[T, ...] -> T strip (#772 next-drift example)."""
+
+    def test_annotated_int_strips_to_int(self):
+        assert strip_annotated(Annotated[int, "x"]) is int
+
+    def test_annotated_parameterized_generic_strips_to_inner(self):
+        assert strip_annotated(Annotated[list[str], "meta"]) == list[str]
+
+    def test_bare_type_passes_through(self):
+        assert strip_annotated(int) is int
+
+    def test_non_annotated_union_passes_through(self):
+        # strip_annotated only unwraps Annotated; a union passes through unchanged.
+        assert strip_annotated(int | None) == (int | None)
+
+
+# --------------------------------------------------------------------------- #
+# Behavioral parity — call each of the four routed helpers, assert return.
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def gen():
+    # NodeGenerator only reads getattr(dataflow_instance, "_test_context", None).
+    return NodeGenerator(_types.SimpleNamespace())
+
+
+def _resolve(annotation: Any):
+    """_resolve_type via a freshly-constructed TypeAwareFieldProcessor."""
+    tp = TypeAwareFieldProcessor({"f": {"type": annotation, "required": False}}, "M")
+    return tp._resolved_types["f"]
+
+
+@pytest.mark.unit
+class TestResolveTypeBehavioralParity:
+    """TypeAwareFieldProcessor._resolve_type: multi-union returns AS-IS."""
+
+    def test_list_str_resolves_to_list(self):
+        assert _resolve(list[str]) is list
+
+    def test_optional_list_str_resolves_to_list(self):
+        assert _resolve(Optional[list[str]]) is list
+
+    def test_pep604_int_or_none_resolves_to_int(self):
+        assert _resolve(int | None) is int
+
+    def test_typing_list_str_resolves_to_list(self):
+        assert _resolve(List[str]) is list
+
+    def test_dict_str_any_resolves_to_dict(self):
+        assert _resolve(Dict[str, Any]) is dict
+
+    def test_multi_union_str_int_returned_as_is(self):
+        # _resolve_type's distinct policy: multi-type union returned UNCHANGED.
+        assert _resolve(str | int) == (str | int)
+
+    def test_annotated_int_strips_to_int(self):
+        # NEW (#772): previously fell through; now strips to int.
+        assert _resolve(Annotated[int, "x"]) is int
+
+    def test_datetime_resolves_to_datetime(self):
+        assert _resolve(datetime) is datetime
+
+    def test_decimal_resolves_to_decimal(self):
+        assert _resolve(Decimal) is Decimal
+
+    def test_plain_str_resolves_to_str(self):
+        assert _resolve(str) is str
+
+
+@pytest.mark.unit
+class TestNormalizeTypeAnnotationBehavioralParity:
+    """NodeGenerator._normalize_type_annotation: union -> first non-None."""
+
+    def test_list_str_normalizes_to_list(self, gen):
+        assert gen._normalize_type_annotation(list[str]) is list
+
+    def test_optional_list_str_normalizes_to_list(self, gen):
+        assert gen._normalize_type_annotation(Optional[list[str]]) is list
+
+    def test_pep604_int_or_none_normalizes_to_int(self, gen):
+        assert gen._normalize_type_annotation(int | None) is int
+
+    def test_typing_list_str_normalizes_to_list(self, gen):
+        assert gen._normalize_type_annotation(List[str]) is list
+
+    def test_dict_str_any_normalizes_to_dict(self, gen):
+        assert gen._normalize_type_annotation(Dict[str, Any]) is dict
+
+    def test_multi_union_str_int_recurses_to_first(self, gen):
+        # Distinct from _resolve_type: this site recurses to the first non-None.
+        assert gen._normalize_type_annotation(str | int) is str
+
+    def test_annotated_int_strips_to_int(self, gen):
+        # NEW (#772): previously fell through to str; now strips to int.
+        assert gen._normalize_type_annotation(Annotated[int, "x"]) is int
+
+    def test_datetime_normalizes_to_datetime(self, gen):
+        assert gen._normalize_type_annotation(datetime) is datetime
+
+    def test_decimal_normalizes_to_decimal(self, gen):
+        assert gen._normalize_type_annotation(Decimal) is Decimal
+
+    def test_plain_str_normalizes_to_str(self, gen):
+        assert gen._normalize_type_annotation(str) is str
+
+
+@pytest.mark.unit
+class TestNormalizeIdTypeBehavioralParity:
+    """nodes._normalize_id_type: union -> first non-None; unknown -> str."""
+
+    def test_optional_int_normalizes_to_int(self):
+        assert _normalize_id_type(Optional[int]) is int
+
+    def test_pep604_int_or_none_normalizes_to_int(self):
+        assert _normalize_id_type(int | None) is int
+
+    def test_multi_union_str_int_recurses_to_first(self):
+        assert _normalize_id_type(str | int) is str
+
+    def test_annotated_int_strips_to_int(self):
+        # NEW (#772): previously fell through to the str fallback; now strips.
+        assert _normalize_id_type(Annotated[int, "x"]) is int
+
+    def test_plain_int_passes_through(self):
+        assert _normalize_id_type(int) is int
+
+    def test_unknown_falls_back_to_str(self):
+        # list[str] is not an isinstance-usable bare type -> str fallback.
+        assert _normalize_id_type(list[str]) is str
+
+
+@pytest.mark.unit
+class TestUnwrapOptionalTypeBehavioralParity:
+    """nodes._unwrap_optional_type: single-non-None collapses; else unchanged."""
+
+    def test_optional_list_collapses_to_list(self):
+        assert _unwrap_optional_type(Optional[list]) is list
+
+    def test_pep604_list_or_none_collapses_to_list(self):
+        assert _unwrap_optional_type(list | None) is list
+
+    def test_multi_union_returned_unchanged(self):
+        # collapse-only policy: a multi-arg union is NOT collapsed.
+        assert _unwrap_optional_type(Union[list, dict]) == Union[list, dict]
+
+    def test_bare_type_passes_through(self):
+        assert _unwrap_optional_type(list) is list
+
+    def test_annotated_passes_through_unchanged(self):
+        # _unwrap_optional_type does NOT strip Annotated (its policy is union-only);
+        # routing the union DETECTION did not change its non-union passthrough.
+        ann = Annotated[list, "m"]
+        assert _unwrap_optional_type(ann) == ann

--- a/workspaces/issue-772-type-introspection-consolidation/02-plans/01-architecture.md
+++ b/workspaces/issue-772-type-introspection-consolidation/02-plans/01-architecture.md
@@ -1,0 +1,102 @@
+# #772 — Consolidate parallel type-introspection helpers (DataFlow core)
+
+Status: design COMPLETE + verified against source (kailash-dataflow 2.11.2). Single shard.
+Verification receipt: forest-verify workflow `wf_4450995c-dab` verdict for #772 + direct source reads
+(type_processor.py:49-93/127-130/335-345, nodes.py:153-172/357-445) this session.
+
+## Root cause (verified, empirically confirmed)
+
+Three+ helpers each independently implement the **two-spelling Optional/Union unwrap**
+(`origin is Union or origin is types.UnionType` → extract non-`None` args → recurse). When a new
+type-form appears, EVERY copy must be patched independently — the maintenance tax #772 predicted.
+
+**The prediction FIRED:** commit `d66fb0090` (#1228, PEP 604 `T | None`, 2026-06-01) patched the
+UnionType spelling into `_normalize_type_annotation` (nodes.py), `_normalize_id_type` (nodes.py),
+AND `_resolve_type` (type_processor.py) — plus engine.py / schema.py / model_validator.py /
+fk_aware_model_integration.py. The exact "patch the Nth site instead of consolidate" anti-pattern
+the issue exists to prevent. #1207 was the prior instance. This is no longer speculative.
+
+### The four drift-prone sites (in-scope)
+
+| Site                                                         | File:line                   | Post-detection policy (MUST preserve)                                                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------ | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TypeAwareFieldProcessor._resolve_type`                      | `type_processor.py:49-93`   | single non-None → recurse; **multi-type union → return annotation as-is**; non-union generic → `get_origin`; else annotation. Returns isinstance-usable type.                                                                                                                                                                                                               |
+| `TypeAwareFieldProcessor.validate_field` (union-passthrough) | `type_processor.py:127-130` | if resolved type is still a (multi-type) union → pass value through unchanged.                                                                                                                                                                                                                                                                                              |
+| `NodeGenerator._normalize_type_annotation`                   | `nodes.py:357-445`          | union → recurse on **first** non-None (Optional, single-union, multi-union all collapse to first); `Union[None]` → `str`; container generic → base type (list/dict/tuple/set); other generic → origin; regular type → itself; datetime/date/time/Decimal → themselves; **fallback `str`**. Optional-detection preserved SEPARATELY (get_parameters reads `required=False`). |
+| `_normalize_id_type`                                         | `nodes.py:153-172`          | union → recurse on first non-None; no non-None → `str`; isinstance(type) → itself; else `str`.                                                                                                                                                                                                                                                                              |
+
+**Semantic divergence to PRESERVE (do NOT unify):** `_resolve_type` returns multi-type unions
+(`str | int`) AS-IS; the other two recurse on the first non-None arg. The consolidation centralizes
+only the DETECTION + non-None extraction; each caller keeps its own post-detection policy.
+
+## Chosen design — single detection primitive, callers keep policy
+
+New module `packages/kailash-dataflow/src/dataflow/core/type_introspection.py`:
+
+```python
+import types
+import typing
+from typing import Any, Union, get_args, get_origin
+
+def union_non_none_args(annotation: Any) -> list | None:
+    """Two-spelling Optional/Union detection — the SINGLE place a new union
+    spelling is handled (issue #772; #1207/#1228 PEP-604 drift is the evidence).
+    Returns the list of non-None args if `annotation` is a Union/Optional in
+    EITHER spelling (typing.Union / Optional[T] OR PEP 604 `T | None`), else None.
+    A multi-type union with no None returns all its args (caller decides policy).
+    """
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        return [a for a in get_args(annotation) if a is not type(None)]
+    return None
+
+def strip_annotated(annotation: Any) -> Any:
+    """Annotated[T, ...] -> T (single layer). Verified 3.12: get_origin is
+    typing.Annotated, get_args[0] is the wrapped type. Non-Annotated passes through.
+    This is the issue's named next-drift example (typing.Annotated) handled in ONE place."""
+    if get_origin(annotation) is typing.Annotated:
+        return get_args(annotation)[0]
+    return annotation
+```
+
+Each site:
+
+- `_resolve_type`: `strip_annotated` first; `union_non_none_args` → len==1 recurse / else return annotation; non-union → `get_origin` or annotation. (behavior-preserving + Annotated now stripped)
+- `_normalize_type_annotation`: `strip_annotated` first; `union_non_none_args` → non-empty recurse on `[0]` / empty → `str`; then the existing container-base + special-type + `str`-fallback block (drop the now-redundant standalone `types.UnionType` block + the `__origin__ is Union` branch — both subsumed by the shared helper).
+- `_normalize_id_type`: `strip_annotated` first; `union_non_none_args` → non-empty recurse / empty → `str`; isinstance → itself; else `str`.
+- `validate_field`: replace the inline `_origin is Union or _origin is types.UnionType` check with `union_non_none_args(expected_type) is not None`.
+
+## Invariants (5) — all must hold post-refactor
+
+1. `_resolve_type` returns isinstance-usable types AND multi-type union → annotation as-is.
+2. `_normalize_type_annotation` base-container mapping + Optional → inner (required=False preserved) + `str` fallback.
+3. `_normalize_id_type` `str` fallback on unknown.
+4. `validate_field` passes multi-type unions through unchanged.
+5. Two-spelling union detection exists in EXACTLY ONE place (structural-invariant test).
+
+## Tests (Tier-1 deterministic + structural invariant; Tier-2 node-gen wiring)
+
+New `packages/kailash-dataflow/tests/.../test_type_introspection.py` (or unit dir):
+
+- `union_non_none_args`: Optional[int]→[int]; int|None→[int]; str|int→[str,int]; list[str]→None; bare int→None; Union[None]/Optional-of-None edge.
+- `strip_annotated`: Annotated[int,"x"]→int; Annotated[list[str],meta]→list[str]; bare int→int.
+- Per-helper behavioral parity (call each helper, assert exact return) for: `list[str]`, `Optional[list[str]]`, `int | None` (PEP604), `typing.List[str]`, `dict[str,Any]`, `str | int` (multi-union — `_resolve_type` returns as-is, others recurse first), `Annotated[int,"x"]` (NEW: now strips to int everywhere — document as the consolidation's proof), datetime/Decimal, plain str.
+- **Structural-invariant** `@pytest.mark.regression`: assert exactly ONE `def union_non_none_args` exists (AST/grep across `packages/kailash-dataflow/src`), AND each of the 4 sites imports/calls it (no inline `is types.UnionType` survives outside type_introspection.py). Directly per cross-sdk-inspection Rule 3a signature-invariant pattern + refactor-invariants.md.
+- Regression `tests/regression/test_issue_772_*.py` mirroring #768 (parameterized-generics on \_resolve_type), #1207, #1228 (PEP604) coverage so the consolidated path keeps them green.
+
+## Cross-SDK (cross-sdk-inspection MUST)
+
+kailash-rs is a different language — Rust's type system has no runtime Optional/Union
+introspection problem (no `get_origin`/`types.UnionType` duck-typing). Structural API divergence
+(Rule 3a): no equivalent parallel-helper duplication exists in Rust. No cross-SDK issue. (Also:
+`terrene-foundation/kailash-rs` is not resolvable on GitHub per session traps — no filing target.)
+
+## Sizing / gates
+
+~1 shard: new module ~50 LOC + 4 site edits ~40 LOC load-bearing; 5 invariants; live pytest loop.
+
+- `/implement` reviewer + security-reviewer: REQUIRED (agents.md MUST gate).
+- kailash-dataflow package change → version bump (2.11.2 → 2.11.3 patch, refactor+Annotated-add)
+  - `/release` — both USER-GATED (BUILD-repo trap; feedback_build_repo_release).
+- Annotated handling is a strict behavior ADD (current helpers fall through to `str` for Annotated).
+  If any existing test changes, surface it — do not silently alter.

--- a/workspaces/issue-772-type-introspection-consolidation/journal/0001-DECISION-772-consolidation-redteam-convergence.md
+++ b/workspaces/issue-772-type-introspection-consolidation/journal/0001-DECISION-772-consolidation-redteam-convergence.md
@@ -1,0 +1,113 @@
+---
+type: DECISION
+date: 2026-06-06
+created_at: 2026-06-06T00:00:00Z
+author: agent
+session_id: autonomize-redteam-2026-06-06
+project: kailash-py / kailash-dataflow
+topic: "#772 type-introspection consolidation — /redteam convergence receipt"
+phase: redteam
+tags: [dataflow, refactor, type-introspection, "772", redteam, convergence]
+---
+
+# DECISION — #772 type-introspection consolidation reached /redteam convergence
+
+## What shipped (working tree, branch `refactor/772-consolidate-type-introspection`)
+
+New `packages/kailash-dataflow/src/dataflow/core/type_introspection.py`:
+
+- `union_non_none_args(annotation) -> list | None` — the SINGLE two-spelling
+  Optional/Union detection primitive (`typing.Union`/`Optional` AND PEP 604 `X | None`).
+- `strip_annotated(annotation)` — `Annotated[T, ...] -> T` (strict ADD; verified 3.12 API).
+
+**10 caller-methods routed** through it (each keeps its own post-detection policy):
+type_processor `_resolve_type` + `validate_field`; nodes `_normalize_type_annotation` +
+`_normalize_id_type` + `_unwrap_optional_type`; engine `_python_type_to_sql_type`;
+schema `_parse_field`; model_validator (×2); fk_aware `_is_nullable_field`; **model_registry
+`_normalize_field_type` (the 10th site, found during redteam — see Round 1)**.
+
+Root cause the consolidation closes: #1228 (PEP 604) had to patch the union-spelling check
+in every site independently — the maintenance tax #772 predicted, now empirically confirmed.
+
+## Round history (durable receipts per verify-resource-existence MUST-4)
+
+| Round | Reviewer                                                                | Verdict         | Findings                                                                                                                                                                                                                                                                                                                |
+| ----- | ----------------------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1    | orchestrator inline (AST sweep + per-site policy diff + behavior probe) | CHANGES → fixed | **1 MEDIUM**: `model_registry._normalize_field_type` was a 10th union-detection site (`isinstance(_, types.UnionType)`) the specialist's "same-unwrap" filter missed; AND the structural-invariant test used a SUBSTRING check (`"is types.UnionType"`) that did not catch the `isinstance` spelling → test blind spot. |
+| R2    | security-reviewer (agent `ace1e3d70d2e23c66`)                           | **APPROVE**     | 0 CRIT/HIGH/MED/LOW. Confirmed `strip_annotated` purely additive (no constraint/classification metadata on annotations anywhere in src; `@classify` is class-decorator-based, orthogonal); no SQL-type-inference drift; PK-rejects-Optional preserved; no injection surface.                                            |
+| R2    | correctness reviewer (agent `a688bd9f8cf6ad271`)                        | **APPROVE**     | 0 CRIT/HIGH/MED. Adversarially injected a re-inlined detection into schema.py → the AST invariant test FIRED (not theatre). model_registry verified byte-for-byte across 11 input classes. 3 non-blocking observations (disposed below).                                                                                |
+
+Two prior redteam dispatches died on infrastructure (Workflow `wf_d40ee06d-961` + a 2-agent
+parallel pass) — server-side rate-limit (`not your usage limit`) following a mid-session
+account swap, NOT any finding. Re-dispatched single/sequential per worktree-isolation Rule 4
+once the account recovered.
+
+## R1 fix (the 10th site)
+
+- `model_registry._normalize_field_type`: hoisted union detection to the top via
+  `union_non_none_args`; removed `isinstance(_, types.UnionType)` + dead `import types` +
+  `get_args` import. **Behavior preserved byte-for-byte** (probed all 7 prior outputs:
+  Optional[int]/int|None→"Optional", str|int/Union[int,str,None]/int|str|None→"Union",
+  list[str]→"list", str→"str").
+- Structural-invariant test rewritten from substring (`"is types.UnionType"`) to **AST**
+  (`ast.Attribute` attr=`UnionType`) — now catches every spelling AND ignores docstring/
+  comment prose without special-casing. model_registry added to the routed-callers list.
+  Behavioral coverage for the site added.
+- engine.py dead `import types` removed (specialist routed its UnionType use but left the
+  import — Ruff-clean now).
+- model_validator.py:469 dead `origin = get_origin(...)` assignment removed (R2 obs 3).
+
+## R2 non-blocking observations — dispositions
+
+1. **Doc site-count** (plan says "9/TEN"): actual = 10 caller-methods / 12 raw call sites
+   (two nodes.py methods detect twice; the #514 site). Cosmetic; recorded here.
+2. **`strip_annotated` applied only at type_processor + nodes, not engine/schema/validators**:
+   NOT a gap. The two reviews are complementary — the security-reviewer showed schema.py +
+   model_validator.py read annotations via `get_type_hints(include_extras=False)`, which the
+   stdlib ALREADY strips Annotated through before those sites see it; only the RAW field-dict
+   paths (type_processor/nodes) ever receive `Annotated[...]`, which is exactly where the
+   strip is placed. Adding it elsewhere would be dead code. Pre-#772 NO site stripped
+   Annotated, so nodes/type_processor strictly improved; nothing regressed.
+3. **model_validator.py:469 dead assignment**: FIXED (removed).
+
+## Test receipts (verified, command-produced)
+
+- `test_type_introspection.py` + `test_issue_772_*.py`: **74 passed**.
+- Prior regressions #768/#1207/#1228: **39 passed** (kept green through the consolidated path).
+- **Broad kailash-dataflow unit suite: 3513 passed, 17 skipped, 56 warnings** — identical to
+  the pre-#772 baseline (zero regression; the 56 warnings are pre-existing — `MLTenantRequiredError`
+  deprecation alias test + VAL-00x assertions).
+- AST single-site: `union_non_none_args` def ×1 (`type_introspection.py:28`); `UnionType`
+  ref ×1 (`type_introspection.py:52`). Invariant holds tree-wide.
+- 20 failed / 19 errors in the `-k model_registry` integration run are pre-existing infra
+  (`psycopg2.OperationalError: role "dataflow_test" does not exist`, port 5434 — no local PG).
+
+## Pre-existing (NOT introduced; cite-pre-session-SHA per zero-tolerance Rule 1c)
+
+- Pyright IDE diagnostics on nodes.py/engine.py/model_registry.py/model_validator.py/
+  fk_aware (Node-shadowing, str|None arg-types, duck-typed attrs) — every flagged line is
+  OUTSIDE the edit hunks; all six modules import cleanly; Ruff + the project pre-commit
+  type-gate pass. Not gated by project CI; out of #772 scope.
+- `fk_aware_model_integration.py` broken `migration_engine` import — unimportable on
+  pristine main; pre-existing, out of scope.
+
+## Outstanding (human-gated — surfaced to user)
+
+1. GPG commit — `commit.gpgsign=true`; the operator key passphrase cannot be supplied
+   non-interactively (subagent + main session both lack a TTY). Commit staged-ready.
+2. kailash-dataflow version bump (2.11.2 → 2.11.3 patch) + PR + `/release` (BUILD-repo gate).
+3. Issue hygiene: close #596 (obsolete, cite SHA 090c0e97a), update #643 status comment.
+
+## For Discussion
+
+1. Should `strip_annotated` be extended to engine/schema/validators for full Annotated parity
+   even though `get_type_hints(include_extras=False)` already strips it there (dead code), to
+   guard against a future caller that bypasses get_type_hints? (Disposition: no — YAGNI; zero
+   Annotated field usage in src; revisit only if Annotated-field support is requested.)
+2. The consolidation went BROADER than the plan's 4 named methods (10 caller-methods). Is the
+   structural-invariant test (single `union_non_none_args` def + zero tree-wide `UnionType`
+   refs) sufficient to prevent a future 11th site from re-inlining, given it caught the 10th
+   only after the substring→AST strengthening?
+3. #1228 patched the union check across 9 sites a month ago; #772 now consolidates 10. Should
+   a follow-up extend the same single-primitive discipline to kailash-rs (different type
+   system — Rust has no runtime Optional/Union introspection, so structurally N/A)?


### PR DESCRIPTION
## Summary

Consolidates the two-spelling Optional/Union detection (`origin is Union or origin is types.UnionType`) that was independently re-implemented across **ten** DataFlow type-introspection caller-methods into a single primitive `union_non_none_args`, plus a `strip_annotated` companion. Closes the maintenance-tax drift that #1228 (PEP 604 `X | None`) demonstrated — that fix had to patch the same check across five modules; #1207 was the prior instance.

## Changes

- New `dataflow/core/type_introspection.py`: `union_non_none_args` (the single detection site) + `strip_annotated`.
- 10 caller-methods routed through it, **each keeping its own post-detection policy** (deliberately divergent — `_resolve_type` returns multi-type unions as-is; the normalize/id helpers recurse on the first non-None): `type_processor` (`_resolve_type`, `validate_field`), `nodes` (`_normalize_type_annotation`, `_normalize_id_type`, `_unwrap_optional_type`), `engine` (`_python_type_to_sql_type`), `schema` (`_parse_field`), `model_registry` (`_normalize_field_type`), `model_validator` (×2), `fk_aware_model_integration` (`_is_nullable_field`).
- Strict ADD: `Annotated[T, ...]` now strips to `T` at the raw-field-dict paths (previously fell through to the `str` fallback); the validation/DDL paths already strip it via `get_type_hints(include_extras=False)`.
- Structural-invariant regression test (AST-based): exactly one `union_non_none_args` definition + zero `types.UnionType` references tree-wide outside the primitive — fails loudly if a future caller re-inlines detection.

## Tests / verification

- 74 new (#772) + 39 prior (#768 / #1207 / #1228) regression tests pass.
- Broad kailash-dataflow unit suite: **3513 passed, 17 skipped** — zero regression vs baseline.
- AST invariant receipt: `union_non_none_args` def ×1; `UnionType` ref ×1 (the primitive only).
- `/redteam` converged: security-reviewer **APPROVE** + correctness-reviewer **APPROVE** (the latter adversarially injected a re-inlined copy into `schema.py` and confirmed the invariant test fires). Round 1 found + fixed a 10th hidden site (`model_registry`) the first implementation missed, plus a blind spot in the safety test (substring → AST).

## Related issues

Closes #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)
