### PR TITLE
fix(kaizen): provider config getters use documented default-model constants (FNEW-5)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [Unreleased]
+
+### Changed — env-model discipline: provider config getters use documented default-model constants
+
+- **The nine `get_*_config()` functions in `kaizen.config.providers` no longer
+  hold inline hardcoded `default_model` literals** (`rules/env-models.md`,
+  FNEW-5). Each provider's final fallback is now a documented module-level
+  `DEFAULT_<PROVIDER>_MODEL` constant — provider-intrinsic (the caller has already
+  chosen the provider, so the default carries no lock-in), overridable via
+  `KAIZEN_<PROVIDER>_MODEL`, and deliberately **not** chained to the
+  provider-agnostic `KAIZEN_DEFAULT_MODEL` (chaining would reintroduce the 2.25.0
+  provider/model mismatch — e.g. a `claude-*` model returned under
+  `provider="openai"`). Zero-config `auto_detect_provider()` is unchanged.
+- **User-visible default refresh:** the stale Anthropic default
+  `claude-3-haiku-20240307` is refreshed to `claude-haiku-4-5`. Callers using the
+  bare `get_anthropic_config()` default (no `model=` arg AND no
+  `KAIZEN_ANTHROPIC_MODEL` env) now receive `claude-haiku-4-5`. Set
+  `KAIZEN_ANTHROPIC_MODEL` or pass `model=` to pin a specific model. Non-breaking
+  (signature and resolution order unchanged; only the final-fallback value moved).
+- New regression suite (`tests/regression/test_issue_fnew5_provider_intrinsic_defaults.py`)
+  locks default resolution, `KAIZEN_<PROVIDER>_MODEL` / `model=` precedence, and
+  the `KAIZEN_DEFAULT_MODEL` no-leak invariant across all nine providers.
+
 ## [2.25.1] — 2026-06-11 — hotfix: slim-core import contract for the autonomy hook system
 
 ### Fixed

--- a/packages/kailash-kaizen/src/kaizen/config/providers.py
+++ b/packages/kailash-kaizen/src/kaizen/config/providers.py
@@ -40,6 +40,43 @@ ProviderType = Literal[
 ]
 
 
+# ---------------------------------------------------------------------------
+# Provider-intrinsic default models (FNEW-5 disposition)
+#
+# These are the per-provider sensible defaults applied ONLY when a caller passes
+# no ``model=`` AND the per-provider override ``KAIZEN_<PROVIDER>_MODEL`` is unset.
+# They are NOT an ``env-models.md`` violation, for three structural reasons:
+#
+#   1. Provider-INTRINSIC — the caller has already selected the provider
+#      (``get_openai_config`` IS OpenAI), so the default carries no provider
+#      lock-in. The lock-in failure mode ``env-models.md`` targets lives in
+#      provider-AGNOSTIC code (the auth/security/compliance nodes), and was
+#      removed there by FNEW-4 (``nodes/_env_model.py::resolve_default_model``).
+#   2. Env-OVERRIDABLE — ``KAIZEN_<PROVIDER>_MODEL`` takes precedence, so
+#      per-environment selection and provider-version rotation are fully
+#      supported without touching code.
+#   3. NOT chained to ``KAIZEN_DEFAULT_MODEL`` — that variable is
+#      provider-agnostic; applying it inside a provider-specific getter would
+#      reintroduce the exact provider/model mismatch FNEW-4 eliminated (e.g. a
+#      ``claude-*`` model returned under ``provider="openai"`` → 401 on the wire).
+#      Embedding providers (cohere, huggingface) further require a non-chat
+#      default, so a global chat default would be wrong for them regardless.
+#
+# The module's zero-config contract (``auto_detect_provider``) depends on these
+# defaults resolving WITHOUT raising. Keep each value current; it is the one half
+# of the env-models concern (model-version rot) the env override cannot mitigate.
+# ---------------------------------------------------------------------------
+DEFAULT_OPENAI_MODEL = "gpt-4o-mini"  # fast, cost-effective
+DEFAULT_OLLAMA_MODEL = "llama3.2"  # commonly available local model
+DEFAULT_AZURE_MODEL = "gpt-4o"  # common Azure deployment
+DEFAULT_DOCKER_MODEL = "ai/llama3.2"  # local GPU-accelerated
+DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5"  # fast, cost-effective
+DEFAULT_COHERE_MODEL = "embed-english-v3.0"  # embeddings (chat default N/A)
+DEFAULT_HUGGINGFACE_MODEL = "sentence-transformers/all-MiniLM-L6-v2"  # local embeddings
+DEFAULT_GOOGLE_MODEL = "gemini-2.0-flash"  # fast, efficient
+DEFAULT_PERPLEXITY_MODEL = "sonar"  # lightweight web-search model
+
+
 @dataclass
 class ProviderConfig:
     """Configuration for a specific LLM provider."""
