### PR TITLE
chore(release): kailash 2.29.4 + kailash-nexus 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.29.4] - 2026-06-12
+
+### Fixed
+
+- **`register_node` no longer erases decorated node subclasses to `type[Node]` (#1286).** The inner decorator was annotated `decorator(node_class: type[Node])` with no generic return type, so static checkers inferred every `@register_node()`-decorated class as `type[Node]` and emitted an `attr-defined` diagnostic at every subclass-specific classmethod call site (e.g. `PythonCodeNode.from_function`). `register_node` is now a generic decorator (`Callable[[type[_NodeT]], type[_NodeT]]`, `_NodeT` bound to `Node`). **Typing-only — zero runtime/behavior change** (`register_node()(cls) is cls` still holds; `NodeRegistry.register` path untouched).
+- **`WorkflowServer` / `WorkflowAPIGateway` now release per-workflow runtimes on teardown (#1285, core half).** `WorkflowServer.register_workflow` builds a `WorkflowAPI` per workflow, each constructing its own `AsyncLocalRuntime`; these were never tracked or closed, leaking one runtime per registered workflow until GC. `WorkflowServer` now tracks the wrappers and gains a `close()` that releases them; `EnterpriseWorkflowServer.close()` cascades via `super().close()` (so closing the gateway releases both its acquired runtime reference and every per-workflow runtime); the legacy `WorkflowAPIGateway` carrying the same bug class is fixed in tandem (track + release on shutdown/`close()`). Pairs with the Nexus-side fix in kailash-nexus 2.9.1.
+
 ## [2.29.3] - 2026-06-06
 
 ### Documentation

--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Nexus Changelog
 
+## [2.9.1] — 2026-06-12 — `Nexus.close()` cascade-closes internal AsyncLocalRuntimes (#1285)
+
+### Fixed
+
+- **`Nexus.close()` now releases every internal `AsyncLocalRuntime` (#1285).** Previously every Nexus app/test emitted `ResourceWarning: Unclosed AsyncLocalRuntime (ref_count=1)` at GC even when `close()` was called, because three runtime references were never released on the synchronous teardown path: (1) the HTTP gateway (`EnterpriseWorkflowServer`) acquires `Nexus.runtime` at construction and was never released; (2) each registered workflow's `WorkflowAPI` owns its own runtime, never tracked/closed (the Core SDK half, fixed in kailash 2.29.4); (3) the MCP/WebSocket transports lazily acquire a `_shared_runtime` on tool invocation and released it only in async `stop()`. `Nexus.close()` now closes the gateway (cascading to every per-workflow runtime) and iterates `self._transports` to release each `_shared_runtime`; the base `Transport` gains a no-op `close()`, and `MCPTransport`/`WebSocketTransport` override it with their async `stop()` delegating to it. Verified clean on every teardown path (explicit `close()`, context-manager `__exit__`, `__del__`/GC, double-close). Requires `kailash>=2.28.4` (the Core SDK `WorkflowServer`/`WorkflowAPIGateway` half ships in kailash 2.29.4).
+
 ## [2.9.0] — 2026-06-01 — WebSocket pre-upgrade handshake rejection + subprotocol echo + typed-status gateway (#1216, #1217, #1218)
 
 Three deferred follow-ups of the #1174 FastAPI-parity work. Requires `kailash>=2.28.4` (the #1218 typed-status gateway fix lives in the Core SDK `WorkflowAPI`).

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.9.0"
+version = "2.9.1"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -116,7 +116,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.9.0"
+__version__ = "2.9.1"
 __all__ = [
     # Core
     "Nexus",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.29.3"
+version = "2.29.4"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.29.3"
+__version__ = "2.29.4"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Release prep — metadata-only

Patch releases carrying the two fixes merged this session:

| Package | Bump | Carries |
|---------|------|---------|
| **kailash** | 2.29.3 → 2.29.4 | #1286 (register_node generic typing) + #1285 core half (WorkflowServer / EnterpriseWorkflowServer / WorkflowAPIGateway runtime release) |
| **kailash-nexus** | 2.9.0 → 2.9.1 | #1285 Nexus half (Nexus.close cascade + base/MCP/WS transport `close()`) |

Diff is strictly metadata: version anchors (`pyproject.toml` + `__init__.py`) + `CHANGELOG.md` for both packages. nexus `kailash>=2.28.4` pin unchanged (PyPI-resolvable per `deployment.md`).

Both underlying fixes already merged (PRs #1299, #1300), reviewer + security-reviewer APPROVED, 10 regression tests green. After merge: tags `v2.29.4` then `nexus-v2.9.1` (pushed individually) trigger the OIDC publish workflow.

## Related issues
Refs #1285, #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)