### PR TITLE
fix(deps): resolve first-party pin drift + add #1183 drift gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,6 +110,22 @@ repos:
         pass_filenames: false
         stages: [pre-commit, manual]
 
+  # First-party dependency-pin drift gate (issue #1183).
+  # See .claude/rules/dependencies.md — floors legitimately differ per
+  # package, but defensive caps on first-party siblings, unsatisfiable
+  # floors, and intra-manifest drift are ERRORS. Read-only (no working-tree
+  # mutation); advisory cross-manifest/staleness findings do NOT fail.
+  - repo: local
+    hooks:
+      - id: check-pin-consistency
+        name: First-party dependency-pin drift gate (#1183)
+        description: "Block caps on first-party siblings, unsatisfiable floors, intra-manifest pin drift."
+        entry: scripts/development/find-venv-python.sh tools/check_pin_consistency.py
+        language: system
+        files: ^(pyproject\.toml|packages/.+/pyproject\.toml|tools/check_pin_consistency\.py)$
+        pass_filenames: false
+        stages: [pre-commit, manual]
+
   # No untracked TODO-NNN markers in production source (issue #781).
   # See .claude/rules/zero-tolerance.md Rule 2 + Rule 6 — every TODO-NNN
   # marker MUST either carry a tracker link (tracked: gh#NNN) or be

--- a/packages/kailash-align/CHANGELOG.md
+++ b/packages/kailash-align/CHANGELOG.md
@@ -1,5 +1,18 @@
 # kailash-align Changelog
 
+## [0.7.2] — 2026-06-08 — drop defensive `kailash-ml` cap + de-stale floor (#1183)
+
+Patch release. **No source changes** — diff is strictly `pyproject.toml` dependency-floor edits + `__version__` anchor + this CHANGELOG entry.
+
+### Changed
+
+- **`[rl-bridge]` extra: `kailash-ml[rl]>=1.1`** (was `kailash-ml[rl]>=1.1,<2.0`). The `<2.0` defensive cap excluded the current `kailash-ml 2.0.0` — a live resolution break per `dependencies.md` § "No Caps". Verified safe: all 9 `kailash_ml.rl.*` symbols the rl-bridge imports are present in ml 2.0.0, and the rl-bridge test suite (74 tests) passes against it.
+- **Core dep `kailash-ml>=1.1`** (was `kailash-ml>=0.11.0`). The `0.11.0` floor was stale (ml is at 2.0.0) and inconsistent with the `[rl-bridge]` floor within the same manifest; raised to the established `>=1.1` minimum.
+
+### Notes
+
+- No public-API changes; no behavior changes; wheel content is identical to 0.7.1 except for the `__version__` constant. Surfaced by the new `tools/check_pin_consistency.py` first-party pin-drift gate (#1183).
+
 ## [0.7.1] — 2026-05-09 — kailash floor bump for #890 slim-core alignment
 
 Patch release pairing kailash-align with the kailash 2.18.0 / #890 slim-core layout. **No source changes** — diff is strictly `pyproject.toml` floor bump + `__version__` anchor + this CHANGELOG entry.

--- a/packages/kailash-align/pyproject.toml
+++ b/packages/kailash-align/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-align"
-version = "0.7.1"
+version = "0.7.2"
 description = "LLM fine-tuning and alignment framework for the Kailash platform"
 readme = "README.md"
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ classifiers = [
 
 dependencies = [
     "kailash>=2.16.0",
-    "kailash-ml>=0.11.0",
+    "kailash-ml>=1.1",
     "kailash-kaizen>=2.7.5",
     "torch>=2.2,<3.0",
     "transformers>=4.40,<5.0",
@@ -53,7 +53,7 @@ online = [
     "vllm>=0.6",
 ]
 rl-bridge = [
-    "kailash-ml[rl]>=1.1,<2.0",
+    "kailash-ml[rl]>=1.1",
 ]
 all = [
     "kailash-align[rlhf,eval,serve,online,rl-bridge]",

--- a/packages/kailash-align/src/kailash_align/_version.py
+++ b/packages/kailash-align/src/kailash_align/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-align package."""
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,17 @@
 # kailash-ml Changelog
 
+## [2.0.1] — 2026-06-08 — `kailash-kaizen` floor consistency (#1183)
+
+Patch release. **No source changes** — diff is strictly `pyproject.toml` dependency-floor edits + `__version__` anchor + this CHANGELOG entry.
+
+### Changed
+
+- **`[kaizen-judges]` and `[kaizen-observability]` extras: `kailash-kaizen>=2.7.5`** (was `kailash-kaizen>=2.7`). The two extras drifted from the `>=2.7.5` floor used elsewhere in the same manifest (`[agents]`); `>=2.7.5` is the consistent floor and additionally pins past the known-bad kaizen 2.7.0–2.7.4 clean-venv `ModuleNotFoundError` class.
+
+### Notes
+
+- No public-API changes; no behavior changes. Surfaced by the new `tools/check_pin_consistency.py` first-party pin-drift gate (#1183).
+
 ## [2.0.0] — 2026-06-07 — BREAKING: FeatureStore canonical cutover (#643 step 3)
 
 Top-level `from kailash_ml import FeatureStore` now resolves to the **canonical

--- a/packages/kailash-ml/README.md
+++ b/packages/kailash-ml/README.md
@@ -4,7 +4,7 @@ Machine learning lifecycle for the Kailash ecosystem. Train models, store featur
 
 Part of the [Kailash Python SDK](https://github.com/terrene-foundation/kailash-py) by the Terrene Foundation.
 
-**Version**: 2.0.0 | **License**: Apache-2.0 | **Python**: 3.11+
+**Version**: 2.0.1 | **License**: Apache-2.0 | **Python**: 3.11+
 
 ---
 

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "2.0.0"
+version = "2.0.1"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -136,8 +136,8 @@ agents = [
 # at the call site; missing the extra produces a loud ImportError per
 # `rules/dependencies.md` § BLOCKED Anti-Patterns, NOT silent fallback.
 alignment = ["kailash-align>=0.6"]
-kaizen-judges = ["kailash-kaizen>=2.7"]
-kaizen-observability = ["kailash-kaizen>=2.7"]
+kaizen-judges = ["kailash-kaizen>=2.7.5"]
+kaizen-observability = ["kailash-kaizen>=2.7.5"]
 explain = ["shap>=0.44"]
 imbalance = ["imbalanced-learn>=0.12"]
 # RAG evaluation backends for kailash_ml.diagnostics.RAGDiagnostics.

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/tests/unit/tools/test_check_pin_consistency.py
+++ b/tests/unit/tools/test_check_pin_consistency.py
@@ -1,0 +1,220 @@
+"""Unit tests for tools/check_pin_consistency.py (issue #1183).
+
+The detector is the structural defense that makes silent first-party pin drift
+loud. These fixtures pin down each verdict class so the logic cannot regress:
+
+* defensive cap on a first-party sibling      -> ERROR (exit 1)
+* floor exceeding the sibling's current ver   -> ERROR (exit 1)
+* same dep at divergent floors within one mfst-> ERROR (exit 1)
+* cross-manifest floor divergence             -> ADVISORY only (exit 0)
+* semantically-equal floors (1.1 == 1.1.0)    -> NOT flagged as drift
+* a clean monorepo                            -> exit 0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_TOOL = Path(__file__).resolve().parents[3] / "tools" / "check_pin_consistency.py"
+_spec = importlib.util.spec_from_file_location("check_pin_consistency", _TOOL)
+assert _spec and _spec.loader
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_pin_consistency"] = mod  # dataclass introspection needs this
+_spec.loader.exec_module(mod)
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+
+
+def _root_manifest(
+    name: str, version: str, deps: list[str], optional: dict | None = None
+) -> str:
+    lines = [
+        "[project]",
+        f'name = "{name}"',
+        f'version = "{version}"',
+        "dependencies = [",
+        *[f'    "{d}",' for d in deps],
+        "]",
+    ]
+    if optional:
+        lines.append("[project.optional-dependencies]")
+        for group, specs in optional.items():
+            lines.append(f"{group} = [")
+            lines.extend(f'    "{s}",' for s in specs)
+            lines.append("]")
+    return "\n".join(lines) + "\n"
+
+
+@pytest.fixture
+def clean_repo(tmp_path: Path) -> Path:
+    # kailash 1.0.0 published; both siblings floor at >=1.0 consistently.
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest("kailash-ml", "2.0.0", ["kailash>=1.0"]),
+    )
+    _write(
+        tmp_path,
+        "packages/kailash-nexus/pyproject.toml",
+        _root_manifest("kailash-nexus", "2.0.0", ["kailash>=1.0"]),
+    )
+    return tmp_path
+
+
+def test_clean_repo_exits_zero(clean_repo: Path):
+    assert mod.main(["--root", str(clean_repo)]) == 0
+    rep = mod.build_report(clean_repo)
+    assert not rep["caps_errors"]
+    assert not rep["unsatisfiable"]
+    assert not rep["intra_manifest"]
+
+
+def test_defensive_cap_on_sibling_is_error(tmp_path: Path):
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest("kailash-ml", "2.0.0", ["kailash>=1.0"]),
+    )
+    # align caps the current ml out: >=1.1,<2.0 while ml is 2.0.0
+    _write(
+        tmp_path,
+        "packages/kailash-align/pyproject.toml",
+        _root_manifest(
+            "kailash-align",
+            "0.7.0",
+            ["kailash>=1.0"],
+            {"rl": ["kailash-ml[rl]>=1.1,<2.0"]},
+        ),
+    )
+    rep = mod.build_report(tmp_path)
+    caps = {n for n, _ in rep["caps_errors"]}
+    assert "kailash-ml" in caps
+    # the cap excludes the current version
+    _, site = rep["caps_errors"][0]
+    assert mod._cap_excludes(site.caps, "2.0.0") is True
+    assert mod.main(["--root", str(tmp_path)]) == 1
+
+
+def test_floor_exceeding_current_is_unsatisfiable(tmp_path: Path):
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    # nexus floors kailash-ml at 3.0 but ml is only 2.0.0 in-repo
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest("kailash-ml", "2.0.0", ["kailash>=1.0"]),
+    )
+    _write(
+        tmp_path,
+        "packages/kailash-nexus/pyproject.toml",
+        _root_manifest("kailash-nexus", "2.0.0", ["kailash>=1.0", "kailash-ml>=3.0"]),
+    )
+    rep = mod.build_report(tmp_path)
+    names = {n for n, _, _ in rep["unsatisfiable"]}
+    assert "kailash-ml" in names
+    assert mod.main(["--root", str(tmp_path)]) == 1
+
+
+def test_intra_manifest_divergence_is_error(tmp_path: Path):
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    # ml pins kailash-kaizen at two different floors in two extras
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest(
+            "kailash-ml",
+            "2.0.0",
+            ["kailash>=1.0"],
+            {"a": ["kailash-kaizen>=2.7"], "b": ["kailash-kaizen>=2.7.5"]},
+        ),
+    )
+    _write(
+        tmp_path,
+        "packages/kailash-kaizen/pyproject.toml",
+        _root_manifest("kailash-kaizen", "2.8.0", ["kailash>=1.0"]),
+    )
+    rep = mod.build_report(tmp_path)
+    names = {n for n, _, _ in rep["intra_manifest"]}
+    assert "kailash-kaizen" in names
+    assert mod.main(["--root", str(tmp_path)]) == 1
+
+
+def test_cross_manifest_divergence_is_advisory_not_error(tmp_path: Path):
+    # two packages floor kailash differently — legitimate per dependencies.md
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "3.0.0", []))
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest("kailash-ml", "2.0.0", ["kailash>=2.0"]),
+    )
+    _write(
+        tmp_path,
+        "packages/kailash-nexus/pyproject.toml",
+        _root_manifest("kailash-nexus", "2.0.0", ["kailash>=2.9"]),
+    )
+    rep = mod.build_report(tmp_path)
+    assert not rep["caps_errors"]
+    assert not rep["intra_manifest"]
+    cross = {n for n, _, _ in rep["cross_manifest"]}
+    assert "kailash" in cross  # surfaced as advisory
+    assert mod.main(["--root", str(tmp_path)]) == 0  # advisory does not fail
+    # but --strict-advisory does
+    assert mod.main(["--root", str(tmp_path), "--strict-advisory"]) == 1
+
+
+def test_semantically_equal_floors_not_flagged(tmp_path: Path):
+    # >=1.1 and >=1.1.0 are the SAME PEP 440 floor — must NOT be intra-manifest drift
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest("kailash-ml", "2.0.0", ["kailash>=1.0"]),
+    )
+    _write(
+        tmp_path,
+        "packages/kailash-align/pyproject.toml",
+        _root_manifest(
+            "kailash-align",
+            "0.7.0",
+            ["kailash>=1.0"],
+            {"a": ["kailash-ml>=1.1"], "b": ["kailash-ml>=1.1.0"]},
+        ),
+    )
+    rep = mod.build_report(tmp_path)
+    intra = {n for n, _, _ in rep["intra_manifest"]}
+    assert "kailash-ml" not in intra  # 1.1 == 1.1.0, no drift
+
+
+def test_version_equality_helper():
+    assert mod._veq("1.1", "1.1.0") is True
+    assert mod._veq("2.0", "2.0.0") is True
+    assert mod._veq("2.7", "2.7.5") is False
+    assert mod._vgt("3.0", "2.0.0") is True
+    assert mod._vgt("1.0", "2.0.0") is False
+
+
+def test_self_extra_reference_ignored(tmp_path: Path):
+    # a package referencing its own extras (kailash-ml[dl]) is not a cross-pin
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest(
+            "kailash-ml",
+            "2.0.0",
+            ["kailash>=1.0"],
+            {"all": ["kailash-ml[dl,rl]"]},
+        ),
+    )
+    rep = mod.build_report(tmp_path)
+    assert "kailash-ml" not in rep["deps"]  # self-reference excluded

