### PR TITLE
feat(trust): verify D2d legacy-acceptance marker, signed-not-remembered (#1316)

### DIFF
--- a/src/kailash/trust/messaging/envelope.py
+++ b/src/kailash/trust/messaging/envelope.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, Optional
 
 from kailash.trust.signing.algorithm_id import (
     ALGORITHM_DEFAULT,
+    D2dVerifierKeys,
     D2dWitness,
     decode_wire_alg_id,
 )
@@ -266,7 +267,11 @@ class SecureMessageEnvelope:
 
     @classmethod
     def from_dict(
-        cls, data: Dict[str, Any], *, witness: Optional[D2dWitness] = None
+        cls,
+        data: Dict[str, Any],
+        *,
+        witness: Optional[D2dWitness] = None,
+        verifier_keys: Optional[D2dVerifierKeys] = None,
     ) -> "SecureMessageEnvelope":
         """
         Deserialize envelope from dictionary (EATP-08 §4.2 D2b / §4.5 D2d).
@@ -282,6 +287,8 @@ class SecureMessageEnvelope:
             data: Dictionary representation of the envelope.
             witness: A :class:`D2dWitness` only when rescuing a pre-registry
                 legacy record; ``None`` (default) means strict.
+            verifier_keys: The :class:`D2dVerifierKeys` config that verifies the
+                witness's ``marker_sig`` (§4.3.2); ``None`` => fail closed.
 
         Returns:
             SecureMessageEnvelope instance.
@@ -297,7 +304,7 @@ class SecureMessageEnvelope:
         if data.get("metadata"):
             metadata = MessageMetadata.from_dict(data["metadata"])
 
-        alg_id = decode_wire_alg_id(data, witness=witness)
+        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
 
         return cls(
             message_id=data["message_id"],

--- a/src/kailash/trust/pact/envelopes.py
+++ b/src/kailash/trust/pact/envelopes.py
@@ -39,6 +39,7 @@ from kailash.trust.pathutils import normalize_resource_path
 from kailash.trust.signing.algorithm_id import (
     ALGORITHM_DEFAULT,
     AlgorithmIdentifier,
+    D2dVerifierKeys,
     D2dWitness,
     UnsupportedAlgorithmError,
     coerce_algorithm_id,
@@ -51,6 +52,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "ALGORITHM_DEFAULT",
     "AlgorithmIdentifier",
+    "D2dVerifierKeys",
     "D2dWitness",
     "UnsupportedAlgorithmError",
     "EffectiveEnvelopeSnapshot",
@@ -1333,7 +1335,11 @@ class SignedEnvelope:
 
     @classmethod
     def from_dict(
-        cls, data: dict[str, Any], *, witness: D2dWitness | None = None
+        cls,
+        data: dict[str, Any],
+        *,
+        witness: D2dWitness | None = None,
+        verifier_keys: D2dVerifierKeys | None = None,
     ) -> SignedEnvelope:
         """Deserialize from a dict (EATP-08 §4.2 D2b / §4.5 D2d).
 
@@ -1359,6 +1365,8 @@ class SignedEnvelope:
             data: Dict as produced by ``to_dict()``.
             witness: A :class:`D2dWitness` only when rescuing a pre-registry
                 legacy record; ``None`` (default) means strict.
+            verifier_keys: The :class:`D2dVerifierKeys` config that verifies the
+                witness's ``marker_sig`` (§4.3.2); ``None`` => fail closed.
 
         Returns:
             A SignedEnvelope instance carrying a registry token.
@@ -1373,7 +1381,7 @@ class SignedEnvelope:
         # Decode + validate alg_id BEFORE other field parsing so a
         # non-conformant token fails loudly rather than paying the cost of
         # envelope reconstruction.
-        alg_id = decode_wire_alg_id(data, witness=witness)
+        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
 
         envelope = ConstraintEnvelopeConfig(**data["envelope"])
 

--- a/src/kailash/trust/signing/algorithm_id.py
+++ b/src/kailash/trust/signing/algorithm_id.py
@@ -44,9 +44,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
+
+from kailash.trust.exceptions import InvalidSignatureError
+from kailash.trust.signing.crypto import verify_signature
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +169,47 @@ class UnsupportedAlgorithmError(Exception):
 
 
 @dataclass(frozen=True)
+class D2dVerifierKeys:
+    """Trusted public keys for verifying a D2d signed marker (EATP-08 §4.3).
+
+    The §4.3.2 detection rule requires the marker to be *signed-not-remembered*:
+    the verifier holds the trusted public key(s) and verifies ``marker_sig``
+    over the signed core ``serialize_for_signing({principal, first_seen})``
+    INSIDE the gate, rather than trusting a passed-in value. This config is the
+    resolution surface — it mirrors :class:`MultiSigPolicy.signer_public_keys`
+    (``multi_sig.py``): a mapping of ``witness_id`` to a base64 Ed25519 public
+    key, plus an optional ``default_key`` used when a marker carries no
+    ``witness_id`` or an unmatched one.
+
+    §4.3 makes the transport implementation-defined ("a transparency log, an
+    in-Foundation witness service, **or per-verifier signing keys**"); this is
+    the per-verifier-signing-key transport. A transparency log / witness service
+    can later become the marker *source* without changing this verification
+    contract (it still resolves a trusted key and verifies ``marker_sig``).
+
+    Attributes:
+        keys: Mapping of ``witness_id`` -> base64 Ed25519 public key.
+        default_key: Optional base64 Ed25519 public key applied when the
+            marker's ``witness_id`` is unset or not present in ``keys``.
+    """
+
+    keys: Mapping[str, str]
+    default_key: Optional[str] = None
+
+    def resolve(self, witness_id: Optional[str]) -> Optional[str]:
+        """Resolve the trusted public key for a marker's ``witness_id``.
+
+        Returns the keyed entry when ``witness_id`` matches, else
+        ``default_key`` (which MAY be ``None``). A ``None`` return means no
+        trusted key resolves and the gate MUST fail closed.
+        """
+
+        if witness_id is not None and witness_id in self.keys:
+            return self.keys[witness_id]
+        return self.default_key
+
+
+@dataclass(frozen=True)
 class D2dWitness:
     """Dated, signed-marker evidence for D2d legacy acceptance (EATP-08 §4.5).
 
@@ -175,39 +219,76 @@ class D2dWitness:
     temporal or witness bound, and :data:`ADOPTION_DATE` was defined but never
     consulted. D2d (§4.5) requires legacy acceptance to be **dated** and
     **witnessed**: a pre-registry explicit form is accepted as ``eatp-v1``
-    ONLY when a witness is present AND its witnessed/head date is strictly
-    before :data:`ADOPTION_DATE` (2026-04-26).
+    ONLY when a signed marker is present, verifies against a configured trusted
+    key, has not expired, corroborates the claimed pre-adoption head date, and
+    its witnessed/head dates are strictly before :data:`ADOPTION_DATE`.
 
     This dataclass is the structured argument that replaces ``legacy_path:
-    bool`` on every signed-record ``from_dict`` site. Its presence (not a bare
-    boolean) is the affirmative assertion that the caller has resolved a
-    pre-adoption witness for the record's chain head; the temporal comparison
-    is enforced here, not deferred to the caller.
+    bool`` on every signed-record ``from_dict`` site. The §4.3.1 REQUIRED
+    signed core is ``{principal, first_seen}``; ``marker_sig`` binds exactly
+    that (NOT ``chain_head_date`` — that is the record's CLAIMED head timestamp,
+    corroborated AGAINST the signed ``first_seen``). The temporal + signature
+    + expiry checks are enforced in :func:`assert_d2d_witness_pre_adoption`,
+    not deferred to the caller.
 
     Attributes:
-        witnessed_at: The timestamp of the witness / transparency-log entry
-            that corroborates the chain head (§4.3.1 ``first_seen``). This is
-            the date the verifier *trusts* (signed-not-remembered): an
-            attacker who backdates the record's own field still fails because
-            no pre-adoption witness corroborates it.
+        witnessed_at: The timestamp of the witness / transparency-log entry.
+            MUST be strictly before the adoption date (temporal gate).
         chain_head_date: The record's claimed chain-head ``timestamp``
-            (Genesis Record Element 1 / Audit Anchor Element 5). Both this and
-            ``witnessed_at`` MUST be strictly before the adoption date.
-        principal: Optional principal-chain id the witness binds (§4.3.1).
-            Informational here; the monotonic-upgrade boundary is enforced by
-            the record consumer, not this temporal gate.
+            (Genesis Record Element 1 / Audit Anchor Element 5). The CLAIMED
+            value corroborated against the signed ``first_seen``; MUST be
+            strictly before the adoption date.
+        principal: The principal-chain id the marker binds (§4.3.1 REQUIRED
+            signed-core field). Part of the ``marker_sig`` pre-image.
+        first_seen: The signed first-contact/adoption boundary (§4.3.1
+            REQUIRED signed-core field). The date the verifier *trusts*: an
+            attacker who backdates the record's own ``chain_head_date`` still
+            fails because a fresh chain cannot obtain a pre-adoption *signed*
+            ``first_seen`` from the trusted witness. Part of the ``marker_sig``
+            pre-image.
+        marker_sig: Base64 Ed25519 signature over
+            ``serialize_for_signing({principal, first_seen})``, produced by the
+            witness/verifier key. Absent ``marker_sig`` => unsigned marker =>
+            ``implicit-v1-witness-failure``.
+        expires_at: Optional marker expiry. When set and ``<= now``, the marker
+            is expired => ``implicit-v1-witness-failure``.
+        witness_id: Optional id selecting which trusted key in
+            :class:`D2dVerifierKeys` verifies ``marker_sig`` (§4.3.1 optional
+            field). Unset falls back to the config ``default_key``.
     """
 
     witnessed_at: datetime
     chain_head_date: datetime
     principal: Optional[str] = None
+    first_seen: Optional[datetime] = None
+    marker_sig: Optional[str] = None
+    expires_at: Optional[datetime] = None
+    witness_id: Optional[str] = None
 
     @staticmethod
     def _as_date(value: datetime) -> date:
         return value.date() if isinstance(value, datetime) else value
 
+    def signed_marker_payload(self) -> Dict[str, Any]:
+        """The §4.3.1 signed core ``{principal, first_seen}``.
+
+        ``marker_sig`` binds EXACTLY this object (serialised via the canonical
+        cross-SDK :func:`serialize_for_signing`). ``chain_head_date`` is NOT in
+        the signed core — it is the claimed value corroborated against the
+        signed ``first_seen``.
+        """
+
+        return {
+            "principal": self.principal,
+            "first_seen": (
+                self.first_seen.isoformat()
+                if isinstance(self.first_seen, datetime)
+                else self.first_seen
+            ),
+        }
+
     def is_pre_adoption(self) -> bool:
-        """True iff BOTH dates are strictly before :data:`ADOPTION_DATE`.
+        """True iff BOTH witnessed/claimed dates are strictly before adoption.
 
         Consumes :data:`ADOPTION_DATE_PARSED` (the E5/D2d temporal bound). A
         witness whose witnessed-date OR chain-head date falls on/after the
@@ -220,40 +301,136 @@ class D2dWitness:
         )
 
 
