### PR TITLE
chore(coc): land ci-runners disclosure scrub + Gate-1 proposal review

### DIFF
--- a/.claude/.proposals/latest.yaml
+++ b/.claude/.proposals/latest.yaml
@@ -1,6 +1,13 @@
 source_repo: kailash-py
 codify_date: '2026-05-18'
-status: pending_review
+status: reviewed
+reviewed_date: 2026-06-11
+# Gate-1 review (2026-06-11, loom): user-approved classification.
+# 19 entries: 13 GLOBAL, 2 VARIANT-py (ml-doc-real-api adopted; featurestore-cutover SUPERSEDED), 4 deferred/withdrawn. verify-claims authored as NEW path-scoped rule (git.md-extension duplicate superseded); doc-api rule folded into spec-accuracy.md (tool deferred to cross-SDK issue).
+# Disclosure: surface scrubbed to 0 findings (receipts in loom session);
+# placement lands via loom feat/gate1-ingest-2026-06-11; status flips to
+# `distributed` when the next /sync cycle carries the placed artifacts.
+
 codify_session: 'Session 2026-05-18 — /codify of issue #1086 ("4 root-cause fixes from
 
   Wave C SessionEnd hook noise audit"). Originating evidence:

--- a/.claude/rules/ci-runners.md
+++ b/.claude/rules/ci-runners.md
@@ -126,7 +126,7 @@ on:
 
 ### 6. Zombie-Job Cancellation Protocol
 
-When a job on a self-hosted runner (e.g. `jacks-mac-studio`, `esperies-mini`, `esperie-linux-arm`) remains `in_progress` for >2× its normal completion time, it is a zombie — the runner process is stuck (network drop, hung test, pip/poetry lock) or the worker crashed without reporting to the dispatcher. From the dispatcher's perspective the runner slot stays `busy: true`, blocking every subsequent job queued for that runner's label.
+When a job on a self-hosted runner (e.g. `<runner-host-1>`, `<runner-host-2>`, `<runner-label-arm>`) remains `in_progress` for >2× its normal completion time, it is a zombie — the runner process is stuck (network drop, hung test, pip/poetry lock) or the worker crashed without reporting to the dispatcher. From the dispatcher's perspective the runner slot stays `busy: true`, blocking every subsequent job queued for that runner's label.
 
 ```bash
 # DO — diagnose then cancel, kickstart if the worker itself is wedged
@@ -240,7 +240,7 @@ jobs:
       startsWith(github.ref, 'refs/tags/v') ||
       (github.event_name == 'workflow_dispatch' &&
        github.event.inputs.target == 'publish-wheels')
-    runs-on: esperie-linux-arm
+    runs-on: <runner-label-arm>
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -265,7 +265,7 @@ on:
     tags: ["v*"]
 jobs:
   publish-wheels:
-    runs-on: esperie-linux-arm
+    runs-on: <runner-label-arm>
     steps:
       - uses: actions/checkout@v4
       - run: python -m build --wheel


### PR DESCRIPTION
## Summary
Lands a `/sync-to-build` COC delivery sitting uncommitted in the working tree, per the SessionStart COC-drift directive (artifacts must reach `main` or they vanish on the next feature-branch switch).

- **`ci-runners.md` §6/§8** — disclosure scrub: concrete operator runner hostnames (`jacks-mac-studio` / `esperies-mini` / `esperie-linux-arm`) replaced with generic placeholders (`<runner-host-1/2>`, `<runner-label-arm>`). Real values stay in the gitignored `ci-runners.operator.local.md` (issue #260/#252 disclosure class).
- **`latest.yaml`** — Gate-1 proposal review status flip `pending_review` → `reviewed` (2026-06-11 loom classification: 19 entries, 13 GLOBAL / 2 VARIANT-py).

## Related issues
Disclosure hygiene per #260 / #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)