--- a/tools/check_pin_consistency.py
+++ b/tools/check_pin_consistency.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Detect version-pin drift + policy violations for first-party Kailash packages.
+
+Issue #1183 — "single source of truth for dependency version-pin sourcing".
+
+The monorepo declares the same first-party dependency (``kailash``,
+``kailash-kaizen``, …) in many ``pyproject.toml`` manifests, each with its own
+``>=`` floor. There is no canonical source, so a bump must touch every manifest
+by hand and any divergence is *silent*. This tool makes the drift *loud*.
+
+It is deliberately aligned with ``.claude/rules/dependencies.md``:
+
+* Floors (``>=X.Y``) are *expected* to reflect each package's actual feature
+  usage, so the SAME dependency pinned at DIFFERENT floors across DIFFERENT
+  packages is **advisory**, not an error — homogenizing floors would violate the
+  rule.
+* What IS an error:
+  1. **Defensive cap on a first-party sibling** (``<``/``<=``/``==``/``!=`` on a
+     ``kailash*`` dep) — ``dependencies.md`` § "No Caps" / "No exact pins in
+     library pyproject". A cap that excludes the sibling's *current* version is
+     a live resolution break.
+  2. **Unsatisfiable floor** — a floor greater than the sibling's own current
+     in-repo version (the pin can never resolve in the workspace).
+  3. **Intra-manifest drift** — the same dependency pinned at two different
+     floors *within one manifest* (an unambiguous inconsistency).
+* **Advisory** signals: cross-manifest floor divergence, and floors far behind
+  the sibling's current version (staleness — a human/feature-usage call).
+
+Exit code is non-zero ONLY on errors (1+2+3), so the check is CI-wireable
+without forcing floor homogenization.
+
+Run:  ``python tools/check_pin_consistency.py``  (exit 0 = no errors).
+      ``python tools/check_pin_consistency.py --json``  for machine output.
+      ``python tools/check_pin_consistency.py --strict-advisory``  also exits
+      non-zero on advisory findings (for a stricter gate).
+
+Stdlib-first (``tomllib``, 3.11+). Uses ``packaging`` for correct PEP 440
+version comparison when available, with a conservative fallback.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+FIRST_PARTY = {
+    "kailash",
+    "kailash-align",
+    "kailash-dataflow",
+    "kailash-kaizen",
+    "kailash-mcp",
+    "kailash-ml",
+    "kailash-nexus",
+    "kailash-pact",
+    "kaizen-agents",
+}
+
+PRUNE_PARTS = {".venv", "node_modules", ".claude", "build", "dist", "site-packages"}
+FIXTURE_MARKERS = ("tests/fixtures/", "tests\\fixtures\\")
+
+# Specifier operators that constrain the UPPER side (a "cap"). dependencies.md
+# forbids these on first-party siblings.
+CAP_OPERATORS = ("<", "<=", "==", "!=", "===")
+
+
+# ---- version comparison --------------------------------------------------
+# Prefer PEP 440 comparison via `packaging`; fall back to a numeric release
+# tuple so the tool still runs in a minimal CI env without the dependency.
+
+try:
+    from packaging.version import Version  # type: ignore
+except ImportError:  # pragma: no cover
+    Version = None  # type: ignore
+
+
+def _release_tuple(v: str):
+    """Best-effort numeric release tuple, trailing zeros stripped ('1.1.0'->(1,1))."""
+    parts = []
+    for chunk in re.split(r"[.+!-]", v):
+        if chunk.isdigit():
+            parts.append(int(chunk))
+        else:
+            break
+    while len(parts) > 1 and parts[-1] == 0:
+        parts.pop()
+    return tuple(parts)
+
+
+def _veq(a: str, b: str) -> bool:
+    if Version is not None:
+        try:
+            return Version(a) == Version(b)
+        except Exception:
+            pass
+    return _release_tuple(a) == _release_tuple(b)
+
+
+def _vgt(a: str, b: str) -> bool:
+    """True if floor `a` is strictly greater than current `b`."""
+    if Version is not None:
+        try:
+            return Version(a) > Version(b)
+        except Exception:
+            pass
+    return _release_tuple(a) > _release_tuple(b)
+
+
+def _cap_excludes(caps: list[str], current: str) -> bool:
+    """True if any upper cap excludes `current` (e.g. '<2.0' vs current 2.0.0)."""
+    for c in caps:
+        m = re.match(r"(<=|<|==|!=|===)\s*(.+)", c)
+        if not m:
+            continue
+        op, ver = m.group(1), m.group(2)
+        if op == "<" and not _vgt(ver, current):  # current >= cap-bound
+            return True
+        if op == "<=" and _vgt(current, ver):  # current > cap-bound
+            return True
+        if op in ("==", "===") and not _veq(ver, current):
+            return True
+        if op == "!=" and _veq(ver, current):
+            return True
+    return False
+
+
+def _normalize(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+# ---- requirement parsing -------------------------------------------------
+
+
+@dataclass
+class Pin:
+    name: str
+    floor: str | None  # lower-bound version string, if any
+    caps: list[str]  # cap specifiers found (operator+version), e.g. ["<2.0"]
+    raw: str  # verbatim requirement string
+
+
+_SPEC_RE = re.compile(r"(<=|>=|==|===|!=|~=|<|>)\s*([0-9][0-9A-Za-z.+!*-]*)")
+_NAME_RE = re.compile(
+    r"^\s*(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?\s*(?P<rest>.*)$"
+)
+
+
+def _parse_req(spec: str) -> Pin | None:
+    m = _NAME_RE.match(spec)
+    if not m:
+        return None
+    name = _normalize(m.group("name"))
+    floor = None
+    caps: list[str] = []
+    for op, ver in _SPEC_RE.findall(m.group("rest") or ""):
+        if op in (">=", "~="):
+            floor = ver  # lower bound
+        elif op == "==" and "*" not in ver:
+            # exact pin acts as both floor and cap
+            floor = ver
+            caps.append(f"=={ver}")
+        elif op in CAP_OPERATORS:
+            caps.append(f"{op}{ver}")
+    return Pin(name=name, floor=floor, caps=caps, raw=spec.strip())
+
+
+# ---- manifest discovery + extraction ------------------------------------
+
+
+def _iter_manifests(root: Path):
+    for p in root.rglob("pyproject.toml"):
+        rel = p.relative_to(root).as_posix()
+        if any(part in PRUNE_PARTS for part in p.parts):
+            continue
+        if any(marker in rel for marker in FIXTURE_MARKERS):
+            continue
+        yield p, rel
+
+
+def _collect_specs(data: dict):
+    proj = data.get("project", {})
+    for spec in proj.get("dependencies", []) or []:
+        yield "project.dependencies", spec
+    for group, specs in (proj.get("optional-dependencies", {}) or {}).items():
+        for spec in specs or []:
+            yield f"optional-dependencies.{group}", spec
+    for group, specs in (data.get("dependency-groups", {}) or {}).items():
+        for spec in specs or []:
+            if isinstance(spec, str):
+                yield f"dependency-groups.{group}", spec
+
+
+@dataclass
+class Site:
+    manifest: str
+    table: str
+    floor: str | None
+    caps: list[str]
+    raw: str
+
+
+@dataclass
+class DepRecord:
+    name: str
+    sites: list[Site] = field(default_factory=list)
+
+
+def scan(root: Path):
+    deps: dict[str, DepRecord] = {}
+    versions: dict[str, str] = {}
+    manifests: list[str] = []
+    for path, rel in _iter_manifests(root):
+        try:
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+        except (tomllib.TOMLDecodeError, OSError) as exc:
+            print(f"WARN: could not parse {rel}: {exc}", file=sys.stderr)
+            continue
+        manifests.append(rel)
+        proj = data.get("project", {})
+        pname = proj.get("name")
+        pver = proj.get("version")
+        own = _normalize(pname) if pname else None
+        if own and own in FIRST_PARTY and pver:
+            versions[own] = pver
+        for table, spec in _collect_specs(data):
+            pin = _parse_req(spec)
+            if not pin or pin.name not in FIRST_PARTY:
+                continue
+            if pin.name == own:
+                continue  # self-extra reference (e.g. "kailash-ml[dl]")
+            if pin.floor is None and not pin.caps:
+                continue  # plain self/extra bundle with no version constraint
+            rec = deps.setdefault(pin.name, DepRecord(name=pin.name))
+            rec.sites.append(Site(rel, table, pin.floor, pin.caps, pin.raw))
+    return deps, versions, manifests
+
+
+# ---- analysis ------------------------------------------------------------
+
+
+def build_report(root: Path):
+    deps, versions, manifests = scan(root)
+
+    caps_errors = []  # (name, site) — defensive cap on first-party sibling
+    unsatisfiable = []  # (name, current, site) — floor > current in-repo version
+    intra_manifest = []  # (name, manifest, {floor: [sites]})
+    cross_manifest = []  # (name, distinct_floors, sites)  [advisory]
+    stale = []  # (name, current, floor, sites)            [advisory]
+
+    for name in sorted(deps):
+        rec = deps[name]
+        current = versions.get(name)
+
+        # 1. caps on first-party siblings
+        for s in rec.sites:
+            if s.caps:
+                caps_errors.append((name, s))
+
+        # 2. unsatisfiable floor (> current in-repo version)
+        if current:
+            for s in rec.sites:
+                if s.floor and _vgt(s.floor, current):
+                    unsatisfiable.append((name, current, s))
+
+        # group sites by floor (semantic equality collapses 1.1 / 1.1.0)
+        def _floor_group(sites):
+            groups: dict[str, list[Site]] = {}
+            for s in sites:
+                if not s.floor:
+                    continue
+                placed = False
+                for key in groups:
+                    if _veq(key, s.floor):
+                        groups[key].append(s)
+                        placed = True
+                        break
+                if not placed:
+                    groups[s.floor] = [s]
+            return groups
+
+        # 3. intra-manifest drift: same dep, >1 floor within one manifest
+        by_manifest: dict[str, list[Site]] = {}
+        for s in rec.sites:
+            by_manifest.setdefault(s.manifest, []).append(s)
+        for manifest, sites in by_manifest.items():
+            g = _floor_group(sites)
+            if len(g) > 1:
+                intra_manifest.append((name, manifest, g))
+
+        # cross-manifest divergence (advisory)
+        allg = _floor_group(rec.sites)
+        if len(allg) > 1:
+            cross_manifest.append((name, sorted(allg), rec.sites))
+
+        # staleness (advisory): floor far behind current. Group floors
+        # semantically (allg collapses 1.1 / 1.1.0) so equal floors emit once.
+        if current:
+            for fl, sites in allg.items():
+                # "far behind" = different major/minor pair than current
+                if _release_tuple(fl)[:2] != _release_tuple(current)[:2] and not _vgt(
+                    fl, current
+                ):
+                    stale.append((name, current, fl, sites))
+
+    return {
+        "deps": deps,
+        "versions": versions,
+        "manifests": manifests,
+        "caps_errors": caps_errors,
+        "unsatisfiable": unsatisfiable,
+        "intra_manifest": intra_manifest,
+        "cross_manifest": cross_manifest,
+        "stale": stale,
+    }
+
+
+def _print_human(rep) -> int:
+    print(
+        f"Scanned {len(rep['manifests'])} manifests; {len(rep['deps'])} first-party deps pinned.\n"
+    )
+
+    errs = 0
+
+    if rep["caps_errors"]:
+        errs += len(rep["caps_errors"])
+        print(
+            f"❌ ERROR — defensive cap on a first-party sibling ({len(rep['caps_errors'])}):"
+        )
+        print("   (dependencies.md § 'No Caps' / 'No exact pins in library pyproject')")
+        for name, s in rep["caps_errors"]:
+            cur = rep["versions"].get(name)
+            note = "  ← EXCLUDES current!" if cur and _cap_excludes(s.caps, cur) else ""
+            print(
+                f"   • {name} caps={s.caps} (current {cur}){note} — {s.manifest} [{s.table}]  «{s.raw}»"
+            )
+        print()
+
+    if rep["unsatisfiable"]:
+        errs += len(rep["unsatisfiable"])
+        print(
+            f"❌ ERROR — floor exceeds sibling's current version, unsatisfiable ({len(rep['unsatisfiable'])}):"
+        )
+        for name, cur, s in rep["unsatisfiable"]:
+            print(
+                f"   • {name} >={s.floor} but current is {cur} — {s.manifest} [{s.table}]"
+            )
+        print()
+
+    if rep["intra_manifest"]:
+        errs += len(rep["intra_manifest"])
+        print(
+            f"❌ ERROR — same dependency pinned at divergent floors WITHIN one manifest ({len(rep['intra_manifest'])}):"
+        )
+        for name, manifest, groups in rep["intra_manifest"]:
+            print(f"   • {name} in {manifest}: floors {{{', '.join(sorted(groups))}}}")
+            for floor in sorted(groups):
+                for s in groups[floor]:
+                    print(f"       >={floor:<8} [{s.table}]  «{s.raw}»")
+        print()
+
+    if errs == 0:
+        print(
+            "✅ No errors (no caps, no unsatisfiable floors, no intra-manifest drift).\n"
+        )
+
+    # advisory
+    if rep["cross_manifest"]:
+        print(
+            f"ℹ  ADVISORY — cross-manifest floor divergence ({len(rep['cross_manifest'])}):"
+        )
+        print(
+            "   (legitimate per-package feature-usage differences per dependencies.md;"
+        )
+        print("    review whether the lower floors are intentional or just stale)")
+        for name, floors, sites in rep["cross_manifest"]:
+            cur = rep["versions"].get(name)
+            print(f"   • {name} (current {cur}) — floors {{{', '.join(floors)}}}")
+            for s in sites:
+                if s.floor:
+                    print(f"       >={s.floor:<8} {s.manifest} [{s.table}]")
+        print()
+
+    if rep["stale"]:
+        seen = set()
+        rows = []
+        for name, cur, floor, sites in rep["stale"]:
+            for s in sites:
+                k = (name, floor, s.manifest, s.table)
+                if k in seen:
+                    continue
+                seen.add(k)
+                rows.append((name, cur, floor, s))
+        if rows:
+            print(
+                f"ℹ  ADVISORY — floor far behind sibling's current version ({len(rows)}):"
+            )
+            for name, cur, floor, s in rows:
+                print(
+                    f"   • {name} >={floor} (current {cur}) — {s.manifest} [{s.table}]"
+                )
+            print()
+
+    return errs
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Detect first-party pin drift (#1183).")
+    ap.add_argument("--root", default=".", help="repo root (default: cwd)")
+    ap.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    ap.add_argument(
+        "--strict-advisory",
+        action="store_true",
+        help="also exit non-zero on advisory findings",
+    )
+    args = ap.parse_args(argv)
+    root = Path(args.root).resolve()
+    rep = build_report(root)
+
+    n_err = (
+        len(rep["caps_errors"]) + len(rep["unsatisfiable"]) + len(rep["intra_manifest"])
+    )
+    n_adv = len(rep["cross_manifest"]) + len(rep["stale"])
+
+    if args.json:
+        out = {
+            "manifests_scanned": len(rep["manifests"]),
+            "first_party_deps": len(rep["deps"]),
+            "errors": {
+                "caps": [
+                    {
+                        "name": n,
+                        "caps": s.caps,
+                        "manifest": s.manifest,
+                        "table": s.table,
+                        "raw": s.raw,
+                    }
+                    for n, s in rep["caps_errors"]
+                ],
+                "unsatisfiable": [
+                    {
+                        "name": n,
+                        "floor": s.floor,
+                        "current": cur,
+                        "manifest": s.manifest,
+                        "table": s.table,
+                    }
+                    for n, cur, s in rep["unsatisfiable"]
+                ],
+                "intra_manifest": [
+                    {"name": n, "manifest": m, "floors": sorted(g)}
+                    for n, m, g in rep["intra_manifest"]
+                ],
+            },
+            "advisory": {
+                "cross_manifest": [
+                    {"name": n, "current": rep["versions"].get(n), "floors": fl}
+                    for n, fl, _ in rep["cross_manifest"]
+                ],
+                "stale": [
+                    {"name": n, "current": cur, "floor": fl, "manifest": s.manifest}
+                    for n, cur, fl, sites in rep["stale"]
+                    for s in sites
+                ],
+            },
+            "error_count": n_err,
+            "advisory_count": n_adv,
+            "ok": n_err == 0,
+        }
+        print(json.dumps(out, indent=2))
+    else:
+        _print_human(rep)
+        print(f"Summary: {n_err} error(s), {n_adv} advisory finding(s).")
+
+    if n_err > 0:
+        return 1
+    if args.strict_advisory and n_adv > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workspaces/issue-1183-pin-source-of-truth/02-plans/findings-and-design.md
+++ b/workspaces/issue-1183-pin-source-of-truth/02-plans/findings-and-design.md
@@ -1,0 +1,85 @@
+# #1183 — Dependency version-pin source-of-truth: findings + design
+
+**Date:** 2026-06-07
+**Issue:** #1183 (design — "single source of truth for dependency version-pin sourcing")
+**Phase:** analyze → implement (detector) ; recommend+gate (pyproject fixes)
+
+## Context — why this is the session's pick
+
+The standing forest from the prior session is fully shipped (F32 ml-docs #1277/#1278;
+nexus #1174 → 2.8.0; nexus parity #1216/#1217/#1218 → 2.28.4/2.9.0; from_brief #1125 →
+2.27.0; dataflow tenant #1249/#1252 → 2.11.x; encoder #1258/#1269; #772). Of the 4 open
+GH issues, 3 are genuinely blocked: #630 (Foundation mint ISS-37), #1086 (loom-side COC
+hooks), #693 (M2-blocked — verified kailash-ml 0.9.0 has no public `@feature`/`FeatureGroup`).
+**#1183 is the single unblocked, in-scope item** — and the documented root cause of the
+recurring `uv.lock`/pin drift the sweeps keep flagging.
+
+## What #1183 actually asks (reconciled with `rules/dependencies.md`)
+
+The naive reading — "one canonical floor for every dependency" — is WRONG and would
+violate `dependencies.md`: floors (`>=X.Y`) are _expected_ to reflect each package's actual
+feature usage, so the same dep legitimately CAN carry different floors across packages. The
+real problems are (a) **silent** drift, (b) **defensive caps** on first-party siblings, and
+(c) **intra-manifest** inconsistency. The fix is to make those _loud_, not to homogenize.
+
+## Deliverable A — `tools/check_pin_consistency.py` (the source-of-truth enforcer)
+
+A read-only, stdlib-first detector that scans all 9 first-party `pyproject.toml` manifests
+and classifies pins, aligned with `dependencies.md`:
+
+- **ERROR (exit 1):**
+  1. Defensive upper cap (`<`/`<=`/`==`/`!=`) on a first-party `kailash*` sibling.
+  2. Floor exceeding that sibling's current in-repo version (unsatisfiable in-workspace).
+  3. Same dep at semantically-distinct floors **within one manifest**.
+- **ADVISORY (exit 0):** cross-manifest floor divergence (legitimate per-package); floors
+  far behind the sibling's current version (staleness — a feature-usage judgment).
+- `--strict-advisory` escalates advisories to exit 1; `--json` for machine output.
+
+Verified by `tests/unit/tools/test_check_pin_consistency.py` (8 tests, all pass) covering
+every verdict class incl. `>=1.1`==`>=1.1.0` semantic equality and self-extra exclusion.
+
+## Findings on current `main` (3 errors, 25 advisories)
+
+### ERROR 1 (live resolution break) — `kailash-align` caps out the current ml
+
+`packages/kailash-align/pyproject.toml [optional-dependencies.rl-bridge]`:
+`kailash-ml[rl]>=1.1,<2.0` — the `<2.0` cap **excludes the current kailash-ml 2.0.0**.
+
+- Origin: commit `4fe9eea87` ("wip(W30.2): bump kailash-align 0.5.0 + [rl-bridge] extra") —
+  added defensively when ml was 1.x, speculatively excluding the then-unreleased 2.0 major.
+- Compat probe (live, against installed ml 2.0.0): all 9 `kailash_ml.rl.*` symbols align's
+  rl-bridge late-imports are present, and `import kailash_align.rl_bridge` succeeds. The cap
+  excludes a working version.
+- **Recommended fix:** drop the cap → `kailash-ml[rl]>=1.1` (per `dependencies.md` § "No
+  Caps"). **Gate:** published-contract change to kailash-align → needs (a) align rl-bridge
+  test suite run against ml 2.0.0 for behavioral (not just import) confidence, (b) align
+  version bump + release (user's gate per BUILD-repo discipline).
+
+### ERROR 2 — `kailash-ml` intra-manifest drift on `kailash-kaizen`
+
+`packages/kailash-ml/pyproject.toml`: `kailash-kaizen>=2.7` (kaizen-judges, kaizen-observability)
+vs `>=2.7.5` (agents). **Recommended fix:** align all three to `>=2.7.5`. Low risk.
+
+### ERROR 3 — `kailash-align` intra-manifest drift on `kailash-ml`
+
+`packages/kailash-align/pyproject.toml`: `kailash-ml>=0.11.0` (core deps — very stale; ml
+is 2.0.0) vs `kailash-ml[rl]>=1.1` (rl-bridge, post-cap-removal). **Recommended fix:** raise
+the core floor to match actual feature usage (≥1.1; confirm with align owner).
+
+### Advisories (25) — not auto-fixed
+
+Cross-manifest floor divergence (legitimate) + staleness. Notable: `kailash` core floored at
+4 values (2.14.0/2.16.0/2.28.0/2.28.4) while core is 2.29.3; several siblings floored 1–2
+minors behind. These are feature-usage judgments, surfaced for review, not errors.
+
+## Deliverable B (recommended, GATED) — wire the detector into the drift gate
+
+To make drift loud _going forward_, wire `check_pin_consistency.py` into either a local
+pre-commit hook or CI. **Not auto-created** per the standing "never auto-create CI workflows
+without asking" directive — recommend + cost-gate to the user.
+
+## Disposition summary
+
+- **DONE (converged):** detector + 8-test suite (this session's autonomous deliverable).
+- **GATED on user (published-contract + release):** the 3 ERROR fixes + the CI/pre-commit
+  wiring. Each carries a specific recommended value + evidence above.

--- a/workspaces/issue-1183-pin-source-of-truth/journal/0001-DISCOVERY-forest-drained-1183-pin-detector-converged.md
+++ b/workspaces/issue-1183-pin-source-of-truth/journal/0001-DISCOVERY-forest-drained-1183-pin-detector-converged.md
@@ -1,0 +1,90 @@
+---
+type: DISCOVERY
+date: 2026-06-07
+project: kailash-py
+topic: "Forest drained to #1183; pin-drift detector built + converged"
+phase: analyze/implement/redteam
+tags: [dependencies, pin-drift, issue-1183, tooling, redteam]
+---
+
+# 0001 — DISCOVERY: forest drained to #1183; pin-drift detector converged
+
+## Forest reconciliation (the session's first finding)
+
+Continuing from F32 (ml-docs, #1277/#1278 merged), I reconciled every outstanding
+thread against live GH + git state. **The entire standing forest has shipped:**
+
+- F32 ml-docs → #1277/#1278 (merged); nexus #1174 → 2.8.0; nexus parity
+  #1216/#1217/#1218 → kailash 2.28.4 + nexus 2.9.0 (`c767aea21`/`9070ecf3f`);
+  from_brief #1125 → 2.27.0; dataflow tenant #1249/#1252 → 2.11.0/2.11.1
+  (`c823a0ab7`/`d03665aa2`); encoder #1258/#1269; #772. The tenant + parity
+  workspaces were completed-but-uncleaned (stale journals), NOT in-flight.
+- Of 4 open GH issues, 3 are genuinely blocked: #630 (Foundation mint ISS-37),
+  #1086 (loom-side COC hooks), **#693 (M2-blocked — verified: kailash-ml 0.9.0
+  exposes only internal `SchemaFeatureGroup`, no public `@feature`/`FeatureGroup`)**.
+- **#1183 is the single unblocked, in-scope item** — the root cause of the
+  recurring `uv.lock`/pin drift the sweeps repeatedly flag.
+
+## #1183 — built the source-of-truth enforcer (not floor homogenization)
+
+Reconciled with `rules/dependencies.md`: per-package floors legitimately differ
+(feature usage), so the fix is to make drift LOUD, not identical. Built
+`tools/check_pin_consistency.py` + `tests/unit/tools/test_check_pin_consistency.py`
+(8 tests). ERROR = caps on first-party siblings / unsatisfiable floors /
+intra-manifest drift; ADVISORY = cross-manifest divergence + staleness.
+
+### Real findings on `main` (3 errors)
+
+1. **Live resolution break:** `kailash-align` rl-bridge `kailash-ml[rl]>=1.1,<2.0`
+   caps out the current ml 2.0.0. Cap origin `4fe9eea87` (defensive, pre-2.0).
+   Live compat probe: all 9 `kailash_ml.rl.*` symbols align imports are present in
+   ml 2.0.0 + `import kailash_align.rl_bridge` succeeds → the cap excludes a working
+   version. (Behavioral major-version compat = align test-suite run; gated.)
+2. `kailash-ml` intra-manifest: `kailash-kaizen` at `>=2.7` vs `>=2.7.5`.
+3. `kailash-align` intra-manifest: `kailash-ml` at `>=0.11.0` (stale) vs `>=1.1`.
+
+## Redteam → CONVERGED
+
+- **Convergence receipt:** reviewer agent task `ade5cdbfa6c3e1607` — verdict
+  **APPROVE**. Ran both mechanical sweeps (8 tests pass; tool reports 3 errors +
+  advisories, exit 1), independently probed ~30 PEP 508 forms (env markers, extras,
+  epoch/local versions, URL refs, `~=`, multi-constraint) + the `packaging`-absent
+  fallback. 0 CRITICAL/HIGH/MEDIUM. 3 LOW (cosmetic).
+- **3 LOW fixed in-shard** (autonomous-execution MUST Rule 4): staleness
+  double-count (semantic floor grouping), `<=` branch in `_cap_excludes`, `===`
+  confirmed already-correct. Re-ran: 8 tests pass, errors still 3, advisory 25→24.
+
+## Disposition
+
+- **DONE / converged:** detector + test suite (additive, untracked; no commits —
+  BUILD repo).
+- **GATED on user (published-contract + release):** the 3 pyproject ERROR fixes +
+  wiring the detector into pre-commit/CI (per the no-auto-CI directive). Specific
+  recommended values + evidence in `02-plans/findings-and-design.md`.
+
+## Completion (2026-06-08, user-approved "please complete")
+
+All 3 ERROR fixes applied in the working tree (BUILD repo — commit/release stays
+with user) + verified:
+
+- align `kailash-ml[rl]>=1.1,<2.0` → `>=1.1` (cap dropped); align core
+  `kailash-ml>=0.11.0` → `>=1.1`; ml `kailash-kaizen>=2.7` → `>=2.7.5` (×2).
+- Behavioral compat gate: **align rl-bridge suite 74 passed against ml 2.0.0**
+  (not just import-surface) — cap removal verified safe.
+- Detector now reports **0 errors** (21 advisories remain — legitimate per-package
+  divergence/staleness, non-failing).
+- Pre-commit hook `check-pin-consistency` added to `.pre-commit-config.yaml`
+  (scoped to pyproject/tool changes); `pre-commit run --all-files` → Passed.
+- Floor values (`>=1.1`, `>=2.7.5`) are PyPI-resolvable per `deployment.md`
+  § "Optional Dependencies Pin to PyPI-Resolvable Versions".
+
+**Release scope (per build-repo-release-discipline):** the align + ml pyproject
+floor edits are consumer-visible → committing them requires version bumps +
+`/release` of kailash-align + kailash-ml (user-authorized structural gate). The
+tooling (`tools/`, `.pre-commit-config.yaml`) is not wheel-packaged → no release.
+
+## Receipts
+
+- `tools/check_pin_consistency.py`, `tests/unit/tools/test_check_pin_consistency.py`
+- Reviewer convergence: agent task `ade5cdbfa6c3e1607` (APPROVE).
+- Compat probe: 9/9 `kailash_ml.rl.*` symbols present in ml 2.0.0; rl_bridge imports OK.


### PR DESCRIPTION
## Summary

The monorepo declared first-party dependency floors across 9 `pyproject.toml` manifests with **no canonical source**, so drift was silent (the recurring `uv.lock`/pin-drift the sweeps keep flagging). A scan surfaced a **live resolution break** plus two intra-manifest inconsistencies, and adds a permanent CI-able gate.

## Fixes (3 real errors)

- **kailash-align `0.7.1 → 0.7.2`:** `[rl-bridge]` extra `kailash-ml[rl]>=1.1,**<2.0**` → `>=1.1`. The `<2.0` defensive cap **excluded the current kailash-ml 2.0.0** — a live resolution break per `dependencies.md` § "No Caps". Core dep `kailash-ml>=0.11.0` → `>=1.1` (stale + intra-manifest-inconsistent). **Verified safe:** all 9 `kailash_ml.rl.*` symbols align imports exist in ml 2.0.0; the rl-bridge suite (74 tests) passes against it.
- **kailash-ml `2.0.0 → 2.0.1`:** `[kaizen-judges]` / `[kaizen-observability]` extras `kailash-kaizen>=2.7` → `>=2.7.5` (consistent floor; also pins past the known-bad kaizen 2.7.0–2.7.4 `ModuleNotFoundError` class).

## New tooling

- `tools/check_pin_consistency.py` + 8 unit tests — a `dependencies.md`-aligned drift gate. **Errors:** defensive caps on first-party siblings, unsatisfiable floors, intra-manifest drift. **Advisory (non-failing):** cross-manifest divergence (legitimately per-package) + staleness.
- Wired as a read-only pre-commit hook (`check-pin-consistency`).

## Verification

- Detector: 0 errors after fixes (was 3). · Detector unit tests: 8 passed.
- align full suite: 481 passed / 1 skipped. · align rl-bridge vs ml 2.0.0: 74 passed.
- Both packages import at the new versions. Floors are PyPI-resolvable.
- Reviewer (detector): APPROVE. Security-reviewer (pre-release): APPROVE (no CRIT/HIGH).
- No source or public-API changes in either package; wheel content identical except `__version__`.

## Related issues

Fixes #1183

🤖 Generated with [Claude Code](https://claude.com/claude-code)