-def assert_d2d_witness_pre_adoption(witness: Optional[D2dWitness]) -> None:
-    """Enforce the D2d dated-and-witnessed gate (EATP-08 §4.5 / §4.3.2).
+def _to_aware_utc(value: datetime) -> datetime:
+    """Coerce a datetime to timezone-aware UTC for safe comparison.
 
-    Raises ``implicit-v1-witness-failure`` when the witness is missing, or
-    when its witnessed/head date is not strictly before the pinned adoption
-    date. Returns silently only when a witness is present AND pre-adoption, in
-    which case the caller MAY accept the pre-registry explicit form as
-    ``eatp-v1`` and MUST log the acceptance for migration tracking.
+    A naive datetime is assumed to be UTC (the trust-plane wire convention is
+    RFC-3339-Z). Aware datetimes are converted to UTC.
+    """
+
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def assert_d2d_witness_pre_adoption(
+    witness: Optional[D2dWitness],
+    *,
+    verifier_keys: Optional[D2dVerifierKeys] = None,
+    now: Optional[datetime] = None,
+) -> None:
+    """Enforce the D2d signed-marker gate (EATP-08 §4.5 / §4.3.2).
+
+    The §4.3.2 detection rule: emit ``implicit-v1-witness-failure`` when ANY of
+    the five fail-closed checks does not hold. Returns silently ONLY when all
+    five hold, in which case the caller MAY accept the pre-registry explicit
+    form as ``eatp-v1`` and MUST log the acceptance for migration tracking.
+
+    The five checks (all map to ``implicit-v1-witness-failure``):
+
+    1. **missing** — no witness was supplied.
+    2. **sig-verify** — the signed core is complete (``principal`` +
+       ``marker_sig``) AND a trusted key resolves from ``verifier_keys`` AND
+       ``marker_sig`` verifies (Ed25519) over
+       ``serialize_for_signing({principal, first_seen})``. This is the
+       *signed-not-remembered* property: a passed-in value is not trusted.
+    3. **first_seen-corroboration** — the signed ``first_seen`` is present AND
+       strictly before adoption (a fresh chain cannot obtain a pre-adoption
+       *signed* ``first_seen``, defeating the backdated-``chain_head_date``
+       attack — §4.3.2(3)).
+    4. **expiry** — the marker is not expired (``expires_at`` unset, or
+       ``> now``).
+    5. **monotonic-boundary** (temporal) — both ``witnessed_at`` and the
+       claimed ``chain_head_date`` are strictly before the adoption date
+       (§4.5).
 
     Args:
-        witness: The :class:`D2dWitness`, or ``None`` if the caller asserted
-            no legacy acceptance.
+        witness: The :class:`D2dWitness`, or ``None`` if no legacy acceptance.
+        verifier_keys: The trusted-key config that resolves and verifies
+            ``marker_sig`` (check 2). ``None`` => no trusted key => fail closed.
+        now: Clock for the expiry check (defaults to ``datetime.now(UTC)``);
+            injectable for deterministic tests.
 
     Raises:
         UnsupportedAlgorithmError: code ``implicit-v1-witness-failure`` when
-            the witness is missing or dated on/after adoption.
+            any of the five checks fails.
     """
 
+    def _fail(detail: str) -> "UnsupportedAlgorithmError":
+        return UnsupportedAlgorithmError("implicit-v1-witness-failure", detail)
+
+    # Check 1 — missing.
     if witness is None:
-        raise UnsupportedAlgorithmError(
-            "implicit-v1-witness-failure",
-            "D2d legacy acceptance requires a dated, signed witness "
+        raise _fail(
+            "D2d legacy acceptance requires a dated, signed marker "
             "(EATP-08 §4.5 / §4.3): no witness was supplied, so the "
             "pre-registry explicit form MUST be rejected, not downgraded "
-            f"to {ALGORITHM_DEFAULT!r}.",
+            f"to {ALGORITHM_DEFAULT!r}."
         )
+
+    # Check 2 — signed-not-remembered: complete signed core + trusted-key verify.
+    if witness.principal is None or witness.marker_sig is None:
+        raise _fail(
+            "D2d marker is unsigned or incomplete: §4.3.1 requires a signed "
+            "core {principal, first_seen} bound by marker_sig. A trusted "
+            "passed-in witness is NOT sufficient — the marker MUST be "
+            "signed-not-remembered (§4.3.2)."
+        )
+    public_key = (
+        verifier_keys.resolve(witness.witness_id) if verifier_keys is not None else None
+    )
+    if public_key is None:
+        raise _fail(
+            "D2d marker cannot be verified: no trusted verifier key resolves "
+            f"for witness_id={witness.witness_id!r}. Configure D2dVerifierKeys "
+            "with the witness's public key (§4.3); an unverifiable marker fails "
+            "closed (§4.3.2)."
+        )
+    try:
+        sig_ok = verify_signature(
+            witness.signed_marker_payload(), witness.marker_sig, public_key
+        )
+    except InvalidSignatureError:
+        sig_ok = False
+    if not sig_ok:
+        raise _fail(
+            "D2d marker_sig failed Ed25519 verification against the configured "
+            "trusted key (§4.3.2): the signed core {principal, first_seen} does "
+            "not verify, so the marker is forged, tampered, or signed by an "
+            "untrusted key."
+        )
+
+    # Check 3 — first_seen corroboration (signed anchor precedes adoption).
+    if witness.first_seen is None:
+        raise _fail(
+            "D2d marker carries no signed first_seen; the claimed pre-adoption "
+            "head date is uncorroborated (§4.3.2(3))."
+        )
+    if not (witness._as_date(witness.first_seen) < ADOPTION_DATE_PARSED):
+        raise _fail(
+            "D2d witnessed first_seen does not precede the adoption date "
+            f"{ADOPTION_DATE!r} (§4.3.2(3)): a fresh chain cannot obtain a "
+            "pre-adoption signed first_seen, so the claimed pre-adoption head "
+            "date is uncorroborated."
+        )
+
+    # Check 4 — expiry.
+    if witness.expires_at is not None:
+        now_utc = _to_aware_utc(now if now is not None else datetime.now(timezone.utc))
+        if now_utc >= _to_aware_utc(witness.expires_at):
+            raise _fail(
+                "D2d marker is expired (expires_at <= now); an expired marker "
+                "does not license legacy acceptance (§4.3.2)."
+            )
+
+    # Check 5 — temporal monotonic boundary (claimed dates strictly < adoption).
     if not witness.is_pre_adoption():
-        raise UnsupportedAlgorithmError(
-            "implicit-v1-witness-failure",
-            "D2d legacy acceptance requires the witnessed chain-head date to "
-            f"be strictly before the adoption date {ADOPTION_DATE!r} "
-            "(EATP-08 §4.5 / §7.1); the supplied witness is dated on/after "
-            "adoption, so the pre-registry explicit form MUST be rejected, "
-            f"not downgraded to {ALGORITHM_DEFAULT!r}.",
+        raise _fail(
+            "D2d legacy acceptance requires the witnessed_at AND claimed "
+            f"chain_head_date to be strictly before the adoption date "
+            f"{ADOPTION_DATE!r} (EATP-08 §4.5 / §7.1); the supplied witness is "
+            f"dated on/after adoption, so the pre-registry explicit form MUST "
+            f"be rejected, not downgraded to {ALGORITHM_DEFAULT!r}."
         )
 
 
@@ -415,7 +592,11 @@ class AlgorithmIdentifier:
 
     @classmethod
     def from_dict(
-        cls, data: Any, *, witness: Optional[D2dWitness] = None
+        cls,
+        data: Any,
+        *,
+        witness: Optional[D2dWitness] = None,
+        verifier_keys: Optional[D2dVerifierKeys] = None,
     ) -> "AlgorithmIdentifier":
         """Reconstruct from a wire value (EATP-08 §4.5 D2b / D2d).
 
@@ -446,9 +627,13 @@ class AlgorithmIdentifier:
                 top-level ``alg_id`` value; on the legacy path it MAY be the
                 pre-registry literal or nested form.
             witness: A :class:`D2dWitness` only when the caller is rescuing a
-                pre-registry record; its dates are enforced strictly-before
-                adoption here. ``None`` (default) means strict, no legacy
+                pre-registry record; its signed marker + dates are enforced
+                here (§4.3.2). ``None`` (default) means strict, no legacy
                 acceptance.
+            verifier_keys: The :class:`D2dVerifierKeys` config that verifies
+                the witness's ``marker_sig`` against a configured trusted key.
+                ``None`` (default) => no trusted key => the D2d marker fails
+                closed with ``implicit-v1-witness-failure``.
 
         Returns:
             An :class:`AlgorithmIdentifier`, always carrying a registry token
@@ -484,7 +669,7 @@ class AlgorithmIdentifier:
             # (When no witness is supplied at all, a pre-registry form falls
             # through to the strict rejection below — shape-mismatch — exactly
             # as the post-adoption default requires.)
