### PR TITLE
release(ml): kailash-ml 2.1.1 — correct core pin to kailash>=2.30.0

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,25 @@
 # kailash-ml Changelog
 
+## [2.1.1] — 2026-06-13 — Fix core dependency floor (feature-store error classes)
+
+Patch release. Corrects the `kailash` dependency floor so the feature-store
+surface installs and imports correctly.
+
+### Fixed
+
+- **`kailash>=2.30.0` dependency floor** (was `kailash>=2.16.0`). The 2.1.0
+  feature-store surface re-exports the ML error hierarchy from
+  `kailash.ml.errors` (via `kailash_ml/errors.py`), including the feature-store
+  subclasses `FeatureStoreError`, `FeatureGroupNotFoundError`,
+  `FeatureVersionImmutableError`, `FeatureVersionNotFoundError`,
+  `FeatureEvolutionError`, `CrossTenantReadError`, `UnsupportedFamily`, and
+  `UnsupportedPrecision`. Those classes were added to core by the FM2 Wave 1+2
+  merge and first published in **`kailash` 2.30.0** — which was released after
+  `kailash-ml` 2.1.0. With the old `>=2.16.0` floor, `pip install
+  kailash-ml==2.1.0` against any core in `[2.16.0, 2.29.4]` raised `ImportError`
+  on first touch of the feature store. The corrected floor pins the version that
+  actually carries the symbols. (`kailash-ml` 2.1.0 is yanked from PyPI.)
+
 ## [2.1.0] — 2026-06-13 — Feature-store M2: authoring, registry, materialize, GDPR erase (#1302)
 
 Minor release. Adds the M2 feature-store authoring + materialization + governance

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "2.1.0"
+version = "2.1.1"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ classifiers = [
 readme = "README.md"
 keywords = ["ml", "machine-learning", "kailash", "automl", "feature-store", "model-registry"]
 dependencies = [
-    "kailash>=2.16.0",
+    "kailash>=2.30.0",
     # FM2 (2.1.0): FeatureStore.materialize() routes derived columns through
     # dataflow.transform + lineage through dataflow.hash, and get_features reads
     # via ml_feature_source — all in dataflow.ml, verified shipped in 2.11.3

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "2.1.0"
+__version__ = "2.1.1"


### PR DESCRIPTION
## Summary

Hotfix for a broken dependency contract in **kailash-ml 2.1.0**.

2.1.0's `kailash_ml/errors.py:21` re-exports the ML error hierarchy from **core** `kailash.ml.errors` — including 8 feature-store subclasses (`FeatureStoreError`, `FeatureGroupNotFoundError`, `FeatureVersionImmutableError`, `FeatureVersionNotFoundError`, `FeatureEvolutionError`, `CrossTenantReadError`, `UnsupportedFamily`, `UnsupportedPrecision`). These classes were added to core by the FM2 Wave 1+2 merge and **first published in `kailash` 2.30.0**, which released *after* kailash-ml 2.1.0.

2.1.0's dependency floor was `kailash>=2.16.0`. Any core in `[2.16.0, 2.29.4]` satisfies that floor and is on PyPI, but lacks the 8 symbols → `pip install kailash-ml==2.1.0` raises `ImportError` on first touch of the feature-store surface (eagerly imported via `features/store.py` + `features/__init__.py`).

## Fix

- Pin floor `kailash>=2.16.0` → `kailash>=2.30.0` (the version that carries the symbols).
- Version 2.1.0 → 2.1.1; CHANGELOG entry.

Verified against ground truth: the 8 symbols are absent at tag `v2.29.4` and present at `kailash` 2.30.0.

## Follow-up

- **kailash-ml 2.1.0 will be yanked from PyPI** after 2.1.1 publishes (replacement-first).

## Related issues

None filed — surfaced via release alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)