### PR TITLE
fix(nexus,core): cascade-close internal AsyncLocalRuntimes on teardown (#1285)

### DIFF
--- a/packages/kailash-nexus/src/nexus/core.py
+++ b/packages/kailash-nexus/src/nexus/core.py
@@ -3679,6 +3679,29 @@ Check the documentation or explore available resources.
                 except Exception:
                     pass
 
+        # Close the HTTP gateway (EnterpriseWorkflowServer). It acquires a
+        # reference to self.runtime at construction and owns the per-workflow
+        # WorkflowAPI runtimes; without this, both leak and emit
+        # ResourceWarning: Unclosed AsyncLocalRuntime at GC (issue #1285).
+        gateway = getattr(getattr(self, "_http_transport", None), "gateway", None)
+        if gateway is not None and hasattr(gateway, "close"):
+            try:
+                gateway.close()
+            except Exception:
+                pass
+
+        # Release runtime refs held by transports (MCP/WS lazily acquire a
+        # _shared_runtime on tool invocation and release it only in async
+        # stop(); this sync close() covers teardown without a prior stop()).
+        # The HTTP transport inherits the base no-op close(), so the gateway
+        # closed above is not double-closed (issue #1285).
+        for transport in getattr(self, "_transports", []) or []:
+            if hasattr(transport, "close"):
+                try:
+                    transport.close()
+                except Exception:
+                    pass
+
         # Release or close the runtime itself
         if hasattr(self, "runtime") and self.runtime is not None:
             self.runtime.release()

--- a/packages/kailash-nexus/src/nexus/transports/base.py
+++ b/packages/kailash-nexus/src/nexus/transports/base.py
@@ -76,3 +76,15 @@ class Transport(ABC):
             handler_def: The newly registered handler definition.
         """
         pass
+
+    def close(self) -> None:
+        """Synchronously release runtime references held by this transport.
+
+        Called by ``Nexus.close()`` on the synchronous teardown path (issue
+        #1285). The async ``stop()`` releases the same resources during a normal
+        served lifecycle; ``close()`` covers teardown WITHOUT a prior ``start()``
+        (e.g. a transport that lazily acquired a shared runtime on a tool
+        invocation and is then closed synchronously). Default is a no-op for
+        transports that hold no releasable runtime reference. Must be idempotent.
+        """
+        pass

--- a/packages/kailash-nexus/src/nexus/transports/mcp.py
+++ b/packages/kailash-nexus/src/nexus/transports/mcp.py
@@ -116,10 +116,20 @@ class MCPTransport(Transport):
             self._thread = None
         self._server = None
         # Release shared runtime (NX-01 fix: prevent connection leak)
-        if hasattr(self, "_shared_runtime") and self._shared_runtime is not None:
+        self.close()
+        logger.info("MCPTransport stopped")
+
+    def close(self) -> None:
+        """Synchronously release the lazily-acquired shared runtime (#1285).
+
+        ``_get_shared_runtime`` acquires/creates ``_shared_runtime`` on first
+        tool invocation; without this sync release the runtime leaks when the
+        owning Nexus is torn down via ``close()`` rather than ``stop()``.
+        Idempotent.
+        """
+        if getattr(self, "_shared_runtime", None) is not None:
             self._shared_runtime.release()
             self._shared_runtime = None
-        logger.info("MCPTransport stopped")
 
     def on_handler_registered(self, handler_def: HandlerDef) -> None:
         """Hot-register a new MCP tool for a handler added at runtime."""

--- a/packages/kailash-nexus/src/nexus/transports/websocket.py
+++ b/packages/kailash-nexus/src/nexus/transports/websocket.py
@@ -252,12 +252,22 @@ class WebSocketTransport(Transport):
         self._connections.clear()
 
         # Release shared runtime (same pattern as MCPTransport)
+        self.close()
+
+        self._server = None
+
+    def close(self) -> None:
+        """Synchronously release the lazily-acquired shared runtime (#1285).
+
+        ``_get_shared_runtime`` acquires/creates ``_shared_runtime`` during
+        handler dispatch; without this sync release the runtime leaks when the
+        owning Nexus is torn down via ``close()`` rather than ``stop()``.
+        Idempotent.
+        """
         if self._shared_runtime is not None:
             if hasattr(self._shared_runtime, "release"):
                 self._shared_runtime.release()
             self._shared_runtime = None
-
-        self._server = None
         logger.info("WebSocketTransport stopped")
 
     def on_handler_registered(self, handler_def: HandlerDef) -> None:

--- a/packages/kailash-nexus/tests/regression/test_issue_1285_close_cascades_runtime.py
+++ b/packages/kailash-nexus/tests/regression/test_issue_1285_close_cascades_runtime.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for #1285: Nexus.close() must cascade-close internal runtimes.
+
+Root cause (two leaks, same bug class — runtime references never released on
+the synchronous close() teardown path):
+
+1. The enterprise gateway (``EnterpriseWorkflowServer`` at
+   ``Nexus._http_transport.gateway``) ``acquire()``s ``Nexus.runtime`` at
+   construction (ref_count 1 -> 2). ``Nexus.close()`` released the owner
+   reference once (2 -> 1) but never asked the gateway to release its acquired
+   reference, so the runtime stayed at ref_count 1 and emitted
+   ``ResourceWarning: Unclosed AsyncLocalRuntime (ref_count=1)`` at GC.
+
+2. ``WorkflowServer.register_workflow`` builds a ``WorkflowAPI`` per workflow,
+   each of which constructs its OWN ``AsyncLocalRuntime``. These were never
+   tracked or closed — a second orphan runtime leaked per registered workflow.
+
+Fix: ``Nexus.close()`` closes the gateway; ``EnterpriseWorkflowServer.close()``
+cascades via ``super().close()`` to the base ``WorkflowServer.close()`` which
+releases every tracked ``WorkflowAPI`` runtime.
+
+Sibling of #211 (which made the gateway SHARE the runtime); this pins the
+RELEASE half of the same lifecycle contract.
+"""
+from __future__ import annotations
+
+import gc
+import warnings
+
+import pytest
+
+from kailash.runtime.async_local import AsyncLocalRuntime
+
+
+def _leaked_runtimes():
+    """Return live AsyncLocalRuntime instances still holding a reference."""
+    gc.collect()
+    return [
+        o
+        for o in gc.get_objects()
+        if isinstance(o, AsyncLocalRuntime) and getattr(o, "_ref_count", 0) > 0
+    ]
+
+
+@pytest.mark.regression
+class TestIssue1285CloseCascadesRuntime:
+    """Nexus.close() drives every internal runtime to ref_count 0."""
+
+    def test_close_releases_all_runtime_refs(self):
+        from nexus import Nexus
+
+        app = Nexus(api_port=20101, mcp_port=20102, enable_durability=False)
+
+        @app.handler("ping")
+        def ping(params):
+            return {"ok": True}
+
+        # The owned runtime is shared with the gateway (ref_count > 1 here).
+        assert app.runtime.ref_count >= 1
+        app.close()
+
+        leaked = _leaked_runtimes()
+        assert not leaked, (
+            f"{len(leaked)} AsyncLocalRuntime(s) still held after Nexus.close(): "
+            f"{[(id(o), o._ref_count) for o in leaked]}"
+        )
+
+    def test_close_emits_no_resource_warning(self):
+        from nexus import Nexus
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ResourceWarning)
+
+            app = Nexus(api_port=20103, mcp_port=20104, enable_durability=False)
+
+            @app.handler("a")
+            def a(params):
+                return {"ok": True}
+
+            @app.handler("b")
+            def b(params):
+                return {"ok": True}
+
+            app.close()
+            # Force the finalizer path that would emit the ResourceWarning.
+            del app, a, b
+            gc.collect()
+            # Reaching here under simplefilter("error") means no warning fired.
+
+    def test_double_close_is_idempotent(self):
+        from nexus import Nexus
+
+        app = Nexus(api_port=20105, mcp_port=20106, enable_durability=False)
+        app.close()
+        app.close()  # must not raise
+        assert app.runtime is None
+
+
+@pytest.mark.regression
+class TestWorkflowServerClosesWorkflowApiRuntimes:
+    """Core-SDK half: WorkflowServer.close() releases per-workflow runtimes."""
+
+    def test_register_then_close_releases_workflow_api_runtime(self):
+        from kailash.servers.workflow_server import WorkflowServer
+        from kailash.workflow.builder import WorkflowBuilder
+
+        server = WorkflowServer(title="test")
+
+        wf = WorkflowBuilder()
+        wf.add_node("PythonCodeNode", "n", {"code": "result = 1"})
+        server.register_workflow("demo", wf.build())
+
+        # The WorkflowAPI is now tracked and its runtime is live.
+        assert "demo" in server._workflow_apis
+        api = server._workflow_apis["demo"]
+        runtime = api.runtime
+        assert runtime is not None
+        assert runtime.ref_count > 0
+
+        server.close()
+
+        # The WorkflowAPI's runtime was released, and tracking was cleared.
+        assert server._workflow_apis == {}
+        assert runtime.ref_count == 0
+
+    def test_workflow_api_gateway_close_releases_runtime(self):
+        """Sibling site (kailash.api.gateway.WorkflowAPIGateway), same bug class."""
+        from kailash.api.gateway import WorkflowAPIGateway
+        from kailash.workflow.builder import WorkflowBuilder
+
+        gateway = WorkflowAPIGateway(title="test")
+
+        wf = WorkflowBuilder()
+        wf.add_node("PythonCodeNode", "n", {"code": "result = 1"})
+        gateway.register_workflow("demo", wf.build())
+
+        assert "demo" in gateway._workflow_apis
+        runtime = gateway._workflow_apis["demo"].runtime
+        assert runtime is not None and runtime.ref_count > 0
+
+        gateway.close()
+
+        assert gateway._workflow_apis == {}
+        assert runtime.ref_count == 0
+
+
+@pytest.mark.regression
+class TestTransportSyncCloseReleasesSharedRuntime:
+    """LOW-1: MCP/WS transports lazily acquire a shared runtime on tool
+    invocation and previously released it only in async stop(). The sync
+    close() path (teardown without a prior stop()) must release it too.
+    """
+
+    def test_mcp_transport_close_releases_shared_runtime(self):
+        from nexus.transports.mcp import MCPTransport
+
+        rt = AsyncLocalRuntime()
+        base = rt.ref_count
+        transport = MCPTransport(runtime=rt)
+        transport._get_shared_runtime()  # lazy acquire (ref +1)
+        assert rt.ref_count == base + 1
+
+        transport.close()
+        assert transport._shared_runtime is None
+        assert rt.ref_count == base
+        transport.close()  # idempotent
+        assert rt.ref_count == base
+        rt.close()
+
+    def test_websocket_transport_close_releases_shared_runtime(self):
+        from nexus.transports.websocket import WebSocketTransport
+
+        rt = AsyncLocalRuntime()
+        base = rt.ref_count
+        transport = WebSocketTransport(runtime=rt)
+        transport._get_shared_runtime()  # lazy acquire (ref +1)
+        assert rt.ref_count == base + 1
+
+        transport.close()
+        assert transport._shared_runtime is None
+        assert rt.ref_count == base
+        transport.close()  # idempotent
+        assert rt.ref_count == base
+        rt.close()

--- a/src/kailash/api/gateway.py
+++ b/src/kailash/api/gateway.py
@@ -142,6 +142,10 @@ class WorkflowAPIGateway:
         """
         self.workflows: dict[str, WorkflowRegistration] = {}
         self.mcp_servers: dict[str, Any] = {}
+        # Per-workflow API wrappers, tracked so their runtimes are released on
+        # shutdown/close() (issue #1285 — each WorkflowAPI builds its own
+        # AsyncLocalRuntime that otherwise leaks at GC).
+        self._workflow_apis: dict[str, "WorkflowAPI"] = {}
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
 
         # Proxy HTTP client (created lazily on first proxied request)
@@ -169,6 +173,7 @@ class WorkflowAPIGateway:
             await drive_router_lifespan_shutdown(app)
             if self._proxy_client:
                 await self._proxy_client.aclose()
+            self._close_workflow_apis()
             self.executor.shutdown(wait=True)
 
         self.app = FastAPI(
@@ -240,6 +245,28 @@ class WorkflowAPIGateway:
             logger.warning(f"MCP health check failed for {name}: {exc}")
             return "unhealthy"
         return "unknown"
+
+    def _close_workflow_apis(self) -> None:
+        """Release per-workflow API runtimes (issue #1285). Idempotent."""
+        for name, workflow_api in getattr(self, "_workflow_apis", {}).items():
+            try:
+                workflow_api.close()
+            except Exception as exc:  # pragma: no cover - teardown best-effort
+                logger.debug(
+                    "Error closing WorkflowAPI for '%s': %s: %s",
+                    name,
+                    type(exc).__name__,
+                    exc,
+                )
+        self._workflow_apis = {}
+
+    def close(self) -> None:
+        """Synchronously release per-workflow API runtimes (issue #1285).
+
+        The async lifespan shutdown also performs this release; ``close()`` is
+        the teardown path for a gateway constructed but never served.
+        """
+        self._close_workflow_apis()
 
     def _register_root_endpoints(self):
         """Register gateway-level endpoints."""
@@ -452,6 +479,8 @@ class WorkflowAPIGateway:
             version=version,
             description=description or f"Workflow: {name}",
         )
+        # Track it so its runtime is released on shutdown/close() (issue #1285).
+        self._workflow_apis[name] = workflow_api
 
         # Mount the workflow app as a sub-application
         self.app.mount(f"/{name}", workflow_api.app)

--- a/src/kailash/servers/enterprise_workflow_server.py
+++ b/src/kailash/servers/enterprise_workflow_server.py
@@ -166,7 +166,13 @@ class EnterpriseWorkflowServer(DurableWorkflowServer):
         self._register_enterprise_endpoints()
 
     def close(self) -> None:
-        """Release runtime reference."""
+        """Release runtime reference and cascade to per-workflow API runtimes.
+
+        Closes child ``WorkflowAPI`` wrappers first (issue #1285), then releases
+        this server's own acquired runtime reference.
+        """
+        # Cascade to per-workflow API runtimes (base WorkflowServer.close()).
+        super().close()
         if hasattr(self, "_async_runtime") and self._async_runtime is not None:
             if self._owns_runtime:
                 self._async_runtime.close()

--- a/src/kailash/servers/workflow_server.py
+++ b/src/kailash/servers/workflow_server.py
@@ -181,6 +181,9 @@ class WorkflowServer:
         """
         self.workflows: dict[str, WorkflowRegistration] = {}
         self.mcp_servers: dict[str, Any] = {}
+        # Per-workflow API wrappers, tracked so their runtimes are released on
+        # close() (issue #1285 — each WorkflowAPI builds its own AsyncLocalRuntime).
+        self._workflow_apis: dict[str, "WorkflowAPI"] = {}
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
         self.runtime = runtime
         self._rate_limiter = _SignalQueryRateLimiter()
@@ -595,6 +598,25 @@ class WorkflowServer:
                     content={"error": "Workflow or query not found"},
                 )
 
+    def close(self) -> None:
+        """Release per-workflow API runtimes (issue #1285).
+
+        Each ``register_workflow`` builds a ``WorkflowAPI`` that owns its own
+        ``AsyncLocalRuntime``; without this teardown those runtimes leak and emit
+        ``ResourceWarning: Unclosed AsyncLocalRuntime`` at GC. Idempotent.
+        """
+        for name, workflow_api in getattr(self, "_workflow_apis", {}).items():
+            try:
+                workflow_api.close()
+            except Exception as exc:  # pragma: no cover - teardown best-effort
+                logger.debug(
+                    "Error closing WorkflowAPI for '%s': %s: %s",
+                    name,
+                    type(exc).__name__,
+                    exc,
+                )
+        self._workflow_apis = {}
+
     def register_workflow(
         self,
         name: str,
@@ -626,6 +648,8 @@ class WorkflowServer:
 
         # Create workflow API wrapper
         workflow_api = WorkflowAPI(workflow)
+        # Track it so its runtime is released on close() (issue #1285).
+        self._workflow_apis[name] = workflow_api
 
         # Register workflow endpoints with prefix
         prefix = f"/workflows/{name}"


### PR DESCRIPTION
## Summary

`Nexus.close()` did not release every internal `AsyncLocalRuntime`, so every Nexus app/test emitted `ResourceWarning: Unclosed AsyncLocalRuntime (ref_count=1)` at GC **even when `close()` was dutifully called**. Ground-truth reproduction surfaced **three leak sites**, all the same bug class — runtime references created/acquired but never released on the synchronous teardown path:

1. **Gateway** — `EnterpriseWorkflowServer` (`Nexus._http_transport.gateway`) `.acquire()`s `Nexus.runtime` at construction (ref 1→2); `close()` released the owner ref once (2→1) but never the gateway's acquired ref → stuck at 1.
2. **Per-workflow runtimes** — `WorkflowServer.register_workflow` builds a `WorkflowAPI` per workflow, each constructing its **own** `AsyncLocalRuntime`, never tracked or closed → one orphan per registered workflow.
3. **Transport `_shared_runtime`** — MCP/WebSocket transports lazily acquire a runtime on tool invocation and released it only in async `stop()` → leaked on the sync-`close()`-without-`stop()` path.

## Fix
- `Nexus.close()` closes the HTTP gateway, which cascades via `EnterpriseWorkflowServer.close()` → `super().close()` (new base `WorkflowServer.close()`) to release every tracked per-workflow `WorkflowAPI` runtime; then iterates `self._transports` to release each `_shared_runtime`.
- Base `Transport` gains a documented no-op `close()`; `MCPTransport`/`WebSocketTransport` override it and their async `stop()` now delegates to it (DRY).
- **Sibling site** (autonomous-execution Rule 4): the legacy `WorkflowAPIGateway` (`kailash.api.gateway`) carrying the same bug class is fixed in the same change (track + release on shutdown/`close()`).

Verified clean on every teardown path — explicit `close()`, context-manager `__exit__`, `__del__`/GC, double-close — with `-W error::ResourceWarning`.

## Acceptance criteria (#1285)
- [x] `Nexus.close()` cascade-closes the internal `AsyncLocalRuntime`
- [x] No `ResourceWarning: Unclosed AsyncLocalRuntime` after `app.close()`
- [x] Regression test covering build → `close()` → assert no ResourceWarning + `ref_count == 0`

## Tests
7 regression tests in `packages/kailash-nexus/tests/regression/test_issue_1285_close_cascades_runtime.py` (Nexus full-cascade ref-count + `simplefilter("error", ResourceWarning)` + idempotency + base `WorkflowServer` + legacy `WorkflowAPIGateway` + MCP/WS transport sync-close). All behavioral, ref-count-asserting.

## Red-team (converged)
- reviewer: APPROVED (0 findings; 6 mechanical sweeps + 4 risk probes clear — MRO cascade, no double-release/underflow, full `WorkflowAPI(` tracking parity).
- security-reviewer R1: APPROVED, 0 CRIT/HIGH; flagged the transport `_shared_runtime` residual (LOW-1).
- LOW-1 fixed in-shard; security-reviewer R2: APPROVED (no double-close of the gateway runtime via the HTTP transport's base no-op; full-sequence release accounting balanced).

## Related issues
Fixes #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)