### PR TITLE
fix(trust): RFC-3161 verify_timestamp fails closed, not open (#1332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.1] - 2026-06-15
+
+### Fixed
+
+- **Security: RFC-3161 `verify_timestamp` no longer fails open** (#1332):
+  `RFC3161TimestampAuthority.verify_timestamp` previously returned `True` with
+  **no cryptographic verification** whenever `rfc3161ng` was importable — the
+  docstring promised "full ASN.1 verification" but the body was a bare
+  `return True`, so a forged or tampered token whose `source`/`authority`
+  metadata matched the configured TSA was accepted as valid. It now performs
+  real verification: the raw DER `TimeStampToken` (carried on
+  `TimestampResponse.raw_response`, now threaded through `verify_anchor`) is
+  checked against a configured trusted TSA `certificate` and the token's hashed
+  message imprint via `rfc3161ng.check_timestamp`. The method returns `True`
+  **only** on cryptographic success and **fails closed** (returns `False`) when
+  any verification material is missing (`rfc3161ng` not installed, no raw DER
+  token, no trusted certificate) or the check fails — per the EATP fail-closed
+  discipline. `RFC3161TimestampAuthority.__init__` gains an optional
+  `certificate` trust-anchor argument; `verify_timestamp` /
+  `verify_timestamp_token` gain an optional `raw_token` argument
+  (backward-compatible additions). A new `rfc3161` optional extra
+  (`pip install 'kailash[rfc3161]'`, included in `[all]`) installs `rfc3161ng`
+  to enable verification.
+
 ## [2.34.0] - 2026-06-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.34.0"
+version = "2.34.1"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}
@@ -149,6 +149,12 @@ align    = ["kailash-align>=0.3.2"]
 # site" pattern.
 shamir = ["shamir-mnemonic>=0.3"]
 
+# RFC 3161 external timestamp verification (CARE-014). Module import succeeds
+# without this extra; RFC3161TimestampAuthority.verify_timestamp fails closed
+# (returns False) until rfc3161ng is installed, per the EATP fail-closed
+# discipline. Install to enable real ASN.1 TimeStampToken verification.
+rfc3161 = ["rfc3161ng>=2.1.3"]
+
 # Secret backends (vendor-specific SDKs).
 vault         = ["hvac>=2.1.0"]
 aws-secrets   = ["boto3>=1.34.0"]
@@ -217,7 +223,7 @@ docs = [
 # DeprecationWarning shim covering one minor cycle before v3.0 enforces it.
 all = [
     # Core capabilities (was the default install pre-#890)
-    "kailash[server,http-client,db-postgres,db-mysql,db-sqlite,redis,trust,auth,auth-azure,monitoring,telemetry,scheduler,mcp,data]",
+    "kailash[server,http-client,db-postgres,db-mysql,db-sqlite,redis,trust,auth,auth-azure,monitoring,telemetry,scheduler,mcp,data,rfc3161]",
     # Sub-package installs — pull each sibling's [security]-equivalent extras
     # so [all] preserves pre-#890 cryptographic posture (Fernet multi-tenancy
     # encryption, Ed25519 audit signing, FastAPI gateway, etc.). Heavy ML /

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.34.0"
+__version__ = "2.34.1"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/trust/signing/timestamping.py
+++ b/src/kailash/trust/signing/timestamping.py
@@ -342,15 +342,29 @@ class TimestampAuthority(ABC):
         pass
 
     @abstractmethod
-    async def verify_timestamp(self, token: TimestampToken) -> bool:
+    async def verify_timestamp(
+        self, token: TimestampToken, raw_token: Optional[bytes] = None
+    ) -> bool:
         """
         Verify a timestamp token.
 
         Args:
             token: The timestamp token to verify
+            raw_token: The raw, authority-native token bytes required for
+                cryptographic verification (e.g. the DER-encoded RFC 3161
+                TimeStampToken carried on
+                :attr:`TimestampResponse.raw_response`). Authorities whose
+                tokens are self-contained (e.g.
+                :class:`LocalTimestampAuthority`, which embeds its signature on
+                the token) MAY ignore this argument; authorities that verify an
+                external token (RFC 3161) REQUIRE it and MUST fail closed when
+                it is ``None``.
 
         Returns:
-            True if the token is valid, False otherwise
+            True if the token is cryptographically valid, False otherwise.
+            Implementations MUST fail closed: an unverifiable token (missing
+            material, unsupported library, failed crypto check) returns False,
+            never True.
         """
         pass
 
@@ -573,7 +587,9 @@ class LocalTimestampAuthority(TimestampAuthority):
             alg_id=canonical.algorithm,
         )
 
-    async def verify_timestamp(self, token: TimestampToken) -> bool:
+    async def verify_timestamp(
+        self, token: TimestampToken, raw_token: Optional[bytes] = None
+    ) -> bool:
         """
         Verify a timestamp token.
 
@@ -581,6 +597,10 @@ class LocalTimestampAuthority(TimestampAuthority):
 
         Args:
             token: The timestamp token to verify
+            raw_token: Unused for local tokens — a :class:`LocalTimestampAuthority`
+                token is self-contained (it carries its own Ed25519 signature on
+                the token). Accepted for interface symmetry with
+                :class:`RFC3161TimestampAuthority`.
 
         Returns:
             True if the token is valid, False otherwise
@@ -631,18 +651,33 @@ class RFC3161TimestampAuthority(TimestampAuthority):
     Attributes:
         _url: TSA URL
         _timeout: Request timeout in seconds
+        _certificate: Trusted TSA certificate (DER or PEM bytes) used as the
+            trust anchor when verifying a TimeStampToken's signature. Without
+            it, :meth:`verify_timestamp` cannot anchor trust and fails closed.
     """
 
-    def __init__(self, tsa_url: str, timeout_seconds: int = 10):
+    def __init__(
+        self,
+        tsa_url: str,
+        timeout_seconds: int = 10,
+        certificate: Optional[bytes] = None,
+    ):
         """
         Initialize RFC 3161 authority.
 
         Args:
             tsa_url: URL of the timestamp authority
             timeout_seconds: Request timeout
+            certificate: Trusted TSA signing certificate as DER or PEM bytes.
+                Required for :meth:`verify_timestamp` to cryptographically
+                verify a token's TSA signature — it is the trust anchor the
+                verifier checks the token's signature against. When ``None``,
+                verification fails closed (a token cannot be trusted without a
+                configured anchor).
         """
         self._url = tsa_url
         self._timeout = timeout_seconds
+        self._certificate = certificate
 
     @property
     def authority_url(self) -> str:
@@ -770,43 +805,125 @@ class RFC3161TimestampAuthority(TimestampAuthority):
                 alg_id=canonical.algorithm,
             )
 
-    async def verify_timestamp(self, token: TimestampToken) -> bool:
+    async def verify_timestamp(
+        self, token: TimestampToken, raw_token: Optional[bytes] = None
+    ) -> bool:
         """
-        Verify an RFC 3161 timestamp token.
+        Verify an RFC 3161 timestamp token via real ASN.1 cryptographic checks.
 
-        Verifies the token was issued by the expected TSA and the hash
-        matches. If rfc3161ng is available, performs full ASN.1 verification.
+        Verification proceeds in two stages:
+
+        1. **Metadata pre-checks (necessary, NOT sufficient):** the token's
+           ``source`` is :attr:`TimestampSource.RFC3161` and its ``authority``
+           matches this authority's configured TSA URL.
+        2. **Cryptographic verification:** the raw DER-encoded ``TimeStampToken``
+           (``raw_token``, carried on :attr:`TimestampResponse.raw_response`) is
+           verified against the configured trusted TSA ``certificate`` and the
+           token's hashed message imprint (``token.hash_value``) using the
+           ``rfc3161ng`` library. This checks the TSA's signature over the token
+           AND that the timestamped imprint matches the hash recorded on the
+           token — the two properties that make a token unforgeable.
+
+        **Fail-closed (EATP):** the method returns ``True`` ONLY when stage 2
+        cryptographically succeeds. If any verification material is missing
+        (``rfc3161ng`` not installed, no ``raw_token``, no trusted
+        ``certificate``), or the cryptographic check raises or returns falsy,
+        the method returns ``False``. A forged or tampered token whose
+        ``source``/``authority`` metadata happen to match the configured TSA is
+        rejected, because metadata alone is never sufficient.
 
         Args:
-            token: The timestamp token to verify
+            token: The timestamp token to verify.
+            raw_token: The raw DER-encoded ``TimeStampToken`` bytes (from
+                :attr:`TimestampResponse.raw_response`). Required for
+                cryptographic verification; ``None`` → fail closed.
 
         Returns:
-            True if the token is valid
+            ``True`` iff the token is cryptographically verified against the
+            trusted TSA certificate; ``False`` otherwise.
         """
-        # Basic validation
+        # Stage 1 — metadata pre-checks (necessary, NOT sufficient).
         if token.source != TimestampSource.RFC3161:
-            logger.warning(f"Token source is {token.source}, expected RFC3161")
+            logger.warning(
+                "RFC3161 verify: token source is %s, expected RFC3161 — rejected",
+                token.source,
+            )
             return False
 
         if token.authority != self._url:
             logger.warning(
-                f"Token authority {token.authority} does not match configured TSA {self._url}"
+                "RFC3161 verify: token authority %s does not match configured "
+                "TSA %s — rejected",
+                token.authority,
+                self._url,
+            )
+            return False
+
+        # Stage 2 — cryptographic verification. Every missing material fails
+        # closed: an unverifiable token is NOT a valid token.
+        try:
+            import rfc3161ng  # type: ignore[import-untyped]
+        except ImportError:
+            logger.warning(
+                "RFC3161 verify: rfc3161ng is not installed — cannot "
+                "cryptographically verify the timestamp token; failing closed. "
+                "Install the 'rfc3161' extra (pip install 'kailash[rfc3161]') to "
+                "enable verification."
+            )
+            return False
+
+        if raw_token is None:
+            logger.warning(
+                "RFC3161 verify: no raw DER TimeStampToken supplied "
+                "(TimestampResponse.raw_response was empty) — cannot verify the "
+                "TSA signature; failing closed."
+            )
+            return False
+
+        if self._certificate is None:
+            logger.warning(
+                "RFC3161 verify: no trusted TSA certificate configured on the "
+                "authority — cannot anchor trust for signature verification; "
+                "failing closed. Construct RFC3161TimestampAuthority(..., "
+                "certificate=<DER/PEM bytes>) to enable verification."
             )
             return False
 
         try:
-            import rfc3161ng  # type: ignore[import-untyped]
-
-            # If we have rfc3161ng, we can do proper verification
-            # by re-timestamping and comparing (simplified)
-            return True
-        except ImportError:
-            # Without rfc3161ng, we can only verify basic metadata
+            data = bytes.fromhex(token.hash_value)
+        except (TypeError, ValueError):
             logger.warning(
-                "rfc3161ng not installed - performing metadata-only verification. "
-                "Install rfc3161ng for full cryptographic verification."
+                "RFC3161 verify: token hash_value is not valid hex — failing closed."
             )
-            return token.hash_value is not None and token.timestamp is not None
+            return False
+
+        try:
+            verified = rfc3161ng.check_timestamp(
+                raw_token,
+                certificate=self._certificate,
+                data=data,
+                hashname="sha256",
+            )
+        except Exception as e:  # noqa: BLE001 — fail closed on ANY crypto error
+            # rfc3161ng raises (rather than returning False) on signature
+            # mismatch, imprint mismatch, malformed DER, or certificate
+            # distrust. Catch-log-reject is the fail-closed disposition
+            # (zero-tolerance Rule 3: catch -> log -> handle, never silent).
+            logger.warning(
+                "RFC3161 verify: cryptographic verification failed (%s) — "
+                "token rejected.",
+                type(e).__name__,
+            )
+            return False
+
+        if not verified:
+            logger.warning(
+                "RFC3161 verify: timestamp token did not verify against the "
+                "trusted TSA certificate — token rejected."
+            )
+            return False
+
+        return True
 
     @staticmethod
     def _build_timestamp_request(hash_bytes: bytes, nonce: int) -> bytes:
@@ -1036,20 +1153,40 @@ class TimestampAnchorManager:
         # Dispatch gate (EATP-08 §5.1) — runs BEFORE any verification work.
         resolve_dispatch(token.alg_id)
 
+        # Imprint binding: the token's hashed imprint MUST equal the hash the
+        # caller actually anchored (the request hash). Cryptographic
+        # verification below proves the TSA signed *token.hash_value* — it does
+        # NOT prove that imprint is the artifact the caller intended to anchor.
+        # Without this cross-check, a (legitimately TSA-signed) token over an
+        # attacker-chosen imprint could be substituted for the intended one
+        # (both raw_response DER and token.hash_value swapped) and still pass.
+        # Fail closed on divergence (EATP: unknown/error -> deny).
+        if token.hash_value != response.request.hash_value:
+            logger.warning(
+                "verify_anchor: token imprint does not match the anchored "
+                "request hash — token rejected (possible imprint substitution)."
+            )
+            return False
+
+        # Thread the raw authority-native token bytes (DER TimeStampToken for
+        # RFC 3161) so the matched authority can cryptographically verify it.
+        # Dropping raw_response here is what forced the prior fail-open stub.
+        raw_token = response.raw_response
+
         # Find matching authority
         if token.authority == self._primary.authority_url:
-            return await self._primary.verify_timestamp(token)
+            return await self._primary.verify_timestamp(token, raw_token)
 
         for fallback in self._fallbacks:
             if token.authority == fallback.authority_url:
-                return await fallback.verify_timestamp(token)
+                return await fallback.verify_timestamp(token, raw_token)
 
         if (
             self._local_fallback
             and self._local is not None
             and token.authority == self._local.authority_url
         ):
-            return await self._local.verify_timestamp(token)
+            return await self._local.verify_timestamp(token, raw_token)
 
         # Unknown authority - cannot verify
         return False
@@ -1080,7 +1217,9 @@ class TimestampAnchorManager:
 
 
 async def verify_timestamp_token(
-    token: TimestampToken, authority: TimestampAuthority
+    token: TimestampToken,
+    authority: TimestampAuthority,
+    raw_token: Optional[bytes] = None,
 ) -> bool:
     """
     Verify a timestamp token using a specific authority.
@@ -1091,8 +1230,14 @@ async def verify_timestamp_token(
     Args:
         token: The timestamp token to verify
         authority: The authority to use for verification
+        raw_token: The raw authority-native token bytes required for
+            cryptographic verification of external tokens (the DER-encoded
+            RFC 3161 ``TimeStampToken`` from
+            :attr:`TimestampResponse.raw_response`). Omit for self-contained
+            tokens (e.g. :class:`LocalTimestampAuthority`); an RFC 3161 token
+            without it fails closed.
 
     Returns:
         True if the token is valid, False otherwise
     """
-    return await authority.verify_timestamp(token)
+    return await authority.verify_timestamp(token, raw_token)

--- a/tests/regression/test_issue_1332_rfc3161_verify_fail_closed.py
+++ b/tests/regression/test_issue_1332_rfc3161_verify_fail_closed.py
@@ -1,0 +1,253 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression: issue #1332 — RFC-3161 ``verify_timestamp`` must NOT fail open.
+
+Before the fix, ``RFC3161TimestampAuthority.verify_timestamp`` returned ``True``
+with **zero cryptographic verification** whenever ``rfc3161ng`` was importable:
+the docstring promised "full ASN.1 verification" but the body was a bare
+``return True``. A forged/tampered token whose ``source``/``authority`` metadata
+happened to match the configured TSA was accepted as valid (security fail-open).
+
+These tests pin the corrected **fail-closed** contract:
+
+1. Metadata-match alone never returns ``True`` (the core security regression).
+2. Missing verification material (no library / no raw DER token / no trusted
+   certificate) returns ``False``.
+3. With all material present, the result is the genuine cryptographic verdict —
+   a tampered token (message-imprint mismatch) is rejected, a valid token is
+   accepted. ``rfc3161ng`` is simulated via a stub module so the dispatch logic
+   is exercised deterministically without a live TSA / the optional dependency
+   (which is not installed in CI).
+
+``verify_anchor`` is also covered: it MUST thread ``response.raw_response`` into
+``verify_timestamp`` (dropping it was the architectural gap that forced the
+fail-open stub).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime, timezone
+
+import pytest
+
+from kailash.trust.signing.timestamping import (
+    LocalTimestampAuthority,
+    RFC3161TimestampAuthority,
+    TimestampAnchorManager,
+    TimestampRequest,
+    TimestampResponse,
+    TimestampSource,
+    TimestampToken,
+)
+
+TSA_URL = "https://tsa.example.test/tsr"
+GOOD_HASH = "a" * 64  # 32-byte sha256 imprint, hex
+TAMPERED_HASH = "b" * 64
+FAKE_CERT = b"-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+RAW_DER = b"\x30\x82\x01\x00fake-der-timestamp-token"
+
+
+def _rfc3161_token(
+    hash_value: str = GOOD_HASH, *, authority: str = TSA_URL
+) -> TimestampToken:
+    return TimestampToken(
+        token_id="tok-1",
+        hash_value=hash_value,
+        timestamp=datetime.now(timezone.utc),
+        source=TimestampSource.RFC3161,
+        authority=authority,
+        nonce="00112233445566778899aabbccddeeff",
+    )
+
+
+@pytest.fixture
+def fake_rfc3161ng(monkeypatch):
+    """Inject a stub ``rfc3161ng`` whose ``check_timestamp`` performs a real
+    message-imprint comparison.
+
+    The stub mirrors the library contract: it RAISES on a mismatch (the library
+    raises rather than returning False), so a token whose hash_value differs
+    from the imprint the TSA signed is rejected by the production catch-log-False
+    path. ``data`` is the bytes of ``token.hash_value`` the production code
+    passes; the stub compares it against the imprint embedded in the raw token.
+    """
+
+    class _ValidationError(Exception):
+        pass
+
+    def check_timestamp(tst, *, certificate, data, hashname, **kwargs):
+        # Trust anchor + materials must be present (production already gates
+        # these, but assert the contract the library would enforce).
+        assert certificate == FAKE_CERT
+        assert hashname == "sha256"
+        assert isinstance(tst, (bytes, bytearray))
+        # Simulate imprint verification: the raw token encodes the imprint it
+        # was issued for; mismatch => library raises.
+        signed_imprint = bytes.fromhex(GOOD_HASH)
+        if data != signed_imprint:
+            raise _ValidationError("message imprint does not match")
+        return True
+
+    module = types.ModuleType("rfc3161ng")
+    module.check_timestamp = check_timestamp  # type: ignore[attr-defined]
+    module.ValidationError = _ValidationError  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "rfc3161ng", module)
+    return module
+
+
+# --------------------------------------------------------------------------- #
+# Core security regression: metadata-match alone NEVER returns True.
+# --------------------------------------------------------------------------- #
+
+
+async def test_verify_fails_closed_when_rfc3161ng_absent(monkeypatch):
+    """Without the verification library, a metadata-matching token is rejected.
+
+    This is the exact fail-open the issue reported: previously this returned
+    True. It MUST now return False — an unverifiable token is not valid.
+    """
+    monkeypatch.setitem(sys.modules, "rfc3161ng", None)  # force ImportError path
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    token = _rfc3161_token()
+    assert await authority.verify_timestamp(token, RAW_DER) is False
+
+
+async def test_verify_rejects_wrong_source(fake_rfc3161ng):
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    token = _rfc3161_token()
+    token.source = TimestampSource.LOCAL
+    assert await authority.verify_timestamp(token, RAW_DER) is False
+
+
+async def test_verify_rejects_wrong_authority(fake_rfc3161ng):
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    token = _rfc3161_token(authority="https://evil.example.test/tsr")
+    assert await authority.verify_timestamp(token, RAW_DER) is False
+
+
+# --------------------------------------------------------------------------- #
+# Missing verification material -> fail closed (even with the library present).
+# --------------------------------------------------------------------------- #
+
+
+async def test_verify_fails_closed_without_raw_token(fake_rfc3161ng):
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    token = _rfc3161_token()
+    # No raw DER token -> cannot verify a TSA signature -> reject.
+    assert await authority.verify_timestamp(token, None) is False
+
+
+async def test_verify_fails_closed_without_certificate(fake_rfc3161ng):
+    authority = RFC3161TimestampAuthority(TSA_URL)  # no trust anchor
+    token = _rfc3161_token()
+    assert await authority.verify_timestamp(token, RAW_DER) is False
+
+
+async def test_verify_fails_closed_on_non_hex_hash(fake_rfc3161ng):
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    token = _rfc3161_token(hash_value="not-hex!!")
+    assert await authority.verify_timestamp(token, RAW_DER) is False
+
+
+# --------------------------------------------------------------------------- #
+# All material present -> genuine cryptographic verdict.
+# --------------------------------------------------------------------------- #
+
+
+async def test_verify_accepts_valid_token(fake_rfc3161ng):
+    """Valid token + trusted cert + raw DER + matching imprint -> True."""
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    token = _rfc3161_token(hash_value=GOOD_HASH)
+    assert await authority.verify_timestamp(token, RAW_DER) is True
+
+
+async def test_verify_rejects_tampered_imprint(fake_rfc3161ng):
+    """A token whose hash_value was altered (imprint mismatch) is rejected.
+
+    Acceptance criterion #2: a tampered token whose source/authority still
+    match the configured TSA is rejected.
+    """
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    token = _rfc3161_token(hash_value=TAMPERED_HASH)
+    assert await authority.verify_timestamp(token, RAW_DER) is False
+
+
+# --------------------------------------------------------------------------- #
+# verify_anchor threads response.raw_response into verify_timestamp.
+# --------------------------------------------------------------------------- #
+
+
+def _rfc3161_response(raw_response: bytes | None) -> TimestampResponse:
+    token = _rfc3161_token()
+    request = TimestampRequest(hash_value=GOOD_HASH, nonce=token.nonce)
+    return TimestampResponse(
+        request=request, token=token, raw_response=raw_response, verified=True
+    )
+
+
+async def test_verify_anchor_threads_raw_response(fake_rfc3161ng):
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    manager = TimestampAnchorManager(primary=authority, local_fallback=False)
+    # raw_response present + valid -> verified True
+    assert await manager.verify_anchor(_rfc3161_response(RAW_DER)) is True
+
+
+async def test_verify_anchor_fails_closed_without_raw_response(fake_rfc3161ng):
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    manager = TimestampAnchorManager(primary=authority, local_fallback=False)
+    # raw_response dropped -> RFC3161 path cannot verify -> False.
+    assert await manager.verify_anchor(_rfc3161_response(None)) is False
+
+
+async def test_verify_anchor_rejects_imprint_substitution(fake_rfc3161ng):
+    """A token whose imprint differs from the anchored request hash is rejected.
+
+    Even with a (simulated) legitimately-TSA-signed token over the substituted
+    imprint, ``verify_anchor`` MUST reject when ``token.hash_value`` diverges
+    from ``request.hash_value`` — otherwise an attacker-chosen-but-TSA-signed
+    imprint could be substituted for the one the caller actually anchored.
+    """
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    manager = TimestampAnchorManager(primary=authority, local_fallback=False)
+    # Build a response whose token anchors GOOD_HASH (the imprint the fake
+    # check_timestamp accepts) but whose request anchored a DIFFERENT hash.
+    token = _rfc3161_token(hash_value=GOOD_HASH)
+    request = TimestampRequest(hash_value=TAMPERED_HASH, nonce=token.nonce)
+    substituted = TimestampResponse(
+        request=request, token=token, raw_response=RAW_DER, verified=True
+    )
+    assert await manager.verify_anchor(substituted) is False
+
+
+# --------------------------------------------------------------------------- #
+# Regression guard: the working local-authority round-trip still verifies.
+# --------------------------------------------------------------------------- #
+
+
+async def test_verify_timestamp_token_helper_threads_raw_token(fake_rfc3161ng):
+    """The module-level ``verify_timestamp_token`` helper forwards ``raw_token``.
+
+    Without the forwarded raw DER token the RFC-3161 path fails closed; with it
+    (valid imprint) it verifies — proving the helper's optional ``raw_token``
+    argument reaches the authority rather than being dropped.
+    """
+    from kailash.trust.signing.timestamping import verify_timestamp_token
+
+    authority = RFC3161TimestampAuthority(TSA_URL, certificate=FAKE_CERT)
+    token = _rfc3161_token(hash_value=GOOD_HASH)
+    assert await verify_timestamp_token(token, authority) is False  # no raw_token
+    assert await verify_timestamp_token(token, authority, RAW_DER) is True
+
+
+async def test_local_authority_roundtrip_unaffected():
+    """The new raw_token parameter must not break self-contained local tokens."""
+    authority = LocalTimestampAuthority()
+    response = await authority.get_timestamp(GOOD_HASH)
+    assert await authority.verify_timestamp(response.token) is True
+    # Tampered local token is rejected.
+    response.token.hash_value = TAMPERED_HASH
+    assert await authority.verify_timestamp(response.token) is False


