### PR TITLE
fix(kaizen-rag): strip simulated-capability over-claims from 5 RAG nodes (F31 Wave 4)

### DIFF
--- a/packages/kailash-kaizen/CHANGELOG.md
+++ b/packages/kailash-kaizen/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to the Kaizen AI Agent Framework will be documented in this file.
 
+## [2.27.0] — 2026-06-11 — RAG node honesty: strip simulated-capability over-claims
+
+### Deprecated
+
+- **`VisualQuestionAnsweringNode`** (`kaizen.nodes.rag.multimodal`) — its answer is
+  a keyword-derived placeholder and its confidence is a fixed value; it does NOT run a
+  vision-language model and cannot read image pixels. No VQA backend is implemented.
+  Constructing it now emits a `DeprecationWarning`. **Scheduled for removal in the next
+  minor release.** Migration: remove the node from workflows — there is no real VQA
+  backend to migrate to.
+- **`ImageTextMatchingNode`** (`kaizen.nodes.rag.multimodal`) — its match scores are
+  keyword-derived placeholders, not CLIP/ALIGN image-text similarity; no image-text
+  model is loaded. Constructing it now emits a `DeprecationWarning`. **Scheduled for
+  removal in the next minor release.** Migration: remove the node from workflows — no
+  real image-text matching backend is provided.
+
+### Changed
+
+- **`MultimodalRAGNode`** docstrings corrected to stop advertising real CLIP/BLIP-2
+  vision models. The node wires real LLM query-analysis + response-generation stages
+  over a lexical/hash-based placeholder encoder (a deterministic hash heuristic, NOT a
+  learned vision model). The hardcoded `gpt-4-vision` model string at the
+  response-generation stage is replaced with an env-resolved `OPENAI_VISION_MODEL`
+  (falling back to the default LLM model) for `rules/env-models.md` compliance. Removed
+  the unverifiable "40-60% quality improvement" / "1-3 seconds" performance claims.
+  Runtime behavior unchanged.
+- **`FederatedRAGNode`** docstrings corrected to stop advertising real distributed
+  cross-host federation. The node demonstrates the federated-RAG aggregation pattern
+  over in-process simulated nodes — it does NOT perform real distributed network
+  queries. Removed the "2-10 seconds depending on federation size" performance claim.
+  Runtime behavior unchanged.
+- **`ColBERTRetrievalNode`** docstrings corrected to stop advertising a real
+  BERT/ColBERT model. The node is a lexical late-interaction approximation
+  (token-overlap MaxSim heuristic), NOT a learned-embedding model; `token_model` is an
+  informational label only and loads no model. Removed the "0.92+ accuracy" / "~500ms"
+  claims. Also removed the dead, never-called `_create_workflow` method whose
+  `token_embedder` generated random `np.random.randn(768)` embeddings (unreachable
+  fabrication — the node's `run()` is the only entry point). Runtime behavior of `run()`
+  unchanged.
+
 ## [2.26.0] — 2026-06-11 — env-model discipline: provider config getters use documented default-model constants
 
 ### Changed

--- a/packages/kailash-kaizen/pyproject.toml
+++ b/packages/kailash-kaizen/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-kaizen"
-version = "2.26.0"
+version = "2.27.0"
 description = "Advanced AI agent framework built on Kailash SDK"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-kaizen/src/kaizen/__init__.py
+++ b/packages/kailash-kaizen/src/kaizen/__init__.py
@@ -6,7 +6,7 @@ auto-optimization, and enhanced AI agent capabilities built on top of the
 proven Kailash SDK infrastructure.
 """
 
-__version__ = "2.26.0"
+__version__ = "2.27.0"
 __author__ = "Terrene Foundation"
 __license__ = "Apache-2.0"
 

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/federated.py
@@ -36,24 +36,23 @@ logger = logging.getLogger(__name__)
 @register_node()
 class FederatedRAGNode(WorkflowNode):
     """
-    Federated RAG for Distributed Data Sources
+    Federated RAG Aggregation Pattern (in-process simulation)
 
-    Implements RAG that operates across multiple distributed data sources
-    without requiring data centralization, preserving data locality and privacy.
+    Demonstrates the federated-RAG aggregation pattern over in-process
+    simulated nodes. It does NOT perform real distributed network queries —
+    the per-node responses are generated in-process (no actual cross-host
+    federation, no network calls). Use this node to demonstrate the
+    aggregation + health-reporting shape of a federated-RAG pipeline.
 
     When to use:
-    - Best for: Multi-organization data, edge computing, privacy-critical scenarios
-    - Not ideal for: Small datasets, single-source data
-    - Performance: 2-10 seconds depending on federation size
-    - Privacy: Data never leaves source organizations
+    - Best for: prototyping the federated-RAG aggregation/health-reporting shape
+    - Not ideal for: production federation requiring real cross-host queries
 
     Key features:
-    - Distributed query execution across federated nodes
-    - Local computation with global aggregation
-    - Heterogeneous data source support
-    - Communication-efficient protocols
-    - Fault tolerance for node failures
-    - Secure aggregation of results
+    - Aggregation of per-node responses (weighted/strategy-based)
+    - Federation-health reporting over the simulated node set
+    - Heterogeneous-source aggregation shape
+    - Minimum-participating-nodes gating
 
     Example:
         federated_rag = FederatedRAGNode(

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/multimodal.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/multimodal.py
@@ -1,14 +1,17 @@
 """
 Multimodal RAG Implementation
 
-Implements RAG with support for multiple modalities:
-- Text + Image retrieval and generation
-- Cross-modal similarity search
-- Visual question answering
-- Image-augmented responses
-- Document understanding with visuals
+Wires a real LLM query-analysis + response-generation pipeline over a
+lexical/hash-based placeholder encoder. The encoder is a deterministic
+hash/character-code heuristic, NOT a learned vision model (no CLIP, no BLIP-2,
+no image-pixel understanding). The LLM stages (query analysis, response
+generation) are genuine; the cross-modal "encoding" is a stand-in that lets the
+pipeline run end-to-end without a vision backend.
 
-Based on CLIP, BLIP-2, and multimodal research from 2024.
+Pipeline stages:
+- Real LLM query analysis (modality detection)
+- Lexical/hash-based placeholder encoding for text + image references
+- Real LLM response generation over the assembled context
 """
 
 import logging
@@ -38,51 +41,62 @@ _DEFAULT_LLM_MODEL = os.environ.get(
     "OPENAI_PROD_MODEL", os.environ.get("DEFAULT_LLM_MODEL")
 )
 
+# Vision-capable model for the response-generation stage. Env-resolved so no
+# provider-locked model string is hardcoded (env-models compliance); falls back
+# to the general default LLM model when OPENAI_VISION_MODEL is unset.
+_DEFAULT_VISION_MODEL = os.environ.get("OPENAI_VISION_MODEL", _DEFAULT_LLM_MODEL)
+
 
 @register_node()
 class MultimodalRAGNode(WorkflowNode):
     """
-    Multimodal RAG with Text + Image Support
+    Multimodal RAG with Text + Image References
 
-    Implements RAG that can process and retrieve from both text and images,
-    enabling richer responses with visual context.
+    Wires a real LLM query-analysis + response-generation pipeline over a
+    lexical/hash-based placeholder encoder. The encoder is a deterministic
+    hash/character-code heuristic — it does NOT run a learned vision model
+    (no CLIP, no BLIP-2) and cannot understand image pixels. Use this node to
+    demonstrate the multimodal-RAG composition pattern; the genuine
+    capabilities are the LLM query-analysis and response-generation stages.
 
     When to use:
-    - Best for: Technical documentation with diagrams, e-commerce, medical imaging
-    - Not ideal for: Audio/video heavy content, pure text scenarios
-    - Performance: 1-3 seconds for retrieval, 2-5 seconds for generation
-    - Quality improvement: 40-60% for visual questions
+    - Best for: prototyping a multimodal-RAG pipeline shape where the LLM
+      stages carry the value and the encoder is a stand-in
+    - Not ideal for: production visual retrieval requiring a real vision model
 
     Key features:
-    - Cross-modal retrieval (text→image, image→text)
-    - Visual question answering
-    - Diagram and chart understanding
-    - Multi-modal fusion for responses
-    - Support for various image formats
+    - Real LLM query analysis (modality detection)
+    - Lexical/hash-based placeholder encoding for text + image references
+    - Real LLM response generation over the assembled context
+    - Support for various image-reference formats (as metadata, not pixels)
 
     Example:
         multimodal_rag = MultimodalRAGNode(
-            image_encoder="clip-base",
+            image_encoder="placeholder",  # informational label only; no model is loaded
             enable_ocr=True
         )
 
         # Query: "Show me the architecture diagram for transformers"
-        # Will retrieve:
-        # 1. Text descriptions of transformer architecture
-        # 2. Architecture diagrams and visualizations
-        # 3. Code implementations with visual outputs
-        # 4. Combine into comprehensive answer with images
+        # The pipeline:
+        # 1. Real LLM analyses the query for required modalities
+        # 2. Placeholder encoder scores text docs + image-reference metadata
+        #    (captions/alt-text/paths) lexically — it does NOT read pixels
+        # 3. Real LLM generates the answer over the assembled text context
+        # Image "results" are the matched image-reference records, not visual
+        # understanding of the images themselves.
 
         result = await multimodal_rag.execute(
-            documents=mixed_media_docs,  # Contains text and image paths
+            documents=mixed_media_docs,  # text docs + image-reference records
             query="Show me the architecture diagram for transformers"
         )
 
     Parameters:
-        image_encoder: Model for image encoding (clip, blip, etc.)
-        text_encoder: Model for text encoding
-        enable_ocr: Extract text from images
-        fusion_strategy: How to combine modalities
+        image_encoder: Informational label for the placeholder image encoder
+            (no vision model is loaded)
+        text_encoder: Informational label for the placeholder text encoder
+        enable_ocr: Attach a placeholder OCR field to image references
+            (no real OCR engine runs)
+        fusion_strategy: How to combine text and image-reference scores
 
     Returns:
         text_results: Retrieved text documents
@@ -176,7 +190,7 @@ def preprocess_documents(documents):
 
             # If OCR is enabled, we'd extract text here
             if {self.enable_ocr} and image_path:
-                # Simulated OCR result
+                # Placeholder OCR result (no real OCR engine is invoked)
                 image_doc["ocr_text"] = f"[OCR text from {{image_path}}]"
 
             image_docs.append(image_doc)
@@ -217,7 +231,9 @@ from typing import List, Dict
 def encode_multimodal(text_docs, image_docs, query, modality_analysis):
     '''Encode documents and query for multimodal retrieval'''
 
-    # Simulated encoding (would use CLIP/BLIP in production)
+    # Deterministic hash/character-code placeholder encoder — NOT a learned
+    # vision/CLIP model. Produces stable numeric vectors from raw bytes so the
+    # pipeline runs end-to-end without a vision backend.
     def text_encoder(text):
         # Documents are arbitrary user input; a present-but-None content/title
         # would crash `text[:10]`. Coerce non-strings to "" at the boundary.
@@ -228,7 +244,7 @@ def encode_multimodal(text_docs, image_docs, query, modality_analysis):
     def image_encoder(image_path):
         # A present-but-None image path would crash `.lower()`. Coerce here.
         image_path = image_path if isinstance(image_path, str) else ""
-        # Simulated image encoding
+        # Deterministic keyword-based placeholder encoding (no vision model)
         if "architecture" in image_path.lower():
             return [0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
         elif "diagram" in image_path.lower():
@@ -387,7 +403,7 @@ Relevant Images:
 - Image 2: [description and relevance]
 
 [Integration of visual and textual insights]""",
-                "model": "gpt-4-vision",  # Vision-capable model
+                "model": _DEFAULT_VISION_MODEL,  # env-resolved vision model
             },
         )
 
