### PR TITLE
release: kailash 2.29.3 — canonical-encoder divergence docs + byte-vector pins (#1258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.29.3] - 2026-06-06
+
+### Documentation
+
+- **Canonical-encoder divergence contract documented + byte-vectors pinned (#1258).** The two canonical-JSON encoders carry **intentionally opposite** `ensure_ascii` settings: `kailash.trust._json.canonical_json_dumps` (the `kailash.delegate.*` cross-SDK encoder) emits raw UTF-8 (`ensure_ascii=False`) to match Rust `serde_json`'s default, while the trust-plane signing family (`kailash.trust.signing.crypto.serialize_for_signing` + the selective-disclosure / PACT-audit signers) emits ASCII-escaped `\uXXXX` (`ensure_ascii=True`) to match the pinned `trust-plane-canonical.json` fixture (#959). Both encoders' docstrings now state the full canonical contract (`ensure_ascii`, `sort_keys`, separators, no-Unicode-normalization) and explain why unifying them is a breaking cross-SDK signing-format migration (tracked in #1258, decision: do not unify). Cross-SDK byte-vectors pinned at `tests/test-vectors/delegate-canonical.json` + `tests/test-vectors/trust-plane-canonical.json`. **Documentation + test-vector only — zero runtime/API/behavior change** (both encoders behave exactly as in 2.29.2).
+
 ## [2.29.2] - 2026-06-04
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.29.2"
+version = "2.29.3"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.29.2"
+__version__ = "2.29.3"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Release-prep for kailash core 2.29.3 (metadata-only: version anchors + CHANGELOG).

## Summary
Closes the sibling drift where #1258/#1269 (merged PR #1269, `d46695d1e`) landed `src/kailash/trust/` docstring changes + cross-SDK byte-vector pins on main without a version bump. This cuts the patch release so main == PyPI.

- `pyproject.toml` + `src/kailash/__init__.py`: 2.29.2 → 2.29.3
- `CHANGELOG.md`: 2.29.3 Documentation entry

## Nature of change
**Documentation + test-vector only — zero runtime/API/behavior change.** The #1258 work added docstrings to `canonical_json_dumps` (`_json.py`) and `serialize_for_signing` (`crypto.py`) documenting their intentional `ensure_ascii` divergence, plus pinned `tests/test-vectors/{delegate,trust-plane}-canonical.json`. Both encoders behave exactly as in 2.29.2. Verified: the #1269 source diff is pure docstring additions.

## Related issues
Refs #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)