### PR TITLE
fix(mcp): document + pin non-ASCII byte-vectors for the 4 MCP canonical encoders (#1258)

### DIFF
--- a/packages/kailash-mcp/src/kailash_mcp/protocol/messages.py
+++ b/packages/kailash-mcp/src/kailash_mcp/protocol/messages.py
@@ -9,13 +9,30 @@ byte-identical canonical JSON for the same logical input per EATP D6.
 
 The canonical form used for cross-SDK round-trip comparison is:
 
-- Keys sorted alphabetically
+- Keys sorted by Unicode code point (``sort_keys=True``)
 - No insignificant whitespace (``separators=(",", ":")``)
+- ``ensure_ascii=False`` -> RAW UTF-8 output (non-ASCII characters are
+  emitted as their literal UTF-8 bytes, NOT ``\\uXXXX`` escapes). This
+  matches ``serde_json``'s default ``to_string`` byte form on the Rust
+  side, so both SDKs produce byte-identical canonical JSON. It is the
+  SAME raw-UTF-8 contract as the delegate encoder
+  (``tests/test-vectors/delegate-canonical.json``) and the OPPOSITE of
+  the trust-plane signing encoder ``serialize_for_signing``
+  (``ensure_ascii=True`` / ASCII-escaped; issue #1258).
+- NO Unicode normalization: an NFC pre-image (``U+00E9``) and its NFD
+  decomposition (``U+0065 U+0301``) serialize to byte-distinct canonical
+  forms. A future normalization step would silently change every existing
+  pre-image, so it is forbidden.
 - ``null`` for explicitly-absent fields (NOT omitted) only where the
   protocol spec requires it; optional fields with ``None`` value are
   omitted from the serialized output
 - Integer error codes as JSON numbers (no string coercion)
 - ``strict=True`` parsing rejects duplicate keys / BOMs / trailing commas
+
+The non-ASCII byte-vectors for all four message types are pinned in
+``tests/test-vectors/mcp-messages-canonical.json`` (issue #1258 follow-up,
+per ``cross-sdk-inspection.md`` Rule 4); the Rust counterpart vendors that
+fixture per Rule 4a.
 
 Classes
 -------
@@ -132,7 +149,13 @@ class JsonRpcError:
         )
 
     def to_canonical_json(self) -> str:
-        """Deterministic JSON (sorted keys, no whitespace) for cross-SDK use."""
+        """Canonical JSON for cross-SDK use (issue #1258).
+
+        ``sort_keys=True`` + ``separators=(",", ":")`` + ``ensure_ascii=False``
+        (raw UTF-8, matching ``serde_json``'s default ``to_string``; no Unicode
+        normalization). See the module docstring for the full byte contract and
+        ``tests/test-vectors/mcp-messages-canonical.json`` for pinned vectors.
+        """
         return json.dumps(
             self.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=False
         )
@@ -252,7 +275,13 @@ class JsonRpcRequest:
         )
 
     def to_canonical_json(self) -> str:
-        """Canonical JSON (sorted keys, no whitespace) per SPEC-09 §2.1."""
+        """Canonical JSON per SPEC-09 §2.1 (issue #1258).
+
+        ``sort_keys=True`` + ``separators=(",", ":")`` + ``ensure_ascii=False``
+        (raw UTF-8, matching ``serde_json``'s default ``to_string``; no Unicode
+        normalization). See the module docstring for the full byte contract and
+        ``tests/test-vectors/mcp-messages-canonical.json`` for pinned vectors.
+        """
         return json.dumps(
             self.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=False
         )
@@ -381,7 +410,13 @@ class JsonRpcResponse:
         )
 
     def to_canonical_json(self) -> str:
