### PR TITLE
feat(ml)!: FeatureStore 2.0.0 canonical cutover (#643 step 3)

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,50 @@
 # kailash-ml Changelog
 
+## [2.0.0] — 2026-06-07 — BREAKING: FeatureStore canonical cutover (#643 step 3)
+
+Top-level `from kailash_ml import FeatureStore` now resolves to the **canonical
+1.0+ read surface** `kailash_ml.features.FeatureStore`, completing the issue #643
+migration whose deprecation bridge shipped in 1.7.2 and whose retrieval blocker
+was fixed in 1.7.5/1.7.6 (#1241). The legacy write-capable engine is **not
+removed** — it remains importable via its explicit module path.
+
+### Changed (BREAKING)
+
+- **`from kailash_ml import FeatureStore` resolves to `kailash_ml.features.FeatureStore`.**
+  Constructor changes from the legacy `FeatureStore(conn: ConnectionManager, *,
+table_prefix=...)` to the canonical `FeatureStore(dataflow: DataFlow, *,
+default_tenant_id=None)`. Any caller constructing the top-level symbol with a
+  `ConnectionManager` now raises `TypeError`. The canonical surface is
+  **read-only** (`get_features` + cache-key helpers); the legacy write/registry/
+  training-set operations are not present on it.
+
+### Removed
+
+- **The 1.7.2 bridge `DeprecationWarning`** emitted on top-level `FeatureStore`
+  access is removed — the warning has served its deprecation cycle (1.7.2 →
+  1.7.6) and the resolution it warned about has now flipped.
+
+### Migration
+
+- **Reads:** swap the construction site — `FeatureStore(df, default_tenant_id=...)`
+  (or `default_tenant_id=CANONICAL_SINGLE_TENANT_SENTINEL` for single-tenant) and
+  call `get_features(schema, timestamp=None, *, tenant_id=None)`.
+- **Writes:** the canonical store owns no DDL. Materialise features as a
+  `@db.model` whose name equals `schema.name`, write rows with `express.create`,
+  and read them back through `get_features`. Full recipe in `MIGRATION.md`.
+- **`get_training_set` / `get_features_lazy` / `list_schemas`** (and all legacy
+  write ops) have no canonical equivalent yet (M2-deferred per
+  `specs/ml-feature-store.md` § 11). Callers that need them keep the explicit
+  import `from kailash_ml.engines.feature_store import FeatureStore`, which is
+  retained and unchanged.
+
+### Fixed
+
+- **README FeatureStore section** documented three phantom methods (`ingest`,
+  `get_features_at_time`, `list_feature_sets`) that exist on neither surface;
+  corrected to the real canonical + legacy operation sets. `docs/guides/02-feature-pipelines.md`
+  rewritten from a fictional `put`/`get` API to the validated canonical pattern.
+
 ## [1.7.6] — 2026-06-03 — fix: get_features without a timestamp returns latest-per-entity (#1241 follow-up)
 
 Follow-up to 1.7.5. The 1.7.5 `SchemaFeatureGroup` adapter gated its latest-per-entity dedup on `point_in_time is not None`, so `get_features(schema)` with **no** timestamp returned **every historical row** (duplicate entities) instead of the latest row per entity. The `get_features` contract is "when timestamp is None the latest values are returned" — one feature vector per entity. Caught by the 1.7.5 published-wheel end-to-end verification walk (the unit/integration tests had used one row per entity, so the dedup gap was unobservable).

--- a/packages/kailash-ml/MIGRATION.md
+++ b/packages/kailash-ml/MIGRATION.md
@@ -275,22 +275,23 @@ removed; imports fail hard.
 # 0.x -- top-level primitive imports
 from kailash_ml import FeatureStore, ModelRegistry, TrainingPipeline
 
-# 1.7.x bridge release (issue #643) — top-level import still works,
-# now emits DeprecationWarning on first access pointing at the canonical
-# surface. Resolves to the LEGACY module
-# `kailash_ml.engines.feature_store.FeatureStore` whose constructor is
-# `FeatureStore(conn: ConnectionManager, *, table_prefix=...)`.
-from kailash_ml import FeatureStore  # DeprecationWarning emitted
+# 1.7.2 bridge release (issue #643 step 1) — top-level import still resolved
+# to the LEGACY module `kailash_ml.engines.feature_store.FeatureStore`
+# (`FeatureStore(conn: ConnectionManager, *, table_prefix=...)`) but emitted a
+# DeprecationWarning on first access pointing at the canonical surface.
 
-# 1.x canonical (preferred — no warning, future-proof)
-from kailash_ml.features import FeatureStore
-# Constructor: FeatureStore(dataflow: DataFlow, *, default_tenant_id=None)
-# See specs/ml-feature-store.md § 1.1 for the contract.
+# 2.0.0 cutover (issue #643 step 3) — top-level `from kailash_ml import
+# FeatureStore` now resolves to the canonical READ surface
+# `kailash_ml.features.FeatureStore`
+# (`FeatureStore(dataflow: DataFlow, *, default_tenant_id=None)`); the
+# DeprecationWarning is removed because the resolution has flipped.
+from kailash_ml import FeatureStore                       # canonical read surface
 
-# 2.0.0 (planned) -- top-level import flips to canonical module; legacy
-# `kailash_ml.engines.feature_store.FeatureStore` is removed. Callers still
-# on the 0.x ConnectionManager constructor MUST migrate to the canonical
-# DataFlow constructor before this cutover.
+# The legacy write-capable engine is NOT removed at 2.0.0 — it remains
+# importable via its explicit module path for the write/registry/training-set
+# surface the canonical read store does not expose. Removal is deferred to a
+# later major (alongside the 3.0 ModelRegistry/TrainingPipeline sweep below).
+from kailash_ml.engines.feature_store import FeatureStore  # explicit legacy (writes)
 
 # 3.0 -- ModelRegistry and TrainingPipeline imports removed; use the
 # legacy namespace explicitly if you still need them
@@ -299,32 +300,68 @@ from kailash_ml.legacy import ModelRegistry  # explicit opt-in; no DeprecationWa
 
 ### FeatureStore canonical surface migration recipe (1.x)
 
-The canonical FeatureStore is a DataFlow-bridge primitive — it wraps a live
-`DataFlow` instance and routes feature reads through
-`dataflow.ml_feature_source(...)`. Migration is two lines:
+The canonical 1.0+ `FeatureStore` is a **read-only** DataFlow-bridge primitive
+(spec § 1.2): it wraps a live `DataFlow` instance and routes feature _reads_
+through `dataflow.ml_feature_source(...)`. The legacy engine's _write_ surface
+(`initialize` / `register_features` / `compute` / `store`) is intentionally NOT
+part of the canonical store — in 1.0+ you materialise features as ordinary
+DataFlow model rows. The migration therefore has two halves.
+
+**Read path** — swap the construction site:
 
 ```python
-# Before (legacy 0.x ConnectionManager constructor — DeprecationWarning at 1.7+)
+# Before (legacy 0.x ConnectionManager constructor)
 from kailash.db.connection import ConnectionManager
-from kailash_ml import FeatureStore
+from kailash_ml.engines.feature_store import FeatureStore
 
 conn = ConnectionManager("sqlite:///ml.db")
 await conn.initialize()
 store = FeatureStore(conn, table_prefix="kml_feat_")
 
-# After (canonical 1.0+ surface — DataFlow-bridge constructor)
+# After (canonical 1.0+ read surface — top-level import resolves here at 2.0.0)
 from dataflow import DataFlow
-from kailash_ml.features import FeatureStore
+from kailash_ml import FeatureStore
 
 df = DataFlow("sqlite:///ml.db", auto_migrate=True)
-store = FeatureStore(df, default_tenant_id="acme")
+store = FeatureStore(df, default_tenant_id="acme")          # multi-tenant
 features = await store.get_features(schema, tenant_id="acme")
+# Single-tenant? bind the canonical sentinel and omit tenant_id thereafter:
+#   from kailash_ml.features import CANONICAL_SINGLE_TENANT_SENTINEL
+#   store = FeatureStore(df, default_tenant_id=CANONICAL_SINGLE_TENANT_SENTINEL)
 ```
 
-Migration only affects the construction site. `get_features`, cache-key
-helpers, and tenant-scoped invalidation patterns share compatible
-return shapes across both surfaces. See
-`specs/ml-feature-store.md` § 4 for the full method contract.
+**Write path** — feature materialisation moves to a DataFlow model. The
+canonical store reads the table whose name equals `schema.name`, so define a
+`@db.model` with that name + the schema's `entity_id_column` / `timestamp_column`
+/ field columns, write rows with `express.create`, and read them back through
+`get_features`:
+
+```python
+# Before (legacy self-contained write path)
+await store.register_features(schema)          # created + tracked the table
+await store.store(rows, schema)                # materialised feature rows
+
+# After (canonical: write via a DataFlow model, read via get_features)
+@df.model
+class UserChurnFeatures:                       # model name == schema.name
+    id: str
+    user_id: str                               # schema.entity_id_column
+    event_time: datetime                       # schema.timestamp_column
+    login_count_7d: int                        # schema field
+
+df.express_sync.create("UserChurnFeatures", {
+    "id": "r1", "user_id": "u1",
+    "event_time": ts, "login_count_7d": 7,
+})
+features = await store.get_features(schema)     # latest-per-entity, point-in-time
+```
+
+**Read methods without a canonical equivalent.** Legacy `get_training_set`,
+`get_features_lazy`, and `list_schemas` are not exposed on the canonical read
+surface (they are M2-deferred per spec § 11). Callers that need them MUST keep
+the explicit legacy import `from kailash_ml.engines.feature_store import
+FeatureStore` until a canonical equivalent ships. See
+`specs/ml-feature-store.md` § 4 (canonical contract) + § 11 (deferred surface).
 
 The migration sequence is deterministic:
 

--- a/packages/kailash-ml/README.md
+++ b/packages/kailash-ml/README.md
@@ -139,12 +139,20 @@ kailash-ml provides 14 engines plus a bridge and compatibility layer, organized 
 #### FeatureStore
 
 ```python
+# Canonical 1.0+ read surface (the top-level default since 2.0.0)
+from kailash_ml import FeatureStore  # → kailash_ml.features.FeatureStore
+```
+
+The canonical `FeatureStore` is a thin, polars-native DataFlow bridge: it wraps a live `DataFlow` instance and serves point-in-time-correct feature reads through `dataflow.ml_feature_source`. Constructor: `FeatureStore(dataflow, *, default_tenant_id=None)`. It owns no DDL — you materialise features as ordinary `@db.model` rows (`db.express.create(...)`) and read them back through the store.
+
+Key operation: `get_features(schema, timestamp=None, *, tenant_id=None, entity_ids=None)` — returns a `polars.DataFrame` (latest value per entity, or the as-of-`timestamp` value). See `specs/ml-feature-store.md` § 4.1 and `MIGRATION.md` for the write-via-model recipe.
+
+```python
+# Legacy 0.x write-capable surface (explicit import; ConnectionManager-based)
 from kailash_ml.engines.feature_store import FeatureStore
 ```
 
-Computes, versions, and serves features with point-in-time correct retrieval. Uses `ConnectionManager` for temporal window queries that require SQL beyond what Express can express. All raw SQL is encapsulated in `_feature_sql.py` -- the engine itself contains zero raw SQL.
-
-Key operations: `ingest()`, `get_features()`, `get_features_at_time()`, `list_feature_sets()`.
+The legacy engine computes, versions, and stores features itself via `ConnectionManager`; all raw SQL is encapsulated in `_feature_sql.py`. Constructor: `FeatureStore(conn, *, table_prefix="kml_feat_")`. Key operations: `initialize()`, `register_features()`, `compute()`, `store()`, `get_features()`, `get_training_set()`, `get_features_lazy()`, `list_schemas()`. Retained for callers needing the self-contained write path; see `MIGRATION.md` for the canonical migration.
 
 #### ModelRegistry
 
@@ -823,22 +831,31 @@ under `kailash_ml.<engine_module>`. Use that path; the top-level lazy
 re-export is kept for backwards compatibility only.
 
 ```python
-# Canonical 1.0+ surface (preferred — no DeprecationWarning, future-proof)
+# Canonical 1.0+ read surface — the top-level default since 2.0.0
+from kailash_ml import FeatureStore  # → kailash_ml.features.FeatureStore
+# Equivalent explicit form:
 from kailash_ml.features import FeatureStore
 # Constructor: FeatureStore(dataflow: DataFlow, *, default_tenant_id=None)
 # See specs/ml-feature-store.md § 1.1.
 
-# Legacy top-level shortcut (still works, emits DeprecationWarning at 1.7+)
-from kailash_ml import FeatureStore  # resolves to kailash_ml.engines.feature_store
-# This path will be removed in kailash-ml 2.0.0; migrate to
-# `from kailash_ml.features import FeatureStore` — see MIGRATION.md for the recipe.
+# Legacy 0.x write-capable surface — explicit import only (no top-level access)
+from kailash_ml.engines.feature_store import FeatureStore
+# Constructor: FeatureStore(conn: ConnectionManager, *, table_prefix=...)
+# Retained for callers needing the self-contained write path
+# (register_features / store / compute / get_training_set / get_features_lazy /
+# list_schemas). See MIGRATION.md for the canonical migration recipe.
 ```
 
-Migration note (1.x → 2.0.0): the top-level legacy resolution targets a
-ConnectionManager-coupled constructor that is incompatible with the
-canonical DataFlow-bridge primitive at `kailash_ml.features.FeatureStore`.
-The 1.7+ bridge release emits a `DeprecationWarning` at first access; the
-2.0.0 cutover flips the legacy resolution path to the canonical module.
+Migration note (2.0.0 cutover): the top-level `from kailash_ml import
+FeatureStore` now resolves to the canonical DataFlow-bridge read surface
+`kailash_ml.features.FeatureStore` (constructor
+`FeatureStore(dataflow, *, default_tenant_id=None)`). The 1.7.2 bridge
+release emitted a `DeprecationWarning` while the top level still resolved to
+the legacy ConnectionManager-coupled engine; that warning is **removed at
+2.0.0** because the resolution has flipped. The legacy engine remains
+importable via its explicit module path
+`kailash_ml.engines.feature_store.FeatureStore` for the write/registry/
+training-set surface the canonical read store does not expose.
 
 ### "kailash-ml-protocols not found"
 

--- a/packages/kailash-ml/docs/guides/02-feature-pipelines.md
+++ b/packages/kailash-ml/docs/guides/02-feature-pipelines.md
@@ -4,29 +4,68 @@ Build polars-native feature pipelines with FeatureStore integration.
 
 ## FeatureStore Basics
 
+Since kailash-ml 2.0.0, the top-level `FeatureStore` is the canonical 1.0+
+**read** surface — a thin polars-native bridge over a live `DataFlow`
+instance. It owns no DDL: you materialise features as ordinary `@db.model`
+rows and read them back point-in-time-correct through `get_features`. The
+backing table's name equals the schema's `name`.
+
 ```python
-from kailash_ml.engines.feature_store import FeatureStore
-import polars as pl
+from datetime import datetime, timezone
 
-store = FeatureStore()
-
-# Register a feature set
-await store.register_features(
-    name="user_features",
-    schema={"age": pl.Int64, "income": pl.Float64, "tenure_days": pl.Int64},
+from dataflow import DataFlow
+from kailash_ml import FeatureStore
+from kailash_ml.features import (
+    CANONICAL_SINGLE_TENANT_SENTINEL,
+    FeatureField,
+    FeatureSchema,
 )
 
-# Store features
-await store.put("user_features", pl.DataFrame({
-    "user_id": ["u1", "u2", "u3"],
-    "age": [25, 34, 45],
-    "income": [50000.0, 75000.0, 120000.0],
-    "tenure_days": [30, 365, 1200],
-}))
+df = DataFlow("sqlite:///ml.db", auto_migrate=True)
 
-# Retrieve for training
-features = await store.get("user_features")
+
+# Write path: features are ordinary DataFlow model rows. The model name
+# MUST equal the FeatureSchema name the store reads.
+@df.model
+class UserFeatures:
+    id: str
+    user_id: str            # entity_id_column
+    event_time: datetime    # timestamp_column
+    income: float
+    tenure_days: int
+
+
+df.express_sync.create("UserFeatures", {
+    "id": "r1", "user_id": "u1",
+    "event_time": datetime(2026, 1, 1, tzinfo=timezone.utc),
+    "income": 50000.0, "tenure_days": 30,
+})
+
+# Read path: declare the schema, then retrieve through the canonical store.
+schema = FeatureSchema(
+    name="UserFeatures",
+    version=1,
+    fields=(
+        FeatureField(name="income", dtype="float64"),
+        FeatureField(name="tenure_days", dtype="int64"),
+    ),
+    entity_id_column="user_id",
+    timestamp_column="event_time",
+)
+
+# Single-tenant: bind the canonical sentinel; multi-tenant: pass tenant_id=...
+store = FeatureStore(df, default_tenant_id=CANONICAL_SINGLE_TENANT_SENTINEL)
+
+# Latest value per entity (or as-of a timestamp) as a polars.DataFrame.
+features = await store.get_features(schema)
+as_of = await store.get_features(schema, timestamp=datetime(2026, 6, 1, tzinfo=timezone.utc))
 ```
+
+> **Need the self-contained write engine?** The legacy 0.x surface
+> (`register_features` / `store` / `compute` / `get_training_set` /
+> `get_features_lazy` / `list_schemas`) remains available via the explicit
+> import `from kailash_ml.engines.feature_store import FeatureStore`
+> (constructor `FeatureStore(conn, *, table_prefix=...)`). See `MIGRATION.md`.
 
 ## Polars Pipelines
 
@@ -36,27 +75,26 @@ kailash-ml is polars-native. All engines accept `pl.DataFrame` directly.
 import polars as pl
 
 # Feature engineering with polars expressions
-df = df.with_columns([
+df_feats = raw.with_columns([
     (pl.col("income") / pl.col("age")).alias("income_per_year_of_age"),
     pl.col("tenure_days").cast(pl.Float64).alias("tenure_years") / 365.0,
     pl.when(pl.col("income") > 100000).then(1).otherwise(0).alias("high_income"),
 ])
 ```
 
-## Schema Validation
+## Point-in-Time Correctness
 
-FeatureStore validates schemas on write:
-
-```python
-# This raises SchemaError -- "unknown_col" not in registered schema
-await store.put("user_features", pl.DataFrame({
-    "user_id": ["u1"],
-    "unknown_col": [42],
-}))
-```
+`get_features(schema, timestamp=T)` returns each entity's value AS OF `T` —
+the latest row with `event_time <= T`, never a value materialised after `T`
+(`specs/ml-feature-store.md` § 6.2). With no `timestamp`, the latest value per
+entity is returned. The backing table can hold the full history; the store
+computes the as-of view.
 
 ## Common Errors
 
-**`SchemaError: column type mismatch`** -- Polars is strict about types. Cast columns explicitly: `pl.col("age").cast(pl.Int64)`.
-
-**`FeatureNotFoundError`** -- Register features before putting data. Call `store.register_features()` first.
+- **`TenantRequiredError`** — `get_features` requires a tenant. Pass
+  `tenant_id=...`, or construct the store with `default_tenant_id=` (use
+  `CANONICAL_SINGLE_TENANT_SENTINEL` for single-tenant deployments).
+- **`FeatureStoreError`** — wraps a failure from the underlying DataFlow read
+  (for example, the backing model named after `schema.name` was never
+  registered or migrated). Define the `@db.model` and `auto_migrate` first.

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "1.7.6"
+version = "2.0.0"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/__init__.py
+++ b/packages/kailash-ml/src/kailash_ml/__init__.py
@@ -13,13 +13,15 @@ via lazy ``__getattr__``).
 Engines that are NOT in the canonical ``__all__`` (e.g. ``FeatureStore``,
 ``PreprocessingPipeline``, ``MLDashboard``, ...) remain reachable via
 module-attribute lookup through the legacy :func:`__getattr__` below so
-existing ``from kailash_ml import FeatureStore`` consumers keep working;
-they are simply not advertised in ``from kailash_ml import *``.
+existing ``from kailash_ml import FeatureStore`` consumers keep resolving
+the symbol; they are simply not advertised in ``from kailash_ml import *``.
+(As of 2.0.0 the ``FeatureStore`` symbol resolves to the canonical
+``kailash_ml.features`` surface — the import resolves, but its constructor
+contract changed; see CHANGELOG 2.0.0 / MIGRATION.md for the breaking swap.)
 """
 from __future__ import annotations
 
 import contextvars as _contextvars
-import warnings as _warnings
 from contextlib import contextmanager as _contextmanager
 from typing import TYPE_CHECKING, Any, Iterator, Optional
 
@@ -628,7 +630,14 @@ def __getattr__(name: str):  # noqa: N807
     the documented ``from kailash_ml import *`` surface.
     """
     _engine_map = {
-        "FeatureStore": "kailash_ml.engines.feature_store",
+        # Issue #643 — 2.0.0 cutover: top-level ``from kailash_ml import
+        # FeatureStore`` now resolves to the canonical 1.0+ read surface
+        # ``kailash_ml.features.FeatureStore`` (ctor
+        # ``FeatureStore(dataflow, *, default_tenant_id=None)``). The legacy
+        # write-capable ``kailash_ml.engines.feature_store.FeatureStore``
+        # (ctor ``FeatureStore(conn, *, table_prefix=...)``) remains importable
+        # via its explicit module path — see ``packages/kailash-ml/MIGRATION.md``.
+        "FeatureStore": "kailash_ml.features",
         "TrainingPipeline": "kailash_ml.engines.training_pipeline",
         # `InferenceServer` lazy-loaded from the canonical surface
         # `kailash_ml.serving.server` after W6-004 deleted the legacy
@@ -662,32 +671,11 @@ def __getattr__(name: str):  # noqa: N807
 
         return importlib.import_module("kailash_ml.metrics")
     if name in _engine_map:
-        # Issue #643 — bridge release: top-level ``kailash_ml.FeatureStore``
-        # currently resolves to the legacy module
-        # ``kailash_ml.engines.feature_store`` whose constructor signature is
-        # ``FeatureStore(conn: ConnectionManager, *, table_prefix=...)``. The
-        # canonical 1.0+ surface lives at ``kailash_ml.features.FeatureStore``
-        # with a different constructor
-        # ``FeatureStore(dataflow: DataFlow, *, default_tenant_id=None)``.
-        # Per ``rules/zero-tolerance.md`` Rule 6a (Public-API Removal Requires
-        # Deprecation Cycle) we emit a DeprecationWarning here so 1.x callers
-        # see the migration path BEFORE the cutover lands in 2.0.0. The
-        # legacy resolution path itself is unchanged — this is signal-only.
-        if name == "FeatureStore":
-            _warnings.warn(
-                "Top-level `from kailash_ml import FeatureStore` resolves to "
-                "the legacy module `kailash_ml.engines.feature_store` "
-                "(constructor: `FeatureStore(conn: ConnectionManager, *, "
-                "table_prefix=...)`). The canonical 1.0+ surface is "
-                "`from kailash_ml.features import FeatureStore` (constructor: "
-                "`FeatureStore(dataflow: DataFlow, *, default_tenant_id=None)`)"
-                ". The legacy resolution will be removed in kailash-ml 2.0.0; "
-                "migrate now. See `specs/ml-feature-store.md` for the canonical "
-                "contract and `packages/kailash-ml/MIGRATION.md` for the "
-                "migration recipe.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        # Lazy-load the engine module on first access. The bridge-release
+        # DeprecationWarning for ``FeatureStore`` (kailash-ml 1.7.2, issue #643
+        # step 1) was removed at the 2.0.0 cutover — the warning lived through
+        # 1.7.2 → 1.7.6, satisfying the deprecation-cycle requirement, and
+        # ``_engine_map["FeatureStore"]`` now points at the canonical surface.
         import importlib
 
         module = importlib.import_module(_engine_map[name])

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "1.7.6"
+__version__ = "2.0.0"

--- a/packages/kailash-ml/src/kailash_ml/engines/feature_store.py
+++ b/packages/kailash-ml/src/kailash_ml/engines/feature_store.py
@@ -14,11 +14,11 @@ from datetime import datetime, timezone
 from typing import Any
 
 import polars as pl
-from kailash.db.connection import ConnectionManager
-from kailash_ml.types import FeatureField, FeatureSchema
-
 from kailash_ml.engines import _feature_sql as sql
 from kailash_ml.interop import polars_to_dict_records
+from kailash_ml.types import FeatureSchema
+
+from kailash.db.connection import ConnectionManager
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +36,23 @@ def _chunked(items: list, size: int):
 
 class FeatureStore:
     """[P0: Production] DataFlow-backed feature versioning engine.
+
+    .. warning::
+
+        **Legacy 0.x surface — single-tenant only, NO tenant isolation.**
+        As of kailash-ml 2.0.0 (issue #643 cutover) the top-level
+        ``from kailash_ml import FeatureStore`` resolves to the canonical,
+        tenant-gated ``kailash_ml.features.FeatureStore`` read surface. This
+        legacy class is reachable only via its explicit module path and is
+        retained for callers needing the self-contained write/registry/
+        training-set path. It takes a raw ``ConnectionManager`` and a
+        ``table_prefix``, with **no ``tenant_id`` anywhere** — every method
+        operates on ``table_prefix``-scoped tables with no per-tenant
+        scoping. Multi-tenant deployments MUST NOT use this class for
+        materialisation; materialise features as a ``@db.model`` +
+        ``express.create`` and read through the canonical tenant-gated
+        ``FeatureStore.get_features`` instead (see
+        ``packages/kailash-ml/MIGRATION.md``).
 
     Parameters
     ----------

--- a/packages/kailash-ml/tests/regression/test_issue_643_featurestore_cutover.py
+++ b/packages/kailash-ml/tests/regression/test_issue_643_featurestore_cutover.py
@@ -1,0 +1,254 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression — issue #643 step 3: the 2.0.0 FeatureStore canonical cutover.
+
+Two contracts are pinned here:
+
+1. **Top-level resolution flip (structural).** After the 2.0.0 cutover,
+   ``from kailash_ml import FeatureStore`` MUST resolve to the canonical
+   read surface ``kailash_ml.features.FeatureStore`` (NOT the legacy
+   ``kailash_ml.engines.feature_store.FeatureStore``) AND MUST NOT emit a
+   ``DeprecationWarning`` on access (the 1.7.2 bridge shim was removed at
+   cutover). The legacy class MUST remain importable via its explicit
+   module path — the non-deprecated home for write-path callers
+   (``packages/kailash-ml/MIGRATION.md``). These are structural assertions
+   (object identity + warning capture), not lexical greps, per
+   ``rules/probe-driven-verification.md`` Rule 3.
+
+2. **Write-via-DataFlow-model → read-via-canonical-get_features round-trip
+   (Tier-2, real infra).** This is the migration story the cutover depends
+   on: the canonical 1.0+ FeatureStore is read-only (spec § 1.2); writers
+   move feature materialisation to a ``@db.model`` + ``express.create`` and
+   read back through ``FeatureStore.get_features``. Before this test the
+   suite only asserted ``get_features`` returns a ``DataFrame`` against an
+   *unseeded* table — it never proved a seeded write is actually
+   retrievable, nor that latest-per-entity / as-of semantics hold. This
+   test seeds real rows in file-backed SQLite (real infrastructure per
+   ``rules/testing.md`` Tier 2 — NO mocks) and asserts the read-back, the
+   latest-per-entity dedup, and point-in-time correctness.
+
+Cross-references:
+
+* ``specs/ml-feature-store.md`` § 1.2 (read-only surface), § 4.1
+  (get_features contract), § 11 (legacy write ops deferred to M2).
+* ``rules/facade-manager-detection.md`` MUST 1 — companion of
+  ``test_feature_store_wiring.py``.
+* ``rules/testing.md`` § "State Persistence Verification" — every write
+  verified with a read-back.
+"""
+from __future__ import annotations
+
+import warnings
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Contract 1 — top-level resolution flip (structural; no DataFlow needed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_top_level_featurestore_resolves_to_canonical() -> None:
+    """``from kailash_ml import FeatureStore`` IS the canonical surface."""
+    import kailash_ml
+    import kailash_ml.features as features_pkg
+
+    assert kailash_ml.FeatureStore is features_pkg.FeatureStore, (
+        "issue #643 2.0.0 cutover: top-level FeatureStore must resolve to "
+        "kailash_ml.features.FeatureStore (the canonical read surface)"
+    )
+    assert (
+        kailash_ml.FeatureStore.__module__ == "kailash_ml.features.store"
+    ), kailash_ml.FeatureStore.__module__
+
+
+@pytest.mark.regression
+def test_top_level_featurestore_access_emits_no_deprecation_warning() -> None:
+    """The 1.7.2 bridge DeprecationWarning is removed at the 2.0.0 cutover."""
+    import importlib
+
+    import kailash_ml
+
+    # Re-import fresh so module-scope side effects are excluded; the access
+    # itself routes through __getattr__ which is where the old shim lived.
+    importlib.reload(kailash_ml)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = kailash_ml.FeatureStore
+    feature_store_deprecations = [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "FeatureStore" in str(w.message)
+    ]
+    assert not feature_store_deprecations, [
+        str(w.message) for w in feature_store_deprecations
+    ]
+
+
+@pytest.mark.regression
+def test_legacy_featurestore_still_importable_via_explicit_path() -> None:
+    """The legacy write-capable surface remains importable (non-deprecated
+    home for write-path callers per MIGRATION.md); it is a DISTINCT class
+    from the canonical surface (different constructor contract)."""
+    import kailash_ml
+    from kailash_ml.engines.feature_store import FeatureStore as LegacyFeatureStore
+
+    assert LegacyFeatureStore.__module__ == "kailash_ml.engines.feature_store"
+    assert kailash_ml.FeatureStore is not LegacyFeatureStore
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — write-then-read round-trip (Tier-2, real file-backed SQLite)
+# ---------------------------------------------------------------------------
+
+# Skip cleanly if the dataflow.ml_feature_source binding FeatureStore consumes
+# is unavailable — never silently no-op (Tier-2 contract).
+try:
+    import polars as pl  # noqa: F401
+except ImportError as exc:  # pragma: no cover — manifest dep
+    pytest.skip(f"polars not installed: {exc}", allow_module_level=True)
+
+from kailash_ml.features.store import _import_ml_feature_source  # noqa: E402
+
+try:
+    _import_ml_feature_source()
+except ImportError as exc:
+    pytest.skip(
+        f"dataflow.ml_feature_source binding unavailable "
+        f"(FeatureStore.get_features consumes it): {exc}",
+        allow_module_level=True,
+    )
+
+from kailash_ml.features import (  # noqa: E402
+    CANONICAL_SINGLE_TENANT_SENTINEL,
+    FeatureField,
+    FeatureSchema,
+    FeatureStore,
+)
+
+from dataflow import DataFlow  # noqa: E402
+
+_T1 = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+_T2 = datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc)  # one week later
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path):
+    """Single-tenant file-backed SQLite DataFlow with a feature table named
+    after the schema, seeded with two observations for ``u1`` (different
+    event times) and one for ``u2`` — so latest-per-entity dedup and as-of
+    semantics are OBSERVABLE (single-row-per-entity tables hide both)."""
+    db_path = tmp_path / "feat_643.sqlite"
+    df = DataFlow(f"sqlite:///{db_path}", auto_migrate=True)
+
+    # schema.name MUST equal the DataFlow model name (the canonical
+    # read adapter reads express_sync.list(schema.name)).
+    @df.model
+    class UserChurnFeatures:
+        id: str
+        user_id: str
+        event_time: datetime
+        login_count_7d: int
+        purchase_amount_30d: float
+
+    df._ensure_connected()
+
+    # The canonical write path: materialise features as DataFlow model rows.
+    df.express_sync.create(
+        "UserChurnFeatures",
+        {
+            "id": "r1",
+            "user_id": "u1",
+            "event_time": _T1,
+            "login_count_7d": 3,
+            "purchase_amount_30d": 10.0,
+        },
+    )
+    df.express_sync.create(
+        "UserChurnFeatures",
+        {
+            "id": "r2",
+            "user_id": "u1",
+            "event_time": _T2,  # newer — latest-per-entity must pick this
+            "login_count_7d": 7,
+            "purchase_amount_30d": 25.0,
+        },
+    )
+    df.express_sync.create(
+        "UserChurnFeatures",
+        {
+            "id": "r3",
+            "user_id": "u2",
+            "event_time": _T1,
+            "login_count_7d": 1,
+            "purchase_amount_30d": 5.0,
+        },
+    )
+    try:
+        yield df
+    finally:
+        try:
+            df.close()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def churn_schema() -> FeatureSchema:
+    return FeatureSchema(
+        name="UserChurnFeatures",
+        version=1,
+        fields=(
+            FeatureField(name="login_count_7d", dtype="int64"),
+            FeatureField(name="purchase_amount_30d", dtype="float64"),
+        ),
+        entity_id_column="user_id",
+        timestamp_column="event_time",
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_cutover_write_via_model_read_via_canonical_get_features(
+    seeded_db: DataFlow,
+    churn_schema: FeatureSchema,
+) -> None:
+    """Migration-story validation: features written through a DataFlow model
+    are retrievable through the canonical ``FeatureStore.get_features`` — and
+    with no timestamp, the LATEST row per entity is returned (not every
+    historical row)."""
+    fs = FeatureStore(seeded_db, default_tenant_id=CANONICAL_SINGLE_TENANT_SENTINEL)
+    result = await fs.get_features(churn_schema)
+
+    assert isinstance(result, pl.DataFrame)
+    # entity_id + declared field columns project through.
+    assert set(result.columns) == {"user_id", "login_count_7d", "purchase_amount_30d"}
+    # latest-per-entity: one row per entity, u1's NEWER (_T2) observation wins.
+    by_user = {row["user_id"]: row for row in result.to_dicts()}
+    assert set(by_user) == {"u1", "u2"}, by_user
+    assert by_user["u1"]["login_count_7d"] == 7, "u1 must reflect the _T2 row"
+    assert by_user["u1"]["purchase_amount_30d"] == 25.0
+    assert by_user["u2"]["login_count_7d"] == 1
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_cutover_get_features_point_in_time_as_of(
+    seeded_db: DataFlow,
+    churn_schema: FeatureSchema,
+) -> None:
+    """Point-in-time correctness: as of ``_T1`` (before u1's second
+    observation), u1's feature value is the _T1 row (login=3), not the
+    later _T2 row (login=7)."""
+    fs = FeatureStore(seeded_db, default_tenant_id=CANONICAL_SINGLE_TENANT_SENTINEL)
+    result = await fs.get_features(churn_schema, timestamp=_T1)
+
+    by_user = {row["user_id"]: row for row in result.to_dicts()}
+    assert by_user["u1"]["login_count_7d"] == 3, (
+        "as-of _T1 must return u1's _T1 value (3), not the post-_T1 value (7) "
+        "— point-in-time correctness per spec § 6.2 MUST 1"
+    )
+    assert by_user["u2"]["login_count_7d"] == 1

--- a/specs/ml-feature-store.md
+++ b/specs/ml-feature-store.md
@@ -1,10 +1,11 @@
 # Kailash ML Feature Store Specification
 
-**Version:** 1.7.4 — package version at last spec sync (`packages/kailash-ml/src/kailash_ml/_version.py`, 2026-06-02). Point-in-time anchor, not a perpetual pin; re-verify against `_version.py` on each spec sync.
+**Version:** 2.0.0 — package version at last spec sync (`packages/kailash-ml/src/kailash_ml/_version.py`, 2026-06-07). Point-in-time anchor, not a perpetual pin; re-verify against `_version.py` on each spec sync.
 **Status:** v2.0.0 (re-derived from filesystem mechanical sweeps 2026-04-26 — supersedes v1.0.0)
 **Package:** `kailash-ml`
 **Canonical module:** `kailash_ml.features` (1.0+ surface)
-**Legacy module:** `kailash_ml.engines.feature_store` (0.x surface, retained for 0.x callers; not specified here)
+**Legacy module:** `kailash_ml.engines.feature_store` (0.x surface, retained for callers needing the self-contained write/registry/training-set path; not specified here)
+**Top-level resolution:** As of kailash-ml 2.0.0 (issue #643 cutover, `__init__.py` `_engine_map["FeatureStore"] = "kailash_ml.features"`), `from kailash_ml import FeatureStore` resolves to the canonical module above — the 1.7.2 bridge `DeprecationWarning` is removed. The legacy module is reachable only via its explicit import path `kailash_ml.engines.feature_store`.
 **Parent domain:** ML Lifecycle. See `ml-engines.md` (MLEngine), `ml-tracking.md` (runs/registry), `ml-drift.md` (monitoring), `dataflow-ml-integration.md §1.1` (the `ml_feature_source` polars binding this spec consumes).
 **License:** Apache-2.0
 **Python:** >=3.11

--- a/workspaces/issue-643-featurestore-canonical/04-validate/R1-cutover-convergence.md
+++ b/workspaces/issue-643-featurestore-canonical/04-validate/R1-cutover-convergence.md
@@ -1,0 +1,59 @@
+# /redteam Round 1 — #643 step-3 2.0.0 cutover — CONVERGED
+
+**Date:** 2026-06-07
+**Diff under review:** working-tree kailash-ml 2.0.0 FeatureStore canonical cutover
+(8 modified files + 1 new regression test; BUILD repo, uncommitted).
+
+## Agents (durable receipts per verify-resource-existence MUST-4)
+
+| Agent                          | Task ID             | Verdict     | Findings                                                      |
+| ------------------------------ | ------------------- | ----------- | ------------------------------------------------------------- |
+| reviewer (+ mechanical sweeps) | `a79a84e8630ff49bc` | **APPROVE** | 6/6 sweeps pass; 1 LOW (docstring backward-compat wording)    |
+| security-reviewer              | `abb5fa4022be8d9f2` | **APPROVE** | 0 CRIT/HIGH; 1 MEDIUM (legacy class tenant-blind — hardening) |
+| spec-source closure-parity     | `afd0c077d3510d841` | **CLEAN**   | 10/10 citations resolve; 0 unresolved                         |
+
+## Mechanical sweep results (reviewer-cited)
+
+1. Cutover regression test: **5 passed**.
+2. Full kailash-ml collect: **2539 collected**, no ModuleNotFoundError.
+3. Version consistency: `_version.py` = `pyproject.toml` = **2.0.0**.
+4. `import kailash_ml; kailash_ml.FeatureStore.__module__` → `kailash_ml.features.store`,
+   **no DeprecationWarning** under `-W error::DeprecationWarning`.
+5. 5 legacy-importing tests: **20 passed** (legacy module intact).
+6. `_warnings` import removed cleanly; `FeatureStore` correctly absent from `__all__`
+   (lazy via `_engine_map`) — no orphan-detection Rule 6 concern.
+
+## Findings + dispositions (all resolved in-round)
+
+- **MEDIUM (security):** the retained legacy `engines.feature_store.FeatureStore` is
+  tenant-blind; an operator reaching for the explicit-path import should be warned.
+  → **FIXED** — added a `.. warning::` banner to the legacy class docstring
+  (`engines/feature_store.py:38`): "single-tenant only — NO tenant isolation; for
+  multi-tenant materialisation use `@db.model` + `express.create` per MIGRATION.md."
+  Docstring-only; security-reviewer noted this is hardening, not a leak introduced by
+  the PR (the legacy class was already tenant-blind; the cutover only changes which
+  surface the _top-level_ symbol resolves to — and it STRENGTHENS posture by moving
+  the default to the tenant-gated canonical surface).
+- **LOW (reviewer):** `__init__.py` module docstring "consumers keep working" could be
+  over-read as fully backward-compatible. → **FIXED** — clarified to "keep resolving
+  the symbol … constructor contract changed; see CHANGELOG 2.0.0 / MIGRATION.md".
+- **Unused import** surfaced when the legacy file was touched: `FeatureField` imported
+  but unused (`FeatureSchema` used 13×, kept). → **FIXED** (removed).
+- **Out-of-blast-radius churn** (reviewer observation): pyright-suppression edits on the
+  unrelated `resume(tolerance=...)` block. → **REVERTED** to keep the diff cutover-only.
+
+## Post-fix verification
+
+- `52 passed, 1 skipped` across cutover + all 5 legacy tests + wiring + hyperparameter +
+  training-pipeline (the skip is the Postgres-gated e2e companion — honest Tier-3 gate).
+- collect-only: **2539 collected**, exit 0.
+- mypy on `__init__.py`: clean at all edits (only a pre-existing third-party
+  `kailash.db.connection` import-untyped note, unrelated). The pyright `reportUnreachable`
+  on the reverted `resume` block is pre-existing LSP-only state, not a mypy/CI error.
+
+## Convergence verdict
+
+Round 1 CONVERGED: 3/3 agents APPROVE/CLEAN, zero CRIT/HIGH, all MED/LOW resolved in-round,
+full suite green. No Round 2 required (residual changes were docstring/import-only, re-verified
+by the 52-passed suite run). The breaking 2.0.0 PyPI publish remains the user's release gate
+(BUILD repo — working-tree only this session).

--- a/workspaces/issue-643-featurestore-canonical/journal/0003-DECISION-step3-cutover-non-stranding-design.md
+++ b/workspaces/issue-643-featurestore-canonical/journal/0003-DECISION-step3-cutover-non-stranding-design.md
@@ -1,0 +1,81 @@
+# DECISION — #643 step 3: ship the non-stranding 2.0.0 cutover (option-a)
+
+**Date:** 2026-06-07
+**Phase:** /analyze → /todos (issue-643-featurestore-canonical)
+**Type:** DECISION
+**Trigger:** user — "continue from last session, /autonomize workflow and /redteam to convergence"
+
+## Context (ground-truth verified this session, not session-notes hearsay)
+
+- **#643 step 1** (deprecation bridge) SHIPPED — kailash-ml **1.7.2**, on PyPI (`f69b8013d`).
+- **#1241** (canonical `get_features` was non-functional — the real cutover blocker) CLOSED —
+  fixed in **1.7.5 + 1.7.6**, gate-reviewed (`39cf441ec`), on PyPI, deploy-recorded
+  (`deploy/deployments/2026-06-03-ml-v1.7.5-v1.7.6-1241-featurestore-getfeatures.md`).
+- Remaining: **#643 step 3** — the 2.0.0 cutover (flip top-level `from kailash_ml import FeatureStore`
+  from the legacy write-capable surface to the canonical read-only surface).
+
+The prior session flagged step 3 "GATED (breaking; needs steer)". Under `/autonomize` + standing
+feedback (`feedback_no_shims`, `feedback_optimal_outcome`, `feedback_drive_to_completion`) the
+"needs steer" is resolved by making the optimal call with evidence. The irreversible PyPI publish
+stays user-gated (BUILD repo).
+
+## Investigation — 3 parallel deep-dive agents (agents.md ≥3-claim MUST)
+
+Durable receipts (verify-resource-existence MUST-4):
+
+| Agent               | Mission                         | Verdict                                                                                                                                                                                                                                                                                   |
+| ------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `af1692f94de96f527` | write-path stranding            | Naive flip **STRANDS** write users: 4 legacy write ops (`initialize`/`register_features`/`compute`/`store`) all §11-M2-deferred, no canonical replacement, no doc, no test. Non-stranding design viable with prerequisites.                                                               |
+| `afabb37e14908251c` | breakage surface                | Flip is **import-safe + collection-safe** repo-wide — no production caller/test uses the top-level symbol (all use explicit `from kailash_ml.engines.feature_store import`). DataFlow binding duck-typed; `_SchemaFeatureGroup` (#1241) satisfies it; flip + even removal don't break it. |
+| `aeb23320cd7ca32a0` | change surface + parity + shard | ~30 LOC load-bearing, **7 invariants, ONE shard**. Legacy MODULE removal NOT feasible this PR (engine.py:843 / dashboard/server.py:459 / engines/registry.py:421-425 + 5 tests bound to it) → option-a only.                                                                              |
+
+## The stranding problem (load-bearing — the reason this is not a switch-flip)
+
+The canonical 1.0+ `FeatureStore` is **read-only by design** (`specs/ml-feature-store.md §1.2`).
+Legacy has 8 ops; 4 are writes, 3 are reads with no canonical equivalent:
+
+| Legacy op                                                 | kind  | canonical replacement                                                                              | disposition at cutover                               |
+| --------------------------------------------------------- | ----- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `initialize` / `register_features` / `compute` / `store`  | WRITE | none (write = `@db.model` + `express.create`; §11.1/.2/.4 M2-deferred as a _FeatureStore_ surface) | explicit legacy import + MIGRATION write-path recipe |
+| `get_features`                                            | READ  | canonical `get_features` (works since #1241)                                                       | top-level default → canonical                        |
+| `get_training_set` / `get_features_lazy` / `list_schemas` | READ  | none on canonical surface                                                                          | explicit legacy import (parity note)                 |
+
+## Decision
+
+**Ship the non-stranding 2.0.0 cutover (option-a):**
+
+1. Flip `_engine_map["FeatureStore"]` → `kailash_ml.features` (`__init__.py:631`); remove the
+   FeatureStore DeprecationWarning shim block (`__init__.py:664-690`) per `feedback_no_shims`
+   (the bridge lived 1.7.2→1.7.6, satisfying Rule 6a's ≥1-minor-cycle).
+2. **Keep** `kailash_ml.engines.feature_store.FeatureStore` importable via its explicit path — the
+   non-deprecated home for writers + the 3 extra read ops. (NOT `kailash_ml.legacy.FeatureStore`:
+   that namespace does not exist — `ModuleNotFoundError` — and minting it is a broader
+   ModelRegistry/TrainingPipeline 3.0 refactor, out of scope.)
+3. MIGRATION.md: correct the stale "2.0.0 removes legacy" claim → "2.0.0 flips the top-level default;
+   legacy stays at the explicit path; removal deferred to a later major (with the 3.0 ModelRegistry/
+   TrainingPipeline sweep)". Add a **write-path recipe** + a **3-read-method parity note**.
+4. README.md: fix phantom methods (`ingest`/`get_features_at_time`/`list_feature_sets` do not exist;
+   real ops are `register_features`/`store`/`compute`/`get_features`/`get_training_set`/
+   `get_features_lazy`/`list_schemas`) and update the top-level-default story.
+5. Tests: NEW top-level-resolution regression (canonical + no DeprecationWarning) + NEW write-then-read
+   round-trip (Tier-2 real DataFlow) **validating the migration story the cutover depends on**.
+6. Spec sync (`ml-feature-store.md`), version → **2.0.0** (`_version.py` + `pyproject.toml`),
+   CHANGELOG 2.0.0 with BREAKING + migration section (Rule 6a).
+
+## Out of scope (flagged, not folded — shard discipline)
+
+- `.claude/skills/*` (9 files) FeatureStore examples → **loom /codify origination** (synced artifacts;
+  repo-scope-discipline). Follow-up ledger item.
+- Legacy **module removal** + migrating engine.py/dashboard/registry off the ConnectionManager store
+  → separate prerequisite shard (3 call-graph hops into MLEngine).
+- `kailash_ml.legacy` namespace phantom (MIGRATION.md ModelRegistry recipe; `engine.py:19` Phase-2
+  note) → separate ModelRegistry/TrainingPipeline 3.0 concern.
+- Porting `get_features_lazy` to the canonical surface → M2 feature decision, not the cutover.
+
+## Receipts
+
+- Source anchors: `__init__.py:631` (flip), `:664-690` (shim), `_version.py:4`, `pyproject.toml:7`.
+- Legacy ops: `engines/feature_store.py:72,81,141,195,253,326,366,393`.
+- Canonical ctor: `features/store.py:98-114`. Binding: `dataflow/ml/_feature_source.py:77-103` (duck-typed).
+- Spec: `specs/ml-feature-store.md:6,37-39,343,348,§11(475-531)`.
+- Agent task IDs above; this entry is the external receipt per verify-resource-existence MUST-4.


### PR DESCRIPTION
## Summary

Completes issue #643: top-level `from kailash_ml import FeatureStore` now resolves to the canonical 1.0+ read surface `kailash_ml.features.FeatureStore` instead of the legacy `engines.feature_store` engine. The 1.7.2 deprecation bridge lived through 1.7.2 → 1.7.6 (deprecation cycle satisfied) and the #1241 retrieval blocker was fixed/released in 1.7.5/1.7.6, so the cutover is unblocked.

**Non-stranding by design:** the legacy write-capable class stays importable via its explicit path `kailash_ml.engines.feature_store.FeatureStore` for callers needing the self-contained write/registry/training-set surface. Only the top-level default flips — which *strengthens* tenant posture (the top-level symbol moves from the tenant-blind legacy class to the tenant-gated canonical surface).

## ⚠️ BREAKING CHANGE

Top-level `FeatureStore` constructor changes from `FeatureStore(conn, *, table_prefix=...)` to `FeatureStore(dataflow, *, default_tenant_id=None)`; the 1.7.2 `DeprecationWarning` is removed. Version **1.7.6 → 2.0.0**.

## Migration

- **Reads:** `FeatureStore(df, default_tenant_id=...)` (or `CANONICAL_SINGLE_TENANT_SENTINEL` single-tenant) → `get_features(schema, timestamp=None, *, tenant_id=None)`.
- **Writes:** the canonical store owns no DDL — materialise features as a `@db.model` whose name equals `schema.name`, write via `express.create`, read back via `get_features`. Recipe in `MIGRATION.md`.
- **`get_training_set`/`get_features_lazy`/`list_schemas`** + all legacy write ops: no canonical equivalent yet (M2-deferred per spec §11); keep the explicit legacy import.

## What changed

- **Source:** `_engine_map["FeatureStore"]` → `kailash_ml.features`; removed the bridge `DeprecationWarning` shim; legacy class gains a tenant-isolation warning banner.
- **Tests:** new `tests/regression/test_issue_643_featurestore_cutover.py` — structural resolution checks + Tier-2 write-via-model → read-via-`get_features` round-trip (latest-per-entity + point-in-time).
- **Docs:** README phantom-method fix (`ingest`/`get_features_at_time`/`list_feature_sets` never existed); MIGRATION write-path recipe; `docs/guides/02-feature-pipelines.md` rewritten from a fictional `put`/`get` API to the validated canonical pattern.
- **Spec:** `specs/ml-feature-store.md` top-level-resolution truth + version 2.0.0.

## Test plan (verified, scrubbed)

```
$ pytest tests/regression/test_issue_643_featurestore_cutover.py
  5 passed
$ pytest tests/ --collect-only            # 2539 collected, exit 0
$ python -W error::DeprecationWarning -c "import kailash_ml; print(kailash_ml.FeatureStore.__module__)"
  kailash_ml.features.store            # canonical, no DeprecationWarning
  (legacy still importable via kailash_ml.engines.feature_store)
```

Redteam: reviewer + security-reviewer + spec-source closure all APPROVE/CLEAN (0 CRIT/HIGH); 1 security MEDIUM + 1 reviewer LOW resolved in-round.

## Related issues

Fixes #643