### PR TITLE
fix(core): make register_node generic so decorated subclasses retain type (#1286)

### DIFF
--- a/src/kailash/nodes/base.py
+++ b/src/kailash/nodes/base.py
@@ -25,6 +25,7 @@ import os
 import threading
 from abc import ABC, abstractmethod
 from collections import OrderedDict
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, TypeVar
 
@@ -2670,7 +2671,12 @@ class NodeRegistry:
         logging.info("Cleared all registered nodes")
 
 
-def register_node(alias: str | None = None):
+_NodeT = TypeVar("_NodeT", bound=Node)
+
+
+def register_node(
+    alias: str | None = None,
+) -> Callable[[type[_NodeT]], type[_NodeT]]:
     """Decorator to register a node class.
 
     Provides a convenient decorator pattern for automatic node
@@ -2717,7 +2723,7 @@ def register_node(alias: str | None = None):
         ...         return pd.read_csv(file)
     """
 
-    def decorator(node_class: type[Node]):
+    def decorator(node_class: type[_NodeT]) -> type[_NodeT]:
         """Inner decorator that performs registration.
 
         Args:

--- a/tests/regression/test_issue_1286_register_node_typevar.py
+++ b/tests/regression/test_issue_1286_register_node_typevar.py
@@ -1,0 +1,95 @@
+"""Regression test for issue #1286.
+
+`register_node` erased decorated node subclasses to ``type[Node]`` because the
+inner decorator was annotated ``def decorator(node_class: type[Node])`` with no
+generic return type. Static checkers therefore inferred every
+``@register_node()``-decorated class as ``type[Node]``, dropping the subclass and
+emitting an ``attr-defined`` diagnostic at every subclass-specific classmethod
+call site (e.g. ``PythonCodeNode.from_function(...)``).
+
+The fix makes the decorator generic via a ``TypeVar`` bound to ``Node`` so the
+decorated class retains its precise type, with ZERO runtime behaviour change.
+
+This test locks BOTH halves of the contract:
+  1. Runtime: the decorator returns the same class object unchanged.
+  2. Typing: ``register_node`` returns a generic decorator whose input and output
+     carry the SAME ``TypeVar`` bound to ``Node`` — if a future edit reverts the
+     signature to ``type[Node]`` the typing assertion fails loudly.
+"""
+
+import inspect
+import typing
+
+import pytest
+
+from kailash.nodes.base import Node, register_node
+
+
+@pytest.mark.regression
+def test_register_node_returns_class_unchanged_at_runtime():
+    """Zero runtime change: the decorator returns the exact class object."""
+
+    class _Probe(Node):
+        def get_parameters(self):
+            return {}
+
+        def run(self, **kwargs):
+            return {}
+
+        @classmethod
+        def special(cls) -> str:
+            return "ok"
+
+    decorated = register_node()(_Probe)
+    assert decorated is _Probe
+    # Subclass-specific classmethod survives (the call site #1286 flagged).
+    assert decorated.special() == "ok"
+
+
+@pytest.mark.regression
+def test_register_node_alias_returns_class_unchanged_at_runtime():
+    """The aliased form preserves identity too."""
+
+    class _AliasProbe(Node):
+        def get_parameters(self):
+            return {}
+
+        def run(self, **kwargs):
+            return {}
+
+    decorated = register_node(alias="AliasProbeCustom")(_AliasProbe)
+    assert decorated is _AliasProbe
+
+
+@pytest.mark.regression
+def test_register_node_signature_is_generic_typevar_bound_to_node():
+    """Typing contract: register_node -> Callable[[type[T]], type[T]], T bound to Node.
+
+    Locks the fix against a revert to the non-generic ``type[Node]`` signature
+    that erased subclasses. base.py does NOT use ``from __future__ import
+    annotations`` so the return annotation is the live typing object, not a str.
+    """
+    ret = inspect.signature(register_node).return_annotation
+    assert (
+        ret is not inspect.Signature.empty
+    ), "register_node lost its return annotation"
+
+    # Callable[[type[T]], type[T]] -> get_args == ([type[T]], type[T])
+    callable_args = typing.get_args(ret)
+    assert callable_args, f"return annotation not parametrized: {ret!r}"
+    params, result = callable_args[0], callable_args[-1]
+    assert (
+        isinstance(params, list) and len(params) == 1
+    ), f"unexpected param shape: {params!r}"
+
+    (in_tv,) = typing.get_args(params[0])  # the type[T] param yields T
+    (out_tv,) = typing.get_args(result)  # the type[T] result yields T
+
+    assert isinstance(
+        in_tv, typing.TypeVar
+    ), f"decorator input is not a TypeVar: {in_tv!r}"
+    assert in_tv is out_tv, (
+        "register_node erases the subclass type — input and output TypeVar differ "
+        "(regressed to a non-generic decorator)"
+    )
+    assert in_tv.__bound__ is Node, f"TypeVar is not bound to Node: {in_tv.__bound__!r}"


### PR DESCRIPTION
## Summary

`kailash.nodes.base.register_node` erased decorated node subclasses to `type[Node]`: the inner decorator was annotated `def decorator(node_class: type[Node])` with no generic return type, so static checkers inferred every `@register_node()`-decorated class as `type[Node]` and emitted a (non-gating) pyright `attr-defined` diagnostic at every subclass-specific classmethod call site — e.g. `PythonCodeNode.from_function(...)`, hit at every call site in kaizen's RAG node family.

The fix makes the decorator generic via a `Node`-bound `TypeVar`:

```python
_NodeT = TypeVar("_NodeT", bound=Node)
def register_node(...) -> Callable[[type[_NodeT]], type[_NodeT]]:
    def decorator(node_class: type[_NodeT]) -> type[_NodeT]: ...
```

**Typing-only, zero runtime change** — `register_node()(cls) is cls` still holds and the `NodeRegistry.register` path is untouched.

## Acceptance criteria (#1286)
- [x] `@register_node()`-decorated subclasses retain their type under static checkers
- [x] `PythonCodeNode.from_function` call sites no longer erase to `type[Node]`
- [x] Zero runtime behavior change (verified: decorator returns the same class object)
- [ ] Cross-SDK inspection of the kailash-rs node-registration path — **deferred, human-gated** (cross-repo filing per repo-scope-discipline; needs your go-ahead)

## Tests
3 regression tests in `tests/regression/test_issue_1286_register_node_typevar.py` (behavioral identity + alias path + a typing-contract lock that fails loudly if the signature regresses to `type[Node]`).

## Red-team
reviewer: APPROVED (0 findings). security-reviewer: APPROVED (zero-runtime confirmed).

## Related issues
Fixes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)