### PR TITLE
chore(release): kailash-kaizen 2.25.0 + kaizen-agents 0.9.9

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
-## [Unreleased]
+## [2.25.0] — 2026-06-11 — env-model discipline: fail-closed provider detection + HF preset router + multi-modal adapter fixes
 
 ### Changed — BREAKING (migration): AI-node model defaults now resolve from `KAIZEN_DEFAULT_MODEL`
 

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.24.6"
+version = "2.25.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.24.6"
+__version__ = "2.25.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.9] — 2026-06-11 — slim-core import contract + ruff-clean test dirs + deprecation fixes
 
 ### Fixed
 

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.9.8"
+version = "0.9.9"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.9.8"
+__version__ = "0.9.9"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate


### PR DESCRIPTION
## Summary

Coordinated release cutting the FNEW wave (PRs #1287/#1288, merged 2026-06-11) to PyPI. Both packages' source landed after their last tags (`kaizen-v2.24.6` / `kaizen-agents-v0.9.8`); merged is not delivered.

- **kailash-kaizen 2.24.6 → 2.25.0** (minor, BREAKING migration): AI-node model defaults resolve from `KAIZEN_DEFAULT_MODEL`; fail-closed `ProviderUndetectable` for unrecognized models (no silent mock route in security/auth/compliance nodes); HuggingFace preset retargeted to the Inference Providers router (`api-inference.huggingface.co` decommissioned); `get_multi_modal_adapter` kwarg filtering (no more `TypeError` for OpenAI-key callers).
- **kaizen-agents 0.9.8 → 0.9.9** (patch): slim-core import contract (`patterns` no longer pulls heavy optional deps), `datetime.utcnow()` → `now(UTC)`, `shutdown(graceful=False)` teardown fix, ruff-clean test dirs enabling CI lint-gating.

Metadata-only diff (version anchors + CHANGELOG) — `release/*` branch auto-skips the PR-gate matrix.

## Convergence

R1-R3 CONVERGED-CLEAN (receipt 22), corroborated live on `main` this session: kaizen FNEW-4 regression 24/24 green, fail-closed provider detection verified; kaizen-agents slim-core import chain OK, ruff exit 0.

## Sibling-drift sweep

`kailash-mcp` (#1258) + `kailash-pact` drifted but are non-functional (docstrings/test-vectors/comments only — no wheel change); deferred to their next functional release.

## Related issues

Closes the FNEW wave release obligation (#1287, #1288).

🤖 Generated with [Claude Code](https://claude.com/claude-code)