### PR TITLE
fix(kaizen): F31 provably-correct completion — FU2+Wave3, FU5 lazy-numpy, FU4 wrong-shape adapters

### DIFF
--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -119,6 +119,7 @@ dev = [
     "fakeredis>=2.20.0",
     "respx>=0.21.0",
     "pytest-benchmark>=4.0.0",
+    "pymongo>=4.6.0",  # tests/utils/docker_config.py MongoDB health check
 ]
 # AWS Bedrock preset (#498 Session 3, S4b-i) -- botocore owns SigV4
 # canonicalization; inlined hmac.new in kaizen.llm.auth.aws is BLOCKED.

--- a/packages/kailash-kaizen/pytest.ini
+++ b/packages/kailash-kaizen/pytest.ini
@@ -6,7 +6,6 @@ python_classes = Test*
 python_functions = test_*
 asyncio_mode = strict
 asyncio_default_fixture_loop_scope = function
-env_files = .env
 addopts =
     -v
     --tb=short
@@ -92,6 +91,7 @@ markers =
     rag_workflow: RAG workflow integration tests
     observability: Tests for observability system (Systems 3-7)
     regression: Regression tests for fixed bugs
+    benchmark: Performance benchmark tests (pytest-benchmark)
 
 # Timeout configurations by tier
 timeout = 120

--- a/packages/kailash-kaizen/src/kaizen/core/agents.py
+++ b/packages/kailash-kaizen/src/kaizen/core/agents.py
@@ -2513,11 +2513,16 @@ Continue this Thought-Action-Observation cycle until you reach a final answer. E
         parameters = {f"comm_response_{target_agent.name}": {"prompt": message}}
         results, run_id = self.kaizen.execute(workflow.build(), parameters)
 
-        # Extract response
+        # Extract response — LLMAgentNode publishes "response" as a nested
+        # dict {"content": ..., "role": ...}; legacy providers may emit a flat
+        # string (same dual-shape contract as _extract_intelligent_response)
         agent_result = results.get(f"comm_response_{target_agent.name}", {})
-        response_text = str(
-            agent_result.get("response", agent_result.get("content", "No response"))
+        raw_response = agent_result.get(
+            "response", agent_result.get("content", "No response")
         )
+        if isinstance(raw_response, dict):
+            raw_response = raw_response.get("content", "No response")
+        response_text = str(raw_response)
 
         # Create response structure
         response = {

--- a/packages/kailash-kaizen/src/kaizen/l3/plan/suspension.py
+++ b/packages/kailash-kaizen/src/kaizen/l3/plan/suspension.py
@@ -7,8 +7,8 @@ execution MUST be resumable from the exact suspension point. This module
 provides the wire-level types that capture WHY a plan suspended and the
 execution frontier needed to resume.
 
-Cross-SDK parity reference:
-``/Users/esperie/repos/loom/kailash-rs/crates/kailash-kaizen/src/l3/core/plan/types.rs``
+Cross-SDK parity reference (kailash-rs repo):
+``crates/kailash-kaizen/src/l3/core/plan/types.rs``
 lines 267-396 (``SuspensionReason`` + ``SuspensionRecord``). Field
 shapes, tag spelling, and label strings MUST match the Rust contract for
 a serialized SuspensionRecord round-tripped between SDKs to compare

--- a/packages/kailash-kaizen/src/kaizen/nodes/_optional.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/_optional.py
@@ -1,0 +1,34 @@
+"""Optional-dependency helpers for kaizen node modules.
+
+numpy (and the other RAG numerics) ship in the ``kailash-kaizen[rag]`` extra,
+NOT the base dependency set. Modules on the base import surface (everything
+eagerly imported by ``kaizen.nodes.ai.__init__`` and below) MUST NOT import
+numpy at module scope — route runtime usage through :func:`require_numpy` so
+absence surfaces as a typed, actionable error at call time instead of an
+ImportError at base ``import kaizen`` time (F31-FU5).
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+
+def require_numpy(feature: str = "this feature") -> ModuleType:
+    """Return the numpy module, or raise a typed install-guidance error.
+
+    Args:
+        feature: Human-readable name of the capability that needs numpy,
+            used in the error message.
+
+    Raises:
+        ImportError: When numpy is not installed, with the ``[rag]`` extra
+            install command.
+    """
+    try:
+        import numpy
+    except ImportError as exc:
+        raise ImportError(
+            f"numpy is required for {feature} but is not installed. "
+            "Install the RAG extra: pip install kailash-kaizen[rag]"
+        ) from exc
+    return numpy

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/hybrid_search.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/hybrid_search.py
@@ -8,18 +8,24 @@ This module provides advanced search capabilities that combine:
 - Performance-weighted ranking
 """
 
+from __future__ import annotations
+
 import math
 import re
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
-import numpy as np
 from kailash.nodes.base import Node, NodeParameter, register_node
+
+from kaizen.nodes._optional import require_numpy
 
 from .a2a import A2AAgentCard
 from .semantic_memory import SimpleEmbeddingProvider
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @dataclass
@@ -128,6 +134,7 @@ class TFIDFVectorizer:
 
     def transform(self, documents: List[str]) -> np.ndarray:
         """Transform documents to TF-IDF vectors."""
+        np = require_numpy("TF-IDF vectorization")
         vectors = []
 
         for doc in documents:
@@ -147,6 +154,7 @@ class TFIDFVectorizer:
 
     def cosine_similarity(self, vec1: np.ndarray, vec2: np.ndarray) -> float:
         """Calculate cosine similarity between two vectors."""
+        np = require_numpy("cosine similarity")
         if np.linalg.norm(vec1) == 0 or np.linalg.norm(vec2) == 0:
             return 0.0
         return np.dot(vec1, vec2) / (np.linalg.norm(vec1) * np.linalg.norm(vec2))
@@ -597,6 +605,7 @@ class SemanticHybridSearchNode(Node):
         self, req_text: str, agent_texts: List[str]
     ) -> List[float]:
         """Calculate semantic similarity scores."""
+        np = require_numpy("semantic similarity scoring")
         try:
             # Generate embeddings
             all_texts = [req_text] + agent_texts

--- a/packages/kailash-kaizen/src/kaizen/nodes/ai/semantic_memory.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/ai/semantic_memory.py
@@ -5,16 +5,21 @@ These nodes add embeddings and vector search capabilities to the A2A system,
 allowing for semantic matching and contextual agent selection.
 """
 
+from __future__ import annotations
+
 import hashlib
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
 import aiohttp
-import numpy as np
-
 from kailash.nodes.base import Node, NodeParameter, register_node
+
+from kaizen.nodes._optional import require_numpy
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @dataclass
@@ -67,6 +72,7 @@ class SimpleEmbeddingProvider:
 
     async def embed_text(self, text: Union[str, List[str]]) -> EmbeddingResult:
         """Generate embeddings for text."""
+        np = require_numpy("embedding generation")
         if isinstance(text, str):
             texts = [text]
         else:
@@ -113,6 +119,7 @@ class SimpleEmbeddingProvider:
 
     def _hash_embedding(self, text: str, dimension: int = 384) -> np.ndarray:
         """Create a simple hash-based embedding as fallback."""
+        np = require_numpy("hash-based embedding fallback")
         # Simple deterministic embedding based on text content
         hash_str = hashlib.md5(text.encode()).hexdigest()
         # Convert hex to numbers and normalize
@@ -152,6 +159,7 @@ class InMemoryVectorStore:
         threshold: float = 0.5,
     ) -> List[Tuple[SemanticMemoryItem, float]]:
         """Search for similar items."""
+        np = require_numpy("vector similarity search")
         results = []
 
         # Filter by collection if specified
@@ -497,6 +505,7 @@ class SemanticAgentMatchingNode(Node):
             req_text = str(requirements)
 
         # Generate embeddings for requirements and agents
+        np = require_numpy("semantic agent matching")
         all_texts = [req_text] + [str(agent) for agent in agents]
         result = await self._provider.embed_text(all_texts)
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/auth/directory_integration.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/auth/directory_integration.py
@@ -14,11 +14,11 @@ import json
 import logging
 from typing import Any, Dict, List
 
-from kaizen.nodes.ai import LLMAgentNode
-
 from kailash.nodes.auth.directory_integration import (
     DirectoryIntegrationNode as CoreDirectoryIntegrationNode,
 )
+
+from kaizen.nodes.ai import LLMAgentNode
 
 logger = logging.getLogger(__name__)
 
@@ -262,9 +262,16 @@ Example output:
                 max_completion_tokens=2000,  # OpenAI API compatibility: use max_completion_tokens for gpt-5-nano models
             )
 
-            # Parse AI response - extract content from LLM response
-            # Format: {"content": "json_string", "role": "assistant", ...}
-            response_content = result.get("content", "{}")
+            # Parse AI response - LLMAgentNode returns nested structure
+            # Format: {"response": {"content": "json_string", ...}, ...}
+            response = result.get("response", {})
+            response_content = (
+                response.get("content") if isinstance(response, dict) else None
+            )
+            if not response_content:
+                # Fail closed: a malformed/missing envelope routes to the
+                # documented fallback in the except branch below
+                raise ValueError("LLM result missing nested response.content")
             search_intent = json.loads(response_content)
 
             logger.info(
@@ -439,9 +446,16 @@ Example output:
                 max_completion_tokens=2000,  # OpenAI API compatibility: use max_completion_tokens for gpt-5-nano models
             )
 
-            # Parse AI response - extract content from LLM response
-            # Format: {"content": "json_string", "role": "assistant", ...}
-            response_content = result.get("content", "[]")
+            # Parse AI response - LLMAgentNode returns nested structure
+            # Format: {"response": {"content": "json_string", ...}, ...}
+            response = result.get("response", {})
+            response_content = (
+                response.get("content") if isinstance(response, dict) else None
+            )
+            if not response_content:
+                # Fail closed: a malformed/missing envelope routes to the
+                # documented fallback in the except branch below
+                raise ValueError("LLM result missing nested response.content")
             roles = json.loads(response_content)
 
             # Ensure "user" is always included
@@ -506,9 +520,16 @@ Example output:
                 max_completion_tokens=2000,  # OpenAI API compatibility: use max_completion_tokens for gpt-5-nano models
             )
 
-            # Parse AI response - extract content from LLM response
-            # Format: {"content": "json_string", "role": "assistant", ...}
-            response_content = result.get("content", "[]")
+            # Parse AI response - LLMAgentNode returns nested structure
+            # Format: {"response": {"content": "json_string", ...}, ...}
+            response = result.get("response", {})
+            response_content = (
+                response.get("content") if isinstance(response, dict) else None
+            )
+            if not response_content:
+                # Fail closed: a malformed/missing envelope routes to the
+                # documented fallback in the except branch below
+                raise ValueError("LLM result missing nested response.content")
             permissions = json.loads(response_content)
 
             # Ensure basic read permission
@@ -570,9 +591,16 @@ Example output:
                 max_completion_tokens=2000,  # OpenAI API compatibility: use max_completion_tokens for gpt-5-nano models
             )
 
-            # Parse AI response - extract content from LLM response
-            # Format: {"content": "json_string", "role": "assistant", ...}
-            response_content = result.get("content", "{}")
+            # Parse AI response - LLMAgentNode returns nested structure
+            # Format: {"response": {"content": "json_string", ...}, ...}
+            response = result.get("response", {})
+            response_content = (
+                response.get("content") if isinstance(response, dict) else None
+            )
+            if not response_content:
+                # Fail closed: a malformed/missing envelope routes to the
+                # documented fallback in the except branch below
+                raise ValueError("LLM result missing nested response.content")
             settings = json.loads(response_content)
 
             return settings

--- a/packages/kailash-kaizen/src/kaizen/nodes/auth/enterprise_auth_provider.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/auth/enterprise_auth_provider.py
@@ -15,11 +15,11 @@ import json
 import logging
 from typing import Any, Dict, List
 
-from kaizen.nodes.ai import LLMAgentNode
-
 from kailash.nodes.auth.enterprise_auth_provider import (
     EnterpriseAuthProviderNode as CoreEnterpriseAuthNode,
 )
+
+from kaizen.nodes.ai import LLMAgentNode
 
 logger = logging.getLogger(__name__)
 
@@ -213,9 +213,19 @@ Example output:
                 max_completion_tokens=2000,  # OpenAI API compatibility: use max_completion_tokens for gpt-5-nano models
             )
 
-            # Parse AI response - extract content from LLM response
-            # Format: {"content": "json_string", "role": "assistant", ...}
-            response_content = result.get("content", "{}")
+            # Parse AI response - LLMAgentNode returns nested structure
+            # Format: {"response": {"content": "json_string", ...}, ...}
+            response = result.get("response", {})
+            response_content = (
+                response.get("content") if isinstance(response, dict) else None
+            )
+            if not response_content:
+                # Fail closed: a malformed/missing envelope routes to the
+                # rule-based fallback below instead of silently scoring 0.0
+                raise ValueError(
+                    "LLM result missing nested response.content; "
+                    "cannot run AI risk assessment"
+                )
             ai_analysis = json.loads(response_content)
 
             risk_score = ai_analysis.get("risk_score", 0.0)

--- a/packages/kailash-kaizen/src/kaizen/nodes/compliance/gdpr.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/compliance/gdpr.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from kailash.nodes.base import Node, NodeParameter
 from kailash.nodes.mixins import LoggingMixin, PerformanceMixin, SecurityMixin
 from kailash.nodes.security.audit_log import AuditLogNode
+
 from kaizen.nodes.ai import LLMAgentNode
 
 logger = logging.getLogger(__name__)
@@ -1546,7 +1547,17 @@ Format your response as JSON with keys: risk_level, legal_implications, best_pra
             result = self.ai_agent.execute(prompt=prompt)
 
             if result and result.get("success"):
-                response_text = result.get("response", "")
+                # LLMAgentNode returns nested structure:
+                # {"response": {"content": "<text>", ...}, ...}
+                response = result.get("response", "")
+                if isinstance(response, dict):
+                    response_text = response.get("content")
+                else:
+                    response_text = response
+                if not response_text or not isinstance(response_text, str):
+                    # Fail closed: malformed/missing envelope routes to the
+                    # documented None degrade in the except branch
+                    raise ValueError("LLM result missing nested response.content")
                 return self._parse_ai_compliance_response(response_text)
             return None
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/advanced.py
@@ -17,6 +17,11 @@ import os
 from typing import Any, Dict, List, Optional
 
 from kailash.nodes.base import Node, NodeParameter, register_node
+
+# PythonCodeNode is imported for its `from_function` classmethod (the COMPUTE
+# stages of create_hybrid_rag_workflow are wired via
+# `PythonCodeNode.from_function(...)`) AND for its @register_node side effect.
+from kailash.nodes.code.python import PythonCodeNode
 from kailash.nodes.logic.workflow import WorkflowNode
 from kailash.workflow.builder import WorkflowBuilder
 
@@ -58,6 +63,106 @@ class RAGConfig:
         self.retrieval_k = kwargs.get("retrieval_k", 5)
 
 
+# ---------------------------------------------------------------------------
+# COMPUTE-stage functions for create_hybrid_rag_workflow (#1117 / #1123
+# root-cause fix — same reference template as optimized.py / graph.py).
+#
+# The two PythonCodeNode COMPUTE stages (`source` fan-out + `fuse` RRF) were
+# inline `code=` codegen blocks; the fuse block was a doubled-brace f-string
+# (#1123). They are lifted to real module-level functions wired via
+# `PythonCodeNode.from_function`, each publishing the SAME flat `result` port.
+#
+# OUTPUT-PORT SHAPE: an inline `code=` block with multiple module-scope `results
+# = ...; scores = ...; metadata = ...` assignments promotes EACH to a top-level
+# output port, which the WorkflowNode `output_mapping` read directly. A
+# `from_function` node publishes ONLY a flat `result` port (the returned dict's
+# keys are NOT promoted). `WorkflowNode.output_mapping` resolves an `output` key
+# against the node's published ports with a FLAT lookup (no `result.<key>`
+# nesting), so the fuse `result` dict's three keys are surfaced to the top-level
+# consumed contract via three thin from_function PROJECTOR nodes — each indexes
+# one key off the fuse `result` and returns the BARE value, which output_mapping
+# then surfaces under the `results` / `scores` / `metadata` contract names. The
+# projectors are pure data projection (the permitted output-formatting exception
+# per rules/agent-reasoning.md — no agent decisions).
+# ---------------------------------------------------------------------------
+
+
+def _hybrid_source_fanout(documents=None, query=None) -> dict:
+    """Entry node: hold ``documents`` + ``query`` and fan them out.
+
+    Lifted ``source`` COMPUTE block. Publishes ``{"documents", "query"}`` on the
+    flat ``result`` port; the existing ``result.documents`` / ``result.query``
+    fan-out edges resolve unchanged.
+    """
+    return {"documents": documents, "query": query}
+
+
+def _make_rrf_fuse(retrieval_k: int):
+    """Build a from_function-compatible RRF fuse bound to ``retrieval_k``.
+
+    The build-time ``retrieval_k`` (the f-string's only interpolation) is bound
+    through the closure, keeping ``dense_result`` / ``sparse_result`` as the
+    declared inputs the DenseRetrievalNode / SparseRetrievalNode ``results``
+    ports wire to. Returns the three-key fusion dict on the flat ``result`` port
+    — the doubled-brace f-string codegen (#1123) is eliminated; the RRF
+    computation is preserved verbatim.
+    """
+
+    def fuse_dense_sparse(dense_result=None, sparse_result=None) -> dict:
+        """Reciprocal Rank Fusion over the dense + sparse result lists."""
+
+        def _reciprocal_rank_fusion(doc_lists, k=60, top_k=retrieval_k):
+            fused_scores = {}
+            doc_info = {}
+            for documents in doc_lists:
+                for rank, doc in enumerate(documents or []):
+                    if not isinstance(doc, dict):
+                        continue
+                    doc_id = doc.get("id") or str(hash((doc.get("content") or "")[:50]))
+                    fused_scores[doc_id] = fused_scores.get(doc_id, 0.0) + 1.0 / (
+                        k + rank + 1
+                    )
+                    doc_info[doc_id] = doc
+            ordered = sorted(fused_scores.items(), key=lambda x: x[1], reverse=True)
+            docs = [doc_info[d] for d, _ in ordered[:top_k]]
+            scores_out = [s for _, s in ordered[:top_k]]
+            return docs, scores_out
+
+        # dense_result / sparse_result are the `results` output lists of the
+        # DenseRetrievalNode / SparseRetrievalNode (a list of document dicts).
+        _dense = dense_result if isinstance(dense_result, list) else []
+        _sparse = sparse_result if isinstance(sparse_result, list) else []
+        _docs, _scores = _reciprocal_rank_fusion([_dense, _sparse])
+        return {
+            "results": _docs,
+            "scores": _scores,
+            "metadata": {
+                "fusion_method": "rrf",
+                "retrieval_modes": ["dense", "sparse"],
+                "retrieval_k": retrieval_k,
+                "dense_count": len(_dense),
+                "sparse_count": len(_sparse),
+            },
+        }
+
+    return fuse_dense_sparse
+
+
+def _project_fused_results(fused=None) -> list:
+    """Project the ``results`` list off the fuse ``result`` dict (bare value)."""
+    return (fused or {}).get("results", []) if isinstance(fused, dict) else []
+
+
+def _project_fused_scores(fused=None) -> list:
+    """Project the ``scores`` list off the fuse ``result`` dict (bare value)."""
+    return (fused or {}).get("scores", []) if isinstance(fused, dict) else []
+
+
+def _project_fused_metadata(fused=None) -> dict:
+    """Project the ``metadata`` dict off the fuse ``result`` dict (bare value)."""
+    return (fused or {}).get("metadata", {}) if isinstance(fused, dict) else {}
+
+
 def create_hybrid_rag_workflow(config: RAGConfig) -> WorkflowNode:
     """Build a genuine hybrid-RAG retrieval workflow.
 
@@ -68,18 +173,27 @@ def create_hybrid_rag_workflow(config: RAGConfig) -> WorkflowNode:
     ``StepBackRAGNode``) via ``self.base_rag_workflow.run(documents=...,
     query=..., operation="retrieve")``.
 
-    Graph shape (4 nodes)::
+    Graph shape (7 nodes)::
 
         source ──documents/query──┬──> dense  ──results──┐
-                                  └──> sparse ──results──┴──> fuse
+                                  └──> sparse ──results──┴──> fuse ──result──┬──> proj_results
+                                                                             ├──> proj_scores
+                                                                             └──> proj_metadata
 
-    - ``source`` (``PythonCodeNode``) — entry node; receives ``documents`` and
-      ``query`` via the WorkflowNode ``input_mapping`` and fans them out.
+    - ``source`` (``PythonCodeNode.from_function``) — entry node; receives
+      ``documents`` and ``query`` via the WorkflowNode ``input_mapping`` and
+      fans them out on the flat ``result`` port.
     - ``dense`` (``DenseRetrievalNode``) — embedding-similarity retrieval; with
       no LLM key configured it runs its deterministic keyword-overlap fallback.
     - ``sparse`` (``SparseRetrievalNode``) — keyword / term-frequency retrieval.
-    - ``fuse`` (``PythonCodeNode``) — Reciprocal Rank Fusion over the dense and
-      sparse result lists; emits ``results`` / ``scores`` / ``metadata``.
+    - ``fuse`` (``PythonCodeNode.from_function``) — Reciprocal Rank Fusion over
+      the dense and sparse result lists; returns ``{"results", "scores",
+      "metadata"}`` on the flat ``result`` port.
+    - ``proj_results`` / ``proj_scores`` / ``proj_metadata``
+      (``PythonCodeNode.from_function``) — thin projector nodes that index one
+      key off the fuse ``result`` dict and return its BARE value, so the
+      WorkflowNode ``output_mapping`` (flat-key resolution, no ``result.<key>``
+      nesting) can surface each under the top-level consumed-contract name.
 
     The returned :class:`WorkflowNode` exposes the consumed contract: a
     ``.run(documents=..., query=..., operation="retrieve")`` call returns a
@@ -98,10 +212,10 @@ def create_hybrid_rag_workflow(config: RAGConfig) -> WorkflowNode:
     builder = WorkflowBuilder()
 
     # Entry node: holds documents + query, fans them out to both retrievers.
-    source_id = builder.add_node(
-        "PythonCodeNode",
+    source_id = builder.add_node_instance(
+        PythonCodeNode.from_function(_hybrid_source_fanout, name="source"),
         node_id="source",
-        config={"code": 'result = {"documents": documents, "query": query}'},
+        _internal=True,
     )
 
     # Dense retrieval (embedding similarity; deterministic fallback when no key).
@@ -118,47 +232,31 @@ def create_hybrid_rag_workflow(config: RAGConfig) -> WorkflowNode:
         config={},
     )
 
-    # Reciprocal Rank Fusion of the dense and sparse result lists.
-    fuse_id = builder.add_node(
-        "PythonCodeNode",
+    # Reciprocal Rank Fusion of the dense and sparse result lists (the build-time
+    # retrieval_k is bound through the closure).
+    fuse_id = builder.add_node_instance(
+        PythonCodeNode.from_function(_make_rrf_fuse(retrieval_k), name="fuse"),
         node_id="fuse",
-        config={
-            "code": f"""
-def _reciprocal_rank_fusion(doc_lists, k=60, top_k={retrieval_k}):
-    fused_scores = {{}}
-    doc_info = {{}}
-    for documents in doc_lists:
-        for rank, doc in enumerate(documents or []):
-            if not isinstance(doc, dict):
-                continue
-            doc_id = doc.get("id") or str(hash((doc.get("content") or "")[:50]))
-            fused_scores[doc_id] = fused_scores.get(doc_id, 0.0) + 1.0 / (k + rank + 1)
-            doc_info[doc_id] = doc
-    ordered = sorted(fused_scores.items(), key=lambda x: x[1], reverse=True)
-    docs = [doc_info[d] for d, _ in ordered[:top_k]]
-    scores_out = [s for _, s in ordered[:top_k]]
-    return docs, scores_out
+        _internal=True,
+    )
 
-
-# dense_result / sparse_result are the `results` output lists of the
-# DenseRetrievalNode / SparseRetrievalNode (a list of document dicts).
-_dense = dense_result if isinstance(dense_result, list) else []
-_sparse = sparse_result if isinstance(sparse_result, list) else []
-_docs, _scores = _reciprocal_rank_fusion([_dense, _sparse])
-results = _docs
-scores = _scores
-# `results`, `scores`, `metadata` are surfaced as separate node outputs so
-# the WorkflowNode output_mapping can flatten them to the top level of the
-# consumed contract.
-metadata = {{
-    "fusion_method": "rrf",
-    "retrieval_modes": ["dense", "sparse"],
-    "retrieval_k": {retrieval_k},
-    "dense_count": len(_dense),
-    "sparse_count": len(_sparse),
-}}
-"""
-        },
+    # Projector nodes — index one key off the fuse `result` dict and return the
+    # BARE value so the flat-resolution output_mapping can surface each under the
+    # top-level consumed-contract name.
+    proj_results_id = builder.add_node_instance(
+        PythonCodeNode.from_function(_project_fused_results, name="proj_results"),
+        node_id="proj_results",
+        _internal=True,
+    )
+    proj_scores_id = builder.add_node_instance(
+        PythonCodeNode.from_function(_project_fused_scores, name="proj_scores"),
+        node_id="proj_scores",
+        _internal=True,
+    )
+    proj_metadata_id = builder.add_node_instance(
+        PythonCodeNode.from_function(_project_fused_metadata, name="proj_metadata"),
+        node_id="proj_metadata",
+        _internal=True,
     )
 
     # Fan documents + query from the source node to both retrievers.
@@ -167,9 +265,19 @@ metadata = {{
     builder.add_connection(source_id, "result.documents", sparse_id, "documents")
     builder.add_connection(source_id, "result.query", sparse_id, "query")
 
-    # Feed both retrieval result lists into the fusion node.
+    # Feed both retrieval result lists into the fusion node. DenseRetrievalNode /
+    # SparseRetrievalNode are `Node` subclasses publishing a top-level `results`
+    # port, so these edges stay flat.
     builder.add_connection(dense_id, "results", fuse_id, "dense_result")
     builder.add_connection(sparse_id, "results", fuse_id, "sparse_result")
+
+    # PHANTOM-PORT FIX: `fuse` is a from_function node publishing ONLY a flat
+    # `result` port (its returned dict's keys are NOT top-level ports). Each
+    # projector reads the WHOLE fuse dict via `result` and returns its one bare
+    # value on its own flat `result` port.
+    builder.add_connection(fuse_id, "result", proj_results_id, "fused")
+    builder.add_connection(fuse_id, "result", proj_scores_id, "fused")
+    builder.add_connection(fuse_id, "result", proj_metadata_id, "fused")
 
     workflow = builder.build(name="hybrid_rag_workflow")
 
@@ -181,10 +289,12 @@ metadata = {{
             "documents": {"node": "source", "parameter": "documents"},
             "query": {"node": "source", "parameter": "query"},
         },
+        # Each projector publishes its bare value on the flat `result` port; the
+        # output_mapping surfaces it under the top-level contract name.
         output_mapping={
-            "results": {"node": "fuse", "output": "results"},
-            "scores": {"node": "fuse", "output": "scores"},
-            "metadata": {"node": "fuse", "output": "metadata"},
+            "results": {"node": "proj_results", "output": "result"},
+            "scores": {"node": "proj_scores", "output": "result"},
+            "metadata": {"node": "proj_metadata", "output": "result"},
         },
     )
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/agentic.py
@@ -442,6 +442,417 @@ def parse_reasoning_chain_response(response=None):
     return {"reasoning_to_verify": _coerce_text(content)}
 
 
+# ---------------------------------------------------------------------------
+# COMPUTE-stage functions (#1117 / #1123 / #1118 root-cause fix — same
+# reference template as optimized.py / graph.py / query_processing.py).
+#
+# The AgenticRAGNode sub-workflow's three PythonCodeNode COMPUTE stages
+# (tool_executor / state_manager / result_synthesizer) were previously inline
+# `code=` codegen blocks. An inline `code=` PythonCodeNode publishes ONLY a flat
+# `result` port (the module-scope `result = {...}` dict is wrapped as
+# `{"result": {...}}` — its keys are NOT promoted to top-level ports), so every
+# downstream edge reading a top-level key (`tool_result`, `reasoning_state`,
+# `context_for_agent`, `continue_reasoning`) was a PHANTOM port the runtime
+# silently dropped (#1117 publish-nothing). The state_manager block was further
+# an f-string carrying doubled `{{ }}` literal braces (#1123 brace-escape) and
+# the tool_executor block carried a raw-string regex (escape-trap risk).
+#
+# These functions lift each block to a real module-level `def` with a `return`
+# (the structural successor of the codegen's module-scope `result =`). Wired via
+# `PythonCodeNode.from_function`, each publishes the SAME flat `result` port; the
+# downstream edges are rewritten to `result.<key>` so the previously-phantom
+# ports resolve. They are pure tool-result computation (the permitted exception
+# per rules/agent-reasoning.md — no agent decisions, no content classification:
+# the ReAct/agent-loop orchestration semantics live UNCHANGED in the line-parser
+# and the cyclic graph wiring).
+# ---------------------------------------------------------------------------
+
+
+def execute_tool_action(reasoning_state=None, documents=None) -> dict:
+    """Execute the current ReAct action against the documents.
+
+    Parses ``reasoning_state["current_action"]`` (e.g. ``search("query")``) and
+    dispatches to the matching tool (search / calculate / database / verify),
+    returning ``{"tool_result": <observation>, "timestamp": <iso>}``. This is the
+    lifted ``tool_executor`` COMPUTE block — the regex action-parser and the
+    AST-walked safe arithmetic evaluator (no eval/exec) are preserved verbatim.
+    """
+    import re
+    from datetime import datetime
+
+    def _execute_tool(action_string, documents, context):
+        """Execute tool based on action string"""
+        # Parse action
+        match = re.match(r"(\w+)\((.*)\)", action_string.strip())
+        if not match:
+            return {"error": "Invalid action format"}
+
+        tool_name = match.group(1)
+        params = match.group(2).strip("\"'")
+
+        results = {}
+
+        if tool_name == "search":
+            # Search through documents
+            query_words = set(params.lower().split())
+            search_results = []
+
+            for doc in documents[:50]:  # Limit for performance
+                if not isinstance(doc, dict):
+                    continue  # skip malformed non-dict document elements
+                # `.get("content", "")` only defaults a MISSING key; a present
+                # key with a None value would still yield None, so coerce.
+                content = (doc.get("content") or "").lower()
+                title = (doc.get("title") or "").lower()
+
+                # Score based on word overlap
+                doc_words = set(content.split())
+                title_words = set(title.split())
+
+                content_score = (
+                    len(query_words & doc_words) / len(query_words)
+                    if query_words
+                    else 0
+                )
+                title_score = (
+                    len(query_words & title_words) / len(query_words)
+                    if query_words
+                    else 0
+                )
+
+                total_score = content_score + (
+                    title_score * 2
+                )  # Title matches weighted higher
+
+                if total_score > 0:
+                    search_results.append(
+                        {
+                            "title": doc.get("title", "Untitled"),
+                            "excerpt": content[:200] + "...",
+                            "score": total_score,
+                            "id": doc.get("id", "unknown"),
+                        }
+                    )
+
+            # Sort by score
+            search_results.sort(key=lambda x: x["score"], reverse=True)
+            results = {
+                "tool": "search",
+                "query": params,
+                "results": search_results[:5],
+                "count": len(search_results),
+            }
+
+        elif tool_name == "calculate":
+            # Safe calculation — AST-walked arithmetic only. `params` is
+            # LLM-generated; eval()/regex-substitution sandboxes are bypassable,
+            # so this whitelists ast node types instead (no eval, no exec, no
+            # regex).
+            import ast
+            import math
+            import operator
+
+            _BINOPS = {
+                ast.Add: operator.add,
+                ast.Sub: operator.sub,
+                ast.Mult: operator.mul,
+                ast.Div: operator.truediv,
+                ast.Pow: operator.pow,
+                ast.Mod: operator.mod,
+                ast.FloorDiv: operator.floordiv,
+            }
+            _UNARYOPS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+            _FUNCS = {
+                "abs": abs,
+                "round": round,
+                "min": min,
+                "max": max,
+                "pow": pow,
+                "sqrt": math.sqrt,
+                "sin": math.sin,
+                "cos": math.cos,
+                "tan": math.tan,
+                "log": math.log,
+                "exp": math.exp,
+            }
+            _CONSTS = {"pi": math.pi, "e": math.e}
+
+            def _safe_arith(node):
+                if isinstance(node, ast.Expression):
+                    return _safe_arith(node.body)
+                if isinstance(node, ast.Constant):
+                    if isinstance(node.value, (int, float)) and not isinstance(
+                        node.value, bool
+                    ):
+                        return node.value
+                    raise ValueError("non-numeric constant")
+                if isinstance(node, ast.BinOp) and type(node.op) in _BINOPS:
+                    return _BINOPS[type(node.op)](
+                        _safe_arith(node.left), _safe_arith(node.right)
+                    )
+                if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARYOPS:
+                    return _UNARYOPS[type(node.op)](_safe_arith(node.operand))
+                if isinstance(node, ast.Name) and node.id in _CONSTS:
+                    return _CONSTS[node.id]
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id in _FUNCS
+                    and not node.keywords
+                ):
+                    return _FUNCS[node.func.id](*[_safe_arith(a) for a in node.args])
+                raise ValueError("disallowed expression element")
+
+            try:
+                try:
+                    calc_result = ast.literal_eval(params)
+                except (ValueError, SyntaxError):
+                    calc_result = _safe_arith(ast.parse(params, mode="eval"))
+                results = {
+                    "tool": "calculate",
+                    "expression": params,
+                    "result": calc_result,
+                }
+            except Exception:
+                results = {
+                    "tool": "calculate",
+                    "error": f"Cannot evaluate expression: {params}",
+                }
+
+        elif tool_name == "database":
+            # Simulated database query
+            if "revenue" in params.lower():
+                # Mock financial data
+                results = {
+                    "tool": "database",
+                    "query": params,
+                    "results": [
+                        {
+                            "company": "TechCorp",
+                            "revenue_2022": 100,
+                            "revenue_2023": 120,
+                        },
+                        {"company": "DataInc", "revenue_2022": 80, "revenue_2023": 95},
+                        {"company": "CloudCo", "revenue_2022": 60, "revenue_2023": 85},
+                    ],
+                }
+            else:
+                results = {"tool": "database", "query": params, "results": []}
+
+        elif tool_name == "verify":
+            # Fact verification (simplified)
+            confidence = 0.85 if "true" not in params.lower() else 0.95
+            results = {
+                "tool": "verify",
+                "claim": params,
+                "verified": confidence > 0.8,
+                "confidence": confidence,
+                "sources": ["Document analysis", "Cross-reference check"],
+            }
+
+        else:
+            results = {"error": f"Unknown tool: {tool_name}"}
+
+        return results
+
+    # Execute current action
+    state = reasoning_state if isinstance(reasoning_state, dict) else {}
+    docs = documents if isinstance(documents, list) else []
+
+    current_action = state.get("current_action", "")
+    if current_action:
+        observation = _execute_tool(current_action, docs, state)
+    else:
+        observation = {"error": "No action specified"}
+
+    return {
+        "tool_result": observation,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+def _make_state_manager(max_reasoning_steps: int):
+    """Build a from_function-compatible state-manager bound to the step cap.
+
+    The build-time ``max_reasoning_steps`` is bound through a thin closure (the
+    f-string's only interpolation), keeping ``plan`` / ``reasoning_response`` /
+    ``tool_result`` as the declared inputs the parser/loop ports wire to. The
+    returned function manages the ReAct reasoning state across iterations and
+    publishes ``{"reasoning_state", "context_for_agent", "continue_reasoning"}``
+    on the flat ``result`` port — the doubled-brace f-string codegen (#1123) is
+    eliminated; the line-parser semantics are preserved verbatim.
+    """
+
+    def update_reasoning_state(plan=None, reasoning_response=None, tool_result=None):
+        """Update the ReAct reasoning state with the latest LLM response."""
+
+        def _update(state, new_response, tool_res=None):
+            if not state:
+                state = {
+                    "steps": [],
+                    "current_step": 0,
+                    "completed": False,
+                    "final_answer": None,
+                }
+
+            # Parse response for thought/action/answer
+            lines = new_response.strip().split("\n")
+            current_thought = None
+            current_action = None
+            final_answer = None
+
+            for line in lines:
+                if line.startswith("Thought:"):
+                    current_thought = line[8:].strip()
+                elif line.startswith("Action:"):
+                    current_action = line[7:].strip()
+                elif line.startswith("Answer:"):
+                    final_answer = line[7:].strip()
+                    state["completed"] = True
+
+            # Add step
+            step = {
+                "step_number": state["current_step"] + 1,
+                "thought": current_thought,
+                "action": current_action,
+                "observation": tool_res.get("tool_result") if tool_res else None,
+            }
+
+            state["steps"].append(step)
+            state["current_step"] += 1
+            state["current_action"] = current_action
+            state["final_answer"] = final_answer
+
+            # Check if we've reached max steps
+            if state["current_step"] >= max_reasoning_steps:
+                state["completed"] = True
+                if not state["final_answer"]:
+                    state["final_answer"] = (
+                        "Reached maximum reasoning steps. "
+                        "Based on gathered information..."
+                    )
+
+            return state
+
+        # Process current iteration. `plan` arrives from the plan parser as the
+        # parsed planner dict; `reasoning_response` arrives from the reasoning
+        # parser as the ReAct prose STRING (the parsers already unwrapped
+        # `response.content` upstream, so NO further `.get("response")` unwrap is
+        # needed). `reasoning_response` may still be a non-str on a defensive
+        # path; coerce so the line parser never crashes.
+        if not isinstance(reasoning_response, str):
+            reasoning_response = (
+                "" if reasoning_response is None else str(reasoning_response)
+            )
+
+        state = _update(None, reasoning_response, tool_result)
+
+        # Record the planner's parsed plan onto the reasoning state so it is
+        # surfaced downstream (the planner → plan_parser → state_manager `plan`
+        # edge is the Wave-2.5 O5 wiring; the prior codegen accepted `plan` but
+        # dropped it — recording it here consumes the input honestly per
+        # zero-tolerance Rule 3c without inventing agent-decision logic).
+        if plan is not None:
+            state["plan"] = plan
+
+        # Prepare context for next iteration
+        context_for_agent = ""
+        for step in state["steps"]:
+            if step["thought"]:
+                context_for_agent += f"\nThought: {step['thought']}"
+            if step["action"]:
+                context_for_agent += f"\nAction: {step['action']}"
+            if step["observation"]:
+                context_for_agent += f"\nObservation: {step['observation']}"
+
+        return {
+            "reasoning_state": state,
+            "context_for_agent": context_for_agent,
+            "continue_reasoning": not state["completed"],
+        }
+
+    return update_reasoning_state
+
+
+def _make_result_synthesizer(planning_strategy: str, max_reasoning_steps: int):
+    """Build a from_function-compatible synthesizer bound to the build config.
+
+    The build-time ``planning_strategy`` / ``max_reasoning_steps`` (the only
+    f-string interpolations in the original codegen) are bound through a thin
+    closure, keeping ``reasoning_state`` / ``verification`` / ``query`` as the
+    declared inputs. Returns the final ``{"agentic_rag_result": {...}}`` dict on
+    the flat ``result`` port — the doubled-brace f-string codegen (#1123) is
+    eliminated; the confidence/trace computation is preserved verbatim.
+    """
+
+    def synthesize_agentic_result(reasoning_state=None, verification=None, query=""):
+        """Synthesize the final agentic-RAG result dict."""
+        state = reasoning_state if isinstance(reasoning_state, dict) else {}
+        steps = state.get("steps", []) if isinstance(state, dict) else []
+
+        # Extract tool usage
+        tools_used = []
+        for step in steps:
+            obs = step.get("observation") if isinstance(step, dict) else None
+            if isinstance(obs, dict) and "tool" in obs:
+                tools_used.append(obs["tool"])
+
+        # Calculate confidence. `verification` arrives from the verification
+        # parser as the PARSED verifier dict (or a parse-error sentinel carrying
+        # `{"parse_error": ...}`) — already unwrapped from `response.content` +
+        # json.loads upstream. A flagged parse-error sentinel carries no real
+        # confidence, so it is treated as "no usable verdict" (NOT a fabricated
+        # 0.8) and confidence is left unadjusted — honest, per zero-tolerance
+        # Rule 2.
+        base_confidence = 0.7
+        confidence_boost = min(0.3, len(tools_used) * 0.1)
+        _has_verdict = (
+            isinstance(verification, dict)
+            and "confidence" in verification
+            and verification.get("parse_error") is None
+        )
+        if _has_verdict:
+            verification_confidence = verification.get("confidence", 0.8)
+            final_confidence = (
+                base_confidence + confidence_boost
+            ) * verification_confidence
+        else:
+            final_confidence = base_confidence + confidence_boost
+
+        # Build reasoning trace
+        reasoning_trace = []
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            reasoning_trace.append(
+                {
+                    "step": step.get("step_number"),
+                    "thought": step.get("thought"),
+                    "action": step.get("action"),
+                    "observation": step.get("observation"),
+                }
+            )
+
+        return {
+            "agentic_rag_result": {
+                "query": query,
+                "answer": state.get("final_answer"),
+                "reasoning_trace": reasoning_trace,
+                "tools_used": list(set(tools_used)),
+                "confidence": final_confidence,
+                "total_steps": len(steps),
+                "verification": verification if _has_verdict else None,
+                "metadata": {
+                    "planning_strategy": planning_strategy,
+                    "max_steps": max_reasoning_steps,
+                    "completed_successfully": state.get("completed", False),
+                },
+            }
+        }
+
+    return synthesize_agentic_result
+
+
 @register_node()
 class AgenticRAGNode(WorkflowNode):
     """
@@ -568,276 +979,24 @@ Maximum steps: {self.max_reasoning_steps}""",
         )
 
         # Tool executor
-        tool_executor_id = builder.add_node(
-            "PythonCodeNode",
+        tool_executor_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                execute_tool_action,
+                name="tool_executor",
+            ),
             node_id="tool_executor",
-            config={
-                "code": r"""
-import re
-import json
-from datetime import datetime
-
-def execute_tool(action_string, documents, context):
-    '''Execute tool based on action string'''
-    # Parse action
-    match = re.match(r'(\w+)\((.*)\)', action_string.strip())
-    if not match:
-        return {"error": "Invalid action format"}
-
-    tool_name = match.group(1)
-    params = match.group(2).strip('"\'')
-
-    results = {}
-
-    if tool_name == "search":
-        # Search through documents
-        query_words = set(params.lower().split())
-        search_results = []
-
-        for doc in documents[:50]:  # Limit for performance
-            if not isinstance(doc, dict):
-                continue  # skip malformed non-dict document elements
-            # `.get("content", "")` only defaults a MISSING key; a present
-            # key with a None value would still yield None, so coerce.
-            content = (doc.get("content") or "").lower()
-            title = (doc.get("title") or "").lower()
-
-            # Score based on word overlap
-            doc_words = set(content.split())
-            title_words = set(title.split())
-
-            content_score = len(query_words & doc_words) / len(query_words) if query_words else 0
-            title_score = len(query_words & title_words) / len(query_words) if query_words else 0
-
-            total_score = content_score + (title_score * 2)  # Title matches weighted higher
-
-            if total_score > 0:
-                search_results.append({
-                    "title": doc.get("title", "Untitled"),
-                    "excerpt": content[:200] + "...",
-                    "score": total_score,
-                    "id": doc.get("id", "unknown")
-                })
-
-        # Sort by score
-        search_results.sort(key=lambda x: x["score"], reverse=True)
-        results = {
-            "tool": "search",
-            "query": params,
-            "results": search_results[:5],
-            "count": len(search_results)
-        }
-
-    elif tool_name == "calculate":
-        # Safe calculation — AST-walked arithmetic only. `params` is
-        # LLM-generated; eval()/regex-substitution sandboxes are bypassable, so
-        # this whitelists ast node types instead (no eval, no exec, no regex).
-        import ast
-        import math
-        import operator
-
-        _BINOPS = {
-            ast.Add: operator.add, ast.Sub: operator.sub,
-            ast.Mult: operator.mul, ast.Div: operator.truediv,
-            ast.Pow: operator.pow, ast.Mod: operator.mod,
-            ast.FloorDiv: operator.floordiv,
-        }
-        _UNARYOPS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
-        _FUNCS = {
-            "abs": abs, "round": round, "min": min, "max": max, "pow": pow,
-            "sqrt": math.sqrt, "sin": math.sin, "cos": math.cos,
-            "tan": math.tan, "log": math.log, "exp": math.exp,
-        }
-        _CONSTS = {"pi": math.pi, "e": math.e}
-
-        def _safe_arith(node):
-            if isinstance(node, ast.Expression):
-                return _safe_arith(node.body)
-            if isinstance(node, ast.Constant):
-                if isinstance(node.value, (int, float)) and not isinstance(node.value, bool):
-                    return node.value
-                raise ValueError("non-numeric constant")
-            if isinstance(node, ast.BinOp) and type(node.op) in _BINOPS:
-                return _BINOPS[type(node.op)](
-                    _safe_arith(node.left), _safe_arith(node.right)
-                )
-            if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARYOPS:
-                return _UNARYOPS[type(node.op)](_safe_arith(node.operand))
-            if isinstance(node, ast.Name) and node.id in _CONSTS:
-                return _CONSTS[node.id]
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id in _FUNCS
-                and not node.keywords
-            ):
-                return _FUNCS[node.func.id](
-                    *[_safe_arith(a) for a in node.args]
-                )
-            raise ValueError("disallowed expression element")
-
-        try:
-            try:
-                result = ast.literal_eval(params)
-            except (ValueError, SyntaxError):
-                result = _safe_arith(ast.parse(params, mode="eval"))
-            results = {
-                "tool": "calculate",
-                "expression": params,
-                "result": result,
-            }
-        except Exception:
-            results = {
-                "tool": "calculate",
-                "error": f"Cannot evaluate expression: {params}",
-            }
-
-    elif tool_name == "database":
-        # Simulated database query
-        if "revenue" in params.lower():
-            # Mock financial data
-            results = {
-                "tool": "database",
-                "query": params,
-                "results": [
-                    {"company": "TechCorp", "revenue_2022": 100, "revenue_2023": 120},
-                    {"company": "DataInc", "revenue_2022": 80, "revenue_2023": 95},
-                    {"company": "CloudCo", "revenue_2022": 60, "revenue_2023": 85}
-                ]
-            }
-        else:
-            results = {
-                "tool": "database",
-                "query": params,
-                "results": []
-            }
-
-    elif tool_name == "verify":
-        # Fact verification (simplified)
-        confidence = 0.85 if "true" not in params.lower() else 0.95
-        results = {
-            "tool": "verify",
-            "claim": params,
-            "verified": confidence > 0.8,
-            "confidence": confidence,
-            "sources": ["Document analysis", "Cross-reference check"]
-        }
-
-    else:
-        results = {"error": f"Unknown tool: {tool_name}"}
-
-    return results
-
-# Execute current action
-reasoning_state = reasoning_state
-documents = documents
-
-current_action = reasoning_state.get("current_action", "")
-if current_action:
-    observation = execute_tool(current_action, documents, reasoning_state)
-else:
-    observation = {"error": "No action specified"}
-
-result = {
-    "tool_result": observation,
-    "timestamp": datetime.now().isoformat()
-}
-"""
-            },
+            _internal=True,
         )
 
         # Reasoning state manager
-        state_manager_id = builder.add_node(
-            "PythonCodeNode",
+        _state_manager_fn = _make_state_manager(self.max_reasoning_steps)
+        state_manager_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _state_manager_fn,
+                name="state_manager",
+            ),
             node_id="state_manager",
-            config={
-                "code": f"""
-# Manage reasoning state across iterations
-import json
-
-def update_reasoning_state(state, new_response, tool_result=None):
-    '''Update state with new reasoning step'''
-    if not state:
-        state = {{
-            "steps": [],
-            "current_step": 0,
-            "completed": False,
-            "final_answer": None
-        }}
-
-    # Parse response for thought/action/answer
-    lines = new_response.strip().split('\\n')
-    current_thought = None
-    current_action = None
-    final_answer = None
-
-    for line in lines:
-        if line.startswith("Thought:"):
-            current_thought = line[8:].strip()
-        elif line.startswith("Action:"):
-            current_action = line[7:].strip()
-        elif line.startswith("Answer:"):
-            final_answer = line[7:].strip()
-            state["completed"] = True
-
-    # Add step
-    step = {{
-        "step_number": state["current_step"] + 1,
-        "thought": current_thought,
-        "action": current_action,
-        "observation": tool_result.get("tool_result") if tool_result else None
-    }}
-
-    state["steps"].append(step)
-    state["current_step"] += 1
-    state["current_action"] = current_action
-    state["final_answer"] = final_answer
-
-    # Check if we've reached max steps
-    if state["current_step"] >= {self.max_reasoning_steps}:
-        state["completed"] = True
-        if not state["final_answer"]:
-            state["final_answer"] = "Reached maximum reasoning steps. Based on gathered information..."
-
-    return state
-
-# Process current iteration. `plan` arrives from the plan parser as the
-# parsed planner dict; `reasoning_response` arrives from the reasoning parser
-# as the ReAct prose STRING (the parsers already unwrapped `response.content`
-# upstream, so NO further `.get("response")` unwrap is needed — and would be
-# wrong, the inner dict has no `response` key). `reasoning_response` may still
-# be a non-str on a defensive path; coerce so the line parser never crashes.
-if not isinstance(reasoning_response, str):
-    reasoning_response = "" if reasoning_response is None else str(reasoning_response)
-tool_result = tool_result if "tool_result" in locals() else None
-
-# Initialize or update state
-if "reasoning_state" not in locals() or not reasoning_state:
-    reasoning_state = None
-
-reasoning_state = update_reasoning_state(
-    reasoning_state,
-    reasoning_response,
-    tool_result
-)
-
-# Prepare context for next iteration
-context_for_agent = ""
-for step in reasoning_state["steps"]:
-    if step["thought"]:
-        context_for_agent += f"\\nThought: {{step['thought']}}"
-    if step["action"]:
-        context_for_agent += f"\\nAction: {{step['action']}}"
-    if step["observation"]:
-        context_for_agent += f"\\nObservation: {{step['observation']}}"
-
-result = {{
-    "reasoning_state": reasoning_state,
-    "context_for_agent": context_for_agent,
-    "continue_reasoning": not reasoning_state["completed"]
-}}
-"""
-            },
+            _internal=True,
         )
 
         # Verification agent (if enabled)
@@ -866,76 +1025,22 @@ Return JSON:
                 },
             )
 
-        # Result synthesizer
-        # NB: this code template is an f-string because the metadata block
-        # interpolates the constructor config (planning_strategy / max steps).
-        # Literal Python braces inside the sandboxed code are doubled ({{ }}).
-        synthesizer_id = builder.add_node(
-            "PythonCodeNode",
+        # Result synthesizer (#1117/#1123 root-cause fix: lifted from the prior
+        # doubled-brace f-string codegen to `_make_result_synthesizer`, with the
+        # build-time planning_strategy / max_reasoning_steps bound through the
+        # closure). Publishes the SAME flat `result` port carrying
+        # `{"agentic_rag_result": {...}}` — it is the terminal synthesis node, so
+        # the WorkflowNode surfaces its output unchanged.
+        _result_synthesizer_fn = _make_result_synthesizer(
+            self.planning_strategy, self.max_reasoning_steps
+        )
+        synthesizer_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _result_synthesizer_fn,
+                name="result_synthesizer",
+            ),
             node_id="result_synthesizer",
-            config={
-                "code": f"""
-# Synthesize final results
-reasoning_state = reasoning_state
-verification = verification if "verification" in locals() else None
-query = query
-
-# Extract tool usage
-tools_used = []
-for step in reasoning_state["steps"]:
-    if step["observation"] and "tool" in step["observation"]:
-        tools_used.append(step["observation"]["tool"])
-
-# Calculate confidence. `verification` arrives from the verification parser
-# as the PARSED verifier dict ({{"verified", "confidence", "issues", ...}} or a
-# parse-error sentinel carrying {{"parse_error": ...}}) — already unwrapped from
-# `response.content` + json.loads upstream. The prior `.get("response")` read a
-# non-existent key off the inner content dict, so the verdict was always
-# dropped. A flagged parse-error sentinel carries no real confidence, so it is
-# treated as "no usable verdict" (NOT a fabricated 0.8) and confidence is left
-# unadjusted — honest, per zero-tolerance Rule 2.
-base_confidence = 0.7
-confidence_boost = min(0.3, len(tools_used) * 0.1)
-_has_verdict = (
-    isinstance(verification, dict)
-    and "confidence" in verification
-    and verification.get("parse_error") is None
-)
-if _has_verdict:
-    verification_confidence = verification.get("confidence", 0.8)
-    final_confidence = (base_confidence + confidence_boost) * verification_confidence
-else:
-    final_confidence = base_confidence + confidence_boost
-
-# Build reasoning trace
-reasoning_trace = []
-for step in reasoning_state["steps"]:
-    trace_entry = {{
-        "step": step["step_number"],
-        "thought": step["thought"],
-        "action": step["action"],
-        "observation": step["observation"]
-    }}
-    reasoning_trace.append(trace_entry)
-
-result = {{
-    "agentic_rag_result": {{
-        "query": query,
-        "answer": reasoning_state["final_answer"],
-        "reasoning_trace": reasoning_trace,
-        "tools_used": list(set(tools_used)),
-        "confidence": final_confidence,
-        "total_steps": len(reasoning_state["steps"]),
-        "verification": verification if _has_verdict else None,
-        "metadata": {{
-            "planning_strategy": "{self.planning_strategy}",
-            "max_steps": {self.max_reasoning_steps},
-            "completed_successfully": reasoning_state["completed"]
-        }}
-    }}
-}}
-"""
-            },
+            _internal=True,
         )
 
         # L3 messages-composers (reference template — conversational.py /
@@ -945,12 +1050,13 @@ result = {{
         # Each composer renders the REAL inputs that stage must reason over into
         # a `messages` list wired to the VALID `messages` port. `from_function`
         # is the correct primitive (real module-level functions: real `return`→
-        # `result`, type-checkable). type: ignore[attr-defined]: `from_function`
-        # is a classmethod on concrete PythonCodeNode, erased to `type[Node]` by
-        # `@register_node` for static checkers (mirrors conversational.py).
-        # `_internal=True` suppresses the consumer-facing instance-API advisory.
+        # `result`, type-checkable). The call is BARE (no `# type: ignore`): the
+        # `from_function` unknown-attr pyright diagnostic is non-gating (gates =
+        # ruff + pytest) and the suppression is normalized away across the rag
+        # from_function sites. `_internal=True` suppresses the consumer-facing
+        # instance-API advisory.
         planner_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_planner_messages,
                 name="planner_messages_composer",
             ),
@@ -958,7 +1064,7 @@ result = {{
             _internal=True,
         )
         react_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_react_messages,
                 name="react_messages_composer",
             ),
@@ -968,7 +1074,7 @@ result = {{
         verifier_messages_composer_id: Optional[str] = None
         if self.verification_enabled:
             verifier_messages_composer_id = builder.add_node_instance(
-                PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                PythonCodeNode.from_function(
                     compose_verifier_messages,
                     name="verifier_messages_composer",
                 ),
@@ -982,7 +1088,7 @@ result = {{
         # consumer reads PARSED fields — NOT the raw `{"content": ...}` wrapper
         # off which the prior `.get("response")` read a non-existent key.
         plan_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_plan_response,
                 name="plan_parser",
             ),
@@ -990,7 +1096,7 @@ result = {{
             _internal=True,
         )
         reasoning_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_reasoning_response,
                 name="reasoning_parser",
             ),
@@ -1000,7 +1106,7 @@ result = {{
         verification_parser_id: Optional[str] = None
         if self.verification_enabled:
             verification_parser_id = builder.add_node_instance(
-                PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                PythonCodeNode.from_function(
                     parse_verification_response,
                     name="verification_parser",
                 ),
@@ -1027,9 +1133,12 @@ result = {{
         # accumulated Thought/Action/Observation transcript) into the react
         # agent's `messages` port. The phantom `additional_context` edge is
         # REMOVED.
+        # PHANTOM-PORT FIX: state_manager is now a `from_function` node, which
+        # publishes ONLY a flat `result` port — `context_for_agent` is a KEY of
+        # that dict, NOT a top-level port. The edge reads `result.context_for_agent`.
         builder.add_connection(
             state_manager_id,
-            "context_for_agent",
+            "result.context_for_agent",
             react_messages_composer_id,
             "context_for_agent",
         )
@@ -1048,18 +1157,28 @@ result = {{
             state_manager_id,
             "reasoning_response",
         )
+        # PHANTOM-PORT FIX (cyclic edges): both state_manager and tool_executor
+        # are `from_function` nodes publishing a flat `result` port, so each
+        # cycle edge reads `result.<key>`. `reasoning_state` / `tool_result` are
+        # KEYS of the respective `result` dict, not top-level ports.
         builder.add_connection(
-            state_manager_id, "reasoning_state", tool_executor_id, "reasoning_state"
+            state_manager_id,
+            "result.reasoning_state",
+            tool_executor_id,
+            "reasoning_state",
         )
         builder.add_connection(
-            tool_executor_id, "tool_result", state_manager_id, "tool_result"
+            tool_executor_id, "result.tool_result", state_manager_id, "tool_result"
         )
 
-        # Loop control - continue if not completed. This is a loop-control edge
-        # (not a context port), so it stays unchanged: it gates whether the react
-        # agent runs again, it does NOT carry reasoning context.
+        # Loop control - continue if not completed. `continue_reasoning` is a KEY
+        # of the state_manager `result` dict (from_function flat port), so the
+        # loop-control edge reads `result.continue_reasoning`.
         builder.add_connection(
-            state_manager_id, "continue_reasoning", react_agent_id, "_continue_if_true"
+            state_manager_id,
+            "result.continue_reasoning",
+            react_agent_id,
+            "_continue_if_true",
         )
 
         # Verification (if enabled).
@@ -1078,7 +1197,7 @@ result = {{
             assert verification_parser_id is not None
             builder.add_connection(
                 state_manager_id,
-                "reasoning_state",
+                "result.reasoning_state",
                 verifier_messages_composer_id,
                 "reasoning_state",
             )
@@ -1101,9 +1220,13 @@ result = {{
                 "verification",
             )
 
-        # Final synthesis
+        # Final synthesis. `reasoning_state` is a KEY of the state_manager
+        # `from_function` `result` dict, so the edge reads `result.reasoning_state`.
         builder.add_connection(
-            state_manager_id, "reasoning_state", synthesizer_id, "reasoning_state"
+            state_manager_id,
+            "result.reasoning_state",
+            synthesizer_id,
+            "reasoning_state",
         )
 
         return builder.build(name="agentic_rag_workflow")
@@ -1400,7 +1523,7 @@ Rate confidence: 0.0-1.0""",
         # Each composer renders the REAL inputs (the query and/or the genuine
         # upstream LLM `response`) into the stage's VALID `messages` port.
         decomposer_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_decomposer_messages,
                 name="decomposer_messages_composer",
             ),
@@ -1408,7 +1531,7 @@ Rate confidence: 0.0-1.0""",
             _internal=True,
         )
         step_reasoner_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_step_reasoner_messages,
                 name="step_reasoner_messages_composer",
             ),
@@ -1416,7 +1539,7 @@ Rate confidence: 0.0-1.0""",
             _internal=True,
         )
         logic_verifier_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_logic_verifier_messages,
                 name="logic_verifier_messages_composer",
             ),
@@ -1432,7 +1555,7 @@ Rate confidence: 0.0-1.0""",
         # wrapper, which `_render_reasoning_plan` would otherwise stringify
         # (the steps/assumptions never extracted).
         decomposition_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_decomposition_response,
                 name="decomposition_parser",
             ),
@@ -1440,7 +1563,7 @@ Rate confidence: 0.0-1.0""",
             _internal=True,
         )
         reasoning_chain_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_reasoning_chain_response,
                 name="reasoning_chain_parser",
             ),

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/conversational.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/conversational.py
@@ -200,6 +200,527 @@ def compose_summary_messages(conversation_context=None):
     return {"messages": [{"role": "user", "content": content}]}
 
 
+# ---------------------------------------------------------------------------
+# COMPUTE-stage functions (S6a — root-cause fix for #1117 publish-nothing /
+# #1123 brace-escape / #1118 import-trap).
+#
+# The five COMPUTE stages of the ConversationalRAGNode workflow were inline
+# `code=` PythonCodeNode codegen blocks. They are now module-level functions
+# wired via `PythonCodeNode.from_function`, the same reference template as the
+# composers above and as optimized.py / evaluation.py / query_processing.py.
+#
+# A `from_function` node publishes its `return` value on the FLAT `result`
+# port — the structural successor of the prior codegen's module-scope
+# `result =` assignment. Each downstream edge reads `result` and the consumer
+# unwraps the nested key it needs (`session_context` / `topic_analysis` /
+# `contextual_retrieval` / `session_update`), so the wiring is unchanged.
+#
+# `from_function` removes the three defect classes the inline codegen carried:
+#   - #1117 publish-nothing: the prior inner `def ...(): result = {...}` bound
+#     a FUNCTION-LOCAL `result` that was never returned, so the module-scope
+#     output port saw nothing. A real `return` publishes on `result`.
+#   - #1123 brace-escape: the f-string `code=` form doubled every literal
+#     brace (`{{...}}`), an error-prone hand-escape. Real functions carry
+#     real dict literals.
+#   - #1118 import-trap: `PythonCodeNode` passes separate (globals, locals) to
+#     `exec()`, so a module-scope import bound into the LOCAL namespace and was
+#     invisible to a nested function's closure (`datetime.now()` raised
+#     AttributeError). A real module-level function closes over real
+#     module-scope imports (`datetime`) natively.
+#
+# Build-time config (`max_context_turns` + the result-formatter flags) is bound
+# through thin closure factories below (mirrors optimized.py's
+# `_decide_cache_use_bound`) so the lifted functions stay pure + testable while
+# the per-instance config interpolates at workflow-construction time.
+# ---------------------------------------------------------------------------
+
+
+def _load_conversation_context(
+    session_id, sessions_store=None, max_context_turns: int = 10
+) -> dict:
+    """Load conversation context for a session (lifted context_loader stage).
+
+    Returns ``{"session_context": {...}}`` on the flat ``result`` port that
+    ``context_retriever`` / ``topic_tracker`` / the composers unwrap.
+    `session_id` is an external workflow input; `sessions_store` is an internal
+    per-run store defaulted to an empty dict when the caller does not wire one.
+    """
+    if sessions_store is None:
+        sessions_store = {}
+
+    if session_id not in sessions_store:
+        # Create new session.
+        session = {
+            "id": session_id,
+            "created_at": datetime.now().isoformat(),
+            "turns": [],
+            "summary": "",
+            "current_topic": None,
+            "user_preferences": {},
+            "metrics": {
+                "turn_count": 0,
+                "topics_discussed": [],
+                "avg_response_length": 0,
+            },
+        }
+        sessions_store[session_id] = session
+
+    session = sessions_store[session_id]
+
+    # Get recent context (sliding window).
+    recent_turns = session["turns"][-max_context_turns:]
+
+    # Format context for processing.
+    context_text = ""
+    for turn in recent_turns:
+        context_text += f"User: {turn['query']}\n"
+        context_text += f"Assistant: {turn['response']}\n\n"
+
+    return {
+        "session_context": {
+            "session_id": session_id,
+            "recent_turns": recent_turns,
+            "context_text": context_text,
+            "summary": session.get("summary", ""),
+            "current_topic": session.get("current_topic"),
+            "turn_count": len(session["turns"]),
+            "user_preferences": session.get("user_preferences", {}),
+        }
+    }
+
+
+def _track_conversation_topic(current_query="", session_context=None) -> dict:
+    """Track and identify topic changes (lifted topic_tracker stage).
+
+    Returns ``{"topic_analysis": {...}}`` on the flat ``result`` port that
+    `context_retriever` / `session_updater` / `result_formatter` unwrap.
+    `current_query` is an external workflow input; `session_context` is wired
+    from `context_loader`'s `result` port (the whole ``{"session_context":
+    ...}`` dict) and unwrapped to the inner dict here.
+    """
+    inner = {}
+    if isinstance(session_context, dict):
+        inner = session_context.get("session_context", session_context)
+    if not isinstance(inner, dict):
+        inner = {}
+
+    current_topic = inner.get("current_topic")
+
+    # Extract key terms from current query.
+    query_terms = set((current_query or "").lower().split())
+
+    # Define topic keywords (simplified - use NER/classification in production).
+    topics = {
+        "transformers": [
+            "transformer",
+            "attention",
+            "self-attention",
+            "encoder",
+            "decoder",
+        ],
+        "bert": ["bert", "bidirectional", "masked", "mlm", "pretraining"],
+        "gpt": ["gpt", "generative", "autoregressive", "language model"],
+        "training": ["training", "optimization", "learning rate", "batch", "epoch"],
+        "architecture": ["architecture", "layer", "network", "model", "structure"],
+    }
+
+    # Identify current query topic.
+    query_topics = []
+    for topic, keywords in topics.items():
+        if any(keyword in query_terms for keyword in keywords):
+            query_topics.append(topic)
+
+    # Determine if topic changed.
+    topic_changed = False
+    transition_type = "continuation"
+
+    if not current_topic and query_topics:
+        # First topic.
+        new_topic = query_topics[0]
+        transition_type = "new_conversation"
+    elif query_topics and query_topics[0] != current_topic:
+        # Topic switch.
+        new_topic = query_topics[0]
+        topic_changed = True
+        transition_type = "topic_switch"
+    elif query_topics:
+        # Same topic.
+        new_topic = query_topics[0]
+        transition_type = "deep_dive"
+    else:
+        # No clear topic.
+        new_topic = current_topic or "general"
+        transition_type = "clarification"
+
+    # Check for explicit transitions.
+    transition_phrases = {
+        "now tell me about": "explicit_switch",
+        "switching to": "explicit_switch",
+        "different topic": "explicit_switch",
+        "another question": "soft_switch",
+        "related to this": "expansion",
+        "furthermore": "continuation",
+        "however": "contrast",
+    }
+
+    for phrase, trans_type in transition_phrases.items():
+        if phrase in (current_query or "").lower():
+            transition_type = trans_type
+            break
+
+    return {
+        "topic_analysis": {
+            "current_topic": new_topic,
+            "previous_topic": current_topic,
+            "topic_changed": topic_changed,
+            "transition_type": transition_type,
+            "identified_topics": query_topics,
+            "confidence": 0.8 if query_topics else 0.3,
+        }
+    }
+
+
+def _retrieve_with_context(
+    query="", documents=None, session_context=None, topic_info=None, resolved_query=None
+) -> dict:
+    """Retrieve documents considering conversation context (lifted
+    context_retriever stage).
+
+    Returns ``{"contextual_retrieval": {...}}`` on the flat ``result`` port
+    that `response_messages_composer` / `result_formatter` unwrap.
+
+    Wiring shapes the inputs receive:
+      - `query` + `documents` are external workflow inputs.
+      - `session_context` is wired from `context_loader`'s `result` port (the
+        whole ``{"session_context": ...}`` dict) and unwrapped to the inner
+        dict here.
+      - `topic_info` is wired from `topic_tracker`'s `result` port (already the
+        ``{"topic_analysis": ...}`` shape) — passed through WITHOUT unwrap.
+      - `resolved_query` (optional) is the coreference_resolver (LLMAgentNode)
+        `response` port value — an inner message dict keyed by "content"; when
+        present its content overrides the raw query string.
+    """
+    if documents is None:
+        documents = []
+
+    inner_context = {}
+    if isinstance(session_context, dict):
+        inner_context = session_context.get("session_context", session_context)
+    if not isinstance(inner_context, dict):
+        inner_context = {}
+
+    # The resolved query (from the coreference stage) overrides the raw query.
+    effective_query = query
+    if isinstance(resolved_query, dict) and resolved_query.get("content"):
+        effective_query = resolved_query["content"]
+    elif isinstance(resolved_query, str) and resolved_query:
+        effective_query = resolved_query
+
+    # Combine current query with context.
+    recent_context = inner_context.get("context_text", "")
+
+    # Build enhanced query.
+    enhanced_query = effective_query
+    current_topic = None
+
+    # Add topic context if available.
+    if topic_info and topic_info.get("topic_analysis"):
+        current_topic = topic_info["topic_analysis"].get("current_topic")
+        if current_topic:
+            enhanced_query = f"{current_topic} context: {effective_query}"
+
+    # Add conversation context keywords.
+    if recent_context:
+        # Extract key terms from recent context.
+        context_words = set(recent_context.lower().split())
+        important_words = [w for w in context_words if len(w) > 4][:5]
+        enhanced_query += " " + " ".join(important_words)
+
+    # Score documents with context awareness.
+    scored_docs = []
+    query_words = set(enhanced_query.lower().split())
+
+    for doc in documents:
+        content = doc.get("content", "").lower()
+        doc_words = set(content.split())
+
+        # Base relevance score.
+        if query_words:
+            relevance = len(query_words & doc_words) / len(query_words)
+        else:
+            relevance = 0
+
+        # Boost score for topic-relevant documents.
+        if topic_info and current_topic in content:
+            relevance *= 1.3
+
+        # Boost for documents related to recent context.
+        if recent_context and any(
+            turn.get("response", "") in content
+            for turn in inner_context.get("recent_turns", [])
+        ):
+            relevance *= 1.2
+
+        scored_docs.append(
+            {
+                "document": doc,
+                "score": min(1.0, relevance),
+                "context_boosted": (
+                    relevance > len(query_words & doc_words) / len(query_words)
+                    if query_words
+                    else False
+                ),
+            }
+        )
+
+    # Sort by score.
+    scored_docs.sort(key=lambda x: x["score"], reverse=True)
+
+    return {
+        "contextual_retrieval": {
+            "documents": [d["document"] for d in scored_docs[:10]],
+            "scores": [d["score"] for d in scored_docs[:10]],
+            "enhanced_query": enhanced_query,
+            "context_influence": (
+                sum(1 for d in scored_docs[:10] if d["context_boosted"])
+                / min(10, len(scored_docs))
+                if scored_docs
+                else 0
+            ),
+        }
+    }
+
+
+def _update_session(
+    session_id,
+    query="",
+    response=None,
+    topic_info=None,
+    summary=None,
+    sessions_store=None,
+    max_context_turns: int = 10,
+) -> dict:
+    """Update the session with a new turn (lifted session_updater stage).
+
+    Returns ``{"session_update": {...}}`` on the flat ``result`` port that
+    `result_formatter` unwraps.
+
+    Wiring shapes the inputs receive:
+      - `session_id` + `query` are external workflow inputs.
+      - `response` is the response_generator (LLMAgentNode) `response` port
+        value — an inner message dict keyed by "content".
+      - `topic_info` is the topic_tracker `result` port (``{"topic_analysis":
+        ...}``); absent on a False optional-branch.
+      - `summary` is the context_summarizer `response` port value (inner
+        message dict keyed by "content") when summarization is enabled.
+      - `sessions_store` is the internal per-run store (defaulted empty).
+
+    PythonCodeNode runs each node with an independent copy of its inputs, so the
+    `sessions_store` mutation context_loader performed is NOT visible here. Seed
+    the session if absent (same shape context_loader creates) so this turn is
+    recorded against a real session record rather than crashing with KeyError.
+    Cross-execution persistence is owned by the WorkflowNode's own
+    `self.sessions` store (see create_session), not this per-run store.
+    """
+    if sessions_store is None:
+        sessions_store = {}
+
+    if session_id not in sessions_store:
+        sessions_store[session_id] = {
+            "id": session_id,
+            "created_at": datetime.now().isoformat(),
+            "turns": [],
+            "summary": "",
+            "current_topic": None,
+            "user_preferences": {},
+            "metrics": {
+                "turn_count": 0,
+                "topics_discussed": [],
+                "avg_response_length": 0,
+            },
+        }
+
+    session = sessions_store[session_id]
+
+    # Add new turn. `response` is the LLMAgentNode `response` port value — an
+    # inner message dict keyed by "content" (NOT "response").
+    new_turn = {
+        "turn_number": len(session["turns"]) + 1,
+        "timestamp": datetime.now().isoformat(),
+        "query": query,
+        "response": (
+            response.get("content", "")
+            if isinstance(response, dict)
+            else (response or "")
+        ),
+        "topic": (
+            topic_info.get("topic_analysis", {}).get("current_topic")
+            if isinstance(topic_info, dict)
+            else None
+        ),
+    }
+
+    session["turns"].append(new_turn)
+
+    # Update summary if provided. `summary` is the context_summarizer
+    # (LLMAgentNode) `response` port value — an inner message dict keyed by
+    # "content" (NOT "response").
+    if isinstance(summary, dict) and summary.get("content"):
+        session["summary"] = summary["content"]
+
+    # Update current topic.
+    if topic_info and topic_info.get("topic_analysis"):
+        session["current_topic"] = topic_info["topic_analysis"]["current_topic"]
+
+        # Track topics discussed.
+        topic = topic_info["topic_analysis"]["current_topic"]
+        if topic and topic not in session["metrics"]["topics_discussed"]:
+            session["metrics"]["topics_discussed"].append(topic)
+
+    # Update metrics.
+    session["metrics"]["turn_count"] = len(session["turns"])
+    total_response_length = sum(
+        len(turn.get("response", "")) for turn in session["turns"]
+    )
+    session["metrics"]["avg_response_length"] = (
+        total_response_length / len(session["turns"]) if session["turns"] else 0
+    )
+
+    # Trim old turns if exceeds max + buffer for summarization.
+    if len(session["turns"]) > max_context_turns * 1.5:
+        # Keep recent turns and rely on summary for older context.
+        session["turns"] = session["turns"][-max_context_turns:]
+
+    # Coherence proxy: topic consistency. Fewer DISTINCT topics across the turns
+    # => the conversation stayed on-topic => more coherent. Derived from the
+    # real session signal (NOT a hardcoded score); single-topic = 1.0.
+    _distinct_topics = len(session["metrics"]["topics_discussed"])
+    _coherence_turns = max(1, session["metrics"]["turn_count"])
+    coherence_score = max(
+        0.0, min(1.0, 1.0 - (max(0, _distinct_topics - 1) / _coherence_turns))
+    )
+
+    # Calculate conversation health metrics.
+    conversation_metrics = {
+        "coherence_score": coherence_score,  # derived from topic consistency
+        "engagement_level": min(1.0, len(session["turns"]) / 10),  # higher w/ turns
+        "topic_diversity": (
+            len(session["metrics"]["topics_discussed"])
+            / max(1, session["metrics"]["turn_count"])
+        ),
+        "avg_turn_length": session["metrics"]["avg_response_length"],
+    }
+
+    return {
+        "session_update": {
+            "session_id": session_id,
+            "turn_added": new_turn["turn_number"],
+            "total_turns": len(session["turns"]),
+            "current_topic": session["current_topic"],
+            "conversation_metrics": conversation_metrics,
+        }
+    }
+
+
+def _format_conversational_result(
+    response=None,
+    session_update=None,
+    topic_info=None,
+    contextual_retrieval=None,
+    max_context_turns: int = 10,
+    enable_summarization: bool = True,
+    coreference_resolution: bool = True,
+    personalization_enabled: bool = True,
+) -> dict:
+    """Format the terminal conversational response (lifted result_formatter
+    stage — publishes the WorkflowNode's documented
+    ``conversational_response``).
+
+    Every wired input arrives as its PRODUCER's published port value:
+      - `response`             <- response_generator.response (LLMAgentNode
+                                  port value = inner message dict keyed by
+                                  "content")
+      - `session_update`       <- session_updater.result ({"session_update"})
+      - `topic_info`           <- topic_tracker.result ({"topic_analysis"})
+      - `contextual_retrieval` <- context_retriever.result
+                                  ({"contextual_retrieval"})
+    so each is unwrapped to the nested shape this formatter consumes. Optional
+    inputs may be unwired on a False optional-branch (topic_tracking off leaves
+    `topic_info` unbound), so each is defaulted to a benign empty value.
+
+    The per-instance config flags (`max_context_turns`, `enable_summarization`,
+    `coreference_resolution`, `personalization_enabled`) are bound at
+    workflow-construction time through the closure factory — the structural
+    successor of the prior f-string `{self.*}` interpolation (#1123 fix).
+    """
+    if topic_info is None:
+        topic_info = {}
+    if session_update is None:
+        session_update = {}
+    if contextual_retrieval is None:
+        contextual_retrieval = {}
+    if response is None:
+        response = {}
+
+    # Format conversational response. `response` is the LLMAgentNode `response`
+    # port value (inner message dict keyed by "content", NOT "response").
+    response_text = (
+        response.get("content", "") if isinstance(response, dict) else (response or "")
+    )
+    session_update = (
+        session_update.get("session_update", {})
+        if isinstance(session_update, dict)
+        else {}
+    )
+    topic_info = (
+        topic_info.get("topic_analysis", {}) if isinstance(topic_info, dict) else {}
+    )
+    contextual_retrieval = (
+        contextual_retrieval.get("contextual_retrieval", {})
+        if isinstance(contextual_retrieval, dict)
+        else {}
+    )
+
+    # Build session state summary.
+    session_state = {
+        "session_id": session_update.get("session_id"),
+        "turn_number": session_update.get("turn_added"),
+        "total_turns": session_update.get("total_turns"),
+        "context_window": max_context_turns,
+        "summary_available": enable_summarization,
+    }
+
+    # Topic information.
+    topic_summary = {
+        "current_topic": topic_info.get("current_topic"),
+        "topic_changed": topic_info.get("topic_changed", False),
+        "transition_type": topic_info.get("transition_type", "continuation"),
+        "topics_discussed": session_update.get("conversation_metrics", {}).get(
+            "topic_diversity", 0
+        ),
+    }
+
+    # Conversation metrics.
+    metrics = session_update.get("conversation_metrics", {})
+    metrics["retrieval_context_influence"] = contextual_retrieval.get(
+        "context_influence", 0
+    )
+
+    return {
+        "conversational_response": {
+            "response": response_text,
+            "session_state": session_state,
+            "topic_info": topic_summary,
+            "conversation_metrics": metrics,
+            "metadata": {
+                "coreference_resolution": coreference_resolution,
+                "personalization": personalization_enabled,
+                "context_enhanced_retrieval": True,
+            },
+        }
+    }
+
+
 @register_node()
 class ConversationalRAGNode(WorkflowNode):
     """
@@ -292,76 +813,36 @@ class ConversationalRAGNode(WorkflowNode):
         topic_tracker_id: Optional[str] = None
         summarizer_id: Optional[str] = None
 
-        # Session context loader
-        context_loader_id = builder.add_node(
-            "PythonCodeNode",
+        # Session context loader.
+        #
+        # S6a #1117/#1123/#1118 root-cause fix: lifted from the prior f-string
+        # codegen to the module-level `_load_conversation_context` function
+        # wired via `PythonCodeNode.from_function`. The build-time
+        # `max_context_turns` is bound through a thin closure (keeps
+        # `session_id` + `sessions_store` as the declared inputs). The node
+        # publishes the SAME flat `result` port carrying
+        # `{"session_context": {...}}`, so the downstream edges resolve
+        # unchanged. `_internal=True` suppresses the consumer-facing
+        # instance-API advisory (SDK-internal construction path, mirrors the
+        # composers above + optimized.py).
+        _max_context_turns = self.max_context_turns
+
+        def _load_conversation_context_bound(session_id, sessions_store=None) -> dict:
+            return _load_conversation_context(
+                session_id=session_id,
+                sessions_store=sessions_store,
+                max_context_turns=_max_context_turns,
+            )
+
+        _load_conversation_context_bound.__name__ = "context_loader"
+        _load_conversation_context_bound.__doc__ = _load_conversation_context.__doc__
+        context_loader_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _load_conversation_context_bound,
+                name="context_loader",
+            ),
             node_id="context_loader",
-            config={
-                "code": f"""
-def load_conversation_context(session_id, sessions_store):
-    '''Load conversation context for session'''
-    # F9 #1118 sibling: import inside the function body. PythonCodeNode passes
-    # separate (globals, locals) to exec(), so a module-scope import binds into
-    # the LOCAL namespace and is invisible to this function's closure
-    # (`datetime.now()` on the module raises AttributeError otherwise).
-    from datetime import datetime as _datetime_class
-
-    if session_id not in sessions_store:
-        # Create new session
-        session = {{
-            "id": session_id,
-            "created_at": _datetime_class.now().isoformat(),
-            "turns": [],
-            "summary": "",
-            "current_topic": None,
-            "user_preferences": {{}},
-            "metrics": {{
-                "turn_count": 0,
-                "topics_discussed": [],
-                "avg_response_length": 0
-            }}
-        }}
-        sessions_store[session_id] = session
-
-    session = sessions_store[session_id]
-
-    # Get recent context (sliding window)
-    recent_turns = session["turns"][-{self.max_context_turns}:]
-
-    # Format context for processing
-    context_text = ""
-    for turn in recent_turns:
-        context_text += f"User: {{turn['query']}}\\n"
-        context_text += f"Assistant: {{turn['response']}}\\n\\n"
-
-    # F9 #1117: function MUST return its dict; the prior `result = {{...}}`
-    # bound a function-scope local that was never returned, so the session
-    # context never reached the module-scope `session_context` output.
-    return {{
-        "session_context": {{
-            "session_id": session_id,
-            "recent_turns": recent_turns,
-            "context_text": context_text,
-            "summary": session.get("summary", ""),
-            "current_topic": session.get("current_topic"),
-            "turn_count": len(session["turns"]),
-            "user_preferences": session.get("user_preferences", {{}})
-        }}
-    }}
-
-# F9 #1117: module-scope call so PythonCodeNode publishes the `result` port
-# (carrying {{"session_context": ...}}) that downstream nodes unwrap. `session_id`
-# is an external workflow input; `sessions_store` is an internal per-run store —
-# default it to an empty dict when the caller does not wire one. `del` the helper
-# so the output gate sees only `result`.
-try:
-    sessions_store
-except NameError:
-    sessions_store = {{}}
-result = load_conversation_context(session_id, sessions_store)
-del load_conversation_context
-"""
-            },
+            _internal=True,
         )
 
         # Coreference resolver
@@ -393,208 +874,48 @@ If no coreferences found, return the original query.""",
                 },
             )
 
-        # Topic tracker
+        # Topic tracker.
+        #
+        # S6a #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_track_conversation_topic` function wired via
+        # `PythonCodeNode.from_function` (BARE — no build-time config to bind).
+        # `current_query` is an external workflow input; `session_context` is
+        # wired from context_loader's `result` port (the whole
+        # `{"session_context": ...}` dict) — the function unwraps the inner dict
+        # internally (the prior codegen unwrapped at the module-scope call
+        # site). The node publishes the SAME flat `result` port carrying
+        # `{"topic_analysis": {...}}`.
         if self.topic_tracking:
-            topic_tracker_id = builder.add_node(
-                "PythonCodeNode",
+            topic_tracker_id = builder.add_node_instance(
+                PythonCodeNode.from_function(
+                    _track_conversation_topic,
+                    name="topic_tracker",
+                ),
                 node_id="topic_tracker",
-                config={
-                    "code": """
-def track_conversation_topic(current_query, session_context):
-    '''Track and identify topic changes in conversation'''
-
-    current_topic = session_context.get("current_topic")
-    recent_turns = session_context.get("recent_turns", [])
-
-    # Extract key terms from current query
-    query_terms = set(current_query.lower().split())
-
-    # Define topic keywords (simplified - use NER/classification in production)
-    topics = {
-        "transformers": ["transformer", "attention", "self-attention", "encoder", "decoder"],
-        "bert": ["bert", "bidirectional", "masked", "mlm", "pretraining"],
-        "gpt": ["gpt", "generative", "autoregressive", "language model"],
-        "training": ["training", "optimization", "learning rate", "batch", "epoch"],
-        "architecture": ["architecture", "layer", "network", "model", "structure"]
-    }
-
-    # Identify current query topic
-    query_topics = []
-    for topic, keywords in topics.items():
-        if any(keyword in query_terms for keyword in keywords):
-            query_topics.append(topic)
-
-    # Determine if topic changed
-    topic_changed = False
-    transition_type = "continuation"
-
-    if not current_topic and query_topics:
-        # First topic
-        new_topic = query_topics[0]
-        transition_type = "new_conversation"
-    elif query_topics and query_topics[0] != current_topic:
-        # Topic switch
-        new_topic = query_topics[0]
-        topic_changed = True
-        transition_type = "topic_switch"
-    elif query_topics:
-        # Same topic
-        new_topic = query_topics[0]
-        transition_type = "deep_dive"
-    else:
-        # No clear topic
-        new_topic = current_topic or "general"
-        transition_type = "clarification"
-
-    # Check for explicit transitions
-    transition_phrases = {
-        "now tell me about": "explicit_switch",
-        "switching to": "explicit_switch",
-        "different topic": "explicit_switch",
-        "another question": "soft_switch",
-        "related to this": "expansion",
-        "furthermore": "continuation",
-        "however": "contrast"
-    }
-
-    for phrase, trans_type in transition_phrases.items():
-        if phrase in current_query.lower():
-            transition_type = trans_type
-            break
-
-    # F9 #1117: function MUST return its dict; the prior `result = {...}`
-    # bound a function-scope local that was never returned, so the topic
-    # analysis never reached the module-scope `topic_analysis` output.
-    return {
-        "topic_analysis": {
-            "current_topic": new_topic,
-            "previous_topic": current_topic,
-            "topic_changed": topic_changed,
-            "transition_type": transition_type,
-            "identified_topics": query_topics,
-            "confidence": 0.8 if query_topics else 0.3
-        }
-    }
-
-# F9 #1117: module-scope call so PythonCodeNode publishes the `result` port
-# (carrying {"topic_analysis": ...}) that context_retriever / session_updater /
-# result_formatter unwrap. `current_query` is an external workflow input;
-# `session_context` is wired from context_loader (unwrapped below).
-result = track_conversation_topic(current_query, session_context.get("session_context", session_context))
-del track_conversation_topic
-"""
-                },
+                _internal=True,
             )
 
-        # Context-aware retriever
-        context_retriever_id = builder.add_node(
-            "PythonCodeNode",
+        # Context-aware retriever.
+        #
+        # S6a #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_retrieve_with_context` function wired via
+        # `PythonCodeNode.from_function` (BARE — no build-time config to bind).
+        # The function declares ALL of `query` / `documents` / `session_context`
+        # / `topic_info` / `resolved_query` as explicit parameters so the
+        # runtime injector + the wired edges deliver each. The function unwraps
+        # `session_context` internally (the prior codegen unwrapped at the
+        # module-scope call site) and folds the prior module-scope
+        # `resolved_query` override logic into the function body — passing
+        # through WITHOUT unwrap for `topic_info` (already the
+        # `{"topic_analysis": ...}` shape). The node publishes the SAME flat
+        # `result` port carrying `{"contextual_retrieval": {...}}`.
+        context_retriever_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _retrieve_with_context,
+                name="context_retriever",
+            ),
             node_id="context_retriever",
-            config={
-                "code": """
-def retrieve_with_context(query, documents, session_context, topic_info=None):
-    '''Retrieve documents considering conversation context'''
-
-    # Combine current query with context
-    context_summary = session_context.get("summary", "")
-    recent_context = session_context.get("context_text", "")
-
-    # Build enhanced query
-    enhanced_query = query
-
-    # Add topic context if available
-    if topic_info and topic_info.get("topic_analysis"):
-        current_topic = topic_info["topic_analysis"].get("current_topic")
-        if current_topic:
-            enhanced_query = f"{current_topic} context: {query}"
-
-    # Add conversation context keywords
-    if recent_context:
-        # Extract key terms from recent context
-        context_words = set(recent_context.lower().split())
-        important_words = [w for w in context_words if len(w) > 4][:5]
-        enhanced_query += " " + " ".join(important_words)
-
-    # Score documents with context awareness
-    scored_docs = []
-    query_words = set(enhanced_query.lower().split())
-
-    for doc in documents:
-        content = doc.get("content", "").lower()
-        doc_words = set(content.split())
-
-        # Base relevance score
-        if query_words:
-            relevance = len(query_words & doc_words) / len(query_words)
-        else:
-            relevance = 0
-
-        # Boost score for topic-relevant documents
-        if topic_info and current_topic in content:
-            relevance *= 1.3
-
-        # Boost for documents related to recent context
-        if recent_context and any(turn.get("response", "") in content for turn in session_context.get("recent_turns", [])):
-            relevance *= 1.2
-
-        scored_docs.append({
-            "document": doc,
-            "score": min(1.0, relevance),
-            "context_boosted": relevance > len(query_words & doc_words) / len(query_words) if query_words else False
-        })
-
-    # Sort by score
-    scored_docs.sort(key=lambda x: x["score"], reverse=True)
-
-    # F9 #1117: function MUST return its dict; the prior `result = {...}`
-    # bound a function-scope local that was never returned, so the contextual
-    # retrieval never reached the module-scope `contextual_retrieval` output.
-    return {
-        "contextual_retrieval": {
-            "documents": [d["document"] for d in scored_docs[:10]],
-            "scores": [d["score"] for d in scored_docs[:10]],
-            "enhanced_query": enhanced_query,
-            "context_influence": sum(1 for d in scored_docs[:10] if d["context_boosted"]) / min(10, len(scored_docs)) if scored_docs else 0
-        }
-    }
-
-# F9 #1117: module-scope call so PythonCodeNode publishes the `result` port
-# (carrying {"contextual_retrieval": ...}) that response_generator /
-# result_formatter unwrap. `query` and `documents` are external workflow inputs.
-# `session_context` is wired from context_loader's `result` port (the whole
-# {"session_context": ...} dict), so unwrap the inner dict the function body's
-# .get("summary")/.get("context_text") calls expect. `topic_info` is wired from
-# topic_tracker's `result` port (already the {"topic_analysis": ...} shape the
-# function's .get("topic_analysis") expects) — passed through WITHOUT unwrap.
-# `resolved_query` (optional) is the coreference_resolver (LLMAgentNode)
-# `response` port value — an inner message dict keyed by "content"; when present
-# its content overrides the raw query string. Default optionals so a False
-# optional-branch leaves the call well-formed.
-try:
-    documents
-except NameError:
-    documents = []
-try:
-    topic_info
-except NameError:
-    topic_info = None
-_effective_query = query
-try:
-    if isinstance(resolved_query, dict) and resolved_query.get("content"):
-        _effective_query = resolved_query["content"]
-    elif isinstance(resolved_query, str) and resolved_query:
-        _effective_query = resolved_query
-except NameError:
-    pass
-result = retrieve_with_context(
-    _effective_query,
-    documents,
-    session_context.get("session_context", session_context),
-    topic_info,
-)
-del retrieve_with_context
-"""
-            },
+            _internal=True,
         )
 
         # Response generator with context
@@ -650,220 +971,103 @@ This will be used to maintain context in future turns.""",
                 },
             )
 
-        # Session updater
-        session_updater_id = builder.add_node(
-            "PythonCodeNode",
+        # Session updater.
+        #
+        # S6a #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_update_session` function wired via `PythonCodeNode.from_function`.
+        # The build-time `max_context_turns` is bound through a thin closure
+        # (keeps `session_id` / `query` / `response` / `topic_info` / `summary`
+        # as the declared inputs the wired edges + injector deliver). Optional
+        # inputs (`topic_info` / `summary`) default to None inside the function
+        # so a False optional-branch leaves the call well-formed. The node
+        # publishes the SAME flat `result` port carrying
+        # `{"session_update": {...}}`.
+        def _update_session_bound(
+            session_id,
+            query="",
+            response=None,
+            topic_info=None,
+            summary=None,
+            sessions_store=None,
+        ) -> dict:
+            return _update_session(
+                session_id=session_id,
+                query=query,
+                response=response,
+                topic_info=topic_info,
+                summary=summary,
+                sessions_store=sessions_store,
+                max_context_turns=_max_context_turns,
+            )
+
+        _update_session_bound.__name__ = "session_updater"
+        _update_session_bound.__doc__ = _update_session.__doc__
+        session_updater_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _update_session_bound,
+                name="session_updater",
+            ),
             node_id="session_updater",
-            config={
-                "code": f"""
-def update_session(session_id, sessions_store, query, response, topic_info, summary=None):
-    '''Update session with new turn'''
-    # F9 #1118 sibling: import inside the function body (separate exec ns).
-    from datetime import datetime as _datetime_class
-
-    # PythonCodeNode runs each node with an independent copy of its inputs, so
-    # the `sessions_store` mutation context_loader performed is NOT visible
-    # here. Seed the session if absent (same shape context_loader creates) so
-    # this turn is recorded against a real session record rather than crashing
-    # with KeyError. Cross-execution persistence is owned by the WorkflowNode's
-    # own `self.sessions` store (see create_session), not this per-run store.
-    if session_id not in sessions_store:
-        sessions_store[session_id] = {{
-            "id": session_id,
-            "created_at": _datetime_class.now().isoformat(),
-            "turns": [],
-            "summary": "",
-            "current_topic": None,
-            "user_preferences": {{}},
-            "metrics": {{
-                "turn_count": 0,
-                "topics_discussed": [],
-                "avg_response_length": 0
-            }}
-        }}
-
-    session = sessions_store[session_id]
-
-    # Add new turn. `response` is the response_generator (LLMAgentNode) `response`
-    # port value — an inner message dict keyed by "content" (NOT "response").
-    new_turn = {{
-        "turn_number": len(session["turns"]) + 1,
-        "timestamp": _datetime_class.now().isoformat(),
-        "query": query,
-        "response": response.get("content", "") if isinstance(response, dict) else (response or ""),
-        "topic": topic_info.get("topic_analysis", {{}}).get("current_topic") if isinstance(topic_info, dict) else None
-    }}
-
-    session["turns"].append(new_turn)
-
-    # Update summary if provided. `summary` is the context_summarizer
-    # (LLMAgentNode) `response` port value — an inner message dict keyed by
-    # "content" (NOT "response").
-    if isinstance(summary, dict) and summary.get("content"):
-        session["summary"] = summary["content"]
-
-    # Update current topic
-    if topic_info and topic_info.get("topic_analysis"):
-        session["current_topic"] = topic_info["topic_analysis"]["current_topic"]
-
-        # Track topics discussed
-        topic = topic_info["topic_analysis"]["current_topic"]
-        if topic and topic not in session["metrics"]["topics_discussed"]:
-            session["metrics"]["topics_discussed"].append(topic)
-
-    # Update metrics
-    session["metrics"]["turn_count"] = len(session["turns"])
-    total_response_length = sum(len(turn.get("response", "")) for turn in session["turns"])
-    session["metrics"]["avg_response_length"] = total_response_length / len(session["turns"]) if session["turns"] else 0
-
-    # Trim old turns if exceeds max + buffer for summarization
-    if len(session["turns"]) > {self.max_context_turns} * 1.5:
-        # Keep recent turns and rely on summary for older context
-        session["turns"] = session["turns"][-{self.max_context_turns}:]
-
-    # Coherence proxy: topic consistency. Fewer DISTINCT topics across the
-    # turns => the conversation stayed on-topic => more coherent. Derived from
-    # the real session signal (NOT a hardcoded score); single-topic = 1.0.
-    _distinct_topics = len(session["metrics"]["topics_discussed"])
-    _coherence_turns = max(1, session["metrics"]["turn_count"])
-    coherence_score = max(0.0, min(1.0, 1.0 - (max(0, _distinct_topics - 1) / _coherence_turns)))
-
-    # Calculate conversation health metrics
-    conversation_metrics = {{
-        "coherence_score": coherence_score,  # derived from topic consistency
-        "engagement_level": min(1.0, len(session["turns"]) / 10),  # Higher with more turns
-        "topic_diversity": len(session["metrics"]["topics_discussed"]) / max(1, session["metrics"]["turn_count"]),
-        "avg_turn_length": session["metrics"]["avg_response_length"]
-    }}
-
-    # F9 #1117: function MUST return its dict; the prior `result = {{...}}`
-    # bound a function-scope local that was never returned, so the session
-    # update never reached the module-scope `session_update` output.
-    return {{
-        "session_update": {{
-            "session_id": session_id,
-            "turn_added": new_turn["turn_number"],
-            "total_turns": len(session["turns"]),
-            "current_topic": session["current_topic"],
-            "conversation_metrics": conversation_metrics
-        }}
-    }}
-
-# F9 #1117: module-scope call so PythonCodeNode publishes the `result` port
-# (carrying {{"session_update": ...}}) that result_formatter unwraps.
-# `session_id` + `query` are external workflow inputs; `sessions_store` bound via
-# config/inputs; `response` <- response_generator.response (LLMAgentNode);
-# `topic_info` <- topic_tracker.result ({{"topic_analysis": ...}}); `summary` <-
-# context_summarizer.response when enable_summarization (else default None).
-# `del` the helper so the output gate sees only `result`.
-try:
-    topic_info
-except NameError:
-    topic_info = None
-try:
-    summary
-except NameError:
-    summary = None
-try:
-    sessions_store
-except NameError:
-    sessions_store = {{}}
-result = update_session(
-    session_id, sessions_store, query, response, topic_info, summary
-)
-del update_session
-"""
-            },
+            _internal=True,
         )
 
         # Result formatter (TERMINAL node — publishes the WorkflowNode's
         # documented `conversational_response` output).
         #
-        # F9 #1123: this config is now an f-string so the {{self.*}} config
-        # flags interpolate to literal Python values. The prior NON-f-string
-        # form left `{{self.max_context_turns}}` etc. as runtime set-literals
-        # referencing undefined names — the terminal node crashed with
-        # NameError, so the whole workflow published nothing.
+        # S6a #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_format_conversational_result` function wired via
+        # `PythonCodeNode.from_function`. The four build-time config flags
+        # (`max_context_turns`, `enable_summarization`, `coreference_resolution`,
+        # `personalization_enabled`) are bound through a thin closure — the
+        # structural successor of the prior f-string `{self.*}` interpolation
+        # (#1123 fix). The function declares `response` / `session_update` /
+        # `topic_info` / `contextual_retrieval` as the explicit inputs the wired
+        # edges deliver, defaulting each to a benign empty value so a False
+        # optional-branch leaves the TERMINAL node well-formed. The node
+        # publishes the SAME flat `result` port carrying
+        # `{"conversational_response": {...}}`.
         #
-        # Every wired input here arrives as its PRODUCER's published port value:
+        # Every wired input arrives as its PRODUCER's published port value:
         #   - `response`             <- response_generator.response (LLMAgentNode
         #                               port value = inner message dict keyed by
         #                               "content")
-        #   - `session_update`       <- session_updater.result ({{"session_update"}})
-        #   - `topic_info`           <- topic_tracker.result ({{"topic_analysis"}})
+        #   - `session_update`       <- session_updater.result ({"session_update"})
+        #   - `topic_info`           <- topic_tracker.result ({"topic_analysis"})
         #   - `contextual_retrieval` <- context_retriever.result
-        #                               ({{"contextual_retrieval"}})
-        # so each is unwrapped to the nested shape this formatter consumes.
-        result_formatter_id = builder.add_node(
-            "PythonCodeNode",
+        #                               ({"contextual_retrieval"})
+        # so the function unwraps each to the nested shape it consumes.
+        _enable_summarization = self.enable_summarization
+        _coreference_resolution = self.coreference_resolution
+        _personalization_enabled = self.personalization_enabled
+
+        def _format_conversational_result_bound(
+            response=None,
+            session_update=None,
+            topic_info=None,
+            contextual_retrieval=None,
+        ) -> dict:
+            return _format_conversational_result(
+                response=response,
+                session_update=session_update,
+                topic_info=topic_info,
+                contextual_retrieval=contextual_retrieval,
+                max_context_turns=_max_context_turns,
+                enable_summarization=_enable_summarization,
+                coreference_resolution=_coreference_resolution,
+                personalization_enabled=_personalization_enabled,
+            )
+
+        _format_conversational_result_bound.__name__ = "result_formatter"
+        _format_conversational_result_bound.__doc__ = (
+            _format_conversational_result.__doc__
+        )
+        result_formatter_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _format_conversational_result_bound,
+                name="result_formatter",
+            ),
             node_id="result_formatter",
-            config={
-                "code": f"""
-# Optional inputs may be unwired on a False optional-branch (topic_tracking off
-# leaves `topic_info` unbound). Default each to a benign empty value so the
-# TERMINAL node still publishes a well-formed conversational_response.
-try:
-    topic_info
-except NameError:
-    topic_info = {{}}
-try:
-    session_update
-except NameError:
-    session_update = {{}}
-try:
-    contextual_retrieval
-except NameError:
-    contextual_retrieval = {{}}
-try:
-    response
-except NameError:
-    response = {{}}
-
-# Format conversational response. `response` is the LLMAgentNode `response`
-# port value (inner message dict keyed by "content", NOT "response").
-response_text = response.get("content", "") if isinstance(response, dict) else (response or "")
-session_update = session_update.get("session_update", {{}}) if isinstance(session_update, dict) else {{}}
-topic_info = topic_info.get("topic_analysis", {{}}) if isinstance(topic_info, dict) else {{}}
-contextual_retrieval = contextual_retrieval.get("contextual_retrieval", {{}}) if isinstance(contextual_retrieval, dict) else {{}}
-
-# Build session state summary
-session_state = {{
-    "session_id": session_update.get("session_id"),
-    "turn_number": session_update.get("turn_added"),
-    "total_turns": session_update.get("total_turns"),
-    "context_window": {self.max_context_turns},
-    "summary_available": {self.enable_summarization}
-}}
-
-# Topic information
-topic_summary = {{
-    "current_topic": topic_info.get("current_topic"),
-    "topic_changed": topic_info.get("topic_changed", False),
-    "transition_type": topic_info.get("transition_type", "continuation"),
-    "topics_discussed": session_update.get("conversation_metrics", {{}}).get("topic_diversity", 0)
-}}
-
-# Conversation metrics
-metrics = session_update.get("conversation_metrics", {{}})
-metrics["retrieval_context_influence"] = contextual_retrieval.get("context_influence", 0)
-
-# F9 #1117/#1123: module-scope `result =` so this TERMINAL node publishes the
-# documented `conversational_response` the WorkflowNode promises.
-result = {{
-    "conversational_response": {{
-        "response": response_text,
-        "session_state": session_state,
-        "topic_info": topic_summary,
-        "conversation_metrics": metrics,
-        "metadata": {{
-            "coreference_resolution": {self.coreference_resolution},
-            "personalization": {self.personalization_enabled},
-            "context_enhanced_retrieval": True
-        }}
-    }}
-}}
-"""
-            },
+            _internal=True,
         )
 
         # Messages-composer nodes (L3 fix). Each LLM stage's context is routed

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/evaluation.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/evaluation.py
@@ -373,6 +373,362 @@ def parse_answer_quality_response(response=None):
     return {"scores": _parse_score_array(response, "overall_quality")}
 
 
+# ---------------------------------------------------------------------------
+# Deterministic COMPUTE functions (#1117/#1123/#1118 root-cause fix — Wave 3
+# Shard S3). These replace the prior code-string PythonCodeNode codegen the
+# RAGEvaluationNode inlined for test_executor / context_evaluator /
+# metric_aggregator. Each is a real module-level function wired via
+# `PythonCodeNode.from_function(...)`: the node publishes its `return` value on
+# the FLAT `result` port (the runtime resolves dotted downstream reads like
+# `result.test_results` into the published dict), so:
+#
+#   - #1117 (publish-nothing): a real `return {...}` always binds the published
+#     `result` port — no module-scope-assignment + `del` gymnastics.
+#   - #1123 (f-string brace-escape): no `{{ }}` escaping; real dict literals.
+#   - #1118 (import-trap): `from datetime import datetime` / `import statistics`
+#     run as REAL imports inside the function body — no separate-(globals,locals)
+#     exec() namespace split that hid module-scope imports from the closure.
+#
+# These are deterministic metric computation + honest pass-through (NOT agent
+# decision-making per rules/agent-reasoning.md): no LLM reasoning, no if-else
+# intent routing. The LLM judges score; these helpers aggregate the parsed
+# scores. Missing inputs resolve to HONEST raises / empty defaults
+# (zero-tolerance Rule 2) — never fabricated answers or scores.
+# ---------------------------------------------------------------------------
+
+
+def collect_rag_results(test_queries=None):
+    """Pass through the caller-provided RAG outputs for downstream judging.
+
+    Provably-correct remediation: this JUDGES results the caller's RAG system
+    already produced — it does NOT fabricate them. Each ``test_queries`` entry
+    MUST carry the caller's real ``generated_answer`` + ``retrieved_contexts``
+    (a sandboxed node cannot invoke an arbitrary passed RAG node; running the
+    system-under-test is ``RAGBenchmarkNode``'s job). No fabricated answers, no
+    fabricated contexts, no synthetic timings.
+
+    Returns ``{"test_results", "total_tests", "avg_execution_time"}`` on the flat
+    ``result`` port. Raises ``ValueError`` (does NOT fabricate) when a test entry
+    is missing the real answer / contexts so incoherent input fails loudly.
+    """
+    from datetime import datetime as _datetime_class
+
+    if not isinstance(test_queries, list):
+        test_queries = []
+
+    test_results = []
+    missing = []
+
+    for i, test_case in enumerate(test_queries):
+        if not isinstance(test_case, dict):
+            missing.append((i, "non-dict-test-case"))
+            continue
+        query = test_case.get("query", "")
+        reference = test_case.get("reference", "")
+
+        # Honest contract: the caller ran their RAG system and supplies the real
+        # answer + contexts. Raise (not fabricate) when absent.
+        if "generated_answer" not in test_case:
+            missing.append((i, "generated_answer"))
+            continue
+        if "retrieved_contexts" not in test_case:
+            missing.append((i, "retrieved_contexts"))
+            continue
+
+        generated_answer = test_case["generated_answer"]
+        retrieved_contexts = test_case["retrieved_contexts"]
+        execution_time = test_case.get("execution_time", 0.0)
+
+        test_results.append(
+            {
+                "test_id": i,
+                "query": query,
+                "reference_answer": reference,
+                "generated_answer": generated_answer,
+                "retrieved_contexts": retrieved_contexts,
+                "execution_time": execution_time,
+                "timestamp": _datetime_class.now().isoformat(),
+            }
+        )
+
+    if missing:
+        raise ValueError(
+            "RAGEvaluationNode judges already-run RAG results: each "
+            "test_queries entry MUST carry 'generated_answer' and "
+            "'retrieved_contexts'. Missing on entries: " + repr(missing) + ". "
+            "Run your RAG system first (or use RAGBenchmarkNode to execute + "
+            "measure the system)."
+        )
+
+    return {
+        "test_results": test_results,
+        "total_tests": len(test_queries),
+        "avg_execution_time": (
+            sum(r["execution_time"] for r in test_results) / len(test_results)
+            if test_results
+            else 0.0
+        ),
+    }
+
+
+def _evaluate_context_precision(test_result: Any) -> dict:
+    """Evaluate the precision of one test's retrieved contexts.
+
+    Deterministic retrieval-quality heuristic over the caller's REAL retrieval
+    scores (P@k, MRR, diversity, avg-relevance). NOT an LLM judgment — the
+    LLM-based relevance judgment is the separate relevance_evaluator. Returns the
+    per-test ``{"context_metrics": {...}}`` dict (or the zeroed early-exit shape
+    when no contexts exist).
+    """
+    if not isinstance(test_result, dict):
+        test_result = {}
+    contexts = test_result.get("retrieved_contexts", []) or []
+    if not isinstance(contexts, list):
+        contexts = []
+
+    if not contexts:
+        return {
+            "context_precision": 0.0,
+            "context_recall": 0.0,
+            "context_ranking_quality": 0.0,
+        }
+
+    # Deterministic relevance heuristic: a context counts as relevant at k when
+    # its caller-provided retrieval score clears 0.7 (a real threshold over real
+    # scores, NOT a fabricated judgment).
+    precision_at_k = {}
+    for k in [1, 3, 5, 10]:
+        if k <= len(contexts):
+            relevant_at_k = sum(
+                1
+                for c in contexts[:k]
+                if isinstance(c, dict) and c.get("score", 0) > 0.7
+            )
+            precision_at_k[f"P@{k}"] = relevant_at_k / k
+
+    # MRR (Mean Reciprocal Rank).
+    first_relevant_rank = None
+    for i, ctx in enumerate(contexts):
+        if isinstance(ctx, dict) and ctx.get("score", 0) > 0.7:
+            first_relevant_rank = i + 1
+            break
+    mrr = 1.0 / first_relevant_rank if first_relevant_rank else 0.0
+
+    # Context diversity.
+    unique_terms: set = set()
+    for ctx in contexts:
+        if isinstance(ctx, dict):
+            unique_terms.update((ctx.get("content") or "").lower().split()[:20])
+    diversity_score = len(unique_terms) / (len(contexts) * 20) if contexts else 0
+
+    avg_relevance_score = sum(
+        c.get("score", 0) for c in contexts if isinstance(c, dict)
+    ) / len(contexts)
+
+    return {
+        "context_metrics": {
+            "precision_at_k": precision_at_k,
+            "mrr": mrr,
+            "diversity_score": diversity_score,
+            "avg_relevance_score": avg_relevance_score,
+            "context_count": len(contexts),
+        }
+    }
+
+
+def evaluate_context_metrics(test_data=None):
+    """Map ``_evaluate_context_precision`` over every test in ``test_data``.
+
+    ``test_data`` is the ``test_executor`` ``result.test_results`` LIST. Returns
+    ``{"context_metrics": [...]}`` on the flat ``result`` port — a LIST of per-test
+    context-metric dicts the aggregator indexes positionally. A single-test
+    arrival as a bare dict is normalized to a one-element list.
+    """
+    if isinstance(test_data, list):
+        rows = test_data
+    elif test_data is None:
+        rows = []
+    else:
+        rows = [test_data]
+    context_metrics = [
+        _evaluate_context_precision(t).get("context_metrics", {}) for t in rows
+    ]
+    return {"context_metrics": context_metrics}
+
+
+def aggregate_evaluation_metrics(
+    test_results=None,
+    faithfulness_scores=None,
+    relevance_scores=None,
+    context_metrics=None,
+    answer_quality_scores=None,
+    metrics=None,
+):
+    """Aggregate all evaluation metrics over the PARSED per-test score lists.
+
+    The judge inputs are PARSED per-test score LISTS (the response-parser nodes
+    did ``response -> .content -> json.loads -> list``). ``faithfulness_scores``
+    is therefore a LIST of per-test dicts like ``[{"faithfulness_score": 0.8},
+    ...]`` aligned 1:1 with ``test_results``. A flagged entry carries
+    ``parse_error`` + ``<key>: None`` — that is NOT a real score, so it is
+    EXCLUDED from the numeric mean (never counted as a fabricated 0 —
+    zero-tolerance Rule 2). ``metrics`` is the build-time RAGEvaluationNode config
+    bound through a thin closure. Returns ``{"evaluation_summary": {...}}``.
+    """
+    import statistics
+    from datetime import datetime as _datetime_class
+
+    if not isinstance(test_results, list):
+        test_results = []
+    if metrics is None:
+        metrics = []
+
+    def _score_at(score_list, idx, key):
+        """Real per-test score, or None when missing / flagged / malformed."""
+        if not isinstance(score_list, list) or idx >= len(score_list):
+            return None
+        entry = score_list[idx]
+        if not isinstance(entry, dict):
+            return None
+        if entry.get("parse_error") is not None:
+            return None  # flagged — honest gap, never a fabricated 0
+        value = entry.get(key)
+        return value if isinstance(value, (int, float)) else None
+
+    per_test = {
+        "faithfulness": [],
+        "relevance": [],
+        "context_precision": [],
+        "answer_quality": [],
+        "execution_time": [],
+    }
+
+    for i, test in enumerate(test_results):
+        per_test["faithfulness"].append(
+            _score_at(faithfulness_scores, i, "faithfulness_score")
+        )
+        per_test["relevance"].append(_score_at(relevance_scores, i, "relevance_score"))
+        ctx_score = None
+        if isinstance(context_metrics, list) and i < len(context_metrics):
+            ctx_entry = context_metrics[i]
+            if isinstance(ctx_entry, dict):
+                ctx_score = ctx_entry.get("context_metrics", {}).get(
+                    "avg_relevance_score"
+                )
+                if ctx_score is None:
+                    # context_metrics may already be the inner dict (flat shape).
+                    ctx_score = ctx_entry.get("avg_relevance_score")
+        per_test["context_precision"].append(
+            ctx_score if isinstance(ctx_score, (int, float)) else None
+        )
+        per_test["execution_time"].append(
+            test.get("execution_time", 0) if isinstance(test, dict) else 0
+        )
+
+        if answer_quality_scores is not None:
+            per_test["answer_quality"].append(
+                _score_at(answer_quality_scores, i, "overall_quality")
+            )
+
+    # Aggregate statistics over the REAL (non-None) scores only — a flagged /
+    # missing per-test entry is excluded from the mean rather than counted as a
+    # fabricated zero. Surface the gap count for honesty.
+    aggregate_stats = {}
+    flagged_counts = {}
+    for metric, raw in per_test.items():
+        valid = [s for s in raw if s is not None]
+        flagged = sum(1 for s in raw if s is None)
+        if flagged:
+            flagged_counts[metric] = flagged
+        if valid:
+            aggregate_stats[metric] = {
+                "mean": statistics.mean(valid),
+                "median": statistics.median(valid),
+                "std_dev": statistics.stdev(valid) if len(valid) > 1 else 0,
+                "min": min(valid),
+                "max": max(valid),
+                "scores": valid,
+            }
+
+    # Identify failure cases (None-safe).
+    failure_threshold = 0.6
+    failures = []
+    for i, test in enumerate(test_results):
+        components = [
+            ("faithfulness", per_test["faithfulness"][i]),
+            ("relevance", per_test["relevance"][i]),
+            ("context_precision", per_test["context_precision"][i]),
+        ]
+        present = [(name, val) for name, val in components if val is not None]
+        if not present:
+            continue
+        overall_score = sum(val for _, val in present) / len(present)
+        if overall_score < failure_threshold:
+            failures.append(
+                {
+                    "test_id": i,
+                    "query": test.get("query") if isinstance(test, dict) else None,
+                    "overall_score": overall_score,
+                    "weakest_metric": min(present, key=lambda x: x[1])[0],
+                }
+            )
+
+    # Recommendations.
+    recommendations = []
+    if aggregate_stats.get("faithfulness", {}).get("mean", 1) < 0.7:
+        recommendations.append(
+            "Improve grounding: Ensure answers strictly follow retrieved content"
+        )
+    if aggregate_stats.get("relevance", {}).get("mean", 1) < 0.7:
+        recommendations.append(
+            "Enhance relevance: Better query understanding and targeted responses"
+        )
+    if aggregate_stats.get("context_precision", {}).get("mean", 1) < 0.7:
+        recommendations.append(
+            "Optimize retrieval: Improve document ranking and selection"
+        )
+    if aggregate_stats.get("execution_time", {}).get("mean", 0) > 2.0:
+        recommendations.append(
+            "Reduce latency: Consider caching or parallel processing"
+        )
+
+    # Roll up overall_score over ONLY the metrics that produced a REAL aggregate
+    # mean — a fully parse-gapped / absent metric is EXCLUDED (never counted as 0).
+    _overall_component_means = [
+        aggregate_stats[_m]["mean"]
+        for _m in ("faithfulness", "relevance", "context_precision")
+        if _m in aggregate_stats and aggregate_stats[_m].get("mean") is not None
+    ]
+    overall_score_value = (
+        statistics.mean(_overall_component_means) if _overall_component_means else None
+    )
+
+    return {
+        "evaluation_summary": {
+            "aggregate_metrics": aggregate_stats,
+            "overall_score": overall_score_value,
+            "failure_analysis": {
+                "failure_count": len(failures),
+                "failure_rate": (
+                    (len(failures) / len(test_results)) if test_results else 0.0
+                ),
+                "failed_queries": failures,
+            },
+            "recommendations": recommendations,
+            # Honesty surface: per-metric count of per-test entries with NO real
+            # score (judge produced fewer than N, or the parser FLAGGED malformed
+            # output). Non-empty means some judge output could not be parsed —
+            # those gaps were EXCLUDED from the means, never fabricated zeros.
+            "parse_gaps": flagged_counts,
+            "evaluation_config": {
+                "metrics_used": metrics,
+                "total_tests": len(test_results),
+                "timestamp": _datetime_class.now().isoformat(),
+            },
+        }
+    }
+
+
 @register_node()
 class RAGEvaluationNode(WorkflowNode):
     """
@@ -479,84 +835,22 @@ class RAGEvaluationNode(WorkflowNode):
         answer_quality_id: Optional[str] = None
 
         # Test executor - runs RAG on test queries
-        test_executor_id = builder.add_node(
-            "PythonCodeNode",
+        # Test executor — passes through caller-provided RAG results for judging.
+        #
+        # Wave-3 #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `collect_rag_results` function wired via `PythonCodeNode.from_function`.
+        # No build-time config to bind (no closure needed). `from datetime import
+        # datetime` runs as a real import inside the function body. The function
+        # returns `{"test_results", "total_tests", "avg_execution_time"}`, so the
+        # downstream `result.test_results` edges resolve unchanged. It RAISES (does
+        # NOT fabricate) when a test entry lacks the caller's real answer/contexts.
+        test_executor_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                collect_rag_results,
+                name="test_executor",
+            ),
             node_id="test_executor",
-            config={
-                "code": """
-# Provably-correct remediation: this node JUDGES results the caller's RAG
-# system already produced — it does NOT fabricate them. Each test_queries
-# entry MUST carry the caller's real `generated_answer` + `retrieved_contexts`
-# (a sandboxed PythonCodeNode cannot invoke an arbitrary passed node; running
-# the system-under-test is RAGBenchmarkNode's job). No fabricated answers,
-# no fabricated contexts, no synthetic timings.
-
-def collect_rag_results(test_queries):
-    '''Pass through the caller-provided RAG outputs for downstream judging.'''
-    # #1118: import the datetime CLASS inside the function body — PythonCodeNode
-    # passes separate (globals, locals) to exec(), so a module-scope
-    # `from datetime import datetime as _datetime_class` binds into LOCAL
-    # namespace and is invisible to this function's closure (the `timestamp`
-    # line below would raise NameError at runtime). The metric_aggregator
-    # already imports inside its body for the same reason.
-    from datetime import datetime as _datetime_class
-
-    test_results = []
-    missing = []
-
-    for i, test_case in enumerate(test_queries):
-        query = test_case.get("query", "")
-        reference = test_case.get("reference", "")
-
-        # Honest contract: the caller ran their RAG system and supplies the
-        # real answer + contexts. Raise (not fabricate) when absent so the
-        # incoherent input fails loudly instead of judging invented data.
-        if "generated_answer" not in test_case:
-            missing.append((i, "generated_answer"))
-            continue
-        if "retrieved_contexts" not in test_case:
-            missing.append((i, "retrieved_contexts"))
-            continue
-
-        generated_answer = test_case["generated_answer"]
-        retrieved_contexts = test_case["retrieved_contexts"]
-        # Optional: caller-measured latency for the answer (real, not synthetic).
-        execution_time = test_case.get("execution_time", 0.0)
-
-        test_results.append({
-            "test_id": i,
-            "query": query,
-            "reference_answer": reference,
-            "generated_answer": generated_answer,
-            "retrieved_contexts": retrieved_contexts,
-            "execution_time": execution_time,
-            "timestamp": _datetime_class.now().isoformat()
-        })
-
-    if missing:
-        raise ValueError(
-            "RAGEvaluationNode judges already-run RAG results: each "
-            "test_queries entry MUST carry 'generated_answer' and "
-            "'retrieved_contexts'. Missing on entries: " + repr(missing) +
-            ". Run your RAG system first (or use RAGBenchmarkNode to "
-            "execute + measure the system)."
-        )
-
-    # F9 umbrella + #1117 sibling: return from function so the module-scope
-    # call below binds `result` (the wire-through happens via the module
-    # namespace, not the function's local scope).
-    return {
-        "test_results": test_results,
-        "total_tests": len(test_queries),
-        "avg_execution_time": sum(r["execution_time"] for r in test_results) / len(test_results) if test_results else 0.0
-    }
-
-# F9: module-scope call + drop the helper so PythonCodeNode's output gate
-# sees only `result`.
-result = collect_rag_results(test_queries)
-del collect_rag_results
-"""
-            },
+            _internal=True,
         )
 
         # Faithfulness evaluator
@@ -615,75 +909,23 @@ Return a JSON ARRAY with exactly one object per test, in the SAME numbered order
         )
 
         # Context precision evaluator
-        context_evaluator_id = builder.add_node(
-            "PythonCodeNode",
+        # Context precision evaluator.
+        #
+        # Wave-3 #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `evaluate_context_metrics` function wired via
+        # `PythonCodeNode.from_function`. It maps `_evaluate_context_precision`
+        # over the `test_data` LIST (the test_executor `result.test_results`) and
+        # returns `{"context_metrics": [...]}` (a per-test list) on the flat
+        # `result` port, so the downstream `result.context_metrics` edge resolves
+        # unchanged. No build-time config to bind. This is a PythonCodeNode (not an
+        # LLMAgentNode); it reads `test_data` directly via its declared param.
+        context_evaluator_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                evaluate_context_metrics,
+                name="context_evaluator",
+            ),
             node_id="context_evaluator",
-            config={
-                "code": """
-def evaluate_context_precision(test_result):
-    '''Evaluate the precision of retrieved contexts'''
-
-    contexts = test_result.get("retrieved_contexts", [])
-    query = test_result.get("query", "")
-
-    if not contexts:
-        return {
-            "context_precision": 0.0,
-            "context_recall": 0.0,
-            "context_ranking_quality": 0.0
-        }
-
-    # Calculate precision at different k values
-    precision_at_k = {}
-    relevant_count = 0
-
-    for k in [1, 3, 5, 10]:
-        if k <= len(contexts):
-            # Deterministic relevance heuristic: a context counts as relevant
-            # at k when its caller-provided retrieval score clears 0.7. This is
-            # a real threshold over real scores (NOT a fabricated judgment); the
-            # LLM-based relevance judgment is the separate relevance_evaluator.
-            relevant_at_k = sum(1 for c in contexts[:k] if c.get("score", 0) > 0.7)
-            precision_at_k[f"P@{k}"] = relevant_at_k / k
-
-    # Calculate MRR (Mean Reciprocal Rank)
-    first_relevant_rank = None
-    for i, ctx in enumerate(contexts):
-        if ctx.get("score", 0) > 0.7:
-            first_relevant_rank = i + 1
-            break
-
-    mrr = 1.0 / first_relevant_rank if first_relevant_rank else 0.0
-
-    # Context diversity
-    unique_terms = set()
-    for ctx in contexts:
-        unique_terms.update(ctx.get("content", "").lower().split()[:20])
-
-    diversity_score = len(unique_terms) / (len(contexts) * 20) if contexts else 0
-
-    # F9 #1117: function MUST return its computed metrics (was bound to
-    # a function-scope `result` local but never returned).
-    return {
-        "context_metrics": {
-            "precision_at_k": precision_at_k,
-            "mrr": mrr,
-            "diversity_score": diversity_score,
-            "avg_relevance_score": sum(c.get("score", 0) for c in contexts) / len(contexts),
-            "context_count": len(contexts)
-        }
-    }
-
-# F9 #1117: module-scope call. `test_data` is the wire from
-# test_executor.test_results (a LIST). Aggregator expects `context_metrics`
-# to be a LIST; map the per-result evaluation. Then `del` the non-JSON
-# helpers so PythonCodeNode's output-validation gate sees only `result`.
-_test_data = test_data if isinstance(test_data, list) else [test_data]
-context_metrics = [evaluate_context_precision(t).get("context_metrics", {}) for t in _test_data]
-result = {"context_metrics": context_metrics}
-del evaluate_context_precision, _test_data
-"""
-            },
+            _internal=True,
         )
 
         # Answer quality evaluator (if reference available)
@@ -718,195 +960,48 @@ Return a JSON ARRAY with exactly one object per test, in the SAME numbered order
             )
 
         # Metric aggregator
-        aggregator_id = builder.add_node(
-            "PythonCodeNode",
-            node_id="metric_aggregator",
-            config={
-                "code": f"""
-import statistics
+        # Metric aggregator.
+        #
+        # Wave-3 #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `aggregate_evaluation_metrics` function wired via
+        # `PythonCodeNode.from_function`. The build-time `metrics` list is bound
+        # through a thin closure (keeps test_results / faithfulness_scores /
+        # relevance_scores / context_metrics / answer_quality_scores as the
+        # declared inputs). `import statistics` + `from datetime import datetime`
+        # run as real imports inside the function body. `answer_quality_scores`
+        # has a `None` default so the from_function node is valid in BOTH
+        # use_reference_answers configurations — on the disabled path that input is
+        # never wired and the default applies (no NameError, unlike the prior
+        # exec-namespace try/except). Returns `{"evaluation_summary": {...}}`.
+        _metrics = self.metrics
 
-def aggregate_evaluation_metrics(test_results, faithfulness_scores, relevance_scores,
-                               context_metrics, answer_quality_scores=None):
-    '''Aggregate all evaluation metrics'''
-    # F9 #1118: import the datetime CLASS inside the function body —
-    # PythonCodeNode passes separate (globals, locals) to exec() so a
-    # module-scope `from datetime import datetime` rebind binds the alias
-    # into LOCAL namespace and is invisible to this function's closure.
-    # Importing here makes the class lookup resolve cleanly.
-    # (`datetime.now()` on the module raises AttributeError.)
-    from datetime import datetime as _datetime_class
-
-    # OUTPUT-side fix: the judge inputs are now PARSED per-test score LISTS
-    # (the response-parser nodes did `response -> .content -> json.loads ->
-    # list`). `faithfulness_scores` is therefore a LIST of per-test dicts like
-    # `[{{"faithfulness_score": 0.8, ...}}, ...]` aligned 1:1 with test_results.
-    # A flagged entry carries `parse_error` and `<key>: None` — that is NOT a
-    # real score, so we extract None and EXCLUDE it from the numeric mean (we
-    # do NOT count an invented 0; zero-tolerance Rule 2).
-    def _score_at(score_list, idx, key):
-        '''Real per-test score, or None when missing / flagged / malformed.'''
-        if not isinstance(score_list, list) or idx >= len(score_list):
-            return None
-        entry = score_list[idx]
-        if not isinstance(entry, dict):
-            return None
-        if entry.get("parse_error") is not None:
-            return None  # flagged — honest gap, never a fabricated 0
-        value = entry.get(key)
-        return value if isinstance(value, (int, float)) else None
-
-    # Per-test aligned lists (None marks an honest gap, NOT a real zero).
-    per_test = {{
-        "faithfulness": [],
-        "relevance": [],
-        "context_precision": [],
-        "answer_quality": [],
-        "execution_time": []
-    }}
-
-    for i, test in enumerate(test_results):
-        per_test["faithfulness"].append(
-            _score_at(faithfulness_scores, i, "faithfulness_score")
-        )
-        per_test["relevance"].append(
-            _score_at(relevance_scores, i, "relevance_score")
-        )
-        # context_metrics is a PythonCodeNode list of `{{"context_metrics": {{...}}}}`
-        # (unchanged shape — it is computed deterministically, never judged).
-        ctx_score = None
-        if isinstance(context_metrics, list) and i < len(context_metrics):
-            ctx_entry = context_metrics[i]
-            if isinstance(ctx_entry, dict):
-                ctx_score = ctx_entry.get("context_metrics", {{}}).get(
-                    "avg_relevance_score"
-                )
-        per_test["context_precision"].append(
-            ctx_score if isinstance(ctx_score, (int, float)) else None
-        )
-        per_test["execution_time"].append(test.get("execution_time", 0))
-
-        if answer_quality_scores is not None:
-            per_test["answer_quality"].append(
-                _score_at(answer_quality_scores, i, "overall_quality")
+        def _aggregate_evaluation_metrics_bound(
+            test_results=None,
+            faithfulness_scores=None,
+            relevance_scores=None,
+            context_metrics=None,
+            answer_quality_scores=None,
+        ) -> dict:
+            return aggregate_evaluation_metrics(
+                test_results=test_results,
+                faithfulness_scores=faithfulness_scores,
+                relevance_scores=relevance_scores,
+                context_metrics=context_metrics,
+                answer_quality_scores=answer_quality_scores,
+                metrics=_metrics,
             )
 
-    # Calculate aggregate statistics over the REAL (non-None) scores only —
-    # a flagged/missing per-test entry is excluded from the mean rather than
-    # counted as a fabricated zero. Surface the gap count for honesty.
-    aggregate_stats = {{}}
-    flagged_counts = {{}}
-    for metric, raw in per_test.items():
-        valid = [s for s in raw if s is not None]
-        flagged = sum(1 for s in raw if s is None)
-        if flagged:
-            flagged_counts[metric] = flagged
-        if valid:
-            aggregate_stats[metric] = {{
-                "mean": statistics.mean(valid),
-                "median": statistics.median(valid),
-                "std_dev": statistics.stdev(valid) if len(valid) > 1 else 0,
-                "min": min(valid),
-                "max": max(valid),
-                "scores": valid
-            }}
-
-    # Identify failure cases (None-safe: a missing score does not silently
-    # become a 0 that drags the overall score below threshold).
-    failure_threshold = 0.6
-    failures = []
-
-    for i, test in enumerate(test_results):
-        components = [
-            ("faithfulness", per_test["faithfulness"][i]),
-            ("relevance", per_test["relevance"][i]),
-            ("context_precision", per_test["context_precision"][i]),
-        ]
-        present = [(name, val) for name, val in components if val is not None]
-        if not present:
-            # No real score for this test at all — surface, don't invent.
-            continue
-        overall_score = sum(val for _, val in present) / len(present)
-
-        if overall_score < failure_threshold:
-            failures.append({{
-                "test_id": i,
-                "query": test.get("query"),
-                "overall_score": overall_score,
-                "weakest_metric": min(present, key=lambda x: x[1])[0]
-            }})
-
-    # Generate recommendations
-    recommendations = []
-
-    if aggregate_stats.get("faithfulness", {{}}).get("mean", 1) < 0.7:
-        recommendations.append("Improve grounding: Ensure answers strictly follow retrieved content")
-
-    if aggregate_stats.get("relevance", {{}}).get("mean", 1) < 0.7:
-        recommendations.append("Enhance relevance: Better query understanding and targeted responses")
-
-    if aggregate_stats.get("context_precision", {{}}).get("mean", 1) < 0.7:
-        recommendations.append("Optimize retrieval: Improve document ranking and selection")
-
-    if aggregate_stats.get("execution_time", {{}}).get("mean", 0) > 2.0:
-        recommendations.append("Reduce latency: Consider caching or parallel processing")
-
-    # Output-side honesty: roll up overall_score over ONLY the metrics that
-    # produced a REAL aggregate mean. A fully parse-gapped / absent metric is
-    # EXCLUDED — never counted as 0 (which would re-fabricate the zero this
-    # shard removes everywhere else). Mirrors the per-test `present`-filter
-    # above; overall_score is None when NO metric has a real mean.
-    _overall_component_means = [
-        aggregate_stats[_m]["mean"]
-        for _m in ("faithfulness", "relevance", "context_precision")
-        if _m in aggregate_stats and aggregate_stats[_m].get("mean") is not None
-    ]
-    overall_score_value = (
-        statistics.mean(_overall_component_means)
-        if _overall_component_means
-        else None
-    )
-
-    # F9 #1117: function MUST return its aggregate dict (the prior
-    # `result = {{...}}` bound a function-scope local that was never
-    # returned).
-    return {{
-        "evaluation_summary": {{
-            "aggregate_metrics": aggregate_stats,
-            "overall_score": overall_score_value,
-            "failure_analysis": {{
-                "failure_count": len(failures),
-                "failure_rate": (len(failures) / len(test_results)) if test_results else 0.0,
-                "failed_queries": failures
-            }},
-            "recommendations": recommendations,
-            # Honesty surface: per-metric count of per-test entries that had NO
-            # real score (judge produced fewer than N, or the response-parser
-            # FLAGGED malformed/non-JSON output). Non-empty means some judge
-            # output could not be parsed into a real score — those gaps were
-            # EXCLUDED from the means above, never counted as fabricated zeros.
-            "parse_gaps": flagged_counts,
-            "evaluation_config": {{
-                "metrics_used": {self.metrics},
-                "total_tests": len(test_results),
-                "timestamp": _datetime_class.now().isoformat()
-            }}
-        }}
-    }}
-
-# F9 #1117: module-scope call. answer_quality_scores is wired in only
-# when self.use_reference_answers=True; defensive try/except so the code
-# is valid in either configuration. `del` non-JSON helpers so
-# PythonCodeNode's output gate sees only `result`.
-try:
-    _aqs = answer_quality_scores
-except NameError:
-    _aqs = None
-result = aggregate_evaluation_metrics(
-    test_results, faithfulness_scores, relevance_scores, context_metrics, _aqs
-)
-del aggregate_evaluation_metrics, _aqs
-"""
-            },
+        _aggregate_evaluation_metrics_bound.__name__ = "metric_aggregator"
+        _aggregate_evaluation_metrics_bound.__doc__ = (
+            aggregate_evaluation_metrics.__doc__
+        )
+        aggregator_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _aggregate_evaluation_metrics_bound,
+                name="metric_aggregator",
+            ),
+            node_id="metric_aggregator",
+            _internal=True,
         )
 
         # Messages-composer nodes (L3 fix). Each LLM judge's context is routed
@@ -930,7 +1025,7 @@ del aggregate_evaluation_metrics, _aqs
         # concrete PythonCodeNode, but `@register_node` erases the subtype to
         # `type[Node]` for static checkers (mirrors conversational.py).
         faithfulness_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_faithfulness_messages,
                 name="faithfulness_messages_composer",
             ),
@@ -938,7 +1033,7 @@ del aggregate_evaluation_metrics, _aqs
             _internal=True,
         )
         relevance_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_relevance_messages,
                 name="relevance_messages_composer",
             ),
@@ -948,7 +1043,7 @@ del aggregate_evaluation_metrics, _aqs
         answer_quality_messages_composer_id: Optional[str] = None
         if self.use_reference_answers:
             answer_quality_messages_composer_id = builder.add_node_instance(
-                PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                PythonCodeNode.from_function(
                     compose_answer_quality_messages,
                     name="answer_quality_messages_composer",
                 ),
@@ -968,7 +1063,7 @@ del aggregate_evaluation_metrics, _aqs
         # silently zeroed (zero-tolerance Rule 2). Same `from_function` +
         # `add_node_instance(_internal=True)` primitive as the composers.
         faithfulness_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_faithfulness_response,
                 name="faithfulness_response_parser",
             ),
@@ -976,7 +1071,7 @@ del aggregate_evaluation_metrics, _aqs
             _internal=True,
         )
         relevance_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_relevance_response,
                 name="relevance_response_parser",
             ),
@@ -986,7 +1081,7 @@ del aggregate_evaluation_metrics, _aqs
         answer_quality_parser_id: Optional[str] = None
         if self.use_reference_answers:
             answer_quality_parser_id = builder.add_node_instance(
-                PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                PythonCodeNode.from_function(
                     parse_answer_quality_response,
                     name="answer_quality_response_parser",
                 ),

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/graph.py
@@ -508,6 +508,350 @@ def parse_global_summary(response=None):
     return {"result": {"global_summary": None, "parse_error": "non-string-content"}}
 
 
+# ---------------------------------------------------------------------------
+# Deterministic graph-algorithm COMPUTE functions (#1117/#1123/#1118 root-cause
+# fix — Wave 3 Shard S3). These replace the prior f-string code-string
+# PythonCodeNode codegen the GraphRAGNode inlined for graph_builder / graph_retriever /
+# result_synthesizer. Each is a real module-level function wired via
+# `PythonCodeNode.from_function(...)`: a from_function node publishes its `return`
+# value on the FLAT `result` port (the runtime resolves dotted downstream reads
+# like `result.graph_data` into the published dict), so:
+#
+#   - #1117 (publish-nothing): a real `return {...}` always binds the published
+#     `result` port — no column-0 module-scope-assignment AST gymnastics.
+#   - #1123 (f-string brace-escape): no `{{ }}` escaping; real dict literals.
+#   - #1118 (import-trap): `import networkx` / `from collections import deque` run
+#     as REAL top-level imports inside the function body — outside the
+#     PythonCodeNode `exec()` sandbox that BLOCKED `import networkx` for the prior
+#     `code=` blocks. (The pre-Wave-3 inner graph could NOT run end-to-end under a
+#     plain LocalRuntime for exactly this reason; from_function closes that gap.)
+#
+# These are legitimate graph-algorithm code (construction / traversal / synthesis)
+# — NOT agent decision-making (rules/agent-reasoning.md): no LLM reasoning, no
+# if-else intent routing. The LLM stages reason; these deterministic helpers run
+# the networkx algorithms over the LLM-parsed entities/relationships. Malformed /
+# edge inputs resolve to HONEST empty graphs / defaults (zero-tolerance Rule 2) —
+# never fabricated entities.
+# ---------------------------------------------------------------------------
+
+
+def build_knowledge_graph(extraction_results=None, community_algorithm="louvain"):
+    """Build a networkx ``MultiDiGraph`` from parsed entity/relationship extractions.
+
+    ``extraction_results`` is the ``entity_extraction_parser`` ``result`` — a LIST
+    of per-doc extraction objects (the single LLM call returns one merged
+    extraction wrapped in a one-element list). Each object carries ``entities`` +
+    ``relationships`` lists. ``community_algorithm`` is the build-time
+    GraphRAGNode config bound through a thin closure (see ``_create_workflow``).
+
+    Returns ``{"graph_data": {...}}`` on the flat ``result`` port. An empty /
+    malformed ``extraction_results`` builds an EMPTY graph honestly — never
+    fabricated entities (zero-tolerance Rule 2).
+    """
+    from collections import defaultdict
+
+    import networkx as nx
+
+    if not isinstance(extraction_results, list):
+        extraction_results = []
+
+    G = nx.MultiDiGraph()
+    all_entities = []
+    all_relationships = []
+
+    for doc_extraction in extraction_results:
+        if not isinstance(doc_extraction, dict):
+            continue
+        entities = doc_extraction.get("entities") or []
+        relationships = doc_extraction.get("relationships") or []
+
+        for entity in entities:
+            if not isinstance(entity, dict) or "name" not in entity:
+                continue
+            node_id = str(entity["name"]).lower()
+            G.add_node(
+                node_id,
+                name=entity["name"],
+                type=entity.get("type", ""),
+                description=entity.get("description", ""),
+                documents=set(),
+            )
+            all_entities.append(entity)
+
+        for rel in relationships:
+            if not isinstance(rel, dict) or "source" not in rel or "target" not in rel:
+                continue
+            source = str(rel["source"]).lower()
+            target = str(rel["target"]).lower()
+            G.add_edge(
+                source,
+                target,
+                type=rel.get("type", ""),
+                description=rel.get("description", ""),
+            )
+            all_relationships.append(rel)
+
+    # Detect communities over the real graph.
+    if len(G) > 0:
+        if community_algorithm == "louvain":
+            import community
+
+            communities = community.best_partition(G.to_undirected())
+        else:
+            communities = {}
+            for i, comp in enumerate(nx.weakly_connected_components(G)):
+                for node in comp:
+                    communities[node] = i
+    else:
+        communities = {}
+
+    community_nodes = defaultdict(list)
+    for node, comm_id in communities.items():
+        community_nodes[comm_id].append(node)
+
+    return {
+        "graph_data": {
+            "graph": nx.node_link_data(G),
+            "entities": all_entities,
+            "relationships": all_relationships,
+            "communities": communities,
+            "community_nodes": dict(community_nodes),
+            "stats": {
+                "num_entities": len(G),
+                "num_relationships": len(G.edges()),
+                "num_communities": (
+                    len(set(communities.values())) if communities else 0
+                ),
+            },
+        }
+    }
+
+
+def retrieve_from_graph(graph_data=None, query_analysis=None, max_hops=2):
+    """Retrieve a relevant subgraph from ``graph_data`` driven by ``query_analysis``.
+
+    ``graph_data`` is the ``graph_builder`` ``result.graph_data`` value;
+    ``query_analysis`` is the ``query_analysis_parser`` ``result`` (the parsed
+    ``{entities, relationship_types, requires_multi_hop, reasoning_type}`` dict).
+    ``max_hops`` is the build-time GraphRAGNode config bound through a thin
+    closure (see ``_create_workflow``).
+
+    Returns ``{"graph_retrieval": {...}}`` on the flat ``result`` port. Absent /
+    malformed inputs yield an honest EMPTY subgraph — the retriever's per-field
+    ``.get()`` defaults already tolerate missing keys (zero-tolerance Rule 2).
+    """
+    from collections import deque
+
+    import networkx as nx
+
+    if not isinstance(graph_data, dict):
+        graph_data = {}
+    if not isinstance(query_analysis, dict):
+        query_analysis = {}
+
+    serialized = graph_data.get("graph")
+    if serialized:
+        G = nx.node_link_graph(serialized)
+    else:
+        G = nx.MultiDiGraph()
+
+    query_entities = [str(e).lower() for e in query_analysis.get("entities", [])]
+    relationship_types = query_analysis.get("relationship_types", [])
+    requires_multi_hop = query_analysis.get("requires_multi_hop", False)
+
+    # Find relevant nodes (fuzzy substring match against query entities).
+    relevant_nodes = set()
+    for entity in query_entities:
+        for node in G.nodes():
+            if entity in node or node in entity:
+                relevant_nodes.add(node)
+
+    # Multi-hop expansion (BFS up to max_hops) when the analysis asks for it.
+    if requires_multi_hop and relevant_nodes:
+        expanded_nodes = set(relevant_nodes)
+        for start_node in relevant_nodes:
+            visited = {start_node}
+            queue = deque([(start_node, 0)])
+            while queue:
+                node, depth = queue.popleft()
+                if depth >= max_hops:
+                    continue
+                for neighbor in G.neighbors(node):
+                    if neighbor not in visited:
+                        visited.add(neighbor)
+                        expanded_nodes.add(neighbor)
+                        queue.append((neighbor, depth + 1))
+        relevant_nodes = expanded_nodes
+
+    if relevant_nodes:
+        subgraph = G.subgraph(relevant_nodes).copy()
+
+        relevant_edges = []
+        for u, v, data in subgraph.edges(data=True):
+            if not relationship_types or data.get("type") in relationship_types:
+                relevant_edges.append(
+                    {
+                        "source": u,
+                        "target": v,
+                        "type": data.get("type"),
+                        "description": data.get("description"),
+                    }
+                )
+
+        relevant_entities = []
+        for node in relevant_nodes:
+            node_data = G.nodes[node]
+            relevant_entities.append(
+                {
+                    "name": node_data.get("name", node),
+                    "type": node_data.get("type"),
+                    "description": node_data.get("description"),
+                    "centrality": nx.degree_centrality(subgraph).get(node, 0),
+                }
+            )
+
+        relevant_entities.sort(key=lambda x: x["centrality"], reverse=True)
+    else:
+        relevant_entities = []
+        relevant_edges = []
+
+    # Community context for the relevant nodes.
+    communities = graph_data.get("communities", {})
+    community_context = {}
+    for node in relevant_nodes:
+        comm_id = communities.get(node)
+        if comm_id is not None:
+            comm_nodes = graph_data.get("community_nodes", {}).get(str(comm_id), [])
+            community_context[comm_id] = comm_nodes
+
+    return {
+        "graph_retrieval": {
+            "entities": relevant_entities[:20],
+            "relationships": relevant_edges[:30],
+            "subgraph_stats": {
+                "nodes": len(relevant_nodes),
+                "edges": len(relevant_edges),
+            },
+            "community_context": community_context,
+            "query_entities_found": len(
+                [e for e in query_entities if any(e in n for n in relevant_nodes)]
+            ),
+        }
+    }
+
+
+def _render_synthesis_context(graph_retrieval: Any) -> str:
+    """Render the retrieved subgraph into a readable context block for synthesis.
+
+    Shared rendering for ``synthesize_results``; pure data formatting (the
+    permitted output-formatting exception per rules/agent-reasoning.md).
+    """
+    parts: List[str] = []
+    entities = graph_retrieval.get("entities") or []
+    if entities:
+        parts.append("Key Entities:")
+        for entity in entities[:10]:
+            if not isinstance(entity, dict):
+                continue
+            parts.append(
+                f"- {entity.get('name', '')} ({entity.get('type', '')}): "
+                f"{entity.get('description', '')}"
+            )
+
+    relationships = graph_retrieval.get("relationships") or []
+    if relationships:
+        parts.append("\nKey Relationships:")
+        for rel in relationships[:10]:
+            if not isinstance(rel, dict):
+                continue
+            parts.append(
+                f"- {rel.get('source', '')} {rel.get('type', '')} "
+                f"{rel.get('target', '')}"
+            )
+
+    community_context = graph_retrieval.get("community_context") or {}
+    if community_context:
+        parts.append("\nRelated Topic Clusters:")
+        for comm_id, nodes in list(community_context.items())[:3]:
+            node_list = nodes if isinstance(nodes, list) else []
+            parts.append(
+                f"- Cluster {comm_id}: " f"{', '.join(str(n) for n in node_list[:5])}"
+            )
+    return "\n".join(parts)
+
+
+def synthesize_results(
+    graph_retrieval=None,
+    query="",
+    graph_data=None,
+    global_summaries=None,
+    use_global_summary=True,
+):
+    """Combine the retrieved subgraph + query + (conditional) global summary.
+
+    ``graph_retrieval`` is the ``graph_retriever`` ``result.graph_retrieval``;
+    ``graph_data`` the ``graph_builder`` ``result.graph_data``; ``global_summaries``
+    the ``global_summary_parser`` ``result`` (the parsed ``{"global_summary":
+    <text or None>}`` dict) — wired ONLY when ``use_global_summary=True``.
+    ``use_global_summary`` is the build-time GraphRAGNode config bound through a
+    thin closure (see ``_create_workflow``).
+
+    CONDITIONAL-BEHAVIOR PRESERVATION (Wave-2.5 O3/F31-FU1): the global-summary
+    read fires ONLY on the enabled path. On the disabled path ``global_summaries``
+    is never wired AND ``use_global_summary`` is False, so ``global_summary`` is
+    ``None`` honestly — the from_function ``global_summaries=None`` default makes
+    the unwired input safe (a from_function node tolerates a missing declared
+    input, unlike the `code=` exec namespace that raised NameError on a bare
+    reference — which is why the prior codegen had to emit the read-lines
+    conditionally). Returns ``{"graph_rag_results": {...}}`` on ``result``.
+    """
+    if not isinstance(graph_retrieval, dict):
+        graph_retrieval = {}
+    if not isinstance(graph_data, dict):
+        graph_data = {}
+
+    # O3 DEFECT 2: read the REAL parsed global summary ONLY on the enabled path.
+    global_summary = None
+    if use_global_summary and isinstance(global_summaries, dict):
+        global_summary = global_summaries.get("global_summary")
+
+    context = _render_synthesis_context(graph_retrieval)
+
+    # Reasoning-path visualization over the retrieved entities.
+    reasoning_path = []
+    entities = graph_retrieval.get("entities") or []
+    if len(entities) > 1:
+        for i in range(min(3, len(entities) - 1)):
+            reasoning_path.append(
+                {
+                    "hop": i + 1,
+                    "from": entities[i].get("name", ""),
+                    "to": entities[i + 1].get("name", ""),
+                    "connection": "related through graph structure",
+                }
+            )
+
+    community_context = graph_retrieval.get("community_context") or {}
+    stats = graph_data.get("stats", {})
+
+    return {
+        "graph_rag_results": {
+            "query": query,
+            "retrieved_entities": entities,
+            "retrieved_relationships": graph_retrieval.get("relationships") or [],
+            "graph_context": context,
+            "global_summary": global_summary,
+            "reasoning_path": reasoning_path,
+            "subgraph_size": graph_retrieval.get("subgraph_stats", {}),
+            "community_info": {
+                "num_communities": len(community_context),
+                "communities_accessed": list(community_context.keys()),
+            },
+            "global_graph_stats": stats,
+        }
+    }
+
+
 @register_node()
 class GraphRAGNode(WorkflowNode):
     """
@@ -617,81 +961,34 @@ class GraphRAGNode(WorkflowNode):
             },
         )
 
-        # Graph builder
-        graph_builder_id = builder.add_node(
-            "PythonCodeNode",
+        # Graph builder.
+        #
+        # Wave-3 #1117/#1123/#1118 root-cause fix: lifted from the prior f-string
+        # `code=` codegen to the module-level `build_knowledge_graph` function
+        # wired via `PythonCodeNode.from_function`. The build-time
+        # `community_algorithm` is bound through a thin closure (keeps
+        # `extraction_results` as the declared input). `import networkx` now runs
+        # OUTSIDE the PythonCodeNode sandbox (which BLOCKED it for the prior
+        # `code=` block — the reason the full inner graph could not run
+        # end-to-end). The function returns `{"graph_data": {...}}`, so the
+        # downstream `result.graph_data` edges resolve unchanged.
+        _community_algorithm = self.community_algorithm
+
+        def _build_knowledge_graph_bound(extraction_results=None) -> dict:
+            return build_knowledge_graph(
+                extraction_results=extraction_results,
+                community_algorithm=_community_algorithm,
+            )
+
+        _build_knowledge_graph_bound.__name__ = "graph_builder"
+        _build_knowledge_graph_bound.__doc__ = build_knowledge_graph.__doc__
+        graph_builder_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _build_knowledge_graph_bound,
+                name="graph_builder",
+            ),
             node_id="graph_builder",
-            config={
-                "code": f"""
-import networkx as nx
-from collections import defaultdict
-
-def build_knowledge_graph(extraction_results):
-    '''Build NetworkX graph from extracted entities and relationships'''
-    G = nx.MultiDiGraph()
-
-    # Add all entities as nodes
-    all_entities = []
-    all_relationships = []
-
-    for doc_extraction in extraction_results:
-        entities = doc_extraction.get("entities", [])
-        relationships = doc_extraction.get("relationships", [])
-
-        # Add entities
-        for entity in entities:
-            node_id = entity["name"].lower()
-            G.add_node(node_id,
-                      name=entity["name"],
-                      type=entity["type"],
-                      description=entity.get("description", ""),
-                      documents=set())
-            all_entities.append(entity)
-
-        # Add relationships
-        for rel in relationships:
-            source = rel["source"].lower()
-            target = rel["target"].lower()
-            G.add_edge(source, target,
-                      type=rel["type"],
-                      description=rel.get("description", ""))
-            all_relationships.append(rel)
-
-    # Detect communities
-    if len(G) > 0:
-        if "{self.community_algorithm}" == "louvain":
-            import community
-            communities = community.best_partition(G.to_undirected())
-        else:
-            # Simple connected components
-            communities = {{}}
-            for i, comp in enumerate(nx.weakly_connected_components(G)):
-                for node in comp:
-                    communities[node] = i
-    else:
-        communities = {{}}
-
-    # Build community summaries
-    community_nodes = defaultdict(list)
-    for node, comm_id in communities.items():
-        community_nodes[comm_id].append(node)
-
-    graph_data = {{
-        "graph": nx.node_link_data(G),
-        "entities": all_entities,
-        "relationships": all_relationships,
-        "communities": communities,
-        "community_nodes": dict(community_nodes),
-        "stats": {{
-            "num_entities": len(G),
-            "num_relationships": len(G.edges()),
-            "num_communities": len(set(communities.values())) if communities else 0
-        }}
-    }}
-
-result = {{"graph_data": build_knowledge_graph(extraction_results)}}
-"""
-            },
+            _internal=True,
         )
 
         # Query processor for graph
@@ -716,111 +1013,33 @@ result = {{"graph_data": build_knowledge_graph(extraction_results)}}
             },
         )
 
-        # Graph traversal and retrieval
-        graph_retriever_id = builder.add_node(
-            "PythonCodeNode",
+        # Graph traversal and retrieval.
+        #
+        # Wave-3 #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `retrieve_from_graph` function wired via `PythonCodeNode.from_function`.
+        # The build-time `max_hops` is bound through a thin closure (keeps
+        # `graph_data` + `query_analysis` as the declared inputs). `import networkx`
+        # / `from collections import deque` now run OUTSIDE the PythonCodeNode
+        # sandbox. The function returns `{"graph_retrieval": {...}}`, so the
+        # downstream `result.graph_retrieval` edges resolve unchanged.
+        _max_hops = self.max_hops
+
+        def _retrieve_from_graph_bound(graph_data=None, query_analysis=None) -> dict:
+            return retrieve_from_graph(
+                graph_data=graph_data,
+                query_analysis=query_analysis,
+                max_hops=_max_hops,
+            )
+
+        _retrieve_from_graph_bound.__name__ = "graph_retriever"
+        _retrieve_from_graph_bound.__doc__ = retrieve_from_graph.__doc__
+        graph_retriever_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _retrieve_from_graph_bound,
+                name="graph_retriever",
+            ),
             node_id="graph_retriever",
-            config={
-                "code": f"""
-import networkx as nx
-from collections import deque
-
-def retrieve_from_graph(graph_data, query_analysis):
-    '''Retrieve relevant subgraph based on query analysis'''
-    # Reconstruct graph
-    G = nx.node_link_graph(graph_data["graph"])
-
-    query_entities = [e.lower() for e in query_analysis.get("entities", [])]
-    relationship_types = query_analysis.get("relationship_types", [])
-    requires_multi_hop = query_analysis.get("requires_multi_hop", False)
-
-    # Find relevant nodes
-    relevant_nodes = set()
-    for entity in query_entities:
-        # Fuzzy match entities
-        for node in G.nodes():
-            if entity in node or node in entity:
-                relevant_nodes.add(node)
-
-    # Multi-hop expansion if needed
-    if requires_multi_hop and relevant_nodes:
-        expanded_nodes = set(relevant_nodes)
-        for start_node in relevant_nodes:
-            # BFS up to max_hops
-            visited = {{start_node}}
-            queue = deque([(start_node, 0)])
-
-            while queue:
-                node, depth = queue.popleft()
-                if depth >= {self.max_hops}:
-                    continue
-
-                # Check neighbors
-                for neighbor in G.neighbors(node):
-                    if neighbor not in visited:
-                        visited.add(neighbor)
-                        expanded_nodes.add(neighbor)
-                        queue.append((neighbor, depth + 1))
-
-        relevant_nodes = expanded_nodes
-
-    # Extract subgraph
-    if relevant_nodes:
-        subgraph = G.subgraph(relevant_nodes).copy()
-
-        # Get relevant relationships
-        relevant_edges = []
-        for u, v, data in subgraph.edges(data=True):
-            if not relationship_types or data.get("type") in relationship_types:
-                relevant_edges.append({{
-                    "source": u,
-                    "target": v,
-                    "type": data.get("type"),
-                    "description": data.get("description")
-                }})
-
-        # Get node details
-        relevant_entities = []
-        for node in relevant_nodes:
-            node_data = G.nodes[node]
-            relevant_entities.append({{
-                "name": node_data.get("name", node),
-                "type": node_data.get("type"),
-                "description": node_data.get("description"),
-                "centrality": nx.degree_centrality(subgraph).get(node, 0)
-            }})
-
-        # Sort by centrality
-        relevant_entities.sort(key=lambda x: x["centrality"], reverse=True)
-
-    else:
-        relevant_entities = []
-        relevant_edges = []
-        subgraph = nx.DiGraph()
-
-    # Get community context if available
-    communities = graph_data.get("communities", {{}})
-    community_context = {{}}
-    for node in relevant_nodes:
-        comm_id = communities.get(node)
-        if comm_id is not None:
-            community_nodes = graph_data.get("community_nodes", {{}}).get(str(comm_id), [])
-            community_context[comm_id] = community_nodes
-
-    retrieval_result = {{
-        "entities": relevant_entities[:20],  # Top 20 by centrality
-        "relationships": relevant_edges[:30],  # Top 30 relationships
-        "subgraph_stats": {{
-            "nodes": len(relevant_nodes),
-            "edges": len(relevant_edges)
-        }},
-        "community_context": community_context,
-        "query_entities_found": len([e for e in query_entities if any(e in n for n in relevant_nodes)])
-    }}
-
-result = {{"graph_retrieval": retrieval_result}}
-"""
-            },
+            _internal=True,
         )
 
         # Global summary generator (if enabled)
@@ -838,108 +1057,45 @@ result = {{"graph_retrieval": retrieval_result}}
 
         # Result synthesizer.
         #
-        # O3 DEFECT 2 fix (F31-FU1): the synthesizer now READS the parsed
-        # `global_summary` and incorporates it into `graph_rag_results` —
-        # previously `global_summaries` was an accepted-but-unread documented
-        # input (zero-tolerance Rule 3c).
+        # Wave-3 #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `synthesize_results` function wired via `PythonCodeNode.from_function`.
+        # The build-time `use_global_summary` is bound through a thin closure
+        # (keeps `graph_retrieval` / `query` / `graph_data` / `global_summaries`
+        # as the declared inputs). The function returns `{"graph_rag_results":
+        # {...}}` on the flat `result` port.
         #
-        # CONDITIONAL-WIRING CARE (the chosen Option (i) — see _create_workflow
-        # connection block): the `global_summaries` edge only exists when
-        # `use_global_summary=True`. A PythonCodeNode `code=` body references its
-        # inputs as bare locals injected from `kwargs`; an UNWIRED input name is
-        # absent from the exec local namespace and a bare reference raises
-        # NameError (confirmed against PythonCodeNode.execute_code, which does
-        # `local_namespace.update(sanitized_inputs)` with NO defaults). So the
-        # `global_summaries`-reading lines are emitted ONLY when
-        # `use_global_summary=True`; on the disabled path the field is `None`
-        # honestly. Option (i) was chosen over Option (ii) (a default-source
-        # node feeding `{"global_summary": None}`) because it adds ZERO new
-        # topology — no extra node, no extra always-on edge — keeping the
-        # disabled-path graph identical to its prior shape.
-        if self.use_global_summary:
-            global_summary_read = """
-# O3 DEFECT 2: read the REAL parsed global summary (wired only on this path).
-# `global_summaries` is the parse_global_summary `result` dict:
-# {"global_summary": <text or None>, ["parse_error": ...]}.
-global_summary = None
-if isinstance(global_summaries, dict):
-    global_summary = global_summaries.get("global_summary")
-"""
-        else:
-            # Disabled path: no global_summaries input is wired; reference NOTHING
-            # by that name so the exec body cannot raise NameError.
-            global_summary_read = """
-# use_global_summary=False: no summary stage; field is None honestly.
-global_summary = None
-"""
+        # CONDITIONAL-BEHAVIOR PRESERVATION (Wave-2.5 O3/F31-FU1): the
+        # `global_summary` read fires ONLY when `use_global_summary=True` AND a
+        # `global_summaries` dict was wired. On the disabled path the
+        # `global_summaries` input is never wired; a from_function node tolerates
+        # a missing declared input (its `global_summaries=None` default applies),
+        # so there is NO NameError risk — the prior `code=` body had to emit the
+        # read-lines CONDITIONALLY precisely because an unwired name raised
+        # NameError in the exec namespace. from_function's parameter defaults make
+        # the single unified function safe on BOTH paths; `global_summary` is
+        # `None` honestly on the disabled path.
+        _use_global_summary = self.use_global_summary
 
-        result_synthesizer_code = (
-            """
-# Combine all graph information
-graph_retrieval = graph_retrieval
-query = query
-graph_data = graph_data
-"""
-            + global_summary_read
-            + """
-# Build context from retrieved subgraph
-context_parts = []
+        def _synthesize_results_bound(
+            graph_retrieval=None, query="", graph_data=None, global_summaries=None
+        ) -> dict:
+            return synthesize_results(
+                graph_retrieval=graph_retrieval,
+                query=query,
+                graph_data=graph_data,
+                global_summaries=global_summaries,
+                use_global_summary=_use_global_summary,
+            )
 
-# Add entity information
-if graph_retrieval["entities"]:
-    context_parts.append("Key Entities:")
-    for entity in graph_retrieval["entities"][:10]:
-        context_parts.append(f"- {entity['name']} ({entity['type']}): {entity['description']}")
-
-# Add relationship information
-if graph_retrieval["relationships"]:
-    context_parts.append("\\nKey Relationships:")
-    for rel in graph_retrieval["relationships"][:10]:
-        context_parts.append(f"- {rel['source']} {rel['type']} {rel['target']}")
-
-# Add community context
-if graph_retrieval["community_context"]:
-    context_parts.append("\\nRelated Topic Clusters:")
-    for comm_id, nodes in list(graph_retrieval["community_context"].items())[:3]:
-        context_parts.append(f"- Cluster {comm_id}: {', '.join(nodes[:5])}")
-
-context = "\\n".join(context_parts)
-
-# Create reasoning path visualization
-reasoning_path = []
-entities = graph_retrieval["entities"]
-if len(entities) > 1:
-    # Simple path representation
-    for i in range(min(3, len(entities)-1)):
-        reasoning_path.append({
-            "hop": i + 1,
-            "from": entities[i]["name"],
-            "to": entities[i+1]["name"],
-            "connection": "related through graph structure"
-        })
-
-result = {
-    "graph_rag_results": {
-        "query": query,
-        "retrieved_entities": graph_retrieval["entities"],
-        "retrieved_relationships": graph_retrieval["relationships"],
-        "graph_context": context,
-        "global_summary": global_summary,
-        "reasoning_path": reasoning_path,
-        "subgraph_size": graph_retrieval["subgraph_stats"],
-        "community_info": {
-            "num_communities": len(graph_retrieval["community_context"]),
-            "communities_accessed": list(graph_retrieval["community_context"].keys())
-        },
-        "global_graph_stats": graph_data["stats"]
-    }
-}
-"""
-        )
-        result_synthesizer_id = builder.add_node(
-            "PythonCodeNode",
+        _synthesize_results_bound.__name__ = "result_synthesizer"
+        _synthesize_results_bound.__doc__ = synthesize_results.__doc__
+        result_synthesizer_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _synthesize_results_bound,
+                name="result_synthesizer",
+            ),
             node_id="result_synthesizer",
-            config={"code": result_synthesizer_code},
+            _internal=True,
         )
 
         # Messages-composer nodes (L3 fix). Each LLM stage's context is routed
@@ -961,7 +1117,7 @@ result = {
         # advisory UserWarning (zero-tolerance Rule 1: no spurious runtime
         # warnings).
         entity_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_entity_extraction_messages,
                 name="entity_messages_composer",
             ),
@@ -969,7 +1125,7 @@ result = {
             _internal=True,
         )
         query_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_query_analysis_messages,
                 name="query_messages_composer",
             ),
@@ -980,7 +1136,7 @@ result = {
         summary_messages_composer_id: Optional[str] = None
         if self.use_global_summary:
             summary_messages_composer_id = builder.add_node_instance(
-                PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                PythonCodeNode.from_function(
                     compose_summary_messages,
                     name="summary_messages_composer",
                 ),
@@ -997,7 +1153,7 @@ result = {
         # iterates — the prior edge fed the raw response dict straight in, so the
         # builder iterated the dict's string KEYS.
         entity_extraction_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_entity_extraction,
                 name="entity_extraction_parser",
             ),
@@ -1014,7 +1170,7 @@ result = {
         # empty subgraph regardless of the LLM's analysis. query_processor is
         # built unconditionally, so this parser is too.
         query_analysis_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_query_analysis,
                 name="query_analysis_parser",
             ),
@@ -1029,7 +1185,7 @@ result = {
         global_summary_parser_id: Optional[str] = None
         if self.use_global_summary:
             global_summary_parser_id = builder.add_node_instance(
-                PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                PythonCodeNode.from_function(
                     parse_global_summary,
                     name="global_summary_parser",
                 ),

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/optimized.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/optimized.py
@@ -10,18 +10,695 @@ Implements high-performance RAG patterns:
 All implementations use existing Kailash components and WorkflowBuilder patterns.
 """
 
+import hashlib
+import inspect
 import logging
-from typing import List, Optional
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
 
 from kailash.nodes.base import register_node
 from kailash.nodes.cache import cache  # noqa: F401 — registers CacheNode
 from kailash.nodes.code.python import PythonCodeNode
 from kailash.nodes.logic.workflow import WorkflowNode
-from kailash.runtime.async_local import AsyncLocalRuntime
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level computation functions (#1117/#1123/#1118 root-cause fix).
+#
+# These replace the brittle f-string / "code"-string PythonCodeNode codegen the
+# Cache + AsyncParallel nodes previously inlined. Each is a real Python function
+# wired via `PythonCodeNode.from_function(...)`: a from_function node publishes
+# its `return` value on the FLAT `result` port (the runtime resolves dotted
+# downstream reads like `result.cache_keys.exact` into the published dict), so:
+#
+#   - #1117 (publish-nothing): a real `return {...}` always binds the published
+#     `result` port — no column-0 module-scope-assignment AST gymnastics.
+#   - #1123 (f-string brace-escape): no `{{ }}` escaping; real dict literals.
+#   - #1118 (import-trap): module-level `import hashlib` / `from datetime ...`
+#     are real top-level imports, not sandbox-hidden nested-scope imports.
+#
+# Malformed / edge inputs resolve to HONEST defaults (zero-tolerance Rule 2) —
+# never fabricated data.
+# ---------------------------------------------------------------------------
+
+
+def _generate_cache_keys(query: Any) -> dict:
+    """Generate deterministic exact + semantic cache keys for a query.
+
+    Replaces the ``cache_key_generator`` codegen block. The exact key is a
+    truncated SHA-256 of the query; the semantic key namespaces it. Honest
+    default for a non-string query: coerce to ``str`` so the hash is stable
+    (an empty query hashes deterministically, not fabricated).
+
+    ``similarity_threshold`` is intentionally NOT a parameter: the original
+    codegen interpolated it only into a dead ``check_semantic_similarity``
+    inner function that was never called, so the published ``cache_keys`` never
+    depended on it (behavior-equivalent to the held baseline).
+    """
+    query_str = (
+        query if isinstance(query, str) else ("" if query is None else str(query))
+    )
+    exact_key = hashlib.sha256(query_str.encode()).hexdigest()[:16]
+    semantic_key = f"semantic_{exact_key[:8]}"
+    return {"cache_keys": {"exact": exact_key, "semantic": semantic_key}}
+
+
+def _decide_cache_use(
+    cache_hit: Any = None,
+    cache_value: Any = None,
+    query: Any = "",
+    similarity_threshold: float = 0.95,
+) -> dict:
+    """Decide whether to serve from cache, reading CacheNode.get's flat ports.
+
+    Replaces the ``semantic_cache_manager`` codegen block. CacheNode's ``get``
+    operation publishes flat ``hit`` / ``value`` ports (NOT a nested dict), so
+    this reads ``cache_hit`` + ``cache_value`` wired from those ports.
+
+    Semantic-similarity caching is honest-but-dormant: no node in this workflow
+    populates a candidate store, so the candidate set is empty (``{}``) and the
+    similarity branch never fires. The similarity logic is real (not simulated);
+    it activates only when a candidate-store node is wired in. The workflow
+    today is a real exact-match cache over CacheNode.
+    """
+    if bool(cache_hit):
+        # Direct cache hit — return the value CacheNode retrieved.
+        return {
+            "use_cache": True,
+            "cache_type": "exact",
+            "cached_result": cache_value,
+        }
+
+    # Check semantic similarity (dormant unless a candidate-store node is wired).
+    # `semantic_candidates` is {} because no candidate-store node feeds it in
+    # this workflow — the exact-match cache is the live path.
+    semantic_candidates: Dict[str, Any] = {}
+    query_str = (
+        query if isinstance(query, str) else ("" if query is None else str(query))
+    )
+    best_match = None
+    best_similarity = 0.0
+
+    for cached_query, cache_entry in semantic_candidates.items():
+        # Simple similarity check (would use embeddings in production).
+        query_words = set(query_str.lower().split())
+        cached_words = set(cached_query.lower().split())
+
+        intersection = len(query_words & cached_words)
+        union = len(query_words | cached_words)
+        similarity = intersection / union if union > 0 else 0.0
+
+        if similarity > best_similarity and similarity >= similarity_threshold:
+            best_similarity = similarity
+            best_match = cache_entry
+
+    if best_match:
+        return {
+            "use_cache": True,
+            "cache_type": "semantic",
+            "cached_result": best_match,
+            "similarity": best_similarity,
+        }
+
+    return {"use_cache": False, "cache_type": None}
+
+
+def _aggregate_cache_result(
+    cache_decision: Any = None, fresh_results: Any = None
+) -> dict:
+    """Aggregate cached-or-fresh results into the documented output shape.
+
+    Replaces the ``result_aggregator`` codegen block. Honest defaults: a missing
+    ``cache_decision`` is treated as a cache miss; missing ``fresh_results`` (the
+    rag_processor is skipped on a cache hit) yields an empty results list, never
+    fabricated documents.
+    """
+    if not isinstance(cache_decision, dict):
+        cache_decision = {}
+
+    if cache_decision.get("use_cache"):
+        final_results = cache_decision.get("cached_result", {})
+        metadata = {
+            "source": "cache",
+            "cache_type": cache_decision.get("cache_type"),
+            "cache_similarity": cache_decision.get("similarity", 1.0),
+        }
+    else:
+        final_results = fresh_results
+        metadata = {"source": "fresh", "cached": True}
+
+    if not isinstance(final_results, dict):
+        final_results = {}
+
+    return {
+        "optimized_results": {
+            "results": final_results.get("results", []),
+            "scores": final_results.get("scores", []),
+            "metadata": metadata,
+            "performance": {
+                "cache_hit": cache_decision.get("use_cache", False),
+                "response_time": (
+                    "fast" if cache_decision.get("use_cache") else "normal"
+                ),
+            },
+        }
+    }
+
+
+def _build_execution_plan(
+    query: Any = "", strategies: Optional[List[str]] = None
+) -> dict:
+    """Build the parallel execution plan + per-strategy configs.
+
+    Replaces the ``parallel_executor`` codegen block. Honest default for a
+    missing strategy list: empty plan (no fabricated strategies).
+
+    ``documents`` is intentionally NOT a parameter: the original codegen placed
+    it only in a dead ``query_data`` local that never reached the published
+    ``result`` (the plan is built from ``strategies`` + ``query`` alone), and no
+    ``add_connection`` wires a ``documents`` port into ``parallel_executor`` —
+    so exposing it would be an accepted-but-ignored phantom input port.
+    """
+    strategies = list(strategies) if strategies else []
+
+    execution_plan = {
+        "strategies": strategies,
+        "query": query,
+        "start_time": datetime.now().isoformat(),
+        "parallel_count": len(strategies),
+    }
+
+    strategy_configs = {
+        strategy: {
+            "enabled": True,
+            "timeout": 5.0,  # 5 second timeout per strategy
+            "fallback": "hybrid",
+        }
+        for strategy in strategies
+    }
+
+    return {"execution_plan": execution_plan, "strategy_configs": strategy_configs}
+
+
+def _combine_strategy_results(
+    execution_plan: Any, strategies: List[str], strategy_results: Dict[str, Any]
+) -> dict:
+    """Fuse per-strategy retrieval results into a single ranked list.
+
+    The shared core for the ``result_combiner`` node. ``strategy_results`` maps
+    each strategy name to its retrieval output (``{"results": [...],
+    "scores": [...]}``). Wrapped by :func:`_make_result_combiner` so the
+    from_function node declares one explicit ``<strategy>_results`` input per
+    declared strategy (the inputs are dynamic at build time).
+
+    Honest defaults: a missing ``execution_plan`` start_time yields a 0.0 total
+    time (no fabricated timing); empty results yield empty fused output.
+    """
+    if not isinstance(execution_plan, dict):
+        execution_plan = {}
+    strategies = list(strategies) if strategies else []
+
+    # Collect non-empty per-strategy results.
+    collected: Dict[str, Any] = {
+        s: strategy_results[s] for s in strategies if strategy_results.get(s)
+    }
+
+    # Analyze timing — honest default when start_time is absent/unparseable.
+    end_time = datetime.now()
+    start_iso = execution_plan.get("start_time")
+    try:
+        start_time = datetime.fromisoformat(start_iso) if start_iso else end_time
+        total_time = (end_time - start_time).total_seconds()
+    except (TypeError, ValueError):
+        total_time = 0.0
+
+    # Combine results using score fusion.
+    all_results: Dict[str, Any] = {}
+    all_scores: Dict[str, Dict[str, Any]] = {}
+
+    for strategy, results in collected.items():
+        if isinstance(results, dict) and "results" in results:
+            docs = results.get("results", []) or []
+            scores = results.get("scores", []) or []
+            for doc, score in zip(docs, scores):
+                if not isinstance(doc, dict):
+                    continue
+                doc_id = doc.get("id", str(hash(doc.get("content", ""))))
+                if doc_id not in all_results:
+                    all_results[doc_id] = doc
+                    all_scores[doc_id] = {}
+                all_scores[doc_id][strategy] = score
+
+    # Aggregate scores (average across strategies that returned the doc).
+    final_scores = {
+        doc_id: sum(scores.values()) / len(scores)
+        for doc_id, scores in all_scores.items()
+        if scores
+    }
+
+    # Sort by aggregated score.
+    sorted_docs = sorted(final_scores.items(), key=lambda x: x[1], reverse=True)
+
+    final_results = []
+    final_score_list = []
+    for doc_id, score in sorted_docs[:10]:
+        final_results.append(all_results[doc_id])
+        final_score_list.append(score)
+
+    num_strategies = len(strategies)
+    return {
+        "parallel_results": {
+            "results": final_results,
+            "scores": final_score_list,
+            "metadata": {
+                # Behavior-equivalent to the original codegen: list every
+                # strategy whose result was wired in (present), NOT only the
+                # truthy ones — fusion still uses `collected` above.
+                "strategies_used": [s for s in strategies if s in strategy_results],
+                "total_execution_time": total_time,
+                "parallel_speedup": num_strategies / max(1, total_time),
+                "strategy_agreements": len(
+                    [sid for sid, s in all_scores.items() if len(s) == num_strategies]
+                ),
+            },
+        }
+    }
+
+
+def _build_streaming_plan(chunk_size: int = 100) -> dict:
+    """Build the progressive-streaming plan for a given chunk size.
+
+    Replaces the ``stream_controller`` codegen block. The build-time
+    ``chunk_size`` is bound through a thin closure (see
+    :class:`StreamingRAGNode`), so the only declared input is ``chunk_size``.
+    The stages are a fixed progressive-refinement ladder (initial → refined →
+    complete); honest default chunk size mirrors the constructor default.
+    """
+    return {
+        "streaming_plan": {
+            "chunk_size": chunk_size,
+            "total_target": 10,
+            "strategy": "progressive",  # Progressive refinement
+            "stages": [
+                {"name": "initial", "k": 3, "fast": True},
+                {"name": "refined", "k": 5, "fast": False},
+                {"name": "complete", "k": 10, "fast": False},
+            ],
+        }
+    }
+
+
+def _progressive_retrieve(
+    streaming_plan: Any = None, query: Any = "", documents: Any = None
+) -> dict:
+    """Run the fast initial-stage progressive retrieval (keyword overlap scan).
+
+    Replaces the ``progressive_retriever`` codegen block. ``streaming_plan`` is
+    wired from the controller's ``result.streaming_plan``; ``query`` and
+    ``documents`` are the top-level workflow inputs.
+
+    Honest defaults: a missing/malformed ``streaming_plan`` falls back to a
+    default initial-stage ``k`` of 3 (the plan's first-stage default — no
+    fabricated stages); a missing ``query`` / ``documents`` yields an empty
+    initial-results list, never fabricated documents.
+    """
+    if not isinstance(documents, list):
+        documents = []
+    query_str = (
+        query if isinstance(query, str) else ("" if query is None else str(query))
+    )
+
+    # Resolve the initial-stage k from the plan, with an honest fallback.
+    initial_k = 3
+    if isinstance(streaming_plan, dict):
+        stages = streaming_plan.get("stages")
+        if isinstance(stages, list) and stages and isinstance(stages[0], dict):
+            initial_k = stages[0].get("k", 3)
+
+    # Stage 1: Fast initial results (keyword matching).
+    initial_results = []
+    query_words = set(query_str.lower().split())
+
+    for doc in documents[:100]:  # Quick scan of first 100 docs
+        if not isinstance(doc, dict):
+            continue
+        doc_words = set(doc.get("content", "").lower().split())
+        overlap = query_words & doc_words
+        if overlap:  # Any overlap
+            initial_results.append(
+                {
+                    "doc": doc,
+                    "stage": "initial",
+                    "score": (len(overlap) / len(query_words) if query_words else 0.0),
+                }
+            )
+
+    # Sort and limit to the initial stage's k.
+    initial_results.sort(key=lambda x: x["score"], reverse=True)
+    initial_results = initial_results[:initial_k]
+
+    return {
+        "progressive_results": {
+            "initial": initial_results,
+            "has_more": len(documents) > 100,
+            "next_stage": "refined",
+            "metadata": {
+                "docs_scanned": min(100, len(documents)),
+                "matches_found": len(initial_results),
+            },
+        }
+    }
+
+
+def _format_stream_chunks(progressive_results: Any = None) -> dict:
+    """Format progressive retrieval results into streamable chunks.
+
+    Replaces the ``stream_formatter`` codegen block. ``progressive_results`` is
+    wired from the retriever's ``result.progressive_results``.
+
+    Honest default: a missing/malformed ``progressive_results`` yields an empty
+    initial set, so the only chunk emitted is the metadata chunk (never a
+    fabricated result chunk).
+    """
+    if not isinstance(progressive_results, dict):
+        progressive_results = {}
+
+    current_results = progressive_results.get("initial", []) or []
+
+    chunks = []
+    for i, result in enumerate(current_results):
+        if not isinstance(result, dict):
+            continue
+        chunks.append(
+            {
+                "chunk_id": i,
+                "type": "result",
+                "content": result.get("doc"),
+                "score": result.get("score"),
+                "stage": result.get("stage"),
+                "is_final": False,
+            }
+        )
+
+    # Add metadata chunk.
+    chunks.append(
+        {
+            "chunk_id": len(chunks),
+            "type": "metadata",
+            "content": progressive_results.get("metadata", {}),
+            "has_more": progressive_results.get("has_more", False),
+            "next_stage": progressive_results.get("next_stage"),
+        }
+    )
+
+    return {
+        "stream_chunks": chunks,
+        "streaming_metadata": {
+            "total_chunks": len(chunks),
+            "result_chunks": len(current_results),
+            "supports_backpressure": True,
+        },
+    }
+
+
+def _organize_batches(queries: Any = None, batch_size: int = 32) -> dict:
+    """Organize queries into similarity-grouped batches.
+
+    Replaces the ``batch_organizer`` codegen block. The build-time ``batch_size``
+    is bound through a thin closure (see :class:`BatchOptimizedRAGNode`); the
+    only wired input is ``queries``.
+
+    Honest defaults: a missing ``queries`` yields an empty batch plan (zero
+    batches, zero queries) — never fabricated queries. A single string query is
+    coerced to a one-element list (mirrors the original codegen's
+    ``[queries]`` coercion).
+    """
+    if queries is None:
+        queries = []
+    elif not isinstance(queries, list):
+        queries = [queries]
+
+    # Create batches.
+    batches = []
+    for i in range(0, len(queries), batch_size):
+        batch = queries[i : i + batch_size]
+        batches.append(
+            {
+                "batch_id": i // batch_size,
+                "queries": batch,
+                "size": len(batch),
+            }
+        )
+
+    # Analyze query similarity for better batching — group similar queries
+    # together for cache efficiency.
+    if len(queries) > 1:
+        # Simple similarity grouping (would use embeddings in production).
+        query_groups: Dict[Any, List[Any]] = {}
+        for q in queries:
+            key_words = tuple(sorted(str(q).lower().split()[:3]))  # First 3 words
+            if key_words not in query_groups:
+                query_groups[key_words] = []
+            query_groups[key_words].append(q)
+
+        # Reorganize batches by similarity.
+        optimized_batches = []
+        current_batch: List[Any] = []
+
+        for group in query_groups.values():
+            for q in group:
+                current_batch.append(q)
+                if len(current_batch) >= batch_size:
+                    optimized_batches.append(
+                        {
+                            "batch_id": len(optimized_batches),
+                            "queries": current_batch[:],
+                            "size": len(current_batch),
+                            "optimized": True,
+                        }
+                    )
+                    current_batch = []
+
+        if current_batch:
+            optimized_batches.append(
+                {
+                    "batch_id": len(optimized_batches),
+                    "queries": current_batch,
+                    "size": len(current_batch),
+                    "optimized": True,
+                }
+            )
+
+        batches = optimized_batches
+
+    return {
+        "batch_plan": {
+            "total_queries": len(queries),
+            "batch_size": batch_size,
+            "num_batches": len(batches),
+            "batches": batches,
+            "optimization_applied": len(queries) > 1,
+        }
+    }
+
+
+def _process_batches(batch_plan: Any = None, documents: Any = None) -> dict:
+    """Score every document for every query in each batch (shared doc reps).
+
+    Replaces the ``batch_processor`` codegen block. ``batch_plan`` is wired from
+    the organizer's ``result.batch_plan``; ``documents`` is the top-level
+    workflow input.
+
+    Honest defaults: a missing ``batch_plan`` yields empty batch results with a
+    zero-query statistics block; missing ``documents`` yields empty per-query
+    score lists — never fabricated documents or scores.
+    """
+    if not isinstance(batch_plan, dict):
+        batch_plan = {}
+    if not isinstance(documents, list):
+        documents = []
+
+    total_queries = batch_plan.get("total_queries", 0)
+    plan_batches = batch_plan.get("batches", []) or []
+
+    # Pre-compute document representations once.
+    doc_representations: Dict[int, Dict[str, Any]] = {}
+    for i, doc in enumerate(documents):
+        if not isinstance(doc, dict):
+            continue
+        doc_words = set(doc.get("content", "").lower().split())
+        doc_representations[i] = {
+            "words": doc_words,
+            "length": len(doc_words),
+            "doc": doc,
+        }
+
+    # Process each batch.
+    batch_results = []
+    for batch in plan_batches:
+        if not isinstance(batch, dict):
+            continue
+        batch_queries = batch.get("queries", []) or []
+        batch_scores = []
+
+        # Score all documents for all queries in the batch.
+        for query in batch_queries:
+            query_words = set(str(query).lower().split())
+            doc_scores = []
+
+            for doc_id, doc_rep in doc_representations.items():
+                overlap = len(query_words & doc_rep["words"])
+                score = overlap / len(query_words) if query_words else 0.0
+                doc_scores.append((doc_id, score))
+
+            # Sort and take top k.
+            doc_scores.sort(key=lambda x: x[1], reverse=True)
+            batch_scores.append(doc_scores[:10])
+
+        batch_results.append(
+            {
+                "batch_id": batch.get("batch_id"),
+                "query_results": batch_scores,
+                "batch_size": len(batch_queries),
+            }
+        )
+
+    # Aggregate statistics.
+    total_scored = sum(len(br["query_results"]) for br in batch_results)
+    avg_score_per_query = total_scored / total_queries if total_queries > 0 else 0.0
+
+    return {
+        "batch_results": {
+            "results": batch_results,
+            "statistics": {
+                "total_queries_processed": total_queries,
+                "batches_processed": len(batch_results),
+                "avg_results_per_query": avg_score_per_query,
+                "batch_efficiency": 1.0,
+            },
+        }
+    }
+
+
+def _format_batch_results(
+    batch_results: Any = None, batch_plan: Any = None, documents: Any = None
+) -> dict:
+    """Map per-batch score tuples back to per-query document results.
+
+    Replaces the ``result_formatter`` codegen block. ``batch_results`` is wired
+    from the processor's ``result.batch_results``; ``batch_plan`` from the
+    organizer's ``result.batch_plan``; ``documents`` is the top-level input.
+
+    Honest defaults: missing inputs yield an empty per-query result map — never
+    fabricated documents. Only documents with a positive overlap score are
+    emitted (mirrors the original codegen's ``if score > 0`` filter).
+    """
+    if not isinstance(batch_results, dict):
+        batch_results = {}
+    if not isinstance(batch_plan, dict):
+        batch_plan = {}
+    if not isinstance(documents, list):
+        documents = []
+
+    plan_batches = batch_plan.get("batches", []) or []
+    inner_results = batch_results.get("results", []) or []
+
+    formatted_results: Dict[Any, Any] = {}
+
+    for batch_result in inner_results:
+        if not isinstance(batch_result, dict):
+            continue
+        batch_id = batch_result.get("batch_id")
+        if not isinstance(batch_id, int) or batch_id >= len(plan_batches):
+            continue
+        batch_queries = plan_batches[batch_id].get("queries", []) or []
+
+        for i, (query, query_scores) in enumerate(
+            zip(batch_queries, batch_result.get("query_results", []) or [])
+        ):
+            results = []
+            scores = []
+
+            for doc_id, score in query_scores:
+                if score > 0 and 0 <= doc_id < len(documents):
+                    results.append(documents[doc_id])
+                    scores.append(score)
+
+            formatted_results[query] = {
+                "results": results,
+                "scores": scores,
+                "batch_id": batch_id,
+                "position_in_batch": i,
+            }
+
+    return {
+        "final_batch_results": {
+            "query_results": formatted_results,
+            "batch_statistics": batch_results.get("statistics", {}),
+            "processing_order": list(formatted_results.keys()),
+        }
+    }
+
+
+def _make_result_combiner(strategies: List[str]) -> Callable[..., dict]:
+    """Build a from_function-compatible combiner for a specific strategy list.
+
+    The ``result_combiner`` reads one input port per declared strategy
+    (``<strategy>_results``, wired from each ``<strategy>_rag`` node). Strategy
+    names are dynamic at build time, so this factory synthesises a real function
+    whose signature declares exactly those per-strategy parameters — letting
+    ``PythonCodeNode.from_function`` introspect them and the runtime wire each
+    edge by name. This is the framework-first equivalent of the prior dynamic
+    f-string codegen, with a statically-introspectable signature.
+    """
+    # The declared strategy list is baked in (build-time known), so the synthetic
+    # signature declares ONLY the input ports the graph wires: `execution_plan`
+    # (from the executor's `result.execution_plan`) plus one `<strategy>_results`
+    # per declared strategy (from each `<strategy>_rag` node). Deduplicate while
+    # preserving order so a repeated strategy name does not declare a duplicate
+    # parameter (an invalid signature).
+    declared_strategies: List[str] = []
+    seen = set()
+    for strategy in strategies:
+        if strategy in seen:
+            continue
+        seen.add(strategy)
+        declared_strategies.append(strategy)
+
+    params = [
+        inspect.Parameter(
+            "execution_plan", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None
+        ),
+    ]
+    for strategy in declared_strategies:
+        params.append(
+            inspect.Parameter(
+                f"{strategy}_results",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=None,
+            )
+        )
+    sig = inspect.Signature(params, return_annotation=dict)
+
+    def result_combiner(*args, **kwargs) -> dict:
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        arguments = bound.arguments
+        strategy_results = {
+            s: arguments.get(f"{s}_results") for s in declared_strategies
+        }
+        return _combine_strategy_results(
+            arguments.get("execution_plan"), declared_strategies, strategy_results
+        )
+
+    result_combiner.__signature__ = sig  # type: ignore[attr-defined]
+    result_combiner.__name__ = "result_combiner"
+    result_combiner.__doc__ = _combine_strategy_results.__doc__
+    return result_combiner
 
 
 @register_node()
@@ -88,55 +765,22 @@ class CacheOptimizedRAGNode(WorkflowNode):
         """Create cache-optimized RAG workflow"""
         builder = WorkflowBuilder()
 
-        # Add cache key generator
-        cache_key_gen_id = builder.add_node(
-            "PythonCodeNode",
+        # Add cache key generator.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted from the prior f-string codegen
+        # to the module-level `_generate_cache_keys` function wired via
+        # `PythonCodeNode.from_function`. The node publishes the SAME flat `result`
+        # port carrying `{"cache_keys": {"exact", "semantic"}}`, so the downstream
+        # `result.cache_keys.exact` edges below resolve unchanged. `_internal=True`
+        # suppresses the consumer-facing instance-API advisory (SDK-internal
+        # construction path, mirrors conversational.py).
+        cache_key_gen_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _generate_cache_keys,
+                name="cache_key_generator",
+            ),
             node_id="cache_key_generator",
-            config={
-                "code": f"""
-import hashlib
-
-def generate_cache_key(query, params=None):
-    '''Generate deterministic cache key'''
-    key_parts = [query]
-    if params:
-        key_parts.extend([f"{{k}}={{v}}" for k, v in sorted(params.items())])
-
-    key_string = "|".join(key_parts)
-    return hashlib.sha256(key_string.encode()).hexdigest()[:16]
-
-def check_semantic_similarity(query, cached_queries, threshold={self.similarity_threshold}):
-    '''Check if any cached query is semantically similar'''
-    # Simplified similarity check for demo
-    # In production, would use actual embeddings
-    query_lower = query.lower()
-    query_words = set(query_lower.split())
-
-    for cached_query, cache_data in cached_queries.items():
-        cached_words = set(cached_query.lower().split())
-
-        # Jaccard similarity
-        intersection = len(query_words & cached_words)
-        union = len(query_words | cached_words)
-        similarity = intersection / union if union > 0 else 0
-
-        if similarity >= threshold:
-            return cached_query, similarity
-
-    return None, 0
-
-# Generate cache keys
-exact_key = generate_cache_key(query)
-semantic_key = f"semantic_{{exact_key[:8]}}"
-
-result = {{
-    "cache_keys": {{
-        "exact": exact_key,
-        "semantic": semantic_key
-    }}
-}}
-"""
-            },
+            _internal=True,
         )
 
         # Add cache checker
@@ -146,81 +790,39 @@ result = {{
             config={"operation": "get", "ttl": self.cache_ttl},
         )
 
-        # Add semantic cache manager
-        semantic_cache_id = builder.add_node(
-            "PythonCodeNode",
+        # Add semantic cache manager.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_decide_cache_use` function wired via `PythonCodeNode.from_function`.
+        # The build-time `similarity_threshold` is bound through a thin closure
+        # (keeps `cache_hit` / `cache_value` / `query` as the declared inputs the
+        # CacheNode `hit`/`value` ports wire to). The node publishes the SAME flat
+        # `result` port carrying the decision dict, so the `result.use_cache`
+        # skip-gate edge + the `result` aggregator edge below resolve unchanged.
+        #
+        # CacheNode's `get` publishes flat ports (`hit`, `value`), NOT a nested
+        # dict — this node reads `cache_hit` + `cache_value` wired from those
+        # ports. Semantic-similarity caching is honest-but-dormant (no candidate
+        # store is wired); the exact-match cache is the live path.
+        _similarity_threshold = self.similarity_threshold
+
+        def _decide_cache_use_bound(cache_hit=None, cache_value=None, query="") -> dict:
+            return _decide_cache_use(
+                cache_hit=cache_hit,
+                cache_value=cache_value,
+                query=query,
+                similarity_threshold=_similarity_threshold,
+            )
+
+        _decide_cache_use_bound.__name__ = "semantic_cache_manager"
+        _decide_cache_use_bound.__doc__ = _decide_cache_use.__doc__
+        semantic_cache_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _decide_cache_use_bound,
+                name="semantic_cache_manager",
+            ),
             node_id="semantic_cache_manager",
-            config={
-                "code": f"""
-# Check semantic cache.
-#
-# F9 #1117/#1123: this node already binds `result` at module scope (inside the
-# if/else branches), so PythonCodeNode publishes a real `result` port — the AST
-# "publishes nothing" flag was a column-0 false positive (the assignment is
-# indented inside the branches, never at module column-0). The genuine defect
-# was a CONTRACT MISMATCH with the upstream CacheNode: this node read
-# `exact_hit` / `exact_result` / `semantic_candidates`, but CacheNode's `get`
-# operation publishes `{{"hit": bool, "value": <cached>, "success": ...}}`. The
-# reads are now aligned to CacheNode's real output shape, so an exact cache hit
-# is detected from the live cache backend instead of always defaulting to miss.
-#
-# Semantic-similarity caching is honest-but-dormant: no node in this workflow
-# populates a candidate store, so `semantic_candidates` is empty and the
-# similarity branch never fires. The similarity logic is real (not simulated);
-# it activates only when a candidate-store node is wired in. The workflow today
-# is a real exact-match cache over CacheNode.
-def decide_cache_use(cache_hit, cache_value, semantic_candidates, query):
-    '''Decide whether to serve from cache. Returns the decision dict.'''
-    if bool(cache_hit):
-        # Direct cache hit — return the value CacheNode retrieved.
-        return {{
-            "use_cache": True,
-            "cache_type": "exact",
-            "cached_result": cache_value
-        }}
-
-    # Check semantic similarity (dormant unless a candidate-store node is wired).
-    best_match = None
-    best_similarity = 0
-
-    for cached_query, cache_entry in semantic_candidates.items():
-        # Simple similarity check (would use embeddings in production)
-        query_words = set(query.lower().split())
-        cached_words = set(cached_query.lower().split())
-
-        intersection = len(query_words & cached_words)
-        union = len(query_words | cached_words)
-        similarity = intersection / union if union > 0 else 0
-
-        if similarity > best_similarity and similarity >= {self.similarity_threshold}:
-            best_similarity = similarity
-            best_match = cache_entry
-
-    if best_match:
-        return {{
-            "use_cache": True,
-            "cache_type": "semantic",
-            "cached_result": best_match,
-            "similarity": best_similarity
-        }}
-
-    return {{
-        "use_cache": False,
-        "cache_type": None
-    }}
-
-# CacheNode's `get` publishes flat ports (`hit`, `value`, ...), NOT a nested
-# dict — so this node reads `cache_hit` + `cache_value` wired from those ports.
-# `semantic_candidates` is {{}} because no candidate-store node feeds it in this
-# workflow (the exact-match cache is the live path; semantic caching is dormant
-# until a candidate-store node is wired in).
-#
-# F9 #1117/#1123: module-scope `result =` (column 0) so PythonCodeNode publishes
-# the `result` port the rag_processor skip-gate + result_aggregator read.
-result = decide_cache_use(cache_hit, cache_value, {{}}, query)
-del decide_cache_use
-"""
-            },
+            _internal=True,
         )
 
         # Add main RAG processor (only runs if cache miss)
@@ -238,44 +840,22 @@ del decide_cache_use
         )
 
         # Add result aggregator
-        result_aggregator_id = builder.add_node(
-            "PythonCodeNode",
+        # Add result aggregator.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_aggregate_cache_result` function wired via
+        # `PythonCodeNode.from_function`. `cache_decision` is wired from the
+        # semantic_cache_manager's `result` port; `fresh_results` from the
+        # rag_processor (absent on a cache hit — the function's honest default
+        # handles the missing input). The node publishes the SAME flat `result`
+        # port carrying `{"optimized_results": {...}}`.
+        result_aggregator_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _aggregate_cache_result,
+                name="result_aggregator",
+            ),
             node_id="result_aggregator",
-            config={
-                "code": """
-# Aggregate results from cache or fresh retrieval
-cache_decision = cache_decision
-fresh_results = fresh_results if 'fresh_results' in locals() else None
-
-if cache_decision.get("use_cache"):
-    # Return cached results
-    final_results = cache_decision.get("cached_result", {})
-    metadata = {
-        "source": "cache",
-        "cache_type": cache_decision.get("cache_type"),
-        "cache_similarity": cache_decision.get("similarity", 1.0)
-    }
-else:
-    # Return fresh results
-    final_results = fresh_results
-    metadata = {
-        "source": "fresh",
-        "cached": True  # Will be cached now
-    }
-
-result = {
-    "optimized_results": {
-        "results": final_results.get("results", []),
-        "scores": final_results.get("scores", []),
-        "metadata": metadata,
-        "performance": {
-            "cache_hit": cache_decision.get("use_cache", False),
-            "response_time": "fast" if cache_decision.get("use_cache") else "normal"
-        }
-    }
-}
-"""
-            },
+            _internal=True,
         )
 
         # Connect workflow with conditional execution.
@@ -378,43 +958,31 @@ class AsyncParallelRAGNode(WorkflowNode):
         builder = WorkflowBuilder()
 
         # Add parallel executor
-        parallel_executor_id = builder.add_node(
-            "PythonCodeNode",
+        # Add parallel executor.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_build_execution_plan` function wired via
+        # `PythonCodeNode.from_function`, with the build-time strategy list bound
+        # through a thin closure (keeps `query` as the declared input). The
+        # function returns `{"execution_plan": ..., "strategy_configs": ...}` on
+        # the flat `result` port. The downstream combiner edge reads
+        # `result.execution_plan` (see below) — the prior codegen published only
+        # `result` while the edge read a phantom `execution_plan` port (latent
+        # #1117 nested-port defect, now closed).
+        _strategies = list(self.strategies)
+
+        def _build_execution_plan_bound(query="") -> dict:
+            return _build_execution_plan(query=query, strategies=_strategies)
+
+        _build_execution_plan_bound.__name__ = "parallel_executor"
+        _build_execution_plan_bound.__doc__ = _build_execution_plan.__doc__
+        parallel_executor_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _build_execution_plan_bound,
+                name="parallel_executor",
+            ),
             node_id="parallel_executor",
-            config={
-                "code": f"""
-import asyncio
-from datetime import datetime
-
-# Prepare parallel execution tasks
-strategies = {self.strategies}
-query_data = {{
-    "query": query,
-    "documents": documents
-}}
-
-# Create execution metadata
-execution_plan = {{
-    "strategies": strategies,
-    "query": query,
-    "start_time": datetime.now().isoformat(),
-    "parallel_count": len(strategies)
-}}
-
-# Note: Actual parallel execution happens at runtime level
-# This node prepares the execution plan
-result = {{
-    "execution_plan": execution_plan,
-    "strategy_configs": {{
-        strategy: {{
-            "enabled": True,
-            "timeout": 5.0,  # 5 second timeout per strategy
-            "fallback": "hybrid"
-        }} for strategy in strategies
-    }}
-}}
-"""
-            },
+            _internal=True,
         )
 
         # Add strategy nodes dynamically
@@ -448,82 +1016,44 @@ result = {{
 
             strategy_nodes[strategy] = node_id
 
-        # Add result combiner
-        result_combiner_id = builder.add_node(
-            "PythonCodeNode",
+        # Add result combiner.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to `_combine_strategy_results`
+        # via the `_make_result_combiner` factory, which synthesises a real
+        # function whose signature declares one `<strategy>_results` input per
+        # declared strategy (strategy names are dynamic at build time). The prior
+        # f-string codegen read those per-strategy inputs via `locals()` inside an
+        # exec sandbox — brittle and brace-escape-prone (#1123). The factory keeps
+        # the inputs statically introspectable so `from_function` declares them
+        # and the runtime wires each `<strategy>_rag` edge by name. The node
+        # publishes the fused output on the flat `result` port.
+        result_combiner_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _make_result_combiner(_strategies),
+                name="result_combiner",
+            ),
             node_id="result_combiner",
-            config={
-                "code": f"""
-from datetime import datetime
-
-# Combine results from parallel strategies
-execution_plan = execution_plan
-strategy_results = {{}}
-
-# Collect results from each strategy
-strategies = {self.strategies}
-for strategy in strategies:
-    key = f"{{strategy}}_results"
-    if key in locals():
-        strategy_results[strategy] = locals()[key]
-
-# Analyze timing
-end_time = datetime.now()
-start_time = datetime.fromisoformat(execution_plan["start_time"])
-total_time = (end_time - start_time).total_seconds()
-
-# Combine results using voting or fusion
-all_results = {{}}
-all_scores = {{}}
-
-for strategy, results in strategy_results.items():
-    if results and "results" in results:
-        for i, (doc, score) in enumerate(zip(results["results"], results.get("scores", []))):
-            doc_id = doc.get("id", str(hash(doc.get("content", ""))))
-
-            if doc_id not in all_results:
-                all_results[doc_id] = doc
-                all_scores[doc_id] = {{}}
-
-            all_scores[doc_id][strategy] = score
-
-# Aggregate scores (average)
-final_scores = {{}}
-for doc_id, scores in all_scores.items():
-    final_scores[doc_id] = sum(scores.values()) / len(scores)
-
-# Sort by aggregated score
-sorted_docs = sorted(final_scores.items(), key=lambda x: x[1], reverse=True)
-
-# Format final results
-final_results = []
-final_score_list = []
-for doc_id, score in sorted_docs[:10]:
-    final_results.append(all_results[doc_id])
-    final_score_list.append(score)
-
-result = {{
-    "parallel_results": {{
-        "results": final_results,
-        "scores": final_score_list,
-        "metadata": {{
-            "strategies_used": list(strategy_results.keys()),
-            "total_execution_time": total_time,
-            "parallel_speedup": len(strategies) / max(1, total_time),
-            "strategy_agreements": len([sid for sid, s in all_scores.items() if len(s) == len(strategies)])
-        }}
-    }}
-}}
-"""
-            },
+            _internal=True,
         )
 
-        # Connect parallel execution
+        # Connect parallel execution.
+        #
+        # The executor publishes `{"execution_plan": ..., "strategy_configs":
+        # ...}` on the flat `result` port, so the combiner's `execution_plan`
+        # input reads `result.execution_plan` (the runtime resolves the dotted
+        # path into the published dict). The pre-fix edge read a phantom
+        # `execution_plan` port the codegen never published — latent #1117
+        # nested-port defect, closed here.
         builder.add_connection(
-            parallel_executor_id, "execution_plan", result_combiner_id, "execution_plan"
+            parallel_executor_id,
+            "result.execution_plan",
+            result_combiner_id,
+            "execution_plan",
         )
 
-        # Connect each strategy to combiner
+        # Connect each strategy to combiner. Each `<strategy>_rag` node publishes
+        # its retrieval output on `output`, wired to the combiner's declared
+        # `<strategy>_results` input.
         for strategy, node_id in strategy_nodes.items():
             builder.add_connection(
                 node_id, "output", result_combiner_id, f"{strategy}_results"
@@ -585,133 +1115,82 @@ class StreamingRAGNode(WorkflowNode):
         """Create streaming RAG workflow"""
         builder = WorkflowBuilder()
 
-        # Add streaming controller
-        stream_controller_id = builder.add_node(
-            "PythonCodeNode",
+        # Add streaming controller.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_build_streaming_plan` function wired via `PythonCodeNode.from_function`,
+        # with the build-time `chunk_size` bound through a thin closure (the
+        # function declares no inputs the graph must wire). The node publishes
+        # `{"streaming_plan": ...}` on the flat `result` port; the downstream
+        # retriever edge reads `result.streaming_plan` (the prior codegen
+        # published only `result` while the edge read a phantom `streaming_plan`
+        # port — latent #1117 nested-port defect, closed here).
+        _chunk_size = self.chunk_size
+
+        def _build_streaming_plan_bound() -> dict:
+            return _build_streaming_plan(chunk_size=_chunk_size)
+
+        _build_streaming_plan_bound.__name__ = "stream_controller"
+        _build_streaming_plan_bound.__doc__ = _build_streaming_plan.__doc__
+        stream_controller_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _build_streaming_plan_bound,
+                name="stream_controller",
+            ),
             node_id="stream_controller",
-            config={
-                "code": f"""
-# Set up streaming parameters
-chunk_size = {self.chunk_size}
-total_results_target = 10
-
-# Create streaming plan
-streaming_plan = {{
-    "chunk_size": chunk_size,
-    "total_target": total_results_target,
-    "strategy": "progressive",  # Progressive refinement
-    "stages": [
-        {{"name": "initial", "k": 3, "fast": True}},
-        {{"name": "refined", "k": 5, "fast": False}},
-        {{"name": "complete", "k": 10, "fast": False}}
-    ]
-}}
-
-result = {{"streaming_plan": streaming_plan}}
-"""
-            },
+            _internal=True,
         )
 
-        # Add progressive retriever
-        progressive_retriever_id = builder.add_node(
-            "PythonCodeNode",
+        # Add progressive retriever.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_progressive_retrieve` function wired via `PythonCodeNode.from_function`.
+        # `streaming_plan` is wired from the controller's `result.streaming_plan`;
+        # `query` / `documents` are the top-level workflow inputs. The node
+        # publishes `{"progressive_results": ...}` on the flat `result` port; the
+        # downstream formatter edge reads `result.progressive_results`.
+        progressive_retriever_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _progressive_retrieve,
+                name="progressive_retriever",
+            ),
             node_id="progressive_retriever",
-            config={
-                "code": """
-# Implement progressive retrieval
-streaming_plan = streaming_plan
-query = query
-documents = documents
-
-# Stage 1: Fast initial results (keyword matching)
-initial_results = []
-query_words = set(query.lower().split())
-
-for doc in documents[:100]:  # Quick scan of first 100 docs
-    doc_words = set(doc.get("content", "").lower().split())
-    if query_words & doc_words:  # Any overlap
-        initial_results.append({
-            "doc": doc,
-            "stage": "initial",
-            "score": len(query_words & doc_words) / len(query_words)
-        })
-
-# Sort and limit
-initial_results.sort(key=lambda x: x["score"], reverse=True)
-initial_results = initial_results[:streaming_plan["stages"][0]["k"]]
-
-# Prepare for next stages
-result = {
-    "progressive_results": {
-        "initial": initial_results,
-        "has_more": len(documents) > 100,
-        "next_stage": "refined",
-        "metadata": {
-            "docs_scanned": min(100, len(documents)),
-            "matches_found": len(initial_results)
-        }
-    }
-}
-"""
-            },
+            _internal=True,
         )
 
-        # Add stream formatter
-        stream_formatter_id = builder.add_node(
-            "PythonCodeNode",
+        # Add stream formatter.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_format_stream_chunks` function wired via `PythonCodeNode.from_function`.
+        # `progressive_results` is wired from the retriever's
+        # `result.progressive_results`. The node publishes
+        # `{"stream_chunks": ..., "streaming_metadata": ...}` on the flat
+        # `result` port (final sink — no downstream consumer).
+        stream_formatter_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _format_stream_chunks,
+                name="stream_formatter",
+            ),
             node_id="stream_formatter",
-            config={
-                "code": """
-# Format results for streaming
-progressive_results = progressive_results
-
-# Create stream chunks
-chunks = []
-current_results = progressive_results.get("initial", [])
-
-for i, result in enumerate(current_results):
-    chunk = {
-        "chunk_id": i,
-        "type": "result",
-        "content": result["doc"],
-        "score": result["score"],
-        "stage": result["stage"],
-        "is_final": False
-    }
-    chunks.append(chunk)
-
-# Add metadata chunk
-metadata_chunk = {
-    "chunk_id": len(chunks),
-    "type": "metadata",
-    "content": progressive_results.get("metadata", {}),
-    "has_more": progressive_results.get("has_more", False),
-    "next_stage": progressive_results.get("next_stage")
-}
-chunks.append(metadata_chunk)
-
-result = {
-    "stream_chunks": chunks,
-    "streaming_metadata": {
-        "total_chunks": len(chunks),
-        "result_chunks": len(current_results),
-        "supports_backpressure": True
-    }
-}
-"""
-            },
+            _internal=True,
         )
 
-        # Connect workflow
+        # Connect workflow.
+        #
+        # Each from_function node publishes on the flat `result` port; the
+        # downstream edges read the nested key via a dotted path
+        # (`result.streaming_plan`, `result.progressive_results`), which the
+        # runtime resolves into the published dict. The pre-fix edges read
+        # phantom top-level ports the codegen never published (#1117).
         builder.add_connection(
             stream_controller_id,
-            "streaming_plan",
+            "result.streaming_plan",
             progressive_retriever_id,
             "streaming_plan",
         )
         builder.add_connection(
             progressive_retriever_id,
-            "progressive_results",
+            "result.progressive_results",
             stream_formatter_id,
             "progressive_results",
         )
@@ -771,199 +1250,85 @@ class BatchOptimizedRAGNode(WorkflowNode):
         """Create batch-optimized RAG workflow"""
         builder = WorkflowBuilder()
 
-        # Add batch organizer
-        batch_organizer_id = builder.add_node(
-            "PythonCodeNode",
+        # Add batch organizer.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_organize_batches` function wired via `PythonCodeNode.from_function`,
+        # with the build-time `batch_size` bound through a thin closure (`queries`
+        # is the only declared input the graph wires). The node publishes
+        # `{"batch_plan": ...}` on the flat `result` port; the downstream
+        # processor + formatter edges read `result.batch_plan` (the prior codegen
+        # published only `result` while the edges read a phantom `batch_plan`
+        # port — latent #1117 nested-port defect, closed here).
+        _batch_size = self.batch_size
+
+        def _organize_batches_bound(queries=None) -> dict:
+            return _organize_batches(queries=queries, batch_size=_batch_size)
+
+        _organize_batches_bound.__name__ = "batch_organizer"
+        _organize_batches_bound.__doc__ = _organize_batches.__doc__
+        batch_organizer_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _organize_batches_bound,
+                name="batch_organizer",
+            ),
             node_id="batch_organizer",
-            config={
-                "code": f"""
-# Organize queries into batches
-queries = queries if isinstance(queries, list) else [queries]
-batch_size = {self.batch_size}
-
-# Create batches
-batches = []
-for i in range(0, len(queries), batch_size):
-    batch = queries[i:i + batch_size]
-    batches.append({{
-        "batch_id": i // batch_size,
-        "queries": batch,
-        "size": len(batch)
-    }})
-
-# Analyze query similarity for better batching
-# Group similar queries together for cache efficiency
-if len(queries) > 1:
-    # Simple similarity grouping (would use embeddings in production)
-    query_groups = {{}}
-    for q in queries:
-        key_words = tuple(sorted(q.lower().split()[:3]))  # First 3 words as key
-        if key_words not in query_groups:
-            query_groups[key_words] = []
-        query_groups[key_words].append(q)
-
-    # Reorganize batches by similarity
-    optimized_batches = []
-    current_batch = []
-
-    for group in query_groups.values():
-        for q in group:
-            current_batch.append(q)
-            if len(current_batch) >= batch_size:
-                optimized_batches.append({{
-                    "batch_id": len(optimized_batches),
-                    "queries": current_batch[:],
-                    "size": len(current_batch),
-                    "optimized": True
-                }})
-                current_batch = []
-
-    if current_batch:
-        optimized_batches.append({{
-            "batch_id": len(optimized_batches),
-            "queries": current_batch,
-            "size": len(current_batch),
-            "optimized": True
-        }})
-
-    batches = optimized_batches
-
-result = {{
-    "batch_plan": {{
-        "total_queries": len(queries),
-        "batch_size": batch_size,
-        "num_batches": len(batches),
-        "batches": batches,
-        "optimization_applied": len(queries) > 1
-    }}
-}}
-"""
-            },
+            _internal=True,
         )
 
-        # Add batch processor
-        batch_processor_id = builder.add_node(
-            "PythonCodeNode",
+        # Add batch processor.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_process_batches` function wired via `PythonCodeNode.from_function`.
+        # `batch_plan` is wired from the organizer's `result.batch_plan`;
+        # `documents` is the top-level workflow input. The node publishes
+        # `{"batch_results": ...}` on the flat `result` port; the downstream
+        # formatter edge reads `result.batch_results`.
+        batch_processor_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _process_batches,
+                name="batch_processor",
+            ),
             node_id="batch_processor",
-            config={
-                "code": """
-# Process batches efficiently
-batch_plan = batch_plan
-documents = documents
-
-# Pre-compute document representations once
-doc_representations = {}
-for i, doc in enumerate(documents):
-    # Simple representation (would use actual embeddings)
-    doc_words = set(doc.get("content", "").lower().split())
-    doc_representations[i] = {
-        "words": doc_words,
-        "length": len(doc_words),
-        "doc": doc
-    }
-
-# Process each batch
-batch_results = []
-
-for batch in batch_plan["batches"]:
-    batch_queries = batch["queries"]
-    batch_scores = []
-
-    # Score all documents for all queries in batch
-    for query in batch_queries:
-        query_words = set(query.lower().split())
-        doc_scores = []
-
-        for doc_id, doc_rep in doc_representations.items():
-            # Compute similarity once
-            overlap = len(query_words & doc_rep["words"])
-            score = overlap / len(query_words) if query_words else 0
-            doc_scores.append((doc_id, score))
-
-        # Sort and take top k
-        doc_scores.sort(key=lambda x: x[1], reverse=True)
-        batch_scores.append(doc_scores[:10])
-
-    batch_results.append({
-        "batch_id": batch["batch_id"],
-        "query_results": batch_scores,
-        "batch_size": len(batch_queries)
-    })
-
-# Aggregate statistics
-total_scored = sum(len(br["query_results"]) for br in batch_results)
-avg_score_per_query = total_scored / batch_plan["total_queries"] if batch_plan["total_queries"] > 0 else 0
-
-result = {
-    "batch_results": {
-        "results": batch_results,
-        "statistics": {
-            "total_queries_processed": batch_plan["total_queries"],
-            "batches_processed": len(batch_results),
-            "avg_results_per_query": avg_score_per_query,
-            "batch_efficiency": 1.0  # Would calculate actual efficiency metrics
-        }
-    }
-}
-"""
-            },
+            _internal=True,
         )
 
-        # Add result formatter
-        result_formatter_id = builder.add_node(
-            "PythonCodeNode",
+        # Add result formatter.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_format_batch_results` function wired via `PythonCodeNode.from_function`.
+        # `batch_results` is wired from the processor's `result.batch_results`;
+        # `batch_plan` from the organizer's `result.batch_plan`; `documents` is
+        # the top-level input. The node publishes
+        # `{"final_batch_results": ...}` on the flat `result` port (final sink —
+        # no downstream consumer).
+        result_formatter_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _format_batch_results,
+                name="result_formatter",
+            ),
             node_id="result_formatter",
-            config={
-                "code": """
-# Format batch results for output
-batch_results = batch_results
-batch_plan = batch_plan
-documents = documents
-
-# Create per-query results
-formatted_results = {}
-
-query_idx = 0
-for batch_result in batch_results["results"]:
-    batch_queries = batch_plan["batches"][batch_result["batch_id"]]["queries"]
-
-    for i, (query, query_scores) in enumerate(zip(batch_queries, batch_result["query_results"])):
-        results = []
-        scores = []
-
-        for doc_id, score in query_scores:
-            if score > 0:
-                results.append(documents[doc_id])
-                scores.append(score)
-
-        formatted_results[query] = {
-            "results": results,
-            "scores": scores,
-            "batch_id": batch_result["batch_id"],
-            "position_in_batch": i
-        }
-        query_idx += 1
-
-result = {
-    "final_batch_results": {
-        "query_results": formatted_results,
-        "batch_statistics": batch_results["statistics"],
-        "processing_order": list(formatted_results.keys())
-    }
-}
-"""
-            },
+            _internal=True,
         )
 
-        # Connect workflow
+        # Connect workflow.
+        #
+        # Each from_function node publishes on the flat `result` port; the
+        # downstream edges read the nested key via a dotted path
+        # (`result.batch_plan`, `result.batch_results`), which the runtime
+        # resolves into the published dict. The pre-fix edges read phantom
+        # top-level ports the codegen never published (#1117).
         builder.add_connection(
-            batch_organizer_id, "batch_plan", batch_processor_id, "batch_plan"
+            batch_organizer_id, "result.batch_plan", batch_processor_id, "batch_plan"
         )
         builder.add_connection(
-            batch_processor_id, "batch_results", result_formatter_id, "batch_results"
+            batch_processor_id,
+            "result.batch_results",
+            result_formatter_id,
+            "batch_results",
         )
         builder.add_connection(
-            batch_organizer_id, "batch_plan", result_formatter_id, "batch_plan"
+            batch_organizer_id, "result.batch_plan", result_formatter_id, "batch_plan"
         )
 
         return builder.build(name="batch_optimized_rag_workflow")

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/query_processing.py
@@ -427,6 +427,350 @@ def parse_hop_plan_response(response=None):
     }
 
 
+# ---------------------------------------------------------------------------
+# COMPUTE processors (#1117 / #1123 / #1118 root-cause fix — same reference
+# template as optimized.py S1/S2 + graph.py/evaluation.py S3).
+#
+# These are the 6 terminal PROCESSOR stages of the query_processing inner
+# workflows. Each consumes the parsed dict its upstream `parse_<stage>`
+# from_function node publishes (the {expansions,...} / {sub_questions,...} /
+# {rewrites,...} / {query_type,...} / {hops,...} dicts) PLUS the top-level
+# `query` input, and produces the node's final documented result.
+#
+# Pre-migration each was an inline `code=` codegen block (an f-string-free
+# triple-quoted string `PythonCodeNode` config). Those blocks suffered the
+# #1117 publish-nothing class (a string-`code` PythonCodeNode publishes on the
+# flat `result` port, but brace-escaping + import-trap hazards made the codegen
+# fragile). Lifting each to a real module-level `def ... -> dict` (real
+# `return`, type-checkable, no brace-escaping, no import trap) and wiring via
+# `PythonCodeNode.from_function(fn)` is the structural fix: the node publishes
+# the SAME flat `result` port carrying the returned dict.
+#
+# Each is pure post-LLM tool-result FORMATTING (the permitted deterministic
+# exception per rules/agent-reasoning.md #3 / #6 — assembling the LLM's parsed
+# decision into the documented output shape). NO if-else routing / keyword
+# classification on query content is added: the LLM already made the expansion
+# / decomposition / rewrite / intent / hop reasoning upstream; these stages
+# only render it.
+#
+# HONESTY (zero-tolerance Rule 2): each defaults to the upstream parser's
+# empty-sentinel (a typed-but-empty dict) on missing/malformed input (an empty
+# expansion set / empty plan / original-query-only rewrite), NEVER a fabricated
+# value. Each
+# input param maps 1:1 to a real `add_connection` edge or the top-level
+# `query` injection — no vestigial params (zero-tolerance Rule 3c).
+# ---------------------------------------------------------------------------
+
+
+def _process_expansions(query: str = "", expansion_response=None) -> dict:
+    """Assemble the QueryExpansionNode ``expanded_query`` result.
+
+    Consumes ``expansion_response`` (the ``{expansions, keywords, concepts}``
+    dict ``expansion_parser`` publishes) + the top-level ``query``. Combines +
+    dedups all terms into the documented ``expanded_query`` shape. Honest
+    default: a missing/non-dict ``expansion_response`` yields empty lists (the
+    parser's empty-sentinel propagates), never fabricated expansions.
+    """
+    original_query = query
+    expansion_result = (
+        expansion_response if isinstance(expansion_response, dict) else {}
+    )
+
+    expansions = expansion_result.get("expansions", []) or []
+    keywords = expansion_result.get("keywords", []) or []
+    concepts = expansion_result.get("concepts", []) or []
+
+    # Combine and deduplicate.
+    all_terms = set()
+    all_terms.add(original_query)
+    all_terms.update(expansions)
+    all_terms.update(keywords)
+
+    return {
+        "expanded_query": {
+            "original": original_query,
+            "expansions": list(expansions),
+            "keywords": list(keywords),
+            "concepts": list(concepts),
+            "all_terms": list(all_terms),
+            "expansion_count": len(all_terms) - 1,
+        }
+    }
+
+
+def _resolve_dependencies(decomposition_result=None) -> dict:
+    """Build the QueryDecompositionNode ``execution_plan`` result.
+
+    Consumes ``decomposition_result`` (the ``{sub_questions,
+    composition_strategy}`` dict ``decomposition_parser`` publishes). Reads each
+    sub-question's ``depends_on`` field (the key the decomposer system_prompt
+    advertises — F25 Shard E), builds the dependency graph, and topologically
+    sorts it into an execution order. Honest default: a missing/non-dict
+    ``decomposition_result`` yields an empty plan, never fabricated
+    sub-questions.
+    """
+    decomposition = (
+        decomposition_result if isinstance(decomposition_result, dict) else {}
+    )
+    sub_questions = decomposition.get("sub_questions", []) or []
+
+    # Build dependency graph. Each sub-question may be a dict carrying
+    # `depends_on` (the field the system_prompt advertises) or a bare value.
+    dependency_graph: Dict[int, List[int]] = {}
+    for i, sq in enumerate(sub_questions):
+        deps = sq.get("depends_on", []) if isinstance(sq, dict) else []
+        dependency_graph[i] = deps
+
+    # Topological sort for execution order.
+    def topological_sort(graph: Dict[int, List[int]]) -> List[int]:
+        visited = set()
+        stack: List[int] = []
+
+        def dfs(node: int) -> None:
+            visited.add(node)
+            for dep in graph.get(node, []):
+                if dep not in visited:
+                    dfs(dep)
+            stack.append(node)
+
+        for node in graph:
+            if node not in visited:
+                dfs(node)
+
+        return stack[::-1]
+
+    execution_order = topological_sort(dependency_graph)
+
+    execution_plan = {
+        "sub_questions": sub_questions,
+        "execution_order": execution_order,
+        "composition_strategy": decomposition.get("composition_strategy", "sequential"),
+        "total_questions": len(sub_questions),
+    }
+
+    return {"execution_plan": execution_plan}
+
+
+def _combine_rewrites(
+    query: str = "", analysis_result=None, rewrite_result=None
+) -> dict:
+    """Assemble the QueryRewritingNode ``rewritten_queries`` result.
+
+    Consumes the top-level ``query`` plus the two parsed LLM-stage dicts:
+    ``analysis_result`` (``{issues, suggestions}`` from ``analysis_parser``) and
+    ``rewrite_result`` (``{rewrites, recommended}`` from ``rewrite_parser``).
+    Merges the original query + all rewrite versions, dedups preserving order,
+    and surfaces the analyzer's issues. Honest defaults: missing parsed dicts
+    yield no issues + only the original query, never fabricated rewrites.
+    """
+    original_query = query
+    analysis = analysis_result if isinstance(analysis_result, dict) else {}
+    rewrites = rewrite_result if isinstance(rewrite_result, dict) else {}
+
+    rewrite_dict = rewrites.get("rewrites", {}) or {}
+
+    all_versions = [original_query]
+    if isinstance(rewrite_dict, dict):
+        all_versions.extend(rewrite_dict.values())
+
+    # Remove duplicates while preserving order.
+    seen = set()
+    unique_versions = []
+    for v in all_versions:
+        if v and v not in seen:
+            seen.add(v)
+            unique_versions.append(v)
+
+    return {
+        "rewritten_queries": {
+            "original": original_query,
+            "issues_found": analysis.get("issues", []),
+            "versions": rewrite_dict,
+            "recommended": rewrites.get("recommended", original_query),
+            "all_unique_versions": unique_versions,
+            "improvement_count": len(unique_versions) - 1,
+        }
+    }
+
+
+def _map_strategy(intent_classification=None) -> dict:
+    """Build the QueryIntentClassifierNode ``routing_decision`` result.
+
+    Consumes ``intent_classification`` (the ``{query_type, domain, complexity,
+    requirements, suggested_strategy}`` dict ``intent_parser`` publishes). Maps
+    the LLM's classification to a retrieval strategy via a static lookup +
+    requirement-aware adjustment (post-LLM tool-result formatting — the LLM
+    made the classification; the map only renders it). Honest default: a
+    missing/non-dict input falls to the documented low-confidence defaults
+    (the parser's None-``query_type`` sentinel surfaces as the ``factual`` /
+    ``simple`` defaults), never a fabricated classification.
+    """
+    intent = intent_classification if isinstance(intent_classification, dict) else {}
+
+    query_type = intent.get("query_type") or "factual"
+    # NOTE: the original strategy_mapper codegen read `domain` into a local that
+    # the strategy logic never consumed (dead in the codegen too); the map keys
+    # on (query_type, complexity) + requirements only. `domain` is intentionally
+    # NOT read here — reading it would be a vestigial input (zero-tolerance 3c).
+    complexity = intent.get("complexity") or "simple"
+    requirements = intent.get("requirements", []) or []
+
+    # Strategy mapping rules.
+    strategy_map = {
+        ("factual", "simple"): "sparse",
+        ("factual", "moderate"): "hybrid",
+        ("analytical", "complex"): "hierarchical",
+        ("comparative", "moderate"): "multi_vector",
+        ("exploratory", "complex"): "self_correcting",
+        ("procedural", "moderate"): "semantic",
+    }
+
+    # Determine base strategy.
+    base_strategy = strategy_map.get((query_type, complexity), "hybrid")
+
+    # Adjust based on requirements.
+    if "needs_recent" in requirements:
+        # Prefer strategies that can handle temporal information.
+        if base_strategy == "sparse":
+            base_strategy = "hybrid"
+    elif "needs_authoritative" in requirements:
+        # Prefer strategies with quality filtering.
+        base_strategy = "self_correcting"
+    elif "needs_examples" in requirements:
+        # Prefer semantic strategies.
+        if base_strategy == "sparse":
+            base_strategy = "semantic"
+
+    routing_decision = {
+        "intent_analysis": intent,
+        "recommended_strategy": base_strategy,
+        "alternative_strategies": ["hybrid", "semantic", "hierarchical"],
+        "confidence": 0.85 if (query_type, complexity) in strategy_map else 0.6,
+        "reasoning": (
+            f"Query type '{query_type}' with '{complexity}' complexity "
+            f"suggests '{base_strategy}' strategy"
+        ),
+    }
+
+    return {"routing_decision": routing_decision}
+
+
+def _plan_execution(hop_plan_result=None) -> dict:
+    """Build the MultiHopQueryPlannerNode ``multi_hop_plan`` result.
+
+    Consumes ``hop_plan_result`` (the ``{hops, combination_strategy,
+    total_hops}`` dict ``hop_plan_parser`` publishes). Validates inter-hop
+    dependencies and groups hops into parallelizable execution batches. Honest
+    default: a missing/non-dict input yields a zero-hop, zero-batch plan, never
+    fabricated hops.
+    """
+    hop_plan = hop_plan_result if isinstance(hop_plan_result, dict) else {}
+    hops = hop_plan.get("hops", []) or []
+
+    # Validate dependencies.
+    hop_dict = {
+        h["hop_number"]: h for h in hops if isinstance(h, dict) and "hop_number" in h
+    }
+    for hop in hops:
+        if not isinstance(hop, dict):
+            continue
+        deps = hop.get("depends_on", [])
+        for dep in deps:
+            if dep not in hop_dict:
+                logger.warning(
+                    f"Hop {hop.get('hop_number')} depends on non-existent hop {dep}"
+                )
+
+    # Create execution batches (hops that can run in parallel).
+    batches = []
+    processed: set = set()
+
+    while len(processed) < len(hops):
+        batch = []
+        for hop in hops:
+            if not isinstance(hop, dict):
+                continue
+            hop_num = hop.get("hop_number")
+            if hop_num not in processed:
+                deps = set(hop.get("depends_on", []))
+                if deps.issubset(processed):
+                    batch.append(hop)
+
+        if not batch:
+            # Circular dependency or error.
+            logger.error("Cannot create valid execution order")
+            break
+
+        batches.append(batch)
+        for hop in batch:
+            processed.add(hop["hop_number"])
+
+    execution_plan = {
+        "batches": batches,
+        "total_hops": len(hops),
+        "parallel_opportunities": len([b for b in batches if len(b) > 1]),
+        "combination_strategy": hop_plan.get("combination_strategy", "sequential"),
+        "estimated_time": len(batches) * 2,  # Rough estimate in seconds
+    }
+
+    return {"multi_hop_plan": execution_plan}
+
+
+def _adaptive_process(query: str = "", routing_decision=None) -> dict:
+    """Build the AdaptiveQueryProcessorNode ``adaptive_plan`` result.
+
+    Consumes the top-level ``query`` plus ``routing_decision`` (the embedded
+    QueryIntentClassifierNode's ``run()``-contract output, wired
+    ``intent_analyzer.routing_decision`` -> here). Derives the processing-step
+    plan from the classifier's intent analysis (post-LLM tool-result
+    formatting — the classifier made the intent decision upstream). Honest
+    default: a missing/non-dict ``routing_decision`` yields the ``factual`` /
+    ``simple`` defaults + a single ``rewrite`` step, never fabricated intent.
+    """
+    routing = routing_decision if isinstance(routing_decision, dict) else {}
+    # The wired value is the classifier's full run() dict, which nests the
+    # routing_decision under the same key (the classifier's contract).
+    routing = routing.get("routing_decision", {}) if isinstance(routing, dict) else {}
+    intent = routing.get("intent_analysis", {}) if isinstance(routing, dict) else {}
+
+    complexity = intent.get("complexity", "simple")
+    query_type = intent.get("query_type", "factual")
+
+    # Determine which processing steps to apply (rendering the LLM's intent
+    # decision to a step plan — NOT classifying the query here).
+    processing_steps = []
+
+    # Always apply basic rewriting.
+    processing_steps.append("rewrite")
+
+    # Apply expansion for exploratory queries.
+    if query_type in ["exploratory", "analytical"]:
+        processing_steps.append("expand")
+
+    # Apply decomposition for complex queries.
+    if complexity == "complex":
+        processing_steps.append("decompose")
+
+    # Apply multi-hop planning for comparative or complex analytical.
+    if query_type == "comparative" or (
+        query_type == "analytical" and complexity == "complex"
+    ):
+        processing_steps.append("multi_hop")
+
+    processing_plan = {
+        "original_query": query,
+        "intent": intent,
+        "recommended_strategy": routing.get("recommended_strategy", "hybrid"),
+        "processing_steps": processing_steps,
+        "rationale": (
+            f"Query type '{query_type}' with complexity '{complexity}' requires "
+            f"{len(processing_steps)} processing steps"
+        ),
+    }
+
+    return {"adaptive_plan": processing_plan}
+
+
 @register_node()
 class QueryExpansionNode(Node):
     """
@@ -589,40 +933,27 @@ class QueryExpansionNode(Node):
             },
         )
 
-        # Add expansion processor
-        processor_id = builder.add_node(
-            "PythonCodeNode",
+        # Add expansion processor.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted from the inline `code=`
+        # codegen to the module-level `_process_expansions` function wired via
+        # `PythonCodeNode.from_function`. The node publishes the SAME flat
+        # `result` port carrying `{"expanded_query": {...}}` (a string-`code`
+        # PythonCodeNode also published on `result` via its local `result`
+        # variable — the runtime result shape `result["expanded_query"]` is
+        # unchanged). It reads `query` (top-level injection) + `expansion_response`
+        # (wired from expansion_parser.result). `_internal=True` suppresses the
+        # consumer-facing instance-API advisory. type: ignore[attr-defined]:
+        # `from_function` is a classmethod on concrete PythonCodeNode, erased to
+        # `type[Node]` by `@register_node` for static checkers (mirrors the
+        # composer/parser nodes above).
+        processor_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _process_expansions,
+                name="expansion_processor",
+            ),
             node_id="expansion_processor",
-            config={
-                "code": """
-# Process expansions
-original_query = query
-expansion_result = expansion_response
-
-# Extract all components
-expansions = expansion_result.get("expansions", [])
-keywords = expansion_result.get("keywords", [])
-concepts = expansion_result.get("concepts", [])
-
-# Combine and deduplicate
-all_terms = set()
-all_terms.add(original_query)
-all_terms.update(expansions)
-all_terms.update(keywords)
-
-# Create structured output
-result = {
-    "expanded_query": {
-        "original": original_query,
-        "expansions": list(expansions),
-        "keywords": list(keywords),
-        "concepts": list(concepts),
-        "all_terms": list(all_terms),
-        "expansion_count": len(all_terms) - 1
-    }
-}
-"""
-            },
+            _internal=True,
         )
 
         # L3 messages-composer (reference template — conversational.py /
@@ -637,7 +968,7 @@ result = {
         # `@register_node` for static checkers (mirrors conversational.py).
         # `_internal=True` suppresses the consumer-facing instance-API advisory.
         expansion_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_expansion_messages,
                 name="expansion_messages_composer",
             ),
@@ -652,7 +983,7 @@ result = {
         # `.get("expansions")` resolved to []. type: ignore[attr-defined] per
         # the composer note above.
         expansion_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_expansion_response,
                 name="expansion_parser",
             ),
@@ -825,58 +1156,25 @@ class QueryDecompositionNode(Node):
             },
         )
 
-        # Add dependency resolver
-        dependency_resolver_id = builder.add_node(
-            "PythonCodeNode",
+        # Add dependency resolver.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted from the inline `code=`
+        # codegen to the module-level `_resolve_dependencies` function wired via
+        # `PythonCodeNode.from_function`. The node publishes the SAME flat
+        # `result` port carrying `{"execution_plan": {...}}` (runtime result
+        # shape `result["execution_plan"]` unchanged). It reads
+        # `decomposition_result` (wired from decomposition_parser.result). The
+        # F25 Shard E `depends_on` contract (the LLM system_prompt advertises
+        # `depends_on` as the dependency field) is preserved verbatim in
+        # `_resolve_dependencies`. type: ignore[attr-defined] per the
+        # composer/parser note above.
+        dependency_resolver_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _resolve_dependencies,
+                name="dependency_resolver",
+            ),
             node_id="dependency_resolver",
-            config={
-                "code": """
-# Resolve dependencies and create execution order
-# F25 Shard E: the LLM system_prompt for query_decomposer advertises
-# `depends_on` as the per-sub-question dependency field (aligning with
-# MultiHopQueryPlannerNode's hop_planner convention). The resolver MUST
-# read the same key the prompt advertises — reading a different key
-# silently produces an empty dependency graph regardless of LLM output.
-decomposition = decomposition_result
-sub_questions = decomposition.get("sub_questions", [])
-
-# Build dependency graph
-dependency_graph = {}
-for i, sq in enumerate(sub_questions):
-    deps = sq.get("depends_on", [])
-    dependency_graph[i] = deps
-
-# Topological sort for execution order
-def topological_sort(graph):
-    visited = set()
-    stack = []
-
-    def dfs(node):
-        visited.add(node)
-        for dep in graph.get(node, []):
-            if dep not in visited:
-                dfs(dep)
-        stack.append(node)
-
-    for node in graph:
-        if node not in visited:
-            dfs(node)
-
-    return stack[::-1]
-
-execution_order = topological_sort(dependency_graph)
-
-# Create ordered execution plan
-execution_plan = {
-    "sub_questions": sub_questions,
-    "execution_order": execution_order,
-    "composition_strategy": decomposition.get("composition_strategy", "sequential"),
-    "total_questions": len(sub_questions)
-}
-
-result = {"execution_plan": execution_plan}
-"""
-            },
+            _internal=True,
         )
 
         # L3 messages-composer (reference template). The query_decomposer
@@ -885,7 +1183,7 @@ result = {"execution_plan": execution_plan}
         # REAL `query` (top-level workflow input via the parameter injector) into
         # a `messages` list wired to the VALID `messages` port.
         decomposition_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_decomposition_messages,
                 name="decomposition_messages_composer",
             ),
@@ -898,7 +1196,7 @@ result = {"execution_plan": execution_plan}
         # dependency_resolver `.get`s. Pre-O4 the raw `response` reached the
         # resolver, so `.get("sub_questions")` resolved to [].
         decomposition_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_decomposition_response,
                 name="decomposition_parser",
             ),
@@ -1117,42 +1415,24 @@ class QueryRewritingNode(Node):
             },
         )
 
-        # Add result combiner
-        combiner_id = builder.add_node(
-            "PythonCodeNode",
+        # Add result combiner.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted from the inline `code=`
+        # codegen to the module-level `_combine_rewrites` function wired via
+        # `PythonCodeNode.from_function`. The node publishes the SAME flat
+        # `result` port carrying `{"rewritten_queries": {...}}` (runtime result
+        # shape `result["rewritten_queries"]` unchanged). It reads `query`
+        # (top-level injection) + `analysis_result` (wired from
+        # analysis_parser.result) + `rewrite_result` (wired from
+        # rewrite_parser.result) — the 3-way fan-in. type: ignore[attr-defined]
+        # per the composer/parser note above.
+        combiner_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _combine_rewrites,
+                name="result_combiner",
+            ),
             node_id="result_combiner",
-            config={
-                "code": """
-# Combine analysis and rewrites
-original_query = query
-analysis = analysis_result
-rewrites = rewrite_result
-
-# Create comprehensive output
-all_versions = [original_query]
-rewrite_dict = rewrites.get("rewrites", {})
-all_versions.extend(rewrite_dict.values())
-
-# Remove duplicates while preserving order
-seen = set()
-unique_versions = []
-for v in all_versions:
-    if v and v not in seen:
-        seen.add(v)
-        unique_versions.append(v)
-
-result = {
-    "rewritten_queries": {
-        "original": original_query,
-        "issues_found": analysis.get("issues", []),
-        "versions": rewrite_dict,
-        "recommended": rewrites.get("recommended", original_query),
-        "all_unique_versions": unique_versions,
-        "improvement_count": len(unique_versions) - 1
-    }
-}
-"""
-            },
+            _internal=True,
         )
 
         # L3 messages-composers (reference template) for the 2-stage chain.
@@ -1169,7 +1449,7 @@ result = {
         # `analyzer.response -> rewriter."analysis"` phantom edge is REMOVED; the
         # analysis now reaches the rewriter through the composer's `messages`.
         analysis_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_analysis_messages,
                 name="analysis_messages_composer",
             ),
@@ -1177,7 +1457,7 @@ result = {
             _internal=True,
         )
         rewrite_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_rewrite_messages,
                 name="rewrite_messages_composer",
             ),
@@ -1194,7 +1474,7 @@ result = {
         # BOTH the rewrite composer AND the combiner so the analysis reaches the
         # rewriter (via its `messages`) AND surfaces in the combined output.
         analysis_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_analysis_response,
                 name="analysis_parser",
             ),
@@ -1202,7 +1482,7 @@ result = {
             _internal=True,
         )
         rewrite_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_rewrite_response,
                 name="rewrite_parser",
             ),
@@ -1515,58 +1795,22 @@ class QueryIntentClassifierNode(Node):
             },
         )
 
-        # Add strategy mapper
-        strategy_mapper_id = builder.add_node(
-            "PythonCodeNode",
+        # Add strategy mapper.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted from the inline `code=`
+        # codegen to the module-level `_map_strategy` function wired via
+        # `PythonCodeNode.from_function`. The node publishes the SAME flat
+        # `result` port carrying `{"routing_decision": {...}}` (runtime result
+        # shape `result["routing_decision"]` unchanged). It reads
+        # `intent_classification` (wired from intent_parser.result). type:
+        # ignore[attr-defined] per the composer/parser note above.
+        strategy_mapper_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _map_strategy,
+                name="strategy_mapper",
+            ),
             node_id="strategy_mapper",
-            config={
-                "code": """
-# Map intent to retrieval strategy
-intent = intent_classification
-
-query_type = intent.get("query_type", "factual")
-domain = intent.get("domain", "general")
-complexity = intent.get("complexity", "simple")
-requirements = intent.get("requirements", [])
-
-# Strategy mapping rules
-strategy_map = {
-    ("factual", "simple"): "sparse",
-    ("factual", "moderate"): "hybrid",
-    ("analytical", "complex"): "hierarchical",
-    ("comparative", "moderate"): "multi_vector",
-    ("exploratory", "complex"): "self_correcting",
-    ("procedural", "moderate"): "semantic"
-}
-
-# Determine base strategy
-base_strategy = strategy_map.get((query_type, complexity), "hybrid")
-
-# Adjust based on requirements
-if "needs_recent" in requirements:
-    # Prefer strategies that can handle temporal information
-    if base_strategy == "sparse":
-        base_strategy = "hybrid"
-elif "needs_authoritative" in requirements:
-    # Prefer strategies with quality filtering
-    base_strategy = "self_correcting"
-elif "needs_examples" in requirements:
-    # Prefer semantic strategies
-    if base_strategy == "sparse":
-        base_strategy = "semantic"
-
-# Create routing decision
-routing_decision = {
-    "intent_analysis": intent,
-    "recommended_strategy": base_strategy,
-    "alternative_strategies": ["hybrid", "semantic", "hierarchical"],
-    "confidence": 0.85 if (query_type, complexity) in strategy_map else 0.6,
-    "reasoning": f"Query type '{query_type}' with '{complexity}' complexity suggests '{base_strategy}' strategy"
-}
-
-result = {"routing_decision": routing_decision}
-"""
-            },
+            _internal=True,
         )
 
         # L3 messages-composer (reference template). The intent_classifier
@@ -1575,7 +1819,7 @@ result = {"routing_decision": routing_decision}
         # REAL `query` (top-level workflow input via the parameter injector) into
         # a `messages` list wired to the VALID `messages` port.
         intent_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_intent_messages,
                 name="intent_messages_composer",
             ),
@@ -1589,7 +1833,7 @@ result = {"routing_decision": routing_decision}
         # `response` reached the mapper, so every `.get(...)` fell to its default
         # and the strategy_map lookup ran on fabricated-default keys.
         intent_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_intent_response,
                 name="intent_parser",
             ),
@@ -1814,58 +2058,26 @@ class MultiHopQueryPlannerNode(Node):
             },
         )
 
-        # Add execution planner
-        execution_planner_id = builder.add_node(
-            "PythonCodeNode",
+        # Add execution planner.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted from the inline `code=`
+        # codegen to the module-level `_plan_execution` function wired via
+        # `PythonCodeNode.from_function`. The node publishes the SAME flat
+        # `result` port carrying `{"multi_hop_plan": {...}}` (runtime result
+        # shape `result["multi_hop_plan"]` unchanged). It reads
+        # `hop_plan_result` (wired from hop_plan_parser.result). The
+        # circular-dependency `logger.warning`/`logger.error` observability is
+        # preserved (the module-level function closes over the module `logger`,
+        # whereas the codegen relied on `logger` being injected into the exec
+        # namespace — the function form is the more robust binding). type:
+        # ignore[attr-defined] per the composer/parser note above.
+        execution_planner_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _plan_execution,
+                name="execution_planner",
+            ),
             node_id="execution_planner",
-            config={
-                "code": """
-# Create executable plan
-hop_plan = hop_plan_result
-hops = hop_plan.get("hops", [])
-
-# Validate dependencies
-hop_dict = {h["hop_number"]: h for h in hops}
-for hop in hops:
-    deps = hop.get("depends_on", [])
-    for dep in deps:
-        if dep not in hop_dict:
-            logger.warning(f"Hop {hop['hop_number']} depends on non-existent hop {dep}")
-
-# Create execution batches (hops that can run in parallel)
-batches = []
-processed = set()
-
-while len(processed) < len(hops):
-    batch = []
-    for hop in hops:
-        hop_num = hop["hop_number"]
-        if hop_num not in processed:
-            deps = set(hop.get("depends_on", []))
-            if deps.issubset(processed):
-                batch.append(hop)
-
-    if not batch:
-        # Circular dependency or error
-        logger.error("Cannot create valid execution order")
-        break
-
-    batches.append(batch)
-    for hop in batch:
-        processed.add(hop["hop_number"])
-
-# Create final execution plan
-execution_plan = {
-    "batches": batches,
-    "total_hops": len(hops),
-    "parallel_opportunities": len([b for b in batches if len(b) > 1]),
-    "combination_strategy": hop_plan.get("combination_strategy", "sequential"),
-    "estimated_time": len(batches) * 2  # Rough estimate in seconds
-}
-
-result = {"multi_hop_plan": execution_plan}
-"""
-            },
+            _internal=True,
         )
 
         # L3 messages-composer (reference template). The hop_planner previously
@@ -1874,7 +2086,7 @@ result = {"multi_hop_plan": execution_plan}
         # (top-level workflow input via the parameter injector) into a `messages`
         # list wired to the VALID `messages` port.
         hop_plan_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_hop_plan_messages,
                 name="hop_plan_messages_composer",
             ),
@@ -1887,7 +2099,7 @@ result = {"multi_hop_plan": execution_plan}
         # execution_planner `.get`s. Pre-O4 the raw `response` reached the
         # planner, so `.get("hops")` resolved to [] (zero batches, zero hops).
         hop_plan_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_hop_plan_response,
                 name="hop_plan_parser",
             ),
@@ -2054,50 +2266,26 @@ class AdaptiveQueryProcessorNode(Node):
             "QueryIntentClassifierNode", node_id="intent_analyzer"
         )
 
-        # Add adaptive processor
-        adaptive_processor_id = builder.add_node(
-            "PythonCodeNode",
+        # Add adaptive processor.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted from the inline `code=`
+        # codegen to the module-level `_adaptive_process` function wired via
+        # `PythonCodeNode.from_function`. The node publishes the SAME flat
+        # `result` port carrying `{"adaptive_plan": {...}}` (runtime result
+        # shape `result["adaptive_plan"]` unchanged). It reads `query`
+        # (top-level injection) + `routing_decision` (wired from
+        # intent_analyzer.routing_decision — the embedded
+        # QueryIntentClassifierNode's run()-contract output, which nests the
+        # routing_decision under the same key; `_adaptive_process` unwraps it
+        # exactly as the codegen did). type: ignore[attr-defined] per the
+        # composer/parser note above.
+        adaptive_processor_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _adaptive_process,
+                name="adaptive_processor",
+            ),
             node_id="adaptive_processor",
-            config={
-                "code": """
-# Adaptively apply query processing based on intent
-query = query
-routing_decision = routing_decision.get("routing_decision", {})
-intent = routing_decision.get("intent_analysis", {})
-
-# Determine which processing steps to apply
-processing_steps = []
-
-complexity = intent.get("complexity", "simple")
-query_type = intent.get("query_type", "factual")
-
-# Always apply basic rewriting
-processing_steps.append("rewrite")
-
-# Apply expansion for exploratory queries
-if query_type in ["exploratory", "analytical"]:
-    processing_steps.append("expand")
-
-# Apply decomposition for complex queries
-if complexity == "complex":
-    processing_steps.append("decompose")
-
-# Apply multi-hop planning for comparative or complex analytical
-if query_type == "comparative" or (query_type == "analytical" and complexity == "complex"):
-    processing_steps.append("multi_hop")
-
-# Create processing plan
-processing_plan = {
-    "original_query": query,
-    "intent": intent,
-    "recommended_strategy": routing_decision.get("recommended_strategy", "hybrid"),
-    "processing_steps": processing_steps,
-    "rationale": f"Query type '{query_type}' with complexity '{complexity}' requires {len(processing_steps)} processing steps"
-}
-
-result = {"adaptive_plan": processing_plan}
-"""
-            },
+            _internal=True,
         )
 
         # Connect workflow

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/strategies.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/strategies.py
@@ -7,10 +7,19 @@ a workflow using WorkflowBuilder and delegates all execution to the SDK.
 """
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from kailash.nodes.base import Node, NodeParameter, register_node
+
+# PythonCodeNode is imported for BOTH its @register_node side effect (the inner
+# graphs reference it by string in add_node(...)) AND its `from_function`
+# classmethod: the COMPUTE-stage nodes below are wired via
+# `PythonCodeNode.from_function(<module_fn>)` (Wave 3 Shard S5b — #1117
+# publish-nothing / #1123 brace-escape / #1118 import-trap root-cause fix),
+# never via an inline source-string body.
+from kailash.nodes.code.python import PythonCodeNode
 from kailash.nodes.logic.workflow import WorkflowNode
 
 # Registering import: kailash uses a lazy module cache, so the
@@ -36,6 +45,173 @@ class RAGConfig:
     vector_db_provider: str = "postgresql"
     retrieval_k: int = 5
     similarity_threshold: float = 0.7
+
+
+# ==========================================================================
+# Wave 3 Shard S5b — COMPUTE-stage `from_function` targets lifted from the
+# prior PythonCodeNode `"code"` strings (#1117 publish-nothing / #1123
+# brace-escape / #1118 import-trap root-cause fix). Each function is a real
+# module-level def wired via `PythonCodeNode.from_function(fn)`; the node
+# publishes its `return` on the SINGLE flat `result` port (the downstream
+# `add_connection(..., "result", ...)` edges read that port). The bodies are
+# behavior-equivalent to the codegen they replace.
+# ==========================================================================
+
+# Stop-word set shared by the statistical keyword extractor (was an inline
+# literal in the prior codegen body).
+_KEYWORD_STOP_WORDS = {
+    "the",
+    "and",
+    "for",
+    "are",
+    "but",
+    "not",
+    "you",
+    "all",
+    "can",
+    "had",
+    "her",
+    "was",
+    "one",
+    "our",
+    "out",
+    "day",
+    "get",
+    "has",
+    "him",
+    "his",
+    "how",
+    "man",
+    "new",
+    "now",
+    "old",
+    "see",
+    "two",
+    "way",
+    "who",
+    "boy",
+    "did",
+    "its",
+    "let",
+    "put",
+    "say",
+    "she",
+    "too",
+    "use",
+}
+
+
+def _extract_keywords(chunks=None) -> dict:
+    """Sparse keyword extraction over the chunk corpus (statistical RAG).
+
+    Was the ``keyword_extractor`` ``code`` string. Reads the ``chunks`` input
+    (list of dicts), extracts 3+-letter alpha tokens minus stop-words, capped
+    at 20 per chunk. A present-but-None ``content`` value is coerced to ``""``
+    so ``.lower()`` never crashes; non-dict elements are filtered. Publishes the
+    flat ``{"keywords": [...]}`` dict on the from_function ``result`` port — the
+    downstream ``vector_db`` reads it as its ``keywords`` input.
+    """
+
+    def extract(text) -> list:
+        # A present-but-None `content` key would otherwise crash text.lower().
+        words = re.findall(r"\b[a-zA-Z]{3,}\b", (text or "").lower())
+        keywords = [word for word in set(words) if word not in _KEYWORD_STOP_WORDS]
+        return keywords[:20]
+
+    return {
+        "keywords": [
+            extract(chunk.get("content"))
+            for chunk in (chunks or [])
+            if isinstance(chunk, dict)
+        ]
+    }
+
+
+def _make_result_fusion(*, fusion_method: str):
+    """Build a from_function-compatible ``result_fusion`` bound to the build-time
+    ``fusion_method`` (hybrid RAG).
+
+    Closure-bound factory (the #1123 brace-escape / #1118 import-trap root-cause
+    fix): the prior ``result_fusion`` was an f-STRING codegen interpolating the
+    ``fusion_method`` literal into the ``code`` body (doubled ``{{`` braces).
+    Lifting to a real function with ``fusion_method`` captured in a closure
+    removes the f-string + brace-escape surface entirely while preserving the
+    SAME behavior — the value is bound as a Python object, never re-rendered into
+    source text.
+
+    The returned function declares ``semantic_results`` / ``statistical_results``
+    as its explicit inputs (the ports the prior codegen read as locals) and
+    returns the flat ``{"fused_results": ...}`` dict on the from_function
+    ``result`` port (terminal — no downstream edge reads it).
+    """
+
+    def _fuse(semantic_results=None, statistical_results=None) -> dict:
+        def rrf_fusion(semantic, statistical, k=60) -> dict:
+            """Reciprocal Rank Fusion for combining results."""
+            doc_scores: dict = {}
+
+            # Add semantic results
+            semantic = semantic if isinstance(semantic, dict) else {}
+            for i, doc in enumerate(semantic.get("results", [])):
+                doc_id = doc.get("id", f"semantic_{i}")
+                doc_scores[doc_id] = {
+                    "document": doc,
+                    "score": 1 / (k + i + 1),
+                    "sources": ["semantic"],
+                }
+
+            # Add statistical results
+            statistical = statistical if isinstance(statistical, dict) else {}
+            for i, doc in enumerate(statistical.get("results", [])):
+                doc_id = doc.get("id", f"statistical_{i}")
+                if doc_id in doc_scores:
+                    doc_scores[doc_id]["score"] += 1 / (k + i + 1)
+                    doc_scores[doc_id]["sources"].append("statistical")
+                else:
+                    doc_scores[doc_id] = {
+                        "document": doc,
+                        "score": 1 / (k + i + 1),
+                        "sources": ["statistical"],
+                    }
+
+            # Sort by fused score
+            sorted_results = sorted(
+                doc_scores.items(), key=lambda x: x[1]["score"], reverse=True
+            )
+
+            return {
+                "documents": [item[1]["document"] for item in sorted_results[:5]],
+                "scores": [item[1]["score"] for item in sorted_results[:5]],
+                "fusion_method": fusion_method,
+            }
+
+        fusion_results = rrf_fusion(semantic_results, statistical_results)
+        return {"fused_results": fusion_results}
+
+    _fuse.__name__ = "result_fusion"
+    _fuse.__doc__ = "Combine semantic + statistical results via rank fusion."
+    return _fuse
+
+
+def _process_levels(chunks=None) -> dict:
+    """Organize chunks by hierarchy level (hierarchical RAG).
+
+    Was the ``level_processor`` ``code`` string. Buckets the ``chunks`` input
+    into document/section/paragraph levels by each chunk's ``hierarchy_level``
+    key; non-dict elements are filtered. Publishes the flat
+    ``{"level_chunks": {...}, "levels": [...]}`` dict on the from_function
+    ``result`` port — each of the three ``vector_db`` nodes reads it as its
+    ``level_chunks`` input.
+    """
+    levels = ["document", "section", "paragraph"]
+    _chunks = [c for c in (chunks or []) if isinstance(c, dict)]
+
+    level_chunks = {
+        level: [chunk for chunk in _chunks if chunk.get("hierarchy_level") == level]
+        for level in levels
+    }
+
+    return {"level_chunks": level_chunks, "levels": levels}
 
 
 def create_semantic_rag_workflow(config: RAGConfig) -> WorkflowNode:
@@ -127,22 +303,18 @@ def create_statistical_rag_workflow(config: RAGConfig) -> WorkflowNode:
     )
 
     # Add keyword extraction for sparse retrieval
-    keyword_extractor_id = builder.add_node(
-        "PythonCodeNode",
+    # `_extract_keywords` function wired via `PythonCodeNode.from_function`. The
+    # node publishes its `{"keywords": [...]}` return on the flat `result` port;
+    # the `vector_db` reads it via the `keyword_extractor → keywords` edge below.
+    # `_internal=True` suppresses the consumer-facing instance-API advisory
+    # (SDK-internal construction path, mirrors optimized.py).
+    keyword_extractor_id = builder.add_node_instance(
+        PythonCodeNode.from_function(
+            _extract_keywords,
+            name="keyword_extractor",
+        ),
         node_id="keyword_extractor",
-        config={
-            "code": """
-import re
-def extract_keywords(text):
-    # A present-but-None `content` key would otherwise crash text.lower().
-    words = re.findall(r'\\b[a-zA-Z]{3,}\\b', (text or "").lower())
-    stop_words = {'the', 'and', 'for', 'are', 'but', 'not', 'you', 'all', 'can', 'had', 'her', 'was', 'one', 'our', 'out', 'day', 'get', 'has', 'him', 'his', 'how', 'man', 'new', 'now', 'old', 'see', 'two', 'way', 'who', 'boy', 'did', 'its', 'let', 'put', 'say', 'she', 'too', 'use'}
-    keywords = [word for word in set(words) if word not in stop_words]
-    return keywords[:20]
-
-result = {"keywords": [extract_keywords(chunk.get("content")) for chunk in (chunks or []) if isinstance(chunk, dict)]}
-"""
-        },
+        _internal=True,
     )
 
     # Add vector database
@@ -212,52 +384,23 @@ def create_hybrid_rag_workflow(
         config={"workflow": statistical_workflow.workflow},  # type: ignore[attr-defined]
     )
 
-    # Add result fusion node
-    fusion_id = builder.add_node(
-        "PythonCodeNode",
+    # Add result fusion node.
+    #
+    # #1117/#1123/#1118 root-cause fix: lifted to the closure-bound
+    # `_make_result_fusion` factory wired via `PythonCodeNode.from_function`,
+    # with the build-time `fusion_method` bound into the closure (no f-string
+    # interpolation / brace-escape surface). The node publishes its
+    # `{"fused_results": {...}}` return on the flat `result` port (terminal — no
+    # downstream edge reads it). `_internal=True` suppresses the consumer-facing
+    # instance-API advisory (SDK-internal construction path, mirrors
+    # optimized.py).
+    fusion_id = builder.add_node_instance(
+        PythonCodeNode.from_function(
+            _make_result_fusion(fusion_method=fusion_method),
+            name="result_fusion",
+        ),
         node_id="result_fusion",
-        config={
-            "code": f"""
-def rrf_fusion(semantic_results, statistical_results, k=60):
-    '''Reciprocal Rank Fusion for combining results'''
-    doc_scores = {{}}
-
-    # Add semantic results
-    for i, doc in enumerate(semantic_results.get("results", [])):
-        doc_id = doc.get("id", f"semantic_{{i}}")
-        doc_scores[doc_id] = {{
-            "document": doc,
-            "score": 1 / (k + i + 1),
-            "sources": ["semantic"]
-        }}
-
-    # Add statistical results
-    for i, doc in enumerate(statistical_results.get("results", [])):
-        doc_id = doc.get("id", f"statistical_{{i}}")
-        if doc_id in doc_scores:
-            doc_scores[doc_id]["score"] += 1 / (k + i + 1)
-            doc_scores[doc_id]["sources"].append("statistical")
-        else:
-            doc_scores[doc_id] = {{
-                "document": doc,
-                "score": 1 / (k + i + 1),
-                "sources": ["statistical"]
-            }}
-
-    # Sort by fused score
-    sorted_results = sorted(doc_scores.items(), key=lambda x: x[1]["score"], reverse=True)
-
-    return {{
-        "documents": [item[1]["document"] for item in sorted_results[:5]],
-        "scores": [item[1]["score"] for item in sorted_results[:5]],
-        "fusion_method": "{fusion_method}"
-    }}
-
-# Execute fusion
-fusion_results = rrf_fusion(semantic_results, statistical_results)
-result = {{"fused_results": fusion_results}}
-"""
-        },
+        _internal=True,
     )
 
     # Connect workflows to fusion
@@ -296,21 +439,18 @@ def create_hierarchical_rag_workflow(config: RAGConfig) -> WorkflowNode:
     )
 
     # Add level processor for organizing chunks by hierarchy
-    level_processor_id = builder.add_node(
-        "PythonCodeNode",
+    # `_process_levels` function wired via `PythonCodeNode.from_function`. The
+    # node publishes its `{"level_chunks": {...}, "levels": [...]}` return on the
+    # flat `result` port; the three `vector_db` nodes read it via the
+    # `level_processor → level_chunks` edges below. `_internal=True` suppresses
+    # the consumer-facing instance-API advisory (mirrors optimized.py).
+    level_processor_id = builder.add_node_instance(
+        PythonCodeNode.from_function(
+            _process_levels,
+            name="level_processor",
+        ),
         node_id="level_processor",
-        config={
-            "code": """
-levels = ["document", "section", "paragraph"]
-level_chunks = {}
-_chunks = [c for c in (chunks or []) if isinstance(c, dict)]
-
-for level in levels:
-    level_chunks[level] = [chunk for chunk in _chunks if chunk.get("hierarchy_level") == level]
-
-result = {"level_chunks": level_chunks, "levels": levels}
-"""
-        },
+        _internal=True,
     )
 
     # Add vector databases for each level

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/workflows.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/workflows.py
@@ -236,6 +236,289 @@ def _unwrap_response_content(response: Any) -> Any:
     return response
 
 
+# ---------------------------------------------------------------------------
+# COMPUTE-stage functions (#1117/#1123/#1118 root-cause fix).
+#
+# Each function below was lifted verbatim from a prior PythonCodeNode `"code"`
+# string body and is wired via `PythonCodeNode.from_function(fn)`. A
+# from_function node publishes its `return` on the SINGLE flat `result` port
+# (NOT the top-level keys the f-string codegen assembled), so every downstream
+# `add_connection(..., "<node_id>", ...)` reading a top-level key was rewired to
+# read the nested `result.<key>` port. The lift makes the bodies statically
+# checkable real functions (real `return` -> `result`) and closes the
+# brace-escape / import-trap / publish-nothing defect classes. Mirrors the
+# reference template landed in optimized.py / graph.py / evaluation.py /
+# query_processing.py + the strategy parser/composer above in this file.
+#
+# IN-GRAPH HONESTY (zero-tolerance Rule 2): each function's computation is
+# behavior-equivalent to the prior codegen; honest defaults on edge inputs
+# (a cache-miss / unwired-optional branch arriving None), never fabricated data.
+# ---------------------------------------------------------------------------
+
+
+def _analyze_documents(documents=None) -> dict:
+    """Analyze document quality and recommend a RAG strategy.
+
+    AdvancedRAGWorkflowNode entry stage (was the ``quality_analyzer`` ``code``
+    string). Filters non-dict elements, computes corpus characteristics, and
+    selects a strategy. Publishes ``{"analysis": <dict>, "documents": <list>}``
+    on the from_function ``result`` port — the SwitchNode router + the validator
+    read ``result.analysis`` / ``result.documents``.
+    """
+
+    def _content(doc):
+        # `_content` filters a present-but-None `content` key (dict.get returns
+        # None, so `or ""` is required); non-dict elements are filtered out by
+        # the comprehension below before this is reached.
+        return (doc.get("content") or "") if isinstance(doc, dict) else ""
+
+    documents = [d for d in (documents or []) if isinstance(d, dict)]
+    analysis = {
+        "total_docs": len(documents),
+        "avg_length": (
+            sum(len(_content(doc)) for doc in documents) / len(documents)
+            if documents
+            else 0
+        ),
+        "has_structure": any("section" in doc or "heading" in doc for doc in documents),
+        "is_technical": any(
+            keyword in _content(doc).lower()
+            for doc in documents
+            for keyword in ["code", "function", "algorithm", "api", "class"]
+        ),
+        "recommended_strategy": "semantic",  # Default
+    }
+
+    # Determine best strategy based on analysis
+    if analysis["has_structure"] and analysis["avg_length"] > 2000:
+        analysis["recommended_strategy"] = "hierarchical"
+    elif analysis["is_technical"]:
+        analysis["recommended_strategy"] = "statistical"
+    elif analysis["total_docs"] > 100:
+        analysis["recommended_strategy"] = "hybrid"
+
+    return {"analysis": analysis, "documents": documents}
+
+
+def _validate_rag_results(rag_results=None, analysis=None) -> dict:
+    """Validate RAG strategy output against quality thresholds.
+
+    AdvancedRAGWorkflowNode terminal stage (was the ``quality_validator``
+    ``code`` string). ``rag_results`` arrives from whichever strategy pipeline
+    fired (``output`` port); ``analysis`` from the quality analyzer. Honest
+    defaults (empty dict) when an upstream branch did not fire. Publishes the
+    full validation envelope on the from_function ``result`` port.
+    """
+    results = rag_results if isinstance(rag_results, dict) else {}
+    analysis = analysis if isinstance(analysis, dict) else {}
+
+    scores = results.get("scores") or []
+    validation = {
+        "results_count": len(results.get("documents", [])),
+        "avg_score": (sum(scores) / len(scores)) if scores else 0,
+        "quality_score": 0.0,
+        "passed": False,
+    }
+
+    # Calculate quality score
+    if validation["results_count"] > 0:
+        validation["quality_score"] = validation["avg_score"] * (
+            validation["results_count"] / 5.0
+        )
+        validation["passed"] = validation["quality_score"] > 0.5
+
+    return {
+        "results": results,
+        "validation": validation,
+        "strategy_used": analysis.get("recommended_strategy"),
+        "final_status": "passed" if validation["passed"] else "needs_improvement",
+    }
+
+
+def _analyze_for_llm(documents=None, query="") -> dict:
+    """Compute document characteristics for AdaptiveRAGWorkflowNode's LLM analyzer.
+
+    Entry stage (was the ``document_preprocessor`` ``code`` string). Filters
+    non-dict elements, derives corpus characteristics + content types, and
+    echoes the ``query`` + filtered ``documents``. Publishes the FLAT analysis
+    dict on the from_function ``result`` port — the strategy-analyzer messages
+    composer reads ``result.document_count`` / ``result.avg_length`` /
+    ``result.has_structure`` / ``result.is_technical`` / ``result.content_types``
+    / ``result.query``; the SwitchNode executor + aggregator read ``result`` as
+    ``preprocessed_data``.
+
+    (The prior codegen carried an ``import re`` that the body never used; it is
+    dropped in the lift — zero behavioral change, no vestigial import.)
+    """
+
+    def _content(doc):
+        # Filter a present-but-None `content` key (dict.get returns None ->
+        # `or ""`); non-dict elements are removed by the comprehension below.
+        return (doc.get("content") or "") if isinstance(doc, dict) else ""
+
+    documents = [d for d in (documents or []) if isinstance(d, dict)]
+    if not documents:
+        return {
+            "document_count": 0,
+            "avg_length": 0,
+            "has_structure": False,
+            "is_technical": False,
+            "content_types": [],
+            "query": query,
+        }
+
+    # Analyze documents
+    total_length = sum(len(_content(doc)) for doc in documents)
+    avg_length = total_length / len(documents)
+
+    # Check for structure
+    has_structure = any(
+        any(
+            keyword in _content(doc).lower()
+            for keyword in ["# ", "## ", "### ", "heading", "section", "chapter"]
+        )
+        for doc in documents
+    )
+
+    # Check for technical content
+    technical_keywords = [
+        "code",
+        "function",
+        "class",
+        "algorithm",
+        "api",
+        "import",
+        "def ",
+        "return",
+        "variable",
+    ]
+    is_technical = any(
+        any(keyword in _content(doc).lower() for keyword in technical_keywords)
+        for doc in documents
+    )
+
+    # Determine content types
+    content_types = []
+    if has_structure:
+        content_types.append("structured")
+    if is_technical:
+        content_types.append("technical")
+    if avg_length > 2000:
+        content_types.append("long_form")
+    if len(documents) > 50:
+        content_types.append("large_collection")
+
+    return {
+        "document_count": len(documents),
+        "avg_length": int(avg_length),
+        "has_structure": has_structure,
+        "is_technical": is_technical,
+        "content_types": content_types,
+        "query": query,
+        "documents": documents,
+    }
+
+
+def _aggregate_adaptive_results(
+    rag_results=None, llm_decision=None, preprocessed_data=None
+) -> dict:
+    """Aggregate the AdaptiveRAGWorkflowNode terminal output.
+
+    Terminal stage (was the ``results_aggregator`` ``code`` string).
+    ``rag_results`` arrives from whichever strategy pipeline fired (``output``
+    port); ``llm_decision`` from the strategy-decision parser's ``result`` port
+    (the PARSED ``{recommended_strategy, reasoning, confidence,
+    fallback_strategy}`` decision); ``preprocessed_data`` from the
+    preprocessor's ``result`` port. Honest defaults (empty dict) when an
+    upstream branch did not fire. Publishes the aggregate envelope on the flat
+    ``result`` port.
+    """
+    llm_decision = llm_decision if isinstance(llm_decision, dict) else {}
+    preprocessed_data = preprocessed_data if isinstance(preprocessed_data, dict) else {}
+
+    return {
+        "results": rag_results,
+        "strategy_used": llm_decision.get("recommended_strategy"),
+        "llm_reasoning": llm_decision.get("reasoning"),
+        "confidence": llm_decision.get("confidence"),
+        "document_analysis": {
+            "count": preprocessed_data.get("document_count"),
+            "avg_length": preprocessed_data.get("avg_length"),
+            "content_types": preprocessed_data.get("content_types"),
+        },
+        "adaptive_metadata": {
+            # F9 #1126: the actual model is read from the upstream LLMAgentNode
+            # config; emit a documented sentinel here (this aggregate does not
+            # carry the build-time model name).
+            "llm_model_used": "<env-default>",
+            "strategy_selection_method": "llm_analysis",
+            "fallback_available": llm_decision.get("fallback_strategy"),
+        },
+    }
+
+
+def _make_config_processor(
+    *,
+    default_strategy: str,
+    chunk_size: int,
+    chunk_overlap: int,
+    embedding_model: str,
+    retrieval_k: int,
+):
+    """Build a from_function-compatible ``config_processor`` bound to build-time
+    RAGConfig values for RAGPipelineWorkflowNode.
+
+    This is the closure-bound factory (#1118 import-trap / #1123 brace-escape
+    root-cause fix): the prior ``config_processor`` was an f-STRING codegen
+    interpolating ``repr()``-escaped RAGConfig literals into the ``code`` body
+    (doubled ``{{`` braces, `repr()` injection-hardening). Lifting to a real
+    function with the literals captured in a closure removes the f-string +
+    brace-escape surface entirely while preserving the SAME injection-safety
+    invariant — the values are bound as Python objects (already typed-coerced by
+    the caller), never re-rendered into source text.
+
+    The returned function declares ``documents`` / ``query`` / ``strategy`` as
+    its explicit inputs (the same ports the prior codegen read as locals) and
+    returns the flat ``processed_config`` dict on the from_function ``result``
+    port. The SwitchNode dispatcher reads ``strategy`` as a top-level key of that
+    dict; the formatter reads the whole dict as ``config``.
+    """
+
+    def _process_config(documents=None, query="", strategy="") -> dict:
+        return {
+            "strategy": strategy if strategy else default_strategy,
+            "documents": documents,
+            "query": query if query else "",
+            "chunk_size": chunk_size,
+            "chunk_overlap": chunk_overlap,
+            "embedding_model": embedding_model,
+            "retrieval_k": retrieval_k,
+        }
+
+    _process_config.__name__ = "config_processor"
+    _process_config.__doc__ = "Build the RAGPipelineWorkflowNode processed_config."
+    return _process_config
+
+
+def _format_pipeline_results(strategy_results=None, processed_config=None) -> dict:
+    """Format the RAGPipelineWorkflowNode terminal output.
+
+    Terminal stage (was the ``results_formatter`` ``code`` string).
+    ``strategy_results`` arrives from whichever strategy pipeline fired
+    (``output`` port); ``processed_config`` from the ``config_processor``'s
+    ``result``. Honest default (empty dict) when no config flowed. Publishes the
+    formatted envelope on the flat ``result`` port.
+    """
+    config = processed_config if isinstance(processed_config, dict) else {}
+    return {
+        "results": strategy_results,
+        "strategy_used": config.get("strategy"),
+        "configuration": config,
+        "pipeline_type": "configurable",
+        "success": True if strategy_results else False,
+    }
+
+
 @register_node()
 class SimpleRAGWorkflowNode(WorkflowNode):
     """
@@ -350,45 +633,25 @@ class AdvancedRAGWorkflowNode(WorkflowNode):
         """Create advanced RAG workflow with quality checks and monitoring"""
         builder = WorkflowBuilder()
 
-        # Document quality analyzer
-        quality_analyzer_id = builder.add_node(
-            "PythonCodeNode",
+        # Document quality analyzer.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_analyze_documents` function wired via `PythonCodeNode.from_function`.
+        # The node publishes its return on the flat `result` port carrying
+        # `{"analysis": {...}, "documents": [...]}`; the downstream router +
+        # validator now read the nested `result.analysis` port (the SwitchNode
+        # `condition_field: "recommended_strategy"` resolves against the analysis
+        # dict's top-level key). `_internal=True` suppresses the consumer-facing
+        # instance-API advisory (SDK-internal construction; mirrors optimized.py).
+        # `type: ignore[attr-defined]`: `from_function` is a classmethod on
+        # concrete PythonCodeNode, erased to `type[Node]` by `@register_node`.
+        quality_analyzer_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _analyze_documents,
+                name="quality_analyzer",
+            ),
             node_id="quality_analyzer",
-            config={
-                "code": """
-# Analyze document quality and determine best RAG strategy
-def analyze_documents(documents):
-    # `_content` is a nested local (PythonCodeNode execs the body in a scope
-    # where module-level defs are not visible to nested genexprs). A
-    # present-but-None `content` key returns None from dict.get(..., ""), so
-    # `or ""` is required; non-dict elements are filtered out first.
-    def _content(doc):
-        return (doc.get("content") or "") if isinstance(doc, dict) else ""
-
-    documents = [d for d in (documents or []) if isinstance(d, dict)]
-    analysis = {
-        "total_docs": len(documents),
-        "avg_length": sum(len(_content(doc)) for doc in documents) / len(documents) if documents else 0,
-        "has_structure": any("section" in doc or "heading" in doc for doc in documents),
-        "is_technical": any(keyword in _content(doc).lower()
-                          for doc in documents
-                          for keyword in ["code", "function", "algorithm", "api", "class"]),
-        "recommended_strategy": "semantic"  # Default
-    }
-
-    # Determine best strategy based on analysis
-    if analysis["has_structure"] and analysis["avg_length"] > 2000:
-        analysis["recommended_strategy"] = "hierarchical"
-    elif analysis["is_technical"]:
-        analysis["recommended_strategy"] = "statistical"
-    elif analysis["total_docs"] > 100:
-        analysis["recommended_strategy"] = "hybrid"
-
-    return analysis
-
-result = {"analysis": analyze_documents(documents), "documents": documents}
-"""
-            },
+            _internal=True,
         )
 
         # Strategy router using switch node.
@@ -437,40 +700,37 @@ result = {"analysis": analyze_documents(documents), "documents": documents}
             config={"workflow": hierarchical_workflow.workflow},  # type: ignore[attr-defined]
         )
 
-        # Quality validator
-        validator_id = builder.add_node(
-            "PythonCodeNode",
+        # Quality validator.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_validate_rag_results` function wired via
+        # `PythonCodeNode.from_function`. Its `rag_results` input arrives from
+        # whichever strategy pipeline fired (`output` port); `analysis` from the
+        # quality analyzer's nested `result.analysis` port. The node publishes
+        # the validation envelope on the flat `result` port.
+        validator_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _validate_rag_results,
+                name="quality_validator",
+            ),
             node_id="quality_validator",
-            config={
-                "code": """
-def validate_rag_results(results, analysis):
-    validation = {
-        "results_count": len(results.get("documents", [])),
-        "avg_score": sum(results.get("scores", [])) / len(results.get("scores", [])) if results.get("scores") else 0,
-        "quality_score": 0.0,
-        "passed": False
-    }
-
-    # Calculate quality score
-    if validation["results_count"] > 0:
-        validation["quality_score"] = validation["avg_score"] * (validation["results_count"] / 5.0)
-        validation["passed"] = validation["quality_score"] > 0.5
-
-    return {
-        "results": results,
-        "validation": validation,
-        "strategy_used": analysis.get("recommended_strategy"),
-        "final_status": "passed" if validation["passed"] else "needs_improvement"
-    }
-
-result = validate_rag_results(rag_results, analysis)
-"""
-            },
+            _internal=True,
         )
 
         # Connect the advanced pipeline. SwitchNode's primary input port is
         # `input_data`; each multi-case match emits on `case_<value>`.
-        builder.add_connection(quality_analyzer_id, "result", router_id, "input_data")
+        #
+        # PHANTOM-PORT FIX: the SwitchNode `condition_field` reads
+        # `recommended_strategy` as a TOP-LEVEL key of `input_data`, but
+        # `_analyze_documents` publishes it nested inside `result.analysis`
+        # (the flat `result` port carries `{"analysis": {...}, "documents": ...}`).
+        # The edge now reads the nested `result.analysis` port so the SwitchNode
+        # switches on the REAL strategy the analyzer selected (the pre-migration
+        # edge fed the whole wrapper dict, whose top-level had no
+        # `recommended_strategy` key).
+        builder.add_connection(
+            quality_analyzer_id, "result.analysis", router_id, "input_data"
+        )
 
         # Connect router to all strategy pipelines via the per-case output ports.
         builder.add_connection(router_id, "case_semantic", semantic_id, "input")
@@ -483,7 +743,13 @@ result = validate_rag_results(rag_results, analysis)
         builder.add_connection(statistical_id, "output", validator_id, "rag_results")
         builder.add_connection(hybrid_id, "output", validator_id, "rag_results")
         builder.add_connection(hierarchical_id, "output", validator_id, "rag_results")
-        builder.add_connection(quality_analyzer_id, "result", validator_id, "analysis")
+        # PHANTOM-PORT FIX: feed the validator the nested `result.analysis` dict
+        # (so `analysis.get("recommended_strategy")` resolves to the real
+        # strategy) rather than the whole `result` wrapper. The strategy
+        # pipelines publish their RAG output on `output`, wired to `rag_results`.
+        builder.add_connection(
+            quality_analyzer_id, "result.analysis", validator_id, "analysis"
+        )
 
         return builder.build(name="advanced_rag_workflow")
 
@@ -595,76 +861,24 @@ Recommend the optimal RAG strategy:""",
             },
         )
 
-        # Document preprocessor for LLM analysis
-        preprocessor_id = builder.add_node(
-            "PythonCodeNode",
+        # Document preprocessor for LLM analysis.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_analyze_for_llm` function wired via `PythonCodeNode.from_function`.
+        # The node publishes the FLAT analysis dict on the `result` port; the
+        # nested `result.<key>` ports (`document_count` / `avg_length` /
+        # `has_structure` / `is_technical` / `content_types` / `query`) feed the
+        # strategy-analyzer messages composer (already wired below), and the
+        # whole `result` feeds the SwitchNode executor + aggregator as
+        # `preprocessed_data`. `_internal=True` suppresses the consumer-facing
+        # instance-API advisory.
+        preprocessor_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _analyze_for_llm,
+                name="document_preprocessor",
+            ),
             node_id="document_preprocessor",
-            config={
-                "code": """
-import re
-
-def analyze_for_llm(documents, query=""):
-    # `_content` is a nested local (PythonCodeNode execs the body in a scope
-    # where module-level defs are not visible to nested genexprs). A
-    # present-but-None `content` key returns None from dict.get(..., ""), so
-    # `or ""` is required; non-dict elements are filtered out first.
-    def _content(doc):
-        return (doc.get("content") or "") if isinstance(doc, dict) else ""
-
-    documents = [d for d in (documents or []) if isinstance(d, dict)]
-    if not documents:
-        return {
-            "document_count": 0,
-            "avg_length": 0,
-            "has_structure": False,
-            "is_technical": False,
-            "content_types": [],
-            "query": query
-        }
-
-    # Analyze documents
-    total_length = sum(len(_content(doc)) for doc in documents)
-    avg_length = total_length / len(documents)
-
-    # Check for structure
-    has_structure = any(
-        any(keyword in _content(doc).lower()
-            for keyword in ["# ", "## ", "### ", "heading", "section", "chapter"])
-        for doc in documents
-    )
-
-    # Check for technical content
-    technical_keywords = ["code", "function", "class", "algorithm", "api", "import", "def ", "return", "variable"]
-    is_technical = any(
-        any(keyword in _content(doc).lower()
-            for keyword in technical_keywords)
-        for doc in documents
-    )
-
-    # Determine content types
-    content_types = []
-    if has_structure:
-        content_types.append("structured")
-    if is_technical:
-        content_types.append("technical")
-    if avg_length > 2000:
-        content_types.append("long_form")
-    if len(documents) > 50:
-        content_types.append("large_collection")
-
-    return {
-        "document_count": len(documents),
-        "avg_length": int(avg_length),
-        "has_structure": has_structure,
-        "is_technical": is_technical,
-        "content_types": content_types,
-        "query": query,
-        "documents": documents
-    }
-
-result = analyze_for_llm(documents, query)
-"""
-            },
+            _internal=True,
         )
 
         # Strategy executor with switch
@@ -707,38 +921,23 @@ result = analyze_for_llm(documents, query)
             config={"workflow": hierarchical_workflow.workflow},  # type: ignore[attr-defined]
         )
 
-        # Results aggregator
-        aggregator_id = builder.add_node(
-            "PythonCodeNode",
+        # Results aggregator.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_aggregate_adaptive_results` function wired via
+        # `PythonCodeNode.from_function`. `llm_decision` reads the PARSED
+        # strategy-decision dict (republished on `strategy_decision_parser.result`
+        # — see the OUTPUT-side wiring below); `preprocessed_data` reads the
+        # preprocessor's `result`; `rag_results` reads the fired strategy
+        # pipeline's `output`. The node publishes the aggregate envelope on the
+        # flat `result` port.
+        aggregator_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _aggregate_adaptive_results,
+                name="results_aggregator",
+            ),
             node_id="results_aggregator",
-            config={
-                "code": """
-def aggregate_adaptive_results(rag_results, llm_decision, preprocessed_data):
-    return {
-        "results": rag_results,
-        "strategy_used": llm_decision.get("recommended_strategy"),
-        "llm_reasoning": llm_decision.get("reasoning"),
-        "confidence": llm_decision.get("confidence"),
-        "document_analysis": {
-            "count": preprocessed_data.get("document_count"),
-            "avg_length": preprocessed_data.get("avg_length"),
-            "content_types": preprocessed_data.get("content_types")
-        },
-        "adaptive_metadata": {
-            # F9 #1126: this dict lives inside a PythonCodeNode codegen
-            # body exec'd in a fresh namespace; the workflows.py
-            # module-scope `_DEFAULT_LLM_MODEL` is NOT visible inside the
-            # exec scope. Emit a documented sentinel; downstream consumers
-            # read the actual model from the upstream LLMAgentNode config.
-            "llm_model_used": "<env-default>",
-            "strategy_selection_method": "llm_analysis",
-            "fallback_available": llm_decision.get("fallback_strategy")
-        }
-    }
-
-result = aggregate_adaptive_results(rag_results, llm_decision, preprocessed_data)
-"""
-            },
+            _internal=True,
         )
 
         # L3 messages-composer (reference template — conversational.py /
@@ -764,7 +963,7 @@ result = aggregate_adaptive_results(rag_results, llm_decision, preprocessed_data
         # `@register_node` for static checkers (mirrors conversational.py).
         # `_internal=True` suppresses the consumer-facing instance-API advisory.
         strategy_analyzer_messages_composer_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 compose_strategy_analyzer_messages,
                 name="strategy_analyzer_messages_composer",
             ),
@@ -784,7 +983,7 @@ result = aggregate_adaptive_results(rag_results, llm_decision, preprocessed_data
         # connections below). Malformed output yields a typed parse-error
         # sentinel, NOT a fabricated strategy (zero-tolerance Rule 2).
         strategy_decision_parser_id = builder.add_node_instance(
-            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+            PythonCodeNode.from_function(
                 parse_strategy_decision,
                 name="strategy_decision_parser",
             ),
@@ -1001,32 +1200,32 @@ class RAGPipelineWorkflowNode(WorkflowNode):
         # dict). Every invocation raised ``NameError: name 'kwargs' is
         # not defined`` at the entry node.
         #
-        # The fix constructs the config dict directly without the wrapper
-        # function + undefined ``**kwargs`` unpacking. The default values
-        # (chunk_size / overlap / embedding_model / retrieval_k) are
-        # interpolated from ``self.rag_config`` at workflow-build time,
-        # matching the original codegen's behavior when no override is
-        # supplied. PythonCodeNode does not expose a kwargs dict, so the
-        # original codegen's "user can override chunk_size at runtime"
-        # contract was never reachable through this PythonCodeNode anyway
-        # — the override path is via ``config: RAGConfig`` at construction
-        # time, which IS preserved.
-        # Security round-1 (H1, M2): RAGConfig values + default_strategy
-        # are interpolated into a PythonCodeNode `code` string at workflow
-        # build time. To prevent code injection if RAGConfig is ever
-        # constructed from untrusted bytes (e.g. a Nexus endpoint that
-        # accepts RAGConfig kwargs), every interpolated value is forced
-        # through a typed coercion + `repr()` (which emits a syntactically
-        # safe Python literal — any embedded quotes / backslashes are
-        # escaped, control characters are encoded, and arbitrary
-        # subclass-`__str__`-override attacks are neutralized because the
-        # repr is computed on the coerced value).
+        # #1117/#1123/#1118 root-cause fix: the prior ``config_processor`` was an
+        # f-STRING codegen interpolating ``repr()``-escaped RAGConfig literals
+        # into the ``code`` body (doubled ``{{`` braces — the #1123 brace-escape
+        # surface). It is lifted to the module-level ``_make_config_processor``
+        # closure factory wired via ``PythonCodeNode.from_function``: the
+        # build-time RAGConfig values are captured as typed Python objects in the
+        # closure, NEVER re-rendered into source text. This removes the f-string +
+        # brace-escape surface entirely while preserving the SAME injection-safety
+        # invariant the prior ``repr()`` hardening provided (the values are bound
+        # objects, already typed-coerced below, so no source-injection path
+        # exists). The returned function declares ``documents`` / ``query`` /
+        # ``strategy`` as its explicit input ports (the same locals the prior
+        # codegen read) and returns the flat ``processed_config`` dict on the
+        # ``result`` port — the SwitchNode dispatcher reads ``strategy`` as a
+        # top-level key, the formatter reads the whole dict as ``config``.
         #
-        # Strategy enum validation (M2): `default_strategy` MUST be one of
-        # the SwitchNode's declared cases. An unknown strategy would silently
-        # fall through to no case match — converting that into a typed
-        # ValueError surfaces misuse at construction instead of producing a
-        # confusing empty workflow output at runtime.
+        # PythonCodeNode does not expose a kwargs dict, so the original codegen's
+        # "user can override chunk_size at runtime" contract was never reachable
+        # through this node anyway — the override path is via ``config: RAGConfig``
+        # at construction time, which IS preserved (the closure captures it).
+        #
+        # Strategy enum validation (M2): `default_strategy` MUST be one of the
+        # SwitchNode's declared cases. An unknown strategy would silently fall
+        # through to no case match — converting that into a typed ValueError
+        # surfaces misuse at construction instead of producing a confusing empty
+        # workflow output at runtime.
         _ALLOWED_STRATEGIES = ("semantic", "statistical", "hybrid", "hierarchical")
         if self.default_strategy not in _ALLOWED_STRATEGIES:
             raise ValueError(
@@ -1035,30 +1234,23 @@ class RAGPipelineWorkflowNode(WorkflowNode):
                 f"SwitchNode would never dispatch to a matching case."
             )
 
-        _default_strategy_lit = repr(self.default_strategy)
-        _chunk_size_lit = repr(int(self.rag_config.chunk_size))
-        _chunk_overlap_lit = repr(int(self.rag_config.chunk_overlap))
-        _embedding_model_lit = repr(str(self.rag_config.embedding_model))
-        _retrieval_k_lit = repr(int(self.rag_config.retrieval_k))
-
-        config_processor_id = builder.add_node(
-            "PythonCodeNode",
+        # Typed coercion of every build-time value before binding into the
+        # closure (mirrors the prior ``repr(int(...))`` / ``repr(str(...))``
+        # coercion — neutralizes a subclass-``__str__``/``__int__`` override
+        # smuggling a non-literal value).
+        config_processor_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _make_config_processor(
+                    default_strategy=str(self.default_strategy),
+                    chunk_size=int(self.rag_config.chunk_size),
+                    chunk_overlap=int(self.rag_config.chunk_overlap),
+                    embedding_model=str(self.rag_config.embedding_model),
+                    retrieval_k=int(self.rag_config.retrieval_k),
+                ),
+                name="config_processor",
+            ),
             node_id="config_processor",
-            config={
-                "code": f"""
-processed_config = {{
-    "strategy": strategy if strategy else {_default_strategy_lit},
-    "documents": documents,
-    "query": query if query else "",
-    "chunk_size": {_chunk_size_lit},
-    "chunk_overlap": {_chunk_overlap_lit},
-    "embedding_model": {_embedding_model_lit},
-    "retrieval_k": {_retrieval_k_lit},
-}}
-
-result = processed_config
-"""
-            },
+            _internal=True,
         )
 
         # Strategy dispatcher
@@ -1088,24 +1280,21 @@ result = processed_config
             )
             strategy_ids[strategy_name] = strategy_id
 
-        # Results formatter
-        formatter_id = builder.add_node(
-            "PythonCodeNode",
+        # Results formatter.
+        #
+        # #1117/#1123/#1118 root-cause fix: lifted to the module-level
+        # `_format_pipeline_results` function wired via
+        # `PythonCodeNode.from_function`. `strategy_results` arrives from
+        # whichever strategy pipeline fired (`output` port); `processed_config`
+        # from the `config_processor`'s `result`. The node publishes the
+        # formatted envelope on the flat `result` port.
+        formatter_id = builder.add_node_instance(
+            PythonCodeNode.from_function(
+                _format_pipeline_results,
+                name="results_formatter",
+            ),
             node_id="results_formatter",
-            config={
-                "code": """
-def format_pipeline_results(results, config):
-    return {
-        "results": results,
-        "strategy_used": config.get("strategy"),
-        "configuration": config,
-        "pipeline_type": "configurable",
-        "success": True if results else False
-    }
-
-result = format_pipeline_results(strategy_results, processed_config)
-"""
-            },
+            _internal=True,
         )
 
         # Connect configurable pipeline. SwitchNode's primary input port is

--- a/packages/kailash-kaizen/src/kaizen/nodes/security/ai_behavior_analysis.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/security/ai_behavior_analysis.py
@@ -250,8 +250,17 @@ Your analysis should help security teams understand:
                     "error": result["error"],
                 }
 
-            # Extract response content
-            response_content = result.get("response", "")
+            # Extract response content — LLMAgentNode returns nested structure
+            # Format: {"response": {"content": "<text>", ...}, ...}
+            response = result.get("response", "")
+            if isinstance(response, dict):
+                response_content = response.get("content")
+            else:
+                response_content = response
+            if not response_content or not isinstance(response_content, str):
+                # Fail closed: a malformed/missing envelope routes to the
+                # documented ai_available=False degrade in the except branch
+                raise ValueError("LLM result missing nested response.content")
 
             # Parse structured response
             # Expected format from LLM:

--- a/packages/kailash-kaizen/src/kaizen/nodes/security/ai_threat_detection.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/security/ai_threat_detection.py
@@ -259,8 +259,17 @@ Your analysis should help security teams understand:
                     "error": result["error"],
                 }
 
-            # Extract response content
-            response_content = result.get("response", "")
+            # Extract response content — LLMAgentNode returns nested structure
+            # Format: {"response": {"content": "<text>", ...}, ...}
+            response = result.get("response", "")
+            if isinstance(response, dict):
+                response_content = response.get("content")
+            else:
+                response_content = response
+            if not response_content or not isinstance(response_content, str):
+                # Fail closed: a malformed/missing envelope routes to the
+                # documented ai_available=False degrade in the except branch
+                raise ValueError("LLM result missing nested response.content")
 
             # Parse structured response
             # Expected format from LLM:

--- a/packages/kailash-kaizen/src/kaizen/runtime/context.py
+++ b/packages/kailash-kaizen/src/kaizen/runtime/context.py
@@ -9,7 +9,7 @@ through the metadata field.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -70,7 +70,7 @@ class ToolCallRecord:
 
     def __post_init__(self):
         if self.timestamp is None:
-            self.timestamp = datetime.utcnow()
+            self.timestamp = datetime.now(UTC)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""

--- a/packages/kailash-kaizen/tests/integration/rag/test_advanced_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_advanced_nodes.py
@@ -55,27 +55,49 @@ class TestHybridRagWorkflowGraph:
     """Assert the A-S2 workflow graph shape directly (no execution)."""
 
     def test_workflow_node_count_and_ids(self):
-        """The hybrid graph is exactly source + dense + sparse + fuse."""
+        """The hybrid graph is source + dense + sparse + fuse + 3 projectors.
+
+        Post-S6b the source / fuse COMPUTE stages are
+        ``PythonCodeNode.from_function`` nodes (flat ``result`` port); the three
+        projector nodes index the fuse ``result`` dict so the output_mapping can
+        surface the ``results`` / ``scores`` / ``metadata`` contract."""
         wf = create_hybrid_rag_workflow(RAGConfig())
         assert isinstance(wf, WorkflowNode)
         nodes = wf._workflow.nodes  # type: ignore[union-attr]
-        assert set(nodes.keys()) == {"source", "dense", "sparse", "fuse"}
+        assert set(nodes.keys()) == {
+            "source",
+            "dense",
+            "sparse",
+            "fuse",
+            "proj_results",
+            "proj_scores",
+            "proj_metadata",
+        }
 
-    def test_workflow_has_six_connections(self):
-        """source fans to 2 retrievers (4 edges) + 2 edges into fuse = 6."""
+    def test_workflow_connection_count(self):
+        """source fans to 2 retrievers (4 edges) + 2 edges into fuse + 3 edges
+        from fuse to the projector nodes = 9 connections."""
         wf = create_hybrid_rag_workflow(RAGConfig())
         connections = wf._workflow.connections  # type: ignore[union-attr]
-        assert len(connections) == 6
+        assert len(connections) == 9
 
-    def test_fuse_node_carries_rrf_code(self):
-        """The fuse PythonCodeNode's code= template implements RRF."""
-        wf = create_hybrid_rag_workflow(RAGConfig())
-        # the built PythonCodeNode instance exposes its template as .code
-        fuse = wf._workflow.get_node("fuse")  # type: ignore[union-attr]
-        code = fuse.code  # type: ignore[attr-defined]
-        assert "_reciprocal_rank_fusion" in code
-        # the codegen template carries the same isinstance guard as run() paths
-        assert "isinstance" in code
+    def test_fuse_node_implements_rrf(self):
+        """The fuse stage implements Reciprocal Rank Fusion (post-S6b it is the
+        lifted ``_make_rrf_fuse`` from_function node, not a code= template).
+
+        Behavioral proof: fusing two ranked lists with a shared doc id boosts
+        that doc's RRF score and orders results by fused score descending."""
+        from kaizen.nodes.rag.advanced import _make_rrf_fuse
+
+        fuse = _make_rrf_fuse(5)
+        out = fuse(
+            dense_result=[{"id": "a", "content": "x"}, {"id": "b", "content": "y"}],
+            sparse_result=[{"id": "a", "content": "x"}, {"id": "c", "content": "z"}],
+        )
+        assert out["metadata"]["fusion_method"] == "rrf"
+        # "a" appears in BOTH lists → highest fused RRF score → ranks first.
+        assert out["results"][0]["id"] == "a"
+        assert out["scores"] == sorted(out["scores"], reverse=True)
 
     def test_input_and_output_mapping_present(self):
         """The WorkflowNode maps documents/query in and results/scores out."""

--- a/packages/kailash-kaizen/tests/integration/rag/test_agentic_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_agentic_nodes.py
@@ -41,6 +41,9 @@ from kaizen.nodes.rag.agentic import (
     AgenticRAGNode,
     ReasoningRAGNode,
     ToolAugmentedRAGNode,
+    _make_result_synthesizer,
+    _make_state_manager,
+    execute_tool_action,
 )
 
 pytestmark = pytest.mark.integration
@@ -155,47 +158,38 @@ class TestAgenticRAGIntegration:
         # The workflow carries real connections between the nodes.
         assert len(wf.connections) > 0
 
-    def test_tool_executor_template_runs_real_search(self):
-        """The tool_executor ``code=`` template executes a real keyword
-        search and ranks documents by overlap score."""
-        wf = _build(AgenticRAGNode())
-        code = wf.nodes["tool_executor"].config["code"]
-        ns = {
-            "reasoning_state": {"current_action": 'search("transformer attention")'},
-            "documents": [
+    def test_tool_executor_fn_runs_real_search(self):
+        """The lifted ``execute_tool_action`` executes a real keyword search and
+        ranks documents by overlap score (post-S6b from_function migration)."""
+        out = execute_tool_action(
+            reasoning_state={"current_action": 'search("transformer attention")'},
+            documents=[
                 {"id": "hit", "content": "the transformer uses attention heavily"},
                 {"id": "miss", "content": "completely unrelated text"},
             ],
-        }
-        exec(code, ns)
-        tr = ns["result"]["tool_result"]
+        )
+        tr = out["tool_result"]
         assert tr["tool"] == "search"
         assert tr["count"] == 1
         # The matching document scored above zero and ranks first.
         assert tr["results"][0]["id"] == "hit"
         assert tr["results"][0]["score"] > 0
 
-    def test_tool_executor_template_calculate_real_arithmetic(self):
-        """The tool_executor ``calculate`` action evaluates real arithmetic
-        via the AST-walked safe evaluator."""
-        wf = _build(AgenticRAGNode())
-        code = wf.nodes["tool_executor"].config["code"]
-        ns = {
-            "reasoning_state": {"current_action": "calculate((100 - 80) / 80 * 100)"},
-            "documents": [],
-        }
-        exec(code, ns)
-        assert ns["result"]["tool_result"]["result"] == pytest.approx(25.0)
-
-    def test_result_synthesizer_template_interpolates_real_config(self):
-        """The result_synthesizer template runs and the constructor config
-        is interpolated into the real metadata block."""
-        wf = _build(
-            AgenticRAGNode(planning_strategy="tree-of-thought", max_reasoning_steps=9)
+    def test_tool_executor_fn_calculate_real_arithmetic(self):
+        """The lifted ``execute_tool_action`` ``calculate`` action evaluates real
+        arithmetic via the AST-walked safe evaluator."""
+        out = execute_tool_action(
+            reasoning_state={"current_action": "calculate((100 - 80) / 80 * 100)"},
+            documents=[],
         )
-        code = wf.nodes["result_synthesizer"].config["code"]
-        ns = {
-            "reasoning_state": {
+        assert out["tool_result"]["result"] == pytest.approx(25.0)
+
+    def test_result_synthesizer_fn_binds_real_config(self):
+        """The lifted ``_make_result_synthesizer`` closure binds the constructor
+        config into the real metadata block and computes the trace."""
+        synth = _make_result_synthesizer("tree-of-thought", 9)
+        out = synth(
+            reasoning_state={
                 "steps": [
                     {
                         "step_number": 1,
@@ -207,10 +201,8 @@ class TestAgenticRAGIntegration:
                 "final_answer": "the answer",
                 "completed": True,
             },
-            "query": "compare revenue",
-        }
-        exec(code, ns)
-        out = ns["result"]["agentic_rag_result"]
+            query="compare revenue",
+        )["agentic_rag_result"]
         assert out["answer"] == "the answer"
         assert out["tools_used"] == ["search"]
         assert out["metadata"]["planning_strategy"] == "tree-of-thought"
@@ -660,11 +652,11 @@ class TestAgenticOutputSideParsed:
     read a non-existent key (state_manager crashed on `None.strip()`; the
     verifier verdict was silently dropped)."""
 
-    def _build_codes(self, **kw):
-        wf = _build(AgenticRAGNode(**kw))
-        return wf
-
     # -- state_manager consumes the PARSED ReAct prose (read-back) ------------
+    # Post-S6b the state_manager COMPUTE stage is the lifted
+    # `_make_state_manager(...)` closure (a `PythonCodeNode.from_function` node).
+    # The O5 parsed-output contract is exercised by calling the lifted function
+    # directly with the parser OUTPUT shapes the production edges wire to.
 
     def test_state_manager_parses_react_answer_from_parsed_prose(self):
         """The state_manager line parser receives the reasoning_parser's
@@ -672,19 +664,18 @@ class TestAgenticOutputSideParsed:
         extracts the Answer, and publishes it in `reasoning_state`. RED pre-O5:
         the consumer read `reasoning_response.get("response")` off the inner
         `{"content": ...}` dict -> None -> `None.strip()` AttributeError."""
-        wf = self._build_codes()
-        code = wf.nodes["state_manager"].config["code"]
-        ns = {
+        sm = _make_state_manager(5)
+        out = sm(
+            # plan_parser publishes `result.plan` = parsed planner dict.
+            plan={"plan": [], "complexity": "simple"},
             # reasoning_parser publishes `result.reasoning_text` = bare prose str.
-            "reasoning_response": (
+            reasoning_response=(
                 "Thought: compare growth\nAction: search(revenue)\n"
                 "Answer: A overtakes B in 4 years"
             ),
-            # plan_parser publishes `result.plan` = parsed planner dict.
-            "plan": {"plan": [], "complexity": "simple"},
-        }
-        exec(code, ns)
-        rs = ns["result"]["reasoning_state"]
+            tool_result=None,
+        )
+        rs = out["reasoning_state"]
         assert rs["final_answer"] == "A overtakes B in 4 years", (
             "state_manager MUST parse the ReAct Answer from the parsed prose; "
             f"got: {rs['final_answer']!r}"
@@ -696,11 +687,9 @@ class TestAgenticOutputSideParsed:
         """When the reasoning_parser emits "" (the honest "no reasoning yet"
         on an empty/missing `response.content`), the state_manager records an
         empty step WITHOUT crashing — no fabricated answer."""
-        wf = self._build_codes()
-        code = wf.nodes["state_manager"].config["code"]
-        ns = {"reasoning_response": "", "plan": {}}
-        exec(code, ns)
-        rs = ns["result"]["reasoning_state"]
+        sm = _make_state_manager(5)
+        out = sm(plan={}, reasoning_response="", tool_result=None)
+        rs = out["reasoning_state"]
         # No Answer line -> final_answer stays None (honest), no crash.
         assert rs["final_answer"] is None
         assert rs["steps"][0]["thought"] is None
@@ -713,10 +702,9 @@ class TestAgenticOutputSideParsed:
         and applies its confidence. RED pre-O5: `verification.get("response")`
         off the inner `{"content": ...}` dict -> None -> verdict silently
         dropped, confidence never adjusted (stuck at base+boost)."""
-        wf = self._build_codes()
-        code = wf.nodes["result_synthesizer"].config["code"]
-        ns = {
-            "reasoning_state": {
+        synth = _make_result_synthesizer("react", 5)
+        out = synth(
+            reasoning_state={
                 "steps": [
                     {
                         "step_number": 1,
@@ -729,11 +717,9 @@ class TestAgenticOutputSideParsed:
                 "completed": True,
             },
             # verification_parser publishes `result.verification` = parsed dict.
-            "verification": {"verified": True, "confidence": 0.5, "issues": []},
-            "query": "q",
-        }
-        exec(code, ns)
-        out = ns["result"]["agentic_rag_result"]
+            verification={"verified": True, "confidence": 0.5, "issues": []},
+            query="q",
+        )["agentic_rag_result"]
         # (base 0.7 + boost 0.1) * verdict 0.5 = 0.4 — the verdict WAS applied.
         assert out["confidence"] == pytest.approx(0.4), (
             "synthesizer MUST apply the parsed verifier confidence; "
@@ -751,10 +737,9 @@ class TestAgenticOutputSideParsed:
         typed `{"parse_error": ...}` sentinel, the synthesizer leaves confidence
         UNADJUSTED and publishes `verification: None` — it does NOT fabricate a
         0.8 verdict (zero-tolerance Rule 2)."""
-        wf = self._build_codes()
-        code = wf.nodes["result_synthesizer"].config["code"]
-        ns = {
-            "reasoning_state": {
+        synth = _make_result_synthesizer("react", 5)
+        out = synth(
+            reasoning_state={
                 "steps": [
                     {
                         "step_number": 1,
@@ -766,11 +751,9 @@ class TestAgenticOutputSideParsed:
                 "final_answer": "A",
                 "completed": True,
             },
-            "verification": {"parse_error": "non-json-response"},
-            "query": "q",
-        }
-        exec(code, ns)
-        out = ns["result"]["agentic_rag_result"]
+            verification={"parse_error": "non-json-response"},
+            query="q",
+        )["agentic_rag_result"]
         # base 0.7 + boost 0.1 = 0.8, UNADJUSTED (no usable verdict).
         assert out["confidence"] == pytest.approx(0.8)
         assert out["verification"] is None

--- a/packages/kailash-kaizen/tests/integration/rag/test_evaluation_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_evaluation_nodes.py
@@ -23,6 +23,7 @@ import tracemalloc
 
 import pytest
 from kailash.nodes.base import Node
+from kailash.nodes.code.python import PythonCodeNode
 from kailash.runtime.local import LocalRuntime
 from kailash.workflow.builder import WorkflowBuilder
 from kailash.workflow.graph import Workflow
@@ -31,6 +32,8 @@ from kaizen.nodes.rag.evaluation import (
     RAGBenchmarkNode,
     RAGEvaluationNode,
     TestDatasetGeneratorNode,
+    aggregate_evaluation_metrics,
+    evaluate_context_metrics,
 )
 
 pytestmark = pytest.mark.integration
@@ -47,30 +50,35 @@ def _build(node: RAGEvaluationNode) -> Workflow:
 
 
 class TestContextPrecisionUnderRealRuntime:
-    """The context_evaluator runs under a real LocalRuntime executor.
+    """The context_evaluator (migrated to ``evaluate_context_metrics`` via
+    ``PythonCodeNode.from_function`` — Wave-3) runs under a real LocalRuntime
+    executor.
 
-    Mirrors B9a's ``TestCodegenRealRuntime`` precedent: extract codegen
-    from the workflow node, embed it in a fresh single-node builder, run
-    it through LocalRuntime against a real input dict. The patched
-    function adds the missing ``return result`` + module-scope call so
-    PythonCodeNode binds a top-level ``result``.
+    Wave-3 migration: the prior f-string ``code=`` codegen is gone. This builds
+    the REAL production ``evaluate_context_metrics`` from_function node (the same
+    one ``_create_workflow`` wires as ``context_evaluator``), embeds it in a
+    single-node builder, and runs it through LocalRuntime against a real
+    ``test_data`` dict — exercising the genuine production node end-to-end and
+    asserting the documented ``context_metrics`` list shape + numeric correctness.
     """
 
-    @pytest.mark.filterwarnings("ignore::SyntaxWarning")
     def test_context_evaluator_under_runtime_returns_documented_shape(self):
+        # The migrated context_evaluator is a from_function node — no `code=`
+        # config to extract; wire the production fn directly (identical to
+        # _create_workflow's `context_evaluator` registration).
         wf = _build(RAGEvaluationNode())
         evaluator = wf.get_node("context_evaluator")
         assert evaluator is not None
-        # F9 #1117: codegen now returns its dict AND iterates `test_data`
-        # at module scope. Embed verbatim; LocalRuntime binds `test_data`
-        # from `parameters` and publishes the module-scope `result`.
-        code = evaluator.config["code"]
+        assert evaluator.config.get("code") is None
 
         builder = WorkflowBuilder()
-        builder.add_node(
-            "PythonCodeNode",
+        builder.add_node_instance(
+            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                evaluate_context_metrics,
+                name="ctx_under_runtime",
+            ),
             node_id="ctx_under_runtime",
-            config={"code": code},
+            _internal=True,
         )
         runtime = LocalRuntime()
         results, _ = runtime.execute(
@@ -92,7 +100,7 @@ class TestContextPrecisionUnderRealRuntime:
         )
         out = results["ctx_under_runtime"]["result"]
         # The shape MUST carry the documented context_metrics list (one
-        # entry per input test_data row after the codegen iterates).
+        # entry per input test_data row after the fn maps).
         assert "context_metrics" in out
         ctx_list = out["context_metrics"]
         assert isinstance(ctx_list, list)
@@ -127,29 +135,45 @@ class TestMetricAggregatorUnderRealRuntime:
     the aggregate values match the formulas.
     """
 
-    @pytest.mark.filterwarnings("ignore::SyntaxWarning")
     def test_metric_aggregator_under_runtime_computes_means(self):
-        wf = _build(RAGEvaluationNode(use_reference_answers=False))
+        # Wave-3 migration: the aggregator is now an
+        # `aggregate_evaluation_metrics` from_function node bound with `metrics`
+        # via closure (no `code=` config). Build the production fn bound exactly
+        # as _create_workflow binds it (the `metrics` list of the constructed
+        # node), and run it under real LocalRuntime against the same fixed
+        # per-test PARSED score lists the response-parser nodes feed it.
+        node = RAGEvaluationNode(use_reference_answers=False)
+        wf = _build(node)
         aggregator = wf.get_node("metric_aggregator")
         assert aggregator is not None
-        # F9 #1117 + #1118: codegen now imports the `datetime` class
-        # explicitly, returns its aggregate dict, AND calls
-        # `aggregate_evaluation_metrics(...)` at module scope. Embed the
-        # codegen verbatim; LocalRuntime binds the wired inputs from
-        # `parameters` and publishes the module-scope `result`.
-        #
-        # OUTPUT-side fix: the aggregator now receives PARSED per-test score
-        # LISTS (the response-parser nodes already did `response -> .content ->
-        # json.loads`). So `faithfulness_scores` is a bare list of per-test score
-        # dicts `[{"faithfulness_score": 0.9}, ...]` — NO `{"response": {...}}`
-        # wrapper (that wrapper was the parse-gap the parser nodes now strip).
-        code = aggregator.config["code"]
+        assert aggregator.config.get("code") is None
+
+        _metrics = node.metrics
+
+        def _agg_bound(
+            test_results=None,
+            faithfulness_scores=None,
+            relevance_scores=None,
+            context_metrics=None,
+            answer_quality_scores=None,
+        ) -> dict:
+            return aggregate_evaluation_metrics(
+                test_results=test_results,
+                faithfulness_scores=faithfulness_scores,
+                relevance_scores=relevance_scores,
+                context_metrics=context_metrics,
+                answer_quality_scores=answer_quality_scores,
+                metrics=_metrics,
+            )
 
         builder = WorkflowBuilder()
-        builder.add_node(
-            "PythonCodeNode",
+        builder.add_node_instance(
+            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                _agg_bound,
+                name="agg_under_runtime",
+            ),
             node_id="agg_under_runtime",
-            config={"code": code},
+            _internal=True,
         )
         runtime = LocalRuntime()
         results, _ = runtime.execute(

--- a/packages/kailash-kaizen/tests/integration/rag/test_graph_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_graph_nodes.py
@@ -193,8 +193,15 @@ class TestGraphRAGNodeIntegration:
 
     def test_create_workflow_builds_real_connected_workflow(self):
         """``_create_workflow()`` returns a real built workflow whose nodes
-        are wired — the PythonCodeNode graph_builder/graph_retriever bodies
-        and the LLM nodes are all present and connected."""
+        are wired — the from_function graph_builder/graph_retriever compute nodes
+        and the LLM nodes are all present and connected.
+
+        Wave-3 migration: graph_builder / graph_retriever / result_synthesizer are
+        now ``PythonCodeNode.from_function`` nodes (the prior f-string ``code=``
+        codegen is gone). The graph-algorithm behavior is asserted directly
+        against ``build_knowledge_graph`` / ``retrieve_from_graph`` /
+        ``synthesize_results`` (see the Wave-3 unit tests + the end-to-end probes
+        below); here we assert structural connectivity + the migrated node shape."""
         # type: ignore[attr-defined] — the @register_node decorator erases the
         # concrete subclass type to base Node, which does not declare the
         # per-node _create_workflow helper. The method exists at runtime; the
@@ -206,17 +213,73 @@ class TestGraphRAGNodeIntegration:
         # global_summary_parser — see TestGraphContextReachesLLM +
         # TestGraphOutputReachesConsumers).
         assert len(wf.nodes) == 12
-        # The graph_builder PythonCodeNode carries a real code template.
-        builder_code = wf.nodes["graph_builder"].config["code"]
-        assert "build_knowledge_graph" in builder_code
-        assert "nx.MultiDiGraph" in builder_code
+        # The graph_builder is now a from_function PythonCodeNode (its `code`
+        # config is None — the f-string template is gone, lifted to the module
+        # function).
+        assert wf.nodes["graph_builder"].config.get("code") is None
+        assert wf.nodes["graph_retriever"].config.get("code") is None
+        assert wf.nodes["result_synthesizer"].config.get("code") is None
 
-    def test_create_workflow_retriever_code_carries_max_hops(self):
-        """``max_hops`` is interpolated into the real graph_retriever code
-        template the sub-workflow executes."""
+    def test_graph_builder_runs_under_real_local_runtime(self):
+        """ROOT-CAUSE FIX (Wave-3): with graph_builder lifted to from_function,
+        `import networkx` runs OUTSIDE the PythonCodeNode sandbox — so the
+        graph_builder node NOW runs end-to-end under a REAL LocalRuntime (the
+        prior `code=` block was BLOCKED by the sandbox's "Import of module
+        'networkx' is not allowed"). Proven by running the production from_function
+        node standalone and asserting a real graph is built."""
+        from kailash.nodes.code.python import PythonCodeNode as _PCN
+        from kailash.runtime.local import LocalRuntime as _RT
+        from kailash.workflow.builder import WorkflowBuilder as _WB
+
+        from kaizen.nodes.rag.graph import build_knowledge_graph
+
+        b = _WB()
+        b.add_node_instance(
+            _PCN.from_function(  # type: ignore[attr-defined]
+                lambda extraction_results=None: build_knowledge_graph(
+                    extraction_results=extraction_results,
+                    community_algorithm="connected_components",
+                ),
+                name="gb",
+            ),
+            node_id="gb",
+            _internal=True,
+        )
+        wf = b.build(name="gb_runtime_probe")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            with _RT() as rt:
+                results, _ = rt.execute(
+                    wf,
+                    parameters={
+                        "extraction_results": [
+                            {
+                                "entities": [
+                                    {
+                                        "name": "BERT",
+                                        "type": "technology",
+                                        "description": "e",
+                                    }
+                                ],
+                                "relationships": [],
+                            }
+                        ]
+                    },
+                )
+        gd = results["gb"]["result"]["graph_data"]
+        # A REAL networkx graph was built under LocalRuntime — the sandbox no
+        # longer blocks the networkx import (it runs in the from_function body).
+        assert gd["stats"]["num_entities"] == 1
+        G = nx.node_link_graph(gd["graph"])
+        assert "bert" in set(G.nodes())
+
+    def test_create_workflow_retriever_carries_max_hops(self):
+        """``max_hops`` is bound into the graph_retriever from_function closure
+        (Wave-3 migration). The migrated node has no ``code=`` template; the BFS
+        depth bound is asserted behaviorally against ``retrieve_from_graph`` in the
+        unit suite. Here we confirm the migrated node shape."""
         wf = GraphRAGNode(max_hops=3)._create_workflow()  # type: ignore[attr-defined]
-        retriever_code = wf.nodes["graph_retriever"].config["code"]
-        assert "depth >= 3" in retriever_code
+        assert wf.nodes["graph_retriever"].config.get("code") is None
 
     def test_create_workflow_summary_disabled_drops_node_and_connections(self):
         """With ``use_global_summary=False`` the real workflow has 9 nodes and
@@ -571,6 +634,7 @@ from kaizen.nodes.rag.graph import (  # noqa: E402
     parse_entity_extraction,
     parse_global_summary,
     parse_query_analysis,
+    synthesize_results,
 )
 
 
@@ -805,11 +869,19 @@ class TestGraphOutputReachesConsumers:
         """Build the load-bearing OUTPUT-side subgraph: a deterministic
         summary-LLM-shaped source publishing ``response`` →
         ``global_summary_parser`` (the real production parser) →
-        ``result_synthesizer`` (the real production synthesizer code, summary
-        path). The result_synthesizer is plain Python (NO networkx) so it RUNS
-        under real LocalRuntime; the graph_retrieval + graph_data inputs are
-        delivered as top-level workflow inputs (parameter-injector auto-
-        distribute), exactly as the full graph delivers them."""
+        ``result_synthesizer`` (the REAL production ``synthesize_results``
+        function, summary-enabled path, wired via from_function exactly as
+        ``_create_workflow`` wires it).
+
+        Wave-3 migration: ``result_synthesizer`` is now a from_function node (the
+        prior ``code=`` template is gone). This subgraph wires the genuine
+        production ``synthesize_results`` (bound with ``use_global_summary=True``,
+        mirroring the enabled-path closure in ``_create_workflow``) — so it is a
+        STRICTLY more faithful end-to-end test than reconstructing a code string.
+        ``synthesize_results`` is plain Python (NO networkx) so it RUNS under real
+        LocalRuntime; the graph_retrieval + graph_data inputs are delivered as
+        top-level workflow inputs (parameter-injector auto-distribute), exactly as
+        the full graph delivers them."""
         builder = WorkflowBuilder()
         builder.add_node_instance(
             PythonCodeNode.from_function(  # type: ignore[attr-defined]
@@ -827,17 +899,27 @@ class TestGraphOutputReachesConsumers:
             node_id="global_summary_parser",
             _internal=True,
         )
-        # The real production result_synthesizer code (summary-enabled path).
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            full_wf = GraphRAGNode(
-                use_global_summary=True
-            )._create_workflow()  # type: ignore[attr-defined]
-        synth_code = full_wf.nodes["result_synthesizer"].config["code"]
-        builder.add_node(
-            "PythonCodeNode",
+
+        # The REAL production synthesizer fn, bound enabled-path (use_global_summary
+        # =True) exactly as _create_workflow's closure binds it.
+        def _synth_bound(
+            graph_retrieval=None, query="", graph_data=None, global_summaries=None
+        ) -> dict:
+            return synthesize_results(
+                graph_retrieval=graph_retrieval,
+                query=query,
+                graph_data=graph_data,
+                global_summaries=global_summaries,
+                use_global_summary=True,
+            )
+
+        builder.add_node_instance(
+            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                _synth_bound,
+                name="result_synthesizer",
+            ),
             node_id="result_synthesizer",
-            config={"code": synth_code},
+            _internal=True,
         )
         builder.add_connection(
             "fake_summary_response",
@@ -908,29 +990,51 @@ class TestGraphOutputReachesConsumers:
         assert synth["global_summary"] is None
 
     def test_summary_disabled_path_synthesizer_has_no_nameerror(self):
-        """CONDITIONAL-WIRING (Option i): with ``use_global_summary=False`` the
-        synthesizer body references NO ``global_summaries`` input (it is unwired),
-        so running it under real LocalRuntime does NOT raise NameError, and
-        ``graph_rag_results.global_summary`` is ``None`` honestly."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            full_wf = GraphRAGNode(
-                use_global_summary=False
-            )._create_workflow()  # type: ignore[attr-defined]
-        synth_code = full_wf.nodes["result_synthesizer"].config["code"]
-        # The disabled-path body MUST NOT reference `global_summaries` (the
-        # unwired name) — referencing it would NameError at exec.
-        assert "global_summaries" not in synth_code
+        """CONDITIONAL-BEHAVIOR PRESERVATION (Wave-3 migration of the Wave-2.5
+        Option-i conditional): with ``use_global_summary=False`` the migrated
+        ``synthesize_results`` from_function node is bound ``use_global_summary=
+        False`` and the ``global_summaries`` input is NEVER wired. Because a
+        from_function node tolerates a missing declared input (its
+        ``global_summaries=None`` default applies), running the disabled-path
+        synthesizer under real LocalRuntime WITHOUT wiring ``global_summaries``
+        does NOT raise (the prior ``code=`` exec namespace raised NameError on a
+        bare unwired reference — which is why the conditional codegen existed; the
+        from_function default replaces that conditional entirely), and
+        ``graph_rag_results.global_summary`` is ``None`` honestly.
+
+        This builds the REAL production ``synthesize_results`` bound exactly as
+        ``_create_workflow``'s disabled-path closure binds it
+        (``use_global_summary=False``), then runs it standalone with ONLY
+        ``graph_retrieval`` / ``graph_data`` / ``query`` wired (no
+        ``global_summaries`` — mirroring the disabled-path graph topology)."""
+
+        def _synth_disabled(
+            graph_retrieval=None, query="", graph_data=None, global_summaries=None
+        ) -> dict:
+            return synthesize_results(
+                graph_retrieval=graph_retrieval,
+                query=query,
+                graph_data=graph_data,
+                global_summaries=global_summaries,
+                use_global_summary=False,
+            )
+
         builder = WorkflowBuilder()
-        builder.add_node(
-            "PythonCodeNode",
+        builder.add_node_instance(
+            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                _synth_disabled,
+                name="result_synthesizer",
+            ),
             node_id="result_synthesizer",
-            config={"code": synth_code},
+            _internal=True,
         )
         wf = builder.build(name="disabled_synth_probe")
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             with LocalRuntime() as runtime:
+                # NOTE: `global_summaries` is deliberately NOT in parameters — the
+                # disabled-path graph never wires it; the from_function default
+                # applies and there is no NameError.
                 results, _ = runtime.execute(
                     wf,
                     parameters={

--- a/packages/kailash-kaizen/tests/integration/rag/test_optimized_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_optimized_nodes.py
@@ -1,39 +1,38 @@
-"""Tier-2a integration coverage — ``kaizen.nodes.rag.optimized``.
+"""Tier-2 integration coverage — ``kaizen.nodes.rag.optimized``.
 
-F8 shard B9c. Real interpreter execution of the 4 optimized RAG
-classes' codegen templates — covering the **cache/stream/batch
-correctness** value-anchor that the resurrection floor never verified.
+F8 shard B9c + Wave-3 S1 ``from_function`` migration. Real ``LocalRuntime``
+execution of the Cache + AsyncParallel optimized RAG node spines — covering the
+**cache/parallel correctness** value-anchor that the resurrection floor never
+verified, now through the PRODUCTION path (real workflow execution, real
+``from_function`` nodes publishing real ``result`` ports).
 
-Value-anchor (F8 plan §B B9c row): "**cache/stream correctness of
-preserved nodes**". This file lifts the cache + parallel + batch
-correctness half by exercising:
+Wave-3 S1 migrated CacheOptimizedRAGNode + AsyncParallelRAGNode from brittle
+f-string ``"code"``-string ``PythonCodeNode`` codegen to
+``PythonCodeNode.from_function`` (#1117 publish-nothing / #1123 brace-escape /
+#1118 import-trap root-cause fix). These tests run the REAL inner-workflow nodes
+(from ``_create_workflow()``) under a real ``LocalRuntime`` and assert the
+computed output reaches the documented downstream consumer.
 
-  - CacheOptimizedRAGNode's cache_key + semantic-cache codegen
-    templates under real interpreter execution; cache hit / miss /
-    bounded-state semantics.
-  - AsyncParallelRAGNode's parallel_executor + result_combiner
-    codegen templates; multi-strategy fusion correctness on fixed
-    score fixtures.
-  - StreamingRAGNode's progressive_retriever codegen template;
-    iterative chunked output semantics.
-  - BatchOptimizedRAGNode's batch_organizer + processor codegen
-    templates; multi-query batch processing correctness.
+Scoping (mirrors the original B9c integration scope): the strategy RAG nodes
+(``SemanticRAGNode`` etc.) and the ``HybridRAGNode`` rag_processor carry a
+SEPARATE, PRE-EXISTING config-shape defect (``config={"config": {...}}`` passes
+a dict where a ``RAGConfig`` is expected) that blocks the full multi-node graph
+and is out of scope for this migration shard. The cache-decision spine
+(key-gen → CacheNode → manager → aggregator) and the parallel
+executor → combiner spine — the surfaces this shard migrated — are exercised in
+full through the real production path.
 
-NO mocking (``@patch`` / ``MagicMock`` / ``unittest.mock`` are BLOCKED
-in Tier 2/3 per ``rules/testing.md``). The PythonCodeNode sandbox
-uses two-scope exec which hides module imports from nested function
-lookups (F9 ledger class) — so the codegen templates are exercised
-through `exec` in a single namespace (real Python interpreter, no
-sandbox), the same pattern B9b used for the metric_aggregator and
-context_evaluator tests.
+NO mocking (``@patch`` / ``MagicMock`` / ``unittest.mock`` are BLOCKED in Tier
+2/3 per ``rules/testing.md``). CacheNode uses a deterministic in-memory backend.
 """
 
 from __future__ import annotations
 
-import time
 from typing import Any, Dict, List
 
 import pytest
+from kailash.runtime.local import LocalRuntime
+from kailash.workflow.builder import WorkflowBuilder
 
 from kaizen.nodes.rag.optimized import (
     AsyncParallelRAGNode,
@@ -45,700 +44,503 @@ from kaizen.nodes.rag.optimized import (
 pytestmark = pytest.mark.integration
 
 
-def _exec_codegen(code: str, ns_seed: Dict[str, Any]) -> Dict[str, Any]:
-    """Exec codegen in a single-namespace real Python interpreter.
-
-    The PythonCodeNode sandbox uses two-scope exec which breaks nested
-    function lookups for module-level imports (F9 ledger class). The
-    test runs the codegen through a real `exec` call — Python's normal
-    one-namespace semantics restore the closure behavior.
-    """
-    ns: dict = dict(ns_seed)
-    exec(code, ns)
-    return ns["result"]
+def _real_cache_nodes() -> Dict[str, Any]:
+    """The real from_function node instances the fixed ``_create_workflow``
+    produces — no re-authoring."""
+    wf = CacheOptimizedRAGNode(similarity_threshold=0.95)._create_workflow()  # type: ignore[attr-defined]
+    return {nid: wf.get_node(nid) for nid in wf.nodes}
 
 
-# ==========================================================================
-# CacheOptimizedRAGNode — cache_key_generator codegen correctness
-# ==========================================================================
-
-
-class TestCacheKeyGenerator:
-    """The cache_key_generator codegen produces deterministic keys."""
-
-    def test_same_query_produces_same_cache_key(self):
-        node = CacheOptimizedRAGNode()
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        key_gen = wf.get_node("cache_key_generator")
-        assert key_gen is not None
-        code = key_gen.config["code"]
-        out_a = _exec_codegen(code, {"query": "what is deep learning"})
-        out_b = _exec_codegen(code, {"query": "what is deep learning"})
-        # Same query → same cache key (deterministic hash).
-        assert out_a["cache_keys"]["exact"] == out_b["cache_keys"]["exact"]
-        assert out_a["cache_keys"]["semantic"] == out_b["cache_keys"]["semantic"]
-        # Both keys are documented-format strings.
-        assert isinstance(out_a["cache_keys"]["exact"], str)
-        assert out_a["cache_keys"]["semantic"].startswith("semantic_")
-
-    def test_different_queries_produce_different_keys(self):
-        node = CacheOptimizedRAGNode()
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        key_gen = wf.get_node("cache_key_generator")
-        assert key_gen is not None
-        code = key_gen.config["code"]
-        out_a = _exec_codegen(code, {"query": "alpha"})
-        out_b = _exec_codegen(code, {"query": "beta"})
-        # Different queries → different cache keys.
-        assert out_a["cache_keys"]["exact"] != out_b["cache_keys"]["exact"]
+def _real_parallel_nodes(strategies: List[str]) -> Dict[str, Any]:
+    wf = AsyncParallelRAGNode(strategies=strategies)._create_workflow()  # type: ignore[attr-defined]
+    return {nid: wf.get_node(nid) for nid in wf.nodes}
 
 
 # ==========================================================================
-# CacheOptimizedRAGNode — semantic_cache_manager hit/miss correctness
+# CacheOptimizedRAGNode — cache-decision spine end-to-end (production path)
 # ==========================================================================
 
 
-class TestSemanticCacheManager:
-    """The semantic_cache_manager codegen routes on CacheNode's real hit/value.
+class TestCacheDecisionSpineEndToEnd:
+    """key-gen → CacheNode.get → semantic_cache_manager → result_aggregator
+    runs end-to-end under a real LocalRuntime, with the REAL from_function nodes
+    and the REAL dotted-path wiring (``result.cache_keys.exact``,
+    ``result.use_cache``, ``result``)."""
 
-    F9 #1117/#1123 contract-alignment: the node reads CacheNode.get's flat
-    ``cache_hit`` / ``cache_value`` ports (NOT the fabricated
-    ``cache_check_result`` nested dict with ``exact_hit`` / ``exact_result``
-    keys CacheNode never produced). ``semantic_candidates`` is hardcoded ``{}``
-    in the node because no candidate-store node feeds it — the semantic-cache
-    branch is honest-but-dormant; the workflow is a real exact-match cache.
-    """
-
-    def test_exact_hit_returns_cached_result(self):
-        node = CacheOptimizedRAGNode()
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        sem_mgr = wf.get_node("semantic_cache_manager")
-        assert sem_mgr is not None
-        code = sem_mgr.config["code"]
-        # CacheNode.get hit shape: cache_hit=True, cache_value=<cached doc>.
-        out = _exec_codegen(
-            code,
-            {
-                "query": "anything",
-                "cache_hit": True,
-                "cache_value": {"results": ["cached_doc"]},
-            },
-        )
-        assert out["use_cache"] is True
-        assert out["cache_type"] == "exact"
-        assert out["cached_result"] == {"results": ["cached_doc"]}
-
-    def test_no_exact_no_semantic_returns_cache_miss(self):
-        node = CacheOptimizedRAGNode()
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        sem_mgr = wf.get_node("semantic_cache_manager")
-        assert sem_mgr is not None
-        code = sem_mgr.config["code"]
-        # CacheNode.get miss shape: cache_hit=False, cache_value=None.
-        out = _exec_codegen(
-            code,
-            {
-                "query": "completely different",
-                "cache_hit": False,
-                "cache_value": None,
-            },
-        )
-        assert out["use_cache"] is False
-        assert out["cache_type"] is None
-
-    def test_falsy_cache_hit_routes_to_miss(self):
-        """A falsy ``cache_hit`` (the CacheNode miss signal) routes to a cache
-        miss regardless of any stale ``cache_value``."""
-        node = CacheOptimizedRAGNode(similarity_threshold=0.95)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        sem_mgr = wf.get_node("semantic_cache_manager")
-        assert sem_mgr is not None
-        code = sem_mgr.config["code"]
-        out = _exec_codegen(
-            code,
-            {
-                "query": "alpha beta gamma",
-                "cache_hit": False,
-                "cache_value": None,
-            },
-        )
-        assert out["use_cache"] is False
-        assert out["cache_type"] is None
-
-    def test_semantic_branch_dormant_without_candidate_store(self):
-        """The semantic-similarity branch is dormant by design: no node feeds
-        ``semantic_candidates`` (hardcoded ``{}``), so a non-hit always routes
-        to a miss — an honest exact-match cache, not a fabricated semantic hit.
-        """
-        node = CacheOptimizedRAGNode(similarity_threshold=0.5)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        sem_mgr = wf.get_node("semantic_cache_manager")
-        assert sem_mgr is not None
-        code = sem_mgr.config["code"]
-        out = _exec_codegen(
-            code,
-            {
-                "query": "alpha beta gamma",
-                "cache_hit": False,
-                "cache_value": None,
-            },
-        )
-        # No candidate store wired → no semantic hit possible → miss.
-        assert out["use_cache"] is False
-        assert out["cache_type"] is None
-
-
-# ==========================================================================
-# CacheOptimizedRAGNode — hit/miss/eviction state semantics through facade
-# ==========================================================================
-
-
-class TestCacheHitMissReadback:
-    """State read-back: same cache_key_generator invocation produces the
-    same key, AND the same query parameters return the same key across
-    invocations — the cache-hit detection invariant."""
-
-    def test_hit_detection_via_repeated_key_generation(self):
-        """Two invocations with the same query produce IDENTICAL cache
-        keys — the cache lookup contract is built on this invariant."""
-        node = CacheOptimizedRAGNode()
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        key_gen = wf.get_node("cache_key_generator")
-        assert key_gen is not None
-        code = key_gen.config["code"]
-        # Call 1: first cache lookup for this query.
-        out_call_1 = _exec_codegen(code, {"query": "deep learning intro"})
-        # Call 2: second cache lookup for the SAME query — would hit cache.
-        out_call_2 = _exec_codegen(code, {"query": "deep learning intro"})
-        # Same key → cache would return the hit.
-        assert out_call_1["cache_keys"]["exact"] == out_call_2["cache_keys"]["exact"]
-
-    def test_miss_distinct_queries_distinct_keys(self):
-        """Distinct queries → distinct cache keys → cache misses."""
-        node = CacheOptimizedRAGNode()
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        key_gen = wf.get_node("cache_key_generator")
-        assert key_gen is not None
-        code = key_gen.config["code"]
-        # 5 distinct queries should produce 5 distinct cache keys.
-        queries = ["one", "two", "three", "four", "five"]
-        keys = set()
-        for q in queries:
-            out = _exec_codegen(code, {"query": q})
-            keys.add(out["cache_keys"]["exact"])
-        assert len(keys) == 5  # all distinct → all would miss the cache.
-
-
-# ==========================================================================
-# AsyncParallelRAGNode — parallel fusion correctness
-# ==========================================================================
-
-
-class TestParallelExecutorAndCombiner:
-    """The parallel_executor produces an execution plan; the result_combiner
-    fuses per-strategy results into a single ranked list."""
-
-    def test_parallel_executor_publishes_strategy_configs(self):
-        node = AsyncParallelRAGNode(strategies=["semantic", "hybrid"])
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        exec_node = wf.get_node("parallel_executor")
-        assert exec_node is not None
-        code = exec_node.config["code"]
-        out = _exec_codegen(
-            code,
-            {"query": "test query", "documents": [{"content": "doc one"}]},
-        )
-        # The execution_plan carries the strategy list + parallel count.
-        assert out["execution_plan"]["strategies"] == ["semantic", "hybrid"]
-        assert out["execution_plan"]["parallel_count"] == 2
-        # strategy_configs carries per-strategy config dicts.
-        assert set(out["strategy_configs"].keys()) == {"semantic", "hybrid"}
-        for cfg in out["strategy_configs"].values():
-            assert cfg["enabled"] is True
-            assert cfg["timeout"] == 5.0
-            assert cfg["fallback"] == "hybrid"
-
-    def test_result_combiner_fuses_per_strategy_results(self):
-        """Combiner aggregates per-strategy scores into a single ranked list."""
-        from datetime import datetime
-
-        node = AsyncParallelRAGNode(strategies=["semantic", "hybrid"])
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        combiner = wf.get_node("result_combiner")
-        assert combiner is not None
-        code = combiner.config["code"]
-        # Each strategy provides results with the documented shape.
-        strategy_a_results = {
-            "results": [
-                {"id": "doc1", "content": "alpha"},
-                {"id": "doc2", "content": "beta"},
-            ],
-            "scores": [0.9, 0.7],
-        }
-        strategy_b_results = {
-            "results": [
-                {"id": "doc1", "content": "alpha"},
-                {"id": "doc3", "content": "gamma"},
-            ],
-            "scores": [0.8, 0.6],
-        }
-        out = _exec_codegen(
-            code,
-            {
-                "execution_plan": {
-                    "strategies": ["semantic", "hybrid"],
-                    "query": "test",
-                    "start_time": datetime.now().isoformat(),
-                    "parallel_count": 2,
-                },
-                "semantic_results": strategy_a_results,
-                "hybrid_results": strategy_b_results,
-            },
-        )
-        parallel = out["parallel_results"]
-        # Documented shape carries results / scores / metadata.
-        assert "results" in parallel
-        assert "scores" in parallel
-        assert "metadata" in parallel
-        # All 3 unique docs end up in the fused result.
-        result_ids = {r["id"] for r in parallel["results"]}
-        assert result_ids == {"doc1", "doc2", "doc3"}
-        # The strategy_agreements counter records how many docs were
-        # returned by ALL strategies — doc1 by both, doc2/doc3 by one.
-        assert parallel["metadata"]["strategy_agreements"] == 1
-        # The strategies_used list is the input strategies.
-        assert set(parallel["metadata"]["strategies_used"]) == {"semantic", "hybrid"}
-
-    def test_combiner_doc1_first_when_appearing_in_both_strategies(self):
-        """A doc returned by BOTH strategies has aggregated higher score
-        than one returned by only one — should rank first."""
-        from datetime import datetime
-
-        node = AsyncParallelRAGNode(strategies=["semantic", "hybrid"])
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        combiner = wf.get_node("result_combiner")
-        assert combiner is not None
-        code = combiner.config["code"]
-        # doc1: in both with mean 0.85; doc2: in one with mean 0.7;
-        # doc3: in one with mean 0.6.
-        out = _exec_codegen(
-            code,
-            {
-                "execution_plan": {
-                    "strategies": ["semantic", "hybrid"],
-                    "query": "q",
-                    "start_time": datetime.now().isoformat(),
-                    "parallel_count": 2,
-                },
-                "semantic_results": {
-                    "results": [
-                        {"id": "doc1", "content": "x"},
-                        {"id": "doc2", "content": "y"},
-                    ],
-                    "scores": [0.9, 0.7],
-                },
-                "hybrid_results": {
-                    "results": [
-                        {"id": "doc1", "content": "x"},
-                        {"id": "doc3", "content": "z"},
-                    ],
-                    "scores": [0.8, 0.6],
-                },
-            },
-        )
-        parallel = out["parallel_results"]
-        # doc1 has mean (0.9+0.8)/2=0.85 — should rank first.
-        assert parallel["results"][0]["id"] == "doc1"
-        assert parallel["scores"][0] == pytest.approx(0.85)
-
-
-# ==========================================================================
-# StreamingRAGNode — progressive_retriever chunked output correctness
-# ==========================================================================
-
-
-class TestStreamingProgressiveRetriever:
-    """The progressive_retriever codegen scans a doc batch and produces
-    initial-stage chunked results — the documented stream contract."""
-
-    def test_progressive_retriever_returns_initial_stage_shape(self):
-        node = StreamingRAGNode(chunk_size=5)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        retriever = wf.get_node("progressive_retriever")
-        assert retriever is not None
-        code = retriever.config["code"]
-        out = _exec_codegen(
-            code,
-            {
-                "streaming_plan": {
-                    "stages": [
-                        {"name": "initial", "k": 3, "fast": True},
-                        {"name": "refined", "k": 5, "fast": False},
-                    ],
-                },
-                "query": "machine learning",
-                "documents": [
-                    {"content": "machine learning is great"},
-                    {"content": "deep learning rocks"},
-                    {"content": "unrelated content here"},
-                    {"content": "another machine learning text"},
-                ],
-            },
-        )
-        prog = out["progressive_results"]
-        # The initial stage results carry the documented shape.
-        assert "initial" in prog
-        assert "has_more" in prog
-        assert "next_stage" in prog
-        assert "metadata" in prog
-        # 3 docs match on either "machine" or "learning"; initial-stage
-        # k=3 caps results to 3.
-        assert len(prog["initial"]) <= 3
-        # next_stage signals refinement is available.
-        assert prog["next_stage"] == "refined"
-        # docs_scanned reports how many docs were inspected.
-        assert prog["metadata"]["docs_scanned"] == 4
-
-    def test_progressive_retriever_results_ranked_by_overlap(self):
-        node = StreamingRAGNode(chunk_size=5)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        retriever = wf.get_node("progressive_retriever")
-        assert retriever is not None
-        code = retriever.config["code"]
-        out = _exec_codegen(
-            code,
-            {
-                "streaming_plan": {
-                    "stages": [{"name": "initial", "k": 3, "fast": True}],
-                },
-                "query": "machine learning algorithms",
-                "documents": [
-                    # 1/3 overlap.
-                    {"content": "machine drilled holes"},
-                    # 3/3 overlap.
-                    {"content": "machine learning algorithms are great"},
-                    # 2/3 overlap.
-                    {"content": "deep learning algorithms exist"},
-                ],
-            },
-        )
-        results = out["progressive_results"]["initial"]
-        # Top-ranked by overlap: 3/3 → 2/3 → 1/3.
-        scores = [r["score"] for r in results]
-        assert scores == sorted(scores, reverse=True)
-        # First result has highest possible score (3/3 = 1.0).
-        assert scores[0] == pytest.approx(1.0)
-
-
-# ==========================================================================
-# BatchOptimizedRAGNode — batch organization + processing correctness
-# ==========================================================================
-
-
-class TestBatchOrganizerAndProcessor:
-    """The batch_organizer batches queries; the batch_processor scores
-    each batch's queries against a shared document set."""
-
-    def test_batch_organizer_splits_queries_into_documented_batches(self):
-        node = BatchOptimizedRAGNode(batch_size=3)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        organizer = wf.get_node("batch_organizer")
-        assert organizer is not None
-        code = organizer.config["code"]
-        out = _exec_codegen(
-            code,
-            {
-                "queries": [
-                    "machine learning a",
-                    "machine learning b",
-                    "deep learning c",
-                    "deep learning d",
-                    "unrelated e",
-                ],
-            },
-        )
-        plan = out["batch_plan"]
-        assert plan["total_queries"] == 5
-        assert plan["batch_size"] == 3
-        # 5 queries / 3 per batch → 2 batches (3 + 2).
-        assert plan["num_batches"] == 2
-        # optimization_applied=True when len(queries) > 1.
-        assert plan["optimization_applied"] is True
-        # Every batch carries the documented shape.
-        for batch in plan["batches"]:
-            assert "batch_id" in batch
-            assert "queries" in batch
-            assert "size" in batch
-
-    def test_batch_organizer_single_query_no_optimization(self):
-        node = BatchOptimizedRAGNode(batch_size=3)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        organizer = wf.get_node("batch_organizer")
-        assert organizer is not None
-        code = organizer.config["code"]
-        out = _exec_codegen(
-            code,
-            {"queries": ["only one query"]},
-        )
-        plan = out["batch_plan"]
-        # 1 query → 1 batch, optimization NOT applied.
-        assert plan["total_queries"] == 1
-        assert plan["num_batches"] == 1
-        assert plan["optimization_applied"] is False
-
-    def test_batch_organizer_string_input_wraps_as_single_query(self):
-        """The codegen accepts a single string and wraps it in a 1-item list."""
-        node = BatchOptimizedRAGNode(batch_size=3)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        organizer = wf.get_node("batch_organizer")
-        assert organizer is not None
-        code = organizer.config["code"]
-        out = _exec_codegen(code, {"queries": "single str query"})
-        assert out["batch_plan"]["total_queries"] == 1
-
-    def test_batch_processor_scores_across_all_queries_in_batch(self):
-        """The batch_processor scores every query in every batch against
-        the document set — the throughput claim's correctness floor."""
-        node = BatchOptimizedRAGNode(batch_size=2)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        processor = wf.get_node("batch_processor")
-        assert processor is not None
-        code = processor.config["code"]
-        out = _exec_codegen(
-            code,
-            {
-                "batch_plan": {
-                    "total_queries": 3,
-                    "batch_size": 2,
-                    "num_batches": 2,
-                    "batches": [
-                        {
-                            "batch_id": 0,
-                            "queries": ["machine learning", "deep learning"],
-                            "size": 2,
-                        },
-                        {
-                            "batch_id": 1,
-                            "queries": ["unrelated"],
-                            "size": 1,
-                        },
-                    ],
-                    "optimization_applied": True,
-                },
-                "documents": [
-                    {"content": "machine learning is good"},
-                    {"content": "deep learning is also good"},
-                    {"content": "completely separate topic"},
-                ],
-            },
-        )
-        batch_out = out["batch_results"]
-        # 2 batches processed.
-        assert len(batch_out["results"]) == 2
-        # Statistics carry the documented shape.
-        stats = batch_out["statistics"]
-        assert stats["total_queries_processed"] == 3
-        assert stats["batches_processed"] == 2
-        # Each batch result has per-query scores.
-        for br in batch_out["results"]:
-            assert "batch_id" in br
-            assert "query_results" in br
-            assert "batch_size" in br
-
-
-# ==========================================================================
-# Real-time stream-mode iteration through StreamingRAGNode (chunked)
-# ==========================================================================
-
-
-class TestStreamingChunkedOutput:
-    """StreamingRAGNode emits chunked stream-formatted output (the
-    documented stream contract)."""
-
-    def test_stream_formatter_yields_per_result_chunks_plus_metadata(self):
-        node = StreamingRAGNode(chunk_size=5)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        formatter = wf.get_node("stream_formatter")
-        assert formatter is not None
-        code = formatter.config["code"]
-        out = _exec_codegen(
-            code,
-            {
-                "progressive_results": {
-                    "initial": [
-                        {
-                            "doc": {"content": "alpha"},
-                            "stage": "initial",
-                            "score": 0.9,
-                        },
-                        {
-                            "doc": {"content": "beta"},
-                            "stage": "initial",
-                            "score": 0.7,
-                        },
-                    ],
-                    "has_more": True,
-                    "next_stage": "refined",
-                    "metadata": {"docs_scanned": 10, "matches_found": 2},
-                },
-            },
-        )
-        # The stream_chunks list carries one chunk per result + 1 metadata
-        # chunk = 3 total.
-        chunks = out["stream_chunks"]
-        result_chunks = [c for c in chunks if c["type"] == "result"]
-        metadata_chunks = [c for c in chunks if c["type"] == "metadata"]
-        assert len(result_chunks) == 2
-        assert len(metadata_chunks) == 1
-        # Per-result chunks carry chunk_id + score + stage.
-        for i, rc in enumerate(result_chunks):
-            assert rc["chunk_id"] == i
-            assert "score" in rc
-            assert rc["stage"] == "initial"
-        # streaming_metadata reports chunk + result counts and bp support.
-        meta = out["streaming_metadata"]
-        assert meta["total_chunks"] == 3
-        assert meta["result_chunks"] == 2
-        assert meta["supports_backpressure"] is True
-
-
-# ==========================================================================
-# F9 #1117/#1123 — CacheOptimizedRAGNode semantic_cache_manager publishes +
-# wires end-to-end through a REAL LocalRuntime (no mocking).
-# ==========================================================================
-
-
-class TestSemanticCacheManagerEndToEnd:
-    """End-to-end proof that ``semantic_cache_manager`` publishes a real
-    ``result`` port AND that its edges read ports the upstream nodes actually
-    publish.
-
-    Pre-fix defects (all confirmed to fail this test):
-
-    1. ``cache_key_generator`` publishes only the ``result`` port (code-mode
-       PythonCodeNode), so the edge reading a non-existent ``cache_keys`` port
-       raised "Source output 'cache_keys' not found ... Available: ['result']".
-    2. The edge read CacheNode's non-existent ``result`` port (CacheNode.get
-       publishes flat ``hit`` / ``value`` ports).
-    3. ``semantic_cache_manager`` read ``exact_hit`` / ``exact_result`` from
-       the cache result, but CacheNode.get publishes ``hit`` / ``value`` — so a
-       real cache hit was ALWAYS treated as a miss (``use_cache`` stuck False).
-
-    The test builds a cache subgraph from the REAL node configs the fixed
-    ``_create_workflow`` produces (no re-authoring of codegen), then runs it
-    under a real ``LocalRuntime`` — NO mocking, deterministic in-memory
-    CacheNode backend. The orthogonal ``rag_processor`` (HybridRAGNode) is
-    excluded because it carries a separate, pre-existing config-shape defect
-    (``config={"config": {...}}`` passes a dict where a ``RAGConfig`` is
-    expected) that blocks the full 5-node graph and is out of scope for this
-    ``semantic_cache_manager`` shard. The cache-decision subgraph the fix
-    repaired is exercised in full.
-    """
-
-    @staticmethod
-    def _real_node_codes() -> Dict[str, str]:
-        node = CacheOptimizedRAGNode(similarity_threshold=0.95)
-        wf = node._create_workflow()  # type: ignore[attr-defined]
-        return {
-            "cache_key_generator": wf.get_node("cache_key_generator").config["code"],
-            "semantic_cache_manager": wf.get_node("semantic_cache_manager").config[
-                "code"
-            ],
-        }
-
-    def test_cache_miss_subgraph_runs_end_to_end_and_publishes_result(self):
-        """key-gen -> CacheNode.get (miss) -> semantic_cache_manager runs
-        end-to-end under LocalRuntime and publishes the documented decision."""
-        from kailash.runtime.local import LocalRuntime
-        from kailash.workflow.builder import WorkflowBuilder
-
-        codes = self._real_node_codes()
-        builder = WorkflowBuilder()
-        builder.add_node(
-            "PythonCodeNode",
+    def _build_cache_spine(self) -> WorkflowBuilder:
+        nodes = _real_cache_nodes()
+        b = WorkflowBuilder()
+        for nid in (
             "cache_key_generator",
-            {"code": codes["cache_key_generator"]},
-        )
-        builder.add_node(
+            "semantic_cache_manager",
+            "result_aggregator",
+        ):
+            b.add_node_instance(nodes[nid], node_id=nid, _internal=True)
+        b.add_node(
             "CacheNode", "cache_checker", {"operation": "get", "backend": "memory"}
         )
-        builder.add_node(
-            "PythonCodeNode",
-            "semantic_cache_manager",
-            {"code": codes["semantic_cache_manager"]},
-        )
-        # The exact wiring the fix produced: flat exact-key string -> CacheNode
-        # `key`; CacheNode flat `hit`/`value` ports -> the manager's inputs.
-        builder.add_connection(
+        # The exact wiring _create_workflow produces.
+        b.add_connection(
             "cache_key_generator", "result.cache_keys.exact", "cache_checker", "key"
         )
-        builder.add_connection(
-            "cache_checker", "hit", "semantic_cache_manager", "cache_hit"
-        )
-        builder.add_connection(
+        b.add_connection("cache_checker", "hit", "semantic_cache_manager", "cache_hit")
+        b.add_connection(
             "cache_checker", "value", "semantic_cache_manager", "cache_value"
         )
-
-        runtime = LocalRuntime()
-        results, _run_id = runtime.execute(
-            builder.build(),
-            parameters={
-                "cache_key_generator": {"query": "what is deep learning"},
-                "semantic_cache_manager": {"query": "what is deep learning"},
-            },
+        b.add_connection(
+            "semantic_cache_manager", "result", "result_aggregator", "cache_decision"
         )
+        return b
 
-        # semantic_cache_manager published a NON-EMPTY result with the
-        # documented keys (empty cache -> miss).
-        published = results["semantic_cache_manager"]["result"]
-        assert published, "semantic_cache_manager published an empty result"
-        assert published["use_cache"] is False
-        assert published["cache_type"] is None
+    def test_cache_miss_spine_publishes_real_output(self):
+        """Empty cache → miss → aggregator publishes a real fresh-source result
+        end-to-end. Pre-migration the manager could publish nothing (#1117);
+        this proves the real ``result`` port flows to the documented consumer."""
+        b = self._build_cache_spine()
+        with LocalRuntime() as rt:
+            results, _ = rt.execute(
+                b.build(),
+                parameters={
+                    "cache_key_generator": {"query": "what is deep learning"},
+                    "semantic_cache_manager": {"query": "what is deep learning"},
+                },
+            )
+        decision = results["semantic_cache_manager"]["result"]
+        assert decision, "semantic_cache_manager published an empty result"
+        assert decision["use_cache"] is False
+        assert decision["cache_type"] is None
+        # The aggregator (documented downstream consumer) received the decision.
+        aggregated = results["result_aggregator"]["result"]["optimized_results"]
+        assert aggregated["metadata"]["source"] == "fresh"
+        assert aggregated["performance"]["cache_hit"] is False
 
     def test_cache_hit_detected_from_real_cachenode_shape(self):
-        """The contract-alignment fix: semantic_cache_manager reads CacheNode's
-        REAL ``hit`` / ``value`` ports, so a populated cache yields an exact
-        hit. Pre-fix (reading ``exact_hit`` / ``exact_result``) this returned a
-        miss for every real CacheNode get — the load-bearing regression."""
-        from kailash.runtime.local import LocalRuntime
-        from kailash.workflow.builder import WorkflowBuilder
-
-        codes = self._real_node_codes()
-        builder = WorkflowBuilder()
-        builder.add_node(
-            "PythonCodeNode",
-            "semantic_cache_manager",
-            {"code": codes["semantic_cache_manager"]},
+        """The contract-alignment fix: the manager reads CacheNode's REAL
+        ``hit`` / ``value`` ports, so a populated cache yields an exact hit that
+        flows through to the aggregator's cache-source output."""
+        nodes = _real_cache_nodes()
+        b = WorkflowBuilder()
+        b.add_node_instance(
+            nodes["semantic_cache_manager"],
+            node_id="semantic_cache_manager",
+            _internal=True,
         )
-        runtime = LocalRuntime()
-        # Feed CacheNode.get's real hit-shape ports directly.
-        results, _run_id = runtime.execute(
-            builder.build(),
-            parameters={
-                "semantic_cache_manager": {
-                    "cache_hit": True,
-                    "cache_value": {"results": ["cached_doc"], "scores": [0.99]},
-                    "query": "what is deep learning",
-                }
-            },
+        b.add_node_instance(
+            nodes["result_aggregator"], node_id="result_aggregator", _internal=True
         )
-        published = results["semantic_cache_manager"]["result"]
-        assert published["use_cache"] is True
-        assert published["cache_type"] == "exact"
-        assert published["cached_result"] == {
-            "results": ["cached_doc"],
-            "scores": [0.99],
-        }
+        b.add_connection(
+            "semantic_cache_manager", "result", "result_aggregator", "cache_decision"
+        )
+        with LocalRuntime() as rt:
+            results, _ = rt.execute(
+                b.build(),
+                parameters={
+                    "semantic_cache_manager": {
+                        "cache_hit": True,
+                        "cache_value": {
+                            "results": ["cached_doc"],
+                            "scores": [0.99],
+                        },
+                        "query": "what is deep learning",
+                    }
+                },
+            )
+        decision = results["semantic_cache_manager"]["result"]
+        assert decision["use_cache"] is True
+        assert decision["cache_type"] == "exact"
+        aggregated = results["result_aggregator"]["result"]["optimized_results"]
+        assert aggregated["metadata"]["source"] == "cache"
+        assert aggregated["results"] == ["cached_doc"]
+        assert aggregated["performance"]["cache_hit"] is True
 
-    def test_semantic_cache_manager_binds_module_scope_result(self):
-        """F9 #1117 acceptance criterion: the codegen ends with a module-scope
-        (column-0) ``result =`` so PythonCodeNode publishes the ``result``
-        port. Pre-fix the assignment lived only inside if/else branches (never
-        at column 0)."""
-        import re
+    def test_red_pre_stripping_cache_wiring_breaks_aggregation(self):
+        """RED-PRE receipt: if the manager→aggregator edge is STRIPPED, the
+        aggregator cannot receive the decision and produces the honest empty
+        default (source=fresh, empty results) — proving the wiring is
+        load-bearing, not decorative. With the edge present (above tests) the
+        decision flows; without it the cached output never reaches the
+        consumer."""
+        nodes = _real_cache_nodes()
+        b = WorkflowBuilder()
+        # Manager produces a cache HIT, but the edge to the aggregator is OMITTED.
+        b.add_node_instance(
+            nodes["result_aggregator"], node_id="result_aggregator", _internal=True
+        )
+        with LocalRuntime() as rt:
+            results, _ = rt.execute(
+                b.build(),
+                # No cache_decision wired → honest empty default.
+                parameters={"result_aggregator": {}},
+            )
+        aggregated = results["result_aggregator"]["result"]["optimized_results"]
+        # Without the wiring, the cached result NEVER reaches the consumer.
+        assert aggregated["results"] == []
+        assert aggregated["performance"]["cache_hit"] is False
 
-        codes = self._real_node_codes()
-        code = codes["semantic_cache_manager"]
-        assert re.search(
-            r"^result\s*=", code, re.M
-        ), "semantic_cache_manager codegen does not bind `result` at module scope"
+
+# ==========================================================================
+# AsyncParallelRAGNode — executor → combiner spine end-to-end (production path)
+# ==========================================================================
+
+
+class TestParallelSpineEndToEnd:
+    """parallel_executor → result_combiner runs end-to-end under a real
+    LocalRuntime, with the REAL from_function nodes and the REAL
+    ``result.execution_plan`` wiring (the latent #1117 nested-port defect this
+    migration closed)."""
+
+    def _build_parallel_spine(self, strategies: List[str]) -> WorkflowBuilder:
+        nodes = _real_parallel_nodes(strategies)
+        b = WorkflowBuilder()
+        b.add_node_instance(
+            nodes["parallel_executor"], node_id="parallel_executor", _internal=True
+        )
+        b.add_node_instance(
+            nodes["result_combiner"], node_id="result_combiner", _internal=True
+        )
+        # The exact wiring _create_workflow produces: executor publishes
+        # `result.execution_plan`, NOT a phantom `execution_plan` port.
+        b.add_connection(
+            "parallel_executor",
+            "result.execution_plan",
+            "result_combiner",
+            "execution_plan",
+        )
+        return b
+
+    def test_executor_plan_reaches_combiner_and_fuses(self):
+        """The executor's plan flows to the combiner via ``result.execution_plan``
+        AND the per-strategy results fuse into a single ranked list — the full
+        migrated spine end-to-end."""
+        b = self._build_parallel_spine(["semantic", "hybrid"])
+        with LocalRuntime() as rt:
+            results, _ = rt.execute(
+                b.build(),
+                parameters={
+                    "parallel_executor": {
+                        "query": "q",
+                        "documents": [{"id": "d1", "content": "x"}],
+                    },
+                    "result_combiner": {
+                        "semantic_results": {
+                            "results": [
+                                {"id": "doc1", "content": "a"},
+                                {"id": "doc2", "content": "b"},
+                            ],
+                            "scores": [0.9, 0.7],
+                        },
+                        "hybrid_results": {
+                            "results": [
+                                {"id": "doc1", "content": "a"},
+                                {"id": "doc3", "content": "c"},
+                            ],
+                            "scores": [0.8, 0.6],
+                        },
+                    },
+                },
+            )
+        parallel = results["result_combiner"]["result"]["parallel_results"]
+        assert {r["id"] for r in parallel["results"]} == {"doc1", "doc2", "doc3"}
+        # doc1 (in both, mean 0.85) ranks first.
+        assert parallel["results"][0]["id"] == "doc1"
+        assert parallel["scores"][0] == pytest.approx(0.85)
+        assert parallel["metadata"]["strategy_agreements"] == 1
+        assert set(parallel["metadata"]["strategies_used"]) == {"semantic", "hybrid"}
+
+    def test_executor_publishes_real_plan_port(self):
+        """The executor publishes a real, non-empty plan on the flat ``result``
+        port (pre-migration the edge read a phantom port that never existed)."""
+        nodes = _real_parallel_nodes(["semantic", "hybrid"])
+        b = WorkflowBuilder()
+        b.add_node_instance(
+            nodes["parallel_executor"], node_id="parallel_executor", _internal=True
+        )
+        with LocalRuntime() as rt:
+            results, _ = rt.execute(
+                b.build(),
+                parameters={
+                    "parallel_executor": {
+                        "query": "q",
+                        "documents": [{"id": "d1", "content": "x"}],
+                    }
+                },
+            )
+        published = results["parallel_executor"]["result"]
+        assert published["execution_plan"]["strategies"] == ["semantic", "hybrid"]
+        assert published["execution_plan"]["parallel_count"] == 2
+
+    def test_red_pre_phantom_port_wiring_drops_plan_silently(self, caplog):
+        """RED-PRE receipt: the executor publishes its plan ONLY on the flat
+        ``result`` port. Wiring the combiner to the OLD phantom ``execution_plan``
+        source port (the pre-migration edge) silently DROPS the plan — the
+        runtime logs "Source output 'execution_plan' not found ... Available
+        outputs: ['result']" and the combiner receives ``execution_plan=None``
+        (honest 0.0 default). With the correct ``result.execution_plan`` wiring
+        (``test_executor_plan_reaches_combiner_and_fuses``) the plan flows. This
+        IS the #1117 silent-drop failure mode the migration's re-wiring closed."""
+        import logging
+
+        nodes = _real_parallel_nodes(["semantic"])
+        b = WorkflowBuilder()
+        b.add_node_instance(
+            nodes["parallel_executor"], node_id="parallel_executor", _internal=True
+        )
+        b.add_node_instance(
+            nodes["result_combiner"], node_id="result_combiner", _internal=True
+        )
+        # The PRE-FIX phantom edge: executor publishes only `result`, never a
+        # top-level `execution_plan` port.
+        b.add_connection(
+            "parallel_executor", "execution_plan", "result_combiner", "execution_plan"
+        )
+        with caplog.at_level(logging.WARNING):
+            with LocalRuntime() as rt:
+                results, _ = rt.execute(
+                    b.build(),
+                    parameters={
+                        "parallel_executor": {
+                            "query": "q",
+                            "documents": [{"id": "d1", "content": "x"}],
+                        },
+                        "result_combiner": {
+                            "semantic_results": {
+                                "results": [{"id": "doc1", "content": "a"}],
+                                "scores": [0.9],
+                            }
+                        },
+                    },
+                )
+        # The runtime surfaced the missing source output (the #1117 signature).
+        assert any(
+            "execution_plan" in rec.getMessage() and "not found" in rec.getMessage()
+            for rec in caplog.records
+        ), "expected a missing-source-output log for the phantom execution_plan port"
+        # The plan never reached the combiner → honest 0.0 total-time default
+        # (a real plan would carry a parseable start_time).
+        parallel = results["result_combiner"]["result"]["parallel_results"]
+        assert parallel["metadata"]["total_execution_time"] == 0.0
+
+    def test_unknown_strategy_results_wire_via_dynamic_signature(self):
+        """The dynamic-signature factory declares a ``<strategy>_results`` input
+        for an arbitrary (unknown) strategy name, so its results wire and fuse —
+        the dynamic-strategy case the prior ``locals()`` codegen handled."""
+        b = self._build_parallel_spine(["unknown_strategy"])
+        with LocalRuntime() as rt:
+            results, _ = rt.execute(
+                b.build(),
+                parameters={
+                    "parallel_executor": {
+                        "query": "q",
+                        "documents": [{"id": "d1", "content": "x"}],
+                    },
+                    "result_combiner": {
+                        "unknown_strategy_results": {
+                            "results": [{"id": "docU", "content": "u"}],
+                            "scores": [0.5],
+                        }
+                    },
+                },
+            )
+        parallel = results["result_combiner"]["result"]["parallel_results"]
+        assert [r["id"] for r in parallel["results"]] == ["docU"]
+        assert parallel["metadata"]["strategies_used"] == ["unknown_strategy"]
+
+
+# ==========================================================================
+# StreamingRAGNode — full streaming spine end-to-end (production path)
+# ==========================================================================
+
+
+class TestStreamingSpineEndToEnd:
+    """The FULL streaming workflow (stream_controller → progressive_retriever →
+    stream_formatter) runs end-to-end under a real LocalRuntime via the
+    PRODUCTION ``_create_workflow()`` graph — every node is a real
+    ``from_function`` node, and the wiring is the REAL dotted-path
+    ``result.streaming_plan`` / ``result.progressive_results`` (the latent #1117
+    nested-port defect this migration closed)."""
+
+    def _streaming_workflow(self, chunk_size: int = 100):
+        """The real production workflow the node builds (no re-authoring)."""
+        return StreamingRAGNode(chunk_size=chunk_size)._create_workflow()  # type: ignore[attr-defined]
+
+    def test_full_streaming_spine_publishes_real_chunks(self):
+        """The controller's plan flows to the retriever (``result.streaming_plan``),
+        the retriever's results flow to the formatter
+        (``result.progressive_results``), and the formatter publishes real
+        stream chunks — the full migrated spine end-to-end through the
+        production graph. Pre-migration the edges read phantom top-level ports
+        that never existed (#1117), so nothing reached the formatter."""
+        wf = self._streaming_workflow(chunk_size=100)
+        with LocalRuntime() as rt:
+            results, _ = rt.execute(
+                wf,
+                parameters={
+                    "progressive_retriever": {
+                        "query": "deep learning",
+                        "documents": [
+                            {"id": "d1", "content": "deep learning models"},
+                            {"id": "d2", "content": "unrelated topic"},
+                        ],
+                    }
+                },
+            )
+        # The controller bound chunk_size through the closure.
+        plan = results["stream_controller"]["result"]["streaming_plan"]
+        assert plan["chunk_size"] == 100
+        # The retriever found exactly the one overlapping doc.
+        prog = results["progressive_retriever"]["result"]["progressive_results"]
+        assert prog["metadata"]["matches_found"] == 1
+        # The formatter (documented downstream consumer) published real chunks.
+        formatted = results["stream_formatter"]["result"]
+        assert [c["type"] for c in formatted["stream_chunks"]] == [
+            "result",
+            "metadata",
+        ]
+        assert formatted["streaming_metadata"]["result_chunks"] == 1
+        assert formatted["streaming_metadata"]["supports_backpressure"] is True
+
+    def test_red_pre_phantom_port_drops_streaming_plan_silently(self, caplog):
+        """RED-PRE receipt: the controller publishes its plan ONLY on the flat
+        ``result`` port. Wiring the retriever to the OLD phantom
+        ``streaming_plan`` source port (the pre-migration edge) silently DROPS
+        the plan — the runtime logs the missing source output and the retriever
+        falls back to its honest default k of 3. This IS the #1117 silent-drop
+        failure mode the migration's re-wiring closed (with the correct
+        ``result.streaming_plan`` wiring above, the plan flows)."""
+        import logging
+
+        src = self._streaming_workflow(chunk_size=100)
+        nodes = {nid: src.get_node(nid) for nid in src.nodes}
+        b = WorkflowBuilder()
+        b.add_node_instance(
+            nodes["stream_controller"], node_id="stream_controller", _internal=True
+        )
+        b.add_node_instance(
+            nodes["progressive_retriever"],
+            node_id="progressive_retriever",
+            _internal=True,
+        )
+        # The PRE-FIX phantom edge: controller publishes only `result`, never a
+        # top-level `streaming_plan` port.
+        b.add_connection(
+            "stream_controller",
+            "streaming_plan",
+            "progressive_retriever",
+            "streaming_plan",
+        )
+        with caplog.at_level(logging.WARNING):
+            with LocalRuntime() as rt:
+                results, _ = rt.execute(
+                    b.build(),
+                    parameters={
+                        "progressive_retriever": {
+                            "query": "a b c d",
+                            "documents": [
+                                {"id": str(i), "content": "a b c d"} for i in range(5)
+                            ],
+                        }
+                    },
+                )
+        # The runtime surfaced the missing source output (the #1117 signature).
+        assert any(
+            "streaming_plan" in rec.getMessage() and "not found" in rec.getMessage()
+            for rec in caplog.records
+        ), "expected a missing-source-output log for the phantom streaming_plan port"
+        # The plan never reached the retriever → honest default k of 3 applied.
+        prog = results["progressive_retriever"]["result"]["progressive_results"]
+        assert len(prog["initial"]) == 3
+
+
+# ==========================================================================
+# BatchOptimizedRAGNode — full batch spine end-to-end (production path)
+# ==========================================================================
+
+
+class TestBatchSpineEndToEnd:
+    """The FULL batch workflow (batch_organizer → batch_processor →
+    result_formatter, plus organizer → formatter) runs end-to-end under a real
+    LocalRuntime via the PRODUCTION ``_create_workflow()`` graph — every node is
+    a real ``from_function`` node, and the wiring is the REAL dotted-path
+    ``result.batch_plan`` / ``result.batch_results`` (the latent #1117
+    nested-port defect this migration closed)."""
+
+    def _batch_workflow(self, batch_size: int = 2):
+        return BatchOptimizedRAGNode(batch_size=batch_size)._create_workflow()  # type: ignore[attr-defined]
+
+    def test_full_batch_spine_maps_results_per_query(self):
+        """The organizer's plan flows to the processor + formatter
+        (``result.batch_plan``), the processor's scores flow to the formatter
+        (``result.batch_results``), and the formatter publishes per-query
+        documents — the full migrated spine end-to-end through the production
+        graph."""
+        documents = [
+            {"id": "d1", "content": "alpha beta"},
+            {"id": "d2", "content": "gamma"},
+        ]
+        wf = self._batch_workflow(batch_size=2)
+        with LocalRuntime() as rt:
+            results, _ = rt.execute(
+                wf,
+                parameters={
+                    "batch_organizer": {"queries": ["alpha", "beta"]},
+                    "batch_processor": {"documents": documents},
+                    "result_formatter": {"documents": documents},
+                },
+            )
+        # The organizer bound batch_size through the closure.
+        assert results["batch_organizer"]["result"]["batch_plan"]["batch_size"] == 2
+        # The processor scored both queries.
+        proc_stats = results["batch_processor"]["result"]["batch_results"]["statistics"]
+        assert proc_stats["total_queries_processed"] == 2
+        # The formatter (documented downstream consumer) mapped scores back to
+        # per-query documents.
+        final = results["result_formatter"]["result"]["final_batch_results"]
+        assert set(final["processing_order"]) == {"alpha", "beta"}
+        # "alpha" overlaps d1 only (positive-score filter).
+        assert final["query_results"]["alpha"]["results"] == [
+            {"id": "d1", "content": "alpha beta"}
+        ]
+
+    def test_red_pre_phantom_port_drops_batch_plan_silently(self, caplog):
+        """RED-PRE receipt: the organizer publishes its plan ONLY on the flat
+        ``result`` port. Wiring the processor to the OLD phantom ``batch_plan``
+        source port (the pre-migration edge) silently DROPS the plan — the
+        runtime logs the missing source output and the processor falls back to
+        its honest zero-query default. This IS the #1117 silent-drop failure
+        mode the migration's re-wiring closed (with the correct
+        ``result.batch_plan`` wiring above, the plan flows)."""
+        import logging
+
+        src = self._batch_workflow(batch_size=2)
+        nodes = {nid: src.get_node(nid) for nid in src.nodes}
+        b = WorkflowBuilder()
+        b.add_node_instance(
+            nodes["batch_organizer"], node_id="batch_organizer", _internal=True
+        )
+        b.add_node_instance(
+            nodes["batch_processor"], node_id="batch_processor", _internal=True
+        )
+        # The PRE-FIX phantom edge: organizer publishes only `result`, never a
+        # top-level `batch_plan` port.
+        b.add_connection(
+            "batch_organizer", "batch_plan", "batch_processor", "batch_plan"
+        )
+        with caplog.at_level(logging.WARNING):
+            with LocalRuntime() as rt:
+                results, _ = rt.execute(
+                    b.build(),
+                    parameters={
+                        "batch_organizer": {"queries": ["alpha", "beta"]},
+                        "batch_processor": {
+                            "documents": [{"id": "d1", "content": "alpha"}]
+                        },
+                    },
+                )
+        # The runtime surfaced the missing source output (the #1117 signature).
+        assert any(
+            "batch_plan" in rec.getMessage() and "not found" in rec.getMessage()
+            for rec in caplog.records
+        ), "expected a missing-source-output log for the phantom batch_plan port"
+        # The plan never reached the processor → honest zero-query default.
+        proc_stats = results["batch_processor"]["result"]["batch_results"]["statistics"]
+        assert proc_stats["total_queries_processed"] == 0

--- a/packages/kailash-kaizen/tests/integration/rag/test_workflows_nodes.py
+++ b/packages/kailash-kaizen/tests/integration/rag/test_workflows_nodes.py
@@ -265,21 +265,34 @@ class TestWorkflowCodegenRealExecution:
         assert "structured" in result["content_types"]
 
     def test_runtime_executes_codegen_node_in_isolation(self):
-        """A real LocalRuntime executes a single-node workflow of the codegen.
+        """A real LocalRuntime executes a single-node workflow of the lifted fn.
 
-        This proves the content:None-guarded codegen runs under the real
-        runtime — not only the node's direct execute() path.
+        This proves the content:None-guarded analyzer LOGIC runs under the real
+        runtime — not only the node's direct execute() path. Post-migration the
+        ``quality_analyzer`` is a ``PythonCodeNode.from_function(_analyze_documents)``
+        node (its prior ``config["code"]`` string is gone — ``config.get("code")``
+        is None), so this exercises the SAME production function via
+        ``from_function`` in an isolated single-node workflow, preserving the
+        original assertion intent (the lifted analyzer's logic yields
+        ``total_docs == 3`` against the mixed corpus under a real LocalRuntime).
         """
+        from kailash.nodes.code.python import PythonCodeNode
         from kailash.workflow.builder import WorkflowBuilder
 
-        analyzer_code = _node(
-            _wf(AdvancedRAGWorkflowNode()), "quality_analyzer"
-        ).config["code"]
+        from kaizen.nodes.rag.workflows import _analyze_documents
+
+        # The migrated node no longer carries a `code` string to re-exec.
+        analyzer_node = _node(_wf(AdvancedRAGWorkflowNode()), "quality_analyzer")
+        assert analyzer_node.config.get("code") is None
+
         builder = WorkflowBuilder()
-        builder.add_node(
-            "PythonCodeNode",
+        builder.add_node_instance(
+            PythonCodeNode.from_function(  # type: ignore[attr-defined]
+                _analyze_documents,
+                name="analyzer",
+            ),
             node_id="analyzer",
-            config={"code": analyzer_code},
+            _internal=True,
         )
         runtime = LocalRuntime()
         results, _ = runtime.execute(

--- a/packages/kailash-kaizen/tests/regression/test_issue_f31_fu4_wrong_shape_adapters.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f31_fu4_wrong_shape_adapters.py
@@ -1,0 +1,358 @@
+"""Regression: F31-FU4 — wrong-shape-adapter false-greens masked real
+production parse defects.
+
+Production LLMAgentNode publishes its result envelope with "response" as a
+NESTED dict: ``{"success": True, "response": {"content": ..., "role": ...},
+...}`` (src/kaizen/nodes/ai/llm_agent.py:995; docstring :586). The FU4 audit
+(2026-06-10, 55 doubles across 26 non-RAG test files) confirmed three test
+doubles publishing shapes production never emits, two of which masked real
+production defects:
+
+1. ``Agent.communicate_with`` (src/kaizen/core/agents.py) str()'d the nested
+   response dict — agent-to-agent messages and conversation history carried
+   dict reprs instead of the response text.
+2. ``EnterpriseAuthProviderNode._ai_risk_assessment``
+   (src/kaizen/nodes/auth/enterprise_auth_provider.py) read
+   ``result.get("content")`` — the key-miss yielded "{}" so every AI-path
+   risk assessment silently returned score 0.0 / "allow" (fail-open; AI
+   fraud detection disabled in production).
+3. ``SSOAuthenticationNode`` AI-path tests routed through the rule-based
+   fallback via wrong-shape envelopes (production parse was correct).
+
+These tests feed the DOCS-EXACT production envelope through each fixed path.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.fixtures.consolidated_test_fixtures import consolidated_fixtures
+
+PRODUCTION_TEXT = "Hello from agent B"
+
+
+@pytest.fixture(autouse=True)
+def _default_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Framework/node creation resolves the model from the environment;
+    supply a deterministic unit-tier value (issue-822 pattern)."""
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
+
+
+def _production_envelope(content: str) -> dict:
+    """The LLMAgentNode result envelope (llm_agent.py:993-1012)."""
+    return {
+        "success": True,
+        "response": {"content": content, "role": "assistant"},
+    }
+
+
+@pytest.mark.regression
+@patch("kailash.runtime.local.LocalRuntime.execute")
+def test_communicate_with_extracts_content_from_production_envelope(mock_execute):
+    """communicate_with must return the response TEXT, never the dict repr."""
+    import kaizen
+
+    mock_execute.return_value = (
+        {"comm_response_agent_b": _production_envelope(PRODUCTION_TEXT)},
+        "test_run_id",
+    )
+
+    config = consolidated_fixtures.get_configuration("minimal")
+    framework = kaizen.Framework(config=config)
+    agent_a = framework.create_agent(config={"name": "agent_a", "role": "analyst"})
+    agent_b = framework.create_agent(config={"name": "agent_b", "role": "researcher"})
+
+    response = agent_a.communicate_with(
+        target_agent=agent_b, message="What's your analysis?", context={}
+    )
+
+    # Equality, not substring: the pre-fix dict repr CONTAINED the text,
+    # so a substring assertion would false-green.
+    assert response["message"] == PRODUCTION_TEXT
+    # Conversation history must carry the text too (agents.py history entry)
+    history = agent_a._conversation_history["agent_b"]
+    assert history[-1]["response"] == PRODUCTION_TEXT
+
+
+@pytest.mark.regression
+def test_communicate_with_still_accepts_legacy_flat_string():
+    """Dual-shape contract: a legacy flat-string response still extracts."""
+    import kaizen
+
+    with patch("kailash.runtime.local.LocalRuntime.execute") as mock_execute:
+        mock_execute.return_value = (
+            {"comm_response_agent_b": {"response": PRODUCTION_TEXT}},
+            "test_run_id",
+        )
+        config = consolidated_fixtures.get_configuration("minimal")
+        framework = kaizen.Framework(config=config)
+        agent_a = framework.create_agent(config={"name": "agent_a", "role": "analyst"})
+        agent_b = framework.create_agent(
+            config={"name": "agent_b", "role": "researcher"}
+        )
+
+        response = agent_a.communicate_with(
+            target_agent=agent_b, message="ping", context={}
+        )
+        assert response["message"] == PRODUCTION_TEXT
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_enterprise_auth_ai_risk_parses_production_envelope():
+    """AI risk assessment must parse the nested envelope — pre-fix it
+    silently returned score 0.0/'allow' for EVERY production response."""
+    from kaizen.nodes.auth.enterprise_auth_provider import EnterpriseAuthProviderNode
+
+    node = EnterpriseAuthProviderNode()
+    analysis = {
+        "risk_score": 0.95,
+        "additional_factors": ["credential_stuffing"],
+        "reasoning": "High-velocity failures from anonymized IP",
+        "recommended_action": "block",
+    }
+    node.llm_agent.async_run = AsyncMock(
+        return_value=_production_envelope(json.dumps(analysis))
+    )
+
+    result = await node._ai_risk_assessment(
+        "user@company.com", {"ip_address": "203.0.113.42"}, []
+    )
+
+    assert result["score"] == 0.95
+    assert result["recommended_action"] == "block"
+    assert result["factors"] == ["credential_stuffing"]
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_enterprise_auth_malformed_envelope_fails_closed_to_rule_based():
+    """A malformed envelope (the OLD flat shape) must route to the
+    rule-based fallback — never the silent 0.0/'allow' default."""
+    from kailash.nodes.auth.enterprise_auth_provider import (
+        EnterpriseAuthProviderNode as CoreEnterpriseAuthNode,
+    )
+
+    from kaizen.nodes.auth.enterprise_auth_provider import EnterpriseAuthProviderNode
+
+    node = EnterpriseAuthProviderNode()
+    # The OLD wrong shape: flat top-level "content", no nested response
+    node.llm_agent.async_run = AsyncMock(
+        return_value={"content": json.dumps({"risk_score": 0.95})}
+    )
+
+    sentinel = {
+        "score": 0.42,
+        "factors": ["rule_based_sentinel"],
+        "reasoning": "rule-based fallback engaged",
+        "recommended_action": "require_additional_verification",
+    }
+    with patch.object(
+        CoreEnterpriseAuthNode,
+        "_ai_risk_assessment",
+        new=AsyncMock(return_value=sentinel),
+    ):
+        result = await node._ai_risk_assessment(
+            "user@company.com", {"ip_address": "203.0.113.42"}, []
+        )
+
+    # Fallback engaged — NOT the fail-open silent default (0.0/"allow")
+    assert result == sentinel
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_directory_security_settings_parse_production_envelope():
+    """R1 security-reviewer sibling sweep: directory_integration.py carried
+    the same flat-shape parse at 4 sites — _ai_security_settings is the
+    security-relevant one (AI-driven MFA tightening was silently dead)."""
+    from kaizen.nodes.auth.directory_integration import DirectoryIntegrationNode
+
+    node = DirectoryIntegrationNode()
+    node.llm_agent.async_run = AsyncMock(
+        return_value=_production_envelope(
+            json.dumps(
+                {
+                    "mfa_required": True,
+                    "password_expiry_days": 60,
+                    "session_timeout_minutes": 240,
+                }
+            )
+        )
+    )
+
+    settings = await node._ai_security_settings(
+        {"job_title": "Infrastructure Admin", "groups": ["admin"]}
+    )
+
+    # Pre-fix: every production envelope key-missed -> "{}" -> settings == {}
+    # and the AI's MFA escalation never fired.
+    assert settings["mfa_required"] is True
+    assert settings["password_expiry_days"] == 60
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_directory_security_settings_malformed_envelope_fails_closed():
+    """A malformed envelope (the OLD flat shape) must engage the documented
+    safe-defaults fallback — never the silent empty dict."""
+    from kaizen.nodes.auth.directory_integration import DirectoryIntegrationNode
+
+    node = DirectoryIntegrationNode()
+    node.llm_agent.async_run = AsyncMock(
+        return_value={"content": json.dumps({"mfa_required": True})}
+    )
+
+    settings = await node._ai_security_settings({"job_title": "Admin"})
+
+    # The documented except-branch fallback, not {} (pre-fix) and not the
+    # attacker-influencable parsed value.
+    assert settings == {
+        "mfa_required": False,
+        "password_expiry_days": 90,
+        "session_timeout_minutes": 480,
+    }
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_directory_role_assignment_parses_production_envelope_and_fails_closed():
+    """_ai_role_assignment: production envelope parses; malformed envelope
+    engages the documented least-privilege ["user"] fallback."""
+    from kaizen.nodes.auth.directory_integration import DirectoryIntegrationNode
+
+    node = DirectoryIntegrationNode()
+    node.llm_agent.async_run = AsyncMock(
+        return_value=_production_envelope(json.dumps(["user", "developer"]))
+    )
+    roles = await node._ai_role_assignment(
+        {"email": "dev@company.com", "job_title": "Engineer"}
+    )
+    assert roles == ["user", "developer"]
+
+    node.llm_agent.async_run = AsyncMock(
+        return_value={"content": json.dumps(["admin"])}  # OLD flat shape
+    )
+    fallback_roles = await node._ai_role_assignment(
+        {"email": "dev@company.com", "job_title": "Engineer"}
+    )
+    # Least-privilege fallback — the flat shape must never grant "admin".
+    assert fallback_roles == ["user"]
+
+
+class _EnvelopeLLMAgentNodeStub:
+    """Stands in for the module-level LLMAgentNode the security nodes
+    instantiate inside their _call_llm_* methods."""
+
+    return_value: dict = {}
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def execute(self, *args, **kwargs):
+        return type(self).return_value
+
+
+@pytest.mark.regression
+def test_threat_detection_parses_production_envelope_and_fails_closed(monkeypatch):
+    """R2 security sweep sibling: ai_threat_detection.py read the flat shape —
+    AI threat intelligence was silently dead (dict.split AttributeError
+    swallowed by the except)."""
+    import kaizen.nodes.security.ai_threat_detection as td_mod
+
+    monkeypatch.setattr(td_mod, "LLMAgentNode", _EnvelopeLLMAgentNodeStub)
+    node = td_mod.AIThreatDetectionNode()
+
+    text = "Narrative.\nThreat Intelligence: lateral movement suspected."
+    _EnvelopeLLMAgentNodeStub.return_value = _production_envelope(text)
+    out = node._call_llm_for_intelligence({"threats": []}, [])
+    assert out["ai_available"] is True
+    assert out["narrative"] == text
+    assert out["intelligence"] == {"analysis": "lateral movement suspected."}
+
+    # Malformed (OLD flat) envelope -> documented ai_available=False degrade
+    _EnvelopeLLMAgentNodeStub.return_value = {"success": True, "response": text}
+    out2 = node._call_llm_for_intelligence({"threats": []}, [])
+    # flat STRING is the legacy-tolerated shape and still parses
+    assert out2["ai_available"] is True
+    _EnvelopeLLMAgentNodeStub.return_value = {"success": True, "response": {}}
+    out3 = node._call_llm_for_intelligence({"threats": []}, [])
+    assert out3["ai_available"] is False
+    assert "error" in out3
+
+
+@pytest.mark.regression
+def test_behavior_analysis_parses_production_envelope_and_fails_closed(monkeypatch):
+    """Same sibling class in ai_behavior_analysis.py."""
+    import kaizen.nodes.security.ai_behavior_analysis as ba_mod
+
+    monkeypatch.setattr(ba_mod, "LLMAgentNode", _EnvelopeLLMAgentNodeStub)
+    node = ba_mod.AIBehaviorAnalysisNode()
+
+    text = "Explanation.\nResponse Recommendations:\n- rotate credentials"
+    _EnvelopeLLMAgentNodeStub.return_value = _production_envelope(text)
+    out = node._call_llm_for_analysis({}, [], {})
+    assert out["ai_available"] is True
+    assert out["explanation"] == text
+    assert out["recommendations"] == ["rotate credentials"]
+
+    _EnvelopeLLMAgentNodeStub.return_value = {"success": True, "response": {}}
+    out2 = node._call_llm_for_analysis({}, [], {})
+    assert out2["ai_available"] is False
+    assert "error" in out2
+
+
+@pytest.mark.regression
+def test_gdpr_ai_compliance_parses_production_envelope_and_fails_closed():
+    """Same sibling class in compliance/gdpr.py — AI compliance analysis
+    returned None on every production envelope (json.loads(dict) TypeError
+    swallowed)."""
+    from unittest.mock import Mock
+
+    from kaizen.nodes.compliance.gdpr import GDPRComplianceNode
+
+    node = GDPRComplianceNode(ai_analysis=True)
+    analysis = {
+        "risk_level": "high",
+        "legal_implications": ["Art. 32"],
+        "best_practices": [],
+        "remediation_steps": ["encrypt at rest"],
+        "additional_insights": [],
+    }
+    node.ai_agent = Mock()
+    node.ai_agent.execute = Mock(
+        return_value=_production_envelope(json.dumps(analysis))
+    )
+
+    out = node._ai_analyze_compliance({}, "user_record", [], [], [])
+    assert out is not None
+    assert out["risk_level"] == "high"
+    assert out["remediation_steps"] == ["encrypt at rest"]
+
+    # Malformed envelope -> documented None degrade (never a parsed value)
+    node.ai_agent.execute = Mock(return_value={"success": True, "response": {}})
+    assert node._ai_analyze_compliance({}, "user_record", [], [], []) is None
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_sso_ai_field_mapping_exercises_ai_path_with_production_envelope():
+    """SSO AI field mapping under the production envelope surfaces the
+    AI-mapped fields — the rule-based fallback would yield None for these."""
+    from kaizen.nodes.auth.sso import SSOAuthenticationNode
+
+    node = SSOAuthenticationNode()
+    node.llm_agent.async_run = AsyncMock(
+        return_value=_production_envelope(
+            json.dumps(
+                {"first_name": "Test", "last_name": "User", "email": "test@azure.com"}
+            )
+        )
+    )
+
+    result = await node._ai_field_mapping({"email": "test@azure.com"}, "azure")
+
+    assert result["first_name"] == "Test"
+    assert result["last_name"] == "User"
+    assert result["email"] == "test@azure.com"

--- a/packages/kailash-kaizen/tests/regression/test_issue_f31_fu5_numpy_lazy_import.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f31_fu5_numpy_lazy_import.py
@@ -1,0 +1,213 @@
+"""Regression: F31-FU5 — numpy is a [rag]-extra dependency; the base import
+surface must not require it.
+
+Pre-fix failure chain: ``kaizen/__init__.py`` -> ``kaizen_agents`` ->
+``patterns/runtime.py`` -> ``from kaizen.nodes.ai.a2a import A2AAgentCard``
+-> ``kaizen/nodes/ai/__init__.py`` eagerly imports ``hybrid_search`` /
+``semantic_memory`` (module-scope ``import numpy``) -> ImportError ->
+runtime.py fallback sets ``A2AAgentCard = None`` -> the eagerly-evaluated
+PEP-604 annotation ``A2AAgentCard | None`` raises
+``TypeError: unsupported operand type(s) for |: 'NoneType' and 'NoneType'``
+at class-creation time, so even bare ``import kaizen`` hard-crashed on any
+install without the [rag] extra.
+
+Fix: lazy numpy in nodes/ai (TYPE_CHECKING + ``require_numpy()`` with [rag]
+install guidance) + ``from __future__ import annotations`` in
+kaizen_agents/patterns/runtime.py.
+
+``import kaizen.nodes.rag`` still requires the [rag] extra BY DESIGN (the
+pyproject [rag] extra is documented as "the complete `import kaizen.nodes.rag`
+dependency set") — the test asserts that failure stays a clean
+ModuleNotFoundError, never a TypeError.
+
+Subprocess-based: sys.modules isolation is impossible in-process once numpy
+has been imported by a sibling test.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Meta-path blocker that simulates the [rag] extra being absent.
+BLOCKER_PRELUDE = textwrap.dedent(
+    """
+    import sys
+    from importlib.abc import MetaPathFinder
+
+    BLOCKED = {"numpy", "PIL", "networkx"}
+
+    class _AbsentExtras(MetaPathFinder):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname.split(".")[0] in BLOCKED:
+                raise ModuleNotFoundError(
+                    f"No module named '{fullname}' (simulated absent)",
+                    name=fullname,
+                )
+            return None
+
+    for _m in list(sys.modules):
+        if _m.split(".")[0] in BLOCKED:
+            del sys.modules[_m]
+    sys.meta_path.insert(0, _AbsentExtras())
+    """
+)
+
+
+def _run_without_rag_extras(body: str) -> subprocess.CompletedProcess:
+    """Run python code in a subprocess with numpy/PIL/networkx blocked."""
+    return subprocess.run(
+        [sys.executable, "-c", BLOCKER_PRELUDE + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize(
+    "target",
+    [
+        "kaizen",
+        "kaizen.nodes",
+        "kaizen.nodes.ai",
+        "kaizen_agents.patterns.runtime",
+    ],
+)
+def test_base_import_succeeds_without_numpy(target):
+    """Base import surface MUST NOT require the [rag] extra."""
+    result = _run_without_rag_extras(f"import {target}")
+    assert result.returncode == 0, (
+        f"`import {target}` failed without numpy (the [rag] extra must not be "
+        f"required on the base import surface):\n{result.stderr}"
+    )
+
+
+@pytest.mark.regression
+def test_runtime_degrades_gracefully_when_a2a_unavailable():
+    """runtime.py must import + AgentMetadata must be constructible when the
+    a2a import chain is unavailable (the pre-fix TypeError fired at
+    class-creation time, so module import itself crashed)."""
+    result = _run_without_rag_extras(
+        """
+        # Block the a2a module itself to force the fallback branch
+        import sys
+        from importlib.abc import MetaPathFinder
+
+        class _BlockA2A(MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "kaizen.nodes.ai.a2a":
+                    raise ModuleNotFoundError(
+                        "No module named 'kaizen.nodes.ai.a2a' (simulated)",
+                        name=fullname,
+                    )
+                return None
+
+        sys.meta_path.insert(0, _BlockA2A())
+
+        import kaizen_agents.patterns.runtime as rt
+
+        assert rt.A2A_AVAILABLE is False, "A2A_AVAILABLE must be False"
+        assert rt.A2AAgentCard is None, "A2AAgentCard fallback must be None"
+
+        # The crash site: AgentMetadata class creation + instantiation
+        import dataclasses
+        fields = {f.name for f in dataclasses.fields(rt.AgentMetadata)}
+        assert "a2a_card" in fields, "a2a_card field must survive the fallback"
+        print("graceful-degrade OK")
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "graceful-degrade OK" in result.stdout
+
+
+@pytest.mark.regression
+def test_rag_import_without_extra_raises_clean_modulenotfound():
+    """`import kaizen.nodes.rag` without [rag] requires the extra BY DESIGN —
+    but the failure MUST be a clean ModuleNotFoundError, never the TypeError
+    crash class this regression pins."""
+    result = _run_without_rag_extras(
+        """
+        try:
+            import kaizen.nodes.rag
+        except ModuleNotFoundError:
+            print("clean-mnfe")
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "clean-mnfe" in result.stdout
+
+
+@pytest.mark.regression
+def test_require_numpy_raises_with_rag_install_guidance():
+    """The lazy-import helper must raise a typed error naming the [rag] extra."""
+    result = _run_without_rag_extras(
+        """
+        from kaizen.nodes._optional import require_numpy
+        try:
+            require_numpy("regression probe")
+        except ImportError as exc:
+            assert "kailash-kaizen[rag]" in str(exc), str(exc)
+            assert "regression probe" in str(exc), str(exc)
+            print("guidance OK")
+        """
+    )
+    assert result.returncode == 0, result.stderr
+    assert "guidance OK" in result.stdout
+
+
+@pytest.mark.regression
+def test_require_numpy_returns_module_when_present():
+    """With numpy installed, the helper returns the real module (in-process)."""
+    from kaizen.nodes._optional import require_numpy
+
+    np = require_numpy("regression probe")
+    assert np.__name__ == "numpy"
+
+
+@pytest.mark.regression
+@pytest.mark.asyncio
+async def test_hash_embedding_and_search_still_work_with_numpy_present():
+    """Behavioral: the lazy-import refactor must not change numeric behavior."""
+    from datetime import UTC, datetime
+
+    from kaizen.nodes.ai.semantic_memory import (
+        InMemoryVectorStore,
+        SemanticMemoryItem,
+        SimpleEmbeddingProvider,
+    )
+
+    provider = SimpleEmbeddingProvider()
+    emb = provider._hash_embedding("hello world")
+    assert emb.shape == (384,)
+
+    store = InMemoryVectorStore()
+    await store.add(
+        SemanticMemoryItem(
+            id="i1",
+            content="hello world",
+            embedding=emb,
+            metadata={},
+            created_at=datetime.now(UTC),
+        )
+    )
+    results = await store.search_similar(emb, threshold=0.9)
+    assert len(results) == 1
+    assert results[0][0].id == "i1"
+    assert results[0][1] == pytest.approx(1.0)
+
+
+@pytest.mark.regression
+def test_tfidf_transform_and_cosine_still_work_with_numpy_present():
+    """Behavioral: hybrid_search TF-IDF path unchanged with numpy installed."""
+    from kaizen.nodes.ai.hybrid_search import TFIDFVectorizer
+
+    v = TFIDFVectorizer()
+    docs = ["the quick brown fox", "the lazy dog", "quick quick fox"]
+    v.fit(docs)
+    vectors = v.transform(docs)
+    assert vectors.shape[0] == 3
+    sim_self = v.cosine_similarity(vectors[0], vectors[0])
+    assert sim_self == pytest.approx(1.0)
+    assert v.cosine_similarity(vectors[0], vectors[1]) < sim_self

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b3_agentic_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b3_agentic_defects.py
@@ -31,113 +31,106 @@ Defect 4 — ToolAugmentedRAGNode non-dict tool-output crash.
   callables with no return-shape contract) raised ``TypeError``.
   Fix: ``not isinstance(output, dict) or "error" not in output``.
 
-Defects 1 + 2 are ``_create_workflow()`` codegen-template defects; defects
+Defects 1 + 2 were ``_create_workflow()`` codegen-template defects; defects
 3 + 4 are ``run()``-path defects. Per the B1 two-path lesson, both the
 ``run()`` paths and the codegen templates were grepped for each pattern.
 
-All tests are behavioral — they call ``run()`` / exec the real codegen
-template and assert success / typed outputs, not source-grep.
+POST-MIGRATION (S6b — #1117/#1123 root-cause fix): the ``tool_executor`` /
+``state_manager`` / ``result_synthesizer`` COMPUTE stages were lifted from
+inline ``code=`` codegen to the module-level functions ``execute_tool_action``
+and the ``_make_state_manager`` / ``_make_result_synthesizer`` closure factories,
+wired via ``PythonCodeNode.from_function``. Defects 1 + 2 are now exercised
+BEHAVIORALLY by calling those lifted functions directly (the structural
+successor of exec'ing the codegen template) — same assertion intent, preserved.
+
+All tests are behavioral — they call ``run()`` / the lifted COMPUTE function and
+assert success / typed outputs, not source-grep.
 """
 
 from __future__ import annotations
 
-import warnings
-
 import pytest
 
-from kaizen.nodes.rag.agentic import AgenticRAGNode, ToolAugmentedRAGNode
+from kaizen.nodes.rag.agentic import (
+    AgenticRAGNode,
+    ToolAugmentedRAGNode,
+    _make_result_synthesizer,
+    execute_tool_action,
+)
 
 pytestmark = pytest.mark.regression
 
 
-def _template(node, node_id):
-    """Return a built sub-workflow node's code= template, silencing the
-    cosmetic PythonCodeNode line-count UserWarnings."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        return node._create_workflow().nodes[node_id].config["code"]
-
-
 # ---------------------------------------------------------------------------
-# Defect 1 — tool_executor codegen None-content / non-dict crash
+# Defect 1 — tool_executor None-content / non-dict crash (lifted COMPUTE fn)
 # ---------------------------------------------------------------------------
 def test_tool_executor_none_content_does_not_crash():
     """The tool_executor search branch must tolerate a document whose
     ``content`` key is present-but-None."""
-    code = _template(AgenticRAGNode(), "tool_executor")
-    ns = {
-        "reasoning_state": {"current_action": 'search("transformer")'},
-        "documents": [{"id": "n", "content": None}],
-    }
-    exec(code, ns)
-    assert ns["result"]["tool_result"]["tool"] == "search"
-    assert ns["result"]["tool_result"]["count"] == 0
+    out = execute_tool_action(
+        reasoning_state={"current_action": 'search("transformer")'},
+        documents=[{"id": "n", "content": None}],
+    )
+    assert out["tool_result"]["tool"] == "search"
+    assert out["tool_result"]["count"] == 0
 
 
 def test_tool_executor_none_title_does_not_crash():
     """A present-but-None ``title`` must not crash the search branch."""
-    code = _template(AgenticRAGNode(), "tool_executor")
-    ns = {
-        "reasoning_state": {"current_action": 'search("transformer")'},
-        "documents": [{"id": "n", "content": "transformer model", "title": None}],
-    }
-    exec(code, ns)
-    assert ns["result"]["tool_result"]["count"] == 1
+    out = execute_tool_action(
+        reasoning_state={"current_action": 'search("transformer")'},
+        documents=[{"id": "n", "content": "transformer model", "title": None}],
+    )
+    assert out["tool_result"]["count"] == 1
 
 
 def test_tool_executor_non_dict_document_is_skipped():
     """A non-dict element in ``documents`` is skipped, not crashed on."""
-    code = _template(AgenticRAGNode(), "tool_executor")
-    ns = {
-        "reasoning_state": {"current_action": 'search("transformer")'},
-        "documents": ["not a dict", {"id": "g", "content": "transformer here"}],
-    }
-    exec(code, ns)
-    assert ns["result"]["tool_result"]["count"] == 1
+    out = execute_tool_action(
+        reasoning_state={"current_action": 'search("transformer")'},
+        documents=["not a dict", {"id": "g", "content": "transformer here"}],
+    )
+    assert out["tool_result"]["count"] == 1
 
 
 def test_tool_executor_none_content_does_not_poison_sibling():
     """A None-content document must not block a well-formed sibling from
     matching the search query."""
-    code = _template(AgenticRAGNode(), "tool_executor")
-    ns = {
-        "reasoning_state": {"current_action": 'search("transformer")'},
-        "documents": [
+    out = execute_tool_action(
+        reasoning_state={"current_action": 'search("transformer")'},
+        documents=[
             {"id": "bad", "content": None},
             {"id": "good", "content": "the transformer model"},
         ],
-    }
-    exec(code, ns)
-    assert ns["result"]["tool_result"]["count"] == 1
-    assert ns["result"]["tool_result"]["results"][0]["id"] == "good"
+    )
+    assert out["tool_result"]["count"] == 1
+    assert out["tool_result"]["results"][0]["id"] == "good"
 
 
 # ---------------------------------------------------------------------------
-# Defect 2 — result_synthesizer codegen NameError
+# Defect 2 — result_synthesizer NameError (was literal {self.x}); now the
+# lifted `_make_result_synthesizer` closure binds the build-time config.
 # ---------------------------------------------------------------------------
-def test_result_synthesizer_template_does_not_raise_nameerror():
-    """The result_synthesizer ``code=`` template must execute without a
-    NameError — it was once a plain string with literal {self.x}."""
-    code = _template(AgenticRAGNode(), "result_synthesizer")
-    ns = {
-        "reasoning_state": {"steps": [], "final_answer": "x", "completed": True},
-        "query": "q",
-    }
-    exec(code, ns)  # must not raise NameError: name 'self' is not defined
-    assert "agentic_rag_result" in ns["result"]
+def test_result_synthesizer_does_not_raise_nameerror():
+    """The result_synthesizer must produce its dict without a NameError — the
+    prior plain-string codegen carried literal {self.x} placeholders."""
+    synth = _make_result_synthesizer("react", 5)
+    out = synth(
+        reasoning_state={"steps": [], "final_answer": "x", "completed": True},
+        query="q",
+    )
+    assert "agentic_rag_result" in out
 
 
-def test_result_synthesizer_interpolates_constructor_config():
+def test_result_synthesizer_binds_constructor_config():
     """The metadata block carries the real constructor config values, not
     the literal placeholder strings."""
-    node = AgenticRAGNode(planning_strategy="tree-of-thought", max_reasoning_steps=11)
-    code = _template(node, "result_synthesizer")
-    ns = {
-        "reasoning_state": {"steps": [], "final_answer": "x", "completed": True},
-        "query": "q",
-    }
-    exec(code, ns)
-    meta = ns["result"]["agentic_rag_result"]["metadata"]
+    synth = _make_result_synthesizer("tree-of-thought", 11)
+    out = synth(
+        reasoning_state={"steps": [], "final_answer": "x", "completed": True},
+        query="q",
+    )
+    meta = out["agentic_rag_result"]["metadata"]
     assert meta["planning_strategy"] == "tree-of-thought"
     assert meta["max_steps"] == 11
     # The literal placeholder must NOT survive into the output.

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b6_advanced_defects.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b6_advanced_defects.py
@@ -76,9 +76,12 @@ class TestAS2HybridWorkflowImplemented:
         assert isinstance(wf, WorkflowNode)
 
     def test_workflow_is_not_empty(self):
-        """The pre-B6 placeholder shipped nodes=[]; the real one has 4 nodes."""
+        """The pre-B6 placeholder shipped nodes=[]; the real one carries the
+        full retrieval pipeline (source + dense + sparse + fuse + the three
+        from_function projector nodes the post-migration output_mapping needs)."""
         wf = create_hybrid_rag_workflow(RAGConfig())
-        assert len(wf._workflow.nodes) == 4  # type: ignore[union-attr]
+        node_ids = set(wf._workflow.nodes.keys())  # type: ignore[union-attr]
+        assert {"source", "dense", "sparse", "fuse"} <= node_ids
 
     def test_workflow_runs_and_returns_consumed_contract(self):
         """The pre-B6 placeholder ImportError'd; the real one executes."""

--- a/packages/kailash-kaizen/tests/regression/test_issue_f9_rag_codegen_cleanup.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f9_rag_codegen_cleanup.py
@@ -116,45 +116,73 @@ def test_issue_1116_session_id_uses_secrets_token_hex():
 
 @pytest.mark.regression
 def test_issue_1117_evaluation_codegen_binds_module_scope_result():
-    """The context_evaluator + metric_aggregator + test_executor codegen
-    bodies MUST execute their inner functions at module scope so the
-    PythonCodeNode outbound port carries the computed dict."""
-    from kaizen.nodes.rag.evaluation import RAGEvaluationNode
+    """The context_evaluator + metric_aggregator + test_executor stages MUST
+    publish their computed dict on the PythonCodeNode outbound port.
+
+    Post-S3 these stages are ``PythonCodeNode.from_function`` nodes (the inline
+    ``code=`` codegen was lifted to the module-level functions
+    ``collect_rag_results`` / ``_evaluate_context_precision`` /
+    ``aggregate_evaluation_metrics``). A from_function node publishes its
+    ``return`` value on the flat ``result`` port — the structural successor of
+    the codegen's module-scope ``result =`` assignment. This test preserves the
+    ORIGINAL intent (the outbound port carries the computed dict) by (a)
+    asserting the production from_function nodes resolve in the built workflow
+    AND (b) calling each lifted function directly and asserting it returns a
+    dict (the value the from_function node publishes on ``result``)."""
+    from kaizen.nodes.rag.evaluation import (
+        RAGEvaluationNode,
+        _evaluate_context_precision,
+        aggregate_evaluation_metrics,
+        collect_rag_results,
+    )
 
     wf = RAGEvaluationNode(use_reference_answers=False)._create_workflow()  # type: ignore[attr-defined]
     for node_id in ("test_executor", "context_evaluator", "metric_aggregator"):
         node = wf.get_node(node_id)
         assert node is not None, node_id
-        code = node.config["code"]
-        # The codegen MUST end with a module-scope `result =` assignment
-        # (per the issue acceptance criterion).
-        assert re.search(
-            r"^result\s*=", code, re.M
-        ), f"{node_id} codegen does not bind `result` at module scope"
+        # The from_function nodes are real PythonCodeNode instances; their
+        # outbound port is the flat `result` carrying the function return.
+        assert type(node).__name__ == "PythonCodeNode", node_id
+
+    # The lifted functions return the dict the from_function `result` port
+    # publishes — the structural successor of the codegen's module-scope
+    # `result =`. Honest empty inputs → honest empty (non-fabricated) dicts.
+    test_out = collect_rag_results(test_queries=[])
+    assert isinstance(test_out, dict) and "test_results" in test_out
+
+    ctx_out = _evaluate_context_precision(
+        {"retrieved_contexts": [], "reference_answer": ""}
+    )
+    assert isinstance(ctx_out, dict)
+
+    agg_out = aggregate_evaluation_metrics(test_results=[], metrics=["faithfulness"])
+    assert isinstance(agg_out, dict) and "evaluation_summary" in agg_out
 
 
 @pytest.mark.regression
 def test_issue_1118_metric_aggregator_uses_datetime_class_not_module():
-    """The metric_aggregator codegen MUST call `_datetime_class.now()`
-    (the imported datetime class) — NOT `datetime.now()` against the
-    module, which raises AttributeError."""
-    from kaizen.nodes.rag.evaluation import RAGEvaluationNode
+    """The metric_aggregator stage MUST call ``_datetime_class.now()`` (the
+    imported datetime CLASS) — NOT ``datetime.now()`` against the module, which
+    raises ``AttributeError: module 'datetime' has no attribute 'now'``.
 
-    wf = RAGEvaluationNode()._create_workflow()  # type: ignore[attr-defined]
-    aggregator = wf.get_node("metric_aggregator")
-    assert aggregator is not None
-    code = aggregator.config["code"]
-    # The codegen MUST import the class (under any alias) AND MUST invoke
-    # via the class symbol, not the module.
-    assert "from datetime import datetime" in code
-    assert "_datetime_class.now()" in code
-    # The bare `datetime.now()` invocation OUTSIDE comments / docstrings
-    # is gone. Strip comments (everything from `#` to EOL) before checking.
-    code_no_comments = re.sub(r"#.*$", "", code, flags=re.M)
-    # Strip backtick-quoted spans (used in module docstrings).
-    code_no_quotes = re.sub(r"`[^`]*`", "", code_no_comments)
-    bare_call_count = len(re.findall(r"(?<!_)datetime\.now\s*\(", code_no_quotes))
-    assert bare_call_count == 0
+    Post-S3 the stage is a ``PythonCodeNode.from_function`` node wrapping
+    ``aggregate_evaluation_metrics`` (the inline ``code=`` codegen was lifted).
+    This test preserves the ORIGINAL intent BEHAVIORALLY (per
+    ``rules/testing.md`` § Behavioral Regression Tests Over Source-Grep): it
+    CALLS ``aggregate_evaluation_metrics`` and asserts the emitted timestamp is
+    a valid ISO-8601 string. A bare ``datetime.now()`` against the module would
+    raise ``AttributeError`` before the dict is built — so a parseable
+    timestamp proves the class-symbol invocation works."""
+    from datetime import datetime
+
+    from kaizen.nodes.rag.evaluation import aggregate_evaluation_metrics
+
+    out = aggregate_evaluation_metrics(test_results=[], metrics=["faithfulness"])
+    timestamp = out["evaluation_summary"]["evaluation_config"]["timestamp"]
+    # `datetime.fromisoformat` raises ValueError on a non-ISO string; a clean
+    # parse proves `_datetime_class.now().isoformat()` ran (no AttributeError).
+    parsed = datetime.fromisoformat(timestamp)
+    assert parsed.year >= 2020
 
 
 # ==========================================================================

--- a/packages/kailash-kaizen/tests/unit/conftest.py
+++ b/packages/kailash-kaizen/tests/unit/conftest.py
@@ -21,9 +21,20 @@ The stub returns the same default list the keyword classifier returned for
 
 from __future__ import annotations
 
+import os
 from typing import List
 
 import pytest
+
+# Unit-tier deterministic model default (issue-822 pattern): agent/framework
+# construction resolves the model from the environment and raises
+# kaizen.errors.EnvModelMissing otherwise. No CI lane or committed .env
+# supplies KAIZEN_DEFAULT_MODEL, so unit tests that construct agents without
+# an explicit model fail on clean environments. setdefault preserves any
+# operator/.env value; the env-model discipline tests
+# (test_kaizen_default_model_env.py) monkeypatch.delenv/setenv per test and
+# are unaffected.
+os.environ.setdefault("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
 
 _DEFAULT_TIER1_TRAITS: List[str] = ["professional", "reliable", "adaptive"]
 

--- a/packages/kailash-kaizen/tests/unit/nodes/auth/test_directory_integration_unit.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/auth/test_directory_integration_unit.py
@@ -17,6 +17,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kaizen.nodes.auth.directory_integration import DirectoryIntegrationNode
 
 
@@ -71,9 +72,15 @@ class TestDirectoryIntegrationNodeUnit:
             "reasoning": "Query targets users with developer role",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_search_intent)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_search_intent),
+                    "role": "assistant",
+                },
+            }
         )
 
         result = await node._ai_search_analysis("find all developers")
@@ -100,9 +107,15 @@ class TestDirectoryIntegrationNodeUnit:
             "reasoning": "Query targets DevOps group",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_search_intent)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_search_intent),
+                    "role": "assistant",
+                },
+            }
         )
 
         result = await node._ai_search_analysis("DevOps team")
@@ -127,9 +140,15 @@ class TestDirectoryIntegrationNodeUnit:
             "reasoning": "Query searches for specific email address",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_search_intent)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_search_intent),
+                    "role": "assistant",
+                },
+            }
         )
 
         result = await node._ai_search_analysis("jane.doe@company.com")
@@ -159,9 +178,12 @@ class TestDirectoryIntegrationNodeUnit:
 
         mock_roles = ["user", "developer", "devops"]
 
-        # Mock format must match what the implementation expects: result.get("content", "[]")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_roles)}
+            return_value={
+                "success": True,
+                "response": {"content": json.dumps(mock_roles), "role": "assistant"},
+            }
         )
 
         user_data = {
@@ -189,9 +211,12 @@ class TestDirectoryIntegrationNodeUnit:
         # Mock without 'user' role - implementation should add it automatically
         mock_roles = ["admin", "manager"]
 
-        # Mock format must match what the implementation expects: result.get("content", "[]")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_roles)}
+            return_value={
+                "success": True,
+                "response": {"content": json.dumps(mock_roles), "role": "assistant"},
+            }
         )
 
         user_data = {"email": "test@example.com", "job_title": "IT Manager"}
@@ -222,9 +247,15 @@ class TestDirectoryIntegrationNodeUnit:
 
         mock_permissions = ["read", "write", "deploy", "monitor"]
 
-        # Mock format must match what the implementation expects: result.get("content", "[]")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_permissions)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_permissions),
+                    "role": "assistant",
+                },
+            }
         )
 
         user_data = {
@@ -248,9 +279,15 @@ class TestDirectoryIntegrationNodeUnit:
         # Mock without read permission - implementation should add it automatically
         mock_permissions = ["write", "delete"]
 
-        # Mock format must match what the implementation expects: result.get("content", "[]")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_permissions)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_permissions),
+                    "role": "assistant",
+                },
+            }
         )
 
         user_data = {"groups": ["admin"]}
@@ -284,9 +321,12 @@ class TestDirectoryIntegrationNodeUnit:
             "session_timeout_minutes": 240,
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_settings)}
+            return_value={
+                "success": True,
+                "response": {"content": json.dumps(mock_settings), "role": "assistant"},
+            }
         )
 
         user_data = {
@@ -314,9 +354,12 @@ class TestDirectoryIntegrationNodeUnit:
             "session_timeout_minutes": 480,
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_settings)}
+            return_value={
+                "success": True,
+                "response": {"content": json.dumps(mock_settings), "role": "assistant"},
+            }
         )
 
         user_data = {
@@ -361,9 +404,15 @@ class TestDirectoryIntegrationNodeUnit:
             "reasoning": "Search for developer users",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content (llm_agent.py:995)
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_search_intent)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_search_intent),
+                    "role": "assistant",
+                },
+            }
         )
 
         # Mock directory search results
@@ -479,16 +528,21 @@ class TestDirectoryIntegrationPromptEngineering:
             messages = kwargs.get("messages", [])
 
             captured_prompt = messages[0]["content"] if messages else ""
+            # Production LLMAgentNode envelope: nested response.content
             return {
-                "response": json.dumps(
-                    {
-                        "search_users": True,
-                        "search_groups": False,
-                        "search_attributes": ["cn"],
-                        "filters": {},
-                        "reasoning": "Test",
-                    }
-                )
+                "success": True,
+                "response": {
+                    "content": json.dumps(
+                        {
+                            "search_users": True,
+                            "search_groups": False,
+                            "search_attributes": ["cn"],
+                            "filters": {},
+                            "reasoning": "Test",
+                        }
+                    ),
+                    "role": "assistant",
+                },
             }
 
         node.llm_agent.async_run = capture_prompt
@@ -517,7 +571,11 @@ class TestDirectoryIntegrationPromptEngineering:
             messages = kwargs.get("messages", [])
 
             captured_prompt = messages[0]["content"] if messages else ""
-            return {"response": json.dumps(["user"])}
+            # Production LLMAgentNode envelope: nested response.content
+            return {
+                "success": True,
+                "response": {"content": json.dumps(["user"]), "role": "assistant"},
+            }
 
         node.llm_agent.async_run = capture_prompt
 
@@ -557,7 +615,11 @@ class TestDirectoryIntegrationPromptEngineering:
             messages = kwargs.get("messages", [])
 
             captured_prompt = messages[0]["content"] if messages else ""
-            return {"response": json.dumps(["read"])}
+            # Production LLMAgentNode envelope: nested response.content
+            return {
+                "success": True,
+                "response": {"content": json.dumps(["read"]), "role": "assistant"},
+            }
 
         node.llm_agent.async_run = capture_prompt
 
@@ -595,14 +657,19 @@ class TestDirectoryIntegrationPromptEngineering:
             messages = kwargs.get("messages", [])
 
             captured_prompt = messages[0]["content"] if messages else ""
+            # Production LLMAgentNode envelope: nested response.content
             return {
-                "response": json.dumps(
-                    {
-                        "mfa_required": False,
-                        "password_expiry_days": 90,
-                        "session_timeout_minutes": 480,
-                    }
-                )
+                "success": True,
+                "response": {
+                    "content": json.dumps(
+                        {
+                            "mfa_required": False,
+                            "password_expiry_days": 90,
+                            "session_timeout_minutes": 480,
+                        }
+                    ),
+                    "role": "assistant",
+                },
             }
 
         node.llm_agent.async_run = capture_prompt

--- a/packages/kailash-kaizen/tests/unit/nodes/auth/test_enterprise_auth_provider_unit.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/auth/test_enterprise_auth_provider_unit.py
@@ -17,6 +17,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kaizen.nodes.auth.enterprise_auth_provider import EnterpriseAuthProviderNode
 
 
@@ -66,9 +67,17 @@ class TestEnterpriseAuthProviderNodeUnit:
             "recommended_action": "allow",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content
+        # (llm_agent.py:995); flat top-level "content" was the F31
+        # wrong-shape false-green that masked the fail-open parse defect.
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_ai_analysis)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_ai_analysis),
+                    "role": "assistant",
+                },
+            }
         )
 
         # Use external IP to bypass fast path (internal IPs trigger fast path)
@@ -103,9 +112,17 @@ class TestEnterpriseAuthProviderNodeUnit:
             "recommended_action": "require_additional_verification",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content
+        # (llm_agent.py:995); flat top-level "content" was the F31
+        # wrong-shape false-green that masked the fail-open parse defect.
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_ai_analysis)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_ai_analysis),
+                    "role": "assistant",
+                },
+            }
         )
 
         risk_context = {
@@ -208,9 +225,14 @@ class TestEnterpriseAuthProviderNodeUnit:
         """Test handling of invalid JSON from LLM."""
         node = EnterpriseAuthProviderNode()
 
-        # Mock LLM to return invalid JSON
+        # Mock LLM to return invalid JSON inside the PRODUCTION envelope —
+        # the failure mode under test is json.JSONDecodeError on the content,
+        # not a malformed envelope.
         node.llm_agent.async_run = AsyncMock(
-            return_value={"response": "This is not valid JSON"}
+            return_value={
+                "success": True,
+                "response": {"content": "This is not valid JSON", "role": "assistant"},
+            }
         )
 
         risk_context = {"ip_address": "1.2.3.4"}
@@ -237,9 +259,17 @@ class TestEnterpriseAuthProviderNodeUnit:
             "recommended_action": "block",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content
+        # (llm_agent.py:995); flat top-level "content" was the F31
+        # wrong-shape false-green that masked the fail-open parse defect.
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_ai_analysis)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_ai_analysis),
+                    "role": "assistant",
+                },
+            }
         )
 
         risk_context = {
@@ -279,9 +309,17 @@ class TestEnterpriseAuthProviderNodeUnit:
             "recommended_action": "require_mfa",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content
+        # (llm_agent.py:995); flat top-level "content" was the F31
+        # wrong-shape false-green that masked the fail-open parse defect.
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_ai_analysis)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_ai_analysis),
+                    "role": "assistant",
+                },
+            }
         )
 
         risk_context = {
@@ -319,9 +357,17 @@ class TestEnterpriseAuthProviderNodeUnit:
             "recommended_action": "require_additional_verification",
         }
 
-        # Mock format must match what the implementation expects: result.get("content", "{}")
+        # Production LLMAgentNode envelope: nested response.content
+        # (llm_agent.py:995); flat top-level "content" was the F31
+        # wrong-shape false-green that masked the fail-open parse defect.
         node.llm_agent.async_run = AsyncMock(
-            return_value={"content": json.dumps(mock_ai_analysis)}
+            return_value={
+                "success": True,
+                "response": {
+                    "content": json.dumps(mock_ai_analysis),
+                    "role": "assistant",
+                },
+            }
         )
 
         risk_context = {
@@ -380,17 +426,21 @@ class TestEnterpriseAuthProviderNodeUnit:
         ]
 
         for scenario in test_scenarios:
-            # Mock format must match what the implementation expects: result.get("content", "{}")
+            # Production LLMAgentNode envelope: nested response.content
             node.llm_agent.async_run = AsyncMock(
                 return_value={
-                    "content": json.dumps(
-                        {
-                            "risk_score": scenario["score"],
-                            "additional_factors": [],
-                            "reasoning": scenario["description"],
-                            "recommended_action": scenario["action"],
-                        }
-                    )
+                    "success": True,
+                    "response": {
+                        "content": json.dumps(
+                            {
+                                "risk_score": scenario["score"],
+                                "additional_factors": [],
+                                "reasoning": scenario["description"],
+                                "recommended_action": scenario["action"],
+                            }
+                        ),
+                        "role": "assistant",
+                    },
                 }
             )
 
@@ -420,15 +470,20 @@ class TestEnterpriseAuthProviderPromptEngineering:
             messages = kwargs.get("messages", [])
 
             captured_prompt = messages[0]["content"] if messages else ""
+            # Production LLMAgentNode envelope: nested response.content
             return {
-                "response": json.dumps(
-                    {
-                        "risk_score": 0.5,
-                        "additional_factors": [],
-                        "reasoning": "Test",
-                        "recommended_action": "allow",
-                    }
-                )
+                "success": True,
+                "response": {
+                    "content": json.dumps(
+                        {
+                            "risk_score": 0.5,
+                            "additional_factors": [],
+                            "reasoning": "Test",
+                            "recommended_action": "allow",
+                        }
+                    ),
+                    "role": "assistant",
+                },
             }
 
         node.llm_agent.async_run = capture_prompt
@@ -476,15 +531,20 @@ class TestEnterpriseAuthProviderPromptEngineering:
             messages = kwargs.get("messages", [])
 
             captured_prompt = messages[0]["content"] if messages else ""
+            # Production LLMAgentNode envelope: nested response.content
             return {
-                "response": json.dumps(
-                    {
-                        "risk_score": 0.0,
-                        "additional_factors": [],
-                        "reasoning": "Test",
-                        "recommended_action": "allow",
-                    }
-                )
+                "success": True,
+                "response": {
+                    "content": json.dumps(
+                        {
+                            "risk_score": 0.0,
+                            "additional_factors": [],
+                            "reasoning": "Test",
+                            "recommended_action": "allow",
+                        }
+                    ),
+                    "role": "assistant",
+                },
             }
 
         node.llm_agent.async_run = capture_prompt

--- a/packages/kailash-kaizen/tests/unit/nodes/auth/test_sso_unit.py
+++ b/packages/kailash-kaizen/tests/unit/nodes/auth/test_sso_unit.py
@@ -17,6 +17,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from kaizen.nodes.auth.sso import SSOAuthenticationNode
 
 
@@ -284,16 +285,23 @@ class TestSSOAuthenticationNodeUnit:
         providers = ["azure", "google", "okta", "auth0", "ping"]
 
         for provider in providers:
-            # Mock LLM response
+            # Mock LLM response — production LLMAgentNode envelope (nested
+            # response.content, llm_agent.py:995). The prior flat-string
+            # shape routed every call through the rule-based fallback, so
+            # this test exercised zero AI-path code (F31 wrong-shape class).
             node.llm_agent.async_run = AsyncMock(
                 return_value={
-                    "response": json.dumps(
-                        {
-                            "first_name": "Test",
-                            "last_name": "User",
-                            "email": f"test@{provider}.com",
-                        }
-                    )
+                    "success": True,
+                    "response": {
+                        "content": json.dumps(
+                            {
+                                "first_name": "Test",
+                                "last_name": "User",
+                                "email": f"test@{provider}.com",
+                            }
+                        ),
+                        "role": "assistant",
+                    },
                 }
             )
 
@@ -301,6 +309,11 @@ class TestSSOAuthenticationNodeUnit:
             result = await node._ai_field_mapping(attrs, provider)
 
             assert result["email"] == f"test@{provider}.com"
+            # These fields only surface via the AI parse path — the
+            # rule-based fallback yields firstName/lastName=None, so the
+            # test can no longer green through the exception fallback.
+            assert result["first_name"] == "Test"
+            assert result["last_name"] == "User"
 
     def test_node_parameter_validation(self):
         """Test parameter validation for node initialization."""
@@ -334,7 +347,14 @@ class TestSSOAuthenticationPromptEngineering:
             messages = kwargs.get("messages", [])
 
             captured_prompt = messages[0]["content"] if messages else ""
-            return {"response": json.dumps({"email": "test@test.com"})}
+            # Production LLMAgentNode envelope: nested response.content
+            return {
+                "success": True,
+                "response": {
+                    "content": json.dumps({"email": "test@test.com"}),
+                    "role": "assistant",
+                },
+            }
 
         node.llm_agent.async_run = capture_prompt
 
@@ -368,7 +388,14 @@ class TestSSOAuthenticationPromptEngineering:
             messages = kwargs.get("messages", [])
 
             captured_prompt = messages[0]["content"] if messages else ""
-            return {"response": json.dumps(["user"])}
+            # Production LLMAgentNode envelope: nested response.content
+            return {
+                "success": True,
+                "response": {
+                    "content": json.dumps(["user"]),
+                    "role": "assistant",
+                },
+            }
 
         node.llm_agent.async_run = capture_prompt
 

--- a/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_advanced_nodes.py
@@ -107,11 +107,25 @@ class TestCreateHybridRagWorkflow:
         wf = create_hybrid_rag_workflow(RAGConfig())
         assert isinstance(wf, WorkflowNode)
 
-    def test_workflow_graph_has_four_nodes(self):
-        """The hybrid graph is source + dense + sparse + fuse = 4 nodes."""
+    def test_workflow_graph_has_expected_nodes(self):
+        """The hybrid graph is source + dense + sparse + fuse + 3 projectors.
+
+        Post-migration the COMPUTE stages (source / fuse) are
+        ``PythonCodeNode.from_function`` nodes publishing a flat ``result`` port;
+        three thin projector nodes index the fuse ``result`` dict's keys so the
+        WorkflowNode ``output_mapping`` (flat-key resolution) can surface the
+        ``results`` / ``scores`` / ``metadata`` consumed contract."""
         wf = create_hybrid_rag_workflow(RAGConfig())
         node_ids = set(wf._workflow.nodes.keys())  # type: ignore[union-attr]
-        assert node_ids == {"source", "dense", "sparse", "fuse"}
+        assert node_ids == {
+            "source",
+            "dense",
+            "sparse",
+            "fuse",
+            "proj_results",
+            "proj_scores",
+            "proj_metadata",
+        }
 
     def test_workflow_is_not_empty(self):
         """Regression guard against the shipped empty-nodes placeholder."""

--- a/packages/kailash-kaizen/tests/unit/rag/test_agentic_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_agentic_nodes.py
@@ -214,11 +214,24 @@ class TestAgenticRAGNode:
         assert "verification_parser" not in wf.nodes
         assert len(wf.nodes) == 9
 
-    def test_max_reasoning_steps_interpolated_into_state_manager(self):
-        """``max_reasoning_steps`` flows into the state_manager code template."""
-        wf = _build(AgenticRAGNode(max_reasoning_steps=8))
-        code = wf.nodes["state_manager"].config["code"]
-        assert 'state["current_step"] >= 8' in code
+    def test_max_reasoning_steps_bound_into_state_manager(self):
+        """``max_reasoning_steps`` is bound into the lifted state_manager closure.
+
+        Post-S6b the state_manager is a ``PythonCodeNode.from_function`` node
+        wrapping ``_make_state_manager(max_reasoning_steps)``; the step cap is
+        bound through the closure (was an f-string interpolation). Behavioral
+        proof: a single update at the cap marks the reasoning complete."""
+        from kaizen.nodes.rag.agentic import _make_state_manager
+
+        sm = _make_state_manager(1)  # cap of 1 → one update completes
+        out = sm(
+            plan=None,
+            reasoning_response="Thought: t\nAction: search(x)",
+            tool_result=None,
+        )
+        # current_step reaches the cap (1) → state marked completed → loop stops.
+        assert out["reasoning_state"]["current_step"] == 1
+        assert out["continue_reasoning"] is False
 
     def test_tools_interpolated_into_planner_prompt(self):
         """The constructor ``tools`` list appears in the planner system prompt."""
@@ -226,49 +239,49 @@ class TestAgenticRAGNode:
         prompt = wf.nodes["planner_agent"].config["system_prompt"]
         assert "search, verify" in prompt
 
-    # --- result_synthesizer code template (B1 codegen-regression pattern) -
-    def test_result_synthesizer_template_executes(self):
-        """The result_synthesizer ``code=`` template runs without NameError
-        and interpolates the constructor config into metadata.
+    # --- COMPUTE-stage lifted functions (post-S6b from_function migration) ---
+    def test_result_synthesizer_fn_binds_config(self):
+        """The lifted result_synthesizer closure binds the constructor config
+        into metadata and produces the documented result dict.
 
-        Regression guard: the block was once a plain (non-f) string with
-        literal ``{self.planning_strategy}`` — invalid Python at runtime."""
-        wf = _build(AgenticRAGNode(planning_strategy="react", max_reasoning_steps=6))
-        code = wf.nodes["result_synthesizer"].config["code"]
-        ns = {
-            "reasoning_state": {"steps": [], "final_answer": "ans", "completed": True},
-            "query": "q",
-        }
-        exec(code, ns)
-        meta = ns["result"]["agentic_rag_result"]["metadata"]
+        Regression guard: the block was once a plain (non-f) string with literal
+        ``{self.planning_strategy}`` — invalid Python at runtime. Post-S6b it is
+        ``_make_result_synthesizer(planning_strategy, max_reasoning_steps)``."""
+        from kaizen.nodes.rag.agentic import _make_result_synthesizer
+
+        synth = _make_result_synthesizer("react", 6)
+        out = synth(
+            reasoning_state={"steps": [], "final_answer": "ans", "completed": True},
+            query="q",
+        )
+        meta = out["agentic_rag_result"]["metadata"]
         assert meta["planning_strategy"] == "react"
         assert meta["max_steps"] == 6
         assert meta["completed_successfully"] is True
 
-    def test_tool_executor_template_search_over_documents(self):
-        """The tool_executor ``code=`` template runs a real keyword search
-        over documents when given a search action."""
-        wf = _build(AgenticRAGNode())
-        code = wf.nodes["tool_executor"].config["code"]
-        ns = {
-            "reasoning_state": {"current_action": 'search("transformer")'},
-            "documents": [{"id": "d", "content": "the transformer model"}],
-        }
-        exec(code, ns)
-        tr = ns["result"]["tool_result"]
+    def test_tool_executor_fn_search_over_documents(self):
+        """The lifted ``execute_tool_action`` runs a real keyword search over
+        documents when given a search action."""
+        from kaizen.nodes.rag.agentic import execute_tool_action
+
+        out = execute_tool_action(
+            reasoning_state={"current_action": 'search("transformer")'},
+            documents=[{"id": "d", "content": "the transformer model"}],
+        )
+        tr = out["tool_result"]
         assert tr["tool"] == "search"
         assert tr["count"] == 1
 
-    def test_tool_executor_template_calculate_action(self):
-        """The tool_executor ``calculate`` action evaluates safe arithmetic."""
-        wf = _build(AgenticRAGNode())
-        code = wf.nodes["tool_executor"].config["code"]
-        ns = {
-            "reasoning_state": {"current_action": "calculate(2 + 3 * 4)"},
-            "documents": [],
-        }
-        exec(code, ns)
-        assert ns["result"]["tool_result"]["result"] == 14
+    def test_tool_executor_fn_calculate_action(self):
+        """The lifted ``execute_tool_action`` ``calculate`` action evaluates
+        safe arithmetic via the AST-walked evaluator."""
+        from kaizen.nodes.rag.agentic import execute_tool_action
+
+        out = execute_tool_action(
+            reasoning_state={"current_action": "calculate(2 + 3 * 4)"},
+            documents=[],
+        )
+        assert out["tool_result"]["result"] == 14
 
 
 # ===========================================================================
@@ -315,3 +328,395 @@ class TestReasoningRAGNode:
         prompt = wf.nodes["problem_decomposer"].config["system_prompt"]
         assert "Strategy: tree_of_thought" in prompt
         assert "Max depth: 4" in prompt
+
+
+# ==========================================================================
+# F31-FU2 Shard B — direct-call Tier-1 coverage of the pure parser / composer
+# `from_function` targets in ``agentic.py`` (module-level functions wired into
+# the inner workflows via ``PythonCodeNode.from_function``). These are pure
+# data rendering / tool-result parsing (the permitted deterministic exceptions
+# per rules/agent-reasoning.md #3 + #6) — NOT agent decision-making. Called
+# DIRECTLY (no LocalRuntime, no mocking — they are pure functions).
+#
+# NOTE on agentic-vs-query_processing divergence (read the source, reconciled):
+# ``agentic.py`` has NO shared ``_loads_response_object`` helper. Each parser
+# is hand-written and the sentinel shape DIFFERS PER PARSER:
+#   * parse_reasoning_response / parse_reasoning_chain_response are PROSE / raw
+#     forwarders — they NEVER emit a ``parse_error`` and NEVER json.loads the
+#     content into a sentinel; an empty/None content yields an HONEST empty
+#     string (``""``), not an ``"empty-response"`` sentinel.
+#   * parse_plan_response / parse_verification_response ARE JSON stages with a
+#     typed sentinel — BUT their EMPTY default is an honest ``{}`` with NO
+#     ``parse_error`` key (query_processing.py emits ``parse_error ==
+#     "empty-response"`` on empty; agentic does NOT). Malformed content DOES
+#     carry the typed sentinel: ``non-json-response`` / ``non-object-json`` /
+#     ``unexpected-content-type``.
+#   * parse_decomposition_response / parse_reasoning_chain_response FORWARD the
+#     raw value faithfully: a non-JSON string is forwarded AS-IS (no sentinel);
+#     a JSON array/scalar is forwarded as the PARSED list/number (NOT a
+#     ``non-object-json`` sentinel — the decomposition/chain composers render
+#     whatever shape is present); a non-str/non-dict content is coerced to text.
+# Every EMPTY / MALFORMED assertion below asserts the parser's OWN honest
+# default (zero-tolerance Rule 2) — never a fabricated value borrowed from the
+# query_processing contract.
+# ==========================================================================
+
+import json
+
+from kaizen.nodes.rag.agentic import (
+    _unwrap_response_content,
+    compose_decomposer_messages,
+    compose_logic_verifier_messages,
+    compose_planner_messages,
+    compose_react_messages,
+    compose_step_reasoner_messages,
+    compose_verifier_messages,
+    parse_decomposition_response,
+    parse_plan_response,
+    parse_reasoning_chain_response,
+    parse_reasoning_response,
+    parse_verification_response,
+)
+
+
+def _wrap(obj) -> dict:
+    """Build the LLMAgentNode ``response`` port shape with JSON-string content."""
+    return {"content": json.dumps(obj)}
+
+
+class TestUnwrapResponseContent:
+    """``_unwrap_response_content``: dict -> .content, bare value -> passthrough."""
+
+    def test_unwrap_dict_returns_content(self):
+        assert _unwrap_response_content({"content": "hello"}) == "hello"
+
+    def test_unwrap_dict_missing_content_returns_none(self):
+        # A dict without a "content" key -> .get("content") -> None.
+        assert _unwrap_response_content({"other": "x"}) is None
+
+    def test_unwrap_bare_string_passthrough(self):
+        assert _unwrap_response_content("raw string") == "raw string"
+
+    def test_unwrap_none_passthrough(self):
+        assert _unwrap_response_content(None) is None
+
+
+# --------------------------------------------------------------------------
+# PROSE parser — parse_reasoning_response. Returns {"reasoning_text": <str>};
+# NEVER a json.loads sentinel. None/empty -> honest "" (not "empty-response").
+# --------------------------------------------------------------------------
+
+
+class TestParseReasoningResponse:
+    def test_parse_reasoning_valid_prose_returns_text(self):
+        prose = "Thought: search\nAction: search(x)\nAnswer: done"
+        result = parse_reasoning_response({"content": prose})
+        assert result["reasoning_text"] == prose
+        assert "parse_error" not in result  # PROSE stage never flags
+
+    def test_parse_reasoning_none_returns_empty_text(self):
+        # None content -> honest "" (no fabricated reasoning), NOT a sentinel.
+        result = parse_reasoning_response(None)
+        assert result["reasoning_text"] == ""
+        assert "parse_error" not in result
+
+    def test_parse_reasoning_dict_missing_content_returns_empty_text(self):
+        # {"other": ...} -> .get("content") is None -> honest "".
+        result = parse_reasoning_response({"other": "x"})
+        assert result["reasoning_text"] == ""
+
+    def test_parse_reasoning_bare_string_passthrough(self):
+        # Defensive: a bare string (not wrapped) is used directly.
+        result = parse_reasoning_response("plain prose")
+        assert result["reasoning_text"] == "plain prose"
+
+    def test_parse_reasoning_preparsed_dict_coerced_to_text(self):
+        # A pre-parsed dict from some providers -> _coerce_text faithfully.
+        result = parse_reasoning_response({"content": {"answer": "42"}})
+        assert isinstance(result["reasoning_text"], str)
+        assert "42" in result["reasoning_text"]
+
+
+# --------------------------------------------------------------------------
+# JSON parsers with typed sentinel — parse_plan_response /
+# parse_verification_response. EMPTY default is an HONEST {} with NO
+# parse_error (agentic diverges from query_processing here — read source).
+# Malformed content DOES carry the typed sentinel.
+# --------------------------------------------------------------------------
+
+
+class TestParsePlanResponse:
+    def test_parse_plan_valid_returns_dict(self):
+        obj = {"plan": [{"step": 1, "action": "search"}], "complexity": "moderate"}
+        result = parse_plan_response(_wrap(obj))
+        assert result["plan"] == obj
+        assert "parse_error" not in result["plan"]
+
+    def test_parse_plan_already_dict_returns_dict(self):
+        obj = {"plan": [{"step": 1}]}
+        result = parse_plan_response({"content": obj})
+        assert result["plan"] == obj
+        assert "parse_error" not in result["plan"]
+
+    def test_parse_plan_none_returns_honest_empty_no_sentinel(self):
+        # agentic's HONEST empty default is {} with NO parse_error
+        # (query_processing emits "empty-response"; agentic does NOT).
+        result = parse_plan_response(None)
+        assert result["plan"] == {}
+        assert "parse_error" not in result["plan"]
+
+    def test_parse_plan_empty_content_returns_honest_empty_no_sentinel(self):
+        result = parse_plan_response({"content": ""})
+        assert result["plan"] == {}
+        assert "parse_error" not in result["plan"]
+
+    def test_parse_plan_non_json_returns_non_json_sentinel(self):
+        result = parse_plan_response({"content": "not json{"})
+        assert result["plan"] == {"parse_error": "non-json-response"}
+
+    def test_parse_plan_array_returns_non_object_sentinel(self):
+        result = parse_plan_response({"content": "[1,2,3]"})
+        assert result["plan"] == {"parse_error": "non-object-json"}
+
+    def test_parse_plan_bad_content_type_returns_unexpected_sentinel(self):
+        result = parse_plan_response({"content": 42})
+        assert result["plan"] == {"parse_error": "unexpected-content-type"}
+
+
+class TestParseVerificationResponse:
+    def test_parse_verification_valid_returns_dict(self):
+        obj = {"verified": True, "confidence": 0.9, "issues": []}
+        result = parse_verification_response(_wrap(obj))
+        assert result["verification"] == obj
+        assert "parse_error" not in result["verification"]
+
+    def test_parse_verification_already_dict_returns_dict(self):
+        obj = {"verified": False, "confidence": 0.4}
+        result = parse_verification_response({"content": obj})
+        assert result["verification"] == obj
+        assert "parse_error" not in result["verification"]
+
+    def test_parse_verification_none_returns_honest_empty_no_sentinel(self):
+        # Honest empty {} — a flagged/fabricated verdict would silently
+        # inflate or deflate confidence downstream (zero-tolerance Rule 2).
+        result = parse_verification_response(None)
+        assert result["verification"] == {}
+        assert "parse_error" not in result["verification"]
+
+    def test_parse_verification_empty_content_returns_honest_empty(self):
+        result = parse_verification_response({"content": "   "})
+        assert result["verification"] == {}
+        assert "parse_error" not in result["verification"]
+
+    def test_parse_verification_non_json_returns_non_json_sentinel(self):
+        result = parse_verification_response({"content": "not json{"})
+        assert result["verification"] == {"parse_error": "non-json-response"}
+
+    def test_parse_verification_array_returns_non_object_sentinel(self):
+        result = parse_verification_response({"content": "[1,2,3]"})
+        assert result["verification"] == {"parse_error": "non-object-json"}
+
+    def test_parse_verification_bad_content_type_returns_unexpected_sentinel(self):
+        result = parse_verification_response({"content": 42})
+        assert result["verification"] == {"parse_error": "unexpected-content-type"}
+
+
+# --------------------------------------------------------------------------
+# FORWARDING parsers — parse_decomposition_response /
+# parse_reasoning_chain_response. They FORWARD the real value faithfully (the
+# downstream composer's _render_reasoning_plan renders whatever shape is
+# present). NO typed parse_error sentinel: non-JSON prose is forwarded AS-IS,
+# a JSON array/scalar is forwarded as the PARSED value, a non-str/dict is
+# coerced to text. None -> honest "" (not a sentinel).
+# --------------------------------------------------------------------------
+
+
+class TestParseDecompositionResponse:
+    def test_parse_decomposition_valid_json_forwards_parsed_dict(self):
+        obj = {"steps": [{"step": 1, "goal": "x"}], "assumptions": []}
+        result = parse_decomposition_response(_wrap(obj))
+        assert result["reasoning_plan"] == obj
+        assert "parse_error" not in result
+
+    def test_parse_decomposition_already_dict_forwards_dict(self):
+        obj = {"steps": [{"step": 1}]}
+        result = parse_decomposition_response({"content": obj})
+        assert result["reasoning_plan"] == obj
+
+    def test_parse_decomposition_none_returns_honest_empty_string(self):
+        # None -> "" (honest no-decomposition), NEVER a fabricated sentinel.
+        result = parse_decomposition_response(None)
+        assert result["reasoning_plan"] == ""
+        assert "parse_error" not in result
+
+    def test_parse_decomposition_non_json_forwards_raw_prose(self):
+        # Non-JSON prose is FORWARDED AS-IS (the composer renders it) — agentic
+        # does NOT emit a "non-json-response" sentinel here. Read source.
+        result = parse_decomposition_response({"content": "Step 1: do x"})
+        assert result["reasoning_plan"] == "Step 1: do x"
+        assert "parse_error" not in result
+
+    def test_parse_decomposition_array_forwards_parsed_list(self):
+        # Valid JSON array is FORWARDED as the parsed list — NOT a
+        # "non-object-json" sentinel (diverges from the plan parser).
+        result = parse_decomposition_response({"content": "[1,2,3]"})
+        assert result["reasoning_plan"] == [1, 2, 3]
+        assert "parse_error" not in result
+
+    def test_parse_decomposition_bad_content_type_coerced_to_text(self):
+        # Non-str/non-dict content is _coerce_text'd faithfully, no sentinel.
+        result = parse_decomposition_response({"content": 42})
+        assert result["reasoning_plan"] == "42"
+        assert "parse_error" not in result
+
+
+class TestParseReasoningChainResponse:
+    def test_parse_chain_valid_json_forwards_parsed(self):
+        obj = {"steps": [{"step": 1, "goal": "y"}]}
+        result = parse_reasoning_chain_response(_wrap(obj))
+        assert result["reasoning_to_verify"] == obj
+        assert "parse_error" not in result
+
+    def test_parse_chain_already_dict_forwards_dict(self):
+        obj = {"conclusion": "z"}
+        result = parse_reasoning_chain_response({"content": obj})
+        assert result["reasoning_to_verify"] == obj
+
+    def test_parse_chain_none_returns_honest_empty_string(self):
+        result = parse_reasoning_chain_response(None)
+        assert result["reasoning_to_verify"] == ""
+        assert "parse_error" not in result
+
+    def test_parse_chain_non_json_forwards_raw_prose(self):
+        result = parse_reasoning_chain_response({"content": "the logic holds"})
+        assert result["reasoning_to_verify"] == "the logic holds"
+        assert "parse_error" not in result
+
+    def test_parse_chain_array_forwards_parsed_list(self):
+        result = parse_reasoning_chain_response({"content": "[1,2,3]"})
+        assert result["reasoning_to_verify"] == [1, 2, 3]
+        assert "parse_error" not in result
+
+    def test_parse_chain_bad_content_type_coerced_to_text(self):
+        result = parse_reasoning_chain_response({"content": 42})
+        assert result["reasoning_to_verify"] == "42"
+        assert "parse_error" not in result
+
+
+# --------------------------------------------------------------------------
+# Composers — one direct test per variant (VALID interpolation + EMPTY).
+# Each returns a well-formed {"messages": [{"role","content"}, ...]} shape.
+# --------------------------------------------------------------------------
+
+
+def _assert_messages_shape(result):
+    """Assert the composer return is a well-formed OpenAI chat ``messages`` list."""
+    assert isinstance(result, dict)
+    assert "messages" in result
+    msgs = result["messages"]
+    assert isinstance(msgs, list) and len(msgs) >= 1
+    for m in msgs:
+        assert isinstance(m, dict)
+        assert "role" in m and "content" in m
+    return msgs
+
+
+class TestComposePlannerMessages:
+    def test_compose_planner_valid_interpolates_query(self):
+        msgs = _assert_messages_shape(
+            compose_planner_messages(query="Compare revenue growth")
+        )
+        assert "Compare revenue growth" in msgs[0]["content"]
+
+    def test_compose_planner_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(compose_planner_messages(query=""))
+        # Honest no-query content — structurally valid, no crash.
+        assert "No query" in msgs[0]["content"]
+
+
+class TestComposeReactMessages:
+    def test_compose_react_valid_interpolates_query_and_observations(self):
+        msgs = _assert_messages_shape(
+            compose_react_messages(
+                query="What is BERT?",
+                context_for_agent="Thought: search\nObservation: found",
+            )
+        )
+        content = msgs[0]["content"]
+        assert "What is BERT?" in content
+        # Real accumulated observations rendered into the ReAct messages.
+        assert "Observation: found" in content
+
+    def test_compose_react_empty_query_no_observations_returns_wellformed(self):
+        # First-pass honesty: no tool has run yet -> explicit "no observations".
+        msgs = _assert_messages_shape(
+            compose_react_messages(query="", context_for_agent=None)
+        )
+        content = msgs[0]["content"]
+        assert "(empty)" in content
+        assert "No observations gathered yet" in content
+
+
+class TestComposeVerifierMessages:
+    def test_compose_verifier_valid_renders_transcript(self):
+        state = {
+            "steps": [{"thought": "t", "action": "a", "observation": "o"}],
+            "final_answer": "the answer",
+        }
+        msgs = _assert_messages_shape(compose_verifier_messages(reasoning_state=state))
+        content = msgs[0]["content"]
+        # The answer AND its supporting evidence (observations) are rendered.
+        assert "the answer" in content
+        assert "Observation: o" in content
+
+    def test_compose_verifier_empty_state_returns_wellformed(self):
+        msgs = _assert_messages_shape(compose_verifier_messages(reasoning_state=None))
+        assert "No answer or evidence" in msgs[0]["content"]
+
+
+class TestComposeDecomposerMessages:
+    def test_compose_decomposer_valid_interpolates_query(self):
+        msgs = _assert_messages_shape(
+            compose_decomposer_messages(query="Solve this multi-step problem")
+        )
+        assert "Solve this multi-step problem" in msgs[0]["content"]
+
+    def test_compose_decomposer_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(compose_decomposer_messages(query=""))
+        assert "No problem" in msgs[0]["content"]
+
+
+class TestComposeStepReasonerMessages:
+    def test_compose_step_reasoner_valid_interpolates_query_and_plan(self):
+        plan = {"steps": [{"step": 1, "goal": "compute growth"}]}
+        msgs = _assert_messages_shape(
+            compose_step_reasoner_messages(query="Revenue math", reasoning_plan=plan)
+        )
+        content = msgs[0]["content"]
+        assert "Revenue math" in content
+        # The real upstream decomposition is rendered into the reasoner's input.
+        assert "compute growth" in content
+
+    def test_compose_step_reasoner_empty_query_none_plan_returns_wellformed(self):
+        msgs = _assert_messages_shape(
+            compose_step_reasoner_messages(query="", reasoning_plan=None)
+        )
+        content = msgs[0]["content"]
+        assert "(empty)" in content
+        # Always appends the explicit next-step instruction.
+        assert "Execute the next reasoning step." in content
+
+
+class TestComposeLogicVerifierMessages:
+    def test_compose_logic_verifier_valid_renders_chain(self):
+        chain = {"steps": [{"step": 1, "goal": "premise A"}]}
+        msgs = _assert_messages_shape(
+            compose_logic_verifier_messages(reasoning_to_verify=chain)
+        )
+        assert "premise A" in msgs[0]["content"]
+
+    def test_compose_logic_verifier_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(
+            compose_logic_verifier_messages(reasoning_to_verify=None)
+        )
+        assert "No reasoning chain" in msgs[0]["content"]

--- a/packages/kailash-kaizen/tests/unit/rag/test_conversational_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_conversational_nodes.py
@@ -268,14 +268,52 @@ class TestConversationalRAGGraphShape:
         inbound = [c for c in wf.connections if c.target_node == "result_formatter"]
         assert len(inbound) >= 4  # session_updater + response_gen + topic + retrieval
 
-    def test_max_context_turns_baked_into_context_loader_code(self):
-        """The max_context_turns kwarg is interpolated into the loader code."""
+    def test_max_context_turns_controls_context_loader_sliding_window(self):
+        """The max_context_turns kwarg controls the sliding-window slice the
+        context_loader applies.
+
+        S6a: the context_loader stage is now a ``PythonCodeNode.from_function``
+        node (the inline ``code=`` codegen with the interpolated
+        ``session["turns"][-{N}:]`` slice was lifted to the module-level
+        ``_load_conversation_context`` function, with ``max_context_turns`` bound
+        at workflow-construction time through a closure). This test preserves the
+        ORIGINAL intent BEHAVIORALLY (per ``rules/testing.md`` § Behavioral
+        Regression Tests Over Source-Grep): it (a) asserts the production node is
+        a ``from_function`` ``PythonCodeNode`` (no ``code=`` config), AND (b)
+        calls the lifted function directly with a pre-seeded session of 5 turns
+        and ``max_context_turns=3``, asserting the returned ``recent_turns`` slice
+        honors the window."""
         wf = _build(ConversationalRAGNode(max_context_turns=3))
         loader = wf.get_node("context_loader")
         assert loader is not None
-        code = loader.config.get("code", "")
-        # The recent_turns slice uses session["turns"][-3:].
-        assert 'session["turns"][-3:]' in code
+        # The lifted node is a from_function PythonCodeNode — no `code=` config.
+        assert type(loader).__name__ == "PythonCodeNode"
+        assert loader.config.get("code") is None
+
+        # Behavioral: the lifted function applies the sliding-window slice.
+        from kaizen.nodes.rag.conversational import _load_conversation_context
+
+        store = {
+            "s1": {
+                "id": "s1",
+                "turns": [{"query": f"q{i}", "response": f"r{i}"} for i in range(5)],
+                "summary": "",
+                "current_topic": None,
+                "user_preferences": {},
+                "metrics": {
+                    "turn_count": 5,
+                    "topics_discussed": [],
+                    "avg_response_length": 0,
+                },
+            }
+        }
+        out = _load_conversation_context(
+            session_id="s1", sessions_store=store, max_context_turns=3
+        )
+        recent = out["session_context"]["recent_turns"]
+        # The window keeps the LAST 3 of the 5 seeded turns.
+        assert len(recent) == 3
+        assert [t["query"] for t in recent] == ["q2", "q3", "q4"]
 
 
 # ==========================================================================
@@ -302,13 +340,11 @@ class TestCreateSession:
         assert session["current_topic"] is None
         assert session["metrics"]["turn_count"] == 0
 
-    def test_create_session_distinct_ids_for_same_user_at_different_timestamps(self):
-        """The sha256 hash includes datetime.now().isoformat() — different calls → different ids."""
-        import time
-
+    def test_create_session_distinct_ids_for_same_user(self):
+        """session_id is a CSPRNG token (secrets.token_hex(16)) — two calls for the
+        same user produce different, unguessable ids (no timestamp dependence)."""
         node = ConversationalRAGNode()
         out_a = node.create_session(user_id="alice")  # type: ignore[attr-defined]
-        time.sleep(0.01)  # ensure isoformat() differs in the microsecond field
         out_b = node.create_session(user_id="alice")  # type: ignore[attr-defined]
         assert out_a["session_id"] != out_b["session_id"]
 
@@ -557,3 +593,337 @@ def test_module_all_exports_two_classes():
         "ConversationalRAGNode",
         "ConversationMemoryNode",
     }
+
+
+# ==========================================================================
+# F31-FU2 Shard B — direct-call Tier-1 coverage of the 3 pure composer
+# `from_function` targets in ``conversational.py``. These render the OpenAI
+# chat `messages` list for each LLM stage — pure data rendering (the permitted
+# output-formatting exception per rules/agent-reasoning.md), NOT agent
+# decision-making. Called DIRECTLY (no LocalRuntime, no mocking — pure funcs).
+#
+# NOTE: conversational has NO `from_function` PARSERS — the consumers read
+# `.get("content")` inline inside the `code=` PythonCodeNode bodies (genuinely
+# correct; there is nothing to cover at the parser layer). Only the 3 composers
+# are direct-callable module-level functions, so ONLY they are covered here.
+# Each composer asserts VALID interpolation + EMPTY/None well-formedness; the
+# EMPTY assertion uses the composer's OWN honest placeholder (read source).
+# ==========================================================================
+
+
+from kaizen.nodes.rag.conversational import (
+    compose_coreference_messages,
+    compose_response_messages,
+    compose_summary_messages,
+)
+
+
+def _assert_messages_shape(result):
+    """Assert the composer return is a well-formed OpenAI chat ``messages`` list."""
+    assert isinstance(result, dict)
+    assert "messages" in result
+    msgs = result["messages"]
+    assert isinstance(msgs, list) and len(msgs) >= 1
+    for m in msgs:
+        assert isinstance(m, dict)
+        assert "role" in m and "content" in m
+    return msgs
+
+
+class TestComposeResponseMessages:
+    def test_compose_response_valid_renders_docs_history_query(self):
+        contextual_retrieval = {
+            "contextual_retrieval": {
+                "documents": [{"content": "BERT is a transformer model"}],
+                "enhanced_query": "What is BERT?",
+            }
+        }
+        conversation_context = {
+            "session_context": {
+                "context_text": "User: hi\nAssistant: hello\n",
+            }
+        }
+        msgs = _assert_messages_shape(
+            compose_response_messages(
+                contextual_retrieval=contextual_retrieval,
+                conversation_context=conversation_context,
+                query="What is BERT?",
+            )
+        )
+        content = msgs[0]["content"]
+        assert "What is BERT?" in content
+        # Retrieved docs + history are grounded into the response messages.
+        assert "BERT is a transformer model" in content
+        assert "User: hi" in content
+
+    def test_compose_response_recovers_query_from_enhanced_query(self):
+        # No explicit `query` -> the composer recovers it from the retriever's
+        # enhanced_query (an in-graph source embedding the original question).
+        contextual_retrieval = {
+            "contextual_retrieval": {
+                "documents": [],
+                "enhanced_query": "transformers context: explain attention",
+            }
+        }
+        msgs = _assert_messages_shape(
+            compose_response_messages(
+                contextual_retrieval=contextual_retrieval,
+                conversation_context=None,
+                query="",
+            )
+        )
+        assert "explain attention" in msgs[0]["content"]
+
+    def test_compose_response_all_empty_returns_wellformed(self):
+        # query="", no retrieval, no history -> still a valid messages shape.
+        msgs = _assert_messages_shape(
+            compose_response_messages(
+                contextual_retrieval=None,
+                conversation_context=None,
+                query="",
+            )
+        )
+        # The composer always appends the "Current question:" block (empty body).
+        assert "Current question:" in msgs[0]["content"]
+
+
+class TestComposeCoreferenceMessages:
+    def test_compose_coreference_valid_renders_query_and_history(self):
+        conversation_context = {
+            "session_context": {
+                "context_text": "User: tell me about transformers\nAssistant: ok\n",
+            }
+        }
+        msgs = _assert_messages_shape(
+            compose_coreference_messages(
+                current_query="How does its attention work?",
+                conversation_context=conversation_context,
+            )
+        )
+        content = msgs[0]["content"]
+        assert "How does its attention work?" in content
+        # The conversation history (the antecedent source) is rendered.
+        assert "tell me about transformers" in content
+
+    def test_compose_coreference_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(
+            compose_coreference_messages(current_query="", conversation_context=None)
+        )
+        # Always appends the "Query to resolve:" block (empty body), no crash.
+        assert "Query to resolve:" in msgs[0]["content"]
+
+
+class TestComposeSummaryMessages:
+    def test_compose_summary_valid_renders_history(self):
+        conversation_context = {
+            "session_context": {
+                "context_text": "User: explain BERT\nAssistant: BERT is...\n",
+            }
+        }
+        msgs = _assert_messages_shape(
+            compose_summary_messages(conversation_context=conversation_context)
+        )
+        assert "explain BERT" in msgs[0]["content"]
+
+    def test_compose_summary_empty_returns_wellformed(self):
+        # No history -> explicit empty-history note (honest, non-empty messages).
+        msgs = _assert_messages_shape(
+            compose_summary_messages(conversation_context=None)
+        )
+        assert "No conversation history yet." in msgs[0]["content"]
+
+
+# ==========================================================================
+# S6a Shard — direct-call Tier-1 coverage of the 5 COMPUTE-stage
+# `from_function` targets lifted from the inline `code=` codegen blocks in
+# ``conversational.py``. These are pure data computations (the permitted
+# tool-fetch / data-transform shape per rules/agent-reasoning.md — no agent
+# decision-making). Called DIRECTLY (no LocalRuntime, no mocking — pure funcs)
+# per the one-direct-test-per-variant Tier-1 mandate. A from_function node
+# publishes its `return` value on the flat `result` port, so the returned dict
+# is exactly what the node publishes downstream.
+#
+# `_load_conversation_context` is covered above by
+# ``test_max_context_turns_controls_context_loader_sliding_window`` (sliding
+# window) — the remaining four lifted functions are covered here.
+# ==========================================================================
+
+
+from kaizen.nodes.rag.conversational import (
+    _format_conversational_result,
+    _load_conversation_context,
+    _retrieve_with_context,
+    _track_conversation_topic,
+    _update_session,
+)
+
+
+class TestLiftedComputeFunctions:
+    def test_load_conversation_context_creates_session_when_absent(self):
+        """An absent session is seeded; the returned shape carries the
+        documented session_context keys + an empty recent_turns window."""
+        store: dict = {}
+        out = _load_conversation_context(
+            session_id="brand_new", sessions_store=store, max_context_turns=10
+        )
+        sc = out["session_context"]
+        assert sc["session_id"] == "brand_new"
+        assert sc["recent_turns"] == []
+        assert sc["turn_count"] == 0
+        assert sc["context_text"] == ""
+        # The seeded session is now in the per-run store.
+        assert "brand_new" in store
+
+    def test_track_conversation_topic_identifies_transformer_topic(self):
+        """A transformer-keyword query yields the 'transformers' topic on the
+        flat result's topic_analysis. session_context is the whole
+        {"session_context": ...} wrapper the function unwraps internally."""
+        out = _track_conversation_topic(
+            current_query="explain self-attention in the encoder",
+            session_context={"session_context": {"current_topic": None}},
+        )
+        ta = out["topic_analysis"]
+        assert ta["current_topic"] == "transformers"
+        assert ta["topic_changed"] is False  # first topic = new_conversation
+        assert ta["transition_type"] == "new_conversation"
+        assert "transformers" in ta["identified_topics"]
+        assert ta["confidence"] == 0.8
+
+    def test_track_conversation_topic_no_keyword_yields_general(self):
+        """A query with no topic keyword falls back to 'general' (honest
+        default, not fabricated)."""
+        out = _track_conversation_topic(
+            current_query="hello there",
+            session_context={"session_context": {"current_topic": None}},
+        )
+        ta = out["topic_analysis"]
+        assert ta["current_topic"] == "general"
+        assert ta["identified_topics"] == []
+        assert ta["confidence"] == 0.3
+
+    def test_retrieve_with_context_scores_and_enhances_query(self):
+        """The retriever ranks docs by query-term overlap and surfaces the
+        enhanced_query on the flat result's contextual_retrieval. topic_info is
+        passed through WITHOUT unwrap (already {"topic_analysis": ...})."""
+        docs = [
+            {"content": "transformer attention mechanism explained"},
+            {"content": "unrelated cooking recipe"},
+        ]
+        out = _retrieve_with_context(
+            query="attention mechanism",
+            documents=docs,
+            session_context={"session_context": {"context_text": ""}},
+            topic_info={"topic_analysis": {"current_topic": "transformers"}},
+        )
+        cr = out["contextual_retrieval"]
+        # The topic prefix is folded into the enhanced query.
+        assert cr["enhanced_query"].startswith("transformers context:")
+        assert len(cr["documents"]) == 2
+        # The transformer doc outranks the cooking doc.
+        assert cr["documents"][0]["content"].startswith("transformer attention")
+
+    def test_retrieve_with_context_resolved_query_overrides_raw(self):
+        """A resolved_query dict (the coreference_resolver `response` port value,
+        keyed by "content") overrides the raw query string."""
+        out = _retrieve_with_context(
+            query="how does it work",
+            documents=[{"content": "bert masked language model"}],
+            session_context={"session_context": {"context_text": ""}},
+            topic_info=None,
+            resolved_query={"content": "how does bert work"},
+        )
+        cr = out["contextual_retrieval"]
+        # The resolved query ("bert") drives scoring, not the raw "it".
+        assert "bert" in cr["enhanced_query"]
+
+    def test_retrieve_with_context_empty_documents_honest_zero_influence(self):
+        """No documents → empty results + honest zero context_influence."""
+        out = _retrieve_with_context(
+            query="anything",
+            documents=[],
+            session_context={"session_context": {"context_text": ""}},
+        )
+        cr = out["contextual_retrieval"]
+        assert cr["documents"] == []
+        assert cr["scores"] == []
+        assert cr["context_influence"] == 0
+
+    def test_update_session_records_turn_and_metrics(self):
+        """A new turn is appended; the returned session_update reflects the
+        recorded turn + derived (non-fabricated) coherence metrics. response is
+        the LLMAgentNode `response` port value keyed by "content"."""
+        store: dict = {}
+        out = _update_session(
+            session_id="s_up",
+            query="what is bert",
+            response={"content": "BERT is a bidirectional model."},
+            topic_info={"topic_analysis": {"current_topic": "bert"}},
+            summary=None,
+            sessions_store=store,
+            max_context_turns=10,
+        )
+        su = out["session_update"]
+        assert su["session_id"] == "s_up"
+        assert su["turn_added"] == 1
+        assert su["total_turns"] == 1
+        assert su["current_topic"] == "bert"
+        # Single-topic conversation → coherence 1.0 (derived from topic count).
+        assert su["conversation_metrics"]["coherence_score"] == 1.0
+
+    def test_update_session_applies_summary_when_provided(self):
+        """A summary dict (context_summarizer `response` port, keyed by
+        "content") updates the session summary."""
+        store: dict = {}
+        _update_session(
+            session_id="s_sum",
+            query="q",
+            response={"content": "r"},
+            summary={"content": "A concise conversation summary."},
+            sessions_store=store,
+            max_context_turns=10,
+        )
+        assert store["s_sum"]["summary"] == "A concise conversation summary."
+
+    def test_format_conversational_result_publishes_documented_shape(self):
+        """The terminal formatter unwraps each producer's nested key and
+        publishes the documented conversational_response. The config flags are
+        passed explicitly (the closure binds them at construction time)."""
+        out = _format_conversational_result(
+            response={"content": "the answer"},
+            session_update={
+                "session_update": {
+                    "session_id": "sid",
+                    "turn_added": 2,
+                    "total_turns": 2,
+                    "conversation_metrics": {"topic_diversity": 0.5},
+                }
+            },
+            topic_info={"topic_analysis": {"current_topic": "gpt"}},
+            contextual_retrieval={"contextual_retrieval": {"context_influence": 0.7}},
+            max_context_turns=8,
+            enable_summarization=False,
+            coreference_resolution=True,
+            personalization_enabled=False,
+        )
+        cr = out["conversational_response"]
+        assert cr["response"] == "the answer"
+        assert cr["session_state"]["session_id"] == "sid"
+        assert cr["session_state"]["total_turns"] == 2
+        # Config flags interpolated through the explicit params (the #1123 fix).
+        assert cr["session_state"]["context_window"] == 8
+        assert cr["session_state"]["summary_available"] is False
+        assert cr["topic_info"]["current_topic"] == "gpt"
+        assert cr["conversation_metrics"]["retrieval_context_influence"] == 0.7
+        assert cr["metadata"]["coreference_resolution"] is True
+        assert cr["metadata"]["personalization"] is False
+        assert cr["metadata"]["context_enhanced_retrieval"] is True
+
+    def test_format_conversational_result_handles_all_empty_inputs(self):
+        """All-None inputs (a False optional-branch with nothing wired) still
+        publish a well-formed conversational_response (honest empty defaults)."""
+        out = _format_conversational_result()
+        cr = out["conversational_response"]
+        assert cr["response"] == ""
+        assert cr["session_state"]["session_id"] is None
+        assert cr["topic_info"]["transition_type"] == "continuation"
+        assert "metadata" in cr

--- a/packages/kailash-kaizen/tests/unit/rag/test_evaluation_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_evaluation_nodes.py
@@ -32,6 +32,10 @@ from kaizen.nodes.rag.evaluation import (
     RAGBenchmarkNode,
     RAGEvaluationNode,
     TestDatasetGeneratorNode,
+    _evaluate_context_precision,
+    aggregate_evaluation_metrics,
+    collect_rag_results,
+    evaluate_context_metrics,
 )
 
 pytestmark = pytest.mark.unit
@@ -260,13 +264,25 @@ class TestRAGEvaluationGraphShape:
         assert len(inbound) == 5
 
     def test_metric_aggregator_carries_configured_metrics(self):
-        """The metrics list is baked into the aggregator's code template."""
+        """The metrics list is bound into the aggregator ``from_function`` closure
+        (Wave-3 migration) and surfaces in the aggregator's output
+        ``evaluation_config.metrics_used`` — proven directly against
+        ``aggregate_evaluation_metrics`` (the lifted fn; no ``code=`` config to
+        inspect anymore)."""
         wf = _build(RAGEvaluationNode(metrics=["faithfulness", "relevance"]))
         aggregator = wf.get_node("metric_aggregator")
         assert aggregator is not None
-        code = aggregator.config.get("code", "")
-        # The metrics list is interpolated into the source via {self.metrics}.
-        assert "['faithfulness', 'relevance']" in code
+        # The migrated node is a from_function PythonCodeNode — no `code=` config.
+        assert aggregator.config.get("code") is None
+        # The metrics list reaches the output through the bound closure.
+        out = aggregate_evaluation_metrics(
+            test_results=[],
+            metrics=["faithfulness", "relevance"],
+        )
+        assert out["evaluation_summary"]["evaluation_config"]["metrics_used"] == [
+            "faithfulness",
+            "relevance",
+        ]
 
     def test_llm_judge_model_baked_into_evaluator_configs(self):
         """The llm_judge_model kwarg flows into the LLM-judge node configs."""
@@ -285,47 +301,24 @@ class TestRAGEvaluationGraphShape:
 
 
 class TestContextPrecisionMetricCorrectness:
-    """The context_evaluator codegen template implements P@k, MRR, diversity.
+    """``_evaluate_context_precision`` (the lifted Wave-3 fn) implements P@k, MRR,
+    diversity over a single test's REAL retrieval scores.
 
     Value-anchor per F8 plan §B B9b row: "metric correctness + real storage
-    read-back" — this class exercises the metric-correctness half by
-    extracting the codegen function from the workflow node, executing it
-    against a known-fixture retrieval result, and asserting deterministic
-    metric values match the documented formulas.
-
-    The codegen DEFINES ``evaluate_context_precision`` but never CALLS it at
-    module scope. We extract the function and call it directly, mirroring
-    the B9a integration-test ``_run_pii_detector`` helper precedent.
+    read-back" — this class exercises the metric-correctness half by calling the
+    lifted module-level function DIRECTLY against known-fixture retrieval results
+    and asserting deterministic values match the documented formulas. (The prior
+    f-string ``code=`` codegen is gone; the from_function node has no ``code``
+    config to extract — the function is called directly.)
     """
 
     @staticmethod
-    def _run_context_evaluator(code: str, test_result: dict) -> dict:
-        """Exec the codegen against a single ``test_result`` fixture.
-
-        F9 #1117 fixed the codegen: the function returns its dict, the
-        codegen invokes ``result = ...`` at module scope iterating
-        ``test_data``, then `del`s the helper so PythonCodeNode's output
-        gate sees only `result`. For unit tests we strip the `del` line
-        so the inner function survives exec, then call it directly on the
-        caller's fixture for per-test-result assertions.
-        """
-        # Strip the F9 #1117 cleanup line so the helper survives exec.
-        code_no_del = "\n".join(
-            line
-            for line in code.splitlines()
-            if not line.startswith("del evaluate_context_precision")
-        )
-        ns: dict = {"test_data": [test_result]}
-        exec(code_no_del, ns)
-        return ns["evaluate_context_precision"](test_result)
+    def _run_context_evaluator(test_result: dict) -> dict:
+        """Call the lifted ``_evaluate_context_precision`` directly."""
+        return _evaluate_context_precision(test_result)
 
     def test_empty_contexts_returns_zero_precision(self):
-        wf = _build(RAGEvaluationNode())
-        evaluator = wf.get_node("context_evaluator")
-        assert evaluator is not None
-        out = self._run_context_evaluator(
-            evaluator.config["code"], {"retrieved_contexts": [], "query": "x"}
-        )
+        out = self._run_context_evaluator({"retrieved_contexts": [], "query": "x"})
         # The early-exit branch returns precision=recall=ranking_quality=0.
         assert out["context_precision"] == 0.0
         assert out["context_recall"] == 0.0
@@ -333,18 +326,12 @@ class TestContextPrecisionMetricCorrectness:
 
     def test_p_at_k_with_all_relevant_contexts(self):
         """3 contexts all scoring > 0.7 → P@1=P@3=1.0."""
-        wf = _build(RAGEvaluationNode())
-        evaluator = wf.get_node("context_evaluator")
-        assert evaluator is not None
         ctxs = [
             {"content": "a b c d e", "score": 0.95},
             {"content": "f g h i j", "score": 0.90},
             {"content": "k l m n o", "score": 0.80},
         ]
-        out = self._run_context_evaluator(
-            evaluator.config["code"],
-            {"retrieved_contexts": ctxs, "query": "test"},
-        )
+        out = self._run_context_evaluator({"retrieved_contexts": ctxs, "query": "test"})
         ctx_metrics = out["context_metrics"]
         assert ctx_metrics["precision_at_k"]["P@1"] == 1.0
         assert ctx_metrics["precision_at_k"]["P@3"] == 1.0
@@ -354,18 +341,12 @@ class TestContextPrecisionMetricCorrectness:
 
     def test_p_at_k_with_mixed_relevance(self):
         """First two contexts < 0.7 → P@1 = 0, MRR = 1/3."""
-        wf = _build(RAGEvaluationNode())
-        evaluator = wf.get_node("context_evaluator")
-        assert evaluator is not None
         ctxs = [
             {"content": "a", "score": 0.5},
             {"content": "b", "score": 0.6},
             {"content": "c", "score": 0.9},
         ]
-        out = self._run_context_evaluator(
-            evaluator.config["code"],
-            {"retrieved_contexts": ctxs, "query": "test"},
-        )
+        out = self._run_context_evaluator({"retrieved_contexts": ctxs, "query": "test"})
         ctx_metrics = out["context_metrics"]
         assert ctx_metrics["precision_at_k"]["P@1"] == 0.0
         # 1 relevant in top-3 → P@3 = 1/3.
@@ -374,33 +355,48 @@ class TestContextPrecisionMetricCorrectness:
         assert ctx_metrics["mrr"] == pytest.approx(1 / 3)
 
     def test_mrr_zero_when_no_relevant_contexts(self):
-        wf = _build(RAGEvaluationNode())
-        evaluator = wf.get_node("context_evaluator")
-        assert evaluator is not None
         ctxs = [{"content": "x", "score": 0.1}, {"content": "y", "score": 0.2}]
-        out = self._run_context_evaluator(
-            evaluator.config["code"],
-            {"retrieved_contexts": ctxs, "query": "q"},
-        )
+        out = self._run_context_evaluator({"retrieved_contexts": ctxs, "query": "q"})
         ctx_metrics = out["context_metrics"]
         assert ctx_metrics["mrr"] == 0.0
 
     def test_avg_relevance_is_arithmetic_mean(self):
         """avg_relevance_score = sum(scores) / len(scores)."""
-        wf = _build(RAGEvaluationNode())
-        evaluator = wf.get_node("context_evaluator")
-        assert evaluator is not None
         ctxs = [
             {"content": "a", "score": 0.8},
             {"content": "b", "score": 0.6},
             {"content": "c", "score": 0.4},
         ]
-        out = self._run_context_evaluator(
-            evaluator.config["code"],
-            {"retrieved_contexts": ctxs, "query": "q"},
-        )
+        out = self._run_context_evaluator({"retrieved_contexts": ctxs, "query": "q"})
         # (0.8 + 0.6 + 0.4) / 3 = 0.6.
         assert out["context_metrics"]["avg_relevance_score"] == pytest.approx(0.6)
+
+    def test_none_content_does_not_crash(self):
+        """Honest edge: a context with present-None content is coerced to "",
+        no AttributeError on .lower()."""
+        out = self._run_context_evaluator(
+            {"retrieved_contexts": [{"content": None, "score": 0.9}], "query": "q"}
+        )
+        assert out["context_metrics"]["context_count"] == 1
+
+    def test_map_over_test_data_list(self):
+        """``evaluate_context_metrics`` maps the per-test fn over the list and
+        returns ``{"context_metrics": [...]}`` (the wire shape the aggregator
+        indexes)."""
+        out = evaluate_context_metrics(
+            [
+                {"retrieved_contexts": [{"content": "a", "score": 0.9}], "query": "q1"},
+                {"retrieved_contexts": [], "query": "q2"},
+            ]
+        )
+        assert isinstance(out["context_metrics"], list)
+        assert len(out["context_metrics"]) == 2
+        # First test has a real context; second is the empty early-exit shape.
+        assert out["context_metrics"][0]["context_count"] == 1
+
+    def test_evaluate_context_metrics_none_input(self):
+        out = evaluate_context_metrics(None)
+        assert out["context_metrics"] == []
 
 
 # ==========================================================================
@@ -409,42 +405,25 @@ class TestContextPrecisionMetricCorrectness:
 
 
 class TestTestExecutorPassThrough:
-    """The test_executor codegen judges caller-provided results, not invented ones.
+    """The lifted ``collect_rag_results`` (Wave-3 fn) judges caller-provided
+    results, not invented ones.
 
-    Provably-correct remediation: the inner ``collect_rag_results`` MUST pass
-    the caller's real ``generated_answer`` + ``retrieved_contexts`` through
-    (no ``f"Generated answer for: {query}"`` fabrication, no hardcoded
-    contexts) and MUST raise when those fields are absent.
-    """
+    Provably-correct remediation: ``collect_rag_results`` MUST pass the caller's
+    real ``generated_answer`` + ``retrieved_contexts`` through (no
+    ``f"Generated answer for: {query}"`` fabrication, no hardcoded contexts) and
+    MUST raise when those fields are absent. Called DIRECTLY (the prior ``code=``
+    codegen is gone; the from_function node has no ``code`` config)."""
 
-    @staticmethod
-    def _exec_collector(code: str, test_queries: list) -> dict:
-        """Exec the codegen with the helper preserved; return module `result`."""
-        # Strip the F9 cleanup `del` so we can also assert on the namespace.
-        code_no_del = "\n".join(
-            line
-            for line in code.splitlines()
-            if not line.startswith("del collect_rag_results")
-        )
-        ns: dict = {"test_queries": test_queries}
-        exec(code_no_del, ns)
-        return ns["result"]
-
-    def test_codegen_no_longer_fabricates_answers(self):
-        """The fabrication template MUST be gone from the source."""
+    def test_node_no_longer_carries_codegen(self):
+        """The migrated test_executor is a from_function node — no ``code=``
+        config, so no f-string fabrication template can lurk in source."""
         wf = _build(RAGEvaluationNode())
         executor = wf.get_node("test_executor")
         assert executor is not None
-        code = executor.config["code"]
-        assert 'f"Generated answer for: {query}"' not in code
-        assert "Context 1 about transformers" not in code
+        assert executor.config.get("code") is None
 
     def test_passes_through_caller_provided_results(self):
-        wf = _build(RAGEvaluationNode())
-        executor = wf.get_node("test_executor")
-        assert executor is not None
-        out = self._exec_collector(
-            executor.config["code"],
+        out = collect_rag_results(
             [
                 {
                     "query": "What is BERT?",
@@ -465,26 +444,25 @@ class TestTestExecutorPassThrough:
         ]
         assert tr["query"] == "What is BERT?"
         assert tr["reference_answer"] == "BERT is bidirectional..."
+        assert "timestamp" in tr
 
     def test_missing_generated_answer_raises(self):
-        wf = _build(RAGEvaluationNode())
-        executor = wf.get_node("test_executor")
-        assert executor is not None
         with pytest.raises(ValueError, match="generated_answer"):
-            self._exec_collector(
-                executor.config["code"],
-                [{"query": "q", "retrieved_contexts": []}],
-            )
+            collect_rag_results([{"query": "q", "retrieved_contexts": []}])
 
     def test_missing_retrieved_contexts_raises(self):
-        wf = _build(RAGEvaluationNode())
-        executor = wf.get_node("test_executor")
-        assert executor is not None
         with pytest.raises(ValueError, match="retrieved_contexts"):
-            self._exec_collector(
-                executor.config["code"],
-                [{"query": "q", "generated_answer": "a"}],
-            )
+            collect_rag_results([{"query": "q", "generated_answer": "a"}])
+
+    def test_empty_queries_returns_zero_tests(self):
+        out = collect_rag_results([])
+        assert out["total_tests"] == 0
+        assert out["test_results"] == []
+        assert out["avg_execution_time"] == 0.0
+
+    def test_none_input_returns_zero_tests(self):
+        out = collect_rag_results(None)
+        assert out["total_tests"] == 0
 
 
 # ==========================================================================
@@ -782,3 +760,258 @@ def test_module_all_exports_three_classes():
         "RAGBenchmarkNode",
         "TestDatasetGeneratorNode",
     }
+
+
+# ==========================================================================
+# F31-FU2 Shard C — direct-call Tier-1 coverage of the pure parser / composer
+# `from_function` targets in `evaluation.py` (the O1 OUTPUT-side judge-response
+# parsers + the judge-message composers). These are pure data rendering /
+# tool-result parsing (the permitted deterministic exceptions per
+# rules/agent-reasoning.md #3 + #6) — NOT agent decision-making. Called DIRECTLY
+# (no LocalRuntime, no mocking — they are pure functions).
+#
+# CRITICAL per-file contract (zero-tolerance Rule 2): the EVALUATION parsers
+# return PER-TEST SCORE ARRAYS shaped `{"scores": [<per-test dict>, ...]}`. The
+# judge returns a JSON ARRAY, one object per numbered test, and the parser keeps
+# them positionally aligned. The honest defaults here DIFFER from the other RAG
+# parsers:
+#   * empty / None response -> `{"scores": []}` — an HONEST "nothing to score"
+#     (NO `parse_error` sentinel; the aggregator treats a missing per-test entry
+#     as a flagged gap, never a fabricated zero).
+#   * non-json / unexpected-content-type / bare-scalar -> a ONE-element list with
+#     a typed `parse_error` sentinel + the score value None (the whole batch is
+#     unparseable).
+#   * non-dict array element -> per-element `parse_error: "non-object-array-element"`.
+#   * already-parsed list/dict content -> passed through (provider pre-parsed).
+# No malformed case is zero-padded; the flagged sentinel carries None, never 0.
+# ==========================================================================
+
+import json
+
+from kaizen.nodes.rag.evaluation import (
+    _parse_score_array,
+    _unwrap_response_content,
+    compose_answer_quality_messages,
+    compose_faithfulness_messages,
+    compose_relevance_messages,
+    parse_answer_quality_response,
+    parse_faithfulness_response,
+    parse_relevance_response,
+)
+
+
+def _wrap(obj) -> dict:
+    """Build the LLMAgentNode `response` port shape with a JSON-string content."""
+    return {"content": json.dumps(obj)}
+
+
+class TestEvaluationUnwrapResponseContent:
+    """`_unwrap_response_content`: dict -> .content, bare value -> passthrough."""
+
+    def test_unwrap_dict_returns_content(self):
+        assert _unwrap_response_content({"content": "hello"}) == "hello"
+
+    def test_unwrap_dict_missing_content_returns_none(self):
+        assert _unwrap_response_content({"other": "x"}) is None
+
+    def test_unwrap_bare_string_passthrough(self):
+        assert _unwrap_response_content("raw string") == "raw string"
+
+    def test_unwrap_none_passthrough(self):
+        assert _unwrap_response_content(None) is None
+
+
+class TestParseScoreArray:
+    """`_parse_score_array`: per-test list, honest [] on empty, flagged sentinels.
+
+    This is the shared core of all three judge parsers; its honest-default
+    contract is asserted directly here (zero-tolerance Rule 2) and re-asserted
+    through each public parser below.
+    """
+
+    def test_valid_array_returns_per_test_dicts(self):
+        arr = [{"faithfulness_score": 0.9}, {"faithfulness_score": 0.5}]
+        result = _parse_score_array(_wrap(arr), "faithfulness_score")
+        assert result == arr
+
+    def test_already_list_content_passthrough(self):
+        # Provider pre-parsed: content is already a list of dicts.
+        arr = [{"relevance_score": 0.3}]
+        result = _parse_score_array({"content": arr}, "relevance_score")
+        assert result == arr
+
+    def test_single_object_content_wrapped_in_list(self):
+        # A degenerate batch-of-one: a single JSON object -> [parsed].
+        obj = {"overall_quality": 0.7}
+        result = _parse_score_array(_wrap(obj), "overall_quality")
+        assert result == [obj]
+
+    def test_none_response_returns_empty_list_no_sentinel(self):
+        # Honest "nothing to score" — NO parse_error, NEVER a fabricated zero.
+        assert _parse_score_array(None, "faithfulness_score") == []
+
+    def test_empty_content_returns_empty_list_no_sentinel(self):
+        assert _parse_score_array({"content": ""}, "faithfulness_score") == []
+
+    def test_whitespace_content_returns_empty_list_no_sentinel(self):
+        assert _parse_score_array({"content": "   "}, "faithfulness_score") == []
+
+    def test_non_json_content_returns_flagged_sentinel(self):
+        result = _parse_score_array({"content": "not json{"}, "faithfulness_score")
+        assert result == [
+            {"faithfulness_score": None, "parse_error": "non-json-response"}
+        ]
+
+    def test_unexpected_content_type_returns_flagged_sentinel(self):
+        result = _parse_score_array({"content": 42}, "faithfulness_score")
+        assert result == [
+            {"faithfulness_score": None, "parse_error": "unexpected-content-type"}
+        ]
+
+    def test_bare_scalar_json_returns_flagged_sentinel(self):
+        # Valid JSON that is neither array nor object (a number).
+        result = _parse_score_array({"content": "0.8"}, "faithfulness_score")
+        assert result == [
+            {"faithfulness_score": None, "parse_error": "non-array-non-object-json"}
+        ]
+
+    def test_non_dict_array_element_flagged_per_element(self):
+        # Array whose elements are not objects -> per-element flagged sentinel.
+        result = _parse_score_array({"content": "[1, 2]"}, "faithfulness_score")
+        assert result == [
+            {"faithfulness_score": None, "parse_error": "non-object-array-element"},
+            {"faithfulness_score": None, "parse_error": "non-object-array-element"},
+        ]
+
+
+class TestParseFaithfulnessResponse:
+    def test_valid_returns_scores_with_faithfulness_key(self):
+        arr = [{"faithfulness_score": 0.9}, {"faithfulness_score": 0.4}]
+        result = parse_faithfulness_response(_wrap(arr))
+        assert result == {"scores": arr}
+
+    def test_none_returns_empty_scores_no_sentinel(self):
+        result = parse_faithfulness_response(None)
+        assert result == {"scores": []}
+
+    def test_empty_content_returns_empty_scores(self):
+        result = parse_faithfulness_response({"content": ""})
+        assert result == {"scores": []}
+
+    def test_non_json_returns_flagged_faithfulness_sentinel(self):
+        result = parse_faithfulness_response({"content": "not json{"})
+        assert result == {
+            "scores": [{"faithfulness_score": None, "parse_error": "non-json-response"}]
+        }
+
+    def test_bad_content_type_returns_flagged_sentinel(self):
+        result = parse_faithfulness_response({"content": 42})
+        assert result == {
+            "scores": [
+                {"faithfulness_score": None, "parse_error": "unexpected-content-type"}
+            ]
+        }
+
+
+class TestParseRelevanceResponse:
+    def test_valid_returns_scores_with_relevance_key(self):
+        arr = [{"relevance_score": 0.8}]
+        result = parse_relevance_response(_wrap(arr))
+        assert result == {"scores": arr}
+
+    def test_none_returns_empty_scores_no_sentinel(self):
+        result = parse_relevance_response(None)
+        assert result == {"scores": []}
+
+    def test_non_json_returns_flagged_relevance_sentinel(self):
+        result = parse_relevance_response({"content": "not json{"})
+        assert result == {
+            "scores": [{"relevance_score": None, "parse_error": "non-json-response"}]
+        }
+
+
+class TestParseAnswerQualityResponse:
+    def test_valid_returns_scores_with_overall_quality_key(self):
+        arr = [{"overall_quality": 0.6}, {"overall_quality": 0.95}]
+        result = parse_answer_quality_response(_wrap(arr))
+        assert result == {"scores": arr}
+
+    def test_none_returns_empty_scores_no_sentinel(self):
+        result = parse_answer_quality_response(None)
+        assert result == {"scores": []}
+
+    def test_non_json_returns_flagged_overall_quality_sentinel(self):
+        result = parse_answer_quality_response({"content": "not json{"})
+        assert result == {
+            "scores": [{"overall_quality": None, "parse_error": "non-json-response"}]
+        }
+
+
+# --------------------------------------------------------------------------
+# Composers — VALID interpolation (real per-test data rendered) + EMPTY input
+# (well-formed messages, honest "No test results" body). Each returns a
+# {"messages": [{"role","content"}, ...]} shape.
+# --------------------------------------------------------------------------
+
+
+def _assert_messages_shape(result):
+    """Assert the composer return is a well-formed OpenAI chat `messages` list."""
+    assert isinstance(result, dict)
+    assert "messages" in result
+    msgs = result["messages"]
+    assert isinstance(msgs, list) and len(msgs) >= 1
+    for m in msgs:
+        assert isinstance(m, dict)
+        assert "role" in m and "content" in m
+    return msgs
+
+
+_ONE_TEST = [
+    {
+        "query": "What is BERT?",
+        "generated_answer": "A bidirectional transformer.",
+        "retrieved_contexts": [{"content": "BERT is bidirectional.", "score": 0.91}],
+        "reference_answer": "BERT is a bidirectional encoder.",
+    }
+]
+
+
+class TestComposeFaithfulnessMessages:
+    def test_valid_interpolates_real_test_data(self):
+        msgs = _assert_messages_shape(compose_faithfulness_messages(_ONE_TEST))
+        content = msgs[0]["content"]
+        # The REAL query + answer + context are rendered into the judge prompt.
+        assert "What is BERT?" in content
+        assert "A bidirectional transformer." in content
+        assert "BERT is bidirectional." in content
+        # Faithfulness does not render the reference answer.
+        assert "BERT is a bidirectional encoder." not in content
+
+    def test_empty_returns_wellformed_no_results_body(self):
+        msgs = _assert_messages_shape(compose_faithfulness_messages([]))
+        assert "No test results were provided to evaluate." in msgs[0]["content"]
+
+
+class TestComposeRelevanceMessages:
+    def test_valid_interpolates_real_test_data(self):
+        msgs = _assert_messages_shape(compose_relevance_messages(_ONE_TEST))
+        content = msgs[0]["content"]
+        assert "What is BERT?" in content
+        assert "A bidirectional transformer." in content
+
+    def test_empty_returns_wellformed_no_results_body(self):
+        msgs = _assert_messages_shape(compose_relevance_messages([]))
+        assert "No test results were provided to evaluate." in msgs[0]["content"]
+
+
+class TestComposeAnswerQualityMessages:
+    def test_valid_interpolates_real_test_data_with_reference(self):
+        msgs = _assert_messages_shape(compose_answer_quality_messages(_ONE_TEST))
+        content = msgs[0]["content"]
+        assert "A bidirectional transformer." in content
+        # answer_quality DOES render the reference answer (it compares against it).
+        assert "BERT is a bidirectional encoder." in content
+
+    def test_empty_returns_wellformed_no_results_body(self):
+        msgs = _assert_messages_shape(compose_answer_quality_messages([]))
+        assert "No test results were provided to evaluate." in msgs[0]["content"]

--- a/packages/kailash-kaizen/tests/unit/rag/test_graph_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_graph_nodes.py
@@ -417,12 +417,21 @@ class TestGraphRAGNode:
         assert "gene" in prompt
         assert "protein" in prompt
 
-    def test_create_workflow_max_hops_flows_into_retriever_code(self):
-        """``max_hops`` is interpolated into the graph_retriever code
-        template — the BFS depth bound reaches the generated code."""
+    def test_create_workflow_max_hops_flows_into_retriever(self):
+        """``max_hops`` is bound into the graph_retriever ``from_function`` closure
+        (Wave-3 migration). The BFS depth bound reaches the retriever via the
+        closure, not an f-string code template. Proven directly: the bound
+        retriever expands the subgraph up to ``max_hops`` hops (see
+        ``TestRetrieveFromGraph.test_multi_hop_bounded_by_max_hops`` for the
+        behavioral floor); here we assert the node is a real registered node
+        (no ``code=`` config to inspect anymore)."""
         wf = GraphRAGNode(max_hops=7)._create_workflow()  # type: ignore[attr-defined]
-        code = wf.nodes["graph_retriever"].config["code"]
-        assert "depth >= 7" in code
+        retriever = wf.nodes["graph_retriever"]
+        # The migrated node is a from_function PythonCodeNode — its `code` config
+        # is None (the prior f-string template is gone). The max_hops bound
+        # behavior is asserted directly against `retrieve_from_graph` below.
+        assert retriever.config.get("code") is None
+        assert retriever is not None
 
     def test_get_parameters_exposes_workflow_inputs(self):
         """As a WorkflowNode, GraphRAGNode exposes the sub-workflow's input
@@ -431,3 +440,583 @@ class TestGraphRAGNode:
         assert isinstance(params, dict)
         # The sub-workflow's leaf inputs are exposed as node parameters.
         assert len(params) > 0
+
+
+# ==========================================================================
+# F31-FU2 Shard C — direct-call Tier-1 coverage of the pure parser / composer
+# `from_function` targets in `graph.py` (the O3 OUTPUT-side parsers + the LLM-
+# stage message composers). Pure data rendering / tool-result parsing (permitted
+# deterministic exceptions per rules/agent-reasoning.md #3 + #6) — NOT agent
+# decision-making. Called DIRECTLY (no LocalRuntime, no mocking — pure functions).
+#
+# Per-file contract (zero-tolerance Rule 2) — the THREE graph parsers each have
+# their OWN distinct shape; never borrow another's contract:
+#   * parse_entity_extraction — publishes the parsed object WRAPPED IN A
+#     ONE-ELEMENT LIST under `result` (`{"result": [ {entities, relationships} ]}`)
+#     because build_knowledge_graph iterates extraction_results as a LIST of
+#     per-doc objects. Malformed -> a one-element list carrying
+#     `{"entities": [], "relationships": [], "parse_error": "<reason>"}` so the
+#     graph builds EMPTY honestly (never fabricated entities, never a crash).
+#   * parse_query_analysis — publishes a DICT under `result`
+#     (`{"result": {entities, relationship_types, requires_multi_hop,
+#     reasoning_type}}`). Malformed -> the same dict with empty defaults +
+#     `parse_error`. requires_multi_hop is coerced via bool(); reasoning_type
+#     stays None when absent (never a fabricated default type).
+#   * parse_global_summary — PROSE (NO json.loads). `{"result": {global_summary}}`.
+#     Sentinels: empty-response (None/empty/blank) and non-string-content. There
+#     is NO non-json sentinel because the summary is free text, not JSON.
+# ==========================================================================
+
+import json as _json
+
+from kaizen.nodes.rag.graph import (
+    _unwrap_response_content,
+    build_knowledge_graph,
+    compose_entity_extraction_messages,
+    compose_query_analysis_messages,
+    compose_summary_messages,
+    parse_entity_extraction,
+    parse_global_summary,
+    parse_query_analysis,
+    retrieve_from_graph,
+    synthesize_results,
+)
+
+
+def _g_wrap(obj) -> dict:
+    """Build the LLMAgentNode `response` port shape with a JSON-string content."""
+    return {"content": _json.dumps(obj)}
+
+
+class TestGraphUnwrapResponseContent:
+    """`_unwrap_response_content`: dict -> .content, bare value -> passthrough."""
+
+    def test_unwrap_dict_returns_content(self):
+        assert _unwrap_response_content({"content": "hello"}) == "hello"
+
+    def test_unwrap_dict_missing_content_returns_none(self):
+        assert _unwrap_response_content({"other": "x"}) is None
+
+    def test_unwrap_bare_string_passthrough(self):
+        assert _unwrap_response_content("raw string") == "raw string"
+
+    def test_unwrap_none_passthrough(self):
+        assert _unwrap_response_content(None) is None
+
+
+class TestParseEntityExtraction:
+    """List-wrapped result; malformed -> one-element flagged extraction.
+
+    The list-wrap is critical: build_knowledge_graph iterates the result as a
+    LIST of per-doc extraction objects. Every variant returns a ONE-element list.
+    """
+
+    def test_valid_returns_one_element_list_of_extraction(self):
+        obj = {"entities": [{"name": "BERT"}], "relationships": [{"a": "b"}]}
+        result = parse_entity_extraction(_g_wrap(obj))
+        assert result == {"result": [obj]}
+        # The wrapper IS a list with exactly one element.
+        assert isinstance(result["result"], list) and len(result["result"]) == 1
+        assert "parse_error" not in result["result"][0]
+
+    def test_already_dict_content_returns_one_element_list(self):
+        # Provider pre-parsed: content is already a dict.
+        obj = {"entities": [{"name": "X"}], "relationships": []}
+        result = parse_entity_extraction({"content": obj})
+        assert result == {"result": [obj]}
+
+    def test_none_returns_flagged_empty_extraction_list(self):
+        result = parse_entity_extraction(None)
+        assert result == {
+            "result": [
+                {"entities": [], "relationships": [], "parse_error": "empty-response"}
+            ]
+        }
+
+    def test_empty_content_returns_flagged_empty_extraction_list(self):
+        result = parse_entity_extraction({"content": ""})
+        assert result == {
+            "result": [
+                {"entities": [], "relationships": [], "parse_error": "empty-response"}
+            ]
+        }
+
+    def test_non_json_returns_flagged_non_json_list(self):
+        result = parse_entity_extraction({"content": "not json{"})
+        assert result == {
+            "result": [
+                {
+                    "entities": [],
+                    "relationships": [],
+                    "parse_error": "non-json-response",
+                }
+            ]
+        }
+
+    def test_unexpected_content_type_returns_flagged_list(self):
+        result = parse_entity_extraction({"content": 42})
+        assert result == {
+            "result": [
+                {
+                    "entities": [],
+                    "relationships": [],
+                    "parse_error": "unexpected-content-type",
+                }
+            ]
+        }
+
+    def test_non_object_json_returns_flagged_list(self):
+        result = parse_entity_extraction({"content": "[1, 2, 3]"})
+        assert result == {
+            "result": [
+                {
+                    "entities": [],
+                    "relationships": [],
+                    "parse_error": "non-object-json",
+                }
+            ]
+        }
+
+    def test_missing_keys_returns_flagged_empty_extraction(self):
+        # Parsed object but entities/relationships keys absent/wrong-shape.
+        result = parse_entity_extraction(_g_wrap({"foo": 1}))
+        assert result == {
+            "result": [
+                {
+                    "entities": [],
+                    "relationships": [],
+                    "parse_error": "missing-entities-or-relationships",
+                }
+            ]
+        }
+
+
+class TestParseQueryAnalysis:
+    """Dict-wrapped result; malformed -> empty-default dict + parse_error."""
+
+    def test_valid_returns_analysis_dict(self):
+        obj = {
+            "entities": ["BERT", "GPT"],
+            "relationship_types": ["influenced"],
+            "requires_multi_hop": True,
+            "reasoning_type": "causal",
+        }
+        result = parse_query_analysis(_g_wrap(obj))
+        assert result == {"result": obj}
+        assert "parse_error" not in result["result"]
+
+    def test_already_dict_content_returns_analysis_dict(self):
+        obj = {
+            "entities": ["X"],
+            "relationship_types": [],
+            "requires_multi_hop": False,
+            "reasoning_type": None,
+        }
+        result = parse_query_analysis({"content": obj})
+        assert result["result"]["entities"] == ["X"]
+        assert "parse_error" not in result["result"]
+
+    def test_none_returns_flagged_empty_analysis(self):
+        result = parse_query_analysis(None)
+        assert result == {
+            "result": {
+                "entities": [],
+                "relationship_types": [],
+                "requires_multi_hop": False,
+                "reasoning_type": None,
+                "parse_error": "empty-response",
+            }
+        }
+
+    def test_empty_content_returns_flagged_empty_analysis(self):
+        result = parse_query_analysis({"content": ""})
+        assert result["result"]["parse_error"] == "empty-response"
+        assert result["result"]["entities"] == []
+        assert result["result"]["requires_multi_hop"] is False
+        assert result["result"]["reasoning_type"] is None
+
+    def test_non_json_returns_flagged_non_json_analysis(self):
+        result = parse_query_analysis({"content": "not json{"})
+        assert result["result"]["parse_error"] == "non-json-response"
+        assert result["result"]["entities"] == []
+
+    def test_unexpected_content_type_returns_flagged_analysis(self):
+        result = parse_query_analysis({"content": 42})
+        assert result["result"]["parse_error"] == "unexpected-content-type"
+        assert result["result"]["entities"] == []
+
+    def test_non_object_json_returns_flagged_analysis(self):
+        result = parse_query_analysis({"content": "[1, 2, 3]"})
+        assert result["result"]["parse_error"] == "non-object-json"
+        assert result["result"]["entities"] == []
+
+    def test_missing_fields_coerced_to_honest_defaults(self):
+        # Parsed object with absent fields: each coerced to its empty default,
+        # requires_multi_hop -> bool(None) == False, reasoning_type stays None.
+        result = parse_query_analysis(_g_wrap({"foo": 1}))
+        analysis = result["result"]
+        assert analysis["entities"] == []
+        assert analysis["relationship_types"] == []
+        assert analysis["requires_multi_hop"] is False
+        assert analysis["reasoning_type"] is None
+        # A valid parse with only-missing-fields carries no parse_error (the dict
+        # was a valid object; the defaults are honest, not a parse failure).
+        assert "parse_error" not in analysis
+
+
+class TestParseGlobalSummary:
+    """Prose (NO json.loads); empty-response + non-string-content sentinels."""
+
+    def test_valid_prose_returns_summary(self):
+        result = parse_global_summary({"content": "The corpus covers transformers."})
+        assert result == {
+            "result": {"global_summary": "The corpus covers transformers."}
+        }
+        assert "parse_error" not in result["result"]
+
+    def test_valid_prose_is_stripped(self):
+        result = parse_global_summary({"content": "  surrounded by space  "})
+        assert result["result"]["global_summary"] == "surrounded by space"
+
+    def test_bare_string_passthrough_returns_summary(self):
+        # A defensive bare-string response (not dict-wrapped) is honored.
+        result = parse_global_summary("plain prose summary")
+        assert result["result"]["global_summary"] == "plain prose summary"
+
+    def test_none_returns_empty_response_sentinel(self):
+        result = parse_global_summary(None)
+        assert result == {
+            "result": {"global_summary": None, "parse_error": "empty-response"}
+        }
+
+    def test_empty_content_returns_empty_response_sentinel(self):
+        result = parse_global_summary({"content": ""})
+        assert result == {
+            "result": {"global_summary": None, "parse_error": "empty-response"}
+        }
+
+    def test_whitespace_content_returns_empty_response_sentinel(self):
+        result = parse_global_summary({"content": "   "})
+        assert result == {
+            "result": {"global_summary": None, "parse_error": "empty-response"}
+        }
+
+    def test_non_string_content_returns_non_string_sentinel(self):
+        # The provider returned a structure where prose was expected.
+        result = parse_global_summary({"content": {"a": 1}})
+        assert result == {
+            "result": {"global_summary": None, "parse_error": "non-string-content"}
+        }
+
+
+def _g_assert_messages_shape(result):
+    """Assert the composer return is a well-formed OpenAI chat `messages` list."""
+    assert isinstance(result, dict)
+    assert "messages" in result
+    msgs = result["messages"]
+    assert isinstance(msgs, list) and len(msgs) >= 1
+    for m in msgs:
+        assert isinstance(m, dict)
+        assert "role" in m and "content" in m
+    return msgs
+
+
+class TestComposeEntityExtractionMessages:
+    def test_valid_interpolates_document_text(self):
+        docs = [{"id": "d1", "content": "BERT is a transformer model."}]
+        msgs = _g_assert_messages_shape(compose_entity_extraction_messages(docs))
+        content = msgs[0]["content"]
+        assert "BERT is a transformer model." in content
+        assert "Extract entities and relationships" in content
+
+    def test_empty_returns_wellformed_no_documents_body(self):
+        msgs = _g_assert_messages_shape(compose_entity_extraction_messages(None))
+        assert (
+            "No documents were provided to extract entities from." in msgs[0]["content"]
+        )
+
+
+class TestComposeQueryAnalysisMessages:
+    def test_valid_interpolates_query(self):
+        msgs = _g_assert_messages_shape(
+            compose_query_analysis_messages(query="How did BERT influence GPT?")
+        )
+        content = msgs[0]["content"]
+        assert "How did BERT influence GPT?" in content
+        assert "Analyze the following query for graph retrieval" in content
+
+    def test_empty_returns_wellformed_no_query_body(self):
+        msgs = _g_assert_messages_shape(compose_query_analysis_messages(query=""))
+        assert "No query was provided to analyze." in msgs[0]["content"]
+
+
+class TestComposeSummaryMessages:
+    def test_valid_interpolates_graph_context_and_query(self):
+        graph_retrieval = {
+            "graph_retrieval": {
+                "relevant_nodes": ["BERT", "GPT"],
+                "relationships": [{"source": "BERT", "target": "GPT"}],
+            }
+        }
+        msgs = _g_assert_messages_shape(
+            compose_summary_messages(
+                graph_retrieval=graph_retrieval, query="Summarize the influence chain"
+            )
+        )
+        content = msgs[0]["content"]
+        # The real query is rendered; the summarize instruction is present.
+        assert "Summarize the influence chain" in content
+        assert "Summarize the main themes" in content
+
+    def test_empty_returns_wellformed_no_context_body(self):
+        # No graph retrieval + empty query MUST still produce a valid shape with
+        # an explicit empty-context note (no fabricated graph data).
+        msgs = _g_assert_messages_shape(
+            compose_summary_messages(graph_retrieval=None, query="")
+        )
+        content = msgs[0]["content"]
+        assert "No graph context was retrieved for this query" in content
+
+
+# ==========================================================================
+# Wave-3 Shard S3 — direct-call Tier-1 coverage of the 3 lifted COMPUTE
+# `from_function` targets in `graph.py` (build_knowledge_graph /
+# retrieve_from_graph / synthesize_results). These replace the prior f-string
+# `code=` codegen blocks. They run REAL networkx (the shipped infra — nothing to
+# mock) DIRECTLY (no LocalRuntime; the functions are pure). One direct-call test
+# per documented behavior + honest-default edge cases (zero-tolerance Rule 2).
+# ==========================================================================
+
+
+class TestBuildKnowledgeGraph:
+    """``build_knowledge_graph`` builds a real networkx graph from the parsed
+    extraction LIST and returns ``{"graph_data": {...}}``."""
+
+    _EXTRACTION = [
+        {
+            "entities": [
+                {"name": "BERT", "type": "technology", "description": "encoder"},
+                {"name": "Attention", "type": "concept", "description": "mechanism"},
+            ],
+            "relationships": [
+                {
+                    "source": "BERT",
+                    "target": "Attention",
+                    "type": "uses",
+                    "description": "core",
+                }
+            ],
+        }
+    ]
+
+    def test_valid_extraction_builds_real_graph(self):
+        out = build_knowledge_graph(
+            self._EXTRACTION, community_algorithm="connected_components"
+        )
+        gd = out["graph_data"]
+        # The serialized graph round-trips into a real networkx MultiDiGraph.
+        G = nx.node_link_graph(gd["graph"])
+        assert set(G.nodes()) == {"bert", "attention"}
+        assert G.has_edge("bert", "attention")
+        assert gd["stats"]["num_entities"] == 2
+        assert gd["stats"]["num_relationships"] == 1
+        assert len(gd["entities"]) == 2
+        assert len(gd["relationships"]) == 1
+
+    def test_connected_components_communities(self):
+        """The non-louvain path uses weakly-connected-components — no `community`
+        dependency, one community for the single connected pair."""
+        out = build_knowledge_graph(
+            self._EXTRACTION, community_algorithm="connected_components"
+        )
+        communities = out["graph_data"]["communities"]
+        # Both nodes are in the same weakly-connected component.
+        assert set(communities.values()) == {0}
+
+    def test_empty_extraction_builds_empty_graph(self):
+        """Honest default: empty extraction → an EMPTY graph, no fabricated
+        entities (zero-tolerance Rule 2)."""
+        out = build_knowledge_graph([], community_algorithm="connected_components")
+        gd = out["graph_data"]
+        G = nx.node_link_graph(gd["graph"])
+        assert G.number_of_nodes() == 0
+        assert gd["stats"]["num_entities"] == 0
+        assert gd["stats"]["num_communities"] == 0
+
+    def test_none_extraction_builds_empty_graph(self):
+        out = build_knowledge_graph(None, community_algorithm="connected_components")
+        assert out["graph_data"]["stats"]["num_entities"] == 0
+
+    def test_malformed_entity_missing_name_skipped(self):
+        """An entity dict missing ``name`` is skipped, not crashed on."""
+        out = build_knowledge_graph(
+            [{"entities": [{"type": "x"}], "relationships": []}],
+            community_algorithm="connected_components",
+        )
+        assert out["graph_data"]["stats"]["num_entities"] == 0
+
+    def test_non_dict_doc_extraction_skipped(self):
+        out = build_knowledge_graph(
+            ["not a dict", self._EXTRACTION[0]],
+            community_algorithm="connected_components",
+        )
+        assert out["graph_data"]["stats"]["num_entities"] == 2
+
+
+class TestRetrieveFromGraph:
+    """``retrieve_from_graph`` retrieves a subgraph driven by the parsed
+    query-analysis; returns ``{"graph_retrieval": {...}}``."""
+
+    def _graph_data(self) -> dict:
+        return build_knowledge_graph(
+            [
+                {
+                    "entities": [
+                        {"name": "BERT", "type": "technology", "description": "e"},
+                        {"name": "GPT", "type": "technology", "description": "d"},
+                        {"name": "Attention", "type": "concept", "description": "m"},
+                    ],
+                    "relationships": [
+                        {"source": "BERT", "target": "Attention", "type": "uses"},
+                        {"source": "Attention", "target": "GPT", "type": "feeds"},
+                    ],
+                }
+            ],
+            community_algorithm="connected_components",
+        )["graph_data"]
+
+    def test_matches_query_entities_to_nodes(self):
+        out = retrieve_from_graph(
+            self._graph_data(),
+            {
+                "entities": ["bert"],
+                "relationship_types": [],
+                "requires_multi_hop": False,
+            },
+            max_hops=2,
+        )
+        # The retriever preserves the ORIGINAL-CASE entity name attribute (the
+        # graph node id is lowercased, but `name` carries the source casing).
+        names = {e["name"] for e in out["graph_retrieval"]["entities"]}
+        assert "BERT" in names
+
+    def test_multi_hop_bounded_by_max_hops(self):
+        """``requires_multi_hop`` expands the subgraph via BFS bounded by
+        ``max_hops`` — proving the closure-bound depth reaches the retriever."""
+        gd = self._graph_data()
+        # 1 hop from bert reaches attention; 2 hops reaches gpt.
+        out1 = retrieve_from_graph(
+            gd,
+            {
+                "entities": ["bert"],
+                "relationship_types": [],
+                "requires_multi_hop": True,
+            },
+            max_hops=1,
+        )
+        names1 = {e["name"] for e in out1["graph_retrieval"]["entities"]}
+        out2 = retrieve_from_graph(
+            gd,
+            {
+                "entities": ["bert"],
+                "relationship_types": [],
+                "requires_multi_hop": True,
+            },
+            max_hops=2,
+        )
+        names2 = {e["name"] for e in out2["graph_retrieval"]["entities"]}
+        # max_hops=2 reaches strictly further than max_hops=1 (GPT is 2 hops away).
+        assert "GPT" not in names1
+        assert "GPT" in names2
+
+    def test_no_matching_entities_empty_subgraph(self):
+        """Honest default: query entities that match no node → empty subgraph,
+        never fabricated entities."""
+        out = retrieve_from_graph(
+            self._graph_data(),
+            {
+                "entities": ["nonexistent"],
+                "relationship_types": [],
+                "requires_multi_hop": False,
+            },
+            max_hops=2,
+        )
+        assert out["graph_retrieval"]["entities"] == []
+        assert out["graph_retrieval"]["subgraph_stats"]["nodes"] == 0
+
+    def test_none_inputs_empty_subgraph(self):
+        out = retrieve_from_graph(None, None, max_hops=2)
+        assert out["graph_retrieval"]["entities"] == []
+
+
+class TestSynthesizeResults:
+    """``synthesize_results`` combines the retrieved subgraph + query +
+    (conditional) global summary; returns ``{"graph_rag_results": {...}}``."""
+
+    _GRAPH_RETRIEVAL = {
+        "entities": [
+            {"name": "BERT", "type": "technology", "description": "encoder"},
+            {"name": "GPT", "type": "technology", "description": "decoder"},
+        ],
+        "relationships": [{"source": "BERT", "target": "GPT", "type": "influenced"}],
+        "community_context": {"0": ["bert", "gpt"]},
+        "subgraph_stats": {"nodes": 2, "edges": 1},
+    }
+    _GRAPH_DATA = {"stats": {"num_entities": 2, "num_relationships": 1}}
+
+    def test_enabled_path_reads_global_summary(self):
+        """use_global_summary=True AND a wired summary dict → the REAL parsed
+        summary reaches graph_rag_results (the Wave-2.5 conditional read)."""
+        out = synthesize_results(
+            graph_retrieval=self._GRAPH_RETRIEVAL,
+            query="how did BERT influence GPT",
+            graph_data=self._GRAPH_DATA,
+            global_summaries={"global_summary": "BERT influenced GPT."},
+            use_global_summary=True,
+        )
+        rr = out["graph_rag_results"]
+        assert rr["global_summary"] == "BERT influenced GPT."
+        assert rr["query"] == "how did BERT influence GPT"
+        assert "BERT" in rr["graph_context"]
+        # reasoning_path is built over >1 entity.
+        assert len(rr["reasoning_path"]) >= 1
+
+    def test_disabled_path_global_summary_is_none(self):
+        """CONDITIONAL PRESERVATION: use_global_summary=False → global_summary is
+        None honestly even if a summary dict is (spuriously) passed; the disabled
+        path NEVER reads it."""
+        out = synthesize_results(
+            graph_retrieval=self._GRAPH_RETRIEVAL,
+            query="q",
+            graph_data=self._GRAPH_DATA,
+            global_summaries={"global_summary": "should be ignored"},
+            use_global_summary=False,
+        )
+        assert out["graph_rag_results"]["global_summary"] is None
+
+    def test_enabled_path_unwired_summary_is_none(self):
+        """use_global_summary=True but global_summaries unwired (None default) →
+        global_summary None honestly, no NameError (the from_function default
+        replaces the prior conditional-codegen NameError guard)."""
+        out = synthesize_results(
+            graph_retrieval=self._GRAPH_RETRIEVAL,
+            query="q",
+            graph_data=self._GRAPH_DATA,
+            global_summaries=None,
+            use_global_summary=True,
+        )
+        assert out["graph_rag_results"]["global_summary"] is None
+
+    def test_empty_retrieval_honest_shape(self):
+        """Honest default: empty retrieval → empty entities / context, no crash."""
+        out = synthesize_results(
+            graph_retrieval={},
+            query="q",
+            graph_data={},
+            global_summaries=None,
+            use_global_summary=True,
+        )
+        rr = out["graph_rag_results"]
+        assert rr["retrieved_entities"] == []
+        assert rr["reasoning_path"] == []
+        assert rr["global_summary"] is None

--- a/packages/kailash-kaizen/tests/unit/rag/test_optimized_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_optimized_nodes.py
@@ -1,9 +1,17 @@
 """Tier 1 unit coverage — ``kaizen.nodes.rag.optimized``.
 
-F8 shard B9c. The 4 classes under test (CacheOptimizedRAGNode,
-AsyncParallelRAGNode, StreamingRAGNode, BatchOptimizedRAGNode) cover
-the cache / parallel / streaming / batch optimization surface of the
-RAG package.
+F8 shard B9c + Wave-3 S1 ``from_function`` migration. The 4 classes under
+test (CacheOptimizedRAGNode, AsyncParallelRAGNode, StreamingRAGNode,
+BatchOptimizedRAGNode) cover the cache / parallel / streaming / batch
+optimization surface of the RAG package.
+
+Wave-3 S1 migrated the Cache + AsyncParallel nodes from brittle f-string /
+``"code"``-string ``PythonCodeNode`` codegen to ``PythonCodeNode.from_function``
+wrapping real module-level functions (#1117 publish-nothing / #1123 f-string
+brace-escape / #1118 import-trap root-cause fix). Wave-3 S2 completes the
+migration for the Streaming + Batch nodes (same pattern); their graph-shape
+assertions now check the from_function shape + flat ``result`` wiring, and each
+new module-level function has a direct-call test below.
 
 Tier 1 scope:
 
@@ -13,17 +21,11 @@ Tier 1 scope:
   that the registering import lands at optimized.py module scope.
 - The inner workflow GRAPH SHAPE produced by each ``_create_workflow``
   method (graphs are documented-shape claims).
-- Strategy-list interpolation invariants for AsyncParallelRAGNode
-  (default 3 strategies, custom strategy lists, unknown-strategy
-  fallback to semantic).
-- chunk_size / batch_size / cache_ttl baked into the codegen templates
-  at builder time.
-
-Value-anchor per the F8 plan §B B9c row is **cache/stream correctness
-of preserved nodes** — this file lifts the structural coverage half
-of the optimized sub-module; the Tier-2a integration suite under
-``tests/integration/rag/test_optimized_nodes.py`` exercises the real
-LocalRuntime cache / parallel / batch end-to-end paths.
+- One DIRECT-CALL test per new module-level function (Cache + AsyncParallel):
+  valid input → correct dict; empty/None/edge input → HONEST default.
+- Strategy-list interpolation invariants for AsyncParallelRAGNode.
+- chunk_size / batch_size baked into the (still-codegen) Streaming/Batch
+  templates at builder time.
 """
 
 from __future__ import annotations
@@ -36,6 +38,18 @@ from kaizen.nodes.rag.optimized import (
     BatchOptimizedRAGNode,
     CacheOptimizedRAGNode,
     StreamingRAGNode,
+    _aggregate_cache_result,
+    _build_execution_plan,
+    _build_streaming_plan,
+    _combine_strategy_results,
+    _decide_cache_use,
+    _format_batch_results,
+    _format_stream_chunks,
+    _generate_cache_keys,
+    _make_result_combiner,
+    _organize_batches,
+    _process_batches,
+    _progressive_retrieve,
 )
 
 pytestmark = pytest.mark.unit
@@ -116,6 +130,502 @@ class TestAllFourConstruct:
 
 
 # ==========================================================================
+# Direct-call tests — _generate_cache_keys (cache_key_generator fn)
+# ==========================================================================
+
+
+class TestGenerateCacheKeys:
+    """Direct-call coverage for the lifted cache-key generator function."""
+
+    def test_same_query_produces_same_keys(self):
+        out_a = _generate_cache_keys("what is deep learning")
+        out_b = _generate_cache_keys("what is deep learning")
+        assert out_a["cache_keys"]["exact"] == out_b["cache_keys"]["exact"]
+        assert out_a["cache_keys"]["semantic"] == out_b["cache_keys"]["semantic"]
+
+    def test_different_queries_produce_different_keys(self):
+        out_a = _generate_cache_keys("alpha")
+        out_b = _generate_cache_keys("beta")
+        assert out_a["cache_keys"]["exact"] != out_b["cache_keys"]["exact"]
+
+    def test_key_format_is_documented_shape(self):
+        out = _generate_cache_keys("query")
+        assert isinstance(out["cache_keys"]["exact"], str)
+        assert out["cache_keys"]["semantic"].startswith("semantic_")
+
+    def test_none_query_yields_honest_deterministic_default(self):
+        """A None query coerces to '' — a stable, deterministic key, not a
+        fabricated value or a crash."""
+        out_a = _generate_cache_keys(None)
+        out_b = _generate_cache_keys("")
+        # None and "" hash to the same (empty-string) key — honest default.
+        assert out_a["cache_keys"]["exact"] == out_b["cache_keys"]["exact"]
+        assert isinstance(out_a["cache_keys"]["exact"], str)
+
+
+# ==========================================================================
+# Direct-call tests — _decide_cache_use (semantic_cache_manager fn)
+# ==========================================================================
+
+
+class TestDecideCacheUse:
+    """Direct-call coverage for the lifted cache-decision function."""
+
+    def test_exact_hit_returns_cached_value(self):
+        out = _decide_cache_use(
+            cache_hit=True,
+            cache_value={"results": ["cached_doc"]},
+            query="anything",
+        )
+        assert out["use_cache"] is True
+        assert out["cache_type"] == "exact"
+        assert out["cached_result"] == {"results": ["cached_doc"]}
+
+    def test_miss_returns_no_cache(self):
+        out = _decide_cache_use(
+            cache_hit=False, cache_value=None, query="completely different"
+        )
+        assert out["use_cache"] is False
+        assert out["cache_type"] is None
+
+    def test_falsy_hit_routes_to_miss(self):
+        """A falsy ``cache_hit`` (CacheNode's miss signal) routes to a miss
+        regardless of any stale ``cache_value``."""
+        out = _decide_cache_use(cache_hit=0, cache_value={"stale": True}, query="q")
+        assert out["use_cache"] is False
+        assert out["cache_type"] is None
+
+    def test_semantic_branch_dormant_without_candidate_store(self):
+        """No candidate store is wired (hardcoded {}), so a non-hit always
+        routes to a miss — an honest exact-match cache, not a fabricated
+        semantic hit."""
+        out = _decide_cache_use(
+            cache_hit=False,
+            cache_value=None,
+            query="alpha beta gamma",
+            similarity_threshold=0.5,
+        )
+        assert out["use_cache"] is False
+        assert out["cache_type"] is None
+
+    def test_none_inputs_yield_honest_miss(self):
+        """All-None inputs → honest miss default, never a crash or fabrication."""
+        out = _decide_cache_use()
+        assert out["use_cache"] is False
+        assert out["cache_type"] is None
+
+
+# ==========================================================================
+# Direct-call tests — _aggregate_cache_result (result_aggregator fn)
+# ==========================================================================
+
+
+class TestAggregateCacheResult:
+    """Direct-call coverage for the lifted result-aggregator function."""
+
+    def test_cache_hit_aggregates_cached_results(self):
+        out = _aggregate_cache_result(
+            cache_decision={
+                "use_cache": True,
+                "cache_type": "exact",
+                "cached_result": {"results": ["d1"], "scores": [0.9]},
+            }
+        )
+        opt = out["optimized_results"]
+        assert opt["results"] == ["d1"]
+        assert opt["scores"] == [0.9]
+        assert opt["metadata"]["source"] == "cache"
+        assert opt["performance"]["cache_hit"] is True
+        assert opt["performance"]["response_time"] == "fast"
+
+    def test_cache_miss_aggregates_fresh_results(self):
+        out = _aggregate_cache_result(
+            cache_decision={"use_cache": False, "cache_type": None},
+            fresh_results={"results": ["fresh1"], "scores": [0.5]},
+        )
+        opt = out["optimized_results"]
+        assert opt["results"] == ["fresh1"]
+        assert opt["metadata"]["source"] == "fresh"
+        assert opt["performance"]["cache_hit"] is False
+        assert opt["performance"]["response_time"] == "normal"
+
+    def test_none_decision_and_none_fresh_yield_honest_empty(self):
+        """Missing decision + missing fresh_results (cache hit skips the
+        rag_processor) → empty results list, never fabricated documents."""
+        out = _aggregate_cache_result(cache_decision=None, fresh_results=None)
+        opt = out["optimized_results"]
+        assert opt["results"] == []
+        assert opt["scores"] == []
+        assert opt["performance"]["cache_hit"] is False
+
+
+# ==========================================================================
+# Direct-call tests — _build_execution_plan (parallel_executor fn)
+# ==========================================================================
+
+
+class TestBuildExecutionPlan:
+    """Direct-call coverage for the lifted parallel-executor function."""
+
+    def test_plan_carries_strategies_and_count(self):
+        out = _build_execution_plan(
+            query="test query",
+            strategies=["semantic", "hybrid"],
+        )
+        assert out["execution_plan"]["strategies"] == ["semantic", "hybrid"]
+        assert out["execution_plan"]["parallel_count"] == 2
+        assert out["execution_plan"]["query"] == "test query"
+
+    def test_strategy_configs_per_strategy(self):
+        out = _build_execution_plan(query="q", strategies=["semantic", "hybrid"])
+        assert set(out["strategy_configs"].keys()) == {"semantic", "hybrid"}
+        for cfg in out["strategy_configs"].values():
+            assert cfg["enabled"] is True
+            assert cfg["timeout"] == 5.0
+            assert cfg["fallback"] == "hybrid"
+
+    def test_empty_strategies_yields_honest_empty_plan(self):
+        """No strategies → empty plan, never fabricated strategies."""
+        out = _build_execution_plan(query="q", strategies=None)
+        assert out["execution_plan"]["strategies"] == []
+        assert out["execution_plan"]["parallel_count"] == 0
+        assert out["strategy_configs"] == {}
+
+
+# ==========================================================================
+# Direct-call tests — _combine_strategy_results + _make_result_combiner
+# ==========================================================================
+
+
+class TestCombineStrategyResults:
+    """Direct-call coverage for the lifted result-combiner core + factory."""
+
+    def test_fuses_per_strategy_results(self):
+        out = _combine_strategy_results(
+            execution_plan={"start_time": None},
+            strategies=["semantic", "hybrid"],
+            strategy_results={
+                "semantic": {
+                    "results": [
+                        {"id": "doc1", "content": "a"},
+                        {"id": "doc2", "content": "b"},
+                    ],
+                    "scores": [0.9, 0.7],
+                },
+                "hybrid": {
+                    "results": [
+                        {"id": "doc1", "content": "a"},
+                        {"id": "doc3", "content": "c"},
+                    ],
+                    "scores": [0.8, 0.6],
+                },
+            },
+        )
+        parallel = out["parallel_results"]
+        assert {r["id"] for r in parallel["results"]} == {"doc1", "doc2", "doc3"}
+        # doc1 returned by both strategies → strategy_agreements == 1.
+        assert parallel["metadata"]["strategy_agreements"] == 1
+        assert set(parallel["metadata"]["strategies_used"]) == {"semantic", "hybrid"}
+
+    def test_doc_in_both_strategies_ranks_first(self):
+        out = _combine_strategy_results(
+            execution_plan={"start_time": None},
+            strategies=["semantic", "hybrid"],
+            strategy_results={
+                "semantic": {
+                    "results": [
+                        {"id": "doc1", "content": "x"},
+                        {"id": "doc2", "content": "y"},
+                    ],
+                    "scores": [0.9, 0.7],
+                },
+                "hybrid": {
+                    "results": [
+                        {"id": "doc1", "content": "x"},
+                        {"id": "doc3", "content": "z"},
+                    ],
+                    "scores": [0.8, 0.6],
+                },
+            },
+        )
+        parallel = out["parallel_results"]
+        # doc1 mean (0.9+0.8)/2 = 0.85 → ranks first.
+        assert parallel["results"][0]["id"] == "doc1"
+        assert parallel["scores"][0] == pytest.approx(0.85)
+
+    def test_empty_results_yield_honest_empty_fusion(self):
+        """No strategy results → empty fused output, never fabricated docs."""
+        out = _combine_strategy_results(
+            execution_plan=None, strategies=["semantic"], strategy_results={}
+        )
+        parallel = out["parallel_results"]
+        assert parallel["results"] == []
+        assert parallel["scores"] == []
+        assert parallel["metadata"]["strategies_used"] == []
+
+    def test_unparseable_start_time_yields_zero_total_time(self):
+        """A malformed execution_plan start_time → 0.0 total time, never a crash."""
+        out = _combine_strategy_results(
+            execution_plan={"start_time": "not-a-timestamp"},
+            strategies=["semantic"],
+            strategy_results={
+                "semantic": {"results": [{"id": "d", "content": "c"}], "scores": [0.5]}
+            },
+        )
+        assert out["parallel_results"]["metadata"]["total_execution_time"] == 0.0
+
+    def test_factory_declares_one_input_per_strategy(self):
+        """The factory synthesises a signature with execution_plan + one
+        <strategy>_results param per declared strategy."""
+        import inspect as _inspect
+
+        fn = _make_result_combiner(["semantic", "sparse"])
+        params = list(_inspect.signature(fn).parameters)
+        assert params == ["execution_plan", "semantic_results", "sparse_results"]
+
+    def test_factory_deduplicates_repeated_strategy(self):
+        """A repeated strategy name must NOT produce a duplicate parameter
+        (an invalid signature)."""
+        import inspect as _inspect
+
+        fn = _make_result_combiner(["semantic", "semantic"])
+        params = list(_inspect.signature(fn).parameters)
+        assert params == ["execution_plan", "semantic_results"]
+
+    def test_factory_combiner_routes_to_core(self):
+        """The factory-built combiner accepts the wired inputs and fuses them."""
+        fn = _make_result_combiner(["semantic"])
+        out = fn(
+            execution_plan={"start_time": None},
+            semantic_results={
+                "results": [{"id": "d1", "content": "c"}],
+                "scores": [0.9],
+            },
+        )
+        assert out["parallel_results"]["results"][0]["id"] == "d1"
+
+
+# ==========================================================================
+# Direct-call tests — _build_streaming_plan (stream_controller fn)
+# ==========================================================================
+
+
+class TestBuildStreamingPlan:
+    """Direct-call coverage for the lifted streaming-plan builder."""
+
+    def test_plan_carries_chunk_size_and_stages(self):
+        out = _build_streaming_plan(chunk_size=50)
+        plan = out["streaming_plan"]
+        assert plan["chunk_size"] == 50
+        assert plan["strategy"] == "progressive"
+        assert [s["name"] for s in plan["stages"]] == [
+            "initial",
+            "refined",
+            "complete",
+        ]
+
+    def test_default_chunk_size_matches_constructor_default(self):
+        out = _build_streaming_plan()
+        assert out["streaming_plan"]["chunk_size"] == 100
+
+
+# ==========================================================================
+# Direct-call tests — _progressive_retrieve (progressive_retriever fn)
+# ==========================================================================
+
+
+class TestProgressiveRetrieve:
+    """Direct-call coverage for the lifted progressive-retrieval function."""
+
+    def test_keyword_overlap_produces_initial_results(self):
+        out = _progressive_retrieve(
+            streaming_plan={"stages": [{"name": "initial", "k": 3}]},
+            query="deep learning",
+            documents=[
+                {"id": "d1", "content": "deep learning models"},
+                {"id": "d2", "content": "unrelated topic"},
+                {"id": "d3", "content": "learning fast"},
+            ],
+        )
+        prog = out["progressive_results"]
+        matched = {r["doc"]["id"] for r in prog["initial"]}
+        assert matched == {"d1", "d3"}  # d2 has no overlap
+        assert prog["metadata"]["matches_found"] == 2
+        assert prog["next_stage"] == "refined"
+
+    def test_results_capped_at_initial_stage_k(self):
+        out = _progressive_retrieve(
+            streaming_plan={"stages": [{"name": "initial", "k": 1}]},
+            query="alpha",
+            documents=[
+                {"id": "d1", "content": "alpha"},
+                {"id": "d2", "content": "alpha"},
+            ],
+        )
+        assert len(out["progressive_results"]["initial"]) == 1
+
+    def test_none_inputs_yield_honest_empty_default(self):
+        """All-None inputs → empty initial results, honest fallback k, never a
+        crash or fabricated documents."""
+        out = _progressive_retrieve()
+        prog = out["progressive_results"]
+        assert prog["initial"] == []
+        assert prog["metadata"]["matches_found"] == 0
+        assert prog["has_more"] is False
+
+    def test_missing_plan_falls_back_to_default_k(self):
+        """A missing streaming_plan → default initial k of 3, never a crash."""
+        out = _progressive_retrieve(
+            streaming_plan=None,
+            query="a b c d",
+            documents=[{"id": str(i), "content": "a b c d"} for i in range(5)],
+        )
+        assert len(out["progressive_results"]["initial"]) == 3
+
+
+# ==========================================================================
+# Direct-call tests — _format_stream_chunks (stream_formatter fn)
+# ==========================================================================
+
+
+class TestFormatStreamChunks:
+    """Direct-call coverage for the lifted stream-formatter function."""
+
+    def test_results_plus_metadata_chunk(self):
+        out = _format_stream_chunks(
+            progressive_results={
+                "initial": [
+                    {"doc": {"id": "d1"}, "score": 0.9, "stage": "initial"},
+                ],
+                "metadata": {"docs_scanned": 1},
+                "has_more": False,
+                "next_stage": "refined",
+            }
+        )
+        chunks = out["stream_chunks"]
+        # 1 result chunk + 1 metadata chunk.
+        assert len(chunks) == 2
+        assert chunks[0]["type"] == "result"
+        assert chunks[0]["content"] == {"id": "d1"}
+        assert chunks[-1]["type"] == "metadata"
+        assert out["streaming_metadata"]["result_chunks"] == 1
+        assert out["streaming_metadata"]["supports_backpressure"] is True
+
+    def test_none_input_yields_metadata_only(self):
+        """A missing progressive_results → only the metadata chunk, never a
+        fabricated result chunk."""
+        out = _format_stream_chunks(progressive_results=None)
+        chunks = out["stream_chunks"]
+        assert len(chunks) == 1
+        assert chunks[0]["type"] == "metadata"
+        assert out["streaming_metadata"]["result_chunks"] == 0
+
+
+# ==========================================================================
+# Direct-call tests — _organize_batches (batch_organizer fn)
+# ==========================================================================
+
+
+class TestOrganizeBatches:
+    """Direct-call coverage for the lifted batch-organizer function."""
+
+    def test_batches_respect_batch_size(self):
+        out = _organize_batches(queries=["q1", "q2", "q3"], batch_size=2)
+        plan = out["batch_plan"]
+        assert plan["total_queries"] == 3
+        assert plan["batch_size"] == 2
+        # 3 queries / batch_size 2 → 2 batches.
+        assert plan["num_batches"] == 2
+        assert plan["optimization_applied"] is True
+
+    def test_single_string_query_coerced_to_list(self):
+        out = _organize_batches(queries="solo", batch_size=4)
+        plan = out["batch_plan"]
+        assert plan["total_queries"] == 1
+        # Single query → optimization NOT applied (len <= 1).
+        assert plan["optimization_applied"] is False
+
+    def test_none_queries_yield_honest_empty_plan(self):
+        """No queries → empty plan, never fabricated queries."""
+        out = _organize_batches(queries=None, batch_size=4)
+        plan = out["batch_plan"]
+        assert plan["total_queries"] == 0
+        assert plan["num_batches"] == 0
+        assert plan["batches"] == []
+
+
+# ==========================================================================
+# Direct-call tests — _process_batches (batch_processor fn)
+# ==========================================================================
+
+
+class TestProcessBatches:
+    """Direct-call coverage for the lifted batch-processor function."""
+
+    def test_scores_documents_per_query(self):
+        plan = _organize_batches(queries=["alpha beta"], batch_size=4)["batch_plan"]
+        out = _process_batches(
+            batch_plan=plan,
+            documents=[
+                {"id": "d1", "content": "alpha beta gamma"},
+                {"id": "d2", "content": "delta"},
+            ],
+        )
+        res = out["batch_results"]
+        assert res["statistics"]["total_queries_processed"] == 1
+        assert res["statistics"]["batches_processed"] == 1
+        # One batch, one query → one query_results entry of doc-score tuples.
+        assert len(res["results"][0]["query_results"]) == 1
+
+    def test_none_inputs_yield_honest_empty_results(self):
+        """Missing batch_plan + documents → empty results, zero-query stats,
+        never fabricated documents or scores."""
+        out = _process_batches(batch_plan=None, documents=None)
+        res = out["batch_results"]
+        assert res["results"] == []
+        assert res["statistics"]["total_queries_processed"] == 0
+        assert res["statistics"]["avg_results_per_query"] == 0.0
+
+
+# ==========================================================================
+# Direct-call tests — _format_batch_results (result_formatter fn)
+# ==========================================================================
+
+
+class TestFormatBatchResults:
+    """Direct-call coverage for the lifted result-formatter function."""
+
+    def test_maps_scores_back_to_per_query_documents(self):
+        documents = [
+            {"id": "d1", "content": "alpha beta"},
+            {"id": "d2", "content": "gamma"},
+        ]
+        plan = _organize_batches(queries=["alpha"], batch_size=4)["batch_plan"]
+        batch_results = _process_batches(batch_plan=plan, documents=documents)[
+            "batch_results"
+        ]
+        out = _format_batch_results(
+            batch_results=batch_results,
+            batch_plan=plan,
+            documents=documents,
+        )
+        final = out["final_batch_results"]
+        assert "alpha" in final["query_results"]
+        # d1 overlaps "alpha"; d2 does not → only positive-score docs emitted.
+        assert final["query_results"]["alpha"]["results"] == [
+            {"id": "d1", "content": "alpha beta"}
+        ]
+        assert final["processing_order"] == ["alpha"]
+
+    def test_none_inputs_yield_honest_empty_map(self):
+        """Missing inputs → empty per-query map, never fabricated documents."""
+        out = _format_batch_results(batch_results=None, batch_plan=None, documents=None)
+        final = out["final_batch_results"]
+        assert final["query_results"] == {}
+        assert final["processing_order"] == []
+
+
+# ==========================================================================
 # CacheOptimizedRAGNode — graph shape + cache wiring
 # ==========================================================================
 
@@ -138,14 +648,10 @@ class TestCacheOptimizedGraphShape:
         """Both cache_checker + cache_updater are typed CacheNode (the
         type registered by the kailash.nodes.cache import)."""
         wf = _build(CacheOptimizedRAGNode())
-        # The cache_checker and cache_updater nodes are instantiated through
-        # the registry from the "CacheNode" string node-type — that's the
-        # R3-L2 surface this commit unblocked.
         cache_checker = wf.get_node("cache_checker")
         cache_updater = wf.get_node("cache_updater")
         assert cache_checker is not None
         assert cache_updater is not None
-        # Both nodes carry the get / set operations specified in optimized.py.
         assert cache_checker.config.get("operation") == "get"
         assert cache_updater.config.get("operation") == "set"
 
@@ -154,17 +660,31 @@ class TestCacheOptimizedGraphShape:
         assert wf.get_node("cache_checker").config.get("ttl") == 42  # type: ignore[union-attr]
         assert wf.get_node("cache_updater").config.get("ttl") == 42  # type: ignore[union-attr]
 
-    def test_similarity_threshold_baked_into_codegen(self):
-        wf = _build(CacheOptimizedRAGNode(similarity_threshold=0.42))
-        sem_mgr = wf.get_node("semantic_cache_manager")
-        assert sem_mgr is not None
-        # The threshold is f-string-interpolated into the codegen template.
-        assert "0.42" in sem_mgr.config["code"]
+    def test_cache_key_generator_is_from_function_node(self):
+        """Post-migration: cache_key_generator wraps a real function (no
+        codegen ``code`` string with logic)."""
+        wf = _build(CacheOptimizedRAGNode())
+        key_gen = wf.get_node("cache_key_generator")
+        assert key_gen is not None
+        assert key_gen.config.get("function") is not None
 
     def test_result_aggregator_is_final_sink(self):
         wf = _build(CacheOptimizedRAGNode())
         outbound = [c for c in wf.connections if c.source_node == "result_aggregator"]
         assert outbound == []
+
+    def test_cache_decision_wiring_reads_result_port(self):
+        """The skip-gate reads the nested ``result.use_cache`` port and the
+        aggregator reads the flat ``result`` port — the from_function shape."""
+        wf = _build(CacheOptimizedRAGNode())
+        skip_edges = [
+            c
+            for c in wf.connections
+            if c.source_node == "semantic_cache_manager"
+            and c.target_node == "rag_processor"
+        ]
+        assert len(skip_edges) == 1
+        assert skip_edges[0].source_output == "result.use_cache"
 
 
 # ==========================================================================
@@ -188,7 +708,6 @@ class TestAsyncParallelGraphShape:
 
     def test_custom_strategies_drive_strategy_nodes(self):
         wf = _build(AsyncParallelRAGNode(strategies=["semantic"]))
-        # Only semantic strategy node + executor + combiner.
         assert set(wf.nodes.keys()) == {
             "parallel_executor",
             "semantic_rag",
@@ -200,14 +719,14 @@ class TestAsyncParallelGraphShape:
         to SemanticRAGNode under the hood)."""
         wf = _build(AsyncParallelRAGNode(strategies=["unknown_strategy"]))
         assert "unknown_strategy_rag" in wf.nodes
-        # Falls back to SemanticRAGNode for the unknown branch — verified
-        # through the underlying node type at the registry layer.
         node = wf.get_node("unknown_strategy_rag")
         assert node is not None
-        # The fallback applies retrieval_k=5 config (semantic strategy).
         assert node.config.get("config", {}).get("retrieval_k") == 5
 
-    def test_executor_connects_to_combiner(self):
+    def test_executor_connects_to_combiner_via_result_port(self):
+        """Post-migration: the executor publishes on the flat ``result`` port,
+        so the combiner edge reads ``result.execution_plan`` (the latent
+        #1117 nested-port defect, now closed)."""
         wf = _build(AsyncParallelRAGNode(strategies=["semantic"]))
         executor_to_combiner = [
             c
@@ -215,7 +734,8 @@ class TestAsyncParallelGraphShape:
             if c.source_node == "parallel_executor"
             and c.target_node == "result_combiner"
         ]
-        assert len(executor_to_combiner) >= 1
+        assert len(executor_to_combiner) == 1
+        assert executor_to_combiner[0].source_output == "result.execution_plan"
 
     def test_each_strategy_node_connects_to_combiner(self):
         wf = _build(AsyncParallelRAGNode(strategies=["semantic", "hybrid"]))
@@ -226,26 +746,35 @@ class TestAsyncParallelGraphShape:
             targets_into_combiner
         )
 
+    def test_strategy_results_wired_to_per_strategy_inputs(self):
+        """Each <strategy>_rag node wires to the combiner's <strategy>_results
+        input — the declared inputs the from_function factory synthesised."""
+        wf = _build(AsyncParallelRAGNode(strategies=["semantic", "hybrid"]))
+        combiner_inputs = {
+            c.target_input for c in wf.connections if c.target_node == "result_combiner"
+        }
+        assert {"semantic_results", "hybrid_results"}.issubset(combiner_inputs)
+
     def test_combiner_is_final_sink(self):
         wf = _build(AsyncParallelRAGNode())
         outbound = [c for c in wf.connections if c.source_node == "result_combiner"]
         assert outbound == []
 
-    def test_strategy_list_baked_into_executor_codegen(self):
-        wf = _build(AsyncParallelRAGNode(strategies=["semantic", "hybrid"]))
+    def test_parallel_executor_is_from_function_node(self):
+        """Post-migration: parallel_executor wraps a real function."""
+        wf = _build(AsyncParallelRAGNode())
         executor = wf.get_node("parallel_executor")
         assert executor is not None
-        # The strategy list is f-string-interpolated into the codegen template.
-        assert "['semantic', 'hybrid']" in executor.config["code"]
+        assert executor.config.get("function") is not None
 
 
 # ==========================================================================
-# StreamingRAGNode — graph shape
+# StreamingRAGNode — graph shape (S2: migrated to from_function)
 # ==========================================================================
 
 
 class TestOptimizedStreamingGraphShape:
-    """The streaming workflow wires 3 nodes."""
+    """The streaming workflow wires 3 from_function nodes (S2 migration)."""
 
     def test_graph_has_three_nodes(self):
         wf = _build(StreamingRAGNode())
@@ -255,7 +784,10 @@ class TestOptimizedStreamingGraphShape:
             "stream_formatter",
         }
 
-    def test_stream_controller_feeds_progressive_retriever(self):
+    def test_stream_controller_feeds_progressive_retriever_via_result_port(self):
+        """Post-migration: the controller publishes on the flat ``result`` port,
+        so the retriever edge reads ``result.streaming_plan`` (the latent #1117
+        nested-port defect, now closed)."""
         wf = _build(StreamingRAGNode())
         edges = [
             c
@@ -264,8 +796,9 @@ class TestOptimizedStreamingGraphShape:
             and c.target_node == "progressive_retriever"
         ]
         assert len(edges) == 1
+        assert edges[0].source_output == "result.streaming_plan"
 
-    def test_progressive_retriever_feeds_stream_formatter(self):
+    def test_progressive_retriever_feeds_stream_formatter_via_result_port(self):
         wf = _build(StreamingRAGNode())
         edges = [
             c
@@ -274,13 +807,25 @@ class TestOptimizedStreamingGraphShape:
             and c.target_node == "stream_formatter"
         ]
         assert len(edges) == 1
+        assert edges[0].source_output == "result.progressive_results"
 
-    def test_chunk_size_baked_into_controller_codegen(self):
+    def test_stream_controller_is_from_function_node(self):
+        """Post-migration: stream_controller wraps a real function (no codegen
+        ``code`` string with logic)."""
         wf = _build(StreamingRAGNode(chunk_size=7))
         controller = wf.get_node("stream_controller")
         assert controller is not None
-        # The chunk_size is f-string-interpolated into the codegen template.
-        assert "chunk_size = 7" in controller.config["code"]
+        assert controller.config.get("function") is not None
+        # No codegen logic string: from_function leaves `code` unset.
+        assert controller.config.get("code") is None
+
+    def test_chunk_size_baked_into_controller_via_closure(self):
+        """The build-time ``chunk_size`` is bound through the closure: the
+        controller's published plan carries it (no codegen string to grep)."""
+        from kaizen.nodes.rag.optimized import _build_streaming_plan
+
+        out = _build_streaming_plan(chunk_size=7)
+        assert out["streaming_plan"]["chunk_size"] == 7
 
     def test_stream_formatter_is_final_sink(self):
         wf = _build(StreamingRAGNode())
@@ -289,12 +834,12 @@ class TestOptimizedStreamingGraphShape:
 
 
 # ==========================================================================
-# BatchOptimizedRAGNode — graph shape
+# BatchOptimizedRAGNode — graph shape (S2: migrated to from_function)
 # ==========================================================================
 
 
 class TestBatchOptimizedGraphShape:
-    """The batch workflow wires 3 nodes."""
+    """The batch workflow wires 3 from_function nodes (S2 migration)."""
 
     def test_graph_has_three_nodes(self):
         wf = _build(BatchOptimizedRAGNode())
@@ -304,14 +849,19 @@ class TestBatchOptimizedGraphShape:
             "result_formatter",
         }
 
-    def test_organizer_feeds_processor_and_formatter(self):
+    def test_organizer_feeds_processor_and_formatter_via_result_port(self):
+        """Post-migration: the organizer publishes on the flat ``result`` port,
+        so both downstream edges read ``result.batch_plan`` (the latent #1117
+        nested-port defect, now closed)."""
         wf = _build(BatchOptimizedRAGNode())
-        targets = {
-            c.target_node for c in wf.connections if c.source_node == "batch_organizer"
-        }
+        organizer_edges = [
+            c for c in wf.connections if c.source_node == "batch_organizer"
+        ]
+        targets = {c.target_node for c in organizer_edges}
         assert {"batch_processor", "result_formatter"}.issubset(targets)
+        assert all(c.source_output == "result.batch_plan" for c in organizer_edges)
 
-    def test_processor_feeds_formatter(self):
+    def test_processor_feeds_formatter_via_result_port(self):
         wf = _build(BatchOptimizedRAGNode())
         edges = [
             c
@@ -320,13 +870,25 @@ class TestBatchOptimizedGraphShape:
             and c.target_node == "result_formatter"
         ]
         assert len(edges) == 1
+        assert edges[0].source_output == "result.batch_results"
 
-    def test_batch_size_baked_into_organizer_codegen(self):
+    def test_batch_organizer_is_from_function_node(self):
+        """Post-migration: batch_organizer wraps a real function (no codegen
+        ``code`` string with logic)."""
         wf = _build(BatchOptimizedRAGNode(batch_size=8))
         organizer = wf.get_node("batch_organizer")
         assert organizer is not None
-        # The batch_size is f-string-interpolated into the codegen template.
-        assert "batch_size = 8" in organizer.config["code"]
+        assert organizer.config.get("function") is not None
+        # No codegen logic string: from_function leaves `code` unset.
+        assert organizer.config.get("code") is None
+
+    def test_batch_size_baked_into_organizer_via_closure(self):
+        """The build-time ``batch_size`` is bound through the closure: the
+        organizer's published plan carries it (no codegen string to grep)."""
+        from kaizen.nodes.rag.optimized import _organize_batches
+
+        out = _organize_batches(queries=["a", "b", "c"], batch_size=8)
+        assert out["batch_plan"]["batch_size"] == 8
 
     def test_result_formatter_is_final_sink(self):
         wf = _build(BatchOptimizedRAGNode())

--- a/packages/kailash-kaizen/tests/unit/rag/test_query_processing_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_query_processing_nodes.py
@@ -753,3 +753,779 @@ def test_module_all_exports_six_classes():
         "MultiHopQueryPlannerNode",
         "AdaptiveQueryProcessorNode",
     }
+
+
+# ==========================================================================
+# F31-FU2 Shard A — direct-call Tier-1 coverage of the pure parser / composer
+# `from_function` targets (module-level functions wired into the inner
+# workflows via `PythonCodeNode.from_function`). These are pure data
+# rendering / tool-result parsing (the permitted deterministic exceptions per
+# rules/agent-reasoning.md #3 + #6) — NOT agent decision-making. Called
+# DIRECTLY (no LocalRuntime, no mocking — they are pure functions).
+#
+# Contract per testing.md "One Direct Test Per Variant": every parser asserts
+# VALID / EMPTY / MALFORMED(non-json, non-object, unexpected-type) /
+# ALREADY-DICT; every composer asserts VALID + EMPTY. zero-tolerance Rule 2:
+# the EMPTY / MALFORMED sentinels assert HONEST empty defaults + the exact
+# parse_error reason string — never a fabricated non-empty value.
+# ==========================================================================
+
+import json
+
+from kaizen.nodes.rag.query_processing import (
+    _adaptive_process,
+    _combine_rewrites,
+    _loads_response_object,
+    _map_strategy,
+    _plan_execution,
+    _process_expansions,
+    _resolve_dependencies,
+    _unwrap_response_content,
+    compose_analysis_messages,
+    compose_decomposition_messages,
+    compose_expansion_messages,
+    compose_hop_plan_messages,
+    compose_intent_messages,
+    compose_rewrite_messages,
+    parse_analysis_response,
+    parse_decomposition_response,
+    parse_expansion_response,
+    parse_hop_plan_response,
+    parse_intent_response,
+    parse_rewrite_response,
+)
+
+
+def _wrap(obj) -> dict:
+    """Build the LLMAgentNode `response` port shape with a JSON-string content."""
+    return {"content": json.dumps(obj)}
+
+
+class TestUnwrapResponseContent:
+    """`_unwrap_response_content`: dict -> .content, bare value -> passthrough."""
+
+    def test_unwrap_dict_returns_content(self):
+        assert _unwrap_response_content({"content": "hello"}) == "hello"
+
+    def test_unwrap_dict_missing_content_returns_none(self):
+        # A dict without a "content" key -> .get("content") -> None.
+        assert _unwrap_response_content({"other": "x"}) is None
+
+    def test_unwrap_bare_string_passthrough(self):
+        assert _unwrap_response_content("raw string") == "raw string"
+
+    def test_unwrap_none_passthrough(self):
+        assert _unwrap_response_content(None) is None
+
+
+class TestLoadsResponseObject:
+    """`_loads_response_object`: dict on valid, exact reason strings on malformed."""
+
+    def test_valid_json_object_returns_dict(self):
+        obj = {"expansions": ["a", "b"]}
+        result = _loads_response_object(_wrap(obj))
+        assert result == obj
+
+    def test_already_dict_content_returns_dict(self):
+        # Provider pre-parsed: content is already a dict.
+        obj = {"hops": [1, 2]}
+        result = _loads_response_object({"content": obj})
+        assert result == obj
+
+    def test_none_response_returns_empty_response(self):
+        assert _loads_response_object(None) == "empty-response"
+
+    def test_empty_string_content_returns_empty_response(self):
+        assert _loads_response_object({"content": ""}) == "empty-response"
+
+    def test_whitespace_content_returns_empty_response(self):
+        assert _loads_response_object({"content": "   "}) == "empty-response"
+
+    def test_non_json_content_returns_non_json_response(self):
+        assert _loads_response_object({"content": "not json{"}) == "non-json-response"
+
+    def test_json_array_returns_non_object_json(self):
+        assert _loads_response_object({"content": "[1,2,3]"}) == "non-object-json"
+
+    def test_json_scalar_returns_non_object_json(self):
+        # Valid JSON that is not an object (a number).
+        assert _loads_response_object({"content": "42"}) == "non-object-json"
+
+    def test_non_str_non_dict_content_returns_unexpected_content_type(self):
+        # content is an int (not str, not dict) -> unexpected-content-type.
+        assert _loads_response_object({"content": 42}) == "unexpected-content-type"
+
+
+# --------------------------------------------------------------------------
+# Parsers — one direct test per variant (VALID / EMPTY / MALFORMED / DICT).
+# --------------------------------------------------------------------------
+
+
+class TestParseExpansionResponse:
+    def test_parse_expansion_valid_returns_fields(self):
+        obj = {
+            "expansions": ["ml optimization", "model tuning"],
+            "keywords": ["ml", "optimization"],
+            "concepts": ["machine_learning"],
+        }
+        result = parse_expansion_response(_wrap(obj))
+        assert result["expansions"] == obj["expansions"]
+        assert result["keywords"] == obj["keywords"]
+        assert result["concepts"] == obj["concepts"]
+        assert "parse_error" not in result
+
+    def test_parse_expansion_already_dict_returns_fields(self):
+        obj = {"expansions": ["x"], "keywords": [], "concepts": []}
+        result = parse_expansion_response({"content": obj})
+        assert result["expansions"] == ["x"]
+        assert "parse_error" not in result
+
+    def test_parse_expansion_none_returns_empty_sentinel(self):
+        result = parse_expansion_response(None)
+        assert result["parse_error"] == "empty-response"
+        # Honest empty default — NEVER a fabricated expansion (zero-tolerance R2).
+        assert result["expansions"] == []
+        assert result["keywords"] == []
+        assert result["concepts"] == []
+
+    def test_parse_expansion_empty_content_returns_empty_sentinel(self):
+        result = parse_expansion_response({"content": ""})
+        assert result["parse_error"] == "empty-response"
+        assert result["expansions"] == []
+
+    def test_parse_expansion_non_json_returns_non_json_sentinel(self):
+        result = parse_expansion_response({"content": "not json{"})
+        assert result["parse_error"] == "non-json-response"
+        assert result["expansions"] == []
+        assert result["keywords"] == []
+        assert result["concepts"] == []
+
+    def test_parse_expansion_array_returns_non_object_sentinel(self):
+        result = parse_expansion_response({"content": "[1,2,3]"})
+        assert result["parse_error"] == "non-object-json"
+        assert result["expansions"] == []
+
+    def test_parse_expansion_bad_content_type_returns_unexpected_sentinel(self):
+        result = parse_expansion_response({"content": 42})
+        assert result["parse_error"] == "unexpected-content-type"
+        assert result["expansions"] == []
+
+
+class TestParseDecompositionResponse:
+    def test_parse_decomposition_valid_returns_fields(self):
+        obj = {
+            "sub_questions": [{"question": "What is X?"}],
+            "composition_strategy": "parallel",
+        }
+        result = parse_decomposition_response(_wrap(obj))
+        assert result["sub_questions"] == obj["sub_questions"]
+        assert result["composition_strategy"] == "parallel"
+        assert "parse_error" not in result
+
+    def test_parse_decomposition_already_dict_returns_fields(self):
+        obj = {"sub_questions": [{"question": "Q"}]}
+        result = parse_decomposition_response({"content": obj})
+        assert result["sub_questions"] == obj["sub_questions"]
+        # Documented default when composition_strategy absent.
+        assert result["composition_strategy"] == "sequential"
+        assert "parse_error" not in result
+
+    def test_parse_decomposition_none_returns_empty_sentinel(self):
+        result = parse_decomposition_response(None)
+        assert result["parse_error"] == "empty-response"
+        assert result["sub_questions"] == []
+
+    def test_parse_decomposition_empty_content_returns_empty_sentinel(self):
+        result = parse_decomposition_response({"content": ""})
+        assert result["parse_error"] == "empty-response"
+        assert result["sub_questions"] == []
+
+    def test_parse_decomposition_non_json_returns_non_json_sentinel(self):
+        result = parse_decomposition_response({"content": "not json{"})
+        assert result["parse_error"] == "non-json-response"
+        assert result["sub_questions"] == []
+
+    def test_parse_decomposition_array_returns_non_object_sentinel(self):
+        result = parse_decomposition_response({"content": "[1,2,3]"})
+        assert result["parse_error"] == "non-object-json"
+        assert result["sub_questions"] == []
+
+    def test_parse_decomposition_bad_content_type_returns_unexpected_sentinel(self):
+        result = parse_decomposition_response({"content": 42})
+        assert result["parse_error"] == "unexpected-content-type"
+        assert result["sub_questions"] == []
+
+
+class TestParseAnalysisResponse:
+    def test_parse_analysis_valid_returns_fields(self):
+        obj = {
+            "issues": ["spelling_errors", "too_short"],
+            "suggestions": {"spelling": "corrected"},
+        }
+        result = parse_analysis_response(_wrap(obj))
+        assert result["issues"] == obj["issues"]
+        assert result["suggestions"] == obj["suggestions"]
+        assert "parse_error" not in result
+
+    def test_parse_analysis_already_dict_returns_fields(self):
+        obj = {"issues": ["x"]}
+        result = parse_analysis_response({"content": obj})
+        assert result["issues"] == ["x"]
+        assert result["suggestions"] == {}  # documented default
+        assert "parse_error" not in result
+
+    def test_parse_analysis_none_returns_empty_sentinel(self):
+        result = parse_analysis_response(None)
+        assert result["parse_error"] == "empty-response"
+        assert result["issues"] == []
+
+    def test_parse_analysis_empty_content_returns_empty_sentinel(self):
+        result = parse_analysis_response({"content": ""})
+        assert result["parse_error"] == "empty-response"
+        assert result["issues"] == []
+
+    def test_parse_analysis_non_json_returns_non_json_sentinel(self):
+        result = parse_analysis_response({"content": "not json{"})
+        assert result["parse_error"] == "non-json-response"
+        assert result["issues"] == []
+
+    def test_parse_analysis_array_returns_non_object_sentinel(self):
+        result = parse_analysis_response({"content": "[1,2,3]"})
+        assert result["parse_error"] == "non-object-json"
+        assert result["issues"] == []
+
+    def test_parse_analysis_bad_content_type_returns_unexpected_sentinel(self):
+        result = parse_analysis_response({"content": 42})
+        assert result["parse_error"] == "unexpected-content-type"
+        assert result["issues"] == []
+
+
+class TestParseRewriteResponse:
+    def test_parse_rewrite_valid_returns_fields(self):
+        obj = {
+            "rewrites": {"corrected": "fixed query", "clarified": "clearer query"},
+            "recommended": "fixed query",
+        }
+        result = parse_rewrite_response(_wrap(obj))
+        assert result["rewrites"] == obj["rewrites"]
+        assert result["recommended"] == "fixed query"
+        assert "parse_error" not in result
+
+    def test_parse_rewrite_already_dict_returns_fields(self):
+        obj = {"rewrites": {"corrected": "x"}}
+        result = parse_rewrite_response({"content": obj})
+        assert result["rewrites"] == {"corrected": "x"}
+        assert result["recommended"] == ""  # documented default
+        assert "parse_error" not in result
+
+    def test_parse_rewrite_none_returns_empty_sentinel(self):
+        result = parse_rewrite_response(None)
+        assert result["parse_error"] == "empty-response"
+        assert result["rewrites"] == {}
+
+    def test_parse_rewrite_empty_content_returns_empty_sentinel(self):
+        result = parse_rewrite_response({"content": ""})
+        assert result["parse_error"] == "empty-response"
+        assert result["rewrites"] == {}
+
+    def test_parse_rewrite_non_json_returns_non_json_sentinel(self):
+        result = parse_rewrite_response({"content": "not json{"})
+        assert result["parse_error"] == "non-json-response"
+        assert result["rewrites"] == {}
+
+    def test_parse_rewrite_array_returns_non_object_sentinel(self):
+        result = parse_rewrite_response({"content": "[1,2,3]"})
+        assert result["parse_error"] == "non-object-json"
+        assert result["rewrites"] == {}
+
+    def test_parse_rewrite_bad_content_type_returns_unexpected_sentinel(self):
+        result = parse_rewrite_response({"content": 42})
+        assert result["parse_error"] == "unexpected-content-type"
+        assert result["rewrites"] == {}
+
+
+class TestParseIntentResponse:
+    def test_parse_intent_valid_returns_fields(self):
+        obj = {
+            "query_type": "procedural",
+            "domain": "technical",
+            "complexity": "moderate",
+            "requirements": ["needs_examples"],
+            "suggested_strategy": "semantic",
+        }
+        result = parse_intent_response(_wrap(obj))
+        assert result["query_type"] == "procedural"
+        assert result["domain"] == "technical"
+        assert result["complexity"] == "moderate"
+        assert result["requirements"] == ["needs_examples"]
+        assert result["suggested_strategy"] == "semantic"
+        assert "parse_error" not in result
+
+    def test_parse_intent_already_dict_returns_fields(self):
+        obj = {"query_type": "factual"}
+        result = parse_intent_response({"content": obj})
+        assert result["query_type"] == "factual"
+        assert result["requirements"] == []  # documented default
+        assert "parse_error" not in result
+
+    def test_parse_intent_none_returns_empty_sentinel(self):
+        result = parse_intent_response(None)
+        assert result["parse_error"] == "empty-response"
+        # Honest None query_type — never a fabricated classification.
+        assert result["query_type"] is None
+
+    def test_parse_intent_empty_content_returns_empty_sentinel(self):
+        result = parse_intent_response({"content": ""})
+        assert result["parse_error"] == "empty-response"
+        assert result["query_type"] is None
+
+    def test_parse_intent_non_json_returns_non_json_sentinel(self):
+        result = parse_intent_response({"content": "not json{"})
+        assert result["parse_error"] == "non-json-response"
+        assert result["query_type"] is None
+
+    def test_parse_intent_array_returns_non_object_sentinel(self):
+        result = parse_intent_response({"content": "[1,2,3]"})
+        assert result["parse_error"] == "non-object-json"
+        assert result["query_type"] is None
+
+    def test_parse_intent_bad_content_type_returns_unexpected_sentinel(self):
+        result = parse_intent_response({"content": 42})
+        assert result["parse_error"] == "unexpected-content-type"
+        assert result["query_type"] is None
+
+
+class TestParseHopPlanResponse:
+    def test_parse_hop_plan_valid_returns_fields(self):
+        obj = {
+            "hops": [{"query": "What is BERT?"}, {"query": "What came after?"}],
+            "combination_strategy": "synthesize",
+            "total_hops": 2,
+        }
+        result = parse_hop_plan_response(_wrap(obj))
+        assert result["hops"] == obj["hops"]
+        assert result["combination_strategy"] == "synthesize"
+        assert result["total_hops"] == 2
+        assert "parse_error" not in result
+
+    def test_parse_hop_plan_already_dict_returns_fields(self):
+        obj = {"hops": [{"query": "Q"}]}
+        result = parse_hop_plan_response({"content": obj})
+        assert result["hops"] == obj["hops"]
+        assert result["combination_strategy"] == "sequential"  # documented default
+        assert result["total_hops"] is None  # documented default
+        assert "parse_error" not in result
+
+    def test_parse_hop_plan_none_returns_empty_sentinel(self):
+        result = parse_hop_plan_response(None)
+        assert result["parse_error"] == "empty-response"
+        assert result["hops"] == []
+
+    def test_parse_hop_plan_empty_content_returns_empty_sentinel(self):
+        result = parse_hop_plan_response({"content": ""})
+        assert result["parse_error"] == "empty-response"
+        assert result["hops"] == []
+
+    def test_parse_hop_plan_non_json_returns_non_json_sentinel(self):
+        result = parse_hop_plan_response({"content": "not json{"})
+        assert result["parse_error"] == "non-json-response"
+        assert result["hops"] == []
+
+    def test_parse_hop_plan_array_returns_non_object_sentinel(self):
+        result = parse_hop_plan_response({"content": "[1,2,3]"})
+        assert result["parse_error"] == "non-object-json"
+        assert result["hops"] == []
+
+    def test_parse_hop_plan_bad_content_type_returns_unexpected_sentinel(self):
+        result = parse_hop_plan_response({"content": 42})
+        assert result["parse_error"] == "unexpected-content-type"
+        assert result["hops"] == []
+
+
+# --------------------------------------------------------------------------
+# Composers — one direct test per variant (VALID interpolation + EMPTY).
+# Each returns a well-formed {"messages": [{"role","content"}, ...]} shape.
+# --------------------------------------------------------------------------
+
+
+def _assert_messages_shape(result):
+    """Assert the composer return is a well-formed OpenAI chat `messages` list."""
+    assert isinstance(result, dict)
+    assert "messages" in result
+    msgs = result["messages"]
+    assert isinstance(msgs, list) and len(msgs) >= 1
+    for m in msgs:
+        assert isinstance(m, dict)
+        assert "role" in m and "content" in m
+    return msgs
+
+
+class TestComposeExpansionMessages:
+    def test_compose_expansion_valid_interpolates_query(self):
+        msgs = _assert_messages_shape(
+            compose_expansion_messages(query="ML optimization")
+        )
+        assert "ML optimization" in msgs[0]["content"]
+
+    def test_compose_expansion_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(compose_expansion_messages(query=""))
+        # Honest no-query content — structurally valid, no crash.
+        assert "No query" in msgs[0]["content"]
+
+
+class TestComposeDecompositionMessages:
+    def test_compose_decomposition_valid_interpolates_query(self):
+        msgs = _assert_messages_shape(
+            compose_decomposition_messages(query="Compare A and B")
+        )
+        assert "Compare A and B" in msgs[0]["content"]
+
+    def test_compose_decomposition_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(compose_decomposition_messages(query=""))
+        assert "No query" in msgs[0]["content"]
+
+
+class TestComposeAnalysisMessages:
+    def test_compose_analysis_valid_interpolates_query(self):
+        msgs = _assert_messages_shape(
+            compose_analysis_messages(query="how 2 trian nueral netwrk")
+        )
+        assert "how 2 trian nueral netwrk" in msgs[0]["content"]
+
+    def test_compose_analysis_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(compose_analysis_messages(query=""))
+        assert "No query" in msgs[0]["content"]
+
+
+class TestComposeRewriteMessages:
+    def test_compose_rewrite_valid_interpolates_query_and_analysis(self):
+        analysis = {
+            "issues": ["spelling_errors"],
+            "suggestions": {"spelling": "corrected"},
+        }
+        msgs = _assert_messages_shape(
+            compose_rewrite_messages(query="trian nueral netwrk", analysis=analysis)
+        )
+        content = msgs[0]["content"]
+        assert "trian nueral netwrk" in content
+        # The real parsed analysis is rendered into the rewriter's messages.
+        assert "spelling_errors" in content
+
+    def test_compose_rewrite_empty_query_none_analysis_returns_wellformed(self):
+        # query="" (default-None analysis) MUST still produce a valid shape.
+        msgs = _assert_messages_shape(compose_rewrite_messages(query="", analysis=None))
+        # The composer renders an explicit "(empty)" placeholder for the query.
+        assert "(empty)" in msgs[0]["content"]
+
+
+class TestComposeIntentMessages:
+    def test_compose_intent_valid_interpolates_query(self):
+        msgs = _assert_messages_shape(
+            compose_intent_messages(query="Show me Python code")
+        )
+        assert "Show me Python code" in msgs[0]["content"]
+
+    def test_compose_intent_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(compose_intent_messages(query=""))
+        assert "No query" in msgs[0]["content"]
+
+
+class TestComposeHopPlanMessages:
+    def test_compose_hop_plan_valid_interpolates_query(self):
+        msgs = _assert_messages_shape(
+            compose_hop_plan_messages(query="How has BERT influenced NLP?")
+        )
+        assert "How has BERT influenced NLP?" in msgs[0]["content"]
+
+    def test_compose_hop_plan_empty_returns_wellformed(self):
+        msgs = _assert_messages_shape(compose_hop_plan_messages(query=""))
+        assert "No query" in msgs[0]["content"]
+
+
+# ==========================================================================
+# COMPUTE-processor functions (#1117/#1123/#1118 from_function migration).
+#
+# Direct unit tests for the 6 module-level processor functions lifted from the
+# inline `code=` codegen blocks (`_process_expansions`, `_resolve_dependencies`,
+# `_combine_rewrites`, `_map_strategy`, `_plan_execution`, `_adaptive_process`).
+# Each is wired into its node's inner workflow via
+# `PythonCodeNode.from_function`; the node publishes the function's `return`
+# dict on the flat `result` port. These tests exercise the function directly
+# (valid input -> documented dict; empty/None/malformed -> HONEST default,
+# never a fabricated value — zero-tolerance Rule 2).
+# ==========================================================================
+
+
+class TestProcessExpansions:
+    """`_process_expansions`: parsed expansion dict + query -> expanded_query."""
+
+    def test_valid_combines_and_dedups_terms(self):
+        out = _process_expansions(
+            query="ml optimization",
+            expansion_response={
+                "expansions": ["ml tuning", "neural net optimization"],
+                "keywords": ["ml", "optimization"],
+                "concepts": ["machine_learning"],
+            },
+        )
+        expanded = out["expanded_query"]
+        assert expanded["original"] == "ml optimization"
+        assert expanded["expansions"] == ["ml tuning", "neural net optimization"]
+        assert expanded["keywords"] == ["ml", "optimization"]
+        assert expanded["concepts"] == ["machine_learning"]
+        # all_terms = {query} | expansions | keywords; dedup is set-based.
+        assert set(expanded["all_terms"]) == {
+            "ml optimization",
+            "ml tuning",
+            "neural net optimization",
+            "ml",
+            "optimization",
+        }
+        # expansion_count is unique-term-count minus the original query.
+        assert expanded["expansion_count"] == len(set(expanded["all_terms"])) - 1
+
+    def test_none_response_yields_honest_empty(self):
+        # Missing parsed dict (parser empty-sentinel) → empty lists, never
+        # fabricated expansions. Only the original query survives in all_terms.
+        out = _process_expansions(query="the query", expansion_response=None)
+        expanded = out["expanded_query"]
+        assert expanded["expansions"] == []
+        assert expanded["keywords"] == []
+        assert expanded["concepts"] == []
+        assert expanded["all_terms"] == ["the query"]
+        assert expanded["expansion_count"] == 0
+
+    def test_empty_query_and_empty_response(self):
+        out = _process_expansions(query="", expansion_response={})
+        expanded = out["expanded_query"]
+        # Empty query is still the lone all_terms entry; no fabrication.
+        assert expanded["all_terms"] == [""]
+        assert expanded["expansions"] == []
+
+
+class TestResolveDependencies:
+    """`_resolve_dependencies`: parsed decomposition dict -> execution_plan."""
+
+    def test_valid_topological_sort_over_depends_on(self):
+        # hop 0 has no deps, hop 1 depends on hop 0 (the `depends_on` field the
+        # decomposer system_prompt advertises — F25 Shard E).
+        out = _resolve_dependencies(
+            decomposition_result={
+                "sub_questions": [
+                    {"question": "What is BERT?", "depends_on": []},
+                    {"question": "How does it train?", "depends_on": [0]},
+                ],
+                "composition_strategy": "sequential",
+            }
+        )
+        plan = out["execution_plan"]
+        assert plan["total_questions"] == 2
+        # Execution order MUST be a valid permutation of the 2 indices.
+        assert set(plan["execution_order"]) == {0, 1}
+        assert plan["composition_strategy"] == "sequential"
+
+    def test_none_yields_honest_empty_plan(self):
+        out = _resolve_dependencies(decomposition_result=None)
+        plan = out["execution_plan"]
+        assert plan["sub_questions"] == []
+        assert plan["execution_order"] == []
+        assert plan["total_questions"] == 0
+        # Default composition strategy, never fabricated sub-questions.
+        assert plan["composition_strategy"] == "sequential"
+
+    def test_bare_string_subquestions_no_deps(self):
+        # A sub-question that is a bare string (not a dict) has no depends_on;
+        # the resolver must not crash and treats it as dependency-free.
+        out = _resolve_dependencies(
+            decomposition_result={"sub_questions": ["q1", "q2"]}
+        )
+        plan = out["execution_plan"]
+        assert plan["total_questions"] == 2
+        assert set(plan["execution_order"]) == {0, 1}
+
+
+class TestCombineRewrites:
+    """`_combine_rewrites`: query + analysis dict + rewrite dict -> output."""
+
+    def test_valid_merges_versions_and_surfaces_issues(self):
+        out = _combine_rewrites(
+            query="trian nueral netwrk",
+            analysis_result={"issues": ["spelling_errors"], "suggestions": {}},
+            rewrite_result={
+                "rewrites": {
+                    "corrected": "train neural network",
+                    "clarified": "how to train a neural network",
+                },
+                "recommended": "how to train a neural network",
+            },
+        )
+        rewritten = out["rewritten_queries"]
+        assert rewritten["original"] == "trian nueral netwrk"
+        assert rewritten["issues_found"] == ["spelling_errors"]
+        assert rewritten["recommended"] == "how to train a neural network"
+        # all_unique_versions = original + rewrite values, dedup preserving order.
+        assert rewritten["all_unique_versions"][0] == "trian nueral netwrk"
+        assert "train neural network" in rewritten["all_unique_versions"]
+        assert (
+            rewritten["improvement_count"] == len(rewritten["all_unique_versions"]) - 1
+        )
+
+    def test_none_parsed_dicts_yield_only_original(self):
+        # Missing parsed dicts → no issues, only the original query, recommended
+        # falls back to the original. Never a fabricated rewrite.
+        out = _combine_rewrites(
+            query="the query", analysis_result=None, rewrite_result=None
+        )
+        rewritten = out["rewritten_queries"]
+        assert rewritten["issues_found"] == []
+        assert rewritten["versions"] == {}
+        assert rewritten["recommended"] == "the query"
+        assert rewritten["all_unique_versions"] == ["the query"]
+        assert rewritten["improvement_count"] == 0
+
+
+class TestMapStrategy:
+    """`_map_strategy`: parsed intent dict -> routing_decision."""
+
+    def test_valid_maps_and_adjusts_for_requirements(self):
+        out = _map_strategy(
+            intent_classification={
+                "query_type": "procedural",
+                "domain": "technical",
+                "complexity": "moderate",
+                "requirements": ["needs_examples"],
+            }
+        )
+        routing = out["routing_decision"]
+        # (procedural, moderate) → "semantic"; needs_examples keeps it semantic.
+        assert routing["recommended_strategy"] == "semantic"
+        assert routing["intent_analysis"]["query_type"] == "procedural"
+        # The (query_type, complexity) pair IS in the strategy_map → 0.85.
+        assert routing["confidence"] == 0.85
+
+    def test_needs_authoritative_upgrades_to_self_correcting(self):
+        out = _map_strategy(
+            intent_classification={
+                "query_type": "factual",
+                "complexity": "simple",
+                "requirements": ["needs_authoritative"],
+            }
+        )
+        # (factual, simple) → "sparse" base, then needs_authoritative →
+        # "self_correcting" (the requirement-aware adjustment).
+        assert out["routing_decision"]["recommended_strategy"] == "self_correcting"
+
+    def test_none_falls_to_documented_defaults(self):
+        # Parser None-sentinel (query_type=None) → factual/simple defaults; the
+        # pair is in strategy_map → "sparse". Never fabricated classification.
+        out = _map_strategy(intent_classification=None)
+        routing = out["routing_decision"]
+        assert routing["recommended_strategy"] == "sparse"
+        # (factual, simple) IS in strategy_map → confidence 0.85.
+        assert routing["confidence"] == 0.85
+
+    def test_unmapped_pair_yields_hybrid_low_confidence(self):
+        # An (query_type, complexity) pair NOT in strategy_map → "hybrid" + 0.6.
+        out = _map_strategy(
+            intent_classification={"query_type": "factual", "complexity": "complex"}
+        )
+        routing = out["routing_decision"]
+        assert routing["recommended_strategy"] == "hybrid"
+        assert routing["confidence"] == 0.6
+
+
+class TestPlanExecution:
+    """`_plan_execution`: parsed hop-plan dict -> multi_hop_plan."""
+
+    def test_valid_builds_sequential_batches_honoring_deps(self):
+        out = _plan_execution(
+            hop_plan_result={
+                "hops": [
+                    {"hop_number": 1, "depends_on": []},
+                    {"hop_number": 2, "depends_on": [1]},
+                ],
+                "combination_strategy": "sequential",
+            }
+        )
+        plan = out["multi_hop_plan"]
+        assert plan["total_hops"] == 2
+        # hop_2 depends on hop_1 → 2 sequential batches, 0 parallel.
+        assert len(plan["batches"]) == 2
+        assert plan["parallel_opportunities"] == 0
+        assert plan["combination_strategy"] == "sequential"
+
+    def test_parallel_hops_share_a_batch(self):
+        out = _plan_execution(
+            hop_plan_result={
+                "hops": [
+                    {"hop_number": 1, "depends_on": []},
+                    {"hop_number": 2, "depends_on": []},
+                ]
+            }
+        )
+        plan = out["multi_hop_plan"]
+        # Two dependency-free hops → one batch holding both → 1 parallel opp.
+        assert len(plan["batches"]) == 1
+        assert plan["parallel_opportunities"] == 1
+
+    def test_none_yields_zero_hop_zero_batch_plan(self):
+        out = _plan_execution(hop_plan_result=None)
+        plan = out["multi_hop_plan"]
+        assert plan["total_hops"] == 0
+        assert plan["batches"] == []
+        assert plan["parallel_opportunities"] == 0
+        # Default combination strategy, never fabricated hops.
+        assert plan["combination_strategy"] == "sequential"
+
+
+class TestAdaptiveProcess:
+    """`_adaptive_process`: query + nested routing_decision -> adaptive_plan."""
+
+    def test_valid_comparative_appends_multi_hop(self):
+        # The wired value is the classifier's full run() dict, which nests the
+        # routing_decision under the same key.
+        out = _adaptive_process(
+            query="compare X vs Y",
+            routing_decision={
+                "routing_decision": {
+                    "intent_analysis": {
+                        "query_type": "comparative",
+                        "complexity": "moderate",
+                    },
+                    "recommended_strategy": "multi_vector",
+                }
+            },
+        )
+        plan = out["adaptive_plan"]
+        assert plan["original_query"] == "compare X vs Y"
+        # Always rewrite; comparative → multi_hop.
+        assert "rewrite" in plan["processing_steps"]
+        assert "multi_hop" in plan["processing_steps"]
+        assert plan["recommended_strategy"] == "multi_vector"
+
+    def test_complex_appends_decompose(self):
+        out = _adaptive_process(
+            query="deep analysis",
+            routing_decision={
+                "routing_decision": {
+                    "intent_analysis": {
+                        "query_type": "analytical",
+                        "complexity": "complex",
+                    }
+                }
+            },
+        )
+        steps = out["adaptive_plan"]["processing_steps"]
+        # analytical → expand; complex → decompose; analytical+complex → multi_hop.
+        assert "expand" in steps
+        assert "decompose" in steps
+        assert "multi_hop" in steps
+
+    def test_none_yields_factual_simple_defaults(self):
+        # Missing routing_decision → factual/simple defaults + single rewrite
+        # step. Never fabricated intent.
+        out = _adaptive_process(query="the query", routing_decision=None)
+        plan = out["adaptive_plan"]
+        assert plan["processing_steps"] == ["rewrite"]
+        assert plan["recommended_strategy"] == "hybrid"
+        assert plan["intent"] == {}

--- a/packages/kailash-kaizen/tests/unit/rag/test_workflows_nodes.py
+++ b/packages/kailash-kaizen/tests/unit/rag/test_workflows_nodes.py
@@ -156,20 +156,29 @@ class TestStrategyWorkflowBuilders:
         assert edge[0].target_input == "texts"
 
     def test_hybrid_builder_default_fusion_method(self):
-        """create_hybrid_rag_workflow defaults to RRF fusion in the codegen."""
+        """create_hybrid_rag_workflow defaults to RRF fusion.
+
+        The `result_fusion` node is wired via ``PythonCodeNode.from_function``
+        with the default ``fusion_method`` bound into the closure; executing it
+        publishes the bound value on the flat ``result`` port (its prior
+        ``config["code"]`` string is gone — assert behavior, not source text).
+        """
         wf = _wf(create_hybrid_rag_workflow(RAGConfig()))
-        fusion_code = _node(wf, "result_fusion").config["code"]
-        assert '"fusion_method": "rrf"' in fusion_code
+        node = _node(wf, "result_fusion")
+        out = node.execute(semantic_results={}, statistical_results={})
+        assert out["result"]["fused_results"]["fusion_method"] == "rrf"
 
     def test_hybrid_builder_honors_fusion_method_arg(self):
-        """The fusion_method arg is consumed — baked into the fusion codegen.
+        """The fusion_method arg is consumed — bound into the closure.
 
-        It flows into the `result_fusion` PythonCodeNode's output field; a
-        Rule-3c silent-drop would leave the codegen with a stale literal.
+        It flows into the `result_fusion` from_function node's output; a
+        Rule-3c silent-drop would leave the bound value stale. Behavior-asserted
+        by executing the production node (the source string no longer exists).
         """
         wf = _wf(create_hybrid_rag_workflow(RAGConfig(), fusion_method="linear"))
-        fusion_code = _node(wf, "result_fusion").config["code"]
-        assert '"fusion_method": "linear"' in fusion_code
+        node = _node(wf, "result_fusion")
+        out = node.execute(semantic_results={}, statistical_results={})
+        assert out["result"]["fused_results"]["fusion_method"] == "linear"
 
     def test_hybrid_builder_graph_has_two_subworkflows_plus_fusion(self):
         wf = _wf(create_hybrid_rag_workflow(RAGConfig()))
@@ -357,3 +366,470 @@ class TestWorkflowNodes:
         for edge in edges:
             assert edge.source_output.startswith("case_")
             assert edge.target_input == "input"
+
+
+# ==========================================================================
+# F31-FU2 Shard C — direct-call Tier-1 coverage of the pure parser / composer
+# `from_function` targets in `workflows.py` (the O2 strategy-decision parser +
+# the strategy-analyzer message composer). Pure data rendering / tool-result
+# parsing (permitted deterministic exceptions per rules/agent-reasoning.md
+# #3 + #6) — NOT agent decision-making. Called DIRECTLY (no LocalRuntime, no
+# mocking — pure functions).
+#
+# Per-file contract (zero-tolerance Rule 2): `parse_strategy_decision` returns
+# the strategy-decision dict DIRECTLY (NOT wrapped in a `result` key). It ships
+# 5 typed parse-error sentinels — empty-response / non-json-response /
+# unexpected-content-type / non-object-json / missing-strategy — each setting
+# `recommended_strategy: None` so the downstream SwitchNode fails CLOSED on the
+# None strategy (no fabricated default like "semantic"). The VALID case surfaces
+# the genuine strategy + reasoning/confidence/fallback metadata. An already-dict
+# `content` (provider pre-parsed) is honored.
+# ==========================================================================
+
+import json as _json
+
+from kaizen.nodes.rag.workflows import (
+    _unwrap_response_content,
+    compose_strategy_analyzer_messages,
+    parse_strategy_decision,
+)
+
+
+def _ws_wrap(obj) -> dict:
+    """Build the LLMAgentNode `response` port shape with a JSON-string content."""
+    return {"content": _json.dumps(obj)}
+
+
+class TestWorkflowsUnwrapResponseContent:
+    """`_unwrap_response_content`: dict -> .content, bare value -> passthrough."""
+
+    def test_unwrap_dict_returns_content(self):
+        assert _unwrap_response_content({"content": "hello"}) == "hello"
+
+    def test_unwrap_dict_missing_content_returns_none(self):
+        assert _unwrap_response_content({"other": "x"}) is None
+
+    def test_unwrap_bare_string_passthrough(self):
+        assert _unwrap_response_content("raw string") == "raw string"
+
+    def test_unwrap_none_passthrough(self):
+        assert _unwrap_response_content(None) is None
+
+
+class TestParseStrategyDecision:
+    """`parse_strategy_decision`: VALID + 5 typed sentinels + already-dict.
+
+    Returns the decision dict DIRECTLY (no `result` wrapper). Every malformed
+    case sets `recommended_strategy: None` so the SwitchNode fails closed —
+    never a fabricated strategy (zero-tolerance Rule 2).
+    """
+
+    def test_valid_returns_strategy_and_metadata(self):
+        obj = {
+            "recommended_strategy": "semantic",
+            "reasoning": "dense corpus",
+            "confidence": 0.9,
+            "fallback_strategy": "hybrid",
+        }
+        result = parse_strategy_decision(_ws_wrap(obj))
+        assert result["recommended_strategy"] == "semantic"
+        assert result["reasoning"] == "dense corpus"
+        assert result["confidence"] == 0.9
+        assert result["fallback_strategy"] == "hybrid"
+        assert "parse_error" not in result
+
+    def test_already_dict_content_returns_strategy(self):
+        # Provider pre-parsed: content is already a dict.
+        result = parse_strategy_decision(
+            {"content": {"recommended_strategy": "hybrid"}}
+        )
+        assert result["recommended_strategy"] == "hybrid"
+        # Absent rationale fields default to None (documented), not fabricated.
+        assert result["reasoning"] is None
+        assert result["confidence"] is None
+        assert result["fallback_strategy"] is None
+        assert "parse_error" not in result
+
+    def test_none_returns_empty_response_sentinel(self):
+        result = parse_strategy_decision(None)
+        assert result["parse_error"] == "empty-response"
+        # Honest None strategy — the SwitchNode fails closed (zero-tolerance R2).
+        assert result["recommended_strategy"] is None
+
+    def test_empty_content_returns_empty_response_sentinel(self):
+        result = parse_strategy_decision({"content": ""})
+        assert result["parse_error"] == "empty-response"
+        assert result["recommended_strategy"] is None
+
+    def test_whitespace_content_returns_empty_response_sentinel(self):
+        result = parse_strategy_decision({"content": "   "})
+        assert result["parse_error"] == "empty-response"
+        assert result["recommended_strategy"] is None
+
+    def test_non_json_returns_non_json_sentinel(self):
+        result = parse_strategy_decision({"content": "not json{"})
+        assert result["parse_error"] == "non-json-response"
+        assert result["recommended_strategy"] is None
+
+    def test_unexpected_content_type_returns_unexpected_sentinel(self):
+        # content is an int (not str, not dict).
+        result = parse_strategy_decision({"content": 42})
+        assert result["parse_error"] == "unexpected-content-type"
+        assert result["recommended_strategy"] is None
+
+    def test_non_object_json_returns_non_object_sentinel(self):
+        # Valid JSON that is not an object (an array).
+        result = parse_strategy_decision({"content": "[1, 2, 3]"})
+        assert result["parse_error"] == "non-object-json"
+        assert result["recommended_strategy"] is None
+
+    def test_missing_strategy_field_returns_missing_strategy_sentinel(self):
+        # Parsed JSON object but the load-bearing recommended_strategy is absent.
+        result = parse_strategy_decision(_ws_wrap({"reasoning": "r"}))
+        assert result["parse_error"] == "missing-strategy"
+        assert result["recommended_strategy"] is None
+
+    def test_blank_strategy_field_returns_missing_strategy_sentinel(self):
+        # A present-but-blank strategy string is treated as missing (fails closed).
+        result = parse_strategy_decision(_ws_wrap({"recommended_strategy": "   "}))
+        assert result["parse_error"] == "missing-strategy"
+        assert result["recommended_strategy"] is None
+
+
+def _ws_assert_messages_shape(result):
+    """Assert the composer return is a well-formed OpenAI chat `messages` list."""
+    assert isinstance(result, dict)
+    assert "messages" in result
+    msgs = result["messages"]
+    assert isinstance(msgs, list) and len(msgs) >= 1
+    for m in msgs:
+        assert isinstance(m, dict)
+        assert "role" in m and "content" in m
+    return msgs
+
+
+class TestComposeStrategyAnalyzerMessages:
+    def test_valid_interpolates_corpus_characteristics_and_query(self):
+        msgs = _ws_assert_messages_shape(
+            compose_strategy_analyzer_messages(
+                query="Compare BERT and GPT",
+                document_count=12,
+                avg_length=2048,
+                has_structure=True,
+                is_technical=True,
+                content_types=["markdown", "code"],
+            )
+        )
+        content = msgs[0]["content"]
+        # The REAL document characteristics + query are rendered into the prompt.
+        assert "Compare BERT and GPT" in content
+        assert "12" in content
+        assert "2048" in content
+        assert "markdown" in content and "code" in content
+
+    def test_empty_returns_wellformed_with_none_query_placeholder(self):
+        # All-default call (empty query, zero counts) MUST produce a valid shape.
+        msgs = _ws_assert_messages_shape(compose_strategy_analyzer_messages())
+        content = msgs[0]["content"]
+        # The composer renders an explicit "(none)" placeholder for the query
+        # and "none detected" for content types.
+        assert "(none)" in content
+        assert "none detected" in content
+
+
+# ==========================================================================
+# Wave 3 Shard S5a — direct-call Tier-1 coverage of the COMPUTE-stage
+# `from_function` targets lifted from the prior PythonCodeNode `"code"` strings
+# (#1117/#1123/#1118 root-cause fix). Each function is called DIRECTLY (pure
+# function, no LocalRuntime, no mocking) and is behavior-equivalent to the
+# codegen body it replaced. One direct test per new module fn.
+# ==========================================================================
+
+from kaizen.nodes.rag.workflows import (  # noqa: E402
+    _aggregate_adaptive_results,
+    _analyze_documents,
+    _analyze_for_llm,
+    _format_pipeline_results,
+    _make_config_processor,
+    _validate_rag_results,
+)
+
+# A mixed corpus mirroring the integration fixture: structured + technical +
+# a present-but-None-content dict + a non-dict element the body must survive.
+_S5A_CORPUS = [
+    {"content": "## Section 1\nNeural network optimization with gradient descent."},
+    {"content": "def train(model): return model.fit()  # code function class api"},
+    {"content": None},
+    "not-a-dict-element",
+]
+
+
+class TestAnalyzeDocuments:
+    """`_analyze_documents` (AdvancedRAGWorkflowNode quality_analyzer)."""
+
+    def test_filters_non_dict_and_picks_strategy(self):
+        out = _analyze_documents(_S5A_CORPUS)
+        analysis = out["analysis"]
+        # 3 dict docs survive (content:None dict included); the str is dropped.
+        assert analysis["total_docs"] == 3
+        assert analysis["is_technical"] is True
+        assert analysis["recommended_strategy"] in {
+            "semantic",
+            "statistical",
+            "hybrid",
+            "hierarchical",
+        }
+        # The filtered documents are echoed for the downstream validator.
+        assert out["documents"] == [d for d in _S5A_CORPUS if isinstance(d, dict)]
+
+    def test_empty_corpus_defaults(self):
+        out = _analyze_documents(None)
+        assert out["analysis"]["total_docs"] == 0
+        assert out["analysis"]["avg_length"] == 0
+        # Empty corpus falls through to the default strategy.
+        assert out["analysis"]["recommended_strategy"] == "semantic"
+
+
+class TestValidateRagResults:
+    """`_validate_rag_results` (AdvancedRAGWorkflowNode quality_validator)."""
+
+    def test_passing_results_compute_quality_score(self):
+        out = _validate_rag_results(
+            rag_results={"documents": [1, 2, 3, 4, 5], "scores": [0.8, 0.9]},
+            analysis={"recommended_strategy": "hybrid"},
+        )
+        v = out["validation"]
+        assert v["results_count"] == 5
+        # avg_score 0.85 * (5/5) = 0.85 > 0.5 -> passed.
+        assert v["passed"] is True
+        assert out["strategy_used"] == "hybrid"
+        assert out["final_status"] == "passed"
+
+    def test_honest_defaults_on_missing_inputs(self):
+        # An unwired upstream branch arrives None — honest defaults, no crash.
+        out = _validate_rag_results(rag_results=None, analysis=None)
+        assert out["validation"]["results_count"] == 0
+        assert out["validation"]["passed"] is False
+        assert out["strategy_used"] is None
+        assert out["final_status"] == "needs_improvement"
+
+    def test_present_but_none_scores_does_not_crash(self):
+        # A present-but-None `scores` key must not raise (sum(None) guard).
+        out = _validate_rag_results(
+            rag_results={"documents": [1], "scores": None}, analysis={}
+        )
+        assert out["validation"]["avg_score"] == 0
+
+
+class TestAnalyzeForLlm:
+    """`_analyze_for_llm` (AdaptiveRAGWorkflowNode document_preprocessor)."""
+
+    def test_publishes_flat_characteristics(self):
+        out = _analyze_for_llm(_S5A_CORPUS, query="optimize neural nets")
+        # Flat dict (no wrapper) — the composer reads result.<key> directly.
+        assert out["document_count"] == 3
+        assert out["is_technical"] is True
+        assert "structured" in out["content_types"]
+        assert out["query"] == "optimize neural nets"
+
+    def test_empty_corpus_defaults_echo_query(self):
+        out = _analyze_for_llm([], query="q")
+        assert out["document_count"] == 0
+        assert out["content_types"] == []
+        assert out["query"] == "q"
+
+
+class TestAggregateAdaptiveResults:
+    """`_aggregate_adaptive_results` (AdaptiveRAGWorkflowNode results_aggregator)."""
+
+    def test_surfaces_parsed_decision_and_characteristics(self):
+        out = _aggregate_adaptive_results(
+            rag_results={"docs": []},
+            llm_decision={
+                "recommended_strategy": "hybrid",
+                "reasoning": "mixed",
+                "confidence": 0.82,
+                "fallback_strategy": "semantic",
+            },
+            preprocessed_data={
+                "document_count": 3,
+                "avg_length": 100,
+                "content_types": ["technical"],
+            },
+        )
+        assert out["strategy_used"] == "hybrid"
+        assert out["llm_reasoning"] == "mixed"
+        assert out["confidence"] == 0.82
+        assert out["document_analysis"]["count"] == 3
+        assert out["adaptive_metadata"]["fallback_available"] == "semantic"
+        assert out["adaptive_metadata"]["strategy_selection_method"] == "llm_analysis"
+
+    def test_honest_defaults_on_missing_decision(self):
+        # A parse-error decision (recommended_strategy None) + unwired branch.
+        out = _aggregate_adaptive_results(
+            rag_results=None, llm_decision=None, preprocessed_data=None
+        )
+        assert out["strategy_used"] is None
+        assert out["document_analysis"]["count"] is None
+        assert out["adaptive_metadata"]["fallback_available"] is None
+
+
+class TestMakeConfigProcessor:
+    """`_make_config_processor` closure factory (RAGPipelineWorkflowNode)."""
+
+    def test_binds_build_time_config_and_publishes_flat_dict(self):
+        fn = _make_config_processor(
+            default_strategy="hybrid",
+            chunk_size=512,
+            chunk_overlap=64,
+            embedding_model="text-embedding-3-small",
+            retrieval_k=7,
+        )
+        # The factory names the function so from_function/registry sees it.
+        assert fn.__name__ == "config_processor"
+        out = fn(documents=[{"content": "x"}], query="", strategy="")
+        # `strategy` is a TOP-LEVEL key (the SwitchNode condition_field reads it).
+        assert out["strategy"] == "hybrid"  # falls back to bound default
+        assert out["chunk_size"] == 512
+        assert out["chunk_overlap"] == 64
+        assert out["embedding_model"] == "text-embedding-3-small"
+        assert out["retrieval_k"] == 7
+        assert out["query"] == ""
+
+    def test_runtime_strategy_overrides_default(self):
+        fn = _make_config_processor(
+            default_strategy="hybrid",
+            chunk_size=1000,
+            chunk_overlap=200,
+            embedding_model="m",
+            retrieval_k=5,
+        )
+        out = fn(documents=[], query="q", strategy="semantic")
+        assert out["strategy"] == "semantic"  # runtime input wins
+        assert out["query"] == "q"
+
+
+class TestFormatPipelineResults:
+    """`_format_pipeline_results` (RAGPipelineWorkflowNode results_formatter)."""
+
+    def test_formats_with_config_strategy(self):
+        out = _format_pipeline_results(
+            strategy_results={"docs": [1]},
+            processed_config={"strategy": "semantic"},
+        )
+        assert out["strategy_used"] == "semantic"
+        assert out["pipeline_type"] == "configurable"
+        assert out["success"] is True
+
+    def test_honest_defaults_on_missing_inputs(self):
+        out = _format_pipeline_results(strategy_results=None, processed_config=None)
+        assert out["strategy_used"] is None
+        assert out["success"] is False
+        assert out["configuration"] == {}
+
+
+# ==========================================================================
+# Wave 3 Shard S5b — direct-call Tier-1 coverage of the COMPUTE-stage
+# `from_function` targets lifted from the prior PythonCodeNode `"code"` strings
+# in strategies.py (#1117 publish-nothing / #1123 brace-escape / #1118
+# import-trap root-cause fix). Each function is called DIRECTLY (pure function,
+# no LocalRuntime, no mocking) and is behavior-equivalent to the codegen body it
+# replaced. One direct test per new module fn.
+# ==========================================================================
+
+from kaizen.nodes.rag.strategies import (  # noqa: E402
+    _extract_keywords,
+    _make_result_fusion,
+    _process_levels,
+)
+
+# A mixed corpus: technical + structured + a present-but-None-content dict + a
+# non-dict element the body must survive (mirrors the integration fixture).
+_S5B_CHUNKS = [
+    {"content": "def train(model): return model.fit()  # gradient optimization api"},
+    {"content": "## Section 1\nNeural network architecture overview."},
+    {"content": None},
+    "not-a-dict-element",
+]
+
+
+class TestExtractKeywords:
+    """`_extract_keywords` (StatisticalRAG keyword_extractor)."""
+
+    def test_filters_non_dict_and_extracts_tokens(self):
+        out = _extract_keywords(_S5B_CHUNKS)
+        keywords = out["keywords"]
+        # 3 dict chunks survive the isinstance filter (the content:None dict is a
+        # valid dict — empty string after `or ""`); the str element is dropped.
+        assert len(keywords) == 3
+        # the technical chunk yields real 3+-letter tokens, stop-words removed.
+        assert any(len(kw) > 0 for kw in keywords)
+        # `the` is a stop-word — never present in any extracted list.
+        assert all("the" not in kw for kw in keywords)
+
+    def test_present_but_none_content_does_not_crash(self):
+        # A present-but-None `content` coerces to "" — no `.lower()` crash.
+        out = _extract_keywords([{"content": None}])
+        assert out["keywords"] == [[]]
+
+    def test_empty_corpus_returns_empty(self):
+        assert _extract_keywords(None) == {"keywords": []}
+
+
+class TestMakeResultFusion:
+    """`_make_result_fusion` closure factory (HybridRAG result_fusion)."""
+
+    def test_default_method_bound_into_closure(self):
+        fn = _make_result_fusion(fusion_method="rrf")
+        out = fn(semantic_results={}, statistical_results={})
+        assert out["fused_results"]["fusion_method"] == "rrf"
+
+    def test_custom_method_bound_into_closure(self):
+        # Rule-3c: the build-time arg is consumed, not silently dropped.
+        fn = _make_result_fusion(fusion_method="linear")
+        out = fn(semantic_results={}, statistical_results={})
+        assert out["fused_results"]["fusion_method"] == "linear"
+
+    def test_fuses_and_ranks_overlapping_docs(self):
+        fn = _make_result_fusion(fusion_method="rrf")
+        out = fn(
+            semantic_results={"results": [{"id": "d1"}, {"id": "d2"}]},
+            statistical_results={"results": [{"id": "d1"}, {"id": "d3"}]},
+        )
+        fused = out["fused_results"]
+        # d1 appears in both → fused from two sources, top-ranked.
+        assert fused["documents"][0]["id"] == "d1"
+        assert len(fused["documents"]) == 3
+
+    def test_present_but_none_inputs_do_not_crash(self):
+        # Unwired upstream branches arrive None — isinstance guard, no crash.
+        fn = _make_result_fusion(fusion_method="rrf")
+        out = fn(semantic_results=None, statistical_results=None)
+        assert out["fused_results"]["documents"] == []
+
+
+class TestProcessLevels:
+    """`_process_levels` (HierarchicalRAG level_processor)."""
+
+    def test_buckets_chunks_by_hierarchy_level(self):
+        out = _process_levels(
+            [
+                {"content": "doc", "hierarchy_level": "document"},
+                {"content": "sec", "hierarchy_level": "section"},
+                {"content": None},
+                "not-a-dict",
+            ]
+        )
+        level_chunks = out["level_chunks"]
+        assert len(level_chunks["document"]) == 1
+        assert len(level_chunks["section"]) == 1
+        assert len(level_chunks["paragraph"]) == 0
+        assert out["levels"] == ["document", "section", "paragraph"]
+
+    def test_empty_corpus_returns_empty_buckets(self):
+        out = _process_levels(None)
+        assert out["level_chunks"] == {
+            "document": [],
+            "section": [],
+            "paragraph": [],
+        }

--- a/packages/kailash-kaizen/tests/unit/test_kaizen_multi_agent_coordination.py
+++ b/packages/kailash-kaizen/tests/unit/test_kaizen_multi_agent_coordination.py
@@ -21,6 +21,14 @@ import pytest
 from tests.fixtures.consolidated_test_fixtures import consolidated_fixtures
 
 
+@pytest.fixture(autouse=True)
+def _default_model_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Framework-creating tests resolve the model from the environment
+    (kaizen.errors.EnvModelMissing otherwise); the unit tier supplies a
+    deterministic value — same pattern as test_issue_822_*."""
+    monkeypatch.setenv("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
+
+
 # Test multi-agent workflow templates
 class TestMultiAgentWorkflowTemplates:
     """Test multi-agent workflow template creation and configuration."""
@@ -210,9 +218,17 @@ class TestAgentCommunication:
         """Test agent communication creates appropriate workflow for execution."""
         import kaizen
 
-        # Mock runtime execution
+        # Mock runtime execution — production LLMAgentNode publishes
+        # "response" as a NESTED dict {"content": ..., "role": ...}
+        # (llm_agent.py:995); flat-string doubles are the F31 wrong-shape
+        # false-green class.
         mock_execute.return_value = (
-            {"comm_response_agent_b": {"response": "Hello from agent B"}},
+            {
+                "comm_response_agent_b": {
+                    "success": True,
+                    "response": {"content": "Hello from agent B", "role": "assistant"},
+                }
+            },
             "test_run_id",
         )
 
@@ -243,10 +259,12 @@ class TestAgentCommunication:
         assert "context" in response
         assert "timestamp" in response
 
-        # Verify response content
+        # Verify response content — equality, not substring: under the
+        # pre-fix parse the message was the dict repr of the nested response
+        # (which CONTAINS the text), so substring would false-green.
         assert response["sender"] == "agent_b"
         assert response["receiver"] == "agent_a"
-        assert "Hello from agent B" in response["message"]
+        assert response["message"] == "Hello from agent B"
 
     def test_agent_communication_tracks_conversation_history(self, performance_tracker):
         """Test agent communication maintains conversation history."""

--- a/packages/kailash-kaizen/tests/utils/docker_config.py
+++ b/packages/kailash-kaizen/tests/utils/docker_config.py
@@ -20,7 +20,6 @@ import time
 from typing import Dict, List
 
 import asyncpg
-import pymongo
 import redis
 import requests
 
@@ -152,6 +151,11 @@ class DockerServicesManager:
     async def _check_mongodb(self) -> bool:
         """Check MongoDB health."""
         try:
+            # Lazy import: pymongo is only needed when a test actually
+            # health-checks MongoDB; a module-scope import poisons collection
+            # for every test importing tests.utils (same class as F31-FU5).
+            import pymongo
+
             client = pymongo.MongoClient(
                 host=MONGODB_CONFIG["host"],
                 port=MONGODB_CONFIG["port"],

--- a/packages/kailash-kaizen/uv.lock
+++ b/packages/kailash-kaizen/uv.lock
@@ -36,15 +36,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aiofiles"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
-]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -156,30 +147,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aiohttp-cors"
-version = "0.8.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/d89e846a5444b3d5eb8985a6ddb0daef3774928e1bfbce8e84ec97b0ffa7/aiohttp_cors-0.8.1.tar.gz", hash = "sha256:ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403", size = 38626, upload-time = "2025-03-31T14:16:20.048Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/3b/40a68de458904bcc143622015fff2352b6461cd92fd66d3527bf1c6f5716/aiohttp_cors-0.8.1-py3-none-any.whl", hash = "sha256:3180cf304c5c712d626b9162b195b1db7ddf976a2a25172b35bb2448b890a80d", size = 25231, upload-time = "2025-03-31T14:16:18.478Z" },
-]
-
-[[package]]
-name = "aiomysql"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pymysql" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/e0/302aeffe8d90853556f47f3106b89c16cc2ec2a4d269bdfd82e3f4ae12cc/aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a", size = 108311, upload-time = "2025-10-22T00:15:21.278Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/af/aae0153c3e28712adaf462328f6c7a3c196a1c1c27b491de4377dd3e6b52/aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2", size = 71834, upload-time = "2025-10-22T00:15:15.905Z" },
-]
-
-[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -230,18 +197,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
-]
-
-[[package]]
-name = "apscheduler"
-version = "3.11.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzlocal" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
 ]
 
 [[package]]
@@ -378,76 +333,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/f1/7b5c9e20222fa33a29d471b710f6641582e1a0d16a2ca16e44914511b640/babe-0.0.7.tar.gz", hash = "sha256:746bf5184236d682de6f0a2b9b26d5dfc1d44a031eb12f30b6fc2451976b0ded", size = 8785, upload-time = "2020-11-11T01:36:41.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/44/a4f6454ad1a91de0757232c182d1ac0314f6b41827b25ed461dc02c84bb5/babe-0.0.7-py3-none-any.whl", hash = "sha256:660b6f1647012e517e1cfdfe362d52949a451fd8ba220d620513f912a04e2c77", size = 6871, upload-time = "2020-11-11T01:36:40.505Z" },
-]
-
-[[package]]
-name = "bcrypt"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
-    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
-    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
-    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
-    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
-    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
-    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
-    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
-    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
-    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
-    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
-    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
-    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
-    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
-    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
-    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
-    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
-    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
-    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
-    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
-    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
-    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
-    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180, upload-time = "2025-09-25T19:50:38.575Z" },
-    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
 ]
 
 [[package]]
@@ -1427,18 +1312,6 @@ wheels = [
 ]
 
 [[package]]
-name = "googleapis-common-protos"
-version = "1.74.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
-]
-
-[[package]]
 name = "graze"
 version = "0.1.39"
 source = { registry = "https://pypi.org/simple" }
@@ -1449,99 +1322,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/c8/f2a0b7143f4a1e0d05dad578c19e1b6d3b839512a011e5123dfa6d83cb73/graze-0.1.39.tar.gz", hash = "sha256:030c7064ddb7cfc167923f626c54a2d0be54d2e103dcca7821da2fd5d6354c84", size = 32971, upload-time = "2025-10-30T18:00:02.003Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/da/74b9fc61ad72e87dd63f1fd25c7f7819c389950b16679e56f3b04a8f4a53/graze-0.1.39-py3-none-any.whl", hash = "sha256:8044a21d0f640675f5070c068f8bdb56116170428e4feb1282cc18f0091a2175", size = 30139, upload-time = "2025-10-30T18:00:00.817Z" },
-]
-
-[[package]]
-name = "greenlet"
-version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/e5/40dbda2736893e3e53d25838e0f19a2b417dfc122b9989c91918db30b5d3/greenlet-3.3.0.tar.gz", hash = "sha256:a82bb225a4e9e4d653dd2fb7b8b2d36e4fb25bc0165422a11e48b88e9e6f78fb", size = 190651, upload-time = "2025-12-04T14:49:44.05Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
-    { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
-    { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/d5/c339b3b4bc8198b7caa4f2bd9fd685ac9f29795816d8db112da3d04175bb/greenlet-3.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:7652ee180d16d447a683c04e4c5f6441bae7ba7b17ffd9f6b3aff4605e9e6f71", size = 301164, upload-time = "2025-12-04T14:42:51.577Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
-    { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
-    { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
-    { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/79/3912a94cf27ec503e51ba493692d6db1e3cd8ac7ac52b0b47c8e33d7f4f9/greenlet-3.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a7a34b13d43a6b78abf828a6d0e87d3385680eaf830cd60d20d52f249faabf39", size = 301964, upload-time = "2025-12-04T14:36:58.316Z" },
-    { url = "https://files.pythonhosted.org/packages/02/2f/28592176381b9ab2cafa12829ba7b472d177f3acc35d8fbcf3673d966fff/greenlet-3.3.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:a1e41a81c7e2825822f4e068c48cb2196002362619e2d70b148f20a831c00739", size = 275140, upload-time = "2025-12-04T14:23:01.282Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/80/fbe937bf81e9fca98c981fe499e59a3f45df2a04da0baa5c2be0dca0d329/greenlet-3.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f515a47d02da4d30caaa85b69474cec77b7929b2e936ff7fb853d42f4bf8808", size = 599219, upload-time = "2025-12-04T14:50:08.309Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/ff/7c985128f0514271b8268476af89aee6866df5eec04ac17dcfbc676213df/greenlet-3.3.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d2d9fd66bfadf230b385fdc90426fcd6eb64db54b40c495b72ac0feb5766c54", size = 610211, upload-time = "2025-12-04T14:57:43.968Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/ba/56699ff9b7c76ca12f1cdc27a886d0f81f2189c3455ff9f65246780f713d/greenlet-3.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ab97cf74045343f6c60a39913fa59710e4bd26a536ce7ab2397adf8b27e67c39", size = 1567256, upload-time = "2025-12-04T15:04:25.276Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/71/ba21c3fb8c5dce83b8c01f458a42e99ffdb1963aeec08fff5a18588d8fd7/greenlet-3.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:9ee1942ea19550094033c35d25d20726e4f1c40d59545815e1128ac58d416d38", size = 301833, upload-time = "2025-12-04T14:32:23.929Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:60c2ef0f578afb3c8d92ea07ad327f9a062547137afe91f38408f08aacab667f", size = 275671, upload-time = "2025-12-04T14:23:05.267Z" },
-    { url = "https://files.pythonhosted.org/packages/44/06/dac639ae1a50f5969d82d2e3dd9767d30d6dbdbab0e1a54010c8fe90263c/greenlet-3.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a5d554d0712ba1de0a6c94c640f7aeba3f85b3a6e1f2899c11c2c0428da9365", size = 646360, upload-time = "2025-12-04T14:50:10.026Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/94/0fb76fe6c5369fba9bf98529ada6f4c3a1adf19e406a47332245ef0eb357/greenlet-3.3.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3a898b1e9c5f7307ebbde4102908e6cbfcb9ea16284a3abe15cab996bee8b9b3", size = 658160, upload-time = "2025-12-04T14:57:45.41Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5773edda4dc00e173820722711d043799d3adb4f01731f40619e07ea2750b955", size = 660166, upload-time = "2025-12-04T14:26:05.099Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/d2/91465d39164eaa0085177f61983d80ffe746c5a1860f009811d498e7259c/greenlet-3.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac0549373982b36d5fd5d30beb8a7a33ee541ff98d2b502714a09f1169f31b55", size = 1615193, upload-time = "2025-12-04T15:04:27.041Z" },
-    { url = "https://files.pythonhosted.org/packages/42/1b/83d110a37044b92423084d52d5d5a3b3a73cafb51b547e6d7366ff62eff1/greenlet-3.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d198d2d977460358c3b3a4dc844f875d1adb33817f0613f663a656f463764ccc", size = 1683653, upload-time = "2025-12-04T14:27:32.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/9a/9030e6f9aa8fd7808e9c31ba4c38f87c4f8ec324ee67431d181fe396d705/greenlet-3.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:73f51dd0e0bdb596fb0417e475fa3c5e32d4c83638296e560086b8d7da7c4170", size = 305387, upload-time = "2025-12-04T14:26:51.063Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/66/bd6317bc5932accf351fc19f177ffba53712a202f9df10587da8df257c7e/greenlet-3.3.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d6ed6f85fae6cdfdb9ce04c9bf7a08d666cfcfb914e7d006f44f840b46741931", size = 282638, upload-time = "2025-12-04T14:25:20.941Z" },
-    { url = "https://files.pythonhosted.org/packages/30/cf/cc81cb030b40e738d6e69502ccbd0dd1bced0588e958f9e757945de24404/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9125050fcf24554e69c4cacb086b87b3b55dc395a8b3ebe6487b045b2614388", size = 651145, upload-time = "2025-12-04T14:50:11.039Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/ea/1020037b5ecfe95ca7df8d8549959baceb8186031da83d5ecceff8b08cd2/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:87e63ccfa13c0a0f6234ed0add552af24cc67dd886731f2261e46e241608bee3", size = 654236, upload-time = "2025-12-04T14:57:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/57/b9/f8025d71a6085c441a7eaff0fd928bbb275a6633773667023d19179fe815/greenlet-3.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3c6e9b9c1527a78520357de498b0e709fb9e2f49c3a513afd5a249007261911b", size = 653783, upload-time = "2025-12-04T14:26:06.225Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/c7/876a8c7a7485d5d6b5c6821201d542ef28be645aa024cfe1145b35c120c1/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:286d093f95ec98fdd92fcb955003b8a3d054b4e2cab3e2707a5039e7b50520fd", size = 1614857, upload-time = "2025-12-04T15:04:28.484Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/dc/041be1dff9f23dac5f48a43323cd0789cb798342011c19a248d9c9335536/greenlet-3.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c10513330af5b8ae16f023e8ddbfb486ab355d04467c4679c5cfe4659975dd9", size = 1676034, upload-time = "2025-12-04T14:27:33.531Z" },
-]
-
-[[package]]
-name = "grpcio"
-version = "1.80.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
-    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
-    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
-    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
-    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
-    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
-    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
-    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
-    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
-    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
-    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
-    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
 ]
 
 [[package]]
@@ -1814,88 +1594,65 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.13.4"
+version = "2.29.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiofiles" },
-    { name = "aiohttp" },
-    { name = "aiohttp-cors" },
-    { name = "aiomysql" },
-    { name = "aiosqlite" },
-    { name = "apscheduler" },
-    { name = "asyncpg" },
-    { name = "bcrypt" },
     { name = "click" },
-    { name = "cryptography" },
-    { name = "fastapi" },
-    { name = "filelock" },
-    { name = "httpx" },
     { name = "jsonschema" },
-    { name = "mcp", extra = ["cli"] },
-    { name = "msal" },
-    { name = "networkx" },
-    { name = "numpy" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
-    { name = "pandas" },
-    { name = "prometheus-client" },
-    { name = "psutil" },
     { name = "pydantic" },
-    { name = "pyjwt" },
-    { name = "pynacl" },
-    { name = "pyotp" },
     { name = "pyyaml" },
-    { name = "qrcode" },
-    { name = "redis" },
-    { name = "requests" },
-    { name = "sqlalchemy" },
-    { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/ae/36d3dbac1a3b15eea1f40f2625292b56b0507c18208e918bf15d75dd1553/kailash-2.13.4.tar.gz", hash = "sha256:94e4d061b1da2c746f9bd2d833a20c9498c019121552b30508f3c422c9f7cdb5", size = 2506315, upload-time = "2026-05-03T13:51:16.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/8c/804f811ed29525085f10ae01b0c95222abb13462ad0f57d880ce44d0a8dc/kailash-2.29.3.tar.gz", hash = "sha256:ffdcd5b7bd9b764435a6b50068ca3a915924dea06e9fa41b55c1d98f81b34a34", size = 2825605, upload-time = "2026-06-06T13:07:48.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/d3/a167b9eda7436f6094268befe47b06c115e828782bb1e7be0c2e5d9f3266/kailash-2.13.4-py3-none-any.whl", hash = "sha256:baec87d5c44376274737f010cb2576f8297aa528f47b5d024d56980e326c80a0", size = 2907969, upload-time = "2026-05-03T13:51:14.639Z" },
+    { url = "https://files.pythonhosted.org/packages/10/95/07c7ffd75048d6a7232021c3c7223880f630bd05d58e953870616d4e5084/kailash-2.29.3-py3-none-any.whl", hash = "sha256:a34110499799bdb947d907c4f8af2faf383e8a7d5d4a013e67fe82ae08daf234", size = 3234015, upload-time = "2026-06-06T13:07:46.262Z" },
 ]
 
 [[package]]
 name = "kailash-kaizen"
-version = "2.18.2"
+version = "2.24.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "anyio" },
+    { name = "cryptography" },
+    { name = "httpx" },
+    { name = "kailash" },
+    { name = "kailash-mcp" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "typing-extensions" },
+]
+
+[package.optional-dependencies]
+all = [
     { name = "asyncpg" },
     { name = "azure-ai-inference" },
     { name = "azure-core" },
     { name = "azure-identity" },
-    { name = "bcrypt" },
-    { name = "cryptography" },
     { name = "fastapi" },
     { name = "gitpython" },
     { name = "google-genai" },
-    { name = "httpx" },
-    { name = "kailash" },
-    { name = "kailash-mcp" },
+    { name = "networkx" },
     { name = "numpy" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
-    { name = "packaging" },
     { name = "pillow" },
     { name = "prometheus-client" },
-    { name = "pydantic" },
-    { name = "pyjwt" },
     { name = "redis" },
     { name = "requests" },
     { name = "structlog" },
     { name = "tiktoken" },
-    { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-
-[package.optional-dependencies]
 bedrock = [
     { name = "botocore" },
+]
+cache = [
+    { name = "redis" },
+]
+db = [
+    { name = "asyncpg" },
 ]
 dev = [
     { name = "black" },
@@ -1922,9 +1679,42 @@ judges = [
     { name = "rouge-score" },
     { name = "sacrebleu" },
 ]
+observability = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+    { name = "structlog" },
+]
+providers-azure = [
+    { name = "azure-ai-inference" },
+    { name = "azure-core" },
+    { name = "azure-identity" },
+]
+providers-google = [
+    { name = "google-genai" },
+]
+providers-http = [
+    { name = "requests" },
+]
+providers-tokens = [
+    { name = "tiktoken" },
+]
+rag = [
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "requests" },
+]
 research = [
     { name = "arxiv" },
     { name = "pypdf" },
+]
+research-validator = [
+    { name = "gitpython" },
+]
+server = [
+    { name = "fastapi" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 vertex = [
     { name = "google-auth" },
@@ -1940,11 +1730,10 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "arxiv", marker = "extra == 'research'", specifier = ">=2.0" },
-    { name = "asyncpg", specifier = ">=0.28.0" },
-    { name = "azure-ai-inference", specifier = ">=1.0.0b9" },
-    { name = "azure-core", specifier = ">=1.38.0" },
-    { name = "azure-identity", specifier = ">=1.15.0" },
-    { name = "bcrypt", specifier = ">=4.0.0" },
+    { name = "asyncpg", marker = "extra == 'db'", specifier = ">=0.28.0" },
+    { name = "azure-ai-inference", marker = "extra == 'providers-azure'", specifier = ">=1.0.0b9" },
+    { name = "azure-core", marker = "extra == 'providers-azure'", specifier = ">=1.38.0" },
+    { name = "azure-identity", marker = "extra == 'providers-azure'", specifier = ">=1.15.0" },
     { name = "beautifulsoup4", marker = "extra == 'web-search'", specifier = ">=4.12" },
     { name = "bert-score", marker = "extra == 'evaluation'", specifier = ">=0.3.13" },
     { name = "bert-score", marker = "extra == 'judges'", specifier = ">=0.3.13" },
@@ -1953,20 +1742,21 @@ requires-dist = [
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "duckduckgo-search", marker = "extra == 'web-search'", specifier = ">=6.0" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.20.0" },
-    { name = "fastapi", specifier = ">=0.104.0" },
-    { name = "gitpython", specifier = ">=3.1.0" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.104.0" },
+    { name = "gitpython", marker = "extra == 'research-validator'", specifier = ">=3.1.0" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = ">=2.0" },
-    { name = "google-genai", specifier = ">=1.21.0" },
+    { name = "google-genai", marker = "extra == 'providers-google'", specifier = ">=1.21.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12" },
-    { name = "kailash", specifier = ">=2.13.4" },
+    { name = "kailash", specifier = ">=2.28.0" },
+    { name = "kailash-kaizen", extras = ["providers-azure", "providers-google", "providers-tokens", "providers-http", "server", "observability", "db", "cache", "rag", "research-validator"], marker = "extra == 'all'" },
     { name = "kailash-mcp", specifier = ">=0.2.4" },
-    { name = "numpy", specifier = ">=1.24.0" },
-    { name = "opentelemetry-api", specifier = ">=1.20.0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
-    { name = "packaging", specifier = ">=23.0" },
-    { name = "pillow", specifier = ">=10.0.0" },
-    { name = "prometheus-client", specifier = ">=0.19.0" },
+    { name = "networkx", marker = "extra == 'rag'", specifier = ">=3.0" },
+    { name = "numpy", marker = "extra == 'rag'", specifier = ">=1.24.0" },
+    { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'observability'", specifier = ">=1.20.0" },
+    { name = "pillow", marker = "extra == 'rag'", specifier = ">=10.0.0" },
+    { name = "prometheus-client", marker = "extra == 'observability'", specifier = ">=0.19.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pypdf", marker = "extra == 'research'", specifier = ">=4.0" },
@@ -1974,8 +1764,9 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "redis", specifier = ">=5.0.0" },
-    { name = "requests", specifier = ">=2.32" },
+    { name = "redis", marker = "extra == 'cache'", specifier = ">=5.0.0" },
+    { name = "requests", marker = "extra == 'providers-http'", specifier = ">=2.32" },
+    { name = "requests", marker = "extra == 'rag'", specifier = ">=2.32" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "rouge-score", marker = "extra == 'evaluation'", specifier = ">=0.1.2" },
     { name = "rouge-score", marker = "extra == 'judges'", specifier = ">=0.1.2" },
@@ -1983,13 +1774,13 @@ requires-dist = [
     { name = "sacrebleu", marker = "extra == 'evaluation'", specifier = ">=2.4" },
     { name = "sacrebleu", marker = "extra == 'judges'", specifier = ">=2.4" },
     { name = "sae-lens", marker = "extra == 'interpretability'", specifier = ">=3.0" },
-    { name = "structlog", specifier = ">=23.0.0" },
-    { name = "tiktoken", specifier = ">=0.5.0" },
+    { name = "structlog", marker = "extra == 'observability'", specifier = ">=23.0.0" },
+    { name = "tiktoken", marker = "extra == 'providers-tokens'", specifier = ">=0.5.0" },
     { name = "transformers", marker = "extra == 'interpretability'", specifier = ">=4.40,<5.0" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.24.0" },
 ]
-provides-extras = ["dev", "bedrock", "vertex", "interpretability", "judges", "evaluation", "research", "web-search"]
+provides-extras = ["providers-azure", "providers-google", "providers-tokens", "providers-http", "server", "observability", "db", "cache", "rag", "research-validator", "dev", "bedrock", "vertex", "interpretability", "judges", "evaluation", "research", "web-search", "all"]
 
 [[package]]
 name = "kailash-mcp"
@@ -2842,79 +2633,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-exporter-otlp"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/9c/3ab1db90f32da200dba332658f2bbe602369e3d19f6aba394031a42635be/opentelemetry_exporter_otlp-1.39.1.tar.gz", hash = "sha256:7cf7470e9fd0060c8a38a23e4f695ac686c06a48ad97f8d4867bc9b420180b9c", size = 6147, upload-time = "2025-12-11T13:32:40.309Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/6c/bdc82a066e6fb1dcf9e8cc8d4e026358fe0f8690700cc6369a6bf9bd17a7/opentelemetry_exporter_otlp-1.39.1-py3-none-any.whl", hash = "sha256:68ae69775291f04f000eb4b698ff16ff685fdebe5cb52871bc4e87938a7b00fe", size = 7019, upload-time = "2025-12-11T13:32:19.387Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-proto" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
-]
-
-[[package]]
 name = "opentelemetry-sdk"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3611,59 +3329,6 @@ crypto = [
 ]
 
 [[package]]
-name = "pymysql"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/ae/1fe3fcd9f959efa0ebe200b8de88b5a5ce3e767e38c7ac32fb179f16a388/pymysql-1.1.2.tar.gz", hash = "sha256:4961d3e165614ae65014e361811a724e2044ad3ea3739de9903ae7c21f539f03", size = 48258, upload-time = "2025-08-24T12:55:55.146Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/4c/ad33b92b9864cbde84f259d5df035a6447f91891f5be77788e2a3892bce3/pymysql-1.1.2-py3-none-any.whl", hash = "sha256:e6b1d89711dd51f8f74b1631fe08f039e7d76cf67a42a323d3178f0f25762ed9", size = 45300, upload-time = "2025-08-24T12:55:53.394Z" },
-]
-
-[[package]]
-name = "pynacl"
-version = "1.6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
-    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
-    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
-    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
-    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
-    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
-    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
-]
-
-[[package]]
-name = "pyotp"
-version = "2.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/b2/1d5994ba2acde054a443bd5e2d384175449c7d2b6d1a0614dbca3a63abfc/pyotp-2.9.0.tar.gz", hash = "sha256:346b6642e0dbdde3b4ff5a930b664ca82abfa116356ed48cc42c7d6590d36f63", size = 17763, upload-time = "2023-07-27T23:41:03.295Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl", hash = "sha256:81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612", size = 13376, upload-time = "2023-07-27T23:41:01.685Z" },
-]
-
-[[package]]
 name = "pyparsing"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3857,18 +3522,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
-name = "qrcode"
-version = "8.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
 ]
 
 [[package]]
@@ -4473,48 +4126,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sqlalchemy"
-version = "2.0.45"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/be/f9/5e4491e5ccf42f5d9cfc663741d261b3e6e1683ae7812114e7636409fcc6/sqlalchemy-2.0.45.tar.gz", hash = "sha256:1632a4bda8d2d25703fdad6363058d882541bdaaee0e5e3ddfa0cd3229efce88", size = 9869912, upload-time = "2025-12-09T21:05:16.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/1c/769552a9d840065137272ebe86ffbb0bc92b0f1e0a68ee5266a225f8cd7b/sqlalchemy-2.0.45-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e90a344c644a4fa871eb01809c32096487928bd2038bf10f3e4515cb688cc56", size = 2153860, upload-time = "2025-12-10T20:03:23.843Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f8/9be54ff620e5b796ca7b44670ef58bc678095d51b0e89d6e3102ea468216/sqlalchemy-2.0.45-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8c8b41b97fba5f62349aa285654230296829672fc9939cd7f35aab246d1c08b", size = 3309379, upload-time = "2025-12-09T22:06:07.461Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/2b/60ce3ee7a5ae172bfcd419ce23259bb874d2cddd44f67c5df3760a1e22f9/sqlalchemy-2.0.45-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12c694ed6468333a090d2f60950e4250b928f457e4962389553d6ba5fe9951ac", size = 3309948, upload-time = "2025-12-09T22:09:57.643Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/42/bac8d393f5db550e4e466d03d16daaafd2bad1f74e48c12673fb499a7fc1/sqlalchemy-2.0.45-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f7d27a1d977a1cfef38a0e2e1ca86f09c4212666ce34e6ae542f3ed0a33bc606", size = 3261239, upload-time = "2025-12-09T22:06:08.879Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/12/43dc70a0528c59842b04ea1c1ed176f072a9b383190eb015384dd102fb19/sqlalchemy-2.0.45-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d62e47f5d8a50099b17e2bfc1b0c7d7ecd8ba6b46b1507b58cc4f05eefc3bb1c", size = 3284065, upload-time = "2025-12-09T22:09:59.454Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/9c/563049cf761d9a2ec7bc489f7879e9d94e7b590496bea5bbee9ed7b4cc32/sqlalchemy-2.0.45-cp311-cp311-win32.whl", hash = "sha256:3c5f76216e7b85770d5bb5130ddd11ee89f4d52b11783674a662c7dd57018177", size = 2113480, upload-time = "2025-12-09T21:29:57.03Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fa/09d0a11fe9f15c7fa5c7f0dd26be3d235b0c0cbf2f9544f43bc42efc8a24/sqlalchemy-2.0.45-cp311-cp311-win_amd64.whl", hash = "sha256:a15b98adb7f277316f2c276c090259129ee4afca783495e212048daf846654b2", size = 2138407, upload-time = "2025-12-09T21:29:58.556Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c7/1900b56ce19bff1c26f39a4ce427faec7716c81ac792bfac8b6a9f3dca93/sqlalchemy-2.0.45-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3ee2aac15169fb0d45822983631466d60b762085bc4535cd39e66bea362df5f", size = 3333760, upload-time = "2025-12-09T22:11:02.66Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/93/3be94d96bb442d0d9a60e55a6bb6e0958dd3457751c6f8502e56ef95fed0/sqlalchemy-2.0.45-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba547ac0b361ab4f1608afbc8432db669bd0819b3e12e29fb5fa9529a8bba81d", size = 3348268, upload-time = "2025-12-09T22:13:49.054Z" },
-    { url = "https://files.pythonhosted.org/packages/48/4b/f88ded696e61513595e4a9778f9d3f2bf7332cce4eb0c7cedaabddd6687b/sqlalchemy-2.0.45-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215f0528b914e5c75ef2559f69dca86878a3beeb0c1be7279d77f18e8d180ed4", size = 3278144, upload-time = "2025-12-09T22:11:04.14Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/6a/310ecb5657221f3e1bd5288ed83aa554923fb5da48d760a9f7622afeb065/sqlalchemy-2.0.45-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:107029bf4f43d076d4011f1afb74f7c3e2ea029ec82eb23d8527d5e909e97aa6", size = 3313907, upload-time = "2025-12-09T22:13:50.598Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/39/69c0b4051079addd57c84a5bfb34920d87456dd4c90cf7ee0df6efafc8ff/sqlalchemy-2.0.45-cp312-cp312-win32.whl", hash = "sha256:0c9f6ada57b58420a2c0277ff853abe40b9e9449f8d7d231763c6bc30f5c4953", size = 2112182, upload-time = "2025-12-09T21:39:30.824Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/4e/510db49dd89fc3a6e994bee51848c94c48c4a00dc905e8d0133c251f41a7/sqlalchemy-2.0.45-cp312-cp312-win_amd64.whl", hash = "sha256:8defe5737c6d2179c7997242d6473587c3beb52e557f5ef0187277009f73e5e1", size = 2139200, upload-time = "2025-12-09T21:39:32.321Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c8/7cc5221b47a54edc72a0140a1efa56e0a2730eefa4058d7ed0b4c4357ff8/sqlalchemy-2.0.45-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe187fc31a54d7fd90352f34e8c008cf3ad5d064d08fedd3de2e8df83eb4a1cf", size = 3277082, upload-time = "2025-12-09T22:11:06.167Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/50/80a8d080ac7d3d321e5e5d420c9a522b0aa770ec7013ea91f9a8b7d36e4a/sqlalchemy-2.0.45-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:672c45cae53ba88e0dad74b9027dddd09ef6f441e927786b05bec75d949fbb2e", size = 3293131, upload-time = "2025-12-09T22:13:52.626Z" },
-    { url = "https://files.pythonhosted.org/packages/da/4c/13dab31266fc9904f7609a5dc308a2432a066141d65b857760c3bef97e69/sqlalchemy-2.0.45-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:470daea2c1ce73910f08caf10575676a37159a6d16c4da33d0033546bddebc9b", size = 3225389, upload-time = "2025-12-09T22:11:08.093Z" },
-    { url = "https://files.pythonhosted.org/packages/74/04/891b5c2e9f83589de202e7abaf24cd4e4fa59e1837d64d528829ad6cc107/sqlalchemy-2.0.45-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9c6378449e0940476577047150fd09e242529b761dc887c9808a9a937fe990c8", size = 3266054, upload-time = "2025-12-09T22:13:54.262Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/24/fc59e7f71b0948cdd4cff7a286210e86b0443ef1d18a23b0d83b87e4b1f7/sqlalchemy-2.0.45-cp313-cp313-win32.whl", hash = "sha256:4b6bec67ca45bc166c8729910bd2a87f1c0407ee955df110d78948f5b5827e8a", size = 2110299, upload-time = "2025-12-09T21:39:33.486Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/c5/d17113020b2d43073412aeca09b60d2009442420372123b8d49cc253f8b8/sqlalchemy-2.0.45-cp313-cp313-win_amd64.whl", hash = "sha256:afbf47dc4de31fa38fd491f3705cac5307d21d4bb828a4f020ee59af412744ee", size = 2136264, upload-time = "2025-12-09T21:39:36.801Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/8d/bb40a5d10e7a5f2195f235c0b2f2c79b0bf6e8f00c0c223130a4fbd2db09/sqlalchemy-2.0.45-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83d7009f40ce619d483d26ac1b757dfe3167b39921379a8bd1b596cf02dab4a6", size = 3521998, upload-time = "2025-12-09T22:13:28.622Z" },
-    { url = "https://files.pythonhosted.org/packages/75/a5/346128b0464886f036c039ea287b7332a410aa2d3fb0bb5d404cb8861635/sqlalchemy-2.0.45-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d8a2ca754e5415cde2b656c27900b19d50ba076aa05ce66e2207623d3fe41f5a", size = 3473434, upload-time = "2025-12-09T22:13:30.188Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/64/4e1913772646b060b025d3fc52ce91a58967fe58957df32b455de5a12b4f/sqlalchemy-2.0.45-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f46ec744e7f51275582e6a24326e10c49fbdd3fc99103e01376841213028774", size = 3272404, upload-time = "2025-12-09T22:11:09.662Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/27/caf606ee924282fe4747ee4fd454b335a72a6e018f97eab5ff7f28199e16/sqlalchemy-2.0.45-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:883c600c345123c033c2f6caca18def08f1f7f4c3ebeb591a63b6fceffc95cce", size = 3277057, upload-time = "2025-12-09T22:13:56.213Z" },
-    { url = "https://files.pythonhosted.org/packages/85/d0/3d64218c9724e91f3d1574d12eb7ff8f19f937643815d8daf792046d88ab/sqlalchemy-2.0.45-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2c0b74aa79e2deade948fe8593654c8ef4228c44ba862bb7c9585c8e0db90f33", size = 3222279, upload-time = "2025-12-09T22:11:11.1Z" },
-    { url = "https://files.pythonhosted.org/packages/24/10/dd7688a81c5bc7690c2a3764d55a238c524cd1a5a19487928844cb247695/sqlalchemy-2.0.45-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a420169cef179d4c9064365f42d779f1e5895ad26ca0c8b4c0233920973db74", size = 3244508, upload-time = "2025-12-09T22:13:57.932Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/41/db75756ca49f777e029968d9c9fee338c7907c563267740c6d310a8e3f60/sqlalchemy-2.0.45-cp314-cp314-win32.whl", hash = "sha256:e50dcb81a5dfe4b7b4a4aa8f338116d127cb209559124f3694c70d6cd072b68f", size = 2113204, upload-time = "2025-12-09T21:39:38.365Z" },
-    { url = "https://files.pythonhosted.org/packages/89/a2/0e1590e9adb292b1d576dbcf67ff7df8cf55e56e78d2c927686d01080f4b/sqlalchemy-2.0.45-cp314-cp314-win_amd64.whl", hash = "sha256:4748601c8ea959e37e03d13dcda4a44837afcd1b21338e637f7c935b8da06177", size = 2138785, upload-time = "2025-12-09T21:39:39.503Z" },
-    { url = "https://files.pythonhosted.org/packages/42/39/f05f0ed54d451156bbed0e23eb0516bcad7cbb9f18b3bf219c786371b3f0/sqlalchemy-2.0.45-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd337d3526ec5298f67d6a30bbbe4ed7e5e68862f0bf6dd21d289f8d37b7d60b", size = 3522029, upload-time = "2025-12-09T22:13:32.09Z" },
-    { url = "https://files.pythonhosted.org/packages/54/0f/d15398b98b65c2bce288d5ee3f7d0a81f77ab89d9456994d5c7cc8b2a9db/sqlalchemy-2.0.45-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9a62b446b7d86a3909abbcd1cd3cc550a832f99c2bc37c5b22e1925438b9367b", size = 3475142, upload-time = "2025-12-09T22:13:33.739Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/e1/3ccb13c643399d22289c6a9786c1a91e3dcbb68bce4beb44926ac2c557bf/sqlalchemy-2.0.45-py3-none-any.whl", hash = "sha256:5225a288e4c8cc2308dbdd874edad6e7d0fd38eac1e9e5f23503425c8eee20d0", size = 1936672, upload-time = "2025-12-09T21:54:52.608Z" },
-]
-
-[[package]]
 name = "sse-starlette"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4946,18 +4557,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
-]
-
-[[package]]
-name = "tzlocal"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -46,6 +46,10 @@ dev = [
     "black>=23.0",
     "ruff>=0.1.0",
     "mypy>=1.0",
+    # Adapter unit tests construct the real provider clients
+    # (delegate/adapters/{anthropic_adapter.py:159, google_adapter.py:162})
+    "anthropic>=0.40.0",
+    "google-generativeai>=0.8.0",
 ]
 
 [project.urls]

--- a/packages/kaizen-agents/src/kaizen_agents/api/agent.py
+++ b/packages/kaizen-agents/src/kaizen_agents/api/agent.py
@@ -24,7 +24,7 @@ import asyncio
 import uuid
 import warnings
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from kaizen_agents.api.config import AgentConfig
@@ -41,10 +41,7 @@ from kaizen_agents.api.types import (
     MemoryDepth,
     ToolAccess,
 )
-from kaizen_agents.api.validation import (
-    ConfigurationError,
-    validate_configuration,
-)
+from kaizen_agents.api.validation import ConfigurationError, validate_configuration
 
 
 class Agent:
@@ -385,7 +382,7 @@ class Agent:
             else:
                 print(f"Error: {result.error}")
         """
-        start_time = datetime.utcnow()
+        start_time = datetime.now(UTC)
         self._is_running = True
 
         try:
@@ -406,7 +403,7 @@ class Agent:
                 result = await self._execute_single(runtime, exec_context)
 
             # Update timing
-            end_time = datetime.utcnow()
+            end_time = datetime.now(UTC)
             result.duration_ms = int((end_time - start_time).total_seconds() * 1000)
             result.completed_at = end_time.isoformat()
             result.session_id = self._session_id
@@ -709,7 +706,7 @@ class Agent:
                 {
                     "user": context["task"],
                     "assistant": result.text,
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(UTC).isoformat(),
                 },
             )
 

--- a/packages/kaizen-agents/src/kaizen_agents/api/result.py
+++ b/packages/kaizen-agents/src/kaizen_agents/api/result.py
@@ -7,7 +7,7 @@ all execution details including output, tool calls, costs, and metrics.
 
 import json
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -57,7 +57,7 @@ class ToolCallRecord:
     duration_ms: int = 0
     """Duration of the tool call in milliseconds."""
 
-    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    timestamp: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     """ISO timestamp when the tool was called."""
 
     cycle: int = 0
@@ -90,7 +90,7 @@ class ToolCallRecord:
             result=data.get("result"),
             error=data.get("error"),
             duration_ms=data.get("duration_ms", 0),
-            timestamp=data.get("timestamp", datetime.utcnow().isoformat()),
+            timestamp=data.get("timestamp", datetime.now(UTC).isoformat()),
             cycle=data.get("cycle", 0),
         )
 
@@ -167,7 +167,7 @@ class AgentResult:
     """Unique run identifier."""
 
     # Timestamps
-    started_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    started_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     """ISO timestamp when execution started."""
 
     completed_at: str = ""
@@ -349,7 +349,7 @@ class AgentResult:
             duration_ms=data.get("duration_ms", 0),
             session_id=data.get("session_id", ""),
             run_id=data.get("run_id", ""),
-            started_at=data.get("started_at", datetime.utcnow().isoformat()),
+            started_at=data.get("started_at", datetime.now(UTC).isoformat()),
             completed_at=data.get("completed_at", ""),
             error=data.get("error"),
             error_type=data.get("error_type"),
@@ -392,7 +392,7 @@ class AgentResult:
         return cls(
             text=text,
             status=ResultStatus.SUCCESS,
-            completed_at=datetime.utcnow().isoformat(),
+            completed_at=datetime.now(UTC).isoformat(),
             **kwargs,
         )
 
@@ -419,7 +419,7 @@ class AgentResult:
             status=ResultStatus.ERROR,
             error=error_message,
             error_type=error_type,
-            completed_at=datetime.utcnow().isoformat(),
+            completed_at=datetime.now(UTC).isoformat(),
             **kwargs,
         )
 
@@ -444,7 +444,7 @@ class AgentResult:
             status=ResultStatus.TIMEOUT,
             error="Execution timed out",
             error_type="TimeoutError",
-            completed_at=datetime.utcnow().isoformat(),
+            completed_at=datetime.now(UTC).isoformat(),
             **kwargs,
         )
 
@@ -467,7 +467,7 @@ class AgentResult:
         return cls(
             text=partial_text,
             status=ResultStatus.INTERRUPTED,
-            completed_at=datetime.utcnow().isoformat(),
+            completed_at=datetime.now(UTC).isoformat(),
             **kwargs,
         )
 

--- a/packages/kaizen-agents/src/kaizen_agents/patterns/runtime.py
+++ b/packages/kaizen-agents/src/kaizen_agents/patterns/runtime.py
@@ -67,6 +67,8 @@ Created: 2025-11-05 (Phase 4, Orchestration Runtime)
 Reference: Based on kaizen-specialist analysis and existing coordination patterns
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import inspect
@@ -743,7 +745,7 @@ class OrchestrationRuntime:
 
     async def execute_workflow(
         self,
-        workflow: "Workflow",
+        workflow: Workflow,
         inputs: dict[str, Any] | None = None,
         workflow_id: str | None = None,
     ) -> dict[str, Any]:

--- a/packages/kaizen-agents/src/kaizen_agents/patterns/state_manager.py
+++ b/packages/kaizen-agents/src/kaizen_agents/patterns/state_manager.py
@@ -235,7 +235,7 @@ class OrchestrationStateManager:
         # (e.g. a LocalRuntime acquired from a pool) lacks that method, so when
         # one is supplied we warn and fall back to an owned AsyncLocalRuntime
         # rather than rejecting it (callers passing a sync runtime keep working).
-        self.runtime: "AsyncLocalRuntime"
+        self.runtime: AsyncLocalRuntime
         if runtime is not None:
             acquired = runtime.acquire()
             if hasattr(acquired, "execute_workflow_async"):

--- a/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/types.py
+++ b/packages/kaizen-agents/src/kaizen_agents/runtime_adapters/types.py
@@ -11,7 +11,7 @@ Defines the core types for the native autonomous agent implementation:
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -244,8 +244,8 @@ class ExecutionState:
     error: str | None = None
 
     # Timestamps
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    updated_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
     @property
     def is_complete(self) -> bool:
@@ -265,32 +265,32 @@ class ExecutionState:
     def advance_cycle(self) -> None:
         """Advance to next cycle."""
         self.current_cycle += 1
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def set_phase(self, phase: AutonomousPhase) -> None:
         """Set current execution phase."""
         self.phase = phase
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def add_message(self, message: dict[str, Any]) -> None:
         """Add a message to conversation history."""
         self.messages.append(message)
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def add_tool_call(self, tool_call: dict[str, Any]) -> None:
         """Add a pending tool call."""
         self.pending_tool_calls.append(tool_call)
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def add_tool_result(self, result: dict[str, Any]) -> None:
         """Add a tool execution result."""
         self.tool_results.append(result)
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def clear_pending_tool_calls(self) -> None:
         """Clear all pending tool calls."""
         self.pending_tool_calls = []
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def update_budget(self, tokens: int, cost: float) -> None:
         """Update token and cost tracking.
@@ -301,7 +301,7 @@ class ExecutionState:
         """
         self.tokens_used += tokens
         self.cost_usd += cost
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def complete(self, result: str) -> None:
         """Mark execution as completed successfully.
@@ -311,7 +311,7 @@ class ExecutionState:
         """
         self.status = "completed"
         self.result = result
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def fail(self, error: str) -> None:
         """Mark execution as failed with error.
@@ -321,12 +321,12 @@ class ExecutionState:
         """
         self.status = "error"
         self.error = error
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def interrupt(self) -> None:
         """Mark execution as interrupted."""
         self.status = "interrupted"
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(UTC)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize state to dictionary for checkpointing.

--- a/packages/kaizen-agents/tests/conftest.py
+++ b/packages/kaizen-agents/tests/conftest.py
@@ -5,7 +5,6 @@ Provides shared fixtures for the agent engine tests migrated from kailash-kaizen
 """
 
 import os
-import sys
 
 try:
     from dotenv import load_dotenv
@@ -14,13 +13,19 @@ try:
 except ImportError:
     pass  # python-dotenv not installed — env vars from shell
 
+# Unit-tier deterministic model default (issue-822 pattern): supervisor /
+# governance tests construct agents that resolve the model from the
+# environment (kaizen.errors.EnvModelMissing otherwise). No kaizen-agents
+# test asserts the missing-var path; tests that need a specific model
+# override per-test. setdefault preserves any operator/.env value.
+os.environ.setdefault("KAIZEN_DEFAULT_MODEL", "gpt-4o-mini")
+
 # Check if we should use real providers (for E2E/integration tests)
 use_real_providers = os.getenv("USE_REAL_PROVIDERS", "").lower() == "true"
 
 if not use_real_providers:
     try:
         import kaizen.nodes.ai.ai_providers as ai_providers_module
-
         from tests.utils.kaizen_mock_provider import KaizenMockProvider
 
         ai_providers_module.PROVIDERS["mock"] = KaizenMockProvider

--- a/packages/kaizen-agents/tests/unit/test_envelope_allocator_sdk.py
+++ b/packages/kaizen-agents/tests/unit/test_envelope_allocator_sdk.py
@@ -13,7 +13,7 @@ results back to local ConstraintEnvelope objects.
 
 from __future__ import annotations
 
-import math
+import inspect
 
 import pytest
 
@@ -24,7 +24,6 @@ from kaizen_agents.policy.envelope_allocator import (
     Subtask,
 )
 from kaizen_agents.types import ConstraintEnvelope, make_envelope
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -39,7 +38,11 @@ def _make_parent_envelope(
     """Create a parent ConstraintEnvelope with depletable dimensions populated."""
     return make_envelope(
         financial={"limit": financial_limit},
-        operational={"allowed": ["search", "write"], "blocked": [], "action_limit": action_limit},
+        operational={
+            "allowed": ["search", "write"],
+            "blocked": [],
+            "action_limit": action_limit,
+        },
         temporal={"limit_seconds": temporal_limit_seconds},
         data_access={"ceiling": "internal", "scopes": ["read"]},
         communication={"recipients": ["parent"], "channels": ["internal"]},
@@ -74,7 +77,7 @@ class TestAllocateWithSdkProducesCorrectChildEnvelopes:
         assert len(children) == 2
 
         # Each child should get 45% of parent (0.90 available / 2 children)
-        for child_id, child_env in children:
+        for _child_id, child_env in children:
             assert isinstance(child_env, ConstraintEnvelope)
             assert child_env.financial.max_spend_usd == pytest.approx(45.0, abs=0.01)
             # temporal limit_seconds not applicable in ConstraintEnvelopeConfig
@@ -102,9 +105,13 @@ class TestAllocateWithSdkProducesCorrectChildEnvelopes:
         assert "light" in child_map
 
         # heavy gets 70% of available (0.9), so 0.63 of parent
-        assert child_map["heavy"].financial.max_spend_usd == pytest.approx(200.0 * 0.63, abs=0.1)
+        assert child_map["heavy"].financial.max_spend_usd == pytest.approx(
+            200.0 * 0.63, abs=0.1
+        )
         # light gets 30% of available (0.9), so 0.27 of parent
-        assert child_map["light"].financial.max_spend_usd == pytest.approx(200.0 * 0.27, abs=0.1)
+        assert child_map["light"].financial.max_spend_usd == pytest.approx(
+            200.0 * 0.27, abs=0.1
+        )
 
     def test_child_envelopes_are_constraint_envelope_instances(self) -> None:
         """Returned child envelopes must be proper ConstraintEnvelope instances."""
@@ -137,7 +144,9 @@ class TestReservePercentageRespected:
         """Sum of all child financial limits + reserve must not exceed parent."""
         policy = BudgetPolicy(reserve_pct=0.20)
         allocator = EnvelopeAllocator(policy=policy)
-        parent = _make_parent_envelope(financial_limit=1000.0, temporal_limit_seconds=10000.0)
+        parent = _make_parent_envelope(
+            financial_limit=1000.0, temporal_limit_seconds=10000.0
+        )
         subtasks = [
             Subtask(child_id=f"child-{i}", description=f"Task {i}", complexity=1.0)
             for i in range(4)
@@ -154,7 +163,9 @@ class TestReservePercentageRespected:
         """With 0% reserve, children get the full parent budget."""
         policy = BudgetPolicy(reserve_pct=0.0)
         allocator = EnvelopeAllocator(policy=policy)
-        parent = _make_parent_envelope(financial_limit=100.0, temporal_limit_seconds=3600.0)
+        parent = _make_parent_envelope(
+            financial_limit=100.0, temporal_limit_seconds=3600.0
+        )
         subtasks = [
             Subtask(child_id="a", description="Task A", complexity=0.5),
             Subtask(child_id="b", description="Task B", complexity=0.5),
@@ -169,7 +180,9 @@ class TestReservePercentageRespected:
         """With 50% reserve, children split the remaining 50%."""
         policy = BudgetPolicy(reserve_pct=0.50)
         allocator = EnvelopeAllocator(policy=policy)
-        parent = _make_parent_envelope(financial_limit=100.0, temporal_limit_seconds=3600.0)
+        parent = _make_parent_envelope(
+            financial_limit=100.0, temporal_limit_seconds=3600.0
+        )
         subtasks = [
             Subtask(child_id="x", description="Task X", complexity=1.0),
         ]
@@ -229,13 +242,17 @@ class TestAllDepletableDimensionsAllocated:
         child_map = {cid: env for cid, env in children}
 
         # small gets 30% of parent (no reserve)
-        assert child_map["small"].financial.max_spend_usd == pytest.approx(300.0, abs=0.1)
+        assert child_map["small"].financial.max_spend_usd == pytest.approx(
+            300.0, abs=0.1
+        )
         # temporal limit_seconds not applicable in ConstraintEnvelopeConfig
         # action_limit mapped to max_actions_per_day in new model
         # assert child_map["small"].operational.max_actions_per_day == 60  # int(200 * 0.3)
 
         # large gets 70% of parent
-        assert child_map["large"].financial.max_spend_usd == pytest.approx(700.0, abs=0.1)
+        assert child_map["large"].financial.max_spend_usd == pytest.approx(
+            700.0, abs=0.1
+        )
         # temporal limit_seconds not applicable in ConstraintEnvelopeConfig
         # action_limit mapped to max_actions_per_day in new model
         # assert child_map["large"].operational.max_actions_per_day == 140  # int(200 * 0.7)
@@ -332,7 +349,9 @@ class TestRoundTripConsistency:
         children = allocator.allocate_with_sdk(parent, subtasks)
 
         # temporal limit_seconds splitting not applicable in ConstraintEnvelopeConfig
-        # (TemporalConstraintConfig uses active_hours, not depletable seconds)
+        # (TemporalConstraintConfig uses active_hours, not depletable seconds) —
+        # assert allocation shape only, mirroring test_action_limit_round_trip
+        assert len(children) == 2
 
     def test_action_limit_round_trip(self) -> None:
         """Sum of child action_limits is approximately parent action_limit * (1 - reserve).
@@ -364,7 +383,9 @@ class TestRoundTripConsistency:
             action_limit=1000,
         )
         subtasks = [
-            Subtask(child_id=f"worker-{i}", description=f"Work {i}", complexity=float(i + 1))
+            Subtask(
+                child_id=f"worker-{i}", description=f"Work {i}", complexity=float(i + 1)
+            )
             for i in range(10)
         ]
 
@@ -385,15 +406,26 @@ class TestRoundTripConsistency:
 
 
 class TestNoDuplicateGradientZone:
-    """Verify that envelope_allocator imports GradientZone from types,
-    not defining its own duplicate."""
+    """Verify that envelope_allocator never defines a local GradientZone
+    duplicate — IF it references one, it must be the kaizen_agents.types
+    enum. (The module legitimately dropped its GradientZone usage in the
+    PactEngine v0.4.0 type-alignment refactor; absence satisfies the
+    no-duplicate contract vacuously.)"""
 
     def test_gradient_zone_is_from_types_module(self) -> None:
-        """The GradientZone used in envelope_allocator must be the one from types."""
-        from kaizen_agents.policy.envelope_allocator import GradientZone as AllocatorGZ
+        """Any GradientZone on envelope_allocator must be the types enum."""
+        import kaizen_agents.policy.envelope_allocator as allocator_module
         from kaizen_agents.types import GradientZone as TypesGZ
 
-        assert AllocatorGZ is TypesGZ, (
-            "GradientZone in envelope_allocator must be imported from kaizen_agents.types, "
-            "not defined locally as a duplicate"
-        )
+        allocator_gz = getattr(allocator_module, "GradientZone", None)
+        if allocator_gz is not None:
+            assert allocator_gz is TypesGZ, (
+                "GradientZone in envelope_allocator must be imported from "
+                "kaizen_agents.types, not defined locally as a duplicate"
+            )
+        else:
+            # No reference at all — the duplicate-definition regression
+            # cannot exist. Guard that a local redefinition hasn't been
+            # smuggled in under another name pattern.
+            src = inspect.getsource(allocator_module)
+            assert "class GradientZone" not in src

--- a/uv.lock
+++ b/uv.lock
@@ -1772,7 +1772,7 @@ wheels = [
 
 [[package]]
 name = "kailash"
-version = "2.28.4"
+version = "2.29.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -2052,7 +2052,7 @@ provides-extras = ["server", "http-client", "db-postgres", "db-mysql", "db-sqlit
 
 [[package]]
 name = "kailash-align"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "packages/kailash-align" }
 dependencies = [
     { name = "accelerate" },
@@ -2079,8 +2079,8 @@ requires-dist = [
     { name = "kailash", specifier = ">=2.16.0" },
     { name = "kailash-align", extras = ["rlhf", "eval", "serve", "online", "rl-bridge"], marker = "extra == 'all'" },
     { name = "kailash-kaizen", specifier = ">=2.7.5" },
-    { name = "kailash-ml", specifier = ">=0.11.0" },
-    { name = "kailash-ml", extras = ["rl"], marker = "extra == 'rl-bridge'", specifier = ">=1.1,<2.0" },
+    { name = "kailash-ml", specifier = ">=1.1" },
+    { name = "kailash-ml", extras = ["rl"], marker = "extra == 'rl-bridge'", specifier = ">=1.1" },
     { name = "llama-cpp-python", marker = "extra == 'serve'", specifier = ">=0.3" },
     { name = "lm-eval", marker = "extra == 'eval'", specifier = ">=0.4,<1.0" },
     { name = "peft", specifier = ">=0.10" },
@@ -2097,7 +2097,7 @@ provides-extras = ["rlhf", "eval", "serve", "online", "rl-bridge", "all", "dev"]
 
 [[package]]
 name = "kailash-dataflow"
-version = "2.10.3"
+version = "2.11.3"
 source = { editable = "packages/kailash-dataflow" }
 dependencies = [
     { name = "asyncpg" },
@@ -2305,7 +2305,7 @@ provides-extras = ["http", "sse", "websocket", "auth-jwt", "auth-oauth", "server
 
 [[package]]
 name = "kailash-ml"
-version = "1.7.4"
+version = "2.0.1"
 source = { editable = "packages/kailash-ml" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2347,8 +2347,8 @@ requires-dist = [
     { name = "kailash-align", marker = "extra == 'alignment'", specifier = ">=0.6" },
     { name = "kailash-dataflow", specifier = ">=2.0.11" },
     { name = "kailash-kaizen", marker = "extra == 'agents'", specifier = ">=2.7.5" },
-    { name = "kailash-kaizen", marker = "extra == 'kaizen-judges'", specifier = ">=2.7" },
-    { name = "kailash-kaizen", marker = "extra == 'kaizen-observability'", specifier = ">=2.7" },
+    { name = "kailash-kaizen", marker = "extra == 'kaizen-judges'", specifier = ">=2.7.5" },
+    { name = "kailash-kaizen", marker = "extra == 'kaizen-observability'", specifier = ">=2.7.5" },
     { name = "kailash-ml", extras = ["dl"], marker = "extra == 'dl-gpu'" },
     { name = "kailash-ml", extras = ["dl"], marker = "extra == 'rl'" },
     { name = "kailash-ml", extras = ["dl", "xgb", "catboost", "stats", "rl", "rl-offline", "rl-envpool", "rl-distributed", "grpc", "automl-bayes", "agents", "hpo", "mlflow", "huggingface", "dashboard", "interop", "imbalance", "explain"], marker = "extra == 'all'" },

--- a/workspaces/issue-643-featurestore-canonical/journal/0001-DISCOVERY-643-bridge-shipped-canonical-getfeatures-broken.md
+++ b/workspaces/issue-643-featurestore-canonical/journal/0001-DISCOVERY-643-bridge-shipped-canonical-getfeatures-broken.md
@@ -52,3 +52,15 @@ issue was ~90% shipped a month before being flagged "actionable." Verifying the 
 claims against PyPI + source (≈6 commands) before committing to a "bridge release cycle" prevented
 re-implementing an already-published warning and a redundant test. Mirrors value-prioritization
 MUST-3 (re-validate deferred items) + zero-tolerance Rule 1c (post-context-boundary claims unprovable).
+
+---
+
+## FOLLOW-UP DISCOVERY (2026-06-03, post-1.7.5 release) — no-timestamp path skips latest-per-entity dedup
+
+The published-wheel end-to-end walk (build-repo-release-discipline Rule 2 + user-flow-validation) caught a semantic bug the unit/integration/regression gates missed: `get_features(schema)` with NO timestamp returned ALL rows including duplicate entities (`u1` twice) instead of the latest row per entity. The `get_features` contract (store.py docstring) states "When timestamp is None the latest values are returned." The adapter's as-of dedup was gated on `point_in_time is not None`, so the no-timestamp "latest" case skipped dedup.
+
+Root of the test gap: every happy-path test used ONE row per entity, so dedup-vs-no-dedup was unobservable. The published-wheel walk used 2 rows for `u1` and exposed it.
+
+Fix (1.7.6): dedup-to-latest-per-entity whenever `timestamp_column` exists (both the timestamp-given as-of case AND the no-timestamp latest case); the window filter (`ts <= T`) still applies only when `point_in_time` is given. Tests strengthened to use multiple rows per entity.
+
+1.7.5 (on PyPI) is correct for the timestamp-given case + single-row-per-entity tables; 1.7.6 supersedes it for the no-timestamp multi-row case.

--- a/workspaces/kaizen-rag-node-coverage/04-validate/20-fu5-fu4-forest-closure-2026-06-10.md
+++ b/workspaces/kaizen-rag-node-coverage/04-validate/20-fu5-fu4-forest-closure-2026-06-10.md
@@ -1,0 +1,170 @@
+# F31-FU5 + F31-FU4 forest closure — 2026-06-10 (session 2)
+
+Value-anchor: brief _"provably correct, not merely importable"_ — FU5 is literally an importability
+defect on the base surface; FU4 is the brief's "false-green hides real defects" clause, generalized
+from the Wave-2 RAG discovery (`04-validate/15` § Wave-level learning) to the non-RAG kaizen surface.
+BUILD repo — ALL work held UNCOMMITTED alongside F31-FU2 + Wave 3; commit stays with the user.
+
+## F31-FU5 — numpy eager-import broke base `import kaizen` (CLOSED)
+
+**Root cause (worse than the ledger claimed):** not just `kaizen.nodes.*` — bare `import kaizen`
+hard-crashed without the `[rag]` extra. Chain: `kaizen/__init__.py:18` → `kaizen_agents` →
+`patterns/runtime.py` → `from kaizen.nodes.ai.a2a import A2AAgentCard` → `nodes/ai/__init__.py`
+eagerly imports `hybrid_search`/`semantic_memory` (module-scope numpy) → ImportError → fallback
+`A2AAgentCard = None` → eager PEP-604 `A2AAgentCard | None` annotation (runtime.py:214) →
+`TypeError: unsupported operand type(s) for |: 'NoneType' and 'NoneType'` at class creation.
+The try/except ImportError in `kaizen/__init__.py` could not catch the TypeError.
+
+**Fixes (root-cause, both layers):**
+
+1. `kaizen/nodes/_optional.py` (NEW) — `require_numpy(feature)` helper: typed ImportError with
+   `pip install kailash-kaizen[rag]` guidance (matches the `llm/auth/*` extras idiom).
+2. `nodes/ai/hybrid_search.py` + `nodes/ai/semantic_memory.py` — `from __future__ import annotations`,
+   numpy under TYPE_CHECKING, function-local `np = require_numpy(...)` at the 7 use sites.
+3. `kaizen-agents/patterns/runtime.py` — `from __future__ import annotations` (annotations lazy;
+   the `A2AAgentCard = None` fallback now degrades gracefully; runtime usage is getattr-based).
+4. Same-class sweep (autonomous-execution Rule 4): PEP-604/isinstance scan over every
+   `except ImportError: X = None` fallback in kaizen + kaizen-agents → runtime.py:214 was the only
+   unguarded crash site (3 isinstance sites are `DATAFLOW_AVAILABLE`/`is None`-guarded upstream).
+5. `tests/utils/docker_config.py` — module-scope `import pymongo` (same FU5 class in test infra:
+   poisoned collection for every test importing `tests.utils`) made lazy in `_check_mongodb`;
+   `pymongo` declared in kaizen `[dev]` (Declared=Imported).
+
+**`kaizen.nodes.rag` requiring `[rag]` is BY DESIGN** (pyproject documents the extra as "the complete
+`import kaizen.nodes.rag` dependency set"); the regression pins that its failure stays a clean
+ModuleNotFoundError, never the TypeError class.
+
+**Regression tests:** `tests/regression/test_issue_f31_fu5_numpy_lazy_import.py` — 10 tests:
+subprocess meta-path blocker proves `kaizen` / `kaizen.nodes` / `kaizen.nodes.ai` /
+`kaizen_agents.patterns.runtime` import WITHOUT numpy; runtime graceful-degrade with a2a blocked
+(A2A_AVAILABLE False, AgentMetadata constructible); rag clean-MNFE; require_numpy guidance both ways;
+behavioral numeric parity with numpy present (hash-embedding round-trip, TF-IDF cosine).
+
+## F31-FU4 — wrong-shape-adapter false-green audit (CLOSED)
+
+**Method:** mechanical prefilter (552 non-RAG kaizen test files → 26 candidates via adapter-class /
+patch / fake-response-shape greps) → 4-cluster parallel audit workflow → adversarial verification of
+every FALSE_GREEN candidate. Durable receipt: workflow run `wf_35c79bbd-b30` (14 agents,
+55 doubles audited, 10 candidates, 3 confirmed). Ground truth: production LLMAgentNode publishes
+`{"success": ..., "response": {"content": ..., "role": ...}}` (llm_agent.py:995, :586, :1020-1024).
+
+**Confirmed #1 (HIGH, production defect FIXED):** `Agent.communicate_with`
+(`src/kaizen/core/agents.py:2517-2520`) `str()`'d the response with no dict-content extraction —
+production agent-to-agent messages + conversation history carried the dict REPR of the nested
+response, not the text. Test double (flat string) masked it. Fix mirrors the existing dual-shape
+handler (agents.py:926-933); adapter corrected to production envelope; assertion tightened
+substring → equality (the dict repr CONTAINS the text — substring would still false-green).
+
+**Confirmed #2 (HIGH, security-critical production defect FIXED):**
+`EnterpriseAuthProviderNode._ai_risk_assessment` (`src/kaizen/nodes/auth/enterprise_auth_provider.py:218`)
+read `result.get("content", "{}")` — the key-miss on every production envelope yielded `"{}"` →
+score 0.0 / "allow": **AI fraud detection silently disabled in production (fail-open)**. The 6 test
+doubles were reverse-engineered from the buggy parse (test comments admitted it). Fix: nested parse
+matching the sibling sso.py:226-228 + RAISE on missing content so the except branch engages the
+rule-based fallback (fail-closed to rule-based, never silent 0.0/allow). All 8 doubles in the file
+corrected to the production envelope (incl. invalid-JSON test now genuinely exercising
+json.JSONDecodeError, and 2 prompt-capture closures).
+
+**Confirmed #3 (MEDIUM, test-only FIXED):** `test_sso_unit.py` "AI methods with various providers"
+exercised ZERO AI-path code — the flat-string double routed through the rule-based fallback via
+AttributeError; the weak email-only assertion greened on fallback output. Production sso.py parse was
+CORRECT. Fix: production envelope + first_name/last_name assertions that only the AI path satisfies;
+same-shape sweep over the 2 prompt-capture doubles in the file.
+
+**Not-confirmed candidates (verified, refuted):** the flat-string doubles in
+`test_kaizen_core_feature_completion.py` / `test_async_execution.py` exercise REAL legacy str-branches
+production parsers retain (parser.py:1016-1017) — wrong-contract fixtures but no masked defect;
+noted as hardening candidates, not defects.
+
+**Regression tests:** `tests/regression/test_issue_f31_fu4_wrong_shape_adapters.py` — 5 behavioral
+tests feeding the docs-exact production envelope: communicate_with equality + history, legacy
+flat-string compatibility, enterprise-auth score/action parse (0.95/block), malformed-envelope
+fail-closed-to-rule-based (sentinel-patched parent), sso AI-path field surfacing.
+
+## Same-session zero-tolerance closures (found-it-own-it)
+
+- `pytest.ini` vestigial `env_files = .env` key removed (pytest-env never installed; .env loads via
+  `tests/conftest.py:18-20`) — kills the PytestConfigWarning.
+- Pre-existing `EnvModelMissing` failure class: 9 tests in `test_kaizen_multi_agent_coordination.py`
+  (byte-identical to HEAD a3de6cbee — proven pre-existing) + 36 in kaizen-agents
+  (supervisor/governance) — no CI lane or .env supplies `KAIZEN_DEFAULT_MODEL`. Fixed via the
+  issue-822 pattern: autouse fixture (kaizen file) + conftest `setdefault` (kaizen-agents; no test
+  asserts the missing-var path).
+- kaizen-agents adapter tests: `anthropic`/`google-generativeai` exercised by unit tests but
+  undeclared — declared in kaizen-agents `[dev]` (Declared=Imported) + installed.
+- `test_envelope_allocator_sdk.py` stale GradientZone contract (module legitimately dropped the
+  symbol in PactEngine v0.4.0 type alignment) — rewritten to assert the original no-duplicate intent
+  durably; + pre-existing lint debt in the file (F401/F841/B007/I001) cleared.
+- 2 pre-existing UP037 quoted annotations (kaizen-agents runtime.py:748, state_manager.py:238) fixed.
+
+## Warning dispositions (observability Rule 5)
+
+- `FutureWarning structured_output_mode='auto' deprecated` (async_single_shot.py:344, fired by the
+  822 regression test): **by-design** — kaizen's own v3.0 deprecation banner on the user-default path
+  the test intentionally exercises; the shim must live through its cycle (zero-tolerance 6a);
+  suppressing in tests would mask the banner. Removal scheduled v3.0.
+- `env_files` PytestConfigWarning: **Fixed** (this session, see above).
+
+## Gates at time of writing
+
+ruff clean across kaizen src+tests AND kaizen-agents src + the test files this session touched
+(kaizen-agents tests/unit carries ~369 PRE-EXISTING lint findings in files untouched by any session
+gate — declared forest item, see 21-* receipt); kaizen RAG+regression suites 1633 passed / 1 warning
+(dispositioned above); FU4-affected files 55/55; kaizen-agents last-failed re-run 40/40 green; full
+kaizen unit + kaizen-agents unit/regression re-runs in flight at writing — final counts in the
+convergence receipt (21-*).
+
+## R1 redteam corrections (2026-06-11)
+
+**R1 security-reviewer HIGH — CLOSED same-session (autonomous-execution Rule 4):**
+`src/kaizen/nodes/auth/directory_integration.py` carried the IDENTICAL flat-shape parse at 4 sites
+the FU4 sweep missed (`_ai_search_analysis` :267, `_ai_role_assignment` :444,
+`_ai_permission_mapping` :511, `_ai_security_settings` :575 pre-fix). Security blast radius:
+`_ai_security_settings` returned `{}` on every production envelope — AI-driven MFA tightening
+silently dead; role/permission sites were fail-safe (least-privilege defaults). Fix: nested parse +
+raise-on-missing at all 4 sites (the enterprise_auth shape, so the documented except-fallbacks
+engage); 10 test doubles in test_directory_integration_unit.py corrected to the production
+envelope; 3 regression tests added to test_issue_f31_fu4_wrong_shape_adapters.py (settings parse,
+settings fail-closed-to-safe-defaults, roles parse + least-privilege fail-closed — the flat shape
+must never grant "admin"). 63/63 across regression + auth suites post-fix.
+
+**R1 verifier LOW precision corrections to this receipt:** (1) the communicate_with extraction
+lives at agents.py:2519-2525 (not :2517-2520); (2) test_enterprise_auth_provider_unit.py has 9
+nested-envelope doubles (not 8); (3) test_sso_unit.py "3 corrected" = the AI-path doubles
+specifically; the file carries 6 nested-envelope literals total (3 were already correct).
+
+**R1 security LOW (advisory, pre-existing, NOT fixed this session):**
+enterprise_auth_provider.py:59 constructor default `ai_model: str = "gpt-4o-mini"` is a hardcoded
+model string (env-models.md) — predates this diff; same class exists across the auth node family;
+forest item.
+
+## R2 redteam corrections (2026-06-11)
+
+R2 reviewer: **APPROVE** (all 5 delta items verified, 63/63, receipt claims confirmed against the
+live tree). R2 security: **CHANGES-REQUESTED** — its mandated WIDER repo sweep (adjudicating ~130
+`.get("content")` hits) surfaced a residual cluster of the SAME bug class at 3 security/compliance
+sites outside the auth family, all CLOSED same-session (Rule 4):
+
+1. `src/kaizen/nodes/security/ai_threat_detection.py:263` (pre-fix) — flat read → dict →
+   `.split()` AttributeError swallowed by the except: **AI threat intelligence dead** on every
+   production envelope. Fixed: dict-guarded content extraction + raise-on-missing → documented
+   `ai_available: False` degrade.
+2. `src/kaizen/nodes/security/ai_behavior_analysis.py:254` (pre-fix) — identical; **AI behavior
+   analysis dead**. Same fix.
+3. `src/kaizen/nodes/compliance/gdpr.py:1549` (pre-fix) — flat read → `json.loads(dict)` TypeError
+   → None: **AI compliance analysis dead**. Same fix (raise → documented None degrade).
+
+None of the three had ANY test coverage of the LLM parse path (why the class survived). 3
+behavioral regression tests added to test_issue_f31_fu4_wrong_shape_adapters.py (now 11 tests):
+production-envelope parses (narrative/intelligence extraction, recommendations extraction,
+risk_level parse) + malformed-envelope fail-closed per site. Module-level `LLMAgentNode` stub via
+monkeypatch for the two security nodes (they instantiate the node inside the method).
+
+R2 security's adjudicated-correct sweep also confirmed: a2a.py (5 sites), multimodal.py, sso.py,
+strategies/agent_loop/providers/wire_protocols/memory `.get("content"/"response")` hits are either
+nested-correct or genuinely different dict shapes — NOT the bug class.
+
+R2 LOW closed: the 4 prompt-capture doubles in test_directory_integration_unit.py
+(TestDirectoryIntegrationPromptEngineering) aligned to the nested production envelope so the
+parse path their names imply is actually exercised. 66/66 across auth + nodes + regression
+post-fix; ruff clean.

--- a/workspaces/kaizen-rag-node-coverage/04-validate/21-fu5-fu4-convergence-2026-06-11.md
+++ b/workspaces/kaizen-rag-node-coverage/04-validate/21-fu5-fu4-convergence-2026-06-11.md
@@ -1,0 +1,75 @@
+# FU5 + FU4 + zero-tolerance closures — /redteam CONVERGED 2026-06-11
+
+Posture L5_DELEGATED. Scope: the full held-uncommitted tree vs HEAD `a3de6cbee` — the already-
+converged F31-FU2 + Wave-3 portions (receipts 16-19) PLUS this session's FU5/FU4/zero-tolerance
+closures (receipt 20 + its R1/R2 correction sections). BUILD repo — commit stays with the user.
+
+## Round history (durable receipts — verify-resource-existence MUST-4)
+
+| Round | Agents (task IDs) | Verdicts | Outcome |
+| ----- | ----------------- | -------- | ------- |
+| FU4 audit | workflow `wf_35c79bbd-b30` (14 agents) | 55 doubles audited, 3 confirmed FALSE_GREEN | 2 production defects + 1 test-only fixed (receipt 20) |
+| R1 | reviewer `a9dc866b983d07efc` / security `a28dc0b3bbc39dd6d` / closure-parity `ac35cecc28c641852` | APPROVE / CHANGES-REQUESTED (1 HIGH) / ALL-VERIFIED (3 LOW precision) | HIGH = directory_integration.py flat-shape ×4 → FIXED same-session |
+| R2 | reviewer `a9874fec67c137b94` / security `a1d55cb61628f8024` | APPROVE / CHANGES-REQUESTED (3 same-class HIGH via wider sweep) | ai_threat_detection + ai_behavior_analysis + gdpr → FIXED same-session; LOW (prompt-capture doubles) also fixed |
+| R3 | kaizen-specialist `a1c2d25d298658200` (Bash+Read) | **CONVERGED-CLEAN** — zero findings; independent fresh sweep; receipts verified claim-by-claim | Convergence confirmed |
+
+Convergence per workspace convention (receipts 16/17/18: fix-round → clean-round = converged):
+R2-reviewer clean + R3 all-clean; every security finding fixed and adversarially re-verified
+in the SAME session (autonomous-execution Rule 4 — zero follow-up issues filed for in-budget gaps).
+
+## The wrong-shape-adapter class — final tally (sessions 1+2)
+
+Production LLMAgentNode envelope: `{"success", "response": {"content", "role"}, ...}`
+(llm_agent.py:993-1012). Sites where production code read the FLAT shape and silently lost the
+AI path, all FIXED with nested parse + raise-on-missing → documented fail-closed fallback:
+
+1. `core/agents.py` communicate_with — dict-repr pollution of agent messages/history.
+2. `nodes/auth/enterprise_auth_provider.py` — AI fraud detection fail-open (0.0/"allow").
+3. `nodes/auth/directory_integration.py` ×4 — incl. AI-driven MFA tightening dead (R1).
+4. `nodes/security/ai_threat_detection.py` — AI threat intelligence dead (R2).
+5. `nodes/security/ai_behavior_analysis.py` — AI behavior analysis dead (R2).
+6. `nodes/compliance/gdpr.py` — AI compliance analysis dead (R2).
+
+R3's independent repo-wide sweep adjudicated every remaining `.get("content")`/`.get("response")`
+hit as nested-correct or different-dict-shape — class CLOSED across kailash-kaizen src.
+
+Test-side: 25+ doubles corrected to the production envelope across 4 unit files;
+`tests/regression/test_issue_f31_fu4_wrong_shape_adapters.py` = 11 behavioral tests
+(parse-production-envelope + fail-closed per site; equality-not-substring; legacy flat-string
+path pinned where production retains it).
+
+## Final gates (all verified by command at write time)
+
+| Gate | Result |
+| ---- | ------ |
+| Canonical workstream gate (`tests/unit/rag tests/integration/rag tests/regression`, env -u KAIZEN_DEFAULT_MODEL) | **1644 passed, 0 failed, 1 warning** (the dispositioned by-design v3.0 deprecation banner) |
+| kaizen-agents `tests/unit tests/regression` (full) | **3171 passed, 0 failed, 61 skipped** |
+| FU4-affected suites (regression + auth + nodes) | 66/66 |
+| FU5 regression (subprocess import-blocker) | 10/10 — `import kaizen` / `kaizen.nodes` / `kaizen.nodes.ai` / `kaizen_agents.patterns.runtime` all green WITHOUT numpy |
+| `grep -c '"code":'` across 9 real-content RAG files | 0 ×9 (Wave-4 files untouched, retain theirs BY DESIGN) |
+| `pytest --collect-only` both packages | exit 0 (13.8k + 3.4k collected) |
+| ruff | clean: kaizen src+tests; kaizen-agents src + every test file this session touched |
+| `uv pip check` | 252 packages compatible |
+| Inline-DDL sweep (schema-migration 1a) | clean |
+| Operator-path sweep (`/Users/esperie` in src) | clean (suspension.py docstring scrubbed) |
+
+## Combined-invocation isolation finding (forest item, NOT a held-work defect)
+
+The FIRST-EVER single-process run of the FULL `tests/unit` tree + `tests/integration/rag`
+(11,394 passed / 51 failed) exhibits cross-suite global-state pollution: 32 rag integration
+tests fail ONLY in that combination (`KeyError: 'model'` inside workflow-launched LLM stages;
+mock-confidence drift 0.8 vs 0.85 — registry/provider global-state class, cf. the v2.23.0
+node-registry-collisions release). Proven NOT the held work: (a) every suite green per-suite;
+(b) env-var A/B negative; (c) all session-enabled files (examples / protocol / providers-document)
+coexist green with the rag tests (209/209 probe). The polluter is long-standing unit-tree code;
+bisecting 11k tests is its own shard. Repro: combined invocation above. Canonical gates for this
+repo are per-suite (matching CI tier separation).
+
+## Remaining 19 pre-existing per-suite failures (documented, out of shard)
+
+In never-previously-gated dirs, all failing identically at HEAD-content: 7×
+test_intelligent_agent_responses (mock-quality assertions), 5× llm/huggingface preset endpoint
+resolution (network-dependent), 2× issue-12 SSRF env-dependent, 1× document_understanding adapter
+kwarg drift, 1× nexus temperature, 1× bs4-not-installed assert (bs4 installed), 1× boto3 sibling,
+1× timestamping multi-fallback. (The 20th — platform-compat hardcoded path — was FIXED this
+session via suspension.py.) Forest item with this list as the acceptance inventory.

--- a/workspaces/kaizen-rag-node-coverage/04-validate/F33-issue-draft.md
+++ b/workspaces/kaizen-rag-node-coverage/04-validate/F33-issue-draft.md
@@ -1,0 +1,69 @@
+# F33 issue draft — APPROVED for filing as separate issue, per-issue go-ahead still required
+
+Target repo: terrene-foundation/kailash-py (this BUILD repo — in-repo filing).
+Per upstream-issue-hygiene MUST-1: present body → explicit user go-ahead → `gh issue create`.
+
+---
+
+**Title:** `fix(core): register_node decorator erases node subclass types — needs generic TypeVar`
+
+**Labels:** `bug`, `typing`, `cross-sdk`
+
+**Body:**
+
+## Affected API
+
+`kailash.nodes.base.register_node` (src/kailash/nodes/base.py:2673; inner decorator at :2720)
+
+## Problem
+
+The inner decorator is annotated `def decorator(node_class: type[Node])` with no generic
+return type. Static checkers therefore infer every `@register_node()`-decorated class as
+`type[Node]`, erasing the subclass. Every subclass-specific classmethod call on a decorated
+class — e.g. `PythonCodeNode.from_function(...)` — emits a (non-gating) pyright
+`attr-defined` diagnostic at every call site.
+
+## Minimal repro
+
+```python
+from kailash.nodes.base import Node, register_node
+
+@register_node()
+class MyNode(Node):
+    @classmethod
+    def special(cls) -> "MyNode": ...
+
+MyNode.special()  # pyright: "special" is not a known attribute of "type[Node]"
+```
+
+## Expected vs actual
+
+Expected: the decorated class retains its precise type (standard generic-decorator pattern).
+Actual: the decorated class is erased to `type[Node]`.
+
+## Fix (typing-only, zero runtime change)
+
+```python
+from typing import Callable, TypeVar
+
+T = TypeVar("T", bound=Node)
+
+def register_node(alias: str | None = None) -> Callable[[type[T]], type[T]]:
+    def decorator(node_class: type[T]) -> type[T]:
+        ...
+        return node_class
+    return decorator
+```
+
+## Severity
+
+LOW (static-typing only). High annoyance multiplier: every `from_function` call site in
+kailash-kaizen's RAG node family emits the diagnostic.
+
+## Acceptance criteria
+
+- [ ] `@register_node()`-decorated subclasses retain their type under pyright.
+- [ ] `PythonCodeNode.from_function` call sites emit no `attr-defined` diagnostic.
+- [ ] Zero runtime behavior change (`NodeRegistry.register` path untouched).
+- [ ] Cross-SDK inspection: check whether the kailash-rs node-registration path has an
+      equivalent type-erasure issue (cross-sdk label).


### PR DESCRIPTION
# kaizen: F31 provably-correct completion — FU2+Wave3 coverage, FU5 lazy-numpy, FU4 wrong-shape adapters, zero-tolerance sweep

## Summary

Lands the /redteam-CONVERGED F31 held work (receipts 16–21 in `workspaces/kaizen-rag-node-coverage/04-validate/`):

- **Wave 3 + F31-FU2** — the 9 real-content RAG node files get direct per-node unit tests; remaining simulated-content paths replaced with consume-context + publish-real-output wiring.
- **F31-FU5** — lazy numpy import: `import kaizen` (and `kaizen.nodes`, `kaizen.nodes.ai`, `kaizen_agents.patterns`) no longer hard-fails without numpy. 10 subprocess regression tests pin it.
- **F31-FU4** — six production sites read the FLAT LLM envelope where LLMAgentNode returns the NESTED `result["response"]["content"]` shape, silently killing the AI path (auth fraud detection fail-open, AI MFA tightening dead, threat intelligence dead, behavior analysis dead, GDPR compliance analysis dead, agent message dict-repr pollution). All six now parse the nested envelope and fail CLOSED. 25+ test doubles corrected to the production envelope; 11 behavioral regression tests.
- **Zero-tolerance sweep** — EnvModelMissing pre-existing unit failure class closed (conftest setdefault both packages), `utcnow→now(UTC)` ×13 sites, Declared=Imported dev-deps (pymongo/anthropic/google-generativeai/pytest-benchmark/respx), env_files warning, GradientZone stale contract, operator-path docstring scrub.

## Validation (verified on committed state at push time)

| Gate | Result |
| ---- | ------ |
| Canonical workstream gate (`tests/unit/rag tests/integration/rag tests/regression`, env -u KAIZEN_DEFAULT_MODEL) | 1644 passed, 1 warning (by-design v3.0 deprecation banner) |
| kaizen-agents `tests/unit tests/regression` (full) | 3171 passed, 61 skipped |
| FU4-affected suites (auth + coordination) | 74 passed |
| ruff | clean on all touched files (pre-commit gate per commit) |

Redteam round history with agent-task-ID receipts: `04-validate/21-fu5-fu4-convergence-2026-06-11.md` (R1 fix → R2 fix → R3 CONVERGED-CLEAN).

## Related issues

- F31 workstream (kaizen RAG provably-correct, continues #1283/#1284 lineage)
- F33 filed separately as #1286 (register_node TypeVar erasure — typing-only, out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
