### PR TITLE
release(core): kailash 2.30.0 — ML feature-store exception classes (#1302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.30.0] - 2026-06-13
+
+### Added
+
+- **Five ML feature-store exception classes in `kailash.ml.errors`** (all `FeatureStoreError` subclasses), supporting the kailash-ml 2.1.0 feature-store M2 authoring/registry/materialize surfaces (FM2, #1302): `FeatureGroupNotFoundError`, `FeatureVersionImmutableError`, `FeatureVersionNotFoundError`, `FeatureEvolutionError`, `CrossTenantReadError`. Purely additive — the canonical ML error taxonomy (`kailash.ml.errors`) is the single source the `kailash-ml` package re-exports from. kailash-ml 2.1.0 floors `kailash>=2.30.0` because it imports these.
+
 ## [2.29.4] - 2026-06-12
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.29.4"
+version = "2.30.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.29.4"
+__version__ = "2.30.0"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
Cuts core **kailash 2.29.4 → 2.30.0** to publish the 5 ML feature-store exception
classes that landed in `src/kailash/ml/errors.py` via the FM2 Wave 1+2 merge (PR #1305)
but were never released. **kailash-ml 2.1.0 is currently broken on PyPI** — it
re-imports these from `kailash.ml.errors` and a clean-venv `pip install kailash-ml==2.1.0`
resolves core 2.29.4 (which lacks them) → `ImportError: CrossTenantReadError`. Caught by
the build-repo-release-discipline Rule 2 clean-venv done-gate. This release unblocks it;
kailash-ml 2.1.1 (floor `kailash>=2.30.0`) follows.

Metadata-only diff (version anchors + CHANGELOG) on `release/v2.30.0` — auto-skips the
PR-gate matrix per the `release/v*` convention.

## Added (additive — minor)
`FeatureGroupNotFoundError`, `FeatureVersionImmutableError`, `FeatureVersionNotFoundError`,
`FeatureEvolutionError`, `CrossTenantReadError` — all `FeatureStoreError` subclasses in the
canonical `kailash.ml.errors` taxonomy. `git diff v2.29.4..main -- src/kailash/` shows ONLY
`src/kailash/ml/errors.py` changed (+87 lines, 5 classes); no behavior change to existing surfaces.

## Related issues
Releases the core half of FM2 #1302 (Waves 1+2). Pairs with kailash-ml 2.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)