### PR TITLE
refactor(ml): consolidate URL credential masking onto core mask_url

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,5 +1,19 @@
 # kailash-ml Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **URL credential masking consolidated onto the core single-source-of-truth.**
+  The three internal URL-masking helpers (`features.online_store._mask_redis_url`,
+  `dashboard.cli._mask_db_url`, `tracking.tracker._mask_url`) are removed in favor of
+  `kailash.utils.url_credentials.mask_url` (`rules/security.md` § Credential Decode Helpers;
+  `rules/observability.md` Rule 6). Masking is identical for credentialed URLs
+  (`redis://u:p@host:port/db` → `redis://***@host:port/db`) and now additionally masks
+  credentials passed via URL query parameters. One subtle change: a **credential-less**
+  URL on a log/error surface (e.g. `redis://127.0.0.1:1/0`) now renders **verbatim**
+  (nothing to mask) instead of the prior forced `redis://***@127.0.0.1:1/0`.
+
 ## [2.2.0] — 2026-06-13 — Feature-store M2 Wave 3: online-store adapter + spec graduation (#693)
 
 Minor release. Completes the M2 feature-store (FM2 Wave 3 of 3): the Redis-backed

--- a/packages/kailash-ml/src/kailash_ml/dashboard/cli.py
+++ b/packages/kailash-ml/src/kailash_ml/dashboard/cli.py
@@ -29,6 +29,8 @@ import sys
 from pathlib import Path
 from typing import Any, Sequence
 
+from kailash.utils.url_credentials import mask_url
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["main", "build_parser", "run"]
@@ -278,7 +280,7 @@ def run(argv: Sequence[str] | None = None) -> int:
             "tenant_id": args.tenant_id,
             "enable_control": args.enable_control,
             "auth_configured": args.auth is not None,
-            "db_url": _mask_db_url(db_url),
+            "db_url": mask_url(db_url),
         },
     )
 
@@ -365,30 +367,3 @@ def main() -> None:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _mask_db_url(db_url: str) -> str:
-    """Mask credentials in DB URL for log lines per rules/observability.md §6."""
-    try:
-        from urllib.parse import urlparse
-
-        parsed = urlparse(db_url)
-    except Exception:
-        return "<unparseable db url>"
-
-    if not parsed.scheme:
-        return "<unparseable db url>"
-
-    if parsed.hostname is None and not parsed.path:
-        return "<unparseable db url>"
-
-    host = parsed.hostname or ""
-    port = f":{parsed.port}" if parsed.port else ""
-    path = parsed.path or ""
-    # SQLite URLs have no userinfo — return verbatim path for them
-    if parsed.scheme.startswith("sqlite"):
-        return db_url
-    # Mask userinfo uniformly (***@host) so credentials never land in logs
-    if parsed.username or parsed.password:
-        return f"{parsed.scheme}://***@{host}{port}{path}"
-    return f"{parsed.scheme}://{host}{port}{path}"

--- a/packages/kailash-ml/src/kailash_ml/features/online_store.py
+++ b/packages/kailash-ml/src/kailash_ml/features/online_store.py
@@ -52,12 +52,13 @@ import warnings
 from datetime import date, datetime
 from datetime import time as _time
 from typing import TYPE_CHECKING, Any, NoReturn
-from urllib.parse import urlsplit, urlunsplit
 
 import polars as pl
 from kailash_ml.errors import OnlineStoreUnavailableError
 from kailash_ml.features.cache_keys import make_feature_cache_key, validate_tenant_id
 from kailash_ml.features.schema import FeatureSchema
+
+from kailash.utils.url_credentials import mask_url
 
 if TYPE_CHECKING:  # avoid importing the optional redis dep on type-only paths
     import redis.asyncio as _redis_async_t
@@ -69,27 +70,6 @@ logger = logging.getLogger(__name__)
 #: Default Redis URL when neither ``url`` nor ``ONLINE_FEATURE_STORE_REDIS_URL``
 #: is supplied — mirrors the events-backend default (``backends.py``).
 _DEFAULT_REDIS_URL = "redis://localhost:6379/0"
-
-
-def _mask_redis_url(url: str) -> str:
-    """Mask credentials in a Redis URL for log / error surfaces.
-
-    Canonical form per ``rules/observability.md`` Rule 6.2:
-    ``scheme://***@host[:port][/path]``. On a parse failure returns a grep-able
-    sentinel distinct from a successful mask (Rule 6.1) so triage can tell
-    "masked OK" apart from "masker bailed".
-    """
-    try:
-        parts = urlsplit(url)
-    except Exception:
-        return "<unparseable redis url>"
-    if not parts.scheme or not parts.hostname:
-        return "<unparseable redis url>"
-    host = parts.hostname
-    netloc = f"***@{host}"
-    if parts.port is not None:
-        netloc = f"{netloc}:{parts.port}"
-    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
 
 
 def _json_default(obj: Any) -> Any:
@@ -153,7 +133,7 @@ class OnlineFeatureStore:
             or os.environ.get("ONLINE_FEATURE_STORE_REDIS_URL")
             or _DEFAULT_REDIS_URL
         )
