### PR TITLE
release(dataflow): kailash-dataflow 2.11.3 — type-introspection consolidation (#772)

### DIFF
--- a/packages/kailash-dataflow/CHANGELOG.md
+++ b/packages/kailash-dataflow/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [2.11.3] — 2026-06-06 — Type-introspection consolidation (#772)
+
+### Changed
+
+- **Two-spelling Optional/Union detection consolidated into a single primitive (#772).** Detection of `Optional[T]` / `Union[..., None]` (the `typing` spelling) AND PEP 604 `T | None` (the `types.UnionType` spelling) was previously re-inlined at 10 separate DataFlow core call-sites — so the #1228 PEP-604 fix had to patch each independently, the maintenance tax #772 predicted. All 10 sites (`type_processor`, `nodes`, `engine`, `schema`, `model_validator`, `fk_aware`, `model_registry`) now route through the single primitive `dataflow.core.type_introspection.union_non_none_args()`; each caller keeps its own post-detection policy. **Behavior-preserving** — verified byte-for-byte against the pre-#772 per-site detection across a full type battery (`Optional`/`Union`/PEP 604/multi-arg/container/all-None edge); SQL-type inference, PK-rejects-Optional, and field-nullability classification are unchanged.
+
+### Fixed
+
+- **`Annotated[T, ...]` now normalizes to `T` at the raw field-dict annotation sites (#772).** A new `strip_annotated()` primitive unwraps `Annotated[T, ...] → T` at `type_processor` + `nodes`, correcting a latent case where an `Annotated` alias could leak through as a "type" instead of resolving to its underlying type. Sites reading annotations via `get_type_hints(include_extras=False)` already stripped `Annotated`, so no double-strip; no metadata consumed anywhere is discarded (DataFlow classification is `@classify`-decorator-keyed by field name, decoupled from annotations).
+
 ## [2.11.2] — 2026-06-04 — SQLite datetime DeprecationWarning fix (#1250)
 
 ### Fixed

--- a/packages/kailash-dataflow/pyproject.toml
+++ b/packages/kailash-dataflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-dataflow"
-version = "2.11.2"
+version = "2.11.3"
 description = "Workflow-native database framework for Kailash SDK"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/kailash-dataflow/src/dataflow/__init__.py
+++ b/packages/kailash-dataflow/src/dataflow/__init__.py
@@ -132,7 +132,7 @@ from dataflow.from_brief import from_brief as _from_brief_impl  # noqa: E402
 DataFlow.from_brief = classmethod(_from_brief_impl)  # type: ignore[attr-defined]
 
 # Legacy compatibility - maintain the original imports
-__version__ = "2.11.2"
+__version__ = "2.11.3"
 
 __all__ = [
     "DataFlow",


### PR DESCRIPTION
Release-prep for kailash-dataflow 2.11.3 (metadata-only: version anchors + CHANGELOG).

## Summary
Cuts the kailash-dataflow 2.11.3 patch release for #772 (type-introspection consolidation), merged to main in PR #1270 (`f97e6bbbb`).

- `pyproject.toml` + `src/dataflow/__init__.py`: 2.11.2 → 2.11.3
- `CHANGELOG.md`: 2.11.3 entry (Changed: 10-site union-detection consolidation; Fixed: Annotated-alias normalization)

## Verification
- Fresh adversarial /redteam round on the #772 diff: reviewer + security-reviewer both APPROVE, 0 CRITICAL/HIGH/MEDIUM (2nd consecutive clean round). Receipt: `workspaces/issue-772-type-introspection-consolidation/journal/0002`.
- PR #1270 CI fully green (Analyze, CodeQL, Test 3.11–3.14, DataFlow Unit, PACT, test-with-infrastructure).
- Behavior-preserving: main-vs-HEAD differential battery confirmed byte-identical detection; only Annotated rows differ (the intended fix).

## Related issues
Refs #772

🤖 Generated with [Claude Code](https://claude.com/claude-code)