@@ -459,13 +475,14 @@ class VisualQuestionAnsweringNode(Node):
     """
     Visual Question Answering (VQA) Node
 
-    Specialized node for answering questions about images.
+    **DEPRECATED (removal: next minor).** This node returns a keyword-derived
+    placeholder answer and a fixed confidence; it does NOT run a
+    vision-language model and cannot read image pixels. No VQA backend is
+    implemented. Remove this node from workflows; there is no real VQA
+    capability to migrate to.
 
     When to use:
-    - Best for: Direct questions about image content
-    - Not ideal for: Abstract reasoning about images
-    - Performance: 1-2 seconds per image
-    - Accuracy: High for descriptive questions
+    - Do not use in production; the answer is a keyword-based placeholder.
 
     Example:
         vqa = VisualQuestionAnsweringNode()
@@ -476,15 +493,14 @@ class VisualQuestionAnsweringNode(Node):
         )
 
     Parameters:
-        model: VQA model to use (blip2, flamingo, etc.)
-        enable_captioning: Generate image captions
-        confidence_threshold: Minimum confidence for answers
+        model: informational label only (no model is loaded)
+        enable_captioning: placeholder flag
 
     Returns:
-        answer: Answer to the visual question
-        confidence: Model confidence
-        image_caption: Generated caption if enabled
-        detected_objects: Objects found in image
+        answer: keyword-derived placeholder answer (not from a vision model)
+        confidence: fixed placeholder value (not a real model confidence)
+        image_caption: placeholder caption if enabled
+        detected_objects: placeholder list
     """
 
     def __init__(
@@ -493,6 +509,16 @@ class VisualQuestionAnsweringNode(Node):
         model: str = "blip2-base",
         enable_captioning: bool = True,
     ):