@@ -256,10 +293,9 @@ def get_openai_config(
         )
     base_url = _validate_base_url(base_url)
 
-    default_model = "gpt-4o-mini"  # Fast, cost-effective model
     return ProviderConfig(
         provider="openai",
-        model=model or os.getenv("KAIZEN_OPENAI_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_OPENAI_MODEL", DEFAULT_OPENAI_MODEL),
         api_key=api_key,
         base_url=base_url,
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "30")),
@@ -289,14 +325,13 @@ def get_ollama_config(
             "Ollama is not available. Install and start Ollama: https://ollama.ai"
         )
 
-    default_model = "llama3.2"  # Using llama3.2 as it's more commonly available
     resolved_base_url = base_url or os.getenv(
         "OLLAMA_BASE_URL", "http://localhost:11434"
     )
 
     return ProviderConfig(
         provider="ollama",
-        model=model or os.getenv("KAIZEN_OLLAMA_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL),
         base_url=resolved_base_url,
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "60")),  # Ollama may need more time
         max_retries=int(os.getenv("KAIZEN_MAX_RETRIES", "3")),
@@ -345,10 +380,9 @@ def get_azure_config(
             "environment variables, or pass api_key and base_url parameters."
         )
 
-    default_model = "gpt-4o"  # Common Azure deployment
     return ProviderConfig(
         provider="azure",
-        model=model or os.getenv("KAIZEN_AZURE_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_AZURE_MODEL", DEFAULT_AZURE_MODEL),
         api_key=resolved_api_key,
         base_url=resolved_base_url,
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "60")),
@@ -376,7 +410,6 @@ def get_docker_config(model: Optional[str] = None) -> ProviderConfig:
             "docker desktop enable model-runner --tcp 12434"
         )
 
-    default_model = "ai/llama3.2"
     base_url = os.getenv(
         "DOCKER_MODEL_RUNNER_URL",
         "http://localhost:12434/engines/llama.cpp/v1",
@@ -384,7 +417,7 @@ def get_docker_config(model: Optional[str] = None) -> ProviderConfig:
 
     return ProviderConfig(
         provider="docker",
-        model=model or os.getenv("KAIZEN_DOCKER_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_DOCKER_MODEL", DEFAULT_DOCKER_MODEL),
         base_url=base_url,
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "120")),  # Local models may be slower
         max_retries=int(os.getenv("KAIZEN_MAX_RETRIES", "3")),
@@ -398,7 +431,7 @@ def get_anthropic_config(
     """Get Anthropic provider configuration.
 
     Args:
-        model: Optional model override (default: claude-3-haiku-20240307)
+        model: Optional model override (default: claude-haiku-4-5)
         api_key: Optional API key override (default: reads from ANTHROPIC_API_KEY env var)
     """
     api_key = _validate_api_key(api_key) or os.getenv("ANTHROPIC_API_KEY")
@@ -408,10 +441,9 @@ def get_anthropic_config(
             "or pass api_key parameter."
         )
 
-    default_model = "claude-3-haiku-20240307"  # Fast, cost-effective
     return ProviderConfig(
         provider="anthropic",
-        model=model or os.getenv("KAIZEN_ANTHROPIC_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_ANTHROPIC_MODEL", DEFAULT_ANTHROPIC_MODEL),
         api_key=api_key,
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "30")),
         max_retries=int(os.getenv("KAIZEN_MAX_RETRIES", "3")),