-        """Canonical JSON (sorted keys, no whitespace) per SPEC-09 §2.1."""
+        """Canonical JSON per SPEC-09 §2.1 (issue #1258).
+
+        ``sort_keys=True`` + ``separators=(",", ":")`` + ``ensure_ascii=False``
+        (raw UTF-8, matching ``serde_json``'s default ``to_string``; no Unicode
+        normalization). See the module docstring for the full byte contract and
+        ``tests/test-vectors/mcp-messages-canonical.json`` for pinned vectors.
+        """
         return json.dumps(
             self.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=False
         )
@@ -471,7 +506,13 @@ class McpToolInfo:
         )
 
     def to_canonical_json(self) -> str:
-        """Canonical JSON (sorted keys, no whitespace) for cross-SDK use."""
+        """Canonical JSON for cross-SDK use (issue #1258).
+
+        ``sort_keys=True`` + ``separators=(",", ":")`` + ``ensure_ascii=False``
+        (raw UTF-8, matching ``serde_json``'s default ``to_string``; no Unicode
+        normalization). See the module docstring for the full byte contract and
+        ``tests/test-vectors/mcp-messages-canonical.json`` for pinned vectors.
+        """
         return json.dumps(
             self.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=False
         )

--- a/packages/kailash-mcp/tests/regression/test_issue_1258_mcp_canonical_parity.py
+++ b/packages/kailash-mcp/tests/regression/test_issue_1258_mcp_canonical_parity.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for #1258 (follow-up) - the four MCP protocol-message
+canonical-JSON encoders.
+
+``kailash_mcp.protocol.messages`` ships FOUR ``to_canonical_json`` encoders
+(``JsonRpcError`` / ``JsonRpcRequest`` / ``JsonRpcResponse`` / ``McpToolInfo``),
+each emitting the cross-SDK canonical wire form per SPEC-01 §7 / SPEC-09 §2.1.
+All four use ``json.dumps(..., sort_keys=True, separators=(",", ":"),
+ensure_ascii=False)`` -> RAW UTF-8 output, matching ``serde_json``'s default
+``to_string`` on the Rust side so both SDKs produce byte-identical canonical
+JSON.
+
+This is the MCP-package counterpart to the trust-layer encoder pins in
+``tests/regression/test_issue_1258_canonical_encoder_parity.py`` (PR #1269,
+which covered ``canonical_json_dumps`` + ``serialize_for_signing``). Issue #1258
+explicitly carved the 4th-encoder family (MCP) into a separate shard because it
+lives in a separate package / spec / Rust counterpart.
+
+This module pins:
+
+1. The byte contract via the vendored fixture
+   ``tests/test-vectors/mcp-messages-canonical.json`` (every vector's RAW-UTF-8
+   canonical bytes + SHA-256 reproduce via ``<type>.from_dict(...).
+   to_canonical_json()``). The sibling kailash-rs ``serde_json`` path consumes
+   the same file per ``cross-sdk-inspection.md`` Rule 4a.
+2. The no-Unicode-normalization invariant (NFC != NFD) - M3 vs M4.
+3. The ``ensure_ascii=False`` raw-UTF-8 contract for ALL FOUR encoders - a
+   behavioral guard that fails loudly if a future edit flips any encoder to
+   ASCII-escaped output (which would break byte-parity with serde_json). This
+   is the disposition for #1258 acceptance criterion 3: do NOT unify / do NOT
+   flip ``ensure_ascii``.
+4. Round-trip stability: ``from_canonical_json`` parses the pinned bytes back
+   and re-serializes to the identical canonical form.
+
+These are BEHAVIORAL pins (call the encoder, assert the bytes) - not
+source-greps - per ``rules/testing.md`` "Behavioral Regression Tests Over
+Source-Grep".
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from pathlib import Path
+
+import pytest
+from kailash_mcp.protocol.messages import (
+    JsonRpcError,
+    JsonRpcRequest,
+    JsonRpcResponse,
+    McpToolInfo,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1] / "test-vectors" / "mcp-messages-canonical.json"
+)
+
+# Map the fixture's ``type`` discriminator to the concrete class so each vector
+# is reconstructed via the same from_dict -> to_canonical_json surface a
+# cross-SDK consumer uses.
+_TYPES = {
+    "JsonRpcError": JsonRpcError,
+    "JsonRpcRequest": JsonRpcRequest,
+    "JsonRpcResponse": JsonRpcResponse,
+    "McpToolInfo": McpToolInfo,
+}
+
+
+def _sha256_hex(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def _canonical_from_vector(vector: dict) -> str:
+    cls = _TYPES[vector["type"]]
+    obj = cls.from_dict(vector["input_wire"])
+    return obj.to_canonical_json()
+
+
+@pytest.mark.regression
+class TestMcpCanonicalFixtureParity:
+    """Iterate ``tests/test-vectors/mcp-messages-canonical.json`` and assert
+    every vector's pinned RAW-UTF-8 canonical bytes / SHA-256 reproduce."""
+
+    @pytest.fixture(scope="class")
+    def fixture(self) -> dict:
+        assert _FIXTURE_PATH.exists(), (
+            f"cross-SDK MCP canonical fixture missing at {_FIXTURE_PATH}; "
+            "this fixture is the cross-SDK byte contract per issue #1258"
+        )
+        return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    def test_fixture_contract_and_floor(self, fixture: dict) -> None:
+        assert fixture["contract"] == "mcp-messages-canonical-bytes"
+        # >=3 non-ASCII byte-vectors + sentinel per cross-sdk-inspection.md
+        # Rule 4.
+        assert len(fixture["vectors"]) >= 6
+        non_ascii = [
+            v for v in fixture["vectors"] if not v["expected_canonical_json"].isascii()
+        ]
+        assert len(non_ascii) >= 3, "need >=3 non-ASCII byte-vectors"
+
+    def test_all_four_encoders_covered(self, fixture: dict) -> None:
+        """Every one of the four ``to_canonical_json`` encoders MUST have at
+        least one pinned vector (the orphan-coverage guard for this family)."""
+        covered = {v["type"] for v in fixture["vectors"]}
+        assert covered == set(_TYPES), (
+            f"fixture covers {sorted(covered)}; "
+            f"missing {sorted(set(_TYPES) - covered)}"
+        )
+
+    def test_every_vector_canonical_json_byte_equal(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            actual = _canonical_from_vector(v)
+            assert actual == v["expected_canonical_json"], (
+                f"vector {v['name']}: canonical-bytes divergence - "
+                f"got {actual!r}, expected {v['expected_canonical_json']!r}"
+            )
+
+    def test_every_vector_sha256_matches(self, fixture: dict) -> None:
+        for v in fixture["vectors"]:
+            actual = _sha256_hex(_canonical_from_vector(v))
+            assert actual == v["expected_sha256"], (
+                f"vector {v['name']}: SHA-256 divergence - "
+                f"got {actual}, expected {v['expected_sha256']}"
+            )
+
+    def test_nfc_and_nfd_vectors_are_byte_distinct(self, fixture: dict) -> None:
+        """The encoders do NOT Unicode-normalize: the NFC and NFD vectors MUST
+        pin DIFFERENT canonical bytes / SHA-256 (else a future normalization
+        refactor would silently change every existing pre-image)."""
+        by_name = {v["name"]: v for v in fixture["vectors"]}
+        nfc = by_name["M3_request_nfc_composed"]
+        nfd = by_name["M4_request_nfd_decomposed"]
+        assert nfc["expected_canonical_json"] != nfd["expected_canonical_json"]
+        assert nfc["expected_sha256"] != nfd["expected_sha256"]
+        # And the encoder reproduces the distinction live.
+        assert _canonical_from_vector(nfc) != _canonical_from_vector(nfd)
+
+    def test_round_trip_through_from_canonical_json(self, fixture: dict) -> None:
+        """``from_canonical_json`` parses the pinned bytes and re-serializes to
+        the identical canonical form (parse/emit stability)."""
+        for v in fixture["vectors"]:
+            cls = _TYPES[v["type"]]
+            obj = cls.from_canonical_json(v["expected_canonical_json"])
+            assert (
+                obj.to_canonical_json() == v["expected_canonical_json"]
+            ), f"vector {v['name']}: round-trip divergence"
+
+
+@pytest.mark.regression
+class TestMcpEncodersRawUtf8Contract:
+    """Behavioral guard for issue #1258 acceptance criterion 3: ALL FOUR MCP
+    encoders MUST keep ``ensure_ascii=False`` (raw UTF-8). A future edit that
+    flips any encoder to ASCII-escaped output would break byte-parity with the
+    Rust ``serde_json`` default and MUST fail here loudly."""
+
+    _CJK = "漢字"  # BMP CJK; raw UTF-8 must appear, never \\u escapes
+
+    def test_jsonrpc_error_raw_utf8(self) -> None:
+        out = JsonRpcError(code=-32000, message=self._CJK).to_canonical_json()
+        assert self._CJK in out
+        assert "\\u" not in out
+
+    def test_jsonrpc_request_raw_utf8(self) -> None:
+        out = JsonRpcRequest(
+            method="notify", params={"name": self._CJK}, id=1
+        ).to_canonical_json()
+        assert self._CJK in out
+        assert "\\u" not in out
+
+    def test_jsonrpc_response_raw_utf8(self) -> None:
+        out = JsonRpcResponse(id=1, result={"flag": self._CJK}).to_canonical_json()
+        assert self._CJK in out
+        assert "\\u" not in out
+
+    def test_mcp_tool_info_raw_utf8(self) -> None:
+        out = McpToolInfo(
+            name="t", description=self._CJK, input_schema={"k": self._CJK}
+        ).to_canonical_json()
+        assert self._CJK in out
+        assert "\\u" not in out
+
+    def test_no_unicode_normalization_in_encoder(self) -> None:
+        """An NFC pre-image and its NFD decomposition MUST serialize to
+        byte-distinct canonical forms through the live encoder (no
+        normalization step)."""
+        nfc = unicodedata.normalize("NFC", "é")
+        nfd = unicodedata.normalize("NFD", "é")
+        assert nfc != nfd  # distinct by construction
+        out_nfc = JsonRpcError(code=-32000, message=nfc).to_canonical_json()
+        out_nfd = JsonRpcError(code=-32000, message=nfd).to_canonical_json()
+        assert out_nfc != out_nfd

--- a/packages/kailash-mcp/tests/test-vectors/mcp-messages-canonical.json
+++ b/packages/kailash-mcp/tests/test-vectors/mcp-messages-canonical.json
@@ -1,0 +1,112 @@
+{
+  "contract": "mcp-messages-canonical-bytes",
+  "version": "1.0.0",
+  "spec_ref": "SPEC-01 §7 / SPEC-09 §2.1",
+  "issue": "https://github.com/terrene-foundation/kailash-py/issues/1258",
+  "description": "Cross-SDK canonical-bytes byte-pin vectors for the four kailash_mcp.protocol.messages.*.to_canonical_json encoders (JsonRpcError / JsonRpcRequest / JsonRpcResponse / McpToolInfo). Both kailash-py and kailash-rs MUST produce byte-identical canonical JSON and identical SHA-256 for every vector. These encoders use ensure_ascii=False (RAW UTF-8 output, matching serde_json's default to_string) with sort_keys=True (keys sorted by Unicode code point) and separators=(\",\",\":\") (no insignificant whitespace). This is the SAME raw-UTF-8 contract as the delegate encoder (tests/test-vectors/delegate-canonical.json) and the OPPOSITE of the trust-plane signing encoder serialize_for_signing (ensure_ascii=True; tests/test-vectors/trust-plane-canonical.json). The encoders perform NO Unicode normalization, so M3 (NFC, U+00E9) and M4 (NFD, U+0065 U+0301) are byte-distinct pre-images. Each vector's input_wire is the to_dict() wire shape; reconstruct the object via <type>.from_dict(input_wire) then call to_canonical_json(). The Rust counterpart vendors this file per cross-sdk-inspection.md Rule 4a.",
+  "vectors": [
+    {
+      "name": "M1_error_ascii_sentinel",
+      "type": "JsonRpcError",
+      "input_wire": {
+        "code": -32600,
+        "message": "Invalid Request"
+      },
+      "expected_canonical_json": "{\"code\":-32600,\"message\":\"Invalid Request\"}",
+      "expected_sha256": "ed916e6993c2860796e280b3ddaab7e0288ae69933965412503e4c65e19d71a1"
+    },
+    {
+      "name": "M2_error_bmp_cjk",
+      "type": "JsonRpcError",
+      "input_wire": {
+        "code": -32000,
+        "message": "サーバ障害"
+      },
+      "expected_canonical_json": "{\"code\":-32000,\"message\":\"サーバ障害\"}",
+      "expected_sha256": "58b46a849f9f0b5074b3e9eb3405c7e55a17c2bbc1f464ab16067d207301df15"
+    },
+    {
+      "name": "M3_request_nfc_composed",
+      "type": "JsonRpcRequest",
+      "input_wire": {
+        "jsonrpc": "2.0",
+        "method": "notify",
+        "params": {
+          "name": "é"
+        },
+        "id": 1
+      },
+      "expected_canonical_json": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"notify\",\"params\":{\"name\":\"é\"}}",
+      "expected_sha256": "e7f9292ca509dee6c1799bed27e4f5c2c26bcbfb7f6788c09455adacbf9b7ebf"
+    },
+    {
+      "name": "M4_request_nfd_decomposed",
+      "type": "JsonRpcRequest",
+      "input_wire": {
+        "jsonrpc": "2.0",
+        "method": "notify",
+        "params": {
+          "name": "é"
+        },
+        "id": 1
+      },
+      "expected_canonical_json": "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"notify\",\"params\":{\"name\":\"é\"}}",
+      "expected_sha256": "b7a2cf5158c731c4e2ed4bd8840e3d4247f5ef601de4d5d31b2f615ed04bd06e"
+    },
+    {
+      "name": "M5_response_astral_emoji",
+      "type": "JsonRpcResponse",
+      "input_wire": {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "result": {
+          "flag": "🎉"
+        }
+      },
+      "expected_canonical_json": "{\"id\":7,\"jsonrpc\":\"2.0\",\"result\":{\"flag\":\"🎉\"}}",
+      "expected_sha256": "4cac969d6dd30f5acfaa8acb1100a65d52a8dbd1be28aad05fa4217e20af1a8f"
+    },
+    {
+      "name": "M6_tool_astral_object_key",
+      "type": "McpToolInfo",
+      "input_wire": {
+        "name": "t",
+        "description": "d",
+        "inputSchema": {
+          "𝄞": "clef"
+        }
+      },
+      "expected_canonical_json": "{\"description\":\"d\",\"inputSchema\":{\"𝄞\":\"clef\"},\"name\":\"t\"}",
+      "expected_sha256": "a7b7c010ec97d788c42aea62443eb931539389451fc51e6f7d4ed706249bd045"
+    },
+    {
+      "name": "M7_tool_mixed_sorted_nonascii",
+      "type": "McpToolInfo",
+      "input_wire": {
+        "name": "工具",
+        "description": "漢字 tool",
+        "inputSchema": {
+          "β": 1,
+          "α": 2,
+          "漢": 3
+        }
+      },
+      "expected_canonical_json": "{\"description\":\"漢字 tool\",\"inputSchema\":{\"α\":2,\"β\":1,\"漢\":3},\"name\":\"工具\"}",
+      "expected_sha256": "50859e7b4d68ba534eed97d336e35bcdfca953f1c03f3a36fb1ba8f1f165402c"
+    },
+    {
+      "name": "M8_response_error_cjk",
+      "type": "JsonRpcResponse",
+      "input_wire": {
+        "jsonrpc": "2.0",
+        "id": null,
+        "error": {
+          "code": -32700,
+          "message": "解析エラー"
+        }
+      },
+      "expected_canonical_json": "{\"error\":{\"code\":-32700,\"message\":\"解析エラー\"},\"id\":null,\"jsonrpc\":\"2.0\"}",
+      "expected_sha256": "0eaec6b7c3a03cc195651334a97df4916e4d5f1d9057b7a107294085ff36b81e"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the cross-SDK byte-parity **verification** gap for the **4th** canonical-JSON encoder family — the four `kailash_mcp.protocol.messages.*.to_canonical_json` encoders (`JsonRpcError` / `JsonRpcRequest` / `JsonRpcResponse` / `McpToolInfo`). #1258 / PR #1269 closed this for the trust + delegate encoders and explicitly carved the MCP family out as a separate shard (separate package / spec / Rust counterpart).

All four MCP encoders use `ensure_ascii=False` (raw UTF-8, matching `serde_json`'s default `to_string`) but had an **undocumented** contract and **zero** pinned non-ASCII byte-vectors. The module docstring already commits to byte-identical output with kailash-rs (SPEC-01 §7 / SPEC-09 §2.1) — this PR makes that contract verifiable.

**No production logic changed** (docstrings + test data only).

## What changed

- **Document** each encoder's canonical contract in the method + module docstrings: `ensure_ascii=False` raw UTF-8, `sort_keys` by code point, `separators=(",",":")`, **no Unicode normalization**.
- **Pin** `packages/kailash-mcp/tests/test-vectors/mcp-messages-canonical.json` — 8 vectors (7 non-ASCII + 1 ASCII sentinel) covering all 4 types: BMP CJK, NFC/NFD byte-distinct pair, astral emoji, astral object key, mixed code-point-sorted keys. Bytes/SHA-256 derived from the documented contract; the Rust counterpart vendors this file per `cross-sdk-inspection.md` Rule 4a.
- **Add** `packages/kailash-mcp/tests/regression/test_issue_1258_mcp_canonical_parity.py` — 11 behavioral tests: byte-equal + SHA-256 + NFC/NFD distinct + round-trip + a guard that all 4 encoders keep `ensure_ascii=False`.
- **Decision (= #1258 acceptance criterion 3): do NOT flip `ensure_ascii`** — it matches the already-shipping `serde_json` default; flipping in Python alone would break cross-SDK parity.

## Redteam — converged

- reviewer: **Clean** — 6 mechanical sweeps pass (zero executable-logic changes, all 4 encoders retain `ensure_ascii=False`, 72 tests green, collection clean, all 8 vectors re-derive byte-for-byte, NFC/NFD verified distinct), contract-docs verified against ground truth, Rule 4/4a compliant.
- security-reviewer: **no CRIT/HIGH/MED** — production logic unchanged, wire-parsing trust boundary (`from_dict` unknown-field rejection + `__post_init__` validation + `strict=True`) intact, fixture carries no secrets/PII, `ensure_ascii=False` is the documented security-neutral byte-parity contract.

## User-flow walk receipts

\`\`\`
$ python -c "JsonRpcError(code=-32000, message='サーバ障害').to_canonical_json()"
→ {"code":-32000,"message":"サーバ障害"}          # raw UTF-8, no \uXXXX escapes
$ McpToolInfo(name='t', description='d', input_schema={'𝄞':'clef'}).to_canonical_json()
→ {"description":"d","inputSchema":{"𝄞":"clef"},"name":"t"}   # round-trip byte-stable: True
$ pytest packages/kailash-mcp/tests/regression/test_issue_1258_mcp_canonical_parity.py -q
→ 11 passed
\`\`\`

## Related issues

Follow-up from #1258 / PR #1269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)