### PR TITLE
release: kailash 2.33.1 — fix #1318 PEP 749 __annotate_func__ on Python 3.14 final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.33.1] - 2026-06-15
+
+### Fixed
+
+- **`get_namespace_annotations` now resolves class-body annotations on Python 3.14 final (PEP 749) (#1318).** PEP 749 (Python 3.14 final) renamed the lazy class-namespace annotate callable from the 3.14-beta `__annotate__` to `__annotate_func__` (and added the eager cache `__annotations_cache__`). `kailash.utils.annotations.get_namespace_annotations` read only `__annotations__` then `__annotate__`, so both lookups missed on 3.14 final and it fell through to `{}` — every class-based `kaizen.signatures.core.Signature` silently lost its declared fields and raised `ValueError: Either define fields as class attributes or provide inputs/outputs` at first instantiation. The helper now also reads `__annotate_func__` and `__annotations_cache__`, resolving on every 3.14 pre-release and the final. HIGH severity on Python 3.14; no effect on ≤3.13 (those interpreters set `__annotations__` eagerly, which is why the bug shipped unseen). Regression tests simulate the 3.14-final namespace shape so they assert the fix on every interpreter, plus a real metaclass-namespace test that exercises the native PEP 749 namespace on the 3.14 CI leg.
+
 ## [2.33.0] - 2026-06-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.33.0"
+version = "2.33.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.33.0"
+__version__ = "2.33.1"
 
 __all__ = [
     # Core workflow components


### PR DESCRIPTION
## Summary

Patch release shipping the **#1318** fix (behavioral change already merged via PR #1322): class-based `kaizen` `Signature` subclasses silently lost their declared fields on Python 3.14 final because `get_namespace_annotations()` did not read PEP 749's renamed `__annotate_func__` / `__annotations_cache__` namespace keys.

Metadata-only release prep (version anchors + CHANGELOG) — `release/v*` branch auto-skips the heavy PR-gate matrix.

## Pre-release gates
- ✅ CI green on the fix PR #1322 across the full Python 3.11–3.14 matrix (the **3.14 leg** exercises the real bug) + CodeQL.
- ✅ security-reviewer: APPROVE, zero blocking findings (no new code-execution surface; eager-cache branch is data-only and checked before the lazy path; fixed 2-call invocation ceiling unchanged).
- ✅ Version consistency: `pyproject.toml` 2.33.1 == `__version__` 2.33.1.
- ✅ CHANGELOG [2.33.1] Fixed entry.

## Related issues
Fixes #1318 (release of the #1322 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)