@@ -435,10 +467,9 @@ def get_cohere_config(
             "or pass api_key parameter."
         )
 
-    default_model = "embed-english-v3.0"
     return ProviderConfig(
         provider="cohere",
-        model=model or os.getenv("KAIZEN_COHERE_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_COHERE_MODEL", DEFAULT_COHERE_MODEL),
         api_key=api_key,
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "30")),
         max_retries=int(os.getenv("KAIZEN_MAX_RETRIES", "3")),
@@ -455,11 +486,10 @@ def get_huggingface_config(
         model: Optional model override
         api_key: Optional API key override (default: reads from HUGGINGFACE_API_KEY)
     """
-    default_model = "sentence-transformers/all-MiniLM-L6-v2"
     resolved_api_key = _validate_api_key(api_key) or os.getenv("HUGGINGFACE_API_KEY")
     return ProviderConfig(
         provider="huggingface",
-        model=model or os.getenv("KAIZEN_HUGGINGFACE_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_HUGGINGFACE_MODEL", DEFAULT_HUGGINGFACE_MODEL),
         api_key=resolved_api_key,  # Optional for local
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "60")),
         max_retries=int(os.getenv("KAIZEN_MAX_RETRIES", "3")),
@@ -496,10 +526,9 @@ def get_google_config(
             "or GOOGLE_CLOUD_PROJECT environment variable, or pass api_key parameter."
         )
 
-    default_model = "gemini-2.0-flash"  # Fast, efficient model
     return ProviderConfig(
         provider="google",
-        model=model or os.getenv("KAIZEN_GOOGLE_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_GOOGLE_MODEL", DEFAULT_GOOGLE_MODEL),
         api_key=api_key,
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "30")),
         max_retries=int(os.getenv("KAIZEN_MAX_RETRIES", "3")),
@@ -533,10 +562,9 @@ def get_perplexity_config(
             "or pass api_key parameter."
         )
 
-    default_model = "sonar"  # Lightweight, fast model
     return ProviderConfig(
         provider="perplexity",
-        model=model or os.getenv("KAIZEN_PERPLEXITY_MODEL", default_model),
+        model=model or os.getenv("KAIZEN_PERPLEXITY_MODEL", DEFAULT_PERPLEXITY_MODEL),
         api_key=api_key,
         base_url="https://api.perplexity.ai",
         timeout=int(os.getenv("KAIZEN_TIMEOUT", "60")),  # Web search may take longer

--- a/packages/kailash-kaizen/src/kaizen/providers/document/openai_vision_provider.py
+++ b/packages/kailash-kaizen/src/kaizen/providers/document/openai_vision_provider.py
@@ -68,6 +68,9 @@ class OpenAIVisionProvider(BaseDocumentProvider):
     """
 
     COST_PER_PAGE = 0.068  # $0.068 per page (approx for gpt-4o-mini)
+    # Provider-intrinsic default (FNEW-5 disposition, see config/providers.py):
+    # this provider IS OpenAI vision, so the pinned default carries no provider
+    # lock-in and is overridable via the `model=` constructor arg.
     DEFAULT_MODEL = "gpt-4o-mini"
 
     def __init__(

--- a/packages/kailash-kaizen/tests/regression/test_issue_fnew5_provider_intrinsic_defaults.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_fnew5_provider_intrinsic_defaults.py
@@ -1,0 +1,227 @@
+"""FNEW-5 regression — provider config getters use documented provider-intrinsic
+default-model constants, never inline literals, and never leak the
+provider-agnostic ``KAIZEN_DEFAULT_MODEL`` into a provider-specific getter.
+
+Disposition (see ``kaizen/config/providers.py`` FNEW-5 header): the per-provider
+``DEFAULT_<PROVIDER>_MODEL`` constants are NOT an ``env-models.md`` violation —
+they are provider-intrinsic (the caller has already chosen the provider, so the
+default carries no lock-in), env-overridable via ``KAIZEN_<PROVIDER>_MODEL``, and
+deliberately NOT chained to ``KAIZEN_DEFAULT_MODEL`` (which is provider-agnostic;
+chaining it would reintroduce the provider/model mismatch FNEW-4 fixed).
+
+These tests lock four contracts:
+  1. each getter resolves to its named constant when no arg / no env override;
+  2. ``KAIZEN_<PROVIDER>_MODEL`` overrides the default; an explicit ``model=`` arg
+     overrides both;
+  3. the provider-agnostic ``KAIZEN_DEFAULT_MODEL`` does NOT leak into any
+     provider-specific getter (the core anti-mismatch invariant);
+  4. value pins — the stale anthropic default was refreshed to a current model,
+     and embedding providers keep embedding (not chat) defaults.
+
+Env-var isolation (rules/testing.md § Env-Var Test Isolation MUST): every test
+that mutates the environment acquires the module-scope ``_ENV_LOCK`` via the
+``_env_serialized`` fixture so xdist-parallel runs cannot race, and clears all
+provider-affecting vars so an ambient ``.env`` cannot bleed into assertions.
+"""
+
+import threading
+from typing import Iterator
+
+import pytest
+
+from kaizen.config import providers as P
+
+pytestmark = pytest.mark.regression
+
+# Module-scope env lock per rules/testing.md.
+_ENV_LOCK = threading.Lock()
+
+# Every env var that can influence a provider getter's resolved model or
+# availability. Cleared before each test so ambient .env never leaks in.
+_AFFECTING_VARS = (
+    "KAIZEN_DEFAULT_MODEL",
+    "KAIZEN_OPENAI_MODEL",
+    "KAIZEN_OLLAMA_MODEL",
+    "KAIZEN_AZURE_MODEL",
+    "KAIZEN_DOCKER_MODEL",
+    "KAIZEN_ANTHROPIC_MODEL",
+    "KAIZEN_COHERE_MODEL",
+    "KAIZEN_HUGGINGFACE_MODEL",
+    "KAIZEN_GOOGLE_MODEL",
+    "KAIZEN_PERPLEXITY_MODEL",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "COHERE_API_KEY",
+    "HUGGINGFACE_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_CLOUD_PROJECT",
+    "PERPLEXITY_API_KEY",
+    "AZURE_API_KEY",
+    "AZURE_ENDPOINT",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_AI_INFERENCE_API_KEY",
+    "AZURE_AI_INFERENCE_ENDPOINT",
+)
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch) -> Iterator[pytest.MonkeyPatch]:
+    """Serialized + cleared environment; ollama/docker availability forced on."""
+    with _ENV_LOCK:
+        for var in _AFFECTING_VARS:
+            monkeypatch.delenv(var, raising=False)
+        # Local providers gate on a live-server probe, not env; force available
+        # so the default-resolution path is reachable without a running server.
+        monkeypatch.setattr(P, "check_ollama_available", lambda: True)
+        monkeypatch.setattr(P, "check_docker_available", lambda: True)
+        yield monkeypatch
+
+
+# (provider label, getter, env-var name, default constant, availability env to set)
+CASES = [
+    (
+        "openai",
+        P.get_openai_config,
+        "KAIZEN_OPENAI_MODEL",
+        P.DEFAULT_OPENAI_MODEL,
+        {"OPENAI_API_KEY": "sk-test"},
+    ),
+    (
+        "anthropic",
+        P.get_anthropic_config,
+        "KAIZEN_ANTHROPIC_MODEL",
+        P.DEFAULT_ANTHROPIC_MODEL,
+        {"ANTHROPIC_API_KEY": "sk-ant-test"},
+    ),
+    (
+        "cohere",
+        P.get_cohere_config,
+        "KAIZEN_COHERE_MODEL",
+        P.DEFAULT_COHERE_MODEL,
+        {"COHERE_API_KEY": "co-test"},
+    ),
+    (
+        "huggingface",
+        P.get_huggingface_config,
+        "KAIZEN_HUGGINGFACE_MODEL",
+        P.DEFAULT_HUGGINGFACE_MODEL,
+        {},
+    ),
+    (
+        "google",
+        P.get_google_config,
+        "KAIZEN_GOOGLE_MODEL",
+        P.DEFAULT_GOOGLE_MODEL,
+        {"GOOGLE_API_KEY": "g-test"},
+    ),
+    (
+        "perplexity",
+        P.get_perplexity_config,
+        "KAIZEN_PERPLEXITY_MODEL",
+        P.DEFAULT_PERPLEXITY_MODEL,
+        {"PERPLEXITY_API_KEY": "pplx-test"},
+    ),
+    (
+        "azure",
+        P.get_azure_config,
+        "KAIZEN_AZURE_MODEL",
+        P.DEFAULT_AZURE_MODEL,
+        {
+            "AZURE_API_KEY": "az-test",
+            "AZURE_ENDPOINT": "https://example.openai.azure.com",
+        },
+    ),
+    ("ollama", P.get_ollama_config, "KAIZEN_OLLAMA_MODEL", P.DEFAULT_OLLAMA_MODEL, {}),
+    ("docker", P.get_docker_config, "KAIZEN_DOCKER_MODEL", P.DEFAULT_DOCKER_MODEL, {}),
+]
+_CASE_PARAMS = [pytest.param(*c[1:], id=c[0]) for c in CASES]
+
+
+@pytest.mark.parametrize("getter,env_var,default_const,avail", _CASE_PARAMS)
+def test_default_resolves_to_named_constant(env, getter, env_var, default_const, avail):
+    """No arg + no override → the provider's documented named constant."""
+    for k, v in avail.items():
+        env.setenv(k, v)
+    assert getter().model == default_const
+
+
+@pytest.mark.parametrize("getter,env_var,default_const,avail", _CASE_PARAMS)
+def test_env_override_wins_over_default(env, getter, env_var, default_const, avail):
+    """KAIZEN_<PROVIDER>_MODEL takes precedence over the intrinsic default."""
+    for k, v in avail.items():
+        env.setenv(k, v)
+    env.setenv(env_var, "env-override-model")
+    assert getter().model == "env-override-model"
+
+
+@pytest.mark.parametrize("getter,env_var,default_const,avail", _CASE_PARAMS)
+def test_explicit_arg_wins_over_env_and_default(
+    env, getter, env_var, default_const, avail
+):
+    """An explicit model= arg beats both the env override and the default."""
+    for k, v in avail.items():
+        env.setenv(k, v)
+    env.setenv(env_var, "env-override-model")
+    assert getter(model="explicit-arg-model").model == "explicit-arg-model"
+
+
+@pytest.mark.parametrize("getter,env_var,default_const,avail", _CASE_PARAMS)
+def test_kaizen_default_model_does_not_leak_into_provider_getter(
+    env, getter, env_var, default_const, avail
+):
+    """Core anti-mismatch invariant: the provider-agnostic KAIZEN_DEFAULT_MODEL
+    MUST NOT be chained into a provider-specific getter — else a claude-* default
+    would be returned under provider="openai" (the FNEW-4 mismatch class).
+    """
+    for k, v in avail.items():
+        env.setenv(k, v)
+    env.setenv("KAIZEN_DEFAULT_MODEL", "leaked-agnostic-model")
+    # KAIZEN_<PROVIDER>_MODEL intentionally unset → provider default, NOT the leak.
+    assert getter().model == default_const
+
+
+def test_named_constant_value_pins(env):
+    """Pin the constant values so any future drift is a loud, reviewable diff.
+
+    These are the provider-intrinsic defaults; the test is the structural defense
+    against silent re-inlining or accidental edits.
+    """
+    assert P.DEFAULT_OPENAI_MODEL == "gpt-4o-mini"
+    assert P.DEFAULT_OLLAMA_MODEL == "llama3.2"
+    assert P.DEFAULT_AZURE_MODEL == "gpt-4o"
+    assert P.DEFAULT_DOCKER_MODEL == "ai/llama3.2"
+    assert P.DEFAULT_COHERE_MODEL == "embed-english-v3.0"
+    assert P.DEFAULT_HUGGINGFACE_MODEL == "sentence-transformers/all-MiniLM-L6-v2"
+    assert P.DEFAULT_GOOGLE_MODEL == "gemini-2.0-flash"
+    assert P.DEFAULT_PERPLEXITY_MODEL == "sonar"
+
+
+def test_anthropic_default_refreshed_off_stale_dated_model(env):
+    """The stale dated default (claude-3-haiku-20240307) was refreshed to the
+    project-canonical current fast Claude. Guard against regressing to the
+    dated model identifier.
+    """
+    assert P.DEFAULT_ANTHROPIC_MODEL == "claude-haiku-4-5"
+    assert "20240307" not in P.DEFAULT_ANTHROPIC_MODEL
+    env.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    assert P.get_anthropic_config().model == "claude-haiku-4-5"
+
+
+def test_embedding_providers_keep_embedding_defaults(env):
+    """Embedding providers MUST default to embedding models, never a chat model
+    (the reason KAIZEN_DEFAULT_MODEL — a chat default — is not chained here).
+    """
+    env.setenv("COHERE_API_KEY", "co-test")
+    assert "embed" in P.get_cohere_config().model
+    assert P.get_huggingface_config().model.startswith("sentence-transformers/")
+
+
+def test_vision_provider_default_is_named_constant():
+    """The OpenAI vision provider's DEFAULT_MODEL is a documented named constant
+    (FNEW-5 same-shard surface), pinned for drift detection.
+    """
+    from kaizen.providers.document.openai_vision_provider import OpenAIVisionProvider
+
+    assert OpenAIVisionProvider.DEFAULT_MODEL == "gpt-4o-mini"

--- a/packages/kailash-kaizen/tests/unit/config/test_providers_azure_docker.py
+++ b/packages/kailash-kaizen/tests/unit/config/test_providers_azure_docker.py
@@ -26,27 +26,44 @@ class TestCheckAzureAvailable:
     """Tests for check_azure_available function."""
 
     def test_returns_true_with_both_credentials(self, monkeypatch):
-        """Should return True when both env vars set."""
-        monkeypatch.setenv("AZURE_AI_INFERENCE_ENDPOINT", "https://test.azure.com")
-        monkeypatch.setenv("AZURE_AI_INFERENCE_API_KEY", "test-key")
+        """Should return True when both canonical env vars set."""
+        monkeypatch.setenv("AZURE_ENDPOINT", "https://test.azure.com")
+        monkeypatch.setenv("AZURE_API_KEY", "test-key")
         assert check_azure_available() is True
 
     def test_returns_false_missing_endpoint(self, monkeypatch):
-        """Should return False when endpoint missing."""
-        monkeypatch.delenv("AZURE_AI_INFERENCE_ENDPOINT", raising=False)
-        monkeypatch.setenv("AZURE_AI_INFERENCE_API_KEY", "test-key")
+        """Should return False when endpoint missing (all endpoint variants)."""
+        for var in (
+            "AZURE_ENDPOINT",
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_AI_INFERENCE_ENDPOINT",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("AZURE_API_KEY", "test-key")
         assert check_azure_available() is False
 
     def test_returns_false_missing_api_key(self, monkeypatch):
-        """Should return False when API key missing."""
-        monkeypatch.setenv("AZURE_AI_INFERENCE_ENDPOINT", "https://test.azure.com")
-        monkeypatch.delenv("AZURE_AI_INFERENCE_API_KEY", raising=False)
+        """Should return False when API key missing (all key variants)."""
+        monkeypatch.setenv("AZURE_ENDPOINT", "https://test.azure.com")
+        for var in (
+            "AZURE_API_KEY",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_AI_INFERENCE_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
         assert check_azure_available() is False
 
     def test_returns_false_both_missing(self, monkeypatch):
-        """Should return False when both missing."""
-        monkeypatch.delenv("AZURE_AI_INFERENCE_ENDPOINT", raising=False)
-        monkeypatch.delenv("AZURE_AI_INFERENCE_API_KEY", raising=False)
+        """Should return False when both missing (all variants cleared)."""
+        for var in (
+            "AZURE_ENDPOINT",
+            "AZURE_API_KEY",
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_AI_INFERENCE_ENDPOINT",
+            "AZURE_AI_INFERENCE_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
         assert check_azure_available() is False
 
 
@@ -109,9 +126,9 @@ class TestGetAzureConfig:
     """Tests for get_azure_config function."""
 
     def test_success_with_credentials(self, monkeypatch):
-        """Should return valid config when credentials set."""
-        monkeypatch.setenv("AZURE_AI_INFERENCE_ENDPOINT", "https://test.azure.com")
-        monkeypatch.setenv("AZURE_AI_INFERENCE_API_KEY", "test-key")
+        """Should return valid config when canonical credentials set."""
+        monkeypatch.setenv("AZURE_ENDPOINT", "https://test.azure.com")
+        monkeypatch.setenv("AZURE_API_KEY", "test-key")
 
         config = get_azure_config()
         assert config.provider == "azure"
@@ -121,25 +138,50 @@ class TestGetAzureConfig:
 
     def test_custom_model(self, monkeypatch):
         """Should use custom model when specified."""
-        monkeypatch.setenv("AZURE_AI_INFERENCE_ENDPOINT", "https://test.azure.com")
-        monkeypatch.setenv("AZURE_AI_INFERENCE_API_KEY", "test-key")
+        monkeypatch.setenv("AZURE_ENDPOINT", "https://test.azure.com")
+        monkeypatch.setenv("AZURE_API_KEY", "test-key")
 
         config = get_azure_config(model="gpt-4-turbo")
         assert config.model == "gpt-4-turbo"
 
     def test_model_from_env(self, monkeypatch):
         """Should use model from environment variable."""
-        monkeypatch.setenv("AZURE_AI_INFERENCE_ENDPOINT", "https://test.azure.com")
-        monkeypatch.setenv("AZURE_AI_INFERENCE_API_KEY", "test-key")
+        monkeypatch.setenv("AZURE_ENDPOINT", "https://test.azure.com")
+        monkeypatch.setenv("AZURE_API_KEY", "test-key")
         monkeypatch.setenv("KAIZEN_AZURE_MODEL", "llama-3.1-70b")
 
         config = get_azure_config()
         assert config.model == "llama-3.1-70b"
 
+    def test_legacy_env_vars_emit_deprecation_warning(self, monkeypatch):
+        """Legacy AZURE_AI_INFERENCE_* vars still resolve, but MUST warn.
+
+        Asserts the deprecation contract explicitly (and consumes the warning so
+        it does not pollute the suite warning summary). Canonical vars are cleared
+        so resolution falls through to the legacy names.
+        """
+        monkeypatch.delenv("AZURE_ENDPOINT", raising=False)
+        monkeypatch.delenv("AZURE_API_KEY", raising=False)
+        monkeypatch.setenv("AZURE_AI_INFERENCE_ENDPOINT", "https://test.azure.com")
+        monkeypatch.setenv("AZURE_AI_INFERENCE_API_KEY", "test-key")
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            config = get_azure_config()
+        assert config.provider == "azure"
+        assert config.base_url == "https://test.azure.com"
+        assert config.api_key == "test-key"
+
     def test_raises_without_credentials(self, monkeypatch):
         """Should raise ConfigurationError when credentials missing."""
-        monkeypatch.delenv("AZURE_AI_INFERENCE_ENDPOINT", raising=False)
-        monkeypatch.delenv("AZURE_AI_INFERENCE_API_KEY", raising=False)
+        for var in (
+            "AZURE_ENDPOINT",
+            "AZURE_API_KEY",
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_AI_INFERENCE_ENDPOINT",
+            "AZURE_AI_INFERENCE_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
 
         with pytest.raises(ConfigurationError, match="Azure not configured"):
             get_azure_config()
@@ -227,8 +269,8 @@ class TestGetProviderConfig:
 
     def test_azure_provider(self, monkeypatch):
         """Should return Azure config when specified."""
-        monkeypatch.setenv("AZURE_AI_INFERENCE_ENDPOINT", "https://test.azure.com")
-        monkeypatch.setenv("AZURE_AI_INFERENCE_API_KEY", "test-key")
+        monkeypatch.setenv("AZURE_ENDPOINT", "https://test.azure.com")
+        monkeypatch.setenv("AZURE_API_KEY", "test-key")
 
         config = get_provider_config(provider="azure")
         assert config.provider == "azure"
@@ -274,8 +316,8 @@ class TestAutoDetectProvider:
     def test_detection_order_azure_second(self, monkeypatch):
         """Should detect Azure second when OpenAI not available."""
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.setenv("AZURE_AI_INFERENCE_ENDPOINT", "https://test.azure.com")
-        monkeypatch.setenv("AZURE_AI_INFERENCE_API_KEY", "test-key")
+        monkeypatch.setenv("AZURE_ENDPOINT", "https://test.azure.com")
+        monkeypatch.setenv("AZURE_API_KEY", "test-key")
 
         config = auto_detect_provider()
         assert config.provider == "azure"


### PR DESCRIPTION
## Summary

Closes the last open **code** item from the FNEW wave (FNEW-5). The nine
`get_*_config()` functions in `kaizen.config.providers` previously held inline
hardcoded `default_model` literals; each is now a documented module-level
`DEFAULT_<PROVIDER>_MODEL` constant — provider-intrinsic, overridable via
`KAIZEN_<PROVIDER>_MODEL`, and deliberately **not** chained to the
provider-agnostic `KAIZEN_DEFAULT_MODEL` (chaining would reintroduce the 2.25.0
provider/model mismatch). Zero-config `auto_detect_provider()` is unchanged.

**User-visible:** the one stale default — anthropic `claude-3-haiku-20240307` —
is refreshed to `claude-haiku-4-5` (project-canonical current fast Claude).
`KAIZEN_ANTHROPIC_MODEL` / `model=` still override. Non-breaking.

Also closes a pre-existing zero-tolerance Rule 1 item surfaced during /redteam:
the Azure config tests set legacy `AZURE_AI_INFERENCE_*` vars and emitted
`DeprecationWarning` without consuming it — switched the general tests to
canonical `AZURE_ENDPOINT`/`AZURE_API_KEY` and added a dedicated `pytest.warns`
deprecation-path test (+coverage).

## Redteam convergence (durable receipts)

- R1 — reviewer / security-reviewer / kaizen-specialist (closure-parity) all
  **CLEAN**: 0 CRITICAL / 0 HIGH / 0 MEDIUM / 0 LOW.
- R2 — full config + provider + regression surface: **193 passed under `-W error`**
  (zero warnings, zero failures); ruff clean; new FNEW-5 suite 40 passed.
- Receipt: `workspaces/kaizen-rag-node-coverage/04-validate/23-fnew5-convergence-2026-06-11.md`.

## Verification

```bash
.venv/bin/python -m pytest \
  packages/kailash-kaizen/tests/unit/config/ \
  packages/kailash-kaizen/tests/regression/test_issue_fnew4_env_model_defaults.py \
  packages/kailash-kaizen/tests/regression/test_issue_fnew5_provider_intrinsic_defaults.py \
  packages/kailash-kaizen/tests/regression/test_issue_255_provider_config_dual_purpose.py \
  -q -p no:randomly -W error          # → 193 passed
grep -nE 'default_model\s*=\s*"' packages/kailash-kaizen/src/kaizen/config/providers.py  # empty
```

## Release

CHANGELOG entered under `[Unreleased]`. This rides the next kaizen release; the
version bump (2.25.1 → next) happens at release-prep. The anthropic default
refresh is the one CHANGELOG-worthy user-visible line.

## Related

Last code item of the FNEW wave (kaizen-rag-node-coverage workspace). FNEW-6
(never-gated integration tiers) remains blocked on a live-infra env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)