### PR DESCRIPTION
## Summary

`RFC3161TimestampAuthority.verify_timestamp` previously returned `True` with **zero cryptographic verification** whenever `rfc3161ng` was importable — the docstring promised "full ASN.1 verification" but the body was a bare `return True`. A forged or tampered token whose `source`/`authority` metadata matched the configured TSA was accepted as valid (security fail-open, surfaced by an independent holistic redteam of the 2.34.0 trust surface).

Root cause: the raw DER `TimeStampToken` needed to verify the TSA signature lived on `TimestampResponse.raw_response` but was **dropped** before reaching `verify_timestamp` — so the stub had no material to verify against.

## What changed

- `verify_anchor` now **threads `response.raw_response`** into `verify_timestamp` (the dropped material that forced the stub).
- `RFC3161TimestampAuthority.__init__` gains an optional **trusted TSA `certificate`** (the trust anchor).
- `verify_timestamp` performs **real verification** via `rfc3161ng.check_timestamp` (TSA signature + message-imprint hash). It returns `True` **only** on cryptographic success and **fails closed** (`False`) when any material is missing (`rfc3161ng` absent / no raw DER token / no trusted certificate) or the check fails — per the EATP fail-closed discipline.
- `verify_anchor` also cross-checks `token.hash_value == request.hash_value`, rejecting imprint-substitution (a legitimately-TSA-signed token over an attacker-chosen imprint swapped for the intended one). *(security-reviewer MED-1, same bug class — fixed in-session per autonomous-execution Rule 4.)*
- New optional `rfc3161` extra (`pip install 'kailash[rfc3161]'`, included in `[all]`) installs `rfc3161ng`. `certificate`/`raw_token` are backward-compatible optional additions.

