### PR TITLE
docs(trust): document D2c signed-marker contract for EATP-08 (#1316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **EATP-08 D2c signed-marker verification** (#1316): the D2d legacy-acceptance
+  witness is now verified-not-trusted. `D2dWitness` gains the §4.3.1 signed-core
+  fields (`first_seen`, `marker_sig`) plus `expires_at` and `witness_id`; new
+  `D2dVerifierKeys` (exported from `kailash.trust.signing.algorithm_id`) holds the
+  trusted Ed25519 public keys that `assert_d2d_witness_pre_adoption` verifies
+  `marker_sig` against — over the canonical `{principal, first_seen}` core.
+  Acceptance now requires five fail-closed checks (missing / signature / first_seen
+  corroboration / expiry / temporal boundary), each rejecting with
+  `implicit-v1-witness-failure`. `verifier_keys` is threaded through every
+  signed-record `from_dict` consumer (`SignedEnvelope`, `TimestampToken`,
+  `TimestampResponse`, `CRLMetadata`, `SecureMessageEnvelope`). The strict
+  post-adoption path (`witness=None`) is unchanged.
+
 ## [2.33.1] - 2026-06-15
 
 ### Fixed

--- a/specs/trust-crypto.md
+++ b/specs/trust-crypto.md
@@ -753,22 +753,53 @@ NOT a D2d pre-registry form, and a D2d witness MUST NOT rescue it. A present
 also raises `unsupported-algorithm` rather than falling through to the
 `algorithm`-key D2d match (`from_dict`, `algorithm_id.py:474`).
 
-The legacy path (D2d, §4.5) is **dated and witnessed**. The pre-1.1 scaffold
-accepted a bare `legacy_path: bool` — a perpetual un-sunsetted downgrade
-channel — and defined `ADOPTION_DATE` but never consulted it. D2d replaces
-that with `D2dWitness` (`algorithm_id.py:169`): a pre-registry explicit form
-(`is_pre_registry_form`, `algorithm_id.py:309`) is accepted as `eatp-v1`
-ONLY when a witness is supplied AND its witnessed-date AND chain-head date
-are both strictly before `ADOPTION_DATE`. The gate is
-`assert_d2d_witness_pre_adoption()` (`algorithm_id.py:223`): a missing
-witness OR a witness dated on/after adoption raises
-`implicit-v1-witness-failure` — the form is rejected, never silently
-downgraded. Accepted legacy acceptance is logged for migration tracking.
+The legacy path (D2c/D2d, §4.5 / §4.3) is **signed, dated, and witnessed**.
+The pre-1.1 scaffold accepted a bare `legacy_path: bool` — a perpetual
+un-sunsetted downgrade channel — and defined `ADOPTION_DATE` but never
+consulted it. The D2c signed-marker regime replaces that: the marker is
+**signed-not-remembered** (EATP-08 §4.3.2), verified inside the gate against a
+configured trusted key rather than trusted as a passed-in value.
+
+`D2dWitness` (`algorithm_id.py:213`) carries the §4.3.1 REQUIRED signed core
+`{principal, first_seen}` bound by `marker_sig`, plus an optional `expires_at`
+and `witness_id` (the back-compat `witnessed_at`/`chain_head_date` remain; the
+claimed `chain_head_date` is corroborated AGAINST the signed `first_seen`, NOT
+part of the signed bytes). `D2dVerifierKeys` (`algorithm_id.py:172`, mirrors
+`MultiSigPolicy.signer_public_keys`) maps `witness_id` → base64 Ed25519 public
+key (+ optional `default_key`) and is the trusted-key resolution surface.
+
+A pre-registry explicit form (`is_pre_registry_form`, `algorithm_id.py:486`) is
+accepted as `eatp-v1` ONLY when ALL five fail-closed checks of
+`assert_d2d_witness_pre_adoption()` (`algorithm_id.py:316`) hold — every
+failure raising `implicit-v1-witness-failure`:
+
+1. **missing** — no witness supplied.
+2. **sig-verify** — `marker_sig` present, `principal` present, a trusted key
+   resolves from `D2dVerifierKeys`, and the Ed25519 signature verifies over
+   `serialize_for_signing({principal, first_seen})`. A passed-in value is NOT
+   trusted; no verifier key configured ⇒ fail closed.
+3. **first_seen-corroboration** — the signed `first_seen` is present and
+   strictly before `ADOPTION_DATE` (a fresh chain cannot obtain a pre-adoption
+   _signed_ `first_seen`, defeating the backdated-`chain_head_date` attack,
+   §4.3.2(3)).
+4. **expiry** — `expires_at` unset or `> now` (tz-safe UTC comparison via
+   `_to_aware_utc`; `now` injectable for tests).
+5. **temporal boundary** — both `witnessed_at` and the claimed
+   `chain_head_date` strictly before `ADOPTION_DATE` (§4.5).
+
+The form is rejected, never silently downgraded; accepted legacy acceptance is
+logged for migration tracking. The marker transport is the
+per-verifier-signing-key form of EATP-08 §4.3 (a transparency log / Foundation
+witness service can later become the marker _source_ without changing this
+verification contract). The decode consumers thread `verifier_keys` alongside
+`witness` (§ 32.4).
 
 ### 32.4 Threaded surface
 
 Every Layer-1 signed-record producer/verifier carries the top-level `alg_id`
-member and decodes it through `decode_wire_alg_id` (witness-aware):
+member and decodes it through `decode_wire_alg_id` (witness- and
+verifier-keys-aware: each consumer's `from_dict` threads both `witness` and
+`verifier_keys` per `rules/security.md` Multi-Site Kwarg Plumbing):
 
 - `src/kailash/trust/pact/envelopes.py` — `SignedEnvelope` (`alg_id` field,
   `envelopes.py:1227`) sign/verify pair.

--- a/workspaces/issue-1316-eatp08-marker-regime-py/journal/0004-AMENDMENT-wave1-boundary-shard1-converged.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/journal/0004-AMENDMENT-wave1-boundary-shard1-converged.md
@@ -1,0 +1,52 @@
+---
+type: AMENDMENT
+date: 2026-06-15
+author: agent
+project: issue-1316-eatp08-marker-regime-py
+topic: Wave-1 boundary — Shard 1 (D2c signed-marker) converged + merged; inter-wave gate G1-G4
+phase: implement
+tags: [eatp-08, wave-loop, shard-1, convergence, d2c]
+relates_to: 0003-DECISION-todos-scope-and-redteam-revisions
+---
+
+# 0004 — AMENDMENT: Wave-1 boundary (Shard 1 converged)
+
+Wave-loop inter-wave gate (`wave-loop.md` MUST-2) for Wave 1 = Shard 1. Durable receipts:
+
+- **G1 — redteam to convergence.** The `/implement` MUST gate ran reviewer +
+  security-reviewer as two independent adversarial agents on the merged diff. Both APPROVE,
+  zero CRIT/HIGH/MED. security-reviewer verified fail-closed across all 5 checks +
+  the V6(iii) backdating defence + constant-time Ed25519 + tz-safe expiry + complete
+  multi-site plumbing. reviewer: 6/6 mechanical sweeps green, 66 regression tests pass.
+  For a single-shard wave this two-agent clean verdict IS the convergence evidence.
+- **Receipts:** PR #1324 (merge commit `167e8c473`, base `686696be8`); CI 29/29 green;
+  admin-merged per owner workflow.
+
+## Claimed-vs-found delta (G2 learning)
+
+The plan's brief-correction #5 estimated "the 5 wire-decode consumers only FORWARD `witness=`
+unchanged; behavioral change contained in 2 functions." Reality at /implement: making the
+marker signed-not-remembered required **threading a new `verifier_keys` kwarg through all 4
+D2dWitness consumers** (`crl`, `timestamping` ×2 from_dict, `messaging/envelope`,
+`pact/envelopes`) per `security.md` Multi-Site Kwarg Plumbing — the verifier key MUST reach
+the gate, and a sibling left on the unqualified signature would ship the exact downgrade the
+shard closes. Not a scope error in the plan (the gate logic stayed ~80 LOC, well within
+budget) — but the consumer surface was 4 files, not "unchanged forwarding." Wave-2 shards
+inherit the now-threaded signature.
+
+`vault/backup.py` was correctly EXCLUDED — its `witness` is a `CeremonyWitness` (EATP-12),
+a different concept, not a D2dWitness consumer.
+
+## G3 — spec + CHANGELOG (first-instance update)
+
+- `specs/trust-crypto.md` §32.3 rewritten from the old trusted-witness gate to the D2c
+  signed-marker contract (5 checks, D2dVerifierKeys, signed core {principal, first_seen});
+  §32.4 notes verifier_keys threading. All citations re-pinned to current line numbers
+  (D2dVerifierKeys:172, D2dWitness:213, gate:316, is_pre_registry_form:486) — resolve
+  against main per `spec-accuracy.md` Rule 1.
+- `CHANGELOG.md` [Unreleased] § Added — the public-surface change (G3-pub).
+
+## G4 — re-validation
+
+Wave-2 value-anchor (EATP-08 §4 conformance) holds. Scope decision (3 §5.3 codes OUT) holds
+— no new evidence. Wave-2 shards (4, 2, 3A, 3B, 5) branch from updated main.


### PR DESCRIPTION
## Summary

Inter-wave gate (G3) for #1316 Wave 1. Documents the D2c signed-marker gate that landed in #1324.

- `specs/trust-crypto.md` §32.3 — rewritten from the old trusted-witness gate to the five fail-closed checks + the §4.3.1 signed core `{principal, first_seen}` + `D2dVerifierKeys`. §32.4 notes `verifier_keys` threading. Citations re-pinned to current line numbers.
- `CHANGELOG.md` [Unreleased] § Added — public-surface change.
- `journal/0004` — Wave-1 boundary receipt.

Spec/docs only — no source change, no version bump.

## Related issues

Refs #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)