### PR TITLE
chore(gitignore): ignore per-package .claude/operator-id runtime stamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,8 +123,12 @@ todos/
 **/.claude/learning/
 
 # Operator-local identity cache (multi-operator coordination substrate;
-# per-machine, mode 0600 — never committed)
+# per-machine, mode 0600 — never committed). The **/ variant covers
+# per-package stamps (packages/*/.claude/operator-id + nested node .claude
+# dirs) which initialise their own runtime identity — same class as
+# .claude/learning/ and packages/*/.claude/.proposals/ below.
 .claude/operator-id
+**/.claude/operator-id
 
 # Per-package proposal manifests are local-only; the canonical
 # proposal lives at root .claude/.proposals/latest.yaml.


### PR DESCRIPTION
## Summary
The `/sweep` on 2026-06-16 surfaced 5 untracked `packages/*/.claude/operator-id` files. `operator-id` is per-machine runtime identity (mode 0600, the multi-operator coordination substrate's local identity stamp). Its sibling runtime state is already gitignored (`.claude/learning/` via `**/.claude/learning/`; `packages/*/.claude/.proposals/`), but the `operator-id` ignore rule was **root-anchored** (`.claude/operator-id`) and missed per-package + nested-node stamps.

Adds the `**/.claude/operator-id` variant. Verified: all 5 stamps now resolve to IGNORED; `packages/*/.claude/` shows no untracked files. **No content committed** — purely closes the gitignore gap.

## Policy note (multi-operator)
Multi-operator coordination is **provisioned but dormant** in this repo (no populated roster, zero `coordination-log.jsonl` entries, single operator). `operator-id` is local runtime state that should never be committed — same class as `.claude/learning/`.

## Related issues
None (gitignore hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)