### PR TITLE
feat(trust): EATP-08 §4.5.3 monotonic-upgrade enforcement + first_v2_seen (#1316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   signed-record `from_dict` consumer (`SignedEnvelope`, `TimestampToken`,
   `TimestampResponse`, `CRLMetadata`, `SecureMessageEnvelope`). The strict
   post-adoption path (`witness=None`) is unchanged.
+- **EATP-08 §4.5.3 monotonic-upgrade enforcement** (#1316): once a
+  principal-chain has emitted a registry-form (v2 / `eatp-v1`) record, a
+  subsequent absent-`alg_id` or pre-registry explicit form is rejected with the
+  new `monotonic-upgrade-violation` error code — taking precedence over D2a/D2d
+  acceptance and over `missing-alg-id-post-adoption`. `D2dWitness` gains the
+  optional signed-marker field `first_v2_seen` (the §4.3.1 monotonic boundary;
+  included in the `marker_sig` pre-image only when set, so existing two-field
+  `{principal, first_seen}` markers verify unchanged). `decode_wire_alg_id` and
+  `AlgorithmIdentifier.from_dict` gain the `prior_registry_form_seen: bool`
+  parameter (the verifier-supplied prior-v2 signal), threaded through every
+  signed-record `from_dict` consumer. A conformant registry token and a bare
+  unregistered string are unaffected. Marker persistence (the write side that
+  sets the signal) is verifier-integration, not SDK-owned — consistent with the
+  §4.3 implementation-defined marker transport.
+- **EATP-08 §6 conformance vectors V1–V9** (#1316): the canonical cross-SDK
+  vector file (`tests/test-vectors/eatp08-alg-id-canonical.json`) gains a named
+  `conformance_vectors` coverage map (V-id, conformance `level`, spec ref,
+  per-vector test mapping), with behavioral regression tests for the full
+  acceptance bar (V4–V7 + V9, plus V6 sub-cases i/ii/iii). V7 is Conformance
+  level **Complete**; the rest are **Conformant**.
 
 ## [2.33.1] - 2026-06-15
 

--- a/specs/trust-crypto.md
+++ b/specs/trust-crypto.md
@@ -720,19 +720,19 @@ returns exactly `{"alg_id": "<token>"}` (`algorithm_id.py:406-415`).
 
 ### 32.2 Registry and dispatch (EATP-08 §3.3 / §5.1)
 
-`ALGORITHM_REGISTRY` (`algorithm_id.py:108-140`) carries `eatp-v1` (Active)
+`ALGORITHM_REGISTRY` (`algorithm_id.py:112-143`) carries `eatp-v1` (Active)
 plus reserved rows (`eatp-v1.1`, `eatp-v2`, `eatp-v2.ml-dsa`,
 `eatp-v2.slh-dsa`). `AlgorithmStatus` enumerates `Active` / `Reserved` /
-`Reserved-Unregistered` (`algorithm_id.py:79-85`).
+`Reserved-Unregistered` (`algorithm_id.py:83`).
 
-- `AlgorithmIdentifier(...)` (`algorithm_id.py:350`, validation `:379`) accepts any **registered**
+- `AlgorithmIdentifier(...)` (`algorithm_id.py:627`, validation `:656`) accepts any **registered**
   token as a value; an unregistered token raises `UnsupportedAlgorithmError`
   with code `unsupported-algorithm`.
-- `resolve_dispatch(alg_id)` (`algorithm_id.py:273`) is the §5.1 step-2
+- `resolve_dispatch(alg_id)` (`algorithm_id.py:550`) is the §5.1 step-2
   dispatch gate: only an **Active** row dispatches. Unregistered, Reserved,
   and Reserved-Unregistered all raise `unsupported-algorithm` and MUST NOT
   fall through to `eatp-v1` semantics.
-- `is_registered` / `is_active` (`algorithm_id.py:260-271`) are the value vs
+- `is_registered` / `is_active` (`algorithm_id.py:537`, `:543`) are the value vs
   dispatchability predicates.
 
 `UnsupportedAlgorithmError` (`algorithm_id.py:146`) carries the normative

--- a/specs/trust-crypto.md
+++ b/specs/trust-crypto.md
@@ -735,14 +735,21 @@ plus reserved rows (`eatp-v1.1`, `eatp-v2`, `eatp-v2.ml-dsa`,
 - `is_registered` / `is_active` (`algorithm_id.py:260-271`) are the value vs
   dispatchability predicates.
 
-`UnsupportedAlgorithmError` (`algorithm_id.py:142`) carries the normative
+`UnsupportedAlgorithmError` (`algorithm_id.py:146`) carries the normative
 EATP-08 §5.3 error code: `unsupported-algorithm`, `alg-id-shape-mismatch`,
-`missing-alg-id-post-adoption`, or `implicit-v1-witness-failure`.
+`missing-alg-id-post-adoption`, `implicit-v1-witness-failure`, or
+`monotonic-upgrade-violation` (the §4.5.3 monotonic-downgrade reject — see
+§ 32.3 below). The remaining three §5.3 codes
+(`pre-registry-form-after-sunset`, `chain-ref-canonical-form-mismatch`,
+`alg-id-strip-detected`) are not surfaced by this module: their triggers (the
+2030 D2d sunset, D1 chain-ref canonicalization, and a signature matching no
+registered algorithm) live in the migration-policy and chain-walk layers, out
+of this alg-id-decode module's scope.
 
 ### 32.3 Backward-compat regime (EATP-08 §4 — D1/D2a/D2b/D2c/D2d)
 
 The post-adoption path is strict (D2b): `AlgorithmIdentifier.from_dict()`
-and the consumer helper `decode_wire_alg_id()` (`algorithm_id.py:417`, `:558`)
+and the consumer helper `decode_wire_alg_id()` (`algorithm_id.py:694`, `:856`)
 do NOT silently default-fill. A missing/empty `alg_id` post-adoption raises
 `missing-alg-id-post-adoption`; a non-string or nested form raises
 `alg-id-shape-mismatch`. A **bare top-level-string** `alg_id` equal to the
@@ -751,7 +758,7 @@ deprecated literal `ed25519+sha256` is an unregistered token and raises
 NOT a D2d pre-registry form, and a D2d witness MUST NOT rescue it. A present
 `alg_id` key is authoritative, so `{"alg_id":"ed25519+sha256","algorithm":...}`
 also raises `unsupported-algorithm` rather than falling through to the
-`algorithm`-key D2d match (`from_dict`, `algorithm_id.py:474`).
+`algorithm`-key D2d match (`from_dict`, `algorithm_id.py:694`).
 
 The legacy path (D2c/D2d, §4.5 / §4.3) is **signed, dated, and witnessed**.
 The pre-1.1 scaffold accepted a bare `legacy_path: bool` — a perpetual
@@ -760,17 +767,23 @@ consulted it. The D2c signed-marker regime replaces that: the marker is
 **signed-not-remembered** (EATP-08 §4.3.2), verified inside the gate against a
 configured trusted key rather than trusted as a passed-in value.
 
-`D2dWitness` (`algorithm_id.py:213`) carries the §4.3.1 REQUIRED signed core
+`D2dWitness` (`algorithm_id.py:222`) carries the §4.3.1 REQUIRED signed core
 `{principal, first_seen}` bound by `marker_sig`, plus an optional `expires_at`
 and `witness_id` (the back-compat `witnessed_at`/`chain_head_date` remain; the
 claimed `chain_head_date` is corroborated AGAINST the signed `first_seen`, NOT
-part of the signed bytes). `D2dVerifierKeys` (`algorithm_id.py:172`, mirrors
-`MultiSigPolicy.signer_public_keys`) maps `witness_id` → base64 Ed25519 public
-key (+ optional `default_key`) and is the trusted-key resolution surface.
+part of the signed bytes), plus the optional §4.5.3 monotonic boundary
+`first_v2_seen` (`algorithm_id.py:288`). `first_v2_seen`, when set, is
+included in the `marker_sig` pre-image (`signed_marker_payload`,
+`algorithm_id.py:294` — §4.3.1 "a field a verifier relies on MUST be in the
+signed bytes"); a marker without it keeps the two-field `{principal, first_seen}`
+core, so existing `marker_sig`s verify unchanged. `D2dVerifierKeys`
+(`algorithm_id.py:181`, mirrors `MultiSigPolicy.signer_public_keys`) maps
+`witness_id` → base64 Ed25519 public key (+ optional `default_key`) and is the
+trusted-key resolution surface.
 
-A pre-registry explicit form (`is_pre_registry_form`, `algorithm_id.py:486`) is
+A pre-registry explicit form (`is_pre_registry_form`, `algorithm_id.py:586`) is
 accepted as `eatp-v1` ONLY when ALL five fail-closed checks of
-`assert_d2d_witness_pre_adoption()` (`algorithm_id.py:316`) hold — every
+`assert_d2d_witness_pre_adoption()` (`algorithm_id.py:350`) hold — every
 failure raising `implicit-v1-witness-failure`:
 
 1. **missing** — no witness supplied.
@@ -794,12 +807,38 @@ witness service can later become the marker _source_ without changing this
 verification contract). The decode consumers thread `verifier_keys` alongside
 `witness` (§ 32.4).
 
+**Monotonic-upgrade enforcement (D2b / D2d — §4.2 / §4.5.3 / §5.1 step 3).**
+Once a principal-chain has emitted a registry-form (v2 / `eatp-v1`) record, a
+subsequent absent-`alg_id` OR pre-registry explicit form is a downgrade and
+`decode_wire_alg_id()` (and `AlgorithmIdentifier.from_dict()`) reject it with
+`monotonic-upgrade-violation`. The check fires BEFORE D2a/D2d acceptance and
+BEFORE `missing-alg-id-post-adoption`, so a chain that has crossed the boundary
+cannot regress even with an otherwise-valid signed pre-adoption witness. It does
+NOT fire for a conformant registry token (forward progress), nor for a bare
+unregistered string / non-string shape (those keep their `unsupported-algorithm`
+/ `alg-id-shape-mismatch` disposition). The prior-v2 state is supplied by the
+verifier via the `prior_registry_form_seen: bool` parameter threaded through
+every consumer `from_dict` (alongside `witness`/`verifier_keys`, § 32.4), OR via
+a resolved `D2dWitness` carrying a signed `first_v2_seen`.
+
+**Marker persistence is verifier-integration, not SDK-owned (signed-not-remembered).**
+The SDK enforces the monotonic READ check; it does NOT persist a per-chain
+first-v2 store. Consistent with the §4.3 "marker transport is
+implementation-defined" stance, the WRITE side that establishes the prior-v2
+state (a transparency log, a witness service, or the verifier's own chain-state
+table) is the integrator's responsibility — the SDK consumes the supplied signal
+(`prior_registry_form_seen` / a resolved marker's `first_v2_seen`) rather than
+owning a marker store. A future SDK-owned store can populate the same signal
+without changing this read contract.
+
 ### 32.4 Threaded surface
 
 Every Layer-1 signed-record producer/verifier carries the top-level `alg_id`
-member and decodes it through `decode_wire_alg_id` (witness- and
-verifier-keys-aware: each consumer's `from_dict` threads both `witness` and
-`verifier_keys` per `rules/security.md` Multi-Site Kwarg Plumbing):
+member and decodes it through `decode_wire_alg_id` (witness-, verifier-keys-, and
+prior-v2-aware: each consumer's `from_dict` threads `witness`, `verifier_keys`,
+AND `prior_registry_form_seen` per `rules/security.md` Multi-Site Kwarg
+Plumbing — the five decode sites are `crl.py`, `timestamping.py` ×2,
+`messaging/envelope.py`, `pact/envelopes.py`):
 
 - `src/kailash/trust/pact/envelopes.py` — `SignedEnvelope` (`alg_id` field,
   `envelopes.py:1227`) sign/verify pair.

--- a/src/kailash/trust/messaging/envelope.py
+++ b/src/kailash/trust/messaging/envelope.py
@@ -272,6 +272,7 @@ class SecureMessageEnvelope:
         *,
         witness: Optional[D2dWitness] = None,
         verifier_keys: Optional[D2dVerifierKeys] = None,
+        prior_registry_form_seen: bool = False,
     ) -> "SecureMessageEnvelope":
         """
         Deserialize envelope from dictionary (EATP-08 §4.2 D2b / §4.5 D2d).
@@ -304,7 +305,12 @@ class SecureMessageEnvelope:
         if data.get("metadata"):
             metadata = MessageMetadata.from_dict(data["metadata"])
 
-        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
+        alg_id = decode_wire_alg_id(
+            data,
+            witness=witness,
+            verifier_keys=verifier_keys,
+            prior_registry_form_seen=prior_registry_form_seen,
+        )
 
         return cls(
             message_id=data["message_id"],

--- a/src/kailash/trust/pact/envelopes.py
+++ b/src/kailash/trust/pact/envelopes.py
@@ -1340,6 +1340,7 @@ class SignedEnvelope:
         *,
         witness: D2dWitness | None = None,
         verifier_keys: D2dVerifierKeys | None = None,
+        prior_registry_form_seen: bool = False,
     ) -> SignedEnvelope:
         """Deserialize from a dict (EATP-08 §4.2 D2b / §4.5 D2d).
 
@@ -1381,7 +1382,12 @@ class SignedEnvelope:
         # Decode + validate alg_id BEFORE other field parsing so a
         # non-conformant token fails loudly rather than paying the cost of
         # envelope reconstruction.
-        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
+        alg_id = decode_wire_alg_id(
+            data,
+            witness=witness,
+            verifier_keys=verifier_keys,
+            prior_registry_form_seen=prior_registry_form_seen,
+        )
 
         envelope = ConstraintEnvelopeConfig(**data["envelope"])
 

--- a/src/kailash/trust/signing/algorithm_id.py
+++ b/src/kailash/trust/signing/algorithm_id.py
@@ -162,6 +162,14 @@ class UnsupportedAlgorithmError(Exception):
     - ``implicit-v1-witness-failure``: a D2d pre-registry form was offered for
       legacy acceptance but the witness is missing or its witnessed/head date
       is not strictly before the adoption date (§4.3.2, §4.5).
+    - ``monotonic-upgrade-violation``: a record without ``alg_id`` OR in a
+      pre-registry explicit form was offered from a principal-chain that has
+      previously emitted a registry-form (v2 / ``eatp-v1``) record — the chain
+      crossed the §4.5.3 monotonic boundary, so the downgrade MUST be rejected
+      (it takes precedence over D2a/D2d acceptance AND over
+      ``missing-alg-id-post-adoption``). The prior-v2 state is supplied by the
+      verifier via ``prior_registry_form_seen=True`` or a resolved
+      :class:`D2dWitness` carrying ``first_v2_seen``.
     """
 
     def __init__(self, code: str, message: str) -> None:
@@ -256,6 +264,18 @@ class D2dWitness:
         witness_id: Optional id selecting which trusted key in
             :class:`D2dVerifierKeys` verifies ``marker_sig`` (§4.3.1 optional
             field). Unset falls back to the config ``default_key``.
+        first_v2_seen: The signed monotonic-upgrade boundary (§4.3.1 / §4.5.3) —
+            the timestamp at which this principal-chain FIRST emitted a
+            registry-form (v2) record. When set, the chain has crossed the
+            monotonic boundary: a subsequent absent-``alg_id`` or pre-registry
+            explicit form is a downgrade and MUST be rejected with
+            ``monotonic-upgrade-violation``. Because a verifier relies on it for a
+            D2 decision it is inside the signed bytes (§4.3.1) — see
+            :meth:`signed_marker_payload`, which includes it in the
+            ``marker_sig`` pre-image when set (markers without it keep the
+            two-field ``{principal, first_seen}`` core, back-compat). The runtime
+            read-check (`decode_wire_alg_id`) also accepts an out-of-band
+            ``prior_registry_form_seen`` bool when no signed marker carries it.
     """
 
     witnessed_at: datetime
@@ -265,6 +285,7 @@ class D2dWitness:
     marker_sig: Optional[str] = None
     expires_at: Optional[datetime] = None
     witness_id: Optional[str] = None
+    first_v2_seen: Optional[datetime] = None
 
     @staticmethod
     def _as_date(value: datetime) -> date:
@@ -279,7 +300,7 @@ class D2dWitness:
         signed ``first_seen``.
         """
 
-        return {
+        payload: Dict[str, Any] = {
             "principal": self.principal,
             "first_seen": (
                 self.first_seen.isoformat()
@@ -287,6 +308,18 @@ class D2dWitness:
                 else self.first_seen
             ),
         }
+        # §4.3.1: a field a verifier relies on for a D2 decision MUST be in the
+        # signed bytes. `first_v2_seen` is signed-when-present so the monotonic
+        # boundary is tamper-proof; markers without it keep the two-field core
+        # (back-compat — existing {principal, first_seen} marker_sigs verify
+        # unchanged). JCS sorts keys, so the pre-image is deterministic.
+        if self.first_v2_seen is not None:
+            payload["first_v2_seen"] = (
+                self.first_v2_seen.isoformat()
+                if isinstance(self.first_v2_seen, datetime)
+                else self.first_v2_seen
+            )
+        return payload
 
     def is_pre_adoption(self) -> bool:
         """True iff BOTH witnessed/claimed dates are strictly before adoption.
@@ -664,6 +697,7 @@ class AlgorithmIdentifier:
         *,
         witness: Optional[D2dWitness] = None,
         verifier_keys: Optional[D2dVerifierKeys] = None,
+        prior_registry_form_seen: bool = False,
     ) -> "AlgorithmIdentifier":
         """Reconstruct from a wire value (EATP-08 §4.5 D2b / D2d).
 
@@ -727,6 +761,28 @@ class AlgorithmIdentifier:
             value: Any = data["alg_id"]
         else:
             value = data
+
+        # Monotonic gate (§4.2 / §4.5.3 / §5.1 step 3): once a principal-chain has
+        # emitted a registry-form (v2) record, a subsequent absent/empty alg_id OR
+        # pre-registry explicit form is a downgrade → monotonic-upgrade-violation.
+        # This takes precedence over the D2d witnessed-acceptance below AND over
+        # missing-alg-id-post-adoption. The prior-v2 state is verifier-supplied:
+        # an explicit `prior_registry_form_seen` flag, OR a resolved marker whose
+        # signed `first_v2_seen` is set (§4.3.1). A bare unregistered string /
+        # non-string shape is NOT a pre-registry form and keeps its
+        # unsupported-algorithm / alg-id-shape-mismatch disposition regardless.
+        prior_v2 = prior_registry_form_seen or (
+            witness is not None and witness.first_v2_seen is not None
+        )
+        if prior_v2 and (is_pre_registry_form(value) or value is None or value == ""):
+            raise UnsupportedAlgorithmError(
+                "monotonic-upgrade-violation",
+                "this principal-chain has previously emitted a registry-form "
+                "record (prior_registry_form_seen / signed first_v2_seen), so a "
+                f"subsequent absent or pre-registry alg_id ({value!r}) is a "
+                "downgrade and MUST be rejected (EATP-08 §4.5.3 / §5.1 step 3); "
+                f"it MUST NOT be accepted as {ALGORITHM_DEFAULT!r} via D2a/D2d.",
+            )
 
         if witness is not None and is_pre_registry_form(value):
             # D2d: a pre-registry explicit form is acceptable ONLY when the
@@ -802,6 +858,7 @@ def decode_wire_alg_id(
     *,
     witness: Optional[D2dWitness] = None,
     verifier_keys: Optional[D2dVerifierKeys] = None,
+    prior_registry_form_seen: bool = False,
 ) -> str:
     """Decode the ``alg_id`` token from a signed-record wire dict.
 
@@ -829,26 +886,59 @@ def decode_wire_alg_id(
             witness's ``marker_sig`` against a configured trusted key (§4.3.2).
             ``None`` (default) => no trusted key resolves => any D2d marker
             fails closed with ``implicit-v1-witness-failure``.
+        prior_registry_form_seen: The verifier-supplied §4.5.3 monotonic signal —
+            ``True`` when this principal-chain has previously emitted a
+            registry-form (v2 / ``eatp-v1``) record. When set (or when ``witness``
+            carries a signed ``first_v2_seen``), an absent-``alg_id`` or
+            pre-registry record is a downgrade and is rejected with
+            ``monotonic-upgrade-violation`` BEFORE any D2a/D2d acceptance or the
+            ``missing-alg-id-post-adoption`` path (§5.1 step 3). Defaults to
+            ``False`` (no prior v2 known — the verifier asserts a fresh chain).
 
     Returns:
         A registry token string (the legacy forms resolve to ``eatp-v1``).
 
     Raises:
         UnsupportedAlgorithmError: ``missing-alg-id-post-adoption``,
-            ``alg-id-shape-mismatch``, ``unsupported-algorithm``, or
-            ``implicit-v1-witness-failure`` per EATP-08 §5.3.
+            ``alg-id-shape-mismatch``, ``unsupported-algorithm``,
+            ``implicit-v1-witness-failure``, or ``monotonic-upgrade-violation``
+            per EATP-08 §5.3.
     """
 
     if "alg_id" in data:
+        # The alg_id-present monotonic + acceptance regime lives in from_dict
+        # (it sees the resolved value); forward the prior-v2 signal so a
+        # pre-registry alg_id from a prior-v2 chain is rejected there.
         return AlgorithmIdentifier.from_dict(
-            data["alg_id"], witness=witness, verifier_keys=verifier_keys
+            data["alg_id"],
+            witness=witness,
+            verifier_keys=verifier_keys,
+            prior_registry_form_seen=prior_registry_form_seen,
         ).algorithm
 
-    # No top-level `alg_id` member. A record carrying the algorithm only under
-    # an unsigned top-level `algorithm` key is a D2d pre-registry form
-    # (kailash-py's historical metadata-only shape). It is accepted ONLY when a
-    # dated, signed witness places the chain head strictly before adoption;
-    # otherwise it is a post-adoption record missing its alg_id (D2b).
+    # No top-level `alg_id` member → a "record without alg_id" (§5.3 case 1).
+    # If the chain has already emitted a registry-form record, regressing to an
+    # absent alg_id is a monotonic downgrade — reject BEFORE the D2d
+    # unsigned-`algorithm`-metadata acceptance and before missing-alg-id
+    # (§4.2 / §4.5.3 / §5.1 step 3). Only the dict-level chokepoint can see that
+    # the `alg_id` KEY is absent (from_dict receives only a value).
+    if prior_registry_form_seen or (
+        witness is not None and witness.first_v2_seen is not None
+    ):
+        raise UnsupportedAlgorithmError(
+            "monotonic-upgrade-violation",
+            "signed record carries no top-level `alg_id`, but this "
+            "principal-chain has previously emitted a registry-form record "
+            "(prior_registry_form_seen / signed first_v2_seen); regressing to an "
+            "absent alg_id is a §4.5.3 monotonic downgrade and MUST be rejected, "
+            f"not accepted as {ALGORITHM_DEFAULT!r} via D2a/D2d.",
+        )
+
+    # A record carrying the algorithm only under an unsigned top-level
+    # `algorithm` key is a D2d pre-registry form (kailash-py's historical
+    # metadata-only shape). It is accepted ONLY when a dated, signed witness
+    # places the chain head strictly before adoption; otherwise it is a
+    # post-adoption record missing its alg_id (D2b).
     if "algorithm" in data:
         legacy_value = data["algorithm"]
         if witness is not None and (

--- a/src/kailash/trust/signing/crl.py
+++ b/src/kailash/trust/signing/crl.py
@@ -163,6 +163,7 @@ class CRLMetadata:
         *,
         witness: Optional[D2dWitness] = None,
         verifier_keys: Optional[D2dVerifierKeys] = None,
+        prior_registry_form_seen: bool = False,
     ) -> "CRLMetadata":
         """Deserialize from dictionary (EATP-08 §4.2 D2b / §4.5 D2d).
 
@@ -186,7 +187,12 @@ class CRLMetadata:
         Raises:
             UnsupportedAlgorithmError: per EATP-08 §5.3.
         """
-        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
+        alg_id = decode_wire_alg_id(
+            data,
+            witness=witness,
+            verifier_keys=verifier_keys,
+            prior_registry_form_seen=prior_registry_form_seen,
+        )
         return cls(
             crl_id=data["crl_id"],
             issuer_id=data["issuer_id"],

--- a/src/kailash/trust/signing/timestamping.py
+++ b/src/kailash/trust/signing/timestamping.py
@@ -151,6 +151,7 @@ class TimestampToken:
         *,
         witness: Optional[D2dWitness] = None,
         verifier_keys: Optional[D2dVerifierKeys] = None,
+        prior_registry_form_seen: bool = False,
     ) -> "TimestampToken":
         """Deserialize token from dictionary (EATP-08 §4.2 D2b / §4.5 D2d).
 
@@ -165,7 +166,12 @@ class TimestampToken:
         Raises:
             UnsupportedAlgorithmError: per EATP-08 §5.3.
         """
-        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
+        alg_id = decode_wire_alg_id(
+            data,
+            witness=witness,
+            verifier_keys=verifier_keys,
+            prior_registry_form_seen=prior_registry_form_seen,
+        )
         return cls(
             token_id=data["token_id"],
             hash_value=data["hash_value"],
@@ -253,6 +259,7 @@ class TimestampResponse:
         *,
         witness: Optional[D2dWitness] = None,
         verifier_keys: Optional[D2dVerifierKeys] = None,
+        prior_registry_form_seen: bool = False,
     ) -> "TimestampResponse":
         """Deserialize response from dictionary (EATP-08 §4.2 D2b / §4.5 D2d).
 
@@ -279,7 +286,12 @@ class TimestampResponse:
         raw_response = (
             bytes.fromhex(data["raw_response"]) if data.get("raw_response") else None
         )
-        alg_id = decode_wire_alg_id(data, witness=witness, verifier_keys=verifier_keys)
+        alg_id = decode_wire_alg_id(
+            data,
+            witness=witness,
+            verifier_keys=verifier_keys,
+            prior_registry_form_seen=prior_registry_form_seen,
+        )
         return cls(
             request=request,
             token=token,

--- a/src/kailash/trust/signing/timestamping.py
+++ b/src/kailash/trust/signing/timestamping.py
@@ -281,7 +281,10 @@ class TimestampResponse:
             algorithm=request_data.get("algorithm", "sha256"),
         )
         token = TimestampToken.from_dict(
-            data["token"], witness=witness, verifier_keys=verifier_keys
+            data["token"],
+            witness=witness,
+            verifier_keys=verifier_keys,
+            prior_registry_form_seen=prior_registry_form_seen,
         )
         raw_response = (
             bytes.fromhex(data["raw_response"]) if data.get("raw_response") else None

--- a/tests/regression/test_eatp08_alg_id_canonical_vectors.py
+++ b/tests/regression/test_eatp08_alg_id_canonical_vectors.py
@@ -331,21 +331,12 @@ def test_v9_pre_registry_unsigned_metadata_d2d_accepts():
 
 
 @pytest.mark.regression
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "V6 sub-case (i) monotonic-upgrade-violation enforcer lands in Shard 3A "
-        "(#1316): decode_wire_alg_id gains `prior_registry_form_seen: bool` and "
-        "rejects an absent/pre-registry record from a chain with a prior "
-        "registry-form record. xfail-strict per testing.md — auto-fails (XPASS) "
-        "the moment Shard 3A wires it, forcing this marker's removal."
-    ),
-)
 def test_v6i_strip_prior_v2_monotonic():
     """V6 sub-case (i) (§6 / §4.2 / §4.5.3): a stripped record from a principal-
     chain that has previously emitted a registry-form (v2) record MUST reject with
-    monotonic-upgrade-violation. Shard-3A contract: the read-check is surfaced via
-    `decode_wire_alg_id(..., prior_registry_form_seen=True)`."""
+    monotonic-upgrade-violation. Enforced in Shard 3A: the read-check is surfaced
+    via `decode_wire_alg_id(..., prior_registry_form_seen=True)` (was xfail-strict
+    in Shard 2 until the enforcer landed)."""
     with pytest.raises(UnsupportedAlgorithmError) as exc:
         decode_wire_alg_id(
             {"payload": "v2-record-stripped"},
@@ -389,10 +380,11 @@ def test_conformance_vector_coverage_map():
         for name in names:
             assert callable(module.get(name)), f"{vid} missing test {name!r}"
 
-    # V6 sub-cases: ii + iii enforced (named tests present); i deferred to Shard 3A.
+    # V6 sub-cases: all three enforced (named tests present). Sub-case (i) was
+    # xfail-strict in Shard 2 and is enforced as of Shard 3A.
     subs = {s["sub_case"]: s for s in cv["V6"]["sub_cases"]}
-    assert subs["i"]["status"] == "deferred-shard-3a"
-    assert callable(module.get("test_v6i_strip_prior_v2_monotonic"))  # xfail-strict
+    assert subs["i"]["status"] == "enforced"
+    assert callable(module.get("test_v6i_strip_prior_v2_monotonic"))
     assert subs["ii"]["status"] == "enforced"
     assert callable(module.get("test_v6ii_strip_fresh_post_adoption_missing"))
     assert subs["iii"]["status"] == "enforced"

--- a/tests/regression/test_issue_1316_monotonic.py
+++ b/tests/regression/test_issue_1316_monotonic.py
@@ -1,0 +1,235 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: EATP-08 §4.2 / §4.5.3 / §5.1-step-3 monotonic-upgrade-violation.
+
+Shard 3A of #1316. Once a principal-chain has emitted a registry-form (v2 /
+eatp-v1) record, a subsequent absent-`alg_id` OR pre-registry explicit form is a
+downgrade and MUST be rejected with `monotonic-upgrade-violation` — taking
+precedence over D2a/D2d acceptance AND over `missing-alg-id-post-adoption`. The
+verifier supplies the prior-v2 state either as an explicit
+`prior_registry_form_seen` flag OR via a resolved `D2dWitness` carrying a signed
+`first_v2_seen` (§4.3.1 — the boundary lives in the signed marker).
+
+This is the read-side enforcement; per journal/0006 there is no marker store (D2c
+is signed-not-remembered), so the WRITE side that SETS the signal is
+verifier-integration, out of #1316 scope.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.trust.signing.algorithm_id import (
+    ALGORITHM_DEFAULT,
+    AlgorithmIdentifier,
+    D2dVerifierKeys,
+    D2dWitness,
+    UnsupportedAlgorithmError,
+    decode_wire_alg_id,
+)
+from kailash.trust.signing.crl import CRLMetadata
+from kailash.trust.signing.crypto import (
+    generate_keypair,
+    serialize_for_signing,
+    sign,
+    verify_signature,
+)
+
+_PRIV, _PUB = generate_keypair()
+_WID = "eatp08-monotonic-witness"
+_BEFORE = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _verifier_keys() -> D2dVerifierKeys:
+    return D2dVerifierKeys(keys={_WID: _PUB})
+
+
+def _signed_pre_adoption_witness(first_v2_seen: datetime | None = None) -> D2dWitness:
+    principal = "chain:eatp08-monotonic"
+    payload = {"principal": principal, "first_seen": _BEFORE.isoformat()}
+    if first_v2_seen is not None:
+        payload["first_v2_seen"] = first_v2_seen.isoformat()
+    return D2dWitness(
+        witnessed_at=_BEFORE,
+        chain_head_date=_BEFORE,
+        principal=principal,
+        first_seen=_BEFORE,
+        marker_sig=sign(payload, _PRIV),
+        witness_id=_WID,
+        first_v2_seen=first_v2_seen,
+    )
+
+
+# ---------------------------------------------------------------------------
+# M2 assertion 1 — monotonic replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_monotonic_replay_after_prior_v2_rejects_stripped_record():
+    """A first-v2 record decodes fine (no prior v2); a SUBSEQUENT stripped record
+    on the same chain (prior_registry_form_seen=True) MUST reject with
+    monotonic-upgrade-violation."""
+    # First emission: a conformant eatp-v1 record, fresh chain — accepts.
+    assert decode_wire_alg_id({"alg_id": "eatp-v1"}) == "eatp-v1"
+    # Replay: the chain has now emitted v2; a stripped record is a downgrade.
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        decode_wire_alg_id(
+            {"payload": "v2-record-with-alg_id-stripped"},
+            prior_registry_form_seen=True,
+        )
+    assert exc.value.code == "monotonic-upgrade-violation"
+
+
+# ---------------------------------------------------------------------------
+# M2 assertion 2 — §4.1.3 D2a trust-store-no-prior-v2 (D2a refused when prior v2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_d2a_acceptance_refused_when_chain_has_prior_v2():
+    """§4.1.3: D2a acceptance ALSO requires the trust store hold NO v2 record for
+    the chain. An otherwise-valid signed pre-adoption witness (which WOULD accept
+    as eatp-v1) MUST be refused with monotonic-upgrade-violation when the chain has
+    already emitted a registry-form record — the monotonic check precedes D2a/D2d
+    acceptance (§5.1 step 3)."""
+    # Sanity: without prior-v2, the same witness accepts under D2a/D2d.
+    assert (
+        decode_wire_alg_id(
+            {"algorithm": ""},
+            witness=_signed_pre_adoption_witness(),
+            verifier_keys=_verifier_keys(),
+        )
+        == ALGORITHM_DEFAULT
+    )
+    # With prior-v2, the SAME acceptance is refused.
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        decode_wire_alg_id(
+            {"algorithm": ""},
+            witness=_signed_pre_adoption_witness(),
+            verifier_keys=_verifier_keys(),
+            prior_registry_form_seen=True,
+        )
+    assert exc.value.code == "monotonic-upgrade-violation"
+
+
+# ---------------------------------------------------------------------------
+# Signed first_v2_seen marker path (§4.3.1 — boundary in the signed bytes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_first_v2_seen_marker_triggers_monotonic_without_explicit_flag():
+    """A resolved marker carrying first_v2_seen is itself the prior-v2 signal: a
+    pre-registry / absent record decoded against it MUST reject with
+    monotonic-upgrade-violation even when prior_registry_form_seen is left
+    False (§4.3.1 — the boundary lives in the signed marker)."""
+    witness = _signed_pre_adoption_witness(first_v2_seen=_BEFORE)
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        decode_wire_alg_id(
+            {"alg_id": {"algorithm": "ed25519+sha256"}},
+            witness=witness,
+            verifier_keys=_verifier_keys(),
+        )
+    assert exc.value.code == "monotonic-upgrade-violation"
+
+
+@pytest.mark.regression
+def test_first_v2_seen_is_in_signed_marker_bytes_when_set():
+    """§4.3.1: first_v2_seen, when set, is inside the marker_sig pre-image — a
+    verifier relying on it gets tamper protection. A marker WITHOUT it keeps the
+    two-field {principal, first_seen} core (back-compat)."""
+    fv2 = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    w = _signed_pre_adoption_witness(first_v2_seen=fv2)
+    payload = w.signed_marker_payload()
+    assert payload["first_v2_seen"] == fv2.isoformat()
+    assert w.marker_sig is not None
+    marker_sig = w.marker_sig
+    # The genuine signed bytes verify…
+    assert verify_signature(payload, marker_sig, _PUB) is True
+    # …and tampering first_v2_seen breaks verification (it IS signed).
+    tampered = dict(payload)
+    tampered["first_v2_seen"] = datetime(2030, 1, 1, tzinfo=timezone.utc).isoformat()
+    assert verify_signature(tampered, marker_sig, _PUB) is False
+    # Back-compat: a marker with no first_v2_seen keeps the two-field core.
+    w0 = _signed_pre_adoption_witness()
+    assert "first_v2_seen" not in w0.signed_marker_payload()
+    assert serialize_for_signing(w0.signed_marker_payload())  # serialisable
+
+
+# ---------------------------------------------------------------------------
+# Over-block guards — a conformant v2 record is NOT blocked by prior-v2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_conformant_token_not_blocked_by_prior_v2():
+    """prior_registry_form_seen=True MUST NOT block a proper conformant registry
+    token — only an absent/pre-registry downgrade. A chain emitting eatp-v1 after
+    eatp-v1 is forward progress, not a violation."""
+    assert (
+        decode_wire_alg_id({"alg_id": "eatp-v1"}, prior_registry_form_seen=True)
+        == "eatp-v1"
+    )
+
+
+@pytest.mark.regression
+def test_bare_unregistered_string_keeps_unsupported_not_monotonic():
+    """A bare unregistered top-level string is NOT a pre-registry form (v1.1.1):
+    it stays unsupported-algorithm even from a prior-v2 chain — monotonic only
+    covers absent-alg_id and recognized pre-registry forms (§5.3)."""
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        decode_wire_alg_id({"alg_id": "ed25519+sha256"}, prior_registry_form_seen=True)
+    assert exc.value.code == "unsupported-algorithm"
+
+
+# ---------------------------------------------------------------------------
+# Precedence + through-consumer (orphan-detection: behavioral, via the facade)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.regression
+def test_monotonic_precedes_d2d_accept_for_pre_registry_nested():
+    """§4.5.3: once a registry-form record appears, the pre-registry form is
+    rejected with monotonic-upgrade-violation — even with a valid signed
+    pre-adoption witness that would otherwise accept it as eatp-v1."""
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        decode_wire_alg_id(
+            {"alg_id": {"algorithm": "ed25519+sha256"}},
+            witness=_signed_pre_adoption_witness(),
+            verifier_keys=_verifier_keys(),
+            prior_registry_form_seen=True,
+        )
+    assert exc.value.code == "monotonic-upgrade-violation"
+
+
+@pytest.mark.regression
+def test_monotonic_threads_through_from_dict_surface():
+    """The exported AlgorithmIdentifier.from_dict honors prior_registry_form_seen
+    for direct callers (the v1.1.1 both-keys-style direct surface)."""
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        AlgorithmIdentifier.from_dict(
+            {"alg_id": {"algorithm": "ed25519+sha256"}},
+            witness=_signed_pre_adoption_witness(),
+            verifier_keys=_verifier_keys(),
+            prior_registry_form_seen=True,
+        )
+    assert exc.value.code == "monotonic-upgrade-violation"
+
+
+@pytest.mark.regression
+def test_monotonic_threads_through_consumer_from_dict():
+    """Orphan-detection (agents.md): the prior_registry_form_seen signal reaches a
+    real consumer (CRLMetadata.from_dict) and rejects a stripped record with
+    monotonic-upgrade-violation through the production facade — not just the
+    decode helper in isolation. The monotonic check fires on alg_id decode BEFORE
+    other field parsing, so no other CRL fields are needed."""
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        CRLMetadata.from_dict(
+            {"payload": "v2-crl-with-alg_id-stripped"},
+            prior_registry_form_seen=True,
+        )
+    assert exc.value.code == "monotonic-upgrade-violation"

--- a/tests/regression/test_issue_1316_monotonic.py
+++ b/tests/regression/test_issue_1316_monotonic.py
@@ -37,6 +37,7 @@ from kailash.trust.signing.crypto import (
     sign,
     verify_signature,
 )
+from kailash.trust.signing.timestamping import TimestampResponse
 
 _PRIV, _PUB = generate_keypair()
 _WID = "eatp08-monotonic-witness"
@@ -217,6 +218,25 @@ def test_monotonic_threads_through_from_dict_surface():
             verifier_keys=_verifier_keys(),
             prior_registry_form_seen=True,
         )
+    assert exc.value.code == "monotonic-upgrade-violation"
+
+
+@pytest.mark.regression
+def test_monotonic_threads_through_nested_timestamp_token():
+    """`TimestampResponse.from_dict` MUST forward `prior_registry_form_seen` into
+    its NESTED `TimestampToken.from_dict` decode (the explicit-flag-mode
+    completeness gap a security review surfaced). The response carries a VALID
+    outer `alg_id` (so the outer decode passes) but a STRIPPED nested token — so
+    the rejection can ONLY come from the nested decode receiving the threaded
+    flag. Without the threading this raises missing-alg-id (or does not raise);
+    with it, monotonic-upgrade-violation."""
+    resp = {
+        "request": {"hash_value": "abc123", "requested_at": _BEFORE.isoformat()},
+        "token": {"payload": "v2-token-with-alg_id-stripped"},  # stripped nested
+        "alg_id": "eatp-v1",  # valid OUTER token — only the nested decode can catch
+    }
+    with pytest.raises(UnsupportedAlgorithmError) as exc:
+        TimestampResponse.from_dict(resp, prior_registry_form_seen=True)
     assert exc.value.code == "monotonic-upgrade-violation"
 
 

--- a/tests/test-vectors/eatp08-alg-id-canonical.json
+++ b/tests/test-vectors/eatp08-alg-id-canonical.json
@@ -147,13 +147,13 @@
       "sub_cases": [
         {
           "sub_case": "i",
-          "scenario": "principal-chain has prior v2 record",
+          "scenario": "principal-chain has prior v2 record (verifier-supplied prior_registry_form_seen / signed first_v2_seen)",
           "expected": {
             "outcome": "reject",
             "code": "monotonic-upgrade-violation"
           },
-          "covered_by": "test_v6i_strip_prior_v2_monotonic (xfail-strict until Shard 3A)",
-          "status": "deferred-shard-3a"
+          "covered_by": "test_v6i_strip_prior_v2_monotonic",
+          "status": "enforced"
         },
         {
           "sub_case": "ii",

--- a/workspaces/issue-1316-eatp08-marker-regime-py/journal/0006-DISCOVERY-no-marker-store-3b-reshard.md
+++ b/workspaces/issue-1316-eatp08-marker-regime-py/journal/0006-DISCOVERY-no-marker-store-3b-reshard.md
@@ -1,0 +1,88 @@
+---
+type: DISCOVERY
+date: 2026-06-15
+author: agent
+project: issue-1316-eatp08-marker-regime-py
+topic: No marker store exists — D2c is signed-not-remembered; Shard 3B (write-path) re-sharded out of scope, 3A delivers monotonic enforcement
+phase: implement
+tags: [eatp-08, shard-3a, shard-3b, m3, monotonic, re-shard, chokepoint]
+relates_to: 0003-DECISION-todos-scope-and-redteam-revisions
+---
+
+# 0006 — DISCOVERY: no marker store; 3B re-shard (M3 chokepoint pin)
+
+The /todos red-team M3 trap mandated pinning the Shard 3B write chokepoint BEFORE
+writing code, and STOP+re-shard if the write spans >1 module / no single
+chokepoint exists. Fresh-session chokepoint analysis (read-only grep) resolves it.
+
+## Findings (evidence)
+
+1. **One read chokepoint, not five.** Every EATP-08 alg-id consumer routes its
+   decode through the single `decode_wire_alg_id()` function. Production call
+   sites (`grep "decode_wire_alg_id("`): `signing/timestamping.py:168,282`,
+   `signing/crl.py:189`, `messaging/envelope.py:307`, `pact/envelopes.py:1384`
+   — **4 modules / 5 sites**, all calling the one chokepoint. So Shard 3A's
+   read-check centralizes in `decode_wire_alg_id` (one place); the 5 consumer
+   `from_dict` methods just forward the signal, exactly as they already forward
+   `verifier_keys`.
+
+2. **vault/backup is a FALSE consumer.** The session-notes listed `vault/backup`
+   as the 5th wire-decode consumer. `vault/registry_ops.py`/`dispatch.py` use
+   `alg_id` as a SLIP-0039 _deployment_ algorithm id riding `event_payload.alg_id`
+   — a different concept entirely, NOT the EATP-08 top-level `alg_id` / `D2dWitness`
+   surface. It does not call `decode_wire_alg_id` and is out of #1316's blast radius.
+
+3. **No marker store exists.** There is no `MarkerStore` / `first_v2_seen` /
+   per-chain v2-emission persistence anywhere in `src/` or `packages/`
+   (`grep -i "marker_store|first_v2_seen|witness_store"` → only unrelated kaizen
+   memory hits). The D2c design is deliberately **signed-not-remembered**: the
+   `witness` + `verifier_keys` are CALLER-SUPPLIED kwargs to each `from_dict`
+   (confirmed `crl.py:160-189`), never resolved from a persistent store. §4.3
+   already declares the marker transport "implementation-defined".
+
+## Disposition (scope decision — surfaced, not silently dropped)
+
+**Shard 3B as planned ("record first-v2 emission into the marker store") is NOT
+implementable within #1316 and SHOULD NOT be built.** Writing a persistent
+first-v2 store is a new subsystem (state, file-locking per
+`trust-plane-security.md`, concurrency, retention) — far beyond the
+marker-regime-tail scope, and §4.3 explicitly leaves marker transport to the
+verifier integration.
+
+**What #1316 needs is the monotonic READ enforcement (Shard 3A):** the §4.2 /
+§4.5.3 / §5.1-step-3 check at the decode chokepoint, consuming a verifier-supplied
+prior-v2 signal. Shard 3A delivers:
+
+- `first_v2_seen: Optional[datetime]` signed field on `D2dWitness` (the §4.3.1
+  "boundary MAY live in the signed marker" — conditionally inside the signed core,
+  backward-compatible: markers without it keep signing `{principal, first_seen}`).
+- `prior_registry_form_seen: bool` param on `decode_wire_alg_id` + `from_dict`
+  (the Shard-2 V6(i) xfail contract), threaded through the 5 consumer `from_dict`
+  sites. Signal = explicit bool OR a resolved marker carrying `first_v2_seen`.
+- Read-check: an absent-alg-id OR pre-registry-form record from a prior-v2 chain
+  → `monotonic-upgrade-violation`, taking precedence over D2a/D2d acceptance and
+  over `missing-alg-id-post-adoption` (§5.1 step 3 / §4.5.3).
+
+**V6(i) acceptance is met by 3A's read-check alone** — the conformance vector
+supplies a prior-v2 signal and asserts the rejection; no write path is required
+for the vector to pass. The WRITE side (who SETS the signal in production) is
+verifier-integration, documented as out-of-#1316 in `specs/trust-crypto.md`.
+
+Net: the 4-shard Wave-2 tail collapses to **3A (monotonic read) + Shard 5 (e2e
+regression)**; Shard 3B is closed as "no store to write to — verifier-integration
+concern, out of scope" with the rationale pinned in the spec.
+
+## For Discussion
+
+1. **Counterfactual:** if a future verifier DID maintain a persistent first-v2
+   store, would the `prior_registry_form_seen` bool + signed `first_v2_seen` marker
+   contract still be the right seam — i.e., is the read-check API stable under a
+   later store landing, or would it want to resolve the marker internally?
+2. **Data-referenced:** §4.5.3 says "once a registry-form record appears in the
+   chain, the pre-registry form is rejected with monotonic-upgrade-violation." With
+   no store, the verifier must supply `prior_registry_form_seen` truthfully — does
+   leaving that to the integrator weaken the anti-downgrade guarantee V6 depends on,
+   versus a (deferred) store that the SDK owns?
+3. Is closing 3B as out-of-scope (vs filing a follow-up issue for an SDK-owned
+   first-v2 store) the right disposition for the cross-SDK parity bar, given
+   kailash-rs ISS-33 vendors the same vectors?


### PR DESCRIPTION
## Summary

Shard 3A of the #1316 EATP-08 marker-regime tail (Wave 2). Adds the read-side
**monotonic-upgrade enforcement** that the §4.2 / §4.5.3 / §5.1-step-3 spec and
the V6(i) conformance vector require — and flips Shard 2's V6(i) xfail-strict to
a passing test.

## What landed

- **New `monotonic-upgrade-violation` code.** Once a principal-chain has emitted
  a registry-form (v2 / `eatp-v1`) record, a subsequent absent-`alg_id` or
  pre-registry explicit form is rejected as a downgrade — precedence over D2a/D2d
  acceptance AND over `missing-alg-id-post-adoption`.
- **`D2dWitness.first_v2_seen` (signed).** The §4.3.1 monotonic boundary, in the
  `marker_sig` pre-image **only when set** — existing `{principal, first_seen}`
  markers verify unchanged (back-compat).
- **`prior_registry_form_seen: bool`** on `decode_wire_alg_id` /
  `AlgorithmIdentifier.from_dict`, threaded through all 5 wire-decode consumer
  `from_dict` sites (multi-site kwarg plumbing).
- Conformant tokens / bare unregistered strings unaffected.

## M3 finding (journal/0006) — 3B re-shard

There is **no marker store** — D2c is *signed-not-remembered* (witness/
verifier_keys are caller-supplied kwargs). The WRITE side that sets the prior-v2
signal is verifier-integration, **out of #1316 scope** (§4.3 declares marker
transport implementation-defined). Shard 3B is re-sharded to this disposition;
V6(i) acceptance is met by the read-check + a marker carrying `first_v2_seen`.

## Tests

`tests/regression/test_issue_1316_monotonic.py` — M2 replay, §4.1.3 D2a-no-prior-v2
refusal, signed-bytes tamper, over-block guards, through-consumer (orphan-detection).
Targeted suite: **88 passed**; broad trust sweep: **6434 passed, 0 fail**.

## Related issues

Refs #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)