+        import warnings
+
+        warnings.warn(
+            "VisualQuestionAnsweringNode is deprecated and will be removed in "
+            "the next minor release. Its output is a keyword-based placeholder, "
+            "not a real vision-language model; no VQA backend is implemented. "
+            "See CHANGELOG.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(
             name=name,
             model=model,
@@ -552,7 +578,8 @@ class VisualQuestionAnsweringNode(Node):
         image_path = kwargs.get("image_path") or ""
         question = kwargs.get("question") or ""
 
-        # Simulated VQA (would use real model in production)
+        # Keyword-based placeholder answer — NOT a vision-language model; it
+        # scores the question text only and cannot read image pixels.
         # Analyze question type
         question_lower = question.lower()
 
@@ -616,13 +643,13 @@ class ImageTextMatchingNode(Node):
     """
     Image-Text Matching Node
 
-    Finds the best matching images for text queries or vice versa.
+    **DEPRECATED (removal: next minor).** This node's match scores are
+    keyword-derived placeholders, NOT CLIP/ALIGN image-text similarity. It does
+    not load or run any image-text model. Remove this node from workflows;
+    there is no real image-text matching capability to migrate to.
 
     When to use:
-    - Best for: Finding relevant visuals for content
-    - Not ideal for: Exact image search
-    - Performance: 200-500ms per comparison
-    - Use cases: Documentation, e-commerce, content creation
+    - Do not use in production; scores are keyword-derived placeholders.
 
     Example:
         matcher = ImageTextMatchingNode()
@@ -633,13 +660,13 @@ class ImageTextMatchingNode(Node):
         )
 
     Parameters:
-        matching_model: Model for similarity (clip, align, etc.)
-        bidirectional: Support both text→image and image→text
+        matching_model: informational label only (no model is loaded)
+        bidirectional: Support both text→image and image→text directions
         top_k: Number of matches to return
 
     Returns:
-        matches: Ranked list of matches
-        similarity_scores: Score for each match
+        matches: Ranked list of matches (keyword-derived)
+        similarity_scores: keyword-derived placeholder scores (not model similarity)
         match_type: Type of matching performed
     """
 
@@ -649,6 +676,15 @@ class ImageTextMatchingNode(Node):
         matching_model: str = "clip",
         bidirectional: bool = True,
     ):
