### PR TITLE
fix(annotations): read PEP 749 __annotate_func__ on Python 3.14 final (#1318)

### DIFF
--- a/packages/kailash-kaizen/src/kaizen/signatures/core.py
+++ b/packages/kailash-kaizen/src/kaizen/signatures/core.py
@@ -146,9 +146,10 @@ class SignatureMeta(type):
                 output_fields.update(base._signature_outputs)
 
         # Now process current class's fields (overrides parent fields).
-        # PEP 649 (Python 3.14+) makes annotations lazy via __annotate__;
-        # the shared helper reads both eager (<=3.13) and lazy (>=3.14)
-        # forms so signatures keep working under both annotation models.
+        # PEP 649/749 (Python 3.14+) makes annotations lazy: 3.14-beta emitted
+        # __annotate__, 3.14-final renamed it to __annotate_func__. The shared
+        # helper reads both eager (<=3.13) and lazy (>=3.14, beta + final)
+        # forms so signatures keep working under every annotation model.
         annotations = get_namespace_annotations(namespace)
         for field_name, field_type in annotations.items():
             field_value = namespace.get(field_name)

--- a/src/kailash/utils/annotations.py
+++ b/src/kailash/utils/annotations.py
@@ -10,10 +10,12 @@ This shifted two contracts that the Kailash stack relied on:
 
 1. **Metaclass namespace.**  Pre-3.14, ``namespace["__annotations__"]`` was
    a pre-built dict during ``__new__``.  In 3.14 the dict is gone — the
-   namespace carries ``__annotate__`` instead.  Code that did
-   ``namespace.get("__annotations__", {})`` silently sees ``{}`` and produces
-   classes with no field metadata.  This is what broke every Kaizen agent
-   using the declarative class-based ``Signature`` style.
+   namespace carries a lazy annotate callable instead.  3.14 *beta* emitted
+   ``__annotate__``; PEP 749 (3.14 *final*) renamed that callable to
+   ``__annotate_func__`` and the eager cache to ``__annotations_cache__``.
+   Code that did ``namespace.get("__annotations__", {})`` silently sees
+   ``{}`` and produces classes with no field metadata.  This is what broke
+   every Kaizen agent using the declarative class-based ``Signature`` style.
 
 2. **Class attribute.**  ``cls.__annotations__`` still works on 3.14, but
    may raise ``NameError`` instead of returning a string for unresolved
@@ -56,19 +58,29 @@ def get_namespace_annotations(namespace: Mapping[str, Any]) -> Dict[str, Any]:
     """Return class-body annotations from a metaclass ``__new__`` namespace.
 
     Pre-3.14 sets ``namespace["__annotations__"]`` directly; 3.14 emits a
-    lazy ``namespace["__annotate__"]`` callable instead.  This helper reads
-    whichever form is present and returns a plain dict.
+    lazy annotate callable instead.  3.14 *beta* named it ``__annotate__``;
+    PEP 749 (3.14 *final*) renamed it to ``__annotate_func__`` and added the
+    eager cache ``__annotations_cache__``.  This helper reads whichever form
+    is present — across every 3.14 pre-release and the final — and returns a
+    plain dict.
 
     The forward-reference (``FORWARDREF``) format is preferred so unresolved
     names do not raise during class construction — callers that store the
     annotation as descriptive metadata (Kaizen ``Signature``) accept the
     ``ForwardRef`` object as-is.
     """
-    annotations = namespace.get("__annotations__")
+    # Eager dict form: pre-3.14 "__annotations__"; 3.14-final materialises
+    # the eager cache under "__annotations_cache__" (PEP 749).
+    annotations = namespace.get("__annotations__") or namespace.get(
+        "__annotations_cache__"
+    )
     if annotations:
         return dict(annotations)
 
-    annotate = namespace.get("__annotate__")
+    # Lazy annotate callable: 3.14 beta emitted "__annotate__"; PEP 749
+    # (3.14 final) renamed it to "__annotate_func__".  Accept either so the
+    # helper resolves on every 3.14 pre-release and the final.
+    annotate = namespace.get("__annotate__") or namespace.get("__annotate_func__")
     if annotate is None:
         return {}
 

--- a/tests/regression/test_python_314_annotations.py
+++ b/tests/regression/test_python_314_annotations.py
@@ -95,6 +95,73 @@ def test_get_namespace_annotations_lazy_falls_back_on_nameerror():
 
 
 @pytest.mark.regression
+def test_get_namespace_annotations_lazy_annotate_func_form():
+    """3.14-FINAL namespace shape: PEP 749 renamed ``__annotate__`` →
+    ``__annotate_func__``.
+
+    Regression for issue #1318: on Python 3.14 final the metaclass namespace
+    carries ``__annotate_func__`` (not the 3.14-beta ``__annotate__``), so the
+    helper's old two-key lookup fell through to ``{}`` and every class-based
+    Signature silently lost its fields.  The helper MUST read the final name.
+    """
+    from kailash.utils.annotations import get_namespace_annotations
+
+    expected = {"a": int, "b": str}
+
+    def fake_annotate(format):
+        # Format.VALUE == 1, Format.FORWARDREF == 2 — accept both so the
+        # helper's fallback path also resolves on pre-3.14 interpreters.
+        if format in (1, 2):
+            return dict(expected)
+        return {}
+
+    # No "__annotations__", no "__annotate__" — only the PEP 749 final name.
+    namespace = {"__annotate_func__": fake_annotate}
+    assert get_namespace_annotations(namespace) == expected
+
+
+@pytest.mark.regression
+def test_get_namespace_annotations_eager_cache_form():
+    """3.14-FINAL eager cache: PEP 749 stores the materialised dict under
+    ``__annotations_cache__``.
+
+    When 3.14 has already evaluated the annotations, the namespace carries the
+    eager cache rather than the lazy callable.  The helper MUST read it without
+    needing to invoke the annotate callable.
+    """
+    from kailash.utils.annotations import get_namespace_annotations
+
+    namespace = {"__annotations_cache__": {"x": int, "y": str}}
+    assert get_namespace_annotations(namespace) == {"x": int, "y": str}
+
+
+@pytest.mark.regression
+def test_get_namespace_annotations_metaclass_namespace_real_shape():
+    """Real metaclass ``__new__`` namespace on the running interpreter.
+
+    Captures the ACTUAL namespace the compiler emits — ``__annotations__`` on
+    ≤3.13, ``__annotate_func__`` on 3.14 final — and asserts the helper
+    extracts the class-body annotations.  Runs on every interpreter, so on the
+    3.14 CI leg it exercises the real PEP 749 namespace natively (issue #1318
+    acceptance criterion: metaclass-constructed class returns its fields).
+    """
+    from kailash.utils.annotations import get_namespace_annotations
+
+    captured = {}
+
+    class _Meta(type):
+        def __new__(mcs, name, bases, namespace):
+            captured["result"] = get_namespace_annotations(namespace)
+            return super().__new__(mcs, name, bases, dict(namespace))
+
+    class _Demo(metaclass=_Meta):
+        x: int
+        y: str
+
+    assert captured["result"] == {"x": int, "y": str}
+
+
+@pytest.mark.regression
 def test_get_class_annotations_returns_dict_for_annotated_class():
     """``get_class_annotations`` returns a copy of the class annotation dict."""
     from kailash.utils.annotations import get_class_annotations


### PR DESCRIPTION
## Summary

On **Python 3.14 final**, `kailash.utils.annotations.get_namespace_annotations()` returned `{}`, so every class-based `kaizen.signatures.core.Signature` silently lost its declared fields and raised `ValueError: Either define fields as class attributes or provide inputs/outputs` at first instantiation. **HIGH severity on 3.14; no effect on ≤3.13.**

**Root cause:** PEP 749 (3.14 final) renamed the lazy class-namespace annotate callable from the 3.14-beta `__annotate__` to `__annotate_func__` (and added the eager cache `__annotations_cache__`). The helper read only `__annotations__` then `__annotate__` — both miss on 3.14 final → falls through to `{}`. The fix adds the renamed keys; the existing forward-ref evaluation logic is unchanged.

## Changes

- `src/kailash/utils/annotations.py` — `get_namespace_annotations` now reads `__annotations_cache__` (eager) and `__annotate_func__` (lazy) in addition to the pre-final names; module + function docstrings updated.
- `tests/regression/test_python_314_annotations.py` — 3 new regression tests: the `__annotate_func__` lazy form, the `__annotations_cache__` eager form, and a real metaclass-namespace test that exercises the native PEP 749 shape on the 3.14 CI leg.
- `packages/kailash-kaizen/src/kaizen/signatures/core.py` — comment accuracy (names the final `__annotate_func__`); the consumer already routes through the helper.

## Acceptance criteria (issue #1318)

- [x] `get_namespace_annotations` returns class-body annotations on 3.14 final (reads `__annotate_func__` / `__annotations_cache__`).
- [x] Regression test: metaclass-constructed class asserts the helper returns its fields (parametrized to run on the 3.14 CI leg).
- [x] A class-based `Signature` with declared fields instantiates without `ValueError` on 3.14 (existing `test_kaizen_signature_subclass_extracts_inputs_and_outputs` covers the Signature path).

## Verification

- 15/15 `tests/regression/test_python_314_annotations.py` pass (12 existing + 3 new).
- 375 kaizen unit signature tests pass.
- Pre-commit (black / isort / ruff / mypy type-annotations / Tier-1 units) all green.

User-flow walk (helper behavior, fixed):
```
3.14-final (__annotate_func__): {'x': <class 'int'>, 'y': <class 'str'>}   # was {} before fix
3.14-final eager cache        : {'x': <class 'int'>, 'y': <class 'str'>}
pre-3.14 (__annotations__)    : {'x': <class 'int'>, 'y': <class 'str'>}
empty namespace               : {}
```

## Cross-SDK (per cross-sdk-inspection)

N/A — PEP 749 is a CPython-3.14 interpreter feature; the Rust SDK has no equivalent class-namespace annotation surface.

## Related issues

Fixes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)