### PR TITLE
feat(channels): session remaining-TTL accessor + sliding-TTL on access (#1336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.36.0] - 2026-06-17
+
+### Added
+
+- **Session sliding-TTL + remaining-TTL accessor (#1336, gateway parity #1349)**:
+  `kailash.channels.CrossChannelSession` gains a `remaining_ttl(timeout=3600)`
+  accessor returning the seconds left before expiry, mirroring the two-mode logic
+  of `is_expired` exactly (absolute-deadline branch when `expires_at` is set, idle
+  branch otherwise) so the two always agree. Sessions may now opt into **sliding
+  expiration** via `SessionManager.create_session(sliding_ttl=<seconds>)`: the
+  deadline re-slides forward to `now + ttl` on every activity (`touch()`, any
+  mutator, or `get_session` access). Sliding is strictly opt-in via a new `ttl`
+  field — fixed-deadline sessions created with `timeout=` keep their existing
+  non-sliding behavior unchanged, and `timeout` / `sliding_ttl` are mutually
+  exclusive (passing both raises `ValueError`).
+
 ## [2.35.0] - 2026-06-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash"
-version = "2.35.0"
+version = "2.36.0"
 description = "Python SDK for the Kailash container-node architecture"
 authors = [
     {name = "Terrene Foundation", email = "info@terrene.foundation"}

--- a/src/kailash/__init__.py
+++ b/src/kailash/__init__.py
@@ -95,7 +95,7 @@ def __getattr__(name):
     raise AttributeError(f"module 'kailash' has no attribute {name!r}")
 
 
-__version__ = "2.35.0"
+__version__ = "2.36.0"
 
 __all__ = [
     # Core workflow components

--- a/src/kailash/channels/session.py
+++ b/src/kailash/channels/session.py
@@ -29,6 +29,13 @@ class CrossChannelSession:
     created_at: float = field(default_factory=time.time)
     last_activity: float = field(default_factory=time.time)
     expires_at: Optional[float] = None
+    # Sliding-expiration window (seconds). When set, `expires_at` is re-slid to
+    # `now + ttl` on every activity (touch / mutation / access via
+    # SessionManager.get_session). When None, expiry is either a fixed absolute
+    # deadline (if `expires_at` was set directly / via timeout=) or idle-based
+    # (the `is_expired` last_activity branch). Sliding is strictly opt-in so
+    # fixed-deadline callers keep their existing semantics.
+    ttl: Optional[int] = None
     status: SessionStatus = SessionStatus.ACTIVE
 
     # Channel tracking
@@ -44,8 +51,16 @@ class CrossChannelSession:
     max_history_size: int = 1000
 
     def touch(self) -> None:
-        """Update last activity timestamp."""
+        """Update last activity timestamp.
+
+        When a sliding-expiration window (``ttl``) is configured, the absolute
+        ``expires_at`` deadline is re-slid forward to ``now + ttl`` so that
+        ongoing activity keeps the session alive. Sessions without ``ttl`` are
+        unaffected (fixed-deadline and idle-based behavior unchanged).
+        """
         self.last_activity = time.time()
+        if self.ttl is not None:
+            self.expires_at = self.last_activity + self.ttl
         if self.status == SessionStatus.IDLE:
             self.status = SessionStatus.ACTIVE
 
@@ -170,6 +185,30 @@ class CrossChannelSession:
             self.expires_at = time.time() + additional_seconds
         self.touch()
 
+    def remaining_ttl(self, timeout: int = 3600) -> float:
+        """Return the seconds remaining before this session expires.
+
+        Mirrors the two-mode logic of :meth:`is_expired` exactly so the two
+        always agree (``remaining_ttl(...) == 0.0`` iff ``is_expired(...)``):
+
+        - If an absolute ``expires_at`` deadline is set (fixed deadline, or a
+          sliding window re-slid by :meth:`touch`), returns
+          ``max(0.0, expires_at - now)``.
+        - Otherwise returns the idle-based remainder
+          ``max(0.0, timeout - (now - last_activity))``.
+
+        Args:
+            timeout: Idle timeout in seconds, used only when no ``expires_at``
+                deadline is set (matches the :meth:`is_expired` default).
+
+        Returns:
+            Seconds remaining, floored at 0.0 (never negative).
+        """
+        now = time.time()
+        if self.expires_at:
+            return max(0.0, self.expires_at - now)
+        return max(0.0, timeout - (now - self.last_activity))
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert session to dictionary for serialization."""
         return {
@@ -178,6 +217,7 @@ class CrossChannelSession:
             "created_at": self.created_at,
             "last_activity": self.last_activity,
             "expires_at": self.expires_at,
+            "ttl": self.ttl,
             "status": self.status.value,
             "active_channels": list(self.active_channels),
             "channel_contexts": self.channel_contexts,
@@ -230,17 +270,34 @@ class SessionManager:
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
         timeout: Optional[int] = None,
+        sliding_ttl: Optional[int] = None,
     ) -> CrossChannelSession:
         """Create a new session.
 
         Args:
             user_id: Optional user ID for the session
             session_id: Optional custom session ID
-            timeout: Optional custom timeout
+            timeout: Optional fixed absolute deadline in seconds. The session
+                expires ``timeout`` seconds after creation regardless of
+                activity (existing behavior — unchanged).
+            sliding_ttl: Optional sliding-expiration window in seconds. The
+                deadline starts at ``now + sliding_ttl`` and is re-slid forward
+                on every activity (touch / mutation / ``get_session`` access).
+                Mutually exclusive with ``timeout``.
 
         Returns:
             New CrossChannelSession instance
+
+        Raises:
+            ValueError: if both ``timeout`` and ``sliding_ttl`` are provided,
+                or if ``session_id`` already exists.
         """
+        if timeout is not None and sliding_ttl is not None:
+            raise ValueError(
+                "create_session: pass either timeout (fixed deadline) or "
+                "sliding_ttl (sliding window), not both"
+            )
+
         if session_id is None:
             session_id = str(uuid.uuid4())
 
@@ -251,6 +308,9 @@ class SessionManager:
 
         if timeout:
             session.expires_at = time.time() + timeout
+        elif sliding_ttl:
+            session.ttl = sliding_ttl
+            session.expires_at = time.time() + sliding_ttl
 
         self._sessions[session_id] = session
         logger.info(f"Created session {session_id} for user {user_id}")
@@ -271,6 +331,12 @@ class SessionManager:
         if session and session.is_expired(self.default_timeout):
             self.terminate_session(session_id)
             return None
+
+        # Sliding-expiration: accessing a session with a configured window
+        # re-slides its deadline forward. Fixed-deadline / idle-based sessions
+        # (ttl is None) are returned unchanged — no silent extension.
+        if session and session.ttl is not None:
+            session.touch()
 
         return session
 

--- a/tests/unit/channels/test_session_ttl.py
+++ b/tests/unit/channels/test_session_ttl.py
@@ -1,0 +1,186 @@
+"""Tier-1 unit tests for CrossChannelSession TTL semantics (#1336 / parity #1349).
+
+Covers the three capabilities the gateway-parity assessment flagged:
+  - remaining_ttl() accessor (both expires_at and idle modes)
+  - sliding-TTL on access (touch / get_session re-slide when ttl configured)
+  - backward-compat (no-window sessions unchanged; fixed-deadline not slid)
+
+Pure logic; uses a controlled clock via monkeypatching time.time so the
+sliding behavior is asserted deterministically without real sleeps.
+"""
+
+import pytest
+
+from kailash.channels.session import CrossChannelSession, SessionManager, SessionStatus
+
+
+class _Clock:
+    """Deterministic monotonic clock the tests advance explicitly."""
+
+    def __init__(self, start: float = 1_000_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    c = _Clock()
+    # Patch the time.time symbol the session module resolves at call time.
+    monkeypatch.setattr("kailash.channels.session.time.time", c)
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# remaining_ttl() — expires_at (fixed deadline) mode
+# --------------------------------------------------------------------------- #
+
+
+def test_remaining_ttl_expires_at_mode(clock):
+    s = CrossChannelSession(session_id="s1")
+    s.expires_at = clock.now + 600  # 10-minute fixed deadline
+    assert s.remaining_ttl() == pytest.approx(600.0)
+
+    clock.advance(250)
+    assert s.remaining_ttl() == pytest.approx(350.0)
+
+
+def test_remaining_ttl_floors_at_zero_when_past_deadline(clock):
+    s = CrossChannelSession(session_id="s1")
+    s.expires_at = clock.now + 100
+    clock.advance(500)  # well past the deadline
+    assert s.remaining_ttl() == 0.0
+    # Agreement contract: remaining_ttl == 0 iff is_expired is True.
+    assert s.is_expired() is True
+
+
+# --------------------------------------------------------------------------- #
+# remaining_ttl() — idle mode (no expires_at)
+# --------------------------------------------------------------------------- #
+
+
+def test_remaining_ttl_idle_mode(clock):
+    s = CrossChannelSession(session_id="s1")  # no expires_at
+    # Baseline last_activity onto the controlled clock (the dataclass
+    # default_factory captures the real builtin at construction).
+    s.last_activity = clock.now
+    assert s.remaining_ttl(timeout=3600) == pytest.approx(3600.0)
+
+    clock.advance(1000)
+    assert s.remaining_ttl(timeout=3600) == pytest.approx(2600.0)
+
+
+def test_remaining_ttl_idle_agrees_with_is_expired(clock):
+    s = CrossChannelSession(session_id="s1")
+    s.last_activity = clock.now
+    clock.advance(4000)  # past the 3600 idle timeout
+    assert s.remaining_ttl(timeout=3600) == 0.0
+    assert s.is_expired(timeout=3600) is True
+
+
+# --------------------------------------------------------------------------- #
+# Sliding-TTL on access — touch() re-slides when ttl configured
+# --------------------------------------------------------------------------- #
+
+
+def test_touch_reslides_expires_at_when_ttl_set(clock):
+    s = CrossChannelSession(session_id="s1", ttl=300)
+    s.expires_at = clock.now + 300
+    assert s.remaining_ttl() == pytest.approx(300.0)
+
+    clock.advance(200)  # 100s left without sliding
+    assert s.remaining_ttl() == pytest.approx(100.0)
+
+    s.touch()  # access re-slides the deadline to now + ttl
+    assert s.remaining_ttl() == pytest.approx(300.0)
+    assert s.expires_at == pytest.approx(clock.now + 300)
+
+
+def test_mutation_reslides_via_touch(clock):
+    s = CrossChannelSession(session_id="s1", ttl=300)
+    s.expires_at = clock.now + 300
+    clock.advance(250)
+    s.set_shared_data("k", "v")  # mutator calls touch()
+    assert s.remaining_ttl() == pytest.approx(300.0)
+
+
+def test_get_session_reslides_ttl_session(clock):
+    mgr = SessionManager(default_timeout=3600)
+    s = mgr.create_session(session_id="s1", sliding_ttl=300)
+    assert s.ttl == 300
+    assert s.remaining_ttl() == pytest.approx(300.0)
+
+    clock.advance(250)  # 50s left
+    fetched = mgr.get_session("s1")
+    assert fetched is not None
+    # Access re-slid the window back to the full 300s.
+    assert fetched.remaining_ttl() == pytest.approx(300.0)
+
+
+def test_sliding_session_expires_without_access(clock):
+    mgr = SessionManager(default_timeout=3600)
+    mgr.create_session(session_id="s1", sliding_ttl=300)
+    clock.advance(400)  # no access within the window
+    assert mgr.get_session("s1") is None  # expired + evicted
+
+
+# --------------------------------------------------------------------------- #
+# Backward-compat — fixed-deadline + idle sessions are NOT silently slid
+# --------------------------------------------------------------------------- #
+
+
+def test_fixed_deadline_does_not_slide_on_touch(clock):
+    # create_session(timeout=...) is the existing fixed-deadline API: ttl stays None.
+    mgr = SessionManager()
+    s = mgr.create_session(session_id="s1", timeout=300)
+    assert s.ttl is None
+    deadline = s.expires_at
+
+    clock.advance(200)
+    s.touch()  # touch MUST NOT move a fixed deadline
+    assert s.expires_at == deadline
+    assert s.remaining_ttl() == pytest.approx(100.0)
+
+
+def test_get_session_does_not_slide_fixed_deadline(clock):
+    mgr = SessionManager()
+    mgr.create_session(session_id="s1", timeout=300)
+    clock.advance(200)
+    s = mgr.get_session("s1")
+    assert s is not None
+    assert s.remaining_ttl() == pytest.approx(100.0)  # not re-slid to 300
+
+
+def test_idle_session_unaffected_by_ttl_logic(clock):
+    s = CrossChannelSession(session_id="s1")  # no expires_at, no ttl
+    clock.advance(100)
+    s.touch()  # updates last_activity only; no expires_at materialized
+    assert s.expires_at is None
+    assert s.ttl is None
+    assert s.remaining_ttl(timeout=3600) == pytest.approx(3600.0)
+
+
+def test_create_session_rejects_both_timeout_and_sliding_ttl():
+    mgr = SessionManager()
+    with pytest.raises(ValueError, match="not both"):
+        mgr.create_session(session_id="s1", timeout=300, sliding_ttl=300)
+
+
+def test_to_dict_includes_ttl(clock):
+    mgr = SessionManager()
+    s = mgr.create_session(session_id="s1", sliding_ttl=120)
+    d = s.to_dict()
+    assert d["ttl"] == 120
+    assert d["expires_at"] == pytest.approx(clock.now + 120)
+
+
+def test_status_active_after_touch_reslide(clock):
+    s = CrossChannelSession(session_id="s1", ttl=300)
+    s.expires_at = clock.now + 300
+    s.status = SessionStatus.IDLE
+    s.touch()
+    assert s.status == SessionStatus.ACTIVE


### PR DESCRIPTION
## Summary

Part of the **#1336 gateway HTTP-middleware parity** assessment (parity #1349 — session store). The verification pass found `kailash.channels.CrossChannelSession` already supports data mutation, but had two real gaps:

- **No remaining-TTL read** — only a bool `is_expired()` and the raw `expires_at` attribute.
- **No sliding-on-access** for the `expires_at` (fixed-deadline) mode — only the no-`expires_at` idle path slid via `touch()`.

This PR closes both, opt-in and backward-compatible.

## Changes

- **`CrossChannelSession.remaining_ttl(timeout=3600)`** — returns seconds remaining, mirroring `is_expired`'s two-mode logic exactly (absolute-deadline branch when `expires_at` is set, idle branch otherwise) so `remaining_ttl() == 0.0` iff `is_expired()`.
- **Sliding TTL** — new opt-in `ttl` field on the dataclass. `SessionManager.create_session(sliding_ttl=<seconds>)` enables it; the deadline re-slides to `now + ttl` on every activity (`touch()`, any mutator, `get_session` access).
- **Backward-compat** — `create_session(timeout=)` (fixed deadline) keeps `ttl=None` and is never slid. `timeout` and `sliding_ttl` are mutually exclusive (`ValueError` if both).
- `to_dict()` includes the new `ttl` field.

## Tests

14 Tier-1 unit tests (`tests/unit/channels/test_session_ttl.py`) — `remaining_ttl` in both modes + `is_expired` agreement; sliding-on-access via `touch`/mutator/`get_session`; backward-compat (fixed-deadline + idle sessions NOT slid); mutual-exclusion guard; `to_dict`. All pass. Uses a controlled clock (no real sleeps).

## User-flow walk

```
$ .venv/bin/python -m pytest tests/unit/channels/test_session_ttl.py -q
..............
14 passed in 0.46s
```
Disposition: every TTL path exercised through the public `SessionManager` / `CrossChannelSession` surface; sliding and backward-compat both confirmed.

## Related issues

Related to #1336 (parity #1349). The issue stays open until all #1336 parity PRs land + the AC is marked per-item.