### PR TITLE
fix(kaizen): slim-core import contract for autonomy hooks (2.25.1 + agents 0.9.10)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.25.1] — 2026-06-11 — hotfix: slim-core import contract for the autonomy hook system
+
+### Fixed
+
+- **`import kaizen_agents.patterns` (and any `kaizen.core.autonomy.hooks` import)
+  no longer requires the optional `observability` extra on a clean install.**
+  `LoggingHook`, `MetricsHook`, and `TracingHook` eagerly pulled `structlog`,
+  `prometheus-client`, and `opentelemetry` (all `[observability]`-extra deps) at
+  module-import time through the hook package's eager re-exports, so a slim-core
+  `pip install kailash-kaizen` raised `ModuleNotFoundError` the moment anything
+  imported the hook system (e.g. for `HookManager`). The three observability
+  hooks are now lazy-loaded via PEP 562 `__getattr__`: importing the hook system
+  stays slim-core clean, and accessing one of those hooks without the extra raises
+  a clear `ImportError` pointing at `pip install 'kailash-kaizen[observability]'`.
+  `LoggingHook(format="text")` (the default) now works without `structlog`. Caught
+  by the 2.25.0 clean-venv install-verification gate.
+
 ## [2.25.0] — 2026-06-11 — env-model discipline: fail-closed provider detection + HF preset router + multi-modal adapter fixes
 
 ### Changed — BREAKING (migration): AI-node model defaults now resolve from `KAIZEN_DEFAULT_MODEL`

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.25.0"
+version = "2.25.1"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.25.0"
+__version__ = "2.25.1"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/__init__.py
@@ -1,12 +1,12 @@
 """Hook system for autonomous agents."""
 
+import importlib
+from typing import TYPE_CHECKING
+
 from kaizen.core.autonomy.hooks.builtin import (
     AuditHook,
     CostTrackingHook,
-    LoggingHook,
-    MetricsHook,
     PerformanceProfilerHook,
-    TracingHook,
 )
 from kaizen.core.autonomy.hooks.manager import HookManager
 from kaizen.core.autonomy.hooks.protocol import BaseHook, HookHandler
@@ -16,6 +16,24 @@ from kaizen.core.autonomy.hooks.types import (
     HookPriority,
     HookResult,
 )