-        self._masked_url = _mask_redis_url(self._url)
+        self._masked_url = mask_url(self._url)
         if default_ttl_seconds is not None:
             if isinstance(default_ttl_seconds, bool) or not isinstance(
                 default_ttl_seconds, int

--- a/packages/kailash-ml/src/kailash_ml/tracking/tracker.py
+++ b/packages/kailash-ml/src/kailash_ml/tracking/tracker.py
@@ -46,6 +46,8 @@ from kailash_ml.tracking.runner import ExperimentRun
 from kailash_ml.tracking.runner import track as _track_async
 from kailash_ml.tracking.storage import AbstractTrackerStore, SqliteTrackerStore
 
+from kailash.utils.url_credentials import mask_url
+
 __all__ = ["ExperimentTracker"]
 
 
@@ -148,7 +150,7 @@ class ExperimentTracker:
         logger.info(
             "kailash_ml.tracker.ready",
             extra={
-                "store_url": _mask_url(resolved),
+                "store_url": mask_url(resolved),
                 "default_tenant_id": default_tenant_id,
             },
         )
@@ -738,23 +740,3 @@ def _runs_dataframe(rows: list[dict[str, Any]]) -> "Any":
         )
     projected = [{col: row.get(col) for col in _RUN_DATAFRAME_COLUMNS} for row in rows]
     return pl.DataFrame(projected)
-
-
-def _mask_url(url: str) -> str:
-    """Mask credentials in a store URL for structured logging.
-
-    SQLite URLs are returned as-is (no credentials). Network URLs
-    get their userinfo collapsed to ``***``.
-    """
-    if url.startswith("sqlite"):
-        return url
-    try:
-        from urllib.parse import urlparse
-
-        parsed = urlparse(url)
-        if not parsed.scheme or not parsed.hostname:
-            return "<unparseable store url>"
-        port = f":{parsed.port}" if parsed.port else ""
-        return f"{parsed.scheme}://***@{parsed.hostname}{port}{parsed.path}"
-    except Exception:
-        return "<unparseable store url>"

--- a/packages/kailash-ml/tests/integration/test_online_store_and_reopen_wiring.py
+++ b/packages/kailash-ml/tests/integration/test_online_store_and_reopen_wiring.py
@@ -85,7 +85,10 @@ def _input_frame() -> pl.DataFrame:
 
 # An unroutable Redis target — 127.0.0.1:1 is the reserved TCP port 1, which
 # refuses immediately, giving a deterministic backend-down without a mock.
-_UNREACHABLE_REDIS_URL = "redis://127.0.0.1:1/0"
+# Credentials are embedded so the error-surface masking assertion below verifies
+# real credential-safety (the canonical mask_url emits credential-less URLs
+# verbatim — there is nothing to mask — so a leak check needs actual credentials).
+_UNREACHABLE_REDIS_URL = "redis://probe_user:probe_secret@127.0.0.1:1/0"
 
 
 # ===========================================================================
@@ -101,8 +104,9 @@ async def test_online_store_populate_unavailable_raises_typed():
     try:
         with pytest.raises(OnlineStoreUnavailableError) as excinfo:
             await online.populate(_schema(), _input_frame(), tenant_id="_single")
-        # The masked URL appears (credential-safe); no raw host:port creds leak.
+        # The masked URL appears (credential-safe); the raw password never leaks.
         assert "***@127.0.0.1:1" in str(excinfo.value)
+        assert "probe_secret" not in str(excinfo.value)
         # Cause-chained from the real redis exception (fail-loud, not swallowed).
         assert excinfo.value.__cause__ is not None
     finally:


### PR DESCRIPTION
## Summary

Three internal URL-masking helpers in kailash-ml each hand-rolled the same `scheme://***@host` credential masking:

- `features/online_store.py::_mask_redis_url`
- `dashboard/cli.py::_mask_db_url`
- `tracking/tracker.py::_mask_url`

All three are removed in favor of the canonical `kailash.utils.url_credentials.mask_url` — the documented single source of truth for credential masking (`rules/security.md` § Credential Decode Helpers; `rules/observability.md` Rule 6). Three parallel maskers drift over time; one canonical helper does not, and `mask_url` additionally masks credentials in URL **query parameters** (e.g. `?password=...`) that the local copies missed.

## Behavior

- **Credentialed URLs**: identical (`redis://u:p@host:port/db` → `redis://***@host:port/db`).
- **Credential-less URLs**: one intentional change — now render **verbatim** (nothing to mask) instead of the old forced `redis://***@host` form. This matches `mask_url`'s documented design (a URL with no userinfo and no credential query params is safe to render as-is).

## Tests

- `tests/integration/test_online_store_and_reopen_wiring.py` strengthened: the unreachable-target URL now carries real credentials so the error-surface masking assertion verifies actual credential-safety, plus a new no-password-leak assertion.
- Full online_store suite (9 passed, 2 skipped) + tracker/dashboard suites (148 passed, 1 skipped) green locally.
- `pytest --collect-only` clean across the package (2651 collected; the one pre-existing `kailash_align`-not-installed collection error in `tests/integration/rl/` is unrelated and untouched).

## User-flow walk

`OnlineFeatureStore("redis://probe_user:probe_secret@127.0.0.1:1/0").populate(...)` raises `OnlineStoreUnavailableError` whose message contains `***@127.0.0.1:1` and does NOT contain `probe_secret` — verified by the strengthened integration test.

## Related issues

Closes the F-FW2 FM2 follow-up (consolidate `_mask_redis_url` onto the shared masker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)