### PR TITLE
fix(trust): EATP-08 ISS-32 — bare top-level-string ed25519+sha256 → unsupported-algorithm, not D2d (v1.1.1/mint#26)

### DIFF
--- a/src/kailash/trust/signing/algorithm_id.py
+++ b/src/kailash/trust/signing/algorithm_id.py
@@ -463,8 +463,15 @@ class AlgorithmIdentifier:
         # Some historical record shapes nested the token under a top-level
         # `{"alg_id": "<token>"}` member; accept that envelope transparently
         # so `from_dict(record_dict)` and `from_dict(record_dict["alg_id"])`
-        # behave identically for a conformant record.
-        if isinstance(data, dict) and "alg_id" in data and "algorithm" not in data:
+        # behave identically for a conformant record. A present `alg_id` key is
+        # authoritative: when it exists we always resolve from it, even if the
+        # record ALSO carries an `algorithm` sibling. This closes a latent
+        # bypass where `{"alg_id":"ed25519+sha256","algorithm":"ed25519+sha256"}`
+        # could otherwise fall through to the whole-dict `algorithm`-key D2d
+        # match and rescue a bare top-level-string literal (v1.1.1 / mint#26).
+        # The unsigned-`algorithm`-metadata D2d form applies only when there is
+        # NO `alg_id` member (handled by `decode_wire_alg_id`'s second branch).
+        if isinstance(data, dict) and "alg_id" in data:
             value: Any = data["alg_id"]
         else:
             value = data

--- a/src/kailash/trust/signing/algorithm_id.py
+++ b/src/kailash/trust/signing/algorithm_id.py
@@ -309,23 +309,35 @@ def resolve_dispatch(alg_id: str) -> RegistryEntry:
 def is_pre_registry_form(value: Any) -> bool:
     """Return True if ``value`` is a recognised D2d pre-registry explicit form.
 
-    EATP-08 §4.5 (D2d) recognises two pre-registry explicit forms that carry
-    the deprecated literal ``ed25519+sha256``:
+    EATP-08 §4.5 (D2d), as clarified by the v1.1.1 erratum, recognises the
+    deprecated literal ``ed25519+sha256`` as a pre-registry explicit form in
+    exactly **two structurally-distinguishable encodings**:
 
-    - the bare deprecated literal string (kailash-py historically signed NO
-      ``alg_id`` at all, carrying the algorithm in unsigned metadata; when a
-      caller surfaces that metadata literal into the field, it lands here);
-      and
-    - the nested-object encoding ``{"algorithm": "ed25519+sha256"}`` that
-      kailash-rs historically signed.
+    - the **nested-object** encoding ``{"algorithm": "ed25519+sha256"}`` — the
+      value of a signed ``alg_id`` field (the kailash-rs historical form); and
+    - the algorithm carried only in **unsigned ``algorithm`` metadata** with no
+      signed ``alg_id`` (the kailash-py historical form), which reaches this
+      predicate as a dict whose ``algorithm`` key holds the literal (see
+      :func:`decode_wire_alg_id`).
 
-    Both map to ``eatp-v1`` under the bounded/witnessed legacy path. This
-    function only RECOGNISES the shape; the dated/witnessed/sunset gating is
-    the verifier's responsibility (§4.5).
+    A **bare top-level-string** ``alg_id`` equal to ``ed25519+sha256`` is NOT a
+    pre-registry form: it is an unregistered top-level token and MUST be
+    rejected with ``unsupported-algorithm`` (§3.3 / §5.1 step 2), never rescued
+    by a witness. Accepting a bare literal string here would dilute the
+    "top-level ``alg_id`` string is a registry token" invariant that the
+    anti-strip design (§4.4 / V6) depends on, and no conformant emitter ever
+    produced one (the reference scaffolds emitted the nested object or unsigned
+    metadata). This is the v1.1.1 / mint#26 ruling (ISS-32).
+
+    Both recognised encodings map to ``eatp-v1`` under the bounded/witnessed
+    legacy path. This function only RECOGNISES the shape; the
+    dated/witnessed/sunset gating is the verifier's responsibility (§4.5).
     """
 
-    if value == DEPRECATED_PRE_REGISTRY_LITERAL:
-        return True
+    # Only the structurally-distinguishable nested form is a D2d pre-registry
+    # shape. A bare string `== DEPRECATED_PRE_REGISTRY_LITERAL` is deliberately
+    # NOT matched here (v1.1.1): it falls through to the registry match and
+    # raises `unsupported-algorithm`.
     if (
         isinstance(value, dict)
         and value.get("algorithm") == DEPRECATED_PRE_REGISTRY_LITERAL
@@ -504,13 +516,25 @@ class AlgorithmIdentifier:
             )
 
         if value == DEPRECATED_PRE_REGISTRY_LITERAL:
-            # The deprecated literal as a bare top-level string is NOT a
-            # registry token. Off the legacy path it is a shape mismatch.
+            # The deprecated literal as a bare top-level `alg_id` string is an
+            # UNREGISTERED top-level token, not a D2d form (v1.1.1 / mint#26):
+            # §5.1 step 2 registry-matches a top-level string, and the literal
+            # is not in the registry, so it is `unsupported-algorithm` with or
+            # without a witness (a witness MUST NOT rescue it). The two D2d
+            # forms are the nested-object `alg_id` value and unsigned
+            # `algorithm` metadata (§4.5), both reached structurally above, not
+            # here. (is_pre_registry_form no longer matches the bare string, so
+            # the witnessed D2d block above is skipped for it.)
             raise UnsupportedAlgorithmError(
-                "alg-id-shape-mismatch",
-                f"alg_id {value!r} is the deprecated pre-registry literal; "
-                f"it is accepted only on the D2d legacy path (§4.5), never "
-                f"as a conformant post-adoption emission.",
+                "unsupported-algorithm",
+                f"alg_id {value!r} is the deprecated pre-registry literal "
+                f"presented as a top-level string; it is an unregistered "
+                f"token and MUST be rejected with unsupported-algorithm "
+                f"(EATP-08 §3.3 / §5.1, v1.1.1). It MUST NOT fall through to "
+                f"{ALGORITHM_DEFAULT!r}, and a D2d witness does not rescue it; "
+                f"the D2d legacy path accepts the literal only as a "
+                f"nested-object alg_id value or unsigned `algorithm` metadata "
+                f"(§4.5).",
             )
 
         if not is_registered(value):

--- a/tests/regression/test_eatp08_alg_id_canonical_vectors.py
+++ b/tests/regression/test_eatp08_alg_id_canonical_vectors.py
@@ -99,15 +99,23 @@ def test_registry_status_and_dispatchability_match(row):
 
 @pytest.mark.regression
 def test_non_conformant_deprecated_literal_decode_regime():
-    # Post-adoption (no witness): the bare deprecated literal is shape-mismatch.
+    # v1.1.1 / mint#26: a bare top-level-string `alg_id` equal to the deprecated
+    # literal is an UNREGISTERED top-level token -> `unsupported-algorithm`, in
+    # BOTH the no-witness and witnessed cases. It is NOT a D2d form, and a
+    # witness MUST NOT rescue it (§5.1 step 2 registry-matches a top-level
+    # string; the literal is not a registry token). The two D2d forms are the
+    # nested-object value and unsigned `algorithm` metadata, exercised by the
+    # sibling tests below.
     with pytest.raises(UnsupportedAlgorithmError) as exc:
         decode_wire_alg_id({"alg_id": "ed25519+sha256"})
-    assert exc.value.code == "alg-id-shape-mismatch"
-    # D2d witnessed legacy path: accepted as eatp-v1.
-    got = decode_wire_alg_id(
-        {"alg_id": "ed25519+sha256"}, witness=_pre_adoption_witness()
-    )
-    assert got == ALGORITHM_DEFAULT == "eatp-v1"
+    assert exc.value.code == "unsupported-algorithm"
+    # An otherwise-valid pre-adoption witness does NOT rescue the bare
+    # top-level-string literal (it is not a D2d encoding).
+    with pytest.raises(UnsupportedAlgorithmError) as exc_witnessed:
+        decode_wire_alg_id(
+            {"alg_id": "ed25519+sha256"}, witness=_pre_adoption_witness()
+        )
+    assert exc_witnessed.value.code == "unsupported-algorithm"
 
 
 @pytest.mark.regression

--- a/tests/regression/test_eatp08_alg_id_canonical_vectors.py
+++ b/tests/regression/test_eatp08_alg_id_canonical_vectors.py
@@ -119,6 +119,28 @@ def test_non_conformant_deprecated_literal_decode_regime():
 
 
 @pytest.mark.regression
+def test_alg_id_key_is_authoritative_over_algorithm_sibling():
+    """A present `alg_id` key is authoritative; a bare-literal `alg_id` is NOT
+    rescued by an `algorithm` sibling.
+
+    Boundary case (v1.1.1 / mint#26): a record carrying BOTH a bare top-level
+    `alg_id` string literal AND an `algorithm` metadata key must resolve from
+    `alg_id` and reject with `unsupported-algorithm` — the `algorithm`-sibling
+    D2d form applies only when there is NO `alg_id` member. Exercises
+    `AlgorithmIdentifier.from_dict` directly (the exported surface), not only
+    the `decode_wire_alg_id` production path."""
+
+    both_keys = {"alg_id": "ed25519+sha256", "algorithm": "ed25519+sha256"}
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        AlgorithmIdentifier.from_dict(both_keys, witness=_pre_adoption_witness())
+    assert exc.value.code == "unsupported-algorithm"
+    # And without a witness.
+    with pytest.raises(UnsupportedAlgorithmError) as exc_nw:
+        AlgorithmIdentifier.from_dict(both_keys)
+    assert exc_nw.value.code == "unsupported-algorithm"
+
+
+@pytest.mark.regression
 def test_non_conformant_nested_pre_registry_object_decode_regime():
     # The kailash-rs pre-publication scaffold form: nested {"algorithm": "..."}.
     nested = {"alg_id": {"algorithm": "ed25519+sha256"}}

--- a/tests/regression/test_issue_604_alg_id_threading.py
+++ b/tests/regression/test_issue_604_alg_id_threading.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 import pytest
+
 from kailash.trust.pact.config import (
     ConfidentialityLevel,
     ConstraintEnvelopeConfig,
@@ -258,14 +259,19 @@ def test_signed_envelope_from_dict_nested_object_shape_mismatch(signed):
 
 
 @pytest.mark.regression
-def test_signed_envelope_from_dict_deprecated_literal_shape_mismatch(signed):
-    """Bare deprecated literal post-adoption is a shape mismatch, not v1."""
+def test_signed_envelope_from_dict_deprecated_literal_unsupported(signed):
+    """Bare top-level-string deprecated literal is an unregistered token.
+
+    v1.1.1 / mint#26: a top-level `alg_id` string equal to the deprecated
+    literal is registry-matched (§5.1 step 2), is not a registry token, and is
+    rejected with `unsupported-algorithm` (not `alg-id-shape-mismatch`, and not
+    a D2d form)."""
 
     payload = signed.to_dict()
     payload["alg_id"] = DEPRECATED_PRE_REGISTRY_LITERAL
     with pytest.raises(UnsupportedAlgorithmError) as exc:
         SignedEnvelope.from_dict(payload)
-    assert exc.value.code == "alg-id-shape-mismatch"
+    assert exc.value.code == "unsupported-algorithm"
 
 
 @pytest.mark.regression
@@ -304,14 +310,17 @@ def test_signed_envelope_from_dict_reserved_token_decodes_but_undispatchable(
 
 
 @pytest.mark.regression
-def test_signed_envelope_from_dict_d2d_bare_literal(signed):
-    """EATP-08 §4.5 (D2d): bare deprecated literal maps to eatp-v1 ONLY with a
-    pre-adoption witness."""
+def test_signed_envelope_from_dict_bare_literal_not_rescued_by_witness(signed):
+    """v1.1.1 / mint#26: a bare top-level-string deprecated literal is NOT a D2d
+    form, so an otherwise-valid pre-adoption witness MUST NOT rescue it; it
+    stays `unsupported-algorithm`. (The D2d forms are the nested-object value
+    and unsigned `algorithm` metadata, exercised by the two tests below.)"""
 
     payload = signed.to_dict()
     payload["alg_id"] = DEPRECATED_PRE_REGISTRY_LITERAL
-    reconstructed = SignedEnvelope.from_dict(payload, witness=_PRE_ADOPTION_WITNESS)
-    assert reconstructed.alg_id == "eatp-v1"
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        SignedEnvelope.from_dict(payload, witness=_PRE_ADOPTION_WITNESS)
+    assert exc.value.code == "unsupported-algorithm"
 
 
 @pytest.mark.regression

--- a/tests/test-vectors/eatp08-alg-id-canonical.json
+++ b/tests/test-vectors/eatp08-alg-id-canonical.json
@@ -46,12 +46,12 @@
   ],
   "non_conformant": [
     {
-      "name": "deprecated_pre_registry_literal",
+      "name": "deprecated_pre_registry_literal_bare_top_level_string",
       "value_repr": "ed25519+sha256",
       "shape": "bare top-level string",
-      "decode_post_adoption": "reject: alg-id-shape-mismatch",
-      "decode_with_pre_adoption_witness": "accept as eatp-v1 (D2d legacy path)",
-      "reason": "deprecated pre-registry literal; accepted only on the dated/witnessed D2d legacy path (EATP-08 §4.5), never a conformant emission"
+      "decode_post_adoption": "reject: unsupported-algorithm",
+      "decode_with_pre_adoption_witness": "reject: unsupported-algorithm (a bare top-level-string literal is an unregistered token, NOT a D2d form; a witness MUST NOT rescue it)",
+      "reason": "EATP-08 v1.1.1 / mint#26: a top-level alg_id string equal to the deprecated literal is registry-matched (§5.1 step 2), is not a registry token, and is rejected with unsupported-algorithm with or without a witness. The two D2d forms are the nested-object alg_id value and unsigned `algorithm` metadata (§4.5), never a bare top-level string. Preserves the §3.3 top-level-string-token invariant the anti-strip design (§4.4/V6) depends on."
     },
     {
       "name": "nested_pre_registry_object",


### PR DESCRIPTION
## Summary

Implements the EATP-08 **v1.1.1 / mint#26** ruling. A bare top-level `alg_id` string equal to the deprecated literal `ed25519+sha256` is an **unregistered token → `unsupported-algorithm`** (§3.3 / §5.1 step 2), **with or without** a D2d witness. It is **not** a D2d pre-registry form. The two D2d forms remain the signed **nested-object** `alg_id` value and the **unsigned `algorithm` metadata** (both reached structurally), preserving the "top-level string ⇒ registry token" invariant the anti-strip design (§4.4/V6) depends on.

This corrects an over-permissive path: `is_pre_registry_form()` previously accepted a bare literal string, so a signed top-level `"alg_id":"ed25519+sha256"` was D2d-accepted as `eatp-v1` (with a witness) or mislabelled `alg-id-shape-mismatch` (without). The #604 scaffold never emitted a bare top-level token (`to_dict()` returned `{"algorithm": ...}`), so no legacy chain continuity is lost.

## Changes
- `algorithm_id.py::is_pre_registry_form` — drop the bare-string branch; only the nested-object `{"algorithm": ...}` form is a D2d shape.
- `algorithm_id.py::AlgorithmIdentifier.from_dict` — bare-literal branch now raises `unsupported-algorithm` (was `alg-id-shape-mismatch`); a witness no longer rescues it.
- Tests updated to assert `unsupported-algorithm` (no-witness **and** witnessed). Nested-object + unsigned-metadata D2d acceptance tests unchanged.
- Cross-SDK canonical vector (`eatp08-alg-id-canonical.json`) — bare-top-level-string row → `unsupported-algorithm` both cases (kailash-rs #1315 inherits this parity bar).

## Test plan
- [x] `tests/regression/test_eatp08_alg_id_canonical_vectors.py` + `test_issue_604_alg_id_threading.py` — **47 passed**.
- [x] Broader signing/envelope/verifier surface — **650 passed, 8 skipped**.
- [x] pre-commit (black, isort, ruff, type-annotation gate, Tier 1 units) — passed.
- [ ] **Independent adversarial security/conformance review before merge** (security-adjacent alg-id verification path; per mint journal 0017 discipline). Human merge gate.

## Related
- Spec: foundation EATP-08 **v1.1.1** erratum — foundation PR #17.
- Ruling: mint envoy-parity **journal 0020** (mint PR #27); resolves `terrene-foundation/mint#26`.
- Tracks **ISS-32**; cross-SDK sibling `esperie-enterprise/kailash-rs#1315`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)