### PR TITLE
chore(codify): F32 doc-sweep gate + kailash-ml skill-adoption proposal (BUILD→loom)

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -697,6 +697,62 @@ changes:
     is bound. Single-record correctness did not imply bulk correctness — a dual-tenant-source split is
     the failure mode. Extends tenant-isolation (which audits cache-key/filter/label/audit sites but not
     write-path tenant-source parity). loom: add Trust Posture Wiring + DO/DO NOT.'
+- type: rule_new
+  artifact: doc-api-import-execution-sweep
+  files:
+  - .claude/rules/spec-accuracy.md
+  - tools/check_doc_api_examples.py
+  classification_suggestion: global
+  context: |
+    F32 (kailash-py BUILD; PR #1277 merged 1decd6c49). NEW gate candidate: every
+    doc/skill python code fence MUST pass an import-execution sweep at /redteam — import
+    each cited symbol and assert every called method, constructor kwarg, and method-call
+    kwarg resolves against installed code; carry variable->class bindings across fences
+    within a file. Extends spec-accuracy.md Rule 1 ("every citation resolves against
+    working code") + user-flow-validation.md (examples must run) from prose/spec to
+    README/skill/guide fences. Reference tool: tools/check_doc_api_examples.py (5 check
+    classes: import / method-existence / ctor-kwarg / method-kwarg / cross-fence; ast-based,
+    never executes fences; kailash_ml-prefix import gate; auditable "# doc-sweep: ignore"
+    per-fence opt-out for intentional before/after migration contrast). loom Gate-1
+    decisions: (a) author the rule (new rules/doc-api-sweep.md OR extend spec-accuracy.md)
+    GLOBAL; (b) decide whether the sweep tool syncs as a global artifact (py + rs variants)
+    or stays per-BUILD-repo tooling. Cross-SDK: the fictional-doc-API failure mode is
+    language-agnostic (rs docs equally exposed). Evidence: journal 0006 (DISCOVERY, 87
+    findings/17 files) + 0007 (AMENDMENT, /redteam R1-R4) in
+    workspaces/issue-643-featurestore-canonical. Result: 87 -> 0 across 417 docs.
+- type: skill_update
+  artifact: kailash-ml-doc-real-api-rewrite
+  files:
+  - .claude/skills/34-kailash-ml/SKILL.md
+  - .claude/skills/34-kailash-ml/ml-feature-pipelines.md
+  - .claude/skills/34-kailash-ml/ml-model-registry.md
+  - .claude/skills/34-kailash-ml/ml-training-pipeline.md
+  - .claude/skills/34-kailash-ml/ml-inference-server.md
+  - .claude/skills/34-kailash-ml/ml-drift-monitoring.md
+  - .claude/skills/34-kailash-ml/ml-onnx-export.md
+  - .claude/skills/34-kailash-ml/ml-agent-guardrails.md
+  - .claude/skills/02-dataflow/dataflow-ml-integration.md
+  - .claude/skills/04-kaizen/kaizen-ml-integration.md
+  classification_suggestion: variant
+  context: |
+    F32 DURABILITY (closes F33). The kailash-ml skill examples taught a platform-wide
+    FICTIONAL API (methods/imports/kwargs absent from shipped 2.0.0). PR #1277 rewrote
+    every fence to the real surface: FeatureStore canonical-read (kailash_ml.features,
+    fields=) vs legacy-write (engines.feature_store, features=) split; ModelRegistry
+    (register_model/promote_model/get_model, no initialize); TrainingPipeline(feature_store=,
+    registry=) + train(data,schema,model_spec,eval_spec,experiment_name); InferenceServer
+    per-model from_registry + predict(features); DriftMonitor(tenant_id=, thresholds at
+    ctor) + DriftReport(overall_severity/feature_results); single HyperparameterSearch +
+    SearchConfig(strategy=) (not 4 fictional classes); two-ExperimentTracker distinction;
+    AutoMLEngine(config=,tenant_id=,actor_id=); OnnxBridge.export(framework=)/validate;
+    EnsembleEngine(data=,target=). These skills are loom-canonical (synced via
+    /sync-to-build) — loom MUST adopt these rewrites as canonical ELSE the next
+    /sync-to-build OVERWRITES the BUILD-local fix with the stale phantom versions.
+    Classification suggestion: variant/py (kailash-ml is Python-specific). NOTE:
+    .claude/skills/project/ml-quick-reference.md was also rewritten but is project-local
+    (not synced) — durable as-is. README/MIGRATION/docs/guides are kailash-ml PACKAGE docs
+    (BUILD-owned, durable on PR merge, not COC artifacts). Verify post-adopt with
+    tools/check_doc_api_examples.py. /redteam converged R1-R4 (journal 0007).
 deferred:
 - id: issue-1086-candidate-3
   summary: 'SessionEnd hook dedup-by-source_commit. Two .pending/ files for

--- a/workspaces/issue-643-featurestore-canonical/journal/0008-DECISION-codify-f32-doc-sweep-gate-to-loom.md
+++ b/workspaces/issue-643-featurestore-canonical/journal/0008-DECISION-codify-f32-doc-sweep-gate-to-loom.md
@@ -1,0 +1,62 @@
+---
+type: DECISION
+date: 2026-06-07
+author: agent
+project: F32 (kailash-ml doc phantom-API remediation)
+topic: /codify the F32 gap — sweep-gate rule candidate + skill durability to loom Gate-1
+phase: codify
+relates_to: 0007-AMENDMENT-f32-redteam-convergence
+tags: [codify, proposal, loom, doc-rot, sweep, durability]
+---
+
+# DECISION — codify the F32 gap (BUILD→loom proposal append)
+
+PR #1277 merged to `main` (`1decd6c49`); F32 is delivered locally. This `/codify` captures
+the institutional gap so it survives + propagates, appending 2 entries to the BUILD→loom
+proposal (`.claude/.proposals/latest.yaml`, `pending_review`, 16 → 18 changes; per
+`artifact-flow.md` "Append, Never Overwrite"; existing `deferred`/`append_session` preserved).
+
+## What was codified
+
+1. **`doc-api-import-execution-sweep` (rule_new, global).** Candidate rule: every doc/skill
+   python code fence MUST pass an import-execution sweep at `/redteam` — extends
+   `spec-accuracy.md` Rule 1 + `user-flow-validation.md` from prose/spec to README/skill/guide
+   fences. Reference tool `tools/check_doc_api_examples.py` (5 check classes). loom Gate-1
+   decides: author the rule (global) + whether the tool syncs (py + rs variants) or stays
+   per-BUILD-repo. Cross-SDK: the failure mode is language-agnostic.
+2. **`kailash-ml-doc-real-api-rewrite` (skill_update, variant/py) — closes F33 durability.**
+   The 10 loom-canonical kailash-ml skill files PR #1277 rewrote MUST be adopted as loom
+   canonical, ELSE the next `/sync-to-build` overwrites the BUILD-local fix with the stale
+   phantom versions. README/MIGRATION/guides are BUILD-owned package docs (durable on merge);
+   `.claude/skills/project/ml-quick-reference.md` is project-local (durable).
+
+## Why these two, and why now
+
+The sweep gate is the durable structural defense (catches recurrence + the rs surface). The
+skill-adoption entry is the ONLY thing standing between "fixed today" and "overwritten on the
+next sync" — F32's skill fixes are not durable until loom adopts them. Both are loom-Gate-1
+work (BUILD originates the proposal; loom authors/classifies).
+
+## Decisions / disposition
+
+- Repo class = BUILD (kailash-py) → Step 7a (BUILD→loom, cross-SDK-first). The rule candidate
+  is flagged cross-SDK; loom authors the global rule.
+- Single-operator repo (no `operators.roster.json`) → codify lease uncontended (L5);
+  `acquireCodifyLease` returned `ok:true` on `codify/esperie-2026-06-07`.
+- NOT self-referential per `self-referential-codify.md` Rule 2: the BUILD-side codify writes
+  `.claude/.proposals/latest.yaml` (not in the allowlist) — it PROPOSES; loom Gate-1 authors
+  the rule (where the multi-agent redteam-with-tests gate fires). No mandatory multi-agent
+  round on the proposal-append itself.
+- `learning-codified.json` updated (local/gitignored): +2 `proposal_append` actions.
+
+## For Discussion
+
+1. Should the rule live as a new `rules/doc-api-sweep.md` or as a clause extension of
+   `spec-accuracy.md` Rule 1? (The sweep is the mechanical enforcement of "citations resolve
+   against working code" — extension keeps the corpus smaller; a new rule gives it its own
+   Trust-Posture-Wiring + grace clock.)
+2. Is the sweep tool worth a Rust variant now (rs docs unverified), or defer until an rs
+   doc-rot incident provides the evidence (codify-on-recurrence)?
+3. Counterfactual: had the import-execution sweep existed at the #643 cutover, would PR #1274
+   have been declared "docs fixed" with 87 sibling-surface findings still open? The gate makes
+   "the docs are correct" a falsifiable exit-code rather than a reviewer's judgment.


### PR DESCRIPTION
Codify of the **F32** gap (follow-on to #1277). Appends 2 entries to the BUILD→loom proposal
(`.claude/.proposals/latest.yaml`, `pending_review`, 16 → 18 changes; append-not-overwrite per
`artifact-flow.md`; `deferred`/`append_session` preserved). Proposal flows to **loom Gate-1**.

## Entries

1. **`doc-api-import-execution-sweep`** (rule_new, **global**) — every doc/skill python fence
   MUST pass an import-execution sweep at `/redteam` (import cited symbols; assert methods /
   ctor-kwargs / method-kwargs / cross-fence-bound calls resolve). Extends `spec-accuracy.md`
   Rule 1 + `user-flow-validation.md` from prose to code fences. Reference tool
   `tools/check_doc_api_examples.py` (shipped in #1277). loom decides: author the global rule +
   whether the tool syncs (py + rs variants) or stays per-BUILD-repo. **Cross-SDK** (rs docs
   equally exposed).
2. **`kailash-ml-doc-real-api-rewrite`** (skill_update, **variant/py**) — the 10 loom-canonical
   kailash-ml skill files #1277 rewrote MUST be adopted as loom canonical, **else the next
   `/sync-to-build` overwrites the fix** with stale phantom versions. **Closes F33 durability.**

## Receipts

- PR #1277 merged (`1decd6c49`); `/redteam` converged R1–R4 (journal 0007).
- Codify DECISION: `workspaces/issue-643-featurestore-canonical/journal/0008-DECISION-codify-f32-doc-sweep-gate-to-loom.md`.
- Not self-referential (the BUILD codify proposes; loom Gate-1 authors the rule).

## Related issues

Refs #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)