### PR TITLE
docs(deploy): record kailash-ml 2.0.0 release (#643 FeatureStore cutover)

### DIFF
--- a/deploy/deployments/2026-06-07-ml-v2.0.0-643-featurestore-cutover.md
+++ b/deploy/deployments/2026-06-07-ml-v2.0.0-643-featurestore-cutover.md
@@ -1,0 +1,91 @@
+# Deployment Record — kailash-ml 2.0.0 (#643 step 3)
+
+**Date:** 2026-06-07
+**Package:** kailash-ml — single-package major release
+**Tag:** `ml-v2.0.0`
+**GitHub Release:** kailash-ml 2.0.0
+**PR:** #1274 (merge `89dfac29e`; squash-base `933b31297`)
+**Issue:** Fixes #643 (FeatureStore canonical surface migration — final step 3).
+
+## What shipped (BREAKING)
+
+Top-level `from kailash_ml import FeatureStore` now resolves to the canonical 1.0+
+**read** surface `kailash_ml.features.FeatureStore` instead of the legacy
+`kailash_ml.engines.feature_store` engine. This completes the issue #643 migration:
+
+- **Step 1** (deprecation bridge) shipped in **1.7.2** (`_engine_map` kept legacy
+  resolution + `DeprecationWarning` on first access).
+- **#1241** (the canonical `get_features` always raised — the real cutover blocker)
+  fixed in **1.7.5 + 1.7.6** (deploy record `2026-06-03-ml-v1.7.5-v1.7.6-...`).
+- **Step 3** (this release): flip `_engine_map["FeatureStore"]` → `kailash_ml.features`;
+  remove the bridge `DeprecationWarning` (it lived 1.7.2 → 1.7.6, satisfying the
+  deprecation cycle per zero-tolerance Rule 6a).
+
+### Non-stranding design (why this is not a switch-flip)
+
+Three parallel investigations confirmed the naive flip would strand write-path users:
+the canonical 1.0+ surface is read-only by design (spec §1.2), and legacy's write ops
+(`register_features`/`store`/`compute` + `get_training_set`/`get_features_lazy`/
+`list_schemas`) are M2-deferred (spec §11) — they have no canonical equivalent. The
+cutover is therefore **non-stranding**: the legacy write-capable class stays importable
+via its explicit module path `kailash_ml.engines.feature_store.FeatureStore`; only the
+top-level default flips. This **strengthens** tenant posture (the top-level symbol moves
+from the tenant-blind legacy class to the tenant-gated canonical surface; the legacy
+class gained an explicit "single-tenant only — NO tenant isolation" docstring banner).
+
+### Breaking-change surface
+
+Top-level `FeatureStore` constructor changes from `FeatureStore(conn, *, table_prefix=...)`
+to `FeatureStore(dataflow, *, default_tenant_id=None)`. Documented callers using the
+legacy constructor at the top level now `TypeError`; migration recipe (reads +
+write-via-`@db.model` + read-method parity) is in `packages/kailash-ml/MIGRATION.md`,
+README, and `docs/guides/02-feature-pipelines.md` (rewritten from a fictional `put`/`get`
+API to the validated canonical pattern). Phantom README methods
+(`ingest`/`get_features_at_time`/`list_feature_sets` — never existed) corrected.
+
+## Tests
+
+New `tests/regression/test_issue_643_featurestore_cutover.py`: structural resolution
+checks (top-level is canonical, no DeprecationWarning, legacy still importable) +
+**Tier-2 write-via-model → read-via-`get_features` round-trip** validating the migration
+story end-to-end (latest-per-entity dedup + point-in-time as-of). 5/5 pass; the
+round-trip would have caught the 1.7.6 latest-per-entity bug.
+
+## Gate reviews (R1 converged, zero CRIT/HIGH)
+
+- **reviewer:** APPROVE — 6/6 mechanical sweeps pass (5 cutover tests; 2539 collect;
+  version consistency; resolution walk; 20 legacy tests; clean shim removal).
+- **security-reviewer:** APPROVE — cutover _strengthens_ tenant posture; 1 MEDIUM
+  (legacy tenant-blindness) resolved via the docstring banner.
+- **spec-source closure-parity:** CLEAN — 10/10 citations resolve.
+- 1 reviewer LOW (docstring backward-compat wording) + an unused import resolved in-round.
+
+Receipt: `workspaces/issue-643-featurestore-canonical/04-validate/R1-cutover-convergence.md`.
+
+## CI + install verification
+
+Full Python 3.10–3.14 matrix green (Base + Test + DataFlow Tier-1 + PACT + spec-drift +
+Version Consistency + Analyze Python: 31 SUCCESS / 12 SKIPPED). The lone non-complete
+check was `CUDA Smoke` stuck QUEUED on an unavailable GPU runner — irrelevant to this
+pure-Python change; admin-merged per the owner workflow. publish-pypi.yml run
+`27080498962` succeeded (Build + Publish to PyPI + GitHub Release; TestPyPI skipped —
+tag-direct path, consistent with all prior kailash-ml releases).
+
+Clean-venv install verified live (`uv pip install --refresh "kailash-ml==2.0.0"`, after
+PyPI cache lag ~45s):
+
+```
+VERSION     : 2.0.0
+TOP-LEVEL FS : kailash_ml.features.store.FeatureStore   (canonical)
+IS CANONICAL : True
+LEGACY OK    : kailash_ml.engines.feature_store          (explicit path intact)
+(ran under -W error::DeprecationWarning — no warning raised)
+```
+
+## Follow-ups (flagged, not folded — out of this repo's scope)
+
+- **loom `/codify`:** 9 `.claude/skills/` files still show the old FeatureStore examples
+  (synced artifacts — must originate at loom, not kailash-py, per repo-scope-discipline).
+- **Cross-SDK:** none — kailash-rs has no equivalent FeatureStore surface (journal 0002).
+- **Legacy module removal:** deferred to a later major (engine.py / dashboard / registry +
+  5 tests still bind the legacy class); 2.0.0 keeps it importable, does not delete it.


### PR DESCRIPTION
Running-log deploy record for the kailash-ml 2.0.0 canonical cutover (#643 step 3), shipped via PR #1274 / tag `ml-v2.0.0` and verified installable from PyPI. Docs-only.

## Related issues
Refs #643