### PR TITLE
chore(records): commit accumulated deploy notes + sweep reports backlog

### DIFF
--- a/SWEEP-2026-05-16.md
+++ b/SWEEP-2026-05-16.md
@@ -1,0 +1,178 @@
+# Sweep — 2026-05-16 (post #1037 close + 2.9.11 ship)
+
+Repo: `terrene-foundation/kailash-py` · main @ `3c63d0e5f` · `0/0` ahead/behind origin
+
+This sweep ran at end of the issue-1037 / kailash-dataflow 2.9.11 session.
+Scope: repo-wide outstanding-work audit per `commands/sweep.md`. Trivial
+fixes applied inline (none applicable); non-trivial findings surfaced
+below with disposition per `rules/value-prioritization.md` MUST-3+4.
+
+---
+
+## Findings
+
+### [MED] [Sweep 6] 12 worktrees retained, 9 locked from prior sessions
+
+**Location:** `.claude/worktrees/agent-*` (9 locked), `.claude/worktrees/w{4,5,6}-*` (3 active-looking)
+
+**Locked worktrees (prior-session feature branches, ≥4d old by branch shape):**
+
+- `agent-a1ab206893ceb93da` → `fix/issue-900-credential-ref-param`
+- `agent-a1af342e8bb6627eb` → `fix/issue-898-dataflow-unit-tests`
+- `agent-a4adf0920513b022e` → `fix/issue-942-asyncsql-wait-for-warning`
+- `agent-a5b8a2861fc971fb0` → harness-default name `worktree-agent-a5b8a2861fc971fb0` (per `worktree-isolation.md` Rule 6 violation — should have been named for a branch)
+- `agent-a5c5e1f0a7fbc31d9` → `work/issue-913-fix`
+- `agent-a78799265ba8722ac` → `fix/issue-929-workflow-round-trip-serialization`
+- `agent-abd85e1583a44188c` → `feat/issue-913-scheduler-admin-api`
+- `agent-ac02636b86de8310e` → `fix/issue-953-localruntime-pool-tracking`
+- `agent-af883b59fe1d4f2b7` → `feat/issue-898-shard2-dataflow-unit-ci-gate`
+
+**Unlocked (active workstream?):**
+
+- `w4-durable-engine` → `feat/w4-durable-execution-engine`
+- `w5-tier3-crash-resume` → `feat/w5-tier3-crash-resume-redaction`
+- `w6-redaction-discipline` → `fix/w6-checkpoint-dispatcher-redaction-discipline`
+
+**Disposition:** (b) abandon-with-user-gate for the 9 locked agent-worktrees; (c) queued-with-value-rank for the 3 w\*-worktrees pending user confirmation they're still active.
+
+**Why this matters:** Each worktree carries its own `target/`, `.venv/`, and uncommitted state. Per `rules/worktree-isolation.md` Rule 3, zero-commit worktrees should be cleaned. Locked worktrees skip auto-cleanup but accumulate cost. The harness-default `worktree-agent-a5b8a2861fc971fb0` name is a Rule 6 violation that should be renamed or pruned.
+
+**Recommended action:** User gate — `git worktree remove` for the 9 locked + confirm w4/w5/w6 are still active before pruning.
+
+---
+
+### [MED] [Sweep 2] 46 pending journal entries across 5 workspaces, 33 in one
+
+**Location:** `workspaces/*/journal/.pending/*.md`
+
+| Workspace                                | Pending count | Oldest          |
+| ---------------------------------------- | ------------- | --------------- |
+| issue-835-dataflow-transaction-eventloop | 33            | 2026-05-07 (9d) |
+| issue-912-task-time-limits               | 9             | —               |
+| issue-871-sqlite-jobstore-toctou         | 2             | —               |
+| issue-979-dataflow-unit-triage           | 1             | —               |
+| issue-1002-aiosqlite-fixture-cleanup     | 1             | —               |
+
+**Disposition:** Per `rules/journal.md`, each `.pending/` entry needs promote-or-discard. issue-835's 33 entries indicate a workstream that's accumulated decisions/discoveries without journal triage.
+
+**Recommended action:** Next session touching issue-835 must triage the 33 pending entries before continuing. Other workspaces have low counts; can be folded into normal session-close.
+
+---
+
+### [LOW] [Sweep 4] 5 stale remote branches without PR
+
+**Location:** `origin/...`
+
+- `debug/issue-1010-phase-a-diagnostics`
+- `debug/issue-1010-phase-a-prime-linux`
+- `fix/dataflow-unit-ci-hang-after-968`
+- `fix/issue-1002-shard4b-remove-setsid-wrapper`
+- `style/align-pre-commit-sweep`
+
+**Disposition:** Orphan work per `rules/agents.md` § MUST: Recover Orphan Writes — these are remote branches with no open PR. Either superseded (delete) or work-in-progress that needs PR creation.
+
+**Recommended action:** User gate — for each, `gh pr create` if still wanted OR `git push origin --delete <branch>` if superseded.
+
+---
+
+### [LOW] [Sweep 7] 9 uncommitted/untracked items in workspaces/ from prior sessions
+
+**Location:** `workspaces/issue-979-*`, `workspaces/issue-1002-*`
+
+```
+M  workspaces/issue-979-b15-tier2-mock-rewrite/.session-notes
+?? workspaces/issue-1002-aiosqlite-fixture-cleanup/.{journal-skipped.log,session-notes}
+?? workspaces/issue-979-b15-tier2-mock-rewrite/{.journal-skipped.log,journal/0009-DECISION-shard-classifications.md}
+?? workspaces/issue-979-workstream-b-parallel/{.journal-skipped.log,.session-notes,briefs/,journal/0001-DECISION-parallel-wave-outcome.md}
+```
+
+**Disposition:** Inherited from prior sessions — NOT this session's scope. The modified `.session-notes` files reference workstreams (#992 B-1.5, PRs #1020/#1021) the current session did not touch.
+
+**Why this matters:** Per `rules/zero-tolerance.md` Rule 1c, I cannot prove these are "pre-existing" without commit SHA pre-dating my first tool call — but the workspaces they live in are clearly other prior sessions' work. Disposition under uncertainty would normally be "fix it" but committing other sessions' incomplete state risks misattribution.
+
+**Recommended action:** User gate — next session touching these workspaces should `git add` the journal DECISION files (clean knowledge captures worth preserving) and either commit the modified `.session-notes` or `git checkout` to discard.
+
+---
+
+### [LOW] [Sweep 3] 6 open issues older than 14 days
+
+**Location:** GitHub issues on `terrene-foundation/kailash-py`
+
+| #   | Age | Labels                         | Title (truncated)                                                   |
+| --- | --- | ------------------------------ | ------------------------------------------------------------------- |
+| 772 | 15d | type/refactor,dataflow         | dataflow: consolidate \_resolve_type and \_normalize_type_annotatio |
+| 760 | 15d | cross-sdk                      | follow-up 2026-05-08: verify kailash-rs#723 fingerprint pin + #75   |
+| 693 | 18d | documentation,spec-conformance | spec: promote specs/dataflow-ml-integration.md from 1.0.0 (draft)   |
+| 643 | 19d | cross-sdk,sdk-engine           | ml: FeatureStore canonical surface migration (kailash_ml.features   |
+| 630 | 20d | —                              | [follow-up] Trust Vault binding for SLIP-0039 Shamir wrapper (min   |
+| 596 | 25d | —                              | [new-primitive] Implement TieredAuditDispatcher for hash-chaine     |
+
+**Disposition:** None are STALE (>30d). Per `rules/value-prioritization.md` MUST-3+4, none can be auto-closed; surfacing for user re-validation as the queue accumulates.
+
+**Recommended action:** No action this sweep. If the queue hits >10 items aged >14d, suggest a backlog-triage session.
+
+---
+
+### [INFO] [Sweep 1] 11 active todos across 3 prior-session workspaces
+
+`workspaces/issue-1002-aiosqlite-fixture-cleanup/todos/active/` (1)
+`workspaces/issue-979-b15-tier2-mock-rewrite/todos/active/` (4)
+`workspaces/issue-979-dataflow-unit-triage/todos/active/` (6)
+
+**Disposition:** (c) queued-with-value-rank — these are inherited prior-session workstreams. The recently-touched .session-notes (within last 1-2 days) suggest they're still active.
+
+**Recommended action:** Future sessions picking these workspaces re-validate per `value-prioritization.md` MUST-3.
+
+---
+
+### [N/A] [Sweep 5] Spec compliance audit — orchestration mode sentinel
+
+<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=true -->
+
+No `workspaces/*/specs/` directories AND no `tools/sweep-redteam.py` in this checkout. Per the sweep skill, this triggers the N/A sentinel for Sweep 5. (kailash-py is structurally a BUILD repo but doesn't use the per-workspace specs pattern this sweep enforces.)
+
+---
+
+## Cross-cutting observations
+
+1. **No carry-forward from this session.** PR #1039 merged + tag pushed + 2.9.11 on PyPI + #1037 closed. The session's scope is complete and clean.
+
+2. **Worktree backlog is the highest-leverage cleanup.** 12 worktrees including 1 harness-default name (`agent-a5b8a2861fc971fb0`) violating `worktree-isolation.md` Rule 6. A 5-minute cleanup pass per `git worktree remove` would reduce dispatcher load + disk usage.
+
+3. **issue-835 journal backlog is a workstream-health signal.** 33 pending entries without promotion means decisions are being made but not surfaced for next-session inheritance. The next session touching that workstream should triage before continuing.
+
+4. **No stub markers introduced this session.** Production code paths fixed in PR #1039 use real type annotations + None-guards (Path C disposition), not suppressions.
+
+5. **PyPI is in sync across all 8 packages** post-2.9.11 release. No sibling drift to address.
+
+---
+
+## Recommended next-session items (ranked by user-anchored value)
+
+User did not surface a brief for the next session. The following ranking is the **agent's view of available work**, NOT a user-anchored prioritization. The user picks; this is the surface menu.
+
+1. **(unknown-value) Worktree cleanup pass** — 5 min, reduces dispatcher load. Mechanical. No user-anchored value, but unblocks future parallel-worktree work.
+
+2. **(unknown-value) Resume issue-979 workstream-b-parallel** — `.session-notes` modified recently; active todos at `workspaces/issue-979-b15-tier2-mock-rewrite/todos/active/`. Needs value-anchor re-validation per `value-prioritization.md` MUST-3 before resuming.
+
+3. **(unknown-value) Resume issue-835 dataflow-transaction-eventloop** — 33 pending journal entries to triage + active workstream context. Same MUST-3 re-validation required.
+
+4. **(unknown-value) Resume issue-1002 aiosqlite-fixture-cleanup** — 1 active todo + 1 pending journal entry. Same re-validation required.
+
+5. **(unknown-value) Triage 6 open issues aged >14d** — including 2 cross-sdk items (#760, #643). Backlog-triage session.
+
+All five lack user-anchored value-anchors per `value-prioritization.md` MUST-1. The user owns the prioritization decision; this sweep surfaces the available menu.
+
+---
+
+## Closure receipts
+
+- Sweep 1: 11 todos surveyed
+- Sweep 2: 46 pending entries surveyed across 5 workspaces
+- Sweep 3: 20 open issues surveyed (0 STALE, 6 old, 14 recent)
+- Sweep 4: 0 open PRs, 5 stale remote branches surveyed
+- Sweep 5: N/A sentinel applied (orchestration mode)
+- Sweep 6: 12 worktrees + 0 stale .session-notes + 0 stale .pending surveyed
+- Sweep 7: 9 inherited uncommitted items + 0/0 origin-divergence + 0 new stubs
+
+Report committed at session-end per skill closure protocol.

--- a/SWEEP-2026-05-18.md
+++ b/SWEEP-2026-05-18.md
@@ -1,0 +1,231 @@
+# Sweep — 2026-05-18 (repo: terrene-foundation/kailash-py)
+
+Entry context: post-#1079 (Wave B release-merge); main at `b8a623123`;
+kailash 2.22.0 + kailash-kaizen 2.21.1 LIVE on PyPI; 0/0 vs origin/main.
+Delta from SWEEP-2026-05-17: 4 issues closed (#1047, #1051, #1054, #1056) +
+Wave B closures (#1068, #1070, #1071) — open issues 19 → 15. Hygiene
+backlog unchanged.
+
+## 100% completion answer
+
+**Repo-wide: NO.** Wave A + B both 100% shipped; ZERO uncommitted code,
+ZERO open PRs, ZERO unmerged work-this-session. Project-level still
+open across:
+
+- **15 open GH issues** (Wave-D candidate surface; ranked below).
+- **4 workspace folders carrying active todos that correspond to CLOSED
+  upstream issues** — archive candidates (Wave C hygiene scope).
+- **Process-hygiene backlog**: 24 locked agent worktrees (10 added
+  during Wave A/B work this week), 33 stale `.pending` journals in
+  issue-835 (parent issue CLOSED 2026-05-06), 5 stale remote branches
+  pointing at CLOSED/MERGED issues.
+
+---
+
+## Sweep 1 — Active todos across workspaces
+
+13 active todo files across 4 workspaces — **ALL FOUR workspaces correspond
+to upstream issues that are now CLOSED.** All four are archive candidates,
+not new-work surface.
+
+| Workspace                              | Active | Parent issue            | Disposition class (per `value-prioritization.md` MUST-3+4)                                                                                                                                                                                                       |
+| -------------------------------------- | -----: | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `issue-979-dataflow-unit-triage`       |      7 | #979 CLOSED 2026-05-14  | (b) **abandon-with-user-gate** — OPTION-C′ was approved 2026-05-13, but parent #979 closed 2026-05-14 via siblings (#998/#999/#1022 all closed). Likely supersedence — confirm with user before archive.                                                         |
+| `issue-979-b15-tier2-mock-rewrite`     |      4 | #992 CLOSED 2026-05-15  | (b) **abandon-with-user-gate** — workspace's own `journal/0009-DECISION-shard-classifications.md` is untracked; confirm closure path before archive.                                                                                                             |
+| `issue-1050-protection-orphan-async`   |      1 | #1050 CLOSED 2026-05-17 | (b) **abandon-with-user-gate** — S1a/S1b shipped via #1050 close; S2/S3 Tier-2 follow-up matrix may have shipped elsewhere or be true follow-up.                                                                                                                 |
+| `issue-1002-aiosqlite-fixture-cleanup` |      1 | #1002/#1010 CLOSED      | (b) **abandon-with-user-gate** — workspace's own `.session-notes:6-7` says VERBATIM "Workspace can be retired — `todos/active/` is empty; only the deferred shard 4b was outstanding, and it shipped via PR #1017." User-anchored retire signal already present. |
+
+**Finding [MED] [Sweep 1]:** All 4 workspaces carry CLOSED-upstream todos. Per `value-prioritization.md` MUST-4, auto-archive without user gate is BLOCKED. Disposition: surface to user as Wave-C hygiene pass (recommend archive), one user-gated decision per workspace OR a single bulk approval. Zero ACTIVE-new work in any active-todo list.
+
+## Sweep 2 — Pending journal entries (52 total)
+
+| Workspace                                  | Pending | Age   | Parent issue status             |
+| ------------------------------------------ | ------: | ----- | ------------------------------- |
+| `issue-835-dataflow-transaction-eventloop` |  **33** | 7-14d | **CLOSED 2026-05-06** (12d ago) |
+| `issue-912-task-time-limits`               |       9 | 14d   | issue #912                      |
+| `issue-979-b15-tier2-mock-rewrite`         |       7 | 1-4d  | parent #992 CLOSED              |
+| `issue-871-sqlite-jobstore-toctou`         |       2 | 14d   | issue #871                      |
+| `issue-1002-aiosqlite-fixture-cleanup`     |       1 | 2d    | parent CLOSED                   |
+| `issue-979-dataflow-unit-triage`           |       1 | 4d    | parent #979 CLOSED              |
+
+**Finding [MED] [Sweep 2]:** issue-835's 33 pending DECISION/RISK/DISCOVERY entries — parent issue CLOSED 2026-05-06 yet journals never promoted. Per `rules/journal.md`: each entry promote (institutional value), codify (recurring lesson), or discard (already-codified / bare merge). 33 entries × triage-by-hand is non-trivial; orchestrator-led batch with cc-architect review is the appropriate surface.
+
+**Finding [LOW] [Sweep 2]:** Other workspaces' pending journals are <14d and many will resolve on natural workspace-archive flow.
+
+## Sweep 3 — Open GH issues (15 — value-ranked per `value-prioritization.md` MUST-1+5)
+
+Each candidate cites a **primary anchor** from the closed-allowlist {a, b, c, d, e}. When no user-anchored source exists, the issue is ranked LOW per MUST-5 (code-health as secondary only).
+
+### HIGH — user-led briefs with explicit anchors
+
+| #         | Title                                                                            | Primary anchor                                                                                                                                            | Notes                                                                                                                                                                                                                                                                        |
+| --------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **#1035** | feat(delegate): open Delegate composition reference                              | (d) literal user quote — 2026-05-17 comment `IC_kwDORmHuac8AAAABCpCcjQ` "IMPLEMENTATION BRIEF + sequencing (locked frame for the kailash-py OSS session)" | **STRUCTURALLY DEFERRED** per `.session-notes:106-108` — needs external spec content from `terrene/contrib/mail-delegate/workspaces/delegate-spine/` OR user opens Claude Code in `~/repos/dev/unicorn-focus/`. Repo-scope-discipline blocks this session from authoring it. |
+| **#643**  | ml: FeatureStore canonical surface migration — breaking-change deprecation cycle | (e) spec § success criterion — sdk-engine labelled cross-sdk breaking change                                                                              | Has explicit deprecation-cycle requirement; needs cross-sdk coordination with kailash-rs sibling.                                                                                                                                                                            |
+
+### MED — user-reported bugs / paired follow-ups
+
+| #         | Title                                                                              | Primary anchor                                                  | Notes                                                                                                              |
+| --------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **#891**  | fix: HybridSearchNode name collision (dataflow vs kaizen)                          | (e) issue body — concrete bug, collision is empirically present | Real bug; user-filed. Single-PR fix scope.                                                                         |
+| **#1012** | feat(handlers): `@app.handler` string-based API                                    | (e) issue body — UserWarning fires per-handler                  | Per `.session-notes:38-39`, "partially superseded by #1071 Gap B (advisory-noise fix)" — verify remaining surface. |
+| **#937**  | feat(nexus): expose SchedulerAdminAPI via Nexus admin panel (follow-up #913)       | (e) parent issue #913 (shipped)                                 | Follow-up to a shipped feature; concrete deliverable.                                                              |
+| **#938**  | feat(scheduler): django-celery-beat PeriodicTask migration helper (follow-up #913) | (e) parent issue #913 (shipped)                                 | Same parent as #937; sibling pair.                                                                                 |
+| **#760**  | follow-up 2026-05-08: verify kailash-rs#723 fingerprint pin + #759 DPI-A repro     | (e) cross-sdk-labelled — verification gate                      | Cross-SDK verification; needs paired-repo session per `repo-scope-discipline.md`.                                  |
+| **#630**  | follow-up Trust Vault binding for SLIP-0039 Shamir wrapper                         | (e) parent ISS-37 (shipped)                                     | Follow-on for a delivered primitive.                                                                               |
+
+### LOW — code-health (secondary anchor only — `value-prioritization.md` MUST-5)
+
+| #    | Title                                                                | Why LOW                                                     |
+| ---- | -------------------------------------------------------------------- | ----------------------------------------------------------- |
+| #972 | ci(pre-commit): python-no-eval exclude list (18 false positives)     | Code-health, no user-anchored brief; mechanical maintenance |
+| #970 | docs/deps: filelock missing on bare `pip install kailash`            | Docs gap, repair-only                                       |
+| #878 | pyright: cross-runtime type-correctness sweep                        | Type cleanup; no user-anchored brief                        |
+| #855 | kaizen-agents: pyright drift                                         | Type cleanup; sibling of #814                               |
+| #772 | dataflow: consolidate `_resolve_type` / `_normalize_type_annotation` | Pure refactor                                               |
+| #693 | spec: promote dataflow-ml-integration.md from draft to versioned     | Spec hygiene, **BLOCKED-on-M2** per issue body              |
+
+### BLOCKED — external authority needed
+
+| #    | Title                                               | Blocker                                                      |
+| ---- | --------------------------------------------------- | ------------------------------------------------------------ |
+| #596 | TieredAuditDispatcher hash-chained tier-based audit | Blocked on mint spec ISS-06 (per agent's 2026-04-25 comment) |
+
+**0 `deferred`-labeled issues** — no Rule 1b deferral surface to audit.
+
+## Sweep 4 — PRs and stale branches
+
+- **0 open PRs** — clean.
+- **5 stale remote branches** — ALL point at CLOSED/MERGED issues:
+
+| Branch                                         | Last commit | Related issue                | Status                                                    |
+| ---------------------------------------------- | ----------- | ---------------------------- | --------------------------------------------------------- |
+| `debug/issue-1010-phase-a-diagnostics`         | 3 days ago  | #1010 CLOSED 2026-05-15      | dead — debug-only, never-merge                            |
+| `debug/issue-1010-phase-a-prime-linux`         | 3 days ago  | #1010 CLOSED 2026-05-15      | dead — debug-only                                         |
+| `fix/dataflow-unit-ci-hang-after-968`          | 5 days ago  | #968 MERGED 2026-05-12       | dead — superseded                                         |
+| `fix/issue-1002-shard4b-remove-setsid-wrapper` | 3 days ago  | #1000/AC#3 CLOSED 2026-05-15 | dead — shipped via #1017 per workspace-1002 session-notes |
+| `style/align-pre-commit-sweep`                 | 10 days ago | (style sweep)                | likely dead                                               |
+
+**Finding [LOW] [Sweep 4]:** 5 prunable remote branches. `git push origin --delete <branch>` for the 4 dead ones; verify `style/align-pre-commit-sweep` with the user (preserved debug branches per `.session-notes` are intentional). Per `cross-repo.md` MUST-2 / `git.md` § Discipline (destructive ops): user-gated per branch, never bulk.
+
+## Sweep 5 — Spec compliance
+
+**Pre-condition gate:**
+
+- `workspaces/*/specs/` → absent (specs live at repo-root `specs/`, ~50 files).
+- `tools/sweep-redteam.py` → absent (no `tools/` directory at all).
+
+`<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=true -->`
+
+Same as SWEEP-2026-05-17: kailash-py IS a BUILD repo and has root-level
+`specs/` — the workspace-scoped sweep tool is the structural gap. Per
+`value-prioritization.md` MUST-5 this is code-health (secondary); surface,
+do not auto-fix. Same finding as yesterday — not a regression, but a
+standing gap.
+
+## Sweep 6 — Workspace + worktree hygiene
+
+- **24 locked worktrees** under `.claude/worktrees/` (up from 14 yesterday — the +10 are post-Wave-A/B agent worktrees that haven't been triaged):
+  - Pre-Wave-A: `agent-a16e85de3ba19b9ba`, `agent-a191f3d896dc291ac` (issue-1068 docs), `agent-a1ab206893ceb93da` (issue-900), `agent-a1af342e8bb6627eb` (issue-898), `agent-a38688c4a9ac0358e` (issue-1045-async-fixture), `agent-a3eb2e0b96f7096b2` (issue-1047b-sanitizer-typeconfusion), `agent-a4adf0920513b022e` (issue-942), `agent-a5299715947a96848` (issue-1070-txn-reset), `agent-a5b8a2861fc971fb0`, `agent-a5c5e1f0a7fbc31d9` (issue-913), `agent-a5de40c1d2fa4673b` (issue-999), `agent-a78799265ba8722ac` (issue-929), `agent-abd85e1583a44188c` (issue-913-scheduler-admin), `agent-abff1f73079de6715` (issue-1050-shard3), `agent-ac02636b86de8310e` (issue-953), `agent-af883b59fe1d4f2b7` (issue-898-shard2), `agent-affb9ed1c7cad4e4c` (issue-1045-middleware)
+  - Post-Wave-A: `shard-a-close`, `w4-durable-engine`, `w5-tier3-crash-resume`, `w6-redaction-discipline`
+  - Post-Wave-B: `agent-a53ad9d3ea542b7bf` (feat/issue-1054-eventbus), `agent-a6fb19e47bf120cb1` (fix/issue-1071-api-discipline)
+
+  All `locked`. Issue parents are mostly CLOSED — these are post-merge orphans. Disposition: per-worktree triage (`git worktree remove --force` after verifying branch has no orphan commits per `agents.md` § Recover Orphan Writes).
+
+- **Stale `.session-notes` >30d:** none.
+- **Stale `.pending` >14d:** none (covered in Sweep 2; the 33 issue-835 entries are 7-14d).
+
+**Finding [MED] [Sweep 6]:** 24 locked worktrees = disk + lock-table debt. Each contains a parked branch; pre-cleanup MUST run `git status` on the parent to surface orphan commits (per `agents.md`). Mechanical, but needs care — user-gated batch or single-bulk approval after sample triage.
+
+## Sweep 7 — Process hygiene
+
+- **`git status --short`:** `.session-notes` modified + 12 untracked workspace scratch files. Per `.session-notes` Wave A/B sessions, these are workspace-internal records (per-session, never tracked) plus `SWEEP-2026-05-16.md` + `workspaces/SWEEP-2026-05-17.md` (the 2 prior sweep reports, untracked). DEFER per Rule 1c on the .session-notes M-flag.
+- **`git rev-list --left-right --count origin/main...HEAD`:** `0 0` — fully synced.
+- **Stub markers in production:** ALL hits are inside `.claude/worktrees/agent-*` (orphan worktrees' frozen state); ZERO hits in the live main checkout's production paths. Clean.
+
+---
+
+## Cross-cutting observations
+
+1. **Wave A + B fully shipped, zero in-flight.** Repo is in the cleanest state it has been all week from a code-delivery angle. Hygiene debt accumulated specifically because the velocity was high.
+
+2. **All 4 active-todo workspaces map to CLOSED issues.** Wave C hygiene
+   is correctly scoped per `.session-notes:30-34`. No new work hiding
+   in the active-todo lists.
+
+3. **Workspace-archive pattern matters.** The pattern that produced
+   the orphans: parent issue closes via PR, but the local workspace
+   `todos/active/`, `.pending/`, `.session-notes` never get rolled
+   forward into archived state. The hygiene sweep is the explicit
+   roll-forward step.
+
+4. **Open-issue surface is 80% non-greenfield.** 12 of 15 are LOW
+   (code-health hygiene) or BLOCKED (external authority). 3 of 15
+   are user-anchored substantive work: #1035 (deferred, external
+   spec), #643 (cross-SDK breaking change), #1012 (partially
+   superseded by #1071). Wave D is more "schedule the non-greenfield
+   3" than "pick from 15".
+
+5. **Wave D candidate is narrower than the sweep numbers suggest.**
+   After removing structurally-deferred (#1035), blocked-external
+   (#596, #693), and code-health hygiene (#972, #970, #878, #855,
+   #772), the **actionable substantive surface is 8 issues**: #643,
+   #891, #1012, #937, #938, #760, #630, #1054 (already shipped — drop).
+   Actionable: **7 substantive + 6 hygiene = 13 in-scope, 2 blocked.**
+
+---
+
+## Recommended next-session items (value-ranked, per `value-prioritization.md` MUST-1)
+
+Each option carries a primary anchor from the closed-allowlist and an
+explicit named trade-off. **User gate per MUST-3 (Rule 3 of time-pressure-
+discipline) — do NOT auto-pick.**
+
+### Option A — Wave C: workspace hygiene (recommended for fastest forest-progress)
+
+- **Anchor (c):** `.session-notes:30-34` — "Wave C (~0.5 session, 3 parallel
+  background): hygiene — archive completed workspaces (#1056/#1051/#1047/
+  #1068/#1070/#979 + #1071/#1054); promote-or-discard ~33 stale issue-835
+  `.pending` journals; triage the locked orphan worktrees…"
+- **Scope:** 4 workspace-archive decisions (user-gated bulk), 33 issue-835
+  pending journal triage (orchestrator-led with cc-architect review), 24
+  worktree triage (sample-verify-then-bulk-cleanup), 4 dead remote
+  branches (delete after confirmation).
+- **Cost:** 0.5-1 session, mostly parallel background agents.
+- **Trade-off:** Pure code-health (secondary anchor per MUST-5). Does not
+  deliver user-facing value; clears institutional debt that compounds.
+  Alternative: skip and let next workstream's `/sweep` re-surface it.
+
+### Option B — Wave D: pick one substantive open issue (delivers user value)
+
+- **Anchor (e):** issue body (user-authored) — 7 substantive candidates.
+- **Recommended sub-pick:** **#891** (HybridSearchNode name collision —
+  real bug, single-PR scope, fits one shard, ~150-300 LOC).
+  - Alternatives ordered by anchor strength:
+    - **#1012** (handler string-API) — needs verification that #1071 Gap B fully covered it before sizing.
+    - **#643** (FeatureStore migration) — cross-SDK coordination required; sharded across sessions; HIGH user value but needs paired kailash-rs session per `repo-scope-discipline.md`.
+    - **#937 + #938** (scheduler follow-ups) — pair, sized together.
+- **Cost:** 1 session for #891; 2-3 sessions for #643 (cross-SDK paired).
+- **Trade-off:** Delivers a real fix; defers Wave C hygiene one cycle.
+  Hygiene cost compounds — next session's `/sweep` rediscovers same
+  state.
+
+### Option C — Codify post-Wave-B Traps (institutional knowledge capture)
+
+- **Anchor (c):** `.session-notes:40-41` — "Codify (~0.5 session): `/codify` this session's recurring lessons (Traps section below) — high institutional value."
+- **Scope:** 7 Traps from `.session-notes:44-76` — eager-imports + base_async cycle, worktree-derived release branches lack pre-commit, isort reverts non-alphabetical orders, `gh pr merge --admin` for BLOCKED chore PRs, uv `--index-strategy unsafe-best-match`, `gh issue close --comment` no-op when already closed, local main vs origin main divergence.
+- **Cost:** ~0.5 session — drafting + cc-architect review + user gate.
+- **Trade-off:** Pure institutional defense (HOW preferences captured as rules); secondary anchor per MUST-5. High dividend (next session won't repeat) but no user-facing delivery.
+
+### Option D — Different priority
+
+You set the priority and I re-rank from there.
+
+---
+
+## Closure status
+
+- [x] Sweeps 1-7 accumulated
+- [x] No trivial inline fixes applied (per `value-prioritization.md` MUST-3 surface only; user-gated dispositions)
+- [x] Report drafted at `SWEEP-2026-05-18.md`
+- [ ] User authorization on next-session scope — **awaiting your pick (A / B / C / D)**

--- a/SWEEP-2026-05-28.md
+++ b/SWEEP-2026-05-28.md
@@ -1,0 +1,244 @@
+# /sweep — 2026-05-28 (full surface, repo-wide)
+
+Repo: `terrene-foundation/kailash-py` (BUILD). Local `main` @ `5885a47a7`,
+in sync with `origin/main` (0/0 divergence). Trust posture: L5_DELEGATED.
+Sweep complements yesterday's `workspaces/from-brief-1125/04-validate/sweep-2026-05-27.md`
+(now ~24h old; this sweep widens scope and adds release-readiness check).
+
+<!-- sweep-redteam:v1:OK specs=0 symbols=0 orphans=0 coverage_gaps=0 stubs=0 -->
+
+## Headline
+
+Six PRs merged to `main` since the `v2.27.0` tag — including TWO HIGH-value SDK
+fixes (#1182 delegate audit sign/verify, #1185 async durable resume) that
+remain unreleased. Two workspace todos are alive: one DELIVERED (archive),
+one APPROVED-and-queued (kaizen-rag-node-coverage A0). No regressions. No
+open PRs. Working-tree drift is the same pre-existing F3 state the user
+told us to LEAVE ALONE on 2026-05-22.
+
+## Findings by sweep
+
+### [HIGH] [Sweep 4 / release-readiness] 6 PRs merged since `v2.27.0` — HIGH SDK fixes sit unreleased
+
+- **Location:** `v2.27.0` @ `4b8aac15f` → `HEAD` @ `5885a47a7` (6 PRs).
+  Version anchors (`pyproject.toml`, `src/kailash/__init__.py`) still report `2.27.0`.
+- **What landed unreleased:**
+  - #1185 — `fix(runtime): short-circuit completed nodes on async durable resume`
+    (HIGH; runtime-correctness, durable-execution semantics)
+  - #1182 — `fix(delegate): make audit-chain sign/verify contract satisfiable`
+    (HIGH; trust / audit-chain integrity)
+  - #1194 — `fix(nexus): eliminate instance-based-API UserWarning on @app.handler` (MED)
+  - #1131 → #1193 — `chore(dataflow-tests)` rename (LOW)
+  - #972 → #1190 — `ci(pre-commit): extend python-no-eval exclude` (LOW)
+  - #1189 — `chore(codify)` pending_review proposal landing (LOW)
+- **Disposition:** still-wanted → recommend `/release` of core `kailash` next session.
+  Anchor: feedback*build_repo_release.md verbatim — *"BUILD repo sessions MUST proceed through /release after merge — never stop at CI merge"\_. The two HIGH fixes reach users only after the tag cuts.
+- **Why-this-matters:** unreleased correctness fixes accumulate user-visible
+  drift between `pip install kailash` and `main`; the gap is the exact failure
+  mode `feedback_build_repo_release.md` was authored against.
+- **Action:** SURFACE-FOR-NEXT-SESSION (release is a structural human gate).
+
+### [MED] [Sweep 1] kaizen-rag-node-coverage — APPROVED, queued for `/implement` at A0
+
+- **Location:** `workspaces/kaizen-rag-node-coverage/todos/active/00-plan.md`
+- **Status frontmatter:** `APPROVED 2026-05-26` by co-owner (jack@integrum.global)
+  at /todos structural gate. Next session: `/implement` at A0
+  (mechanical R4/CLASS4 pre-flight, no blocked-by).
+- **Value-anchor (recorded, source-allowlist (b) `briefs/`):**
+  `workspaces/kaizen-rag-resurrection/briefs/00-brief.md` § "Out of scope",
+  VERBATIM: _"the RAG capability the user chose to preserve is provably correct,
+  not merely importable."_ Empirical state: 0 of 55 registered rag node classes
+  can be constructed — preserved capability is 100% non-functional.
+- **Disposition:** queued-with-value-rank — re-pickup MUST re-validate the
+  value-anchor with the user before resuming (`value-prioritization.md` MUST-3).
+  Branch base `0f906a1e0` is stale (today's main `5885a47a7`); orchestrator
+  re-bases at shard launch per `specs-authority.md` MUST-5c.
+- **Action:** SURFACE-FOR-NEXT-SESSION. This is the only fresh, co-owner-approved,
+  fully-anchored workstream waiting in the queue.
+
+### [LOW] [Sweep 1] from-brief-1125 todo — DELIVERED in `v2.27.0`; archive
+
+- **Location:** `workspaces/from-brief-1125/todos/active/00-plan.md`
+- **Disposition:** still-wanted → DELIVERED. `#1125 from_brief()` shipped in
+  `kailash 2.27.0` (production PyPI, install-verified). Value-anchor:
+  issue #1125 (CLOSED COMPLETED). Same finding as the 2026-05-27 sweep
+  (still pending workspace archive).
+- **Action:** FILE-NOTE — archive `workspaces/from-brief-1125/todos/active/` →
+  `todos/completed/` at next workspace touch. Not auto-moved (no urgency;
+  workspace-only artifact).
+
+### [N/A] [Sweep 2] Pending journal entries
+
+None. `find workspaces/*/journal/.pending -name "*.md"` → 0 matches.
+
+### [INFO] [Sweep 3] 14 open GH issues — categorized; none closeable
+
+```
+F20 in-flight        #1174  nexus FastAPI parity            (awaits user Q2/Q4/Q5)
+design / owner gate  #1183  deps version-pin SSOT           (upd 2026-05-27)
+                     #970   filelock / standard-deps fork   (upd 2026-05-27; design-fork)
+                     #1086  codify: 4 root-cause fixes
+queued multi-session #855   kaizen-agents pyright drift     (typing-only, not runtime — trap per session-notes)
+                     #878   pyright LocalRuntime / dialect
+                     #772   dataflow type-helper consolidation
+                     #693   spec promotion dataflow-ml-integration → versioned
+                     #643   ML FeatureStore canonical surface migration
+                     #630   Trust Vault SLIP-0039 Shamir
+                     #596   TieredAuditDispatcher
+                     #937   nexus SchedulerAdminAPI
+                     #938   django-celery-beat migration helper
+cross-SDK            #760   follow-up: kailash-rs#723 fingerprint pin + #759 DPI-A repro
+```
+
+- **None closeable** by `gh issue close <N>` with a delivered-code SHA per
+  `git.md` § Issue Closure Discipline.
+- **None stale-with-decay.** All carry user-anchored value (issue body =
+  user-authored brief = source (a) of `value-prioritization.md` Rule 1 allowlist).
+- **Disposition:** queued. Re-rank at next selection event.
+- **Trap re-confirmation (per prior session-notes):** #970's filelock repro
+  in the body may be stale (`from kailash.trust.plane import TrustPlane` raises a
+  name-error today, not the filelock error); residual is eager
+  `chain_store/filesystem.py:30 from filelock import`. Owner gate before action.
+
+### [LOW] [Sweep 4] Orphan branch `feat/1174-nexus-fastapi-parity-analyze` — 17 commits, no PR
+
+- **Location:** worktree `.claude/worktrees/nexus-fastapi-1174` (branch `feat/1174-nexus-fastapi-parity-analyze`).
+- **Disposition:** **F20 in-flight (legitimate)** per prior session-notes —
+  this is the analyze-phase work for #1174 Nexus FastAPI parity, awaiting
+  user Q2/Q4/Q5 to advance. Not orphan-work; F20 owner gate.
+- **Action:** DEFER. No PR yet because the work has not crossed the analyze→
+  implement gate.
+
+### [LOW] [Sweep 6] 4 locked zero-commit `worktree-agent-*` worktrees from completed parallel agents
+
+- **Location:**
+  - `.claude/worktrees/agent-a14f8fada23734fa1` @ `9f45d120c` (now-merged #1189)
+  - `.claude/worktrees/agent-a2c8fe624ac7eecd8` @ `086b9de63` (now-merged #1182 fix commit)
+  - `.claude/worktrees/agent-a44ae56b9bfd7813f` @ `dcae69c5d` (now-merged #1185 test commit)
+  - `.claude/worktrees/agent-a7f9ebde5847e3207` @ `378f50a5b` (now-merged #1194 fix commit)
+- **State:** all 4 are at SHAs that have already merged to `main`; 0 commits
+  ahead of `main`. All 4 carry the same lock-tag `claude agent ... (pid 82110)`.
+- **Disposition:** DEFER-WITH-REASON. The branches are zero-ahead, so removal
+  is safe per `worktree-isolation.md`, BUT the lock-tag pins pid 82110 — if
+  that process is still resident, removing the worktree would surprise it.
+  Recommend at next session: confirm `ps -p 82110` is dead, then
+  `git worktree remove --force <path>` per worktree.
+- **Why-this-matters:** Leftover locked worktrees mask future parallel-launch
+  errors and consume disk; cleanup is hygiene, not urgent.
+
+### [INFO] [Sweep 5] Redteam tool — structural N/A (no workspace-level specs)
+
+- **Sentinel (verbatim):** `<!-- sweep-redteam:v1:OK specs=0 symbols=0 orphans=0 coverage_gaps=0 stubs=0 -->`
+- **Why N/A:** `tools/sweep-redteam.py` walks `workspaces/*/specs/**/*.md` per
+  its own docstring (see `tools/sweep-redteam.py:9-12`). No workspace under
+  `workspaces/*/` carries a `specs/` directory; root `specs/` (77 files) is
+  SDK domain authority, outside this tool's scan. This is the precondition
+  result the local `commands/sweep.md` Sweep-5 gate documents, not a
+  substitution per `sweep-completeness.md`.
+- **Action:** none required for THIS sweep. Future workspaces that author
+  `specs/` will automatically come into the tool's scan.
+
+### [INFO] [Sweep 7] Process hygiene
+
+- **Working tree drift:** `M uv.lock`, `M workspaces/issue-1035-delegate-py/.session-notes`,
+  ~50 untracked workspace artifacts. **PRE-EXISTING per F3** — user verbatim
+  `LEAVE ALONE` (2026-05-22). NOT a session-introduced change. HELD.
+  Includes prior `SWEEP-2026-05-16.md` + `SWEEP-2026-05-17.md` + `SWEEP-2026-05-18.md`
+  at root, also untracked under the same F3 hold.
+- **Divergence:** 0/0 with `origin/main`. Clean.
+- **Stub markers in production:** 211 marker hits across `src/` + `packages/*/src`
+  (67 are `raise NotImplementedError`). These are baseline abstract-method
+  patterns in a 140+ node SDK — `raise NotImplementedError` is the canonical
+  ABC contract surface. Not session-introduced (zero session writes to `src/`).
+  No FIX-NOW; surfaced only so the count is on the record.
+
+## Cross-cutting observations
+
+1. **F23 release-readiness is the loudest signal.** Two HIGH SDK fixes
+   (#1182, #1185) merged to main 2026-05-28; the version anchors still report
+   2.27.0. Per `feedback_build_repo_release.md`, BUILD-repo sessions MUST
+   proceed through `/release` after merge.
+
+2. **kaizen-rag-node-coverage is the highest-value queued workstream.** It is
+   fresh-approved (2026-05-26), value-anchored to the kaizen-rag-resurrection
+   brief, and the empirical state (0/55 rag node classes constructable) means
+   every B-coverage shard delivers zero value until Milestone A lands. This
+   is the canonical "decompose, don't defer" workstream
+   per `value-prioritization.md` MUST NOT § "Treat decomposition pressure as
+   a deferral signal".
+
+3. **Working-tree drift remains F3-held.** Three prior SWEEP-\*.md at root,
+   ~20 issue-1035 redteam/closure artifacts under
+   `workspaces/issue-1035-delegate-py/04-validate/`, and 4 kaizen workspace
+   files are untracked. Per user 2026-05-22 directive, these are LEFT ALONE.
+   This sweep report respects that hold by NOT auto-committing — see
+   "Report disposition" below.
+
+## Ranked recommended next-session items
+
+Per `recommendation-quality.md` MUST-1+3 and `value-prioritization.md`
+MUST-1 (value-rank FIRST, fit SECOND; user-anchored citations only).
+
+**1. /release core `kailash` 2.27.0 → 2.28.0 (F23) — HIGH value, low effort, ships completed work**
+
+- **Primary anchor (Rule 1 source c — journal/issue DECISION):** issues #1182
+  and #1185 themselves are closed user-authored briefs whose acceptance
+  criteria delivered as commits `086b9de63` (#1182 fix) and `c2a415f9b` (#1185
+  fix) — both HIGH severity, both now sitting on `main` past the v2.27.0 tag.
+- **Implications:** version-anchor bump (`pyproject.toml` + `__init__.py`) +
+  CHANGELOG entry + tag + PyPI publish; ~1 session per `feedback_build_repo_release.md`.
+  Reaches users immediately via `pip install --upgrade kailash`.
+- **Pros:** ships two HIGH-severity correctness fixes (durable-execution
+  short-circuit; delegate audit signing); closes the F23 release-drift loop;
+  honors `feedback_build_repo_release.md` HOW preference.
+- **Cons (real, not glossed):** four lower-severity chores ride along
+  (#1189/#1190/#1193/#1194) — the release notes need to surface what landed
+  vs what users care about. The release IS a structural human gate
+  (`autonomous-execution.md`), so the user still gates the tag itself.
+
+**2. kaizen-rag-node-coverage `/implement` at A0 (Milestone A — make functional)**
+
+- **Primary anchor (Rule 1 source b — `briefs/`):**
+  `workspaces/kaizen-rag-resurrection/briefs/00-brief.md` § "Out of scope",
+  verbatim: _"the RAG capability the user chose to preserve is provably correct,
+  not merely importable."_ Co-owner APPROVED 2026-05-26 at /todos structural gate.
+- **Implications:** multi-shard workstream — A0 mechanical pre-flight, then
+  Milestone-A make-functional shards (0/55 → ≥1 constructable), then
+  Milestone-B behavioral coverage of the user-named capabilities (GraphRAG,
+  AgenticRAG, FederatedRAG, MultimodalRAG, ColBERT/HyDE). Re-validate the
+  anchor at session-start per `value-prioritization.md` MUST-3.
+- **Pros:** restores a 100%-broken capability the user explicitly chose to
+  preserve; user-anchored value is documented verbatim in the brief; plan
+  is APPROVED so `/implement` is unblocked.
+- **Cons (real):** branch base is 7d stale — orchestrator must re-base at
+  shard launch (one extra `git rebase`); kaizen package is not the same
+  cadence as core `kailash`, so this does NOT block the core /release in #1.
+
+**3. F20 #1174 nexus FastAPI parity — BLOCKED on user Q2/Q4/Q5**
+
+- **Primary anchor:** issue #1174 body. Cannot advance without the three
+  pending answers. SURFACE-ONLY at this sweep.
+
+**4. Multi-issue cleanup batch (#1086 codify root-causes, #855/#878 pyright LOW)**
+
+- These are real fixes but lower-blast-radius than #1 or #2; not recommended
+  before #1 ships (release-then-fix is cleaner than fix-then-release).
+
+**Recommendation: Item #1 (/release core kailash 2.28.0) next session.**
+
+Yes/no to authorize next-session scope as `/release core kailash to 2.28.0
+covering #1182 + #1185 + chore tail`? (Sweep is read-only; the agent does
+not act on the recommendation without human gate.)
+
+## Report disposition
+
+Written to `SWEEP-2026-05-28.md` (root), **untracked**, consistent with the
+three prior root sweep files left untracked under the F3 "LEAVE ALONE"
+working-tree hold (user verbatim 2026-05-22). The local `commands/sweep.md`
+Closure step 4 ("Report committed") is HELD pending user direction on the F3
+drift: committing this file in isolation would either (a) need a dedicated
+PR to main (per branch protection), or (b) be swept up alongside F3 drift
+in a future cleanup PR. Neither is autonomous-execution-class — both want
+explicit user direction.
+
+— end of sweep —

--- a/SWEEP-2026-06-01.md
+++ b/SWEEP-2026-06-01.md
@@ -1,0 +1,125 @@
+# /sweep — kailash-py — 2026-06-01
+
+Full-surface repo-wide outstanding-work audit, run after the kailash-dataflow
+2.10.2 + 2.10.3 release cycle (#1228, #753, #979, F34). All 8 sweeps executed.
+
+## Verdict
+
+**This session's own work is fully clean** — dataflow #1228/#753/#979/F34 all
+released (2.10.2 + 2.10.3), PyPI-verified, deploy-recorded; main in sync with
+origin (0/0); no orphan branches; no stubs in any touched file. **Zero CRIT/HIGH.**
+One MED (pre-existing `uv.lock` drift), the rest are other-workstream queue items
+and known holds.
+
+## Findings
+
+### [MED] [Sweep 7] Pre-existing `uv.lock` drift — editable versions lag main
+
+- **Location:** root `uv.lock` (` M` since session start, NOT introduced this session)
+- **Evidence:** `git diff uv.lock` shows editable pins `kailash 2.21.0 → 2.28.3`,
+  `kailash-dataflow 2.9.9 → 2.10.2` (65 lines). Now also 1 patch behind — dataflow
+  is 2.10.3 on main after this session.
+- **Disposition:** SURFACE — do NOT auto-fix. This is the dev-environment
+  (editable) lockfile, not what PyPI consumers install. It was left modified by a
+  prior session. Per `feedback_no_bulk_worktree_discard` I won't discard or
+  force-commit working-tree drift without confirmation.
+- **Why it matters:** A stale root `uv.lock` makes `uv sync` resolve intermediate
+  editable versions; harmless for PyPI consumers but can confuse a fresh dev setup.
+- **Recommended action (user gate):** `uv lock` to refresh to dataflow 2.10.3, then
+  commit via a `chore/relock` PR — OR confirm the drift is intentionally held.
+
+### [LOW] [Sweep 6] Worktree cleanup — `1200-contextvars` is releasable
+
+- **Location:** `.claude/worktrees/1200-contextvars` (branch `fix/1200-contextvars-propagation`, merged/released)
+- **Disposition:** SAFE TO REMOVE — #1200 shipped (kailash 2.28.3) two sessions ago;
+  worktree is clean. `git worktree remove .claude/worktrees/1200-contextvars`.
+- **HOLD:** `.claude/worktrees/1207-jsonb-optional` holds **F3 LEAVE-ALONE drift**
+  (uv.lock + session-notes + nexus spec) per explicit user instruction — DO NOT remove.
+
+### [LOW] [Sweep 2] 7 pending journal entries in two other workstreams
+
+- **Location:** `nexus-fastapi-parity-py/journal/.pending/` (2 RISK),
+  `issue-1035-delegate-py/journal/.pending/` (5: DECISION/RISK/DISCOVERY)
+- **Disposition:** DEFER to owning workstream — none are >14d stale; none belong to
+  this session's dataflow work (which generated no pending entries). They await the
+  next `/codify` or `/wrapup` of their own workstreams.
+
+### [LOW] [Sweep 5-F34] Redundant test-only import (reviewer LOW, deferred)
+
+- **Location:** `tests/unit/core/test_issue_1228_pep604_union_introspection.py` —
+  class-body `from typing import Union` (methods re-import locally).
+- **Disposition:** DEFER — cosmetic, test-only (not in wheel), 17/17 pass. Amending
+  would re-trigger the full CI matrix for a dead import. Clean up on next touch of
+  the file.
+
+## Informational (the user's forest — not this session's scope)
+
+### [INFO] [Sweep 1] 4 active todos, all value-anchored, awaiting human pickup
+
+| Workspace                   | Issue                           | Status                                   | Value-anchor                |
+| --------------------------- | ------------------------------- | ---------------------------------------- | --------------------------- |
+| `from-brief-1125`           | #1125 `from_brief()` primitives | Draft for human approval                 | brief #1125 + AC 1-11       |
+| `nexus-fastapi-parity-py`   | #1174                           | AWAITING HUMAN APPROVAL (gen 2026-05-30) | value-rank §, MUST-1        |
+| `nexus-scheduler-admin-937` | #937                            | decisions resolved 2026-05-29            | AC5 per #937 body           |
+| `kaizen-rag-node-coverage`  | F8                              | APPROVED 2026-05-26 by co-owner          | value-prioritization MUST-1 |
+
+All four are alive, value-anchored, at a structural human-approval gate. None
+abandoned, none stale-for-closure. These are the standing forest queue — a human
+prioritization call, not auto-actioned.
+
+### [INFO] [Sweep 3] 12 open GH issues — actionable backlog
+
+Nexus cluster (#1218 NexusHandlerError typed status, #1217 WS subprotocol echo,
+#1216 WS pre-upgrade rejection — all the #1174 parity family), #1209 delegate
+observed_at field, #1183 dep-pin source-of-truth, #1086 codify hook-noise,
+#938 scheduler celery-beat helper, #772 dataflow `_resolve_type`/`_normalize_type_annotation`
+consolidation, #760 cross-SDK fingerprint verify, #693/#643/#630/#596 (ml/trust/spec).
+None carry `deferred` labels needing Rule-1b verification. None closeable (no
+delivered code unattached). All genuinely-actionable backlog — human prioritization.
+
+> Note: #772 (consolidate `_resolve_type` + `_normalize_type_annotation`) is now
+> adjacent to this session's #1228/F34 work — both touched the union-introspection
+> surface. A future consolidation shard would naturally fold the PEP604 handling
+> into one helper. Surfaced for the user; not actioned (separate refactor shard).
+
+### [INFO] [Sweep 4] No open PRs; no orphan remote branches
+
+`git fetch --prune` cleared stale tracking refs; `git branch -r --no-merged` empty.
+
+### [INFO] [Sweep 5] N/A — orchestration-mode by precondition
+
+<!-- sweep-redteam:v1:N/A reason=no-workspace-specs no_specs=true no_tool=false -->
+
+`workspaces/*/specs/` count = 0 (no per-workspace specs materialized), so the
+synced Sweep-5 per-workspace redteam gate is structurally N/A. `tools/sweep-redteam.py`
+IS present; the BUILD-local `commands/sweep.md` carries the richer cross-SDK +
+top-level-`specs/` coverage for a dedicated redteam pass when a workstream needs it.
+No proxy substituted (per `rules/sweep-completeness.md`).
+
+### [INFO] [Sweep 8] All packages at release parity
+
+- Core `kailash`: v2.28.3 tag == version; zero `src/` commits since v2.28.3.
+- `kailash-dataflow`: dataflow-v2.10.3 tag == version 2.10.3 (released this session).
+- All other framework packages at PyPI parity (no sibling drift).
+
+## Cross-cutting observations
+
+1. The session closed its own loop completely — value (the #1228/#1207-sibling
+   correctness fix the user prioritized) shipped end-to-end with both releases
+   verified in clean venvs. No deferred-without-anchor items generated.
+2. The standing forest is **4 human-approval-gated workstreams** (from-brief-1125,
+   nexus #1174 parity, nexus #937 scheduler, kaizen RAG F8) — all value-anchored.
+   The next session's pick is a user prioritization call across these + the 12 issues.
+
+## Recommended next-session items (ranked — human call)
+
+1. **(MED) Refresh + commit `uv.lock`** — bring the dev lockfile to dataflow 2.10.3;
+   trivial, removes the standing working-tree drift. (Or confirm intentional hold.)
+2. **(value: HIGH) Nexus #1174 parity family** (#1216/#1217/#1218) — largest
+   value-anchored cluster awaiting approval; `nexus-fastapi-parity-py` plan is
+   converged and AWAITING HUMAN APPROVAL.
+3. **(value: HIGH) kaizen RAG F8** — already co-owner-APPROVED 2026-05-26; ready to
+   `/implement` without a new approval gate.
+4. **(LOW) Worktree cleanup** — remove the clean `1200-contextvars` worktree.
+
+The report is the deliverable. Next-session scope is a human call.

--- a/SWEEP-2026-06-08.md
+++ b/SWEEP-2026-06-08.md
@@ -1,0 +1,67 @@
+# Sweep — 2026-06-08
+
+Repo-wide outstanding-work audit (kailash-py BUILD repo). Run after F29 (MCP
+canonical byte-vectors, PR #1281) closed + cross-SDK filing rs#1247.
+
+State at sweep: `main` @ `5352caa32`, clean vs origin/main (0/0), pin gate green.
+
+---
+
+## Findings
+
+### [LOW] [Sweep 6] Two stale worktrees — 1200 pruned, 1207 holds uncommitted drift
+
+- **Location:** `.claude/worktrees/1200-contextvars` (PR #1226 MERGED), `.claude/worktrees/1207-jsonb-optional` (PR #1227 MERGED). Both branches 0 commits ahead of main; issues #1200/#1207 CLOSED.
+- **Disposition (1200):** FIXED — `git worktree remove` + branch `fix/1200-contextvars-propagation` deleted.
+- **Disposition (1207):** DEFER-WITH-REASON — worktree carries 3 uncommitted files: `uv.lock` (regen drift), `workspaces/issue-1035-delegate-py/.session-notes` (cross-workspace drift), and a **2-line spec annotation** in `workspaces/nexus-fastapi-parity-py/specs/nexus-fastapi-parity.md` recording that WebSocket deferrals were filed as #1216/#1217/#1218 (2026-05-31). The spec edit **differs from main HEAD** → potential real work; `--force` removal BLOCKED per `feedback_no_bulk_worktree_discard` + `git.md` destructive-op discipline.
+- **Action for human:** review the 2-line spec annotation; if wanted, commit it to main's copy of the nexus-fastapi-parity spec, then `git worktree remove --force .claude/worktrees/1207-jsonb-optional`.
+
+### [LOW] [Sweep 8] kailash-mcp #1258 merged but unreleased — docstring+test-only
+
+- **Location:** `packages/kailash-mcp` @ v0.2.14; commit `1e17d63df` (PR #1281) not contained in any tag.
+- **Evidence:** `git tag --contains 1e17d63df` → empty. Core `kailash` src/ has 0 commits since v2.29.3 (fully released). #643 (FeatureStore) + #1183 (pin drift) already released under `ml-v2.0.1` / `align-v0.7.2`.
+- **Why it matters:** `feedback_build_repo_release` — BUILD sessions proceed through `/release` after merge. BUT #1258 is **docstrings + test-vectors + regression test only**; zero runtime behavior change, and the cross-SDK fixture is consumed from the git repo (not the wheel), so a PyPI release ships only updated docstrings.
+- **Disposition:** SURFACE — recommend an OPTIONAL `kailash-mcp` patch (0.2.14 → 0.2.15) to publish the documented contract, OR defer (marginal value; fixture not wheel-delivered). `/release` is a human-authorized gate — not cut inside `/sweep`. **Top recommended next item.**
+
+### [MED] [Sweep 1] 4 stale workspace todo-plans need value-anchor re-validation
+
+- **Location:** active `00-plan.md` in `kaizen-rag-node-coverage` (18d stale), `from-brief-1125` (12d), `nexus-fastapi-parity-py` (8d), `nexus-scheduler-admin-937`.
+- **Disposition:** SURFACE — per `value-prioritization.md` MUST-3/4, each is **still-wanted / abandon-with-user-gate / queued-with-value-rank**; auto-close is BLOCKED. Value-anchors not loaded this session → request from user before re-queue or closure. Not this session's blast radius.
+
+### [LOW] [Sweep 2] 10 pending journal entries awaiting promotion/discard
+
+- **Location:** `.pending/` in issue-855 (1), issue-1035 (5), issue-1252 (1), issue-772 (1), nexus-fastapi-parity-py (2).
+- **Disposition:** DEFER — belong to the owning workspaces' next sessions (promote high-value commit-body content / discard bare-merge per `journal.md`). None >14d by mtime. Out of this session's scope; surfaced for owning-workspace pickup.
+
+### [INFO] [Sweep 3] 3 open issues — all documented-blocked
+
+- **#1086** codify (loom-side candidates blocked — cand.1/2/4 landed, cand.3 loom hooks pending) · **#693** spec promotion (M2-blocked — kailash-ml exports only private `SchemaFeatureGroup`) · **#630** Shamir Trust Vault (Foundation-blocked).
+- **Disposition:** SURFACE — each carries a standing block reason; none closeable, none newly-actionable in-repo.
+
+### [INFO] [Sweep 7] Process hygiene
+
+- **Held F3 drift** (per user "LEAVE ALONE", 2026-05-22): `M workspaces/issue-643.../0001-DISCOVERY...` + untracked `SWEEP-*.md` / `deploy/deployments/*` / `packages/*/.claude/` / `workspaces/_archive/*`. NOT swept.
+- **`M .session-notes`** — this session's ledger edits (F29 closed, F26 corrected) + cross-repo receipt; pending `/wrapup`.
+- **Stub markers:** 189 platform-wide in `src/` (pre-existing baseline across the multi-package SDK; many legitimate abstract-method `NotImplementedError`). This session's changed file (`messages.py`) has **zero** new stubs.
+- **vs origin/main:** 0 ahead / 0 behind (clean).
+
+### [N/A] [Sweep 5] Redteam — orchestration-mode N/A
+
+`<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->`
+spec_count=0 (no `workspaces/*/specs/` dirs with per-workspace specs at sweep time); `tools/sweep-redteam.py` present but no specs to verify. Structural N/A, not a proxy substitution.
+
+### [CLEAN] [Sweep 4] No open PRs, no unmerged remote branches.
+
+---
+
+## Cross-cutting observations
+
+1. **Forest is drained of actionable in-repo work.** Every standing ledger item (F1/F10/F12 loom, F24 codify, F26 rs→now reframed, F27 Foundation) is externally blocked or held. F29 closed this session + cross-SDK loop closed (rs#1247).
+2. **F26 corrected:** the Rust SDK is `esperie-enterprise/kailash-rs` (private), NOT `terrene-foundation/kailash-rs` (doesn't exist). Cross-SDK filing IS available with user authorization (memory persisted).
+3. **No CRIT/HIGH findings.** Repo is in a healthy converged state; remaining items are stale-workspace re-validation (human call) + one optional docs-only release.
+
+## Recommended next-session items (ranked)
+
+1. **(LOW, optional) `/release` kailash-mcp 0.2.15** — publish the #1258 documented contract. Marginal value (docs-only; fixture is repo-consumed). Human call per `feedback_build_repo_release`.
+2. **(MED) Stale-workspace triage** — re-validate value-anchors for the 4 stale todo-plans + 10 pending journals with the user; classify still-wanted / abandon / queue. Requires user input (value-anchors not in-session).
+3. **(LOW) 1207 worktree cleanup** — review the 2-line spec annotation, commit if wanted, then force-remove the merged worktree.

--- a/SWEEP-2026-06-12.md
+++ b/SWEEP-2026-06-12.md
@@ -1,0 +1,129 @@
+# /sweep — 2026-06-12
+
+Repo: terrene-foundation/kailash-py · Branch: main (clean, 0/0 vs origin) · Latest tag: v2.29.4
+
+**Headline:** The root `.session-notes` claimed "Remaining forest is all blocked/gated."
+That is **incorrect**. The sweep recovered **four value-anchored workstreams parked in
+`todos/active/`** that fell off the root ledger (the forest-loss failure mode
+`value-prioritization.md` exists to block). Three are user-authored feature workstreams
+sitting at the `/todos` human-approval gate; one (kaizen-rag F8) has a **decayed value-anchor**
+and appears already delivered.
+
+---
+
+## Findings
+
+### [HIGH] [Sweep 1] kaizen-rag-node-coverage F8 — value-anchor DECAYED, likely superseded
+
+- **Location:** `workspaces/kaizen-rag-node-coverage/todos/active/00-plan.md` (APPROVED 2026-05-26, 17d stale)
+- **Anchor (recorded):** brief — _"the RAG capability the user chose to preserve is provably
+  correct, not merely importable"_; empirical claim _"0 of 55 registered rag node classes
+  can be constructed — 100% non-functional."_
+- **Live re-validation (2026-06-12):** `kaizen.nodes.rag.__all__` = 57; **57/57 construct, 0 failures.**
+  Make-functional (Milestone A) appears already delivered (rag-resurrection kaizen v2.23.0/v2.23.1
+  — cf. untracked `deploy/deployments/2026-05-19-kaizen-...-rag-resurrection.md`).
+- **Disposition:** RE-VALIDATE → recommend **close Milestone A as superseded** (value delivered by
+  a different path). Residual: Milestone B (behavioral coverage tests for GraphRAG/AgenticRAG/etc.)
+  MAY still carry value but its primary anchor is gone. **User gate required** per
+  `value-prioritization.md` MUST-4 (closing value-bearing deferred work).
+
+### [HIGH] [Sweep 1] nexus-fastapi-parity (#1174) — awaiting /todos approval
+
+- **Location:** `workspaces/nexus-fastapi-parity-py/todos/active/00-plan.md` (AWAITING HUMAN APPROVAL, generated 2026-05-30, 13d stale)
+- **Anchor:** issue #1174 body (user-authored), 7 ACs → 5 shards. Code lands in `packages/kailash-nexus/`.
+- **Disposition:** STRUCTURAL GATE (human-required per `autonomous-execution.md`). Cannot proceed past `/todos` autonomously. **User approval needed to launch `/implement`.**
+
+### [HIGH] [Sweep 1] nexus-scheduler-admin (#937) — decisions resolved, awaiting implement
+
+- **Location:** `workspaces/nexus-scheduler-admin-937/todos/active/00-plan.md` (decisions resolved 2026-05-29, 14d stale)
+- **Anchor:** issue #937 ACs (user-authored). S1 = NexusError→HTTP exception handler (SDK root fix); S2 = admin handler module + auth + response models.
+- **Disposition:** STRUCTURAL GATE. **User approval needed.**
+
+### [MED] [Sweep 1] from-brief-1125 (#1125) — draft awaiting /todos approval
+
+- **Location:** `workspaces/from-brief-1125/todos/active/00-plan.md` (Draft for approval 2026-05-27, 16d stale)
+- **Anchor:** issue #1125 body (user-authored), 11 ACs, 8 approved dispositions baked in.
+- **Disposition:** STRUCTURAL GATE. **User approval needed.**
+
+### [MED] [Sweep 3] #1086 — codify chore (SessionEnd hook noise, 4 candidates)
+
+- 4 codify candidates closing the structural cause of SessionEnd hook mis-attributing commit bodies.
+- **Disposition:** ACTIONABLE but COC-artifact / loom-synced surface (`.claude/rules/deployment.md`).
+  Lower user-facing value; process hygiene. Defer unless user prioritizes.
+
+### [LOW] [Sweep 3] #630 — Trust Vault SLIP-0039 binding — BLOCKED on mint ISS-37
+
+- `back_up_vault_key` raises `NotImplementedError` referencing this issue; gated on external mint ISS-37.
+- **Disposition:** CORRECTLY DEFERRED (Rule-1b shape: NotImplementedError references the gating issue). Leave open.
+
+### [LOW] [Sweep 3] #693 — promote dataflow-ml-integration spec after M2 — gated
+
+- Live check: `kailash_ml.features` (M2 surfaces `@feature`/`FeatureGroup`) **does not exist** → M2 not shipped.
+- **Disposition:** CORRECTLY GATED on M2. Leave open.
+
+### [LOW] [Sweep 6] Stale worktree `1207-jsonb-optional` — merged, cleanup candidate
+
+- `git worktree list`: `.claude/worktrees/1207-jsonb-optional` @ `6a4edd536`. Issue #1207 CLOSED; branch IS ancestor of main (merged).
+- Worktree carries stray uncommitted edits (`uv.lock`, `issue-1035-delegate-py/.session-notes`, `nexus-fastapi-parity/specs/...md`).
+- **Disposition:** CLEANUP — inspect the 3 uncommitted edits before `git worktree remove` (do not discard per `feedback_no_bulk_worktree_discard`). NOT done inline (under F3 hold awareness).
+
+### [LOW] [Sweep 2] 10 pending journal entries awaiting promotion
+
+- Across issue-1035 (closed), issue-1252 (closed), issue-772, issue-855, nexus-fastapi-parity, etc.
+- **Disposition:** promote-high-value / discard-bare at each owning workspace's next `/codify`. Not urgent.
+
+### [N/A] [Sweep 5] redteam-vs-spec
+
+`<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->`
+
+- Precondition gate: `workspaces/*/specs` contains spec **files**, not spec sub-directories → `spec_count=0` by the gate's `-type d -mindepth 1` measure → N/A sentinel. `tools/sweep-redteam.py` IS present. Per-workspace spec compliance is better re-derived via `/redteam` when each parked workstream resumes.
+
+### [CLEAN] Sweeps 4, 7, 8
+
+- No open PRs; no unmerged remote branches; 0/0 divergence vs origin/main.
+- No shippable diff since v2.29.4; anchor matches (`version = "2.29.4"`). Release converged.
+- Stub-marker grep = pre-existing legitimate set (abstract-method `NotImplementedError`, docstring TODOs); 0/0 divergence confirms no new production stubs.
+
+---
+
+## Cross-cutting observation
+
+The root `.session-notes` "Outstanding ledger (forest)" omitted all four `todos/active/`
+workstreams — they were tracked only in per-workspace todos, never rolled into the root
+forest. This is the `value-prioritization.md` deferral-as-forgetting pattern: technical
+state survived in workspace todos; the root-ledger value-rank evaporated. Re-pickup of all
+four therefore requires MUST-3 value-anchor re-validation (done for F8 above — anchor decayed).
+
+## GROUND-TRUTH RECONCILIATION (2026-06-12, post-verification) — supersedes the recommendation below
+
+The "approve & implement" framing below was based on `todos/active/` **status fields**, which
+were STALE. Deeper verification (GH issue state + implementation files on `main` + a
+verify-resource-existence deep-dive by the from_brief implementer agent) established that **all
+four headline workstreams are ALREADY implemented, merged, released, and CLOSED**:
+
+| Workstream           | GH     | Implementation on main                             | Shipped in                         |
+| -------------------- | ------ | -------------------------------------------------- | ---------------------------------- |
+| #1125 from_brief     | CLOSED | `src/kailash/_from_brief/` (8 modules + tests)     | kailash **2.27.0** (`5abc806f8`)   |
+| #1174 nexus parity   | CLOSED | `nexus/extractors/` + `handler_extract` in core.py | kailash-nexus **2.8.0** (PR #1214) |
+| #937 scheduler admin | CLOSED | `nexus/admin/scheduler.py` + NexusError handler    | kailash-nexus **2.7.0** (PR #1202) |
+| F8 kaizen RAG        | n/a    | 57/57 rag nodes construct                          | kaizen **2.23.x**                  |
+
+**Disposition applied:** the three stale active todos (#1174/#937/#1125) were moved to
+`todos/completed/00-plan-DELIVERED.md` with a delivery marker; F8's plan was likewise closed.
+The throwaway foundation-wave worktrees/branches were removed (zero-commit, off-main, nothing lost).
+**No implementation was performed — doing so would have created divergent duplicates colliding with
+released code (`zero-tolerance` Rule 4, `verify-resource-existence` MUST-3).**
+
+Root cause: when each workstream shipped, its `todos/active/` file was never archived to
+`completed/`, and the root `.session-notes` ledger never tracked them — so they read as "pending
+approval" when they were in fact "shipped." This sweep + reconciliation closes that gap.
+
+## Genuinely-remaining items (human-gated)
+
+1. **kaizen-rag wave3 `from_function` migration** (`workspaces/kaizen-rag-node-coverage/todos/active/01-wave3-...md`) — DRAFT, never approved, **code-health refactor** (secondary anchor per `value-prioritization.md` MUST-5); primary anchor is the now-satisfied F8 brief. Recommend: leave as draft / decide at a future `/sweep`. Not auto-actioned.
+2. **#1086 codify chore** — SessionEnd hook-noise process hygiene; COC/loom-synced surface, low user value. Defer unless prioritized.
+3. **#630 / #693** — correctly blocked (mint ISS-37; M2 not shipped — `kailash_ml.features` confirmed absent). Leave open.
+4. **Hygiene:** stale `1207-jsonb-optional` worktree (merged) still carries 3 stray uncommitted edits — inspect-then-remove; 10 pending journal entries to promote/discard at owning workspaces.
+
+Net: the four workstreams the operator asked to "drive to convergence" were **already converged
+and released**. There is no implementation work outstanding.

--- a/SWEEP-2026-06-15-post-2.34.2.md
+++ b/SWEEP-2026-06-15-post-2.34.2.md
@@ -1,0 +1,107 @@
+# /sweep — 2026-06-15 (post-v2.34.2)
+
+Repo: terrene-foundation/kailash-py · Branch: main (clean, 0/0 vs origin) · Latest tag: v2.34.2
+
+**Headline:** Repo is at a clean, fully-released terminus. main == PyPI == **2.34.2**
+(version consistent across `pyproject.toml`, `__init__.py`, installed package). NO
+unreleased shippable work, NO open PRs, NO open GH issues, NO orphan worktrees/branches.
+Every workspace carrying an "active" todo tracks **already-shipped, CLOSED-COMPLETED**
+work — there is **no live in-repo feature work outstanding**. Remaining items are
+workspace hygiene (stale active-todo scaffolding + pending journals) plus the two
+cross-repo ledger items (F2/F3) that cannot be actioned from this repo.
+
+**Supersedes** `SWEEP-2026-06-15.md` (09:42): that sweep's sole HIGH finding (#1316
+EATP-08 marker-regime tail, then OPEN) was **delivered and closed COMPLETED** at 11:25
+the same day and is released. No HIGH/CRIT findings remain.
+
+---
+
+## Sweep results
+
+| #   | Sweep               | Result                                                                                                              |
+| --- | ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| 1   | Active todos        | 3 workspaces — ALL track CLOSED-COMPLETED + released issues (hygiene, not work)                                     |
+| 2   | Pending journals    | 10 RISK entries in `eatp-12` (shipped ws) — promote/discard pass                                                    |
+| 3   | Open GH issues      | **0 open**                                                                                                          |
+| 4   | Open PRs / branches | **0 open PRs**; single worktree at HEAD; no orphan branches                                                         |
+| 5   | Redteam vs specs    | N/A — `<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->`                         |
+| 6   | Workspace hygiene   | clean — no `.session-notes` >30d, no `.pending` >14d, no orphan worktrees                                           |
+| 7   | Process hygiene     | 0/0 vs origin/main; 213 stub-markers in src = **pre-existing baseline** (0 new this session — repo 0 commits ahead) |
+| 8   | Release readiness   | **No shippable change since v2.34.2** (0 commits touching `src/`,`packages/*/src`)                                  |
+
+> Sweep 5 note: the precondition gate (`find workspaces/*/specs -type d -mindepth 1`)
+> returns 0 because workspace specs are FILES, not nested dirs — so the documented gate
+> records the structural N/A sentinel. `tools/sweep-redteam.py` IS present; the gate is
+> spec-dir-shaped, not tool-shaped. Per-workspace spec compliance was exercised at each
+> issue's own `/redteam` before closure (all three issues CLOSED COMPLETED).
+
+---
+
+## Findings
+
+### [LOW] [Sweep 1] Three stale `active/` todo plans track already-delivered work
+
+- **Location / disposition (all = ARCHIVE — delivered & released):**
+  - `workspaces/issue-1316-eatp08-marker-regime-py/todos/active/00-todos.md` →
+    **#1316 CLOSED COMPLETED 2026-06-15 11:25**. Todo file mtime 12:56 (post-closure note).
+  - `workspaces/eatp-12-vault-binding-py/todos/active/00-plan.md` →
+    **#1312 CLOSED COMPLETED 2026-06-14 18:43**, shipped **v2.33.0** (deploy receipt
+    `deploy/deployments/2026-06-15-v2.33.0-eatp12-vault-1312.md`).
+  - `workspaces/fm2-feature-store-m2-py/todos/active/00-plan.md` →
+    **#1302 CLOSED COMPLETED 2026-06-13 16:19**.
+- **Evidence:** all three issues CLOSED-COMPLETED on GitHub; Sweep 8 confirms 0 shippable
+  diff since v2.34.2 (everything closed-completed is an ancestor of the release tag).
+- **Why it matters:** stale `active/` scaffolding makes future sweeps re-flag finished
+  work as "in flight" (the false-positive that makes sweeps feel neverending). Not a
+  value/closure decision — the work is verifiably DELIVERED, so `value-prioritization.md`
+  MUST-4 (no auto-close of value-bearing work) does not apply; this is archival of
+  completed scaffolding, not abandonment.
+- **Action:** recommend a batch archive of the three `active/` plans into each workspace's
+  completed/archive state. NOT done inline — touches 3 workspaces; surfaced for a single
+  user-gated archival (per `no_bulk_worktree_discard` discipline).
+
+### [LOW] [Sweep 2] 10 pending RISK journals in a shipped workspace
+
+- **Location:** `workspaces/eatp-12-vault-binding-py/journal/.pending/*.md` (10 files,
+  all `status: pending`, session `17a44899`, captured during EATP-12 implementation Jun 14).
+- **Disposition:** promote-or-discard per `rules/journal.md`. EATP-12 shipped (v2.33.0,
+  #1312 closed), so these RISK entries are either (a) high-value risk insight → promote to
+  numbered journal, or (b) already-codified into the spec/release → discard with note.
+- **Why it matters:** pending journals never auto-resolve; they accumulate as silent debt.
+  Not urgent (well under the 14d staleness line — captured Jun 14).
+- **Action:** recommend a focused promotion pass reading the 10 entries. NOT done inline
+  (requires per-entry promote/discard judgment, out of /sweep's report scope).
+
+### [INFO] [Sweep 7] 213 stub-markers in `src/` — pre-existing baseline, 0 new
+
+- Repo is 0 commits ahead of origin/main; this session introduced no code. The 213
+  `TODO|FIXME|HACK|XXX|NotImplementedError` hits are the standing legitimate population
+  (abstract-method `NotImplementedError`, doc strings, etc.), not session-introduced
+  violations. No `zero-tolerance.md` Rule 2 action — nothing new shipped.
+
+---
+
+## Cross-cutting observations
+
+1. **The repo is genuinely converged.** Sweeps 3/4/8 are all empty; sweeps 1/2/6/7 surface
+   only hygiene. There is no actionable in-repo feature/bug/release work.
+2. **The only forward work is cross-repo and parked by design** (per the root
+   `.session-notes` ledger): **F2** — log-triage-gate `EXCLUDED_FILES` fix must land at
+   **loom** + re-sync (else the local kailash-py edit reverts on next `/sync-to-build`);
+   **F3** — cross-SDK check of kailash-rs for the RFC-3161 fail-open + data-vs-digest bug.
+   Neither is self-authorizable from kailash-py (`repo-scope-discipline.md`).
+3. **Two same-day sweep files now exist** (09:42 + this one). The morning one is a
+   historical receipt at an earlier release point (2.33.1) and is superseded here.
+
+## Recommended next-session items (ranked; human gate per /sweep closure)
+
+1. **(loom session) Land F2** — log-triage-gate `EXCLUDED_FILES` at loom + `/sync-to-build`.
+   Highest value: until it lands, the local kailash-py fix is overwritten on every sync and
+   never reaches sibling repos. Cross-repo — requires a loom session.
+2. **(kailash-rs session) F3 cross-SDK RFC-3161 check** — #1332 acceptance criterion 4.
+   Cross-repo — requires a kailash-rs session.
+3. **(this repo, low) Archive the 3 delivered `active/` todo plans** + promotion-pass the 10
+   `eatp-12` pending RISK journals. Pure hygiene; reduces future-sweep noise.
+
+**Disposition:** /sweep is the report. No next-action decided here — items 1–2 require
+context-switches the operator owns; item 3 is in-repo hygiene awaiting your go-ahead.

--- a/SWEEP-2026-06-15.md
+++ b/SWEEP-2026-06-15.md
@@ -1,0 +1,130 @@
+# /sweep — 2026-06-15
+
+Repo: terrene-foundation/kailash-py · Branch: main (clean, 0/0 vs origin) · Latest tag: v2.33.1
+
+**Headline:** Repo is in a clean post-release state. main == PyPI == **2.33.1**
+(issue #1318 PEP 749 fix shipped this session). NO unreleased shippable work; no
+open PRs; no orphan worktrees/branches. **One genuinely-actionable open issue
+(#1316, EATP-08 marker-regime tail).** Two stale active-todo plans both track
+already-shipped work (close-with-gate candidates). Ten pending journal entries
+sit in a shipped workspace (promote/discard, not urgent).
+
+---
+
+## Findings
+
+### [HIGH] [Sweep 3] #1316 — EATP-08 ISS-32 marker regime: real tail outstanding
+
+- **Location:** `gh issue 1316` (open, no labels, updated 2026-06-13). Spec-referenced
+  tracker that makes the `kailash-py ISS-32` label resolve (sibling of #1304/ISS-31).
+- **Value-anchor (source e — spec § success criterion):** EATP-08 v1.1.1
+  `08-algorithm-identifier.md` §4.5/§4.6/§5.1/§7.1 + cross-SDK parity with
+  `esperie-enterprise/kailash-rs` ISS-33. External gates (Foundation erratum PR #17,
+  mint#26/#27) are RESOLVED per the issue body.
+- **Done (shipped):** E6 silent-default-fill removal (#1304/#1309), D2d witness gate
+  (`D2dWitness`, `assert_d2d_witness_pre_adoption`, present in
+  `src/kailash/trust/signing/__init__.py`), bare-literal reject (#1315 → **2.32.0**).
+- **Outstanding (the §4.6 "neither SDK yet implements the full marker regime" tail):**
+  - [ ] **D2c signed-marker store** (§4.3.1/§4.3.2) — `D2dWitness` is currently a
+        passed-in value; D2c requires a signed-not-remembered `{principal, first_seen,
+marker_sig}` marker + the `implicit-v1-witness-failure` detection rule.
+  - [ ] **V6 (alg-id-strip-attack)** executable vector (3 sub-cases).
+  - [ ] **V7 (witnessed-adoption-marker, Complete level)** — marker-tamper detection.
+  - [ ] **Compatible-Legacy logging** (§7.1) — log D2a/D2d acceptances until the
+        marker store + adoption-date gate ship.
+- **Disposition:** **GENUINELY ACTIONABLE — top next-session candidate.** NOT closeable
+  (real spec-anchored work outstanding). Substantial: D2c is signing infrastructure
+  (multi-shard, security-critical trust surface) + cross-SDK parity gate. Recommend a
+  dedicated `/analyze` → `/todos` cycle, NOT inline. Per `value-prioritization.md` MUST-4
+  this is NOT a stale-close — it carries a live spec value-anchor.
+
+### [MED] [Sweep 1] fm2-feature-store-m2-py — active plan tracks shipped work
+
+- **Location:** `workspaces/fm2-feature-store-m2-py/todos/active/00-plan.md`
+  (Status: "awaiting human approval — structural /todos gate").
+- **Evidence:** FM2 feature-store M2 (Redis-backed `OnlineFeatureStore`, self-healing
+  model re-registration, closes **#693**) shipped 2026-06-13 as **kailash 2.31.0 +
+  kailash-ml 2.2.0** via PR #1310 (per `deploy/deployment-config.md`). #693 is CLOSED.
+- **Disposition:** **CLOSE-WITH-GATE** — the plan is a pre-implementation draft overtaken
+  by the actual delivery (different path, PR #1310). Recommend archiving the active plan
+  as superseded (value delivered). Per `value-prioritization.md` MUST-4, surface to user;
+  do NOT auto-close. **User gate needed.**
+
+### [LOW] [Sweep 1] eatp-12-vault-binding-py — active plan tracks shipped work
+
+- **Location:** `workspaces/eatp-12-vault-binding-py/todos/active/00-plan.md` (issue #1312).
+- **Evidence:** #1312 CLOSED; shipped as **kailash 2.33.0** (vault sub-package, PR #1320,
+  release #1321) on 2026-06-14.
+- **Disposition:** **ARCHIVE** — completed-work residual; the plan's waves all delivered.
+  Cleanup only (move `todos/active/` → `todos/completed/` or archive the workspace).
+
+### [LOW] [Sweep 2] eatp-12-vault-binding-py — 10 pending journal entries
+
+- **Location:** `workspaces/eatp-12-vault-binding-py/journal/.pending/*.md` (10 RISK
+  entries, all <14d, auto-generated during the shipped vault work).
+- **Disposition:** **PROMOTE-OR-DISCARD** at the workspace's next `/codify`. The vault
+  work is fully shipped + codified, so most are likely discard-with-note (already-codified)
+  per `rules/journal.md`. Not urgent; not blocking.
+
+### [N/A] [Sweep 5] redteam-vs-spec
+
+`<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=false -->`
+
+- Precondition gate: `workspaces/*/specs` contains spec **files**, not spec
+  sub-directories → `spec_count=0` by the gate's `-type d -mindepth 1` measure → N/A
+  sentinel. `tools/sweep-redteam.py` IS present. Per-workspace spec compliance is better
+  re-derived via `/redteam` when each parked workstream resumes. (Same disposition as the
+  2026-06-12 sweep.)
+
+### [CLEAN] [Sweep 4] PRs + branches · [Sweep 6] worktrees · [Sweep 8] release
+
+- **Sweep 4:** 0 open PRs; 0 unmerged remote branches; no orphan/local-only work.
+- **Sweep 6:** single worktree at HEAD (`63532704d [main]`); no `.session-notes` >30d;
+  no `.pending` >14d.
+- **Sweep 8:** `LATEST=v2.33.1`; shippable diff `v2.33.1..HEAD -- src/ packages/*/src` is
+  **EMPTY**; anchor `version = "2.33.1"`. **No unreleased work.** All 8 framework packages
+  AT-PARITY with PyPI (dataflow 2.11.3, nexus 2.9.1, kaizen 2.27.0, mcp 0.2.14, ml 2.2.1,
+  align 0.7.2, pact 0.12.0, kaizen-agents 0.9.10).
+
+### [INFO] [Sweep 7] process hygiene
+
+- `git status --short`: 95 untracked entries — **pre-existing forest drift** (prior
+  `SWEEP-*.md`, `deploy/deployments/*.md`, workspace `.claude/` dirs) that predates this
+  session, PLUS this session's new untracked deploy record
+  (`2026-06-15-v2.33.1-...md`) which matches established untracked-deploy-record practice.
+  None are uncommitted SOURCE changes.
+- Divergence: `0  0` (main == origin/main).
+- New stub markers in src since v2.33.0: **none** — the 3 files touched this session
+  (`annotations.py`, `__init__.py`, kaizen `core.py`) introduced no
+  `TODO`/`FIXME`/`NotImplementedError`.
+
+---
+
+## Cross-cutting observations
+
+1. **Sweep accuracy improved vs 2026-06-12.** The prior sweep mis-flagged three closed
+   feature workstreams (#1174/#937/#1125) as "awaiting approval" because it read stale
+   `todos/active/` plan files instead of issue state. This sweep cross-checks issue state:
+   the two remaining active-plan residuals (fm2, eatp-12) are confirmed
+   shipped-and-superseded, and the single live issue (#1316) is verified against source.
+2. **The repo has converged.** Of the entire forest, exactly ONE item (#1316) carries
+   live, un-delivered, spec-anchored value. Everything else is shipped or hygiene cleanup.
+3. **Stale-plan hygiene is the recurring noise source.** `todos/active/` plans for shipped
+   work persist and re-surface every sweep. Archiving them on delivery (move to
+   `completed/`) would make future sweeps quieter.
+
+## Recommended next-session items (ranked by user value)
+
+1. **#1316 — EATP-08 marker-regime tail (HIGH).** Anchor: EATP-08 v1.1.1 spec §4.5/§4.6
+   success criteria + kailash-rs ISS-33 parity. Substantial security-critical trust work
+   (D2c signed-marker store + V6/V7 vectors + Compatible-Legacy logging). Recommend a
+   dedicated `/analyze` → `/todos` cycle; external gates already resolved. **User decision:
+   prioritize now, or defer?**
+2. **fm2 + eatp-12 stale-plan cleanup (MED/LOW).** Close fm2 plan as superseded
+   (delivered via PR #1310 / ml 2.2.0) with user gate; archive eatp-12 completed plan.
+   Quiets future sweeps.
+3. **eatp-12 `.pending` journal promote/discard (LOW).** At the vault workspace's next
+   `/codify`; non-blocking.
+
+**The report is the deliverable. Next-session scope is a human call (#1316 is the clear
+top candidate but is substantial — confirm before launching).**

--- a/SWEEP-2026-06-16.md
+++ b/SWEEP-2026-06-16.md
@@ -1,0 +1,86 @@
+# SWEEP — kailash-py — 2026-06-16
+
+Repo: `terrene-foundation/kailash-py` · Branch: `main` (in sync with origin, 0↑/0↓) · Latest tag: `v2.34.2`
+
+**Headline:** The working tree is functionally clean — no in-flight todos, no open PRs, no orphan worktrees, no unreleased shippable code, no new stubs. The single material finding is an **accumulated backlog of uncommitted institutional records** (deployment notes, prior sweep reports, completed workspace validation artifacts) that follow established tracked patterns but were never committed across many prior sessions.
+
+---
+
+## Sweep-by-sweep
+
+### Sweep 1 — Active todos · CLEAN
+
+No files under `workspaces/*/todos/active/`. Nothing in flight.
+
+### Sweep 2 — Pending journal entries · CLEAN
+
+No files under `workspaces/*/journal/.pending/`.
+
+### Sweep 3 — Open GitHub issues · 5 open, all fresh & actionable
+
+| #    | Labels                                  | Title                                                                                  | Age |
+| ---- | --------------------------------------- | -------------------------------------------------------------------------------------- | --- |
+| 1339 | enhancement, cross-sdk                  | [parity][infra] DistributedLock / Lease primitive — absent in kailash-py (NEW FEATURE) | 0d  |
+| 1338 | enhancement, cross-sdk                  | [parity][events] Tenant-prefixed-topic recipe for in-memory event bus                  | 0d  |
+| 1337 | enhancement, cross-sdk                  | [parity][database] Standalone callable masking + record-agnostic redaction             | 0d  |
+| 1336 | enhancement, cross-sdk                  | [parity][gateway] HTTP middleware: rate-limit absent; assess error/metrics/CSP/session | 0d  |
+| 1335 | cross-sdk, pact, spec-conformance, eatp | [conformance] envoy-parity v1.1 errata — PACT-05 + EATP-09/10/12 behaviour errata      | 1d  |
+
+**Disposition:** all genuinely-actionable, all created 2026-06-15/16, correctly labeled. **None stale, none carry the `deferred` label** (no Rule-1b 4-condition check needed). These are cross-SDK parity enhancements queued from recent Rust-side work — no closure candidates, no auto-close risk. Queued-with-value-rank; the user owns prioritization.
+
+### Sweep 4 — Open PRs & stale branches · CLEAN
+
+No open PRs. No unmerged remote branches. No orphan/local-only branch work.
+
+### Sweep 5 — Redteam (spec-vs-code) · ran, no NEW actionable gaps
+
+`tools/sweep-redteam.py --all --json` →
+
+```
+<!-- sweep-redteam:v1:OK specs=2 symbols=18 orphans=17 coverage_gaps=0 stubs=0 -->
+```
+
+(Note: the literal precondition gate `find workspaces/*/specs -type d -mindepth 1` returns 0 because the one workspace with specs — `nexus-fastapi-parity-py` — stores them as **flat files**, not subdirs. The tool is present and discovers flat specs, so it was run rather than recording an N/A sentinel.)
+
+**17 "orphans" — triaged:**
+
+- **~13 are tool false-positives** — the symbol extractor picks up illustrative/stdlib references in spec prose: `inspect.signature`, `UploadFile.filename`, `puremagic.from_string`, `Headers.__setitem__`, `__class__.__name__`, `pyproject.toml`, `packages/my-app/src/handlers/users.py:42`, `Request.client.host`, etc. These are example code in the parity narrative, not promised SDK symbols.
+- **~4 are real parity gaps, already tracked as GH issues**: `nexus.extractors` / `nexus.handler_extract` / `_ws_message_handlers.register` → #1216/#1217/#1218; `nexus.auth.rate_limit` → #1336 (filed today). The spec itself (modified, see Sweep 7) records these were converted to trackers on 2026-05-31.
+
+`coverage_gaps=0`, `stubs=0`. **No workspace has ≥3 unresolved gaps requiring a follow-up `/redteam`.**
+
+### Sweep 6 — Workspace & worktree hygiene · CLEAN
+
+No `.session-notes` older than 30d. `git worktree list` shows only the main checkout (no orphans). No `.pending` entries.
+
+### Sweep 7 — Process hygiene · ⚠ accumulated uncommitted records
+
+- Branch `main` in sync with origin (0/0). No source (`.py`) files modified this session → the 30+ files carrying `TODO|FIXME|…` markers are **pre-existing baseline in a mature SDK, not introduced** (no shippable diff this session — confirmed by Sweep 8).
+- **Tracked modifications (3):** `.session-notes` (M, normal churn); `workspaces/from-brief-1125/todos/active/00-plan.md` (D — completed-workspace cleanup, plan was last touched at commit `26abb375c`); `workspaces/nexus-fastapi-parity-py/specs/nexus-fastapi-parity.md` (M — documents the #1216/#1217/#1218 tracker filing; legit, ready to commit).
+- **Untracked backlog following tracked patterns:**
+  - `deploy/deployments/*.md` — **9 untracked** deployment records (dir has **42 tracked**; this IS a committed convention). Dated records for v2.22.1 through v2.34.2 — institutional deployment history left out of git.
+  - `SWEEP-*.md` (root) — **16 untracked** prior sweep reports (pattern has 8 tracked).
+  - `workspaces/issue-1035-delegate-py/04-validate/*` — ~20 completed redteam/convergence artifacts.
+  - New workspace dirs: `workspaces/issue-1249-dataflow-tenant-leak/`, `workspaces/cross-sdk-rs-2026-06-01/`, `workspaces/_redteam-2026-05-18/`, several `workspaces/_archive/issue-*` moves.
+  - `packages/{kailash-dataflow,kailash-kaizen,kailash-ml,kaizen-agents}/.claude/` + `…/rag/.claude/` — package-level COC artifact dirs (not gitignored; **needs a human glance** — may be sync residue that doesn't belong in the BUILD repo).
+
+### Sweep 8 — Release readiness · CLEAN
+
+`LATEST=v2.34.2`, root anchor `version = "2.34.2"` — match. `git log v2.34.2..HEAD -- src/ packages/*/src` is **empty**: no shippable code since the last tag. Fully released; nothing to publish.
+
+---
+
+## Cross-cutting observations
+
+1. **The repo is operationally idle and clean** — every "work in flight" sweep (todos, PRs, worktrees, unreleased code) is empty. v2.34.2 is shipped and matched.
+2. **The only debt is record-keeping, not code.** A multi-session backlog of institutional artifacts (deploy notes, sweep reports, completed-workspace validation files) accumulated untracked. The deploy notes and sweep reports are unambiguous "should be committed" cases (established tracked patterns); the package-level `.claude/` dirs and whole new workspace dirs warrant a glance before committing.
+3. **Open issues are healthy** — 5 fresh cross-SDK parity items, well-labeled, none stale, none deferred. They represent forward feature work, not rot.
+
+## Recommended next-session items (ranked)
+
+1. **Commit the institutional-record backlog** (HIGH) — stage `deploy/deployments/*.md` (9) + root `SWEEP-*.md` (16) + the nexus-spec modification explicitly; commit as a `chore(records): …` PR. These follow 42- and 8-file tracked conventions; leaving them out makes git's deployment/sweep history incomplete. (Stage explicit paths — `git add -A` BLOCKED per `git.md`.)
+2. **Adjudicate `packages/*/.claude/` untracked dirs** (MED) — confirm whether these are legitimate tracked COC artifacts or sync residue; gitignore or commit accordingly.
+3. **Triage the new workspace dirs** (MED) — `issue-1249-dataflow-tenant-leak/`, `cross-sdk-rs-2026-06-01/`, `_redteam-2026-05-18/`: commit if institutional, `_archive/` if complete.
+4. **Pick up the cross-SDK parity queue** (user-prioritized) — #1335–#1339 are the actionable forward work; #1336 (gateway rate-limit) overlaps the one real open redteam orphan.
+
+— Sweep complete. Report is the deliverable; commit decisions on the record backlog are a human call.

--- a/deploy/deployments/2026-05-18-v2.22.1-dataflow-v2.9.19.md
+++ b/deploy/deployments/2026-05-18-v2.22.1-dataflow-v2.9.19.md
@@ -1,0 +1,45 @@
+# Deployment Record — 2026-05-18 — kailash 2.22.1 + kailash-dataflow 2.9.19
+
+Coordinated patch release closing two unreleased split-version states
+(`zero-tolerance.md` Rule 5) surfaced at `/release` scope detection during
+the #1083/#1084/#1085 closure + redteam-to-convergence session.
+
+## Scope
+
+| Package          | PyPI before | Released   | Severity | Driver                                                                                                                                                                                                                                                   |
+| ---------------- | ----------- | ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| kailash          | 2.22.0      | **2.22.1** | CRITICAL | `import kailash` failed on every clean-venv install of 2.22.0 — EventPublishNode circular import. Fix `d9d9a597c` landed on main after the 2.22.0 tag; catch-up patch per `build-repo-release-discipline.md` Rule 2.                                     |
+| kailash-dataflow | 2.9.18      | **2.9.19** | HIGH     | `TransactionScope.execute_raw` (async + sync) write-protection bypass — `read_only_mode=True` was bypassable via raw SQL in transactions (#1083 follow-up, PR #1088 `ea2d9ad84`). + observability Rule 8 schema-name hashing in `auditor.log_violation`. |
+
+All 7 other framework packages AT PyPI parity at release-time enumeration — no sibling release. `kailash-dataflow` `kailash>=` pin advanced `2.21.2 → 2.22.1` (framework pin resolves vs local editable kailash per `deployment.md`, not PyPI).
+
+## Provenance
+
+- HIGH fix surfaced by 3-round multi-agent `/redteam` against the #1083 closure: R1 0 CRIT/0 HIGH; R2 (pact-specialist pentest axis) surfaced the `TransactionScope.execute_raw` bypass as the 4th unprotected DataFlow write surface; R3 verified the fix bundle 0/0/0/0. Receipts: `workspaces/_redteam-2026-05-18/r{1,2,3}-*.md`.
+- PR #1088 (`fix/issue-1083-followup-transactions-execute-raw-protection`) — full PR-gate matrix green (Python 3.11-3.14 + DataFlow Tier-1 + PACT + infra + CodeQL), merge `cee81cfe8`. Post-merge sync regression test PASSED on main.
+- Release-prep PR #1089 (`release/v2.22.1`) — metadata-only diff, PR-gate matrix auto-skipped per `release/v*` convention (11 checks skipped), docs-build gate green. Merge `4d3dd52cf`.
+
+## Release mechanics
+
+- Tags pushed individually with pause per `deployment.md` MUST (batch-push silently drops webhook triggers): `v2.22.1` then `dataflow-v2.9.19`, both on `4d3dd52cfd94176fcc5a3bb9f8a12627e3f6525e`.
+- publish-pypi.yml: run for `v2.22.1` (success) + run for `dataflow-v2.9.19` (success). OIDC trusted-publisher, no manual twine.
+- TestPyPI skipped — both are patch releases (`deployment.md` patch-release exception); underlying code CI-verified via PR #1088's full matrix + the kailash fix `d9d9a597c` already on main. Authorized in-session ("approved, i don't have time for you to ask for permissions" + standing `feedback_build_repo_release.md`).
+
+## Done-gate verification (clean venv, NOT build venv)
+
+```
+/tmp/verify-rel-2221  (uv venv, python 3.12)
+python -m pip install --no-cache-dir "kailash==2.22.1" "kailash-dataflow==2.9.19"
+→ kailash 2.22.1
+→ kailash-dataflow 2.9.19
+→ import kailash clean (CRITICAL circular-import fix confirmed live)
+→ dataflow.features.transactions: _execute_raw_with_protection + _classify_raw_sql_operation present
+→ TransactionScope.__init__ plumbs dataflow_instance
+→ ProtectionAuditor.log_violation emits schema_hash (observability Rule 8)
+```
+
+`uv pip install --refresh` hit the documented index-cache lag; pip `--no-cache-dir` fallback (per `build-repo-release-discipline.md` Rule 2) resolved immediately. Version-specific endpoints `pypi.org/pypi/kailash/2.22.1/json` + `.../kailash-dataflow/2.9.19/json` both HTTP 200.
+
+## No sibling drift
+
+Release-time enumeration: kailash-nexus 2.6.3, kailash-kaizen 2.21.1, kailash-mcp 0.2.14, kailash-ml 1.7.4, kailash-align 0.7.1, kailash-pact 0.12.0, kaizen-agents 0.9.7 — all AT PyPI parity. No catch-up needed.

--- a/deploy/deployments/2026-05-19-kaizen-v2.23.0-v2.23.1-rag-resurrection.md
+++ b/deploy/deployments/2026-05-19-kaizen-v2.23.0-v2.23.1-rag-resurrection.md
@@ -1,0 +1,82 @@
+# Deployment — 2026-05-19 — kaizen.nodes.rag resurrection (#891 follow-up)
+
+Two kaizen releases completing the resurrection of the dead `kaizen.nodes.rag`
+package (PR #1096 + release-prep PR #1097). User-gated separate workstream from
+the #891 collision fix.
+
+## Released
+
+| Package        | PyPI   | →      | Tag              | publish run         |
+| -------------- | ------ | ------ | ---------------- | ------------------- |
+| kailash-kaizen | 2.22.0 | 2.23.0 | `kaizen-v2.23.0` | 26062036003 success |
+| kailash-kaizen | 2.23.0 | 2.23.1 | `kaizen-v2.23.1` | 26063153204 success |
+
+## What shipped
+
+**2.23.0 (PR #1096) — resurrection.** `kaizen.nodes.rag` (17 modules, ~53 RAG
+node classes: GraphRAG, AgenticRAG, FederatedRAG, MultimodalRAG,
+privacy-preserving RAG, ColBERT/HyDE retrieval, RAG evaluation, …) was
+un-importable from the 2026-03-11 monorepo move (`b553104c`) — every module's
+relative imports pointed at a non-existent
+`kaizen.nodes.{base,code,data,logic,security}` / `kaizen.runtime` /
+`kaizen.workflow` tree. Surfaced by the #891 collision census (dead code never
+registers → dropped from #1094; resurrection user-gated).
+
+- ~40 broken imports across 14 modules repointed to verified `kailash.*`
+  targets (11 distinct; `..ai.llm_agent` valid intra-kaizen, left).
+- `rag.realtime.StreamingRAGNode` → `RealtimeStreamingRAGNode` — the only
+  intra-rag duplicate; mandatory once importable (the live kailash 2.23.0
+  #891 guard rejects the realtime↔optimized collision). `rag.optimized`
+  keeps `StreamingRAGNode`.
+- Gate review (both agents): HIGH — smoke test newly surfaced a pre-existing
+  `\w` SyntaxWarning (embedded PythonCodeNode source-string not raw) → fixed
+  (`"code": r"""`). MEDIUM-security — resurrection re-enabled an `eval()`
+  arithmetic path on LLM input → replaced with an AST whitelist evaluator
+  (no eval/exec/regex; rejects `__import__`/`.__class__`/comprehension/`open`).
+  MEDIUM — smoke test strengthened with a broader-registry coexistence case.
+  20-case import-smoke regression test.
+
+**2.23.1 (PR #1097) — `[rag]` extra completion.** The clean-venv release gate
+caught that 2.23.0's `[rag]` extra (`numpy`, `Pillow`) was insufficient: the
+resurrected import graph also needs `networkx` (graph RAG — was declared
+nowhere) + `requests` + `aiosqlite` (transitive via `kailash.nodes.api.rest` /
+the kailash data path). `[rag]` now the complete set:
+`numpy, Pillow, networkx, requests, aiosqlite`. Metadata-only; `release/v*`
+branch auto-skipped the PR-gate matrix.
+
+## Gates
+
+- PR #1096: full Python 3.11–3.14 matrix + DataFlow + PACT CI — all pass on
+  the gate-fix commit `a5186e103`. reviewer + security-reviewer: all findings
+  resolved + verified pre-merge.
+- PR #1097: metadata-only, matrix auto-skipped (`release/v*` convention).
+- TestPyPI: skipped per documented minor/patch exception (matrix CI green +
+  gates clean), explicit human approval 2026-05-19.
+
+## Verification (clean venv, PyPI)
+
+- 2.23.0: `kailash-kaizen==2.23.0` + node deps → all 16 rag submodules import
+  clean, `RealtimeStreamingRAGNode`/`StreamingRAGNode` register distinctly, no
+  guard `NodeConfigurationError`.
+- 2.23.1: **`pip install "kailash-kaizen[rag]==2.23.1"` (extra only, NO manual
+  deps)** → all 16 rag submodules import clean. The `[rag]` extra is now the
+  complete, self-sufficient install path. (Attempt 1 hit the documented PyPI
+  index-cache lag; retry loop handled it.)
+
+## Notes
+
+- `kaizen.nodes.rag` requires `pip install "kailash-kaizen[rag]"` — its
+  node-functional deps are intentionally behind the extra per the issue #890
+  core-dep audit (kaizen core held to 9 deps). Bare `import kaizen` is
+  unaffected — the rag package is deep-import-only (not in `kaizen/__init__`).
+- Deep per-node behavioral coverage of the ~53 RAG classes is a value-anchored
+  tracked follow-up (`workspaces/kaizen-rag-resurrection/briefs/00-brief.md`
+  § Out of scope; `journal/0001`). Import-clean under the live guard is the
+  shipped structural floor — zero regression risk (package was 100% dead
+  before; purely additive).
+
+## Sibling drift
+
+None — only kailash-kaizen changed in this workstream; the #891 release
+(kailash 2.23.0 / kailash-dataflow 2.10.0 / kailash-kaizen 2.22.0) preceded
+this and the other packages remain at PyPI parity.

--- a/deploy/deployments/2026-05-19-v2.23.0-issue-891-node-registry-collisions.md
+++ b/deploy/deployments/2026-05-19-v2.23.0-issue-891-node-registry-collisions.md
@@ -1,0 +1,73 @@
+# Deployment — 2026-05-19 — issue #891 node-registry collision fix
+
+Three-package minor release closing issue #891 (PR #1094 + release-prep PR #1095).
+
+## Released
+
+| Package          | PyPI   | →      | Tag                | publish-pypi.yml run |
+| ---------------- | ------ | ------ | ------------------ | -------------------- |
+| kailash          | 2.22.1 | 2.23.0 | `v2.23.0`          | 26058798252 success  |
+| kailash-dataflow | 2.9.19 | 2.10.0 | `dataflow-v2.10.0` | 26058803251 success  |
+| kailash-kaizen   | 2.21.1 | 2.22.0 | `kaizen-v2.22.0`   | 26058808644 success  |
+
+## What shipped
+
+Three pairs of distinct node classes each registered the same global
+`NodeRegistry` string, making `add_node("<name>")` import-order-dependent
+(issue #891 named one; a registry census found three live collisions):
+
+- `HybridSearchNode` → `PgVectorHybridSearchNode` (dataflow; one-cycle module
+  alias `HybridSearchNode` retained — public symbol) / `SemanticHybridSearchNode`
+  (kaizen; internal-only, no shim).
+- `BulkUpsertNode` → `SQLBulkUpsertNode` (kailash core) / `DataFlowBulkUpsertNode`
+  (kailash-dataflow). DataFlow per-model generated `{Model}BulkUpsertNode`
+  names unaffected.
+- `AggregateNode` → `MongoAggregateNode` (dataflow mongodb_nodes);
+  `aggregate_operations` keeps `AggregateNode` (convention owner).
+- Core SDK `NodeRegistry.register` raises `NodeConfigurationError` on a
+  cross-module name collision; `allow_override=True` (passed by DataFlow's
+  generated-CRUD-node registration) exempts intentional dynamic overwrites;
+  exemption tracks the live incumbent via `_dynamic_names`, never permanently
+  sticky (HIGH found + fixed in gate re-review). Same-module re-registration
+  stays INFO-log (ADR-002).
+
+`kailash-dataflow` + `kailash-kaizen` pins moved to `kailash>=2.23.0` (PR #1095)
+— dataflow 2.10.0 calls `register(allow_override=True)`, a 2.23.0 API.
+
+## Gates
+
+- PR #1094: full Python 3.11–3.14 matrix CI + DataFlow + PACT — all pass.
+- reviewer + security-reviewer: clean first pass; re-review of the
+  DataFlow-generation guard fix surfaced one HIGH (permanently-sticky
+  exemption) → fixed + pinned by regression test; security re-review CLEAN.
+- TestPyPI: skipped per documented minor-release exception (matrix CI green +
+  both gates clean), explicit human approval 2026-05-19.
+
+## Verification (clean venv, PyPI)
+
+`uv venv /tmp/verify-891`; `uv pip install kailash==2.23.0
+kailash-dataflow==2.10.0 kailash-kaizen==2.22.0` (attempt 2 — attempt 1 hit the
+documented PyPI/uv index cache lag, retry loop handled it). With node deps
+present: all 3 `__version__` correct; `NodeRegistry.register` has
+`allow_override` + `_dynamic_names`; all 6 renamed names resolve in the
+registry; collided `HybridSearchNode` / `BulkUpsertNode` strings absent;
+dataflow one-cycle `HybridSearchNode` alias `is PgVectorHybridSearchNode`.
+
+Note: a _bare_ `pip install kailash-dataflow` / `kailash-kaizen` cannot import
+node modules without `aiosqlite` / `numpy` (in extras) — pre-existing packaging
+behavior (the non-renamed `VectorSearchNode` is equally absent), not a #891
+regression; tracked by the issue #1086 transitive-deps class.
+
+## Sibling drift
+
+None — the other 6 framework packages (nexus, pact, ml, align, mcp,
+kaizen-agents) were AT-PARITY with PyPI at release-time enumeration; this
+session touched only the 3 released packages.
+
+## Follow-up (separate workstream, user-gated this session)
+
+`kaizen.nodes.rag` — 17 modules / 53 RAG node classes, dead-on-arrival since
+the 2026-03-11 monorepo move (`b553104c`; imports point at a non-existent
+`kaizen.nodes.{code,data,logic}` tree). NOT a live collision (dead code never
+registers). User chose to resurrect it as a separate PR. See
+`workspaces/issue-891-hybridsearch-collision/journal/0004`.

--- a/deploy/deployments/2026-06-08-ml-v2.0.1-align-v0.7.2-1183.md
+++ b/deploy/deployments/2026-06-08-ml-v2.0.1-align-v0.7.2-1183.md
@@ -1,0 +1,65 @@
+# Deployment — kailash-ml 2.0.1 + kailash-align 0.7.2 (#1183)
+
+**Date:** 2026-06-08
+**Issue:** #1183 — "single source of truth for dependency version-pin sourcing"
+**Type:** Two-package coordinated patch release (dependency-floor fixes + new drift gate)
+
+## Summary
+
+Closes #1183 by making silent first-party pin drift LOUD: a new
+`tools/check_pin_consistency.py` drift gate (aligned with `dependencies.md` —
+per-package floors legitimately differ, so caps/unsatisfiable/intra-manifest are
+errors while cross-manifest divergence is advisory) surfaced **3 real errors**,
+including a **live resolution break**.
+
+## What shipped
+
+- **kailash-ml `2.0.0 → 2.0.1`:** `[kaizen-judges]` + `[kaizen-observability]`
+  extras `kailash-kaizen>=2.7` → `>=2.7.5` (consistent floor; also pins past the
+  known-bad kaizen 2.7.0–2.7.4 `ModuleNotFoundError` class). No source change.
+- **kailash-align `0.7.1 → 0.7.2`:** `[rl-bridge]` extra `kailash-ml[rl]>=1.1,<2.0`
+  → `>=1.1` (the `<2.0` defensive cap **excluded the current ml 2.0.0** — a live
+  resolution break per `dependencies.md` § "No Caps"); core `kailash-ml>=0.11.0`
+  → `>=1.1` (stale + intra-manifest-inconsistent). No source change.
+- **Tooling (not wheel-packaged):** `tools/check_pin_consistency.py` + 8 unit
+  tests + a read-only `check-pin-consistency` pre-commit hook.
+
+## Verification
+
+- **Cap-removal safety (behavioral, not just import):** all 9 `kailash_ml.rl.*`
+  symbols align's rl-bridge imports exist in ml 2.0.0; align rl-bridge suite
+  **74 passed** against ml 2.0.0; align full suite 481 passed / 1 skipped.
+- **Detector:** 0 errors after fixes (was 3); 8 unit tests pass.
+- **Reviews:** reviewer (detector) APPROVE; security-reviewer (pre-release)
+  APPROVE — zero CRIT/HIGH/MED, clean on supply-chain / parse-safety / secrets /
+  hook-injection.
+- **Floors PyPI-resolvable** (`>=1.1`, `>=2.7.5` long-published) per
+  `deployment.md` § "Optional Dependencies Pin to PyPI-Resolvable Versions".
+
+## Release mechanics
+
+- Fix + version bumps + CHANGELOG in PR **#1279** (`fix/1183-pin-drift-detector`,
+  merge `fc876f635`); full PR-gate matrix green (44 pass / 14 skip / 0 fail);
+  admin-merged.
+- Tags pushed individually: `ml-v2.0.1` (publish-pypi run `27109217345` SUCCESS)
+  - `align-v0.7.2` (run `27109222202` SUCCESS).
+- TestPyPI skipped per the patch-release human-approval exception (user
+  authorized "approved").
+- **Clean-venv install verified:** `uv pip install --refresh kailash-ml==2.0.1
+kailash-align==0.7.2` → `kailash_ml.__version__ == "2.0.1"` +
+  `kailash_align.__version__ == "0.7.2"` (attempt 2 after the documented PyPI/uv
+  index-cache lag, per `build-repo-release-discipline.md` Rule 2).
+
+## Sibling drift
+
+No real drift — all 9 framework packages at PyPI parity at release-time
+enumeration. (The `kailash-ml json info.version` endpoint briefly showed 2.0.0
+post-publish — the documented metadata-cache lag; the live `==2.0.1` install
+proves 2.0.1 is on PyPI.)
+
+## Receipts
+
+- Workspace: `workspaces/issue-1183-pin-source-of-truth/`
+  (journal `0001-DISCOVERY-...`, `02-plans/findings-and-design.md`).
+- Reviewer task `ade5cdbfa6c3e1607` (APPROVE); security-reviewer task
+  `acdb7b785f059e506` (APPROVE).

--- a/deploy/deployments/2026-06-13-ml-v2.1.1-pin-hotfix.md
+++ b/deploy/deployments/2026-06-13-ml-v2.1.1-pin-hotfix.md
@@ -1,0 +1,59 @@
+# Deployment — kailash-ml 2.1.1 (core-pin hotfix + 2.1.0 yank)
+
+**Date:** 2026-06-13
+**Issue:** None filed — surfaced via release alert.
+**Type:** Single-package patch release (dependency-floor correction) + yank of 2.1.0
+
+## Summary
+
+kailash-ml **2.1.0** shipped a broken dependency contract: its feature-store
+surface re-exports the ML error hierarchy from **core** `kailash.ml.errors`
+(`kailash_ml/errors.py:21`), including 8 feature-store subclasses
+(`FeatureStoreError`, `FeatureGroupNotFoundError`, `FeatureVersionImmutableError`,
+`FeatureVersionNotFoundError`, `FeatureEvolutionError`, `CrossTenantReadError`,
+`UnsupportedFamily`, `UnsupportedPrecision`). Those classes were added to core by
+the FM2 Wave 1+2 merge and **first published in `kailash` 2.30.0** (#1307), which
+released ~10h _after_ kailash-ml 2.1.0 (#1306). The 2.1.0 floor `kailash>=2.16.0`
+lets pip resolve a core in `[2.16.0, 2.29.4]` that lacks the symbols → `ImportError`
+on first touch of the eagerly-imported feature-store surface.
+
+## Ground-truth verification
+
+- 8 symbols **absent** at tag `v2.29.4` (`067026e4d`, pre-FM2-merge), **present** at `kailash` 2.30.0.
+- ml 2.1.0/2.1.1 imports all 8 from `kailash.ml.errors` (git-grep confirmed).
+
+## What shipped
+
+- **kailash-ml `2.1.0 → 2.1.1`:** floor `kailash>=2.16.0` → `kailash>=2.30.0`.
+  No source change — metadata only (pyproject + `_version.py` + CHANGELOG).
+
+## Pipeline
+
+- PR **#1308** (`release/ml-v2.1.1`, branch convention auto-skipped full PR-gate matrix;
+  "Version Consistency" pass) → admin-merge `0c887fe8d`.
+- Tag `ml-v2.1.1` → `publish-pypi.yml` run `27455475676` SUCCESS
+  (Build + Publish to PyPI + GitHub Release; TestPyPI skipped per patch exception).
+
+## Done gate (build-repo-release-discipline Rule 2)
+
+Clean-venv walk (`/tmp/verify-ml211`, uv, Python 3.12):
+
+```
+uv pip install --refresh kailash-ml==2.1.1   # attempt 2 OK (attempt 1 = index cache lag)
+kailash 2.30.0              # corrected floor pulls the right core
+kailash-ml 2.1.1
+from kailash_ml.features import FeatureStore, FeatureRegistry, FeatureGroup, feature  # OK
+from kailash_ml.errors import (8 feature-store symbols)                                # OK
+```
+
+## Outstanding — 2.1.0 yank (USER ACTION, web-UI only)
+
+PyPI exposes no token/API yank; the project owner MUST yank via the web session:
+
+- URL: https://pypi.org/manage/project/kailash-ml/release/2.1.0/
+- Action: **Options → Yank** · Reason: `Broken dependency floor — requires kailash>=2.30.0; use 2.1.1.`
+- Sequencing: 2.1.1 is already live + verified installable (replacement-first), so yanking 2.1.0 now leaves no install gap.
+
+## Sibling drift at release time
+
+Clean — only kailash-ml ahead of PyPI (the hotfix). Core 2.30.0 + all siblings match PyPI.

--- a/deploy/deployments/2026-06-15-v2.33.0-eatp12-vault-1312.md
+++ b/deploy/deployments/2026-06-15-v2.33.0-eatp12-vault-1312.md
@@ -1,0 +1,72 @@
+# Deployment — kailash 2.33.0 (EATP-12 v1.0 Trust Vault Key-Binding, #1312)
+
+**Date:** 2026-06-15
+**Package:** kailash (core SDK) — single-package minor release
+**Version:** 2.32.0 → 2.33.0
+
+## What shipped
+
+EATP-12 v1.0 Trust Vault Key-Binding — the new `kailash.trust.vault` sub-package
+(63-symbol public surface). Binds KEK backup/recovery to an audited,
+commitment-anchored trust substrate:
+
+- **Entry points:** `back_up_vault_key` / `restore_vault_key` (SLIP-39 shard
+  backup + reconstruction), `back_up_raw_vault_key`.
+- **KEK class + generation substrate:** `VaultKeyResolver`, `ResolvedKek`,
+  `VaultKeyHandle`, `current_generation_from_chain`.
+- **Commitment binding:** `kek_identity_commitment`, `key_check_value`,
+  `verify_commitment`, `verify_kcv`, `CommitmentRegistry`.
+- **Audited dispatch:** `AuditDispatcher`, `AuditTier`, `DispatchReceipt`,
+  `require_receipt_or_abort` (AU-02b fail-closed ordering interlock).
+- **Holder governance + Complete-level ceremony gates + generation rotation +
+  clearance/cooling-off + typed errors** (`VaultBindingError`, `N12FT01Code`).
+
+Master secret never crosses the audit boundary (N12-AU-01 contents-exclusion);
+only one-way commitments / KCV + the SLIP-39 bit-length parameter are anchored;
+resolved key material zeroized after use.
+
+## Release path
+
+- Feature converged across 6 implementation waves + holistic R3–R5 redteam
+  (security-reviewer; receipt `workspaces/eatp-12-vault-binding-py/journal/0012`).
+- Merged to main via **PR #1320** (`8663cd47`). CodeQL: 2 genuine findings fixed
+  in `fb05d77df` (unused import + cleanup-except comment); 10 dismissed as
+  false positives with inline evidence (3 HIGH `clear-text-logging` proven FP —
+  the tainted dict key `master_secret_bits` is the integer bit-length 128/256,
+  not the secret; full SARIF taint-chain analysis in PR #1320 description).
+- Issue **#1312** auto-closed on merge.
+- Release-prep **PR #1321** (`release/v2.33.0`, metadata-only → PR-gate matrix
+  auto-skipped; Build Documentation green) admin-merged.
+- Lightweight tag `v2.33.0` pushed → `publish-pypi.yml` run `27508621947`
+  **success** (OIDC trusted publisher, direct to PyPI).
+
+## Scope
+
+Core SDK only — 12 commits since `v2.32.0`, all under `src/kailash/` (EATP-12).
+Zero framework-package changes. No framework SDK-pin sweep: existing `kailash>=`
+floors admit a minor bump and no framework imports the new vault surface
+(same disposition as the v2.17.0 precedent).
+
+## TestPyPI
+
+Skipped per the minor-release exception with explicit operator authorization
+("ship it", cross-SDK parity confirmed). Tag-triggered OIDC flow goes direct
+to PyPI; TestPyPI requires a separate `workflow_dispatch`.
+
+## Verification (clean-venv — the done gate)
+
+```
+uv venv /tmp/verify-kailash-233 --python 3.12
+uv pip install --refresh "kailash==2.33.0"
+python -c "import kailash; ..."
+# →
+kailash.__version__ = 2.33.0
+vault __all__ symbols: 63
+entry points: back_up_vault_key / restore_vault_key
+```
+
+PyPI metadata: `pypi.org/pypi/kailash/2.33.0/json` → version 2.33.0.
+
+## Sibling drift
+
+None — no other framework package had `main` ahead of PyPI at release-time.

--- a/deploy/deployments/2026-06-15-v2.33.1-issue-1318-pep749-annotate-func.md
+++ b/deploy/deployments/2026-06-15-v2.33.1-issue-1318-pep749-annotate-func.md
@@ -1,0 +1,87 @@
+# Deployment Record — kailash 2.33.1 (#1318)
+
+**Date:** 2026-06-15
+**Package:** kailash (core SDK) — single-package patch release
+**Tag:** `v2.33.1` · publish-pypi run `27518918019` (SUCCESS)
+**main == PyPI == 2.33.1**
+
+## What shipped
+
+Patch fix for **#1318** — `kailash.utils.annotations.get_namespace_annotations()`
+returned `{}` on **Python 3.14 final**, so every class-based
+`kaizen.signatures.core.Signature` silently lost its declared fields and raised
+`ValueError: Either define fields as class attributes or provide inputs/outputs`
+at first instantiation. **HIGH severity on 3.14; no effect on ≤3.13.**
+
+Root cause: PEP 749 (Python 3.14 final) renamed the lazy class-namespace annotate
+callable from the 3.14-beta `__annotate__` to `__annotate_func__` (and added the
+eager cache `__annotations_cache__`). The helper read only `__annotations__` then
+`__annotate__`, so both lookups missed on 3.14 final → fell through to `{}`. The
+fix adds the two renamed keys; the forward-ref evaluation logic is unchanged.
+
+## Surface changed
+
+- `src/kailash/utils/annotations.py` — `get_namespace_annotations` now reads
+  `__annotations_cache__` (eager) and `__annotate_func__` (lazy) in addition to
+  the pre-final names; module + function docstrings updated.
+- `tests/regression/test_python_314_annotations.py` — 3 new regression tests
+  (lazy `__annotate_func__` form, eager `__annotations_cache__` form, real
+  metaclass-namespace test that exercises the native PEP 749 shape on the 3.14
+  CI leg). 15/15 pass (12 existing + 3 new).
+- `packages/kailash-kaizen/src/kaizen/signatures/core.py` — comment-accuracy
+  only (the consumer already routes through the helper). **kaizen version NOT
+  bumped** — comment-only change, zero functional/wheel-behavioral effect; rides
+  kaizen's next functional release. Fresh `pip install kailash-kaizen` resolves
+  the latest compatible `kailash` (now 2.33.1, `kailash>=2.28.0` pin admits it),
+  so 3.14 kaizen users get the fix automatically without a kaizen release.
+
+## PRs
+
+- **#1322** (`fix/issue-1318-pep749-annotate-func`, change commit `35a1f4777`,
+  merge `4e7b35451`) — the behavioral fix. Full PR-gate matrix green across
+  Python 3.11–3.14 (the **3.14 leg** exercises the real bug) + CodeQL.
+- **#1323** (`release/v2.33.1`, merge `63532704d`) — metadata-only release prep
+  (version anchors + CHANGELOG); PR-gate path-filter-skipped on `release/v*`;
+  `--admin` cleared REVIEW_REQUIRED.
+
+## Gates
+
+- CI: full Python 3.11–3.14 matrix + DataFlow/PACT/infrastructure + CodeQL green
+  on #1322.
+- security-reviewer: **APPROVE, zero blocking findings** — no new code-execution
+  surface (the eager-cache branch is data-only and checked before the lazy path;
+  fixed 2-call invocation ceiling unchanged; trust boundary identical to the
+  prior `__annotate__` path).
+- Version consistency: `pyproject.toml` 2.33.1 == `src/kailash/__init__.py`
+  `__version__` 2.33.1.
+- CHANGELOG: `[2.33.1]` Fixed entry.
+
+## Clean-venv verification (done gate)
+
+`pip install --no-cache-dir kailash==2.33.1` in a fresh Python 3.12 venv
+(documented uv deeper-index-cache-lag fallback per
+`build-repo-release-discipline.md` Rule 2 — `uv pip install --refresh` reported
+unsatisfiable while `pypi.org/pypi/kailash/2.33.1/json` returned metadata):
+
+```
+kailash.__version__ = 2.33.1
+__annotate_func__ path      = {'x': <class 'int'>, 'y': <class 'str'>}   # was {} before fix
+__annotations_cache__ path  = {'a': <class 'int'>}
+```
+
+## Sibling drift
+
+None — all 8 framework packages AT-PARITY with PyPI at release-time enumeration
+(dataflow 2.11.3, nexus 2.9.1, kaizen 2.27.0, mcp 0.2.14, ml 2.2.1, align 0.7.2,
+pact 0.12.0, kaizen-agents 0.9.10). Only core `kailash` had main ahead of PyPI.
+
+## Cross-SDK
+
+N/A — PEP 749 is a CPython-3.14 interpreter feature; the Rust SDK has no
+equivalent class-namespace annotation surface.
+
+## Notes
+
+- TestPyPI skipped per the patch-release human-approval exception (`/release`
+  arg explicitly authorized "patch — kailash 2.33.1").
+- Issue #1318 auto-closed COMPLETED via "Fixes #1318" on #1322 merge.

--- a/deploy/deployments/2026-06-15-v2.34.1-issue-1332-rfc3161-verify-fail-closed.md
+++ b/deploy/deployments/2026-06-15-v2.34.1-issue-1332-rfc3161-verify-fail-closed.md
@@ -1,0 +1,92 @@
+# Deployment Record — kailash 2.34.1 (#1332)
+
+**Date:** 2026-06-15
+**Package:** kailash (core SDK) — single-package security patch release
+**Tag:** `v2.34.1` · publish-pypi run `27549460259` (SUCCESS)
+**main == PyPI == 2.34.1**
+
+## What shipped
+
+Security patch for **#1332** — `RFC3161TimestampAuthority.verify_timestamp`
+returned `True` with **zero cryptographic verification** whenever `rfc3161ng`
+was importable. The docstring promised "full ASN.1 verification" but the body
+was a bare `return True`, so a forged or tampered RFC-3161 timestamp token whose
+`source`/`authority` metadata matched the configured TSA was accepted as valid
+(**security fail-open**, MEDIUM). Surfaced by an independent holistic redteam of
+the 2.34.0 trust-crypto surface.
+
+Root cause: the raw DER `TimeStampToken` needed to verify the TSA signature
+lived on `TimestampResponse.raw_response` but was **dropped** before reaching
+`verify_timestamp` — so the stub had no material to verify against and "papered
+over" the gap with `return True`.
+
+## Surface changed
+
+- `src/kailash/trust/signing/timestamping.py`:
+  - `verify_anchor` now **threads `response.raw_response`** into
+    `verify_timestamp` (the dropped material), AND cross-checks
+    `token.hash_value == request.hash_value` to reject imprint-substitution
+    (a legitimately-TSA-signed token over an attacker-chosen imprint swapped for
+    the intended one — security-reviewer MED-1, same bug class, fixed in-session
+    per `autonomous-execution.md` Rule 4).
+  - `RFC3161TimestampAuthority.__init__` gains an optional trusted TSA
+    `certificate` (the trust anchor).
+  - `verify_timestamp` performs real verification via
+    `rfc3161ng.check_timestamp` (TSA signature + message-imprint hash). Returns
+    `True` **only** on cryptographic success; **fails closed** (`False`) when
+    any material is missing (`rfc3161ng` absent / no raw DER token / no trusted
+    certificate) or the check fails — per EATP fail-closed discipline.
+  - The abstract `TimestampAuthority.verify_timestamp`, the
+    `LocalTimestampAuthority` override (ignores `raw_token`; self-contained
+    Ed25519 token), and the module helper `verify_timestamp_token` gain the
+    optional `raw_token` param (backward-compatible).
+- `pyproject.toml`: new optional `rfc3161 = ["rfc3161ng>=2.1.3"]` extra,
+  included in `[all]`. Without it the path fails closed.
+- `tests/regression/test_issue_1332_rfc3161_verify_fail_closed.py` — 13
+  behavioral regression tests (`@pytest.mark.regression`): fail-closed without
+  library/raw-token/certificate/valid-hex; tampered-imprint rejected; valid
+  token accepted; `verify_anchor` raw_response threading + imprint-substitution
+  rejection; helper `raw_token` forwarding; local-authority round-trip
+  unaffected. `rfc3161ng` (not installable in CI) is exercised via a
+  deterministic stub module (Protocol-satisfying optional-dep pattern, not a
+  Tier-2 mock).
+
+## Gates
+
+- reviewer: **APPROVE** (all mechanical sweeps pass; 1316 + 162 trust-signing
+  tests green; version anchors atomic at 2.34.1).
+- security-reviewer: **APPROVE-WITH-FIXES** → MED-1 (imprint substitution) fixed
+  in PR; fail-open fully eliminated; LOW items (hardcoded sha256 hashname)
+  documented. Two LOW + LOW-2 (direct helper test) — helper test added.
+- User-flow walk receipt: `verify_anchor(unverifiable token)` → `False`
+  (was `True`/fail-open pre-#1332). Re-verified from the published wheel.
+
+## Release flow
+
+PR #1333 (`fix/issue-1332-rfc3161-verify-fail-closed`, fix commit `4c5330b6a`,
+merge `307e9a082`) — version bump + CHANGELOG `[2.34.1]` carried IN the fix PR
+(no separate release-prep PR needed; full PR-gate matrix ran since src changed,
+29 SUCCESS / 0 genuine failure — the lone CANCELLED was a concurrency-superseded
+doc-build duplicate). Admin-merged → tag `v2.34.1` pushed individually →
+publish-pypi run `27549460259` SUCCESS. **TestPyPI skipped** per the patch
+human-approval exception (owner authorized "merge + release 2.34.1").
+
+Clean-venv install verified live: `uv pip install --refresh` hit the documented
+deeper-index-cache lag (`pypi.org/pypi/kailash/2.34.1/json` HTTP 200 while uv
+reported unsatisfiable); `python -m pip install --no-cache-dir` fallback per
+`build-repo-release-discipline.md` Rule 2 succeeded first try.
+`kailash.__version__ == "2.34.1"`; published-wheel source carries the real
+`rfc3161ng.check_timestamp` call with exactly one (gated) `return True`, the new
+`certificate` + `raw_token` params, and `verify_anchor(unverifiable token)`
+returns `False`.
+
+No sibling drift — all 8 other framework packages AT-PARITY with PyPI at
+release-time enumeration (kailash was the only package with main ahead of PyPI).
+
+## Cross-SDK follow-up (deferred, owner-owned)
+
+Issue #1332 acceptance criterion 4 (inspect kailash-rs for the same RFC-3161
+fail-open) is **deferred to a dedicated kailash-rs session** by owner decision —
+out of this Python BUILD repo's scope per `repo-scope-discipline.md`. The Rust
+TSA verifier was NOT inspected from this session; the same fail-open class may
+exist there. Noted on #1332 (comment) for the owner's Rust session.

--- a/deploy/deployments/2026-06-15-v2.34.2-issue-1332-rfc3161-digest-binding.md
+++ b/deploy/deployments/2026-06-15-v2.34.2-issue-1332-rfc3161-digest-binding.md
@@ -1,0 +1,88 @@
+# Deployment Record — kailash 2.34.2 (#1332 follow-up)
+
+**Date:** 2026-06-15
+**Package:** kailash (core SDK) — single-package patch release
+**Tag:** `v2.34.2` · publish-pypi run `27552305959` (SUCCESS)
+**main == PyPI == 2.34.2**
+
+## What shipped
+
+Correctness follow-up to the #1332 RFC-3161 fix (v2.34.1). The 2.34.1 fix passed
+the token's pre-computed SHA-256 message imprint to `rfc3161ng.check_timestamp`
+as **`data=`** — which the library **re-hashes** before comparison. With
+`rfc3161ng` actually installed, the double-hash rejected **every valid token**:
+the verification was fail-closed (safe) but **non-functional**. The offline stub
+used in 2.34.1's tests did not replicate the data-vs-digest hashing, so the suite
+stayed green over a broken binding.
+
+This is exactly the gap the #1333 reviewer flagged ("couldn't live-verify the
+`check_timestamp` kwarg binding offline"); installing the real library in CI
+surfaced it.
+
+## Surface changed
+
+- `src/kailash/trust/signing/timestamping.py` — `verify_timestamp` now passes
+  the imprint as **`digest=`** (compared directly), not `data=` (re-hashed). A
+  genuine TSA-signed token verifies `True`; tampered imprint / untrusted cert →
+  `False`. Fail-closed contract + the #1333 MED-1 imprint cross-check in
+  `verify_anchor` both intact.
+- `tests/regression/test_issue_1332_rfc3161_live_binding.py` (new) — runs
+  `verify_timestamp` against the **real `rfc3161ng`** using committed fixtures
+  minted offline with `openssl ts`: a `timeStamping`-EKU self-signed TSA cert +
+  a real signed RFC-3161 `TimeStampToken` over a known SHA-256 imprint. Cases:
+  valid→True, tampered-imprint→False, untrusted-cert→False, full
+  `verify_anchor`→True. `pytest.importorskip`s where `rfc3161ng` is absent.
+- `tests/fixtures/rfc3161/{tsa-cert.pem,valid-token.der,imprint.hex}` (new) —
+  public cert + token + imprint only (the TSA private key is NOT committed,
+  security-reviewer verified).
+- `tests/regression/test_issue_1332_rfc3161_verify_fail_closed.py` — stub
+  `check_timestamp` updated to assert the `digest=` binding (and that `data=` is
+  NOT passed), so the broken binding can't regress silently.
+- `.github/workflows/trust-tests.yml` — installs the `rfc3161` extra and runs
+  both #1332 regression files, so the real-library binding is verified on every
+  trust-touching PR.
+- `.claude/hooks/log-triage-gate.js` — adds an `EXCLUDED_FILES` basename
+  allowlist (`.journal-skipped.log`) per `observability.md` Rule 5a, resolving a
+  recurring Stop-hook false positive (an audit log recording a commit subject
+  containing the word "WARN"). **NOTE: loom-canonical synced artifact — the same
+  fix must also land at loom + `/sync-to-build`** to survive future syncs and
+  reach sibling repos (flagged in session notes).
+
+## Gates
+
+- reviewer: **APPROVE** (27 regression tests pass incl. live-binding running for
+  real against installed `rfc3161ng`; version atomic at 2.34.2; no private key
+  committed).
+- security-reviewer: **APPROVE-WITH-FIXES** — zero CRIT/HIGH/MED; load-bearing
+  check passed (no TSA private key committed). One LOW (untrusted-cert test uses
+  malformed PEM → rejection could be a parse error vs trust-distrust; still
+  asserts rejection) — documented non-blocking, different bug class from the
+  production fix.
+- **Trust Unit Tests CI job: SUCCESS** — the live `rfc3161ng` binding verified
+  green in CI (the whole point of this follow-up).
+
+## Release flow
+
+PR #1334 (`fix/issue-1332-rfc3161-digest-binding`, fix commit `1cbf5141b`, merge
+`46cbea7b7`) — version bump + CHANGELOG `[2.34.2]` carried in the fix PR; full
+PR-gate matrix 23 SUCCESS / 0 genuine failure (1 CANCELLED = concurrency-
+superseded doc-build duplicate). Admin-merged → tag `v2.34.2` pushed
+individually → publish-pypi run `27552305959` SUCCESS. **TestPyPI skipped** per
+the patch human-approval exception (owner authorized "merge + release").
+
+Clean-venv install verified live (`python -m pip install --no-cache-dir`
+fallback per `build-repo-release-discipline.md` Rule 2 after the documented
+simple-index propagation lag; `pypi.org/pypi/kailash/2.34.2/json` HTTP 200):
+`kailash.__version__ == "2.34.2"`; the published-wheel `check_timestamp` call
+uses kwargs `certificate=, digest=, hashname=` (no `data=`).
+
+No sibling drift — all 8 other framework packages were at PyPI parity at the
+2.34.1 release minutes earlier; only kailash advanced 2.34.1 → 2.34.2.
+
+## Cross-SDK follow-up (deferred, owner-owned)
+
+Issue #1332 acceptance criterion 4 (inspect kailash-rs for the same RFC-3161
+fail-open AND the data-vs-digest binding bug) remains **deferred to a dedicated
+kailash-rs session** by owner decision — out of this Python BUILD repo's scope.
+The Rust TSA verifier may share BOTH the original fail-open AND the digest-vs-data
+class. Noted on #1332.

--- a/workspaces/SWEEP-2026-05-17.md
+++ b/workspaces/SWEEP-2026-05-17.md
@@ -1,0 +1,115 @@
+# Sweep — 2026-05-17 (repo: terrene-foundation/kailash-py)
+
+Entry context: post-#1058 / dataflow-v2.9.16 ship. Branch=main, 0/0 vs origin/main, 448 pre-existing M files in working tree (Rule 1c — unprovable provenance, left untouched).
+
+## 100% completion answer
+
+**Repo-wide: NO.** Last session's workstream (#1058 → kailash-dataflow 2.9.16) shipped to PyPI — that branch is 100%. Project-level completion is open across:
+
+- **19 open GH issues** (5 filed in last 48h, 14 older).
+- **1 approved-but-unstarted multi-shard workstream** (issue-979 DataFlow Unit Triage, OPTION-C′ approved 2026-05-13, 7 shards, /implement not yet begun).
+- **Process-hygiene backlog**: 14 locked orphan worktrees, 45+ stale `.pending` journal entries (33 in issue-835 alone, 7-14d old), and one workspace (issue-1002) the session-notes mark as retire-ready.
+
+The headline number is workstream-by-workstream — there is no aggregate "X% complete" because the backlog has no fixed scope, but the structural picture is: zero in-flight PRs, zero unmerged work-this-session, one ready-to-implement multi-shard workstream, plus discrete bug-class issues and hygiene work.
+
+---
+
+## Sweep 1 — Active todos across workspaces
+
+13 active todo files across 4 workspaces.
+
+| Workspace                              | Active todos | Disposition class                                                                                                   |
+| -------------------------------------- | -----------: | ------------------------------------------------------------------------------------------------------------------- |
+| `issue-979-dataflow-unit-triage`       |            7 | (a) **still-wanted** — user "approved" OPTION-C′ 2026-05-13; brief AC anchors per shard. S1→[S2a,S-EV,S3,S4,S5a]→S6 |
+| `issue-979-b15-tier2-mock-rewrite`     |            4 | (a) **still-wanted re-validate** — session-notes say #992 closed today (PR #1020+#1021); todos may be stale         |
+| `issue-1050-protection-orphan-async`   |            1 | (a→complete) **still-wanted** — workstream shipped in 2.9.16; verify todo is closure marker, not new work           |
+| `issue-1002-aiosqlite-fixture-cleanup` |            1 | (b) **abandon-with-user-gate** — workspace's own .session-notes (2026-05-15) says "workspace can be retired"        |
+
+**Finding [Sweep 1]:** issue-979-b15 + issue-1050 + issue-1002 likely have completed-but-not-archived todos; only issue-979-dataflow-unit-triage carries true unstarted work.
+
+## Sweep 2 — Pending journal entries
+
+| Workspace                                  | Pending | Age   |
+| ------------------------------------------ | ------: | ----- |
+| `issue-835-dataflow-transaction-eventloop` |      33 | 7-14d |
+| `issue-912-task-time-limits`               |       9 | 14d   |
+| `issue-871-sqlite-jobstore-toctou`         |       2 | 14d   |
+| `issue-979-dataflow-unit-triage`           |       1 | 4d    |
+| `issue-979-b15-tier2-mock-rewrite`         |       1 | 1d    |
+| `issue-1002-aiosqlite-fixture-cleanup`     |       1 | 2d    |
+
+**Finding [MED] [Sweep 2]:** issue-835 has 33 unpromoted DECISION/RISK/DISCOVERY entries from 7-14d ago — no `.session-notes` activity since 2026-05-10. Per `rules/journal.md`: promote, codify, or discard.
+
+## Sweep 3 — Open GH issues (terrene-foundation/kailash-py)
+
+19 open. Sorted by recency:
+
+| #    | Age | Type           | Title                                                                                    |
+| ---- | --- | -------------- | ---------------------------------------------------------------------------------------- |
+| 1056 | 7h  | cross-sdk auth | fix(nexus-auth): query-string API-key percent-decode rejects invalid-UTF-8 + NUL         |
+| 1054 | 8h  | new-primitive  | feat: add kailash.EventBus domain-event primitive                                        |
+| 1051 | 16h | bug, cross-sdk | fix(dataflow): aiosqlite :memory: Connection leaked on close (MED)                       |
+| 1047 | 1d  | dataflow       | feat(dataflow-tests): tier-1 sanitizer-contract tests — C-1 of #979 triage               |
+| 1035 | 1d  | feat           | feat(delegate): open Delegate composition reference                                      |
+| 1012 | 2d  | feat           | feat(handlers): @app.handler string-based API to avoid per-handler User class            |
+| 972  | 5d  | ci             | ci(pre-commit): python-no-eval exclude list maintenance — 18 baseline false positives    |
+| 970  | 5d  | docs/deps      | docs/deps: filelock missing on bare `pip install kailash`                                |
+| 938  | 7d  | feat (sched)   | feat(scheduler): django-celery-beat PeriodicTask migration helper                        |
+| 937  | 7d  | feat (nexus)   | feat(nexus): expose SchedulerAdminAPI via Nexus admin panel                              |
+| 891  | 9d  | bug            | fix: HybridSearchNode name collision (dataflow vs kaizen)                                |
+| 878  | 10d | type           | pyright: cross-runtime type-correctness sweep                                            |
+| 855  | 11d | type           | kaizen-agents: pyright drift                                                             |
+| 772  | 16d | refactor       | dataflow: consolidate \_resolve_type / \_normalize_type_annotation                       |
+| 760  | 16d | cross-sdk      | follow-up: verify kailash-rs#723 fingerprint pin + #759 DPI-A repro                      |
+| 643  | 17d | cross-sdk ml   | ml: FeatureStore canonical surface migration                                             |
+| 596  | 17d | new-primitive  | TieredAuditDispatcher hash-chained tier-based audit                                      |
+| 693  | 19d | spec           | spec: promote dataflow-ml-integration.md from 1.0.0 (draft) to versioned (BLOCKED on M2) |
+| 630  | 21d | follow-up      | Trust Vault binding for SLIP-0039 Shamir wrapper                                         |
+
+**0 `deferred`-labeled issues** — no Rule 1b deferral surface to audit.
+
+## Sweep 4 — PRs and stale branches
+
+- **0 open PRs.** Clean state.
+- **5 remote unmerged branches** (debug + fix/ + style/ — pre-existing, not this session).
+- **>30 local unmerged branches** (audit/w5-_, feat/w6-_, debug/_, feature/_). Most likely orphans from prior worktree sessions.
+
+**Finding [LOW] [Sweep 4]:** Local branch backlog is large but not actionable inline — needs separate cleanup pass.
+
+## Sweep 5 — Spec compliance
+
+**Pre-condition gate:**
+
+- `workspaces/*/specs/` → absent (specs live at repo-root `specs/`, 50+ files).
+- `tools/sweep-redteam.py` → absent (no `tools/` directory at all).
+
+`<!-- sweep-redteam:v1:N/A reason=orchestration-mode no_specs=true no_tool=true -->`
+
+Per skill protocol, this repo is in **orchestration mode** for the workspace-scoped redteam tool — but kailash-py IS a BUILD repo and DOES have root-level specs. Recommendation captured below as cross-cutting finding: the BUILD-local `commands/sweep.md` and a `tools/sweep-redteam.py` analog would close the Sweep 5 gap, but per `rules/value-prioritization.md` this is a code-health (secondary) finding — surface, don't fix.
+
+## Sweep 6 — Workspace + worktree hygiene
+
+- **14 locked worktrees** under `.claude/worktrees/` from prior agent runs (fix/issue-900, fix/issue-898, fix/issue-1045, fix/issue-942, fix/issue-953, feat/issue-913, feat/issue-1050-shard3, feat/issue-999, fix/issue-929, fix/issue-1045-protection-middleware, feat/issue-898-shard2, plus 3 anonymous `worktree-agent-*` and `agent-a16e85de3ba19b9ba`).
+- **Stale `.session-notes` >30d:** none.
+- **Stale `.pending` >14d:** none (all journal pending entries are 1-14d).
+
+**Finding [MED] [Sweep 6]:** 14 locked worktrees are disk + lock-table debt. Each is a prior agent's parked branch; many likely have orphan commits worth recovering (per `rules/agents.md` § Recover Orphan Writes). Disposition: per-worktree triage (recover/merge/abandon).
+
+## Sweep 7 — Process hygiene
+
+- **`git status --short`:** 448 modified files. Pre-existing per `.session-notes` (last session note: "Working tree carries 400+ pre-existing modified files from earlier sessions … Unprovable provenance per zero-tolerance.md Rule 1c — leave untouched"). DEFER per Rule 1c — cannot prove provenance after context boundary.
+- **Divergence:** 0/0 vs origin/main. Clean.
+- **Stub markers in production:** 253 raw hits; after filtering abstract-method `NotImplementedError` + docstring ADR-XXX placeholders, **2 genuine stubs** remain:
+  - `src/kailash/utils/migrations/generator.py:122` — `raise NotImplementedError("Forward migration not implemented")`
+  - `src/kailash/utils/migrations/generator.py:127` — `raise NotImplementedError("Backward migration not implemented")`
+
+**Finding [LOW] [Sweep 7]:** Migration generator forward/backward stubs are pre-existing scaffolding (not introduced this session). Rule 1c → cannot fix without value-anchor for the wider migration-generator scope.
+
+---
+
+## Cross-cutting observations
+
+1. **Zero in-flight PRs.** Repo is a clean inflection point — good moment to start a new workstream OR a hygiene pass.
+2. **Issue-979 multi-shard triage is the only approved-but-unstarted user-anchored workstream.** Brief + journal DECISION + user "approved" anchor are all present.
+3. **Recent issues (last 48h) cluster on bug + cross-SDK + feature** — 5 issues filed by the user (#1051, #1054, #1056, #1047, #1035). Per `value-prioritization.md` MUST-1, these are (d) literal user-authored sources for their respective scopes.
+4. **Process hygiene queue is real but not user-anchored.** Worktrees, stale journals, retire-ready workspaces — code-health (secondary anchor per MUST-5).

--- a/workspaces/nexus-fastapi-parity-py/specs/nexus-fastapi-parity.md
+++ b/workspaces/nexus-fastapi-parity-py/specs/nexus-fastapi-parity.md
@@ -377,3 +377,5 @@ Per `rules/agents.md` § Quality Gates — `/implement` is a MUST gate; reviewer
 ## Open scope decisions (Q1-Q5 — user gates before /todos)
 
 The five open questions live in `02-plans/01-architecture.md` § "Open questions for the user". **ALL RESOLVED at the 2026-05-30 user gate** matching the spec's assumed recommended dispositions (Q2 two-layer staging, Q4 Option-A overload, Q5 cite-rs-prior-art) — no scope widening, so the surface contract above stands unchanged. The workspace is `/todos`-ready.
+
+**Filed as GitHub trackers (2026-05-31):** item 1 → #1216 (pre-upgrade `process_request`), item 2 → #1217 (subprotocol echo). A third typed-status follow-up surfaced at S4 convergence — `NexusHandlerError` collapsed to 500 on `/workflows/{name}/execute` — filed as #1218.


### PR DESCRIPTION
## Summary
The `/sweep` on 2026-06-16 found the repo operationally clean (no in-flight todos, no open PRs, no orphan worktrees, no unreleased shippable code, v2.34.2 fully released) — but surfaced a multi-session backlog of **uncommitted institutional records** that follow established tracked conventions.

This PR commits the **unambiguous** part of that backlog via explicit paths (`git add -A`/`-u` BLOCKED per `rules/git.md`):
- **9 deploy records** (`deploy/deployments/` v2.22.1 → v2.34.2) — the dir already has 42 tracked files; these complete the deployment history.
- **9 sweep reports** (root `SWEEP-*.md` incl. today's + 1 misplaced under `workspaces/`) — pattern has 8 tracked; restores the audit trail.
- **nexus-fastapi-parity spec** modification documenting the #1216/#1217/#1218 tracker filing.

Deliberately **excluded** for separate human adjudication (per the sweep report): `packages/*/.claude/` dirs (possible sync residue), new workspace dirs, `.session-notes`, and the `from-brief-1125` todo deletion.

## Sweep findings (full report: `SWEEP-2026-06-16.md`)
- Sweeps 1,2,4,6,8: CLEAN.
- Sweep 3: 5 fresh cross-SDK parity issues (#1335–#1339), none stale/deferred.
- Sweep 5: `sweep-redteam:v1:OK specs=2 orphans=17 coverage_gaps=0 stubs=0` — ~13 orphans are tool false-positives (illustrative/stdlib refs in spec prose); ~4 real gaps already tracked (#1216/#1217/#1218/#1336).
- Sweep 7: this backlog.

## Related issues
None (chore/records hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)