+        import warnings
+
+        warnings.warn(
+            "ImageTextMatchingNode is deprecated and will be removed in the "
+            "next minor release. Its match scores are keyword-derived "
+            "placeholders, not CLIP/ALIGN similarity. See CHANGELOG.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(
             name=name,
             matching_model=matching_model,

--- a/packages/kailash-kaizen/src/kaizen/nodes/rag/similarity.py
+++ b/packages/kailash-kaizen/src/kaizen/nodes/rag/similarity.py
@@ -537,43 +537,42 @@ result = {{
 @register_node()
 class ColBERTRetrievalNode(Node):
     """
-    ColBERT-style Late Interaction Retrieval
+    Lexical Late-Interaction Approximation (token-overlap MaxSim heuristic)
 
-    Implements token-level similarity matching for fine-grained retrieval.
-    Uses MaxSim operation for each query token across document tokens.
+    Approximates ColBERT-style late interaction using a lexical token-overlap
+    MaxSim heuristic — exact-match tokens score 1.0, substring overlaps score
+    0.5. It is NOT a real BERT/ColBERT model: there are no learned token
+    embeddings, no neural late interaction. The class name is retained for API
+    compatibility; the behavior is a deterministic lexical approximation.
 
     When to use:
-    - Best for: Complex queries with multiple concepts, fine-grained matching
-    - Not ideal for: Simple lookups, when speed is critical
-    - Performance: ~500ms per query (computationally intensive)
-    - Accuracy: Highest precision for multi-faceted queries (0.92+)
+    - Best for: lightweight token-overlap matching with no model dependency
+    - Not ideal for: workloads needing true learned-embedding retrieval
 
     Key features:
-    - Token-level interaction for precise matching
+    - Token-overlap MaxSim heuristic (exact-match 1.0, substring 0.5)
     - Handles queries with multiple independent concepts
-    - Better than dense retrieval for specific details
-    - Preserves word importance in context
+    - No model load, no embeddings — pure lexical scoring
 
     Example:
         colbert = ColBERTRetrievalNode(
             token_model="bert-base-uncased"
         )
 
-        # Excellent for queries with multiple specific requirements
         results = await colbert.execute(
             query="transformer architecture with attention mechanism for NLP tasks",
             documents=research_papers
         )
 
     Parameters:
-        token_model: BERT model for token embeddings
+        token_model: informational label only — does NOT load a model
         max_query_length: Maximum query tokens (default: 32)
         max_doc_length: Maximum document tokens (default: 256)
 
     Returns:
-        results: Documents ranked by token-level similarity
-        scores: MaxSim aggregated scores
-        token_interactions: Token-level similarity matrix
+        results: Documents ranked by lexical token-overlap score
+        scores: aggregated token-overlap MaxSim scores
+        retrieval_method: "colbert"
     """
 
     def __init__(
@@ -686,131 +685,6 @@ class ColBERTRetrievalNode(Node):
                 "retrieval_method": "colbert",
                 "error": str(e),
             }
-
-    def _create_workflow(self) -> Workflow:
-        """Create ColBERT-style retrieval workflow"""
-        builder = WorkflowBuilder()
-
-        # Add token embedder
-        token_embedder_id = builder.add_node(
-            "PythonCodeNode",
-            node_id="token_embedder",
-            config={
-                "code": f"""
-# Simplified token embedding for demonstration
-# In production, would use actual BERT tokenizer and model
-
-def get_token_embeddings(text, model="{self.token_model}"):
-    '''Generate token-level embeddings'''
-    # For demonstration, using word embeddings
-    tokens = text.lower().split()
-
-    # Simplified: generate random embeddings for each token
-    # In production: use actual BERT model
-    import numpy as np
-    np.random.seed(hash(text) % 2**32)
-
-    embeddings = []
-    for token in tokens:
-        # Generate consistent embedding for each token
-        np.random.seed(hash(token) % 2**32)
-        embedding = np.random.randn(768)  # BERT dimension
-        embedding = embedding / np.linalg.norm(embedding)
-        embeddings.append(embedding)
-
-    return {{
-        "tokens": tokens,
-        "embeddings": embeddings
-    }}
-
-# Process query and documents
-query = input_data.get("query", "")
-documents = input_data.get("documents", [])
-
-query_tokens = get_token_embeddings(query)
-doc_token_embeddings = []
-
-for doc in documents:
-    doc_tokens = get_token_embeddings(doc.get("content") or "")
-    doc_token_embeddings.append(doc_tokens)
-
-result = {{
-    "token_data": {{
-        "query_tokens": query_tokens,
-        "doc_token_embeddings": doc_token_embeddings,
-        "documents": documents
-    }}
-}}
-"""
-            },
-        )
-
-        # Add late interaction scorer
-        late_interaction_id = builder.add_node(
-            "PythonCodeNode",
-            node_id="late_interaction_scorer",
-            config={
-                "code": """
-import numpy as np
-
-def maxsim_score(query_embeddings, doc_embeddings):
-    '''Calculate MaxSim score for late interaction'''
-    total_score = 0
-
-    # For each query token
-    for q_emb in query_embeddings:
-        # Find max similarity with any document token
-        max_sim = -1
-        for d_emb in doc_embeddings:
-            sim = np.dot(q_emb, d_emb)  # Cosine similarity (normalized embeddings)
-            max_sim = max(max_sim, sim)
-        total_score += max_sim
-
-    return total_score / len(query_embeddings) if query_embeddings else 0
-
-# Calculate scores for all documents
-token_data = token_data
-query_tokens = token_data["query_tokens"]
-doc_token_embeddings = token_data["doc_token_embeddings"]
-documents = token_data["documents"]
-
-scores = []
-for doc_tokens in doc_token_embeddings:
-    score = maxsim_score(
-        query_tokens["embeddings"],
-        doc_tokens["embeddings"]
-    )
-    scores.append(score)
-
-# Sort and return results
-indexed_scores = list(enumerate(scores))
-indexed_scores.sort(key=lambda x: x[1], reverse=True)
-
-results = []
-result_scores = []
-for idx, score in indexed_scores[:10]:  # Top 10
-    results.append(documents[idx])
-    result_scores.append(score)
-
-result = {
-    "colbert_results": {
-        "results": results,
-        "scores": result_scores,
-        "method": "late_interaction",
-        "query_token_count": len(query_tokens["tokens"]),
-        "avg_doc_token_count": sum(len(dt["tokens"]) for dt in doc_token_embeddings) / len(doc_token_embeddings)
-    }
-}
-"""
-            },
-        )
-
-        # Connect workflow
-        builder.add_connection(
-            token_embedder_id, "token_data", late_interaction_id, "token_data"
-        )
-
-        return builder.build(name="colbert_retrieval_workflow")
 
 
 @register_node()

--- a/packages/kailash-kaizen/tests/regression/test_issue_f8b1_none_content.py
+++ b/packages/kailash-kaizen/tests/regression/test_issue_f8b1_none_content.py
@@ -147,18 +147,24 @@ def test_sparse_codegen_template_handles_none_content():
     assert len(sparse_results["results"]) == 1
 
 
-def test_colbert_codegen_template_handles_none_content():
-    """ColBERTRetrievalNode._create_workflow()'s token_embedder PythonCodeNode
-    template (get_token_embeddings) must not crash on None-content docs."""
-    wf = ColBERTRetrievalNode()._create_workflow()  # type: ignore[attr-defined]
-    code = wf.nodes["token_embedder"].config["code"]
-    corpus = [_NONE_DOC, {"content": "machine learning", "id": "g"}]
-    result = _run_codegen_template(
-        code, input_data={"query": "machine learning", "documents": corpus}
-    )
-    token_data = result["token_data"]
-    # Both docs are tokenised; the None-content doc yields an empty token list.
-    assert len(token_data["doc_token_embeddings"]) == 2
+def test_colbert_run_handles_none_content():
+    """ColBERTRetrievalNode.run()'s lexical late-interaction retrieval must not
+    crash on a None-content doc (content key present, value None).
+
+    Ported from the former codegen-template test: F31 Wave 4 removed the dead,
+    never-called ``_create_workflow`` (it generated random embeddings) and the
+    real retrieval path is ``run()`` (token-overlap MaxSim), so the None-content
+    guard is verified behaviourally against the surviving entry point."""
+    node = ColBERTRetrievalNode()
+    corpus = [_NONE_DOC, {"content": "machine learning models", "id": "g"}]
+    result = node.run(query="machine learning", documents=corpus)
+    # No crash, no error path; the None-content doc tokenises to empty and is
+    # excluded (score 0), while the well-formed doc still ranks.
+    assert "error" not in result
+    assert result["retrieval_method"] == "colbert"
+    result_ids = [r["id"] for r in result["results"]]
+    assert "g" in result_ids
+    assert "none-content" not in result_ids
 
 
 def test_multivector_codegen_template_handles_none_content():


### PR DESCRIPTION
## Summary

Closes the final honesty gap in the RAG-coverage workstream (brief: *"provably correct, not merely importable"*). Five `kaizen.nodes.rag` nodes advertised ML capabilities they only simulate. After Waves 1–3 made the eval/privacy/codegen nodes provably correct, these five were the last surface where a node imports + constructs fine but lies about what it does.

## Dispositions (Wave 4 = strip-or-flag; building real CLIP/BLIP/BERT/federation is out of scope)

**Deprecated** (warn-on-construction shim, kept importable per zero-tolerance Rule 6a; removal scheduled next minor):
- `VisualQuestionAnsweringNode` — keyword-derived placeholder answer + fixed confidence; never reads pixels.
- `ImageTextMatchingNode` — keyword-derived placeholder match scores; not CLIP/ALIGN.

**Reduced** (real core kept; docstrings corrected to stop advertising the simulated backend; runtime unchanged):
- `MultimodalRAGNode` — real LLM query-analysis + response-generation over a hash/lexical placeholder encoder (not CLIP/BLIP-2). Also fixes a hardcoded `model="gpt-4-vision"` → env-resolved `OPENAI_VISION_MODEL` (`env-models.md`).
- `FederatedRAGNode` — in-process aggregation pattern, not real distributed/network federation.
- `ColBERTRetrievalNode` — lexical late-interaction (token-overlap MaxSim) approximation, not a learned BERT model. Deleted the dead, never-called `_create_workflow` whose `token_embedder` generated random `np.random.randn(768)` embeddings; ported its orphaned None-content test to a behavioural `run()` test.

## Verification

- **235** RAG unit + integration + regression tests pass.
- security-reviewer **APPROVE** (env-models compliant, no secrets, net removal of fabrication, deprecation-shim ordering safe).
- reviewer findings (orphaned test + residual Example-block over-claim) resolved in-change.
- User-flow walk: deprecated nodes warn on construction; reduced nodes don't; `ColBERT.run()` ranks correctly.

Version `2.26.0 → 2.27.0` (public-API deprecation).

## Related issues

F31 Wave 4 (kaizen-rag-node-coverage workstream).