+
+if TYPE_CHECKING:
+    # LoggingHook/MetricsHook/TracingHook require the optional `observability`
+    # extra; they are lazy-loaded from the builtin package via __getattr__ so
+    # importing the hook system (e.g. for HookManager) stays slim-core clean.
+    from kaizen.core.autonomy.hooks.builtin import LoggingHook, MetricsHook, TracingHook
+
+# Re-exported from the builtin package but lazy-loaded there (optional extra);
+# delegate name resolution to builtin.__getattr__.
+_OPTIONAL_HOOKS = ("LoggingHook", "MetricsHook", "TracingHook")
+
+
+def __getattr__(name):
+    if name in _OPTIONAL_HOOKS:
+        builtin = importlib.import_module("kaizen.core.autonomy.hooks.builtin")
+        return getattr(builtin, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "HookEvent",
@@ -32,3 +50,7 @@ __all__ = [
     "AuditHook",
     "TracingHook",
 ]
+
+
+def __dir__():
+    return sorted(__all__)

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/__init__.py
@@ -2,14 +2,29 @@
 Built-in hook implementations.
 
 Provides common hooks for logging, metrics, cost tracking, performance profiling, audit, and tracing.
+
+``LoggingHook``, ``MetricsHook``, and ``TracingHook`` depend on the optional
+``observability`` extra (structlog / prometheus-client / opentelemetry). They are
+lazy-loaded via PEP 562 ``__getattr__`` so that merely importing the hook system
+(e.g. for ``HookManager``) does not require the extra on a slim-core install.
+Accessing one of these names without the extra installed raises a clear,
+actionable ImportError.
 """
+
+import importlib
+from typing import TYPE_CHECKING
 
 from .audit_hook import AuditHook
 from .cost_tracking_hook import CostTrackingHook
-from .logging_hook import LoggingHook
-from .metrics_hook import MetricsHook
 from .performance_profiler_hook import PerformanceProfilerHook
-from .tracing_hook import TracingHook
+
+if TYPE_CHECKING:
+    # Analyzer-only imports (PEP 562 lazy exports) — keep static analysis,
+    # Sphinx autodoc, and `from pkg import *` resolution working while the
+    # runtime import stays deferred behind __getattr__ (orphan-detection Rule 6b).
+    from .logging_hook import LoggingHook
+    from .metrics_hook import MetricsHook
+    from .tracing_hook import TracingHook
 
 __all__ = [
     "LoggingHook",
@@ -19,3 +34,30 @@ __all__ = [
     "AuditHook",
     "TracingHook",
 ]
+
+# Public name -> submodule providing it. Each submodule pulls a dependency that
+# ships only with the `observability` extra, so they are imported on demand.
+_OPTIONAL_HOOKS = {
+    "LoggingHook": "logging_hook",
+    "MetricsHook": "metrics_hook",
+    "TracingHook": "tracing_hook",
+}
+
+
+def __getattr__(name):
+    module_name = _OPTIONAL_HOOKS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    try:
+        module = importlib.import_module(f".{module_name}", __name__)
+    except ImportError as exc:
+        raise ImportError(
+            f"{name} requires the optional 'observability' extra "
+            "(structlog / prometheus-client / opentelemetry). Install it with: "
+            "pip install 'kailash-kaizen[observability]'"
+        ) from exc
+    return getattr(module, name)
+
+
+def __dir__():
+    return sorted(__all__)

--- a/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
+++ b/packages/kailash-kaizen/src/kaizen/core/autonomy/hooks/builtin/logging_hook.py
@@ -10,8 +10,6 @@ SECURITY: Supports sensitive data redaction (Finding #4 fix).
 import logging
 from typing import ClassVar, Optional
 
-import structlog
-
 from ..protocol import BaseHook
 from ..types import HookContext, HookEvent, HookResult
 
@@ -90,6 +88,18 @@ class LoggingHook(BaseHook):
 
         # Configure logger based on format
         if format == "json":
+            # structlog is an optional observability dependency (slim core).
+            # Import it lazily so the text format (default) and merely importing
+            # this module never require it; raise a clear, actionable error only
+            # when JSON output is actually requested without the extra installed.
+            try:
+                import structlog
+            except ImportError as exc:
+                raise ImportError(
+                    "LoggingHook(format='json') requires structlog. Install the "
+                    "observability extra: pip install 'kailash-kaizen[observability]'"
+                ) from exc
+
             # Configure structlog for JSON output
             structlog.configure(
                 processors=[

--- a/packages/kaizen-agents/CHANGELOG.md
+++ b/packages/kaizen-agents/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the kaizen-agents package will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.10] — 2026-06-11 — enforce the slim-core import fix via the kailash-kaizen floor
+
+### Changed
+
+- **`kailash-kaizen` floor raised to `>=2.25.1`.** The slim-core
+  `import kaizen_agents.patterns` contract claimed in 0.9.9 is only actually
+  satisfied by kailash-kaizen 2.25.1, which lazy-loads the optional-extra autonomy
+  hooks (`structlog` / `prometheus-client` / `opentelemetry`). Pinning the floor
+  guarantees a fresh `pip install kaizen-agents` receives the fixed kaizen. No
+  kaizen-agents source change.
+
 ## [0.9.9] — 2026-06-11 — slim-core import contract + ruff-clean test dirs + deprecation fixes
 
 ### Fixed

--- a/packages/kaizen-agents/pyproject.toml
+++ b/packages/kaizen-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kaizen-agents"
-version = "0.9.9"
+version = "0.9.10"
 description = "PACT-governed autonomous agent engines built on Kailash Kaizen SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"
@@ -33,7 +33,7 @@ dependencies = [
     #   `kailash` core), not the separate `kailash-pact` package.
     # ─────────────────────────────────────────────────────────────
     "kailash>=2.14.0",
-    "kailash-kaizen>=2.18.1",
+    "kailash-kaizen>=2.25.1",
     "openai>=1.30.0",
     "httpx>=0.27.0",
 ]

--- a/packages/kaizen-agents/src/kaizen_agents/__init__.py
+++ b/packages/kaizen-agents/src/kaizen_agents/__init__.py
@@ -14,7 +14,7 @@ Provides:
 - Governance: accountability, clearance, cascade, vacancy, dereliction, bypass, budget
 """
 
-__version__ = "0.9.9"
+__version__ = "0.9.10"
 
 # Delegate facade — the primary entry point for autonomous AI execution
 from kaizen_agents.delegate import Delegate


### PR DESCRIPTION
## Summary

Hotfix caught by the **2.25.0 clean-venv install-verification gate** (build-repo-release-discipline Rule 2): `import kaizen_agents.patterns` — and any import of `kaizen.core.autonomy.hooks` (e.g. for `HookManager`) — raised `ModuleNotFoundError` on a slim-core `pip install`. The hook package eagerly re-exported `LoggingHook` / `MetricsHook` / `TracingHook`, which import `structlog` / `prometheus-client` / `opentelemetry` at module scope — all `[observability]`-extra deps, not core. This is exactly the slim-core import contract kaizen-agents 0.9.9 claimed to complete (the FU5 fix addressed type-annotation imports but missed the hooks path).

## Fix

- **kailash-kaizen 2.25.0 → 2.25.1**: lazy-load the three observability hooks via PEP 562 `__getattr__` at both `hooks/__init__.py` and `hooks/builtin/__init__.py` (`TYPE_CHECKING` blocks keep static analysis + `import *` working per orphan-detection Rule 6b). `logging_hook`'s `import structlog` moved into the JSON-format branch so the default text format needs no extra. Accessing an observability hook without the extra raises a clear `ImportError` → `pip install 'kailash-kaizen[observability]'`.
- **kaizen-agents 0.9.9 → 0.9.10**: floor `kailash-kaizen>=2.25.1` so a fresh install receives the fixed kaizen. No kaizen-agents source change.

## Verification

- Clean slim-core venv (no observability extra) imports the full `kaizen_agents.patterns` chain + `HookManager`.
- Observability hooks still resolve when the extra is present; raise the actionable error without it.
- **119/119** autonomy hooks unit tests pass.

## Related issues

Hotfix for the kaizen 2.25.0 / kaizen-agents 0.9.9 release (this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)