### PR TITLE
fix(tools): pin-drift gate misses ~= and > caps on first-party siblings (#1183)

### DIFF
--- a/tests/unit/tools/test_check_pin_consistency.py
+++ b/tests/unit/tools/test_check_pin_consistency.py
@@ -195,6 +195,83 @@ def test_semantically_equal_floors_not_flagged(tmp_path: Path):
     assert "kailash-ml" not in intra  # 1.1 == 1.1.0, no drift
 
 
+def test_tilde_compatible_release_is_cap_error(tmp_path: Path):
+    # `~=2.7.5` means `>=2.7.5,<2.8` — the implicit upper bound is a cap on a
+    # first-party sibling that EXCLUDES the current 2.24.5. The detector MUST
+    # flag it as an ERROR, not wave it through as a bare floor. Regression for
+    # the #1183 redteam: PEP 440 compatible-release was mis-parsed as a pure
+    # floor, so a live `~=` resolution break passed the gate with exit 0.
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    _write(
+        tmp_path,
+        "packages/kailash-kaizen/pyproject.toml",
+        _root_manifest("kailash-kaizen", "2.24.5", ["kailash>=1.0"]),
+    )
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest(
+            "kailash-ml",
+            "2.0.0",
+            ["kailash>=1.0", "kailash-kaizen~=2.7.5"],
+        ),
+    )
+    rep = mod.build_report(tmp_path)
+    caps = {n for n, _ in rep["caps_errors"]}
+    assert "kailash-kaizen" in caps
+    kz_sites = [s for n, s in rep["caps_errors"] if n == "kailash-kaizen"]
+    assert kz_sites and kz_sites[0].caps == ["<2.8"]
+    assert mod._cap_excludes(kz_sites[0].caps, "2.24.5") is True
+    assert mod.main(["--root", str(tmp_path)]) == 1
+
+
+def test_tilde_floor_still_recorded(tmp_path: Path):
+    # The `~=` lower bound MUST still be tracked as a floor so the
+    # unsatisfiable / cross-manifest / staleness logic keeps working; adding
+    # the synthesized cap must not drop the floor.
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest("kailash-ml", "2.0.0", ["kailash~=1.0"]),
+    )
+    rep = mod.build_report(tmp_path)
+    site = rep["deps"]["kailash"].sites[0]
+    assert site.floor == "1.0"
+    assert site.caps == ["<2"]  # ~=1.0 -> >=1.0,<2
+
+
+def test_strict_gt_floor_is_tracked_and_can_be_unsatisfiable(tmp_path: Path):
+    # `kailash-kaizen>3.0` is a strict lower bound. Before the fix, `>` matched
+    # no parse branch, the dep vanished from the report, and an unsatisfiable
+    # floor (>3.0 against in-repo 2.0.0) passed the gate silently. Regression
+    # for the #1183 round-2 redteam (same false-negative class as `~=`).
+    _write(tmp_path, "pyproject.toml", _root_manifest("kailash", "1.0.0", []))
+    _write(
+        tmp_path,
+        "packages/kailash-kaizen/pyproject.toml",
+        _root_manifest("kailash-kaizen", "2.0.0", ["kailash>=1.0"]),
+    )
+    _write(
+        tmp_path,
+        "packages/kailash-ml/pyproject.toml",
+        _root_manifest("kailash-ml", "2.0.0", ["kailash>=1.0", "kailash-kaizen>3.0"]),
+    )
+    rep = mod.build_report(tmp_path)
+    assert "kailash-kaizen" in rep["deps"]  # no longer dropped
+    assert rep["deps"]["kailash-kaizen"].sites[0].floor == "3.0"
+    names = {n for n, _, _ in rep["unsatisfiable"]}
+    assert "kailash-kaizen" in names  # >3.0 exceeds in-repo 2.0.0
+    assert mod.main(["--root", str(tmp_path)]) == 1
+
+
+def test_tilde_upper_helper():
+    assert mod._tilde_upper("2.7.5") == "2.8"
+    assert mod._tilde_upper("2.7") == "3"
+    assert mod._tilde_upper("1.0.0") == "1.1"
+    assert mod._tilde_upper("2") is None  # invalid PEP 440 ~=, no cap to synthesize
+
+
 def test_version_equality_helper():
     assert mod._veq("1.1", "1.1.0") is True
     assert mod._veq("2.0", "2.0.0") is True

