### PR TITLE
release(ml): kailash-ml 2.2.1

### DIFF
--- a/packages/kailash-ml/CHANGELOG.md
+++ b/packages/kailash-ml/CHANGELOG.md
@@ -1,6 +1,9 @@
 # kailash-ml Changelog
 
-## [Unreleased]
+## [2.2.1] — 2026-06-13 — URL credential masking consolidated onto core helper
+
+Patch release. Internal refactor — no public API change. Replaces three
+hand-rolled URL-masking helpers with the canonical core `mask_url`.
 
 ### Changed
 

--- a/packages/kailash-ml/pyproject.toml
+++ b/packages/kailash-ml/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kailash-ml"
-version = "2.2.0"
+version = "2.2.1"
 description = "Machine learning lifecycle for the Kailash ecosystem"
 requires-python = ">=3.11"
 license = "Apache-2.0"

--- a/packages/kailash-ml/src/kailash_ml/_version.py
+++ b/packages/kailash-ml/src/kailash_ml/_version.py
@@ -1,4 +1,4 @@
 # Copyright 2026 Terrene Foundation
 # SPDX-License-Identifier: Apache-2.0
 """Version for kailash-ml package."""
-__version__ = "2.2.0"
+__version__ = "2.2.1"


### PR DESCRIPTION
Release-prep for kailash-ml **2.2.1** (patch). Metadata-only diff — version anchors + CHANGELOG.

Ships the masker consolidation merged in #1313 (three hand-rolled URL maskers → canonical `kailash.utils.url_credentials.mask_url`; tighter query-param credential masking). Internal refactor, no public API change.

- `pyproject.toml` + `_version.py`: 2.2.0 → 2.2.1 (atomic)
- CHANGELOG `[Unreleased]` → `[2.2.1] — 2026-06-13`

## Related issues
Follows #1313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)