### PR TITLE
release(kaizen): 2.26.0 — FNEW-5 provider config intrinsic defaults

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
-## [Unreleased]
+## [2.26.0] — 2026-06-11 — env-model discipline: provider config getters use documented default-model constants
 
-### Changed — env-model discipline: provider config getters use documented default-model constants
+### Changed
 
 - **The nine `get_*_config()` functions in `kaizen.config.providers` no longer
   hold inline hardcoded `default_model` literals** (`rules/env-models.md`,

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.25.1"
+version = "2.26.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.25.1"
+__version__ = "2.26.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Summary
Release-prep for **kailash-kaizen 2.26.0**. Versions the FNEW-5 change (merged to main under CHANGELOG `[Unreleased]` via #1292) for PyPI publication.

- `pyproject.toml` + `__init__.py::__version__` → 2.26.0
- CHANGELOG `[Unreleased]` → `[2.26.0] — 2026-06-11`

**Why minor:** FNEW-5 refreshes the bare `get_anthropic_config()` default model (`claude-3-haiku-20240307` → `claude-haiku-4-5`) — a user-visible, non-breaking behavior change, not a pure internal fix.

Metadata-only diff on a `release/v*` branch → PR-gate matrix auto-skips. `kaizen-agents` floors `kailash-kaizen>=2.25.1`, satisfied by 2.26.0 (no coupled release).

## Related issues
FNEW-5 (provider config intrinsic defaults), originating PR #1292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)