### PR TITLE
feat(nexus): preset auto-wiring — rate-limit + CSP passthrough (#1336)

### DIFF
--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Nexus Changelog
 
+## [2.10.0] — 2026-06-17 — Preset auto-wiring: rate-limit + CSP passthrough (#1336)
+
+### Added
+
+- **Rate-limit preset auto-wiring (#1336, parity #1345).** The `standard`, `saas`, and `enterprise` presets now auto-attach the built `RateLimitMiddleware` (token-bucket + 429 body + `X-RateLimit-*` / `Retry-After` headers) using a `RateLimitConfig` derived from `NexusConfig.rate_limit` (per-minute limit) and `NexusConfig.rate_limit_config` (a dict of further `RateLimitConfig` fields — `burst_size`, `backend`, `route_limits`, …). Previously the preset factory was a placeholder that logged "not yet implemented (coming in WS02)" and attached nothing; the rate limiter had to be wired manually via `add_middleware`. Setting `rate_limit=None` still omits the middleware.
+- **Consumer CSP + security-header passthrough (#1336, parity #1348).** `NexusConfig` gains `csp: Optional[str]` (a custom Content-Security-Policy string) and `security_header_overrides: Optional[Dict[str, Any]]` (per-field overrides — `frame_options`, `hsts_*`, `referrer_policy`, …), both threaded into the `SecurityHeadersConfig` the security-headers preset constructs. Previously the preset hardcoded the config and ignored consumer settings; a custom CSP required an explicit `add_middleware(SecurityHeadersMiddleware, config=...)` call. Defaults are unchanged when neither field is set.
+
+### Removed
+
+- **Dead `_error_handler_middleware_factory` preset placeholder (#1336).** Removed the WS02 placeholder factory (it always returned `None`). The exception → canonical-error-envelope contract ships via the HTTP transport's `NexusError` handler (`transports/http.py::_install_exception_handlers`, installed at transport startup), not a preset middleware — so the placeholder was dead. No behavior change (it attached nothing).
+
 ## [2.9.1] — 2026-06-12 — `Nexus.close()` cascade-closes internal AsyncLocalRuntimes (#1285)
 
 ### Fixed

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.9.1"
+version = "2.10.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -116,7 +116,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.9.1"
+__version__ = "2.10.0"
 __all__ = [
     # Core
     "Nexus",

--- a/packages/kailash-nexus/src/nexus/presets.py
+++ b/packages/kailash-nexus/src/nexus/presets.py
@@ -62,6 +62,14 @@ class NexusConfig:
     rate_limit: Optional[int] = 100
     rate_limit_config: Optional[Dict[str, Any]] = None
 
+    # Security Headers (threaded into the security-headers preset middleware)
+    # csp: custom Content-Security-Policy string; None keeps SecurityHeadersConfig's
+    # secure default. security_header_overrides: per-field overrides
+    # (hsts_max_age, frame_options, referrer_policy, etc.) merged into the
+    # SecurityHeadersConfig the preset constructs.
+    csp: Optional[str] = None
+    security_header_overrides: Optional[Dict[str, Any]] = None
+
     # Audit
     audit_enabled: bool = True
     audit_log_bodies: bool = False
@@ -138,15 +146,27 @@ def _cors_middleware_factory(config: NexusConfig) -> tuple:
 
 
 def _security_headers_middleware_factory(config: NexusConfig) -> Optional[tuple]:
-    """Create security headers middleware configuration."""
+    """Create security headers middleware configuration.
+
+    Threads a consumer-supplied CSP string (``config.csp``) and any per-field
+    security-header overrides (``config.security_header_overrides``) into the
+    ``SecurityHeadersConfig`` the preset constructs. When neither is set, the
+    SecurityHeadersConfig secure defaults apply unchanged.
+    """
     from nexus.middleware.security_headers import (
         SecurityHeadersConfig,
         SecurityHeadersMiddleware,
     )
 
-    sec_config = SecurityHeadersConfig(
-        exclude_paths=("/healthz", "/readyz", "/startup"),
-    )
+    sec_kwargs: Dict[str, Any] = {
+        "exclude_paths": ("/healthz", "/readyz", "/startup"),
+    }
+    if config.csp is not None:
+        sec_kwargs["csp"] = config.csp
+    if config.security_header_overrides:
+        sec_kwargs.update(config.security_header_overrides)
+
+    sec_config = SecurityHeadersConfig(**sec_kwargs)
     return (SecurityHeadersMiddleware, {"config": sec_config})
 
 
@@ -174,26 +194,34 @@ def _csrf_middleware_factory(config: NexusConfig) -> Optional[tuple]:
     )
 
 
-# NOTE: Placeholder factories for WS02 auth package.
-# These will be replaced with real implementations when auth package is complete.
-
-
 def _rate_limit_middleware_factory(config: NexusConfig) -> Optional[tuple]:
-    """Placeholder: Create rate limiting middleware configuration."""
+    """Create the token-bucket rate-limit middleware from NexusConfig.
+
+    Auto-attaches the built ``RateLimitMiddleware`` (token-bucket + 429 body +
+    ``X-RateLimit-*`` / ``Retry-After`` headers) using ``config.rate_limit`` as
+    the per-minute limit. ``config.rate_limit_config`` (a dict) supplies any
+    further ``RateLimitConfig`` fields (burst_size, backend, route_limits, …).
+    Returns None when rate limiting is disabled (``config.rate_limit is None``).
+    """
     if config.rate_limit is None:
         return None
 
-    logger.warning(
-        "Rate limiting middleware not yet implemented. "
-        "Install with: pip install kailash-nexus[auth] (coming in WS02)"
-    )
-    return None
+    from nexus.auth import RateLimitConfig, RateLimitMiddleware
+
+    rl_kwargs: Dict[str, Any] = {"requests_per_minute": config.rate_limit}
+    if config.rate_limit_config:
+        rl_kwargs.update(config.rate_limit_config)
+
+    rl_config = RateLimitConfig(**rl_kwargs)
+    return (RateLimitMiddleware, {"config": rl_config})
 
 
-def _error_handler_middleware_factory(config: NexusConfig) -> Optional[tuple]:
-    """Placeholder: Create error handling middleware configuration."""
-    logger.debug("Error handler middleware not yet implemented (coming in WS02)")
-    return None
+# NOTE: The exception → canonical-error-envelope contract (the WS02
+# "error handler middleware" placeholder formerly stubbed here) ships via the
+# HTTP transport's NexusError handler — see
+# nexus/transports/http.py::_install_exception_handlers (installs
+# app.add_exception_handler(NexusError, ...) producing the canonical
+# {"error", "detail"} body). No preset middleware is required for it.
 
 
 # =============================================================================
@@ -298,7 +326,6 @@ PRESETS: Dict[str, PresetConfig] = {
             _security_headers_middleware_factory,
             _csrf_middleware_factory,
             _rate_limit_middleware_factory,
-            _error_handler_middleware_factory,
         ],
         plugin_factories=[],
     ),
@@ -310,7 +337,6 @@ PRESETS: Dict[str, PresetConfig] = {
             _security_headers_middleware_factory,
             _csrf_middleware_factory,
             _rate_limit_middleware_factory,
-            _error_handler_middleware_factory,
         ],
         plugin_factories=[
             _jwt_auth_plugin_factory,
@@ -327,7 +353,6 @@ PRESETS: Dict[str, PresetConfig] = {
             _security_headers_middleware_factory,
             _csrf_middleware_factory,
             _rate_limit_middleware_factory,
-            _error_handler_middleware_factory,
         ],
         plugin_factories=[
             _jwt_auth_plugin_factory,

--- a/packages/kailash-nexus/tests/unit/test_preset_system.py
+++ b/packages/kailash-nexus/tests/unit/test_preset_system.py
@@ -8,6 +8,7 @@ Tier 1 tests - mocking allowed for isolated unit testing.
 import logging
 
 import pytest
+
 from nexus import Nexus
 from nexus.presets import (
     PRESETS,
@@ -15,11 +16,11 @@ from nexus.presets import (
     PresetConfig,
     _audit_plugin_factory,
     _cors_middleware_factory,
-    _error_handler_middleware_factory,
     _feature_flags_plugin_factory,
     _jwt_auth_plugin_factory,
     _rate_limit_middleware_factory,
     _rbac_plugin_factory,
+    _security_headers_middleware_factory,
     _sso_plugin_factory,
     _tenant_isolation_plugin_factory,
     apply_preset,
@@ -191,25 +192,30 @@ class TestPresetRegistry:
         assert preset.middleware_factories[0] is _cors_middleware_factory
         assert preset.plugin_factories == []
 
-    def test_standard_has_five_middleware(self):
-        """'standard' preset has CORS + security headers + CSRF + rate limit + error handler."""
+    def test_standard_has_four_middleware(self):
+        """'standard' preset has CORS + security headers + CSRF + rate limit.
+
+        (The former error-handler placeholder factory was removed — the
+        exception→canonical-envelope contract ships via the HTTP transport's
+        NexusError handler, not a preset middleware.)
+        """
         preset = get_preset("standard")
 
-        assert len(preset.middleware_factories) == 5
+        assert len(preset.middleware_factories) == 4
         assert preset.plugin_factories == []
 
     def test_saas_has_middleware_and_plugins(self):
         """'saas' preset has middleware and plugin factories."""
         preset = get_preset("saas")
 
-        assert len(preset.middleware_factories) == 5
+        assert len(preset.middleware_factories) == 4
         assert len(preset.plugin_factories) == 4
 
     def test_enterprise_has_most_plugins(self):
         """'enterprise' preset has the most plugin factories."""
         preset = get_preset("enterprise")
 
-        assert len(preset.middleware_factories) == 5
+        assert len(preset.middleware_factories) == 4
         assert len(preset.plugin_factories) == 6
 
 
@@ -238,22 +244,73 @@ class TestFactoryFunctions:
         result = _rate_limit_middleware_factory(config)
         assert result is None
 
-    def test_rate_limit_factory_warns_not_implemented(self, caplog):
-        """Rate limit factory logs warning (placeholder)."""
-        config = NexusConfig(rate_limit=100)
+    def test_rate_limit_factory_attaches_middleware_with_threaded_limit(self):
+        """Rate limit factory wires RateLimitMiddleware with the configured limit."""
+        from nexus.auth import RateLimitConfig, RateLimitMiddleware
 
-        with caplog.at_level(logging.WARNING):
-            result = _rate_limit_middleware_factory(config)
+        config = NexusConfig(rate_limit=42)
 
-        assert result is None
-        assert "not yet implemented" in caplog.text
+        result = _rate_limit_middleware_factory(config)
+        assert result is not None
+        middleware_class, kwargs = result
+        assert middleware_class is RateLimitMiddleware
+        rl_config = kwargs["config"]
+        assert isinstance(rl_config, RateLimitConfig)
+        assert rl_config.requests_per_minute == 42
 
-    def test_error_handler_factory_returns_none(self):
-        """Error handler factory returns None (placeholder)."""
-        config = NexusConfig()
+    def test_rate_limit_factory_merges_rate_limit_config_overrides(self):
+        """rate_limit_config dict overrides flow into the RateLimitConfig."""
+        config = NexusConfig(
+            rate_limit=100,
+            rate_limit_config={"burst_size": 5, "fail_open": False},
+        )
 
-        result = _error_handler_middleware_factory(config)
-        assert result is None
+        result = _rate_limit_middleware_factory(config)
+        assert result is not None
+        _, kwargs = result
+        rl_config = kwargs["config"]
+        assert rl_config.requests_per_minute == 100
+        assert rl_config.burst_size == 5
+        assert rl_config.fail_open is False
+
+    def test_security_headers_factory_uses_default_csp_when_unset(self):
+        """No config.csp → SecurityHeadersConfig secure default CSP is kept."""
+        from nexus.middleware.security_headers import SecurityHeadersConfig
+
+        config = NexusConfig()  # csp defaults to None
+        result = _security_headers_middleware_factory(config)
+        assert result is not None
+        _, kwargs = result
+        sec_config = kwargs["config"]
+        assert sec_config.csp == SecurityHeadersConfig().csp  # untouched default
+
+    def test_security_headers_factory_threads_custom_csp(self):
+        """config.csp is threaded into the SecurityHeadersConfig."""
+        custom_csp = "default-src 'none'; script-src 'self' https://cdn.example.com"
+        config = NexusConfig(csp=custom_csp)
+
+        result = _security_headers_middleware_factory(config)
+        assert result is not None
+        _, kwargs = result
+        assert kwargs["config"].csp == custom_csp
+
+    def test_security_headers_factory_merges_header_overrides(self):
+        """security_header_overrides flow into the SecurityHeadersConfig."""
+        config = NexusConfig(
+            security_header_overrides={
+                "frame_options": "SAMEORIGIN",
+                "hsts_preload": True,
+            }
+        )
+
+        result = _security_headers_middleware_factory(config)
+        assert result is not None
+        _, kwargs = result
+        sec_config = kwargs["config"]
+        assert sec_config.frame_options == "SAMEORIGIN"
+        assert sec_config.hsts_preload is True
+        # exclude_paths default preserved when overriding unrelated fields
+        assert "/healthz" in sec_config.exclude_paths
 
     def test_jwt_factory_returns_none_without_secret(self):
         """JWT factory returns None when no jwt_secret."""
@@ -331,6 +388,40 @@ class TestApplyPreset:
         names = [m.name for m in app._middleware_stack]
         assert "CORSMiddleware" in names
         assert "SecurityHeadersMiddleware" in names
+
+    def test_apply_standard_attaches_rate_limit_middleware(self):
+        """'standard' preset now actually attaches RateLimitMiddleware end-to-end."""
+        app = Nexus(enable_durability=False)
+        config = NexusConfig(rate_limit=100)
+
+        apply_preset(app, "standard", config)
+
+        names = [m.name for m in app._middleware_stack]
+        assert "RateLimitMiddleware" in names
+
+    def test_apply_standard_with_disabled_rate_limit_omits_middleware(self):
+        """rate_limit=None → RateLimitMiddleware is not attached."""
+        app = Nexus(enable_durability=False)
+        config = NexusConfig(rate_limit=None)
+
+        apply_preset(app, "standard", config)
+
+        names = [m.name for m in app._middleware_stack]
+        assert "RateLimitMiddleware" not in names
+
+    def test_apply_threads_custom_csp_into_security_headers(self):
+        """A custom CSP on NexusConfig reaches the attached SecurityHeadersMiddleware."""
+        custom_csp = "default-src 'none'"
+        app = Nexus(enable_durability=False)
+        config = NexusConfig(csp=custom_csp)
+
+        apply_preset(app, "lightweight", config)
+
+        sec = next(
+            m for m in app._middleware_stack if m.name == "SecurityHeadersMiddleware"
+        )
+        # The threaded CSP is carried in the middleware's stored config kwargs.
+        assert sec.kwargs["config"].csp == custom_csp
 
     def test_apply_preset_logs_info(self, caplog):
         """apply_preset() logs info messages."""


### PR DESCRIPTION
## Summary

Part of **#1336 gateway HTTP-middleware parity**. Verification (one agent per cluster, re-confirmed against the **Nexus package** during implementation) found most of the issue's "gaps" already shipped in `kailash-nexus` — the issue probed core `kailash.gateway`/`servers` and missed the Nexus surface. This PR wires the already-built capability through the presets and removes a dead placeholder.

| Parity item | Finding | This PR |
|---|---|---|
| #1345 rate-limit | Middleware already built (`nexus.auth`), preset stub returned `None` | **Wires it** |
| #1346 exception envelope | Already-present: `errors.py` hierarchy + transport `add_exception_handler` (#937 CLOSED) | Removes dead preset stub |
| #1347 per-request metrics | **Real gap** — no per-request middleware | **Deferred** (see below) |
| #1348 CSP | `SecurityHeadersConfig` already supports it, preset hardcoded | **Threads `NexusConfig.csp`** |

## Changes

- **Rate-limit preset wiring (#1345):** `_rate_limit_middleware_factory` now attaches the built `RateLimitMiddleware` with a `RateLimitConfig` from `NexusConfig.rate_limit` + `rate_limit_config`. `rate_limit=None` still omits it.
- **CSP passthrough (#1348):** new `NexusConfig.csp` + `security_header_overrides`, threaded into the security-headers preset's `SecurityHeadersConfig`. Defaults unchanged when unset.
- **Dead stub removed (#1346):** `_error_handler_middleware_factory` (always returned `None`) — the exception→canonical-envelope contract ships via `transports/http.py::_install_exception_handlers`, not a preset.
- kailash-nexus 2.9.1 → 2.10.0.

## Tests

Extended `tests/unit/test_preset_system.py`: rate-limit factory attaches `RateLimitMiddleware` with threaded limit + `rate_limit_config` overrides + disabled case; CSP factory threads custom CSP + header overrides + keeps default; `apply_preset` end-to-end attaches the rate-limiter and threads CSP into the live middleware stack. Count-dependent preset tests + the removed-stub test swept in the same commit. **280 nexus-suite tests pass; collect-only clean (1781).**

## User-flow walk

```
$ .venv/bin/python -m pytest packages/kailash-nexus/tests/unit/test_preset_system.py -q
...............................................
47 passed
```
Disposition: `Nexus(preset="standard")` now auto-attaches the rate limiter; a custom CSP set on config reaches the live `SecurityHeadersMiddleware`.

## Deferred — per-request metrics (#1347)

The one genuinely-new build (a prometheus-integrated `BaseHTTPMiddleware` recording method/route/status/latency). Deferred to a fresh session with working review gates — recorded with a value-anchor in `workspaces/issue-1336-gateway-parity-py/journal/0002`.

## Related issues

Related to #1336 (parity #1345/#1346/#1348). #1336 stays open until #1347 (metrics) lands.