-            assert_d2d_witness_pre_adoption(witness)
+            assert_d2d_witness_pre_adoption(witness, verifier_keys=verifier_keys)
             logger.info(
                 "EATP-08 D2d: accepting pre-registry explicit form %r as "
                 "%r under the bounded/witnessed legacy path "
@@ -559,6 +744,7 @@ def decode_wire_alg_id(
     data: Dict[str, Any],
     *,
     witness: Optional[D2dWitness] = None,
+    verifier_keys: Optional[D2dVerifierKeys] = None,
 ) -> str:
     """Decode the ``alg_id`` token from a signed-record wire dict.
 
@@ -582,6 +768,10 @@ def decode_wire_alg_id(
         witness: A :class:`D2dWitness` only when rescuing a pre-registry
             legacy record; ``None`` (default) means strict, no legacy
             acceptance.
+        verifier_keys: The :class:`D2dVerifierKeys` config that verifies the
+            witness's ``marker_sig`` against a configured trusted key (§4.3.2).
+            ``None`` (default) => no trusted key resolves => any D2d marker
+            fails closed with ``implicit-v1-witness-failure``.
 
     Returns:
         A registry token string (the legacy forms resolve to ``eatp-v1``).
@@ -593,7 +783,9 @@ def decode_wire_alg_id(
     """
 
     if "alg_id" in data:
-        return AlgorithmIdentifier.from_dict(data["alg_id"], witness=witness).algorithm
+        return AlgorithmIdentifier.from_dict(
+            data["alg_id"], witness=witness, verifier_keys=verifier_keys
+        ).algorithm
 
     # No top-level `alg_id` member. A record carrying the algorithm only under
     # an unsigned top-level `algorithm` key is a D2d pre-registry form
@@ -607,7 +799,7 @@ def decode_wire_alg_id(
             or legacy_value in ("", None)
         ):
             # Enforce ADOPTION_DATE: missing/post-adoption witness rejects.
-            assert_d2d_witness_pre_adoption(witness)
+            assert_d2d_witness_pre_adoption(witness, verifier_keys=verifier_keys)
             logger.info(
                 "EATP-08 D2d: accepting unsigned `algorithm`=%r metadata as "
                 "%r under the bounded/witnessed legacy path "
@@ -658,6 +850,7 @@ __all__ = [
     "ALGORITHM_REGISTRY",
     "AlgorithmIdentifier",
     "AlgorithmStatus",
+    "D2dVerifierKeys",
     "D2dWitness",
     "DEPRECATED_PRE_REGISTRY_LITERAL",
     "RegistryEntry",

--- a/src/kailash/trust/signing/crl.py
+++ b/src/kailash/trust/signing/crl.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 from kailash.trust.signing.algorithm_id import (
     ALGORITHM_DEFAULT,
     AlgorithmIdentifier,
+    D2dVerifierKeys,
     D2dWitness,
     coerce_algorithm_id,
     decode_wire_alg_id,
@@ -157,7 +158,11 @@ class CRLMetadata:
 
     @classmethod
     def from_dict(
-        cls, data: Dict[str, Any], *, witness: Optional[D2dWitness] = None
+        cls,
+        data: Dict[str, Any],
+        *,
+        witness: Optional[D2dWitness] = None,
+        verifier_keys: Optional[D2dVerifierKeys] = None,
     ) -> "CRLMetadata":
         """Deserialize from dictionary (EATP-08 §4.2 D2b / §4.5 D2d).
 
@@ -172,6 +177,8 @@ class CRLMetadata:
             data: Dictionary with CRLMetadata fields
             witness: A :class:`D2dWitness` only when rescuing a pre-registry
                 legacy record; ``None`` (default) means strict.
+            verifier_keys: The :class:`D2dVerifierKeys` config that verifies the
+                witness's ``marker_sig`` (§4.3.2); ``None`` => fail closed.
 
         Returns:
             CRLMetadata instance
@@ -179,7 +186,7 @@ class CRLMetadata:
         Raises:
             UnsupportedAlgorithmError: per EATP-08 §5.3.
         """
-        alg_id = decode_wire_alg_id(data, witness=witness)
+        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
         return cls(
             crl_id=data["crl_id"],
             issuer_id=data["issuer_id"],

--- a/src/kailash/trust/signing/timestamping.py
+++ b/src/kailash/trust/signing/timestamping.py
@@ -49,6 +49,7 @@ from uuid import uuid4
 from kailash.trust.signing.algorithm_id import (
     ALGORITHM_DEFAULT,
     AlgorithmIdentifier,
+    D2dVerifierKeys,
     D2dWitness,
     UnsupportedAlgorithmError,
     coerce_algorithm_id,
@@ -145,21 +146,26 @@ class TimestampToken:
 
     @classmethod
     def from_dict(
-        cls, data: Dict[str, Any], *, witness: Optional[D2dWitness] = None
+        cls,
+        data: Dict[str, Any],
+        *,
+        witness: Optional[D2dWitness] = None,
+        verifier_keys: Optional[D2dVerifierKeys] = None,
     ) -> "TimestampToken":
         """Deserialize token from dictionary (EATP-08 §4.2 D2b / §4.5 D2d).
 
         Post-adoption: the dict MUST carry a top-level ``alg_id`` string
         token; a missing/empty value raises ``missing-alg-id-post-adoption``.
         Legacy acceptance of a pre-registry explicit form requires a
-        :class:`D2dWitness` whose witnessed/head date is strictly before
-        :data:`ADOPTION_DATE` (§4.5); otherwise the form is rejected with
-        ``implicit-v1-witness-failure`` (no downgrade).
+        :class:`D2dWitness` whose signed marker verifies against a configured
+        :class:`D2dVerifierKeys` trusted key and whose witnessed/head date is
+        strictly before :data:`ADOPTION_DATE` (§4.5); otherwise the form is
+        rejected with ``implicit-v1-witness-failure`` (no downgrade).
 
         Raises:
             UnsupportedAlgorithmError: per EATP-08 §5.3.
         """
-        alg_id = decode_wire_alg_id(data, witness=witness)
+        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
         return cls(
             token_id=data["token_id"],
             hash_value=data["hash_value"],
@@ -242,15 +248,20 @@ class TimestampResponse:
 
     @classmethod
     def from_dict(
-        cls, data: Dict[str, Any], *, witness: Optional[D2dWitness] = None
+        cls,
+        data: Dict[str, Any],
+        *,
+        witness: Optional[D2dWitness] = None,
+        verifier_keys: Optional[D2dVerifierKeys] = None,
     ) -> "TimestampResponse":
         """Deserialize response from dictionary (EATP-08 §4.2 D2b / §4.5 D2d).
 
         The top-level ``alg_id`` is the signing-algorithm registry token,
         decoded under the D2b/D2d regime (legacy acceptance requires a dated
-        :class:`D2dWitness` strictly before :data:`ADOPTION_DATE`, §4.5). The
-        nested ``request.algorithm`` retains its original semantics (hash
-        algorithm; sha256).
+        :class:`D2dWitness` with a signed marker verified against a configured
+        :class:`D2dVerifierKeys` trusted key, strictly before
+        :data:`ADOPTION_DATE`, §4.5). The nested ``request.algorithm`` retains
+        its original semantics (hash algorithm; sha256).
 
         Raises:
             UnsupportedAlgorithmError: per EATP-08 §5.3.
@@ -262,11 +273,13 @@ class TimestampResponse:
             requested_at=datetime.fromisoformat(request_data["requested_at"]),
             algorithm=request_data.get("algorithm", "sha256"),
         )
-        token = TimestampToken.from_dict(data["token"], witness=witness)
+        token = TimestampToken.from_dict(
+            data["token"], witness=witness, verifier_keys=verifier_keys
+        )
         raw_response = (
             bytes.fromhex(data["raw_response"]) if data.get("raw_response") else None
         )
-        alg_id = decode_wire_alg_id(data, witness=witness)
+        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
         return cls(
             request=request,
             token=token,

--- a/tests/regression/test_eatp08_alg_id_canonical_vectors.py
+++ b/tests/regression/test_eatp08_alg_id_canonical_vectors.py
@@ -28,12 +28,13 @@ from kailash.trust.signing.algorithm_id import (
     ALGORITHM_DEFAULT,
     ALGORITHM_REGISTRY,
     AlgorithmIdentifier,
+    D2dVerifierKeys,
     D2dWitness,
     UnsupportedAlgorithmError,
     decode_wire_alg_id,
     resolve_dispatch,
 )
-from kailash.trust.signing.crypto import serialize_for_signing
+from kailash.trust.signing.crypto import generate_keypair, serialize_for_signing, sign
 
 _VECTORS_PATH = (
     Path(__file__).resolve().parents[1]
@@ -52,9 +53,43 @@ def _canonical_member_bytes(token: str) -> bytes:
 
 
 def _pre_adoption_witness() -> D2dWitness:
-    # Both dates strictly before ADOPTION_DATE (2026-04-26).
+    # Unsigned witness — for the rejection paths (bare-literal, unknown token,
+    # both-keys) where the value is rejected at the registry/shape gate BEFORE
+    # the D2d signed-marker gate is ever reached, so the marker need not verify.
     before = datetime(2026, 1, 1, tzinfo=timezone.utc)
     return D2dWitness(witnessed_at=before, chain_head_date=before)
+
+
+# A trusted verifier keypair, fixed for the module so the signed-marker accept
+# path (§4.3.2) is deterministic. The witness signs the §4.3.1 core
+# {principal, first_seen} with the private key; the verifier holds the public.
+_WITNESS_PRIVATE_KEY, _WITNESS_PUBLIC_KEY = generate_keypair()
+_WITNESS_ID = "eatp08-test-witness"
+
+
+def _verifier_keys() -> D2dVerifierKeys:
+    return D2dVerifierKeys(keys={_WITNESS_ID: _WITNESS_PUBLIC_KEY})
+
+
+def _signed_pre_adoption_witness() -> D2dWitness:
+    # A complete, signed, pre-adoption D2d marker that passes all five gate
+    # checks: principal + signed first_seen (both strictly < ADOPTION_DATE),
+    # marker_sig over the §4.3.1 signed core, no expiry.
+    before = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    principal = "chain:eatp08-test"
+    first_seen = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    marker_sig = sign(
+        {"principal": principal, "first_seen": first_seen.isoformat()},
+        _WITNESS_PRIVATE_KEY,
+    )
+    return D2dWitness(
+        witnessed_at=before,
+        chain_head_date=before,
+        principal=principal,
+        first_seen=first_seen,
+        marker_sig=marker_sig,
+        witness_id=_WITNESS_ID,
+    )
 
 
 @pytest.mark.regression
@@ -147,7 +182,14 @@ def test_non_conformant_nested_pre_registry_object_decode_regime():
     with pytest.raises(UnsupportedAlgorithmError) as exc:
         decode_wire_alg_id(nested)
     assert exc.value.code == "alg-id-shape-mismatch"
-    got = decode_wire_alg_id(nested, witness=_pre_adoption_witness())
+    # D2d accept requires a SIGNED marker verified against a trusted key
+    # (§4.3.2). An unsigned witness no longer rescues (see the signed-marker
+    # gate tests in test_issue_1316_d2c_marker.py).
+    got = decode_wire_alg_id(
+        nested,
+        witness=_signed_pre_adoption_witness(),
+        verifier_keys=_verifier_keys(),
+    )
     assert got == ALGORITHM_DEFAULT == "eatp-v1"
 
 

--- a/tests/regression/test_issue_1316_d2c_marker.py
+++ b/tests/regression/test_issue_1316_d2c_marker.py
@@ -1,0 +1,298 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""D2c signed-marker gate — EATP-08 §4.3.1 / §4.3.2 (issue #1316, Shard 1).
+
+The pre-1.1 ``D2dWitness`` was a TRUSTED passed-in value: the gate never
+verified a signature, so any caller asserting a pre-adoption witness downgraded
+a pre-registry form to ``eatp-v1`` forever. EATP-08 §4.3 requires the marker to
+be **signed-not-remembered**: the verifier holds a configured trusted key
+(:class:`D2dVerifierKeys`) and verifies ``marker_sig`` over the §4.3.1 signed
+core ``{principal, first_seen}`` INSIDE the gate.
+
+This file pins the §4.3.2 detection rule — the five fail-closed checks of
+:func:`assert_d2d_witness_pre_adoption` — both directly (the gate function) and
+through the centralised production decode path (:func:`decode_wire_alg_id`,
+which every signed-record ``from_dict`` consumer calls). All checks map to
+``implicit-v1-witness-failure``.
+
+Tests are behavioral (call the function; assert raise/return) per
+rules/testing.md, against REAL Ed25519 crypto (PyNaCl) — no mocking.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from kailash.trust.signing.algorithm_id import (
+    ADOPTION_DATE_PARSED,
+    ALGORITHM_DEFAULT,
+    D2dVerifierKeys,
+    D2dWitness,
+    UnsupportedAlgorithmError,
+    assert_d2d_witness_pre_adoption,
+    decode_wire_alg_id,
+)
+from kailash.trust.signing.crypto import generate_keypair, sign
+
+UTC = timezone.utc
+
+# A trusted verifier keypair fixed for the module so the signed-marker accept
+# path is deterministic.
+_PRIVATE_KEY, _PUBLIC_KEY = generate_keypair()
+_OTHER_PRIVATE_KEY, _ = generate_keypair()  # an UNtrusted key (private half only)
+_WITNESS_ID = "eatp08-1316-witness"
+
+_PRINCIPAL = "chain:eatp08-1316"
+_PRE_ADOPTION = datetime(2026, 1, 1, tzinfo=UTC)  # strictly before 2026-04-26
+_ON_ADOPTION = datetime(
+    ADOPTION_DATE_PARSED.year,
+    ADOPTION_DATE_PARSED.month,
+    ADOPTION_DATE_PARSED.day,
+    tzinfo=UTC,
+)
+
+
+def _keys() -> D2dVerifierKeys:
+    return D2dVerifierKeys(keys={_WITNESS_ID: _PUBLIC_KEY})
+
+
+def _sign(
+    principal: str | None, first_seen: datetime | None, key: str = _PRIVATE_KEY
+) -> str:
+    first_seen_repr = (
+        first_seen.isoformat() if isinstance(first_seen, datetime) else first_seen
+    )
+    return sign({"principal": principal, "first_seen": first_seen_repr}, key)
+
+
+def _valid_witness(**overrides) -> D2dWitness:
+    """A complete, signed, pre-adoption marker that passes ALL five checks."""
+    base: dict[str, Any] = dict(
+        witnessed_at=_PRE_ADOPTION,
+        chain_head_date=_PRE_ADOPTION,
+        principal=_PRINCIPAL,
+        first_seen=_PRE_ADOPTION,
+        marker_sig=_sign(_PRINCIPAL, _PRE_ADOPTION),
+        witness_id=_WITNESS_ID,
+    )
+    base.update(overrides)
+    return D2dWitness(**base)
+
+
+# The nested pre-registry form — the production D2d shape decode_wire_alg_id
+# routes through the witness gate.
+_NESTED_FORM = {"alg_id": {"algorithm": "ed25519+sha256"}}
+
+
+# ---------------------------------------------------------------------------
+# Accept path (all five checks hold) — direct gate AND through decode_wire_alg_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_valid_signed_marker_passes_gate_directly():
+    # Returns silently when all five checks hold.
+    assert_d2d_witness_pre_adoption(_valid_witness(), verifier_keys=_keys()) is None
+
+
+@pytest.mark.regression
+def test_valid_signed_marker_accepts_through_decode_wire():
+    # Wiring: the production decode chokepoint accepts the nested pre-registry
+    # form as eatp-v1 ONLY with a verified signed marker.
+    got = decode_wire_alg_id(
+        _NESTED_FORM, witness=_valid_witness(), verifier_keys=_keys()
+    )
+    assert got == ALGORITHM_DEFAULT == "eatp-v1"
+
+
+# ---------------------------------------------------------------------------
+# Check 1 — missing witness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_check1_missing_witness_rejected():
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(None, verifier_keys=_keys())
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+# ---------------------------------------------------------------------------
+# Check 2 — signed-not-remembered (signature verification)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_check2_unsigned_marker_rejected():
+    # The pre-1.1 trusted-passed-in witness (no marker_sig) no longer rescues.
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(
+            _valid_witness(marker_sig=None), verifier_keys=_keys()
+        )
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check2_missing_principal_rejected():
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(
+            _valid_witness(principal=None), verifier_keys=_keys()
+        )
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check2_no_verifier_keys_configured_rejected():
+    # A signed marker with NO trusted-key config fails closed.
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(_valid_witness(), verifier_keys=None)
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check2_unknown_witness_id_rejected():
+    # witness_id resolves to no key, and no default_key is set.
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(
+            _valid_witness(witness_id="not-in-config"), verifier_keys=_keys()
+        )
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check2_signature_by_untrusted_key_rejected():
+    # The marker is signed by a different key than the configured trusted one.
+    forged = _valid_witness(
+        marker_sig=_sign(_PRINCIPAL, _PRE_ADOPTION, key=_OTHER_PRIVATE_KEY)
+    )
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(forged, verifier_keys=_keys())
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check2_tampered_principal_breaks_signature():
+    # marker_sig binds {principal, first_seen}; mutating principal after signing
+    # breaks verification (the signed core no longer matches).
+    tampered = _valid_witness(principal="chain:attacker")
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(tampered, verifier_keys=_keys())
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check2_default_key_resolves_when_witness_id_unset():
+    # A marker with no witness_id verifies against the config default_key.
+    w = _valid_witness(witness_id=None)
+    keys = D2dVerifierKeys(keys={}, default_key=_PUBLIC_KEY)
+    assert assert_d2d_witness_pre_adoption(w, verifier_keys=keys) is None
+
+
+# ---------------------------------------------------------------------------
+# Check 3 — first_seen corroboration (defeats backdated chain_head_date)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_check3_missing_first_seen_rejected():
+    # No signed first_seen => uncorroborated. (Sign over first_seen=None so the
+    # signature itself verifies; check 3 then rejects on the missing field.)
+    w = _valid_witness(first_seen=None, marker_sig=_sign(_PRINCIPAL, None))
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(w, verifier_keys=_keys())
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check3_fresh_record_backdated_head_rejected():
+    # The V6(iii) attack: a FRESH record (post-adoption first_seen, signed by
+    # the real witness) backdates its claimed chain_head_date to pre-adoption.
+    # The SIGNED first_seen is post-adoption, so corroboration fails — the
+    # attacker cannot obtain a pre-adoption signed first_seen for a fresh chain.
+    post_adoption_first_seen = _ON_ADOPTION
+    w = D2dWitness(
+        witnessed_at=_PRE_ADOPTION,
+        chain_head_date=_PRE_ADOPTION,  # attacker's backdated CLAIM
+        principal=_PRINCIPAL,
+        first_seen=post_adoption_first_seen,  # the SIGNED truth: post-adoption
+        marker_sig=_sign(_PRINCIPAL, post_adoption_first_seen),
+        witness_id=_WITNESS_ID,
+    )
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(w, verifier_keys=_keys())
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+# ---------------------------------------------------------------------------
+# Check 4 — expiry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_check4_expired_marker_rejected():
+    now = datetime(2026, 2, 1, tzinfo=UTC)
+    expired = _valid_witness(expires_at=datetime(2026, 1, 15, tzinfo=UTC))
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(expired, verifier_keys=_keys(), now=now)
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check4_unexpired_marker_accepted():
+    now = datetime(2026, 2, 1, tzinfo=UTC)
+    fresh = _valid_witness(expires_at=datetime(2026, 3, 1, tzinfo=UTC))
+    assert (
+        assert_d2d_witness_pre_adoption(fresh, verifier_keys=_keys(), now=now) is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check 5 — temporal monotonic boundary (claimed dates strictly < adoption)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_check5_chain_head_on_adoption_rejected():
+    # Signature + first_seen corroboration pass, but the claimed chain_head_date
+    # is ON the adoption date (not strictly before) => temporal-boundary reject.
+    w = _valid_witness(chain_head_date=_ON_ADOPTION)
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(w, verifier_keys=_keys())
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_check5_witnessed_at_on_adoption_rejected():
+    w = _valid_witness(witnessed_at=_ON_ADOPTION)
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        assert_d2d_witness_pre_adoption(w, verifier_keys=_keys())
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+# ---------------------------------------------------------------------------
+# Wiring: an unsigned witness through the production decode path is rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_unsigned_witness_through_decode_wire_rejected():
+    # The pre-1.1 acceptance path (trusted unsigned witness) is closed end-to-end.
+    legacy_unsigned = D2dWitness(
+        witnessed_at=_PRE_ADOPTION, chain_head_date=_PRE_ADOPTION
+    )
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        decode_wire_alg_id(_NESTED_FORM, witness=legacy_unsigned, verifier_keys=_keys())
+    assert exc.value.code == "implicit-v1-witness-failure"
+
+
+@pytest.mark.regression
+def test_signed_witness_no_verifier_keys_through_decode_wire_rejected():
+    # Forwarding a signed witness but no verifier_keys (the default consumer
+    # call) fails closed — the marker cannot be verified.
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        decode_wire_alg_id(_NESTED_FORM, witness=_valid_witness(), verifier_keys=None)
+    assert exc.value.code == "implicit-v1-witness-failure"

--- a/tests/regression/test_issue_604_alg_id_threading.py
+++ b/tests/regression/test_issue_604_alg_id_threading.py
@@ -43,25 +43,51 @@ from kailash.trust.pact.envelopes import (
 from kailash.trust.signing.algorithm_id import (
     ADOPTION_DATE,
     DEPRECATED_PRE_REGISTRY_LITERAL,
+    D2dVerifierKeys,
     D2dWitness,
     resolve_dispatch,
 )
-from kailash.trust.signing.crypto import generate_keypair
+from kailash.trust.signing.crypto import generate_keypair, sign
 
-# A witness whose witnessed/head dates are strictly BEFORE the pinned
-# adoption date (2026-04-26). This is what D2d requires to accept a
+# Trusted verifier keypair for the D2d signed-marker gate (§4.3.2). The witness
+# signs the §4.3.1 core {principal, first_seen}; the verifier holds the public
+# key. D2d acceptance is signed-not-remembered: an unsigned witness no longer
+# rescues a pre-registry form (see test_issue_1316_d2c_marker.py for the gate).
+_WITNESS_PRIVATE_KEY, _WITNESS_PUBLIC_KEY = generate_keypair()
+_WITNESS_ID = "issue604-test-witness"
+_VERIFIER_KEYS = D2dVerifierKeys(keys={_WITNESS_ID: _WITNESS_PUBLIC_KEY})
+
+
+def _signed_marker(principal: str, first_seen: datetime) -> str:
+    return sign(
+        {"principal": principal, "first_seen": first_seen.isoformat()},
+        _WITNESS_PRIVATE_KEY,
+    )
+
+
+# A signed witness whose witnessed/head/first_seen dates are strictly BEFORE the
+# pinned adoption date (2026-04-26). This is what D2d requires to accept a
 # pre-registry explicit form as eatp-v1.
+_PRE_ADOPTION_FIRST_SEEN = datetime(2026, 3, 1, tzinfo=UTC)
 _PRE_ADOPTION_WITNESS = D2dWitness(
     witnessed_at=datetime(2026, 3, 1, tzinfo=UTC),
     chain_head_date=datetime(2026, 3, 1, tzinfo=UTC),
     principal="D1-R1",
+    first_seen=_PRE_ADOPTION_FIRST_SEEN,
+    marker_sig=_signed_marker("D1-R1", _PRE_ADOPTION_FIRST_SEEN),
+    witness_id=_WITNESS_ID,
 )
 
-# A witness dated ON the adoption date — must be REJECTED (not strictly before).
+# A signed witness with a pre-adoption first_seen (passes the signature +
+# corroboration checks) but witnessed/head dates ON the adoption date — must be
+# REJECTED at the temporal boundary check (not strictly before adoption).
 _POST_ADOPTION_WITNESS = D2dWitness(
     witnessed_at=datetime(2026, 4, 26, tzinfo=UTC),
     chain_head_date=datetime(2026, 4, 26, tzinfo=UTC),
     principal="D1-R1",
+    first_seen=_PRE_ADOPTION_FIRST_SEEN,
+    marker_sig=_signed_marker("D1-R1", _PRE_ADOPTION_FIRST_SEEN),
+    witness_id=_WITNESS_ID,
 )
 
 # ---------------------------------------------------------------------------
@@ -330,7 +356,9 @@ def test_signed_envelope_from_dict_d2d_nested_form(signed):
 
     payload = signed.to_dict()
     payload["alg_id"] = {"algorithm": DEPRECATED_PRE_REGISTRY_LITERAL}
-    reconstructed = SignedEnvelope.from_dict(payload, witness=_PRE_ADOPTION_WITNESS)
+    reconstructed = SignedEnvelope.from_dict(
+        payload, witness=_PRE_ADOPTION_WITNESS, verifier_keys=_VERIFIER_KEYS
+    )
     assert reconstructed.alg_id == "eatp-v1"
 
 
@@ -345,7 +373,9 @@ def test_signed_envelope_from_dict_d2d_unsigned_metadata_form(signed):
     payload = signed.to_dict()
     payload.pop("alg_id")
     payload["algorithm"] = DEPRECATED_PRE_REGISTRY_LITERAL
-    reconstructed = SignedEnvelope.from_dict(payload, witness=_PRE_ADOPTION_WITNESS)
+    reconstructed = SignedEnvelope.from_dict(
+        payload, witness=_PRE_ADOPTION_WITNESS, verifier_keys=_VERIFIER_KEYS
+    )
     assert reconstructed.alg_id == "eatp-v1"
 
 
@@ -363,7 +393,9 @@ def test_d2d_pre_adoption_witnessed_legacy_record_accepted(signed):
     assert ADOPTION_DATE == "2026-04-26"
     payload = signed.to_dict()
     payload["alg_id"] = {"algorithm": DEPRECATED_PRE_REGISTRY_LITERAL}
-    reconstructed = SignedEnvelope.from_dict(payload, witness=_PRE_ADOPTION_WITNESS)
+    reconstructed = SignedEnvelope.from_dict(
+        payload, witness=_PRE_ADOPTION_WITNESS, verifier_keys=_VERIFIER_KEYS
+    )
     assert reconstructed.alg_id == "eatp-v1"
 
 
@@ -379,7 +411,9 @@ def test_d2d_on_or_after_adoption_witness_rejected(signed):
     payload = signed.to_dict()
     payload["alg_id"] = {"algorithm": DEPRECATED_PRE_REGISTRY_LITERAL}
     with pytest.raises(UnsupportedAlgorithmError) as exc:
-        SignedEnvelope.from_dict(payload, witness=_POST_ADOPTION_WITNESS)
+        SignedEnvelope.from_dict(
+            payload, witness=_POST_ADOPTION_WITNESS, verifier_keys=_VERIFIER_KEYS
+        )
     assert exc.value.code == "implicit-v1-witness-failure"
 
 

--- a/workspaces/issue-1316-eatp08-marker-regime-py/01-analysis/01-verification-findings.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/01-analysis/01-verification-findings.md
@@ -1,0 +1,90 @@
+# 01 — Parallel brief-claim verification (4 independent deep-dive agents)
+
+Per `rules/agents.md` § "Parallel Brief-Claim Verification When Issue Count ≥ 3". Four
+agents, four claim clusters, one wall-clock unit. All citations re-derived from source.
+
+## Cluster 1 — D2c marker store (call-site map + crypto reuse)
+
+- **CONFIRMED**: `D2dWitness` (`algorithm_id.py:168-220`) is a frozen 3-field value object
+  (`witnessed_at`, `chain_head_date`, `principal`); no signature, no `first_seen`, no
+  `marker_sig`. Docstring `:188-192` "signed-not-remembered" is aspirational, not code.
+- **CONFIRMED**: `assert_d2d_witness_pre_adoption` (`:223-257`) has exactly 2 raise paths
+  (`witness is None` :241; `not is_pre_adoption()` :249) — both `implicit-v1-witness-failure`.
+  No unverifiable/expired/non-corroborating branch.
+- **CONFIRMED**: zero `marker_sig`/`first_seen`/`MarkerStore` in `src/kailash/trust/`.
+- **Blast radius (mechanical for callers)**: NO production code constructs a `D2dWitness`
+  (0 src hits; 3 test constructions only). The marker-population path is greenfield. 5
+  wire-decode consumers forward `witness=witness` unchanged:
+  `timestamping.py:162`, `timestamping.py:269`, `crl.py:182`, `messaging/envelope.py:300`,
+  `pact/envelopes.py:1376`. Behavioral change is contained in `D2dWitness` +
+  `assert_d2d_witness_pre_adoption`.
+- **Crypto reuse (ready)**: `kailash.trust.signing.crypto` — `verify_signature(payload, sig,
+pubkey)` (`crypto.py:170`), `sign(...)` (`:122`), `serialize_for_signing(obj)` (`:225`,
+  the JCS canonical pre-image builder, `sort_keys`+`separators=(",",":")`+`allow_nan=False`).
+  Marker signs `serialize_for_signing({principal, first_seen, chain_head_date})`.
+- **Trusted-verifier-key config — MUST BE ADDED (inference, not existing)**: no
+  `trusted_verifier_key` in the trust layer. Closest pattern: `MultiSigPolicy.signer_public_keys:
+Dict[str,str]` (`multi_sig.py:170`) iterated by `verify_multi_sig` (`:493`). Recommend
+  resolving the trusted key INSIDE the gate from module/instance config — NOT threading it
+  through `decode_wire_alg_id` — keeping call-graph ≤3 hops and the 5 consumer signatures
+  untouched.
+- **Insertion point**: extend `assert_d2d_witness_pre_adoption` in place (single chokepoint
+  both D2d branches `:487`/`:610` call; already raises the §4.3.2 code). 2 checks → 5.
+- **Invariant count CONFIRMED ~5**: sig-verify · first_seen-corroboration · expiry ·
+  monotonic-boundary · fail-closed. `D2dWitness` also needs `first_seen` + `marker_sig` +
+  an expiry/TTL field (none exists today).
+
+## Cluster 2 — V6/V7 vectors + monotonic enforcement (BRIEF CORRECTION)
+
+- **CONFIRMED**: vector file has no V6/V7/strip/marker entries. Schema = 3 sibling
+  collections (`registry[]` byte-pins: `token`/`status`/`dispatchable`/`canonical_member`/
+  `expected_sha256`; `non_conformant[]` decode-regime: `name`/`value_repr`/`shape`/
+  `decode_post_adoption`/`decode_with_pre_adoption_witness`/`reason`). **No
+  `conformance_level` field** — V6/V7 need a new `level` field added to the schema.
+- **CORRECTION — `monotonic-upgrade-violation` is NOT implemented**. Only a forward-reference
+  docstring at `algorithm_id.py:197-198` ("enforced by the record consumer, not this temporal
+  gate"). The enforcer does NOT exist anywhere in `src/`. V6 sub-case (i) (prior-v2 →
+  `monotonic-upgrade-violation`) is therefore NOT "author a vector" — it requires
+  IMPLEMENTING the enforcer (new load-bearing code, record-consumer layer, cross-file).
+  Sub-cases (ii) `missing-alg-id-post-adoption` and (iii) `implicit-v1-witness-failure` are
+  already enforced in `algorithm_id.py` (`:505-506`/`:623-624`, `:242-243`/`:250-251`) and
+  immediately testable.
+- Decode-regime tests are hand-written (not data-driven), assert `exc.value.code ==
+"<code>"`. `test_issue_604_alg_id_threading.py` already has executable analogues of V6 (ii)
+  - (iii) through the `SignedEnvelope.from_dict` surface, with `_PRE_ADOPTION_WITNESS` /
+    `_POST_ADOPTION_WITNESS` fixtures.
+
+## Cluster 3 — Compatible-Legacy logging §7.1 (BRIEF CORRECTION)
+
+- **CORRECTION — logging is NOT greenfield (brief claim FALSE)**. Two `logger.info`
+  D2d-acceptance lines already ship: `algorithm_id.py:488-498` (nested-object form) and
+  `:611-621` (unsigned-`algorithm` form). Both carry `witnessed_at`/`chain_head_date`/
+  `ADOPTION_DATE` and fire on successful acceptance.
+- §7.1 work reduces to: (a) INFO→WARN decision (a D2d acceptance is a degraded/fallback
+  path → `observability.md` Rule 3 argues WARN); (b) optionally consolidate the two into one
+  helper for uniform level/fields; (c) guard that `principal`/chain-head id is NOT logged at
+  raw severity (`observability.md` Rule 8 — DEBUG or sha256[:8]). Currently `principal` is
+  NOT logged (safe today); preserve that.
+- Module logger present (`algorithm_id.py:51`); printf-lazy style (compliant). Note
+  `messaging/envelope.py` has no module logger (irrelevant — it routes through the primitive).
+
+## Cluster 4 — Cross-SDK parity (BRIEF CORRECTION — direction inverted)
+
+- **CORRECTION — kailash-py is the CANONICAL AUTHOR, not the vendoring consumer**.
+  `eatp08-alg-id-canonical.json:7`: "kailash-py is the canonical AUTHOR … kailash-rs VENDORS
+  this file byte-for-byte (#1315)". So V6/V7 byte values (`canonical_member`,
+  `expected_sha256`) are DERIVED HERE deterministically via `serialize_for_signing(
+AlgorithmIdentifier(algorithm=token).to_dict())` + sha256 — NOT coordinated with rs.
+  **No upstream byte-value dependency blocks the py work.**
+- Parity assertion is byte-pinned (Rule-4 compliant): `test_eatp08_alg_id_canonical_vectors.py`
+  re-derives `canonical_member` + `expected_sha256` per registry row and asserts equality;
+  `test_vectors_file_loads_and_pins_the_active_default` asserts vector-set == `ALGORITHM_REGISTRY`
+  (so a new token without a vector row fails loudly).
+- Canonicalization helper: `serialize_for_signing` (`crypto.py:225`, `ensure_ascii=True` →
+  ASCII-escaped, load-bearing for rs serde_json parity). Distinct from the delegate-family
+  `kailash.trust._json.canonical_json_dumps` (`ensure_ascii=False`, issue #1258) — alg-id
+  vectors use the signing family. Alg-id tokens are ASCII so the distinction is moot for
+  these bytes, but use the signing-family helper.
+- **Handoff boundary**: full V6/V7 authoring is doable here (registry + vectors + byte-pins).
+  The only cross-repo step is the downstream rs vendor-pull, which happens in the rs sibling
+  session — py → rs, not a blocker.

--- a/workspaces/issue-1316-eatp08-marker-regime-py/01-analysis/02-spec-locked-facts.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/01-analysis/02-spec-locked-facts.md
@@ -1,0 +1,91 @@
+# 02 — Spec-locked normative facts (EATP-08 v1.1, §4.3/§4.5/§5/§6)
+
+Source (user-authorized cross-repo read, journal 0002):
+`~/repos/terrene/mint/workspaces/envoy-parity/03-drafts/finalized/eatp-08-v1.1.md`.
+Verbatim normative pins below resolve the Shard-3 open question and correct Shard 1's
+marker payload.
+
+## §4.3.1 Witnessed-marker contents (normative) — Shard 1 field shape
+
+REQUIRED signed core (`:195-205`):
+
+```json
+{
+  "principal": "<principal_chain_id>",
+  "first_seen": "<RFC-3339-Z first-contact/adoption boundary>",
+  "marker_sig": "<signature over the marker by witness or verifier key>"
+}
+```
+
+- `marker_sig` binds `principal` + `first_seen` ("the values D2a/D2b/D2d compare against").
+- **CORRECTION to brief/shard-1 design**: the signed payload is `{principal, first_seen}`,
+  NOT `{principal, first_seen, chain_head_date}`. `chain_head_date` is the record's CLAIMED
+  head timestamp that gets corroborated AGAINST the witnessed `first_seen` — it is not signed
+  into the marker.
+- A marker MAY carry additional fields — explicitly `first_v2_seen` (flag-and-timestamp for
+  the monotonic-upgrade boundary) and `witness_id` — but **any field a verifier relies on for
+  a D2 decision MUST be inside the signed bytes** (`:205`).
+
+## §4.3 Transport (normative split) — design (a) is spec-blessed
+
+`:191`: transport is implementation-defined — "a Trillian-style transparency log, an
+in-Foundation witness service, **or per-verifier signing keys**". Contents (§4.3.1) +
+detection (§4.3.2) are normative; transport is not. → The recommended **verifier-key signed
+marker** IS a first-class conformant transport, not a compromise.
+
+## §4.3.2 Detection rule (normative) — Shard 1 detection branch
+
+`:207-209`: emit `implicit-v1-witness-failure` when ANY of:
+
+1. the marker is missing;
+2. `marker_sig` fails verification OR the marker is expired;
+3. the record's claimed pre-adoption head date is not corroborated by a signed pre-adoption
+   `first_seen` (witnessed `first_seen` does not precede adoption, OR no pre-adoption witness
+   entry exists for the head's hash).
+
+## §4.1.3 / §4.2 / §4.5.3 — the monotonic dimension (Shard 3)
+
+- §4.1.3 (`:177`): D2a acceptance ALSO requires "the verifier's trust store contains no v2
+  record from this principal-chain." **This trust-store-no-prior-v2 check is a SEPARATE state
+  dimension from the temporal witness, and is unenforced today** (the gate only does temporal
+  - missing).
+- §4.2 (`:185`): reject any record without `alg_id` from a principal-chain that has
+  previously emitted a v2 record → `monotonic-upgrade-violation`.
+- §4.5.3 (`:229`): once a registry-form `eatp-v1`(or later) record appears in the chain, the
+  pre-registry form is rejected with `monotonic-upgrade-violation`.
+- The boundary MAY live in the SAME signed marker (`first_v2_seen`, §4.3.1). So Shard 3 =
+  (a) a `first_v2_seen` field on Shard 1's marker store + (b) the WRITE path that records
+  first-v2 emission (record-consumer layer) + (c) the READ check in resolver dispatch §5.1
+  step 3.
+
+## §5.1 Resolver dispatch (the wiring point)
+
+`:245-249` step 3: "If `alg_id` is absent, apply D2a/D2b/D2c. If acceptance is permitted
+under D2a, dispatch `eatp-v1`; otherwise reject with `missing-alg-id-post-adoption` or
+`monotonic-upgrade-violation`. If a pre-registry explicit form is present, apply D2d."
+
+## §5.3 Error codes (full set — some unimplemented today)
+
+Confirmed normative codes (`:259-268`): `unsupported-algorithm`, `alg-id-shape-mismatch`,
+`missing-alg-id-post-adoption`, `monotonic-upgrade-violation`, `implicit-v1-witness-failure`,
+`pre-registry-form-after-sunset` (D2d 2030 sunset), `chain-ref-canonical-form-mismatch`,
+`alg-id-strip-detected` (signature matches no registered algorithm). The last three may be
+absent today — confirm at /todos which are already raised vs new.
+
+## §6 Vectors + levels (Shard 2 schema `level` field)
+
+`:272`: V1–V7 required at **Conformant**; **V7 at Complete only**. V9 (D2d accept) present.
+V8 is an amendment-procedure obligation, NOT a runtime vector (exclude from executable set).
+V6 three sub-cases pinned `:302-306` (prior-v2 → `monotonic-upgrade-violation`; fresh
+post-adoption → `missing-alg-id-post-adoption`; fresh attacker-pre-adoption-date →
+`implicit-v1-witness-failure`, fixture REQUIRED). V7 `:308-311` local-marker-tamper →
+`implicit-v1-witness-failure`.
+
+## Net architectural insight
+
+The D2c signed-marker store is the unifying substrate for THREE D2 decisions: D2a
+(`first_seen`/adoption witness), D2b+D2d-monotonic (`first_v2_seen`), and the §4.3.2
+detection. Shard 1 builds the store + witness side; Shard 3 adds the `first_v2_seen`
+dimension + the record-consumer write path + the resolver read. This couples Shard 3 to
+Shard 1 (shared store) but removes the "separate cross-layer subsystem" risk — it is one
+store with two state fields.

--- a/workspaces/issue-1316-eatp08-marker-regime-py/02-plans/01-architecture.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/02-plans/01-architecture.md
@@ -1,0 +1,117 @@
+# Architecture plan — #1316 EATP-08 marker-regime tail (D2c + V6/V7 + §7.1 logging)
+
+Phase-01 output. Decomposition under the autonomous execution model
+(`rules/autonomous-execution.md` — sessions, not days; value-anchored shards per
+`rules/value-prioritization.md` Rule 2). Value anchor: EATP-08 §4 backward-compat
+conformance + cross-SDK parity, the only open actionable py-side item (HIGH, spec-anchored;
+user-approved this session).
+
+## Brief corrections (THE GATE before /todos — `rules/agents.md` MUST)
+
+Four parallel deep-dive agents re-derived every brief claim from source. Material
+corrections:
+
+1. **Cross-SDK direction inverted — in our favor.** Brief framed parity as a cross-repo
+   blocker (rs-canonical). FALSE: kailash-py is the **canonical author**; kailash-rs vendors
+   this file (`eatp08-alg-id-canonical.json:7`). V6/V7 byte-pins are derived here
+   deterministically. **No cross-repo dependency blocks any shard.**
+2. **Compatible-Legacy logging is NOT greenfield.** Brief implied §7.1 logging was unbuilt.
+   FALSE: two `logger.info` acceptance lines already ship (`algorithm_id.py:488-498`,
+   `:611-621`). Shard 4 shrinks to a level/consolidation decision.
+3. **`monotonic-upgrade-violation` is unimplemented** (only a forward-reference docstring,
+   `algorithm_id.py:197-198`). V6 sub-case (i) is a NEW ENFORCER, not a vector. Split into
+   its own shard with cross-file reach into the record-consumer layer. **This is the one
+   genuine scope increase and the one open spec question** (see § Open question).
+4. **D2c trusted-verifier-key config must be built** (no existing config; pattern =
+   `MultiSigPolicy.signer_public_keys`, `multi_sig.py:170`). Crypto primitives are ready
+   (`crypto.py:170`/`:225`).
+5. **D2c blast radius is mechanical for callers** — 0 production constructions of
+   `D2dWitness`; the 5 wire-decode consumers only forward `witness=`. Behavioral change is
+   contained in 2 functions. Invariant count confirmed ~5.
+
+## Design decision (recommended — confirm marker field shape against spec at /todos)
+
+**(a) Verifier-key signed marker — SPEC-BLESSED** (§4.3 explicitly lists "per-verifier
+signing keys" as a conformant transport; see `01-analysis/02-spec-locked-facts.md`).
+`D2dWitness` grows `first_seen`, `marker_sig`, and an expiry bound; the marker signs
+`serialize_for_signing({principal, first_seen})` (NOT `chain_head_date` — corrected per
+§4.3.1: `chain_head_date` is the record's CLAIMED value, corroborated AGAINST the signed
+`first_seen`, not part of the signed bytes). Verification resolves a configured trusted key
+INSIDE the gate. Self-contained, no external infra, full cross-SDK byte parity, not a
+one-way door (a transparency log / Foundation witness service can later become the marker
+_source_ without changing this verification contract). Options (b)/(c) require external
+infrastructure whose existence is unverified — out of scope until a live existence check
+confirms an endpoint.
+
+## Shard decomposition (4 shards, ~2 sessions)
+
+### Shard 1 — D2c signed-marker + verifier + §4.3.2 detection (load-bearing crypto)
+
+- `D2dWitness` (`algorithm_id.py:168`) grows `first_seen`, `marker_sig`, expiry/TTL.
+- Add trusted-verifier-key config (mirror `signer_public_keys`); resolve inside the gate.
+- Extend `assert_d2d_witness_pre_adoption` (`:223`) from 2 → 5 checks (missing · sig-verify ·
+  first_seen-corroboration · expiry · monotonic-boundary), all fail-closed →
+  `implicit-v1-witness-failure`.
+- **Invariants: 5. Call-graph: ≤3 hops (key resolved in-gate). Live pytest loop → feedback
+  multiplier.** Tier-2 wiring test through a real `from_dict` consumer (orphan-detection).
+- Deps: none. **~1 session.**
+
+### Shard 2 — V6 (ii)+(iii) + V7 vectors + schema `level` field
+
+- Add `level` field to the vector schema; author V6 sub-cases (ii) `missing-alg-id-post-adoption`
+  - (iii) `implicit-v1-witness-failure` and V7 Complete-level local-marker-tamper (depends on
+    Shard 1's signed marker). Byte-pins derived here.
+- Decode-regime tests hand-written, `exc.value.code` assertions (existing style).
+- Deps: Shard 1 (V7 + the (iii) marker path). **Small; live test loop.**
+
+### Shard 3 — monotonic-upgrade enforcer (NEW load-bearing logic — SCOPED, spec-locked)
+
+Spec resolves the boundary (§4.1.3 / §4.2 / §4.5.3): the monotonic dimension is "has this
+principal-chain previously emitted a registry-form record?" The spec lets that boundary live
+in the SAME signed marker (`first_v2_seen`, §4.3.1). So this shard is three pieces, NOT a
+separate subsystem:
+
+- **(a) `first_v2_seen` field** on Shard 1's signed marker (inside the signed bytes per
+  §4.3.1).
+- **(b) write path** — record-consumer layer records first-registry-form emission for a
+  principal-chain (the cross-file piece; the verify/record path, e.g. `pact/envelopes.py`
+  consumer surface).
+- **(c) read check** in resolver dispatch §5.1 step 3 (`algorithm_id.py` /
+  `decode_wire_alg_id`): absent-alg-id OR pre-registry-form from a chain with a prior
+  registry-form record → `monotonic-upgrade-violation`. Then author the V6 (i) vector.
+- Note §4.1.3 also requires the D2a "trust store contains no prior-v2" check, currently
+  unenforced — same `first_v2_seen` substrate covers it.
+- Deps: Shard 1 (shares the marker store). **~1 session.** Cross-file reach into the
+  record-consumer write path is the real surface here.
+
+### Shard 4 — Compatible-Legacy logging §7.1 (observability; small)
+
+- Decide INFO→WARN (degraded-path → WARN per `observability.md` Rule 3); consolidate the two
+  existing acceptance logs (`:488`/`:611`) into one helper; guard `principal`/chain-head id
+  at DEBUG-or-hashed (Rule 8). Add a migration-tracking counter.
+- Deps: touches the same gate as Shard 1 — sequence AFTER Shard 1 to avoid churn. **Small.**
+
+## Open question — RESOLVED (spec read, user-authorized 2026-06-15, journal 0002)
+
+The `monotonic-upgrade-violation` enforcer is now fully scoped against EATP-08 v1.1
+§4.1.3/§4.2/§4.3.1/§4.5.3 (`01-analysis/02-spec-locked-facts.md`). All four shards are
+spec-locked. The spec authority is the EXTERNAL finalized doc at
+`~/repos/terrene/mint/workspaces/envoy-parity/03-drafts/finalized/eatp-08-v1.1.md` (the
+v1.1.1 erratum = the already-shipped bare-literal reject); no competing `specs/` is created
+in this repo — the EATP-08 doc is the domain truth, mirrored in 02-spec-locked-facts.
+
+**Residual to confirm at /todos** (small): which of the full §5.3 error-code set is already
+raised vs new — `pre-registry-form-after-sunset` (2030 D2d sunset) and `alg-id-strip-detected`
+may be absent today; confirm by grep before locking Shard 2/3 vector coverage.
+
+## Cross-SDK + repo-scope boundary
+
+Full V6/V7 authoring + byte-pins land here (py is canonical author). The rs vendor-pull is a
+downstream `esperie-enterprise/kailash-rs` session — NOT performed from this repo
+(`rules/repo-scope-discipline.md`).
+
+## Gate
+
+This plan stops at the `/analyze → /todos` boundary. `/todos` is the human-approval gate
+(`rules/autonomous-execution.md` § Structural Gates). Recommended /todos sequence:
+**Shard 1 → Shard 4 → Shard 2 → Shard 3** (3 last, pending the spec answer).

--- a/workspaces/issue-1316-eatp08-marker-regime-py/briefs/issue-1316-marker-regime.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/briefs/issue-1316-marker-regime.md
@@ -1,0 +1,80 @@
+# Brief: #1316 — EATP-08 ISS-32 marker-regime tail (D2c + V6/V7 + Compatible-Legacy logging)
+
+**Source issue**: `terrene-foundation/kailash-py#1316` (OPEN) — "[conformance] EATP-08 ISS-32
+— D2b/D2c/D2d marker regime + bare-literal reject (spec-referenced tracker)".
+
+**Spec anchor**: `foundation/docs/02-standards/eatp/08-algorithm-identifier.md@v1.1.1`
+§4.5/§4.6/§5.1/§7.1, vectors V6/V7/V9. Foundation erratum PR #17; ruling mint PR #27
+(resolves `terrene-foundation/mint#26`).
+
+**Value anchor** (user-stated, this session): the only open actionable py-side item;
+HIGH, spec-anchored. Delivers EATP-08 §4 backward-compat conformance + cross-SDK parity
+with `esperie-enterprise/kailash-rs` ISS-33. Approved scope-first then `/analyze` by the
+user 2026-06-15.
+
+## Already shipped (do NOT redo)
+
+- **E6** silent default-fill removed (#1304 / merged #1309): `from_dict` no longer
+  default-fills a missing/empty `alg_id`; post-adoption missing raises
+  `missing-alg-id-post-adoption` (D2b).
+- **D2d dated/witnessed gate**: `D2dWitness`, `assert_d2d_witness_pre_adoption`,
+  `ADOPTION_DATE = 2026-04-26` — pre-registry explicit form accepted as `eatp-v1` only with
+  a witness dated strictly before adoption.
+- **Bare-literal reject** (v1.1.1 / mint#26, PR #1315): bare top-level-string
+  `alg_id:"ed25519+sha256"` → `unsupported-algorithm`, not D2d.
+
+## Outstanding tail (this workstream)
+
+1. **D2c signed-marker store** (§4.3.1 / §4.3.2). `D2dWitness` today is a TRUSTED passed-in
+   value (`witnessed_at`, `chain_head_date`, `principal`); D2c requires the witnessed
+   `{principal, first_seen, marker_sig}` marker to be **signed-not-remembered** (verifier
+   key / transparency log / Foundation witness service) AND the §4.3.2 detection rule:
+   `implicit-v1-witness-failure` when the marker is missing / expired / unverifiable OR does
+   not corroborate the claimed pre-adoption head date.
+2. **V6 (alg-id-strip-attack)** executable vector — three sub-cases: prior-v2 →
+   `monotonic-upgrade-violation`; fresh post-adoption → `missing-alg-id-post-adoption`;
+   fresh attacker-chosen-pre-adoption-date → `implicit-v1-witness-failure`.
+3. **V7 (witnessed-adoption-marker, Complete level)** — local-marker-tamper detection via
+   the signed marker.
+4. **Compatible-Legacy logging** (§7.1) — log every D2a/D2d acceptance for migration
+   tracking until the marker store + adoption-date gate fully ship.
+
+## Acceptance (from issue)
+
+- All §4.2/§4.3/§4.5 normative requirements implemented; V4–V7 + V9 pass at stated
+  conformance levels.
+- Cross-SDK byte/behavior parity with `esperie-enterprise/kailash-rs` (ISS-33 / #1315) on the
+  alg-id-canonical vectors, incl. the v1.1.1 bare-literal negative sub-case.
+
+## Code-state findings (this session, evidence)
+
+- `src/kailash/trust/signing/algorithm_id.py:169` — `D2dWitness` value object; `:209`
+  `is_pre_adoption()` (both dates `< ADOPTION_DATE`). Docstring `:190` claims
+  "signed-not-remembered" but NO signature is verified anywhere.
+- `:223` `assert_d2d_witness_pre_adoption()` raises `implicit-v1-witness-failure` only on
+  missing-or-post-adoption — NOT on unverifiable/expired/non-corroborating marker.
+- Greenfield: zero `marker_sig` / `first_seen` / `MarkerStore` in `src/kailash/trust/`.
+  `principal` field exists but is "informational".
+- `tests/test-vectors/eatp08-alg-id-canonical.json` (81 lines) — NO V6/V7/strip/marker
+  vectors; must be authored fresh and byte-matched to kailash-rs.
+- Existing crypto layer: `kailash.trust.signing` (Ed25519 mandatory per `rules/eatp.md`).
+
+## Recommended design decision (to confirm at /analyze against spec)
+
+**(a) Verifier-key signed marker** — Ed25519 signature over `{principal, first_seen,
+chain_head_date}`, verified against a configured trusted verifier key; self-contained, no
+external infra, full cross-SDK byte parity. (b) transparency log and (c) Foundation witness
+service require external infrastructure whose existence is UNVERIFIED — do not scope (b)/(c)
+until a live existence check confirms the endpoint. (a) is not a one-way door: (b)/(c) can
+later become the marker _source_ without changing the verification contract.
+
+## Boundaries
+
+- **Cross-SDK parity is half-out-of-repo**: kailash-rs ISS-33 lives in
+  `esperie-enterprise/kailash-rs` — NOT touchable from this session (repo-scope-discipline).
+  Parity is achieved here by authoring the canonical vector file to match; rs-side landing is
+  a separate session in that repo.
+- **Spec not local**: `08-algorithm-identifier.md` §4.3.1/§4.3.2 is not in this repo. The
+  issue body quotes the marker shape (`{principal, first_seen, marker_sig}`) + the §4.3.2
+  detection predicate; lock shard-1's exact field shape against the spec text before
+  implementing.

--- a/workspaces/issue-1316-eatp08-marker-regime-py/journal/0001-DISCOVERY-brief-corrections-from-parallel-verification.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/journal/0001-DISCOVERY-brief-corrections-from-parallel-verification.md
@@ -1,0 +1,27 @@
+# 0001 — DISCOVERY: brief corrections from parallel verification
+
+**Phase**: /analyze · **Date**: 2026-06-15 · **Issue**: #1316
+
+Four parallel deep-dive agents (`rules/agents.md` § Parallel Brief-Claim Verification, ≥3
+clusters) re-derived every brief claim from source. Four material corrections — recorded
+here and in `02-plans/01-architecture.md` § "Brief corrections" as the gate before /todos.
+
+1. **Cross-SDK direction inverted (favorable).** kailash-py is the CANONICAL AUTHOR of
+   `tests/test-vectors/eatp08-alg-id-canonical.json:7`; kailash-rs vendors it. V6/V7 byte-pins
+   derived here — no cross-repo dependency blocks any shard. (Brief framed parity as a
+   blocker.)
+2. **Compatible-Legacy logging is NOT greenfield.** Two `logger.info` acceptance lines
+   already ship (`algorithm_id.py:488-498`, `:611-621`). §7.1 reduces to INFO→WARN +
+   consolidation. (Brief claimed none exists — FALSE.)
+3. **`monotonic-upgrade-violation` is unimplemented** — only a forward-reference docstring
+   (`algorithm_id.py:197-198`). V6 sub-case (i) is a new record-consumer enforcer (cross-file),
+   not a vector. Promoted to its own shard (Shard 3) carrying the one open spec question.
+4. **D2c trusted-verifier-key config must be built** (no existing config; pattern
+   `MultiSigPolicy.signer_public_keys`, `multi_sig.py:170`). Crypto primitives ready
+   (`crypto.py:170`/`:225`). D2c caller blast radius is mechanical (0 production
+   `D2dWitness` constructions; 5 consumers forward `witness=` unchanged). Invariant count
+   confirmed ~5.
+
+**Net effect on plan**: still ~2 sessions, 4 shards. Shard 3 (monotonic enforcer) is the
+only shard needing spec §4.5/§4.6 before sizing; Shards 1/2/4 are fully scoped and
+spec-quoted via the issue body. Detail: `01-analysis/01-verification-findings.md`.

--- a/workspaces/issue-1316-eatp08-marker-regime-py/journal/0002-DECISION-cross-repo-authorized-mint-spec-read.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/journal/0002-DECISION-cross-repo-authorized-mint-spec-read.md
@@ -1,0 +1,16 @@
+# 0002 — DECISION: cross-repo authorized read of mint spec
+
+**Phase**: /analyze · **Date**: 2026-06-15 · **Issue**: #1316
+
+cross-repo-authorized: terrene-foundation/mint
+
+- **Requester**: user (this session, genuine user turn).
+- **Verbatim instruction**: "check ~/repos/terrene/mint"
+- **Target**: `~/repos/terrene/mint` (the EATP standards tracker repo).
+- **Action (bounded)**: READ-ONLY — locate + read `08-algorithm-identifier.md`
+  §4.3.1/§4.3.2 (signed-marker shape) and §4.5/§4.6 (monotonic-upgrade semantics) to lock
+  Shard 1's marker field shape and size Shard 3's `monotonic-upgrade-violation` enforcer.
+- **Scope**: read only the EATP-08 algorithm-identifier spec (+ adjacent conformance refs if
+  cited). No writes, no `gh`, no edits to the mint repo.
+- **Rule basis**: `repo-scope-discipline.md` § User-Authorized Exception — user-initiated +
+  explicit + journaled-before-acting. Receipt lands BEFORE the read command runs.

--- a/workspaces/issue-1316-eatp08-marker-regime-py/journal/0003-DECISION-todos-scope-and-redteam-revisions.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/journal/0003-DECISION-todos-scope-and-redteam-revisions.md
@@ -1,0 +1,65 @@
+---
+type: DECISION
+date: 2026-06-15
+author: agent
+project: issue-1316-eatp08-marker-regime-py
+topic: /todos scope decision (3 §5.3 codes out of scope) + red-team-driven revisions
+phase: todos
+tags: [eatp-08, scope, redteam, todos, conformance]
+relates_to: 0001-DISCOVERY-brief-corrections-from-parallel-verification
+---
+
+# 0003 — DECISION: /todos scope + red-team revisions
+
+`/todos` produced `todos/active/00-todos.md` from the converged `/analyze` plan. Two
+decisions made at this gate, both recorded here before the human-approval STOP.
+
+## Decision 1 — three §5.3 error codes are OUT of #1316 scope
+
+A launch-time grep (`specs-authority.md` Rule 5c) showed FOUR §5.3 codes are NEW (0 files),
+not the 2 the plan flagged. `monotonic-upgrade-violation` IS in scope (V6 sub-case i, Shard
+3A). The other three — `pre-registry-form-after-sunset` (D2d 2030 sunset),
+`chain-ref-canonical-form-mismatch`, `alg-id-strip-detected` (registry-lookup-miss) — are
+declared OUT of scope.
+
+**Rationale (spec-anchored):** the required conformance vectors are V1–V7 (Conformant), V7
+(Complete), V9 per `02-spec-locked-facts.md` §6; issue #1316 acceptance is "V4–V7 + V9 pass."
+None of the three is exercised by any required vector (verified: the canonical vector file has
+no such vector, and V6's "alg-id-strip-attack" name maps to monotonic/missing/witness-failure
+sub-cases, NOT the `alg-id-strip-detected` code). Per `spec-accuracy.md`, adding enforcers +
+vectors for codes with no triggering vector in this issue's scope is speculative.
+
+**Alternative considered:** expand #1316 to enforce the full §5.3 set now (+~1 session: 3
+enforcers + 3 vectors). Rejected as default — it delivers no #1316 acceptance criterion. Left
+as an explicit gate item for the user to override.
+
+## Decision 2 — Shard 3 split into 3A/3B + 2 added shards (red-team-driven)
+
+An analyst red-team of the todo list returned REVISE (2 HIGH + 3 MED). All findings sound;
+all closed in-gate per `autonomous-execution.md` Rule 4 (fix same-class gaps immediately):
+
+- **H1** → Shard 2e: V4/V5/V9 have no named vector (file is `registry`/`non_conformant`-keyed);
+  added a coverage-map todo (map-or-author with `--collect-only` receipt).
+- **H2** → Shard 5: committed end-to-end resolver-dispatch pipeline regression (the manual T3
+  walk is not a CI test); catches the frozen-`D2dWitness`-None-`marker_sig` fake-integration risk.
+- **M1** → Shard 2 annotated: only 2a + 2b(ii) parallel with Shard 4; 2c + 2b(iii) gated on 1c.
+- **M2** → Shard 3A-d: added the §4.1.3 D2a trust-store-no-prior-v2 test (separate state dim).
+- **M3** → Shard 3 split: write-path spans 5 wire-decode consumer modules (`crl`,
+  `timestamping`, `messaging/envelope`, `pact/envelopes`, `vault/backup`), so 3B carries its
+  own budget and pins the chokepoint at shard start (not deferred to `/implement`).
+- **L3** → G3-pub: public-surface shape (3 new `D2dWitness` fields + new code constant + CHANGELOG).
+
+Result: 6 implementation shards (1, 4, 2, 3A, 3B, 5) across 2 waves, ~2 sessions. Scope
+decisions L1 (the 3 OUT-of-scope codes) and L2 (build/wire split) confirmed sound by the red-team.
+
+## For Discussion
+
+1. **Counterfactual:** if a future EATP-08 erratum adds a required vector for
+   `alg-id-strip-detected`, does the OUT-of-scope call here create a silent gap, or does the
+   vector-driven conformance model (a new vector → a new shard) catch it by construction?
+2. **Data:** the write-path chokepoint (3B-a) is unproven to be a single site — the 5
+   consumers all DECODE; the v2-first-emission RECORD site may be one verify chokepoint or
+   distributed. Is splitting 3B with a "pin-or-re-shard" gate the right hedge, or should the
+   chokepoint be grep-pinned before approval rather than at shard start?
+3. **Scope:** is "V4–V7 + V9" the complete acceptance bar, or does cross-SDK byte-parity with
+   kailash-rs ISS-33 implicitly require any of the three OUT-of-scope codes that rs may enforce?


### PR DESCRIPTION
## Summary

Shard 1 of #1316 (EATP-08 marker-regime tail, Wave 1). Turns the D2d legacy-acceptance witness from a **trusted passed-in value** into a **verified signed marker** (EATP-08 §4.3.2 "signed-not-remembered").

Before: the pre-1.1 `D2dWitness` carried `witnessed_at`/`chain_head_date`/`principal` and the gate verified NO signature — any caller asserting a pre-adoption witness could downgrade a pre-registry `ed25519+sha256` form to `eatp-v1` forever (an unverified downgrade channel; the docstring even claimed "signed-not-remembered" but nothing was signed).

After: `assert_d2d_witness_pre_adoption` enforces **five fail-closed checks**, all → `implicit-v1-witness-failure`:
1. **missing** — no witness
2. **sig-verify** — `marker_sig` (Ed25519) verifies against a configured trusted key over the §4.3.1 signed core `{principal, first_seen}`
3. **first_seen-corroboration** — the *signed* `first_seen` is strictly pre-adoption (defeats the V6(iii) backdated-`chain_head_date` attack: a fresh chain can't obtain a pre-adoption *signed* first_seen)
4. **expiry** — marker not expired
5. **temporal boundary** — claimed `witnessed_at` + `chain_head_date` strictly before the adoption date

New `D2dVerifierKeys` (mirrors `MultiSigPolicy.signer_public_keys`) is the trusted-key resolution surface. `verifier_keys` is threaded through **every** `D2dWitness` consumer — `crl`, `timestamping`, `messaging/envelope`, `pact/envelopes` — per `security.md` Multi-Site Kwarg Plumbing.

## Scope boundary

- D2d **accept** now requires a verified signed marker; the strict default path (`witness=None`) is unchanged.
- Three §5.3 codes (`pre-registry-form-after-sunset`, `chain-ref-canonical-form-mismatch`, `alg-id-strip-detected`) are **out of #1316 scope** — no required V4–V7/V9 vector exercises them.

## Test plan

- New `tests/regression/test_issue_1316_d2c_marker.py` — 18 behavioral tests against real PyNaCl Ed25519 (no mocking): all 5 checks (incl. forged/tampered/wrong-key/untrusted-key), accept path direct + through `decode_wire_alg_id`, V6(iii) backdating attack, expiry, default-key resolution.
- Existing D2d-acceptance tests swept to signed markers (orphan-detection Rule 4a).
- 66 regression tests green; `mypy --strict` clean on the core module; pre-commit all gates pass.
- Gate review: reviewer APPROVE (6/6 mechanical sweeps), security-reviewer APPROVE (zero CRIT/HIGH/MED).

## Related issues

Refs #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)