### PR TITLE
feat(nexus): per-request HTTP metrics middleware — closes #1336

### DIFF
--- a/packages/kailash-nexus/CHANGELOG.md
+++ b/packages/kailash-nexus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Nexus Changelog
 
+## [2.11.0] — 2026-06-17 — Per-request HTTP metrics middleware (#1336)
+
+### Added
+
+- **Per-request HTTP metrics middleware (#1336).** `RequestMetricsMiddleware` (module `nexus.middleware.request_metrics`) emits `nexus_http_requests_total` (Counter) + `nexus_http_request_duration_seconds` (Histogram) — labelled by `method` / `route` (matched route template) / `status` — for every HTTP request, on the existing `/metrics` Prometheus endpoint. Opt-in via `NexusConfig.metrics_enabled` (default False because `prometheus_client` is an optional dep); auto-wired LAST (outermost, so it measures total request latency including all other middleware) in the `standard`, `saas`, and `enterprise` preset chains. The route label is the matched TEMPLATE (`/users/{id}`), never the concrete path, with an `__unmatched__` sentinel for unmatched traffic — bounding Prometheus label cardinality against path-scanning DoS. Closes the last gateway HTTP-middleware-parity gap with the Rust engine. The middleware is a pure-ASGI implementation (not Starlette `BaseHTTPMiddleware`) and is a cheap pass-through when `prometheus_client` is absent.
+
 ## [2.10.0] — 2026-06-17 — Preset auto-wiring: rate-limit + CSP passthrough (#1336)
 
 ### Added

--- a/packages/kailash-nexus/pyproject.toml
+++ b/packages/kailash-nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kailash-nexus"
-version = "2.10.0"
+version = "2.11.0"
 description = "Zero-configuration multi-channel workflow orchestration platform"
 authors = [{name = "Terrene Foundation", email = "info@terrene.foundation"}]
 readme = "README.md"

--- a/packages/kailash-nexus/src/nexus/__init__.py
+++ b/packages/kailash-nexus/src/nexus/__init__.py
@@ -57,6 +57,7 @@ from .extractors import (
 )
 from .files import NexusFile
 from .metrics import register_metrics_endpoint
+from .middleware.request_metrics import RequestMetricsMiddleware
 from .openapi import OpenApiGenerator, OpenApiInfo
 from .presets import PRESETS, NexusConfig, PresetConfig, apply_preset, get_preset
 from .probes import ProbeManager, ProbeResponse, ProbeState
@@ -116,7 +117,7 @@ from .service_client import (
 )
 from .typed_service_client import Decoder, TypedServiceClient
 
-__version__ = "2.10.0"
+__version__ = "2.11.0"
 __all__ = [
     # Core
     "Nexus",
@@ -163,6 +164,7 @@ __all__ = [
     "OpenApiInfo",
     # Metrics & SSE
     "register_metrics_endpoint",
+    "RequestMetricsMiddleware",
     "register_sse_endpoint",
     # Class-based WebSocket message handlers (issue #448)
     "Connection",

--- a/packages/kailash-nexus/src/nexus/metrics.py
+++ b/packages/kailash-nexus/src/nexus/metrics.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["register_metrics_endpoint"]
+__all__ = ["register_metrics_endpoint", "observe_http_request"]
 
 # ---------------------------------------------------------------------------
 # Lazy import helper
@@ -59,6 +59,79 @@ _failure_recovery_hist = None
 _session_sync_latency_hist = None
 _active_sessions_gauge = None
 _registered_workflows_gauge = None
+
+# Per-request HTTP metrics — created lazily + independently of the deque-synced
+# metrics above so the request middleware can record without a registered
+# /metrics endpoint (it still surfaces on /metrics because both use the
+# prometheus DEFAULT registry).
+_request_metrics_initialized = False
+_http_requests_total = None
+_http_request_duration_hist = None
+
+
+def _init_request_metrics():
+    """Create the per-request HTTP Prometheus metric objects on first use."""
+    global _request_metrics_initialized  # noqa: PLW0603
+    global _http_requests_total, _http_request_duration_hist  # noqa: PLW0603
+    if _request_metrics_initialized:
+        return
+
+    pc = _require_prometheus_client()
+
+    _http_requests_total = pc.Counter(
+        "nexus_http_requests_total",
+        "Total HTTP requests processed by Nexus",
+        ["method", "route", "status"],
+    )
+    _http_request_duration_hist = pc.Histogram(
+        "nexus_http_request_duration_seconds",
+        "HTTP request latency in seconds by method/route/status",
+        ["method", "route", "status"],
+        buckets=(
+            0.005,
+            0.01,
+            0.025,
+            0.05,
+            0.1,
+            0.25,
+            0.5,
+            1.0,
+            2.5,
+            5.0,
+            10.0,
+        ),
+    )
+
+    _request_metrics_initialized = True
+
+
+def observe_http_request(
+    method: str, route: str, status: int, duration_seconds: float
+) -> None:
+    """Record one HTTP request into the per-request Nexus metrics.
+
+    Increments ``nexus_http_requests_total`` and observes
+    ``nexus_http_request_duration_seconds`` under the
+    ``(method, route, status)`` label set. Called by
+    :class:`~nexus.middleware.request_metrics.RequestMetricsMiddleware`.
+
+    Args:
+        method: HTTP method (e.g. ``"GET"``).
+        route: Matched route template (e.g. ``"/users/{id}"``), or the
+            ``"__unmatched__"`` sentinel when no route matched — the label
+            is the template, never the concrete path, to bound cardinality.
+        status: HTTP status code.
+        duration_seconds: Wall-clock request duration in seconds.
+
+    Raises:
+        ImportError: If ``prometheus_client`` is not installed.
+    """
+    _init_request_metrics()
+    status_label = str(status)
+    _http_requests_total.labels(method=method, route=route, status=status_label).inc()
+    _http_request_duration_hist.labels(
+        method=method, route=route, status=status_label
+    ).observe(duration_seconds)
 
 
 def _init_metrics():

--- a/packages/kailash-nexus/src/nexus/metrics.py
+++ b/packages/kailash-nexus/src/nexus/metrics.py
@@ -127,6 +127,10 @@ def observe_http_request(
         ImportError: If ``prometheus_client`` is not installed.
     """
     _init_request_metrics()
+    # _init_request_metrics() guarantees both objects are non-None; the assert
+    # makes that explicit for static analysis of the lazy-init globals.
+    assert _http_requests_total is not None  # noqa: S101
+    assert _http_request_duration_hist is not None  # noqa: S101
     status_label = str(status)
     _http_requests_total.labels(method=method, route=route, status=status_label).inc()
     _http_request_duration_hist.labels(
@@ -191,6 +195,10 @@ def _sync_from_nexus(nexus: Nexus) -> None:
     exactly once.
     """
     _init_metrics()
+    # _init_metrics() guarantees the metric objects are non-None; the asserts
+    # make that explicit for static analysis of the lazy-init globals.
+    assert _registered_workflows_gauge is not None  # noqa: S101
+    assert _active_sessions_gauge is not None  # noqa: S101
 
     perf = getattr(nexus, "_performance_metrics", {})
 
@@ -211,7 +219,7 @@ def _sync_from_nexus(nexus: Nexus) -> None:
 
     for deque_name, hist in histogram_map.items():
         deque_obj = perf.get(deque_name)
-        if deque_obj is None:
+        if deque_obj is None or hist is None:
             continue
         values = list(deque_obj)
         start = offsets.get(deque_name, 0)

--- a/packages/kailash-nexus/src/nexus/middleware/__init__.py
+++ b/packages/kailash-nexus/src/nexus/middleware/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from nexus.middleware.cache import CacheConfig, CacheStats, ResponseCacheMiddleware
 from nexus.middleware.csrf import CSRFMiddleware
 from nexus.middleware.governance import PACTGovernanceError, PACTMiddleware
+from nexus.middleware.request_metrics import RequestMetricsMiddleware
 from nexus.middleware.security_headers import (
     SecurityHeadersConfig,
     SecurityHeadersMiddleware,
@@ -22,6 +23,7 @@ __all__ = [
     "CSRFMiddleware",
     "PACTGovernanceError",
     "PACTMiddleware",
+    "RequestMetricsMiddleware",
     "ResponseCacheMiddleware",
     "SecurityHeadersConfig",
     "SecurityHeadersMiddleware",

--- a/packages/kailash-nexus/src/nexus/middleware/request_metrics.py
+++ b/packages/kailash-nexus/src/nexus/middleware/request_metrics.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+"""Per-request HTTP metrics middleware for Nexus.
+
+Records ``nexus_http_requests_total`` (Counter) and
+``nexus_http_request_duration_seconds`` (Histogram) — labelled by
+``method`` / ``route`` (matched template) / ``status`` — for every HTTP
+request. The metrics surface on the existing Prometheus ``/metrics`` endpoint
+(``register_metrics_endpoint``) because they live in the default registry.
+
+This is a PURE-ASGI middleware (matching ``SecurityHeadersMiddleware``), NOT a
+Starlette ``BaseHTTPMiddleware`` — the latter breaks streaming responses and
+background tasks. ``prometheus_client`` is an OPTIONAL dependency; when it is
+absent the middleware is a cheap pass-through.
+
+Usage:
+    from nexus.middleware.request_metrics import RequestMetricsMiddleware
+
+    app.add_middleware(RequestMetricsMiddleware)
+
+Wire it LAST in a preset chain (outermost) so it measures TOTAL request
+latency including every other middleware.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["RequestMetricsMiddleware"]
+
+
+def _route_label(scope: Dict[str, Any]) -> str:
+    """Return a bounded-cardinality route label for the request.
+
+    Starlette/FastAPI populate ``scope["route"]`` once routing has run. By the
+    time this middleware's instrumentation executes (it wraps OUTERMOST, so its
+    ``finally`` runs after the inner app — including the router — completes),
+    the matched route is available. We return the route TEMPLATE
+    (``/users/{id}``), never the concrete path (``/users/123``), to bound
+    Prometheus label cardinality and prevent a cardinality explosion / DoS via
+    path scanning. When no route matched, the ``"__unmatched__"`` sentinel is
+    used so unmatched traffic collapses to a single label.
+    """
+    route = scope.get("route")
+    if route is not None:
+        tmpl = getattr(route, "path_format", None) or getattr(route, "path", None)
+        if tmpl:
+            return tmpl
+    return "__unmatched__"
+
+
+class RequestMetricsMiddleware:
+    """ASGI middleware recording per-request HTTP metrics.
+
+    Compatible with Starlette's ``add_middleware()`` pattern.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        exclude_paths: Any = ("/metrics", "/healthz", "/readyz", "/startup"),
+    ) -> None:
+        """Initialize the middleware.
+
+        Args:
+            app: The ASGI application to wrap.
+            exclude_paths: Exact request paths to skip (no metric recorded).
+                Defaults to the metrics + Kubernetes-probe endpoints so the
+                scrape path and health checks do not pollute the route labels.
+        """
+        self.app = app
+        self._exclude = set(exclude_paths)
+
+        # Detect prometheus availability ONCE. When absent the middleware is a
+        # cheap pass-through; the warning names the install extra so operators
+        # know how to enable metrics.
+        try:
+            import prometheus_client  # noqa: F401
+
+            self._enabled = True
+        except ImportError:
+            self._enabled = False
+            logger.warning(
+                "prometheus_client is not installed; RequestMetricsMiddleware "
+                "is a no-op pass-through. Install it with: "
+                "pip install kailash-nexus[metrics]"
+            )
+
+    async def __call__(self, scope: Dict[str, Any], receive: Any, send: Any) -> None:
+        """ASGI interface."""
+        if scope["type"] != "http" or not self._enabled:
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if path in self._exclude:
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "UNKNOWN")
+        # Default to 500 so an unhandled exception (which never emits an
+        # http.response.start) is recorded as a server error.
+        status_box = {"status": 500}
+
+        async def send_wrapper(message: Dict[str, Any]) -> None:
+            if message["type"] == "http.response.start":
+                status_box["status"] = message["status"]
+            await send(message)
+
+        start = time.perf_counter()
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            duration = time.perf_counter() - start
+            route = _route_label(scope)
+            # Lazy import inside finally avoids an import cycle at module load
+            # (metrics.py has no dependency on this module, but this keeps the
+            # ASGI hot-path import resolved only after prometheus is confirmed).
+            from nexus.metrics import observe_http_request
+
+            observe_http_request(method, route, status_box["status"], duration)

--- a/packages/kailash-nexus/src/nexus/presets.py
+++ b/packages/kailash-nexus/src/nexus/presets.py
@@ -62,6 +62,14 @@ class NexusConfig:
     rate_limit: Optional[int] = 100
     rate_limit_config: Optional[Dict[str, Any]] = None
 
+    # Per-request HTTP metrics
+    # Opt-in per-request HTTP metrics middleware (RequestMetricsMiddleware:
+    # nexus_http_requests_total + nexus_http_request_duration_seconds, labelled
+    # by method/route-template/status). Requires prometheus_client AND a
+    # registered /metrics endpoint (register_metrics_endpoint). Default False
+    # because prometheus_client is an optional dependency.
+    metrics_enabled: bool = False
+
     # Security Headers (threaded into the security-headers preset middleware)
     # csp: custom Content-Security-Policy string; None keeps SecurityHeadersConfig's
     # secure default. security_header_overrides: per-field overrides
@@ -216,6 +224,23 @@ def _rate_limit_middleware_factory(config: NexusConfig) -> Optional[tuple]:
     return (RateLimitMiddleware, {"config": rl_config})
 
 
+def _request_metrics_middleware_factory(config: NexusConfig) -> Optional[tuple]:
+    """Create the per-request HTTP metrics middleware when opted-in.
+
+    Returns None unless ``config.metrics_enabled`` is True. When enabled,
+    attaches ``RequestMetricsMiddleware`` (which records
+    ``nexus_http_requests_total`` + ``nexus_http_request_duration_seconds``).
+    Appended LAST in the standard/saas/enterprise chains so it is the OUTERMOST
+    middleware (LIFO) and measures total request latency including all others.
+    """
+    if not config.metrics_enabled:
+        return None
+
+    from nexus.middleware.request_metrics import RequestMetricsMiddleware
+
+    return (RequestMetricsMiddleware, {})
+
+
 # NOTE: The exception → canonical-error-envelope contract (the WS02
 # "error handler middleware" placeholder formerly stubbed here) ships via the
 # HTTP transport's NexusError handler — see
@@ -326,6 +351,7 @@ PRESETS: Dict[str, PresetConfig] = {
             _security_headers_middleware_factory,
             _csrf_middleware_factory,
             _rate_limit_middleware_factory,
+            _request_metrics_middleware_factory,
         ],
         plugin_factories=[],
     ),
@@ -337,6 +363,7 @@ PRESETS: Dict[str, PresetConfig] = {
             _security_headers_middleware_factory,
             _csrf_middleware_factory,
             _rate_limit_middleware_factory,
+            _request_metrics_middleware_factory,
         ],
         plugin_factories=[
             _jwt_auth_plugin_factory,
@@ -353,6 +380,7 @@ PRESETS: Dict[str, PresetConfig] = {
             _security_headers_middleware_factory,
             _csrf_middleware_factory,
             _rate_limit_middleware_factory,
+            _request_metrics_middleware_factory,
         ],
         plugin_factories=[
             _jwt_auth_plugin_factory,

--- a/packages/kailash-nexus/tests/integration/test_request_metrics_middleware.py
+++ b/packages/kailash-nexus/tests/integration/test_request_metrics_middleware.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for RequestMetricsMiddleware (Tier 2 — real Nexus).
+
+Exercises the middleware end-to-end through a real Nexus instance + a
+registered workflow + the real /metrics endpoint via fastapi TestClient:
+
+- Counter nexus_http_requests_total increments + appears in /metrics, with
+  method / route-template / status labels.
+- Histogram nexus_http_request_duration_seconds appears after a request.
+- The matched-route TEMPLATE is recorded (cardinality control) — never a
+  raw concrete path.
+- The excluded /metrics path itself records no route sample.
+
+Mirrors test_metrics.py's setup idiom: resets the metrics module globals
+(including the new request-metric globals) and clears the prometheus default
+registry in setup_method to avoid "Duplicated timeseries in CollectorRegistry".
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kailash.workflow.builder import WorkflowBuilder
+from nexus import Nexus, RequestMetricsMiddleware
+from nexus.metrics import register_metrics_endpoint
+
+
+@pytest.mark.integration
+class TestRequestMetricsMiddleware:
+    """Tier 2 suite for the per-request HTTP metrics middleware."""
+
+    def setup_method(self):
+        """Reset metrics module state + prometheus registry, build a Nexus app."""
+        import nexus.metrics as _mod
+
+        # Deque-synced metric globals (mirror test_metrics.py).
+        _mod._metrics_initialized = False
+        _mod._workflow_registration_hist = None
+        _mod._cross_channel_sync_hist = None
+        _mod._failure_recovery_hist = None
+        _mod._session_sync_latency_hist = None
+        _mod._active_sessions_gauge = None
+        _mod._registered_workflows_gauge = None
+
+        # New per-request metric globals — reset so _init_request_metrics
+        # re-creates fresh collectors against the cleared registry below.
+        _mod._request_metrics_initialized = False
+        _mod._http_requests_total = None
+        _mod._http_request_duration_hist = None
+
+        import prometheus_client
+
+        collectors = list(prometheus_client.REGISTRY._names_to_collectors.values())
+        for c in collectors:
+            try:
+                prometheus_client.REGISTRY.unregister(c)
+            except Exception:
+                pass
+
+        self.app = Nexus(
+            api_port=8233,
+            enable_durability=False,
+            enable_auth=False,
+            enable_monitoring=False,
+        )
+
+        workflow = WorkflowBuilder()
+        workflow.add_node("PythonCodeNode", "t", {"code": "result = {'status': 'ok'}"})
+        self.app.register("metrics_mw_test", workflow.build())
+        self.app.add_middleware(RequestMetricsMiddleware)
+        register_metrics_endpoint(self.app)
+
+        self.client = TestClient(self.app.fastapi_app)
+
+    def teardown_method(self):
+        if hasattr(self, "app") and self.app._running:
+            self.app.stop()
+
+    # A simple registered GET route the middleware can wrap. The workflow
+    # health route is registered by Nexus at registration time.
+    _PROBE_PATH = "/workflows/metrics_mw_test/health"
+
+    def test_counter_increments_and_appears_in_metrics(self):
+        """Hitting a registered route emits nexus_http_requests_total with labels."""
+        resp = self.client.get(self._PROBE_PATH)
+        assert resp.status_code == 200
+
+        body = self.client.get("/metrics").text
+        assert "nexus_http_requests_total" in body
+
+        # A labelled sample for our GET 200 request must be present.
+        sample_lines = [
+            ln
+            for ln in body.splitlines()
+            if ln.startswith("nexus_http_requests_total{")
+        ]
+        assert sample_lines, "no nexus_http_requests_total sample emitted"
+
+        get_200 = [
+            ln for ln in sample_lines if 'method="GET"' in ln and 'status="200"' in ln
+        ]
+        assert get_200, f"no GET/200 counter sample found in: {sample_lines}"
+        # The sample carries a route label (cardinality control — a template).
+        assert any('route="' in ln for ln in get_200)
+
+    def test_histogram_present_after_request(self):
+        """nexus_http_request_duration_seconds appears in /metrics after a request."""
+        self.client.get(self._PROBE_PATH)
+        body = self.client.get("/metrics").text
+        assert "nexus_http_request_duration_seconds" in body
+        assert any(
+            ln.startswith("nexus_http_request_duration_seconds_count{")
+            for ln in body.splitlines()
+        )
+
+    def test_route_label_is_template_not_concrete_path(self):
+        """The route label is a bounded matched-route template, not a raw path.
+
+        Cardinality control: the recorded route label MUST be a route the
+        application registered (a template / mounted sub-path), never the
+        verbatim request path with a workflow-id embedded. We assert the
+        label set is bounded — every emitted route label is a non-empty
+        string and none equals the full concrete probe path (which would
+        signal raw-path labelling).
+        """
+        self.client.get(self._PROBE_PATH)
+        body = self.client.get("/metrics").text
+
+        route_labels = set()
+        for ln in body.splitlines():
+            if ln.startswith("nexus_http_requests_total{"):
+                # extract route="..."
+                start = ln.find('route="')
+                if start != -1:
+                    start += len('route="')
+                    end = ln.find('"', start)
+                    route_labels.add(ln[start:end])
+
+        assert route_labels, "no route labels recorded"
+        # No label is the full concrete request path (that would be raw-path
+        # labelling). The matched-route template is recorded instead.
+        assert self._PROBE_PATH not in route_labels
+        # Every recorded route label is a non-empty bounded template string.
+        assert all(isinstance(r, str) and r for r in route_labels)
+
+    def test_metrics_path_itself_records_no_route_sample(self):
+        """The excluded /metrics path does not appear as a recorded route label."""
+        # First request to a real route so the metric families exist.
+        self.client.get(self._PROBE_PATH)
+        # Scrape twice; the scrape path is in exclude_paths.
+        self.client.get("/metrics")
+        body = self.client.get("/metrics").text
+
+        for ln in body.splitlines():
+            if ln.startswith("nexus_http_requests_total{"):
+                assert (
+                    'route="/metrics"' not in ln
+                ), f"/metrics scrape path was recorded as a route label: {ln}"

--- a/packages/kailash-nexus/tests/unit/test_preset_system.py
+++ b/packages/kailash-nexus/tests/unit/test_preset_system.py
@@ -192,30 +192,43 @@ class TestPresetRegistry:
         assert preset.middleware_factories[0] is _cors_middleware_factory
         assert preset.plugin_factories == []
 
-    def test_standard_has_four_middleware(self):
-        """'standard' preset has CORS + security headers + CSRF + rate limit.
+    def test_standard_has_five_middleware(self):
+        """'standard' preset has CORS + security headers + CSRF + rate limit
+        + request metrics (the metrics factory is LAST → outermost → total latency).
 
         (The former error-handler placeholder factory was removed — the
         exception→canonical-envelope contract ships via the HTTP transport's
-        NexusError handler, not a preset middleware.)
+        NexusError handler, not a preset middleware. The request-metrics
+        factory was appended last for #1336 gateway HTTP-middleware parity.)
         """
+        from nexus.presets import _request_metrics_middleware_factory
+
         preset = get_preset("standard")
 
-        assert len(preset.middleware_factories) == 4
+        assert len(preset.middleware_factories) == 5
+        # Metrics middleware MUST be last → outermost (LIFO) → measures total
+        # request latency including all other middleware.
+        assert preset.middleware_factories[-1] is _request_metrics_middleware_factory
         assert preset.plugin_factories == []
 
     def test_saas_has_middleware_and_plugins(self):
         """'saas' preset has middleware and plugin factories."""
+        from nexus.presets import _request_metrics_middleware_factory
+
         preset = get_preset("saas")
 
-        assert len(preset.middleware_factories) == 4
+        assert len(preset.middleware_factories) == 5
+        assert preset.middleware_factories[-1] is _request_metrics_middleware_factory
         assert len(preset.plugin_factories) == 4
 
     def test_enterprise_has_most_plugins(self):
         """'enterprise' preset has the most plugin factories."""
+        from nexus.presets import _request_metrics_middleware_factory
+
         preset = get_preset("enterprise")
 
-        assert len(preset.middleware_factories) == 4
+        assert len(preset.middleware_factories) == 5
+        assert preset.middleware_factories[-1] is _request_metrics_middleware_factory
         assert len(preset.plugin_factories) == 6
 
 
@@ -272,6 +285,27 @@ class TestFactoryFunctions:
         assert rl_config.requests_per_minute == 100
         assert rl_config.burst_size == 5
         assert rl_config.fail_open is False
+
+    def test_request_metrics_factory_returns_none_by_default(self):
+        """Request-metrics factory returns None when metrics_enabled is False (default)."""
+        from nexus.presets import _request_metrics_middleware_factory
+
+        config = NexusConfig()
+        assert config.metrics_enabled is False
+        assert _request_metrics_middleware_factory(config) is None
+
+    def test_request_metrics_factory_attaches_middleware_when_enabled(self):
+        """Opt-in via metrics_enabled wires RequestMetricsMiddleware (no kwargs)."""
+        from nexus.middleware.request_metrics import RequestMetricsMiddleware
+        from nexus.presets import _request_metrics_middleware_factory
+
+        config = NexusConfig(metrics_enabled=True)
+
+        result = _request_metrics_middleware_factory(config)
+        assert result is not None
+        middleware_class, kwargs = result
+        assert middleware_class is RequestMetricsMiddleware
+        assert kwargs == {}
 
     def test_security_headers_factory_uses_default_csp_when_unset(self):
         """No config.csp → SecurityHeadersConfig secure default CSP is kept."""

--- a/packages/kailash-nexus/tests/unit/test_request_metrics_middleware_unit.py
+++ b/packages/kailash-nexus/tests/unit/test_request_metrics_middleware_unit.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Terrene Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tier 1 unit tests for RequestMetricsMiddleware internals.
+
+Covers the cardinality-control route-label helper and the middleware's
+ASGI __call__ behavior against a fake inner app — exception-path status
+recording, exclude-paths pass-through, and the prometheus-absent no-op —
+without standing up a real Nexus instance.
+"""
+
+import types
+
+import pytest
+
+from nexus.middleware.request_metrics import RequestMetricsMiddleware, _route_label
+
+# ---------------------------------------------------------------------------
+# _route_label — cardinality control
+# ---------------------------------------------------------------------------
+
+
+def test_route_label_prefers_path_format():
+    """A route exposing path_format returns the template, not a concrete path."""
+    route = types.SimpleNamespace(path_format="/users/{id}", path="/users/{id}")
+    scope = {"route": route}
+    assert _route_label(scope) == "/users/{id}"
+
+
+def test_route_label_falls_back_to_path():
+    """When path_format is absent, the route's path attribute is used."""
+    route = types.SimpleNamespace(path="/x")
+    scope = {"route": route}
+    assert _route_label(scope) == "/x"
+
+
+def test_route_label_no_route_returns_sentinel():
+    """No matched route collapses to the bounded __unmatched__ sentinel."""
+    assert _route_label({}) == "__unmatched__"
+
+
+def test_route_label_route_without_usable_template_returns_sentinel():
+    """A route object with neither path_format nor path returns the sentinel."""
+    route = types.SimpleNamespace(path_format=None, path=None)
+    assert _route_label({"route": route}) == "__unmatched__"
+
+
+# ---------------------------------------------------------------------------
+# __call__ — exception path records status 500 and re-propagates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_records_500_on_unhandled_exception(monkeypatch):
+    """An inner app raising before http.response.start is recorded as 500."""
+    observed = {}
+
+    def _fake_observe(method, route, status, duration):
+        observed["method"] = method
+        observed["route"] = route
+        observed["status"] = status
+        observed["duration"] = duration
+
+    monkeypatch.setattr(
+        "nexus.metrics.observe_http_request", _fake_observe, raising=True
+    )
+
+    async def boom(scope, receive, send):
+        raise RuntimeError("handler exploded")
+
+    mw = RequestMetricsMiddleware(boom)
+    mw._enabled = True
+
+    scope = {"type": "http", "path": "/boom", "method": "POST"}
+
+    async def receive():
+        return {"type": "http.request"}
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    with pytest.raises(RuntimeError, match="handler exploded"):
+        await mw(scope, receive, send)
+
+    # finally-block recorded the request before re-propagating
+    assert observed["status"] == 500
+    assert observed["method"] == "POST"
+    assert observed["route"] == "__unmatched__"
+    assert observed["duration"] >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_call_records_response_start_status(monkeypatch):
+    """A normal response records the status carried on http.response.start."""
+    observed = {}
+
+    monkeypatch.setattr(
+        "nexus.metrics.observe_http_request",
+        lambda method, route, status, duration: observed.update(
+            method=method, route=route, status=status
+        ),
+        raising=True,
+    )
+
+    async def ok_app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 201, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    mw = RequestMetricsMiddleware(ok_app)
+    mw._enabled = True
+
+    scope = {"type": "http", "path": "/ok", "method": "GET"}
+
+    async def receive():
+        return {"type": "http.request"}
+
+    async def send(msg):
+        pass
+
+    await mw(scope, receive, send)
+    assert observed["status"] == 201
+    assert observed["method"] == "GET"
+
+
+# ---------------------------------------------------------------------------
+# __call__ — exclude paths + non-http + prometheus-absent pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_excludes_metrics_path(monkeypatch):
+    """A request to an excluded path is passed through with no metric recorded."""
+    called = {"observe": False}
+    monkeypatch.setattr(
+        "nexus.metrics.observe_http_request",
+        lambda *a, **k: called.update(observe=True),
+        raising=True,
+    )
+
+    inner_called = {"hit": False}
+
+    async def inner(scope, receive, send):
+        inner_called["hit"] = True
+
+    mw = RequestMetricsMiddleware(inner)
+    mw._enabled = True
+
+    scope = {"type": "http", "path": "/metrics", "method": "GET"}
+    await mw(scope, lambda: None, lambda m: None)
+
+    assert inner_called["hit"] is True
+    assert called["observe"] is False
+
+
+@pytest.mark.asyncio
+async def test_call_passthrough_for_non_http_scope(monkeypatch):
+    """A non-http scope (websocket/lifespan) bypasses instrumentation."""
+    called = {"observe": False}
+    monkeypatch.setattr(
+        "nexus.metrics.observe_http_request",
+        lambda *a, **k: called.update(observe=True),
+        raising=True,
+    )
+
+    inner_called = {"hit": False}
+
+    async def inner(scope, receive, send):
+        inner_called["hit"] = True
+
+    mw = RequestMetricsMiddleware(inner)
+    mw._enabled = True
+
+    scope = {"type": "websocket", "path": "/ws"}
+    await mw(scope, lambda: None, lambda m: None)
+
+    assert inner_called["hit"] is True
+    assert called["observe"] is False
+
+
+@pytest.mark.asyncio
+async def test_call_noop_when_prometheus_absent(monkeypatch):
+    """With prometheus disabled the middleware passes through and never observes."""
+    called = {"observe": False}
+    monkeypatch.setattr(
+        "nexus.metrics.observe_http_request",
+        lambda *a, **k: called.update(observe=True),
+        raising=True,
+    )
+
+    inner_called = {"hit": False}
+
+    async def inner(scope, receive, send):
+        inner_called["hit"] = True
+
+    mw = RequestMetricsMiddleware(inner)
+    # Force the prometheus-absent branch regardless of install state.
+    mw._enabled = False
+
+    scope = {"type": "http", "path": "/anything", "method": "GET"}
+    await mw(scope, lambda: None, lambda m: None)
+
+    assert inner_called["hit"] is True
+    assert called["observe"] is False

--- a/specs/nexus-services.md
+++ b/specs/nexus-services.md
@@ -213,6 +213,30 @@ class CacheConfig:
 
 Features: TTL-based expiration, LRU eviction, ETag generation (SHA-256), Cache-Control parsing, per-handler exemption, thread-safe, cache statistics, programmatic invalidation.
 
+#### RequestMetricsMiddleware
+
+**Module:** `nexus.middleware.request_metrics`
+
+Pure-ASGI middleware that records per-request HTTP metrics (`nexus_http_requests_total` + `nexus_http_request_duration_seconds`, see §14) into the prometheus default registry, so they surface on the existing `/metrics` endpoint.
+
+**Constructor:**
+
+```python
+RequestMetricsMiddleware(
+    app,
+    *,
+    exclude_paths=("/metrics", "/healthz", "/readyz", "/startup"),
+)
+```
+
+**Behavior:**
+
+- Opt-in via `NexusConfig.metrics_enabled` (default `False`); wired LAST in the `standard` / `saas` / `enterprise` preset chains so it is outermost (LIFO) and measures total request latency including all other middleware.
+- Records each request under labels `method` / `route` / `status`. The `route` label is the matched route TEMPLATE (`/users/{id}` from `scope["route"]`), never the concrete path, with an `__unmatched__` sentinel when no route matched — bounding Prometheus label cardinality against path-scanning DoS.
+- An unhandled handler exception (no `http.response.start` emitted) is recorded with `status="500"`, then re-propagated (the middleware does not swallow exceptions).
+- Detects `prometheus_client` availability once at construction; when absent it is a cheap pass-through and logs a one-time WARNING naming `pip install kailash-nexus[metrics]`.
+- Requests to `exclude_paths` are passed through without a metric (so the scrape path and probes do not pollute route labels).
+
 ---
 
 ## 12. Kubernetes Probes
@@ -333,16 +357,20 @@ class OpenApiGenerator:
 
 **Prometheus metrics registered:**
 
-| Metric                                | Type      | Description                              |
-| ------------------------------------- | --------- | ---------------------------------------- |
-| `nexus_workflow_registration_seconds` | Histogram | Time to register a workflow.             |
-| `nexus_cross_channel_sync_seconds`    | Histogram | Time to sync state across channels.      |
-| `nexus_failure_recovery_seconds`      | Histogram | Time to recover from a workflow failure. |
-| `nexus_session_sync_latency_seconds`  | Histogram | Latency of session synchronization.      |
-| `nexus_active_sessions`               | Gauge     | Number of currently active sessions.     |
-| `nexus_registered_workflows`          | Gauge     | Number of registered workflows.          |
+| Metric                                | Type      | Description                                      |
+| ------------------------------------- | --------- | ------------------------------------------------ |
+| `nexus_workflow_registration_seconds` | Histogram | Time to register a workflow.                     |
+| `nexus_cross_channel_sync_seconds`    | Histogram | Time to sync state across channels.              |
+| `nexus_failure_recovery_seconds`      | Histogram | Time to recover from a workflow failure.         |
+| `nexus_session_sync_latency_seconds`  | Histogram | Latency of session synchronization.              |
+| `nexus_active_sessions`               | Gauge     | Number of currently active sessions.             |
+| `nexus_registered_workflows`          | Gauge     | Number of registered workflows.                  |
+| `nexus_http_requests_total`           | Counter   | Total HTTP requests by method/route/status.      |
+| `nexus_http_request_duration_seconds` | Histogram | Per-request HTTP latency by method/route/status. |
 
-Metrics are synced from Nexus's internal performance deques on every `/metrics` scrape. Each deque value is observed exactly once (tracked via per-instance offset dict).
+The first six metrics are synced from Nexus's internal performance deques on every `/metrics` scrape. Each deque value is observed exactly once (tracked via per-instance offset dict).
+
+The two `nexus_http_*` metrics are recorded by `RequestMetricsMiddleware` (module `nexus.middleware.request_metrics`) — opt-in via `NexusConfig.metrics_enabled` (default `False` because `prometheus_client` is optional), wired LAST in the `standard` / `saas` / `enterprise` preset chains so it is the outermost middleware (LIFO) and measures total request latency including all other middleware. The `route` label is the matched route TEMPLATE (e.g. `/users/{id}`), never the concrete path, with an `__unmatched__` sentinel for unmatched traffic — bounding Prometheus label cardinality against path-scanning DoS. They surface on the same `/metrics` endpoint because they live in the prometheus default registry; an unhandled handler exception is recorded with `status="500"`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `RequestMetricsMiddleware` to **kailash-nexus** — per-request HTTP method/route/status/latency instrumentation surfaced on the existing Prometheus `/metrics` endpoint. This closes the last gateway HTTP-middleware-parity gap with the Rust engine for **#1336** (the four other parity items — rate-limit, exception envelope, CSP, session-TTL — landed in #1346/#1347 or were already-present in the Nexus package).

Operators can now see, per route, how many requests are served and how long they take — the one capability `metrics.py` lacked (it previously exposed only workflow-registration / sync / session histograms synced from internal deques).

## What changed

- **`RequestMetricsMiddleware`** (`nexus/middleware/request_metrics.py`) — pure-ASGI (matches `SecurityHeadersMiddleware`, not Starlette `BaseHTTPMiddleware`). Emits `nexus_http_requests_total` (Counter) + `nexus_http_request_duration_seconds` (Histogram), labelled `method` / `route` / `status`.
- **Cardinality-bounded labels** — the `route` label is the matched-route **template** (`/users/{id}`), with a single `__unmatched__` sentinel for 404/unmatched traffic. Raw concrete paths never become labels (path-scanning DoS defense).
- **`observe_http_request`** helper in `metrics.py` — lazy prometheus init in the default registry, so the existing `/metrics` scrape picks it up automatically.
- **Opt-in preset wiring** — `NexusConfig.metrics_enabled: bool = False` (prometheus is an optional `[metrics]` extra); factory appended **last** in `standard`/`saas`/`enterprise` chains → outermost (LIFO) → measures total latency.
- **No-op when prometheus absent** — clean pass-through; warns once naming `pip install kailash-nexus[metrics]`.
- Version bump **kailash-nexus 2.10.0 → 2.11.0** (pyproject.toml + `__version__`, atomic), CHANGELOG, spec (`specs/nexus-services.md` §14 + §7.3).

## Tests
- Tier-1 unit (`tests/unit/test_request_metrics_middleware_unit.py`) — `_route_label` template/fallback/`__unmatched__`, exception-path 500, no-op-when-absent, exclusion.
- Tier-2 wiring (`tests/integration/test_request_metrics_middleware.py`) — real Nexus + `/metrics` scrape end-to-end (orphan-detection Rule 2 / facade-manager).
- `72 passed`; existing `test_metrics.py` `10 passed` (no registry collisions); `--collect-only` clean.

## Gate reviews
- **reviewer: APPROVE** — cardinality provably bounded, exception path correct, LIFO ordering verified, version 2.11.0 both anchors.
- **security-reviewer: APPROVE** — no CRIT/HIGH/MED; cardinality-DoS surface closed (template-only labels, `__unmatched__` collapses path-scanning to one timeseries); no PII/secrets in labels. One informational LOW: exact-match exclusion won't match prefix-mounted scrape paths (configurable via `exclude_paths`; not a cardinality risk).

## User-flow walk receipt
```
$ # operator: app.add_middleware(RequestMetricsMiddleware); register_metrics_endpoint(app)
$ # 3× GET /health, then scrape:
$ GET /metrics → 200
nexus_http_requests_total{method="GET",route="/health",status="200"} 3.0
nexus_http_request_duration_seconds_count{method="GET",route="/health",status="200"} 3.0
```
Route label is the template (bounded cardinality); `/metrics` itself produced no route sample (excluded). Disposition: works end-to-end, two-line operator wiring.

## Related issues
Closes #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)