## Tests

`tests/regression/test_issue_1332_rfc3161_verify_fail_closed.py` (13 tests) pins the fail-closed contract behaviorally: rejection without library/raw-token/certificate/valid-hex; tampered-imprint rejected; valid token accepted; `verify_anchor` raw_response threading + imprint-substitution rejection; helper raw_token forwarding; local-authority round-trip unaffected. `rfc3161ng` (not installable in CI) is exercised via a deterministic stub module — the standard optional-dependency test pattern.

## User-flow walk receipt

```
verify_anchor (no rfc3161ng installed, unverifiable token): False
  -> BEFORE #1332 this returned True (fail-OPEN); now fails closed: True
```

## Acceptance criteria

- [x] With `rfc3161ng` + trusted cert + raw DER, `verify_timestamp` does real ASN.1 verification and returns `True` only on success.
- [x] A tampered/forged token whose source/authority match is rejected (Tier-1 regression pins it).
- [x] Fail-closed documented; docstring's "ASN.1 verification" claim now matches the implementation.
- [ ] **Cross-SDK (kailash-rs):** inspect the equivalent Rust TSA verification path for the same fail-open. Deferred — requires cross-repo authorization (out of this BUILD repo's scope); surfaced to the owner.

## Review gates

- reviewer: **APPROVE** (all mechanical sweeps pass; version anchors atomic at 2.34.1).
- security-reviewer: **APPROVE-WITH-FIXES** → MED-1 fixed in this PR; LOW items (hardcoded sha256 hashname; documented). Fail-open fully eliminated.

## Related issues

Fixes #1332

🤖 Generated with [Claude Code](https://claude.com/claude-code)