--- a/tools/check_pin_consistency.py
+++ b/tools/check_pin_consistency.py
@@ -128,6 +128,27 @@ def _cap_excludes(caps: list[str], current: str) -> bool:
     return False
 
 
+def _tilde_upper(ver: str) -> str | None:
+    """Exclusive upper bound for a PEP 440 ``~=`` compatible-release specifier.
+
+    ``~=2.7.5`` -> ``"2.8"`` (i.e. ``>=2.7.5,<2.8``); ``~=2.7`` -> ``"3"``
+    (``>=2.7,<3``). Returns ``None`` when fewer than two numeric release
+    components are present (``~=2`` is not a valid PEP 440 specifier, so there
+    is no compatible-release cap to synthesise).
+    """
+    rel: list[int] = []
+    for chunk in re.split(r"[.+!-]", ver):
+        if chunk.isdigit():
+            rel.append(int(chunk))
+        else:
+            break
+    if len(rel) < 2:
+        return None
+    rel = rel[:-1]
+    rel[-1] += 1
+    return ".".join(str(p) for p in rel)
+
+
 def _normalize(name: str) -> str:
     return re.sub(r"[-_.]+", "-", name).lower()
 
@@ -157,8 +178,21 @@ def _parse_req(spec: str) -> Pin | None:
     floor = None
     caps: list[str] = []
     for op, ver in _SPEC_RE.findall(m.group("rest") or ""):
-        if op in (">=", "~="):
+        if op in (">=", ">"):
+            # `>` is a strict lower bound; treat it as a floor for drift checks
+            # (an unsatisfiable `kailash-ml>3.0` against an in-repo 2.0.0 is the
+            # same resolution break a `>=3.0` floor would be). Without this, `>`
+            # is parsed into no branch and the dep vanishes from the report.
             floor = ver  # lower bound
+        elif op == "~=":
+            # PEP 440 compatible-release: a lower bound AND an implicit upper
+            # cap (`~=2.7.5` == `>=2.7.5,<2.8`). The cap on a first-party
+            # sibling is exactly what dependencies.md § "No Caps" forbids, so
+            # it MUST be recorded as a cap — not waved through as a bare floor.
+            floor = ver
+            upper = _tilde_upper(ver)
+            if upper:
+                caps.append(f"<{upper}")
         elif op == "==" and "*" not in ver:
             # exact pin acts as both floor and cap
             floor = ver


### PR DESCRIPTION
## Summary

`/redteam` of the #1183 pin-drift detector (`tools/check_pin_consistency.py`, shipped in #1279) surfaced two **false-negatives of the same class** — the gate's core purpose is catching caps/unsatisfiable floors on first-party siblings, and two valid PEP 440 operator forms slipped through as `exit 0`:

1. **`~=` compatible-release parsed as a bare floor.** `kailash-ml~=2.7.5` means `>=2.7.5,<2.8`; the implicit `<2.8` cap (which excludes a current 2.24.5) was waved through as a mere staleness advisory.
2. **Strict `>` dropped entirely.** `>` matched no parse branch, so the dependency vanished from the report — an unsatisfiable `kailash-ml>3.0` against an in-repo 2.0.0 passed silently.

## Fix

- New `_tilde_upper()` synthesizes the exclusive upper bound; `~=` now records floor **and** `<upper` cap.
- `>` is treated as a floor (strict lower bound) for drift checks.
- Round-3 operator-coverage probe confirms all 9 PEP 440 operators + `==X.*` now route to a floor and/or cap; none is silently dropped.

## Verification

- 12/12 detector tests green (8 prior + **4 new regression tests**).
- Live gate unchanged: `exit 0`, 21 advisories.
- The `~=` fixture that previously passed now correctly fails (`exit 1`, "← EXCLUDES current!").

## Related issues

Follow-up to #1183 / #1279 (the gate this hardens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)